### PR TITLE
Hint, completion fix, cleanup

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.0-pre.4]
+
+- Updates the worker, fixing an issue with deletion
+
 ## [0.1.0-pre.3]
 
 - Removes the `v` from version output

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Refactoring
 
 - Cleans up the CLI `main.rs` file
+- Moves the default GraphQL schema to a file
 
 ## [0.1.0-pre.4]
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.1.0-pre.5]
+
+### Features
+
+- Adds a hint when `init` is run in an initialized project
+
+### Fixes
+
+- Fixes the CLI header being printed when printing completions
+
+### Refactoring
+
+- Cleans up the CLI `main.rs` file
+
 ## [0.1.0-pre.4]
 
 - Updates the worker, fixing an issue with deletion

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -590,7 +590,7 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "grafbase"
-version = "0.1.0-pre.3"
+version = "0.1.0-pre.4"
 dependencies = [
  "backtrace",
  "clap",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.1.0-pre.3"
+version = "0.1.0-pre.4"
 dependencies = [
  "exitcode",
  "grafbase-local-common",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.1.0-pre.3"
+version = "0.1.0-pre.4"
 dependencies = [
  "dirs",
  "exitcode",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.1.0-pre.3"
+version = "0.1.0-pre.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -590,7 +590,7 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "grafbase"
-version = "0.1.0-pre.4"
+version = "0.1.0-pre.5"
 dependencies = [
  "backtrace",
  "clap",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.1.0-pre.4"
+version = "0.1.0-pre.5"
 dependencies = [
  "exitcode",
  "grafbase-local-common",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.1.0-pre.4"
+version = "0.1.0-pre.5"
 dependencies = [
  "dirs",
  "exitcode",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.1.0-pre.4"
+version = "0.1.0-pre.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-local-backend"
-version = "0.1.0-pre.3"
+version = "0.1.0-pre.4"
 edition = "2021"
 description = "The local backend for grafbase developer tools"
 license = "Apache-2.0"
@@ -10,8 +10,8 @@ readme = "README.md"
 repository = "https://github.com/grafbase/grafbase"
 
 [dependencies]
-common = { package = "grafbase-local-common", path = "../common", version = "0.1.0-pre.3" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.1.0-pre.3" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.1.0-pre.4" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.1.0-pre.4" }
 exitcode = "1"
 indoc = "1"
 thiserror = "1"

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-local-backend"
-version = "0.1.0-pre.4"
+version = "0.1.0-pre.5"
 edition = "2021"
 description = "The local backend for grafbase developer tools"
 license = "Apache-2.0"
@@ -10,8 +10,8 @@ readme = "README.md"
 repository = "https://github.com/grafbase/grafbase"
 
 [dependencies]
-common = { package = "grafbase-local-common", path = "../common", version = "0.1.0-pre.4" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.1.0-pre.4" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.1.0-pre.5" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.1.0-pre.5" }
 exitcode = "1"
 indoc = "1"
 thiserror = "1"

--- a/cli/crates/backend/assets/default-schema.graphql
+++ b/cli/crates/backend/assets/default-schema.graphql
@@ -1,0 +1,3 @@
+type Placeholder @model {
+  id: ID!
+}

--- a/cli/crates/backend/src/consts.rs
+++ b/cli/crates/backend/src/consts.rs
@@ -1,5 +1,1 @@
-pub const DEFAULT_SCHEMA: &str = indoc::indoc! {"
-    type Placeholder @model {
-        id: ID!
-    }
-"};
+pub const DEFAULT_SCHEMA: &str = include_str!("../assets/default-schema.graphql");

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase"
-version = "0.1.0-pre.3"
+version = "0.1.0-pre.4"
 edition = "2021"
 description = "The Grafbase command line interface"
 license = "Apache-2.0"
@@ -15,11 +15,11 @@ backtrace = "0.3"
 clap = { version = "3", features = ["cargo"] }
 clap_complete = "3"
 clap_generate = "3"
-common = { package = "grafbase-local-common", path = "../common", version = "0.1.0-pre.3" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.1.0-pre.4" }
 ctrlc = "3"
 exitcode = "1.1"
 indoc = "1.0"
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.1.0-pre.3" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.1.0-pre.4" }
 log = "0.4"
 os_type = "2"
 serde = "1"

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase"
-version = "0.1.0-pre.4"
+version = "0.1.0-pre.5"
 edition = "2021"
 description = "The Grafbase command line interface"
 license = "Apache-2.0"
@@ -11,15 +11,15 @@ repository = "https://github.com/grafbase/grafbase"
 categories = ["command-line-utilities"]
 
 [dependencies]
-backtrace = "0.3"
+backtrace = "0.3.66"
 clap = { version = "3", features = ["cargo"] }
 clap_complete = "3"
 clap_generate = "3"
-common = { package = "grafbase-local-common", path = "../common", version = "0.1.0-pre.4" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.1.0-pre.5" }
 ctrlc = "3"
 exitcode = "1"
 indoc = "1"
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.1.0-pre.4" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.1.0-pre.5" }
 log = "0.4"
 os_type = "2"
 serde = "1"

--- a/cli/crates/cli/src/dev.rs
+++ b/cli/crates/cli/src/dev.rs
@@ -3,6 +3,7 @@ use crate::CliError;
 use backend::server_api::start_server;
 use backend::types::ServerMessage;
 use common::consts::DEFAULT_PORT;
+use common::environment::Environment;
 use common::utils::get_thread_panic_message;
 
 /// cli wrapper for [`backend::server_api::start_server`]
@@ -14,6 +15,9 @@ use common::utils::get_thread_panic_message;
 /// returns [`CliError::ServerPanic`] if the development server panics
 pub fn dev(search: bool, external_port: Option<u16>) -> Result<(), CliError> {
     trace!("attempting to start server");
+
+    Environment::try_init().map_err(CliError::CommonError)?;
+
     let start_port = external_port.unwrap_or(DEFAULT_PORT);
     let server_handle = match start_server(external_port, search) {
         Ok((handle, receiver)) => {

--- a/cli/crates/cli/src/errors.rs
+++ b/cli/crates/cli/src/errors.rs
@@ -55,6 +55,9 @@ impl CliError {
             Self::ServerError(ServerError::OutdatedNode(_, min_version)) => {
                 Some(format!("please update your Node.js version to {min_version} or higher to continue (https://nodejs.org/en/download)"))
             }
+            Self::BackendError(BackendError::AlreadyAProject(_)) => {
+                Some("try running 'grafbase dev'".to_owned())
+            }
             _ => None,
         }
     }

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -53,15 +53,16 @@ fn try_main() -> Result<(), CliError> {
 
     tracing_subscriber::registry().with(fmt::layer()).with(filter).init();
 
+    if let Some(("completions", matches)) = matches.subcommand() {
+        let shell = matches.get_one::<String>("shell").expect("must be present");
+        completions::generate(shell)?;
+        return Ok(());
+    }
+
     report::cli_header();
 
     // commands that do not need an initialized environment
     match matches.subcommand() {
-        Some(("completions", matches)) => {
-            let shell = matches.get_one::<String>("shell").expect("must be present");
-            completions::generate(shell)?;
-            return Ok(());
-        }
         Some(("init", matches)) => {
             let name = matches.get_one::<String>("name").map(AsRef::as_ref);
             return init(name);

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -59,6 +59,11 @@ fn try_main() -> Result<(), CliError> {
     }
 
     match subcommand {
+        Some(("completions", matches)) => {
+            let shell = matches.get_one::<String>("shell").expect("must be present");
+            completions::generate(shell)?;
+            Ok(())
+        }
         Some(("dev", matches)) => {
             // ignoring any errors to fall back to the normal handler if there's an issue
             let _set_handler_result = ctrlc::set_handler(|| {
@@ -69,11 +74,6 @@ fn try_main() -> Result<(), CliError> {
             let search = matches.contains_id("search");
             let port = matches.get_one::<u16>("port").copied();
             dev(search, port)
-        }
-        Some(("completions", matches)) => {
-            let shell = matches.get_one::<String>("shell").expect("must be present");
-            completions::generate(shell)?;
-            Ok(())
         }
         Some(("init", matches)) => {
             let name = matches.get_one::<String>("name").map(AsRef::as_ref);

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -73,11 +73,11 @@ fn try_main() -> Result<(), CliError> {
         Some(("completions", matches)) => {
             let shell = matches.get_one::<String>("shell").expect("must be present");
             completions::generate(shell)?;
-            return Ok(());
+            Ok(())
         }
         Some(("init", matches)) => {
             let name = matches.get_one::<String>("name").map(AsRef::as_ref);
-            return init(name);
+            init(name)
         }
         _ => unreachable!(),
     }

--- a/cli/crates/common/Cargo.toml
+++ b/cli/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-local-common"
-version = "0.1.0-pre.3"
+version = "0.1.0-pre.4"
 edition = "2021"
 description = "Common code used in multiple crates in the CLI workspace"
 license = "Apache-2.0"

--- a/cli/crates/common/Cargo.toml
+++ b/cli/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-local-common"
-version = "0.1.0-pre.4"
+version = "0.1.0-pre.5"
 edition = "2021"
 description = "Common code used in multiple crates in the CLI workspace"
 license = "Apache-2.0"

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-local-server"
-version = "0.1.0-pre.3"
+version = "0.1.0-pre.4"
 edition = "2021"
 description = "A wrapper for the grafbase worker"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ include = ["/src", "/assets"]
 [dependencies]
 axum = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
-common = { package = "grafbase-local-common", path = "../common", version = "0.1.0-pre.3" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.1.0-pre.4" }
 exitcode = "1"
 hyper = "0.14"
 log = "0.4"

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-local-server"
-version = "0.1.0-pre.4"
+version = "0.1.0-pre.5"
 edition = "2021"
 description = "A wrapper for the grafbase worker"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ include = ["/src", "/assets"]
 [dependencies]
 axum = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
-common = { package = "grafbase-local-common", path = "../common", version = "0.1.0-pre.4" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.1.0-pre.5" }
 exitcode = "1"
 hyper = "0.14"
 log = "0.4"


### PR DESCRIPTION
# Description

## Features

- Adds a hint when `init` is run in an initialized project

## Fixes

- Fixes the CLI header being printed when printing completions

## Refactoring

- Cleans up the CLI `main.rs` file
- Moves the default GraphQL schema to a file

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [x] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
