### PR TITLE
allow downgrading CLI version

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [0.1.0-pre.7]
 
+## Fixes
+
 - Exports embedded files when downgrading a version as well as upgrading
+- Updates the default schema to add a field other than id
 
 ## [0.1.0-pre.6]
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.0-pre.7]
+
+- Exports embedded files when downgrading a version as well as upgrading
+
 ## [0.1.0-pre.6]
 
 ### Tooling

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -590,7 +590,7 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "grafbase"
-version = "0.1.0-pre.5"
+version = "0.1.0-pre.7"
 dependencies = [
  "backtrace",
  "clap",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.1.0-pre.5"
+version = "0.1.0-pre.7"
 dependencies = [
  "exitcode",
  "grafbase-local-common",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.1.0-pre.5"
+version = "0.1.0-pre.7"
 dependencies = [
  "dirs",
  "exitcode",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.1.0-pre.5"
+version = "0.1.0-pre.7"
 dependencies = [
  "anyhow",
  "axum",

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-local-backend"
-version = "0.1.0-pre.5"
+version = "0.1.0-pre.7"
 edition = "2021"
 description = "The local backend for grafbase developer tools"
 license = "Apache-2.0"
@@ -10,8 +10,8 @@ readme = "README.md"
 repository = "https://github.com/grafbase/grafbase"
 
 [dependencies]
-common = { package = "grafbase-local-common", path = "../common", version = "0.1.0-pre.5" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.1.0-pre.5" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.1.0-pre.7" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.1.0-pre.7" }
 exitcode = "1"
 indoc = "1"
 thiserror = "1"

--- a/cli/crates/backend/assets/default-schema.graphql
+++ b/cli/crates/backend/assets/default-schema.graphql
@@ -1,3 +1,4 @@
 type Placeholder @model {
   id: ID!
+  name: String!
 }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase"
-version = "0.1.0-pre.5"
+version = "0.1.0-pre.7"
 edition = "2021"
 description = "The Grafbase command line interface"
 license = "Apache-2.0"
@@ -15,11 +15,11 @@ backtrace = "0.3"
 clap = { version = "3", features = ["cargo"] }
 clap_complete = "3"
 clap_generate = "3"
-common = { package = "grafbase-local-common", path = "../common", version = "0.1.0-pre.5" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.1.0-pre.7" }
 ctrlc = "3"
 exitcode = "1"
 indoc = "1"
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.1.0-pre.5" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.1.0-pre.7" }
 log = "0.4"
 os_type = "2"
 serde = "1"

--- a/cli/crates/cli/src/output.rs
+++ b/cli/crates/cli/src/output.rs
@@ -4,12 +4,14 @@ pub mod report {
         errors::CliError,
         watercolor::{self, watercolor},
     };
+    use colored::Colorize;
     use common::consts::LOCALHOST;
 
     /// reports to stdout that the server has started
     pub fn cli_header() {
         let version = env!("CARGO_PKG_VERSION");
-        watercolor::output!("Grafbase CLI {version}", @hex("4A9C6D"), @@BrightBlue);
+        // TODO: integrate this with watercolor
+        println!("{}", format!("Grafbase CLI {version}\n").dimmed())
     }
 
     /// reports to stdout that the server has started
@@ -20,9 +22,14 @@ pub mod report {
                 watercolor!("{start_port}", @BrightBlue)
             );
         }
+        println!("📡 listening on port {}\n", watercolor!("{port}", @BrightBlue));
         println!(
-            "📡 started dev server on {}",
+            "- playground: {}",
             watercolor!("http://{LOCALHOST}:{port}", @BrightBlue)
+        );
+        println!(
+            "- endpoint: {}\n",
+            watercolor!("http://{LOCALHOST}:{port}/graphql", @BrightBlue)
         );
     }
 

--- a/cli/crates/cli/src/watercolor.rs
+++ b/cli/crates/cli/src/watercolor.rs
@@ -3,6 +3,7 @@ pub use colored::control::ShouldColorize;
 pub use hex_literal;
 use once_cell::sync::Lazy;
 
+#[allow(dead_code)]
 pub static TRUECOLOR_SUPPORTED: Lazy<bool> = Lazy::new(|| {
     let colorterm = std::env::var("COLORTERM").ok();
     colorterm.as_deref() == Some("truecolor") || colorterm.as_deref() == Some("24bit")

--- a/cli/crates/common/Cargo.toml
+++ b/cli/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-local-common"
-version = "0.1.0-pre.5"
+version = "0.1.0-pre.7"
 edition = "2021"
 description = "Common code used in multiple crates in the CLI workspace"
 license = "Apache-2.0"

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-local-server"
-version = "0.1.0-pre.5"
+version = "0.1.0-pre.7"
 edition = "2021"
 description = "A wrapper for the grafbase worker"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ include = ["/src", "/assets"]
 [dependencies]
 axum = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
-common = { package = "grafbase-local-common", path = "../common", version = "0.1.0-pre.5" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.1.0-pre.7" }
 exitcode = "1"
 hyper = "0.14"
 log = "0.4"

--- a/cli/crates/server/src/consts.rs
+++ b/cli/crates/server/src/consts.rs
@@ -1,7 +1,6 @@
 use std::ops::Range;
 
-pub const WORKER_DIR: &str = "worker";
-pub const WORKER_FOLDER_VERSION_FILE: &str = "version.txt";
+pub const ASSET_VERSION_FILE: &str = "version.txt";
 pub const EPHEMERAL_PORT_RANGE: Range<u16> = 49152..65535;
 pub const SCHEMA_PARSER_DIR: &str = "parser";
 pub const SCHEMA_PARSER_INDEX: &str = "index.js";

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -138,7 +138,7 @@ fn export_embedded_files() -> Result<(), ServerError> {
     let export_files = if environment.user_dot_grafbase_path.is_dir() {
         let asset_version = fs::read_to_string(&version_path).map_err(|_| ServerError::ReadVersion)?;
 
-        current_version != &asset_version
+        current_version != asset_version
     } else {
         true
     };

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -1,6 +1,6 @@
 use crate::consts::{
-    EPHEMERAL_PORT_RANGE, GIT_IGNORE_CONTENTS, GIT_IGNORE_FILE, MIN_NODE_VERSION, SCHEMA_PARSER_DIR,
-    SCHEMA_PARSER_INDEX, WORKER_DIR, WORKER_FOLDER_VERSION_FILE,
+    ASSET_VERSION_FILE, EPHEMERAL_PORT_RANGE, GIT_IGNORE_CONTENTS, GIT_IGNORE_FILE, MIN_NODE_VERSION,
+    SCHEMA_PARSER_DIR, SCHEMA_PARSER_INDEX,
 };
 use crate::types::{Assets, ServerMessage};
 use crate::{bridge, errors::ServerError};
@@ -131,18 +131,14 @@ async fn spawn_servers(worker_port: u16, bridge_port: u16, sender: Sender<Server
 fn export_embedded_files() -> Result<(), ServerError> {
     let environment = Environment::get();
 
-    let worker_path = environment.user_dot_grafbase_path.join(WORKER_DIR);
+    let current_version = env!("CARGO_PKG_VERSION");
 
-    // CARGO_PKG_VERSION is guaranteed be valid semver
-    let current_version = Version::from(env!("CARGO_PKG_VERSION")).unwrap();
+    let version_path = environment.user_dot_grafbase_path.join(ASSET_VERSION_FILE);
 
-    let worker_version_path = worker_path.join(WORKER_FOLDER_VERSION_FILE);
+    let export_files = if environment.user_dot_grafbase_path.is_dir() {
+        let asset_version = fs::read_to_string(&version_path).map_err(|_| ServerError::ReadVersion)?;
 
-    let export_files = if worker_path.is_dir() {
-        let worker_version = fs::read_to_string(&worker_version_path).map_err(|_| ServerError::ReadVersion)?;
-
-        // derived from CARGO_PKG_VERSION, guaranteed be valid semver
-        current_version > Version::from(&worker_version).unwrap()
+        current_version != &asset_version
     } else {
         true
     };
@@ -183,9 +179,9 @@ fn export_embedded_files() -> Result<(), ServerError> {
             return Err(ServerError::WriteFile(error_path_string));
         }
 
-        if fs::write(&worker_version_path, current_version.as_str()).is_err() {
-            let worker_version_path_string = worker_version_path.to_string_lossy().into_owned();
-            return Err(ServerError::WriteFile(worker_version_path_string));
+        if fs::write(&version_path, current_version).is_err() {
+            let version_path_string = version_path.to_string_lossy().into_owned();
+            return Err(ServerError::WriteFile(version_path_string));
         };
     }
 


### PR DESCRIPTION
# Description

## Features

- Outputs playground and endpoint links on `dev`

## Fixes

- Exports embedded files when downgrading a version as well as upgrading
- Updates the default schema to add a field other than id

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
