### PR TITLE
remove detect-libc as it's not currently in use

### DIFF
--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -21,9 +21,7 @@
   "scripts": {
     "postinstall": "node ./postinstall.js"
   },
-  "dependencies": {
-    "detect-libc": "^2.0.1"
-  },
+  "dependencies": {},
   "devDependencies": {
     "jest": "^28.1.2"
   },


### PR DESCRIPTION
# Description

## Dependencies

- Remove `detect-libc` from the NPM package as it's not currently in use

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [x] 📦 Dependency
- [ ] 📖 Requires documentation update
