### PR TITLE
docs(examples/nextjs): remove schema.grapql from .gitignore

### DIFF
--- a/examples/nextjs/.gitignore
+++ b/examples/nextjs/.gitignore
@@ -39,4 +39,3 @@ yarn-error.log*
 
 # graphql
 .graphqlconfig
-schema.graphql


### PR DESCRIPTION
# Description

Thank you for providing a very great services.

When using the sample project, the `schema.grapql` file was listed in the `.gitignore` file and needed to be edited when deploying.
I thought it would be easier to use the example if it was removed from the target.

Thank you.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [x] 📖 Requires documentation update
