### PR TITLE
fix: use correct codesandbox link in nextjs example

### DIFF
--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -28,4 +28,4 @@ To learn more about Next.js, take a look at the following resources:
 
 ### Run on Codesandbox
 
-[![Develop with Codesandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://github.com/grafbase/grafbase/tree/main/examples/nextjs)
+[![Develop with Codesandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/grafbase/grafbase/tree/main/examples/nextjs)

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -28,4 +28,4 @@ To learn more about Next.js, take a look at the following resources:
 
 ### Run on Codesandbox
 
-[![Develop with Codesandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/grafbase/grafbase/tree/main/examples/nextjs)
+[![Develop with Codesandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://githubbox.com/grafbase/grafbase/tree/main/examples/nextjs)


### PR DESCRIPTION
# Description

Use the correct codesandbox link.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
