### PR TITLE
clippy fixes, upgrade rust

### DIFF
--- a/cli/crates/cli/tests/unique.rs
+++ b/cli/crates/cli/tests/unique.rs
@@ -74,5 +74,5 @@ fn unique() {
 
     let first_author: Option<Value> = response.dot_get("data.author").unwrap();
 
-    assert!(first_author.is_none())
+    assert!(first_author.is_none());
 }

--- a/cli/crates/cli/tests/utils/environment.rs
+++ b/cli/crates/cli/tests/utils/environment.rs
@@ -89,6 +89,6 @@ impl Drop for Environment {
     fn drop(&mut self) {
         self.commands.iter().for_each(|command| {
             kill_with_children(*command.pids().first().unwrap());
-        })
+        });
     }
 }

--- a/cli/crates/cli/tests/utils/kill_with_children.rs
+++ b/cli/crates/cli/tests/utils/kill_with_children.rs
@@ -2,7 +2,7 @@ use sysinfo::{Pid, ProcessExt, Signal, System, SystemExt};
 
 pub fn kill_with_children(pid: u32) {
     #[cfg(target_family = "unix")]
-    let target_id = Pid::from(pid as i32);
+    let target_id = Pid::from(i32::try_from(pid).unwrap());
     #[cfg(target_family = "windows")]
     let target_id = Pid::from(pid as usize);
 

--- a/cli/rust-toolchain.toml
+++ b/cli/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.62.1"
+channel = "1.63.0"


### PR DESCRIPTION
# Description

## Tooling

- Updates Rust to `1.63.0`

## Refactoring

- Misc. Clippy fixes

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [x] 🛠️ Tooling
- [x] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
