### PR TITLE
Add concurrency test

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -738,6 +738,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "thiserror",
+ "tokio",
  "toml",
  "tracing-subscriber",
  "uuid",
@@ -2193,9 +2194,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
+checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
 dependencies = [
  "autocfg",
  "bytes",

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -41,6 +41,7 @@ serde_json = "1.0.83"
 sysinfo = "0.25.2"
 tempfile = "3.3.0"
 json_dotpath = "1.1.0"
+tokio = { version = "1.20.1", features = ["full"] }
 
 [[bin]]
 name = "grafbase"

--- a/cli/crates/cli/tests/concurrency-process.rs
+++ b/cli/crates/cli/tests/concurrency-process.rs
@@ -11,7 +11,6 @@ async fn process() {
 
     env1.grafbase_init();
     env1.write_schema(CONCURRENCY_SCHEMA);
-
     env1.grafbase_dev();
 
     let async_client1 = env1.create_async_client();

--- a/cli/crates/cli/tests/concurrency-process.rs
+++ b/cli/crates/cli/tests/concurrency-process.rs
@@ -1,0 +1,49 @@
+mod utils;
+
+use serde_json::{json, Value};
+use utils::consts::{CONCURRENCY_MUTATION, CONCURRENCY_QUERY, CONCURRENCY_SCHEMA};
+use utils::environment::Environment;
+
+#[tokio::test]
+async fn process() {
+    let mut env1 = Environment::init(4005);
+    let mut env2 = Environment::from(&env1, 4006);
+
+    env1.grafbase_init();
+    env1.write_schema(CONCURRENCY_SCHEMA);
+
+    env1.grafbase_dev();
+
+    let async_client1 = env1.create_async_client();
+    async_client1.poll_endpoint(30, 300).await;
+
+    env2.grafbase_dev();
+    let async_client2 = env2.create_async_client();
+    async_client2.poll_endpoint(30, 300).await;
+
+    for _ in 0..15 {
+        let (response1, response2): (Value, Value) = tokio::join!(
+            async_client1.gql::<Value>(json!({ "query": CONCURRENCY_MUTATION }).to_string()),
+            async_client2.gql::<Value>(json!({ "query": CONCURRENCY_MUTATION }).to_string())
+        );
+
+        let errors1: Option<Value> = dot_get_opt!(response1, "errors");
+        let errors2: Option<Value> = dot_get_opt!(response2, "errors");
+
+        assert!(errors1.is_none());
+        assert!(errors2.is_none());
+    }
+
+    let response1 = async_client1
+        .gql::<Value>(json!({ "query": CONCURRENCY_QUERY }).to_string())
+        .await;
+    let response2 = async_client2
+        .gql::<Value>(json!({ "query": CONCURRENCY_QUERY }).to_string())
+        .await;
+
+    let result_list1: Vec<Value> = dot_get!(response1, "data.todoListCollection.edges");
+    let result_list2: Vec<Value> = dot_get!(response2, "data.todoListCollection.edges");
+
+    assert_eq!(result_list1.len(), 30);
+    assert_eq!(result_list2.len(), 30);
+}

--- a/cli/crates/cli/tests/concurrency-thread.rs
+++ b/cli/crates/cli/tests/concurrency-thread.rs
@@ -1,66 +1,15 @@
 mod utils;
 
-use std::time::Duration;
-
 use serde_json::{json, Value};
-use tokio::time::sleep;
 use utils::consts::{CONCURRENCY_MUTATION, CONCURRENCY_QUERY, CONCURRENCY_SCHEMA};
 use utils::environment::Environment;
 
 #[tokio::test]
-async fn process() {
-    let mut env1 = Environment::init(4005);
-    let mut env2 = Environment::from(&env1, 4006);
-
-    env1.grafbase_init();
-    env1.write_schema(CONCURRENCY_SCHEMA);
-
-    env1.grafbase_dev();
-
-    let async_client1 = env1.create_async_client();
-    async_client1.poll_endpoint(30, 300).await;
-
-    // apparently if creating two dev servers at the exact same time, the bridge server can attempt to use the same port twice
-    // TODO: look into a solution for this edge case
-    sleep(Duration::from_millis(100)).await;
-
-    env2.grafbase_dev();
-    let async_client2 = env2.create_async_client();
-    async_client2.poll_endpoint(30, 300).await;
-
-    for _ in 0..15 {
-        let (response1, response2): (Value, Value) = tokio::join!(
-            async_client1.gql::<Value>(json!({ "query": CONCURRENCY_MUTATION }).to_string()),
-            async_client2.gql::<Value>(json!({ "query": CONCURRENCY_MUTATION }).to_string())
-        );
-
-        let errors1: Option<Value> = dot_get_opt!(response1, "errors");
-        let errors2: Option<Value> = dot_get_opt!(response2, "errors");
-
-        assert!(errors1.is_none());
-        assert!(errors2.is_none());
-    }
-
-    let response1 = async_client1
-        .gql::<Value>(json!({ "query": CONCURRENCY_QUERY }).to_string())
-        .await;
-    let response2 = async_client2
-        .gql::<Value>(json!({ "query": CONCURRENCY_QUERY }).to_string())
-        .await;
-
-    let result_list1: Vec<Value> = dot_get!(response1, "data.todoListCollection.edges");
-    let result_list2: Vec<Value> = dot_get!(response2, "data.todoListCollection.edges");
-
-    assert_eq!(result_list1.len(), 30);
-    assert_eq!(result_list2.len(), 30);
-}
-
-#[tokio::test]
 async fn thread() {
-    // 4007 seems to be in use in the CI
-    let mut env = Environment::init(4008);
+    let mut env = Environment::init(4007);
 
     env.grafbase_init();
+    env.write_schema(CONCURRENCY_SCHEMA);
     env.grafbase_dev();
 
     // if using multiple clients, has issues in the CI with the connection being reset,

--- a/cli/crates/cli/tests/concurrency.rs
+++ b/cli/crates/cli/tests/concurrency.rs
@@ -1,0 +1,54 @@
+mod utils;
+
+use serde_json::{json, Value};
+use std::time::Duration;
+use tokio::time::sleep;
+use utils::consts::{CONCURRENCY_MUTATION, CONCURRENCY_QUERY, CONCURRENCY_SCHEMA};
+use utils::environment::Environment;
+
+// takes 45 seconds to run
+#[ignore]
+#[tokio::test]
+async fn dev() {
+    let mut env1 = Environment::init(4005);
+    let mut env2 = Environment::from(&env1, 4006);
+
+    env1.grafbase_init();
+    env1.write_schema(CONCURRENCY_SCHEMA);
+
+    env1.grafbase_dev();
+    // apparently if creating two dev servers at the exact same time, the bridge server can attempt to use the same port twice
+    // TODO: look into a solution for this edge case
+    let async_client1 = env1.create_async_client();
+    async_client1.poll_endpoint(30, 300).await;
+
+    env2.grafbase_dev();
+    let async_client2 = env2.create_async_client();
+    async_client2.poll_endpoint(30, 300).await;
+
+    for _ in 0..99 {
+        let (response1, response2): (Value, Value) = tokio::join!(
+            async_client1.gql::<Value>(json!({ "query": CONCURRENCY_MUTATION }).to_string()),
+            async_client2.gql::<Value>(json!({ "query": CONCURRENCY_MUTATION }).to_string())
+        );
+
+        let errors1: Option<Value> = dot_get_opt!(response1, "errors");
+        let errors2: Option<Value> = dot_get_opt!(response2, "errors");
+
+        assert!(errors1.is_none());
+        assert!(errors2.is_none());
+    }
+
+    let response1 = async_client1
+        .gql::<Value>(json!({ "query": CONCURRENCY_QUERY }).to_string())
+        .await;
+    let response2 = async_client2
+        .gql::<Value>(json!({ "query": CONCURRENCY_QUERY }).to_string())
+        .await;
+
+    let result_list1: Vec<Value> = dot_get!(response1, "data.todoListCollection.edges");
+    let result_list2: Vec<Value> = dot_get!(response2, "data.todoListCollection.edges");
+
+    assert_eq!(result_list1.len(), 100);
+    assert_eq!(result_list2.len(), 100);
+}

--- a/cli/crates/cli/tests/concurrency.rs
+++ b/cli/crates/cli/tests/concurrency.rs
@@ -4,8 +4,6 @@ use serde_json::{json, Value};
 use utils::consts::{CONCURRENCY_MUTATION, CONCURRENCY_QUERY, CONCURRENCY_SCHEMA};
 use utils::environment::Environment;
 
-// takes 45 seconds to run
-#[ignore]
 #[tokio::test]
 async fn process() {
     let mut env1 = Environment::init(4005);
@@ -24,7 +22,7 @@ async fn process() {
     let async_client2 = env2.create_async_client();
     async_client2.poll_endpoint(30, 300).await;
 
-    for _ in 0..50 {
+    for _ in 0..15 {
         let (response1, response2): (Value, Value) = tokio::join!(
             async_client1.gql::<Value>(json!({ "query": CONCURRENCY_MUTATION }).to_string()),
             async_client2.gql::<Value>(json!({ "query": CONCURRENCY_MUTATION }).to_string())
@@ -47,8 +45,8 @@ async fn process() {
     let result_list1: Vec<Value> = dot_get!(response1, "data.todoListCollection.edges");
     let result_list2: Vec<Value> = dot_get!(response2, "data.todoListCollection.edges");
 
-    assert_eq!(result_list1.len(), 100);
-    assert_eq!(result_list2.len(), 100);
+    assert_eq!(result_list1.len(), 30);
+    assert_eq!(result_list2.len(), 30);
 }
 
 #[tokio::test]

--- a/cli/crates/cli/tests/concurrency.rs
+++ b/cli/crates/cli/tests/concurrency.rs
@@ -4,6 +4,12 @@ use serde_json::{json, Value};
 use utils::consts::{CONCURRENCY_MUTATION, CONCURRENCY_QUERY, CONCURRENCY_SCHEMA};
 use utils::environment::Environment;
 
+// has issues in the CI with the connection being reset,
+// also happens locally if using a larger number of requests.
+// due to the CLI not erroring this seems like a configuration issue or due to using multiple clients
+// but
+// TODO: make sure this isn't due to a concurrency issue
+#[ignore]
 #[tokio::test]
 async fn process() {
     let mut env1 = Environment::init(4005);
@@ -49,6 +55,12 @@ async fn process() {
     assert_eq!(result_list2.len(), 30);
 }
 
+// has issues in the CI with the connection being reset,
+// also happens locally if using a larger number of requests.
+// due to the CLI not erroring this seems like a configuration issue or due to using multiple clients
+// but
+// TODO: make sure this isn't due to a concurrency issue
+#[ignore]
 #[tokio::test]
 async fn thread() {
     let mut env = Environment::init(4007);

--- a/cli/crates/cli/tests/concurrency.rs
+++ b/cli/crates/cli/tests/concurrency.rs
@@ -1,8 +1,6 @@
 mod utils;
 
 use serde_json::{json, Value};
-use std::time::Duration;
-use tokio::time::sleep;
 use utils::consts::{CONCURRENCY_MUTATION, CONCURRENCY_QUERY, CONCURRENCY_SCHEMA};
 use utils::environment::Environment;
 

--- a/cli/crates/cli/tests/concurrency.rs
+++ b/cli/crates/cli/tests/concurrency.rs
@@ -1,6 +1,9 @@
 mod utils;
 
+use std::time::Duration;
+
 use serde_json::{json, Value};
+use tokio::time::sleep;
 use utils::consts::{CONCURRENCY_MUTATION, CONCURRENCY_QUERY, CONCURRENCY_SCHEMA};
 use utils::environment::Environment;
 
@@ -13,10 +16,13 @@ async fn process() {
     env1.write_schema(CONCURRENCY_SCHEMA);
 
     env1.grafbase_dev();
-    // apparently if creating two dev servers at the exact same time, the bridge server can attempt to use the same port twice
-    // TODO: look into a solution for this edge case
+
     let async_client1 = env1.create_async_client();
     async_client1.poll_endpoint(30, 300).await;
+
+    // apparently if creating two dev servers at the exact same time, the bridge server can attempt to use the same port twice
+    // TODO: look into a solution for this edge case
+    sleep(Duration::from_millis(100)).await;
 
     env2.grafbase_dev();
     let async_client2 = env2.create_async_client();

--- a/cli/crates/cli/tests/concurrency.rs
+++ b/cli/crates/cli/tests/concurrency.rs
@@ -4,12 +4,6 @@ use serde_json::{json, Value};
 use utils::consts::{CONCURRENCY_MUTATION, CONCURRENCY_QUERY, CONCURRENCY_SCHEMA};
 use utils::environment::Environment;
 
-// has issues in the CI with the connection being reset,
-// also happens locally if using a larger number of requests.
-// due to the CLI not erroring this seems like a configuration issue or due to using multiple clients
-// but
-// TODO: make sure this isn't due to a concurrency issue
-#[ignore]
 #[tokio::test]
 async fn process() {
     let mut env1 = Environment::init(4005);
@@ -76,6 +70,7 @@ async fn thread() {
     // if using larger amounts of requests this crashes due to the connection being reset.
     // this most likely has to do with limits in how Axum is configured as there's no stderr output from the CLI itself
     // this does not happen if using one client and making multiple requests.
+    // this does not happen if using one client.
     //
     // TODO: verify that this is not related to SQLite locking issues
     for _ in 0..10 {

--- a/cli/crates/cli/tests/concurrency.rs
+++ b/cli/crates/cli/tests/concurrency.rs
@@ -51,7 +51,8 @@ async fn process() {
 
 #[tokio::test]
 async fn thread() {
-    let mut env = Environment::init(4007);
+    // 4007 seems to be in use in the CI
+    let mut env = Environment::init(4008);
 
     env.grafbase_init();
     env.grafbase_dev();

--- a/cli/crates/cli/tests/graphql/concurrency/mutation.graphql
+++ b/cli/crates/cli/tests/graphql/concurrency/mutation.graphql
@@ -1,0 +1,29 @@
+mutation {
+  todoListCreate(
+    input: {
+      title: "My todo list"
+      todos: [
+        { create: { title: "todo 1", complete: true } }
+        { create: { title: "todo 2", complete: false } }
+        { create: { title: "todo 3", complete: true } }
+        { create: { title: "todo 4", complete: false } }
+        { create: { title: "todo 5", complete: true } }
+        { create: { title: "todo 6", complete: false } }
+        { create: { title: "todo 7", complete: true } }
+        { create: { title: "todo 8", complete: false } }
+        { create: { title: "todo 9", complete: true } }
+        { create: { title: "todo 10", complete: false } }
+      ]
+    }
+  ) {
+    todoList {
+      id
+      title
+      todos {
+        id
+        title
+        complete
+      }
+    }
+  }
+}

--- a/cli/crates/cli/tests/graphql/concurrency/query.graphql
+++ b/cli/crates/cli/tests/graphql/concurrency/query.graphql
@@ -1,0 +1,15 @@
+{
+  todoListCollection(first: 100) {
+    edges {
+      node {
+        id
+        title
+        todos {
+          id
+          title
+          complete
+        }
+      }
+    }
+  }
+}

--- a/cli/crates/cli/tests/graphql/concurrency/schema.graphql
+++ b/cli/crates/cli/tests/graphql/concurrency/schema.graphql
@@ -1,0 +1,11 @@
+type TodoList @model {
+  id: ID!
+  title: String!
+  todos: [Todo]
+}
+
+type Todo @model {
+  id: ID!
+  title: String!
+  complete: Boolean!
+}

--- a/cli/crates/cli/tests/graphql/introspection.graphql
+++ b/cli/crates/cli/tests/graphql/introspection.graphql
@@ -1,0 +1,98 @@
+# the query used by https://github.com/graphql/graphql-js/blob/main/src/utilities/getIntrospectionQuery.ts
+
+query IntrospectionQuery {
+  __schema {
+    queryType {
+      name
+    }
+    mutationType {
+      name
+    }
+    subscriptionType {
+      name
+    }
+    types {
+      ...FullType
+    }
+    directives {
+      name
+      description
+      locations
+      args {
+        ...InputValue
+      }
+    }
+  }
+}
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ...InputValue
+    }
+    type {
+      ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ...InputValue
+  }
+  interfaces {
+    ...TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ...TypeRef
+  }
+}
+fragment InputValue on __InputValue {
+  name
+  description
+  type {
+    ...TypeRef
+  }
+  defaultValue
+}
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/cli/crates/cli/tests/utils/async_client.rs
+++ b/cli/crates/cli/tests/utils/async_client.rs
@@ -1,0 +1,113 @@
+#![allow(dead_code)]
+use serde_json::json;
+use std::{
+    thread::sleep,
+    time::{Duration, SystemTime},
+};
+
+pub struct AsyncClient {
+    endpoint: String,
+    client: reqwest::Client,
+    snapshot: Option<String>,
+}
+
+// the query used by https://github.com/graphql/graphql-js/blob/main/src/utilities/getIntrospectionQuery.ts
+const INTROSPECTION_QUERY: &str = r#"
+query  IntrospectionQuery  {  __schema  {  queryType  {  name  }  mutationType  {  name  }  subscriptionType  {  name  }  types  {  ...FullType  }  directives  {  name  description  locations  args  {  ...InputValue  }  }  }  }  fragment  FullType  on  __Type  {  kind  name  description  fields(includeDeprecated:  true)  {  name  description  args  {  ...InputValue  }  type  {  ...TypeRef  }  isDeprecated  deprecationReason  }  inputFields  {  ...InputValue  }  interfaces  {  ...TypeRef  }  enumValues(includeDeprecated:  true)  {  name  description  isDeprecated  deprecationReason  }  possibleTypes  {  ...TypeRef  }  }  fragment  InputValue  on  __InputValue  {  name  description  type  {  ...TypeRef  }  defaultValue  }  fragment  TypeRef  on  __Type  {  kind  name  ofType  {  kind  name  ofType  {  kind  name  ofType  {  kind  name  ofType  {  kind  name  ofType  {  kind  name  ofType  {  kind  name  ofType  {  kind  name  }  }  }  }  }  }  }  }  
+"#;
+
+impl AsyncClient {
+    pub fn new(endpoint: String) -> Self {
+        Self {
+            endpoint,
+            client: reqwest::Client::new(),
+            snapshot: None,
+        }
+    }
+
+    pub async fn gql<T>(&self, body: String) -> T
+    where
+        T: for<'de> serde::de::Deserialize<'de>,
+    {
+        self.client
+            .post(&self.endpoint)
+            .body(body)
+            .send()
+            .await
+            .unwrap()
+            .json::<T>()
+            .await
+            .unwrap()
+    }
+
+    async fn introspect(&self) -> String {
+        self.client
+            .post(&self.endpoint)
+            .body(json!({"operationName":"IntrospectionQuery", "query": INTROSPECTION_QUERY}).to_string())
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap()
+    }
+
+    async fn safe_introspect(&self) -> Option<String> {
+        if let Ok(response) = self
+            .client
+            .post(&self.endpoint)
+            .body(json!({"operationName":"IntrospectionQuery", "query": INTROSPECTION_QUERY}).to_string())
+            .send()
+            .await
+        {
+            if let Ok(text) = response.text().await {
+                return Some(text);
+            }
+        }
+
+        None
+    }
+
+    /// # Panics
+    ///
+    /// panics if the set timeout is reached
+    pub async fn poll_endpoint(&self, timeout_secs: u64, interval_millis: u64) {
+        let start = SystemTime::now();
+
+        loop {
+            if self.client.head(&self.endpoint).send().await.is_ok() {
+                break;
+            }
+
+            assert!(start.elapsed().unwrap().as_secs() < timeout_secs, "timeout");
+
+            sleep(Duration::from_millis(interval_millis));
+        }
+    }
+
+    pub async fn snapshot(&mut self) {
+        self.snapshot = Some(self.introspect().await);
+    }
+
+    pub async fn poll_endpoint_for_changes(&mut self, timeout_secs: u64, interval_millis: u64) {
+        let start = SystemTime::now();
+
+        loop {
+            // panic if a snapshot was not taken
+            let snapshot = self.snapshot.clone().unwrap();
+
+            match self.safe_introspect().await {
+                Some(current) => {
+                    if snapshot != current {
+                        self.snapshot = Some(current);
+                        break;
+                    }
+                }
+                None => continue,
+            };
+
+            assert!(start.elapsed().unwrap().as_secs() < timeout_secs, "timeout");
+            sleep(Duration::from_millis(interval_millis));
+        }
+    }
+}

--- a/cli/crates/cli/tests/utils/async_client.rs
+++ b/cli/crates/cli/tests/utils/async_client.rs
@@ -1,9 +1,7 @@
 #![allow(dead_code)]
 use serde_json::json;
-use std::{
-    thread::sleep,
-    time::{Duration, SystemTime},
-};
+use std::time::{Duration, SystemTime};
+use tokio::time::sleep;
 
 pub struct AsyncClient {
     endpoint: String,
@@ -81,7 +79,7 @@ impl AsyncClient {
 
             assert!(start.elapsed().unwrap().as_secs() < timeout_secs, "timeout");
 
-            sleep(Duration::from_millis(interval_millis));
+            sleep(Duration::from_millis(interval_millis)).await;
         }
     }
 
@@ -107,7 +105,7 @@ impl AsyncClient {
             };
 
             assert!(start.elapsed().unwrap().as_secs() < timeout_secs, "timeout");
-            sleep(Duration::from_millis(interval_millis));
+            sleep(Duration::from_millis(interval_millis)).await;
         }
     }
 }

--- a/cli/crates/cli/tests/utils/async_client.rs
+++ b/cli/crates/cli/tests/utils/async_client.rs
@@ -3,16 +3,13 @@ use serde_json::json;
 use std::time::{Duration, SystemTime};
 use tokio::time::sleep;
 
+use crate::utils::consts::INTROSPECTION_QUERY;
+
 pub struct AsyncClient {
     endpoint: String,
     client: reqwest::Client,
     snapshot: Option<String>,
 }
-
-// the query used by https://github.com/graphql/graphql-js/blob/main/src/utilities/getIntrospectionQuery.ts
-const INTROSPECTION_QUERY: &str = r#"
-query  IntrospectionQuery  {  __schema  {  queryType  {  name  }  mutationType  {  name  }  subscriptionType  {  name  }  types  {  ...FullType  }  directives  {  name  description  locations  args  {  ...InputValue  }  }  }  }  fragment  FullType  on  __Type  {  kind  name  description  fields(includeDeprecated:  true)  {  name  description  args  {  ...InputValue  }  type  {  ...TypeRef  }  isDeprecated  deprecationReason  }  inputFields  {  ...InputValue  }  interfaces  {  ...TypeRef  }  enumValues(includeDeprecated:  true)  {  name  description  isDeprecated  deprecationReason  }  possibleTypes  {  ...TypeRef  }  }  fragment  InputValue  on  __InputValue  {  name  description  type  {  ...TypeRef  }  defaultValue  }  fragment  TypeRef  on  __Type  {  kind  name  ofType  {  kind  name  ofType  {  kind  name  ofType  {  kind  name  ofType  {  kind  name  ofType  {  kind  name  ofType  {  kind  name  ofType  {  kind  name  }  }  }  }  }  }  }  }  
-"#;
 
 impl AsyncClient {
     pub fn new(endpoint: String) -> Self {

--- a/cli/crates/cli/tests/utils/client.rs
+++ b/cli/crates/cli/tests/utils/client.rs
@@ -5,16 +5,13 @@ use std::{
     time::{Duration, SystemTime},
 };
 
+use crate::utils::consts::INTROSPECTION_QUERY;
+
 pub struct Client {
     endpoint: String,
     client: reqwest::blocking::Client,
     snapshot: Option<String>,
 }
-
-// the query used by https://github.com/graphql/graphql-js/blob/main/src/utilities/getIntrospectionQuery.ts
-const INTROSPECTION_QUERY: &str = r#"
-query  IntrospectionQuery  {  __schema  {  queryType  {  name  }  mutationType  {  name  }  subscriptionType  {  name  }  types  {  ...FullType  }  directives  {  name  description  locations  args  {  ...InputValue  }  }  }  }  fragment  FullType  on  __Type  {  kind  name  description  fields(includeDeprecated:  true)  {  name  description  args  {  ...InputValue  }  type  {  ...TypeRef  }  isDeprecated  deprecationReason  }  inputFields  {  ...InputValue  }  interfaces  {  ...TypeRef  }  enumValues(includeDeprecated:  true)  {  name  description  isDeprecated  deprecationReason  }  possibleTypes  {  ...TypeRef  }  }  fragment  InputValue  on  __InputValue  {  name  description  type  {  ...TypeRef  }  defaultValue  }  fragment  TypeRef  on  __Type  {  kind  name  ofType  {  kind  name  ofType  {  kind  name  ofType  {  kind  name  ofType  {  kind  name  ofType  {  kind  name  ofType  {  kind  name  ofType  {  kind  name  }  }  }  }  }  }  }  }  
-"#;
 
 impl Client {
     pub fn new(endpoint: String) -> Self {

--- a/cli/crates/cli/tests/utils/consts.rs
+++ b/cli/crates/cli/tests/utils/consts.rs
@@ -24,3 +24,5 @@ pub const UNIQUE_QUERY: &str = include_str!("../graphql/unique/query.graphql");
 pub const CONCURRENCY_SCHEMA: &str = include_str!("../graphql/concurrency/schema.graphql");
 pub const CONCURRENCY_MUTATION: &str = include_str!("../graphql/concurrency/mutation.graphql");
 pub const CONCURRENCY_QUERY: &str = include_str!("../graphql/concurrency/query.graphql");
+
+pub const INTROSPECTION_QUERY: &str = include_str!("../graphql/introspection.graphql");

--- a/cli/crates/cli/tests/utils/consts.rs
+++ b/cli/crates/cli/tests/utils/consts.rs
@@ -20,3 +20,7 @@ pub const UNIQUE_CREATE_MUTATION: &str = include_str!("../graphql/unique/create-
 pub const UNIQUE_DELETE_MUTATION: &str = include_str!("../graphql/unique/delete-mutation.graphql");
 pub const UNIQUE_PAGINATED_QUERY: &str = include_str!("../graphql/unique/paginated-query.graphql");
 pub const UNIQUE_QUERY: &str = include_str!("../graphql/unique/query.graphql");
+
+pub const CONCURRENCY_SCHEMA: &str = include_str!("../graphql/concurrency/schema.graphql");
+pub const CONCURRENCY_MUTATION: &str = include_str!("../graphql/concurrency/mutation.graphql");
+pub const CONCURRENCY_QUERY: &str = include_str!("../graphql/concurrency/query.graphql");

--- a/cli/crates/cli/tests/utils/macros.rs
+++ b/cli/crates/cli/tests/utils/macros.rs
@@ -1,8 +1,23 @@
 pub use json_dotpath::DotPaths;
+
 #[macro_export]
-macro_rules! dot_get {
+macro_rules! dot_get_opt {
+    ($item: ident, $dotpath: literal, $ty: ty) => {{
+        use json_dotpath::DotPaths;
+        $item.dot_get::<$ty>($dotpath).ok().flatten()
+    }};
     ($item: ident, $dotpath: literal) => {{
         use json_dotpath::DotPaths;
-        $item.dot_get($dotpath).ok().flatten().unwrap()
+        $item.dot_get::<_>($dotpath).ok().flatten()
+    }};
+}
+
+#[macro_export]
+macro_rules! dot_get {
+    ($item: ident, $dotpath: literal, $ty: ty) => {{
+        $crate::dot_get_opt!($item, $dotpath, $ty).expect(concat!("path `", $dotpath, "` cannot be resolved"))
+    }};
+    ($item: ident, $dotpath: literal) => {{
+        $crate::dot_get_opt!($item, $dotpath).expect(concat!("path `", $dotpath, "` cannot be resolved"))
     }};
 }

--- a/cli/crates/cli/tests/utils/mod.rs
+++ b/cli/crates/cli/tests/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod async_client;
 pub mod cargo_bin;
 pub mod client;
 pub mod consts;


### PR DESCRIPTION
# Description

## Testing

- Adds a concurrency test (disabled due to being long running, but can be used manually)
- Adds an async client for `Environment`
- Allows to create an environment from a different environment (same directory, different port)
- Updates path macros to version used in API (with optional and typing)

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
