### PR TITLE
Add cargo about template

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -34,6 +34,9 @@ coverage
 grafbase/
 .grafbase/
 
+# cargo-about
+licenses.html
+
 #=================================#
 # Rust
 #=================================#

--- a/cli/about.hbs
+++ b/cli/about.hbs
@@ -1,0 +1,70 @@
+<html>
+
+<head>
+    <style>
+        @media (prefers-color-scheme: dark) {
+            body {
+                background: #333;
+                color: white;
+            }
+            a {
+                color: skyblue;
+            }
+        }
+        .container {
+            font-family: sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+        }
+        .intro {
+            text-align: center;
+        }
+        .licenses-list {
+            list-style-type: none;
+            margin: 0;
+            padding: 0;
+        }
+        .license-used-by {
+            margin-top: -10px;
+        }
+        .license-text {
+            max-height: 200px;
+            overflow-y: scroll;
+            white-space: pre-wrap;
+        }
+    </style>
+</head>
+
+<body>
+    <main class="container">
+        <div class="intro">
+            <h1>Third Party Licenses</h1>
+            <p>This page lists the licenses of the projects used in Grafbase CLI</p>
+        </div>
+    
+        <h2>Overview of licenses:</h2>
+        <ul class="licenses-overview">
+            {{#each overview}}
+            <li><a href="#{{id}}">{{name}}</a> ({{count}})</li>
+            {{/each}}
+        </ul>
+
+        <h2>All license text:</h2>
+        <ul class="licenses-list">
+            {{#each licenses}}
+            <li class="license">
+                <h3 id="{{id}}">{{name}}</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    {{#each used_by}}
+                    <li><a href="{{#if crate.repository}} {{crate.repository}} {{else}} https://crates.io/crates/{{crate.name}} {{/if}}">{{crate.name}} {{crate.version}}</a></li>
+                    {{/each}}
+                </ul>
+                <pre class="license-text">{{text}}</pre>
+            </li>
+            {{/each}}
+        </ul>
+    </main>
+</body>
+
+</html>

--- a/cli/about.toml
+++ b/cli/about.toml
@@ -1,0 +1,17 @@
+accepted = [
+    "Apache-2.0",
+    "MIT",
+    "BSD-3-Clause",
+    "MPL-2.0",
+    "Zlib",
+    "ISC",
+    "OpenSSL",
+    "NOASSERTION",
+    "CC0-1.0",
+]
+targets = [
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+    "x86_64-unknown-linux-musl",
+]

--- a/cli/about.toml
+++ b/cli/about.toml
@@ -9,6 +9,7 @@ accepted = [
     "NOASSERTION",
     "CC0-1.0",
 ]
+
 targets = [
     "aarch64-apple-darwin",
     "x86_64-apple-darwin",


### PR DESCRIPTION
# Description

## Tooling

- Adds the [`cargo-about`](https://github.com/EmbarkStudios/cargo-about) templates and allowed licenses to simplify license information creation
  - Usage: `cargo about generate  -o "licenses.html" about.hbs`

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [x] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
