### PR TITLE
GB-2050: Infer environment variables from the standard environment and `dotenv`

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -771,6 +771,7 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",
+ "dotenv",
  "exitcode",
  "futures",
  "grafbase-local-common",

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -13,6 +13,7 @@ include = ["/src", "/assets"]
 [dependencies]
 axum = "0.5"
 common = { package = "grafbase-local-common", path = "../common", version = "0.6.0" }
+dotenv = "0.15"
 exitcode = "1"
 futures = "0.3.23"
 hyper = "0.14"

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -291,9 +291,9 @@ async fn run_schema_parser() -> Result<(), ServerError> {
             .spawn()
             .map_err(ServerError::SchemaParserError)?;
 
-        let node_command_stdin = node_command.stdin.as_mut().unwrap();
+        let node_command_stdin = node_command.stdin.as_mut().expect("stdin must be available");
         node_command_stdin
-            .write_all(&serde_json::to_vec(&environment_variables).unwrap())
+            .write_all(&serde_json::to_vec(&environment_variables).expect("must serialise to JSON just fine"))
             .await
             .map_err(ServerError::SchemaParserError)?;
 


### PR DESCRIPTION
# Description

This enables support for environment variables inferred from the environment of the process + .env files as supported by the [`dotenv`](https://crates.io/crates/dotenv) package.

# Type of change

- [ ] 💔 Breaking
- [X] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
