### PR TITLE
Bump min node version

### DIFF
--- a/cli/crates/server/src/consts.rs
+++ b/cli/crates/server/src/consts.rs
@@ -6,4 +6,4 @@ pub const SCHEMA_PARSER_DIR: &str = "parser";
 pub const SCHEMA_PARSER_INDEX: &str = "index.js";
 pub const GIT_IGNORE_FILE: &str = ".gitignore";
 pub const GIT_IGNORE_CONTENTS: &str = "*\n";
-pub const MIN_NODE_VERSION: &str = "v16.7.0";
+pub const MIN_NODE_VERSION: &str = "v16.13.0";

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -15,7 +15,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=16.7.0"
+    "node": ">=16.13.0"
   },
   "os": [
     "darwin"

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -33,6 +33,6 @@
     "@grafbase/cli-x86_64-unknown-linux-musl": "^0.6.0"
   },
   "engines": {
-    "node": ">=16.7.0"
+    "node": ">=16.13.0"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -15,7 +15,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=16.7.0"
+    "node": ">=16.13.0"
   },
   "os": [
     "darwin"

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -16,7 +16,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=16.7.0"
+    "node": ">=16.13.0"
   },
   "os": [
     "win32"

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -15,7 +15,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=16.7.0"
+    "node": ">=16.13.0"
   },
   "os": [
     "linux"


### PR DESCRIPTION
# Description

## Tooling

- Bump the minimal supported Node.js version to `16.13.0` to match miniflare's new versions

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [x] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
