### PR TITLE
Add updatedAt and createdAt to scalars test

### DIFF
--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -34,6 +34,7 @@ colored = "2"
 cfg-if = "1"
 
 [dev-dependencies]
+chrono = "0.4.22"
 duct = "0.13"
 reqwest = { version = "0.11", features = ["json", "blocking"] }
 serde = { version = "1", features = ["derive"] }

--- a/cli/crates/cli/tests/graphql/unique/query.graphql
+++ b/cli/crates/cli/tests/graphql/unique/query.graphql
@@ -2,5 +2,7 @@ query Author($id: ID!) {
   author(id: $id) {
     id
     name
+    updatedAt
+    createdAt
   }
 }

--- a/cli/crates/cli/tests/unique.rs
+++ b/cli/crates/cli/tests/unique.rs
@@ -32,8 +32,21 @@ fn unique() {
     let response =
         client.gql::<Value>(json!({ "query": UNIQUE_QUERY, "variables": {"id": first_author_id } }).to_string());
 
-    let first_author_name: String = dot_get!(response, "data.author.name");
+    let updated_at: String = dot_get!(response, "data.author.updatedAt");
+    assert!(
+        chrono::DateTime::parse_from_rfc3339(&updated_at).is_ok(),
+        "{}",
+        updated_at
+    );
 
+    let created_at: String = dot_get!(response, "data.author.createdAt");
+    assert!(
+        chrono::DateTime::parse_from_rfc3339(&created_at).is_ok(),
+        "{}",
+        created_at
+    );
+
+    let first_author_name: String = dot_get!(response, "data.author.name");
     assert_eq!(first_author_name, "1");
 
     let response =


### PR DESCRIPTION
# Description

This adds an additional test to the cli to check that updatedAt and createdAt are returned on models and that they are in the correct format

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [X] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
