### PR TITLE
revert clap 4 update

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -231,33 +231,44 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.12"
+version = "3.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385007cbbed899260395a4107435fead4cad80684461b3cc78238bdcb0bad58f"
+checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
 dependencies = [
  "atty",
  "bitflags",
  "clap_lex",
+ "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "terminal_size",
+ "textwrap",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "4.0.2"
+version = "3.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cba7abac9b56dfe2f035098cdb3a43946f276e6db83b72c4e692343f9aab9a"
+checksum = "ead064480dfc4880a10764488415a97fdd36a4cf1bb022d372f02e8faf8386e1"
 dependencies = [
  "clap",
 ]
 
 [[package]]
-name = "clap_lex"
-version = "0.3.0"
+name = "clap_generate"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+checksum = "8e1b28c4a802ac3628604fd267cac62aaea74dc61af3410db6b1c44c03b42599"
+dependencies = [
+ "clap",
+ "clap_complete",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -522,27 +533,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +778,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "clap_generate",
  "colored",
  "ctrlc",
  "duct",
@@ -1120,12 +1111,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
-
-[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,12 +1228,6 @@ checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.0.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lock_api"
@@ -1885,20 +1864,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
-name = "rustix"
-version = "0.35.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb2fda4666def1433b1b05431ab402e42a1084285477222b72d6c564c417cef"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
 name = "rustls"
 version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2283,14 +2248,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "terminal_size"
-version = "0.2.1"
+name = "textwrap"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1"
-dependencies = [
- "rustix",
- "windows-sys",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -12,8 +12,9 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 backtrace = "0.3"
-clap = { version = "4", features = ["cargo", "wrap_help"] }
-clap_complete = "4"
+clap = { version = "3", features = ["cargo"] }
+clap_complete = "3"
+clap_generate = "3"
 common = { package = "grafbase-local-common", path = "../common", version = "0.9.0" }
 ctrlc = "3"
 exitcode = "1"

--- a/cli/crates/cli/src/cli_input.rs
+++ b/cli/crates/cli/src/cli_input.rs
@@ -1,13 +1,13 @@
 use cfg_if::cfg_if;
-use clap::{arg, command, value_parser, Arg, ArgAction, Command};
+use clap::{arg, command, value_parser, Arg, Command};
 use indoc::indoc;
 
 /// creates the cli interface
 #[must_use]
-pub fn build_cli() -> Command {
+pub fn build_cli() -> Command<'static> {
     cfg_if! {
         if #[cfg(debug_assertions)] {
-            let command_builder = command!().arg(arg!(-t --trace "Activate tracing").action(ArgAction::SetTrue));
+            let command_builder = command!().arg(arg!(-t --trace "Activate tracing"));
         } else {
             let command_builder = command!();
         }
@@ -19,12 +19,13 @@ pub fn build_cli() -> Command {
         .subcommand(
             Command::new("dev").about("Run your grafbase project locally").args(&[
                 arg!(-p --port <port> "Use a specific port")
+                    .takes_value(true)
                     .default_value("4000")
-                    .value_parser(value_parser!(u16)),
-                arg!(-s --search "If a given port is unavailable, search for another").action(ArgAction::SetTrue),
+                    .value_parser(value_parser!(u16))
+                    .required(false),
+                arg!(-s --search "If a given port is unavailable, search for another"),
                 Arg::new("disable-watch")
-                    .long("disable-watch")
-                    .action(ArgAction::SetTrue)
+                    .long("--disable-watch")
                     .help("Do not listen for schema changes and reload"),
             ]),
         )
@@ -57,9 +58,4 @@ pub fn build_cli() -> Command {
     // .subcommand(Command::new("deploy").about("TBD"))
     // .subcommand(Command::new("logs").about("TBD"))
     // // TODO: schema edit / view
-}
-
-#[test]
-fn verify_cli() {
-    build_cli().debug_assert();
 }

--- a/cli/crates/cli/src/completions.rs
+++ b/cli/crates/cli/src/completions.rs
@@ -1,7 +1,7 @@
 use crate::cli_input::build_cli;
 use crate::errors::CliError;
-use clap_complete::shells::{Bash, Elvish, Fish, PowerShell, Zsh};
-use clap_complete::Generator;
+use clap_generate::generators::{Bash, Elvish, Fish, PowerShell, Zsh};
+use clap_generate::Generator;
 use std::io;
 
 /// generates shell specific completions for the cli and prints them to stdout

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -46,7 +46,7 @@ fn main() {
 fn try_main() -> Result<(), CliError> {
     let matches = build_cli().get_matches();
 
-    let filter = EnvFilter::builder().parse_lossy(if matches.get_flag("trace") {
+    let filter = EnvFilter::builder().parse_lossy(if matches.contains_id("trace") {
         TRACE_LOG_FILTER
     } else {
         DEFAULT_LOG_FILTER
@@ -73,8 +73,8 @@ fn try_main() -> Result<(), CliError> {
                 process::exit(exitcode::OK);
             });
 
-            let search = matches.get_flag("search");
-            let watch = !matches.get_flag("disable-watch");
+            let search = matches.contains_id("search");
+            let watch = !matches.contains_id("disable-watch");
             let port = matches.get_one::<u16>("port").copied();
 
             dev(search, watch, port)


### PR DESCRIPTION
# Description

## Fixes

- Reverts the update to clap 4 as it crashes when built in release mode

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
