### PR TITLE
Add reset to commands

### DIFF
--- a/cli/changelog/0.11.0.md
+++ b/cli/changelog/0.11.0.md
@@ -10,3 +10,4 @@
 ### Fixes
 
 - Fixes an issue causing relations not to be updated after an initial mutation
+- Prints the CLI header when running the `reset` command

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -56,7 +56,7 @@ fn try_main() -> Result<(), CliError> {
 
     let subcommand = matches.subcommand();
 
-    if let Some(("dev" | "init", ..)) = subcommand {
+    if let Some(("dev" | "init" | "reset", ..)) = subcommand {
         report::cli_header();
     }
 


### PR DESCRIPTION
# Description

## Fixes

- Prints the CLI header when running the `reset` command

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
