### PR TITLE
update rust to 1.65.0

### DIFF
--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -217,7 +217,7 @@ fn export_embedded_files() -> Result<(), ServerError> {
             let create_dir_result = if parent_exists {
                 Ok(())
             } else {
-                fs::create_dir_all(&parent)
+                fs::create_dir_all(parent)
             };
 
             // must be Some(file) since we're iterating over existing paths
@@ -285,7 +285,7 @@ async fn run_schema_parser() -> Result<(), ServerError> {
 
     let output = {
         let mut node_command = Command::new("node")
-            .args(&[
+            .args([
                 &parser_path.to_str().ok_or(ServerError::CachePath)?,
                 &environment
                     .project_grafbase_schema_path

--- a/cli/rust-toolchain.toml
+++ b/cli/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 profile = "default"
-channel = "1.64.0"
+channel = "1.65.0"
 targets = [
     "aarch64-apple-darwin",
     "x86_64-apple-darwin",


### PR DESCRIPTION
# Description

## Fixes

- Clippy fixes for version `1.65.0`

## Tooling

- Update Rust to version `1.65.0`

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [x] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
