### PR TITLE
fix release

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -43,6 +43,20 @@ jobs:
           name: clippy
           token: ${{ github.token }}
 
+      - name: Individual package build
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd crates
+          # The actual features used for each dependency depends on what is being built simultaneously.
+          # However, each package is published individually, so we're checking that all packages compile
+          # with only their defined features.
+          # See: https://github.com/rust-lang/cargo/issues/4463
+          (cd common && cargo check)
+          (cd server && cargo check)
+          (cd backend && cargo check)
+          (cd cli && cargo check)
+
   windows:
     runs-on: windows-latest
     needs: [lint]

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -36,7 +36,7 @@ cfg-if = "1"
 chrono = "0.4.22"
 duct = "0.13"
 jwt-compact = { version = "0.6", default-features = false, features = [
-    "clock",
+  "clock",
 ] }
 reqwest = { version = "0.11", features = ["json", "blocking"] }
 serde = { version = "1", features = ["derive"] }

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -34,7 +34,7 @@ thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.3", features = ["trace"] }
 tracing = "0.1"
-uuid = "1.2.2"
+uuid = { version = "1.2.2", features = ["v4"] }
 version-compare = "0.1"
 which = "4"
 

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,13 @@
         overlays = [(import rust-overlay)];
       };
 
+      x86_64LinuxPkgs = import nixpkgs {
+        inherit system;
+        crossSystem = {
+          config = "x86_64-unknown-linux-musl";
+        };
+      };
+
       rustToolChain = pkgs.rust-bin.fromRustupToolchainFile ./cli/rust-toolchain.toml;
     in {
       devShells.default = pkgs.mkShell {
@@ -49,7 +56,15 @@
           nodejs
         ];
 
+        # This is hack to avoid the redefinition of CC, CXX and so on to use aarch64.
+        # There's probably a better way to do this.
+        buildInputs = with pkgs; [
+          x86_64LinuxPkgs.buildPackages.gcc
+        ];
+
         RUSTC_WRAPPER = "${pkgs.sccache.out}/bin/sccache";
+        CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = "${x86_64LinuxPkgs.buildPackages.gcc.out}/bin/x86_64-unknown-linux-gnu-gcc";
+        CC_x86_64_unknown_linux_musl = "${x86_64LinuxPkgs.buildPackages.gcc.out}/bin/x86_64-unknown-linux-gnu-gcc";
 
         shellHook = ''
           export CARGO_INSTALL_ROOT="$(git rev-parse --show-toplevel)/cli/.cargo"


### PR DESCRIPTION
Not specifying the "v4" feature worked when compiling the whole
workspace, but not for server package alone. So this blocked
`cargo publish` which only runs for a single package.

I'm adding an additional step to the CI to ensure we won't encounter
the same error.