### PR TITLE
Rename change 0.14.0 to 0.14.1

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [0.14.0]
+## [0.14.1]
 
-[CHANGELOG](changelog/0.14.0.md)
+[CHANGELOG](changelog/0.14.1.md)
 
 ## [0.13.0]
 

--- a/cli/changelog/0.14.1.md
+++ b/cli/changelog/0.14.1.md
@@ -17,7 +17,7 @@
 
 ### Tooling
 
-- Updates Rust to version `0.66.0`
+- Updates Rust to version `1.66.0`
 
 ### Dependencies
 


### PR DESCRIPTION
The release 0.14.0 was a failure and we pushed 0.14.1 instead.

# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
