### PR TITLE
Set rust toolchain to 1.66

### DIFF
--- a/cli/changelog/0.15.0.md
+++ b/cli/changelog/0.15.0.md
@@ -10,3 +10,7 @@
 - Fixes a missing field issue when creating nested relations
 - Fixes formatting for dates and phone numbers
 - Fixes OpenSSL being required on Linux
+
+### Tooling
+
+- Sets the Rust toolchain channel as 1.66

--- a/cli/changelog/0.15.0.md
+++ b/cli/changelog/0.15.0.md
@@ -13,4 +13,4 @@
 
 ### Tooling
 
-- Sets the Rust toolchain channel as 1.66
+- Sets the Rust toolchain channel to `1.66`

--- a/cli/rust-toolchain.toml
+++ b/cli/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 profile = "default"
-channel = "1.66.0"
+channel = "1.66"
 targets = [
     "aarch64-apple-darwin",
     "x86_64-apple-darwin",


### PR DESCRIPTION
# Description

## Tooling

- Set Rust toolchain to 1.66

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [x] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
