### PR TITLE
Update rust and deps

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1485,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "1.0.7"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
+checksum = "6fe2b9d82064e8a0226fddb3547f37f28eaa46d0fc210e275d835f08cf3b76a7"
 
 [[package]]
 name = "inotify"
@@ -1885,6 +1885,15 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2475,6 +2484,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c68e921cef53841b8925c2abadd27c9b891d9613bdc43d6b823062866df38e8"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3001,11 +3019,36 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "2f560bc7fb3eb31f5eee1340c68a2160cad39605b7b9c9ec32045ddbdee13b85"
 dependencies = [
  "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886f31a9b85b6182cabd4d8b07df3b451afcc216563748201490940d2a28ed36"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d8716cdc5d20ec88a18a839edaf545edc71efa4a5ff700ef4a102c26cd8fa"
+dependencies = [
+ "indexmap",
+ "nom8",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
 ]
 
 [[package]]

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -19,14 +19,14 @@ colored = "2"
 ctrlc = "3"
 exitcode = "1"
 hex-literal = "0.3"
-indoc = "1"
+indoc = "2"
 log = "0.4"
 once_cell = "1"
 os_type = "2"
 serde = "1"
 serde_derive = "1"
 thiserror = "1"
-toml = "0.5"
+toml = "0.7"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
 

--- a/cli/crates/cli/tests/scalars.rs
+++ b/cli/crates/cli/tests/scalars.rs
@@ -46,11 +46,7 @@ impl TestCase {
         match expected {
             Ok(expected) => {
                 let result: Value = dot_get!(response, &format!("data.scalarsCreate.scalars.{}", &ty));
-                assert_eq!(
-                    result, expected,
-                    "{}: expected {:#?} but got {:#?}",
-                    ty, expected, result
-                );
+                assert_eq!(result, expected, "{ty}: expected {expected:#?} but got {result:#?}",);
             }
             Err(regex) => {
                 // Clippy doesn't like the format call within expect but the suggest alternative of
@@ -58,12 +54,7 @@ impl TestCase {
                 #[allow(clippy::expect_fun_call)]
                 let result = dot_get_opt!(response, "errors.0.message", String)
                     .expect(&format!("No errors for '{ty}' with: {input:#?}"));
-                assert!(
-                    regex.is_match(&result),
-                    "'{}' didn't match the pattern '{}'",
-                    result,
-                    regex
-                );
+                assert!(regex.is_match(&result), "'{result}' didn't match the pattern '{regex}'");
             }
         }
     }

--- a/cli/rust-toolchain.toml
+++ b/cli/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 profile = "default"
-channel = "1.66"
+channel = "1.67"
 targets = [
     "aarch64-apple-darwin",
     "x86_64-apple-darwin",


### PR DESCRIPTION
# Description

## Tooling

- Updates Rust to version `1.67`
  - Fixes related clippy warnings

## Dependencies

- Updates `indoc` and `toml`

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [x] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [x] 📦 Dependency
- [ ] 📖 Requires documentation update
