### PR TITLE
Print miniflare logs when tracing is enabled

### DIFF
--- a/cli/crates/backend/src/server_api.rs
+++ b/cli/crates/backend/src/server_api.rs
@@ -15,10 +15,10 @@ type ServerInfo = (thread::JoinHandle<Result<(), ServerError>>, Receiver<ServerM
 /// returns [`BackendError::AvailablePort`] if no available port can  be found
 ///
 /// returns [`BackendError::PortInUse`] if search is off and the supplied port is in use
-pub fn start_server(start_port: u16, search: bool, watch: bool) -> Result<ServerInfo, BackendError> {
+pub fn start_server(start_port: u16, search: bool, watch: bool, tracing: bool) -> Result<ServerInfo, BackendError> {
     match find_available_port(search, start_port, LocalAddressType::Localhost) {
         Some(port) => {
-            let (handle, receiver) = server::start(port, watch);
+            let (handle, receiver) = server::start(port, watch, tracing);
             Ok((handle, receiver))
         }
         None => {

--- a/cli/crates/cli/src/cli_input.rs
+++ b/cli/crates/cli/src/cli_input.rs
@@ -7,7 +7,7 @@ use indoc::indoc;
 pub fn build_cli() -> Command {
     cfg_if! {
         if #[cfg(debug_assertions)] {
-            let command_builder = command!().arg(arg!(-t --trace "Activate tracing").action(ArgAction::SetTrue));
+            let command_builder = command!().arg(arg!(-t --trace <level> "Set tracing level").default_value("0").value_parser(value_parser!(u16)));
         } else {
             let command_builder = command!();
         }
@@ -31,7 +31,7 @@ pub fn build_cli() -> Command {
         .subcommand(
             Command::new("completions")
                 .arg(Arg::new("shell").help(indoc! {"
-                        The shell to generate completions for. 
+                        The shell to generate completions for.
                         Supported: bash, fish, zsh, elvish, powershell
                     "}))
                 .arg_required_else_help(true)

--- a/cli/crates/cli/src/dev.rs
+++ b/cli/crates/cli/src/dev.rs
@@ -17,13 +17,13 @@ static READY: Once = Once::new();
 /// returns [`CliError::BackendError`] if the the local gateway returns an error
 ///
 /// returns [`CliError::ServerPanic`] if the development server panics
-pub fn dev(search: bool, watch: bool, external_port: Option<u16>) -> Result<(), CliError> {
+pub fn dev(search: bool, watch: bool, external_port: Option<u16>, tracing: bool) -> Result<(), CliError> {
     trace!("attempting to start server");
 
     Environment::try_init().map_err(CliError::CommonError)?;
 
     let start_port = external_port.unwrap_or(DEFAULT_PORT);
-    let (server_handle, reporter_handle) = match start_server(start_port, search, watch) {
+    let (server_handle, reporter_handle) = match start_server(start_port, search, watch, tracing) {
         Ok((server_handle, receiver)) => {
             let reporter_handle = spawn(move || loop {
                 match receiver.recv() {

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -45,11 +45,7 @@ fn main() {
 
 fn try_main() -> Result<(), CliError> {
     let matches = build_cli().get_matches();
-    let tracing = if let Ok(Some(true)) = matches.try_get_one("trace") {
-        true
-    } else {
-        false
-    };
+    let tracing = matches!(matches.try_get_one("trace"), Ok(Some(true)));
     let filter = EnvFilter::builder().parse_lossy(if tracing { TRACE_LOG_FILTER } else { DEFAULT_LOG_FILTER });
 
     tracing_subscriber::registry().with(fmt::layer()).with(filter).init();

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -45,12 +45,12 @@ fn main() {
 
 fn try_main() -> Result<(), CliError> {
     let matches = build_cli().get_matches();
-
-    let filter = EnvFilter::builder().parse_lossy(if let Ok(Some(true)) = matches.try_get_one("trace") {
-        TRACE_LOG_FILTER
+    let tracing = if let Ok(Some(true)) = matches.try_get_one("trace") {
+        true
     } else {
-        DEFAULT_LOG_FILTER
-    });
+        false
+    };
+    let filter = EnvFilter::builder().parse_lossy(if tracing { TRACE_LOG_FILTER } else { DEFAULT_LOG_FILTER });
 
     tracing_subscriber::registry().with(fmt::layer()).with(filter).init();
 
@@ -79,7 +79,7 @@ fn try_main() -> Result<(), CliError> {
             let watch = !matches.get_flag("disable-watch");
             let port = matches.get_one::<u16>("port").copied();
 
-            dev(search, watch, port)
+            dev(search, watch, port, tracing)
         }
         Some(("init", matches)) => {
             let name = matches.get_one::<String>("name").map(AsRef::as_ref);


### PR DESCRIPTION
# Description

Use the inherited stdout, stderr for the miniflare process when the CLI is started with `--trace 2`.
To preserve current behavior (debug messages of CLI), use `--trace 1` . Passing `2` will print miniflare logs as well.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
