### PR TITLE
Fail on bridge startup error instead of hanging forever

### DIFF
--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -124,9 +124,9 @@ async fn spawn_servers(
 
     trace!("waiting for bridge ready");
     tokio::select! {
-        _result = wait_for_event(receiver, Event::BridgeReady) => (),
-        result = &mut bridge_handle => result??
-    }
+        _ = wait_for_event(receiver, Event::BridgeReady) => (),
+        result = &mut bridge_handle => {result??; return Ok(());}
+    };
     trace!("bridge ready");
 
     let registry_path = environment

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -10,6 +10,7 @@ use common::consts::EPHEMERAL_PORT_RANGE;
 use common::environment::Environment;
 use common::types::LocalAddressType;
 use common::utils::find_available_port_in_range;
+use futures_util::FutureExt;
 use std::env;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::{
@@ -118,12 +119,14 @@ async fn spawn_servers(
 
     let environment = Environment::get();
 
-    let bridge_handle = tokio::spawn(async move { bridge::start(bridge_port, worker_port, bridge_sender).await });
+    let mut bridge_handle =
+        tokio::spawn(async move { bridge::start(bridge_port, worker_port, bridge_sender).await }).fuse();
 
     trace!("waiting for bridge ready");
-
-    wait_for_event(receiver, Event::BridgeReady).await;
-
+    tokio::select! {
+        _result = wait_for_event(receiver, Event::BridgeReady) => (),
+        result = &mut bridge_handle => result??
+    }
     trace!("bridge ready");
 
     let registry_path = environment


### PR DESCRIPTION
# Description

If an error occurs e.g. during sqlite initialization, `Event::BridgeReady` is never sent. 

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
