### PR TITLE
GB-3086: Add an initial implementation of custom resolvers

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -144,6 +144,8 @@ jobs:
           lint: false
 
       - name: Build release
+        env:
+          V8_FROM_SOURCE: 1
         run: |
           cd cli
           cargo build --release --target x86_64-unknown-linux-musl

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -409,9 +409,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cacache"
@@ -1258,6 +1258,7 @@ dependencies = [
 name = "grafbase-local-server"
 version = "0.17.0"
 dependencies = [
+ "async-trait",
  "axum",
  "chrono",
  "dotenv",
@@ -1266,6 +1267,7 @@ dependencies = [
  "grafbase-local-common",
  "hyper",
  "ipnet",
+ "itertools",
  "log",
  "notify",
  "once_cell",
@@ -1275,6 +1277,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "strum",
+ "strum_macros",
  "tantivy",
  "tempfile",
  "thiserror",
@@ -3085,6 +3089,25 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/cli/crates/common/src/consts.rs
+++ b/cli/crates/common/src/consts.rs
@@ -14,6 +14,8 @@ pub const GRAFBASE_SCHEMA: &str = "schema.graphql";
 pub const DOT_GRAFBASE_DIRECTORY: &str = ".grafbase";
 /// the registry.json file generated from schema.graphql
 pub const REGISTRY_FILE: &str = "registry.json";
+/// the /resolvers directory containing resolver implementations
+pub const RESOLVERS_DIRECTORY_NAME: &str = "resolvers";
 /// the tracing filter to be used when tracing is on
 pub const TRACE_LOG_FILTER: &str = "grafbase=trace,grafbase_local_common=trace,grafbase_local_server=trace,grafbase_local_backend=trace,tower_http=debug";
 /// the tracing filter to be used when tracing is off

--- a/cli/crates/common/src/environment.rs
+++ b/cli/crates/common/src/environment.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use crate::{
-    consts::{DOT_GRAFBASE_DIRECTORY, GRAFBASE_DIRECTORY, GRAFBASE_SCHEMA, REGISTRY_FILE},
+    consts::{DOT_GRAFBASE_DIRECTORY, GRAFBASE_DIRECTORY, GRAFBASE_SCHEMA, REGISTRY_FILE, RESOLVERS_DIRECTORY_NAME},
     errors::CommonError,
 };
 use once_cell::sync::OnceCell;
@@ -32,6 +32,10 @@ pub struct Environment {
     /// the path of `$PROJECT/.grafbase/registry.json`, the registry derived from `schema.graphql`,
     /// in the nearest ancestor directory with a `grabase/schema.graphql` file
     pub project_grafbase_registry_path: PathBuf,
+    /// the path of the `grafbase/resolvers` directory.
+    pub resolvers_source_path: PathBuf,
+    /// the path within `$PROJECT/.grafbase/` containing build artifacts for custom resolvers.
+    pub resolvers_build_artifact_path: PathBuf,
 }
 
 /// static singleton for the environment struct
@@ -65,6 +69,8 @@ impl Environment {
         let user_dot_grafbase_path =
             get_user_dot_grafbase_path().unwrap_or_else(|| project_grafbase_path.join(DOT_GRAFBASE_DIRECTORY));
         let project_grafbase_registry_path = project_dot_grafbase_path.join(REGISTRY_FILE);
+        let resolvers_source_path = project_grafbase_path.join(RESOLVERS_DIRECTORY_NAME);
+        let resolvers_build_artifact_path = project_dot_grafbase_path.join(RESOLVERS_DIRECTORY_NAME);
         ENVIRONMENT
             .set(Self {
                 project_path,
@@ -73,6 +79,8 @@ impl Environment {
                 project_grafbase_schema_path,
                 user_dot_grafbase_path,
                 project_grafbase_registry_path,
+                resolvers_source_path,
+                resolvers_build_artifact_path,
             })
             .expect("cannot set environment twice");
 

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -12,11 +12,18 @@ include = ["/src", "/assets"]
 
 [dependencies]
 axum = "0.6"
+async-trait = "0.1"
+chrono = "0.4"
 dotenv = "0.15"
 exitcode = "1"
+futures-util = "0.3"
 hyper = "0.14"
+ipnet = "2"
+itertools = "0.10"
 log = "0.4"
 notify = "4"
+once_cell = "1"
+regex = "1"
 reqwest = { version = "0.11", features = [
   "rustls-tls",
   "json",
@@ -29,7 +36,10 @@ sqlx = { version = "0.6", features = [
   "sqlite",
   "json",
 ] }
+strum = "0.24"
+strum_macros = "0.24"
 tempfile = "3"
+tantivy = "0.19"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.4", features = ["trace"] }
@@ -37,14 +47,8 @@ tracing = "0.1"
 uuid = { version = "1", features = ["v4"] }
 version-compare = "0.1"
 which = "4"
-regex = "1"
 
 common = { package = "grafbase-local-common", path = "../common", version = "0.17.0" }
-tantivy = "0.19"
-futures-util = "0.3"
-chrono = "0.4"
-ipnet = "2"
-once_cell = "1"
 
 [dev-dependencies]
 serde_json = "1"

--- a/cli/crates/server/src/bridge.rs
+++ b/cli/crates/server/src/bridge.rs
@@ -1,5 +1,6 @@
 mod consts;
 mod listener;
+mod resolvers;
 mod search;
 mod server;
 mod sqlite;

--- a/cli/crates/server/src/bridge/errors.rs
+++ b/cli/crates/server/src/bridge/errors.rs
@@ -18,9 +18,12 @@ pub enum ApiError {
     /// used to return a 500 status to the worker for bugs / logic errors
     #[error(transparent)]
     SqlError(SqlxError),
-
     #[error("server error")]
     ServerError,
+    #[error("resolver {0} does not exist")]
+    ResolverDoesNotExist(String),
+    #[error("resolver {0} is invalid")]
+    ResolverInvalid(String),
 }
 
 #[derive(Serialize, Debug)]
@@ -45,7 +48,11 @@ impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         match self {
             ApiError::User(user_error) => (StatusCode::CONFLICT, Json(user_error)).into_response(),
-            ApiError::SqlError(_) | ApiError::ServerError => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+
+            ApiError::SqlError(_)
+            | ApiError::ServerError
+            | ApiError::ResolverDoesNotExist(_)
+            | ApiError::ResolverInvalid(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
         }
     }
 }

--- a/cli/crates/server/src/bridge/resolvers.rs
+++ b/cli/crates/server/src/bridge/resolvers.rs
@@ -1,0 +1,32 @@
+use std::collections::HashMap;
+
+use super::errors::ApiError;
+
+#[derive(serde::Serialize)]
+struct ResolverContext<'a> {
+    env: &'a HashMap<String, String>,
+}
+
+#[derive(serde::Serialize)]
+struct ResolverArgs<'a> {
+    context: ResolverContext<'a>,
+}
+
+pub async fn invoke_resolver(
+    port: u16,
+    resolver_name: &str,
+    _environment_variables: &HashMap<String, String>,
+) -> Result<serde_json::Value, ApiError> {
+    use futures_util::TryFutureExt;
+    trace!("resolver invocation of '{resolver_name}'");
+    reqwest::Client::new()
+        .post(format!("http://127.0.0.1:{port}/resolver/{resolver_name}/invoke"))
+        .send()
+        .inspect_err(|err| error!("resolver worker error: {err:?}"))
+        .await
+        .map_err(|_| ApiError::ServerError)?
+        .json()
+        .inspect_err(|err| error!("resolver worker error: {err:?}"))
+        .await
+        .map_err(|_| ApiError::ServerError)
+}

--- a/cli/crates/server/src/bridge/types.rs
+++ b/cli/crates/server/src/bridge/types.rs
@@ -106,3 +106,10 @@ pub enum SearchScalar {
     Boolean,
     IPAddress,
 }
+
+#[derive(Deserialize, Debug)]
+pub struct ResolverInvocation {
+    pub resolver_name: String,
+    #[serde(default)]
+    pub arguments: Option<serde_json::Value>,
+}

--- a/cli/crates/server/src/custom_resolvers.rs
+++ b/cli/crates/server/src/custom_resolvers.rs
@@ -1,0 +1,273 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+use common::environment::Environment;
+use futures_util::{pin_mut, TryStreamExt};
+use tokio::process::Command;
+
+use crate::consts::{SCHEMA_PARSER_DIR, SCHEMA_PARSER_INDEX};
+use crate::errors::ServerError;
+
+#[derive(strum_macros::AsRefStr)]
+enum CommandType {
+    Npm,
+    Npx,
+}
+
+async fn run_npm_command<P: AsRef<Path>>(
+    command_type: CommandType,
+    artifact_directory_path: P,
+    extra_arguments: &[&str],
+    tracing: bool,
+    environment: &[(&'static str, &'static str)],
+) -> Result<(), ServerError> {
+    use itertools::Itertools;
+
+    let artifact_directory_path_string = artifact_directory_path
+        .as_ref()
+        .to_str()
+        .ok_or(ServerError::CachePath)?;
+
+    let mut arguments = vec!["--prefix", artifact_directory_path_string];
+    arguments.extend(extra_arguments);
+
+    trace!("running 'npm {}'", arguments.iter().format(" "));
+
+    let npm_command = Command::new(command_type.as_ref())
+        .envs(environment.iter().cloned())
+        .args(arguments)
+        .stdout(if tracing { Stdio::inherit() } else { Stdio::piped() })
+        .stderr(if tracing { Stdio::inherit() } else { Stdio::piped() })
+        .current_dir(artifact_directory_path)
+        .spawn()
+        .map_err(ServerError::NpmCommandError)?;
+
+    let output = npm_command
+        .wait_with_output()
+        .await
+        .map_err(ServerError::NpmCommandError)?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(ServerError::NpmCommand(
+            String::from_utf8_lossy(&output.stderr).into_owned(),
+        ))
+    }
+}
+
+async fn build_resolver(
+    environment: &Environment,
+    worker_port: u16,
+    resolver_name: &str,
+    resolver_wrapper_worker_contents: &str,
+    tracing: bool,
+) -> Result<PathBuf, ServerError> {
+    use futures_util::StreamExt;
+
+    trace!("building resolver {resolver_name}");
+
+    let resolver_input_file_path = environment
+        .resolvers_source_path
+        .join(resolver_name)
+        .with_extension("js");
+    if tokio::fs::metadata(&resolver_input_file_path).await.is_err() {
+        return Err(ServerError::ResolverDoesNotExist(resolver_input_file_path));
+    }
+
+    let package_json_file_path = {
+        let paths = futures_util::stream::iter(
+            resolver_input_file_path
+                .ancestors()
+                .skip(1)
+                .take_while(|path| path.starts_with(&environment.project_path))
+                .map(|directory_path| directory_path.join("package.json")),
+        )
+        .filter_map(|path| async {
+            if tokio::fs::metadata(&path).await.is_ok() {
+                Some(path)
+            } else {
+                None
+            }
+        });
+        pin_mut!(paths);
+        paths.next().await
+    };
+
+    let resolvers_build_artifact_directory_path = environment.resolvers_build_artifact_path.as_path();
+    let resolver_build_artifact_directory_path = resolvers_build_artifact_directory_path.join(resolver_name);
+    tokio::fs::create_dir_all(&resolver_build_artifact_directory_path)
+        .await
+        .map_err(ServerError::CreateTemporaryFile)?;
+    let resolver_build_entrypoint_path = resolver_build_artifact_directory_path.join("entrypoint.js");
+
+    if let Some(package_json_file_path) = package_json_file_path {
+        trace!("copying package.json from {}", package_json_file_path.display());
+        tokio::fs::copy(
+            package_json_file_path,
+            resolver_build_artifact_directory_path.join("package.json"),
+        )
+        .await
+        .map_err(ServerError::NpmCommandError)?;
+    }
+
+    run_npm_command(
+        CommandType::Npm,
+        resolvers_build_artifact_directory_path,
+        &["add", "--save-dev", "wrangler"],
+        tracing,
+        &[],
+    )
+    .await?;
+    run_npm_command(
+        CommandType::Npm,
+        resolvers_build_artifact_directory_path,
+        &["install"],
+        tracing,
+        &[],
+    )
+    .await?;
+
+    let entrypoint_contents = resolver_wrapper_worker_contents.replace(
+        "${RESOLVER_MAIN_FILE_PATH}",
+        resolver_input_file_path.to_str().ok_or(ServerError::CachePath)?,
+    );
+    tokio::fs::write(&resolver_build_entrypoint_path, entrypoint_contents)
+        .await
+        .map_err(ServerError::CreateTemporaryFile)?;
+
+    let wrangler_output_directory_path = resolver_build_artifact_directory_path.join("wrangler");
+    let outdir_argument = format!(
+        "--outdir={}",
+        wrangler_output_directory_path.to_str().ok_or(ServerError::CachePath)?
+    );
+
+    trace!("writing wrangler.toml for '{resolver_name}'");
+
+    tokio::fs::write(
+        resolver_build_artifact_directory_path.join("package.json"),
+        r#"{ "module": "wrangler/entrypoint.js" }"#,
+    )
+    .await
+    .map_err(ServerError::CreateTemporaryFile)?;
+
+    tokio::fs::write(
+        resolver_build_artifact_directory_path.join("wrangler.toml"),
+        format!(
+            r#"
+                name = "{resolver_name}"
+                [build.upload]
+                format = "modules"
+                [miniflare]
+                routes = ["127.0.0.1/resolver/{resolver_name}"]
+            "#
+        ),
+    )
+    .await
+    .map_err(ServerError::CreateTemporaryFile)?;
+
+    // Not great. We use wrangler to produce the JS file that is then used as the input for the resolver-specific worker.
+    // FIXME: Swap out for the internal logic that wrangler effectively uses under the hood.
+    run_npm_command(
+        CommandType::Npx,
+        resolvers_build_artifact_directory_path,
+        &[
+            "wrangler",
+            "publish",
+            "--dry-run",
+            &outdir_argument,
+            "--compatibility-date",
+            "2023-02-08",
+            "--name",
+            "STUB",
+            resolver_build_entrypoint_path.to_str().ok_or(ServerError::CachePath)?,
+        ],
+        tracing,
+        &[("FORCE_COLOR", "0"), ("CLOUDFLARE_API_TOKEN", "STUB")],
+    )
+    .await?;
+
+    Ok(resolver_build_artifact_directory_path)
+}
+
+async fn extract_resolver_wrapper_worker_contents() -> Result<String, ServerError> {
+    trace!("extracting resolver wrapper worker contents");
+
+    let environment = Environment::get();
+
+    let parser_path = environment
+        .user_dot_grafbase_path
+        .join(SCHEMA_PARSER_DIR)
+        .join(SCHEMA_PARSER_INDEX);
+
+    let contents_path = tokio::task::spawn_blocking(tempfile::NamedTempFile::new)
+        .await?
+        .map_err(ServerError::CreateTemporaryFile)?
+        .into_temp_path();
+
+    trace!(
+        "using a temporary file for the output: {contents_path}",
+        contents_path = contents_path.display()
+    );
+
+    let output = {
+        let node_command = Command::new("node")
+            .args([
+                parser_path.to_str().ok_or(ServerError::CachePath)?,
+                "extract-resolver-wrapper-worker-contents",
+                contents_path.to_str().expect("must be a valid path"),
+            ])
+            .stderr(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .map_err(ServerError::SchemaParserError)?;
+
+        node_command
+            .wait_with_output()
+            .await
+            .map_err(ServerError::SchemaParserError)?
+    };
+
+    if !output.status.success() {
+        return Err(ServerError::ExtractResolverWrapperWorkerContents(
+            String::from_utf8_lossy(&output.stderr).into_owned(),
+        ));
+    }
+
+    tokio::fs::read_to_string(&contents_path)
+        .await
+        .map_err(ServerError::SchemaParserResultRead)
+}
+
+pub async fn build_resolvers(
+    environment: &Environment,
+    worker_port: u16,
+    resolvers: impl IntoIterator<Item = String>,
+    tracing: bool,
+) -> Result<HashMap<String, PathBuf>, ServerError> {
+    use futures_util::StreamExt;
+
+    let mut resolvers_iterator = resolvers.into_iter().peekable();
+    if resolvers_iterator.peek().is_none() {
+        return Ok(HashMap::new());
+    }
+
+    let resolver_wrapper_worker_contents = extract_resolver_wrapper_worker_contents().await?;
+
+    futures_util::stream::iter(resolvers_iterator)
+        .map(Ok)
+        .and_then(|resolver_name| async {
+            let output_file_path = build_resolver(
+                environment,
+                worker_port,
+                resolver_name.as_str(),
+                &resolver_wrapper_worker_contents,
+                tracing,
+            )
+            .await?;
+            Ok((resolver_name, output_file_path))
+        })
+        .try_collect()
+        .await
+}

--- a/cli/crates/server/src/environment.rs
+++ b/cli/crates/server/src/environment.rs
@@ -1,0 +1,18 @@
+use common::environment::Environment;
+
+use crate::consts::DOT_ENV_FILE;
+
+#[allow(deprecated)] // https://github.com/dotenv-rs/dotenv/pull/54
+pub fn variables() -> impl Iterator<Item = (String, String)> {
+    let environment = Environment::get();
+    let dot_env_file_path = environment.project_grafbase_path.join(DOT_ENV_FILE);
+    // We don't use dotenv::dotenv() as we don't want to pollute the process' environment.
+    // Doing otherwise would make us unable to properly refresh it whenever any of the .env files
+    // changes which is something we may want to do in the future.
+    std::env::vars().chain(
+        dotenv::from_path_iter(dot_env_file_path)
+            .into_iter()
+            .flatten()
+            .filter_map(Result::ok),
+    )
+}

--- a/cli/crates/server/src/file_watcher.rs
+++ b/cli/crates/server/src/file_watcher.rs
@@ -17,7 +17,7 @@ where
     let (notify_sender, notify_receiver) = mpsc::channel();
 
     let mut watcher: RecommendedWatcher = Watcher::new(notify_sender, FILE_WATCHER_INTERVAL)?;
-    watcher.watch(&file, RecursiveMode::NonRecursive)?;
+    watcher.watch(&file, RecursiveMode::Recursive)?;
 
     tokio::task::spawn_blocking(move || -> Result<(), ServerError> {
         loop {

--- a/cli/crates/server/src/lib.rs
+++ b/cli/crates/server/src/lib.rs
@@ -23,6 +23,8 @@ extern crate log;
 
 mod bridge;
 mod consts;
+mod custom_resolvers;
+mod environment;
 mod event;
 mod file_watcher;
 mod servers;


### PR DESCRIPTION
# Description

Add an initial implementation of custom resolvers.
This PR builds them with `npm` and runs the resolvers within the same single instance of `miniflare` by using [mounting](https://miniflare.dev/core/mount) (I am contemplating creating at least a separate instance just for resolver workers, though).

# Type of change

- [ ] 💔 Breaking
- [X] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
