### PR TITLE
Refactor the `Client::gql` functions in tests

### DIFF
--- a/cli/crates/cli/tests/auth.rs
+++ b/cli/crates/cli/tests/auth.rs
@@ -2,7 +2,7 @@ mod utils;
 
 use std::collections::HashMap;
 
-use serde_json::{json, Value};
+use serde_json::Value;
 use utils::consts::{JWT_PROVIDER_QUERY, JWT_PROVIDER_SCHEMA};
 use utils::environment::Environment;
 
@@ -24,20 +24,20 @@ fn jwt_provider() {
     client.poll_endpoint(30, 300);
 
     // No auth header -> no authorization done in CLI
-    let resp = client.gql::<Value>(json!({ "query": JWT_PROVIDER_QUERY }).to_string());
+    let resp = client.gql::<Value>(JWT_PROVIDER_QUERY).send();
     let errors: Option<Value> = dot_get_opt!(resp, "errors");
     assert!(errors.is_none(), "errors: {errors:#?}");
 
     // Reject invalid token
     let client = client.with_header("Authorization", "Bearer invalid-token");
-    let resp = client.gql::<Value>(json!({ "query": JWT_PROVIDER_QUERY }).to_string());
+    let resp = client.gql::<Value>(JWT_PROVIDER_QUERY).send();
     let error: Option<String> = dot_get_opt!(resp, "errors.0.message");
     assert_eq!(error, Some("Unauthorized".to_string()), "error: {error:#?}");
 
     // Reject valid token with wrong group
     let token = generate_token("cli_user", &["some-group"]);
     let client = client.with_header("Authorization", &format!("Bearer {token}"));
-    let resp = client.gql::<Value>(json!({ "query": JWT_PROVIDER_QUERY }).to_string());
+    let resp = client.gql::<Value>(JWT_PROVIDER_QUERY).send();
     let error: Option<String> = dot_get_opt!(resp, "errors.0.message");
     assert_eq!(
         error,
@@ -48,7 +48,7 @@ fn jwt_provider() {
     // Accept valid token with correct group
     let token = generate_token("cli_user", &["backend"]);
     let client = client.with_header("Authorization", &format!("Bearer {token}"));
-    let resp = client.gql::<Value>(json!({ "query": JWT_PROVIDER_QUERY }).to_string());
+    let resp = client.gql::<Value>(JWT_PROVIDER_QUERY).send();
     let errors: Option<Value> = dot_get_opt!(resp, "errors");
     assert!(errors.is_none(), "errors: {errors:#?}");
 }

--- a/cli/crates/cli/tests/coercion.rs
+++ b/cli/crates/cli/tests/coercion.rs
@@ -13,9 +13,7 @@ fn coercion() {
     let client = env.create_client();
     client.poll_endpoint(30, 300);
 
-    let coerce = |variables: Value| {
-        client.gql::<Value>(json!({"query": COERCION_CREATE_DUMMY, "variables": variables}).to_string())
-    };
+    let coerce = |variables: Value| client.gql::<Value>(COERCION_CREATE_DUMMY).variables(variables).send();
 
     // Test from the spec
     // https://spec.graphql.org/October2021/#sec-List.Input-Coercion

--- a/cli/crates/cli/tests/concurrency_thread.rs
+++ b/cli/crates/cli/tests/concurrency_thread.rs
@@ -1,6 +1,8 @@
 mod utils;
 
-use serde_json::{json, Value};
+use std::future::IntoFuture;
+
+use serde_json::Value;
 use utils::consts::{CONCURRENCY_MUTATION, CONCURRENCY_QUERY, CONCURRENCY_SCHEMA};
 use utils::environment::Environment;
 
@@ -23,9 +25,9 @@ async fn concurrency_thread() {
 
     for _ in 0..10 {
         let (response1, response2, response3): (Value, Value, Value) = tokio::join!(
-            async_client.gql::<Value>(json!({ "query": CONCURRENCY_MUTATION }).to_string()),
-            async_client.gql::<Value>(json!({ "query": CONCURRENCY_MUTATION }).to_string()),
-            async_client.gql::<Value>(json!({ "query": CONCURRENCY_MUTATION }).to_string())
+            async_client.gql::<Value>(CONCURRENCY_MUTATION).into_future(),
+            async_client.gql::<Value>(CONCURRENCY_MUTATION).into_future(),
+            async_client.gql::<Value>(CONCURRENCY_MUTATION).into_future()
         );
 
         let errors1: Option<Value> = dot_get_opt!(response1, "errors");
@@ -37,15 +39,9 @@ async fn concurrency_thread() {
         assert!(errors3.is_none());
     }
 
-    let response1 = async_client
-        .gql::<Value>(json!({ "query": CONCURRENCY_QUERY }).to_string())
-        .await;
-    let response2 = async_client
-        .gql::<Value>(json!({ "query": CONCURRENCY_QUERY }).to_string())
-        .await;
-    let response3 = async_client
-        .gql::<Value>(json!({ "query": CONCURRENCY_QUERY }).to_string())
-        .await;
+    let response1 = async_client.gql::<Value>(CONCURRENCY_QUERY).await;
+    let response2 = async_client.gql::<Value>(CONCURRENCY_QUERY).await;
+    let response3 = async_client.gql::<Value>(CONCURRENCY_QUERY).await;
 
     let result_list1: Vec<Value> = dot_get!(response1, "data.todoListCollection.edges");
     let result_list2: Vec<Value> = dot_get!(response2, "data.todoListCollection.edges");

--- a/cli/crates/cli/tests/default_directive.rs
+++ b/cli/crates/cli/tests/default_directive.rs
@@ -1,7 +1,7 @@
 mod utils;
 
 use crate::utils::consts::{DEFAULT_DIRECTIVE_CREATE_USER1, DEFAULT_DIRECTIVE_CREATE_USER2, DEFAULT_DIRECTIVE_SCHEMA};
-use serde_json::{json, Value};
+use serde_json::Value;
 use utils::environment::Environment;
 
 #[test]
@@ -13,13 +13,7 @@ fn default_directive() {
     let client = env.create_client();
     client.poll_endpoint(30, 300);
 
-    let response = client.gql::<Value>(
-        json!({
-            "query": DEFAULT_DIRECTIVE_CREATE_USER1,
-            "variables": {}
-        })
-        .to_string(),
-    );
+    let response = client.gql::<Value>(DEFAULT_DIRECTIVE_CREATE_USER1).send();
 
     let user: serde_json::Value = dot_get!(response, "data.userCreate.user");
     assert_eq!(dot_get!(user, "signInCount", usize), 0);
@@ -32,13 +26,7 @@ fn default_directive() {
         serde_json::json!({ "content": "" })
     );
 
-    let response = client.gql::<Value>(
-        json!({
-            "query": DEFAULT_DIRECTIVE_CREATE_USER2,
-            "variables": {}
-        })
-        .to_string(),
-    );
+    let response = client.gql::<Value>(DEFAULT_DIRECTIVE_CREATE_USER2).send();
     let user: serde_json::Value = dot_get!(response, "data.userCreate.user");
     assert_eq!(dot_get!(user, "signInCount", usize), 1);
     assert_eq!(dot_get!(user, "country", String), "France");

--- a/cli/crates/cli/tests/dev.rs
+++ b/cli/crates/cli/tests/dev.rs
@@ -16,7 +16,7 @@ fn dev() {
     //
     // CREATE
     //
-    let response = client.gql::<Value>(json!({ "query": DEFAULT_CREATE }).to_string());
+    let response = client.gql::<Value>(DEFAULT_CREATE).send();
     let todo_list: Value = dot_get!(response, "data.todoListCreate.todoList");
     let todo_list_id: String = dot_get!(todo_list, "id");
     assert!(!todo_list_id.is_empty());
@@ -41,7 +41,7 @@ fn dev() {
     //
     // QUERY
     //
-    let response = client.gql::<Value>(json!({ "query": DEFAULT_QUERY }).to_string());
+    let response = client.gql::<Value>(DEFAULT_QUERY).send();
     let edges: Value = dot_get!(response, "data.todoListCollection.edges");
     assert_eq!(edges.as_array().map(Vec::len).unwrap(), 1);
 
@@ -75,8 +75,10 @@ fn dev() {
     //
     // UPDATE
     //
-    let response =
-        client.gql::<Value>(json!({ "query": DEFAULT_UPDATE, "variables": { "id": todo_list_id } }).to_string());
+    let response = client
+        .gql::<Value>(DEFAULT_UPDATE)
+        .variables(json!({ "id": todo_list_id }))
+        .send();
     let updated_todo_list: Value = dot_get!(response, "data.todoListUpdate.todoList");
     assert_eq!(dot_get!(updated_todo_list, "title", String), "Updated Title");
 }

--- a/cli/crates/cli/tests/dev_watch.rs
+++ b/cli/crates/cli/tests/dev_watch.rs
@@ -1,7 +1,7 @@
 mod utils;
 
 use json_dotpath::DotPaths;
-use serde_json::{json, Value};
+use serde_json::Value;
 use utils::consts::{DEFAULT_QUERY, DEFAULT_SCHEMA, UPDATED_MUTATION, UPDATED_QUERY, UPDATED_SCHEMA};
 use utils::environment::Environment;
 
@@ -19,7 +19,7 @@ fn dev_watch() {
 
     client.poll_endpoint(30, 300);
 
-    let response = client.gql::<Value>(json!({ "query": DEFAULT_QUERY }).to_string());
+    let response = client.gql::<Value>(DEFAULT_QUERY).send();
 
     let todo_list_collection: Value = dot_get!(response, "data.todoListCollection.edges");
 
@@ -32,9 +32,9 @@ fn dev_watch() {
 
     client.poll_endpoint_for_changes(30, 300);
 
-    client.gql::<Value>(json!({ "query": UPDATED_MUTATION }).to_string());
+    client.gql::<Value>(UPDATED_MUTATION).send();
 
-    let response = client.gql::<Value>(json!({ "query": UPDATED_QUERY }).to_string());
+    let response = client.gql::<Value>(UPDATED_QUERY).send();
 
     let user_id: String = dot_get!(response, "data.userCollection.edges.0.node.id");
     let user_birthday: String = dot_get!(response, "data.userCollection.edges.0.node.birthday");

--- a/cli/crates/cli/tests/length.rs
+++ b/cli/crates/cli/tests/length.rs
@@ -19,9 +19,10 @@ fn length() {
 
     client.poll_endpoint(30, 300);
 
-    let response = client.gql::<Value>(
-        json!({ "query": LENGTH_CREATE_MUTATION, "variables": { "name": "hello", "age": 30 } }).to_string(),
-    );
+    let response = client
+        .gql::<Value>(LENGTH_CREATE_MUTATION)
+        .variables(json!({ "name": "hello", "age": 30 }))
+        .send();
 
     let errors: Option<Value> = response.dot_get("errors").unwrap();
     assert!(errors.is_none());
@@ -29,7 +30,9 @@ fn length() {
     let first_author_id: String = dot_get!(response, "data.authorCreate.author.id");
 
     let response = client
-        .gql::<Value>(json!({ "query": LENGTH_CREATE_MUTATION, "variables": { "name": "1", "age": 30 } }).to_string());
+        .gql::<Value>(LENGTH_CREATE_MUTATION)
+        .variables(json!({ "name": "1", "age": 30 }))
+        .send();
 
     let errors: Option<Value> = response.dot_get("errors").unwrap();
     assert!(errors.is_some());
@@ -40,17 +43,19 @@ fn length() {
     assert!(error.contains("length"));
     assert!(error.contains("short"));
 
-    let response = client.gql::<Value>(
-        json!({ "query": LENGTH_CREATE_MUTATION, "variables": { "name": "helloworld!", "age": 30 } }).to_string(),
-    );
+    let response = client
+        .gql::<Value>(LENGTH_CREATE_MUTATION)
+        .variables(json!({ "name": "helloworld!", "age": 30 }))
+        .send();
 
     let errors: Option<Value> = response.dot_get("errors").unwrap();
 
     assert!(errors.is_some());
 
-    client.gql::<Value>(
-        json!({ "query": LENGTH_UPDATE_MUTATION, "variables": { "id": first_author_id, "name": "helloworld!", "age": 40 } }).to_string(),
-    );
+    client
+        .gql::<Value>(LENGTH_UPDATE_MUTATION)
+        .variables(json!({ "id": first_author_id, "name": "helloworld!", "age": 40 }))
+        .send();
 
     let errors: Option<Value> = response.dot_get("errors").unwrap();
 

--- a/cli/crates/cli/tests/pagination.rs
+++ b/cli/crates/cli/tests/pagination.rs
@@ -41,13 +41,11 @@ struct Todo {
 
 fn generate_todos(client: &Client, n: usize) -> Vec<Todo> {
     (0..n).fold(Vec::new(), |mut buffer, number| {
-        let response = client.gql::<Value>(
-            json!({
-                "query": PAGINATION_CREATE_TODO,
-                "variables": { "title": format!("Todo#{number}") }
-            })
-            .to_string(),
-        );
+        let response = client
+            .gql::<Value>(PAGINATION_CREATE_TODO)
+            .variables(json!({ "title": format!("Todo#{number}") }))
+            .send();
+
         buffer.push(dot_get!(response, "data.todoCreate.todo", Todo));
         buffer
     })
@@ -65,18 +63,15 @@ fn pagination() {
     let todos = generate_todos(&client, 3);
 
     for number in 0..3 {
-        client.gql::<Value>(
-            json!({
-                "query": PAGINATION_CREATE_TODO_LIST,
-                "variables": {
+        client
+            .gql::<Value>(PAGINATION_CREATE_TODO_LIST)
+            .variables(json!({
                 "title": (number + 1).to_string() ,
                 "todo0": todos[0].id,
                 "todo1": todos[1].id,
                 "todo2": todos[2].id,
-            }
-            })
-            .to_string(),
-        );
+            }))
+            .send();
     }
 
     for (query, path) in &[
@@ -87,13 +82,7 @@ fn pagination() {
         ),
     ] {
         let todo_collection = |variables: Value| {
-            let response = client.gql::<Value>(
-                json!({
-                    "query": query,
-                    "variables": variables
-                })
-                .to_string(),
-            );
+            let response = client.gql::<Value>(*query).variables(variables).send();
             dot_get!(response, path, Collection<Todo>)
         };
 
@@ -239,13 +228,10 @@ fn pagination_order() {
     };
 
     let todo_collection = |variables: Value| {
-        let response = client.gql::<Value>(
-            json!({
-                "query": PAGINATION_PAGINATE_TODOS,
-                "variables": variables
-            })
-            .to_string(),
-        );
+        let response = client
+            .gql::<Value>(PAGINATION_PAGINATE_TODOS)
+            .variables(variables)
+            .send();
         dot_get!(response, "data.todoCollection", Collection<Todo>)
     };
 

--- a/cli/crates/cli/tests/relations.rs
+++ b/cli/crates/cli/tests/relations.rs
@@ -23,9 +23,9 @@ fn relations() {
     // wait for node to be ready
     client.poll_endpoint(30, 300);
 
-    client.gql::<Value>(json!({ "query": RELATIONS_MUTATION }).to_string());
+    client.gql::<Value>(RELATIONS_MUTATION).send();
 
-    let response = client.gql::<Value>(json!({ "query": RELATIONS_QUERY }).to_string());
+    let response = client.gql::<Value>(RELATIONS_QUERY).send();
 
     let blog: Value = dot_get!(response, "data.blogCollection.edges.0.node");
     let blog_id: String = dot_get!(blog, "id");
@@ -41,13 +41,10 @@ fn relations() {
     assert_eq!(first_author_name, "1");
     assert!(first_authors_blogs.is_empty());
 
-    client.gql::<Value>(
-        json!({
-            "query": RELATIONS_LINK_BLOG_TO_AUTHOR,
-            "variables": { "id": first_author_id, "blogId": blog_id}
-        })
-        .to_string(),
-    );
+    client
+        .gql::<Value>(RELATIONS_LINK_BLOG_TO_AUTHOR)
+        .variables(json!({ "id": first_author_id, "blogId": blog_id}))
+        .send();
 
     // disabled due to a pending issue in live queries where an item exists in the graph more than once
 
@@ -64,15 +61,12 @@ fn relations() {
     // assert_eq!(blog_id, first_authors_first_blog_id);
     // assert_eq!(blog_id, first_authors_first_blog_id);
 
-    client.gql::<Value>(
-        json!({
-            "query": RELATIONS_UNLINK_BLOG_FROM_AUTHOR,
-            "variables": { "id": first_author_id, "blogId": blog_id}
-        })
-        .to_string(),
-    );
+    client
+        .gql::<Value>(RELATIONS_UNLINK_BLOG_FROM_AUTHOR)
+        .variables(json!({ "id": first_author_id, "blogId": blog_id}))
+        .send();
 
-    let response = client.gql::<Value>(json!({ "query": RELATIONS_QUERY }).to_string());
+    let response = client.gql::<Value>(RELATIONS_QUERY).send();
 
     let current_first_author_id: String =
         dot_get!(response, "data.blogCollection.edges.0.node.authors.edges.0.node.id");
@@ -84,29 +78,20 @@ fn relations() {
     assert_eq!(current_first_author_id, first_author_id);
     assert!(first_authors_blogs.is_empty());
 
-    client.gql::<Value>(
-        json!({
-            "query": RELATIONS_LINK_BLOG_TO_AUTHOR,
-            "variables": { "id": first_author_id, "blogId": blog_id}
-        })
-        .to_string(),
-    );
+    client
+        .gql::<Value>(RELATIONS_LINK_BLOG_TO_AUTHOR)
+        .variables(json!({ "id": first_author_id, "blogId": blog_id}))
+        .send();
 
-    client.gql::<Value>(
-        json!({
-            "query": REALTIONS_LINK_SECONDARY_AUTHOR_TO_BLOG,
-            "variables": { "id": blog_id, "authorId": first_author_id }
-        })
-        .to_string(),
-    );
+    client
+        .gql::<Value>(REALTIONS_LINK_SECONDARY_AUTHOR_TO_BLOG)
+        .variables(json!({ "id": blog_id, "authorId": first_author_id }))
+        .send();
 
-    client.gql::<Value>(
-        json!({
-            "query": REALTIONS_RENAME_AUTHOR,
-            "variables": { "id": second_author_id, "name": "renamed"  }
-        })
-        .to_string(),
-    );
+    client
+        .gql::<Value>(REALTIONS_RENAME_AUTHOR)
+        .variables(json!({ "id": second_author_id, "name": "renamed" }))
+        .send();
 
     // disabled due to the race condition between mutations and response payloads
 
@@ -114,17 +99,14 @@ fn relations() {
 
     // assert_eq!(current_author_name, "renamed");
 
-    let response = client.gql::<Value>(
-        json!({
-            "query": RELATIONS_UNLINK_AUTHORS_FROM_BLOG,
-            "variables": {
+    let response = client
+        .gql::<Value>(RELATIONS_UNLINK_AUTHORS_FROM_BLOG)
+        .variables(json!({
                 "id": blog_id,
                 "author1": first_author_id,
                 "author2": second_author_id
-            }
-        })
-        .to_string(),
-    );
+        }))
+        .send();
 
     let errors: Option<Value> = dot_get_opt!(response, "errors");
 

--- a/cli/crates/cli/tests/reserved_dates.rs
+++ b/cli/crates/cli/tests/reserved_dates.rs
@@ -17,13 +17,7 @@ fn reserved_dates() {
     let client = env.create_client();
     client.poll_endpoint(30, 300);
 
-    let response = client.gql::<Value>(
-        json!({
-            "query": RESERVED_DATES_NESTED_CREATION,
-            "variables": {}
-        })
-        .to_string(),
-    );
+    let response = client.gql::<Value>(RESERVED_DATES_NESTED_CREATION).send();
 
     let user: Value = dot_get!(response, "data.userCreate.user");
     assert_eq!(dot_get!(user, "name", String), "John");
@@ -58,15 +52,12 @@ fn reserved_dates() {
     assert_eq!(dot_get!(nested_user, "createdAt", String), created_at);
     assert_eq!(dot_get!(nested_user, "updatedAt", String), created_at);
 
-    let response = client.gql::<Value>(
-        json!({
-            "query": RESERVED_DATES_CREATE_TODO,
-            "variables": {
+    let response = client
+        .gql::<Value>(RESERVED_DATES_CREATE_TODO)
+        .variables(json!({
                 "title": "Champion"
-            }
-        })
-        .to_string(),
-    );
+        }))
+        .send();
     let todo: Value = dot_get!(response, "data.todoCreate.todo");
     let todo_created_at = dot_get!(todo, "createdAt", String);
     assert!(todo_created_at
@@ -75,16 +66,13 @@ fn reserved_dates() {
         .gt(&Utc::now().checked_sub_signed(Duration::hours(1)).unwrap()));
     assert_eq!(dot_get!(todo, "updatedAt", String), todo_created_at);
 
-    let response = client.gql::<Value>(
-        json!({
-            "query": RESERVED_DATES_CREATE_TODO_LIST,
-            "variables": {
-                "title": "Champion List",
-                "todoId": dot_get!(todo, "id", String)
-            }
-        })
-        .to_string(),
-    );
+    let response = client
+        .gql::<Value>(RESERVED_DATES_CREATE_TODO_LIST)
+        .variables(json!({
+            "title": "Champion List",
+            "todoId": dot_get!(todo, "id", String)
+        }))
+        .send();
     let todo_list: Value = dot_get!(response, "data.todoListCreate.todoList");
     let todo_list_created_at = dot_get!(todo_list, "createdAt", String);
     assert!(todo_list_created_at

--- a/cli/crates/cli/tests/scalars.rs
+++ b/cli/crates/cli/tests/scalars.rs
@@ -6,30 +6,13 @@ use utils::client::Client;
 use utils::consts::{SCALARS_CREATE_OPTIONAL, SCALARS_CREATE_REQUIRED, SCALARS_SCHEMA};
 use utils::environment::Environment;
 
-trait ClientScalarExt {
-    fn create_opt(&self, variables: Value) -> Value;
-    fn create_req(&self, variables: Value) -> Value;
-}
-
-impl ClientScalarExt for Client {
+impl Client {
     fn create_opt(&self, variables: Value) -> Value {
-        self.gql::<Value>(
-            json!({
-                "query": SCALARS_CREATE_OPTIONAL,
-                "variables": variables
-            })
-            .to_string(),
-        )
+        self.gql::<Value>(SCALARS_CREATE_OPTIONAL).variables(variables).send()
     }
 
     fn create_req(&self, variables: Value) -> Value {
-        self.gql::<Value>(
-            json!({
-                "query": SCALARS_CREATE_REQUIRED,
-                "variables": variables
-            })
-            .to_string(),
-        )
+        self.gql::<Value>(SCALARS_CREATE_REQUIRED).variables(variables).send()
     }
 }
 

--- a/cli/crates/cli/tests/search.rs
+++ b/cli/crates/cli/tests/search.rs
@@ -129,13 +129,7 @@ fn basic_search(#[case] name: &str, #[case] create_query: &str, #[case] search_q
     client.poll_endpoint(30, 300);
 
     let create = |variables: Value| -> String {
-        let response = client.gql::<Value>(
-            json!({
-                "query": create_query,
-                "variables": variables
-            })
-            .to_string(),
-        );
+        let response = client.gql::<Value>(create_query).variables(variables).send();
         dot_get!(response, &format!("data.{name}Create.{name}.id"))
     };
     let search = |query: &str, fields: Option<Vec<&str>>, filter: Value| -> Collection<Value> {
@@ -144,13 +138,10 @@ fn basic_search(#[case] name: &str, #[case] create_query: &str, #[case] search_q
         } else {
             Value::String(query.to_string())
         };
-        let response = client.gql::<Value>(
-            json!({
-                "query": search_query,
-                "variables": json!({"query": query, "first": 10, "filter": filter, "fields": fields})
-            })
-            .to_string(),
-        );
+        let response = client
+            .gql::<Value>(search_query)
+            .variables(json!({"query": query, "first": 10, "filter": filter, "fields": fields}))
+            .send();
         dot_get!(response, &format!("data.{name}Search"))
     };
     let search_text = |query: &str| search(query, None, Value::Null);
@@ -410,23 +401,11 @@ fn search_created_updated_at() {
     client.poll_endpoint(30, 300);
 
     let create = |variables: Value| -> String {
-        let response = client.gql::<Value>(
-            json!({
-                "query": SEARCH_CREATE_OPTIONAL,
-                "variables": variables
-            })
-            .to_string(),
-        );
+        let response = client.gql::<Value>(SEARCH_CREATE_OPTIONAL).variables(variables).send();
         dot_get!(response, "data.fieldsCreate.fields.id")
     };
     let search = |variables: Value| -> Collection<Value> {
-        let response = client.gql::<Value>(
-            json!({
-                "query": SEARCH_METADATA_FIELDS,
-                "variables": variables
-            })
-            .to_string(),
-        );
+        let response = client.gql::<Value>(SEARCH_METADATA_FIELDS).variables(variables).send();
         dot_get!(response, "data.fieldsSearch")
     };
 
@@ -483,23 +462,11 @@ fn search_pagination_and_total_hits() {
     client.poll_endpoint(30, 300);
 
     let create = |variables: Value| -> String {
-        let response = client.gql::<Value>(
-            json!({
-                "query": SEARCH_CREATE_OPTIONAL,
-                "variables": variables
-            })
-            .to_string(),
-        );
+        let response = client.gql::<Value>(SEARCH_CREATE_OPTIONAL).variables(variables).send();
         dot_get!(response, "data.fieldsCreate.fields.id")
     };
     let search = |variables: Value| -> Collection<Value> {
-        let response = client.gql::<Value>(
-            json!({
-                "query": SEARCH_PAGINATION,
-                "variables": variables
-            })
-            .to_string(),
-        );
+        let response = client.gql::<Value>(SEARCH_PAGINATION).variables(variables).send();
         dot_get!(response, "data.fieldsSearch")
     };
 

--- a/cli/crates/cli/tests/unique.rs
+++ b/cli/crates/cli/tests/unique.rs
@@ -10,6 +10,7 @@ use utils::consts::{
 use utils::{client::Client, environment::Environment};
 
 #[test]
+#[allow(clippy::too_many_lines)]
 fn unique() {
     let mut env = Environment::init(4003);
 
@@ -24,16 +25,20 @@ fn unique() {
     client.poll_endpoint(30, 300);
 
     client
-        .gql::<Value>(json!({ "query": UNIQUE_CREATE_MUTATION, "variables": { "name": "1", "age": 30 } }).to_string());
+        .gql::<Value>(UNIQUE_CREATE_MUTATION)
+        .variables(json!({ "name": "1", "age": 30 }))
+        .send();
 
-    let response = client.gql::<Value>(json!({ "query": UNIQUE_PAGINATED_QUERY }).to_string());
+    let response = client.gql::<Value>(UNIQUE_PAGINATED_QUERY).send();
 
     let first_author_id: String = dot_get!(response, "data.authorCollection.edges.0.node.id");
 
     assert!(first_author_id.starts_with("author_"));
 
-    let response =
-        client.gql::<Value>(json!({ "query": UNIQUE_QUERY, "variables": { "id": first_author_id } }).to_string());
+    let response = client
+        .gql::<Value>(UNIQUE_QUERY)
+        .variables(json!({ "id": first_author_id }))
+        .send();
 
     let updated_at: String = dot_get!(response, "data.author.updatedAt");
     assert!(
@@ -53,14 +58,18 @@ fn unique() {
     assert_eq!(first_author_name, "1");
 
     let response = client
-        .gql::<Value>(json!({ "query": UNIQUE_QUERY_BY_NAME, "variables": { "name": first_author_name } }).to_string());
+        .gql::<Value>(UNIQUE_QUERY_BY_NAME)
+        .variables(json!({ "name": first_author_name }))
+        .send();
 
     let first_query_author_id: String = dot_get!(response, "data.author.id");
 
     assert_eq!(first_query_author_id, first_author_id);
 
     let response = client
-        .gql::<Value>(json!({ "query": UNIQUE_CREATE_MUTATION, "variables": { "name": "1", "age": 30 } }).to_string());
+        .gql::<Value>(UNIQUE_CREATE_MUTATION)
+        .variables(json!({ "name": "1", "age": 30 }))
+        .send();
 
     let errors: Option<Value> = response.dot_get("errors").unwrap();
 
@@ -72,22 +81,27 @@ fn unique() {
     assert!(error.contains("field"));
 
     let response = client
-        .gql::<Value>(json!({ "query": UNIQUE_CREATE_MUTATION, "variables": { "name": "2", "age": 30 } }).to_string());
+        .gql::<Value>(UNIQUE_CREATE_MUTATION)
+        .variables(json!({ "name": "2", "age": 30 }))
+        .send();
 
     let errors: Option<Value> = response.dot_get("errors").unwrap();
 
     assert!(errors.is_none(), "Expected no errors, but got {errors:?}");
 
-    let response = client.gql::<Value>(
-        json!({ "query": UNIQUE_UPDATE_MUTATION, "variables": { "id": first_author_id, "age": 40 } }).to_string(),
-    );
+    let response = client
+        .gql::<Value>(UNIQUE_UPDATE_MUTATION)
+        .variables(json!({ "id": first_author_id, "age": 40 }))
+        .send();
 
     let errors: Option<Value> = response.dot_get("errors").unwrap();
 
     assert!(errors.is_none(), "Expected no errors, but got {errors:?}");
 
-    let response =
-        client.gql::<Value>(json!({ "query": UNIQUE_QUERY_BY_NAME, "variables": {"name": "1" } }).to_string());
+    let response = client
+        .gql::<Value>(UNIQUE_QUERY_BY_NAME)
+        .variables(json!({"name": "1" }))
+        .send();
 
     let query_author_id: String = dot_get!(response, "data.author.id");
     let query_author_age: usize = dot_get!(response, "data.author.age");
@@ -96,13 +110,15 @@ fn unique() {
     assert_eq!(query_author_id, first_author_id);
     assert_eq!(query_author_age, 40);
 
-    client.gql::<Value>(
-        json!({ "query": UNIQUE_UPDATE_BY_NAME_MUTATION, "variables": { "name": query_author_name, "age": 50 } })
-            .to_string(),
-    );
+    client
+        .gql::<Value>(UNIQUE_UPDATE_BY_NAME_MUTATION)
+        .variables(json!({ "name": query_author_name, "age": 50 }))
+        .send();
 
     let response = client
-        .gql::<Value>(json!({ "query": UNIQUE_QUERY_BY_NAME, "variables": {"name": query_author_name } }).to_string());
+        .gql::<Value>(UNIQUE_QUERY_BY_NAME)
+        .variables(json!({ "name": query_author_name }))
+        .send();
 
     let query_author_id: String = dot_get!(response, "data.author.id");
     let query_author_age: usize = dot_get!(response, "data.author.age");
@@ -110,13 +126,15 @@ fn unique() {
     assert_eq!(query_author_id, first_author_id);
     assert_eq!(query_author_age, 50);
 
-    client.gql::<Value>(
-        json!({ "query": UNIQUE_UPDATE_UNIQUE_MUTATION, "variables": { "id": first_author_id, "name": "3" } })
-            .to_string(),
-    );
+    client
+        .gql::<Value>(UNIQUE_UPDATE_UNIQUE_MUTATION)
+        .variables(json!({ "id": first_author_id, "name": "3" }))
+        .send();
 
-    let response =
-        client.gql::<Value>(json!({ "query": UNIQUE_QUERY_BY_NAME, "variables": { "name": "3" } }).to_string());
+    let response = client
+        .gql::<Value>(UNIQUE_QUERY_BY_NAME)
+        .variables(json!({ "name": "3" }))
+        .send();
 
     let query_author_id: String = dot_get!(response, "data.author.id");
     let query_author_name: String = dot_get!(response, "data.author.name");
@@ -124,13 +142,15 @@ fn unique() {
     assert_eq!(query_author_id, first_author_id);
     assert_eq!(query_author_name, "3");
 
-    client.gql::<Value>(
-        json!({ "query": UNIQUE_UPDATE_UNIQUE_BY_NAME_MUTATION, "variables": { "queryName": query_author_name, "name": "4" } })
-            .to_string(),
-    );
+    client
+        .gql::<Value>(UNIQUE_UPDATE_UNIQUE_BY_NAME_MUTATION)
+        .variables(json!({ "queryName": query_author_name, "name": "4" }))
+        .send();
 
-    let response =
-        client.gql::<Value>(json!({ "query": UNIQUE_QUERY_BY_NAME, "variables": { "name": "4" } }).to_string());
+    let response = client
+        .gql::<Value>(UNIQUE_QUERY_BY_NAME)
+        .variables(json!({ "name": "4" }))
+        .send();
 
     let query_author_id: String = dot_get!(response, "data.author.id");
     let query_author_name: String = dot_get!(response, "data.author.name");
@@ -139,21 +159,27 @@ fn unique() {
     assert_eq!(query_author_name, "4");
 
     let response = client
-        .gql::<Value>(json!({ "query": UNIQUE_DELETE_MUTATION, "variables": { "id": first_author_id } }).to_string());
+        .gql::<Value>(UNIQUE_DELETE_MUTATION)
+        .variables(json!({ "id": first_author_id }))
+        .send();
 
     let errors: Option<Value> = response.dot_get("errors").unwrap();
 
     assert!(errors.is_none(), "Expected no errors, but got {errors:?}");
 
     let response = client
-        .gql::<Value>(json!({ "query": UNIQUE_CREATE_MUTATION, "variables": { "name": "1", "age": 30 } }).to_string());
+        .gql::<Value>(UNIQUE_CREATE_MUTATION)
+        .variables(json!({ "name": "1", "age": 30 }))
+        .send();
 
     let errors: Option<Value> = response.dot_get("errors").unwrap();
 
     assert!(errors.is_none(), "Expected no errors, but got {errors:?}");
 
-    let response =
-        client.gql::<Value>(json!({ "query": UNIQUE_QUERY, "variables": { "id": first_author_id } }).to_string());
+    let response = client
+        .gql::<Value>(UNIQUE_QUERY)
+        .variables(json!({ "id": first_author_id }))
+        .send();
 
     let first_author: Option<Value> = response.dot_get("data.author").unwrap();
 
@@ -272,46 +298,24 @@ fn unique_with_multiple_fields() {
 
 impl Client {
     fn get_account(&self, by: &Value) -> Value {
-        self.gql(
-            json!({
-                "query": ACCOUNT_QUERY_ONE,
-                "variables": { "by": by }
-            })
-            .to_string(),
-        )
+        self.gql(ACCOUNT_QUERY_ONE).variables(json!({ "by": by })).send()
     }
 
     fn account_collection(&self) -> Value {
-        self.gql(json!({ "query": ACCOUNT_QUERY_PAGINATED }).to_string())
+        self.gql(ACCOUNT_QUERY_PAGINATED).send()
     }
 
     fn create_account(&self, input: &Value) -> Value {
-        self.gql(
-            json!({
-                "query": ACCOUNT_CREATE_MUTATION,
-                "variables": {"input": input}
-            })
-            .to_string(),
-        )
+        self.gql(ACCOUNT_CREATE_MUTATION)
+            .variables(json!({ "input": input }))
+            .send()
     }
 
     fn update_account(&self, vars: &Value) -> Value {
-        self.gql(
-            json!({
-                "query": ACCOUNT_CREATE_MUTATION,
-                "variables": vars
-            })
-            .to_string(),
-        )
+        self.gql(ACCOUNT_CREATE_MUTATION).variables(vars).send()
     }
 
     fn delete_account(&self, by: &Value) -> Value {
-        self.gql(
-            json!({
-                "query": ACCOUNT_DELETE_MUTATION,
-                "variables": { "by": by }
-            })
-            .to_string(),
-        )
+        self.gql(ACCOUNT_DELETE_MUTATION).variables(json!({ "by": by })).send()
     }
 }

--- a/cli/crates/cli/tests/utils/client.rs
+++ b/cli/crates/cli/tests/utils/client.rs
@@ -122,7 +122,7 @@ impl Client {
 
 #[derive(serde::Serialize)]
 #[must_use]
-pub struct GqlRequestBuilder<Response = serde_json::Value> {
+pub struct GqlRequestBuilder<Response> {
     // These two will be serialized into the request
     query: String,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
# Description

Our tests currently contain _a lot_ of hand coded GQL JSON request bodies.  Seems a bit much to be typing these out every single time we want to make a GQL call, so I've put together a super simple builder API instead.

Thoughts?

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [x] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
