### PR TITLE
Add Unlicese & zlib-acknowledgement to accepted licenses

### DIFF
--- a/cli/about.toml
+++ b/cli/about.toml
@@ -10,6 +10,8 @@ accepted = [
     "CC0-1.0",
     "Unicode-DFS-2016",
     "BSD-2-Clause",
+    "Unlicense",
+    "zlib-acknowledgement"
 ]
 
 targets = [


### PR DESCRIPTION
# Description

The build of 0.18.0-rc.1 failed because it found two licenses that weren't explicitly allowed.  I've added them to the list so that the build works.