### PR TITLE
Fix publish-release action, and update to 0.18.0-rc.2

### DIFF
--- a/.github/workflows/cli-partial-release.yml
+++ b/.github/workflows/cli-partial-release.yml
@@ -119,11 +119,11 @@ jobs:
           if [[ $INPUT_PRERELEASE != "false" ]]; then
               PUBLISH_ARGUMENTS+=(--tag next)
           fi
-          (cd aarch64-apple-darwin && npm publish "${PUBLISH_ARGUMENTS[@]/#/-}")
-          (cd x86_64-apple-darwin && npm publish "${PUBLISH_ARGUMENTS[@]/#/-}")
-          (cd x86_64-pc-windows-msvc && npm publish "${PUBLISH_ARGUMENTS[@]/#/-}")
-          (cd x86_64-unknown-linux-musl && npm publish "${PUBLISH_ARGUMENTS[@]/#/-}")
-          (cd cli && npm publish "${PUBLISH_ARGUMENTS[@]/#/-}")
+          (cd aarch64-apple-darwin && npm publish "${PUBLISH_ARGUMENTS[@]}")
+          (cd x86_64-apple-darwin && npm publish "${PUBLISH_ARGUMENTS[@]}")
+          (cd x86_64-pc-windows-msvc && npm publish "${PUBLISH_ARGUMENTS[@]}")
+          (cd x86_64-unknown-linux-musl && npm publish "${PUBLISH_ARGUMENTS[@]}")
+          (cd cli && npm publish "${PUBLISH_ARGUMENTS[@]}")
 
       - name: Github Release
         id: gh-release

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.18.0-rc.1"
+version = "0.18.0-rc.2"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.18.0-rc.1"
+version = "0.18.0-rc.2"
 dependencies = [
  "async-compression",
  "async-tar",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.18.0-rc.1"
+version = "0.18.0-rc.2"
 dependencies = [
  "dirs",
  "exitcode",
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.18.0-rc.1"
+version = "0.18.0-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cli/changelog/0.18.0-rc.2.md
+++ b/cli/changelog/0.18.0-rc.2.md
@@ -1,0 +1,12 @@
+This release is the same as 0.18.0-rc.1
+
+### Features
+
+- Adds an `@openapi` directive that generates queries and mutations that call an API described by an OpenAPI specification.
+- Added `grafbase login` & `grafbase logout` commands
+
+### Fixes
+
+- Fixes a panic in schema parsing if a users type had underscores in its name.
+- Fixes a panic in schema parsing if the name of a users type clashed with a generated type.
+- Fixes a panic when a missing input argument is passed to a mutation

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-local-backend"
-version = "0.18.0-rc.1"
+version = "0.18.0-rc.2"
 edition = "2021"
 description = "The local backend for grafbase developer tools"
 license = "Apache-2.0"
@@ -33,5 +33,5 @@ url = "2"
 urlencoding = "2"
 webbrowser = "0.8"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.18.0-rc.1" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.18.0-rc.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.18.0-rc.2" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.18.0-rc.2" }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase"
-version = "0.18.0-rc.1"
+version = "0.18.0-rc.2"
 edition = "2021"
 description = "The Grafbase command line interface"
 license = "Apache-2.0"
@@ -33,8 +33,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
 webbrowser = "0.8"
 
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.18.0-rc.1" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.18.0-rc.1" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.18.0-rc.2" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.18.0-rc.2" }
 
 [dev-dependencies]
 chrono = "0.4"

--- a/cli/crates/common/Cargo.toml
+++ b/cli/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-local-common"
-version = "0.18.0-rc.1"
+version = "0.18.0-rc.2"
 edition = "2021"
 description = "Common code used in multiple crates in the CLI workspace"
 license = "Apache-2.0"

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-local-server"
-version = "0.18.0-rc.1"
+version = "0.18.0-rc.2"
 edition = "2021"
 description = "A wrapper for the grafbase worker"
 license = "Apache-2.0"
@@ -52,7 +52,7 @@ uuid = { version = "1", features = ["v4"] }
 version-compare = "0.1"
 which = "4"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.18.0-rc.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.18.0-rc.2" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.18.0-rc.1",
+  "version": "0.18.0-rc.2",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.18.0-rc.1",
+  "version": "0.18.0-rc.2",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.4.3"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.18.0-rc.1",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.18.0-rc.1",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.18.0-rc.1",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.18.0-rc.1"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.18.0-rc.2",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.18.0-rc.2",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.18.0-rc.2",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.18.0-rc.2"
   },
   "engines": {
     "node": ">=16.13.0"

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.18.0-rc.1",
+  "version": "0.18.0-rc.2",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.18.0-rc.1",
+  "version": "0.18.0-rc.2",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.18.0-rc.1",
+  "version": "0.18.0-rc.2",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
I made a bash mistake in the cli-partial-release script.  This fixes that.

Also updated all the versions to 0.18.0-rc.2 since the crates.io release was succesful, but the npm release wasn't - so probably can't re-run the action with the same version number.