### PR TITLE
Bump the minimum node version to 18

### DIFF
--- a/cli/crates/server/src/consts.rs
+++ b/cli/crates/server/src/consts.rs
@@ -3,5 +3,5 @@ pub const SCHEMA_PARSER_DIR: &str = "parser";
 pub const SCHEMA_PARSER_INDEX: &str = "index.js";
 pub const GIT_IGNORE_FILE: &str = ".gitignore";
 pub const GIT_IGNORE_CONTENTS: &str = "*\n";
-pub const MIN_NODE_VERSION: &str = "v16.13.0";
+pub const MIN_NODE_VERSION: &str = "v18.0.0";
 pub const DOT_ENV_FILE: &str = ".env";


### PR DESCRIPTION
# Description

The `@openapi` directive work requires NodeJS versions that support `fetch`.  This was stable from 18 onwards, so I'm increasing the MIN_NODE_VERSION to that so we get warnings when a user is on an older version instead of an obscure error.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
