### PR TITLE
Introduce a synchronised file-based counter for the port number used in tests

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1196,6 +1196,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,6 +1419,7 @@ dependencies = [
  "ctrlc",
  "duct",
  "exitcode",
+ "fslock",
  "grafbase-local-backend",
  "grafbase-local-common",
  "hex-literal",

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -17,6 +17,7 @@ clap = { version = "4", features = ["cargo", "wrap_help"] }
 clap_complete = "4"
 colored = "2"
 ctrlc = "3"
+fslock = "0.2"
 indicatif = "0.17"
 inquire = "0.6"
 exitcode = "1"

--- a/cli/crates/cli/tests/auth.rs
+++ b/cli/crates/cli/tests/auth.rs
@@ -11,7 +11,7 @@ const JWT_SECRET: &str = "topsecret";
 
 #[test]
 fn jwt_provider() {
-    let mut env = Environment::init(4015);
+    let mut env = Environment::init();
     env.grafbase_init();
     env.write_schema(JWT_PROVIDER_SCHEMA);
     env.set_variables(HashMap::from([

--- a/cli/crates/cli/tests/coercion.rs
+++ b/cli/crates/cli/tests/coercion.rs
@@ -6,7 +6,7 @@ use utils::environment::Environment;
 
 #[test]
 fn coercion() {
-    let mut env = Environment::init(4020);
+    let mut env = Environment::init();
     env.grafbase_init();
     env.write_schema(COERCION_SCHEMA);
     env.grafbase_dev();

--- a/cli/crates/cli/tests/concurrency_process.rs
+++ b/cli/crates/cli/tests/concurrency_process.rs
@@ -8,8 +8,8 @@ use utils::environment::Environment;
 
 #[tokio::test]
 async fn concurrency_process() {
-    let mut env1 = Environment::init(4005);
-    let mut env2 = Environment::from(&env1, 4006);
+    let mut env1 = Environment::init();
+    let mut env2 = Environment::from(&env1);
 
     env1.grafbase_init();
     env1.write_schema(CONCURRENCY_SCHEMA);

--- a/cli/crates/cli/tests/concurrency_thread.rs
+++ b/cli/crates/cli/tests/concurrency_thread.rs
@@ -8,7 +8,7 @@ use utils::environment::Environment;
 
 #[tokio::test]
 async fn concurrency_thread() {
-    let mut env = Environment::init(4007);
+    let mut env = Environment::init();
 
     env.grafbase_init();
     env.write_schema(CONCURRENCY_SCHEMA);

--- a/cli/crates/cli/tests/default_directive.rs
+++ b/cli/crates/cli/tests/default_directive.rs
@@ -6,7 +6,7 @@ use utils::environment::Environment;
 
 #[test]
 fn default_directive() {
-    let mut env = Environment::init(4017);
+    let mut env = Environment::init();
     env.grafbase_init();
     env.write_schema(DEFAULT_DIRECTIVE_SCHEMA);
     env.grafbase_dev();

--- a/cli/crates/cli/tests/dev.rs
+++ b/cli/crates/cli/tests/dev.rs
@@ -6,7 +6,7 @@ use utils::environment::Environment;
 
 #[test]
 fn dev() {
-    let mut env = Environment::init(4000);
+    let mut env = Environment::init();
     env.grafbase_init();
     env.write_schema(DEFAULT_SCHEMA);
     env.grafbase_dev();

--- a/cli/crates/cli/tests/dev_watch.rs
+++ b/cli/crates/cli/tests/dev_watch.rs
@@ -7,7 +7,7 @@ use utils::environment::Environment;
 
 #[test]
 fn dev_watch() {
-    let mut env = Environment::init(4001);
+    let mut env = Environment::init();
 
     env.grafbase_init();
 

--- a/cli/crates/cli/tests/environment_file.rs
+++ b/cli/crates/cli/tests/environment_file.rs
@@ -6,7 +6,7 @@ use utils::environment::Environment;
 
 #[test]
 fn environment_file() {
-    let mut env = Environment::init(4012);
+    let mut env = Environment::init();
 
     env.grafbase_init();
 

--- a/cli/crates/cli/tests/environment_process.rs
+++ b/cli/crates/cli/tests/environment_process.rs
@@ -5,7 +5,7 @@ use utils::environment::Environment;
 
 #[test]
 fn environment_process() {
-    let mut env = Environment::init(4013);
+    let mut env = Environment::init();
 
     env.grafbase_init();
 

--- a/cli/crates/cli/tests/init.rs
+++ b/cli/crates/cli/tests/init.rs
@@ -4,7 +4,7 @@ use utils::environment::Environment;
 
 #[test]
 fn init() {
-    let env = Environment::init(4016);
+    let env = Environment::init();
 
     env.grafbase_init();
 

--- a/cli/crates/cli/tests/length.rs
+++ b/cli/crates/cli/tests/length.rs
@@ -7,7 +7,7 @@ use utils::environment::Environment;
 
 #[test]
 fn length() {
-    let mut env = Environment::init(4014);
+    let mut env = Environment::init();
 
     env.grafbase_init();
 

--- a/cli/crates/cli/tests/openapi/main.rs
+++ b/cli/crates/cli/tests/openapi/main.rs
@@ -4,7 +4,6 @@ mod utils;
 use std::net::SocketAddr;
 
 use crossbeam_channel::{Receiver, Sender};
-use rand::Rng;
 use serde_json::{json, Value};
 use utils::{async_client::AsyncClient, environment::Environment};
 use wiremock::{
@@ -17,7 +16,7 @@ async fn openapi_test() {
     let mock_server = wiremock::MockServer::start().await;
     mount_petstore_spec(&mock_server).await;
 
-    let mut env = Environment::init(rand::thread_rng().gen_range(49152..65535));
+    let mut env = Environment::init();
     let client = start_grafbase_with_petstore_schema(&mut env, mock_server.address()).await;
 
     Mock::given(method("GET"))

--- a/cli/crates/cli/tests/pagination.rs
+++ b/cli/crates/cli/tests/pagination.rs
@@ -53,7 +53,7 @@ fn generate_todos(client: &Client, n: usize) -> Vec<Todo> {
 
 #[test]
 fn pagination() {
-    let mut env = Environment::init(4010);
+    let mut env = Environment::init();
     env.grafbase_init();
     env.write_schema(PAGINATION_SCHEMA);
     env.grafbase_dev();
@@ -213,7 +213,7 @@ macro_rules! assert_same_todos {
 
 #[test]
 fn pagination_order() {
-    let mut env = Environment::init(4019);
+    let mut env = Environment::init();
     env.grafbase_init();
     env.write_schema(PAGINATION_SCHEMA);
     env.grafbase_dev();

--- a/cli/crates/cli/tests/relations.rs
+++ b/cli/crates/cli/tests/relations.rs
@@ -10,7 +10,7 @@ use utils::environment::Environment;
 
 #[test]
 fn relations() {
-    let mut env = Environment::init(4002);
+    let mut env = Environment::init();
 
     env.grafbase_init();
 

--- a/cli/crates/cli/tests/reserved_dates.rs
+++ b/cli/crates/cli/tests/reserved_dates.rs
@@ -10,7 +10,7 @@ use utils::environment::Environment;
 #[test]
 fn reserved_dates() {
     // TODO: Create simpler client setup (one-line)
-    let mut env = Environment::init(4018);
+    let mut env = Environment::init();
     env.grafbase_init();
     env.write_schema(RESERVED_DATES_SCHEMA);
     env.grafbase_dev();

--- a/cli/crates/cli/tests/reset.rs
+++ b/cli/crates/cli/tests/reset.rs
@@ -4,7 +4,7 @@ use utils::environment::Environment;
 
 #[test]
 fn reset() {
-    let mut env = Environment::init(4004);
+    let mut env = Environment::init();
 
     env.grafbase_init();
     env.grafbase_dev();

--- a/cli/crates/cli/tests/scalars.rs
+++ b/cli/crates/cli/tests/scalars.rs
@@ -51,7 +51,7 @@ fn error_matching(pattern: &str) -> Result<Value, Regex> {
 #[allow(clippy::too_many_lines)]
 #[test]
 fn scalars() {
-    let mut env = Environment::init(4011);
+    let mut env = Environment::init();
     env.grafbase_init();
     env.write_schema(SCALARS_SCHEMA);
     env.grafbase_dev();

--- a/cli/crates/cli/tests/search.rs
+++ b/cli/crates/cli/tests/search.rs
@@ -117,11 +117,11 @@ struct Edge<N> {
 // Tantivy query syntax
 // https://docs.rs/tantivy/latest/tantivy/query/struct.QueryParser.html
 #[rstest]
-#[case("fields", SEARCH_CREATE_OPTIONAL, SEARCH_SEARCH_OPTIONAL, 4022)]
-#[case("requiredFields", SEARCH_CREATE_REQUIRED, SEARCH_SEARCH_REQUIRED, 4023)]
-#[case("listFields", SEARCH_CREATE_LIST, SEARCH_SEARCH_LIST, 4024)]
-fn basic_search(#[case] name: &str, #[case] create_query: &str, #[case] search_query: &str, #[case] port: u16) {
-    let mut env = Environment::init(port);
+#[case("fields", SEARCH_CREATE_OPTIONAL, SEARCH_SEARCH_OPTIONAL)]
+#[case("requiredFields", SEARCH_CREATE_REQUIRED, SEARCH_SEARCH_REQUIRED)]
+#[case("listFields", SEARCH_CREATE_LIST, SEARCH_SEARCH_LIST)]
+fn basic_search(#[case] name: &str, #[case] create_query: &str, #[case] search_query: &str) {
+    let mut env = Environment::init();
     env.grafbase_init();
     env.write_schema(SEARCH_SCHEMA);
     env.grafbase_dev();
@@ -393,7 +393,7 @@ fn basic_search(#[case] name: &str, #[case] create_query: &str, #[case] search_q
 
 #[test]
 fn search_created_updated_at() {
-    let mut env = Environment::init(4026);
+    let mut env = Environment::init();
     env.grafbase_init();
     env.write_schema(SEARCH_SCHEMA);
     env.grafbase_dev();
@@ -454,7 +454,7 @@ fn search_created_updated_at() {
 
 #[test]
 fn search_pagination_and_total_hits() {
-    let mut env = Environment::init(4025);
+    let mut env = Environment::init();
     env.grafbase_init();
     env.write_schema(SEARCH_SCHEMA);
     env.grafbase_dev();

--- a/cli/crates/cli/tests/unique.rs
+++ b/cli/crates/cli/tests/unique.rs
@@ -12,7 +12,7 @@ use utils::{client::Client, environment::Environment};
 #[test]
 #[allow(clippy::too_many_lines)]
 fn unique() {
-    let mut env = Environment::init(4003);
+    let mut env = Environment::init();
 
     env.grafbase_init();
 
@@ -194,7 +194,7 @@ pub const ACCOUNT_QUERY_PAGINATED: &str = include_str!("graphql/unique/multiple-
 
 #[test]
 fn unique_with_multiple_fields() {
-    let mut env = Environment::init(4021);
+    let mut env = Environment::init();
 
     env.grafbase_init();
 


### PR DESCRIPTION
# Description

This used the [fslock](https://docs.rs/fslock) package to synchronise the access to the counter.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
