### PR TITLE
GB-3463: Add a dummy x-api-key header for local playground

### DIFF
--- a/packages/standalone/src/App.tsx
+++ b/packages/standalone/src/App.tsx
@@ -8,6 +8,7 @@ function App() {
       <Playground
         logo={<></>}
         endpoint={(window as any).GRAPHQL_URL}
+        defaultHeaders={'{ "x-api-key": "" }'}
       ></Playground>
     </div>
   )


### PR DESCRIPTION
# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
