### PR TITLE
Downgrade cacache to 11.1.0 to get rid of the reflink dependency

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -121,6 +121,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,10 +469,11 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cacache"
-version = "11.5.2"
+version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61f9f035b98caee1c86f2283542474d8d9c24e7a527eeb69dae03c201c29090"
+checksum = "c0b0ef34f142c013684f51b4d427ca8afcd9107ebde2a6c7f6c7ae049d128d52"
 dependencies = [
+ "async-attributes",
  "async-std",
  "digest",
  "either",
@@ -470,7 +481,6 @@ dependencies = [
  "hex",
  "memmap2",
  "miette",
- "reflink",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2993,16 +3003,6 @@ dependencies = [
  "getrandom 0.2.8",
  "redox_syscall 0.2.16",
  "thiserror",
-]
-
-[[package]]
-name = "reflink"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc585ec28b565b4c28977ce8363a6636cedc280351ba25a7915f6c9f37f68cbe"
-dependencies = [
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
