### PR TITLE
Keep reloading on compilation errors

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -105,6 +105,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "ascii"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,6 +1585,7 @@ dependencies = [
  "serde_json",
  "slug",
  "sqlx",
+ "strip-ansi-escapes",
  "strum",
  "tantivy",
  "tempfile",
@@ -3654,6 +3661,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4328,6 +4344,27 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "waker-fn"

--- a/cli/crates/cli/src/dev.rs
+++ b/cli/crates/cli/src/dev.rs
@@ -45,6 +45,7 @@ pub fn dev(search: bool, watch: bool, external_port: Option<u16>, tracing: bool)
                         }) => {
                             report::resolver_message(&resolver_name, &message, level);
                         }
+                        Ok(ServerMessage::CompilationError(error)) => report::error(&CliError::CompilationError(error)),
                         Err(_) => break,
                     }
                 }

--- a/cli/crates/cli/src/errors.rs
+++ b/cli/crates/cli/src/errors.rs
@@ -41,6 +41,9 @@ pub enum CliError {
     /// returned if an account selected for linking a project has no projects
     #[error("the selected account has no projects")]
     AccountWithNoProjects,
+    /// returned if the schema parser failed to compile a file
+    #[error("{0}")]
+    CompilationError(String),
 }
 
 #[cfg(target_family = "windows")]

--- a/cli/crates/cli/tests/compilation_error.rs
+++ b/cli/crates/cli/tests/compilation_error.rs
@@ -4,31 +4,31 @@ use serde_json::Value;
 use utils::consts::{COMPILATION_ERROR_QUERY, COMPILATION_ERROR_SCHEMA, DEFAULT_QUERY, DEFAULT_SCHEMA};
 use utils::environment::Environment;
 
-#[tokio::test]
-async fn compilation_error() {
+#[test]
+fn compilation_error() {
     let mut env = Environment::init();
     env.grafbase_init();
     env.write_schema(COMPILATION_ERROR_SCHEMA);
     env.grafbase_dev_watch();
-    let mut client = env.create_async_client().with_api_key();
-    client.poll_endpoint(30, 300).await;
+    let mut client = env.create_client().with_api_key();
+    client.poll_endpoint(30, 300);
 
-    let response = client.gql::<Value>(COMPILATION_ERROR_QUERY).await;
+    let response = client.gql::<Value>(COMPILATION_ERROR_QUERY).send();
     let errors: Option<Vec<String>> = dot_get_opt!(response, "errors");
 
     assert_eq!(errors.map(|errors| !errors.is_empty()), Some(true));
 
-    let error_page = client.get_playground_html().await;
+    let error_page = client.get_playground_html();
 
     assert!(error_page.contains("Encountered a compilation error"));
 
     env.write_schema(DEFAULT_SCHEMA);
 
-    client.snapshot().await;
+    client.snapshot();
 
-    client.poll_endpoint_for_changes(30, 300).await;
+    client.poll_endpoint_for_changes(30, 300);
 
-    let response = client.gql::<Value>(DEFAULT_QUERY).await;
+    let response = client.gql::<Value>(DEFAULT_QUERY).send();
 
     let errors: Option<Vec<String>> = dot_get_opt!(response, "errors");
 

--- a/cli/crates/cli/tests/compilation_error.rs
+++ b/cli/crates/cli/tests/compilation_error.rs
@@ -54,8 +54,6 @@ fn compilation_error() {
 
     let response = client.gql::<Value>(COMPILATION_ERROR_RESOLVER_MUTATION).send();
 
-    dbg!(&response);
-
     let errors: Option<Vec<String>> = dot_get_opt!(response, "errors");
 
     assert_eq!(errors.map(|errors| !errors.is_empty()), Some(true));

--- a/cli/crates/cli/tests/compilation_error.rs
+++ b/cli/crates/cli/tests/compilation_error.rs
@@ -26,7 +26,6 @@ fn compilation_error() {
 
     let response = client.gql::<Value>(DEFAULT_QUERY).send();
 
-    dbg!(&response);
     let errors: Option<Vec<String>> = dot_get_opt!(response, "errors");
 
     assert!(errors.is_none());

--- a/cli/crates/cli/tests/compilation_error.rs
+++ b/cli/crates/cli/tests/compilation_error.rs
@@ -10,6 +10,7 @@ use utils::consts::{
 use utils::environment::Environment;
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore)]
 fn compilation_error() {
     let mut env = Environment::init();
     env.grafbase_init();

--- a/cli/crates/cli/tests/compilation_error.rs
+++ b/cli/crates/cli/tests/compilation_error.rs
@@ -1,0 +1,33 @@
+mod utils;
+
+use serde_json::Value;
+use utils::consts::{COMPILATION_ERROR_QUERY, COMPILATION_ERROR_SCHEMA, DEFAULT_QUERY, DEFAULT_SCHEMA};
+use utils::environment::Environment;
+
+#[test]
+fn compilation_error() {
+    let mut env = Environment::init();
+    env.grafbase_init();
+    env.write_schema(COMPILATION_ERROR_SCHEMA);
+    env.grafbase_dev_watch();
+    let mut client = env.create_client().with_api_key();
+    client.poll_endpoint(30, 300);
+
+    let response = client.gql::<Value>(COMPILATION_ERROR_QUERY).send();
+    let errors: Option<Vec<String>> = dot_get_opt!(response, "errors");
+
+    assert_eq!(errors.map(|errors| !errors.is_empty()), Some(true));
+
+    env.write_schema(DEFAULT_SCHEMA);
+
+    client.snapshot();
+
+    client.poll_endpoint_for_changes(30, 300);
+
+    let response = client.gql::<Value>(DEFAULT_QUERY).send();
+
+    dbg!(&response);
+    let errors: Option<Vec<String>> = dot_get_opt!(response, "errors");
+
+    assert!(errors.is_none());
+}

--- a/cli/crates/cli/tests/compilation_error.rs
+++ b/cli/crates/cli/tests/compilation_error.rs
@@ -22,9 +22,9 @@ fn compilation_error() {
 
     assert!(error_page.contains("Encountered a compilation error"));
 
-    env.write_schema(DEFAULT_SCHEMA);
-
     client.snapshot();
+
+    env.write_schema(DEFAULT_SCHEMA);
 
     client.poll_endpoint_for_changes(30, 300);
 

--- a/cli/crates/cli/tests/compilation_error.rs
+++ b/cli/crates/cli/tests/compilation_error.rs
@@ -4,27 +4,36 @@ use serde_json::Value;
 use utils::consts::{COMPILATION_ERROR_QUERY, COMPILATION_ERROR_SCHEMA, DEFAULT_QUERY, DEFAULT_SCHEMA};
 use utils::environment::Environment;
 
-#[test]
-fn compilation_error() {
+#[tokio::test]
+async fn compilation_error() {
     let mut env = Environment::init();
     env.grafbase_init();
     env.write_schema(COMPILATION_ERROR_SCHEMA);
     env.grafbase_dev_watch();
-    let mut client = env.create_client().with_api_key();
-    client.poll_endpoint(30, 300);
+    let mut client = env.create_async_client().with_api_key();
+    client.poll_endpoint(30, 300).await;
 
-    let response = client.gql::<Value>(COMPILATION_ERROR_QUERY).send();
+    let response = client.gql::<Value>(COMPILATION_ERROR_QUERY).await;
     let errors: Option<Vec<String>> = dot_get_opt!(response, "errors");
 
     assert_eq!(errors.map(|errors| !errors.is_empty()), Some(true));
 
+    let error_page = reqwest::get(format!("http://127.0.0.1:{}", env.port))
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    assert!(error_page.contains("Encountered a compilation error"));
+
     env.write_schema(DEFAULT_SCHEMA);
 
-    client.snapshot();
+    client.snapshot().await;
 
-    client.poll_endpoint_for_changes(30, 300);
+    client.poll_endpoint_for_changes(30, 300).await;
 
-    let response = client.gql::<Value>(DEFAULT_QUERY).send();
+    let response = client.gql::<Value>(DEFAULT_QUERY).await;
 
     let errors: Option<Vec<String>> = dot_get_opt!(response, "errors");
 

--- a/cli/crates/cli/tests/compilation_error.rs
+++ b/cli/crates/cli/tests/compilation_error.rs
@@ -61,4 +61,25 @@ fn compilation_error() {
     let error_page = client.get_playground_html();
 
     assert!(error_page.contains("Encountered a compilation error"));
+
+    client.snapshot();
+
+    env.write_resolver(
+        "return-title.js",
+        r#"
+            export default function Resolver({ parent, args, context, info }) {
+                return parent.title;
+            }
+        "#,
+    );
+
+    env.write_schema(COMPILATION_ERROR_RESOLVER_SCHEMA);
+
+    client.poll_endpoint_for_changes(30, 300);
+
+    let response = client.gql::<Value>(COMPILATION_ERROR_RESOLVER_MUTATION).send();
+
+    let errors: Option<Vec<String>> = dot_get_opt!(response, "errors");
+
+    assert!(errors.is_none());
 }

--- a/cli/crates/cli/tests/compilation_error.rs
+++ b/cli/crates/cli/tests/compilation_error.rs
@@ -1,9 +1,11 @@
 mod utils;
 
+use std::collections::HashMap;
+
 use serde_json::Value;
 use utils::consts::{
     COMPILATION_ERROR_QUERY, COMPILATION_ERROR_RESOLVER_MUTATION, COMPILATION_ERROR_RESOLVER_SCHEMA,
-    COMPILATION_ERROR_SCHEMA, DEFAULT_QUERY, DEFAULT_SCHEMA,
+    COMPILATION_ERROR_SCHEMA, DEFAULT_QUERY, DEFAULT_SCHEMA, ENVIRONMENT_SCHEMA,
 };
 use utils::environment::Environment;
 
@@ -82,4 +84,27 @@ fn compilation_error() {
     let errors: Option<Vec<String>> = dot_get_opt!(response, "errors");
 
     assert!(errors.is_none());
+
+    client.snapshot();
+
+    env.write_schema(ENVIRONMENT_SCHEMA);
+
+    client.poll_endpoint_for_changes(30, 300);
+
+    let error_page = client.get_playground_html();
+
+    assert!(error_page.contains("Encountered a compilation error"));
+
+    client.snapshot();
+
+    env.set_variables(HashMap::from([(
+        "ISSUER_URL".to_owned(),
+        "https://example.com".to_owned(),
+    )]));
+
+    client.poll_endpoint_for_changes(30, 300);
+
+    let error_page = client.get_playground_html();
+
+    assert!(!error_page.contains("Encountered a compilation error"));
 }

--- a/cli/crates/cli/tests/compilation_error.rs
+++ b/cli/crates/cli/tests/compilation_error.rs
@@ -18,12 +18,7 @@ async fn compilation_error() {
 
     assert_eq!(errors.map(|errors| !errors.is_empty()), Some(true));
 
-    let error_page = reqwest::get(format!("http://127.0.0.1:{}", env.port))
-        .await
-        .unwrap()
-        .text()
-        .await
-        .unwrap();
+    let error_page = client.get_playground_html().await;
 
     assert!(error_page.contains("Encountered a compilation error"));
 

--- a/cli/crates/cli/tests/compilation_error.rs
+++ b/cli/crates/cli/tests/compilation_error.rs
@@ -1,7 +1,10 @@
 mod utils;
 
 use serde_json::Value;
-use utils::consts::{COMPILATION_ERROR_QUERY, COMPILATION_ERROR_SCHEMA, DEFAULT_QUERY, DEFAULT_SCHEMA};
+use utils::consts::{
+    COMPILATION_ERROR_QUERY, COMPILATION_ERROR_RESOLVER_MUTATION, COMPILATION_ERROR_RESOLVER_SCHEMA,
+    COMPILATION_ERROR_SCHEMA, DEFAULT_QUERY, DEFAULT_SCHEMA,
+};
 use utils::environment::Environment;
 
 #[test]
@@ -33,4 +36,31 @@ fn compilation_error() {
     let errors: Option<Vec<String>> = dot_get_opt!(response, "errors");
 
     assert!(errors.is_none());
+
+    client.snapshot();
+
+    env.write_resolver(
+        "return-title.js",
+        r#"
+            export xyz {
+                return parent.title;
+            }
+        "#,
+    );
+
+    env.write_schema(COMPILATION_ERROR_RESOLVER_SCHEMA);
+
+    client.poll_endpoint_for_changes(30, 300);
+
+    let response = client.gql::<Value>(COMPILATION_ERROR_RESOLVER_MUTATION).send();
+
+    dbg!(&response);
+
+    let errors: Option<Vec<String>> = dot_get_opt!(response, "errors");
+
+    assert_eq!(errors.map(|errors| !errors.is_empty()), Some(true));
+
+    let error_page = client.get_playground_html();
+
+    assert!(error_page.contains("Encountered a compilation error"));
 }

--- a/cli/crates/cli/tests/environment_file.rs
+++ b/cli/crates/cli/tests/environment_file.rs
@@ -12,10 +12,6 @@ fn environment_file() {
 
     env.write_schema(ENVIRONMENT_SCHEMA);
 
-    let dev_output = env.grafbase_dev_output();
-
-    assert!(dev_output.is_err());
-
     env.set_variables(HashMap::from([(
         "ISSUER_URL".to_owned(),
         "https://example.com".to_owned(),

--- a/cli/crates/cli/tests/environment_process.rs
+++ b/cli/crates/cli/tests/environment_process.rs
@@ -11,10 +11,6 @@ fn environment_process() {
 
     env.write_schema(ENVIRONMENT_SCHEMA);
 
-    let dev_output = env.grafbase_dev_output();
-
-    assert!(dev_output.is_err());
-
     std::env::set_var("ISSUER_URL", "https://example.com");
 
     env.grafbase_dev();

--- a/cli/crates/cli/tests/graphql/compilation_error/query.graphql
+++ b/cli/crates/cli/tests/graphql/compilation_error/query.graphql
@@ -1,0 +1,9 @@
+query {
+  todoListCollection(first: 100) {
+    edges {
+      node {
+        id
+      }
+    }
+  }
+}

--- a/cli/crates/cli/tests/graphql/compilation_error/resolver-mutation.graphql
+++ b/cli/crates/cli/tests/graphql/compilation_error/resolver-mutation.graphql
@@ -1,0 +1,7 @@
+mutation {
+  postCreate(input: { title: "Hello" }) {
+    post {
+      id
+    }
+  }
+}

--- a/cli/crates/cli/tests/graphql/compilation_error/resolver-schema.graphql
+++ b/cli/crates/cli/tests/graphql/compilation_error/resolver-schema.graphql
@@ -1,0 +1,4 @@
+type Post @model {
+  title: String!
+  title2: String! @resolver(name: "return-title")
+}

--- a/cli/crates/cli/tests/graphql/compilation_error/schema.graphql
+++ b/cli/crates/cli/tests/graphql/compilation_error/schema.graphql
@@ -1,0 +1,1 @@
+type Xyz e

--- a/cli/crates/cli/tests/graphql/search/create-person.graphql
+++ b/cli/crates/cli/tests/graphql/search/create-person.graphql
@@ -1,5 +1,5 @@
 mutation CreatePerson($alive: Alive!, $favoritePet: Pet, $pets: [Pet!]) {
-  personCreate(input: {alive: $alive, favoritePet: $favoritePet, pets: $pets}) {
+  personCreate(input: { alive: $alive, favoritePet: $favoritePet, pets: $pets }) {
     person {
       id
     }

--- a/cli/crates/cli/tests/scalars.rs
+++ b/cli/crates/cli/tests/scalars.rs
@@ -83,7 +83,6 @@ fn scalars() {
             client.create_req(variables.clone()),
         ),
     ] {
-        dbg!(&response);
         assert_eq!(
             dot_get!(response, &format!("{prefix}.ip"), String),
             dot_get!(variables, "ip", String)

--- a/cli/crates/cli/tests/utils/async_client.rs
+++ b/cli/crates/cli/tests/utils/async_client.rs
@@ -13,15 +13,17 @@ use crate::utils::consts::INTROSPECTION_QUERY;
 
 pub struct AsyncClient {
     endpoint: String,
+    playground_endpoint: String,
     headers: HeaderMap,
     client: reqwest::Client,
     snapshot: Option<String>,
 }
 
 impl AsyncClient {
-    pub fn new(endpoint: String) -> Self {
+    pub fn new(endpoint: String, playground_endpoint: String) -> Self {
         Self {
             endpoint,
+            playground_endpoint,
             client: reqwest::Client::builder()
                 .connect_timeout(Duration::from_secs(1))
                 .timeout(Duration::from_secs(5))
@@ -132,6 +134,17 @@ impl AsyncClient {
             assert!(start.elapsed().unwrap().as_secs() < timeout_secs, "timeout");
             sleep(Duration::from_millis(interval_millis)).await;
         }
+    }
+
+    pub async fn get_playground_html(&self) -> String {
+        self.client
+            .get(&self.playground_endpoint)
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap()
     }
 }
 

--- a/cli/crates/cli/tests/utils/client.rs
+++ b/cli/crates/cli/tests/utils/client.rs
@@ -131,7 +131,7 @@ impl Client {
         }
     }
 
-    pub async fn get_playground_html(&self) -> String {
+    pub fn get_playground_html(&self) -> String {
         self.client
             .get(&self.playground_endpoint)
             .send()

--- a/cli/crates/cli/tests/utils/client.rs
+++ b/cli/crates/cli/tests/utils/client.rs
@@ -11,15 +11,17 @@ use crate::utils::consts::INTROSPECTION_QUERY;
 
 pub struct Client {
     endpoint: String,
+    playground_endpoint: String,
     headers: HeaderMap,
     client: reqwest::blocking::Client,
     snapshot: Option<String>,
 }
 
 impl Client {
-    pub fn new(endpoint: String) -> Self {
+    pub fn new(endpoint: String, playground_endpoint: String) -> Self {
         Self {
             endpoint,
+            playground_endpoint,
             headers: HeaderMap::new(),
             client: reqwest::blocking::Client::builder()
                 .connect_timeout(Duration::from_secs(1))
@@ -127,6 +129,15 @@ impl Client {
             assert!(start.elapsed().unwrap().as_secs() < timeout_secs, "timeout");
             sleep(Duration::from_millis(interval_millis));
         }
+    }
+
+    pub async fn get_playground_html(&self) -> String {
+        self.client
+            .get(&self.playground_endpoint)
+            .send()
+            .unwrap()
+            .text()
+            .unwrap()
     }
 }
 

--- a/cli/crates/cli/tests/utils/consts.rs
+++ b/cli/crates/cli/tests/utils/consts.rs
@@ -94,3 +94,6 @@ pub const OWNER_TWITTER_USER_CREATE: &str = include_str!("../graphql/owner/globa
 pub const OWNER_TWITTER_USER_GET_BY_ID: &str = include_str!("../graphql/owner/global/twitter/user-get-by-id.graphql");
 pub const OWNER_TWITTER_USER_GET_BY_EMAIL: &str =
     include_str!("../graphql/owner/global/twitter/user-get-by-email.graphql");
+
+pub const COMPILATION_ERROR_SCHEMA: &str = include_str!("../graphql/compilation_error/schema.graphql");
+pub const COMPILATION_ERROR_QUERY: &str = include_str!("../graphql/compilation_error/query.graphql");

--- a/cli/crates/cli/tests/utils/consts.rs
+++ b/cli/crates/cli/tests/utils/consts.rs
@@ -97,3 +97,7 @@ pub const OWNER_TWITTER_USER_GET_BY_EMAIL: &str =
 
 pub const COMPILATION_ERROR_SCHEMA: &str = include_str!("../graphql/compilation_error/schema.graphql");
 pub const COMPILATION_ERROR_QUERY: &str = include_str!("../graphql/compilation_error/query.graphql");
+pub const COMPILATION_ERROR_RESOLVER_SCHEMA: &str =
+    include_str!("../graphql/compilation_error/resolver-schema.graphql");
+pub const COMPILATION_ERROR_RESOLVER_MUTATION: &str =
+    include_str!("../graphql/compilation_error/resolver-mutation.graphql");

--- a/cli/crates/cli/tests/utils/environment.rs
+++ b/cli/crates/cli/tests/utils/environment.rs
@@ -13,10 +13,10 @@ use tempfile::{tempdir, TempDir};
 pub struct Environment {
     pub endpoint: String,
     pub directory: PathBuf,
+    pub port: u16,
     temp_dir: Arc<TempDir>,
     schema_path: PathBuf,
     commands: Vec<Handle>,
-    port: u16,
 }
 
 const DOT_ENV_FILE: &str = ".env";

--- a/cli/crates/cli/tests/utils/environment.rs
+++ b/cli/crates/cli/tests/utils/environment.rs
@@ -12,6 +12,7 @@ use tempfile::{tempdir, TempDir};
 
 pub struct Environment {
     pub endpoint: String,
+    pub playground_endpoint: String,
     pub directory: PathBuf,
     pub port: u16,
     temp_dir: Arc<TempDir>,
@@ -58,6 +59,7 @@ impl Environment {
             directory: temp_dir.path().to_owned(),
             commands: vec![],
             endpoint: format!("http://127.0.0.1:{port}/graphql"),
+            playground_endpoint: format!("http://127.0.0.1:{port}"),
             schema_path,
             temp_dir,
             port,
@@ -73,6 +75,7 @@ impl Environment {
             directory: other.directory.clone(),
             commands: vec![],
             endpoint: format!("http://127.0.0.1:{port}/graphql"),
+            playground_endpoint: format!("http://127.0.0.1:{port}"),
             schema_path: other.schema_path.clone(),
             temp_dir,
             port,
@@ -80,11 +83,11 @@ impl Environment {
     }
 
     pub fn create_client(&self) -> Client {
-        Client::new(self.endpoint.clone())
+        Client::new(self.endpoint.clone(), self.playground_endpoint.clone())
     }
 
     pub fn create_async_client(&self) -> AsyncClient {
-        AsyncClient::new(self.endpoint.clone())
+        AsyncClient::new(self.endpoint.clone(), self.playground_endpoint.clone())
     }
 
     pub fn write_schema(&self, schema: impl AsRef<str>) {

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/grafbase/grafbase"
 include = ["/src", "/assets"]
 
 [dependencies]
+strip-ansi-escapes = "0.1"
 anyhow = "1"
 axum = "0.6"
 async-trait = "0.1"

--- a/cli/crates/server/src/error_server.rs
+++ b/cli/crates/server/src/error_server.rs
@@ -1,0 +1,3 @@
+mod server;
+
+pub use server::start;

--- a/cli/crates/server/src/error_server/error-page.html
+++ b/cli/crates/server/src/error_server/error-page.html
@@ -1,0 +1,30 @@
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Compilation Error</title>
+        <style>
+            html {
+                font-family: BlinkMacSystemFont, "Segoe UI", "Ubuntu", "Helvetica Neue", sans-serif;
+            }
+            body {
+                margin: 0;
+            }
+            .header {
+                color: #BF3135;
+                margin-left: 10px;
+                margin-top: 10px;
+            }
+            .error-contents {
+                background: #FBF3F4; 
+                margin-left: 10px;
+                margin-right: 10px;
+                padding: 10px;
+            }
+        </style>
+    </head>
+    <body>
+        <h2 class="header">Encountered a compilation error</h2>
+        <pre class="error-contents">{{error}}</pre>
+    </body>
+</html>

--- a/cli/crates/server/src/error_server/error-page.html
+++ b/cli/crates/server/src/error_server/error-page.html
@@ -1,30 +1,30 @@
 <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Compilation Error</title>
-        <style>
-            html {
-                font-family: BlinkMacSystemFont, "Segoe UI", "Ubuntu", "Helvetica Neue", sans-serif;
-            }
-            body {
-                margin: 0;
-            }
-            .header {
-                color: #BF3135;
-                margin-left: 10px;
-                margin-top: 10px;
-            }
-            .error-contents {
-                background: #FBF3F4; 
-                margin-left: 10px;
-                margin-right: 10px;
-                padding: 10px;
-            }
-        </style>
-    </head>
-    <body>
-        <h2 class="header">Encountered a compilation error</h2>
-        <pre class="error-contents">{{error}}</pre>
-    </body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Compilation Error</title>
+    <style>
+      html {
+        font-family: BlinkMacSystemFont, 'Segoe UI', 'Ubuntu', 'Helvetica Neue', sans-serif;
+      }
+      body {
+        margin: 0;
+      }
+      .header {
+        color: #bf3135;
+        margin-left: 10px;
+        margin-top: 10px;
+      }
+      .error-contents {
+        background: #fbf3f4;
+        margin-left: 10px;
+        margin-right: 10px;
+        padding: 10px;
+      }
+    </style>
+  </head>
+  <body>
+    <h2 class="header">Encountered a compilation error</h2>
+    <pre class="error-contents">{{error}}</pre>
+  </body>
 </html>

--- a/cli/crates/server/src/error_server/server.rs
+++ b/cli/crates/server/src/error_server/server.rs
@@ -12,18 +12,18 @@ use serde_json::{json, Value};
 use std::net::{Ipv4Addr, SocketAddr};
 use tower_http::trace::TraceLayer;
 
+#[allow(clippy::unused_async)]
 async fn playground(State(error): State<String>) -> Html<String> {
-    let document = include_str!("./error-page.html")
-        .replace("{{error}}", &error)
-        .to_owned();
+    let document = include_str!("./error-page.html").replace("{{error}}", &error);
 
     Html(document)
 }
 
+#[allow(clippy::unused_async)]
 async fn endpoint(State(error): State<String>) -> Json<Value> {
     let document = json!(
         {
-            "data": Value::Null,
+            "data": null,
             "errors": [error]
         }
     );

--- a/cli/crates/server/src/error_server/server.rs
+++ b/cli/crates/server/src/error_server/server.rs
@@ -14,7 +14,7 @@ use tower_http::trace::TraceLayer;
 
 #[allow(clippy::unused_async)]
 async fn playground(State(error): State<String>) -> Html<String> {
-    let document = include_str!("./error-page.html").replace("{{error}}", &error);
+    let document = include_str!("error-page.html").replace("{{error}}", &error);
 
     Html(document)
 }

--- a/cli/crates/server/src/error_server/server.rs
+++ b/cli/crates/server/src/error_server/server.rs
@@ -1,0 +1,59 @@
+use crate::{
+    errors::ServerError,
+    event::{wait_for_event, Event},
+};
+use axum::{
+    extract::State,
+    response::Html,
+    routing::{get, post},
+    Json, Router,
+};
+use serde_json::{json, Value};
+use std::net::{Ipv4Addr, SocketAddr};
+use tower_http::trace::TraceLayer;
+
+async fn playground(State(error): State<String>) -> Html<String> {
+    let document = include_str!("./error-page.html")
+        .replace("{{error}}", &error)
+        .to_owned();
+
+    Html(document)
+}
+
+async fn endpoint(State(error): State<String>) -> Json<Value> {
+    let document = json!(
+        {
+            "data": Value::Null,
+            "errors": [error]
+        }
+    );
+
+    Json(document)
+}
+
+pub async fn start(
+    port: u16,
+    error: String,
+    event_bus: tokio::sync::broadcast::Sender<Event>,
+) -> Result<(), ServerError> {
+    trace!("starting error server at port {port}");
+
+    let router = Router::new()
+        .route("/", get(playground))
+        .route("/graphql", post(endpoint))
+        .route("/graphql", get(endpoint))
+        .with_state(error)
+        .layer(TraceLayer::new_for_http());
+
+    let socket_address = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+
+    let server = axum::Server::bind(&socket_address)
+        .serve(router.into_make_service())
+        .with_graceful_shutdown(wait_for_event(event_bus.subscribe(), |event| {
+            matches!(event, Event::Reload(_, _))
+        }));
+
+    server.await?;
+
+    Ok(())
+}

--- a/cli/crates/server/src/event.rs
+++ b/cli/crates/server/src/event.rs
@@ -1,8 +1,6 @@
-use std::path::PathBuf;
-
-use tokio::sync::broadcast::Receiver;
-
 use crate::file_watcher::FileEventType;
+use std::path::PathBuf;
+use tokio::sync::broadcast::Receiver;
 
 /// server lifecycle related events
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/cli/crates/server/src/file_watcher.rs
+++ b/cli/crates/server/src/file_watcher.rs
@@ -15,7 +15,7 @@ pub enum FileEventType {
     Changed,
 }
 
-/// watches a file for write events, running a callback on each write
+/// watches a path for file system events, running a callback on each write
 pub async fn start_watcher<P, T>(path: P, on_write: T) -> Result<(), ServerError>
 where
     P: AsRef<Path> + Send + 'static,

--- a/cli/crates/server/src/file_watcher.rs
+++ b/cli/crates/server/src/file_watcher.rs
@@ -16,7 +16,7 @@ pub enum FileEventType {
 }
 
 /// watches a file for write events, running a callback on each write
-pub async fn start_watcher<P, T>(file: P, on_write: T) -> Result<(), ServerError>
+pub async fn start_watcher<P, T>(path: P, on_write: T) -> Result<(), ServerError>
 where
     P: AsRef<Path> + Send + 'static,
     T: Fn(PathBuf, FileEventType) + Send + 'static,
@@ -24,7 +24,7 @@ where
     let (notify_sender, notify_receiver) = mpsc::channel();
 
     let mut watcher: RecommendedWatcher = Watcher::new(notify_sender, FILE_WATCHER_INTERVAL)?;
-    watcher.watch(&file, RecursiveMode::Recursive)?;
+    watcher.watch(&path, RecursiveMode::Recursive)?;
 
     tokio::task::spawn_blocking(move || -> Result<(), ServerError> {
         loop {

--- a/cli/crates/server/src/lib.rs
+++ b/cli/crates/server/src/lib.rs
@@ -25,6 +25,7 @@ mod bridge;
 mod consts;
 mod custom_resolvers;
 mod environment;
+mod error_server;
 mod event;
 mod file_watcher;
 mod servers;

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -147,8 +147,7 @@ async fn spawn_servers(
                 .ok()
                 .and_then(|stripped| String::from_utf8(stripped).ok())
                 .unwrap_or(error.to_string());
-            tokio::spawn(async move { error_server::start(worker_port, error.to_string(), bridge_event_bus).await })
-                .await??;
+            tokio::spawn(async move { error_server::start(worker_port, error, bridge_event_bus).await }).await??;
             return Ok(());
         }
     };

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -141,6 +141,9 @@ async fn spawn_servers(
         Ok(resolver_paths) => resolver_paths,
         Err(error) => {
             let _ = sender.send(ServerMessage::CompilationError(error.to_string()));
+            let error_byte_vec = error.to_string().as_bytes().to_vec();
+            let error = String::from_utf8(strip_ansi_escapes::strip(&error_byte_vec).unwrap_or(error_byte_vec))
+                .expect("must parse");
             tokio::spawn(async move { error_server::start(worker_port, error.to_string(), bridge_event_bus).await })
                 .await??;
             return Ok(());

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -143,7 +143,9 @@ async fn spawn_servers(
             let _ = sender.send(ServerMessage::CompilationError(error.to_string()));
             // TODO consider disabling colored output from wrangler
             let error_byte_vec = error.to_string().as_bytes().to_vec();
-            let error = String::from_utf8(strip_ansi_escapes::strip(&error_byte_vec).unwrap_or(error_byte_vec))
+            let error = strip_ansi_escapes::strip(&error_byte_vec)
+                .ok()
+                .and_then(|stripped| String::from_utf8(stripped).ok())
                 .unwrap_or(error.to_string());
             tokio::spawn(async move { error_server::start(worker_port, error.to_string(), bridge_event_bus).await })
                 .await??;

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -141,7 +141,7 @@ async fn spawn_servers(
         Ok(resolver_paths) => resolver_paths,
         Err(error) => {
             let _ = sender.send(ServerMessage::CompilationError(error.to_string()));
-            // TODO disable colored output from wrangler
+            // TODO consider disabling colored output from wrangler
             let error_byte_vec = error.to_string().as_bytes().to_vec();
             let error = String::from_utf8(strip_ansi_escapes::strip(&error_byte_vec).unwrap_or(error_byte_vec))
                 .expect("must parse");

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -2,6 +2,7 @@ use crate::consts::{
     ASSET_VERSION_FILE, GIT_IGNORE_CONTENTS, GIT_IGNORE_FILE, MIN_NODE_VERSION, SCHEMA_PARSER_DIR, SCHEMA_PARSER_INDEX,
 };
 use crate::custom_resolvers::build_resolvers;
+use crate::error_server;
 use crate::event::{wait_for_event, wait_for_event_and_match, Event};
 use crate::file_watcher::start_watcher;
 use crate::types::{Assets, ServerMessage};
@@ -98,7 +99,7 @@ async fn server_loop(
             }
             (path, file_event_type) = wait_for_event_and_match(receiver, |event| match event {
                 Event::Reload(path, file_event_type) => Some((path, file_event_type)),
-                Event::BridgeReady => None
+                Event::BridgeReady => None,
             }) => {
                 trace!("reload");
                 let _ = sender.send(ServerMessage::Reload(path, file_event_type));
@@ -124,7 +125,15 @@ async fn spawn_servers(
 
     let environment_variables: std::collections::HashMap<_, _> = crate::environment::variables().collect();
 
-    let resolvers = run_schema_parser(&environment_variables).await?;
+    let resolvers = match run_schema_parser(&environment_variables).await {
+        Ok(resolvers) => resolvers,
+        Err(error) => {
+            let _ = sender.send(ServerMessage::CompilationError(error.to_string()));
+            tokio::spawn(async move { error_server::start(worker_port, error.to_string(), bridge_event_bus).await })
+                .await??;
+            return Ok(());
+        }
+    };
     let environment = Environment::get();
 
     let resolver_paths = build_resolvers(&sender, environment, &environment_variables, resolvers, tracing).await?;

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -141,6 +141,7 @@ async fn spawn_servers(
         Ok(resolver_paths) => resolver_paths,
         Err(error) => {
             let _ = sender.send(ServerMessage::CompilationError(error.to_string()));
+            // TODO disable colored output from wrangler
             let error_byte_vec = error.to_string().as_bytes().to_vec();
             let error = String::from_utf8(strip_ansi_escapes::strip(&error_byte_vec).unwrap_or(error_byte_vec))
                 .expect("must parse");

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -144,7 +144,7 @@ async fn spawn_servers(
             // TODO consider disabling colored output from wrangler
             let error_byte_vec = error.to_string().as_bytes().to_vec();
             let error = String::from_utf8(strip_ansi_escapes::strip(&error_byte_vec).unwrap_or(error_byte_vec))
-                .expect("must parse");
+                .unwrap_or(error.to_string());
             tokio::spawn(async move { error_server::start(worker_port, error.to_string(), bridge_event_bus).await })
                 .await??;
             return Ok(());

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -142,11 +142,10 @@ async fn spawn_servers(
         Err(error) => {
             let _ = sender.send(ServerMessage::CompilationError(error.to_string()));
             // TODO consider disabling colored output from wrangler
-            let error_byte_vec = error.to_string().as_bytes().to_vec();
-            let error = strip_ansi_escapes::strip(&error_byte_vec)
+            let error = strip_ansi_escapes::strip(error.to_string().as_bytes())
                 .ok()
                 .and_then(|stripped| String::from_utf8(stripped).ok())
-                .unwrap_or(error.to_string());
+                .unwrap_or_else(|| error.to_string());
             tokio::spawn(async move { error_server::start(worker_port, error, bridge_event_bus).await }).await??;
             return Ok(());
         }

--- a/cli/crates/server/src/types.rs
+++ b/cli/crates/server/src/types.rs
@@ -1,10 +1,7 @@
-use std::path::PathBuf;
-
-use rust_embed::RustEmbed;
-
-use common::types::ResolverMessageLevel;
-
 pub use crate::file_watcher::FileEventType;
+use common::types::ResolverMessageLevel;
+use rust_embed::RustEmbed;
+use std::path::PathBuf;
 
 #[derive(RustEmbed)]
 #[folder = "assets/"]
@@ -24,4 +21,5 @@ pub enum ServerMessage {
         level: ResolverMessageLevel,
         message: String,
     },
+    CompilationError(String),
 }


### PR DESCRIPTION
# Description

## Features

- Continues the reload cycle on compilation errors, displays an error page instead of the playground and a GQL response instead of the endpoint containing the error

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
