### PR TITLE
GB-3487: Inject `request` into `context` with a `headers` field

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   GRAFBASE_SKIP_ASSET_VERSION_CHECK: 'true'
-  ASSETS_VERSION: 'release/8c6850e-2023-04-07'
+  ASSETS_VERSION: 'release/d93094f-2023-04-08'
   PROD_ASSETS: assets.grafbase.com
   CARGO_TERM_COLOR: 'always'
 

--- a/cli/crates/cli/tests/snapshots/custom_resolvers__field_resolver_7_1.snap
+++ b/cli/crates/cli/tests/snapshots/custom_resolvers__field_resolver_7_1.snap
@@ -1,0 +1,5 @@
+---
+source: crates/cli/tests/custom_resolvers.rs
+expression: value
+---
+test-value

--- a/cli/crates/cli/tests/utils/client.rs
+++ b/cli/crates/cli/tests/utils/client.rs
@@ -167,7 +167,13 @@ impl<Response> GqlRequestBuilder<Response> {
             variables,
         } = self;
         reqwest_builder = reqwest_builder.header(name, value);
-        Self { query, variables, phantom, reqwest_builder, bearer }
+        Self {
+            query,
+            variables,
+            phantom,
+            reqwest_builder,
+            bearer,
+        }
     }
 
     pub fn send(self) -> Response

--- a/cli/crates/cli/tests/utils/client.rs
+++ b/cli/crates/cli/tests/utils/client.rs
@@ -158,6 +158,24 @@ impl<Response> GqlRequestBuilder<Response> {
         self
     }
 
+    pub fn header(self, name: &str, value: &str) -> Self {
+        let Self {
+            bearer,
+            phantom,
+            query,
+            mut reqwest_builder,
+            variables,
+        } = self;
+        reqwest_builder = reqwest_builder.header(name, value);
+        Self {
+            bearer,
+            phantom,
+            query,
+            reqwest_builder,
+            variables,
+        }
+    }
+
     pub fn send(self) -> Response
     where
         Response: for<'de> serde::de::Deserialize<'de>,

--- a/cli/crates/cli/tests/utils/client.rs
+++ b/cli/crates/cli/tests/utils/client.rs
@@ -167,13 +167,7 @@ impl<Response> GqlRequestBuilder<Response> {
             variables,
         } = self;
         reqwest_builder = reqwest_builder.header(name, value);
-        Self {
-            bearer,
-            phantom,
-            query,
-            reqwest_builder,
-            variables,
-        }
+        Self { query, variables, phantom, reqwest_builder, bearer }
     }
 
     pub fn send(self) -> Response


### PR DESCRIPTION
# Description

Exposes `{ request { headers } }` as the third argument to resolvers.

# Type of change

- [ ] 💔 Breaking
- [X] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
