### PR TITLE
GB-3507: Add a short circuit to avoid resolvers getting rebuilt if only the schema.graphql file changes

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1569,6 +1569,7 @@ dependencies = [
  "combine 4.6.6",
  "dotenv",
  "exitcode",
+ "filetime",
  "futures-util",
  "grafbase-local-common",
  "hyper",

--- a/cli/crates/backend/src/api/consts.rs
+++ b/cli/crates/backend/src/api/consts.rs
@@ -3,5 +3,4 @@ pub const PROJECT_METADATA_FILE: &str = "project.json";
 pub const AUTH_URL: &str = "https://grafbase.com/auth/cli";
 pub const API_URL: &str = "https://api.grafbase.com/graphql";
 pub const PACKAGE_JSON: &str = "package.json";
-pub const GRAFBASE_DIR_NAME: &str = "grafbase";
 pub const TAR_CONTENT_TYPE: &str = "application/x-tar";

--- a/cli/crates/backend/src/api/deploy.rs
+++ b/cli/crates/backend/src/api/deploy.rs
@@ -1,5 +1,5 @@
 use super::client::create_client;
-use super::consts::{API_URL, GRAFBASE_DIR_NAME, PACKAGE_JSON, PROJECT_METADATA_FILE, TAR_CONTENT_TYPE};
+use super::consts::{API_URL, PACKAGE_JSON, PROJECT_METADATA_FILE, TAR_CONTENT_TYPE};
 use super::errors::{ApiError, DeployError};
 use super::graphql::mutations::{
     ArchiveFileSizeLimitExceededError, DailyDeploymentCountLimitExceededError, DeploymentCreate,
@@ -7,6 +7,7 @@ use super::graphql::mutations::{
 };
 use super::types::ProjectMetadata;
 use crate::consts::USER_AGENT;
+use common::consts::GRAFBASE_DIRECTORY_NAME;
 use common::environment::Environment;
 use cynic::http::ReqwestExt;
 use cynic::{Id, MutationBuilder};
@@ -52,7 +53,7 @@ pub async fn deploy() -> Result<(), ApiError> {
             .map_err(ApiError::AppendToArchive)?;
     }
 
-    tar.append_dir_all(GRAFBASE_DIR_NAME, &environment.project_grafbase_path)
+    tar.append_dir_all(GRAFBASE_DIRECTORY_NAME, &environment.project_grafbase_path)
         .await
         .map_err(ApiError::AppendToArchive)?;
 

--- a/cli/crates/backend/src/project.rs
+++ b/cli/crates/backend/src/project.rs
@@ -2,7 +2,7 @@ use crate::consts::{DEFAULT_SCHEMA, USER_AGENT};
 use crate::errors::BackendError;
 use async_compression::tokio::bufread::GzipDecoder;
 use async_tar::Archive;
-use common::consts::{GRAFBASE_DIRECTORY, GRAFBASE_SCHEMA};
+use common::consts::{GRAFBASE_DIRECTORY_NAME, GRAFBASE_SCHEMA_FILE_NAME};
 use common::environment::Environment;
 use http_cache_reqwest::{CACacheManager, Cache, CacheMode, HttpCache};
 use reqwest::{header, Client};
@@ -62,8 +62,8 @@ use url::Url;
 #[tokio::main]
 pub async fn init(name: Option<&str>, template: Option<&str>) -> Result<(), BackendError> {
     let project_path = to_project_path(name)?;
-    let grafbase_path = project_path.join(GRAFBASE_DIRECTORY);
-    let schema_path = grafbase_path.join(GRAFBASE_SCHEMA);
+    let grafbase_path = project_path.join(GRAFBASE_DIRECTORY_NAME);
+    let schema_path = grafbase_path.join(GRAFBASE_SCHEMA_FILE_NAME);
 
     if grafbase_path.exists() {
         Err(BackendError::AlreadyAProject(grafbase_path))

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use backend::types::FileEventType;
 use colored::Colorize;
-use common::consts::LOCALHOST;
+use common::consts::{GRAFBASE_DIRECTORY_NAME, GRAFBASE_SCHEMA_FILE_NAME, LOCALHOST};
 use common::types::ResolverMessageLevel;
 
 /// reports to stdout that the server has started
@@ -45,7 +45,7 @@ pub fn project_created(name: Option<&str>) {
     if let Some(name) = name {
         watercolor::output!(r#"✨ {name} was successfully initialized!"#, @BrightBlue);
 
-        let schema_path = &[".", name, "grafbase", "schema.graphql"].join(&slash);
+        let schema_path = &[".", name, GRAFBASE_DIRECTORY_NAME, GRAFBASE_SCHEMA_FILE_NAME].join(&slash);
 
         println!(
             "The schema for your new project can be found at {}",
@@ -54,7 +54,7 @@ pub fn project_created(name: Option<&str>) {
     } else {
         watercolor::output!(r#"✨ Your project was successfully set up for Grafbase!"#, @BrightBlue);
 
-        let schema_path = &[".", "grafbase", "schema.graphql"].join(&slash);
+        let schema_path = &[".", GRAFBASE_DIRECTORY_NAME, GRAFBASE_SCHEMA_FILE_NAME].join(&slash);
 
         println!(
             "Your new schema can be found at {}",

--- a/cli/crates/cli/tests/utils/environment.rs
+++ b/cli/crates/cli/tests/utils/environment.rs
@@ -3,6 +3,7 @@
 use super::async_client::AsyncClient;
 use super::kill_with_children::kill_with_children;
 use super::{cargo_bin::cargo_bin, client::Client};
+use common::consts::{GRAFBASE_DIRECTORY_NAME, GRAFBASE_SCHEMA_FILE_NAME};
 use duct::{cmd, Handle};
 use std::io;
 use std::process::Output;
@@ -53,7 +54,10 @@ impl Environment {
         let temp_dir = Arc::new(tempdir().unwrap());
         env::set_current_dir(temp_dir.path()).unwrap();
 
-        let schema_path = temp_dir.path().join("grafbase").join("schema.graphql");
+        let schema_path = temp_dir
+            .path()
+            .join(GRAFBASE_DIRECTORY_NAME)
+            .join(GRAFBASE_SCHEMA_FILE_NAME);
 
         Self {
             directory: temp_dir.path().to_owned(),

--- a/cli/crates/common/src/consts.rs
+++ b/cli/crates/common/src/consts.rs
@@ -7,9 +7,9 @@ pub const MAX_PORT: u16 = u16::MAX;
 /// localhost IP
 pub const LOCALHOST: &str = "127.0.0.1";
 /// the name of the directory indicating a grafbase project
-pub const GRAFBASE_DIRECTORY: &str = "grafbase";
+pub const GRAFBASE_DIRECTORY_NAME: &str = "grafbase";
 /// a file expected to be in the grafbase directory
-pub const GRAFBASE_SCHEMA: &str = "schema.graphql";
+pub const GRAFBASE_SCHEMA_FILE_NAME: &str = "schema.graphql";
 /// the name for the db / cache directory per project and the global cache directory for the user
 pub const DOT_GRAFBASE_DIRECTORY: &str = ".grafbase";
 /// the registry.json file generated from schema.graphql

--- a/cli/crates/common/src/environment.rs
+++ b/cli/crates/common/src/environment.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     consts::{
-        DATABASE_DIRECTORY, DOT_GRAFBASE_DIRECTORY, GRAFBASE_DIRECTORY, GRAFBASE_SCHEMA, REGISTRY_FILE,
+        DATABASE_DIRECTORY, DOT_GRAFBASE_DIRECTORY, GRAFBASE_DIRECTORY_NAME, GRAFBASE_SCHEMA_FILE_NAME, REGISTRY_FILE,
         RESOLVERS_DIRECTORY_NAME,
     },
     errors::CommonError,
@@ -125,8 +125,8 @@ impl Environment {
 
                 // if we're looking at a directory called `grafbase`, also check for the schema in the current directory
                 if let Some(first) = path.components().next() {
-                    if Path::new(&first) == PathBuf::from(GRAFBASE_DIRECTORY) {
-                        path.push(GRAFBASE_SCHEMA);
+                    if Path::new(&first) == PathBuf::from(GRAFBASE_DIRECTORY_NAME) {
+                        path.push(GRAFBASE_SCHEMA_FILE_NAME);
                         if path.is_file() {
                             return Some(path);
                         }
@@ -134,7 +134,11 @@ impl Environment {
                     }
                 }
 
-                path.push([GRAFBASE_DIRECTORY, GRAFBASE_SCHEMA].iter().collect::<PathBuf>());
+                path.push(
+                    [GRAFBASE_DIRECTORY_NAME, GRAFBASE_SCHEMA_FILE_NAME]
+                        .iter()
+                        .collect::<PathBuf>(),
+                );
 
                 if path.is_file() {
                     Some(path)

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -11,19 +11,19 @@ repository = "https://github.com/grafbase/grafbase"
 include = ["/src", "/assets"]
 
 [dependencies]
-strip-ansi-escapes = "0.1"
 anyhow = "1"
-axum = "0.6"
 async-trait = "0.1"
+axum = "0.6"
 base64 = "0.21"
 chrono = { version = "0.4", features = ["serde"] }
 combine = "4"
 dotenv = "0.15"
 exitcode = "1"
+filetime = "0.2"
 futures-util = "0.3"
 hyper = "0.14"
-ipnet = "2"
 integer-encoding = "3"
+ipnet = "2"
 itertools = "0.10"
 log = "0.4"
 notify = "4"
@@ -42,9 +42,10 @@ sqlx = { version = "0.6", features = [
   "sqlite",
   "json",
 ] }
+strip-ansi-escapes = "0.1"
 strum = { version = "0.24", features = ["derive"] }
-tempfile = "3"
 tantivy = "0.19"
+tempfile = "3"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.4", features = ["trace"] }

--- a/cli/crates/server/src/custom_resolvers.rs
+++ b/cli/crates/server/src/custom_resolvers.rs
@@ -294,7 +294,7 @@ pub async fn build_resolvers(
                     let wrangler_toml_path = resolver_build_artifact_directory_path.join("wrangler.toml");
                     // Only touch the file to ensure the modified time relation is preserved.
                     tokio::task::spawn_blocking(|| {
-                        filetime::set_file_mtime(wrangler_toml_path, filetime::FileTime::now()).expect("must succeed")
+                        filetime::set_file_mtime(wrangler_toml_path, filetime::FileTime::now()).expect("must succeed");
                     })
                     .await
                     .expect("must succeed");

--- a/cli/crates/server/src/custom_resolvers.rs
+++ b/cli/crates/server/src/custom_resolvers.rs
@@ -75,7 +75,6 @@ async fn build_resolver(
 
     trace!("building resolver {resolver_name}");
 
-    let resolvers_build_artifact_directory_path = environment.resolvers_build_artifact_path.as_path();
     let resolver_input_file_path_without_extension = environment.resolvers_source_path.join(resolver_name);
 
     let resolver_paths = futures_util::stream::iter(
@@ -178,7 +177,7 @@ async fn build_resolver(
     // FIXME: Swap out for the internal logic that wrangler effectively uses under the hood.
     run_npm_command(
         CommandType::Npx,
-        resolvers_build_artifact_directory_path,
+        resolver_build_artifact_directory_path,
         &[
             "wrangler",
             "publish",

--- a/cli/crates/server/src/custom_resolvers.rs
+++ b/cli/crates/server/src/custom_resolvers.rs
@@ -189,7 +189,11 @@ async fn build_resolver(
             resolver_build_entrypoint_path.to_str().expect("must be valid utf-8"),
         ],
         tracing,
-        &[("FORCE_COLOR", "0"), ("CLOUDFLARE_API_TOKEN", "STUB")],
+        &[
+            ("CLOUDFLARE_API_TOKEN", "STUB"),
+            ("FORCE_COLOR", "0"),
+            ("WRANGLER_SEND_METRICS", "false"),
+        ],
     )
     .await
     .map_err(|err| match err {

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -7,7 +7,7 @@ use crate::event::{wait_for_event, wait_for_event_and_match, Event};
 use crate::file_watcher::start_watcher;
 use crate::types::{Assets, ServerMessage};
 use crate::{bridge, errors::ServerError};
-use common::consts::EPHEMERAL_PORT_RANGE;
+use common::consts::{EPHEMERAL_PORT_RANGE, GRAFBASE_DIRECTORY_NAME, GRAFBASE_SCHEMA_FILE_NAME};
 use common::environment::Environment;
 use common::types::LocalAddressType;
 use common::utils::find_available_port_in_range;
@@ -147,7 +147,7 @@ async fn spawn_servers(
     // For this logic to become more fine-grained we would need to have an understanding of the module dependency graph
     // in resolvers, and that's a non-trivial problem.
     if !path_changed
-        .map(|path| path == Path::new("grafbase/schema.graphql"))
+        .map(|path| path == Path::new(GRAFBASE_DIRECTORY_NAME).join(GRAFBASE_SCHEMA_FILE_NAME))
         .unwrap_or_default()
     {
         for resolver in &mut resolvers {

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -14,6 +14,7 @@ use common::utils::find_available_port_in_range;
 use futures_util::FutureExt;
 
 use std::env;
+use std::path::Path;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::{
     fs,
@@ -75,7 +76,7 @@ pub fn start(port: u16, watch: bool, tracing: bool) -> (JoinHandle<Result<(), Se
                         result = server_loop(port, bridge_port, watch, sender, event_bus.clone(), tracing) => { result }
                     }
                 } else {
-                    Ok(spawn_servers(port, bridge_port, watch, sender, event_bus, tracing).await?)
+                    Ok(spawn_servers(port, bridge_port, watch, sender, event_bus, None, tracing).await?)
                 }
             })
     });
@@ -91,10 +92,11 @@ async fn server_loop(
     event_bus: broadcast::Sender<Event>,
     tracing: bool,
 ) -> Result<(), ServerError> {
+    let mut path_changed = None;
     loop {
         let receiver = event_bus.subscribe();
         tokio::select! {
-            result = spawn_servers(worker_port, bridge_port, watch, sender.clone(), event_bus.clone(), tracing) => {
+            result = spawn_servers(worker_port, bridge_port, watch, sender.clone(), event_bus.clone(), path_changed.as_deref(), tracing) => {
                 result?;
             }
             (path, file_event_type) = wait_for_event_and_match(receiver, |event| match event {
@@ -102,6 +104,7 @@ async fn server_loop(
                 Event::BridgeReady => None,
             }) => {
                 trace!("reload");
+                path_changed = Some(path.clone());
                 let _ = sender.send(ServerMessage::Reload(path, file_event_type));
             }
         }
@@ -115,6 +118,7 @@ async fn spawn_servers(
     watch: bool,
     sender: Sender<ServerMessage>,
     event_bus: broadcast::Sender<Event>,
+    path_changed: Option<&Path>,
     tracing: bool,
 ) -> Result<(), ServerError> {
     let bridge_event_bus = event_bus.clone();
@@ -125,7 +129,7 @@ async fn spawn_servers(
 
     let environment_variables: std::collections::HashMap<_, _> = crate::environment::variables().collect();
 
-    let resolvers = match run_schema_parser(&environment_variables).await {
+    let mut resolvers = match run_schema_parser(&environment_variables).await {
         Ok(resolvers) => resolvers,
         Err(error) => {
             let _ = sender.send(ServerMessage::CompilationError(error.to_string()));
@@ -134,6 +138,22 @@ async fn spawn_servers(
             return Ok(());
         }
     };
+
+    // If the rebuild has been triggered by a change in the schema file, we can honour the freshness of resolvers
+    // determined by inspecting the modified time of final artifacts of detected resolvers compared to the modified time
+    // of the generated schema registry file.
+    // Otherwise, we trigger a rebuild all resolvers. That, individually, will still more often than not be very quick
+    // because the build naturally reuses the intermediate artifacts from node_modules from previous builds.
+    // For this logic to become more fine-grained we would need to have an understanding of the module dependency graph
+    // in resolvers, and that's a non-trivial problem.
+    if !path_changed
+        .map(|path| path == Path::new("grafbase/schema.graphql"))
+        .unwrap_or_default()
+    {
+        for resolver in &mut resolvers {
+            resolver.fresh = false;
+        }
+    }
 
     let environment = Environment::get();
 
@@ -327,11 +347,16 @@ struct SchemaParserResult {
     versioned_registry: serde_json::Value,
 }
 
+pub struct DetectedResolver {
+    pub resolver_name: String,
+    pub fresh: bool,
+}
+
 // schema-parser is run via NodeJS due to it being built to run in a Wasm (via wasm-bindgen) environement
 // and due to schema-parser not being open source
 async fn run_schema_parser(
     environment_variables: &std::collections::HashMap<String, String>,
-) -> Result<Vec<String>, ServerError> {
+) -> Result<Vec<DetectedResolver>, ServerError> {
     trace!("parsing schema");
 
     let environment = Environment::get();
@@ -389,18 +414,44 @@ async fn run_schema_parser(
     let parser_result_string = tokio::fs::read_to_string(&parser_result_path)
         .await
         .map_err(ServerError::SchemaParserResultRead)?;
-    let parser_result: SchemaParserResult =
-        serde_json::from_str(&parser_result_string).map_err(ServerError::SchemaParserResultJson)?;
+    let SchemaParserResult {
+        versioned_registry,
+        required_resolvers,
+    } = serde_json::from_str(&parser_result_string).map_err(ServerError::SchemaParserResultJson)?;
+
+    let registry_mtime = tokio::fs::metadata(&environment.project_grafbase_registry_path)
+        .await
+        .ok()
+        .map(|metadata| metadata.modified().expect("must be supported"));
+
+    let detected_resolvers = futures_util::future::join_all(required_resolvers.into_iter().map(|resolver_name| {
+        // Last file to be written to in the build process.
+        let wrangler_toml_path = environment
+            .resolvers_build_artifact_path
+            .join(&resolver_name)
+            .join("wrangler.toml");
+        async move {
+            let wrangler_toml_mtime = tokio::fs::metadata(&wrangler_toml_path)
+                .await
+                .ok()
+                .map(|metadata| metadata.modified().expect("must be supported"));
+            let fresh = registry_mtime
+                .zip(wrangler_toml_mtime)
+                .map(|(registry_mtime, wrangler_toml_mtime)| wrangler_toml_mtime > registry_mtime)
+                .unwrap_or_default();
+            DetectedResolver { resolver_name, fresh }
+        }
+    }))
+    .await;
 
     tokio::fs::write(
         &environment.project_grafbase_registry_path,
-        serde_json::to_string(&parser_result.versioned_registry)
-            .expect("serde_json::Value serialises just fine for sure"),
+        serde_json::to_string(&versioned_registry).expect("serde_json::Value serialises just fine for sure"),
     )
     .await
     .map_err(ServerError::SchemaRegistryWrite)?;
 
-    Ok(parser_result.required_resolvers)
+    Ok(detected_resolvers)
 }
 
 async fn get_node_version_string() -> Result<String, ServerError> {


### PR DESCRIPTION
# Description

This adds an mtime-based freshness check that enables the dev mode loop to avoid recompiling some of the resolvers (not the newly attached ones, for one) on schema.graphql changes.
Right now the check is very limited, but it will cut out a large share of unnecessary rebuilds. We could be smarter if we were aware of all the files that a particular resolver's build depends on, but that'd require analysing the module dependency graph. To be investigated in the future.

# Type of change

- [ ] 💔 Breaking
- [X] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
