### PR TITLE
Rename playground to pathfinder

### DIFF
--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -30,7 +30,7 @@ pub fn start_server(resolvers_reported: bool, port: u16, start_port: u16) {
     }
     println!("📡 Listening on port {}\n", watercolor!("{port}", @BrightBlue));
     println!(
-        "- Playground: {}",
+        "- Pathfinder: {}",
         watercolor!("http://{LOCALHOST}:{port}", @BrightBlue)
     );
     // TODO: use proper formatting here


### PR DESCRIPTION
# Description

## Fixes

- Renames the playground to Pathfinder

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
