### PR TITLE
fix(resolvers): Fix custom resolvers on Windows

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1766,6 +1766,7 @@ dependencies = [
  "log",
  "notify",
  "notify-debouncer-mini",
+ "path-slash",
  "reqwest",
  "serde",
  "serde_json",
@@ -2984,6 +2985,12 @@ name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "pem-rfc7468"

--- a/cli/crates/cli/tests/compilation_error.rs
+++ b/cli/crates/cli/tests/compilation_error.rs
@@ -12,7 +12,6 @@ use utils::consts::{
 use utils::environment::Environment;
 
 #[test]
-#[cfg_attr(target_os = "windows", ignore)]
 fn compilation_error_schema() {
     let mut env = Environment::init();
     env.grafbase_init(ConfigType::GraphQL);
@@ -68,7 +67,6 @@ fn compilation_error_schema() {
 }
 
 #[test]
-#[cfg_attr(target_os = "windows", ignore)]
 fn compilation_error_resolvers() {
     let mut env = Environment::init();
     env.grafbase_init(ConfigType::GraphQL);

--- a/cli/crates/cli/tests/custom_resolvers.rs
+++ b/cli/crates/cli/tests/custom_resolvers.rs
@@ -257,7 +257,6 @@ use utils::environment::Environment;
         }
     "#)
 )]
-#[cfg_attr(target_os = "windows", ignore)]
 fn test_field_resolver(
     #[case] case_index: usize,
     #[case] schema: &str,
@@ -368,7 +367,6 @@ fn test_field_resolver(
         ),
     ],
 )]
-#[cfg_attr(target_os = "windows", ignore)]
 fn test_query_mutation_resolver(
     #[case] case_index: usize,
     #[case] schema: &str,

--- a/cli/crates/cli/tests/custom_resolvers.rs
+++ b/cli/crates/cli/tests/custom_resolvers.rs
@@ -197,6 +197,7 @@ use utils::environment::Environment;
     ],
     Some(r#"
         {
+            "name": "my-package",
             "dependencies": {
                 "is-palindrome": "^0.3.0"
             }

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -27,6 +27,7 @@ notify = { version = "5", default-features = false, features = [
   "macos_fsevent",
 ] }
 notify-debouncer-mini = { version = "0.2", default-features = false }
+path-slash = "0.2"
 reqwest = { version = "0.11", features = [
   "rustls-tls",
   "json",

--- a/cli/crates/server/src/errors.rs
+++ b/cli/crates/server/src/errors.rs
@@ -15,11 +15,15 @@ use crate::custom_resolvers::JavaScriptPackageManager;
 
 #[derive(Error, Debug)]
 pub enum JavascriptPackageManagerComamndError {
-    /// returned if any of the npm commands exits unsuccessfully
+    /// returned if npm/pnpm/yarn cannot be found
+    #[error("could not find {0}: {1}")]
+    NotFound(JavaScriptPackageManager, which::Error),
+
+    /// returned if any of the npm/pnpm/yarn commands exits unsuccessfully
     #[error("{0} encountered an error: {1}")]
     CommandError(JavaScriptPackageManager, IoError),
 
-    /// returned if any of the npm commands exits unsuccessfully
+    /// returned if any of the npm/pnpm/yarn commands exits unsuccessfully
     #[error("{0} failed with output:\n{1}")]
     OutputError(JavaScriptPackageManager, String),
 }


### PR DESCRIPTION
# Description

Fix npm/pnpm/yarn search on Windows.
Translate the main resolver module path in to use POSIX-style slashes.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
