### PR TITLE
Publish server/assets

### DIFF
--- a/.github/workflows/cli-partial-release.yml
+++ b/.github/workflows/cli-partial-release.yml
@@ -106,7 +106,8 @@ jobs:
           }
 
           (cd common && retryable 'cargo publish --allow-dirty')
-          (cd server && retryable 'cargo publish --allow-dirty')
+          # removing the .gitignore because we want those assets to be published  
+          (cd server && rm assets/.gitignore && retryable 'cargo publish --allow-dirty')
           (cd backend && retryable 'cargo publish --allow-dirty')
           (cd cli && retryable 'cargo publish --allow-dirty')
 


### PR DESCRIPTION
# Description

Before publishing to cargo, remove `crates/server/assets/.ignore` so the assets get published bundled with the crate

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
