### PR TITLE
See if rust-cache is better than plain actions cache

### DIFF
--- a/.github/actions/init_rust_job/action.yml
+++ b/.github/actions/init_rust_job/action.yml
@@ -35,7 +35,7 @@ runs:
       run: |
         rustup target list
         
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@v2
       with:
         workspaces: |
           cli

--- a/.github/actions/init_rust_job/action.yml
+++ b/.github/actions/init_rust_job/action.yml
@@ -17,16 +17,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Cargo cache
-      uses: actions/cache@v3
-      continue-on-error: false
-      with:
-        key: ${{ inputs.cache-key }}
-        restore-keys: ${{ runner.os }}-${{ runner.arch }}-cargo-
-        path: |
-          ~/.cargo/
-          cli/target/
-
     - name: Extract the Rust version to use from the `rust-toolchain.toml` file
       shell: bash
       run: |
@@ -44,6 +34,11 @@ runs:
       shell: bash
       run: |
         rustup target list
+        
+    - uses: Swatinem/rust-cache@v1
+      with:
+        workspaces: |
+          cli
 
     - name: Install cargo-nextest & libs linux
       if: ${{ inputs.platform == 'linux' }}

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,5 +3,3 @@ members = ["crates/*"]
 
 [profile.release]
 strip = "symbols"
-lto = true
-codegen-units = 1

--- a/cli/crates/cli/tests/openapi/main.rs
+++ b/cli/crates/cli/tests/openapi/main.rs
@@ -97,6 +97,7 @@ async fn openapi_test() {
     "###
     );
 
+    // Make sure we got the request body we were expecting
     insta::assert_yaml_snapshot!(request_body_spy.drain_requests(), @r###"
     ---
     - category: {}


### PR DESCRIPTION
# Description

We've been seeing pretty slow builds in CI.  This PR updates our rust builds to use the specialised rust-cache action rather than the plain actions cache, which _might_ be more effective.  Going to do a CI run or two and see.