### PR TITLE
Specify queryNaming strategy in openai template

### DIFF
--- a/templates/openapi-openai/grafbase/schema.graphql
+++ b/templates/openapi-openai/grafbase/schema.graphql
@@ -6,4 +6,7 @@ extend schema
     headers: [
       { name: "Authorization", value: "Bearer {{ env.OPENAI_API_KEY }}" }
     ]
+    transforms: {
+      queryNaming: OPERATION_ID
+    }
   )


### PR DESCRIPTION
By default the OpenAPI connector uses schema names to define the names of the query & mutation fields.  

But the specification we're using for the OpenAI example is structured to use responses as it's schemas rather than resources.  This means that by default we get rather poor query & mutation names for OpenAI.

This PR updates the OpenAI template to specify the OPERATION_ID naming strategy, which improves things somewhat.