### PR TITLE
GB-3604: Allow running CLI integration tests with DynamoDB Local

### DIFF
--- a/.github/actions/sanitize/action.yml
+++ b/.github/actions/sanitize/action.yml
@@ -49,4 +49,4 @@ runs:
       shell: bash
       run: |
         cd ${{ inputs.working-directory }}
-        cargo nextest run --profile ci
+        RUST_BACKTRACE=1 cargo nextest run --profile ci

--- a/cli/.config/nextest.toml
+++ b/cli/.config/nextest.toml
@@ -1,6 +1,6 @@
 [profile.ci]
 fail-fast = false
-failure-output = "immediate-final"
+failure-output = "immediate"
 
 [profile.ci.junit]
 path = "junit.xml"

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -434,6 +434,15 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -481,7 +490,7 @@ checksum = "c0b0ef34f142c013684f51b4d427ca8afcd9107ebde2a6c7f6c7ae049d128d52"
 dependencies = [
  "async-attributes",
  "async-std",
- "digest",
+ "digest 0.10.6",
  "either",
  "futures",
  "hex",
@@ -491,7 +500,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha1",
- "sha2",
+ "sha2 0.10.6",
  "ssri",
  "tempfile",
  "thiserror",
@@ -832,6 +841,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "ctor"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,11 +1016,20 @@ checksum = "850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690"
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "crypto-common",
  "subtle",
 ]
@@ -1025,6 +1053,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1082,17 @@ dependencies = [
  "libc",
  "redox_users",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1215,6 +1264,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1455,6 +1519,7 @@ dependencies = [
  "fslock",
  "grafbase-local-backend",
  "grafbase-local-common",
+ "grafbase-local-server",
  "hex-literal",
  "humantime",
  "indicatif",
@@ -1470,6 +1535,8 @@ dependencies = [
  "regex",
  "reqwest",
  "rstest",
+ "rusoto_core",
+ "rusoto_dynamodb",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1663,11 +1730,21 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1837,6 +1914,19 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -2113,11 +2203,11 @@ dependencies = [
  "anyhow",
  "base64ct",
  "chrono",
- "hmac",
+ "hmac 0.12.1",
  "rand_core 0.6.4",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.6",
  "smallvec",
  "subtle",
  "zeroize",
@@ -2311,6 +2401,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
+name = "md-5"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
 name = "measure_time"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2417,6 +2518,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d736ff882f0e85fe9689fb23db229616c4c00aee2b3ac282f666d8f20eb25d4a"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2571,6 +2690,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2711,7 +2880,7 @@ checksum = "6733073c7cff3d8459fda0e42f13a047870242aed8b509fe98000928975f359e"
 dependencies = [
  "once_cell",
  "pest",
- "sha2",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -3069,6 +3238,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusoto_core"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db30db44ea73551326269adcf7a2169428a054f14faf9e1768f2163494f2fa2"
+dependencies = [
+ "async-trait",
+ "base64 0.13.1",
+ "bytes",
+ "crc32fast",
+ "futures",
+ "http",
+ "hyper",
+ "hyper-tls",
+ "lazy_static",
+ "log",
+ "rusoto_credential",
+ "rusoto_signature",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "tokio",
+ "xml-rs",
+]
+
+[[package]]
+name = "rusoto_credential"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee0a6c13db5aad6047b6a44ef023dbbc21a056b6dab5be3b79ce4283d5c02d05"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "dirs-next",
+ "futures",
+ "hyper",
+ "serde",
+ "serde_json",
+ "shlex",
+ "tokio",
+ "zeroize",
+]
+
+[[package]]
+name = "rusoto_dynamodb"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63ad8e126a46122a171587bbee590c5a51f311b65a5e83bb78a1f2adee720762"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "rusoto_core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "rusoto_signature"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ae95491c8b4847931e291b151127eccd6ff8ca13f33603eb3d0035ecb05272"
+dependencies = [
+ "base64 0.13.1",
+ "bytes",
+ "chrono",
+ "digest 0.9.0",
+ "futures",
+ "hex",
+ "hmac 0.11.0",
+ "http",
+ "hyper",
+ "log",
+ "md-5",
+ "percent-encoding",
+ "pin-project-lite",
+ "rusoto_credential",
+ "rustc_version",
+ "serde",
+ "sha2 0.9.9",
+ "tokio",
+]
+
+[[package]]
 name = "rust-embed"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3099,7 +3351,7 @@ version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512b0ab6853f7e14e3c8754acb43d6f748bb9ced66aa5915a6553ac8213f7731"
 dependencies = [
- "sha2",
+ "sha2 0.10.6",
  "walkdir",
 ]
 
@@ -3191,6 +3443,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+dependencies = [
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3216,6 +3477,29 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3304,7 +3588,7 @@ checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -3315,7 +3599,20 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.6",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -3326,7 +3623,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -3347,6 +3644,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook"
@@ -3500,7 +3803,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.6",
  "smallvec",
  "sqlformat",
  "sqlx-rt",
@@ -3524,7 +3827,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "sha2",
+ "sha2 0.10.6",
  "sqlx-core",
  "sqlx-rt",
  "syn 1.0.109",
@@ -3549,12 +3852,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312a252a15c120718e8ce073aefab69d0de6fba7daadeb869edfc6e6a1e1a417"
 dependencies = [
  "base64 0.21.0",
- "digest",
+ "digest 0.10.6",
  "hex",
  "miette",
  "serde",
  "sha-1",
- "sha2",
+ "sha2 0.10.6",
  "thiserror",
 ]
 
@@ -3908,6 +4211,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.13",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -4710,6 +5023,12 @@ checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "yaml-rust"

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1058,7 +1058,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "dirs-sys-next",
 ]
 
@@ -1092,7 +1092,7 @@ checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2701,7 +2701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -3608,7 +3608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1519,7 +1519,6 @@ dependencies = [
  "fslock",
  "grafbase-local-backend",
  "grafbase-local-common",
- "grafbase-local-server",
  "hex-literal",
  "humantime",
  "indicatif",

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -38,3 +38,6 @@ webbrowser = "0.8"
 
 common = { package = "grafbase-local-common", path = "../common", version = "0.18.12" }
 server = { package = "grafbase-local-server", path = "../server", version = "0.18.12" }
+
+[features]
+dynamodb = ["server/dynamodb"]

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -62,6 +62,8 @@ tempfile = "3"
 tokio = { version = "1", features = ["full"] }
 regex = "1"
 rstest = "0.17"
+rusoto_core = "0.48"
+rusoto_dynamodb = "0.48"
 wiremock = "0.5"
 
 [[bin]]

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -69,7 +69,5 @@ wiremock = "0.5"
 [[bin]]
 name = "grafbase"
 
-
 [features]
-default = ["sqlite"]
-sqlite = []
+dynamodb = ["backend/dynamodb"]

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -68,3 +68,8 @@ wiremock = "0.5"
 
 [[bin]]
 name = "grafbase"
+
+
+[features]
+default = ["sqlite"]
+sqlite = []

--- a/cli/crates/cli/tests/README.md
+++ b/cli/crates/cli/tests/README.md
@@ -32,7 +32,7 @@ dy -r local admin create index gsi2 -t gateway --keys __gsi2pk __gsi2sk
 ```sh
 export AWS_ACCESS_KEY_ID="fakeMyKeyId"
 export AWS_SECRET_ACCESS_KEY="fakeSecretAccessKey"
-export DYNAMODB_REPLICATION_REGIONS="custom:http://localhost:8000"
+export DYNAMODB_REGION="custom:http://localhost:8000"
 export DYNAMODB_TABLE_NAME=gateway
 
 rm -rf ~/.grafbase # version is the same so the cache can contain the wrong wasm variant
@@ -45,7 +45,7 @@ cargo run -p grafbase --features=dynamodb -- -t 2 dev
 ```sh
 export AWS_ACCESS_KEY_ID="fakeMyKeyId"
 export AWS_SECRET_ACCESS_KEY="fakeSecretAccessKey"
-export DYNAMODB_REPLICATION_REGIONS="custom:http://localhost:8000"
+export DYNAMODB_REGION="custom:http://localhost:8000"
 
 cargo nextest run --features=dynamodb  -P ci
 ```

--- a/cli/crates/cli/tests/README.md
+++ b/cli/crates/cli/tests/README.md
@@ -1,0 +1,49 @@
+# Running with DynamoDB Local
+
+## Assets
+Assets in the API repo need to be built:
+
+```sh
+RELEASE_FLAG="--dev" GATEWAY_FEATURES=local ./scripts/dev/build-cli-assets.sh
+```
+
+## Set up
+DynamoDB Local must be running:
+
+```sh
+docker run -p 8000:8000 --rm --name dynamodb -d amazon/dynamodb-local
+```
+
+Testing tables are created and deleted on the fly.
+To execute the CLI, one must create a table:
+
+```sh
+export AWS_ACCESS_KEY_ID="fakeMyKeyId"
+export AWS_SECRET_ACCESS_KEY="fakeSecretAccessKey"
+dy -r local admin create table gateway --keys __pk __sk
+dy -r local admin create index gsi1 -t gateway --keys __gsi1pk __gsi1sk
+dy -r local admin create index gsi2 -t gateway --keys __gsi2pk __gsi2sk
+```
+
+## Running the CLI
+
+```sh
+export AWS_ACCESS_KEY_ID="fakeMyKeyId"
+export AWS_SECRET_ACCESS_KEY="fakeSecretAccessKey"
+export DYNAMODB_REPLICATION_REGIONS="custom:http://localhost:8000"
+export DYNAMODB_TABLE_NAME=gateway
+
+rm -rf ~/.grafbase # version is the same so the cache can contain the wrong wasm variant
+
+cargo run -p grafbase --features=dynamodb -- -t 2 dev
+```
+
+## Running the tests
+
+```sh
+export AWS_ACCESS_KEY_ID="fakeMyKeyId"
+export AWS_SECRET_ACCESS_KEY="fakeSecretAccessKey"
+export DYNAMODB_REPLICATION_REGIONS="custom:http://localhost:8000"
+
+cargo nextest run --features=dynamodb  -P ci
+```

--- a/cli/crates/cli/tests/README.md
+++ b/cli/crates/cli/tests/README.md
@@ -17,6 +17,8 @@ docker run -p 8000:8000 --rm --name dynamodb -d amazon/dynamodb-local
 Testing tables are created and deleted on the fly.
 To execute the CLI, one must create a table:
 
+## Preparing the table for the CLI
+
 ```sh
 export AWS_ACCESS_KEY_ID="fakeMyKeyId"
 export AWS_SECRET_ACCESS_KEY="fakeSecretAccessKey"

--- a/cli/crates/cli/tests/concurrency_process.rs
+++ b/cli/crates/cli/tests/concurrency_process.rs
@@ -6,9 +6,9 @@ use serde_json::Value;
 use utils::consts::{CONCURRENCY_MUTATION, CONCURRENCY_QUERY, CONCURRENCY_SCHEMA};
 use utils::environment::Environment;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn concurrency_process() {
-    let (mut env1, cleanup_fut) = Environment::init_async().await;
+    let mut env1 = Environment::init_async().await;
     let mut env2 = Environment::from(&env1);
 
     env1.grafbase_init();
@@ -43,5 +43,4 @@ async fn concurrency_process() {
 
     assert_eq!(result_list1.len(), 30);
     assert_eq!(result_list2.len(), 30);
-    cleanup_fut.await;
 }

--- a/cli/crates/cli/tests/concurrency_process.rs
+++ b/cli/crates/cli/tests/concurrency_process.rs
@@ -8,7 +8,7 @@ use utils::environment::Environment;
 
 #[tokio::test]
 async fn concurrency_process() {
-    let mut env1 = Environment::init();
+    let (mut env1, cleanup_fut) = Environment::init_async().await;
     let mut env2 = Environment::from(&env1);
 
     env1.grafbase_init();
@@ -43,4 +43,5 @@ async fn concurrency_process() {
 
     assert_eq!(result_list1.len(), 30);
     assert_eq!(result_list2.len(), 30);
+    cleanup_fut.await;
 }

--- a/cli/crates/cli/tests/concurrency_thread.rs
+++ b/cli/crates/cli/tests/concurrency_thread.rs
@@ -8,7 +8,7 @@ use utils::environment::Environment;
 
 #[tokio::test]
 async fn concurrency_thread() {
-    let mut env = Environment::init();
+    let (mut env, cleanup_fut) = Environment::init_async().await;
 
     env.grafbase_init();
     env.write_schema(CONCURRENCY_SCHEMA);
@@ -50,4 +50,5 @@ async fn concurrency_thread() {
     assert_eq!(result_list1.len(), 30);
     assert_eq!(result_list2.len(), 30);
     assert_eq!(result_list3.len(), 30);
+    cleanup_fut.await;
 }

--- a/cli/crates/cli/tests/concurrency_thread.rs
+++ b/cli/crates/cli/tests/concurrency_thread.rs
@@ -6,9 +6,9 @@ use serde_json::Value;
 use utils::consts::{CONCURRENCY_MUTATION, CONCURRENCY_QUERY, CONCURRENCY_SCHEMA};
 use utils::environment::Environment;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn concurrency_thread() {
-    let (mut env, cleanup_fut) = Environment::init_async().await;
+    let mut env = Environment::init_async().await;
 
     env.grafbase_init();
     env.write_schema(CONCURRENCY_SCHEMA);
@@ -50,5 +50,4 @@ async fn concurrency_thread() {
     assert_eq!(result_list1.len(), 30);
     assert_eq!(result_list2.len(), 30);
     assert_eq!(result_list3.len(), 30);
-    cleanup_fut.await;
 }

--- a/cli/crates/cli/tests/openapi/main.rs
+++ b/cli/crates/cli/tests/openapi/main.rs
@@ -18,7 +18,7 @@ async fn openapi_test() {
     let mock_server = wiremock::MockServer::start().await;
     mount_petstore_spec(&mock_server).await;
 
-    let mut env = Environment::init();
+    let (mut env, cleanup_fut) = Environment::init_async().await;
     let client = start_grafbase_with_petstore_schema(&mut env, mock_server.address()).await;
 
     Mock::given(method("GET"))
@@ -108,6 +108,8 @@ async fn openapi_test() {
       status: available
       tags: []
     "###);
+
+    cleanup_fut.await;
 }
 
 #[derive(Clone)]

--- a/cli/crates/cli/tests/openapi/main.rs
+++ b/cli/crates/cli/tests/openapi/main.rs
@@ -13,12 +13,12 @@ use wiremock::{
     Match, Mock, ResponseTemplate,
 };
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn openapi_test() {
     let mock_server = wiremock::MockServer::start().await;
     mount_petstore_spec(&mock_server).await;
 
-    let (mut env, cleanup_fut) = Environment::init_async().await;
+    let mut env = Environment::init_async().await;
     let client = start_grafbase_with_petstore_schema(&mut env, mock_server.address()).await;
 
     Mock::given(method("GET"))
@@ -108,8 +108,6 @@ async fn openapi_test() {
       status: available
       tags: []
     "###);
-
-    cleanup_fut.await;
 }
 
 #[derive(Clone)]

--- a/cli/crates/cli/tests/search.rs
+++ b/cli/crates/cli/tests/search.rs
@@ -115,7 +115,7 @@ struct Edge<N> {
     node: N,
 }
 
-#[cfg(feature = "sqlite")] // GB-3636
+#[cfg(not(feature = "dynamodb"))] // GB-3636
 #[test]
 fn search_enums() {
     let mut env = Environment::init();
@@ -169,7 +169,7 @@ fn search_enums() {
     assert_hits_unordered!(search_text("shroidnger"), cat_person);
 }
 
-#[cfg(feature = "sqlite")] // GB-3636
+#[cfg(not(feature = "dynamodb"))] // GB-3636
 #[rstest]
 #[case("fields", SEARCH_CREATE_OPTIONAL, SEARCH_SEARCH_OPTIONAL)]
 #[case("requiredFields", SEARCH_CREATE_REQUIRED, SEARCH_SEARCH_REQUIRED)]
@@ -445,7 +445,7 @@ fn basic_search(#[case] name: &str, #[case] create_query: &str, #[case] search_q
     }
 }
 
-#[cfg(feature = "sqlite")] // GB-3636
+#[cfg(not(feature = "dynamodb"))] // GB-3636
 #[test]
 fn search_created_updated_at() {
     let mut env = Environment::init();
@@ -507,7 +507,7 @@ fn search_created_updated_at() {
     );
 }
 
-#[cfg(feature = "sqlite")] // GB-3636
+#[cfg(not(feature = "dynamodb"))] // GB-3636
 #[test]
 fn search_pagination_and_total_hits() {
     let mut env = Environment::init();

--- a/cli/crates/cli/tests/search.rs
+++ b/cli/crates/cli/tests/search.rs
@@ -115,6 +115,7 @@ struct Edge<N> {
     node: N,
 }
 
+#[cfg(feature = "sqlite")] // GB-3636
 #[test]
 fn search_enums() {
     let mut env = Environment::init();
@@ -168,6 +169,7 @@ fn search_enums() {
     assert_hits_unordered!(search_text("shroidnger"), cat_person);
 }
 
+#[cfg(feature = "sqlite")] // GB-3636
 #[rstest]
 #[case("fields", SEARCH_CREATE_OPTIONAL, SEARCH_SEARCH_OPTIONAL)]
 #[case("requiredFields", SEARCH_CREATE_REQUIRED, SEARCH_SEARCH_REQUIRED)]
@@ -443,6 +445,7 @@ fn basic_search(#[case] name: &str, #[case] create_query: &str, #[case] search_q
     }
 }
 
+#[cfg(feature = "sqlite")] // GB-3636
 #[test]
 fn search_created_updated_at() {
     let mut env = Environment::init();
@@ -504,6 +507,7 @@ fn search_created_updated_at() {
     );
 }
 
+#[cfg(feature = "sqlite")] // GB-3636
 #[test]
 fn search_pagination_and_total_hits() {
     let mut env = Environment::init();

--- a/cli/crates/cli/tests/utils/environment.rs
+++ b/cli/crates/cli/tests/utils/environment.rs
@@ -305,7 +305,7 @@ mod dynamodb {
 
         let aws_access_key_id = std::env::var("AWS_ACCESS_KEY_ID").unwrap();
         let aws_secret_access_key = std::env::var("AWS_SECRET_ACCESS_KEY").unwrap();
-        let dynamodb_region = std::env::var("DYNAMODB_REPLICATION_REGIONS").unwrap();
+        let dynamodb_region = std::env::var("DYNAMODB_REGION").unwrap();
 
         let dynamodb_region = match dynamodb_region.strip_prefix("custom:") {
             Some(suffix) => rusoto_core::Region::Custom {

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -64,5 +64,4 @@ common = { package = "grafbase-local-common", path = "../common", version = "0.1
 serde_json = "1"
 
 [features]
-default = ["sqlite"]
-sqlite = []
+dynamodb = []

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -62,3 +62,7 @@ common = { package = "grafbase-local-common", path = "../common", version = "0.1
 
 [dev-dependencies]
 serde_json = "1"
+
+[features]
+default = ["sqlite"]
+sqlite = []

--- a/cli/crates/server/src/bridge/search.rs
+++ b/cli/crates/server/src/bridge/search.rs
@@ -85,6 +85,7 @@ impl<'a> Index<'a> {
         let id_field = index.schema().get_field(search::ID_FIELD).unwrap();
 
         let mut writer = index.writer_with_num_threads(1, 20_000_000)?;
+        // FIXME: GB-3636 Implement DynamoDB variant
         let mut fut = sqlx::query_as(
             r#"
         SELECT pk AS id, document

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -250,7 +250,7 @@ async fn spawn_servers(
             vec![
                 "AWS_ACCESS_KEY_ID",
                 "AWS_SECRET_ACCESS_KEY",
-                "DYNAMODB_REPLICATION_REGIONS",
+                "DYNAMODB_REGION",
                 "DYNAMODB_TABLE_NAME",
             ]
             .iter()

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -238,6 +238,28 @@ async fn spawn_servers(
         ]
     }));
 
+    #[cfg(not(feature = "sqlite"))]
+    {
+        fn get_env(key: &str) -> String {
+            let val = std::env::var(key).unwrap_or_else(|_| panic!("Environment variable not found:{key}"));
+            format!("{key}={val}")
+        }
+
+        miniflare_arguments.extend(
+            vec![
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+                "DYNAMODB_REPLICATION_REGIONS",
+                "DYNAMODB_TABLE_NAME",
+            ]
+            .iter()
+            .map(|key| get_env(key))
+            .flat_map(|env| {
+                std::iter::once(std::borrow::Cow::Borrowed("--binding")).chain(std::iter::once(env.into()))
+            }),
+        );
+    }
+
     let mut miniflare = Command::new("node");
     miniflare
         // Unbounded worker limit

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -238,8 +238,9 @@ async fn spawn_servers(
         ]
     }));
 
-    #[cfg(not(feature = "sqlite"))]
+    #[cfg(feature = "dynamodb")]
     {
+        #[allow(clippy::panic)]
         fn get_env(key: &str) -> String {
             let val = std::env::var(key).unwrap_or_else(|_| panic!("Environment variable not found:{key}"));
             format!("{key}={val}")


### PR DESCRIPTION
# Description

Introduce feature `dynamodb` that is used for selecting between sqlite and dynamodb test harness. 
DynamoDB tests run the following steps:

1. `Environment.init` creates a new DynamoDB table
2. `grafbase dev` is called with the env var  `DYNAMODB_TABLE_NAME` and the inherited env vars.
3. After the test finishes, the table is dropped. In async context this must be done by the test.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
