### PR TITLE
GB-3654 - Update to Rust 1.69 and fix related Clippy issues

### DIFF
--- a/cli/crates/cli/src/login.rs
+++ b/cli/crates/cli/src/login.rs
@@ -19,7 +19,7 @@ pub fn login() -> Result<(), CliError> {
         sleep(Duration::from_secs(1));
         // as we show the URL in the CLI output, not being able
         // to open the browser needs no handling
-        let _ = webbrowser::open(&url);
+        let _: Result<_, _> = webbrowser::open(&url);
     };
 
     let spinner = ProgressBar::new_spinner()

--- a/cli/crates/cli/src/panic_hook/mod.rs
+++ b/cli/crates/cli/src/panic_hook/mod.rs
@@ -117,7 +117,7 @@ pub fn handle_dump(meta: &Metadata, panic_info: &PanicInfo<'_>) -> Option<PathBu
 
     match panic_info.location() {
         Some(location) => {
-            let _ = writeln!(
+            let _: Result<_, _> = writeln!(
                 explanation,
                 "Panic occurred in file '{}' at line {}",
                 location.file(),

--- a/cli/crates/cli/src/panic_hook/report.rs
+++ b/cli/crates/cli/src/panic_hook/report.rs
@@ -65,11 +65,11 @@ impl Report {
         //if it is available
         for (idx, frame) in Backtrace::new().frames().iter().skip(SKIP_FRAMES_NUM).enumerate() {
             let ip = frame.ip();
-            let _ = write!(backtrace, "\n{idx:4}: {ip:HEX_WIDTH$?}");
+            let _: Result<_, _> = write!(backtrace, "\n{idx:4}: {ip:HEX_WIDTH$?}");
 
             let symbols = frame.symbols();
             if symbols.is_empty() {
-                let _ = write!(backtrace, " - <unresolved>");
+                let _: Result<_, _> = write!(backtrace, " - <unresolved>");
                 continue;
             }
 
@@ -78,18 +78,18 @@ impl Report {
                 //if there are several addresses
                 //we need to put it on next line
                 if idx != 0 {
-                    let _ = write!(backtrace, "\n{:NEXT_SYMBOL_PADDING$}", "");
+                    let _: Result<_, _> = write!(backtrace, "\n{:NEXT_SYMBOL_PADDING$}", "");
                 }
 
                 if let Some(name) = symbol.name() {
-                    let _ = write!(backtrace, " - {name}");
+                    let _: Result<_, _> = write!(backtrace, " - {name}");
                 } else {
-                    let _ = write!(backtrace, " - <unknown>");
+                    let _: Result<_, _> = write!(backtrace, " - <unknown>");
                 }
 
                 //See if there is debug information with file name and line
                 if let (Some(file), Some(line)) = (symbol.filename(), symbol.lineno()) {
-                    let _ = write!(
+                    let _: Result<_, _> = write!(
                         backtrace,
                         "\n{:3$}at {}:{}",
                         "",

--- a/cli/crates/server/src/custom_resolvers.rs
+++ b/cli/crates/server/src/custom_resolvers.rs
@@ -290,7 +290,7 @@ async fn build_resolver(
 
     let wrangler_toml_file_path = resolver_build_artifact_directory_path.join("wrangler.toml");
 
-    let _ = tokio::fs::remove_file(&wrangler_toml_file_path).await;
+    let _: Result<_, _> = tokio::fs::remove_file(&wrangler_toml_file_path).await;
 
     let wrangler_arguments = &[
         "wrangler",
@@ -431,7 +431,7 @@ pub async fn build_resolvers(
                     .expect("must succeed");
                 } else {
                     let start = std::time::Instant::now();
-                    let _ = sender.send(ServerMessage::StartResolverBuild(resolver_name.clone()));
+                    let _: Result<_, _> = sender.send(ServerMessage::StartResolverBuild(resolver_name.clone()));
                     build_resolver(
                         environment,
                         environment_variables,
@@ -441,7 +441,7 @@ pub async fn build_resolvers(
                         tracing,
                     )
                     .await?;
-                    let _ = sender.send(ServerMessage::CompleteResolverBuild {
+                    let _: Result<_, _> = sender.send(ServerMessage::CompleteResolverBuild {
                         name: resolver_name.clone(),
                         duration: start.elapsed(),
                     });

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -105,7 +105,7 @@ async fn server_loop(
             }) => {
                 trace!("reload");
                 path_changed = Some(path.clone());
-                let _ = sender.send(ServerMessage::Reload(path, file_event_type));
+                let _: Result<_, _> = sender.send(ServerMessage::Reload(path, file_event_type));
             }
         }
     }
@@ -132,7 +132,7 @@ async fn spawn_servers(
     let mut resolvers = match run_schema_parser(&environment_variables).await {
         Ok(resolvers) => resolvers,
         Err(error) => {
-            let _ = sender.send(ServerMessage::CompilationError(error.to_string()));
+            let _: Result<_, _> = sender.send(ServerMessage::CompilationError(error.to_string()));
             tokio::spawn(async move { error_server::start(worker_port, error.to_string(), bridge_event_bus).await })
                 .await??;
             return Ok(());
@@ -160,7 +160,7 @@ async fn spawn_servers(
     let resolver_paths = match build_resolvers(&sender, environment, &environment_variables, resolvers, tracing).await {
         Ok(resolver_paths) => resolver_paths,
         Err(error) => {
-            let _ = sender.send(ServerMessage::CompilationError(error.to_string()));
+            let _: Result<_, _> = sender.send(ServerMessage::CompilationError(error.to_string()));
             // TODO consider disabling colored output from wrangler
             let error = strip_ansi_escapes::strip(error.to_string().as_bytes())
                 .ok()
@@ -250,7 +250,7 @@ async fn spawn_servers(
     trace!("Spawning {miniflare:?}");
     let miniflare = miniflare.spawn().map_err(ServerError::MiniflareCommandError)?;
 
-    let _ = sender.send(ServerMessage::Ready(worker_port));
+    let _: Result<_, _> = sender.send(ServerMessage::Ready(worker_port));
 
     let miniflare_output_result = miniflare.wait_with_output();
 

--- a/cli/rust-toolchain.toml
+++ b/cli/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 profile = "default"
-channel = "1.68"
+channel = "1.69"
 targets = [
     "aarch64-apple-darwin",
     "x86_64-apple-darwin",


### PR DESCRIPTION
# Description

## Tooling

- Updates to Rust 1.69
  - Fixes related Clippy issues

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [x] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
