### PR TITLE
Add a test of `@openapi` unions

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   GRAFBASE_SKIP_ASSET_VERSION_CHECK: 'true'
-  ASSETS_VERSION: 'release/23717dd-2023-04-28'
+  ASSETS_VERSION: 'release/9ec0a56-2023-05-02'
   PROD_ASSETS: assets.grafbase.com
   CARGO_TERM_COLOR: 'always'
 

--- a/cli/crates/cli/tests/openapi/main.rs
+++ b/cli/crates/cli/tests/openapi/main.rs
@@ -1,6 +1,8 @@
 #[path = "../utils/mod.rs"]
 mod utils;
 
+mod remote_unions;
+
 use std::net::SocketAddr;
 
 use crossbeam_channel::{Receiver, Sender};

--- a/cli/crates/cli/tests/openapi/remote_union_spec.json
+++ b/cli/crates/cli/tests/openapi/remote_union_spec.json
@@ -1,0 +1,131 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Swagger Petstore - OpenAPI 3.0",
+    "description": "This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about\nSwagger at [http://swagger.io](http://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!\nYou can now help us improve the API whether it's by making changes to the definition itself or to the code.\nThat way, with time, we can improve the API in general, and expose some of the new features in OAS3.\n\nSome useful links:\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "email": "apiteam@swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "1.0.17"
+  },
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  },
+  "servers": [
+    {
+      "url": "/api/v3"
+    }
+  ],
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders",
+      "externalDocs": {
+        "description": "Find out more about our store",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "user",
+      "description": "Operations about user"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "operationId": "listPets",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mainOwner": {
+      "get": {
+        "operationId": "getOwner",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "succesfull operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Owner"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "required": [
+          "id"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "example": 10
+          },
+          "owner": {
+            "$ref": "#/components/schemas/Owner"
+          }
+        }
+      },
+      "Owner": {
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/components/schemas/Person"
+          }
+        ]
+      },
+      "Person": {
+        "required": [
+          "id"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "example": 10
+          }
+        }
+      }
+    }
+  }
+}

--- a/cli/crates/cli/tests/openapi/remote_unions.rs
+++ b/cli/crates/cli/tests/openapi/remote_unions.rs
@@ -1,0 +1,141 @@
+use std::net::SocketAddr;
+
+use crate::utils::{async_client::AsyncClient, environment::Environment};
+use serde_json::{json, Value};
+use wiremock::{
+    matchers::{method, path},
+    Mock, ResponseTemplate,
+};
+
+#[tokio::test]
+async fn remote_unions_test() {
+    let mock_server = wiremock::MockServer::start().await;
+    mount_remote_union_spec(&mock_server).await;
+
+    let mut env = Environment::init();
+    let client = start_grafbase(&mut env, mock_server.address()).await;
+
+    Mock::given(method("GET"))
+        .and(path("/pets"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(json!([doggie(json!("Mrs Krabappel")), doggie(json!({"id": 123}))])),
+        )
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    insta::assert_yaml_snapshot!(
+        client
+            .gql::<Value>(
+                r#"
+                    query {
+                        petstore {
+                            pets {
+                                id
+                                owner {
+                                    __typename
+                                    ... on PetstorePerson {
+                                        id
+                                    }
+                                    ... on PetstoreString {
+                                        data
+                                    }
+                                }
+                            }
+                        }
+                    }
+                "#,
+            )
+            .await,
+        @r###"
+    ---
+    data:
+      petstore:
+        pets:
+          - id: 123
+            owner:
+              __typename: PetstoreString
+              data: Mrs Krabappel
+          - id: 123
+            owner:
+              __typename: PetstorePerson
+              id: 123
+    "###
+    );
+
+    Mock::given(method("GET"))
+        .and(path("/mainOwner"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!("Mrs Krabappel")))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    insta::assert_yaml_snapshot!(
+        client
+            .gql::<Value>(
+                r#"
+                    query {
+                        petstore {
+                            owner {
+                                __typename
+                                ... on PetstorePerson {
+                                    id
+                                }
+                                ... on PetstoreString {
+                                    data
+                                }
+                            }
+                        }
+                    }
+                "#,
+            )
+            .await,
+        @r###"
+    ---
+    data:
+      petstore:
+        owner:
+          __typename: PetstoreString
+          data: Mrs Krabappel
+    "###
+    );
+}
+
+async fn start_grafbase(env: &mut Environment, mock_address: &SocketAddr) -> AsyncClient {
+    env.grafbase_init();
+    env.write_schema(schema(mock_address));
+    env.grafbase_dev_watch();
+
+    let client = env.create_async_client().with_api_key();
+
+    client.poll_endpoint(30, 300).await;
+
+    client
+}
+
+fn schema(address: &SocketAddr) -> String {
+    format!(
+        r#"
+          extend schema
+          @openapi(
+            name: "petstore",
+            url: "http://{address}",
+            schema: "http://{address}/spec.json",
+          )
+        "#
+    )
+}
+
+async fn mount_remote_union_spec(server: &wiremock::MockServer) {
+    Mock::given(method("GET"))
+        .and(path("spec.json"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(include_str!("remote_union_spec.json")))
+        .mount(server)
+        .await;
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn doggie(owner: serde_json::Value) -> serde_json::Value {
+    json!({ "id": 123, "owner": owner })
+}


### PR DESCRIPTION
This adds a test of the `@openapi` union fixes I've been working on over the past week and a bit.  Quite hard to test these thoroughly in the `api` repo right now (although I want to work on that), so at least wanted to get a test in this repo in the meantime.