### PR TITLE
GB-3326: TypeScript Config

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -74,8 +74,8 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
-  build:
-    name: Build
+  build-and-test:
+    name: Build and test
     needs: [lint]
     runs-on: ubuntu-latest-8-cores
     steps:
@@ -113,3 +113,6 @@ jobs:
 
       - name: Build
         run: pnpm run build
+
+      - name: Run tests
+        run: pnpm turbo test

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -81,6 +81,7 @@ fn try_main() -> Result<(), CliError> {
 
     if let Some(("dev" | "create" | "deploy" | "link" | "unlink", ..)) = subcommand {
         Environment::try_init().map_err(CliError::CommonError)?;
+        report::warnings(&Environment::get().warnings);
     }
 
     match subcommand {

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -3,8 +3,11 @@ use crate::{
     watercolor::{self, watercolor},
 };
 use colored::Colorize;
-use common::consts::{GRAFBASE_DIRECTORY_NAME, GRAFBASE_SCHEMA_FILE_NAME, LOCALHOST};
 use common::types::ResolverMessageLevel;
+use common::{
+    consts::{GRAFBASE_DIRECTORY_NAME, GRAFBASE_SCHEMA_FILE_NAME, LOCALHOST},
+    environment::Warning,
+};
 use std::path::Path;
 
 /// reports to stdout that the server has started
@@ -66,6 +69,20 @@ pub fn error(error: &CliError) {
     watercolor::output_error!("Error: {error}", @BrightRed);
     if let Some(hint) = error.to_hint() {
         watercolor::output_error!("Hint: {hint}", @BrightBlue);
+    }
+}
+
+pub fn warnings(warnings: &[Warning]) {
+    for warning in warnings {
+        let msg = warning.message();
+
+        watercolor::output!("Warning: {msg}", @BrightYellow);
+
+        if let Some(hint) = warning.hint() {
+            watercolor::output!("Hint: {hint}", @BrightBlue)
+        }
+
+        println!();
     }
 }
 

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -79,7 +79,7 @@ pub fn warnings(warnings: &[Warning]) {
         watercolor::output!("Warning: {msg}", @BrightYellow);
 
         if let Some(hint) = warning.hint() {
-            watercolor::output!("Hint: {hint}", @BrightBlue)
+            watercolor::output!("Hint: {hint}", @BrightBlue);
         }
 
         println!();

--- a/cli/crates/common/src/consts.rs
+++ b/cli/crates/common/src/consts.rs
@@ -11,6 +11,8 @@ pub const GRAFBASE_DIRECTORY_NAME: &str = "grafbase";
 /// a file expected to be in the grafbase directory
 pub const GRAFBASE_SCHEMA_FILE_NAME: &str = "schema.graphql";
 /// a file expected to be in the grafbase directory
+pub const GRAFBASE_TS_CONFIG_FILE_NAME: &str = "grafbase.config.ts";
+/// a file expected to be in the grafbase directory
 pub const GRAFBASE_ENV_FILE_NAME: &str = ".env";
 /// the name for the db / cache directory per project and the global cache directory for the user
 pub const DOT_GRAFBASE_DIRECTORY: &str = ".grafbase";

--- a/cli/crates/common/src/environment.rs
+++ b/cli/crates/common/src/environment.rs
@@ -33,11 +33,13 @@ pub struct GrafbaseSchemaPath {
 
 impl GrafbaseSchemaPath {
     /// The location of the schema file.
+    #[must_use]
     pub fn location(&self) -> &SchemaLocation {
         &self.location
     }
 
     /// True, if we find both `schema.graphql` and `grafbase.config.ts`.
+    #[must_use]
     pub fn has_both_files(&self) -> bool {
         self.has_both_files
     }

--- a/cli/crates/common/src/environment.rs
+++ b/cli/crates/common/src/environment.rs
@@ -73,14 +73,18 @@ impl Warning {
         }
     }
 
-    pub fn set_hint(&mut self, message: impl Into<Cow<'static, str>>) {
+    #[must_use]
+    pub fn with_hint(mut self, message: impl Into<Cow<'static, str>>) -> Self {
         self.hint = Some(message.into());
+        self
     }
 
+    #[must_use]
     pub fn message(&self) -> &str {
         &self.message
     }
 
+    #[must_use]
     pub fn hint(&self) -> Option<&str> {
         self.hint.as_deref()
     }
@@ -208,9 +212,9 @@ impl Environment {
             let path = GrafbaseSchemaPath::ts_config(path);
 
             if gql.is_some() {
-                let mut warning = Warning::new("Found both grafbase.config.ts and schema.graphql files");
+                let warning = Warning::new("Found both grafbase.config.ts and schema.graphql files")
+                    .with_hint("Delete one of them to avoid conflicts");
 
-                warning.set_hint("Delete one of them to avoid conflicts");
                 warnings.push(warning);
             }
 

--- a/cli/crates/common/src/errors.rs
+++ b/cli/crates/common/src/errors.rs
@@ -6,6 +6,8 @@ pub enum CommonError {
     #[error("could not read the current path")]
     ReadCurrentDirectory,
     /// returned if the grafbase directory cannot be found
-    #[error("could not find grafbase/schema.graphql in the current or any parent directory")]
+    #[error(
+        "could not find grafbase/grafbase.config.ts or grafbase/schema.graphql in the current or any parent directory"
+    )]
     FindGrafbaseDirectory,
 }

--- a/cli/crates/server/src/consts.rs
+++ b/cli/crates/server/src/consts.rs
@@ -1,6 +1,8 @@
 pub const ASSET_VERSION_FILE: &str = "version.txt";
 pub const SCHEMA_PARSER_DIR: &str = "parser";
+pub const GENERATED_SCHEMAS_DIR: &str = "generated/schemas";
 pub const SCHEMA_PARSER_INDEX: &str = "index.js";
+pub const CONFIG_PARSER_SCRIPT: &str = "parse-config.ts";
 pub const GIT_IGNORE_FILE: &str = ".gitignore";
 pub const GIT_IGNORE_CONTENTS: &str = "*\n";
 pub const MIN_NODE_VERSION: &str = "v18.0.0";

--- a/cli/crates/server/src/consts.rs
+++ b/cli/crates/server/src/consts.rs
@@ -7,4 +7,4 @@ pub const GIT_IGNORE_FILE: &str = ".gitignore";
 pub const GIT_IGNORE_CONTENTS: &str = "*\n";
 pub const MIN_NODE_VERSION: &str = "v18.0.0";
 pub const DOT_ENV_FILE: &str = ".env";
-pub const TS_NODE_SCRIPT: &str = "node_modules/ts-node/dist/bin.js";
+pub const TS_NODE_SCRIPT_PATH: &str = "node_modules/ts-node/dist/bin.js";

--- a/cli/crates/server/src/consts.rs
+++ b/cli/crates/server/src/consts.rs
@@ -7,3 +7,4 @@ pub const GIT_IGNORE_FILE: &str = ".gitignore";
 pub const GIT_IGNORE_CONTENTS: &str = "*\n";
 pub const MIN_NODE_VERSION: &str = "v18.0.0";
 pub const DOT_ENV_FILE: &str = ".env";
+pub const TS_NODE_SCRIPT: &str = "node_modules/ts-node/dist/bin.js";

--- a/cli/crates/server/src/errors.rs
+++ b/cli/crates/server/src/errors.rs
@@ -88,7 +88,7 @@ pub enum ServerError {
     ParseSchema(String),
 
     /// returned if the typescript config parser command exits unsuccessfully
-    #[error("could not load grafbase/grafbase.config.ts\n{0}")]
+    #[error("could not load grafbase/grafbase.config.ts\ncaused by: {0}")]
     LoadTsConfig(String),
 
     #[error("could not find a resolver referenced in the schema under the path {0}.{{js,ts}}")]

--- a/cli/crates/server/src/errors.rs
+++ b/cli/crates/server/src/errors.rs
@@ -87,6 +87,10 @@ pub enum ServerError {
     #[error("could not parse grafbase/schema.graphql\n{0}")]
     ParseSchema(String),
 
+    /// returned if the typescript config parser command exits unsuccessfully
+    #[error("could not load grafbase/grafbase.config.ts\n{0}")]
+    LoadTsConfig(String),
+
     #[error("could not find a resolver referenced in the schema under the path {0}.{{js,ts}}")]
     ResolverDoesNotExist(PathBuf),
 

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -524,10 +524,15 @@ async fn parse_and_generate_config_from_ts(ts_config_path: &Path) -> Result<Stri
         .spawn()
         .map_err(ServerError::SchemaParserError)?;
 
-    node_command
+    let output = node_command
         .wait_with_output()
         .await
         .map_err(ServerError::SchemaParserError)?;
+
+    if !output.status.success() {
+        let msg = String::from_utf8_lossy(&output.stderr);
+        return Err(ServerError::LoadTsConfig(msg.into_owned()));
+    }
 
     let generated_config_path = generated_config_path.to_str().ok_or(ServerError::ProjectPath)?;
 

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -1,6 +1,6 @@
 use crate::consts::{
     ASSET_VERSION_FILE, CONFIG_PARSER_SCRIPT, GENERATED_SCHEMAS_DIR, GIT_IGNORE_CONTENTS, GIT_IGNORE_FILE,
-    MIN_NODE_VERSION, SCHEMA_PARSER_DIR, SCHEMA_PARSER_INDEX, TS_NODE_SCRIPT,
+    MIN_NODE_VERSION, SCHEMA_PARSER_DIR, SCHEMA_PARSER_INDEX, TS_NODE_SCRIPT_PATH,
 };
 use crate::custom_resolvers::build_resolvers;
 use crate::error_server;
@@ -500,7 +500,7 @@ async fn parse_and_generate_config_from_ts(ts_config_path: &Path) -> Result<Stri
         .join(SCHEMA_PARSER_DIR)
         .join(CONFIG_PARSER_SCRIPT);
 
-    let ts_node_path = environment.user_dot_grafbase_path.join(TS_NODE_SCRIPT);
+    let ts_node_path = environment.user_dot_grafbase_path.join(TS_NODE_SCRIPT_PATH);
 
     let args = [
         ts_node_path.as_path(),

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -404,11 +404,7 @@ async fn run_schema_parser(
     let output = {
         let schema_path = match environment.project_grafbase_schema_path {
             GrafbaseSchemaPath::TsConfig(ref ts_config_path) => {
-                trace!(
-                    "Converting a TypeScript config file in {}, converting to GraphQL SDL.",
-                    ts_config_path.display()
-                );
-
+                trace!("found a typescript config file in {}", ts_config_path.display());
                 Cow::Owned(parse_and_generate_config_from_ts(ts_config_path).await?)
             }
             GrafbaseSchemaPath::Graphql(ref path) => Cow::Borrowed(path.to_str().ok_or(ServerError::ProjectPath)?),
@@ -492,7 +488,7 @@ async fn run_schema_parser(
 /// file to the filesystem, returning a path to the generated file.
 async fn parse_and_generate_config_from_ts(ts_config_path: &Path) -> Result<String, ServerError> {
     let environment = Environment::get();
-    let generated_schemas_dir = environment.user_dot_grafbase_path.join(GENERATED_SCHEMAS_DIR);
+    let generated_schemas_dir = environment.project_dot_grafbase_path.join(GENERATED_SCHEMAS_DIR);
     let generated_config_path = generated_schemas_dir.join(GRAFBASE_SCHEMA_FILE_NAME);
 
     if !generated_schemas_dir.exists() {

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -1,5 +1,6 @@
 use crate::consts::{
-    ASSET_VERSION_FILE, GIT_IGNORE_CONTENTS, GIT_IGNORE_FILE, MIN_NODE_VERSION, SCHEMA_PARSER_DIR, SCHEMA_PARSER_INDEX,
+    ASSET_VERSION_FILE, CONFIG_PARSER_SCRIPT, GENERATED_SCHEMAS_DIR, GIT_IGNORE_CONTENTS, GIT_IGNORE_FILE,
+    MIN_NODE_VERSION, SCHEMA_PARSER_DIR, SCHEMA_PARSER_INDEX,
 };
 use crate::custom_resolvers::build_resolvers;
 use crate::error_server;
@@ -8,11 +9,12 @@ use crate::file_watcher::start_watcher;
 use crate::types::{Assets, ServerMessage};
 use crate::{bridge, errors::ServerError};
 use common::consts::{EPHEMERAL_PORT_RANGE, GRAFBASE_DIRECTORY_NAME, GRAFBASE_SCHEMA_FILE_NAME};
-use common::environment::Environment;
+use common::environment::{Environment, GrafbaseSchemaPath};
 use common::types::LocalAddressType;
 use common::utils::find_available_port_in_range;
 use futures_util::FutureExt;
 
+use std::borrow::Cow;
 use std::env;
 use std::path::Path;
 use std::sync::mpsc::{self, Receiver, Sender};
@@ -400,13 +402,22 @@ async fn run_schema_parser(
     );
 
     let output = {
+        let schema_path = match environment.project_grafbase_schema_path {
+            GrafbaseSchemaPath::TsConfig(ref ts_config_path) => {
+                trace!(
+                    "Converting a TypeScript config file in {}, converting to GraphQL SDL.",
+                    ts_config_path.display()
+                );
+
+                Cow::Owned(parse_and_generate_config_from_ts(ts_config_path).await?)
+            }
+            GrafbaseSchemaPath::Graphql(ref path) => Cow::Borrowed(path.to_str().ok_or(ServerError::ProjectPath)?),
+        };
+
         let mut node_command = Command::new("node")
             .args([
                 parser_path.to_str().ok_or(ServerError::CachePath)?,
-                environment
-                    .project_grafbase_schema_path
-                    .to_str()
-                    .ok_or(ServerError::ProjectPath)?,
+                &schema_path,
                 parser_result_path.to_str().expect("must be a valid path"),
             ])
             .current_dir(&environment.project_dot_grafbase_path)
@@ -475,6 +486,54 @@ async fn run_schema_parser(
     .map_err(ServerError::SchemaRegistryWrite)?;
 
     Ok(detected_resolvers)
+}
+
+/// Parses a TypeScript Grafbase configuration and generates a GraphQL schema
+/// file to the filesystem, returning a path to the generated file.
+async fn parse_and_generate_config_from_ts(ts_config_path: &Path) -> Result<String, ServerError> {
+    let environment = Environment::get();
+    let generated_schemas_dir = environment.user_dot_grafbase_path.join(GENERATED_SCHEMAS_DIR);
+    let generated_config_path = generated_schemas_dir.join(GRAFBASE_SCHEMA_FILE_NAME);
+
+    if !generated_schemas_dir.exists() {
+        std::fs::create_dir_all(generated_schemas_dir).map_err(ServerError::SchemaParserError)?;
+    }
+
+    let config_parser_path = environment
+        .user_dot_grafbase_path
+        .join(SCHEMA_PARSER_DIR)
+        .join(CONFIG_PARSER_SCRIPT);
+
+    let ts_node_path = environment
+        .user_dot_grafbase_path
+        .join("node_modules/ts-node/dist/bin.js");
+
+    let args = [
+        ts_node_path.as_path(),
+        config_parser_path.as_path(),
+        ts_config_path,
+        &generated_config_path,
+    ];
+
+    let node_command = Command::new("node")
+        .args(args)
+        .current_dir(&environment.project_dot_grafbase_path)
+        .stdin(Stdio::piped())
+        .stderr(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .map_err(ServerError::SchemaParserError)?;
+
+    node_command
+        .wait_with_output()
+        .await
+        .map_err(ServerError::SchemaParserError)?;
+
+    let generated_config_path = generated_config_path.to_str().ok_or(ServerError::ProjectPath)?;
+
+    trace!("Generated configuration in {}.", generated_config_path);
+
+    Ok(generated_config_path.to_string())
 }
 
 async fn get_node_version_string() -> Result<String, ServerError> {

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -1,6 +1,6 @@
 use crate::consts::{
     ASSET_VERSION_FILE, CONFIG_PARSER_SCRIPT, GENERATED_SCHEMAS_DIR, GIT_IGNORE_CONTENTS, GIT_IGNORE_FILE,
-    MIN_NODE_VERSION, SCHEMA_PARSER_DIR, SCHEMA_PARSER_INDEX,
+    MIN_NODE_VERSION, SCHEMA_PARSER_DIR, SCHEMA_PARSER_INDEX, TS_NODE_SCRIPT,
 };
 use crate::custom_resolvers::build_resolvers;
 use crate::error_server;
@@ -488,10 +488,6 @@ async fn run_schema_parser(
 async fn parse_and_generate_config_from_ts(ts_config_path: &Path) -> Result<String, ServerError> {
     let environment = Environment::get();
 
-    if environment.project_grafbase_schema_path.has_both_files() {
-        warn!("grafbase.config.ts takes precedence over schema.graphql - please choose one and delete the other to avoid conflicts");
-    }
-
     let generated_schemas_dir = environment.project_dot_grafbase_path.join(GENERATED_SCHEMAS_DIR);
     let generated_config_path = generated_schemas_dir.join(GRAFBASE_SCHEMA_FILE_NAME);
 
@@ -504,9 +500,7 @@ async fn parse_and_generate_config_from_ts(ts_config_path: &Path) -> Result<Stri
         .join(SCHEMA_PARSER_DIR)
         .join(CONFIG_PARSER_SCRIPT);
 
-    let ts_node_path = environment
-        .user_dot_grafbase_path
-        .join("node_modules/ts-node/dist/bin.js");
+    let ts_node_path = environment.user_dot_grafbase_path.join(TS_NODE_SCRIPT);
 
     let args = [
         ts_node_path.as_path(),
@@ -518,7 +512,6 @@ async fn parse_and_generate_config_from_ts(ts_config_path: &Path) -> Result<Stri
     let node_command = Command::new("node")
         .args(args)
         .current_dir(&environment.user_dot_grafbase_path)
-        .stdin(Stdio::piped())
         .stderr(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682109806,
-        "narHash": "sha256-d9g7RKNShMLboTWwukM+RObDWWpHKaqTYXB48clBWXI=",
+        "lastModified": 1683267615,
+        "narHash": "sha256-A/zAy9YauwdPut90h6cYC1zgP/WmuW9zmJ+K/c5i6uc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2362848adf8def2866fabbffc50462e929d7fffb",
+        "rev": "0b6445b611472740f02eae9015150c07c5373340",
         "type": "github"
       },
       "original": {
@@ -51,11 +51,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682302828,
-        "narHash": "sha256-5uKDELNLWozRhv02ynzvGf8rx30b0m8DhPTT63IFVHo=",
+        "lastModified": 1683253065,
+        "narHash": "sha256-92vzWdV7VNGNQJeF+gtlcw18nj3ERU+i/fnSVzI7Lsw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "55de807250dd207007a0697e6e06d9fcba578d81",
+        "rev": "59e9ddf0c5232136f71c458eea1303a418f7a117",
         "type": "github"
       },
       "original": {

--- a/packages/grafbase-sdk/.eslintrc.cjs
+++ b/packages/grafbase-sdk/.eslintrc.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  root: true,
+};

--- a/packages/grafbase-sdk/README.md
+++ b/packages/grafbase-sdk/README.md
@@ -75,13 +75,23 @@ enum Fruits {
   Oranges
 }
 
-g.enumType('Fruits', Fruits)
+g.enum('Fruits', Fruits)
 ```
 
 or
 
 ```typescript
-g.enumType('Fruits', ['Apples', 'Oranges'])
+g.enum('Fruits', ['Apples', 'Oranges'])
+```
+
+An enum can be used as a field type with the `ref` method:
+
+```typescript
+const e = g.enum('Fruits', ['Apples', 'Oranges'])
+
+g.type("User", {
+  favoriteFruit: g.ref(e)
+})
 ```
 
 ## Queries and Mutations

--- a/packages/grafbase-sdk/README.md
+++ b/packages/grafbase-sdk/README.md
@@ -1,0 +1,300 @@
+# The Grafbase SDK
+
+A TypeScript library to generate a Grafbase configuration. It replaces the `schema.graphql` file with `grafbase.config.ts`, which should be placed into the project's `grafbase` directory.
+
+The configuration should define the schema, exporting the config as `default`:
+
+```typescript
+// g is a schema generator, config the final object to return
+import { g, config } from '@grafbase/sdk'
+
+// types are generated with the `type` method,
+// followed by the name and fields.
+const profile = g.type("Profile", {
+  address: g.string(),
+})
+
+// models can be generated with the `model` method
+const user = g.model("User", {
+  name: g.string(),
+  age: g.int().optional(),
+  profile: g.ref(profile).optional(),
+  parent: g.relation(() => user).optional()
+})
+
+// finally we export the default config
+export default config({
+  schema: g
+})
+```
+
+When `grafbase dev` finds the above config from `$PROJECT/grafbase/grafbase.config.ts`, it genereates the SDL to `$PROJECT/.grafbase/generated/schema/schema.graphql`:
+
+```graphql
+type Profile {
+  address: String!
+}
+
+type User @model {
+  name: String!
+  age: Int
+  profile: Profile
+  parent: User
+}
+```
+
+The above SDL is now used when starting the dev.
+
+## Types
+
+Types are generated with the `type` method:
+
+```typescript
+g.type("Profile", {
+  address: g.string()
+})
+```
+
+## Models
+
+Types are generated with the `model` method:
+
+```typescript
+g.model("User", {
+  name: g.string()
+})
+```
+
+## Enums
+
+Enums can be generated either from TypeScript enums or from a dynamic array:
+
+```typescript
+enum Fruits {
+  Apples,
+  Oranges
+}
+
+g.enumType('Fruits', Fruits)
+```
+
+or
+
+```typescript
+g.enumType('Fruits', ['Apples', 'Oranges'])
+```
+
+## Queries and Mutations
+
+Queries are generated with the `query` method, mutations with the `mutation` method:
+
+```typescript
+g.query('greet', {
+  args: { name: g.string().optional() },
+  returns: g.string(),
+  resolver: 'hello'
+})
+
+const input = g.type('CheckoutSessionInput', { name: g.string() })
+const output = g.type('CheckoutSessionOutput', { successful: g.boolean() })
+
+g.mutation('checkout', {
+  args: { input: g.ref(input) },
+  returns: g.ref(output),
+  resolver: 'checkout'
+})
+```
+
+## Unions
+
+Unions can be done using the `union` method:
+
+```typescript
+const user = g.type('User', {
+  name: g.string(),
+  age: g.int().optional()
+})
+
+const address = g.type('Address', {
+  street: g.string().optional()
+})
+
+g.union('UserOrAddress', { user, address })
+```
+
+## Interfaces
+
+Interfaces can be generated using the `interface` method, and a type can be extended with an interface:
+
+```typescript
+const produce = g.interface('Produce', {
+  name: g.string(),
+  quantity: g.int(),
+  price: g.float(),
+  nutrients: g.string().optional().list().optional()
+})
+
+g.type('Fruit', {
+  isSeedless: g.boolean().optional(),
+  ripenessIndicators: g.string().optional().list().optional()
+}).implements(produce)
+```
+
+Notice how one doesn't need to type the fields to the type: they are inferred to the final SDL from the interface definition.
+
+## Field generation
+
+Fields are generated from the `g` object:
+
+- String: `g.string()`
+- ID: `g.id()`
+- Email: `g.email()`
+- Int: `g.int()`
+- Float: `g.float()`
+- Boolean: `g.boolean()`
+- Date: `g.date()`
+- DateTime: `g.datetime()`
+- IPAddress: `g.ipAddress()`
+- Timestamp: `g.timestamp()`
+- URL: `g.url()`
+- JSON: `g.json()`
+
+## Enum fields
+
+```typescript
+// first greate an enum
+enum Fruits {
+  Apples,
+  Oranges
+}
+
+const fruits = g.enumType("Fruits", Fruits)
+
+// then use it e.g. in a model
+g.model("User", {
+  favoriteFruit: g.enum(fruits)
+})
+```
+
+## Reference fields
+
+Referencing a type is with the `ref` method:
+
+```typescript
+const profile = g.type("Profile", {
+  address: g.string()
+})
+
+g.model("User", {
+  profile: g.ref(profile)
+})
+```
+
+## Relation fields
+
+Creating a relation between models is with the `relation` method.
+
+```typescript
+const user = g.model("User", {
+  posts: g.relation(() => post).name("relationName").list()
+})
+
+const post = g.model("Post", {
+  author: g.relation(user).name("relationName")
+})
+```
+
+## Optional fields
+
+By default the generated fields are _required_. To make them optional is with the `optional` method:
+
+```typescript
+const user = g.model("User", {
+  posts: g.string().optional()
+})
+```
+
+## List fields
+
+List fields can be done with the `list` method:
+
+```typescript
+const user = g.model("User", {
+  names: g.string().list()
+})
+```
+
+By default, the list or list items are _required_. To make the items nullable, call the `optional` method to the base type:
+
+```typescript
+const user = g.model("User", {
+  names: g.string().optional().list()
+})
+```
+
+To make the list itself optional, call the `optional` method to the list type:
+
+```typescript
+const user = g.model("User", {
+  names: g.string().list().optional()
+})
+```
+
+## Unique
+
+Unique field can be defined to certain types of fields with the `unique` method:
+
+```typescript
+const user = g.model("User", {
+  name: g.string().unique()
+})
+```
+
+Additional unique scope can be given as a parameter:
+
+```typescript
+const user = g.model("User", {
+  name: g.string().unique(["email"]),
+  email: g.string()
+})
+```
+
+## Length limit
+
+Certain field types can have a limited length:
+
+```typescript
+const user = g.model("User", {
+  name: g.string().length({ min: 1, max: 255 })
+})
+```
+
+## Defaults
+
+Default values for certain field types can be given with the `default` method. The default parameters are type-checked to fit the field type:
+
+```typescript
+const user = g.model("User", {
+  name: g.string().default("meow"),
+  age: g.int().default(11)
+})
+```
+
+## Search
+
+Certain types of fields can be searchable:
+
+```typescript
+const user = g.model("User", {
+  name: g.string().search(),
+})
+```
+
+Additionally, the whole model can be searchable:
+
+```typescript
+const user = g.model("User", {
+  name: g.string(),
+  age: g.int()
+}).search()
+```

--- a/packages/grafbase-sdk/jest.config.js
+++ b/packages/grafbase-sdk/jest.config.js
@@ -2,4 +2,4 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-};
+}

--- a/packages/grafbase-sdk/jest.config.js
+++ b/packages/grafbase-sdk/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@grafbase/sdk",
+  "version": "0.0.1",
+  "description": "The Grafbase SDK",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/grafbase/grafbase",
+    "directory": "packages/grafbase-sdk"
+  },
+  "keywords": [
+    "grafbase",
+    "typescript",
+    "graphql"
+  ],
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "files": [
+    "/dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "pnpm exec jest"
+  },
+  "watch": {
+    "build": {
+      "patterns": [
+        "src",
+        "tests"
+      ],
+      "extensions": "ts"
+    }
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@jest/globals": "=29.5.0",
+    "@types/node": "^18.14.2",
+    "@typescript-eslint/eslint-plugin": "^5.59.2",
+    "@typescript-eslint/parser": "^5.59.2",
+    "eslint": "^8.39.0",
+    "jest": "=29.5.0",
+    "npm-watch": "^0.11.0",
+    "ts-jest": "=29.1.0",
+    "ts-node": "^10.9.1",
+    "tsconfig": "workspace:*",
+    "typescript": "^5.0.2"
+  },
+  "dependencies": {
+    "type-fest": "^3.9.0"
+  },
+  "engines": {
+    "node": ">=16.13.0"
+  }
+}

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",

--- a/packages/grafbase-sdk/src/config.ts
+++ b/packages/grafbase-sdk/src/config.ts
@@ -1,0 +1,38 @@
+import { Enum } from './enum';
+import { Interface } from './interface';
+import { Model } from './model'
+import { Query } from './query';
+import { Type } from './type';
+import { Union } from './union';
+
+export interface Schema {
+  enums?: Enum[]
+  types?: Type[]
+  unions?: Union[]
+  models?: Model[]
+  interfaces?: Interface[]
+  queries?: Query[]
+}
+
+export class Config {
+  graphqlSchema?: Schema;
+
+  public schema(schema: Schema): Config {
+    this.graphqlSchema = schema
+
+    return this
+  }
+
+  public toString(): string {
+    const queries = this.graphqlSchema?.queries?.map(String).join("\n\n") ?? ""
+    const interfaces = this.graphqlSchema?.interfaces?.map(String).join("\n\n") ?? ""
+    const types = this.graphqlSchema?.types?.map(String).join("\n\n") ?? ""
+    const unions = this.graphqlSchema?.unions?.map(String).join("\n\n") ?? ""
+    const enums = this.graphqlSchema?.enums?.map(String).join("\n\n") ?? ""
+    const models = this.graphqlSchema?.models?.map(String).join("\n\n") ?? ""
+
+    const renderOrder = [interfaces, enums, types, queries, unions, models]
+
+    return renderOrder.filter(Boolean).flat().map(String).join("\n\n")
+  }
+}

--- a/packages/grafbase-sdk/src/config.ts
+++ b/packages/grafbase-sdk/src/config.ts
@@ -1,4 +1,4 @@
-import { GrafbaseSchema } from './grafbase-schema';
+import { GrafbaseSchema } from './grafbase-schema'
 
 export interface ConfigInput {
   schema: GrafbaseSchema

--- a/packages/grafbase-sdk/src/config.ts
+++ b/packages/grafbase-sdk/src/config.ts
@@ -1,38 +1,17 @@
-import { Enum } from './enum';
-import { Interface } from './interface';
-import { Model } from './model'
-import { Query } from './query';
-import { Type } from './type';
-import { Union } from './union';
+import { GrafbaseSchema } from './grafbase_schema';
 
-export interface Schema {
-  enums?: Enum[]
-  types?: Type[]
-  unions?: Union[]
-  models?: Model[]
-  interfaces?: Interface[]
-  queries?: Query[]
+export interface ConfigInput {
+  schema: GrafbaseSchema
 }
 
 export class Config {
-  graphqlSchema?: Schema;
+  schema: GrafbaseSchema
 
-  public schema(schema: Schema): Config {
-    this.graphqlSchema = schema
-
-    return this
+  constructor(input: ConfigInput) {
+    this.schema = input.schema
   }
 
   public toString(): string {
-    const queries = this.graphqlSchema?.queries?.map(String).join("\n\n") ?? ""
-    const interfaces = this.graphqlSchema?.interfaces?.map(String).join("\n\n") ?? ""
-    const types = this.graphqlSchema?.types?.map(String).join("\n\n") ?? ""
-    const unions = this.graphqlSchema?.unions?.map(String).join("\n\n") ?? ""
-    const enums = this.graphqlSchema?.enums?.map(String).join("\n\n") ?? ""
-    const models = this.graphqlSchema?.models?.map(String).join("\n\n") ?? ""
-
-    const renderOrder = [interfaces, enums, types, queries, unions, models]
-
-    return renderOrder.filter(Boolean).flat().map(String).join("\n\n")
+    return this.schema.toString()
   }
 }

--- a/packages/grafbase-sdk/src/config.ts
+++ b/packages/grafbase-sdk/src/config.ts
@@ -1,4 +1,4 @@
-import { GrafbaseSchema } from './grafbase_schema';
+import { GrafbaseSchema } from './grafbase-schema';
 
 export interface ConfigInput {
   schema: GrafbaseSchema

--- a/packages/grafbase-sdk/src/enum.ts
+++ b/packages/grafbase-sdk/src/enum.ts
@@ -1,0 +1,24 @@
+import { EnumShape } from "."
+
+export class Enum {
+  name: string
+  variants: string[]
+
+  constructor(name: string, variants: EnumShape) {
+    this.name = name
+
+    if (Array.isArray(variants)) {
+      this.variants = variants
+    } else {
+      this.variants = Object.keys(variants).filter((key) => isNaN(Number(key)))
+    }
+  }
+
+  public toString(): string {
+    const header = `enum ${this.name} {`
+    const variants = this.variants.map((variant) => `  ${variant}`).join(",\n")
+    const footer = "}"
+
+    return `${header}\n${variants}\n${footer}`
+  }
+}

--- a/packages/grafbase-sdk/src/enum.ts
+++ b/packages/grafbase-sdk/src/enum.ts
@@ -1,4 +1,4 @@
-import { EnumShape } from "."
+import { EnumShape } from '.'
 
 export class Enum {
   name: string
@@ -16,8 +16,8 @@ export class Enum {
 
   public toString(): string {
     const header = `enum ${this.name} {`
-    const variants = this.variants.map((variant) => `  ${variant}`).join(",\n")
-    const footer = "}"
+    const variants = this.variants.map((variant) => `  ${variant}`).join(',\n')
+    const footer = '}'
 
     return `${header}\n${variants}\n${footer}`
   }

--- a/packages/grafbase-sdk/src/field.ts
+++ b/packages/grafbase-sdk/src/field.ts
@@ -1,0 +1,15 @@
+import { FieldShape } from '.'
+
+export class Field {
+  name: string
+  shape: FieldShape
+
+  constructor(name: string, shape: FieldShape) {
+    this.name = name
+    this.shape = shape
+  }
+
+  public toString(): string {
+    return `${this.name}: ${this.shape}`
+  }
+}

--- a/packages/grafbase-sdk/src/field/list.ts
+++ b/packages/grafbase-sdk/src/field/list.ts
@@ -1,35 +1,37 @@
 import { ScalarType } from '..'
-import { ReferenceDef } from '../reference'
-import { RelationDef } from '../relation'
+import { ReferenceDefinition } from '../reference'
+import { RelationDefinition } from '../relation'
 import {
   FieldType,
-  BooleanDef,
-  DateDef,
-  NumberDef,
-  ScalarDef,
-  SearchDef,
-  StringDef,
+  BooleanDefinition,
+  DateDefinition,
+  NumberDefinition,
+  ScalarDefinition,
+  SearchDefinition,
+  StringDefinition,
   renderDefault
 } from './typedefs'
 
-export class ListDef {
-  fieldDefinition: ScalarDef | RelationDef | ReferenceDef
+export class ListDefinition {
+  fieldDefinition: ScalarDefinition | RelationDefinition | ReferenceDefinition
   isOptional: boolean
   defaultValue?: ScalarType[]
 
-  constructor(fieldDefinition: ScalarDef | RelationDef | ReferenceDef) {
+  constructor(
+    fieldDefinition: ScalarDefinition | RelationDefinition | ReferenceDefinition
+  ) {
     this.fieldDefinition = fieldDefinition
     this.isOptional = false
   }
 
-  public optional(): ListDef {
+  public optional(): ListDefinition {
     this.isOptional = true
 
     return this
   }
 
-  public search(): SearchDef {
-    return new SearchDef(this)
+  public search(): SearchDefinition {
+    return new SearchDefinition(this)
   }
 
   public toString(): string {
@@ -39,10 +41,10 @@ export class ListDef {
   }
 }
 
-class ListWithDefaultDef extends ListDef {
+class ListWithDefaultDefinition extends ListDefinition {
   fieldType: FieldType
 
-  constructor(fieldDefinition: ScalarDef) {
+  constructor(fieldDefinition: ScalarDefinition) {
     super(fieldDefinition)
 
     this.fieldType = fieldDefinition.fieldType as FieldType
@@ -60,48 +62,48 @@ class ListWithDefaultDef extends ListDef {
   }
 }
 
-export class StringListDef extends ListWithDefaultDef {
-  constructor(fieldDefinition: StringDef) {
+export class StringListDefinition extends ListWithDefaultDefinition {
+  constructor(fieldDefinition: StringDefinition) {
     super(fieldDefinition)
   }
 
-  public default(val: string[]): StringListDef {
+  public default(val: string[]): StringListDefinition {
     this.defaultValue = val
 
     return this
   }
 }
 
-export class NumberListDef extends ListWithDefaultDef {
-  constructor(fieldDefinition: NumberDef) {
+export class NumberListDefinition extends ListWithDefaultDefinition {
+  constructor(fieldDefinition: NumberDefinition) {
     super(fieldDefinition)
   }
 
-  public default(val: number[]): NumberListDef {
+  public default(val: number[]): NumberListDefinition {
     this.defaultValue = val
 
     return this
   }
 }
 
-export class BooleanListDef extends ListWithDefaultDef {
-  constructor(fieldDefinition: BooleanDef) {
+export class BooleanListDefinition extends ListWithDefaultDefinition {
+  constructor(fieldDefinition: BooleanDefinition) {
     super(fieldDefinition)
   }
 
-  public default(val: boolean[]): BooleanListDef {
+  public default(val: boolean[]): BooleanListDefinition {
     this.defaultValue = val
 
     return this
   }
 }
 
-export class DateListDef extends ListWithDefaultDef {
-  constructor(fieldDefinition: DateDef) {
+export class DateListDefinition extends ListWithDefaultDefinition {
+  constructor(fieldDefinition: DateDefinition) {
     super(fieldDefinition)
   }
 
-  public default(val: Date[]): DateListDef {
+  public default(val: Date[]): DateListDefinition {
     this.defaultValue = val
 
     return this

--- a/packages/grafbase-sdk/src/field/list.ts
+++ b/packages/grafbase-sdk/src/field/list.ts
@@ -1,35 +1,35 @@
 import { ScalarType } from '..'
-import { GReferenceDef } from '../reference'
-import { GRelationDef } from '../relation'
+import { ReferenceDef } from '../reference'
+import { RelationDef } from '../relation'
 import {
   FieldType,
-  GBooleanDef,
-  GDateDef,
-  GNumberDef,
-  GScalarDef,
-  GSearchDef,
-  GStringDef,
+  BooleanDef,
+  DateDef,
+  NumberDef,
+  ScalarDef,
+  SearchDef,
+  StringDef,
   renderDefault
 } from './typedefs'
 
-export class GListDef {
-  fieldDefinition: GScalarDef | GRelationDef | GReferenceDef
+export class ListDef {
+  fieldDefinition: ScalarDef | RelationDef | ReferenceDef
   isOptional: boolean
   defaultValue?: ScalarType[]
 
-  constructor(fieldDefinition: GScalarDef | GRelationDef | GReferenceDef) {
+  constructor(fieldDefinition: ScalarDef | RelationDef | ReferenceDef) {
     this.fieldDefinition = fieldDefinition
     this.isOptional = false
   }
 
-  public optional(): GListDef {
+  public optional(): ListDef {
     this.isOptional = true
 
     return this
   }
 
-  public search(): GSearchDef {
-    return new GSearchDef(this)
+  public search(): SearchDef {
+    return new SearchDef(this)
   }
 
   public toString(): string {
@@ -39,10 +39,10 @@ export class GListDef {
   }
 }
 
-class GListWithDefaultDef extends GListDef {
+class ListWithDefaultDef extends ListDef {
   fieldType: FieldType
 
-  constructor(fieldDefinition: GScalarDef) {
+  constructor(fieldDefinition: ScalarDef) {
     super(fieldDefinition)
 
     this.fieldType = fieldDefinition.fieldType as FieldType
@@ -60,48 +60,48 @@ class GListWithDefaultDef extends GListDef {
   }
 }
 
-export class GStringListDef extends GListWithDefaultDef {
-  constructor(fieldDefinition: GStringDef) {
+export class StringListDef extends ListWithDefaultDef {
+  constructor(fieldDefinition: StringDef) {
     super(fieldDefinition)
   }
 
-  public default(val: string[]): GStringListDef {
+  public default(val: string[]): StringListDef {
     this.defaultValue = val
 
     return this
   }
 }
 
-export class GNumberListDef extends GListWithDefaultDef {
-  constructor(fieldDefinition: GNumberDef) {
+export class NumberListDef extends ListWithDefaultDef {
+  constructor(fieldDefinition: NumberDef) {
     super(fieldDefinition)
   }
 
-  public default(val: number[]): GNumberListDef {
+  public default(val: number[]): NumberListDef {
     this.defaultValue = val
 
     return this
   }
 }
 
-export class GBooleanListDef extends GListWithDefaultDef {
-  constructor(fieldDefinition: GBooleanDef) {
+export class BooleanListDef extends ListWithDefaultDef {
+  constructor(fieldDefinition: BooleanDef) {
     super(fieldDefinition)
   }
 
-  public default(val: boolean[]): GBooleanListDef {
+  public default(val: boolean[]): BooleanListDef {
     this.defaultValue = val
 
     return this
   }
 }
 
-export class GDateListDef extends GListWithDefaultDef {
-  constructor(fieldDefinition: GDateDef) {
+export class DateListDef extends ListWithDefaultDef {
+  constructor(fieldDefinition: DateDef) {
     super(fieldDefinition)
   }
 
-  public default(val: Date[]): GDateListDef {
+  public default(val: Date[]): DateListDef {
     this.defaultValue = val
 
     return this

--- a/packages/grafbase-sdk/src/field/list.ts
+++ b/packages/grafbase-sdk/src/field/list.ts
@@ -1,0 +1,97 @@
+import { ScalarType } from ".."
+import { GReferenceDef } from "../reference"
+import { GRelationDef } from "../relation"
+import { FieldType, GBooleanDef, GDateDef, GNumberDef, GScalarDef, GSearchDef, GStringDef, renderDefault } from "./typedefs"
+
+export class GListDef {
+  fieldDefinition: GScalarDef | GRelationDef | GReferenceDef
+  isOptional: boolean
+  defaultValue?: ScalarType[]
+  
+  constructor(fieldDefinition: GScalarDef | GRelationDef | GReferenceDef) {
+    this.fieldDefinition = fieldDefinition
+    this.isOptional = false
+  }
+
+  public optional(): GListDef {
+    this.isOptional = true
+
+    return this
+  }
+
+  public search(): GSearchDef {
+    return new GSearchDef(this)
+  }
+
+  public toString(): string {
+    const required = this.isOptional ? "" : "!"
+
+    return `[${this.fieldDefinition}]${required}`
+  }
+}
+
+class GListWithDefaultDef extends GListDef {
+  fieldType: FieldType
+
+  constructor(fieldDefinition: GScalarDef) {
+    super(fieldDefinition)
+
+    this.fieldType = fieldDefinition.fieldType as FieldType
+  }
+
+  public toString(): string {
+    const defaultValue = this.defaultValue != null ?
+      ` @default(value: [${this.defaultValue.map((v) => renderDefault(v, this.fieldType)).join(', ')}])` : 
+      ""
+
+    return `${super.toString()}${defaultValue}`
+  }
+}
+
+export class GStringListDef extends GListWithDefaultDef {
+  constructor(fieldDefinition: GStringDef) {
+    super(fieldDefinition)
+  }
+
+  public default(val: string[]): GStringListDef {
+    this.defaultValue = val
+
+    return this
+  }
+}
+
+export class GNumberListDef extends GListWithDefaultDef {
+  constructor(fieldDefinition: GNumberDef) {
+    super(fieldDefinition)
+  }
+
+  public default(val: number[]): GNumberListDef {
+    this.defaultValue = val
+
+    return this
+  }
+}
+
+export class GBooleanListDef extends GListWithDefaultDef {
+  constructor(fieldDefinition: GBooleanDef) {
+    super(fieldDefinition)
+  }
+
+  public default(val: boolean[]): GBooleanListDef {
+    this.defaultValue = val
+
+    return this
+  }
+}
+
+export class GDateListDef extends GListWithDefaultDef {
+  constructor(fieldDefinition: GDateDef) {
+    super(fieldDefinition)
+  }
+
+  public default(val: Date[]): GDateListDef {
+    this.defaultValue = val
+
+    return this
+  }
+}

--- a/packages/grafbase-sdk/src/field/list.ts
+++ b/packages/grafbase-sdk/src/field/list.ts
@@ -1,13 +1,22 @@
-import { ScalarType } from ".."
-import { GReferenceDef } from "../reference"
-import { GRelationDef } from "../relation"
-import { FieldType, GBooleanDef, GDateDef, GNumberDef, GScalarDef, GSearchDef, GStringDef, renderDefault } from "./typedefs"
+import { ScalarType } from '..'
+import { GReferenceDef } from '../reference'
+import { GRelationDef } from '../relation'
+import {
+  FieldType,
+  GBooleanDef,
+  GDateDef,
+  GNumberDef,
+  GScalarDef,
+  GSearchDef,
+  GStringDef,
+  renderDefault
+} from './typedefs'
 
 export class GListDef {
   fieldDefinition: GScalarDef | GRelationDef | GReferenceDef
   isOptional: boolean
   defaultValue?: ScalarType[]
-  
+
   constructor(fieldDefinition: GScalarDef | GRelationDef | GReferenceDef) {
     this.fieldDefinition = fieldDefinition
     this.isOptional = false
@@ -24,7 +33,7 @@ export class GListDef {
   }
 
   public toString(): string {
-    const required = this.isOptional ? "" : "!"
+    const required = this.isOptional ? '' : '!'
 
     return `[${this.fieldDefinition}]${required}`
   }
@@ -40,9 +49,12 @@ class GListWithDefaultDef extends GListDef {
   }
 
   public toString(): string {
-    const defaultValue = this.defaultValue != null ?
-      ` @default(value: [${this.defaultValue.map((v) => renderDefault(v, this.fieldType)).join(', ')}])` : 
-      ""
+    const defaultValue =
+      this.defaultValue != null
+        ? ` @default(value: [${this.defaultValue
+            .map((v) => renderDefault(v, this.fieldType))
+            .join(', ')}])`
+        : ''
 
     return `${super.toString()}${defaultValue}`
   }

--- a/packages/grafbase-sdk/src/field/typedefs.ts
+++ b/packages/grafbase-sdk/src/field/typedefs.ts
@@ -1,11 +1,11 @@
 import { RequireAtLeastOne } from 'type-fest'
 import { Enum } from '../enum'
 import {
-  GBooleanListDef,
-  GDateListDef,
-  GListDef,
-  GNumberListDef,
-  GStringListDef
+  BooleanListDef,
+  DateListDef,
+  ListDef,
+  NumberListDef,
+  StringListDef
 } from './list'
 import { ScalarType, Searchable } from '..'
 
@@ -30,7 +30,7 @@ export enum FieldType {
   PhoneNumber = 'PhoneNumber'
 }
 
-export class GSearchDef {
+export class SearchDef {
   field: Searchable
 
   constructor(field: Searchable) {
@@ -43,12 +43,12 @@ export class GSearchDef {
 }
 
 type UniqueScalarType =
-  | GScalarDef
-  | GDefaultDef
-  | GSearchDef
-  | GLengthLimitedStringDef
+  | ScalarDef
+  | DefaultDef
+  | SearchDef
+  | LengthLimitedStringDef
 
-export class GUniqueDef {
+export class UniqueDef {
   compoundScope?: string[]
   scalar: UniqueScalarType
 
@@ -57,8 +57,8 @@ export class GUniqueDef {
     this.compoundScope = scope
   }
 
-  public search(): GSearchDef {
-    return new GSearchDef(this)
+  public search(): SearchDef {
+    return new SearchDef(this)
   }
 
   public toString(): string {
@@ -71,23 +71,23 @@ export class GUniqueDef {
   }
 }
 
-export class GDefaultDef {
+export class DefaultDef {
   defaultValue: ScalarType
-  scalar: GScalarDef | GLengthLimitedStringDef
+  scalar: ScalarDef | LengthLimitedStringDef
 
   constructor(
-    scalar: GScalarDef | GLengthLimitedStringDef,
+    scalar: ScalarDef | LengthLimitedStringDef,
     defaultValue: ScalarType
   ) {
     this.defaultValue = defaultValue
     this.scalar = scalar
   }
 
-  public unique(): GUniqueDef {
-    return new GUniqueDef(this)
+  public unique(): UniqueDef {
+    return new UniqueDef(this)
   }
 
-  public optional(): GDefaultDef {
+  public optional(): DefaultDef {
     this.scalar.optional()
     return this
   }
@@ -100,7 +100,7 @@ export class GDefaultDef {
   }
 }
 
-export class GScalarDef {
+export class ScalarDef {
   fieldType: FieldType | Enum
   isOptional: boolean
   defaultValue?: ScalarType
@@ -110,22 +110,22 @@ export class GScalarDef {
     this.isOptional = false
   }
 
-  public optional(): GScalarDef {
+  public optional(): ScalarDef {
     this.isOptional = true
 
     return this
   }
 
-  public unique(scope?: string[]): GUniqueDef {
-    return new GUniqueDef(this, scope)
+  public unique(scope?: string[]): UniqueDef {
+    return new UniqueDef(this, scope)
   }
 
-  public search(): GSearchDef {
-    return new GSearchDef(this)
+  public search(): SearchDef {
+    return new SearchDef(this)
   }
 
-  public list(): GListDef {
-    return new GListDef(this)
+  public list(): ListDef {
+    return new ListDef(this)
   }
 
   fieldTypeVal(): FieldType | Enum {
@@ -146,47 +146,47 @@ export class GScalarDef {
   }
 }
 
-export class GStringDef extends GScalarDef {
-  public default(val: string): GDefaultDef {
-    return new GDefaultDef(this, val)
+export class StringDef extends ScalarDef {
+  public default(val: string): DefaultDef {
+    return new DefaultDef(this, val)
   }
 
   public length(
     fieldLength: RequireAtLeastOne<FieldLength, 'min' | 'max'>
-  ): GLengthLimitedStringDef {
-    return new GLengthLimitedStringDef(this, fieldLength)
+  ): LengthLimitedStringDef {
+    return new LengthLimitedStringDef(this, fieldLength)
   }
 
-  public list(): GStringListDef {
-    return new GStringListDef(this)
+  public list(): StringListDef {
+    return new StringListDef(this)
   }
 }
 
-export class GLengthLimitedStringDef {
+export class LengthLimitedStringDef {
   fieldLength: RequireAtLeastOne<FieldLength, 'min' | 'max'>
-  scalar: GStringDef
+  scalar: StringDef
 
   constructor(
-    scalar: GStringDef,
+    scalar: StringDef,
     fieldLength: RequireAtLeastOne<FieldLength, 'min' | 'max'>
   ) {
     this.fieldLength = fieldLength
     this.scalar = scalar
   }
 
-  public unique(scope?: string[]): GUniqueDef {
-    return new GUniqueDef(this, scope)
+  public unique(scope?: string[]): UniqueDef {
+    return new UniqueDef(this, scope)
   }
 
-  public search(): GSearchDef {
-    return new GSearchDef(this)
+  public search(): SearchDef {
+    return new SearchDef(this)
   }
 
-  public default(val: string): GDefaultDef {
-    return new GDefaultDef(this, val)
+  public default(val: string): DefaultDef {
+    return new DefaultDef(this, val)
   }
 
-  public optional(): GLengthLimitedStringDef {
+  public optional(): LengthLimitedStringDef {
     this.scalar.optional()
 
     return this
@@ -209,39 +209,39 @@ export class GLengthLimitedStringDef {
   }
 }
 
-export class GNumberDef extends GScalarDef {
-  public default(val: number): GDefaultDef {
-    return new GDefaultDef(this, val)
+export class NumberDef extends ScalarDef {
+  public default(val: number): DefaultDef {
+    return new DefaultDef(this, val)
   }
 
-  public list(): GNumberListDef {
-    return new GNumberListDef(this)
-  }
-}
-
-export class GBooleanDef extends GScalarDef {
-  public default(val: boolean): GDefaultDef {
-    return new GDefaultDef(this, val)
-  }
-
-  public list(): GBooleanListDef {
-    return new GBooleanListDef(this)
+  public list(): NumberListDef {
+    return new NumberListDef(this)
   }
 }
 
-export class GDateDef extends GScalarDef {
-  public default(val: Date): GDefaultDef {
-    return new GDefaultDef(this, val)
+export class BooleanDef extends ScalarDef {
+  public default(val: boolean): DefaultDef {
+    return new DefaultDef(this, val)
   }
 
-  public list(): GDateListDef {
-    return new GDateListDef(this)
+  public list(): BooleanListDef {
+    return new BooleanListDef(this)
   }
 }
 
-export class GObjectDef extends GScalarDef {
-  public default(val: object): GDefaultDef {
-    return new GDefaultDef(this, val)
+export class DateDef extends ScalarDef {
+  public default(val: Date): DefaultDef {
+    return new DefaultDef(this, val)
+  }
+
+  public list(): DateListDef {
+    return new DateListDef(this)
+  }
+}
+
+export class ObjectDef extends ScalarDef {
+  public default(val: object): DefaultDef {
+    return new DefaultDef(this, val)
   }
 }
 
@@ -266,21 +266,11 @@ export function renderDefault(val: any, fieldType: FieldType | Enum) {
     return val.toString()
   } else {
     switch (fieldType) {
-      case FieldType.String: {
-        return `"${val}"`
-      }
-      case FieldType.ID: {
-        return `"${val}"`
-      }
-      case FieldType.Email: {
-        return `"${val}"`
-      }
-      case FieldType.PhoneNumber: {
-        return `"${val}"`
-      }
-      case FieldType.IPAddress: {
-        return `"${val}"`
-      }
+      case FieldType.String:
+      case FieldType.ID:
+      case FieldType.Email:
+      case FieldType.PhoneNumber:
+      case FieldType.IPAddress:
       case FieldType.URL: {
         return `"${val}"`
       }

--- a/packages/grafbase-sdk/src/field/typedefs.ts
+++ b/packages/grafbase-sdk/src/field/typedefs.ts
@@ -174,7 +174,7 @@ export class GLengthLimitedStringDef {
   }
 
   public toString(): string { 
-    let length = this.fieldLength
+    const length = this.fieldLength
 
     if (length.min != null && length.max != null) {
       return `${this.scalar} @length(min: ${length.min}, max: ${length.max})`

--- a/packages/grafbase-sdk/src/field/typedefs.ts
+++ b/packages/grafbase-sdk/src/field/typedefs.ts
@@ -1,7 +1,13 @@
-import { RequireAtLeastOne } from "type-fest"
-import { Enum } from "../enum"
-import { GBooleanListDef, GDateListDef, GListDef, GNumberListDef, GStringListDef } from "./list"
-import { ScalarType, Searchable } from ".."
+import { RequireAtLeastOne } from 'type-fest'
+import { Enum } from '../enum'
+import {
+  GBooleanListDef,
+  GDateListDef,
+  GListDef,
+  GNumberListDef,
+  GStringListDef
+} from './list'
+import { ScalarType, Searchable } from '..'
 
 interface FieldLength {
   min?: number
@@ -9,19 +15,19 @@ interface FieldLength {
 }
 
 export enum FieldType {
-  String = "String",
-  Int = "Int",
-  Email = "Email",
-  ID = "ID",
-  Float = "Float",
-  Boolean = "Boolean",
-  Date = "Date",
-  DateTime = "DateTime",
-  IPAddress = "IPAddress",
-  Timestamp = "Timestamp",
-  URL = "URL",
-  JSON = "JSON",
-  PhoneNumber = "PhoneNumber",
+  String = 'String',
+  Int = 'Int',
+  Email = 'Email',
+  ID = 'ID',
+  Float = 'Float',
+  Boolean = 'Boolean',
+  Date = 'Date',
+  DateTime = 'DateTime',
+  IPAddress = 'IPAddress',
+  Timestamp = 'Timestamp',
+  URL = 'URL',
+  JSON = 'JSON',
+  PhoneNumber = 'PhoneNumber'
 }
 
 export class GSearchDef {
@@ -36,7 +42,11 @@ export class GSearchDef {
   }
 }
 
-type UniqueScalarType = GScalarDef | GDefaultDef | GSearchDef | GLengthLimitedStringDef
+type UniqueScalarType =
+  | GScalarDef
+  | GDefaultDef
+  | GSearchDef
+  | GLengthLimitedStringDef
 
 export class GUniqueDef {
   compoundScope?: string[]
@@ -52,10 +62,12 @@ export class GUniqueDef {
   }
 
   public toString(): string {
-    const scope = this.compoundScope?.map((field) => `"${field}"`).join(", ")
+    const scope = this.compoundScope?.map((field) => `"${field}"`).join(', ')
     const scopeArray = scope ? `[${scope}]` : null
 
-    return scopeArray ? `${this.scalar} @unique(fields: ${scopeArray})` : `${this.scalar} @unique`
+    return scopeArray
+      ? `${this.scalar} @unique(fields: ${scopeArray})`
+      : `${this.scalar} @unique`
   }
 }
 
@@ -63,7 +75,10 @@ export class GDefaultDef {
   defaultValue: ScalarType
   scalar: GScalarDef | GLengthLimitedStringDef
 
-  constructor(scalar: GScalarDef | GLengthLimitedStringDef, defaultValue: ScalarType) {
+  constructor(
+    scalar: GScalarDef | GLengthLimitedStringDef,
+    defaultValue: ScalarType
+  ) {
     this.defaultValue = defaultValue
     this.scalar = scalar
   }
@@ -78,7 +93,10 @@ export class GDefaultDef {
   }
 
   public toString(): string {
-    return `${this.scalar} @default(value: ${renderDefault(this.defaultValue, this.scalar.fieldTypeVal())})`
+    return `${this.scalar} @default(value: ${renderDefault(
+      this.defaultValue,
+      this.scalar.fieldTypeVal()
+    )})`
   }
 }
 
@@ -115,7 +133,7 @@ export class GScalarDef {
   }
 
   public toString(): string {
-    const required = this.isOptional ? "" : "!"
+    const required = this.isOptional ? '' : '!'
 
     let fieldType
     if (this.fieldType instanceof Enum) {
@@ -133,7 +151,9 @@ export class GStringDef extends GScalarDef {
     return new GDefaultDef(this, val)
   }
 
-  public length(fieldLength: RequireAtLeastOne<FieldLength, 'min' | 'max'>): GLengthLimitedStringDef {
+  public length(
+    fieldLength: RequireAtLeastOne<FieldLength, 'min' | 'max'>
+  ): GLengthLimitedStringDef {
     return new GLengthLimitedStringDef(this, fieldLength)
   }
 
@@ -146,7 +166,10 @@ export class GLengthLimitedStringDef {
   fieldLength: RequireAtLeastOne<FieldLength, 'min' | 'max'>
   scalar: GStringDef
 
-  constructor(scalar: GStringDef, fieldLength: RequireAtLeastOne<FieldLength, 'min' | 'max'>) {
+  constructor(
+    scalar: GStringDef,
+    fieldLength: RequireAtLeastOne<FieldLength, 'min' | 'max'>
+  ) {
     this.fieldLength = fieldLength
     this.scalar = scalar
   }
@@ -173,7 +196,7 @@ export class GLengthLimitedStringDef {
     return this.scalar.fieldType
   }
 
-  public toString(): string { 
+  public toString(): string {
     const length = this.fieldLength
 
     if (length.min != null && length.max != null) {
@@ -185,7 +208,6 @@ export class GLengthLimitedStringDef {
     }
   }
 }
-
 
 export class GNumberDef extends GScalarDef {
   public default(val: number): GDefaultDef {
@@ -243,7 +265,7 @@ export function renderDefault(val: any, fieldType: FieldType | Enum) {
   if (fieldType instanceof Enum) {
     return val.toString()
   } else {
-    switch(fieldType) {
+    switch (fieldType) {
       case FieldType.String: {
         return `"${val}"`
       }

--- a/packages/grafbase-sdk/src/field/typedefs.ts
+++ b/packages/grafbase-sdk/src/field/typedefs.ts
@@ -1,11 +1,11 @@
 import { RequireAtLeastOne } from 'type-fest'
 import { Enum } from '../enum'
 import {
-  BooleanListDef,
-  DateListDef,
-  ListDef,
-  NumberListDef,
-  StringListDef
+  BooleanListDefinition,
+  DateListDefinition,
+  ListDefinition,
+  NumberListDefinition,
+  StringListDefinition
 } from './list'
 import { ScalarType, Searchable } from '..'
 
@@ -30,7 +30,7 @@ export enum FieldType {
   PhoneNumber = 'PhoneNumber'
 }
 
-export class SearchDef {
+export class SearchDefinition {
   field: Searchable
 
   constructor(field: Searchable) {
@@ -43,12 +43,12 @@ export class SearchDef {
 }
 
 type UniqueScalarType =
-  | ScalarDef
-  | DefaultDef
-  | SearchDef
-  | LengthLimitedStringDef
+  | ScalarDefinition
+  | DefaultDefinition
+  | SearchDefinition
+  | LengthLimitedStringDefinition
 
-export class UniqueDef {
+export class UniqueDefinition {
   compoundScope?: string[]
   scalar: UniqueScalarType
 
@@ -57,8 +57,8 @@ export class UniqueDef {
     this.compoundScope = scope
   }
 
-  public search(): SearchDef {
-    return new SearchDef(this)
+  public search(): SearchDefinition {
+    return new SearchDefinition(this)
   }
 
   public toString(): string {
@@ -71,23 +71,23 @@ export class UniqueDef {
   }
 }
 
-export class DefaultDef {
+export class DefaultDefinition {
   defaultValue: ScalarType
-  scalar: ScalarDef | LengthLimitedStringDef
+  scalar: ScalarDefinition | LengthLimitedStringDefinition
 
   constructor(
-    scalar: ScalarDef | LengthLimitedStringDef,
+    scalar: ScalarDefinition | LengthLimitedStringDefinition,
     defaultValue: ScalarType
   ) {
     this.defaultValue = defaultValue
     this.scalar = scalar
   }
 
-  public unique(): UniqueDef {
-    return new UniqueDef(this)
+  public unique(): UniqueDefinition {
+    return new UniqueDefinition(this)
   }
 
-  public optional(): DefaultDef {
+  public optional(): DefaultDefinition {
     this.scalar.optional()
     return this
   }
@@ -100,7 +100,7 @@ export class DefaultDef {
   }
 }
 
-export class ScalarDef {
+export class ScalarDefinition {
   fieldType: FieldType | Enum
   isOptional: boolean
   defaultValue?: ScalarType
@@ -110,22 +110,22 @@ export class ScalarDef {
     this.isOptional = false
   }
 
-  public optional(): ScalarDef {
+  public optional(): ScalarDefinition {
     this.isOptional = true
 
     return this
   }
 
-  public unique(scope?: string[]): UniqueDef {
-    return new UniqueDef(this, scope)
+  public unique(scope?: string[]): UniqueDefinition {
+    return new UniqueDefinition(this, scope)
   }
 
-  public search(): SearchDef {
-    return new SearchDef(this)
+  public search(): SearchDefinition {
+    return new SearchDefinition(this)
   }
 
-  public list(): ListDef {
-    return new ListDef(this)
+  public list(): ListDefinition {
+    return new ListDefinition(this)
   }
 
   fieldTypeVal(): FieldType | Enum {
@@ -146,47 +146,47 @@ export class ScalarDef {
   }
 }
 
-export class StringDef extends ScalarDef {
-  public default(val: string): DefaultDef {
-    return new DefaultDef(this, val)
+export class StringDefinition extends ScalarDefinition {
+  public default(val: string): DefaultDefinition {
+    return new DefaultDefinition(this, val)
   }
 
   public length(
     fieldLength: RequireAtLeastOne<FieldLength, 'min' | 'max'>
-  ): LengthLimitedStringDef {
-    return new LengthLimitedStringDef(this, fieldLength)
+  ): LengthLimitedStringDefinition {
+    return new LengthLimitedStringDefinition(this, fieldLength)
   }
 
-  public list(): StringListDef {
-    return new StringListDef(this)
+  public list(): StringListDefinition {
+    return new StringListDefinition(this)
   }
 }
 
-export class LengthLimitedStringDef {
+export class LengthLimitedStringDefinition {
   fieldLength: RequireAtLeastOne<FieldLength, 'min' | 'max'>
-  scalar: StringDef
+  scalar: StringDefinition
 
   constructor(
-    scalar: StringDef,
+    scalar: StringDefinition,
     fieldLength: RequireAtLeastOne<FieldLength, 'min' | 'max'>
   ) {
     this.fieldLength = fieldLength
     this.scalar = scalar
   }
 
-  public unique(scope?: string[]): UniqueDef {
-    return new UniqueDef(this, scope)
+  public unique(scope?: string[]): UniqueDefinition {
+    return new UniqueDefinition(this, scope)
   }
 
-  public search(): SearchDef {
-    return new SearchDef(this)
+  public search(): SearchDefinition {
+    return new SearchDefinition(this)
   }
 
-  public default(val: string): DefaultDef {
-    return new DefaultDef(this, val)
+  public default(val: string): DefaultDefinition {
+    return new DefaultDefinition(this, val)
   }
 
-  public optional(): LengthLimitedStringDef {
+  public optional(): LengthLimitedStringDefinition {
     this.scalar.optional()
 
     return this
@@ -209,39 +209,39 @@ export class LengthLimitedStringDef {
   }
 }
 
-export class NumberDef extends ScalarDef {
-  public default(val: number): DefaultDef {
-    return new DefaultDef(this, val)
+export class NumberDefinition extends ScalarDefinition {
+  public default(val: number): DefaultDefinition {
+    return new DefaultDefinition(this, val)
   }
 
-  public list(): NumberListDef {
-    return new NumberListDef(this)
-  }
-}
-
-export class BooleanDef extends ScalarDef {
-  public default(val: boolean): DefaultDef {
-    return new DefaultDef(this, val)
-  }
-
-  public list(): BooleanListDef {
-    return new BooleanListDef(this)
+  public list(): NumberListDefinition {
+    return new NumberListDefinition(this)
   }
 }
 
-export class DateDef extends ScalarDef {
-  public default(val: Date): DefaultDef {
-    return new DefaultDef(this, val)
+export class BooleanDefinition extends ScalarDefinition {
+  public default(val: boolean): DefaultDefinition {
+    return new DefaultDefinition(this, val)
   }
 
-  public list(): DateListDef {
-    return new DateListDef(this)
+  public list(): BooleanListDefinition {
+    return new BooleanListDefinition(this)
   }
 }
 
-export class ObjectDef extends ScalarDef {
-  public default(val: object): DefaultDef {
-    return new DefaultDef(this, val)
+export class DateDefinition extends ScalarDefinition {
+  public default(val: Date): DefaultDefinition {
+    return new DefaultDefinition(this, val)
+  }
+
+  public list(): DateListDefinition {
+    return new DateListDefinition(this)
+  }
+}
+
+export class ObjectDefinition extends ScalarDefinition {
+  public default(val: object): DefaultDefinition {
+    return new DefaultDefinition(this, val)
   }
 }
 

--- a/packages/grafbase-sdk/src/field/typedefs.ts
+++ b/packages/grafbase-sdk/src/field/typedefs.ts
@@ -1,0 +1,286 @@
+import { RequireAtLeastOne } from "type-fest"
+import { Enum } from "../enum"
+import { GBooleanListDef, GDateListDef, GListDef, GNumberListDef, GStringListDef } from "./list"
+import { ScalarType, Searchable } from ".."
+
+interface FieldLength {
+  min?: number
+  max?: number
+}
+
+export enum FieldType {
+  String = "String",
+  Int = "Int",
+  Email = "Email",
+  ID = "ID",
+  Float = "Float",
+  Boolean = "Boolean",
+  Date = "Date",
+  DateTime = "DateTime",
+  IPAddress = "IPAddress",
+  Timestamp = "Timestamp",
+  URL = "URL",
+  JSON = "JSON",
+  PhoneNumber = "PhoneNumber",
+}
+
+export class GSearchDef {
+  field: Searchable
+
+  constructor(field: Searchable) {
+    this.field = field
+  }
+
+  public toString(): string {
+    return `${this.field} @search`
+  }
+}
+
+type UniqueScalarType = GScalarDef | GDefaultDef | GSearchDef | GLengthLimitedStringDef
+
+export class GUniqueDef {
+  compoundScope?: string[]
+  scalar: UniqueScalarType
+
+  constructor(scalar: UniqueScalarType, scope?: string[]) {
+    this.scalar = scalar
+    this.compoundScope = scope
+  }
+
+  public search(): GSearchDef {
+    return new GSearchDef(this)
+  }
+
+  public toString(): string {
+    const scope = this.compoundScope?.map((field) => `"${field}"`).join(", ")
+    const scopeArray = scope ? `[${scope}]` : null
+
+    return scopeArray ? `${this.scalar} @unique(fields: ${scopeArray})` : `${this.scalar} @unique`
+  }
+}
+
+export class GDefaultDef {
+  defaultValue: ScalarType
+  scalar: GScalarDef | GLengthLimitedStringDef
+
+  constructor(scalar: GScalarDef | GLengthLimitedStringDef, defaultValue: ScalarType) {
+    this.defaultValue = defaultValue
+    this.scalar = scalar
+  }
+
+  public unique(): GUniqueDef {
+    return new GUniqueDef(this)
+  }
+
+  public optional(): GDefaultDef {
+    this.scalar.optional()
+    return this
+  }
+
+  public toString(): string {
+    return `${this.scalar} @default(value: ${renderDefault(this.defaultValue, this.scalar.fieldTypeVal())})`
+  }
+}
+
+export class GScalarDef {
+  fieldType: FieldType | Enum
+  isOptional: boolean
+  defaultValue?: ScalarType
+
+  constructor(fieldType: FieldType | Enum) {
+    this.fieldType = fieldType
+    this.isOptional = false
+  }
+
+  public optional(): GScalarDef {
+    this.isOptional = true
+
+    return this
+  }
+
+  public unique(scope?: string[]): GUniqueDef {
+    return new GUniqueDef(this, scope)
+  }
+
+  public search(): GSearchDef {
+    return new GSearchDef(this)
+  }
+
+  public list(): GListDef {
+    return new GListDef(this)
+  }
+
+  fieldTypeVal(): FieldType | Enum {
+    return this.fieldType
+  }
+
+  public toString(): string {
+    const required = this.isOptional ? "" : "!"
+
+    let fieldType
+    if (this.fieldType instanceof Enum) {
+      fieldType = this.fieldType.name
+    } else {
+      fieldType = this.fieldType.toString()
+    }
+
+    return `${fieldType}${required}`
+  }
+}
+
+export class GStringDef extends GScalarDef {
+  public default(val: string): GDefaultDef {
+    return new GDefaultDef(this, val)
+  }
+
+  public length(fieldLength: RequireAtLeastOne<FieldLength, 'min' | 'max'>): GLengthLimitedStringDef {
+    return new GLengthLimitedStringDef(this, fieldLength)
+  }
+
+  public list(): GStringListDef {
+    return new GStringListDef(this)
+  }
+}
+
+export class GLengthLimitedStringDef {
+  fieldLength: RequireAtLeastOne<FieldLength, 'min' | 'max'>
+  scalar: GStringDef
+
+  constructor(scalar: GStringDef, fieldLength: RequireAtLeastOne<FieldLength, 'min' | 'max'>) {
+    this.fieldLength = fieldLength
+    this.scalar = scalar
+  }
+
+  public unique(scope?: string[]): GUniqueDef {
+    return new GUniqueDef(this, scope)
+  }
+
+  public search(): GSearchDef {
+    return new GSearchDef(this)
+  }
+
+  public default(val: string): GDefaultDef {
+    return new GDefaultDef(this, val)
+  }
+
+  public optional(): GLengthLimitedStringDef {
+    this.scalar.optional()
+
+    return this
+  }
+
+  fieldTypeVal(): FieldType | Enum {
+    return this.scalar.fieldType
+  }
+
+  public toString(): string { 
+    let length = this.fieldLength
+
+    if (length.min != null && length.max != null) {
+      return `${this.scalar} @length(min: ${length.min}, max: ${length.max})`
+    } else if (length.min != null) {
+      return `${this.scalar} @length(min: ${length.min})`
+    } else {
+      return `${this.scalar} @length(max: ${length.max})`
+    }
+  }
+}
+
+
+export class GNumberDef extends GScalarDef {
+  public default(val: number): GDefaultDef {
+    return new GDefaultDef(this, val)
+  }
+
+  public list(): GNumberListDef {
+    return new GNumberListDef(this)
+  }
+}
+
+export class GBooleanDef extends GScalarDef {
+  public default(val: boolean): GDefaultDef {
+    return new GDefaultDef(this, val)
+  }
+
+  public list(): GBooleanListDef {
+    return new GBooleanListDef(this)
+  }
+}
+
+export class GDateDef extends GScalarDef {
+  public default(val: Date): GDefaultDef {
+    return new GDefaultDef(this, val)
+  }
+
+  public list(): GDateListDef {
+    return new GDateListDef(this)
+  }
+}
+
+export class GObjectDef extends GScalarDef {
+  public default(val: object): GDefaultDef {
+    return new GDefaultDef(this, val)
+  }
+}
+
+export function renderDefault(val: any, fieldType: FieldType | Enum) {
+  const pad2 = (n: number): string => {
+    return n < 10 ? `0${n}` : `${n}`
+  }
+
+  const pad4 = (n: number): string => {
+    if (n < 10) {
+      return `000${n}`
+    } else if (n < 100) {
+      return `00${n}`
+    } else if (n < 1000) {
+      return `0${n}`
+    } else {
+      return `${n}`
+    }
+  }
+
+  if (fieldType instanceof Enum) {
+    return val.toString()
+  } else {
+    switch(fieldType) {
+      case FieldType.String: {
+        return `"${val}"`
+      }
+      case FieldType.ID: {
+        return `"${val}"`
+      }
+      case FieldType.Email: {
+        return `"${val}"`
+      }
+      case FieldType.PhoneNumber: {
+        return `"${val}"`
+      }
+      case FieldType.IPAddress: {
+        return `"${val}"`
+      }
+      case FieldType.URL: {
+        return `"${val}"`
+      }
+      case FieldType.Date: {
+        const year = pad4(val.getUTCFullYear())
+        const month = pad2(val.getUTCMonth() + 1)
+        const date = pad2(val.getUTCDate())
+
+        return `"${year}-${month}-${date}"`
+      }
+      case FieldType.DateTime:
+        const year = pad4(val.getUTCFullYear())
+        const month = pad2(val.getUTCMonth() + 1)
+        const date = pad2(val.getUTCDate())
+        const hours = pad2(val.getUTCHours())
+        const minutes = pad2(val.getUTCMinutes())
+        const seconds = pad2(val.getUTCSeconds())
+
+        return `"${year}-${month}-${date}T${hours}:${minutes}:${seconds}Z"`
+      default: {
+        return val.toString()
+      }
+    }
+  }
+}

--- a/packages/grafbase-sdk/src/grafbase-schema.ts
+++ b/packages/grafbase-sdk/src/grafbase-schema.ts
@@ -1,18 +1,18 @@
 import { Model } from './model'
-import { GRelationDef } from './relation'
+import { RelationDef } from './relation'
 import { Enum } from './enum'
 import {
   FieldType,
-  GBooleanDef,
-  GDateDef,
-  GNumberDef,
-  GObjectDef,
-  GStringDef,
-  GScalarDef
+  BooleanDef,
+  DateDef,
+  NumberDef,
+  ObjectDef,
+  StringDef,
+  ScalarDef
 } from './field/typedefs'
-import { GListDef } from './field/list'
+import { ListDef } from './field/list'
 import { Type } from './type'
-import { GReferenceDef } from './reference'
+import { ReferenceDef } from './reference'
 import { Union } from './union'
 import { Interface } from './interface'
 import { Query, QueryInput, QueryType } from './query'
@@ -48,7 +48,7 @@ export class GrafbaseSchema {
 
   public type(
     name: string,
-    fields: Record<string, GScalarDef | GListDef | GReferenceDef>
+    fields: Record<string, ScalarDef | ListDef | ReferenceDef>
   ): Type {
     const type = Object.entries(fields).reduce(
       (type, [name, definition]) => type.field(name, definition),
@@ -62,7 +62,7 @@ export class GrafbaseSchema {
 
   public interface(
     name: string,
-    types: Record<string, GScalarDef | GListDef>
+    types: Record<string, ScalarDef | ListDef>
   ): Interface {
     const iface = Object.entries(types).reduce(
       (iface, [name, definition]) => iface.field(name, definition),
@@ -86,21 +86,17 @@ export class GrafbaseSchema {
   }
 
   public query(name: string, definition: QueryInput): Query {
-    const q = new Query(
+    var query = new Query(
       name,
       QueryType.Query,
       definition.returns,
       definition.resolver
     )
 
-    let query
     if (definition.args != null) {
-      query = Object.entries(definition.args).reduce(
-        (query, [name, type]) => query.pushArgument(name, type),
-        q
+      Object.entries(definition.args).forEach(([name, type]) =>
+        query.pushArgument(name, type)
       )
-    } else {
-      query = q
     }
 
     this.queries.push(query)
@@ -109,21 +105,18 @@ export class GrafbaseSchema {
   }
 
   public mutation(name: string, definition: QueryInput): Query {
-    const q = new Query(
+    var query = new Query(
       name,
       QueryType.Mutation,
       definition.returns,
       definition.resolver
     )
 
-    let query
     if (definition.args != null) {
-      query = Object.entries(definition.args).reduce(
-        (query, [name, type]) => query.pushArgument(name, type),
-        q
+      Object.entries(definition.args).forEach(
+        ([name, type]) => query.pushArgument(name, type),
+        query
       )
-    } else {
-      query = q
     }
 
     this.queries.push(query)
@@ -139,64 +132,64 @@ export class GrafbaseSchema {
     return e
   }
 
-  public string(): GStringDef {
-    return new GStringDef(FieldType.String)
+  public string(): StringDef {
+    return new StringDef(FieldType.String)
   }
 
-  public id(): GStringDef {
-    return new GStringDef(FieldType.ID)
+  public id(): StringDef {
+    return new StringDef(FieldType.ID)
   }
 
-  public email(): GStringDef {
-    return new GStringDef(FieldType.Email)
+  public email(): StringDef {
+    return new StringDef(FieldType.Email)
   }
 
-  public int(): GNumberDef {
-    return new GNumberDef(FieldType.Int)
+  public int(): NumberDef {
+    return new NumberDef(FieldType.Int)
   }
 
-  public float(): GNumberDef {
-    return new GNumberDef(FieldType.Float)
+  public float(): NumberDef {
+    return new NumberDef(FieldType.Float)
   }
 
-  public boolean(): GBooleanDef {
-    return new GBooleanDef(FieldType.Boolean)
+  public boolean(): BooleanDef {
+    return new BooleanDef(FieldType.Boolean)
   }
 
-  public date(): GDateDef {
-    return new GDateDef(FieldType.Date)
+  public date(): DateDef {
+    return new DateDef(FieldType.Date)
   }
 
-  public datetime(): GDateDef {
-    return new GDateDef(FieldType.DateTime)
+  public datetime(): DateDef {
+    return new DateDef(FieldType.DateTime)
   }
 
-  public ipAddress(): GStringDef {
-    return new GStringDef(FieldType.IPAddress)
+  public ipAddress(): StringDef {
+    return new StringDef(FieldType.IPAddress)
   }
 
-  public timestamp(): GNumberDef {
-    return new GNumberDef(FieldType.Timestamp)
+  public timestamp(): NumberDef {
+    return new NumberDef(FieldType.Timestamp)
   }
 
-  public url(): GStringDef {
-    return new GStringDef(FieldType.URL)
+  public url(): StringDef {
+    return new StringDef(FieldType.URL)
   }
 
-  public json(): GObjectDef {
-    return new GObjectDef(FieldType.JSON)
+  public json(): ObjectDef {
+    return new ObjectDef(FieldType.JSON)
   }
 
-  public phoneNumber(): GStringDef {
-    return new GStringDef(FieldType.PhoneNumber)
+  public phoneNumber(): StringDef {
+    return new StringDef(FieldType.PhoneNumber)
   }
 
-  public relation(ref: RelationRef): GRelationDef {
-    return new GRelationDef(ref)
+  public relation(ref: RelationRef): RelationDef {
+    return new RelationDef(ref)
   }
 
-  public ref(type: Type | Enum): GReferenceDef {
-    return new GReferenceDef(type)
+  public ref(type: Type | Enum): ReferenceDef {
+    return new ReferenceDef(type)
   }
 
   public clear() {

--- a/packages/grafbase-sdk/src/grafbase-schema.ts
+++ b/packages/grafbase-sdk/src/grafbase-schema.ts
@@ -48,7 +48,7 @@ export class GrafbaseSchema {
 
   public type(
     name: string,
-    fields: Record<string, GScalarDef | GListDef>
+    fields: Record<string, GScalarDef | GListDef | GReferenceDef>
   ): Type {
     const type = Object.entries(fields).reduce(
       (type, [name, definition]) => type.field(name, definition),

--- a/packages/grafbase-sdk/src/grafbase-schema.ts
+++ b/packages/grafbase-sdk/src/grafbase-schema.ts
@@ -1,7 +1,15 @@
 import { Model } from './model'
 import { GRelationDef } from './relation'
 import { Enum } from './enum'
-import { FieldType, GBooleanDef, GDateDef, GNumberDef, GObjectDef, GStringDef, GScalarDef } from './field/typedefs'
+import {
+  FieldType,
+  GBooleanDef,
+  GDateDef,
+  GNumberDef,
+  GObjectDef,
+  GStringDef,
+  GScalarDef
+} from './field/typedefs'
 import { GListDef } from './field/list'
 import { Type } from './type'
 import { GReferenceDef } from './reference'
@@ -28,29 +36,38 @@ export class GrafbaseSchema {
   }
 
   public model(name: string, fields: Record<string, FieldShape>): Model {
-    const model = Object
-      .entries(fields)
-      .reduce((model, [name, definition]) => model.field(name, definition), new Model(name))
+    const model = Object.entries(fields).reduce(
+      (model, [name, definition]) => model.field(name, definition),
+      new Model(name)
+    )
 
     this.models.push(model)
 
     return model
   }
 
-  public type(name: string, fields: Record<string, GScalarDef | GListDef>): Type {
-    const type = Object
-      .entries(fields)
-      .reduce((type, [name, definition]) => type.field(name, definition), new Type(name))
+  public type(
+    name: string,
+    fields: Record<string, GScalarDef | GListDef>
+  ): Type {
+    const type = Object.entries(fields).reduce(
+      (type, [name, definition]) => type.field(name, definition),
+      new Type(name)
+    )
 
     this.types.push(type)
 
     return type
   }
 
-  public interface(name: string, types: Record<string, GScalarDef | GListDef>): Interface {
-    const iface = Object
-      .entries(types)
-      .reduce((iface, [name, definition]) => iface.field(name, definition), new Interface(name))
+  public interface(
+    name: string,
+    types: Record<string, GScalarDef | GListDef>
+  ): Interface {
+    const iface = Object.entries(types).reduce(
+      (iface, [name, definition]) => iface.field(name, definition),
+      new Interface(name)
+    )
 
     this.interfaces.push(iface)
 
@@ -58,9 +75,10 @@ export class GrafbaseSchema {
   }
 
   public union(name: string, types: Record<string, Type>): Union {
-    const union = Object
-      .entries(types)
-      .reduce((model, [_, type]) => model.type(type), new Union(name))
+    const union = Object.entries(types).reduce(
+      (model, [_, type]) => model.type(type),
+      new Union(name)
+    )
 
     this.unions.push(union)
 
@@ -68,13 +86,19 @@ export class GrafbaseSchema {
   }
 
   public query(name: string, definition: QueryInput): Query {
-    const q = new Query(name, QueryType.Query, definition.returns, definition.resolver)
+    const q = new Query(
+      name,
+      QueryType.Query,
+      definition.returns,
+      definition.resolver
+    )
 
     let query
     if (definition.args != null) {
-      query = Object
-        .entries(definition.args)
-        .reduce((query, [name, type]) => query.pushArgument(name, type), q)
+      query = Object.entries(definition.args).reduce(
+        (query, [name, type]) => query.pushArgument(name, type),
+        q
+      )
     } else {
       query = q
     }
@@ -85,13 +109,19 @@ export class GrafbaseSchema {
   }
 
   public mutation(name: string, definition: QueryInput): Query {
-    const q = new Query(name, QueryType.Mutation, definition.returns, definition.resolver)
+    const q = new Query(
+      name,
+      QueryType.Mutation,
+      definition.returns,
+      definition.resolver
+    )
 
     let query
     if (definition.args != null) {
-      query = Object
-        .entries(definition.args)
-        .reduce((query, [name, type]) => query.pushArgument(name, type), q)
+      query = Object.entries(definition.args).reduce(
+        (query, [name, type]) => query.pushArgument(name, type),
+        q
+      )
     } else {
       query = q
     }
@@ -179,15 +209,15 @@ export class GrafbaseSchema {
   }
 
   public toString(): string {
-    const queries = this.queries.map(String).join("\n\n")
-    const interfaces = this.interfaces.map(String).join("\n\n")
-    const types = this.types.map(String).join("\n\n")
-    const unions = this.unions.map(String).join("\n\n")
-    const enums = this.enums.map(String).join("\n\n")
-    const models = this.models.map(String).join("\n\n")
+    const queries = this.queries.map(String).join('\n\n')
+    const interfaces = this.interfaces.map(String).join('\n\n')
+    const types = this.types.map(String).join('\n\n')
+    const unions = this.unions.map(String).join('\n\n')
+    const enums = this.enums.map(String).join('\n\n')
+    const models = this.models.map(String).join('\n\n')
 
     const renderOrder = [interfaces, enums, types, queries, unions, models]
 
-    return renderOrder.filter(Boolean).flat().map(String).join("\n\n")
+    return renderOrder.filter(Boolean).flat().map(String).join('\n\n')
   }
 }

--- a/packages/grafbase-sdk/src/grafbase-schema.ts
+++ b/packages/grafbase-sdk/src/grafbase-schema.ts
@@ -1,18 +1,18 @@
 import { Model } from './model'
-import { RelationDef } from './relation'
+import { RelationDefinition } from './relation'
 import { Enum } from './enum'
 import {
   FieldType,
-  BooleanDef,
-  DateDef,
-  NumberDef,
-  ObjectDef,
-  StringDef,
-  ScalarDef
+  BooleanDefinition,
+  DateDefinition,
+  NumberDefinition,
+  ObjectDefinition,
+  StringDefinition,
+  ScalarDefinition
 } from './field/typedefs'
-import { ListDef } from './field/list'
+import { ListDefinition } from './field/list'
 import { Type } from './type'
-import { ReferenceDef } from './reference'
+import { ReferenceDefinition } from './reference'
 import { Union } from './union'
 import { Interface } from './interface'
 import { Query, QueryInput, QueryType } from './query'
@@ -48,7 +48,10 @@ export class GrafbaseSchema {
 
   public type(
     name: string,
-    fields: Record<string, ScalarDef | ListDef | ReferenceDef>
+    fields: Record<
+      string,
+      ScalarDefinition | ListDefinition | ReferenceDefinition
+    >
   ): Type {
     const type = Object.entries(fields).reduce(
       (type, [name, definition]) => type.field(name, definition),
@@ -62,7 +65,7 @@ export class GrafbaseSchema {
 
   public interface(
     name: string,
-    types: Record<string, ScalarDef | ListDef>
+    types: Record<string, ScalarDefinition | ListDefinition>
   ): Interface {
     const iface = Object.entries(types).reduce(
       (iface, [name, definition]) => iface.field(name, definition),
@@ -132,64 +135,64 @@ export class GrafbaseSchema {
     return e
   }
 
-  public string(): StringDef {
-    return new StringDef(FieldType.String)
+  public string(): StringDefinition {
+    return new StringDefinition(FieldType.String)
   }
 
-  public id(): StringDef {
-    return new StringDef(FieldType.ID)
+  public id(): StringDefinition {
+    return new StringDefinition(FieldType.ID)
   }
 
-  public email(): StringDef {
-    return new StringDef(FieldType.Email)
+  public email(): StringDefinition {
+    return new StringDefinition(FieldType.Email)
   }
 
-  public int(): NumberDef {
-    return new NumberDef(FieldType.Int)
+  public int(): NumberDefinition {
+    return new NumberDefinition(FieldType.Int)
   }
 
-  public float(): NumberDef {
-    return new NumberDef(FieldType.Float)
+  public float(): NumberDefinition {
+    return new NumberDefinition(FieldType.Float)
   }
 
-  public boolean(): BooleanDef {
-    return new BooleanDef(FieldType.Boolean)
+  public boolean(): BooleanDefinition {
+    return new BooleanDefinition(FieldType.Boolean)
   }
 
-  public date(): DateDef {
-    return new DateDef(FieldType.Date)
+  public date(): DateDefinition {
+    return new DateDefinition(FieldType.Date)
   }
 
-  public datetime(): DateDef {
-    return new DateDef(FieldType.DateTime)
+  public datetime(): DateDefinition {
+    return new DateDefinition(FieldType.DateTime)
   }
 
-  public ipAddress(): StringDef {
-    return new StringDef(FieldType.IPAddress)
+  public ipAddress(): StringDefinition {
+    return new StringDefinition(FieldType.IPAddress)
   }
 
-  public timestamp(): NumberDef {
-    return new NumberDef(FieldType.Timestamp)
+  public timestamp(): NumberDefinition {
+    return new NumberDefinition(FieldType.Timestamp)
   }
 
-  public url(): StringDef {
-    return new StringDef(FieldType.URL)
+  public url(): StringDefinition {
+    return new StringDefinition(FieldType.URL)
   }
 
-  public json(): ObjectDef {
-    return new ObjectDef(FieldType.JSON)
+  public json(): ObjectDefinition {
+    return new ObjectDefinition(FieldType.JSON)
   }
 
-  public phoneNumber(): StringDef {
-    return new StringDef(FieldType.PhoneNumber)
+  public phoneNumber(): StringDefinition {
+    return new StringDefinition(FieldType.PhoneNumber)
   }
 
-  public relation(ref: RelationRef): RelationDef {
-    return new RelationDef(ref)
+  public relation(ref: RelationRef): RelationDefinition {
+    return new RelationDefinition(ref)
   }
 
-  public ref(type: Type | Enum): ReferenceDef {
-    return new ReferenceDef(type)
+  public ref(type: Type | Enum): ReferenceDefinition {
+    return new ReferenceDefinition(type)
   }
 
   public clear() {

--- a/packages/grafbase-sdk/src/grafbase-schema.ts
+++ b/packages/grafbase-sdk/src/grafbase-schema.ts
@@ -70,9 +70,14 @@ export class GrafbaseSchema {
   public query(name: string, definition: QueryInput): Query {
     const q = new Query(name, QueryType.Query, definition.returns, definition.resolver)
 
-    const query = Object
-      .entries(definition.args)
-      .reduce((query, [name, type]) => query.pushArgument(name, type), q)
+    let query
+    if (definition.args != null) {
+      query = Object
+        .entries(definition.args)
+        .reduce((query, [name, type]) => query.pushArgument(name, type), q)
+    } else {
+      query = q
+    }
 
     this.queries.push(query)
 
@@ -82,25 +87,26 @@ export class GrafbaseSchema {
   public mutation(name: string, definition: QueryInput): Query {
     const q = new Query(name, QueryType.Mutation, definition.returns, definition.resolver)
 
-    const query = Object
-      .entries(definition.args)
-      .reduce((query, [name, type]) => query.pushArgument(name, type), q)
+    let query
+    if (definition.args != null) {
+      query = Object
+        .entries(definition.args)
+        .reduce((query, [name, type]) => query.pushArgument(name, type), q)
+    } else {
+      query = q
+    }
 
     this.queries.push(query)
 
     return query
   }
 
-  public enumType(name: string, variants: EnumShape): Enum {
+  public enum(name: string, variants: EnumShape): Enum {
     const e = new Enum(name, variants)
 
     this.enums.push(e)
 
     return e
-  }
-
-  public enum(e: Enum): GStringDef {
-    return new GStringDef(e)
   }
 
   public string(): GStringDef {
@@ -159,7 +165,7 @@ export class GrafbaseSchema {
     return new GRelationDef(ref)
   }
 
-  public ref(type: Type): GReferenceDef {
+  public ref(type: Type | Enum): GReferenceDef {
     return new GReferenceDef(type)
   }
 

--- a/packages/grafbase-sdk/src/grafbase_schema.ts
+++ b/packages/grafbase-sdk/src/grafbase_schema.ts
@@ -1,0 +1,187 @@
+import { Model } from './model'
+import { GRelationDef } from './relation'
+import { Enum } from './enum'
+import { FieldType, GBooleanDef, GDateDef, GNumberDef, GObjectDef, GStringDef, GScalarDef } from './field/typedefs'
+import { GListDef } from './field/list'
+import { Type } from './type'
+import { GReferenceDef } from './reference'
+import { Union } from './union'
+import { Interface } from './interface'
+import { Query, QueryInput, QueryType } from './query'
+import { EnumShape, FieldShape, RelationRef } from '.'
+
+export class GrafbaseSchema {
+  enums: Enum[]
+  types: Type[]
+  unions: Union[]
+  models: Model[]
+  interfaces: Interface[]
+  queries: Query[]
+
+  constructor() {
+    this.enums = []
+    this.types = []
+    this.unions = []
+    this.models = []
+    this.interfaces = []
+    this.queries = []
+  }
+
+  public model(name: string, fields: Record<string, FieldShape>): Model {
+    const model = Object
+      .entries(fields)
+      .reduce((model, [name, definition]) => model.field(name, definition), new Model(name))
+
+    this.models.push(model)
+
+    return model
+  }
+
+  public type(name: string, fields: Record<string, GScalarDef | GListDef>): Type {
+    const type = Object
+      .entries(fields)
+      .reduce((type, [name, definition]) => type.field(name, definition), new Type(name))
+
+    this.types.push(type)
+
+    return type
+  }
+
+  public interface(name: string, types: Record<string, GScalarDef | GListDef>): Interface {
+    const iface = Object
+      .entries(types)
+      .reduce((iface, [name, definition]) => iface.field(name, definition), new Interface(name))
+
+    this.interfaces.push(iface)
+
+    return iface
+  }
+
+  public union(name: string, types: Record<string, Type>): Union {
+    const union = Object
+      .entries(types)
+      .reduce((model, [_, type]) => model.type(type), new Union(name))
+
+    this.unions.push(union)
+
+    return union
+  }
+
+  public query(name: string, definition: QueryInput): Query {
+    const q = new Query(name, QueryType.Query, definition.returns, definition.resolver)
+
+    const query = Object
+      .entries(definition.args)
+      .reduce((query, [name, type]) => query.pushArgument(name, type), q)
+
+    this.queries.push(query)
+
+    return query
+  }
+
+  public mutation(name: string, definition: QueryInput): Query {
+    const q = new Query(name, QueryType.Mutation, definition.returns, definition.resolver)
+
+    const query = Object
+      .entries(definition.args)
+      .reduce((query, [name, type]) => query.pushArgument(name, type), q)
+
+    this.queries.push(query)
+
+    return query
+  }
+
+  public enumType(name: string, variants: EnumShape): Enum {
+    const e = new Enum(name, variants)
+
+    this.enums.push(e)
+
+    return e
+  }
+
+  public enum(e: Enum): GStringDef {
+    return new GStringDef(e)
+  }
+
+  public string(): GStringDef {
+    return new GStringDef(FieldType.String)
+  }
+
+  public id(): GStringDef {
+    return new GStringDef(FieldType.ID)
+  }
+
+  public email(): GStringDef {
+    return new GStringDef(FieldType.Email)
+  }
+
+  public int(): GNumberDef {
+    return new GNumberDef(FieldType.Int)
+  }
+
+  public float(): GNumberDef {
+    return new GNumberDef(FieldType.Float)
+  }
+
+  public boolean(): GBooleanDef {
+    return new GBooleanDef(FieldType.Boolean)
+  }
+
+  public date(): GDateDef {
+    return new GDateDef(FieldType.Date)
+  }
+
+  public datetime(): GDateDef {
+    return new GDateDef(FieldType.DateTime)
+  }
+
+  public ipAddress(): GStringDef {
+    return new GStringDef(FieldType.IPAddress)
+  }
+
+  public timestamp(): GNumberDef {
+    return new GNumberDef(FieldType.Timestamp)
+  }
+
+  public url(): GStringDef {
+    return new GStringDef(FieldType.URL)
+  }
+
+  public json(): GObjectDef {
+    return new GObjectDef(FieldType.JSON)
+  }
+
+  public phoneNumber(): GStringDef {
+    return new GStringDef(FieldType.PhoneNumber)
+  }
+
+  public relation(ref: RelationRef): GRelationDef {
+    return new GRelationDef(ref)
+  }
+
+  public ref(type: Type): GReferenceDef {
+    return new GReferenceDef(type)
+  }
+
+  public clear() {
+    this.queries = []
+    this.interfaces = []
+    this.types = []
+    this.unions = []
+    this.enums = []
+    this.models = []
+  }
+
+  public toString(): string {
+    const queries = this.queries.map(String).join("\n\n")
+    const interfaces = this.interfaces.map(String).join("\n\n")
+    const types = this.types.map(String).join("\n\n")
+    const unions = this.unions.map(String).join("\n\n")
+    const enums = this.enums.map(String).join("\n\n")
+    const models = this.models.map(String).join("\n\n")
+
+    const renderOrder = [interfaces, enums, types, queries, unions, models]
+
+    return renderOrder.filter(Boolean).flat().map(String).join("\n\n")
+  }
+}

--- a/packages/grafbase-sdk/src/index.ts
+++ b/packages/grafbase-sdk/src/index.ts
@@ -1,0 +1,134 @@
+import { Model } from './model'
+import { Config } from './config'
+import { GRelationDef } from './relation'
+import { Enum } from './enum'
+import { FieldType, GBooleanDef, GDateDef, GNumberDef, GObjectDef, GStringDef, GScalarDef, GSearchDef, GUniqueDef, GDefaultDef, GLengthLimitedStringDef } from './field/typedefs'
+import { GListDef } from './field/list'
+import { Type } from './type'
+import { GReferenceDef } from './reference'
+import { Union } from './union'
+import { Interface } from './interface'
+import { PartialQuery, QueryInput, QueryType } from './query'
+
+export type AtLeastOne<T> = [T, ...T[]]
+export type ScalarType = string | number | Date | object | boolean;
+export type FieldShape = GScalarDef | GRelationDef | GListDef | GSearchDef | GReferenceDef | GUniqueDef | GDefaultDef | GLengthLimitedStringDef
+export type EnumShape = AtLeastOne<string> | { [s: number]: string }
+export type RelationRef = RelationF | Model
+export type Searchable = GScalarDef | GListDef | GUniqueDef
+
+type RelationF = () => Model
+
+export const g = {
+  model: function(name: string, fields: Record<string, FieldShape>): Model {
+    return Object
+      .entries(fields)
+      .reduce((model, [name, definition]) => model.field(name, definition), new Model(name))
+  },
+
+  type: function(name: string, fields: Record<string, GScalarDef | GListDef>): Type {
+    return Object
+      .entries(fields)
+      .reduce((type, [name, definition]) => type.field(name, definition), new Type(name))
+  },
+
+  interface: function(name: string, types: Record<string, GScalarDef | GListDef>): Interface {
+    return Object
+      .entries(types)
+      .reduce((iface, [name, definition]) => iface.field(name, definition), new Interface(name))
+  },
+
+  union: function(name: string, types: Record<string, Type>): Union {
+    return Object
+      .entries(types)
+      .reduce((model, [_, type]) => model.type(type), new Union(name))
+  },
+
+  query: function(name: string, definition: QueryInput): PartialQuery {
+    const q = new PartialQuery(name, QueryType.Query, definition.returns)
+
+    return Object
+      .entries(definition.args)
+      .reduce((query, [name, type]) => query.argument(name, type), q)
+  },
+
+  mutation: function(name: string, definition: QueryInput): PartialQuery {
+    const q = new PartialQuery(name, QueryType.Mutation, definition.returns)
+
+    return Object
+      .entries(definition.args)
+      .reduce((query, [name, type]) => query.argument(name, type), q)
+  },
+
+  enumType: function(name: string, variants: EnumShape): Enum {
+    return new Enum(name, variants)
+  },
+
+  enum: function(e: Enum): GStringDef {
+    return new GStringDef(e)
+  },
+
+  string: function(): GStringDef {
+    return new GStringDef(FieldType.String)
+  },
+
+  id: function(): GStringDef {
+    return new GStringDef(FieldType.ID)
+  },
+
+  email: function(): GStringDef {
+    return new GStringDef(FieldType.Email)
+  },
+
+  int: function(): GNumberDef {
+    return new GNumberDef(FieldType.Int)
+  },
+
+  float: function(): GNumberDef {
+    return new GNumberDef(FieldType.Float)
+  },
+
+  boolean: function(): GBooleanDef {
+    return new GBooleanDef(FieldType.Boolean)
+  },
+
+  date: function(): GDateDef {
+    return new GDateDef(FieldType.Date)
+  },
+
+  datetime: function(): GDateDef {
+    return new GDateDef(FieldType.DateTime)
+  },
+
+  ipAddress: function(): GStringDef {
+    return new GStringDef(FieldType.IPAddress)
+  },
+
+  timestamp: function(): GNumberDef {
+    return new GNumberDef(FieldType.Timestamp)
+  },
+
+  url: function(): GStringDef {
+    return new GStringDef(FieldType.URL)
+  },
+
+  json: function(): GObjectDef {
+    return new GObjectDef(FieldType.JSON)
+  },
+
+  phoneNumber: function(): GStringDef {
+    return new GStringDef(FieldType.PhoneNumber)
+  },
+
+  relation: function(ref: RelationRef): GRelationDef {
+    return new GRelationDef(ref)
+  },
+
+  ref: function(ref: Type): GReferenceDef {
+    return new GReferenceDef(ref)
+  }
+}
+
+export function config(): Config {
+  return new Config()
+}

--- a/packages/grafbase-sdk/src/index.ts
+++ b/packages/grafbase-sdk/src/index.ts
@@ -1,32 +1,32 @@
-import { ListDef } from './field/list'
+import { ListDefinition } from './field/list'
 import {
-  DefaultDef,
-  LengthLimitedStringDef,
-  ScalarDef,
-  SearchDef,
-  UniqueDef
+  DefaultDefinition,
+  LengthLimitedStringDefinition,
+  ScalarDefinition,
+  SearchDefinition,
+  UniqueDefinition
 } from './field/typedefs'
 import { Model } from './model'
-import { ReferenceDef } from './reference'
-import { RelationDef } from './relation'
+import { ReferenceDefinition } from './reference'
+import { RelationDefinition } from './relation'
 import { GrafbaseSchema } from './grafbase-schema'
 import { Config, ConfigInput } from './config'
 
 export type FieldShape =
-  | ScalarDef
-  | RelationDef
-  | ListDef
-  | SearchDef
-  | ReferenceDef
-  | UniqueDef
-  | DefaultDef
-  | LengthLimitedStringDef
+  | ScalarDefinition
+  | RelationDefinition
+  | ListDefinition
+  | SearchDefinition
+  | ReferenceDefinition
+  | UniqueDefinition
+  | DefaultDefinition
+  | LengthLimitedStringDefinition
 
 export type AtLeastOne<T> = [T, ...T[]]
 export type ScalarType = string | number | Date | object | boolean
 export type EnumShape = AtLeastOne<string> | { [s: number]: string }
 export type RelationRef = RelationF | Model
-export type Searchable = ScalarDef | ListDef | UniqueDef
+export type Searchable = ScalarDefinition | ListDefinition | UniqueDefinition
 
 type RelationF = () => Model
 

--- a/packages/grafbase-sdk/src/index.ts
+++ b/packages/grafbase-sdk/src/index.ts
@@ -1,12 +1,19 @@
-import { GListDef } from "./field/list"
-import { GDefaultDef, GLengthLimitedStringDef, GScalarDef, GSearchDef, GUniqueDef } from "./field/typedefs"
-import { Model } from "./model"
-import { GReferenceDef } from "./reference"
-import { GRelationDef } from "./relation"
-import { GrafbaseSchema } from "./grafbase-schema"
-import { Config, ConfigInput } from "./config"
+import { GListDef } from './field/list'
+import {
+  GDefaultDef,
+  GLengthLimitedStringDef,
+  GScalarDef,
+  GSearchDef,
+  GUniqueDef
+} from './field/typedefs'
+import { Model } from './model'
+import { GReferenceDef } from './reference'
+import { GRelationDef } from './relation'
+import { GrafbaseSchema } from './grafbase-schema'
+import { Config, ConfigInput } from './config'
 
-export type FieldShape = GScalarDef
+export type FieldShape =
+  | GScalarDef
   | GRelationDef
   | GListDef
   | GSearchDef
@@ -16,7 +23,7 @@ export type FieldShape = GScalarDef
   | GLengthLimitedStringDef
 
 export type AtLeastOne<T> = [T, ...T[]]
-export type ScalarType = string | number | Date | object | boolean;
+export type ScalarType = string | number | Date | object | boolean
 export type EnumShape = AtLeastOne<string> | { [s: number]: string }
 export type RelationRef = RelationF | Model
 export type Searchable = GScalarDef | GListDef | GUniqueDef

--- a/packages/grafbase-sdk/src/index.ts
+++ b/packages/grafbase-sdk/src/index.ts
@@ -1,134 +1,30 @@
-import { Model } from './model'
-import { Config } from './config'
-import { GRelationDef } from './relation'
-import { Enum } from './enum'
-import { FieldType, GBooleanDef, GDateDef, GNumberDef, GObjectDef, GStringDef, GScalarDef, GSearchDef, GUniqueDef, GDefaultDef, GLengthLimitedStringDef } from './field/typedefs'
-import { GListDef } from './field/list'
-import { Type } from './type'
-import { GReferenceDef } from './reference'
-import { Union } from './union'
-import { Interface } from './interface'
-import { PartialQuery, QueryInput, QueryType } from './query'
+import { GListDef } from "./field/list"
+import { GDefaultDef, GLengthLimitedStringDef, GScalarDef, GSearchDef, GUniqueDef } from "./field/typedefs"
+import { Model } from "./model"
+import { GReferenceDef } from "./reference"
+import { GRelationDef } from "./relation"
+import { GrafbaseSchema } from "./grafbase_schema"
+import { Config, ConfigInput } from "./config"
+
+export type FieldShape = GScalarDef
+  | GRelationDef
+  | GListDef
+  | GSearchDef
+  | GReferenceDef
+  | GUniqueDef
+  | GDefaultDef
+  | GLengthLimitedStringDef
 
 export type AtLeastOne<T> = [T, ...T[]]
 export type ScalarType = string | number | Date | object | boolean;
-export type FieldShape = GScalarDef | GRelationDef | GListDef | GSearchDef | GReferenceDef | GUniqueDef | GDefaultDef | GLengthLimitedStringDef
 export type EnumShape = AtLeastOne<string> | { [s: number]: string }
 export type RelationRef = RelationF | Model
 export type Searchable = GScalarDef | GListDef | GUniqueDef
 
 type RelationF = () => Model
 
-export const g = {
-  model: function(name: string, fields: Record<string, FieldShape>): Model {
-    return Object
-      .entries(fields)
-      .reduce((model, [name, definition]) => model.field(name, definition), new Model(name))
-  },
+export const g = new GrafbaseSchema()
 
-  type: function(name: string, fields: Record<string, GScalarDef | GListDef>): Type {
-    return Object
-      .entries(fields)
-      .reduce((type, [name, definition]) => type.field(name, definition), new Type(name))
-  },
-
-  interface: function(name: string, types: Record<string, GScalarDef | GListDef>): Interface {
-    return Object
-      .entries(types)
-      .reduce((iface, [name, definition]) => iface.field(name, definition), new Interface(name))
-  },
-
-  union: function(name: string, types: Record<string, Type>): Union {
-    return Object
-      .entries(types)
-      .reduce((model, [_, type]) => model.type(type), new Union(name))
-  },
-
-  query: function(name: string, definition: QueryInput): PartialQuery {
-    const q = new PartialQuery(name, QueryType.Query, definition.returns)
-
-    return Object
-      .entries(definition.args)
-      .reduce((query, [name, type]) => query.argument(name, type), q)
-  },
-
-  mutation: function(name: string, definition: QueryInput): PartialQuery {
-    const q = new PartialQuery(name, QueryType.Mutation, definition.returns)
-
-    return Object
-      .entries(definition.args)
-      .reduce((query, [name, type]) => query.argument(name, type), q)
-  },
-
-  enumType: function(name: string, variants: EnumShape): Enum {
-    return new Enum(name, variants)
-  },
-
-  enum: function(e: Enum): GStringDef {
-    return new GStringDef(e)
-  },
-
-  string: function(): GStringDef {
-    return new GStringDef(FieldType.String)
-  },
-
-  id: function(): GStringDef {
-    return new GStringDef(FieldType.ID)
-  },
-
-  email: function(): GStringDef {
-    return new GStringDef(FieldType.Email)
-  },
-
-  int: function(): GNumberDef {
-    return new GNumberDef(FieldType.Int)
-  },
-
-  float: function(): GNumberDef {
-    return new GNumberDef(FieldType.Float)
-  },
-
-  boolean: function(): GBooleanDef {
-    return new GBooleanDef(FieldType.Boolean)
-  },
-
-  date: function(): GDateDef {
-    return new GDateDef(FieldType.Date)
-  },
-
-  datetime: function(): GDateDef {
-    return new GDateDef(FieldType.DateTime)
-  },
-
-  ipAddress: function(): GStringDef {
-    return new GStringDef(FieldType.IPAddress)
-  },
-
-  timestamp: function(): GNumberDef {
-    return new GNumberDef(FieldType.Timestamp)
-  },
-
-  url: function(): GStringDef {
-    return new GStringDef(FieldType.URL)
-  },
-
-  json: function(): GObjectDef {
-    return new GObjectDef(FieldType.JSON)
-  },
-
-  phoneNumber: function(): GStringDef {
-    return new GStringDef(FieldType.PhoneNumber)
-  },
-
-  relation: function(ref: RelationRef): GRelationDef {
-    return new GRelationDef(ref)
-  },
-
-  ref: function(ref: Type): GReferenceDef {
-    return new GReferenceDef(ref)
-  }
-}
-
-export function config(): Config {
-  return new Config()
+export function config(input: ConfigInput): Config {
+  return new Config(input)
 }

--- a/packages/grafbase-sdk/src/index.ts
+++ b/packages/grafbase-sdk/src/index.ts
@@ -3,7 +3,7 @@ import { GDefaultDef, GLengthLimitedStringDef, GScalarDef, GSearchDef, GUniqueDe
 import { Model } from "./model"
 import { GReferenceDef } from "./reference"
 import { GRelationDef } from "./relation"
-import { GrafbaseSchema } from "./grafbase_schema"
+import { GrafbaseSchema } from "./grafbase-schema"
 import { Config, ConfigInput } from "./config"
 
 export type FieldShape = GScalarDef

--- a/packages/grafbase-sdk/src/index.ts
+++ b/packages/grafbase-sdk/src/index.ts
@@ -1,32 +1,32 @@
-import { GListDef } from './field/list'
+import { ListDef } from './field/list'
 import {
-  GDefaultDef,
-  GLengthLimitedStringDef,
-  GScalarDef,
-  GSearchDef,
-  GUniqueDef
+  DefaultDef,
+  LengthLimitedStringDef,
+  ScalarDef,
+  SearchDef,
+  UniqueDef
 } from './field/typedefs'
 import { Model } from './model'
-import { GReferenceDef } from './reference'
-import { GRelationDef } from './relation'
+import { ReferenceDef } from './reference'
+import { RelationDef } from './relation'
 import { GrafbaseSchema } from './grafbase-schema'
 import { Config, ConfigInput } from './config'
 
 export type FieldShape =
-  | GScalarDef
-  | GRelationDef
-  | GListDef
-  | GSearchDef
-  | GReferenceDef
-  | GUniqueDef
-  | GDefaultDef
-  | GLengthLimitedStringDef
+  | ScalarDef
+  | RelationDef
+  | ListDef
+  | SearchDef
+  | ReferenceDef
+  | UniqueDef
+  | DefaultDef
+  | LengthLimitedStringDef
 
 export type AtLeastOne<T> = [T, ...T[]]
 export type ScalarType = string | number | Date | object | boolean
 export type EnumShape = AtLeastOne<string> | { [s: number]: string }
 export type RelationRef = RelationF | Model
-export type Searchable = GScalarDef | GListDef | GUniqueDef
+export type Searchable = ScalarDef | ListDef | UniqueDef
 
 type RelationF = () => Model
 

--- a/packages/grafbase-sdk/src/interface.ts
+++ b/packages/grafbase-sdk/src/interface.ts
@@ -1,6 +1,6 @@
-import { Field } from "./field"
-import { GListDef } from "./field/list"
-import { GScalarDef } from "./field/typedefs"
+import { Field } from './field'
+import { GListDef } from './field/list'
+import { GScalarDef } from './field/typedefs'
 
 export class Interface {
   name: string
@@ -20,9 +20,7 @@ export class Interface {
   public toString(): string {
     const header = `interface ${this.name} {`
 
-    const fields = this
-      .fields
-      .map((field) => `  ${field}`).join("\n")
+    const fields = this.fields.map((field) => `  ${field}`).join('\n')
 
     const footer = '}'
 

--- a/packages/grafbase-sdk/src/interface.ts
+++ b/packages/grafbase-sdk/src/interface.ts
@@ -1,6 +1,6 @@
 import { Field } from './field'
-import { GListDef } from './field/list'
-import { GScalarDef } from './field/typedefs'
+import { ListDef } from './field/list'
+import { ScalarDef } from './field/typedefs'
 
 export class Interface {
   name: string
@@ -11,7 +11,7 @@ export class Interface {
     this.fields = []
   }
 
-  public field(name: string, definition: GScalarDef | GListDef): Interface {
+  public field(name: string, definition: ScalarDef | ListDef): Interface {
     this.fields.push(new Field(name, definition))
 
     return this

--- a/packages/grafbase-sdk/src/interface.ts
+++ b/packages/grafbase-sdk/src/interface.ts
@@ -1,6 +1,6 @@
 import { Field } from './field'
-import { ListDef } from './field/list'
-import { ScalarDef } from './field/typedefs'
+import { ListDefinition } from './field/list'
+import { ScalarDefinition } from './field/typedefs'
 
 export class Interface {
   name: string
@@ -11,7 +11,10 @@ export class Interface {
     this.fields = []
   }
 
-  public field(name: string, definition: ScalarDef | ListDef): Interface {
+  public field(
+    name: string,
+    definition: ScalarDefinition | ListDefinition
+  ): Interface {
     this.fields.push(new Field(name, definition))
 
     return this

--- a/packages/grafbase-sdk/src/interface.ts
+++ b/packages/grafbase-sdk/src/interface.ts
@@ -1,0 +1,31 @@
+import { Field } from "./field"
+import { GListDef } from "./field/list"
+import { GScalarDef } from "./field/typedefs"
+
+export class Interface {
+  name: string
+  fields: Field[]
+
+  constructor(name: string) {
+    this.name = name
+    this.fields = []
+  }
+
+  public field(name: string, definition: GScalarDef | GListDef): Interface {
+    this.fields.push(new Field(name, definition))
+
+    return this
+  }
+
+  public toString(): string {
+    const header = `interface ${this.name} {`
+
+    const fields = this
+      .fields
+      .map((field) => `  ${field}`).join("\n")
+
+    const footer = '}'
+
+    return `${header}\n${fields}\n${footer}`
+  }
+}

--- a/packages/grafbase-sdk/src/model.ts
+++ b/packages/grafbase-sdk/src/model.ts
@@ -1,0 +1,48 @@
+import { FieldShape } from '.'
+import { Field } from './field'
+
+export class Model {
+  name: string
+  fields: Field[]
+  isSearch: boolean
+  isLive: boolean
+
+  constructor(name: string) {
+    this.name = name
+    this.fields = []
+    this.isSearch = false
+    this.isLive = false
+  }
+
+  public field(name: string, definition: FieldShape): Model {
+    this.fields.push(new Field(name, definition))
+
+    return this
+  }
+
+  public search(): Model {
+    this.isSearch = true;
+
+    return this
+  }
+
+  public live(): Model {
+    this.isLive = true;
+
+    return this
+  }
+
+  public toString(): string {
+    const search = this.isSearch ? " @search" : ""
+    const live = this.isLive ? " @live" : ""
+    const header = `type ${this.name} @model${search}${live} {`
+
+    const fields = this
+      .fields
+      .map((field) => `  ${field}`).join("\n")
+
+    const footer = '}'
+
+    return `${header}\n${fields}\n${footer}`
+  }
+}

--- a/packages/grafbase-sdk/src/model.ts
+++ b/packages/grafbase-sdk/src/model.ts
@@ -21,25 +21,23 @@ export class Model {
   }
 
   public search(): Model {
-    this.isSearch = true;
+    this.isSearch = true
 
     return this
   }
 
   public live(): Model {
-    this.isLive = true;
+    this.isLive = true
 
     return this
   }
 
   public toString(): string {
-    const search = this.isSearch ? " @search" : ""
-    const live = this.isLive ? " @live" : ""
+    const search = this.isSearch ? ' @search' : ''
+    const live = this.isLive ? ' @live' : ''
     const header = `type ${this.name} @model${search}${live} {`
 
-    const fields = this
-      .fields
-      .map((field) => `  ${field}`).join("\n")
+    const fields = this.fields.map((field) => `  ${field}`).join('\n')
 
     const footer = '}'
 

--- a/packages/grafbase-sdk/src/query.ts
+++ b/packages/grafbase-sdk/src/query.ts
@@ -1,9 +1,9 @@
-import { GListDef } from './field/list'
-import { GScalarDef } from './field/typedefs'
-import { GReferenceDef } from './reference'
+import { ListDef } from './field/list'
+import { ScalarDef } from './field/typedefs'
+import { ReferenceDef } from './reference'
 
-export type InputType = GScalarDef | GListDef | GReferenceDef
-export type OutputType = GScalarDef | GListDef | GReferenceDef
+export type InputType = ScalarDef | ListDef | ReferenceDef
+export type OutputType = ScalarDef | ListDef | ReferenceDef
 
 export interface QueryInput {
   args?: Record<string, InputType>

--- a/packages/grafbase-sdk/src/query.ts
+++ b/packages/grafbase-sdk/src/query.ts
@@ -6,7 +6,7 @@ export type InputType = GScalarDef | GListDef | GReferenceDef
 export type OutputType = GScalarDef | GListDef | GReferenceDef
 
 export interface QueryInput {
-  args: Record<string, InputType>,
+  args?: Record<string, InputType>,
   returns: OutputType,
   resolver: string
 }
@@ -57,10 +57,11 @@ export class Query {
   }
   
   public toString(): string {
-    let header = `extend type ${this.type} {`
-    let args = this.arguments.map(String).join(", ")
-    let query = `  ${this.name}(${args}): ${this.returns} @resolver(name: "${this.resolver}")`
-    let footer = "}"
+    const header = `extend type ${this.type} {`
+    const args = this.arguments.map(String).join(", ")
+    const argsStr = args ? `(${args})` : ""
+    const query = `  ${this.name}${argsStr}: ${this.returns} @resolver(name: "${this.resolver}")`
+    const footer = "}"
 
     return `${header}\n${query}\n${footer}`
   }

--- a/packages/grafbase-sdk/src/query.ts
+++ b/packages/grafbase-sdk/src/query.ts
@@ -1,13 +1,13 @@
-import { GListDef } from "./field/list"
-import { GScalarDef } from "./field/typedefs"
-import { GReferenceDef } from "./reference"
+import { GListDef } from './field/list'
+import { GScalarDef } from './field/typedefs'
+import { GReferenceDef } from './reference'
 
 export type InputType = GScalarDef | GListDef | GReferenceDef
 export type OutputType = GScalarDef | GListDef | GReferenceDef
 
 export interface QueryInput {
-  args?: Record<string, InputType>,
-  returns: OutputType,
+  args?: Record<string, InputType>
+  returns: OutputType
   resolver: string
 }
 
@@ -26,8 +26,8 @@ export class QueryArgument {
 }
 
 export enum QueryType {
-  Query = "Query",
-  Mutation = "Mutation",
+  Query = 'Query',
+  Mutation = 'Mutation'
 }
 
 export class Query {
@@ -41,7 +41,7 @@ export class Query {
     name: string,
     type: QueryType,
     returnType: OutputType,
-    resolverName: string,
+    resolverName: string
   ) {
     this.name = name
     this.arguments = []
@@ -55,13 +55,13 @@ export class Query {
 
     return this
   }
-  
+
   public toString(): string {
     const header = `extend type ${this.type} {`
-    const args = this.arguments.map(String).join(", ")
-    const argsStr = args ? `(${args})` : ""
+    const args = this.arguments.map(String).join(', ')
+    const argsStr = args ? `(${args})` : ''
     const query = `  ${this.name}${argsStr}: ${this.returns} @resolver(name: "${this.resolver}")`
-    const footer = "}"
+    const footer = '}'
 
     return `${header}\n${query}\n${footer}`
   }

--- a/packages/grafbase-sdk/src/query.ts
+++ b/packages/grafbase-sdk/src/query.ts
@@ -1,0 +1,85 @@
+import { GListDef } from "./field/list"
+import { GScalarDef } from "./field/typedefs"
+import { GReferenceDef } from "./reference"
+
+export type InputType = GScalarDef | GListDef | GReferenceDef
+export type OutputType = GScalarDef | GListDef | GReferenceDef
+
+export interface QueryInput {
+  args: Record<string, InputType>,
+  returns: OutputType
+}
+
+export class QueryArgument {
+  name: string
+  type: InputType
+
+  constructor(name: string, type: InputType) {
+    this.name = name
+    this.type = type
+  }
+
+  public toString(): string {
+    return `${this.name}: ${this.type}`
+  }
+}
+
+export enum QueryType {
+  Query = "Query",
+  Mutation = "Mutation",
+}
+
+export class PartialQuery {
+  name: string
+  arguments: QueryArgument[]
+  returns: OutputType
+  type: QueryType
+
+  constructor(name: string, type: QueryType, returns: OutputType) {
+    this.name = name
+    this.arguments = []
+    this.returns = returns
+    this.type = type
+  }
+
+  public argument(name: string, inputType: InputType): PartialQuery {
+    this.arguments.push(new QueryArgument(name, inputType))
+
+    return this
+  }
+
+  public resolver(resolverName: string): Query {
+    return new Query(this.name, this.arguments, this.returns, resolverName, this.type)
+  }
+}
+
+export class Query {
+  name: string
+  arguments: QueryArgument[]
+  returns: OutputType
+  resolver: string
+  type: QueryType
+
+  constructor(
+    name: string,
+    args: QueryArgument[],
+    returnType: OutputType,
+    resolverName: string,
+    type: QueryType
+  ) {
+    this.name = name
+    this.arguments = args
+    this.returns = returnType
+    this.resolver = resolverName
+    this.type = type
+  }
+
+  public toString(): string {
+    let header = `extend type ${this.type} {`
+    let args = this.arguments.map(String).join(", ")
+    let query = `  ${this.name}(${args}): ${this.returns} @resolver(name: "${this.resolver}")`
+    let footer = "}"
+
+    return `${header}\n${query}\n${footer}`
+  }
+}

--- a/packages/grafbase-sdk/src/query.ts
+++ b/packages/grafbase-sdk/src/query.ts
@@ -7,7 +7,8 @@ export type OutputType = GScalarDef | GListDef | GReferenceDef
 
 export interface QueryInput {
   args: Record<string, InputType>,
-  returns: OutputType
+  returns: OutputType,
+  resolver: string
 }
 
 export class QueryArgument {
@@ -29,30 +30,6 @@ export enum QueryType {
   Mutation = "Mutation",
 }
 
-export class PartialQuery {
-  name: string
-  arguments: QueryArgument[]
-  returns: OutputType
-  type: QueryType
-
-  constructor(name: string, type: QueryType, returns: OutputType) {
-    this.name = name
-    this.arguments = []
-    this.returns = returns
-    this.type = type
-  }
-
-  public argument(name: string, inputType: InputType): PartialQuery {
-    this.arguments.push(new QueryArgument(name, inputType))
-
-    return this
-  }
-
-  public resolver(resolverName: string): Query {
-    return new Query(this.name, this.arguments, this.returns, resolverName, this.type)
-  }
-}
-
 export class Query {
   name: string
   arguments: QueryArgument[]
@@ -62,18 +39,23 @@ export class Query {
 
   constructor(
     name: string,
-    args: QueryArgument[],
+    type: QueryType,
     returnType: OutputType,
     resolverName: string,
-    type: QueryType
   ) {
     this.name = name
-    this.arguments = args
+    this.arguments = []
     this.returns = returnType
     this.resolver = resolverName
     this.type = type
   }
 
+  public pushArgument(name: string, type: InputType): Query {
+    this.arguments.push(new QueryArgument(name, type))
+
+    return this
+  }
+  
   public toString(): string {
     let header = `extend type ${this.type} {`
     let args = this.arguments.map(String).join(", ")

--- a/packages/grafbase-sdk/src/query.ts
+++ b/packages/grafbase-sdk/src/query.ts
@@ -1,9 +1,9 @@
-import { ListDef } from './field/list'
-import { ScalarDef } from './field/typedefs'
-import { ReferenceDef } from './reference'
+import { ListDefinition } from './field/list'
+import { ScalarDefinition } from './field/typedefs'
+import { ReferenceDefinition } from './reference'
 
-export type InputType = ScalarDef | ListDef | ReferenceDef
-export type OutputType = ScalarDef | ListDef | ReferenceDef
+export type InputType = ScalarDefinition | ListDefinition | ReferenceDefinition
+export type OutputType = ScalarDefinition | ListDefinition | ReferenceDefinition
 
 export interface QueryInput {
   args?: Record<string, InputType>

--- a/packages/grafbase-sdk/src/reference.ts
+++ b/packages/grafbase-sdk/src/reference.ts
@@ -1,8 +1,8 @@
 import { Enum } from './enum'
-import { GListDef } from './field/list'
+import { ListDef } from './field/list'
 import { Type } from './type'
 
-export class GReferenceDef {
+export class ReferenceDef {
   referencedType: string
   isOptional: boolean
 
@@ -11,14 +11,14 @@ export class GReferenceDef {
     this.isOptional = false
   }
 
-  public optional(): GReferenceDef {
+  public optional(): ReferenceDef {
     this.isOptional = true
 
     return this
   }
 
-  public list(): GListDef {
-    return new GListDef(this)
+  public list(): ListDef {
+    return new ListDef(this)
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/reference.ts
+++ b/packages/grafbase-sdk/src/reference.ts
@@ -1,3 +1,4 @@
+import { Enum } from "./enum";
 import { GListDef } from "./field/list";
 import { Type } from "./type";
 
@@ -5,7 +6,7 @@ export class GReferenceDef {
   referencedType: string
   isOptional: boolean
 
-  constructor(referencedType: Type) {
+  constructor(referencedType: Type | Enum) {
     this.referencedType = referencedType.name
     this.isOptional = false
   }

--- a/packages/grafbase-sdk/src/reference.ts
+++ b/packages/grafbase-sdk/src/reference.ts
@@ -1,0 +1,28 @@
+import { GListDef } from "./field/list";
+import { Type } from "./type";
+
+export class GReferenceDef {
+  referencedType: string
+  isOptional: boolean
+
+  constructor(referencedType: Type) {
+    this.referencedType = referencedType.name
+    this.isOptional = false
+  }
+  
+  public optional(): GReferenceDef {
+    this.isOptional = true
+
+    return this
+  }
+
+  public list(): GListDef {
+    return new GListDef(this)
+  }
+
+  public toString(): string {
+    const required = this.isOptional ? "" : "!"
+
+    return `${this.referencedType}${required}`
+  }
+}

--- a/packages/grafbase-sdk/src/reference.ts
+++ b/packages/grafbase-sdk/src/reference.ts
@@ -1,6 +1,6 @@
-import { Enum } from "./enum";
-import { GListDef } from "./field/list";
-import { Type } from "./type";
+import { Enum } from './enum'
+import { GListDef } from './field/list'
+import { Type } from './type'
 
 export class GReferenceDef {
   referencedType: string
@@ -10,7 +10,7 @@ export class GReferenceDef {
     this.referencedType = referencedType.name
     this.isOptional = false
   }
-  
+
   public optional(): GReferenceDef {
     this.isOptional = true
 
@@ -22,7 +22,7 @@ export class GReferenceDef {
   }
 
   public toString(): string {
-    const required = this.isOptional ? "" : "!"
+    const required = this.isOptional ? '' : '!'
 
     return `${this.referencedType}${required}`
   }

--- a/packages/grafbase-sdk/src/reference.ts
+++ b/packages/grafbase-sdk/src/reference.ts
@@ -1,8 +1,8 @@
 import { Enum } from './enum'
-import { ListDef } from './field/list'
+import { ListDefinition } from './field/list'
 import { Type } from './type'
 
-export class ReferenceDef {
+export class ReferenceDefinition {
   referencedType: string
   isOptional: boolean
 
@@ -11,14 +11,14 @@ export class ReferenceDef {
     this.isOptional = false
   }
 
-  public optional(): ReferenceDef {
+  public optional(): ReferenceDefinition {
     this.isOptional = true
 
     return this
   }
 
-  public list(): ListDef {
-    return new ListDef(this)
+  public list(): ListDefinition {
+    return new ListDefinition(this)
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/relation.ts
+++ b/packages/grafbase-sdk/src/relation.ts
@@ -36,8 +36,8 @@ export class GRelationDef {
       modelName = this.referencedModel.name
     }
 
-    let required = this.isOptional ? "" : "!"
-    let relationAttribute = this.relationName ? ` @relation(name: ${this.relationName})` : ""
+    const required = this.isOptional ? "" : "!"
+    const relationAttribute = this.relationName ? ` @relation(name: ${this.relationName})` : ""
 
     return `${modelName}${required}${relationAttribute}`
   }

--- a/packages/grafbase-sdk/src/relation.ts
+++ b/packages/grafbase-sdk/src/relation.ts
@@ -1,5 +1,5 @@
-import { RelationRef } from ".";
-import { GListDef } from "./field/list";
+import { RelationRef } from '.'
+import { GListDef } from './field/list'
 
 export class GRelationDef {
   relationName?: string
@@ -22,9 +22,9 @@ export class GRelationDef {
   }
 
   public name(name: string): GRelationDef {
-    this.relationName = name;
+    this.relationName = name
 
-    return this;
+    return this
   }
 
   public toString(): string {
@@ -36,8 +36,10 @@ export class GRelationDef {
       modelName = this.referencedModel.name
     }
 
-    const required = this.isOptional ? "" : "!"
-    const relationAttribute = this.relationName ? ` @relation(name: ${this.relationName})` : ""
+    const required = this.isOptional ? '' : '!'
+    const relationAttribute = this.relationName
+      ? ` @relation(name: ${this.relationName})`
+      : ''
 
     return `${modelName}${required}${relationAttribute}`
   }

--- a/packages/grafbase-sdk/src/relation.ts
+++ b/packages/grafbase-sdk/src/relation.ts
@@ -1,0 +1,44 @@
+import { RelationRef } from ".";
+import { GListDef } from "./field/list";
+
+export class GRelationDef {
+  relationName?: string
+  referencedModel: RelationRef
+  isOptional: boolean
+
+  constructor(referencedModel: RelationRef) {
+    this.referencedModel = referencedModel
+    this.isOptional = false
+  }
+
+  public optional(): GRelationDef {
+    this.isOptional = true
+
+    return this
+  }
+
+  public list(): GListDef {
+    return new GListDef(this)
+  }
+
+  public name(name: string): GRelationDef {
+    this.relationName = name;
+
+    return this;
+  }
+
+  public toString(): string {
+    let modelName
+
+    if (typeof this.referencedModel === 'function') {
+      modelName = this.referencedModel().name
+    } else {
+      modelName = this.referencedModel.name
+    }
+
+    let required = this.isOptional ? "" : "!"
+    let relationAttribute = this.relationName ? ` @relation(name: ${this.relationName})` : ""
+
+    return `${modelName}${required}${relationAttribute}`
+  }
+}

--- a/packages/grafbase-sdk/src/relation.ts
+++ b/packages/grafbase-sdk/src/relation.ts
@@ -1,7 +1,7 @@
 import { RelationRef } from '.'
-import { GListDef } from './field/list'
+import { ListDef } from './field/list'
 
-export class GRelationDef {
+export class RelationDef {
   relationName?: string
   referencedModel: RelationRef
   isOptional: boolean
@@ -11,17 +11,17 @@ export class GRelationDef {
     this.isOptional = false
   }
 
-  public optional(): GRelationDef {
+  public optional(): RelationDef {
     this.isOptional = true
 
     return this
   }
 
-  public list(): GListDef {
-    return new GListDef(this)
+  public list(): ListDef {
+    return new ListDef(this)
   }
 
-  public name(name: string): GRelationDef {
+  public name(name: string): RelationDef {
     this.relationName = name
 
     return this

--- a/packages/grafbase-sdk/src/relation.ts
+++ b/packages/grafbase-sdk/src/relation.ts
@@ -1,7 +1,7 @@
 import { RelationRef } from '.'
-import { ListDef } from './field/list'
+import { ListDefinition } from './field/list'
 
-export class RelationDef {
+export class RelationDefinition {
   relationName?: string
   referencedModel: RelationRef
   isOptional: boolean
@@ -11,17 +11,17 @@ export class RelationDef {
     this.isOptional = false
   }
 
-  public optional(): RelationDef {
+  public optional(): RelationDefinition {
     this.isOptional = true
 
     return this
   }
 
-  public list(): ListDef {
-    return new ListDef(this)
+  public list(): ListDefinition {
+    return new ListDefinition(this)
   }
 
-  public name(name: string): RelationDef {
+  public name(name: string): RelationDefinition {
     this.relationName = name
 
     return this

--- a/packages/grafbase-sdk/src/type.ts
+++ b/packages/grafbase-sdk/src/type.ts
@@ -1,8 +1,8 @@
 import { Field } from './field'
-import { GListDef } from './field/list'
-import { GScalarDef } from './field/typedefs'
+import { ListDef } from './field/list'
+import { ScalarDef } from './field/typedefs'
 import { Interface } from './interface'
-import { GReferenceDef } from './reference'
+import { ReferenceDef } from './reference'
 
 export class Type {
   name: string
@@ -17,7 +17,7 @@ export class Type {
 
   public field(
     name: string,
-    definition: GScalarDef | GListDef | GReferenceDef
+    definition: ScalarDef | ListDef | ReferenceDef
   ): Type {
     this.fields.push(new Field(name, definition))
 

--- a/packages/grafbase-sdk/src/type.ts
+++ b/packages/grafbase-sdk/src/type.ts
@@ -2,6 +2,7 @@ import { Field } from './field'
 import { GListDef } from './field/list'
 import { GScalarDef } from './field/typedefs'
 import { Interface } from './interface'
+import { GReferenceDef } from './reference'
 
 export class Type {
   name: string
@@ -14,7 +15,10 @@ export class Type {
     this.interfaces = []
   }
 
-  public field(name: string, definition: GScalarDef | GListDef): Type {
+  public field(
+    name: string,
+    definition: GScalarDef | GListDef | GReferenceDef
+  ): Type {
     this.fields.push(new Field(name, definition))
 
     return this

--- a/packages/grafbase-sdk/src/type.ts
+++ b/packages/grafbase-sdk/src/type.ts
@@ -1,8 +1,8 @@
 import { Field } from './field'
-import { ListDef } from './field/list'
-import { ScalarDef } from './field/typedefs'
+import { ListDefinition } from './field/list'
+import { ScalarDefinition } from './field/typedefs'
 import { Interface } from './interface'
-import { ReferenceDef } from './reference'
+import { ReferenceDefinition } from './reference'
 
 export class Type {
   name: string
@@ -17,7 +17,7 @@ export class Type {
 
   public field(
     name: string,
-    definition: ScalarDef | ListDef | ReferenceDef
+    definition: ScalarDefinition | ListDefinition | ReferenceDefinition
   ): Type {
     this.fields.push(new Field(name, definition))
 

--- a/packages/grafbase-sdk/src/type.ts
+++ b/packages/grafbase-sdk/src/type.ts
@@ -1,0 +1,41 @@
+import { Field } from "./field"
+import { GListDef } from "./field/list"
+import { GScalarDef } from "./field/typedefs"
+import { Interface } from "./interface"
+
+export class Type {
+  name: string
+  fields: Field[]
+  interface?: Interface
+
+  constructor(name: string) {
+    this.name = name
+    this.fields = []
+  }
+
+  public field(name: string, definition: GScalarDef | GListDef): Type {
+    this.fields.push(new Field(name, definition))
+
+    return this
+  }
+
+  public implements(i: Interface): Type {
+    this.interface = i
+
+    return this
+  }
+
+  public toString(): string {
+    const impl = this.interface ? ` implements ${this.interface?.name}` : ""
+    const header = `type ${this.name}${impl} {`
+
+    let fields = (this.interface?.fields ?? [])
+      .concat(this.fields)
+      .map((field) => `  ${field}`)
+      .join("\n")
+
+    const footer = '}'
+
+    return `${header}\n${fields}\n${footer}`
+  }
+}

--- a/packages/grafbase-sdk/src/type.ts
+++ b/packages/grafbase-sdk/src/type.ts
@@ -1,7 +1,7 @@
-import { Field } from "./field"
-import { GListDef } from "./field/list"
-import { GScalarDef } from "./field/typedefs"
-import { Interface } from "./interface"
+import { Field } from './field'
+import { GListDef } from './field/list'
+import { GScalarDef } from './field/typedefs'
+import { Interface } from './interface'
 
 export class Type {
   name: string
@@ -27,13 +27,15 @@ export class Type {
   }
 
   public toString(): string {
-    const interfaces = this.interfaces.map((i) => i.name).join(" & ")
-    const impl = interfaces ? ` implements ${interfaces}` : ""
+    const interfaces = this.interfaces.map((i) => i.name).join(' & ')
+    const impl = interfaces ? ` implements ${interfaces}` : ''
     const header = `type ${this.name}${impl} {`
 
-    const fields = distinct((this.interfaces.flatMap((i) => i.fields) ?? []).concat(this.fields))
+    const fields = distinct(
+      (this.interfaces.flatMap((i) => i.fields) ?? []).concat(this.fields)
+    )
       .map((field) => `  ${field}`)
-      .join("\n")
+      .join('\n')
 
     const footer = '}'
 

--- a/packages/grafbase-sdk/src/union.ts
+++ b/packages/grafbase-sdk/src/union.ts
@@ -1,0 +1,23 @@
+import { Type } from "./type"
+
+export class Union {
+  name: string
+  types: string[]
+
+  constructor(name: string) {
+    this.name = name
+    this.types = []
+  }
+
+  public type(type: Type): Union {
+    this.types.push(type.name)
+
+    return this
+  }
+
+  public toString(): string {
+    const types = this.types.join(" | ")
+
+    return `union ${this.name} = ${types}`
+  }
+}

--- a/packages/grafbase-sdk/src/union.ts
+++ b/packages/grafbase-sdk/src/union.ts
@@ -1,4 +1,4 @@
-import { Type } from "./type"
+import { Type } from './type'
 
 export class Union {
   name: string
@@ -16,7 +16,7 @@ export class Union {
   }
 
   public toString(): string {
-    const types = this.types.join(" | ")
+    const types = this.types.join(' | ')
 
     return `union ${this.name} = ${types}`
   }

--- a/packages/grafbase-sdk/tests/unit/defaults.test.ts
+++ b/packages/grafbase-sdk/tests/unit/defaults.test.ts
@@ -1,0 +1,313 @@
+import { g } from '../../src/index'
+import { describe, expect, it } from '@jest/globals'
+
+describe('Default value generation', () => {
+  it('generates String default', () => {
+    const model = g.model('User', {
+      name: g.string().default('Bob')
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String! @default(value: "Bob")
+      }"
+    `)
+  })
+
+  it('generates String default as optional', () => {
+    const model = g.model('User', {
+      name: g.string().default('Bob').optional()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String @default(value: "Bob")
+      }"
+    `)
+  })
+
+  it('generates String list default', () => {
+    const model = g.model('User', {
+      name: g.string().list().default(['Bob'])
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: [String!]! @default(value: ["Bob"])
+      }"
+    `)
+  })
+
+  it('generates ID default', () => {
+    const model = g.model('User', {
+      name: g.id().default('asdf123')
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: ID! @default(value: "asdf123")
+      }"
+    `)
+  })
+
+  it('generates ID list default', () => {
+    const model = g.model('User', {
+      name: g.id().list().default(['asdf123', 'omg123'])
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: [ID!]! @default(value: ["asdf123", "omg123"])
+      }"
+    `)
+  })
+
+  it('generates PhoneNumber default', () => {
+    const model = g.model('User', {
+      name: g.phoneNumber().default('555 123 123')
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: PhoneNumber! @default(value: "555 123 123")
+      }"
+    `)
+  })
+
+  it('generates PhoneNumber list default', () => {
+    const model = g.model('User', {
+      name: g.phoneNumber().list().default(['555 123 123', '555 432 432'])
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: [PhoneNumber!]! @default(value: ["555 123 123", "555 432 432"])
+      }"
+    `)
+  })
+
+  it('generates IPAddress default', () => {
+    const model = g.model('User', {
+      name: g.ipAddress().default('0.0.0.0')
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: IPAddress! @default(value: "0.0.0.0")
+      }"
+    `)
+  })
+
+  it('generates IPAddress list default', () => {
+    const model = g.model('User', {
+      name: g.ipAddress().list().default(['0.0.0.0', '1.1.1.1'])
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: [IPAddress!]! @default(value: ["0.0.0.0", "1.1.1.1"])
+      }"
+    `)
+  })
+
+  it('generates Email default', () => {
+    const model = g.model('User', {
+      name: g.email().default('foo@bar.lol')
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: Email! @default(value: "foo@bar.lol")
+      }"
+    `)
+  })
+
+  it('generates Email list default', () => {
+    const model = g.model('User', {
+      name: g.email().list().default(['foo@bar.lol'])
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: [Email!]! @default(value: ["foo@bar.lol"])
+      }"
+    `)
+  })
+
+  it('generates URL default', () => {
+    const model = g.model('User', {
+      name: g.url().default('https://github.com')
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: URL! @default(value: "https://github.com")
+      }"
+    `)
+  })
+
+  it('generates URL list default', () => {
+    const model = g.model('User', {
+      name: g.url().list().default(['https://github.com', 'https://codeberg.org'])
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: [URL!]! @default(value: ["https://github.com", "https://codeberg.org"])
+      }"
+    `)
+  })
+
+  it('generates Int default', () => {
+    const model = g.model('User', {
+      name: g.int().default(2)
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: Int! @default(value: 2)
+      }"
+    `)
+  })
+
+  it('generates Int list default', () => {
+    const model = g.model('User', {
+      name: g.int().list().default([2])
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: [Int!]! @default(value: [2])
+      }"
+    `)
+  })
+
+  it('generates Float default', () => {
+    const model = g.model('User', {
+      name: g.float().default(1.337)
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: Float! @default(value: 1.337)
+      }"
+    `)
+  })
+
+  it('generates Float list default', () => {
+    const model = g.model('User', {
+      name: g.float().list().default([1.337, 2.32])
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: [Float!]! @default(value: [1.337, 2.32])
+      }"
+    `)
+  })
+
+  it('generates Boolean default', () => {
+    const model = g.model('User', {
+      name: g.boolean().default(false)
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: Boolean! @default(value: false)
+      }"
+    `)
+  })
+
+  it('generates Boolean list default', () => {
+    const model = g.model('User', {
+      name: g.boolean().list().default([true, false])
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: [Boolean!]! @default(value: [true, false])
+      }"
+    `)
+  })
+
+  it('generates Date default', () => {
+    const model = g.model('User', {
+      date: g.date().default(new Date('1995-12-17'))
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        date: Date! @default(value: "1995-12-17")
+      }"
+    `)
+  })
+
+  it('generates Date list default', () => {
+    const model = g.model('User', {
+      date: g
+        .date()
+        .list()
+        .default([new Date('1995-12-17'), new Date('2002-01-01')])
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        date: [Date!]! @default(value: ["1995-12-17", "2002-01-01"])
+      }"
+    `)
+  })
+
+  it('generates DateTime default', () => {
+    const model = g.model('User', {
+      date: g.datetime().default(new Date('1995-12-17T04:20:00Z'))
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        date: DateTime! @default(value: "1995-12-17T04:20:00Z")
+      }"
+    `)
+  })
+
+  it('generates DateTime list default', () => {
+    const model = g.model('User', {
+      date: g
+        .datetime()
+        .list()
+        .default([
+          new Date('1995-12-17T04:20:00Z'),
+          new Date('2002-12-17T04:20:00Z')
+        ])
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        date: [DateTime!]! @default(value: ["1995-12-17T04:20:00Z", "2002-12-17T04:20:00Z"])
+      }"
+    `)
+  })
+
+  it('generates Timestamp default', () => {
+    const model = g.model('User', {
+      date: g.timestamp().default(1683644443566)
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        date: Timestamp! @default(value: 1683644443566)
+      }"
+    `)
+  })
+
+  it('generates Timestamp list default', () => {
+    const model = g.model('User', {
+      date: g.timestamp().list().default([1683644443566, 1683644443569])
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        date: [Timestamp!]! @default(value: [1683644443566, 1683644443569])
+      }"
+    `)
+  })
+})

--- a/packages/grafbase-sdk/tests/unit/enum.test.ts
+++ b/packages/grafbase-sdk/tests/unit/enum.test.ts
@@ -1,0 +1,55 @@
+import { config, g } from '../../src/index'
+import { describe, expect, it } from '@jest/globals'
+
+describe('Enum generator', () => {
+  it('generates an enum from an array of strings', () => {
+    const e = g.enumType('Fruits', ['Apples', 'Oranges'])
+
+    expect(e.toString()).toMatchInlineSnapshot(`
+      "enum Fruits {
+        Apples,
+        Oranges
+      }"
+    `)
+  })
+
+  it('generates an enum from a typescript enum', () => {
+    enum Fruits {
+      Apples,
+      Oranges
+    }
+
+    const e = g.enumType('Fruits', Fruits)
+
+    expect(e.toString()).toMatchInlineSnapshot(`
+      "enum Fruits {
+        Apples,
+        Oranges
+      }"
+    `)
+  })
+
+  it('generates an enum field', () => {
+    const e = g.enumType('Fruits', ['Apples', 'Oranges'])
+
+    const m = g.model('Basket', {
+      fruitType: g.enum(e)
+    })
+
+    const cfg = config().schema({
+      models: [m],
+      enums: [e]
+    })
+
+    expect(cfg.toString()).toMatchInlineSnapshot(`
+      "enum Fruits {
+        Apples,
+        Oranges
+      }
+
+      type Basket @model {
+        fruitType: Fruits!
+      }"
+    `)
+  })
+})

--- a/packages/grafbase-sdk/tests/unit/enum.test.ts
+++ b/packages/grafbase-sdk/tests/unit/enum.test.ts
@@ -1,7 +1,11 @@
 import { config, g } from '../../src/index'
-import { describe, expect, it } from '@jest/globals'
+import { describe, expect, it, beforeEach } from '@jest/globals'
 
 describe('Enum generator', () => {
+  beforeEach(() => {
+    g.clear()
+  })
+
   it('generates an enum from an array of strings', () => {
     const e = g.enumType('Fruits', ['Apples', 'Oranges'])
 
@@ -32,16 +36,11 @@ describe('Enum generator', () => {
   it('generates an enum field', () => {
     const e = g.enumType('Fruits', ['Apples', 'Oranges'])
 
-    const m = g.model('Basket', {
+    g.model('Basket', {
       fruitType: g.enum(e)
     })
 
-    const cfg = config().schema({
-      models: [m],
-      enums: [e]
-    })
-
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "enum Fruits {
         Apples,
         Oranges

--- a/packages/grafbase-sdk/tests/unit/enum.test.ts
+++ b/packages/grafbase-sdk/tests/unit/enum.test.ts
@@ -7,7 +7,7 @@ describe('Enum generator', () => {
   })
 
   it('generates an enum from an array of strings', () => {
-    const e = g.enumType('Fruits', ['Apples', 'Oranges'])
+    const e = g.enum('Fruits', ['Apples', 'Oranges'])
 
     expect(e.toString()).toMatchInlineSnapshot(`
       "enum Fruits {
@@ -23,7 +23,7 @@ describe('Enum generator', () => {
       Oranges
     }
 
-    const e = g.enumType('Fruits', Fruits)
+    const e = g.enum('Fruits', Fruits)
 
     expect(e.toString()).toMatchInlineSnapshot(`
       "enum Fruits {
@@ -34,10 +34,10 @@ describe('Enum generator', () => {
   })
 
   it('generates an enum field', () => {
-    const e = g.enumType('Fruits', ['Apples', 'Oranges'])
+    const e = g.enum('Fruits', ['Apples', 'Oranges'])
 
     g.model('Basket', {
-      fruitType: g.enum(e)
+      fruitType: g.ref(e)
     })
 
     expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`

--- a/packages/grafbase-sdk/tests/unit/interface.test.ts
+++ b/packages/grafbase-sdk/tests/unit/interface.test.ts
@@ -1,0 +1,61 @@
+import { config, g } from '../../src/index'
+import { describe, expect, it } from '@jest/globals'
+
+describe('Interface generator', () => {
+  it('generates a simple interface', () => {
+    const i = g.interface('Produce', {
+      name: g.string(),
+      quantity: g.int(),
+      price: g.float(),
+      nutrients: g.string().optional().list().optional()
+    })
+
+    expect(i.toString()).toMatchInlineSnapshot(`
+      "interface Produce {
+        name: String!
+        quantity: Int!
+        price: Float!
+        nutrients: [String]
+      }"
+    `)
+  })
+
+  it('generates a type implementing an interface', () => {
+    const produce = g.interface('Produce', {
+      name: g.string(),
+      quantity: g.int(),
+      price: g.float(),
+      nutrients: g.string().optional().list().optional()
+    })
+
+    const fruit = g
+      .type('Fruit', {
+        isSeedless: g.boolean().optional(),
+        ripenessIndicators: g.string().optional().list().optional()
+      })
+      .implements(produce)
+
+    const cfg = config().schema({
+      types: [fruit],
+      interfaces: [produce]
+    })
+
+    expect(cfg.toString()).toMatchInlineSnapshot(`
+      "interface Produce {
+        name: String!
+        quantity: Int!
+        price: Float!
+        nutrients: [String]
+      }
+
+      type Fruit implements Produce {
+        name: String!
+        quantity: Int!
+        price: Float!
+        nutrients: [String]
+        isSeedless: Boolean
+        ripenessIndicators: [String]
+      }"
+    `)
+  })
+})

--- a/packages/grafbase-sdk/tests/unit/interface.test.ts
+++ b/packages/grafbase-sdk/tests/unit/interface.test.ts
@@ -53,4 +53,40 @@ describe('Interface generator', () => {
       }"
     `)
   })
+
+  it('generates a type implementing multiple interfaces', () => {
+    const produce = g.interface('Produce', {
+      name: g.string()
+    })
+
+    const sweets = g.interface('Sweets', {
+      name: g.string(),
+      sweetness: g.int()
+    })
+
+    g.type('Fruit', {
+        isSeedless: g.boolean().optional(),
+        ripenessIndicators: g.string().optional().list().optional()
+      })
+      .implements(produce)
+      .implements(sweets)
+
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+      "interface Produce {
+        name: String!
+      }
+
+      interface Sweets {
+        name: String!
+        sweetness: Int!
+      }
+
+      type Fruit implements Produce & Sweets {
+        name: String!
+        sweetness: Int!
+        isSeedless: Boolean
+        ripenessIndicators: [String]
+      }"
+    `)
+  })
 })

--- a/packages/grafbase-sdk/tests/unit/interface.test.ts
+++ b/packages/grafbase-sdk/tests/unit/interface.test.ts
@@ -1,7 +1,9 @@
 import { config, g } from '../../src/index'
-import { describe, expect, it } from '@jest/globals'
+import { describe, expect, it, beforeEach } from '@jest/globals'
 
 describe('Interface generator', () => {
+  beforeEach(() => g.clear())
+
   it('generates a simple interface', () => {
     const i = g.interface('Produce', {
       name: g.string(),
@@ -28,19 +30,12 @@ describe('Interface generator', () => {
       nutrients: g.string().optional().list().optional()
     })
 
-    const fruit = g
-      .type('Fruit', {
-        isSeedless: g.boolean().optional(),
-        ripenessIndicators: g.string().optional().list().optional()
-      })
-      .implements(produce)
+    g.type('Fruit', {
+      isSeedless: g.boolean().optional(),
+      ripenessIndicators: g.string().optional().list().optional()
+    }).implements(produce)
 
-    const cfg = config().schema({
-      types: [fruit],
-      interfaces: [produce]
-    })
-
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "interface Produce {
         name: String!
         quantity: Int!

--- a/packages/grafbase-sdk/tests/unit/model.test.ts
+++ b/packages/grafbase-sdk/tests/unit/model.test.ts
@@ -1,7 +1,9 @@
 import { config, g } from '../../src/index'
-import { describe, expect, it } from '@jest/globals'
+import { describe, expect, it, beforeEach } from '@jest/globals'
 
 describe('Model generator', () => {
+  beforeEach(() => g.clear())
+
   it('generates required String field', () => {
     const model = g.model('User', {
       name: g.string()
@@ -387,17 +389,12 @@ describe('Model generator', () => {
       street: g.string().optional()
     })
 
-    const user = g.model('User', {
+    g.model('User', {
       name: g.string(),
       address: g.ref(address)
     })
 
-    const cfg = config().schema({
-      types: [address],
-      models: [user]
-    })
-
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "type Address {
         street: String
       }
@@ -426,17 +423,12 @@ describe('Model generator', () => {
       street: g.string().optional()
     })
 
-    const user = g.model('User', {
+    g.model('User', {
       name: g.string(),
       address: g.ref(address).optional()
     })
 
-    const cfg = config().schema({
-      types: [address],
-      models: [user]
-    })
-
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "type Address {
         street: String
       }
@@ -453,17 +445,12 @@ describe('Model generator', () => {
       street: g.string().optional()
     })
 
-    const user = g.model('User', {
+    g.model('User', {
       name: g.string(),
       addresses: g.ref(address).list()
     })
 
-    const cfg = config().schema({
-      types: [address],
-      models: [user]
-    })
-
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "type Address {
         street: String
       }

--- a/packages/grafbase-sdk/tests/unit/model.test.ts
+++ b/packages/grafbase-sdk/tests/unit/model.test.ts
@@ -391,7 +391,7 @@ describe('Model generator', () => {
 
     g.model('User', {
       name: g.string(),
-      address: g.ref(address)
+      address: g.ref(address).optional()
     })
 
     expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
@@ -401,7 +401,7 @@ describe('Model generator', () => {
 
       type User @model {
         name: String!
-        address: Address!
+        address: Address
       }"
     `)
   })

--- a/packages/grafbase-sdk/tests/unit/model.test.ts
+++ b/packages/grafbase-sdk/tests/unit/model.test.ts
@@ -1,0 +1,477 @@
+import { config, g } from '../../src/index'
+import { describe, expect, it } from '@jest/globals'
+
+describe('Model generator', () => {
+  it('generates required String field', () => {
+    const model = g.model('User', {
+      name: g.string()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String!
+      }"
+    `)
+  })
+
+  it('generates required ID field', () => {
+    const model = g.model('User', {
+      identifier: g.id()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        identifier: ID!
+      }"
+    `)
+  })
+
+  it('generates required Int field', () => {
+    const model = g.model('User', {
+      age: g.int()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        age: Int!
+      }"
+    `)
+  })
+
+  it('generates required Float field', () => {
+    const model = g.model('User', {
+      weight: g.float()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        weight: Float!
+      }"
+    `)
+  })
+
+  it('generates required Boolean field', () => {
+    const model = g.model('User', {
+      registered: g.boolean()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        registered: Boolean!
+      }"
+    `)
+  })
+
+  it('generates required Date field', () => {
+    const model = g.model('User', {
+      birthday: g.date()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        birthday: Date!
+      }"
+    `)
+  })
+
+  it('generates required DateTime field', () => {
+    const model = g.model('User', {
+      registerationDate: g.datetime()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        registerationDate: DateTime!
+      }"
+    `)
+  })
+
+  it('generates required Enum field', () => {
+    const model = g.model('User', {
+      email: g.email()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        email: Email!
+      }"
+    `)
+  })
+
+  it('generates required IPAddress field', () => {
+    const model = g.model('User', {
+      ipAddress: g.ipAddress()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        ipAddress: IPAddress!
+      }"
+    `)
+  })
+
+  it('generates required Timestamp field', () => {
+    const model = g.model('User', {
+      lastSeen: g.timestamp()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        lastSeen: Timestamp!
+      }"
+    `)
+  })
+
+  it('generates required URL field', () => {
+    const model = g.model('User', {
+      fediverseInstance: g.url()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        fediverseInstance: URL!
+      }"
+    `)
+  })
+
+  it('generates required JSON field', () => {
+    const model = g.model('User', {
+      customData: g.json()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        customData: JSON!
+      }"
+    `)
+  })
+
+  it('generates required PhoneNumber field', () => {
+    const model = g.model('User', {
+      phoneNumber: g.phoneNumber()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        phoneNumber: PhoneNumber!
+      }"
+    `)
+  })
+
+  it('generates more than one field', () => {
+    const model = g.model('User', {
+      name: g.string(),
+      age: g.int()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String!
+        age: Int!
+      }"
+    `)
+  })
+
+  it('generates an optional field', () => {
+    const model = g.model('User', {
+      name: g.string().optional()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String
+      }"
+    `)
+  })
+
+  it('generates a required list', () => {
+    const model = g.model('User', {
+      name: g.string().list()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: [String!]!
+      }"
+    `)
+  })
+
+  it('generates a searchable list', () => {
+    const model = g.model('User', {
+      name: g.string().list().search()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: [String!]! @search
+      }"
+    `)
+  })
+
+  it('generates a searchable optional list', () => {
+    const model = g.model('User', {
+      name: g.string().list().optional().search()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: [String!] @search
+      }"
+    `)
+  })
+
+  it('generates a searchable optional list with optional values', () => {
+    const model = g.model('User', {
+      name: g.string().optional().list().optional().search()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: [String] @search
+      }"
+    `)
+  })
+
+  it('generates an optional list with required values', () => {
+    const model = g.model('User', {
+      name: g.string().list().optional()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: [String!]
+      }"
+    `)
+  })
+
+  it('generates an optional list with optional values', () => {
+    const model = g.model('User', {
+      name: g.string().optional().list().optional()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: [String]
+      }"
+    `)
+  })
+
+  it('generates a required list with optional values', () => {
+    const model = g.model('User', {
+      name: g.string().optional().list()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: [String]!
+      }"
+    `)
+  })
+
+  it('generates a searchable model', () => {
+    const model = g
+      .model('User', {
+        name: g.string()
+      })
+      .search()
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model @search {
+        name: String!
+      }"
+    `)
+  })
+
+  it('generates a searchable field', () => {
+    const model = g.model('User', {
+      name: g.string().search()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String! @search
+      }"
+    `)
+  })
+
+  it('generates a unique field', () => {
+    const model = g.model('User', {
+      name: g.string().unique()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String! @unique
+      }"
+    `)
+  })
+
+  it('generates a unique field with scope', () => {
+    const model = g.model('User', {
+      name: g.string().unique(['age']),
+      age: g.int()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String! @unique(fields: ["age"])
+        age: Int!
+      }"
+    `)
+  })
+
+  it('generates a live model', () => {
+    const model = g
+      .model('User', {
+        name: g.string()
+      })
+      .live()
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model @live {
+        name: String!
+      }"
+    `)
+  })
+
+  it('generates a length with minimum', () => {
+    const model = g.model('User', {
+      name: g.string().length({ min: 2 })
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String! @length(min: 2)
+      }"
+    `)
+  })
+
+  it('generates a length with minimum and unique + search', () => {
+    const model = g.model('User', {
+      name: g.string().length({ min: 2 }).unique().search()
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String! @length(min: 2) @unique @search
+      }"
+    `)
+  })
+
+  it('generates a length with maximum', () => {
+    const model = g.model('User', {
+      name: g.string().length({ max: 255 })
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String! @length(max: 255)
+      }"
+    `)
+  })
+
+  it('generates a length with minimum and maximum', () => {
+    const model = g.model('User', {
+      name: g.string().length({ min: 2, max: 255 })
+    })
+
+    expect(model.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String! @length(min: 2, max: 255)
+      }"
+    `)
+  })
+
+  it('generates a referenced type', () => {
+    const address = g.type('Address', {
+      street: g.string().optional()
+    })
+
+    const user = g.model('User', {
+      name: g.string(),
+      address: g.ref(address)
+    })
+
+    const cfg = config().schema({
+      types: [address],
+      models: [user]
+    })
+
+    expect(cfg.toString()).toMatchInlineSnapshot(`
+      "type Address {
+        street: String
+      }
+
+      type User @model {
+        name: String!
+        address: Address!
+      }"
+    `)
+  })
+
+  it('generates a kitchen sink model', () => {
+    const user = g.model('User', {
+      name: g.string().length({ min: 2 }).default('foo').unique().search()
+    })
+
+    expect(user.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String! @length(min: 2) @default(value: "foo") @unique @search
+      }"
+    `)
+  })
+
+  it('generates an optional referenced type', () => {
+    const address = g.type('Address', {
+      street: g.string().optional()
+    })
+
+    const user = g.model('User', {
+      name: g.string(),
+      address: g.ref(address).optional()
+    })
+
+    const cfg = config().schema({
+      types: [address],
+      models: [user]
+    })
+
+    expect(cfg.toString()).toMatchInlineSnapshot(`
+      "type Address {
+        street: String
+      }
+
+      type User @model {
+        name: String!
+        address: Address
+      }"
+    `)
+  })
+
+  it('generates a list referenced type', () => {
+    const address = g.type('Address', {
+      street: g.string().optional()
+    })
+
+    const user = g.model('User', {
+      name: g.string(),
+      addresses: g.ref(address).list()
+    })
+
+    const cfg = config().schema({
+      types: [address],
+      models: [user]
+    })
+
+    expect(cfg.toString()).toMatchInlineSnapshot(`
+      "type Address {
+        street: String
+      }
+
+      type User @model {
+        name: String!
+        addresses: [Address!]!
+      }"
+    `)
+  })
+})

--- a/packages/grafbase-sdk/tests/unit/queries.test.ts
+++ b/packages/grafbase-sdk/tests/unit/queries.test.ts
@@ -1,0 +1,163 @@
+import { config, g } from '../../src/index'
+import { describe, expect, it } from '@jest/globals'
+
+describe('Query generator', () => {
+  it('generates a resolver with required input and output', () => {
+    const greetQuery = g
+      .query('greet', {
+        args: { name: g.string() },
+        returns: g.string()
+      })
+      .resolver('hello')
+
+    expect(greetQuery.toString()).toMatchInlineSnapshot(`
+      "extend type Query {
+        greet(name: String!): String! @resolver(name: "hello")
+      }"
+    `)
+  })
+
+  it('generates a resolver with optional input', () => {
+    const greetQuery = g
+      .query('greet', {
+        args: { name: g.string().optional() },
+        returns: g.string()
+      })
+      .resolver('hello')
+
+    expect(greetQuery.toString()).toMatchInlineSnapshot(`
+      "extend type Query {
+        greet(name: String): String! @resolver(name: "hello")
+      }"
+    `)
+  })
+
+  it('generates a resolver with optional input and output', () => {
+    const greetQuery = g
+      .query('greet', {
+        args: { name: g.string().optional() },
+        returns: g.string().optional()
+      })
+      .resolver('hello')
+
+    expect(greetQuery.toString()).toMatchInlineSnapshot(`
+      "extend type Query {
+        greet(name: String): String @resolver(name: "hello")
+      }"
+    `)
+  })
+
+  it('generates a resolver with list input', () => {
+    const greetQuery = g
+      .query('greet', {
+        args: { name: g.string().list() },
+        returns: g.string()
+      })
+      .resolver('hello')
+
+    expect(greetQuery.toString()).toMatchInlineSnapshot(`
+      "extend type Query {
+        greet(name: [String!]!): String! @resolver(name: "hello")
+      }"
+    `)
+  })
+
+  it('generates a resolver with list output', () => {
+    const greetQuery = g
+      .query('greet', {
+        args: { name: g.string() },
+        returns: g.string().list()
+      })
+      .resolver('hello')
+
+    expect(greetQuery.toString()).toMatchInlineSnapshot(`
+      "extend type Query {
+        greet(name: String!): [String!]! @resolver(name: "hello")
+      }"
+    `)
+  })
+
+  it('generates a resolver with list output', () => {
+    const greetQuery = g
+      .query('greet', {
+        args: { name: g.string() },
+        returns: g.string().list()
+      })
+      .resolver('hello')
+
+    expect(greetQuery.toString()).toMatchInlineSnapshot(`
+      "extend type Query {
+        greet(name: String!): [String!]! @resolver(name: "hello")
+      }"
+    `)
+  })
+
+  it('generates a mutation resolver with required input and output', () => {
+    const input = g.type('CheckoutSessionInput', { name: g.string() })
+    const output = g.type('CheckoutSessionOutput', { successful: g.boolean() })
+
+    const checkout = g
+      .mutation('checkout', {
+        args: { input: g.ref(input) },
+        returns: g.ref(output)
+      })
+      .resolver('checkout')
+
+    const cfg = config().schema({
+      types: [input, output],
+      queries: [checkout]
+    })
+
+    expect(cfg.toString()).toMatchInlineSnapshot(`
+      "type CheckoutSessionInput {
+        name: String!
+      }
+
+      type CheckoutSessionOutput {
+        successful: Boolean!
+      }
+
+      extend type Mutation {
+        checkout(input: CheckoutSessionInput!): CheckoutSessionOutput! @resolver(name: "checkout")
+      }"
+    `)
+  })
+
+  it('generates a query as part of the full SDL', () => {
+    const enm = g.enumType('Foo', ['Bar', 'Baz'])
+
+    const greetQuery = g
+      .query('greet', {
+        args: { name: g.string() },
+        returns: g.string().list()
+      })
+      .resolver('hello')
+
+    const sweepQuery = g
+      .query('greet', {
+        args: { game: g.int().optional() },
+        returns: g.enum(enm).list()
+      })
+      .resolver('hello')
+
+    const cfg = config().schema({
+      queries: [greetQuery, sweepQuery],
+      enums: [enm]
+    })
+
+    expect(cfg.toString()).toMatchInlineSnapshot(`
+      "enum Foo {
+        Bar,
+        Baz
+      }
+
+      extend type Query {
+        greet(name: String!): [String!]! @resolver(name: "hello")
+      }
+
+      extend type Query {
+        greet(game: Int): [Foo!]! @resolver(name: "hello")
+      }"
+    `)
+  })
+})

--- a/packages/grafbase-sdk/tests/unit/queries.test.ts
+++ b/packages/grafbase-sdk/tests/unit/queries.test.ts
@@ -1,14 +1,16 @@
 import { config, g } from '../../src/index'
-import { describe, expect, it } from '@jest/globals'
+import { describe, expect, it, beforeEach } from '@jest/globals'
 
 describe('Query generator', () => {
+  beforeEach(() => g.clear())
+
   it('generates a resolver with required input and output', () => {
     const greetQuery = g
       .query('greet', {
         args: { name: g.string() },
-        returns: g.string()
+        returns: g.string(),
+        resolver: 'hello'
       })
-      .resolver('hello')
 
     expect(greetQuery.toString()).toMatchInlineSnapshot(`
       "extend type Query {
@@ -21,9 +23,9 @@ describe('Query generator', () => {
     const greetQuery = g
       .query('greet', {
         args: { name: g.string().optional() },
-        returns: g.string()
+        returns: g.string(),
+        resolver: 'hello'
       })
-      .resolver('hello')
 
     expect(greetQuery.toString()).toMatchInlineSnapshot(`
       "extend type Query {
@@ -36,9 +38,9 @@ describe('Query generator', () => {
     const greetQuery = g
       .query('greet', {
         args: { name: g.string().optional() },
-        returns: g.string().optional()
+        returns: g.string().optional(),
+        resolver: 'hello',
       })
-      .resolver('hello')
 
     expect(greetQuery.toString()).toMatchInlineSnapshot(`
       "extend type Query {
@@ -51,9 +53,9 @@ describe('Query generator', () => {
     const greetQuery = g
       .query('greet', {
         args: { name: g.string().list() },
-        returns: g.string()
+        returns: g.string(),
+        resolver: 'hello'
       })
-      .resolver('hello')
 
     expect(greetQuery.toString()).toMatchInlineSnapshot(`
       "extend type Query {
@@ -66,9 +68,9 @@ describe('Query generator', () => {
     const greetQuery = g
       .query('greet', {
         args: { name: g.string() },
-        returns: g.string().list()
+        returns: g.string().list(),
+        resolver: 'hello'
       })
-      .resolver('hello')
 
     expect(greetQuery.toString()).toMatchInlineSnapshot(`
       "extend type Query {
@@ -81,9 +83,9 @@ describe('Query generator', () => {
     const greetQuery = g
       .query('greet', {
         args: { name: g.string() },
-        returns: g.string().list()
+        returns: g.string().list(),
+        resolver: 'hello'
       })
-      .resolver('hello')
 
     expect(greetQuery.toString()).toMatchInlineSnapshot(`
       "extend type Query {
@@ -96,16 +98,14 @@ describe('Query generator', () => {
     const input = g.type('CheckoutSessionInput', { name: g.string() })
     const output = g.type('CheckoutSessionOutput', { successful: g.boolean() })
 
-    const checkout = g
-      .mutation('checkout', {
-        args: { input: g.ref(input) },
-        returns: g.ref(output)
-      })
-      .resolver('checkout')
+    g.mutation('checkout', {
+      args: { input: g.ref(input) },
+      returns: g.ref(output),
+      resolver: 'checkout'
+    })
 
-    const cfg = config().schema({
-      types: [input, output],
-      queries: [checkout]
+    const cfg = config({
+      schema: g
     })
 
     expect(cfg.toString()).toMatchInlineSnapshot(`
@@ -126,23 +126,20 @@ describe('Query generator', () => {
   it('generates a query as part of the full SDL', () => {
     const enm = g.enumType('Foo', ['Bar', 'Baz'])
 
-    const greetQuery = g
-      .query('greet', {
-        args: { name: g.string() },
-        returns: g.string().list()
-      })
-      .resolver('hello')
+    g.query('greet', {
+      args: { name: g.string() },
+      returns: g.string().list(),
+      resolver: 'hello'
+    })
 
-    const sweepQuery = g
-      .query('greet', {
-        args: { game: g.int().optional() },
-        returns: g.enum(enm).list()
-      })
-      .resolver('hello')
+    g.query('greet', {
+      args: { game: g.int().optional() },
+      returns: g.enum(enm).list(),
+      resolver: 'hello'
+    })
 
-    const cfg = config().schema({
-      queries: [greetQuery, sweepQuery],
-      enums: [enm]
+    const cfg = config({
+      schema: g
     })
 
     expect(cfg.toString()).toMatchInlineSnapshot(`

--- a/packages/grafbase-sdk/tests/unit/queries.test.ts
+++ b/packages/grafbase-sdk/tests/unit/queries.test.ts
@@ -4,6 +4,20 @@ import { describe, expect, it, beforeEach } from '@jest/globals'
 describe('Query generator', () => {
   beforeEach(() => g.clear())
 
+  it('generates a resolver with empty args', () => {
+    const greetQuery = g
+      .query('greet', {
+        returns: g.string(),
+        resolver: 'hello'
+      })
+
+    expect(greetQuery.toString()).toMatchInlineSnapshot(`
+      "extend type Query {
+        greet: String! @resolver(name: "hello")
+      }"
+    `)
+  })
+
   it('generates a resolver with required input and output', () => {
     const greetQuery = g
       .query('greet', {
@@ -124,7 +138,7 @@ describe('Query generator', () => {
   })
 
   it('generates a query as part of the full SDL', () => {
-    const enm = g.enumType('Foo', ['Bar', 'Baz'])
+    const enm = g.enum('Foo', ['Bar', 'Baz'])
 
     g.query('greet', {
       args: { name: g.string() },
@@ -134,7 +148,7 @@ describe('Query generator', () => {
 
     g.query('greet', {
       args: { game: g.int().optional() },
-      returns: g.enum(enm).list(),
+      returns: g.ref(enm).list(),
       resolver: 'hello'
     })
 

--- a/packages/grafbase-sdk/tests/unit/relation.test.ts
+++ b/packages/grafbase-sdk/tests/unit/relation.test.ts
@@ -1,0 +1,216 @@
+import { g, config } from '../../src/index'
+import { describe, expect, it } from '@jest/globals'
+
+describe('Relations generator', () => {
+  it('generates 1:1 required relations', () => {
+    const user = g.model('User', {
+      profile: g.relation(() => profile)
+    })
+
+    const profile = g.model('Profile', {
+      user: g.relation(user)
+    })
+
+    const cfg = config().schema({
+      models: [user, profile]
+    })
+
+    expect(cfg.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        profile: Profile!
+      }
+
+      type Profile @model {
+        user: User!
+      }"
+    `)
+  })
+
+  it('generates 1:1 optional relations', () => {
+    const user = g.model('User', {
+      profile: g.relation(() => profile).optional()
+    })
+
+    const profile = g.model('Profile', {
+      user: g.relation(user)
+    })
+
+    const cfg = config().schema({
+      models: [user, profile]
+    })
+
+    expect(cfg.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        profile: Profile
+      }
+
+      type Profile @model {
+        user: User!
+      }"
+    `)
+  })
+
+  it('generates 1:m relations', () => {
+    const user = g.model('User', {
+      posts: g.relation(() => post).list()
+    })
+
+    const post = g.model('Post', {
+      author: g.relation(user)
+    })
+
+    const cfg = config().schema({
+      models: [user, post]
+    })
+
+    expect(cfg.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        posts: [Post!]!
+      }
+
+      type Post @model {
+        author: User!
+      }"
+    `)
+  })
+
+  it('generates 1:m relations with nullable content', () => {
+    const user = g.model('User', {
+      posts: g.relation(() => post).optional().list()
+    })
+
+    const post = g.model('Post', {
+      author: g.relation(user)
+    })
+
+    const cfg = config().schema({
+      models: [user, post]
+    })
+
+    expect(cfg.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        posts: [Post]!
+      }
+
+      type Post @model {
+        author: User!
+      }"
+    `)
+  })
+
+  it('generates 1:m relations with nullable list', () => {
+    const user = g.model('User', {
+      posts: g.relation(() => post).list().optional()
+    })
+
+    const post = g.model('Post', {
+      author: g.relation(user)
+    })
+
+    const cfg = config().schema({
+      models: [user, post]
+    })
+
+    expect(cfg.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        posts: [Post!]
+      }
+
+      type Post @model {
+        author: User!
+      }"
+    `)
+  })
+
+  it('generates 1:m relations with nullable list and content', () => {
+    const user = g.model('User', {
+      posts: g.relation(() => post).optional().list().optional()
+    })
+
+    const post = g.model('Post', {
+      author: g.relation(user)
+    })
+
+    const cfg = config().schema({
+      models: [user, post]
+    })
+
+    expect(cfg.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        posts: [Post]
+      }
+
+      type Post @model {
+        author: User!
+      }"
+    `)
+  })
+
+  it('generates m:m relations', () => {
+    const user = g.model('User', {
+      posts: g.relation(() => post).list()
+    })
+
+    const post = g.model('Post', {
+      author: g.relation(user).list()
+    })
+
+    const cfg = config().schema({
+      models: [user, post]
+    })
+
+    expect(cfg.toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        posts: [Post!]!
+      }
+
+      type Post @model {
+        author: [User!]!
+      }"
+    `)
+  })
+
+  it('generates self-relations', () => {
+    const human = g.model('Human', {
+      children: g.relation(() => human).list(),
+      parent: g.relation(() => human).optional()
+    })
+
+    const cfg = config().schema({
+      models: [human]
+    })
+
+    expect(cfg.toString()).toMatchInlineSnapshot(`
+      "type Human @model {
+        children: [Human!]!
+        parent: Human
+      }"
+    `)
+  })
+
+  it('generates named relations', () => {
+    const address = g.model('Address', {
+      line1: g.string()
+    })
+
+    const order = g.model('Order', {
+      billingAddress: g.relation(address).name('billing'),
+      shippingAddress: g.relation(address).name('shipping')
+    })
+
+    const cfg = config().schema({
+      models: [address, order]
+    })
+
+    expect(cfg.toString()).toMatchInlineSnapshot(`
+      "type Address @model {
+        line1: String!
+      }
+
+      type Order @model {
+        billingAddress: Address! @relation(name: billing)
+        shippingAddress: Address! @relation(name: shipping)
+      }"
+    `)
+  })
+})

--- a/packages/grafbase-sdk/tests/unit/relation.test.ts
+++ b/packages/grafbase-sdk/tests/unit/relation.test.ts
@@ -1,7 +1,9 @@
 import { g, config } from '../../src/index'
-import { describe, expect, it } from '@jest/globals'
+import { describe, expect, it, beforeEach } from '@jest/globals'
 
 describe('Relations generator', () => {
+  beforeEach(() => g.clear())
+
   it('generates 1:1 required relations', () => {
     const user = g.model('User', {
       profile: g.relation(() => profile)
@@ -11,11 +13,7 @@ describe('Relations generator', () => {
       user: g.relation(user)
     })
 
-    const cfg = config().schema({
-      models: [user, profile]
-    })
-
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "type User @model {
         profile: Profile!
       }
@@ -35,11 +33,7 @@ describe('Relations generator', () => {
       user: g.relation(user)
     })
 
-    const cfg = config().schema({
-      models: [user, profile]
-    })
-
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "type User @model {
         profile: Profile
       }
@@ -59,11 +53,7 @@ describe('Relations generator', () => {
       author: g.relation(user)
     })
 
-    const cfg = config().schema({
-      models: [user, post]
-    })
-
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "type User @model {
         posts: [Post!]!
       }
@@ -83,11 +73,7 @@ describe('Relations generator', () => {
       author: g.relation(user)
     })
 
-    const cfg = config().schema({
-      models: [user, post]
-    })
-
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "type User @model {
         posts: [Post]!
       }
@@ -107,11 +93,7 @@ describe('Relations generator', () => {
       author: g.relation(user)
     })
 
-    const cfg = config().schema({
-      models: [user, post]
-    })
-
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "type User @model {
         posts: [Post!]
       }
@@ -131,11 +113,7 @@ describe('Relations generator', () => {
       author: g.relation(user)
     })
 
-    const cfg = config().schema({
-      models: [user, post]
-    })
-
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "type User @model {
         posts: [Post]
       }
@@ -155,11 +133,7 @@ describe('Relations generator', () => {
       author: g.relation(user).list()
     })
 
-    const cfg = config().schema({
-      models: [user, post]
-    })
-
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "type User @model {
         posts: [Post!]!
       }
@@ -176,11 +150,7 @@ describe('Relations generator', () => {
       parent: g.relation(() => human).optional()
     })
 
-    const cfg = config().schema({
-      models: [human]
-    })
-
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "type Human @model {
         children: [Human!]!
         parent: Human
@@ -193,16 +163,12 @@ describe('Relations generator', () => {
       line1: g.string()
     })
 
-    const order = g.model('Order', {
+    g.model('Order', {
       billingAddress: g.relation(address).name('billing'),
       shippingAddress: g.relation(address).name('shipping')
     })
 
-    const cfg = config().schema({
-      models: [address, order]
-    })
-
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "type Address @model {
         line1: String!
       }

--- a/packages/grafbase-sdk/tests/unit/types.test.ts
+++ b/packages/grafbase-sdk/tests/unit/types.test.ts
@@ -1,0 +1,61 @@
+import { g, config } from '../../src/index'
+import { describe, expect, it } from '@jest/globals'
+
+describe('Type generator', () => {
+  it('generates one with a single field', () => {
+    const t = g.type('User', {
+      name: g.string()
+    })
+
+    expect(t.toString()).toMatchInlineSnapshot(`
+      "type User {
+        name: String!
+      }"
+    `)
+  })
+
+  it('generates one with many fields', () => {
+    const t = g.type('User', {
+      name: g.string(),
+      age: g.int().optional()
+    })
+
+    expect(t.toString()).toMatchInlineSnapshot(`
+      "type User {
+        name: String!
+        age: Int
+      }"
+    `)
+  })
+
+  it('generates a union of multiple types', () => {
+    const user = g.type('User', {
+      name: g.string(),
+      age: g.int().optional()
+    })
+
+    const address = g.type('Address', {
+      street: g.string().optional()
+    })
+
+    const union = g.union('UserOrAddress', { user, address })
+
+    const cfg = config().schema({
+      types: [user, address],
+      unions: [union]
+    })
+
+    expect(cfg.toString()).toMatchInlineSnapshot(`
+      "type User {
+        name: String!
+        age: Int
+      }
+
+      type Address {
+        street: String
+      }
+
+      union UserOrAddress = User | Address"
+    `)
+  })
+})

--- a/packages/grafbase-sdk/tests/unit/types.test.ts
+++ b/packages/grafbase-sdk/tests/unit/types.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, beforeEach } from '@jest/globals'
 
 describe('Type generator', () => {
   beforeEach(() => {
-    g.clear()  
+    g.clear()
   })
 
   it('generates one with a single field', () => {
@@ -55,6 +55,69 @@ describe('Type generator', () => {
       }
 
       union UserOrAddress = User | Address"
+    `)
+  })
+
+  it('references another type', () => {
+    g.type('User', {
+      name: g.string(),
+      age: g.int().optional()
+    })
+
+    const city = g.type('City', {
+      country: g.string()
+    })
+
+    g.type('Address', {
+      street: g.string().optional(),
+      city: g.ref(city)
+    })
+
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+      "type User {
+        name: String!
+        age: Int
+      }
+
+      type City {
+        country: String!
+      }
+
+      type Address {
+        street: String
+        city: City!
+      }"
+    `)
+  })
+
+  it('references another an enum', () => {
+    g.type('User', {
+      name: g.string(),
+      age: g.int().optional()
+    })
+
+    const enm = g.enum('Color', ['Red', 'Green'])
+
+    g.type('Address', {
+      street: g.string().optional(),
+      color: g.ref(enm).optional()
+    })
+
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+      "enum Color {
+        Red,
+        Green
+      }
+
+      type User {
+        name: String!
+        age: Int
+      }
+
+      type Address {
+        street: String
+        color: Color
+      }"
     `)
   })
 })

--- a/packages/grafbase-sdk/tests/unit/types.test.ts
+++ b/packages/grafbase-sdk/tests/unit/types.test.ts
@@ -1,7 +1,11 @@
 import { g, config } from '../../src/index'
-import { describe, expect, it } from '@jest/globals'
+import { describe, expect, it, beforeEach } from '@jest/globals'
 
 describe('Type generator', () => {
+  beforeEach(() => {
+    g.clear()  
+  })
+
   it('generates one with a single field', () => {
     const t = g.type('User', {
       name: g.string()
@@ -38,14 +42,9 @@ describe('Type generator', () => {
       street: g.string().optional()
     })
 
-    const union = g.union('UserOrAddress', { user, address })
+    g.union('UserOrAddress', { user, address })
 
-    const cfg = config().schema({
-      types: [user, address],
-      unions: [union]
-    })
-
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "type User {
         name: String!
         age: Int

--- a/packages/grafbase-sdk/tsconfig.json
+++ b/packages/grafbase-sdk/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": [
+    "src/**/*",
+    "tests/**/*"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
         version: 13.2.1(eslint@8.35.0)(typescript@5.0.4)
       eslint-config-prettier:
         specifier: ^8.3.0
-        version: 8.5.0(eslint@8.35.0)
+        version: 8.3.0(eslint@8.35.0)
       eslint-config-turbo:
         specifier: latest
         version: 1.9.3(eslint@8.35.0)
@@ -62,7 +62,7 @@ importers:
     devDependencies:
       eslint:
         specifier: ^8.0.0
-        version: 8.29.0
+        version: 8.35.0
       eslint-config-grafbase:
         specifier: workspace:*
         version: link:../eslint-config-grafbase
@@ -71,7 +71,7 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: 6.6.3
-        version: 6.6.3(postcss@8.4.21)(typescript@5.0.4)
+        version: 6.6.3(postcss@8.4.19)(typescript@5.0.4)
       typescript:
         specifier: ^5.0.0
         version: 5.0.4
@@ -120,10 +120,10 @@ importers:
         version: 16.6.0
       postcss:
         specifier: ^8.4.19
-        version: 8.4.21
+        version: 8.4.19
       postcss-nesting:
         specifier: 11.2.2
-        version: 11.2.2(postcss@8.4.21)
+        version: 11.2.2(postcss@8.4.19)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -135,7 +135,7 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: 6.6.3
-        version: 6.6.3(postcss@8.4.21)(typescript@5.0.4)
+        version: 6.6.3(postcss@8.4.19)(typescript@5.0.4)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -154,7 +154,7 @@ importers:
     devDependencies:
       eslint:
         specifier: ^8.0.0
-        version: 8.29.0
+        version: 8.35.0
       eslint-config-grafbase:
         specifier: workspace:*
         version: link:../eslint-config-grafbase
@@ -185,13 +185,13 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ^18.11.18
-        version: 18.11.18
+        version: 18.14.2
       '@types/react':
         specifier: ^18.0.17
-        version: 18.0.26
+        version: 18.0.28
       '@types/react-dom':
         specifier: ^18.0.6
-        version: 18.0.9
+        version: 18.0.11
       eslint:
         specifier: ^8.0.0
         version: 8.35.0
@@ -200,7 +200,7 @@ importers:
         version: link:../eslint-config-grafbase
       next:
         specifier: ^13.0.2
-        version: 13.0.6(react-dom@18.2.0)(react@18.2.0)
+        version: 13.0.2(react-dom@18.2.0)(react@18.2.0)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -210,6 +210,46 @@ importers:
       typescript:
         specifier: 5.0.4
         version: 5.0.4
+
+  packages/grafbase-sdk:
+    dependencies:
+      type-fest:
+        specifier: ^3.9.0
+        version: 3.9.0
+    devDependencies:
+      '@jest/globals':
+        specifier: '=29.5.0'
+        version: 29.5.0
+      '@types/node':
+        specifier: ^18.14.2
+        version: 18.14.2
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^5.59.2
+        version: 5.59.2(@typescript-eslint/parser@5.59.2)(eslint@8.39.0)(typescript@5.0.2)
+      '@typescript-eslint/parser':
+        specifier: ^5.59.2
+        version: 5.59.2(eslint@8.39.0)(typescript@5.0.2)
+      eslint:
+        specifier: ^8.39.0
+        version: 8.39.0
+      jest:
+        specifier: '=29.5.0'
+        version: 29.5.0(@types/node@18.14.2)(ts-node@10.9.1)
+      npm-watch:
+        specifier: ^0.11.0
+        version: 0.11.0
+      ts-jest:
+        specifier: '=29.1.0'
+        version: 29.1.0(@babel/core@7.21.8)(jest@29.5.0)(typescript@5.0.2)
+      ts-node:
+        specifier: ^10.9.1
+        version: 10.9.1(@types/node@18.14.2)(typescript@5.0.2)
+      tsconfig:
+        specifier: workspace:*
+        version: link:../tsconfig
+      typescript:
+        specifier: ^5.0.2
+        version: 5.0.2
 
   packages/grafbase-urql-exchange:
     dependencies:
@@ -240,7 +280,7 @@ importers:
     devDependencies:
       eslint:
         specifier: ^8.0.0
-        version: 8.29.0
+        version: 8.35.0
       eslint-config-grafbase:
         specifier: workspace:*
         version: link:../eslint-config-grafbase
@@ -249,7 +289,7 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: 6.6.3
-        version: 6.6.3(postcss@8.4.21)(typescript@5.0.4)
+        version: 6.6.3(postcss@8.4.19)(typescript@5.0.4)
       typescript:
         specifier: ^5.0.0
         version: 5.0.4
@@ -268,6 +308,14 @@ packages:
     dependencies:
       graphql: 16.6.0
     dev: false
+
+  /@ampproject/remapping@2.2.1:
+    resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.18
+    dev: true
 
   /@apollo/client@3.7.9(graphql@16.6.0):
     resolution: {integrity: sha512-YnJvrJOVWrp4y/zdNvUaM8q4GuSHCEIecsRDTJhK/veT33P/B7lfqGJ24NeLdKMj8tDEuXYF7V0t+th4+rgC+Q==}
@@ -288,8 +336,8 @@ packages:
         optional: true
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
-      '@wry/context': 0.7.0
-      '@wry/equality': 0.5.3
+      '@wry/context': 0.7.2
+      '@wry/equality': 0.5.5
       '@wry/trie': 0.3.2
       graphql: 16.6.0
       graphql-tag: 2.12.6(graphql@16.6.0)
@@ -303,46 +351,340 @@ packages:
       zen-observable-ts: 1.2.5
     dev: false
 
-  /@babel/helper-string-parser@7.19.4:
-    resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
+  /@babel/code-frame@7.21.4:
+    resolution: {integrity: sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==}
     engines: {node: '>=6.9.0'}
-    dev: false
+    dependencies:
+      '@babel/highlight': 7.18.6
+    dev: true
+
+  /@babel/compat-data@7.21.7:
+    resolution: {integrity: sha512-KYMqFYTaenzMK4yUtf4EW9wc4N9ef80FsbMtkwool5zpwl4YrT1SdWYSTRcT94KO4hannogdS+LxY7L+arP3gA==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/core@7.21.8:
+    resolution: {integrity: sha512-YeM22Sondbo523Sz0+CirSPnbj9bG3P0CdHcBZdqUuaeOaYEFbOLoGU7lebvGP6P5J/WE9wOn7u7C4J9HvS1xQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@babel/code-frame': 7.21.4
+      '@babel/generator': 7.21.5
+      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.8)
+      '@babel/helper-module-transforms': 7.21.5
+      '@babel/helpers': 7.21.5
+      '@babel/parser': 7.21.8
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.21.5
+      '@babel/types': 7.21.5
+      convert-source-map: 1.9.0
+      debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/generator@7.21.5:
+    resolution: {integrity: sha512-SrKK/sRv8GesIW1bDagf9cCG38IOMYZusoe1dfg0D8aiUe3Amvoj1QtjTPAWcfrZFvIwlleLb0gxzQidL9w14w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.21.5
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.18
+      jsesc: 2.5.2
+    dev: true
+
+  /@babel/helper-compilation-targets@7.21.5(@babel/core@7.21.8):
+    resolution: {integrity: sha512-1RkbFGUKex4lvsB9yhIfWltJM5cZKUftB2eNajaDv3dCMEp49iBG0K14uH8NnX9IPux2+mK7JGEOB0jn48/J6w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/compat-data': 7.21.7
+      '@babel/core': 7.21.8
+      '@babel/helper-validator-option': 7.21.0
+      browserslist: 4.21.5
+      lru-cache: 5.1.1
+      semver: 6.3.0
+    dev: true
+
+  /@babel/helper-environment-visitor@7.21.5:
+    resolution: {integrity: sha512-IYl4gZ3ETsWocUWgsFZLM5i1BYx9SoemminVEXadgLBa9TdeorzgLKm8wWLA6J1N/kT3Kch8XIk1laNzYoHKvQ==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-function-name@7.21.0:
+    resolution: {integrity: sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.20.7
+      '@babel/types': 7.21.5
+    dev: true
+
+  /@babel/helper-hoist-variables@7.18.6:
+    resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.21.5
+    dev: true
+
+  /@babel/helper-module-imports@7.21.4:
+    resolution: {integrity: sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.21.5
+    dev: true
+
+  /@babel/helper-module-transforms@7.21.5:
+    resolution: {integrity: sha512-bI2Z9zBGY2q5yMHoBvJ2a9iX3ZOAzJPm7Q8Yz6YeoUjU/Cvhmi2G4QyTNyPBqqXSgTjUxRg3L0xV45HvkNWWBw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-environment-visitor': 7.21.5
+      '@babel/helper-module-imports': 7.21.4
+      '@babel/helper-simple-access': 7.21.5
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.21.5
+      '@babel/types': 7.21.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/helper-plugin-utils@7.21.5:
+    resolution: {integrity: sha512-0WDaIlXKOX/3KfBK/dwP1oQGiPh6rjMkT7HIRv7i5RR2VUMwrx5ZL0dwBkKx7+SW1zwNdgjHd34IMk5ZjTeHVg==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-simple-access@7.21.5:
+    resolution: {integrity: sha512-ENPDAMC1wAjR0uaCUwliBdiSl1KBJAVnMTzXqi64c2MG8MPR6ii4qf7bSXDqSFbr4W6W028/rf5ivoHop5/mkg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.21.5
+    dev: true
+
+  /@babel/helper-split-export-declaration@7.18.6:
+    resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.21.5
+    dev: true
+
+  /@babel/helper-string-parser@7.21.5:
+    resolution: {integrity: sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==}
+    engines: {node: '>=6.9.0'}
 
   /@babel/helper-validator-identifier@7.19.1:
     resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
     engines: {node: '>=6.9.0'}
-    dev: false
 
-  /@babel/parser@7.20.13:
-    resolution: {integrity: sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==}
+  /@babel/helper-validator-option@7.21.0:
+    resolution: {integrity: sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helpers@7.21.5:
+    resolution: {integrity: sha512-BSY+JSlHxOmGsPTydUkPf1MdMQ3M81x5xGCOVgWM3G8XH77sJ292Y2oqcp0CbbgxhqBuI46iUz1tT7hqP7EfgA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.21.5
+      '@babel/types': 7.21.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/highlight@7.18.6:
+    resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.19.1
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    dev: true
+
+  /@babel/parser@7.21.8:
+    resolution: {integrity: sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.21.3
-    dev: false
+      '@babel/types': 7.21.5
 
-  /@babel/runtime-corejs3@7.20.6:
-    resolution: {integrity: sha512-tqeujPiuEfcH067mx+7otTQWROVMKHXEaOQcAeNV5dDdbPWvPcFA8/W9LXw2NfjNmOetqLl03dfnG2WALPlsRQ==}
+  /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.21.8):
+    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.8
+      '@babel/helper-plugin-utils': 7.21.5
+    dev: true
+
+  /@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.21.8):
+    resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.8
+      '@babel/helper-plugin-utils': 7.21.5
+    dev: true
+
+  /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.21.8):
+    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.8
+      '@babel/helper-plugin-utils': 7.21.5
+    dev: true
+
+  /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.21.8):
+    resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.8
+      '@babel/helper-plugin-utils': 7.21.5
+    dev: true
+
+  /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.21.8):
+    resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.8
+      '@babel/helper-plugin-utils': 7.21.5
+    dev: true
+
+  /@babel/plugin-syntax-jsx@7.21.4(@babel/core@7.21.8):
+    resolution: {integrity: sha512-5hewiLct5OKyh6PLKEYaFclcqtIgCb6bmELouxjF6up5q3Sov7rOayW4RwhbaBL0dit8rA80GNfY+UuDp2mBbQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.8
+      '@babel/helper-plugin-utils': 7.21.5
+    dev: true
+
+  /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.21.8):
+    resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.8
+      '@babel/helper-plugin-utils': 7.21.5
+    dev: true
+
+  /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.21.8):
+    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.8
+      '@babel/helper-plugin-utils': 7.21.5
+    dev: true
+
+  /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.21.8):
+    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.8
+      '@babel/helper-plugin-utils': 7.21.5
+    dev: true
+
+  /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.21.8):
+    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.8
+      '@babel/helper-plugin-utils': 7.21.5
+    dev: true
+
+  /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.21.8):
+    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.8
+      '@babel/helper-plugin-utils': 7.21.5
+    dev: true
+
+  /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.21.8):
+    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.8
+      '@babel/helper-plugin-utils': 7.21.5
+    dev: true
+
+  /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.21.8):
+    resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.8
+      '@babel/helper-plugin-utils': 7.21.5
+    dev: true
+
+  /@babel/plugin-syntax-typescript@7.21.4(@babel/core@7.21.8):
+    resolution: {integrity: sha512-xz0D39NvhQn4t4RNsHmDnnsaQizIlUkdtYvLs8La1BlfjQ6JEwxkJGeqJMW2tAXx+q6H+WFuUTXNdYVpEya0YA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.8
+      '@babel/helper-plugin-utils': 7.21.5
+    dev: true
+
+  /@babel/runtime@7.21.5:
+    resolution: {integrity: sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      core-js-pure: 3.26.1
       regenerator-runtime: 0.13.11
-    dev: false
 
-  /@babel/runtime@7.20.6:
-    resolution: {integrity: sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==}
+  /@babel/template@7.20.7:
+    resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      regenerator-runtime: 0.13.11
+      '@babel/code-frame': 7.21.4
+      '@babel/parser': 7.21.8
+      '@babel/types': 7.21.5
+    dev: true
 
-  /@babel/types@7.21.3:
-    resolution: {integrity: sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==}
+  /@babel/traverse@7.21.5:
+    resolution: {integrity: sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-string-parser': 7.19.4
+      '@babel/code-frame': 7.21.4
+      '@babel/generator': 7.21.5
+      '@babel/helper-environment-visitor': 7.21.5
+      '@babel/helper-function-name': 7.21.0
+      '@babel/helper-hoist-variables': 7.18.6
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/parser': 7.21.8
+      '@babel/types': 7.21.5
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/types@7.21.5:
+    resolution: {integrity: sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.21.5
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
-    dev: false
+
+  /@bcoe/v8-coverage@0.2.3:
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+    dev: true
 
   /@codemirror/language@6.0.0:
     resolution: {integrity: sha512-rtjk5ifyMzOna1c7PBu7J1VCt0PvA5wy3o8eMVnxMKb7z8KA7JFecvD04dSn14vj/bBaAbqRsGed5OjtofEnLA==}
@@ -364,19 +706,24 @@ packages:
       style-mod: 4.0.3
       w3c-keyname: 2.2.6
 
-  /@csstools/selector-specificity@2.1.0(postcss-selector-parser@6.0.11)(postcss@8.4.21):
-    resolution: {integrity: sha512-zJ6hb3FDgBbO8d2e83vg6zq7tNvDqSq9RwdwfzJ8tdm9JHNvANq2fqwyRn6mlpUb7CwTs5ILdUrGwi9Gk4vY5w==}
-    engines: {node: ^14 || ^16 || >=18}
-    peerDependencies:
-      postcss: ^8.4
-      postcss-selector-parser: ^6.0.10
+  /@cspotcode/source-map-support@0.8.1:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
     dependencies:
-      postcss: 8.4.21
-      postcss-selector-parser: 6.0.11
+      '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
-  /@esbuild/android-arm64@0.17.10:
-    resolution: {integrity: sha512-ht1P9CmvrPF5yKDtyC+z43RczVs4rrHpRqrmIuoSvSdn44Fs1n6DGlpZKdK6rM83pFLbVaSUwle8IN+TPmkv7g==}
+  /@csstools/selector-specificity@2.2.0(postcss-selector-parser@6.0.12):
+    resolution: {integrity: sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==}
+    engines: {node: ^14 || ^16 || >=18}
+    peerDependencies:
+      postcss-selector-parser: ^6.0.10
+    dependencies:
+      postcss-selector-parser: 6.0.12
+    dev: true
+
+  /@esbuild/android-arm64@0.17.18:
+    resolution: {integrity: sha512-/iq0aK0eeHgSC3z55ucMAHO05OIqmQehiGay8eP5l/5l+iEr4EIbh4/MI8xD9qRFjqzgkc0JkX0LculNC9mXBw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -393,8 +740,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm@0.17.10:
-    resolution: {integrity: sha512-7YEBfZ5lSem9Tqpsz+tjbdsEshlO9j/REJrfv4DXgKTt1+/MHqGwbtlyxQuaSlMeUZLxUKBaX8wdzlTfHkmnLw==}
+  /@esbuild/android-arm@0.17.18:
+    resolution: {integrity: sha512-EmwL+vUBZJ7mhFCs5lA4ZimpUH3WMAoqvOIYhVQwdIgSpHC8ImHdsRyhHAVxpDYUSm0lWvd63z0XH1IlImS2Qw==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -402,8 +749,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-x64@0.17.10:
-    resolution: {integrity: sha512-CYzrm+hTiY5QICji64aJ/xKdN70IK8XZ6iiyq0tZkd3tfnwwSWTYH1t3m6zyaaBxkuj40kxgMyj1km/NqdjQZA==}
+  /@esbuild/android-x64@0.17.18:
+    resolution: {integrity: sha512-x+0efYNBF3NPW2Xc5bFOSFW7tTXdAcpfEg2nXmxegm4mJuVeS+i109m/7HMiOQ6M12aVGGFlqJX3RhNdYM2lWg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -411,8 +758,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.17.10:
-    resolution: {integrity: sha512-3HaGIowI+nMZlopqyW6+jxYr01KvNaLB5znXfbyyjuo4lE0VZfvFGcguIJapQeQMS4cX/NEispwOekJt3gr5Dg==}
+  /@esbuild/darwin-arm64@0.17.18:
+    resolution: {integrity: sha512-6tY+djEAdF48M1ONWnQb1C+6LiXrKjmqjzPNPWXhu/GzOHTHX2nh8Mo2ZAmBFg0kIodHhciEgUBtcYCAIjGbjQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -420,8 +767,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-x64@0.17.10:
-    resolution: {integrity: sha512-J4MJzGchuCRG5n+B4EHpAMoJmBeAE1L3wGYDIN5oWNqX0tEr7VKOzw0ymSwpoeSpdCa030lagGUfnfhS7OvzrQ==}
+  /@esbuild/darwin-x64@0.17.18:
+    resolution: {integrity: sha512-Qq84ykvLvya3dO49wVC9FFCNUfSrQJLbxhoQk/TE1r6MjHo3sFF2tlJCwMjhkBVq3/ahUisj7+EpRSz0/+8+9A==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -429,8 +776,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.17.10:
-    resolution: {integrity: sha512-ZkX40Z7qCbugeK4U5/gbzna/UQkM9d9LNV+Fro8r7HA7sRof5Rwxc46SsqeMvB5ZaR0b1/ITQ/8Y1NmV2F0fXQ==}
+  /@esbuild/freebsd-arm64@0.17.18:
+    resolution: {integrity: sha512-fw/ZfxfAzuHfaQeMDhbzxp9mc+mHn1Y94VDHFHjGvt2Uxl10mT4CDavHm+/L9KG441t1QdABqkVYwakMUeyLRA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -438,8 +785,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-x64@0.17.10:
-    resolution: {integrity: sha512-0m0YX1IWSLG9hWh7tZa3kdAugFbZFFx9XrvfpaCMMvrswSTvUZypp0NFKriUurHpBA3xsHVE9Qb/0u2Bbi/otg==}
+  /@esbuild/freebsd-x64@0.17.18:
+    resolution: {integrity: sha512-FQFbRtTaEi8ZBi/A6kxOC0V0E9B/97vPdYjY9NdawyLd4Qk5VD5g2pbWN2VR1c0xhzcJm74HWpObPszWC+qTew==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -447,8 +794,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm64@0.17.10:
-    resolution: {integrity: sha512-g1EZJR1/c+MmCgVwpdZdKi4QAJ8DCLP5uTgLWSAVd9wlqk9GMscaNMEViG3aE1wS+cNMzXXgdWiW/VX4J+5nTA==}
+  /@esbuild/linux-arm64@0.17.18:
+    resolution: {integrity: sha512-R7pZvQZFOY2sxUG8P6A21eq6q+eBv7JPQYIybHVf1XkQYC+lT7nDBdC7wWKTrbvMXKRaGudp/dzZCwL/863mZQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -456,8 +803,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm@0.17.10:
-    resolution: {integrity: sha512-whRdrrl0X+9D6o5f0sTZtDM9s86Xt4wk1bf7ltx6iQqrIIOH+sre1yjpcCdrVXntQPCNw/G+XqsD4HuxeS+2QA==}
+  /@esbuild/linux-arm@0.17.18:
+    resolution: {integrity: sha512-jW+UCM40LzHcouIaqv3e/oRs0JM76JfhHjCavPxMUti7VAPh8CaGSlS7cmyrdpzSk7A+8f0hiedHqr/LMnfijg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -465,8 +812,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ia32@0.17.10:
-    resolution: {integrity: sha512-1vKYCjfv/bEwxngHERp7huYfJ4jJzldfxyfaF7hc3216xiDA62xbXJfRlradiMhGZbdNLj2WA1YwYFzs9IWNPw==}
+  /@esbuild/linux-ia32@0.17.18:
+    resolution: {integrity: sha512-ygIMc3I7wxgXIxk6j3V00VlABIjq260i967Cp9BNAk5pOOpIXmd1RFQJQX9Io7KRsthDrQYrtcx7QCof4o3ZoQ==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -483,8 +830,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-loong64@0.17.10:
-    resolution: {integrity: sha512-mvwAr75q3Fgc/qz3K6sya3gBmJIYZCgcJ0s7XshpoqIAIBszzfXsqhpRrRdVFAyV1G9VUjj7VopL2HnAS8aHFA==}
+  /@esbuild/linux-loong64@0.17.18:
+    resolution: {integrity: sha512-bvPG+MyFs5ZlwYclCG1D744oHk1Pv7j8psF5TfYx7otCVmcJsEXgFEhQkbhNW8otDHL1a2KDINW20cfCgnzgMQ==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -492,8 +839,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.17.10:
-    resolution: {integrity: sha512-XilKPgM2u1zR1YuvCsFQWl9Fc35BqSqktooumOY2zj7CSn5czJn279j9TE1JEqSqz88izJo7yE4x3LSf7oxHzg==}
+  /@esbuild/linux-mips64el@0.17.18:
+    resolution: {integrity: sha512-oVqckATOAGuiUOa6wr8TXaVPSa+6IwVJrGidmNZS1cZVx0HqkTMkqFGD2HIx9H1RvOwFeWYdaYbdY6B89KUMxA==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -501,8 +848,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ppc64@0.17.10:
-    resolution: {integrity: sha512-kM4Rmh9l670SwjlGkIe7pYWezk8uxKHX4Lnn5jBZYBNlWpKMBCVfpAgAJqp5doLobhzF3l64VZVrmGeZ8+uKmQ==}
+  /@esbuild/linux-ppc64@0.17.18:
+    resolution: {integrity: sha512-3dLlQO+b/LnQNxgH4l9rqa2/IwRJVN9u/bK63FhOPB4xqiRqlQAU0qDU3JJuf0BmaH0yytTBdoSBHrb2jqc5qQ==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -510,8 +857,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.17.10:
-    resolution: {integrity: sha512-r1m9ZMNJBtOvYYGQVXKy+WvWd0BPvSxMsVq8Hp4GzdMBQvfZRvRr5TtX/1RdN6Va8JMVQGpxqde3O+e8+khNJQ==}
+  /@esbuild/linux-riscv64@0.17.18:
+    resolution: {integrity: sha512-/x7leOyDPjZV3TcsdfrSI107zItVnsX1q2nho7hbbQoKnmoeUWjs+08rKKt4AUXju7+3aRZSsKrJtaRmsdL1xA==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -519,8 +866,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-s390x@0.17.10:
-    resolution: {integrity: sha512-LsY7QvOLPw9WRJ+fU5pNB3qrSfA00u32ND5JVDrn/xG5hIQo3kvTxSlWFRP0NJ0+n6HmhPGG0Q4jtQsb6PFoyg==}
+  /@esbuild/linux-s390x@0.17.18:
+    resolution: {integrity: sha512-cX0I8Q9xQkL/6F5zWdYmVf5JSQt+ZfZD2bJudZrWD+4mnUvoZ3TDDXtDX2mUaq6upMFv9FlfIh4Gfun0tbGzuw==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -528,8 +875,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-x64@0.17.10:
-    resolution: {integrity: sha512-zJUfJLebCYzBdIz/Z9vqwFjIA7iSlLCFvVi7glMgnu2MK7XYigwsonXshy9wP9S7szF+nmwrelNaP3WGanstEg==}
+  /@esbuild/linux-x64@0.17.18:
+    resolution: {integrity: sha512-66RmRsPlYy4jFl0vG80GcNRdirx4nVWAzJmXkevgphP1qf4dsLQCpSKGM3DUQCojwU1hnepI63gNZdrr02wHUA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -537,8 +884,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/netbsd-x64@0.17.10:
-    resolution: {integrity: sha512-lOMkailn4Ok9Vbp/q7uJfgicpDTbZFlXlnKT2DqC8uBijmm5oGtXAJy2ZZVo5hX7IOVXikV9LpCMj2U8cTguWA==}
+  /@esbuild/netbsd-x64@0.17.18:
+    resolution: {integrity: sha512-95IRY7mI2yrkLlTLb1gpDxdC5WLC5mZDi+kA9dmM5XAGxCME0F8i4bYH4jZreaJ6lIZ0B8hTrweqG1fUyW7jbg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -546,8 +893,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/openbsd-x64@0.17.10:
-    resolution: {integrity: sha512-/VE0Kx6y7eekqZ+ZLU4AjMlB80ov9tEz4H067Y0STwnGOYL8CsNg4J+cCmBznk1tMpxMoUOf0AbWlb1d2Pkbig==}
+  /@esbuild/openbsd-x64@0.17.18:
+    resolution: {integrity: sha512-WevVOgcng+8hSZ4Q3BKL3n1xTv5H6Nb53cBrtzzEjDbbnOmucEVcZeGCsCOi9bAOcDYEeBZbD2SJNBxlfP3qiA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -555,8 +902,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/sunos-x64@0.17.10:
-    resolution: {integrity: sha512-ERNO0838OUm8HfUjjsEs71cLjLMu/xt6bhOlxcJ0/1MG3hNqCmbWaS+w/8nFLa0DDjbwZQuGKVtCUJliLmbVgg==}
+  /@esbuild/sunos-x64@0.17.18:
+    resolution: {integrity: sha512-Rzf4QfQagnwhQXVBS3BYUlxmEbcV7MY+BH5vfDZekU5eYpcffHSyjU8T0xucKVuOcdCsMo+Ur5wmgQJH2GfNrg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -564,8 +911,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-arm64@0.17.10:
-    resolution: {integrity: sha512-fXv+L+Bw2AeK+XJHwDAQ9m3NRlNemG6Z6ijLwJAAVdu4cyoFbBWbEtyZzDeL+rpG2lWI51cXeMt70HA8g2MqIg==}
+  /@esbuild/win32-arm64@0.17.18:
+    resolution: {integrity: sha512-Kb3Ko/KKaWhjeAm2YoT/cNZaHaD1Yk/pa3FTsmqo9uFh1D1Rfco7BBLIPdDOozrObj2sahslFuAQGvWbgWldAg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -573,8 +920,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-ia32@0.17.10:
-    resolution: {integrity: sha512-3s+HADrOdCdGOi5lnh5DMQEzgbsFsd4w57L/eLKKjMnN0CN4AIEP0DCP3F3N14xnxh3ruNc32A0Na9zYe1Z/AQ==}
+  /@esbuild/win32-ia32@0.17.18:
+    resolution: {integrity: sha512-0/xUMIdkVHwkvxfbd5+lfG7mHOf2FRrxNbPiKWg9C4fFrB8H0guClmaM3BFiRUYrznVoyxTIyC/Ou2B7QQSwmw==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -582,8 +929,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-x64@0.17.10:
-    resolution: {integrity: sha512-oP+zFUjYNaMNmjTwlFtWep85hvwUu19cZklB3QsBOcZSs6y7hmH4LNCJ7075bsqzYaNvZFXJlAVaQ2ApITDXtw==}
+  /@esbuild/win32-x64@0.17.18:
+    resolution: {integrity: sha512-qU25Ma1I3NqTSHJUOKi9sAH1/Mzuvlke0ioMJRthLXKm7JiSKVwFghlGbDLOO2sARECGhja4xYfRAZNPAkooYg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -591,21 +938,19 @@ packages:
     dev: true
     optional: true
 
-  /@eslint/eslintrc@1.4.1:
-    resolution: {integrity: sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==}
+  /@eslint-community/eslint-utils@4.4.0(eslint@8.39.0):
+    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
-      ajv: 6.12.6
-      debug: 4.3.4
-      espree: 9.5.1
-      globals: 13.19.0
-      ignore: 5.2.1
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
+      eslint: 8.39.0
+      eslint-visitor-keys: 3.4.0
+    dev: true
+
+  /@eslint-community/regexpp@4.5.1:
+    resolution: {integrity: sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     dev: true
 
   /@eslint/eslintrc@2.0.2:
@@ -615,8 +960,8 @@ packages:
       ajv: 6.12.6
       debug: 4.3.4
       espree: 9.5.1
-      globals: 13.19.0
-      ignore: 5.2.1
+      globals: 13.20.0
+      ignore: 5.2.4
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -627,6 +972,11 @@ packages:
   /@eslint/js@8.35.0:
     resolution: {integrity: sha512-JXdzbRiWclLVoD8sNUjR443VVlYqiYmDVT6rGUEIEHU5YJW0gaVZwV2xgM7D4arkvASqD0IlLUVjHiFuxaftRw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  /@eslint/js@8.39.0:
+    resolution: {integrity: sha512-kf9RB0Fg7NZfap83B3QOqOGg9QmD9yBudqQXzzOtn3i4y7ZUXe5ONeW34Gwi+TxhH4mvj72R1Zc300KUMa9Bng==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
 
   /@graphiql/react@0.15.0(@codemirror/language@6.0.0)(@types/react@18.0.28)(graphql@16.6.0)(react-dom@18.2.0)(react-is@17.0.2)(react@18.2.0):
     resolution: {integrity: sha512-kJqkdf6d4Cck05Wt5yCDZXWfs7HZgcpuoWq/v8nOa698qVaNMM3qdG4CpRsZEexku0DSSJzWWuanxd5x+sRcFg==}
@@ -642,8 +992,8 @@ packages:
       '@reach/menu-button': 0.17.0(react-dom@18.2.0)(react-is@17.0.2)(react@18.2.0)
       '@reach/tooltip': 0.17.0(react-dom@18.2.0)(react@18.2.0)
       '@reach/visually-hidden': 0.17.0(react-dom@18.2.0)(react@18.2.0)
-      codemirror: 5.65.11
-      codemirror-graphql: 2.0.6(@codemirror/language@6.0.0)(codemirror@5.65.11)(graphql@16.6.0)
+      codemirror: 5.65.13
+      codemirror-graphql: 2.0.6(@codemirror/language@6.0.0)(codemirror@5.65.13)(graphql@16.6.0)
       copy-to-clipboard: 3.3.3
       graphql: 16.6.0
       graphql-language-service: 5.1.4(graphql@16.6.0)
@@ -673,8 +1023,8 @@ packages:
     transitivePeerDependencies:
       - '@types/node'
 
-  /@graphql-tools/merge@8.3.18(graphql@15.8.0):
-    resolution: {integrity: sha512-R8nBglvRWPAyLpZL/f3lxsY7wjnAeE0l056zHhcO/CgpvK76KYUt9oEkR05i8Hmt8DLRycBN0FiotJ0yDQWTVA==}
+  /@graphql-tools/merge@8.4.1(graphql@15.8.0):
+    resolution: {integrity: sha512-hssnPpZ818mxgl5+GfyOOSnnflAxiaTn1A1AojZcIbh4J52sS1Q0gSuBR5VrnUDjuxiqoCotpXdAQl+K+U6KLQ==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
@@ -683,12 +1033,12 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@graphql-tools/schema@9.0.16(graphql@15.8.0):
-    resolution: {integrity: sha512-kF+tbYPPf/6K2aHG3e1SWIbapDLQaqnIHVRG6ow3onkFoowwtKszvUyOASL6Krcv2x9bIMvd1UkvRf9OaoROQQ==}
+  /@graphql-tools/schema@9.0.19(graphql@15.8.0):
+    resolution: {integrity: sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/merge': 8.3.18(graphql@15.8.0)
+      '@graphql-tools/merge': 8.4.1(graphql@15.8.0)
       '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
       graphql: 15.8.0
       tslib: 2.5.0
@@ -738,6 +1088,281 @@ packages:
   /@humanwhocodes/object-schema@1.2.1:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
 
+  /@istanbuljs/load-nyc-config@1.1.0:
+    resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      camelcase: 5.3.1
+      find-up: 4.1.0
+      get-package-type: 0.1.0
+      js-yaml: 3.14.1
+      resolve-from: 5.0.0
+    dev: true
+
+  /@istanbuljs/schema@0.1.3:
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /@jest/console@29.5.0:
+    resolution: {integrity: sha512-NEpkObxPwyw/XxZVLPmAGKE89IQRp4puc6IQRPru6JKd1M3fW9v1xM1AnzIJE65hbCkzQAdnL8P47e9hzhiYLQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.5.0
+      '@types/node': 18.14.2
+      chalk: 4.1.2
+      jest-message-util: 29.5.0
+      jest-util: 29.5.0
+      slash: 3.0.0
+    dev: true
+
+  /@jest/core@29.5.0(ts-node@10.9.1):
+    resolution: {integrity: sha512-28UzQc7ulUrOQw1IsN/kv1QES3q2kkbl/wGslyhAclqZ/8cMdB5M68BffkIdSJgKBUt50d3hbwJ92XESlE7LiQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/console': 29.5.0
+      '@jest/reporters': 29.5.0
+      '@jest/test-result': 29.5.0
+      '@jest/transform': 29.5.0
+      '@jest/types': 29.5.0
+      '@types/node': 18.14.2
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.5.0
+      jest-config: 29.5.0(@types/node@18.14.2)(ts-node@10.9.1)
+      jest-haste-map: 29.5.0
+      jest-message-util: 29.5.0
+      jest-regex-util: 29.4.3
+      jest-resolve: 29.5.0
+      jest-resolve-dependencies: 29.5.0
+      jest-runner: 29.5.0
+      jest-runtime: 29.5.0
+      jest-snapshot: 29.5.0
+      jest-util: 29.5.0
+      jest-validate: 29.5.0
+      jest-watcher: 29.5.0
+      micromatch: 4.0.5
+      pretty-format: 29.5.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+    dev: true
+
+  /@jest/environment@29.5.0:
+    resolution: {integrity: sha512-5FXw2+wD29YU1d4I2htpRX7jYnAyTRjP2CsXQdo9SAM8g3ifxWPSV0HnClSn71xwctr0U3oZIIH+dtbfmnbXVQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/fake-timers': 29.5.0
+      '@jest/types': 29.5.0
+      '@types/node': 18.14.2
+      jest-mock: 29.5.0
+    dev: true
+
+  /@jest/expect-utils@29.5.0:
+    resolution: {integrity: sha512-fmKzsidoXQT2KwnrwE0SQq3uj8Z763vzR8LnLBwC2qYWEFpjX8daRsk6rHUM1QvNlEW/UJXNXm59ztmJJWs2Mg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      jest-get-type: 29.4.3
+    dev: true
+
+  /@jest/expect@29.5.0:
+    resolution: {integrity: sha512-PueDR2HGihN3ciUNGr4uelropW7rqUfTiOn+8u0leg/42UhblPxHkfoh0Ruu3I9Y1962P3u2DY4+h7GVTSVU6g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      expect: 29.5.0
+      jest-snapshot: 29.5.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@jest/fake-timers@29.5.0:
+    resolution: {integrity: sha512-9ARvuAAQcBwDAqOnglWq2zwNIRUDtk/SCkp/ToGEhFv5r86K21l+VEs0qNTaXtyiY0lEePl3kylijSYJQqdbDg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.5.0
+      '@sinonjs/fake-timers': 10.0.2
+      '@types/node': 18.14.2
+      jest-message-util: 29.5.0
+      jest-mock: 29.5.0
+      jest-util: 29.5.0
+    dev: true
+
+  /@jest/globals@29.5.0:
+    resolution: {integrity: sha512-S02y0qMWGihdzNbUiqSAiKSpSozSuHX5UYc7QbnHP+D9Lyw8DgGGCinrN9uSuHPeKgSSzvPom2q1nAtBvUsvPQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/environment': 29.5.0
+      '@jest/expect': 29.5.0
+      '@jest/types': 29.5.0
+      jest-mock: 29.5.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@jest/reporters@29.5.0:
+    resolution: {integrity: sha512-D05STXqj/M8bP9hQNSICtPqz97u7ffGzZu+9XLucXhkOFBqKcXe04JLZOgIekOxdb73MAoBUFnqvf7MCpKk5OA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@bcoe/v8-coverage': 0.2.3
+      '@jest/console': 29.5.0
+      '@jest/test-result': 29.5.0
+      '@jest/transform': 29.5.0
+      '@jest/types': 29.5.0
+      '@jridgewell/trace-mapping': 0.3.18
+      '@types/node': 18.14.2
+      chalk: 4.1.2
+      collect-v8-coverage: 1.0.1
+      exit: 0.1.2
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      istanbul-lib-coverage: 3.2.0
+      istanbul-lib-instrument: 5.2.1
+      istanbul-lib-report: 3.0.0
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.1.5
+      jest-message-util: 29.5.0
+      jest-util: 29.5.0
+      jest-worker: 29.5.0
+      slash: 3.0.0
+      string-length: 4.0.2
+      strip-ansi: 6.0.1
+      v8-to-istanbul: 9.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@jest/schemas@29.4.3:
+    resolution: {integrity: sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.25.24
+    dev: true
+
+  /@jest/source-map@29.4.3:
+    resolution: {integrity: sha512-qyt/mb6rLyd9j1jUts4EQncvS6Yy3PM9HghnNv86QBlV+zdL2inCdK1tuVlL+J+lpiw2BI67qXOrX3UurBqQ1w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.18
+      callsites: 3.1.0
+      graceful-fs: 4.2.11
+    dev: true
+
+  /@jest/test-result@29.5.0:
+    resolution: {integrity: sha512-fGl4rfitnbfLsrfx1uUpDEESS7zM8JdgZgOCQuxQvL1Sn/I6ijeAVQWGfXI9zb1i9Mzo495cIpVZhA0yr60PkQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/console': 29.5.0
+      '@jest/types': 29.5.0
+      '@types/istanbul-lib-coverage': 2.0.4
+      collect-v8-coverage: 1.0.1
+    dev: true
+
+  /@jest/test-sequencer@29.5.0:
+    resolution: {integrity: sha512-yPafQEcKjkSfDXyvtgiV4pevSeyuA6MQr6ZIdVkWJly9vkqjnFfcfhRQqpD5whjoU8EORki752xQmjaqoFjzMQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/test-result': 29.5.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.5.0
+      slash: 3.0.0
+    dev: true
+
+  /@jest/transform@29.5.0:
+    resolution: {integrity: sha512-8vbeZWqLJOvHaDfeMuoHITGKSz5qWc9u04lnWrQE3VyuSw604PzQM824ZeX9XSjUCeDiE3GuxZe5UKa8J61NQw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@babel/core': 7.21.8
+      '@jest/types': 29.5.0
+      '@jridgewell/trace-mapping': 0.3.18
+      babel-plugin-istanbul: 6.1.1
+      chalk: 4.1.2
+      convert-source-map: 2.0.0
+      fast-json-stable-stringify: 2.1.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.5.0
+      jest-regex-util: 29.4.3
+      jest-util: 29.5.0
+      micromatch: 4.0.5
+      pirates: 4.0.5
+      slash: 3.0.0
+      write-file-atomic: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@jest/types@29.5.0:
+    resolution: {integrity: sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.4.3
+      '@types/istanbul-lib-coverage': 2.0.4
+      '@types/istanbul-reports': 3.0.1
+      '@types/node': 18.14.2
+      '@types/yargs': 17.0.24
+      chalk: 4.1.2
+    dev: true
+
+  /@jridgewell/gen-mapping@0.3.3:
+    resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/set-array': 1.1.2
+      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/trace-mapping': 0.3.18
+    dev: true
+
+  /@jridgewell/resolve-uri@3.1.0:
+    resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/resolve-uri@3.1.1:
+    resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/set-array@1.1.2:
+    resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/sourcemap-codec@1.4.14:
+    resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
+    dev: true
+
+  /@jridgewell/sourcemap-codec@1.4.15:
+    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
+    dev: true
+
+  /@jridgewell/trace-mapping@0.3.18:
+    resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
+
+  /@jridgewell/trace-mapping@0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.1
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
   /@kitql/helper@0.5.0:
     resolution: {integrity: sha512-qTDsv8qmbvSyZLb75hE9N4AnmZHtCi8JxgHYAj4dbgViEjs6HVYJKqHabGR7rZCAVQj7LwWu+cTfh52QhlNMcg==}
     dev: false
@@ -745,7 +1370,7 @@ packages:
   /@kitql/helper@0.6.1:
     resolution: {integrity: sha512-jHl1YHItwOI8Z0h4kvx5LaJjcjY4zbmgSZVajWaGanCmbBKYphVP3UoNHDhs5944Ar7fJ/L7MNSdIINBhurIOA==}
     dependencies:
-      safe-stable-stringify: 2.4.2
+      safe-stable-stringify: 2.4.3
     dev: false
 
   /@lezer/common@1.0.2:
@@ -796,8 +1421,8 @@ packages:
     resolution: {integrity: sha512-3fkKj25kEjsfObL6IlKPAlHYPq/oYwUkkQ03zsTTiDjD7vg/RxjdiLeCydqtxHZP0JgsXL3D/X5oAkMGzuUp/Q==}
     engines: {node: '>=12'}
 
-  /@next/env@13.0.6:
-    resolution: {integrity: sha512-yceT6DCHKqPRS1cAm8DHvDvK74DLIkDQdm5iV+GnIts8h0QbdHvkUIkdOvQoOODgpr6018skbmSQp12z5OWIQQ==}
+  /@next/env@13.0.2:
+    resolution: {integrity: sha512-Qb6WPuRriGIQ19qd6NBxpcrFOfj8ziN7l9eZUfwff5gl4zLXluqtuZPddYZM/oWjN53ZYcuRXzL+oowKyJeYtA==}
     dev: true
 
   /@next/eslint-plugin-next@13.2.1:
@@ -806,8 +1431,8 @@ packages:
       glob: 7.1.7
     dev: false
 
-  /@next/swc-android-arm-eabi@13.0.6:
-    resolution: {integrity: sha512-FGFSj3v2Bluw8fD/X+1eXIEB0PhoJE0zfutsAauRhmNpjjZshLDgoXMWm1jTRL/04K/o9gwwO2+A8+sPVCH1uw==}
+  /@next/swc-android-arm-eabi@13.0.2:
+    resolution: {integrity: sha512-X54UQCTFyOGnJP//Z71dPPlp4BCYcQL2ncikKXQcPzVpqPs4C3m+tKC8ivBNH6edAXkppwsLRz1/yQwgSZ9Swg==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [android]
@@ -815,8 +1440,8 @@ packages:
     dev: true
     optional: true
 
-  /@next/swc-android-arm64@13.0.6:
-    resolution: {integrity: sha512-7MgbtU7kimxuovVsd7jSJWMkIHBDBUsNLmmlkrBRHTvgzx5nDBXogP0hzZm7EImdOPwVMPpUHRQMBP9mbsiJYQ==}
+  /@next/swc-android-arm64@13.0.2:
+    resolution: {integrity: sha512-1P00Kv8uKaLubqo7JzPrTqgFAzSOmfb8iwqJrOb9in5IvTRtNGlkR4hU0sXzqbQNM/+SaYxze6Z5ry1IDyb/cQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [android]
@@ -824,8 +1449,8 @@ packages:
     dev: true
     optional: true
 
-  /@next/swc-darwin-arm64@13.0.6:
-    resolution: {integrity: sha512-AUVEpVTxbP/fxdFsjVI9d5a0CFn6NVV7A/RXOb0Y+pXKIIZ1V5rFjPwpYfIfyOo2lrqgehMNQcyMRoTrhq04xg==}
+  /@next/swc-darwin-arm64@13.0.2:
+    resolution: {integrity: sha512-1zGIOkInkOLRv0QQGZ+3wffYsyKI4vIy62LYTvDWUn7TAYqnmXwougp9NSLqDeagLwgsv2URrykyAFixA/YqxA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -833,8 +1458,8 @@ packages:
     dev: true
     optional: true
 
-  /@next/swc-darwin-x64@13.0.6:
-    resolution: {integrity: sha512-SasCDJlshglsPnbzhWaIF6VEGkQy2NECcAOxPwaPr0cwbbt4aUlZ7QmskNzgolr5eAjFS/xTr7CEeKJtZpAAtQ==}
+  /@next/swc-darwin-x64@13.0.2:
+    resolution: {integrity: sha512-ECDAjoMP1Y90cARaelS6X+k6BQx+MikAYJ8f/eaJrLur44NIOYc9HA/dgcTp5jenguY4yT8V+HCquLjAVle6fA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -842,8 +1467,8 @@ packages:
     dev: true
     optional: true
 
-  /@next/swc-freebsd-x64@13.0.6:
-    resolution: {integrity: sha512-6Lbxd9gAdXneTkwHyYW/qtX1Tdw7ND9UbiGsGz/SP43ZInNWnW6q0au4hEVPZ9bOWWRKzcVoeTBdoMpQk9Hx9w==}
+  /@next/swc-freebsd-x64@13.0.2:
+    resolution: {integrity: sha512-2DcL/ofQdBnQX3IoI9sjlIAyLCD1oZoUBuhrhWbejvBQjutWrI0JTEv9uG69WcxWhVMm3BCsjv8GK2/68OKp7A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [freebsd]
@@ -851,8 +1476,8 @@ packages:
     dev: true
     optional: true
 
-  /@next/swc-linux-arm-gnueabihf@13.0.6:
-    resolution: {integrity: sha512-wNdi5A519e1P+ozEuYOhWPzzE6m1y7mkO6NFwn6watUwO0X9nZs7fT9THmnekvmFQpaZ6U+xf2MQ9poQoCh6jQ==}
+  /@next/swc-linux-arm-gnueabihf@13.0.2:
+    resolution: {integrity: sha512-Y3OQF1CSBSWW2vGkmvOIuOUNqOq8qX7f1ZpcKUVWP3/Uq++DZmVi9d18lgnSe1I3QFqc+nXWyun9ljsN83j0sw==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
@@ -860,8 +1485,8 @@ packages:
     dev: true
     optional: true
 
-  /@next/swc-linux-arm64-gnu@13.0.6:
-    resolution: {integrity: sha512-e8KTRnleQY1KLk5PwGV5hrmvKksCc74QRpHl5ffWnEEAtL2FE0ave5aIkXqErsPdXkiKuA/owp3LjQrP+/AH7Q==}
+  /@next/swc-linux-arm64-gnu@13.0.2:
+    resolution: {integrity: sha512-mNyzwsFF6kwZYEjnGicx9ksDZYEZvyzEc1BtCu8vdZi/v8UeixQwCiAT6FyYX9uxMPEkzk8qiU0t0u9gvltsKw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -869,8 +1494,8 @@ packages:
     dev: true
     optional: true
 
-  /@next/swc-linux-arm64-musl@13.0.6:
-    resolution: {integrity: sha512-/7RF03C3mhjYpHN+pqOolgME3guiHU5T3TsejuyteqyEyzdEyLHod+jcYH6ft7UZ71a6TdOewvmbLOtzHW2O8A==}
+  /@next/swc-linux-arm64-musl@13.0.2:
+    resolution: {integrity: sha512-M6SdYjWgRrY3tJBxz0663zCRPTu5BRONmxlftKWWHv9LjAJ59neTLaGj4rp0A08DkJglZIoCkLOzLrzST6TGag==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -878,8 +1503,8 @@ packages:
     dev: true
     optional: true
 
-  /@next/swc-linux-x64-gnu@13.0.6:
-    resolution: {integrity: sha512-kxyEXnYHpOEkFnmrlwB1QlzJtjC6sAJytKcceIyFUHbCaD3W/Qb5tnclcnHKTaFccizZRePXvV25Ok/eUSpKTw==}
+  /@next/swc-linux-x64-gnu@13.0.2:
+    resolution: {integrity: sha512-pi63RoxvG4ES1KS06Zpm0MATVIXTs/TIbLbdckeLoM40u1d3mQl/+hSSrLRSxzc2OtyL8fh92sM4gkJrQXAMAw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -887,8 +1512,8 @@ packages:
     dev: true
     optional: true
 
-  /@next/swc-linux-x64-musl@13.0.6:
-    resolution: {integrity: sha512-N0c6gubS3WW1oYYgo02xzZnNatfVQP/CiJq2ax+DJ55ePV62IACbRCU99TZNXXg+Kos6vNW4k+/qgvkvpGDeyA==}
+  /@next/swc-linux-x64-musl@13.0.2:
+    resolution: {integrity: sha512-9Pv91gfYnDONgjtRm78n64b/c54+azeHtlnqBLTnIFWSMBDRl1/WDkhKWIj3fBGPLimtK7Tko3ULR3og9RRUPw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -896,8 +1521,8 @@ packages:
     dev: true
     optional: true
 
-  /@next/swc-win32-arm64-msvc@13.0.6:
-    resolution: {integrity: sha512-QjeMB2EBqBFPb/ac0CYr7GytbhUkrG4EwFWbcE0vsRp4H8grt25kYpFQckL4Jak3SUrp7vKfDwZ/SwO7QdO8vw==}
+  /@next/swc-win32-arm64-msvc@13.0.2:
+    resolution: {integrity: sha512-Nvewe6YZaizAkGHHprbMkYqQulBjZCHKBGKeFPwoPtOA+a2Qi4pZzc/qXFyC5/2A6Z0mr2U1zg9rd04WBYMwBw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -905,8 +1530,8 @@ packages:
     dev: true
     optional: true
 
-  /@next/swc-win32-ia32-msvc@13.0.6:
-    resolution: {integrity: sha512-EQzXtdqRTcmhT/tCq81rIwE36Y3fNHPInaCuJzM/kftdXfa0F+64y7FAoMO13npX8EG1+SamXgp/emSusKrCXg==}
+  /@next/swc-win32-ia32-msvc@13.0.2:
+    resolution: {integrity: sha512-ZUBYGZw5G3QrqDpRq1EWi3aHmvPZM8ijK5TFL6UbH16cYQ0JpANmuG2P66KB93Qe/lWWzbeAZk/tj1XqwoCuPA==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
@@ -914,8 +1539,8 @@ packages:
     dev: true
     optional: true
 
-  /@next/swc-win32-x64-msvc@13.0.6:
-    resolution: {integrity: sha512-pSkqZ//UP/f2sS9T7IvHLfEWDPTX0vRyXJnAUNisKvO3eF3e1xdhDX7dix/X3Z3lnN4UjSwOzclAI87JFbOwmQ==}
+  /@next/swc-win32-x64-msvc@13.0.2:
+    resolution: {integrity: sha512-fA9uW1dm7C0mEYGcKlbmLcVm2sKcye+1kPxh2cM4jVR+kQQMtHWsjIzeSpe2grQLSDan06z4n6hbr8b1c3hA8w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -939,17 +1564,17 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.14.0
+      fastq: 1.15.0
 
-  /@pkgr/utils@2.3.1:
-    resolution: {integrity: sha512-wfzX8kc1PMyUILA+1Z/EqoE4UCXGy0iRGMhPwdfae1+f0OXlLqCk+By+aMzgJBzR9AzS4CDizioG6Ss1gvAFJw==}
+  /@pkgr/utils@2.4.0:
+    resolution: {integrity: sha512-2OCURAmRtdlL8iUDTypMrrxfwe8frXTeXaxGsVOaYtc/wrUyk8Z/0OBetM7cdlsy7ZFWlMX72VogKeh+A4Xcjw==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     dependencies:
       cross-spawn: 7.0.3
+      fast-glob: 3.2.12
       is-glob: 4.0.3
-      open: 8.4.0
+      open: 9.1.0
       picocolors: 1.0.0
-      tiny-glob: 0.2.9
       tslib: 2.5.0
     dev: false
 
@@ -1003,8 +1628,8 @@ packages:
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-focus-lock: 2.9.2(@types/react@18.0.28)(react@18.2.0)
-      react-remove-scroll: 2.5.5(@types/react@18.0.28)(react@18.2.0)
+      react-focus-lock: 2.9.4(@types/react@18.0.28)(react@18.2.0)
+      react-remove-scroll: 2.5.6(@types/react@18.0.28)(react@18.2.0)
       tslib: 2.5.0
     transitivePeerDependencies:
       - '@types/react'
@@ -1157,25 +1782,112 @@ packages:
     resolution: {integrity: sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==}
     dev: false
 
-  /@swc/helpers@0.4.14:
-    resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
+  /@sinclair/typebox@0.25.24:
+    resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
+    dev: true
+
+  /@sinonjs/commons@2.0.0:
+    resolution: {integrity: sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==}
+    dependencies:
+      type-detect: 4.0.8
+    dev: true
+
+  /@sinonjs/fake-timers@10.0.2:
+    resolution: {integrity: sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==}
+    dependencies:
+      '@sinonjs/commons': 2.0.0
+    dev: true
+
+  /@swc/helpers@0.4.11:
+    resolution: {integrity: sha512-rEUrBSGIoSFuYxwBYtlUFMlE2CwGhmW+w9355/5oduSw8e5h2+Tj4UrAGNNgP9915++wj5vkQo0UuOBqOAq4nw==}
     dependencies:
       tslib: 2.5.0
+    dev: true
+
+  /@tsconfig/node10@1.0.9:
+    resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
+    dev: true
+
+  /@tsconfig/node12@1.0.11:
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+    dev: true
+
+  /@tsconfig/node14@1.0.3:
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    dev: true
+
+  /@tsconfig/node16@1.0.3:
+    resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
+    dev: true
+
+  /@types/babel__core@7.20.0:
+    resolution: {integrity: sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==}
+    dependencies:
+      '@babel/parser': 7.21.8
+      '@babel/types': 7.21.5
+      '@types/babel__generator': 7.6.4
+      '@types/babel__template': 7.4.1
+      '@types/babel__traverse': 7.18.5
+    dev: true
+
+  /@types/babel__generator@7.6.4:
+    resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
+    dependencies:
+      '@babel/types': 7.21.5
+    dev: true
+
+  /@types/babel__template@7.4.1:
+    resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
+    dependencies:
+      '@babel/parser': 7.21.8
+      '@babel/types': 7.21.5
+    dev: true
+
+  /@types/babel__traverse@7.18.5:
+    resolution: {integrity: sha512-enCvTL8m/EHS/zIvJno9nE+ndYPh1/oNFzRYRmtUqJICG2VnCSBzMLW5VN2KCQU91f23tsNKR8v7VJJQMatl7Q==}
+    dependencies:
+      '@babel/types': 7.21.5
     dev: true
 
   /@types/braces@3.0.1:
     resolution: {integrity: sha512-+euflG6ygo4bn0JHtn4pYqcXwRtLvElQ7/nnjDu7iYG56H0+OhCd7d6Ug0IE3WcFpZozBKW2+80FUbv5QGk5AQ==}
     dev: false
 
-  /@types/estree@1.0.0:
-    resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
+  /@types/estree@1.0.1:
+    resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
     dev: false
 
   /@types/fs-extra@9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
-      '@types/node': 18.11.18
+      '@types/node': 18.14.2
     dev: false
+
+  /@types/graceful-fs@4.1.6:
+    resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
+    dependencies:
+      '@types/node': 18.14.2
+    dev: true
+
+  /@types/istanbul-lib-coverage@2.0.4:
+    resolution: {integrity: sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==}
+    dev: true
+
+  /@types/istanbul-lib-report@3.0.0:
+    resolution: {integrity: sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==}
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.4
+    dev: true
+
+  /@types/istanbul-reports@3.0.1:
+    resolution: {integrity: sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==}
+    dependencies:
+      '@types/istanbul-lib-report': 3.0.0
+    dev: true
+
+  /@types/json-schema@7.0.11:
+    resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
+    dev: true
 
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
@@ -1187,13 +1899,17 @@ packages:
       '@types/braces': 3.0.1
     dev: false
 
-  /@types/node@18.11.18:
-    resolution: {integrity: sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==}
+  /@types/node@18.14.2:
+    resolution: {integrity: sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA==}
 
-  /@types/prompts@2.4.2:
-    resolution: {integrity: sha512-TwNx7qsjvRIUv/BCx583tqF5IINEVjCNqg9ofKHRlSoUHE62WBHrem4B1HGXcIrG511v29d1kJ9a/t2Esz7MIg==}
+  /@types/prettier@2.7.2:
+    resolution: {integrity: sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==}
+    dev: true
+
+  /@types/prompts@2.4.4:
+    resolution: {integrity: sha512-p5N9uoTH76lLvSAaYSZtBCdEXzpOOufsRjnhjVSrZGXikVGHX9+cc9ERtHRV4hvBKHyZb1bg4K+56Bd2TqUn4A==}
     dependencies:
-      '@types/node': 18.11.18
+      '@types/node': 18.14.2
       kleur: 3.0.3
     dev: false
 
@@ -1206,32 +1922,64 @@ packages:
       '@types/react': 18.0.28
     dev: true
 
-  /@types/react-dom@18.0.9:
-    resolution: {integrity: sha512-qnVvHxASt/H7i+XG1U1xMiY5t+IHcPGUK7TDMDzom08xa7e86eCeKOiLZezwCKVxJn6NEiiy2ekgX8aQssjIKg==}
-    dependencies:
-      '@types/react': 18.0.28
-    dev: true
-
-  /@types/react@18.0.26:
-    resolution: {integrity: sha512-hCR3PJQsAIXyxhTNSiDFY//LhnMZWpNNr5etoCqx/iUfGc5gXWtQR2Phl908jVR6uPXacojQWTg4qRpkxTuGug==}
-    dependencies:
-      '@types/prop-types': 15.7.5
-      '@types/scheduler': 0.16.2
-      csstype: 3.1.1
-    dev: true
-
   /@types/react@18.0.28:
     resolution: {integrity: sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==}
     dependencies:
       '@types/prop-types': 15.7.5
-      '@types/scheduler': 0.16.2
-      csstype: 3.1.1
+      '@types/scheduler': 0.16.3
+      csstype: 3.1.2
 
-  /@types/scheduler@0.16.2:
-    resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
+  /@types/scheduler@0.16.3:
+    resolution: {integrity: sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==}
 
-  /@typescript-eslint/parser@5.46.1(eslint@8.35.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-RelQ5cGypPh4ySAtfIMBzBGyrNerQcmfA1oJvPj5f+H4jI59rl9xxpn4bonC0tQvUKOEN7eGBFWxFLK3Xepneg==}
+  /@types/semver@7.3.13:
+    resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
+    dev: true
+
+  /@types/stack-utils@2.0.1:
+    resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
+    dev: true
+
+  /@types/yargs-parser@21.0.0:
+    resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
+    dev: true
+
+  /@types/yargs@17.0.24:
+    resolution: {integrity: sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==}
+    dependencies:
+      '@types/yargs-parser': 21.0.0
+    dev: true
+
+  /@typescript-eslint/eslint-plugin@5.59.2(@typescript-eslint/parser@5.59.2)(eslint@8.39.0)(typescript@5.0.2):
+    resolution: {integrity: sha512-yVrXupeHjRxLDcPKL10sGQ/QlVrA8J5IYOEWVqk0lJaSZP7X5DfnP7Ns3cc74/blmbipQ1htFNVGsHX6wsYm0A==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@eslint-community/regexpp': 4.5.1
+      '@typescript-eslint/parser': 5.59.2(eslint@8.39.0)(typescript@5.0.2)
+      '@typescript-eslint/scope-manager': 5.59.2
+      '@typescript-eslint/type-utils': 5.59.2(eslint@8.39.0)(typescript@5.0.2)
+      '@typescript-eslint/utils': 5.59.2(eslint@8.39.0)(typescript@5.0.2)
+      debug: 4.3.4
+      eslint: 8.39.0
+      grapheme-splitter: 1.0.4
+      ignore: 5.2.4
+      natural-compare-lite: 1.4.0
+      semver: 7.5.0
+      tsutils: 3.21.0(typescript@5.0.2)
+      typescript: 5.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/parser@5.59.2(eslint@8.35.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-uq0sKyw6ao1iFOZZGk9F8Nro/8+gfB5ezl1cA06SrqbgJAt0SRoFhb9pXaHvkrxUpZaoLxt8KlovHNk8Gp6/HQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1240,9 +1988,9 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 5.46.1
-      '@typescript-eslint/types': 5.46.1
-      '@typescript-eslint/typescript-estree': 5.46.1(typescript@5.0.4)
+      '@typescript-eslint/scope-manager': 5.59.2
+      '@typescript-eslint/types': 5.59.2
+      '@typescript-eslint/typescript-estree': 5.59.2(typescript@5.0.4)
       debug: 4.3.4
       eslint: 8.35.0
       typescript: 5.0.4
@@ -1250,21 +1998,59 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/scope-manager@5.46.1:
-    resolution: {integrity: sha512-iOChVivo4jpwUdrJZyXSMrEIM/PvsbbDOX1y3UCKjSgWn+W89skxWaYXACQfxmIGhPVpRWK/VWPYc+bad6smIA==}
+  /@typescript-eslint/parser@5.59.2(eslint@8.39.0)(typescript@5.0.2):
+    resolution: {integrity: sha512-uq0sKyw6ao1iFOZZGk9F8Nro/8+gfB5ezl1cA06SrqbgJAt0SRoFhb9pXaHvkrxUpZaoLxt8KlovHNk8Gp6/HQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.59.2
+      '@typescript-eslint/types': 5.59.2
+      '@typescript-eslint/typescript-estree': 5.59.2(typescript@5.0.2)
+      debug: 4.3.4
+      eslint: 8.39.0
+      typescript: 5.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/scope-manager@5.59.2:
+    resolution: {integrity: sha512-dB1v7ROySwQWKqQ8rEWcdbTsFjh2G0vn8KUyvTXdPoyzSL6lLGkiXEV5CvpJsEe9xIdKV+8Zqb7wif2issoOFA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.46.1
-      '@typescript-eslint/visitor-keys': 5.46.1
-    dev: false
+      '@typescript-eslint/types': 5.59.2
+      '@typescript-eslint/visitor-keys': 5.59.2
 
-  /@typescript-eslint/types@5.46.1:
-    resolution: {integrity: sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==}
+  /@typescript-eslint/type-utils@5.59.2(eslint@8.39.0)(typescript@5.0.2):
+    resolution: {integrity: sha512-b1LS2phBOsEy/T381bxkkywfQXkV1dWda/z0PhnIy3bC5+rQWQDS7fk9CSpcXBccPY27Z6vBEuaPBCKCgYezyQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: false
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 5.59.2(typescript@5.0.2)
+      '@typescript-eslint/utils': 5.59.2(eslint@8.39.0)(typescript@5.0.2)
+      debug: 4.3.4
+      eslint: 8.39.0
+      tsutils: 3.21.0(typescript@5.0.2)
+      typescript: 5.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
-  /@typescript-eslint/typescript-estree@5.46.1(typescript@5.0.4):
-    resolution: {integrity: sha512-j9W4t67QiNp90kh5Nbr1w92wzt+toiIsaVPnEblB2Ih2U9fqBTyqV9T3pYWZBRt6QoMh/zVWP59EpuCjc4VRBg==}
+  /@typescript-eslint/types@5.59.2:
+    resolution: {integrity: sha512-LbJ/HqoVs2XTGq5shkiKaNTuVv5tTejdHgfdjqRUGdYhjW1crm/M7og2jhVskMt8/4wS3T1+PfFvL1K3wqYj4w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  /@typescript-eslint/typescript-estree@5.59.2(typescript@5.0.2):
+    resolution: {integrity: sha512-+j4SmbwVmZsQ9jEyBMgpuBD0rKwi9RxRpjX71Brr73RsYnEr3Lt5QZ624Bxphp8HUkSKfqGnPJp1kA5nl0Sh7Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -1272,25 +2058,65 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 5.46.1
-      '@typescript-eslint/visitor-keys': 5.46.1
+      '@typescript-eslint/types': 5.59.2
+      '@typescript-eslint/visitor-keys': 5.59.2
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.8
+      semver: 7.5.0
+      tsutils: 3.21.0(typescript@5.0.2)
+      typescript: 5.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/typescript-estree@5.59.2(typescript@5.0.4):
+    resolution: {integrity: sha512-+j4SmbwVmZsQ9jEyBMgpuBD0rKwi9RxRpjX71Brr73RsYnEr3Lt5QZ624Bxphp8HUkSKfqGnPJp1kA5nl0Sh7Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.59.2
+      '@typescript-eslint/visitor-keys': 5.59.2
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.0
       tsutils: 3.21.0(typescript@5.0.4)
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/visitor-keys@5.46.1:
-    resolution: {integrity: sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==}
+  /@typescript-eslint/utils@5.59.2(eslint@8.39.0)(typescript@5.0.2):
+    resolution: {integrity: sha512-kSuF6/77TZzyGPhGO4uVp+f0SBoYxCDf+lW3GKhtKru/L8k/Hd7NFQxyWUeY7Z/KGB2C6Fe3yf2vVi4V9TsCSQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.39.0)
+      '@types/json-schema': 7.0.11
+      '@types/semver': 7.3.13
+      '@typescript-eslint/scope-manager': 5.59.2
+      '@typescript-eslint/types': 5.59.2
+      '@typescript-eslint/typescript-estree': 5.59.2(typescript@5.0.2)
+      eslint: 8.39.0
+      eslint-scope: 5.1.1
+      semver: 7.5.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/visitor-keys@5.59.2:
+    resolution: {integrity: sha512-EEpsO8m3RASrKAHI9jpavNv9NlEUebV4qmF1OWxSTtKSFBpC1NCmWazDQHFivRf0O1DV11BA645yrLEVQ0/Lig==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.46.1
+      '@typescript-eslint/types': 5.59.2
       eslint-visitor-keys: 3.4.0
-    dev: false
 
   /@urql/core@4.0.6(graphql@16.6.0):
     resolution: {integrity: sha512-RxlX5nxWZsvS1lPCvOdgdYbIVVfih/DrjPzGZ0ThP1GuVycaxw5t0O7XEXXYHICeXNKj95HJBxW0o/37zg+z6Q==}
@@ -1301,15 +2127,15 @@ packages:
       - graphql
     dev: false
 
-  /@wry/context@0.7.0:
-    resolution: {integrity: sha512-LcDAiYWRtwAoSOArfk7cuYvFXytxfVrdX7yxoUmK7pPITLk5jYh2F8knCwS7LjgYL8u1eidPlKKV6Ikqq0ODqQ==}
+  /@wry/context@0.7.2:
+    resolution: {integrity: sha512-WBGObg2bxt9UYGX4Dh3heUpHeULiFIP/yLpKrcebPfwaLuwCSj6rS7kpQegQ/K7jbkTQ1nLGZnfyAvY1T2LG4g==}
     engines: {node: '>=8'}
     dependencies:
       tslib: 2.5.0
     dev: false
 
-  /@wry/equality@0.5.3:
-    resolution: {integrity: sha512-avR+UXdSrsF2v8vIqIgmeTY0UR91UT+IyablCyKe/uk22uOJ8fusKZnH9JH9e1/EtLeNJBtagNmL3eJdnOV53g==}
+  /@wry/equality@0.5.5:
+    resolution: {integrity: sha512-tI95+tJlL2LoOY27EHy0V0zKRVgbPp6vk9p6ZqWZOCSVslEhYEGeI+gaskc2rnjQxfszsXhtgYZTQ1xAUrMkOg==}
     engines: {node: '>=8'}
     dependencies:
       tslib: 2.5.0
@@ -1325,12 +2151,21 @@ packages:
   /@xstate/fsm@1.4.0:
     resolution: {integrity: sha512-uTHDeu2xI5E1IFwf37JFQM31RrH7mY7877RqPBS4ZqSNUwoLDuct8AhBWaXGnVizBAYyimVwgCyGa9z/NiRhXA==}
 
+  /abbrev@1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+    dev: true
+
   /acorn-jsx@5.3.2(acorn@8.8.2):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       acorn: 8.8.2
+
+  /acorn-walk@8.2.0:
+    resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
+    engines: {node: '>=0.4.0'}
+    dev: true
 
   /acorn@8.8.2:
     resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
@@ -1345,15 +2180,34 @@ packages:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  /ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      type-fest: 0.21.3
+    dev: true
+
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
+
+  /ansi-styles@3.2.1:
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
+    dependencies:
+      color-convert: 1.9.3
+    dev: true
 
   /ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
+
+  /ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+    dev: true
 
   /any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -1367,15 +2221,30 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+    dev: true
+
+  /argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+    dependencies:
+      sprintf-js: 1.0.3
+    dev: true
+
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  /aria-query@4.2.2:
-    resolution: {integrity: sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==}
-    engines: {node: '>=6.0'}
+  /aria-query@5.1.3:
+    resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
     dependencies:
-      '@babel/runtime': 7.20.6
-      '@babel/runtime-corejs3': 7.20.6
+      deep-equal: 2.2.1
+    dev: false
+
+  /array-buffer-byte-length@1.0.0:
+    resolution: {integrity: sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==}
+    dependencies:
+      call-bind: 1.0.2
+      is-array-buffer: 3.0.2
     dev: false
 
   /array-includes@3.1.6:
@@ -1383,9 +2252,9 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.5
-      get-intrinsic: 1.1.3
+      define-properties: 1.2.0
+      es-abstract: 1.21.2
+      get-intrinsic: 1.2.0
       is-string: 1.0.7
     dev: false
 
@@ -1398,8 +2267,8 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.5
+      define-properties: 1.2.0
+      es-abstract: 1.21.2
       es-shim-unscopables: 1.0.0
     dev: false
 
@@ -1408,8 +2277,8 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.5
+      define-properties: 1.2.0
+      es-abstract: 1.21.2
       es-shim-unscopables: 1.0.0
     dev: false
 
@@ -1417,10 +2286,10 @@ packages:
     resolution: {integrity: sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.5
+      define-properties: 1.2.0
+      es-abstract: 1.21.2
       es-shim-unscopables: 1.0.0
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
     dev: false
 
   /assert@2.0.0:
@@ -1448,22 +2317,108 @@ packages:
     engines: {node: '>= 0.4'}
     dev: false
 
-  /axe-core@4.6.0:
-    resolution: {integrity: sha512-L3ZNbXPTxMrl0+qTXAzn9FBRvk5XdO56K8CvcCKtlxv44Aw2w2NCclGuvCWxHPw1Riiq3ncP/sxFYj2nUqdoTw==}
+  /axe-core@4.7.0:
+    resolution: {integrity: sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==}
     engines: {node: '>=4'}
     dev: false
 
-  /axobject-query@2.2.0:
-    resolution: {integrity: sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==}
+  /axobject-query@3.1.1:
+    resolution: {integrity: sha512-goKlv8DZrK9hUh975fnHzhNIO4jUnFCfv/dszV5VwUGDFjI6vQ2VwoyjYjYNEbBE8AH87TduWP5uyDR1D+Iteg==}
+    dependencies:
+      deep-equal: 2.2.1
     dev: false
+
+  /babel-jest@29.5.0(@babel/core@7.21.8):
+    resolution: {integrity: sha512-mA4eCDh5mSo2EcA9xQjVTpmbbNk32Zb3Q3QFQsNhaK56Q+yoXowzFodLux30HRgyOho5rsQ6B0P9QpMkvvnJ0Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@babel/core': ^7.8.0
+    dependencies:
+      '@babel/core': 7.21.8
+      '@jest/transform': 29.5.0
+      '@types/babel__core': 7.20.0
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.5.0(@babel/core@7.21.8)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /babel-plugin-istanbul@6.1.1:
+    resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@babel/helper-plugin-utils': 7.21.5
+      '@istanbuljs/load-nyc-config': 1.1.0
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-instrument: 5.2.1
+      test-exclude: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /babel-plugin-jest-hoist@29.5.0:
+    resolution: {integrity: sha512-zSuuuAlTMT4mzLj2nPnUm6fsE6270vdOfnpbJ+RmruU75UhLFvL0N2NgI7xpeS7NaB6hGqmd5pVpGTDYvi4Q3w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@babel/template': 7.20.7
+      '@babel/types': 7.21.5
+      '@types/babel__core': 7.20.0
+      '@types/babel__traverse': 7.18.5
+    dev: true
+
+  /babel-preset-current-node-syntax@1.0.1(@babel/core@7.21.8):
+    resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.21.8
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.21.8)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.21.8)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.21.8)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.21.8)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.21.8)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.21.8)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.21.8)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.21.8)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.21.8)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.21.8)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.21.8)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.21.8)
+    dev: true
+
+  /babel-preset-jest@29.5.0(@babel/core@7.21.8):
+    resolution: {integrity: sha512-JOMloxOqdiBSxMAzjRaH023/vvcaSaec49zvg+2LmNsktC7ei39LTJGw02J+9uUtTZUq6xbLyJ4dxe9sSmIuAg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.21.8
+      babel-plugin-jest-hoist: 29.5.0
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.21.8)
+    dev: true
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  /big-integer@1.6.51:
+    resolution: {integrity: sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==}
+    engines: {node: '>=0.6'}
+    dev: false
 
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
     dev: true
+
+  /bplist-parser@0.2.0:
+    resolution: {integrity: sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==}
+    engines: {node: '>= 5.10.0'}
+    dependencies:
+      big-integer: 1.6.51
+    dev: false
 
   /brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -1483,10 +2438,45 @@ packages:
     dependencies:
       fill-range: 7.0.1
 
+  /browserslist@4.21.5:
+    resolution: {integrity: sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+    dependencies:
+      caniuse-lite: 1.0.30001482
+      electron-to-chromium: 1.4.384
+      node-releases: 2.0.10
+      update-browserslist-db: 1.0.11(browserslist@4.21.5)
+    dev: true
+
+  /bs-logger@0.2.6:
+    resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
+    engines: {node: '>= 6'}
+    dependencies:
+      fast-json-stable-stringify: 2.1.0
+    dev: true
+
+  /bser@2.1.1:
+    resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
+    dependencies:
+      node-int64: 0.4.0
+    dev: true
+
+  /buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+    dev: true
+
   /builtins@5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
     dependencies:
-      semver: 7.3.8
+      semver: 7.5.0
+    dev: false
+
+  /bundle-name@3.0.0:
+    resolution: {integrity: sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==}
+    engines: {node: '>=12'}
+    dependencies:
+      run-applescript: 5.0.0
     dev: false
 
   /bundle-require@3.1.2(esbuild@0.15.18):
@@ -1496,17 +2486,17 @@ packages:
       esbuild: '>=0.13'
     dependencies:
       esbuild: 0.15.18
-      load-tsconfig: 0.2.3
+      load-tsconfig: 0.2.5
     dev: true
 
-  /bundle-require@4.0.1(esbuild@0.17.10):
+  /bundle-require@4.0.1(esbuild@0.17.18):
     resolution: {integrity: sha512-9NQkRHlNdNpDBGmLpngF3EFDcwodhMUuLz9PaWYciVcQF9SE4LFjM2DB/xV1Li5JiuDMv7ZUWuC3rGbqR0MAXQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.17'
     dependencies:
-      esbuild: 0.17.10
-      load-tsconfig: 0.2.3
+      esbuild: 0.17.18
+      load-tsconfig: 0.2.5
     dev: true
 
   /cac@6.7.14:
@@ -1518,15 +2508,34 @@ packages:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
       function-bind: 1.1.1
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
     dev: false
 
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  /caniuse-lite@1.0.30001439:
-    resolution: {integrity: sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==}
+  /camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /caniuse-lite@1.0.30001482:
+    resolution: {integrity: sha512-F1ZInsg53cegyjroxLNW9DmrEQ1SuGRTO1QlpA0o2/6OpQ0gFeDRoq1yFmnr8Sakn9qwwt9DmbxHB6w167OSuQ==}
+    dev: true
+
+  /chalk@2.4.2:
+    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
+    engines: {node: '>=4'}
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
     dev: true
 
   /chalk@4.1.2:
@@ -1535,6 +2544,11 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  /char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
+    dev: true
 
   /chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -1551,11 +2565,34 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /ci-info@3.8.0:
+    resolution: {integrity: sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /cjs-module-lexer@1.2.2:
+    resolution: {integrity: sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==}
+    dev: true
+
   /client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
     dev: true
 
-  /codemirror-graphql@2.0.6(@codemirror/language@6.0.0)(codemirror@5.65.11)(graphql@16.6.0):
+  /cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    dev: true
+
+  /co@4.6.0:
+    resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
+    engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
+    dev: true
+
+  /codemirror-graphql@2.0.6(@codemirror/language@6.0.0)(codemirror@5.65.13)(graphql@16.6.0):
     resolution: {integrity: sha512-ZuvT4+iBYabyLWaqVHdsGyiB2atvu0v1eSnGUuziX7x7tJmo5WziZGvc2j6w6EnL5aUjvYnJU0aCBhTgCdzJVg==}
     peerDependencies:
       '@codemirror/language': 6.0.0
@@ -1563,18 +2600,32 @@ packages:
       graphql: ^15.5.0 || ^16.0.0
     dependencies:
       '@codemirror/language': 6.0.0
-      codemirror: 5.65.11
+      codemirror: 5.65.13
       graphql: 16.6.0
       graphql-language-service: 5.1.4(graphql@16.6.0)
 
-  /codemirror@5.65.11:
-    resolution: {integrity: sha512-Gp62g2eKSCHYt10axmGhKq3WoJSvVpvhXmowNq7pZdRVowwtvBR/hi2LSP5srtctKkRT33T6/n8Kv1UGp7JW4A==}
+  /codemirror@5.65.13:
+    resolution: {integrity: sha512-SVWEzKXmbHmTQQWaz03Shrh4nybG0wXx2MEu3FO4ezbPW8IbnZEd5iGHGEffSUaitKYa3i+pHpBsSvw8sPHtzg==}
+
+  /collect-v8-coverage@1.0.1:
+    resolution: {integrity: sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==}
+    dev: true
+
+  /color-convert@1.9.3:
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+    dependencies:
+      color-name: 1.1.3
+    dev: true
 
   /color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
+
+  /color-name@1.1.3:
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+    dev: true
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -1592,15 +2643,22 @@ packages:
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  /convert-source-map@1.9.0:
+    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+    dev: true
+
+  /convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+    dev: true
+
   /copy-to-clipboard@3.3.3:
     resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
     dependencies:
       toggle-selection: 1.0.6
 
-  /core-js-pure@3.26.1:
-    resolution: {integrity: sha512-VVXcDpp/xJ21KdULRq/lXdLzQAtX7+37LzpyfFM973il0tWSsDEoyzG38G14AjTpK9VTfiNM9jnFauq/CpaWGQ==}
-    requiresBuild: true
-    dev: false
+  /create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: true
 
   /cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
@@ -1616,8 +2674,8 @@ packages:
     hasBin: true
     dev: true
 
-  /csstype@3.1.1:
-    resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
+  /csstype@3.1.2:
+    resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
 
   /damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -1628,18 +2686,7 @@ packages:
     engines: {node: '>= 12'}
     dev: false
 
-  /debug@2.6.9:
-    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.0.0
-    dev: false
-
-  /debug@3.2.7:
+  /debug@3.2.7(supports-color@5.5.0):
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
       supports-color: '*'
@@ -1648,7 +2695,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
-    dev: false
+      supports-color: 5.5.0
 
   /debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -1661,29 +2708,88 @@ packages:
     dependencies:
       ms: 2.1.2
 
+  /dedent@0.7.0:
+    resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
+    dev: true
+
+  /deep-equal@2.2.1:
+    resolution: {integrity: sha512-lKdkdV6EOGoVn65XaOsPdH4rMxTZOnmFyuIkMjM1i5HHCbfjC97dawgTAy0deYNfuqUqW+Q5VrVaQYtUpSd6yQ==}
+    dependencies:
+      array-buffer-byte-length: 1.0.0
+      call-bind: 1.0.2
+      es-get-iterator: 1.1.3
+      get-intrinsic: 1.2.0
+      is-arguments: 1.1.1
+      is-array-buffer: 3.0.2
+      is-date-object: 1.0.5
+      is-regex: 1.1.4
+      is-shared-array-buffer: 1.0.2
+      isarray: 2.0.5
+      object-is: 1.1.5
+      object-keys: 1.1.1
+      object.assign: 4.1.4
+      regexp.prototype.flags: 1.5.0
+      side-channel: 1.0.4
+      which-boxed-primitive: 1.0.2
+      which-collection: 1.0.1
+      which-typed-array: 1.1.9
+    dev: false
+
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  /deepmerge@4.2.2:
-    resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
+  /deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  /default-browser-id@3.0.0:
+    resolution: {integrity: sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==}
+    engines: {node: '>=12'}
+    dependencies:
+      bplist-parser: 0.2.0
+      untildify: 4.0.0
     dev: false
 
-  /define-lazy-prop@2.0.0:
-    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
-    engines: {node: '>=8'}
+  /default-browser@4.0.0:
+    resolution: {integrity: sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==}
+    engines: {node: '>=14.16'}
+    dependencies:
+      bundle-name: 3.0.0
+      default-browser-id: 3.0.0
+      execa: 7.1.1
+      titleize: 3.0.0
     dev: false
 
-  /define-properties@1.1.4:
-    resolution: {integrity: sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==}
+  /define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /define-properties@1.2.0:
+    resolution: {integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
     dev: false
 
+  /detect-newline@3.1.0:
+    resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
+    engines: {node: '>=8'}
+    dev: true
+
   /detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  /diff-sequences@29.4.3:
+    resolution: {integrity: sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+
+  /diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+    dev: true
 
   /dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -1704,50 +2810,105 @@ packages:
     dependencies:
       esutils: 2.0.3
 
+  /electron-to-chromium@1.4.384:
+    resolution: {integrity: sha512-I97q0MmRAAqj53+a8vZsDkEXBZki+ehYAOPzwtQzALip52aEp2+BJqHFtTlsfjoqVZYwPpHC8wM6MbsSZQ/Eqw==}
+    dev: true
+
+  /emittery@0.13.1:
+    resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    dev: true
+
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
     dev: false
 
-  /enhanced-resolve@5.12.0:
-    resolution: {integrity: sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==}
+  /enhanced-resolve@5.13.0:
+    resolution: {integrity: sha512-eyV8f0y1+bzyfh8xAwW/WTSZpLbjhqc4ne9eGSH4Zo2ejdyiNG9pU6mf9DG8a7+Auk6MFTlNOT4Y2y/9k8GKVg==}
     engines: {node: '>=10.13.0'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       tapable: 2.2.1
     dev: false
 
   /entities@2.1.0:
     resolution: {integrity: sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==}
 
-  /es-abstract@1.20.5:
-    resolution: {integrity: sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==}
+  /entities@2.2.0:
+    resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
+    dev: true
+
+  /error-ex@1.3.2:
+    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+    dependencies:
+      is-arrayish: 0.2.1
+    dev: true
+
+  /es-abstract@1.21.2:
+    resolution: {integrity: sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==}
     engines: {node: '>= 0.4'}
     dependencies:
+      array-buffer-byte-length: 1.0.0
+      available-typed-arrays: 1.0.5
       call-bind: 1.0.2
+      es-set-tostringtag: 2.0.1
       es-to-primitive: 1.2.1
-      function-bind: 1.1.1
       function.prototype.name: 1.1.5
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       get-symbol-description: 1.0.0
+      globalthis: 1.0.3
       gopd: 1.0.1
       has: 1.0.3
       has-property-descriptors: 1.0.0
+      has-proto: 1.0.1
       has-symbols: 1.0.3
-      internal-slot: 1.0.4
+      internal-slot: 1.0.5
+      is-array-buffer: 3.0.2
       is-callable: 1.2.7
       is-negative-zero: 2.0.2
       is-regex: 1.1.4
       is-shared-array-buffer: 1.0.2
       is-string: 1.0.7
+      is-typed-array: 1.1.10
       is-weakref: 1.0.2
-      object-inspect: 1.12.2
+      object-inspect: 1.12.3
       object-keys: 1.1.1
       object.assign: 4.1.4
-      regexp.prototype.flags: 1.4.3
+      regexp.prototype.flags: 1.5.0
       safe-regex-test: 1.0.0
+      string.prototype.trim: 1.2.7
       string.prototype.trimend: 1.0.6
       string.prototype.trimstart: 1.0.6
+      typed-array-length: 1.0.4
       unbox-primitive: 1.0.2
+      which-typed-array: 1.1.9
+    dev: false
+
+  /es-get-iterator@1.1.3:
+    resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.2.0
+      has-symbols: 1.0.3
+      is-arguments: 1.1.1
+      is-map: 2.0.2
+      is-set: 2.0.2
+      is-string: 1.0.7
+      isarray: 2.0.5
+      stop-iteration-iterator: 1.0.0
+    dev: false
+
+  /es-set-tostringtag@2.0.1:
+    resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      get-intrinsic: 1.2.0
+      has: 1.0.3
+      has-tostringtag: 1.0.0
     dev: false
 
   /es-shim-unscopables@1.0.0:
@@ -1979,34 +3140,49 @@ packages:
       esbuild-windows-arm64: 0.15.18
     dev: true
 
-  /esbuild@0.17.10:
-    resolution: {integrity: sha512-n7V3v29IuZy5qgxx25TKJrEm0FHghAlS6QweUcyIgh/U0zYmQcvogWROitrTyZId1mHSkuhhuyEXtI9OXioq7A==}
+  /esbuild@0.17.18:
+    resolution: {integrity: sha512-z1lix43jBs6UKjcZVKOw2xx69ffE2aG0PygLL5qJ9OS/gy0Ewd1gW/PUQIOIQGXBHWNywSc0floSKoMFF8aK2w==}
     engines: {node: '>=12'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@esbuild/android-arm': 0.17.10
-      '@esbuild/android-arm64': 0.17.10
-      '@esbuild/android-x64': 0.17.10
-      '@esbuild/darwin-arm64': 0.17.10
-      '@esbuild/darwin-x64': 0.17.10
-      '@esbuild/freebsd-arm64': 0.17.10
-      '@esbuild/freebsd-x64': 0.17.10
-      '@esbuild/linux-arm': 0.17.10
-      '@esbuild/linux-arm64': 0.17.10
-      '@esbuild/linux-ia32': 0.17.10
-      '@esbuild/linux-loong64': 0.17.10
-      '@esbuild/linux-mips64el': 0.17.10
-      '@esbuild/linux-ppc64': 0.17.10
-      '@esbuild/linux-riscv64': 0.17.10
-      '@esbuild/linux-s390x': 0.17.10
-      '@esbuild/linux-x64': 0.17.10
-      '@esbuild/netbsd-x64': 0.17.10
-      '@esbuild/openbsd-x64': 0.17.10
-      '@esbuild/sunos-x64': 0.17.10
-      '@esbuild/win32-arm64': 0.17.10
-      '@esbuild/win32-ia32': 0.17.10
-      '@esbuild/win32-x64': 0.17.10
+      '@esbuild/android-arm': 0.17.18
+      '@esbuild/android-arm64': 0.17.18
+      '@esbuild/android-x64': 0.17.18
+      '@esbuild/darwin-arm64': 0.17.18
+      '@esbuild/darwin-x64': 0.17.18
+      '@esbuild/freebsd-arm64': 0.17.18
+      '@esbuild/freebsd-x64': 0.17.18
+      '@esbuild/linux-arm': 0.17.18
+      '@esbuild/linux-arm64': 0.17.18
+      '@esbuild/linux-ia32': 0.17.18
+      '@esbuild/linux-loong64': 0.17.18
+      '@esbuild/linux-mips64el': 0.17.18
+      '@esbuild/linux-ppc64': 0.17.18
+      '@esbuild/linux-riscv64': 0.17.18
+      '@esbuild/linux-s390x': 0.17.18
+      '@esbuild/linux-x64': 0.17.18
+      '@esbuild/netbsd-x64': 0.17.18
+      '@esbuild/openbsd-x64': 0.17.18
+      '@esbuild/sunos-x64': 0.17.18
+      '@esbuild/win32-arm64': 0.17.18
+      '@esbuild/win32-ia32': 0.17.18
+      '@esbuild/win32-x64': 0.17.18
+    dev: true
+
+  /escalade@3.1.1:
+    resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+    dev: true
+
+  /escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
     dev: true
 
   /escape-string-regexp@4.0.0:
@@ -2024,12 +3200,12 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 13.2.1
       '@rushstack/eslint-patch': 1.2.0
-      '@typescript-eslint/parser': 5.46.1(eslint@8.35.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.59.2(eslint@8.35.0)(typescript@5.0.4)
       eslint: 8.35.0
-      eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.26.0)(eslint@8.35.0)
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.46.1)(eslint-import-resolver-typescript@3.5.3)(eslint@8.35.0)
-      eslint-plugin-jsx-a11y: 6.6.1(eslint@8.35.0)
+      eslint-import-resolver-node: 0.3.7
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.35.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-typescript@3.5.5)(eslint@8.35.0)
+      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.35.0)
       eslint-plugin-react: 7.32.2(eslint@8.35.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.35.0)
       typescript: 5.0.4
@@ -2038,8 +3214,8 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-config-prettier@8.5.0(eslint@8.35.0):
-    resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
+  /eslint-config-prettier@8.3.0(eslint@8.35.0):
+    resolution: {integrity: sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
@@ -2056,37 +3232,42 @@ packages:
       eslint-plugin-turbo: 1.9.3(eslint@8.35.0)
     dev: false
 
-  /eslint-import-resolver-node@0.3.6:
-    resolution: {integrity: sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==}
+  /eslint-import-resolver-node@0.3.7:
+    resolution: {integrity: sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==}
     dependencies:
-      debug: 3.2.7
-      resolve: 1.22.1
+      debug: 3.2.7(supports-color@5.5.0)
+      is-core-module: 2.12.0
+      resolve: 1.22.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.26.0)(eslint@8.35.0):
-    resolution: {integrity: sha512-njRcKYBc3isE42LaTcJNVANR3R99H9bAxBDMNDr2W7yq5gYPxbU3MkdhsQukxZ/Xg9C2vcyLlDsbKfRDg0QvCQ==}
+  /eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.35.0):
+    resolution: {integrity: sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
       eslint-plugin-import: '*'
     dependencies:
       debug: 4.3.4
-      enhanced-resolve: 5.12.0
+      enhanced-resolve: 5.13.0
       eslint: 8.35.0
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.46.1)(eslint-import-resolver-typescript@3.5.3)(eslint@8.35.0)
-      get-tsconfig: 4.4.0
-      globby: 13.1.3
-      is-core-module: 2.11.0
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.35.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-typescript@3.5.5)(eslint@8.35.0)
+      get-tsconfig: 4.5.0
+      globby: 13.1.4
+      is-core-module: 2.12.0
       is-glob: 4.0.3
       synckit: 0.8.5
     transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-node
+      - eslint-import-resolver-webpack
       - supports-color
     dev: false
 
-  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.46.1)(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@3.5.3)(eslint@8.35.0):
-    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.35.0):
+    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
@@ -2106,17 +3287,17 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.46.1(eslint@8.35.0)(typescript@5.0.4)
-      debug: 3.2.7
+      '@typescript-eslint/parser': 5.59.2(eslint@8.35.0)(typescript@5.0.4)
+      debug: 3.2.7(supports-color@5.5.0)
       eslint: 8.35.0
-      eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.26.0)(eslint@8.35.0)
+      eslint-import-resolver-node: 0.3.7
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.35.0)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.46.1)(eslint-import-resolver-typescript@3.5.3)(eslint@8.35.0):
-    resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
+  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-typescript@3.5.5)(eslint@8.35.0):
+    resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
@@ -2125,46 +3306,51 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.46.1(eslint@8.35.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.59.2(eslint@8.35.0)(typescript@5.0.4)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
-      debug: 2.6.9
+      array.prototype.flatmap: 1.3.1
+      debug: 3.2.7(supports-color@5.5.0)
       doctrine: 2.1.0
       eslint: 8.35.0
-      eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.46.1)(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@3.5.3)(eslint@8.35.0)
+      eslint-import-resolver-node: 0.3.7
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.35.0)
       has: 1.0.3
-      is-core-module: 2.11.0
+      is-core-module: 2.12.0
       is-glob: 4.0.3
       minimatch: 3.1.2
       object.values: 1.1.6
-      resolve: 1.22.1
-      tsconfig-paths: 3.14.1
+      resolve: 1.22.2
+      semver: 6.3.0
+      tsconfig-paths: 3.14.2
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
     dev: false
 
-  /eslint-plugin-jsx-a11y@6.6.1(eslint@8.35.0):
-    resolution: {integrity: sha512-sXgFVNHiWffBq23uiS/JaP6eVR622DqwB4yTzKvGZGcPq6/yZ3WmOZfuBks/vHWo9GaFOqC2ZK4i6+C35knx7Q==}
+  /eslint-plugin-jsx-a11y@6.7.1(eslint@8.35.0):
+    resolution: {integrity: sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==}
     engines: {node: '>=4.0'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
     dependencies:
-      '@babel/runtime': 7.20.6
-      aria-query: 4.2.2
+      '@babel/runtime': 7.21.5
+      aria-query: 5.1.3
       array-includes: 3.1.6
+      array.prototype.flatmap: 1.3.1
       ast-types-flow: 0.0.7
-      axe-core: 4.6.0
-      axobject-query: 2.2.0
+      axe-core: 4.7.0
+      axobject-query: 3.1.1
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
       eslint: 8.35.0
       has: 1.0.3
       jsx-ast-utils: 3.3.3
-      language-tags: 1.0.6
+      language-tags: 1.0.5
       minimatch: 3.1.2
+      object.entries: 1.1.6
+      object.fromentries: 2.0.6
       semver: 6.3.0
     dev: false
 
@@ -2209,12 +3395,12 @@ packages:
       eslint: 8.35.0
     dev: false
 
-  /eslint-scope@7.1.1:
-    resolution: {integrity: sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /eslint-scope@5.1.1:
+    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
+    engines: {node: '>=8.0.0'}
     dependencies:
       esrecurse: 4.3.0
-      estraverse: 5.3.0
+      estraverse: 4.3.0
     dev: true
 
   /eslint-scope@7.2.0:
@@ -2223,16 +3409,6 @@ packages:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
-
-  /eslint-utils@3.0.0(eslint@8.29.0):
-    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
-    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
-    peerDependencies:
-      eslint: '>=5'
-    dependencies:
-      eslint: 8.29.0
-      eslint-visitor-keys: 2.1.0
-    dev: true
 
   /eslint-utils@3.0.0(eslint@8.35.0):
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
@@ -2247,62 +3423,9 @@ packages:
     resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
     engines: {node: '>=10'}
 
-  /eslint-visitor-keys@3.3.0:
-    resolution: {integrity: sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
-
   /eslint-visitor-keys@3.4.0:
     resolution: {integrity: sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  /eslint@8.29.0:
-    resolution: {integrity: sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    hasBin: true
-    dependencies:
-      '@eslint/eslintrc': 1.4.1
-      '@humanwhocodes/config-array': 0.11.8
-      '@humanwhocodes/module-importer': 1.0.1
-      '@nodelib/fs.walk': 1.2.8
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      debug: 4.3.4
-      doctrine: 3.0.0
-      escape-string-regexp: 4.0.0
-      eslint-scope: 7.1.1
-      eslint-utils: 3.0.0(eslint@8.29.0)
-      eslint-visitor-keys: 3.3.0
-      espree: 9.4.1
-      esquery: 1.4.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      globals: 13.19.0
-      grapheme-splitter: 1.0.4
-      ignore: 5.2.1
-      import-fresh: 3.3.0
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      is-path-inside: 3.0.3
-      js-sdsl: 4.3.0
-      js-yaml: 4.1.0
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.1
-      regexpp: 3.2.0
-      strip-ansi: 6.0.1
-      strip-json-comments: 3.1.1
-      text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /eslint@8.35.0:
     resolution: {integrity: sha512-BxAf1fVL7w+JLRQhWl2pzGeSiGqbWumV4WNvc9Rhp6tiCtm4oHnyPBSEtMGZwrQgudFQ+otqzWoPB7x+hxoWsw==}
@@ -2324,20 +3447,20 @@ packages:
       eslint-utils: 3.0.0(eslint@8.35.0)
       eslint-visitor-keys: 3.4.0
       espree: 9.5.1
-      esquery: 1.4.2
+      esquery: 1.5.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
       file-entry-cache: 6.0.1
       find-up: 5.0.0
       glob-parent: 6.0.2
-      globals: 13.19.0
+      globals: 13.20.0
       grapheme-splitter: 1.0.4
-      ignore: 5.2.1
+      ignore: 5.2.4
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-sdsl: 4.3.0
+      js-sdsl: 4.4.0
       js-yaml: 4.1.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
@@ -2352,13 +3475,53 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /espree@9.4.1:
-    resolution: {integrity: sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==}
+  /eslint@8.39.0:
+    resolution: {integrity: sha512-mwiok6cy7KTW7rBpo05k6+p4YVZByLNjAZ/ACB9DRCu4YDRwjXI01tWHp6KAUWelsBetTxKK/2sHB0vdS8Z2Og==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    hasBin: true
     dependencies:
-      acorn: 8.8.2
-      acorn-jsx: 5.3.2(acorn@8.8.2)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.39.0)
+      '@eslint-community/regexpp': 4.5.1
+      '@eslint/eslintrc': 2.0.2
+      '@eslint/js': 8.39.0
+      '@humanwhocodes/config-array': 0.11.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@nodelib/fs.walk': 1.2.8
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      debug: 4.3.4
+      doctrine: 3.0.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.2.0
       eslint-visitor-keys: 3.4.0
+      espree: 9.5.1
+      esquery: 1.5.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      globals: 13.20.0
+      grapheme-splitter: 1.0.4
+      ignore: 5.2.4
+      import-fresh: 3.3.0
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      is-path-inside: 3.0.3
+      js-sdsl: 4.4.0
+      js-yaml: 4.1.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.1
+      strip-ansi: 6.0.1
+      strip-json-comments: 3.1.1
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /espree@9.5.1:
@@ -2373,17 +3536,9 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: false
 
-  /esquery@1.4.0:
-    resolution: {integrity: sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==}
-    engines: {node: '>=0.10'}
-    dependencies:
-      estraverse: 5.3.0
-    dev: true
-
-  /esquery@1.4.2:
-    resolution: {integrity: sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==}
+  /esquery@1.5.0:
+    resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
     engines: {node: '>=0.10'}
     dependencies:
       estraverse: 5.3.0
@@ -2394,6 +3549,11 @@ packages:
     dependencies:
       estraverse: 5.3.0
 
+  /estraverse@4.3.0:
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
+    engines: {node: '>=4.0'}
+    dev: true
+
   /estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
@@ -2401,7 +3561,7 @@ packages:
   /estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.1
     dev: false
 
   /esutils@2.0.3:
@@ -2421,7 +3581,6 @@ packages:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
-    dev: true
 
   /execa@6.1.0:
     resolution: {integrity: sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==}
@@ -2437,6 +3596,37 @@ packages:
       signal-exit: 3.0.7
       strip-final-newline: 3.0.0
     dev: false
+
+  /execa@7.1.1:
+    resolution: {integrity: sha512-wH0eMf/UXckdUYnO21+HDztteVv05rq2GXksxT4fCGeHkBhw1DROXh40wcjMcRqDOWE7iPJ4n3M7e2+YFP+76Q==}
+    engines: {node: ^14.18.0 || ^16.14.0 || >=18.0.0}
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 6.0.1
+      human-signals: 4.3.1
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.1.0
+      onetime: 6.0.0
+      signal-exit: 3.0.7
+      strip-final-newline: 3.0.0
+    dev: false
+
+  /exit@0.1.2:
+    resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
+    engines: {node: '>= 0.8.0'}
+    dev: true
+
+  /expect@29.5.0:
+    resolution: {integrity: sha512-yM7xqUrCO2JdpFo4XpM82t+PJBFybdqoQuJLDGeDX2ij8NZzqRHyu3Hp188/JX7SWqud+7t4MUdvcgGBICMHZg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/expect-utils': 29.5.0
+      jest-get-type: 29.4.3
+      jest-matcher-utils: 29.5.0
+      jest-message-util: 29.5.0
+      jest-util: 29.5.0
+    dev: true
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2461,10 +3651,16 @@ packages:
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  /fastq@1.14.0:
-    resolution: {integrity: sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==}
+  /fastq@1.15.0:
+    resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
     dependencies:
       reusify: 1.0.4
+
+  /fb-watchman@2.0.2:
+    resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+    dependencies:
+      bser: 2.1.1
+    dev: true
 
   /fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
@@ -2486,6 +3682,14 @@ packages:
     dependencies:
       to-regex-range: 5.0.1
 
+  /find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+    dev: true
+
   /find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -2503,8 +3707,8 @@ packages:
   /flatted@3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
 
-  /focus-lock@0.11.4:
-    resolution: {integrity: sha512-LzZWJcOBIcHslQ46N3SUu/760iLPSrUtp8omM4gh9du438V2CQdks8TcOu1yvmu2C68nVOBnl1WFiKGPbQ8L6g==}
+  /focus-lock@0.11.6:
+    resolution: {integrity: sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==}
     engines: {node: '>=10'}
     dependencies:
       tslib: 2.5.0
@@ -2526,7 +3730,7 @@ packages:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.0
     dev: false
@@ -2548,15 +3752,14 @@ packages:
 
   /function-bind@1.1.1:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
-    dev: false
 
   /function.prototype.name@1.1.5:
     resolution: {integrity: sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.5
+      define-properties: 1.2.0
+      es-abstract: 1.21.2
       functions-have-names: 1.2.3
     dev: false
 
@@ -2564,8 +3767,18 @@ packages:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
     dev: false
 
-  /get-intrinsic@1.1.3:
-    resolution: {integrity: sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==}
+  /gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+    dev: true
+
+  /get-intrinsic@1.2.0:
+    resolution: {integrity: sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==}
     dependencies:
       function-bind: 1.1.1
       has: 1.0.3
@@ -2576,6 +3789,11 @@ packages:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
 
+  /get-package-type@0.1.0:
+    resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
+    engines: {node: '>=8.0.0'}
+    dev: true
+
   /get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -2585,11 +3803,11 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
     dev: false
 
-  /get-tsconfig@4.4.0:
-    resolution: {integrity: sha512-0Gdjo/9+FzsYhXCEFueo2aY1z1tpXrxWZzP7k8ul9qt1U5o8rYJwTJYmaeHdrVosYIVYkOy2iwCJ9FdpocJhPQ==}
+  /get-tsconfig@4.5.0:
+    resolution: {integrity: sha512-MjhiaIWCJ1sAU4pIQ5i5OfOuHHxVo1oYeNsWTON7jxYkod8pHocXeh+SSbmu5OZZZK73B6cbJ2XADzXehLyovQ==}
     dev: false
 
   /glob-parent@5.1.2:
@@ -2647,14 +3865,22 @@ packages:
       once: 1.4.0
     dev: false
 
-  /globals@13.19.0:
-    resolution: {integrity: sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==}
+  /globals@11.12.0:
+    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /globals@13.20.0:
+    resolution: {integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
 
-  /globalyzer@0.1.0:
-    resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
+  /globalthis@1.0.3:
+    resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-properties: 1.2.0
     dev: false
 
   /globby@11.1.0:
@@ -2664,34 +3890,29 @@ packages:
       array-union: 2.1.0
       dir-glob: 3.0.1
       fast-glob: 3.2.12
-      ignore: 5.2.1
+      ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
 
-  /globby@13.1.3:
-    resolution: {integrity: sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==}
+  /globby@13.1.4:
+    resolution: {integrity: sha512-iui/IiiW+QrJ1X1hKH5qwlMQyv34wJAYwH1vrf8b9kBA4sNiif3gKsMHa+BrdnOpEudWjpotfa7LrTzB1ERS/g==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       dir-glob: 3.0.1
       fast-glob: 3.2.12
-      ignore: 5.2.1
+      ignore: 5.2.4
       merge2: 1.4.1
       slash: 4.0.0
-    dev: false
-
-  /globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
     dev: false
 
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
     dev: false
 
-  /graceful-fs@4.2.10:
-    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
-    dev: false
+  /graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   /grafbase@0.1.0:
     resolution: {integrity: sha512-R5QSAyI2VtUQFG8njRS0a+fe8DTXMVUDXxrelR18NcBc11yx56clI8oYr1wTkqdPJAZ6BxF67SCSEBpgwjm57A==}
@@ -2709,7 +3930,7 @@ packages:
     dependencies:
       '@graphiql/react': 0.15.0(@codemirror/language@6.0.0)(@types/react@18.0.28)(graphql@16.6.0)(react-dom@18.2.0)(react-is@17.0.2)(react@18.2.0)
       '@graphiql/toolkit': 0.8.0(graphql@16.6.0)
-      entities: 2.1.0
+      entities: 2.2.0
       graphql: 16.6.0
       graphql-language-service: 5.1.4(graphql@16.6.0)
       markdown-it: 12.3.2
@@ -2731,7 +3952,7 @@ packages:
     dependencies:
       graphql: 16.6.0
       nullthrows: 1.1.1
-      vscode-languageserver-types: 3.17.2
+      vscode-languageserver-types: 3.17.3
 
   /graphql-tag@2.12.6(graphql@16.6.0):
     resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
@@ -2756,6 +3977,10 @@ packages:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
     dev: false
 
+  /has-flag@3.0.0:
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
+
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -2763,7 +3988,12 @@ packages:
   /has-property-descriptors@1.0.0:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
     dependencies:
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
+    dev: false
+
+  /has-proto@1.0.1:
+    resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==}
+    engines: {node: '>= 0.4'}
     dev: false
 
   /has-symbols@1.0.3:
@@ -2783,7 +4013,6 @@ packages:
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
-    dev: false
 
   /hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
@@ -2795,42 +4024,54 @@ packages:
     resolution: {integrity: sha512-5V3VQ/SPixO6gnPXKx1I69PPQc5Bqf5cq6R/FVRFMiK4I2OVsQtect37VveO+6bqs7jElhxfJXKoiRCJh3ALcQ==}
     hasBin: true
     dependencies:
-      '@babel/parser': 7.20.13
-      '@graphql-tools/schema': 9.0.16(graphql@15.8.0)
+      '@babel/parser': 7.21.8
+      '@graphql-tools/schema': 9.0.19(graphql@15.8.0)
       '@kitql/helper': 0.5.0
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.1
       '@types/fs-extra': 9.0.13
       '@types/micromatch': 4.0.2
-      '@types/prompts': 2.4.2
+      '@types/prompts': 2.4.4
       ast-types: 0.16.1
       commander: 9.5.0
-      deepmerge: 4.2.2
+      deepmerge: 4.3.1
       estree-walker: 3.0.3
       fs-extra: 10.1.0
       glob: 8.1.0
       graphql: 15.8.0
-      memfs: 3.4.13
+      memfs: 3.5.1
       micromatch: 4.0.5
       minimatch: 5.1.6
-      node-fetch: 3.3.0
+      node-fetch: 3.3.1
       npx-import: 1.1.4
       prompts: 2.4.2
       recast: 0.23.1
-      vite-plugin-watch-and-run: 1.1.1
+      vite-plugin-watch-and-run: 1.1.2
     dev: false
+
+  /html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+    dev: true
 
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
-    dev: true
 
   /human-signals@3.0.1:
     resolution: {integrity: sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==}
     engines: {node: '>=12.20.0'}
     dev: false
 
-  /ignore@5.2.1:
-    resolution: {integrity: sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==}
+  /human-signals@4.3.1:
+    resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
+    engines: {node: '>=14.18.0'}
+    dev: false
+
+  /ignore-by-default@1.0.1:
+    resolution: {integrity: sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==}
+    dev: true
+
+  /ignore@5.2.4:
+    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
     engines: {node: '>= 4'}
 
   /import-fresh@3.3.0:
@@ -2839,6 +4080,15 @@ packages:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+
+  /import-local@3.1.0:
+    resolution: {integrity: sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      pkg-dir: 4.2.0
+      resolve-cwd: 3.0.0
+    dev: true
 
   /imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -2853,11 +4103,11 @@ packages:
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  /internal-slot@1.0.4:
-    resolution: {integrity: sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==}
+  /internal-slot@1.0.5:
+    resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       has: 1.0.3
       side-channel: 1.0.4
     dev: false
@@ -2874,6 +4124,18 @@ packages:
       call-bind: 1.0.2
       has-tostringtag: 1.0.0
     dev: false
+
+  /is-array-buffer@3.0.2:
+    resolution: {integrity: sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.2.0
+      is-typed-array: 1.1.10
+    dev: false
+
+  /is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+    dev: true
 
   /is-bigint@1.0.4:
     resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
@@ -2901,11 +4163,10 @@ packages:
     engines: {node: '>= 0.4'}
     dev: false
 
-  /is-core-module@2.11.0:
-    resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
+  /is-core-module@2.12.0:
+    resolution: {integrity: sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==}
     dependencies:
       has: 1.0.3
-    dev: false
 
   /is-date-object@1.0.5:
     resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
@@ -2920,9 +4181,25 @@ packages:
     hasBin: true
     dev: false
 
+  /is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+    dev: false
+
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+
+  /is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /is-generator-fn@2.1.0:
+    resolution: {integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==}
+    engines: {node: '>=6'}
+    dev: true
 
   /is-generator-function@1.0.10:
     resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
@@ -2937,12 +4214,24 @@ packages:
     dependencies:
       is-extglob: 2.1.1
 
+  /is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+    dependencies:
+      is-docker: 3.0.0
+    dev: false
+
+  /is-map@2.0.2:
+    resolution: {integrity: sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==}
+    dev: false
+
   /is-nan@1.3.2:
     resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
+      define-properties: 1.2.0
     dev: false
 
   /is-negative-zero@2.0.2:
@@ -2983,6 +4272,10 @@ packages:
       has-tostringtag: 1.0.0
     dev: false
 
+  /is-set@2.0.2:
+    resolution: {integrity: sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==}
+    dev: false
+
   /is-shared-array-buffer@1.0.2:
     resolution: {integrity: sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==}
     dependencies:
@@ -2992,7 +4285,6 @@ packages:
   /is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
-    dev: true
 
   /is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
@@ -3024,10 +4316,21 @@ packages:
       has-tostringtag: 1.0.0
     dev: false
 
+  /is-weakmap@2.0.1:
+    resolution: {integrity: sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==}
+    dev: false
+
   /is-weakref@1.0.2:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
     dependencies:
       call-bind: 1.0.2
+    dev: false
+
+  /is-weakset@2.0.2:
+    resolution: {integrity: sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.2.0
     dev: false
 
   /is-wsl@2.2.0:
@@ -3037,6 +4340,10 @@ packages:
       is-docker: 2.2.1
     dev: false
 
+  /isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+    dev: false
+
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -3044,16 +4351,480 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
 
+  /istanbul-lib-coverage@3.2.0:
+    resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /istanbul-lib-instrument@5.2.1:
+    resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@babel/core': 7.21.8
+      '@babel/parser': 7.21.8
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-coverage: 3.2.0
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /istanbul-lib-report@3.0.0:
+    resolution: {integrity: sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==}
+    engines: {node: '>=8'}
+    dependencies:
+      istanbul-lib-coverage: 3.2.0
+      make-dir: 3.1.0
+      supports-color: 7.2.0
+    dev: true
+
+  /istanbul-lib-source-maps@4.0.1:
+    resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
+    engines: {node: '>=10'}
+    dependencies:
+      debug: 4.3.4
+      istanbul-lib-coverage: 3.2.0
+      source-map: 0.6.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /istanbul-reports@3.1.5:
+    resolution: {integrity: sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==}
+    engines: {node: '>=8'}
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.0
+    dev: true
+
+  /jest-changed-files@29.5.0:
+    resolution: {integrity: sha512-IFG34IUMUaNBIxjQXF/iu7g6EcdMrGRRxaUSw92I/2g2YC6vCdTltl4nHvt7Ci5nSJwXIkCu8Ka1DKF+X7Z1Ag==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      execa: 5.1.1
+      p-limit: 3.1.0
+    dev: true
+
+  /jest-circus@29.5.0:
+    resolution: {integrity: sha512-gq/ongqeQKAplVxqJmbeUOJJKkW3dDNPY8PjhJ5G0lBRvu0e3EWGxGy5cI4LAGA7gV2UHCtWBI4EMXK8c9nQKA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/environment': 29.5.0
+      '@jest/expect': 29.5.0
+      '@jest/test-result': 29.5.0
+      '@jest/types': 29.5.0
+      '@types/node': 18.14.2
+      chalk: 4.1.2
+      co: 4.6.0
+      dedent: 0.7.0
+      is-generator-fn: 2.1.0
+      jest-each: 29.5.0
+      jest-matcher-utils: 29.5.0
+      jest-message-util: 29.5.0
+      jest-runtime: 29.5.0
+      jest-snapshot: 29.5.0
+      jest-util: 29.5.0
+      p-limit: 3.1.0
+      pretty-format: 29.5.0
+      pure-rand: 6.0.2
+      slash: 3.0.0
+      stack-utils: 2.0.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /jest-cli@29.5.0(@types/node@18.14.2)(ts-node@10.9.1):
+    resolution: {integrity: sha512-L1KcP1l4HtfwdxXNFCL5bmUbLQiKrakMUriBEcc1Vfz6gx31ORKdreuWvmQVBit+1ss9NNR3yxjwfwzZNdQXJw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 29.5.0(ts-node@10.9.1)
+      '@jest/test-result': 29.5.0
+      '@jest/types': 29.5.0
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      import-local: 3.1.0
+      jest-config: 29.5.0(@types/node@18.14.2)(ts-node@10.9.1)
+      jest-util: 29.5.0
+      jest-validate: 29.5.0
+      prompts: 2.4.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - ts-node
+    dev: true
+
+  /jest-config@29.5.0(@types/node@18.14.2)(ts-node@10.9.1):
+    resolution: {integrity: sha512-kvDUKBnNJPNBmFFOhDbm59iu1Fii1Q6SxyhXfvylq3UTHbg6o7j/g8k2dZyXWLvfdKB1vAPxNZnMgtKJcmu3kA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.21.8
+      '@jest/test-sequencer': 29.5.0
+      '@jest/types': 29.5.0
+      '@types/node': 18.14.2
+      babel-jest: 29.5.0(@babel/core@7.21.8)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.5.0
+      jest-environment-node: 29.5.0
+      jest-get-type: 29.4.3
+      jest-regex-util: 29.4.3
+      jest-resolve: 29.5.0
+      jest-runner: 29.5.0
+      jest-util: 29.5.0
+      jest-validate: 29.5.0
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 29.5.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+      ts-node: 10.9.1(@types/node@18.14.2)(typescript@5.0.2)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /jest-diff@29.5.0:
+    resolution: {integrity: sha512-LtxijLLZBduXnHSniy0WMdaHjmQnt3g5sa16W4p0HqukYTTsyTW3GD1q41TyGl5YFXj/5B2U6dlh5FM1LIMgxw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.4.3
+      jest-get-type: 29.4.3
+      pretty-format: 29.5.0
+    dev: true
+
+  /jest-docblock@29.4.3:
+    resolution: {integrity: sha512-fzdTftThczeSD9nZ3fzA/4KkHtnmllawWrXO69vtI+L9WjEIuXWs4AmyME7lN5hU7dB0sHhuPfcKofRsUb/2Fg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      detect-newline: 3.1.0
+    dev: true
+
+  /jest-each@29.5.0:
+    resolution: {integrity: sha512-HM5kIJ1BTnVt+DQZ2ALp3rzXEl+g726csObrW/jpEGl+CDSSQpOJJX2KE/vEg8cxcMXdyEPu6U4QX5eruQv5hA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.5.0
+      chalk: 4.1.2
+      jest-get-type: 29.4.3
+      jest-util: 29.5.0
+      pretty-format: 29.5.0
+    dev: true
+
+  /jest-environment-node@29.5.0:
+    resolution: {integrity: sha512-ExxuIK/+yQ+6PRGaHkKewYtg6hto2uGCgvKdb2nfJfKXgZ17DfXjvbZ+jA1Qt9A8EQSfPnt5FKIfnOO3u1h9qw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/environment': 29.5.0
+      '@jest/fake-timers': 29.5.0
+      '@jest/types': 29.5.0
+      '@types/node': 18.14.2
+      jest-mock: 29.5.0
+      jest-util: 29.5.0
+    dev: true
+
+  /jest-get-type@29.4.3:
+    resolution: {integrity: sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+
+  /jest-haste-map@29.5.0:
+    resolution: {integrity: sha512-IspOPnnBro8YfVYSw6yDRKh/TiCdRngjxeacCps1cQ9cgVN6+10JUcuJ1EabrgYLOATsIAigxA0rLR9x/YlrSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.5.0
+      '@types/graceful-fs': 4.1.6
+      '@types/node': 18.14.2
+      anymatch: 3.1.3
+      fb-watchman: 2.0.2
+      graceful-fs: 4.2.11
+      jest-regex-util: 29.4.3
+      jest-util: 29.5.0
+      jest-worker: 29.5.0
+      micromatch: 4.0.5
+      walker: 1.0.8
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /jest-leak-detector@29.5.0:
+    resolution: {integrity: sha512-u9YdeeVnghBUtpN5mVxjID7KbkKE1QU4f6uUwuxiY0vYRi9BUCLKlPEZfDGR67ofdFmDz9oPAy2G92Ujrntmow==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      jest-get-type: 29.4.3
+      pretty-format: 29.5.0
+    dev: true
+
+  /jest-matcher-utils@29.5.0:
+    resolution: {integrity: sha512-lecRtgm/rjIK0CQ7LPQwzCs2VwW6WAahA55YBuI+xqmhm7LAaxokSB8C97yJeYyT+HvQkH741StzpU41wohhWw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.5.0
+      jest-get-type: 29.4.3
+      pretty-format: 29.5.0
+    dev: true
+
+  /jest-message-util@29.5.0:
+    resolution: {integrity: sha512-Kijeg9Dag6CKtIDA7O21zNTACqD5MD/8HfIV8pdD94vFyFuer52SigdC3IQMhab3vACxXMiFk+yMHNdbqtyTGA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@babel/code-frame': 7.21.4
+      '@jest/types': 29.5.0
+      '@types/stack-utils': 2.0.1
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      micromatch: 4.0.5
+      pretty-format: 29.5.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+    dev: true
+
+  /jest-mock@29.5.0:
+    resolution: {integrity: sha512-GqOzvdWDE4fAV2bWQLQCkujxYWL7RxjCnj71b5VhDAGOevB3qj3Ovg26A5NI84ZpODxyzaozXLOh2NCgkbvyaw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.5.0
+      '@types/node': 18.14.2
+      jest-util: 29.5.0
+    dev: true
+
+  /jest-pnp-resolver@1.2.3(jest-resolve@29.5.0):
+    resolution: {integrity: sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==}
+    engines: {node: '>=6'}
+    peerDependencies:
+      jest-resolve: '*'
+    peerDependenciesMeta:
+      jest-resolve:
+        optional: true
+    dependencies:
+      jest-resolve: 29.5.0
+    dev: true
+
+  /jest-regex-util@29.4.3:
+    resolution: {integrity: sha512-O4FglZaMmWXbGHSQInfXewIsd1LMn9p3ZXB/6r4FOkyhX2/iP/soMG98jGvk/A3HAN78+5VWcBGO0BJAPRh4kg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+
+  /jest-resolve-dependencies@29.5.0:
+    resolution: {integrity: sha512-sjV3GFr0hDJMBpYeUuGduP+YeCRbd7S/ck6IvL3kQ9cpySYKqcqhdLLC2rFwrcL7tz5vYibomBrsFYWkIGGjOg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      jest-regex-util: 29.4.3
+      jest-snapshot: 29.5.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /jest-resolve@29.5.0:
+    resolution: {integrity: sha512-1TzxJ37FQq7J10jPtQjcc+MkCkE3GBpBecsSUWJ0qZNJpmg6m0D9/7II03yJulm3H/fvVjgqLh/k2eYg+ui52w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.5.0
+      jest-pnp-resolver: 1.2.3(jest-resolve@29.5.0)
+      jest-util: 29.5.0
+      jest-validate: 29.5.0
+      resolve: 1.22.2
+      resolve.exports: 2.0.2
+      slash: 3.0.0
+    dev: true
+
+  /jest-runner@29.5.0:
+    resolution: {integrity: sha512-m7b6ypERhFghJsslMLhydaXBiLf7+jXy8FwGRHO3BGV1mcQpPbwiqiKUR2zU2NJuNeMenJmlFZCsIqzJCTeGLQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/console': 29.5.0
+      '@jest/environment': 29.5.0
+      '@jest/test-result': 29.5.0
+      '@jest/transform': 29.5.0
+      '@jest/types': 29.5.0
+      '@types/node': 18.14.2
+      chalk: 4.1.2
+      emittery: 0.13.1
+      graceful-fs: 4.2.11
+      jest-docblock: 29.4.3
+      jest-environment-node: 29.5.0
+      jest-haste-map: 29.5.0
+      jest-leak-detector: 29.5.0
+      jest-message-util: 29.5.0
+      jest-resolve: 29.5.0
+      jest-runtime: 29.5.0
+      jest-util: 29.5.0
+      jest-watcher: 29.5.0
+      jest-worker: 29.5.0
+      p-limit: 3.1.0
+      source-map-support: 0.5.13
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /jest-runtime@29.5.0:
+    resolution: {integrity: sha512-1Hr6Hh7bAgXQP+pln3homOiEZtCDZFqwmle7Ew2j8OlbkIu6uE3Y/etJQG8MLQs3Zy90xrp2C0BRrtPHG4zryw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/environment': 29.5.0
+      '@jest/fake-timers': 29.5.0
+      '@jest/globals': 29.5.0
+      '@jest/source-map': 29.4.3
+      '@jest/test-result': 29.5.0
+      '@jest/transform': 29.5.0
+      '@jest/types': 29.5.0
+      '@types/node': 18.14.2
+      chalk: 4.1.2
+      cjs-module-lexer: 1.2.2
+      collect-v8-coverage: 1.0.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.5.0
+      jest-message-util: 29.5.0
+      jest-mock: 29.5.0
+      jest-regex-util: 29.4.3
+      jest-resolve: 29.5.0
+      jest-snapshot: 29.5.0
+      jest-util: 29.5.0
+      slash: 3.0.0
+      strip-bom: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /jest-snapshot@29.5.0:
+    resolution: {integrity: sha512-x7Wolra5V0tt3wRs3/ts3S6ciSQVypgGQlJpz2rsdQYoUKxMxPNaoHMGJN6qAuPJqS+2iQ1ZUn5kl7HCyls84g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@babel/core': 7.21.8
+      '@babel/generator': 7.21.5
+      '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.21.8)
+      '@babel/plugin-syntax-typescript': 7.21.4(@babel/core@7.21.8)
+      '@babel/traverse': 7.21.5
+      '@babel/types': 7.21.5
+      '@jest/expect-utils': 29.5.0
+      '@jest/transform': 29.5.0
+      '@jest/types': 29.5.0
+      '@types/babel__traverse': 7.18.5
+      '@types/prettier': 2.7.2
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.21.8)
+      chalk: 4.1.2
+      expect: 29.5.0
+      graceful-fs: 4.2.11
+      jest-diff: 29.5.0
+      jest-get-type: 29.4.3
+      jest-matcher-utils: 29.5.0
+      jest-message-util: 29.5.0
+      jest-util: 29.5.0
+      natural-compare: 1.4.0
+      pretty-format: 29.5.0
+      semver: 7.5.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /jest-util@29.5.0:
+    resolution: {integrity: sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.5.0
+      '@types/node': 18.14.2
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      graceful-fs: 4.2.11
+      picomatch: 2.3.1
+    dev: true
+
+  /jest-validate@29.5.0:
+    resolution: {integrity: sha512-pC26etNIi+y3HV8A+tUGr/lph9B18GnzSRAkPaaZJIE1eFdiYm6/CewuiJQ8/RlfHd1u/8Ioi8/sJ+CmbA+zAQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.5.0
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      jest-get-type: 29.4.3
+      leven: 3.1.0
+      pretty-format: 29.5.0
+    dev: true
+
+  /jest-watcher@29.5.0:
+    resolution: {integrity: sha512-KmTojKcapuqYrKDpRwfqcQ3zjMlwu27SYext9pt4GlF5FUgB+7XE1mcCnSm6a4uUpFyQIkb6ZhzZvHl+jiBCiA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/test-result': 29.5.0
+      '@jest/types': 29.5.0
+      '@types/node': 18.14.2
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      emittery: 0.13.1
+      jest-util: 29.5.0
+      string-length: 4.0.2
+    dev: true
+
+  /jest-worker@29.5.0:
+    resolution: {integrity: sha512-NcrQnevGoSp4b5kg+akIpthoAFHxPBcb5P6mYPY0fUNT+sSvmtu6jlkEle3anczUKIKEbMxFimk9oTP/tpIPgA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@types/node': 18.14.2
+      jest-util: 29.5.0
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+    dev: true
+
+  /jest@29.5.0(@types/node@18.14.2)(ts-node@10.9.1):
+    resolution: {integrity: sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 29.5.0(ts-node@10.9.1)
+      '@jest/types': 29.5.0
+      import-local: 3.1.0
+      jest-cli: 29.5.0(@types/node@18.14.2)(ts-node@10.9.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - ts-node
+    dev: true
+
   /joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
     dev: true
 
-  /js-sdsl@4.3.0:
-    resolution: {integrity: sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==}
+  /js-sdsl@4.4.0:
+    resolution: {integrity: sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==}
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  /js-yaml@3.14.1:
+    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+    hasBin: true
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+    dev: true
 
   /js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -3061,25 +4832,41 @@ packages:
     dependencies:
       argparse: 2.0.1
 
+  /jsesc@2.5.2:
+    resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
+    engines: {node: '>=4'}
+    hasBin: true
+    dev: true
+
+  /json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+    dev: true
+
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
-  /json5@1.0.1:
-    resolution: {integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==}
+  /json5@1.0.2:
+    resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
     dependencies:
-      minimist: 1.2.7
+      minimist: 1.2.8
     dev: false
+
+  /json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+    dev: true
 
   /jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
     dev: false
 
   /jsx-ast-utils@3.3.3:
@@ -3093,17 +4880,21 @@ packages:
   /kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
-    dev: false
 
   /language-subtag-registry@0.3.22:
     resolution: {integrity: sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==}
     dev: false
 
-  /language-tags@1.0.6:
-    resolution: {integrity: sha512-HNkaCgM8wZgE/BZACeotAAgpL9FUjEnhgF0FVQMIgH//zqTPreLYMb3rWYkYAqPoF75Jwuycp1da7uz66cfFQg==}
+  /language-tags@1.0.5:
+    resolution: {integrity: sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==}
     dependencies:
       language-subtag-registry: 0.3.22
     dev: false
+
+  /leven@3.1.0:
+    resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
+    engines: {node: '>=6'}
+    dev: true
 
   /levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -3112,8 +4903,8 @@ packages:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  /lilconfig@2.0.6:
-    resolution: {integrity: sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==}
+  /lilconfig@2.1.0:
+    resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
     dev: true
 
@@ -3126,9 +4917,16 @@ packages:
     dependencies:
       uc.micro: 1.0.6
 
-  /load-tsconfig@0.2.3:
-    resolution: {integrity: sha512-iyT2MXws+dc2Wi6o3grCFtGXpeMvHmJqS27sMPGtV2eUu4PeFnG+33I8BlFK1t1NWMjOpcx9bridn5yxLDX2gQ==}
+  /load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
+
+  /locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+    dependencies:
+      p-locate: 4.1.0
     dev: true
 
   /locate-path@6.0.0:
@@ -3136,6 +4934,10 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       p-locate: 5.0.0
+
+  /lodash.memoize@4.1.2:
+    resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
+    dev: true
 
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -3150,12 +4952,34 @@ packages:
     dependencies:
       js-tokens: 4.0.0
 
+  /lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+    dependencies:
+      yallist: 3.1.1
+    dev: true
+
   /lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
-    dev: false
+
+  /make-dir@3.1.0:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
+    engines: {node: '>=8'}
+    dependencies:
+      semver: 6.3.0
+    dev: true
+
+  /make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+    dev: true
+
+  /makeerror@1.0.12:
+    resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
+    dependencies:
+      tmpl: 1.0.5
+    dev: true
 
   /markdown-it@12.3.2:
     resolution: {integrity: sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==}
@@ -3170,8 +4994,8 @@ packages:
   /mdurl@1.0.1:
     resolution: {integrity: sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==}
 
-  /memfs@3.4.13:
-    resolution: {integrity: sha512-omTM41g3Skpvx5dSYeZIbXKcXoAVc/AoMNwn9TKx++L/gaen/+4TTttmu8ZSch5vfVJ8uJvGbroTsIlslRg6lg==}
+  /memfs@3.5.1:
+    resolution: {integrity: sha512-UWbFJKvj5k+nETdteFndTpYxdeTMox/ULeqX5k/dpaQJCCFmj5EeKv3dBcyO2xmkRAx2vppRu5dVG7SOtsGOzA==}
     engines: {node: '>= 4.0.0'}
     dependencies:
       fs-monkey: 1.0.3
@@ -3203,7 +5027,6 @@ packages:
   /mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
-    dev: true
 
   /mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
@@ -3222,12 +5045,8 @@ packages:
       brace-expansion: 2.0.1
     dev: false
 
-  /minimist@1.2.7:
-    resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
-    dev: false
-
-  /ms@2.0.0:
-    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+  /minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: false
 
   /ms@2.1.2:
@@ -3235,7 +5054,6 @@ packages:
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-    dev: false
 
   /mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -3245,17 +5063,21 @@ packages:
       thenify-all: 1.6.0
     dev: true
 
-  /nanoid@3.3.4:
-    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
+  /nanoid@3.3.6:
+    resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+    dev: true
+
+  /natural-compare-lite@1.4.0:
+    resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
     dev: true
 
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  /next@13.0.6(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-COvigvms2LRt1rrzfBQcMQ2GZd86Mvk1z+LOLY5pniFtL4VrTmhZ9salrbKfSiXbhsD01TrDdD68ec3ABDyscA==}
+  /next@13.0.2(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-uQ5z5e4D9mOe8+upy6bQdYYjo/kk1v3jMW87kTy2TgAyAsEO+CkwRnMgyZ4JoHEnhPZLHwh7dk0XymRNLe1gFw==}
     engines: {node: '>=14.6.0'}
     hasBin: true
     peerDependencies:
@@ -3272,27 +5094,28 @@ packages:
       sass:
         optional: true
     dependencies:
-      '@next/env': 13.0.6
-      '@swc/helpers': 0.4.14
-      caniuse-lite: 1.0.30001439
+      '@next/env': 13.0.2
+      '@swc/helpers': 0.4.11
+      caniuse-lite: 1.0.30001482
       postcss: 8.4.14
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       styled-jsx: 5.1.0(react@18.2.0)
+      use-sync-external-store: 1.2.0(react@18.2.0)
     optionalDependencies:
-      '@next/swc-android-arm-eabi': 13.0.6
-      '@next/swc-android-arm64': 13.0.6
-      '@next/swc-darwin-arm64': 13.0.6
-      '@next/swc-darwin-x64': 13.0.6
-      '@next/swc-freebsd-x64': 13.0.6
-      '@next/swc-linux-arm-gnueabihf': 13.0.6
-      '@next/swc-linux-arm64-gnu': 13.0.6
-      '@next/swc-linux-arm64-musl': 13.0.6
-      '@next/swc-linux-x64-gnu': 13.0.6
-      '@next/swc-linux-x64-musl': 13.0.6
-      '@next/swc-win32-arm64-msvc': 13.0.6
-      '@next/swc-win32-ia32-msvc': 13.0.6
-      '@next/swc-win32-x64-msvc': 13.0.6
+      '@next/swc-android-arm-eabi': 13.0.2
+      '@next/swc-android-arm64': 13.0.2
+      '@next/swc-darwin-arm64': 13.0.2
+      '@next/swc-darwin-x64': 13.0.2
+      '@next/swc-freebsd-x64': 13.0.2
+      '@next/swc-linux-arm-gnueabihf': 13.0.2
+      '@next/swc-linux-arm64-gnu': 13.0.2
+      '@next/swc-linux-arm64-musl': 13.0.2
+      '@next/swc-linux-x64-gnu': 13.0.2
+      '@next/swc-linux-x64-musl': 13.0.2
+      '@next/swc-win32-arm64-msvc': 13.0.2
+      '@next/swc-win32-ia32-msvc': 13.0.2
+      '@next/swc-win32-x64-msvc': 13.0.2
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -3303,14 +5126,46 @@ packages:
     engines: {node: '>=10.5.0'}
     dev: false
 
-  /node-fetch@3.3.0:
-    resolution: {integrity: sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==}
+  /node-fetch@3.3.1:
+    resolution: {integrity: sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
     dev: false
+
+  /node-int64@0.4.0:
+    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
+    dev: true
+
+  /node-releases@2.0.10:
+    resolution: {integrity: sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==}
+    dev: true
+
+  /nodemon@2.0.22:
+    resolution: {integrity: sha512-B8YqaKMmyuCO7BowF1Z1/mkPqLk6cs/l63Ojtd6otKjMx47Dq1utxfRxcavH1I7VSaL8n5BUaoutadnsX3AAVQ==}
+    engines: {node: '>=8.10.0'}
+    hasBin: true
+    dependencies:
+      chokidar: 3.5.3
+      debug: 3.2.7(supports-color@5.5.0)
+      ignore-by-default: 1.0.1
+      minimatch: 3.1.2
+      pstree.remy: 1.1.8
+      semver: 5.7.1
+      simple-update-notifier: 1.1.0
+      supports-color: 5.5.0
+      touch: 3.1.0
+      undefsafe: 2.0.5
+    dev: true
+
+  /nopt@1.0.10:
+    resolution: {integrity: sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==}
+    hasBin: true
+    dependencies:
+      abbrev: 1.1.1
+    dev: true
 
   /normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -3322,7 +5177,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       path-key: 3.1.1
-    dev: true
 
   /npm-run-path@5.1.0:
     resolution: {integrity: sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==}
@@ -3331,12 +5185,20 @@ packages:
       path-key: 4.0.0
     dev: false
 
+  /npm-watch@0.11.0:
+    resolution: {integrity: sha512-wAOd0moNX2kSA2FNvt8+7ORwYaJpQ1ZoWjUYdb1bBCxq4nkWuU0IiJa9VpVxrj5Ks+FGXQd62OC/Bjk0aSr+dg==}
+    hasBin: true
+    dependencies:
+      nodemon: 2.0.22
+      through2: 4.0.2
+    dev: true
+
   /npx-import@1.1.4:
     resolution: {integrity: sha512-3ShymTWOgqGyNlh5lMJAejLuIv3W1K3fbI5Ewc6YErZU3Sp0PqsNs8UIU1O8z5+KVl/Du5ag56Gza9vdorGEoA==}
     dependencies:
       execa: 6.1.0
       parse-package-name: 1.0.0
-      semver: 7.3.8
+      semver: 7.5.0
       validate-npm-package-name: 4.0.0
     dev: false
 
@@ -3347,8 +5209,8 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
-  /object-inspect@1.12.2:
-    resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
+  /object-inspect@1.12.3:
+    resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
     dev: false
 
   /object-is@1.1.5:
@@ -3356,7 +5218,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
+      define-properties: 1.2.0
     dev: false
 
   /object-keys@1.1.1:
@@ -3369,7 +5231,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
+      define-properties: 1.2.0
       has-symbols: 1.0.3
       object-keys: 1.1.1
     dev: false
@@ -3379,8 +5241,8 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.5
+      define-properties: 1.2.0
+      es-abstract: 1.21.2
     dev: false
 
   /object.fromentries@2.0.6:
@@ -3388,15 +5250,15 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.5
+      define-properties: 1.2.0
+      es-abstract: 1.21.2
     dev: false
 
   /object.hasown@1.1.2:
     resolution: {integrity: sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==}
     dependencies:
-      define-properties: 1.1.4
-      es-abstract: 1.20.5
+      define-properties: 1.2.0
+      es-abstract: 1.21.2
     dev: false
 
   /object.values@1.1.6:
@@ -3404,8 +5266,8 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.5
+      define-properties: 1.2.0
+      es-abstract: 1.21.2
     dev: false
 
   /once@1.4.0:
@@ -3418,7 +5280,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       mimic-fn: 2.1.0
-    dev: true
 
   /onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
@@ -3427,19 +5288,20 @@ packages:
       mimic-fn: 4.0.0
     dev: false
 
-  /open@8.4.0:
-    resolution: {integrity: sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==}
-    engines: {node: '>=12'}
+  /open@9.1.0:
+    resolution: {integrity: sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==}
+    engines: {node: '>=14.16'}
     dependencies:
-      define-lazy-prop: 2.0.0
-      is-docker: 2.2.1
+      default-browser: 4.0.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
       is-wsl: 2.2.0
     dev: false
 
   /optimism@0.16.2:
     resolution: {integrity: sha512-zWNbgWj+3vLEjZNIh/okkY2EUfX+vB9TJopzIZwT1xxaMqC5hRLLraePod4c5n4He08xuXNH+zhKFFCu390wiQ==}
     dependencies:
-      '@wry/context': 0.7.0
+      '@wry/context': 0.7.2
       '@wry/trie': 0.3.2
     dev: false
 
@@ -3454,11 +5316,25 @@ packages:
       type-check: 0.4.0
       word-wrap: 1.2.3
 
+  /p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+    dependencies:
+      p-try: 2.2.0
+    dev: true
+
   /p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
     dependencies:
       yocto-queue: 0.1.0
+
+  /p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+    dependencies:
+      p-limit: 2.3.0
+    dev: true
 
   /p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -3466,11 +5342,26 @@ packages:
     dependencies:
       p-limit: 3.1.0
 
+  /p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+    dev: true
+
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
+
+  /parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@babel/code-frame': 7.21.4
+      error-ex: 1.3.2
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+    dev: true
 
   /parse-package-name@1.0.0:
     resolution: {integrity: sha512-kBeTUtcj+SkyfaW4+KBe0HtsloBJ/mKTPoxpVdA57GZiPerREsUWJOhVj9anXweFiJkm5y8FG1sxFZkZ0SN6wg==}
@@ -3495,7 +5386,6 @@ packages:
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-    dev: false
 
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -3513,7 +5403,14 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
-  /postcss-load-config@3.1.4(postcss@8.4.21):
+  /pkg-dir@4.2.0:
+    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      find-up: 4.1.0
+    dev: true
+
+  /postcss-load-config@3.1.4(postcss@8.4.19):
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
     peerDependencies:
@@ -3525,24 +5422,24 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      lilconfig: 2.0.6
-      postcss: 8.4.21
+      lilconfig: 2.1.0
+      postcss: 8.4.19
       yaml: 1.10.2
     dev: true
 
-  /postcss-nesting@11.2.2(postcss@8.4.21):
+  /postcss-nesting@11.2.2(postcss@8.4.19):
     resolution: {integrity: sha512-aOTiUniAB1bcPE6GGiynWRa6PZFPhOTAm5q3q5cem6QeSijIHHkWr6gs65ukCZMXeak8yXeZVbBJET3VM+HlhA==}
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      '@csstools/selector-specificity': 2.1.0(postcss-selector-parser@6.0.11)(postcss@8.4.21)
-      postcss: 8.4.21
-      postcss-selector-parser: 6.0.11
+      '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.0.12)
+      postcss: 8.4.19
+      postcss-selector-parser: 6.0.12
     dev: true
 
-  /postcss-selector-parser@6.0.11:
-    resolution: {integrity: sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==}
+  /postcss-selector-parser@6.0.12:
+    resolution: {integrity: sha512-NdxGCAZdRrwVI1sy59+Wzrh+pMMHxapGnpfenDVlMEXoOcvt4pGE0JLK9YY2F5dLxcFYA/YbVQKhcGU+FtSYQg==}
     engines: {node: '>=4'}
     dependencies:
       cssesc: 3.0.0
@@ -3553,16 +5450,16 @@ packages:
     resolution: {integrity: sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.4
+      nanoid: 3.3.6
       picocolors: 1.0.0
       source-map-js: 1.0.2
     dev: true
 
-  /postcss@8.4.21:
-    resolution: {integrity: sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==}
+  /postcss@8.4.19:
+    resolution: {integrity: sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.4
+      nanoid: 3.3.6
       picocolors: 1.0.0
       source-map-js: 1.0.2
     dev: true
@@ -3577,13 +5474,21 @@ packages:
     hasBin: true
     dev: true
 
+  /pretty-format@29.5.0:
+    resolution: {integrity: sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.4.3
+      ansi-styles: 5.2.0
+      react-is: 18.2.0
+    dev: true
+
   /prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
-    dev: false
 
   /prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -3592,9 +5497,17 @@ packages:
       object-assign: 4.1.1
       react-is: 16.13.1
 
-  /punycode@2.1.1:
-    resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
+  /pstree.remy@1.1.8:
+    resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
+    dev: true
+
+  /punycode@2.3.0:
+    resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
+
+  /pure-rand@6.0.2:
+    resolution: {integrity: sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==}
+    dev: true
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -3604,7 +5517,7 @@ packages:
     peerDependencies:
       react: ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.21.5
       react: 18.2.0
 
   /react-dom@18.2.0(react@18.2.0):
@@ -3616,8 +5529,8 @@ packages:
       react: 18.2.0
       scheduler: 0.23.0
 
-  /react-focus-lock@2.9.2(@types/react@18.0.28)(react@18.2.0):
-    resolution: {integrity: sha512-5JfrsOKyA5Zn3h958mk7bAcfphr24jPoMoznJ8vaJF6fUrPQ8zrtEd3ILLOK8P5jvGxdMd96OxWNjDzATfR2qw==}
+  /react-focus-lock@2.9.4(@types/react@18.0.28)(react@18.2.0):
+    resolution: {integrity: sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3625,9 +5538,9 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.21.5
       '@types/react': 18.0.28
-      focus-lock: 0.11.4
+      focus-lock: 0.11.6
       prop-types: 15.8.1
       react: 18.2.0
       react-clientside-effect: 1.2.6(react@18.2.0)
@@ -3639,6 +5552,10 @@ packages:
 
   /react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  /react-is@18.2.0:
+    resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
+    dev: true
 
   /react-remove-scroll-bar@2.3.4(@types/react@18.0.28)(react@18.2.0):
     resolution: {integrity: sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==}
@@ -3655,8 +5572,8 @@ packages:
       react-style-singleton: 2.2.1(@types/react@18.0.28)(react@18.2.0)
       tslib: 2.5.0
 
-  /react-remove-scroll@2.5.5(@types/react@18.0.28)(react@18.2.0):
-    resolution: {integrity: sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==}
+  /react-remove-scroll@2.5.6(@types/react@18.0.28)(react@18.2.0):
+    resolution: {integrity: sha512-bO856ad1uDYLefgArk559IzUNeQ6SWH4QnrevIUjH+GczV56giDfl3h0Idptf2oIKxQmd1p9BN25jleKodTALg==}
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3695,6 +5612,15 @@ packages:
     dependencies:
       loose-envify: 1.4.0
 
+  /readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+    dev: true
+
   /readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -3721,18 +5647,30 @@ packages:
   /regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
-  /regexp.prototype.flags@1.4.3:
-    resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==}
+  /regexp.prototype.flags@1.5.0:
+    resolution: {integrity: sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
+      define-properties: 1.2.0
       functions-have-names: 1.2.3
     dev: false
 
   /regexpp@3.2.0:
     resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
     engines: {node: '>=8'}
+
+  /require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /resolve-cwd@3.0.0:
+    resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
+    engines: {node: '>=8'}
+    dependencies:
+      resolve-from: 5.0.0
+    dev: true
 
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3743,20 +5681,24 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /resolve@1.22.1:
-    resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
+  /resolve.exports@2.0.2:
+    resolution: {integrity: sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /resolve@1.22.2:
+    resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
     hasBin: true
     dependencies:
-      is-core-module: 2.11.0
+      is-core-module: 2.12.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-    dev: false
 
   /resolve@2.0.0-next.4:
     resolution: {integrity: sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==}
     hasBin: true
     dependencies:
-      is-core-module: 2.11.0
+      is-core-module: 2.12.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: false
@@ -3776,29 +5718,40 @@ packages:
     dependencies:
       glob: 7.2.3
 
-  /rollup@3.7.4:
-    resolution: {integrity: sha512-jN9rx3k5pfg9H9al0r0y1EYKSeiRANZRYX32SuNXAnKzh6cVyf4LZVto1KAuDnbHT03E1CpsgqDKaqQ8FZtgxw==}
+  /rollup@3.21.5:
+    resolution: {integrity: sha512-a4NTKS4u9PusbUJcfF4IMxuqjFzjm6ifj76P54a7cKnvVzJaG12BLVR+hgU2YDGHzyMMQNxLAZWuALsn8q2oQg==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
 
+  /run-applescript@5.0.0:
+    resolution: {integrity: sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==}
+    engines: {node: '>=12'}
+    dependencies:
+      execa: 5.1.1
+    dev: false
+
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
 
+  /safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: true
+
   /safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.3
+      get-intrinsic: 1.2.0
       is-regex: 1.1.4
     dev: false
 
-  /safe-stable-stringify@2.4.2:
-    resolution: {integrity: sha512-gMxvPJYhP0O9n2pvcfYfIuYgbledAOJFcqRThtPRmjscaipiwcwPPKLytpVzMkG2HAN87Qmo2d4PtGiri1dSLA==}
+  /safe-stable-stringify@2.4.3:
+    resolution: {integrity: sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==}
     engines: {node: '>=10'}
     dev: false
 
@@ -3807,18 +5760,26 @@ packages:
     dependencies:
       loose-envify: 1.4.0
 
+  /semver@5.7.1:
+    resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
+    hasBin: true
+    dev: true
+
   /semver@6.3.0:
     resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
     hasBin: true
-    dev: false
 
-  /semver@7.3.8:
-    resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
+  /semver@7.0.0:
+    resolution: {integrity: sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==}
+    hasBin: true
+    dev: true
+
+  /semver@7.5.0:
+    resolution: {integrity: sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-    dev: false
 
   /set-value@4.1.0:
     resolution: {integrity: sha512-zTEg4HL0RwVrqcWs3ztF+x1vkxfm0lP+MQQFPiMJTKVceBwEV0A569Ou8l9IYQG8jOZdMVI1hGsc0tmeD2o/Lw==}
@@ -3841,16 +5802,22 @@ packages:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.3
-      object-inspect: 1.12.2
+      get-intrinsic: 1.2.0
+      object-inspect: 1.12.3
     dev: false
 
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
+  /simple-update-notifier@1.1.0:
+    resolution: {integrity: sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==}
+    engines: {node: '>=8.10.0'}
+    dependencies:
+      semver: 7.0.0
+    dev: true
+
   /sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
-    dev: false
 
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -3866,10 +5833,16 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /source-map-support@0.5.13:
+    resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+    dev: true
+
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
@@ -3878,34 +5851,84 @@ packages:
       whatwg-url: 7.1.0
     dev: true
 
+  /sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+    dev: true
+
+  /stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      escape-string-regexp: 2.0.0
+    dev: true
+
+  /stop-iteration-iterator@1.0.0:
+    resolution: {integrity: sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      internal-slot: 1.0.5
+    dev: false
+
+  /string-length@4.0.2:
+    resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      char-regex: 1.0.2
+      strip-ansi: 6.0.1
+    dev: true
+
+  /string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+    dev: true
+
   /string.prototype.matchall@4.0.8:
     resolution: {integrity: sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.5
-      get-intrinsic: 1.1.3
+      define-properties: 1.2.0
+      es-abstract: 1.21.2
+      get-intrinsic: 1.2.0
       has-symbols: 1.0.3
-      internal-slot: 1.0.4
-      regexp.prototype.flags: 1.4.3
+      internal-slot: 1.0.5
+      regexp.prototype.flags: 1.5.0
       side-channel: 1.0.4
+    dev: false
+
+  /string.prototype.trim@1.2.7:
+    resolution: {integrity: sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      es-abstract: 1.21.2
     dev: false
 
   /string.prototype.trimend@1.0.6:
     resolution: {integrity: sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.5
+      define-properties: 1.2.0
+      es-abstract: 1.21.2
     dev: false
 
   /string.prototype.trimstart@1.0.6:
     resolution: {integrity: sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.5
+      define-properties: 1.2.0
+      es-abstract: 1.21.2
     dev: false
+
+  /string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: true
 
   /strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -3918,10 +5941,14 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
+  /strip-bom@4.0.0:
+    resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
+    engines: {node: '>=8'}
+    dev: true
+
   /strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
-    dev: true
 
   /strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
@@ -3952,11 +5979,12 @@ packages:
       react: 18.2.0
     dev: true
 
-  /sucrase@3.29.0:
-    resolution: {integrity: sha512-bZPAuGA5SdFHuzqIhTAqt9fvNEo9rESqXIG3oiKdF8K4UmkQxC4KlNL3lVyAErXp+mPvUqZ5l13qx6TrDIGf3A==}
+  /sucrase@3.32.0:
+    resolution: {integrity: sha512-ydQOU34rpSyj2TGyz4D2p8rbktIOZ8QY9s+DGLvFU1i5pWJE8vkpruCjGCMHsdXwnD7JDcS+noSwM/a7zyNFDQ==}
     engines: {node: '>=8'}
     hasBin: true
     dependencies:
+      '@jridgewell/gen-mapping': 0.3.3
       commander: 4.1.1
       glob: 7.1.6
       lines-and-columns: 1.2.4
@@ -3965,16 +5993,28 @@ packages:
       ts-interface-checker: 0.1.13
     dev: true
 
+  /supports-color@5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
+    dependencies:
+      has-flag: 3.0.0
+
   /supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
 
+  /supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      has-flag: 4.0.0
+    dev: true
+
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-    dev: false
 
   /symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
@@ -3985,7 +6025,7 @@ packages:
     resolution: {integrity: sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==}
     engines: {node: ^14.18.0 || >=16.0.0}
     dependencies:
-      '@pkgr/utils': 2.3.1
+      '@pkgr/utils': 2.4.0
       tslib: 2.5.0
     dev: false
 
@@ -3996,6 +6036,15 @@ packages:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
     dev: false
+
+  /test-exclude@6.0.0:
+    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 7.2.3
+      minimatch: 3.1.2
+    dev: true
 
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -4013,20 +6062,27 @@ packages:
       any-promise: 1.3.0
     dev: true
 
-  /tiny-glob@0.2.9:
-    resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
+  /through2@4.0.2:
+    resolution: {integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==}
     dependencies:
-      globalyzer: 0.1.0
-      globrex: 0.1.2
-    dev: false
+      readable-stream: 3.6.2
+    dev: true
 
   /tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
+  /titleize@3.0.0:
+    resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /tmpl@1.0.5:
+    resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
+    dev: true
+
   /to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
-    dev: false
 
   /to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -4037,10 +6093,17 @@ packages:
   /toggle-selection@1.0.6:
     resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
 
+  /touch@3.1.0:
+    resolution: {integrity: sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==}
+    hasBin: true
+    dependencies:
+      nopt: 1.0.10
+    dev: true
+
   /tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
     dependencies:
-      punycode: 2.1.1
+      punycode: 2.3.0
     dev: true
 
   /tree-kill@1.2.2:
@@ -4059,18 +6122,82 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /tsconfig-paths@3.14.1:
-    resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
+  /ts-jest@29.1.0(@babel/core@7.21.8)(jest@29.5.0)(typescript@5.0.2):
+    resolution: {integrity: sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
+      esbuild: '*'
+      jest: ^29.0.0
+      typescript: '>=4.3 <6'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@babel/core': 7.21.8
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.5.0(@types/node@18.14.2)(ts-node@10.9.1)
+      jest-util: 29.5.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.5.0
+      typescript: 5.0.2
+      yargs-parser: 21.1.1
+    dev: true
+
+  /ts-node@10.9.1(@types/node@18.14.2)(typescript@5.0.2):
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.3
+      '@types/node': 18.14.2
+      acorn: 8.8.2
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.0.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
+  /tsconfig-paths@3.14.2:
+    resolution: {integrity: sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==}
     dependencies:
       '@types/json5': 0.0.29
-      json5: 1.0.1
-      minimist: 1.2.7
+      json5: 1.0.2
+      minimist: 1.2.8
       strip-bom: 3.0.0
     dev: false
 
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
-    dev: false
 
   /tslib@2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
@@ -4099,11 +6226,11 @@ packages:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 3.1.4(postcss@8.4.21)
+      postcss-load-config: 3.1.4(postcss@8.4.19)
       resolve-from: 5.0.0
-      rollup: 3.7.4
+      rollup: 3.21.5
       source-map: 0.8.0-beta.0
-      sucrase: 3.29.0
+      sucrase: 3.32.0
       tree-kill: 1.2.2
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -4111,7 +6238,7 @@ packages:
       - ts-node
     dev: true
 
-  /tsup@6.6.3(postcss@8.4.21)(typescript@5.0.4):
+  /tsup@6.6.3(postcss@8.4.19)(typescript@5.0.4):
     resolution: {integrity: sha512-OLx/jFllYlVeZQ7sCHBuRVEQBBa1tFbouoc/gbYakyipjVQdWy/iQOvmExUA/ewap9iQ7tbJf9pW0PgcEFfJcQ==}
     engines: {node: '>=14.18'}
     hasBin: true
@@ -4127,25 +6254,35 @@ packages:
       typescript:
         optional: true
     dependencies:
-      bundle-require: 4.0.1(esbuild@0.17.10)
+      bundle-require: 4.0.1(esbuild@0.17.18)
       cac: 6.7.14
       chokidar: 3.5.3
       debug: 4.3.4
-      esbuild: 0.17.10
+      esbuild: 0.17.18
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss: 8.4.21
-      postcss-load-config: 3.1.4(postcss@8.4.21)
+      postcss: 8.4.19
+      postcss-load-config: 3.1.4(postcss@8.4.19)
       resolve-from: 5.0.0
-      rollup: 3.7.4
+      rollup: 3.21.5
       source-map: 0.8.0-beta.0
-      sucrase: 3.29.0
+      sucrase: 3.32.0
       tree-kill: 1.2.2
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
       - ts-node
+    dev: true
+
+  /tsutils@3.21.0(typescript@5.0.2):
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 5.0.2
     dev: true
 
   /tsutils@3.21.0(typescript@5.0.4):
@@ -4225,9 +6362,38 @@ packages:
     dependencies:
       prelude-ls: 1.2.1
 
+  /type-detect@4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
+    dev: true
+
   /type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
+
+  /type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /type-fest@3.9.0:
+    resolution: {integrity: sha512-hR8JP2e8UiH7SME5JZjsobBlEiatFoxpzCP+R3ZeCo7kAaG1jXQE5X/buLzogM6GJu8le9Y4OcfNuIQX0rZskA==}
+    engines: {node: '>=14.16'}
+    dev: false
+
+  /typed-array-length@1.0.4:
+    resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
+    dependencies:
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      is-typed-array: 1.1.10
+    dev: false
+
+  /typescript@5.0.2:
+    resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}
+    engines: {node: '>=12.20'}
+    hasBin: true
+    dev: true
 
   /typescript@5.0.4:
     resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
@@ -4246,15 +6412,35 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: false
 
+  /undefsafe@2.0.5:
+    resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
+    dev: true
+
   /universalify@2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
     dev: false
 
+  /untildify@4.0.0:
+    resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /update-browserslist-db@1.0.11(browserslist@4.21.5):
+    resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+    dependencies:
+      browserslist: 4.21.5
+      escalade: 3.1.1
+      picocolors: 1.0.0
+    dev: true
+
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
-      punycode: 2.1.1
+      punycode: 2.3.0
 
   /use-callback-ref@1.3.0(@types/react@18.0.28)(react@18.2.0):
     resolution: {integrity: sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==}
@@ -4285,6 +6471,14 @@ packages:
       react: 18.2.0
       tslib: 2.5.0
 
+  /use-sync-external-store@1.2.0(react@18.2.0):
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+    dev: true
+
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
@@ -4299,6 +6493,19 @@ packages:
       which-typed-array: 1.1.9
     dev: false
 
+  /v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+    dev: true
+
+  /v8-to-istanbul@9.1.0:
+    resolution: {integrity: sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==}
+    engines: {node: '>=10.12.0'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.18
+      '@types/istanbul-lib-coverage': 2.0.4
+      convert-source-map: 1.9.0
+    dev: true
+
   /validate-npm-package-name@4.0.0:
     resolution: {integrity: sha512-mzR0L8ZDktZjpX4OB46KT+56MAhl4EIazWP/+G/HPGuvfdaqg4YsCdtOm6U9+LOFyYDoh4dpnpxZRB9MQQns5Q==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -4311,18 +6518,24 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
-  /vite-plugin-watch-and-run@1.1.1:
-    resolution: {integrity: sha512-bm+Li/EQTpD/H29OYx457YHNchAyWVe8AJq9beSkMP2u4QIQGx4eYJMPgjVIFZBAY0S8mj2toiQqYm2fJQhsow==}
+  /vite-plugin-watch-and-run@1.1.2:
+    resolution: {integrity: sha512-OPSSNlHVQ5aGM46/otto5Nq8gTQbPDPpCoHuOJI2vrE5IFUCufhQukeZdudzPtG8Re0FfAV849WPsQEhcNMaAQ==}
     dependencies:
       '@kitql/helper': 0.6.1
       micromatch: 4.0.5
     dev: false
 
-  /vscode-languageserver-types@3.17.2:
-    resolution: {integrity: sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==}
+  /vscode-languageserver-types@3.17.3:
+    resolution: {integrity: sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==}
 
   /w3c-keyname@2.2.6:
     resolution: {integrity: sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg==}
+
+  /walker@1.0.8:
+    resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+    dependencies:
+      makeerror: 1.0.12
+    dev: true
 
   /web-streams-polyfill@3.2.1:
     resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
@@ -4349,6 +6562,15 @@ packages:
       is-number-object: 1.0.7
       is-string: 1.0.7
       is-symbol: 1.0.4
+    dev: false
+
+  /which-collection@1.0.1:
+    resolution: {integrity: sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==}
+    dependencies:
+      is-map: 2.0.2
+      is-set: 2.0.2
+      is-weakmap: 2.0.1
+      is-weakset: 2.0.2
     dev: false
 
   /which-typed-array@1.1.9:
@@ -4378,16 +6600,64 @@ packages:
     resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}
     engines: {node: '>=0.10.0'}
 
+  /wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+    dev: true
+
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  /write-file-atomic@4.0.2:
+    resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 3.0.7
+    dev: true
+
+  /y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+    dev: true
+
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-    dev: false
 
   /yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
+    dev: true
+
+  /yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.1.1
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+    dev: true
+
+  /yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
     dev: true
 
   /yocto-queue@0.1.0:

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,7 @@
     "lint": {
       "outputs": []
     },
+    "test": {},
     "dev": {
       "cache": false
     }


### PR DESCRIPTION
# Description

Introduce the ability to configure Grafbase projects using TypeScript to add type safety.

How to read the pull request(s):

- [New glue scripts to API](https://github.com/grafbase/api/pull/2166)
- [The @grafbase/sdk library to generate configs](https://github.com/grafbase/grafbase/tree/tsconfig/packages/grafbase-sdk)
- The changes in cli Rust code detecting are we using a TS config file or the graphql schema file.
- Running the embedded `ts-node` library for the client's TS config, which generates a new file in `~/.grafbase/generated/schema/schema.grapql`

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [x] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [x] 📖 Requires documentation update
