### PR TITLE
GB-3577 - Add bump script

### DIFF
--- a/cli/Makefile.toml
+++ b/cli/Makefile.toml
@@ -1,0 +1,38 @@
+[config]
+default_to_workspace = false
+
+[tasks.install-cargo-release]
+install_crate = { crate_name = "cargo-release", binary = "cargo", test_arg = [
+    "release",
+    "--version",
+], version = "0.24.10" }
+
+[tasks.install-sd]
+install_crate = { crate_name = "sd", binary = "sd", test_arg = [
+    "--version",
+], version = "0.7.6" }
+
+
+[tasks.bump]
+dependencies = ["install-cargo-release", "install-sd"]
+script = '''
+VERSION=${@}
+
+cargo release version $VERSION --execute --no-confirm
+
+cd npm/cli
+npm version --git-tag-version false $VERSION
+cd ../aarch64-apple-darwin
+npm version --git-tag-version false $VERSION
+cd ../x86_64-apple-darwin
+npm version --git-tag-version false $VERSION
+cd ../x86_64-pc-windows-msvc
+npm version --git-tag-version false $VERSION
+cd ../x86_64-unknown-linux-musl
+npm version --git-tag-version false $VERSION
+cd ../
+sd "@grafbase/cli-aarch64-apple-darwin\": \"\^\d+.\d+.\d+.*\"" "@grafbase/cli-aarch64-apple-darwin\": \"^$VERSION\""  cli/package.json
+sd "@grafbase/cli-x86_64-apple-darwin\": \"\^\d+.\d+.\d+.*\"" "@grafbase/cli-x86_64-apple-darwin\": \"^$VERSION\""  cli/package.json
+sd "@grafbase/cli-x86_64-pc-windows-msvc\": \"\^\d+.\d+.\d+.*\"" "@grafbase/cli-x86_64-pc-windows-msvc\": \"^$VERSION\""  cli/package.json
+sd "@grafbase/cli-x86_64-unknown-linux-musl\": \"\^\d+.\d+.\d+.*\"" "@grafbase/cli-x86_64-unknown-linux-musl\": \"^$VERSION\""  cli/package.json
+'''


### PR DESCRIPTION
# Description

## Tooling

- Adds a script to bump the CLI versions to a specific semver

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [x] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
