### PR TITLE
GB-3701 - async watcher

### DIFF
--- a/cli/crates/server/src/file_watcher.rs
+++ b/cli/crates/server/src/file_watcher.rs
@@ -22,7 +22,7 @@ where
 
     let mut debouncer = new_debouncer(FILE_WATCHER_INTERVAL, None, move |res| {
         let _guard = handle.enter();
-        handle.block_on(async { notify_sender.send(res).await.expect("must be open") })
+        handle.block_on(async { notify_sender.send(res).await.expect("must be open") });
     })?;
 
     debouncer.watcher().watch(path.as_ref(), RecursiveMode::Recursive)?;

--- a/cli/crates/server/src/file_watcher.rs
+++ b/cli/crates/server/src/file_watcher.rs
@@ -49,15 +49,10 @@ where
                 }
                 // errors for specific files, ignored
             }
-            // since `watcher` will go out of scope once the runtime restarts, we'll get a `None`
-            // here on reload, which allows us to stop the loop
-            None => {
-                debouncer.watcher().unwatch(path.as_ref())?;
-                break;
-            }
+            // unreachable, should always be stopped externally by `select!`
+            None => {}
         }
     }
-    Ok(())
 }
 
 const ROOT_FILE_WHITELIST: [&str; 2] = [GRAFBASE_SCHEMA_FILE_NAME, DOT_ENV_FILE];

--- a/cli/crates/server/src/file_watcher.rs
+++ b/cli/crates/server/src/file_watcher.rs
@@ -21,7 +21,6 @@ where
     let handle = Handle::current();
 
     let mut debouncer = new_debouncer(FILE_WATCHER_INTERVAL, None, move |res| {
-        let _guard = handle.enter();
         handle.block_on(async { notify_sender.send(res).await.expect("must be open") });
     })?;
 

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -14,9 +14,6 @@
     "directory": "cli"
   },
   "license": "Apache-2.0",
-  "engines": {
-    "node": ">=16.13.0"
-  },
   "os": [
     "darwin"
   ],

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -31,8 +31,5 @@
     "@grafbase/cli-x86_64-apple-darwin": "^0.18.10",
     "@grafbase/cli-x86_64-pc-windows-msvc": "^0.18.10",
     "@grafbase/cli-x86_64-unknown-linux-musl": "^0.18.10"
-  },
-  "engines": {
-    "node": ">=16.13.0"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -14,9 +14,6 @@
     "directory": "cli"
   },
   "license": "Apache-2.0",
-  "engines": {
-    "node": ">=16.13.0"
-  },
   "os": [
     "darwin"
   ],

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -15,9 +15,6 @@
     "directory": "cli"
   },
   "license": "Apache-2.0",
-  "engines": {
-    "node": ">=16.13.0"
-  },
   "os": [
     "win32"
   ],

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -14,9 +14,6 @@
     "directory": "cli"
   },
   "license": "Apache-2.0",
-  "engines": {
-    "node": ">=16.13.0"
-  },
   "os": [
     "linux"
   ],


### PR DESCRIPTION
# Description

## Fixes

- Converts the watcher to async to prevent it from hanging when encountering external errors
- Removes the engine requirement when installing the CLI as it's enforced by the CLI itself with a clearer error message

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
