### PR TITLE
Fix release if you have a @ in your path

### DIFF
--- a/cli/Makefile.toml
+++ b/cli/Makefile.toml
@@ -41,7 +41,7 @@ script = '''
 git switch main
 git pull
 cd crates/cli
-VERSION=$(cargo pkgid | cut -d "@" -f 2)
+VERSION=$(cargo pkgid | rev | cut -d '@' -f 1 | rev)
 cd ../..
 git tag $VERSION
 git push --tags


### PR DESCRIPTION
# Description

## Tooling

- Fixes the `release` scripts in cases with `@` in the path

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [x] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
