### PR TITLE
Fix remote_unions_test when running with dynamodb

### DIFF
--- a/cli/crates/cli/tests/README.md
+++ b/cli/crates/cli/tests/README.md
@@ -1,6 +1,7 @@
 # Running with DynamoDB Local
 
 ## Assets
+
 Assets in the API repo need to be built:
 
 ```sh
@@ -8,6 +9,7 @@ RELEASE_FLAG="--dev" GATEWAY_FEATURES=local ./scripts/dev/build-cli-assets.sh
 ```
 
 ## Set up
+
 DynamoDB Local must be running:
 
 ```sh

--- a/cli/crates/cli/tests/openapi/remote_unions.rs
+++ b/cli/crates/cli/tests/openapi/remote_unions.rs
@@ -7,12 +7,12 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn remote_unions_test() {
     let mock_server = wiremock::MockServer::start().await;
     mount_remote_union_spec(&mock_server).await;
 
-    let mut env = Environment::init();
+    let mut env = Environment::init_async().await;
     let client = start_grafbase(&mut env, mock_server.address()).await;
 
     Mock::given(method("GET"))


### PR DESCRIPTION
# Description

Switch the test to `multi_thread` flavor and call `Environment::init_async` instead of `init` so that dynamodb cleanup routine in `Environment::drop` works.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
