### PR TITLE
GB-3397 - Add argument support for `create`

### DIFF
--- a/cli/crates/backend/src/api/create.rs
+++ b/cli/crates/backend/src/api/create.rs
@@ -70,11 +70,7 @@ pub async fn get_viewer_data_for_creation() -> Result<(Vec<Account>, Vec<Databas
 /// # Errors
 ///
 /// See [`ApiError`]
-pub async fn create(
-    account_id: &str,
-    project_slug: &str,
-    database_regions: &[DatabaseRegion],
-) -> Result<Vec<String>, ApiError> {
+pub async fn create(account_id: &str, project_slug: &str, database_regions: &[&str]) -> Result<Vec<String>, ApiError> {
     let environment = Environment::get();
 
     match environment.project_dot_grafbase_path.try_exists() {

--- a/cli/crates/cli/src/cli_input.rs
+++ b/cli/crates/cli/src/cli_input.rs
@@ -1,4 +1,4 @@
-use clap::{arg, command, value_parser, Arg, ArgAction, Command};
+use clap::{arg, command, value_parser, Arg, ArgAction, ArgGroup, Command};
 use indoc::indoc;
 
 /// creates the cli interface
@@ -51,7 +51,17 @@ pub fn build_cli() -> Command {
         "}))
         .subcommand(Command::new("login").about("Logs into your Grafbase account"))
         .subcommand(Command::new("logout").about("Logs out of your Grafbase account"))
-        .subcommand(Command::new("create").about("Set up and deploy a new project"))
+        .subcommand(
+            Command::new("create").about("Set up and deploy a new project").args(&[
+                arg!(-n --name <name> "The name to use for the new project"),
+                arg!(-a --account <slug> "The slug of the account in which the new project should be created"),
+                arg!(-r --regions <region> "The regions in which the database for the new project should be created")
+            ])
+            .group(ArgGroup::new("create")
+            .args(["regions", "account", "name"])
+            .multiple(true)
+            .requires_all(["regions", "account", "name"])),
+        )
         .subcommand(Command::new("deploy").about("Deploy your project"))
         .subcommand(Command::new("link").about("Connect a local project to a remote project"))
         .subcommand(Command::new("unlink").about("Disconnect a local project from a remote project"))

--- a/cli/crates/cli/src/create.rs
+++ b/cli/crates/cli/src/create.rs
@@ -41,6 +41,8 @@ pub async fn create(arguments: &Option<CreateArguments<'_>>) -> Result<(), CliEr
 }
 
 async fn from_arguments(arguments: &CreateArguments<'_>) -> Result<(), CliError> {
+    report::create();
+
     // TODO do this with a separate mutation that accepts an account slug
     let (accounts, ..) = create::get_viewer_data_for_creation()
         .await
@@ -56,7 +58,7 @@ async fn from_arguments(arguments: &CreateArguments<'_>) -> Result<(), CliError>
         .await
         .map_err(CliError::BackendApiError)?;
 
-    report::created(arguments.name, &domains);
+    report::create_success(arguments.name, &domains);
 
     Ok(())
 }
@@ -118,7 +120,7 @@ async fn interactive() -> Result<(), CliError> {
             .await
             .map_err(CliError::BackendApiError)?;
 
-        report::created(&project_name, &domains);
+        report::create_success(&project_name, &domains);
     }
 
     Ok(())

--- a/cli/crates/cli/src/create.rs
+++ b/cli/crates/cli/src/create.rs
@@ -34,10 +34,9 @@ pub struct CreateArguments<'a> {
 
 #[tokio::main]
 pub async fn create(arguments: &Option<CreateArguments<'_>>) -> Result<(), CliError> {
-    if let Some(arguments) = arguments {
-        from_arguments(arguments).await
-    } else {
-        interactive().await
+    match arguments {
+        Some(arguments) => from_arguments(arguments).await,
+        None => interactive().await,
     }
 }
 

--- a/cli/crates/cli/src/deploy.rs
+++ b/cli/crates/cli/src/deploy.rs
@@ -1,7 +1,6 @@
 use crate::{errors::CliError, output::report};
 use backend::api::deploy;
 
-/// # Errors
 #[tokio::main]
 pub async fn deploy() -> Result<(), CliError> {
     report::deploy();

--- a/cli/crates/cli/src/errors.rs
+++ b/cli/crates/cli/src/errors.rs
@@ -41,6 +41,9 @@ pub enum CliError {
     /// returned if an account selected for linking a project has no projects
     #[error("the selected account has no projects")]
     AccountWithNoProjects,
+    /// returned if the account name argument provided to create is not an existing account
+    #[error("could not find an account with the provided name")]
+    NoAccountFound,
     /// returned if the schema parser failed to compile a file
     #[error("{0}")]
     CompilationError(String),

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -111,13 +111,12 @@ fn try_main() -> Result<(), CliError> {
         Some(("login", _)) => login(),
         Some(("logout", _)) => logout(),
         Some(("create", matches)) => {
-            let account_slug = matches.get_one::<String>("account").map(AsRef::as_ref);
-            let name = matches.get_one::<String>("name").map(AsRef::as_ref);
-            // TODO change this once we support multiple regions from the CLI
-            let regions = matches.get_one::<String>("regions").map(AsRef::as_ref);
-            let arguments = account_slug
-                .zip(name)
-                .zip(regions)
+            let arguments = matches
+                .get_one::<String>("account")
+                .map(AsRef::as_ref)
+                .zip(matches.get_one::<String>("name").map(AsRef::as_ref))
+                // TODO change this once we support multiple regions from the CLI
+                .zip(matches.get_one::<String>("regions").map(AsRef::as_ref))
                 .map(|((account_slug, name), regions)| CreateArguments {
                     account_slug,
                     name,

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -21,7 +21,14 @@ mod watercolor;
 extern crate log;
 
 use crate::{
-    create::create, deploy::deploy, dev::dev, init::init, link::link, login::login, logout::logout, reset::reset,
+    create::{create, CreateArguments},
+    deploy::deploy,
+    dev::dev,
+    init::init,
+    link::link,
+    login::login,
+    logout::logout,
+    reset::reset,
     unlink::unlink,
 };
 use cli_input::build_cli;
@@ -103,7 +110,22 @@ fn try_main() -> Result<(), CliError> {
         Some(("reset", _)) => reset(),
         Some(("login", _)) => login(),
         Some(("logout", _)) => logout(),
-        Some(("create", _)) => create(),
+        Some(("create", matches)) => {
+            let account_slug = matches.get_one::<String>("account").map(AsRef::as_ref);
+            let name = matches.get_one::<String>("name").map(AsRef::as_ref);
+            // TODO change this once we support multiple regions from the CLI
+            let regions = matches.get_one::<String>("regions").map(AsRef::as_ref);
+            let arguments = account_slug
+                .zip(name)
+                .zip(regions)
+                .map(|((account_slug, name), regions)| CreateArguments {
+                    account_slug,
+                    name,
+                    // TODO change this once we support multiple regions from the CLI
+                    regions: vec![regions],
+                });
+            create(&arguments)
+        }
         Some(("deploy", _)) => deploy(),
         Some(("link", _)) => link(),
         Some(("unlink", _)) => unlink(),

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -113,10 +113,9 @@ fn try_main() -> Result<(), CliError> {
         Some(("create", matches)) => {
             let arguments = matches
                 .get_one::<String>("account")
-                .map(AsRef::as_ref)
-                .zip(matches.get_one::<String>("name").map(AsRef::as_ref))
+                .zip(matches.get_one::<String>("name"))
                 // TODO change this once we support multiple regions from the CLI
-                .zip(matches.get_one::<String>("regions").map(AsRef::as_ref))
+                .zip(matches.get_one::<String>("regions"))
                 .map(|((account_slug, name), regions)| CreateArguments {
                     account_slug,
                     name,

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -70,7 +70,7 @@ pub fn error(error: &CliError) {
 }
 
 pub fn goodbye() {
-    watercolor::output_error!("\n👋 See you next time!", @BrightBlue);
+    watercolor::output!("\n👋 See you next time!", @BrightBlue);
 }
 
 pub fn start_resolver_build(resolver_name: &str) {
@@ -122,39 +122,44 @@ pub fn login(url: &str) {
 }
 
 pub fn login_success() {
-    watercolor::output_error!("\n\n✨ Successfully logged in!", @BrightBlue);
+    watercolor::output!("\n\n✨ Successfully logged in!", @BrightBlue);
 }
 
 // TODO: better handling of spinner position to avoid this extra function
 pub fn login_error(error: &CliError) {
-    watercolor::output_error!("\n\nError: {error}", @BrightRed);
+    watercolor::output!("\n\nError: {error}", @BrightRed);
     if let Some(hint) = error.to_hint() {
-        watercolor::output_error!("Hint: {hint}", @BrightBlue);
+        watercolor::output!("Hint: {hint}", @BrightBlue);
     }
 }
 
 pub fn logout() {
-    watercolor::output_error!("✨ Successfully logged out!", @BrightBlue);
+    watercolor::output!("✨ Successfully logged out!", @BrightBlue);
 }
 
 // TODO change this to a spinner that is removed on success
 pub fn deploy() {
-    watercolor::output_error!("🕒 Your project is being deployed", @BrightBlue);
+    watercolor::output!("🕒 Your project is being deployed", @BrightBlue);
+}
+
+// TODO change this to a spinner that is removed on success
+pub fn create() {
+    watercolor::output!("🕒 Your project is being created", @BrightBlue);
 }
 
 pub fn deploy_success() {
-    watercolor::output_error!("\n✨ Your project has been deployed successfully!", @BrightBlue);
+    watercolor::output!("\n✨ Your project has been deployed successfully!", @BrightBlue);
 }
 
 pub fn linked(name: &str) {
-    watercolor::output_error!("\n✨ Successfully linked your local project to {name}!", @BrightBlue);
+    watercolor::output!("\n✨ Successfully linked your local project to {name}!", @BrightBlue);
 }
 
 pub fn unlinked() {
-    watercolor::output_error!("✨ Successfully unlinked your project!", @BrightBlue);
+    watercolor::output!("✨ Successfully unlinked your project!", @BrightBlue);
 }
 
-pub fn created(name: &str, urls: &[String]) {
+pub fn create_success(name: &str, urls: &[String]) {
     watercolor::output!("\n✨ {name} was successfully created!\n", @BrightBlue);
     watercolor::output!("Endpoints:", @BrightBlue);
     for url in urls {

--- a/cli/crates/cli/src/reset.rs
+++ b/cli/crates/cli/src/reset.rs
@@ -1,7 +1,6 @@
+use crate::{errors::CliError, output::report};
 use backend::project;
 use common::environment::Environment;
-
-use crate::{errors::CliError, output::report};
 
 pub fn reset() -> Result<(), CliError> {
     Environment::try_init().map_err(CliError::CommonError)?;


### PR DESCRIPTION
# Description

## Features

- Allows passing arguments to `create` rather than using interactive input|

```
Usage: grafbase create [OPTIONS]

Options:
  -n, --name <name>       The name to use for the new project
  -a, --account <slug>    The slug of the account in which the new project should be created
  -r, --regions <region>  The regions in which the database for the new project should be created
  -h, --help              Print help
```

## Fixes

- Fixes a few cases of output to STDERR instead of STDOUT

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
