### PR TITLE
Update `dot_get!` in the tests to pretty print.

### DIFF
--- a/cli/crates/cli/tests/utils/macros.rs
+++ b/cli/crates/cli/tests/utils/macros.rs
@@ -17,11 +17,11 @@ macro_rules! dot_get {
     ($item: expr, $dotpath: expr, $ty: ty) => {{
         let path = $dotpath;
         let item = &$item;
-        $crate::dot_get_opt!(item, path, $ty).expect(&format!("path `{path}` cannot be resolved in {item:?}"))
+        $crate::dot_get_opt!(item, path, $ty).expect(&format!("path `{path}` cannot be resolved in {item:#?}"))
     }};
     ($item: expr, $dotpath: expr) => {{
         let path = $dotpath;
         let item = &$item;
-        $crate::dot_get_opt!(item, path).expect(&format!("path `{path}` cannot be resolved in {item:?}"))
+        $crate::dot_get_opt!(item, path).expect(&format!("path `{path}` cannot be resolved in {item:#?}"))
     }};
 }


### PR DESCRIPTION
A small thing, but makes it a bit easier to spot problems when this fails.