### PR TITLE
GB-3729 - Support passing the access token via an env var

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1504,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.18.13"
+version = "0.19.0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.18.13"
+version = "0.19.0"
 dependencies = [
  "async-compression",
  "async-tar",
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.18.13"
+version = "0.19.0"
 dependencies = [
  "dirs 5.0.0",
  "exitcode",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.18.13"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cli/Makefile.toml
+++ b/cli/Makefile.toml
@@ -48,7 +48,7 @@ sd "@grafbase/cli-x86_64-apple-darwin\": \"\^\d+.\d+.\d+.*\"" "@grafbase/cli-x86
 sd "@grafbase/cli-x86_64-pc-windows-msvc\": \"\^\d+.\d+.\d+.*\"" "@grafbase/cli-x86_64-pc-windows-msvc\": \"^$VERSION\""  cli/package.json
 sd "@grafbase/cli-x86_64-unknown-linux-musl\": \"\^\d+.\d+.\d+.*\"" "@grafbase/cli-x86_64-unknown-linux-musl\": \"^$VERSION\""  cli/package.json
 cd ../
-touch "changelog/${VERSION}.md"
+touch "changelog/$VERSION.md"
 '''
 
 [tasks.release]

--- a/cli/Makefile.toml
+++ b/cli/Makefile.toml
@@ -47,6 +47,8 @@ sd "@grafbase/cli-aarch64-apple-darwin\": \"\^\d+.\d+.\d+.*\"" "@grafbase/cli-aa
 sd "@grafbase/cli-x86_64-apple-darwin\": \"\^\d+.\d+.\d+.*\"" "@grafbase/cli-x86_64-apple-darwin\": \"^$VERSION\""  cli/package.json
 sd "@grafbase/cli-x86_64-pc-windows-msvc\": \"\^\d+.\d+.\d+.*\"" "@grafbase/cli-x86_64-pc-windows-msvc\": \"^$VERSION\""  cli/package.json
 sd "@grafbase/cli-x86_64-unknown-linux-musl\": \"\^\d+.\d+.\d+.*\"" "@grafbase/cli-x86_64-unknown-linux-musl\": \"^$VERSION\""  cli/package.json
+cd ../
+touch "changelog/${VERSION}.md"
 '''
 
 [tasks.release]

--- a/cli/changelog/0.19.0.md
+++ b/cli/changelog/0.19.0.md
@@ -1,0 +1,20 @@
+### Features
+
+- Allows passing arguments to `create` rather than using interactive input
+
+  ```
+  Usage: grafbase create [OPTIONS]
+
+  Options:
+  -n, --name <name>       The name to use for the new project
+  -a, --account <slug>    The slug of the account in which the new project should be created
+  -r, --regions <region>  The regions in which the database for the new project should be created
+  -h, --help              Print help
+  ```
+
+- Supports passing a `GRAFBASE_ACCESS_TOKEN` environment variable rather than logging in (e.g. for CI environments)
+  - Note: being logged in via `grafbase login` takes precedence over supplying `GRAFBASE_ACCESS_TOKEN`
+
+### Fixes
+
+- Fixes a few cases of output to STDERR instead of STDOUT

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-local-backend"
-version = "0.18.13"
+version = "0.19.0"
 edition = "2021"
 description = "The local backend for grafbase developer tools"
 license = "Apache-2.0"
@@ -36,8 +36,8 @@ url = "2"
 urlencoding = "2"
 webbrowser = "0.8"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.18.13" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.18.13" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.19.0" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.19.0" }
 
 [features]
 dynamodb = ["server/dynamodb"]

--- a/cli/crates/backend/src/api/consts.rs
+++ b/cli/crates/backend/src/api/consts.rs
@@ -4,3 +4,4 @@ pub const AUTH_URL: &str = "https://grafbase.com/auth/cli";
 pub const API_URL: &str = "https://api.grafbase.com/graphql";
 pub const PACKAGE_JSON: &str = "package.json";
 pub const TAR_CONTENT_TYPE: &str = "application/x-tar";
+pub const GRAFBASE_ACCESS_TOKEN_ENV_VAR: &str = "GRAFBASE_ACCESS_TOKEN";

--- a/cli/crates/backend/src/api/errors.rs
+++ b/cli/crates/backend/src/api/errors.rs
@@ -44,6 +44,10 @@ pub enum ApiError {
     #[error("could not complete the action as your credential file is corrupt")]
     CorruptCredentialsFile,
 
+    /// returned if the provided access token is corrupt
+    #[error("could not complete the action as your access token is corrupt")]
+    CorruptAccessToken,
+
     /// returned if the contents of the project metadata file are corrupt
     #[error("could not complete the action as your project metadata file are corrupt")]
     CorruptProjectMetadataFile,

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase"
-version = "0.18.13"
+version = "0.19.0"
 edition = "2021"
 description = "The Grafbase command line interface"
 license = "Apache-2.0"
@@ -37,8 +37,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
 webbrowser = "0.8"
 
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.18.13" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.18.13" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.19.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.19.0" }
 
 [dev-dependencies]
 chrono = "0.4"

--- a/cli/crates/cli/src/errors.rs
+++ b/cli/crates/cli/src/errors.rs
@@ -85,7 +85,7 @@ impl CliError {
             Self::BackendApiError(ApiError::RequestError |
             ApiError::CreateError(CreateError::Unknown) |
             ApiError::DeployError(DeployError::Unknown)) => Some("you may be using an older version of the Grafbase CLI, try updating".to_owned()),
-            Self::BackendApiError(ApiError::NotLoggedIn | ApiError::CorruptAccessToken) => Some("try running 'grafbase login'".to_owned()),
+            Self::BackendApiError(ApiError::NotLoggedIn | ApiError::CorruptCredentialsFile) => Some("try running 'grafbase login'".to_owned()),
             Self::BackendApiError(ApiError::ProjectAlreadyLinked) => Some("try running 'grafbase deploy'".to_owned()),
             Self::BackendApiError(ApiError::CorruptProjectMetadataFile | ApiError::UnlinkedProject) => Some("try running 'grafbase link'".to_owned()),
             _ => None,

--- a/cli/crates/cli/src/errors.rs
+++ b/cli/crates/cli/src/errors.rs
@@ -85,7 +85,7 @@ impl CliError {
             Self::BackendApiError(ApiError::RequestError |
             ApiError::CreateError(CreateError::Unknown) |
             ApiError::DeployError(DeployError::Unknown)) => Some("you may be using an older version of the Grafbase CLI, try updating".to_owned()),
-            Self::BackendApiError(ApiError::NotLoggedIn | ApiError::CorruptCredentialsFile) => Some("try running 'grafbase login'".to_owned()),
+            Self::BackendApiError(ApiError::NotLoggedIn | ApiError::CorruptAccessToken) => Some("try running 'grafbase login'".to_owned()),
             Self::BackendApiError(ApiError::ProjectAlreadyLinked) => Some("try running 'grafbase deploy'".to_owned()),
             Self::BackendApiError(ApiError::CorruptProjectMetadataFile | ApiError::UnlinkedProject) => Some("try running 'grafbase link'".to_owned()),
             _ => None,

--- a/cli/crates/common/Cargo.toml
+++ b/cli/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-local-common"
-version = "0.18.13"
+version = "0.19.0"
 edition = "2021"
 description = "Common code used in multiple crates in the CLI workspace"
 license = "Apache-2.0"

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-local-server"
-version = "0.18.13"
+version = "0.19.0"
 edition = "2021"
 description = "A wrapper for the grafbase worker"
 license = "Apache-2.0"
@@ -58,7 +58,7 @@ uuid = { version = "1", features = ["v4"] }
 version-compare = "0.1"
 which = "4"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.18.13" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.19.0" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.18.13",
+  "version": "0.19.0",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.18.13",
+  "version": "0.19.0",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,9 +27,9 @@
     "jest": "29.4.3"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.18.13",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.18.13",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.18.13",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.18.13"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.19.0",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.19.0",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.19.0",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.19.0"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.18.13",
+  "version": "0.19.0",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.18.13",
+  "version": "0.19.0",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.18.13",
+  "version": "0.19.0",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
# Description

## Features

- Supports passing a `GRAFBASE_ACCESS_TOKEN` environment variable rather than logging in (e.g. for CI environments)
  - Note: being logged in via `grafbase login` takes precedence over supplying `GRAFBASE_ACCESS_TOKEN`

## Misc.

- Version bumps and changelog for `0.19.0`

## Tooling

- `touch "changelog/$VERSION.md"` when running the `bump` script

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [x] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
