### PR TITLE
Speed up CI for the CLI

### DIFF
--- a/.github/actions/cdn_assets/action.yml
+++ b/.github/actions/cdn_assets/action.yml
@@ -20,9 +20,13 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        curl https://${{ inputs.cdn }}/cli/${{ inputs.assets_version }}.zip --output assets.zip
-        unzip assets.zip -d assets
-        rm -rf crates/server/assets
-        mv assets crates/server/assets
-        cp -r crates/server/assets ~/.grafbase/
+        curl https://${{ inputs.cdn }}/cli/${{ inputs.assets_version }}.tar.gz --output assets.tar.gz --fail
+        cp assets.tar.gz crates/server
+        mkdir ~/.grafbase
+        cp assets.tar.gz ~/.grafbase
+        (cd ~/.grafbase && tar -xf assets.tar.gz)
+        #unzip assets.zip -d assets
+        #rm -rf crates/server/assets
+        #mv assets crates/server/assets
+        #cp -r crates/server/assets ~/.grafbase/
         touch ~/.grafbase/version.txt

--- a/.github/actions/cdn_assets/action.yml
+++ b/.github/actions/cdn_assets/action.yml
@@ -25,8 +25,4 @@ runs:
         mkdir ~/.grafbase
         cp assets.tar.gz ~/.grafbase
         (cd ~/.grafbase && tar -xf assets.tar.gz)
-        #unzip assets.zip -d assets
-        #rm -rf crates/server/assets
-        #mv assets crates/server/assets
-        #cp -r crates/server/assets ~/.grafbase/
         touch ~/.grafbase/version.txt

--- a/.github/actions/init_rust_job/action.yml
+++ b/.github/actions/init_rust_job/action.yml
@@ -5,6 +5,9 @@ inputs:
   cache-key:
     required: true
     description: The cache key used on actions/cache
+  restore-key:
+    required: true
+    description: A cache key prefix to fall back on if the above isnt found
   platform:
     type: choice
     description: Target platform to use when installing nextest
@@ -25,6 +28,7 @@ runs:
         restore-keys: ${{ runner.os }}-${{ runner.arch }}-cargo-
         path: |
           ~/.cargo/
+          !~/.cargo/registry/src
           cli/target/
 
     - name: Extract the Rust version to use from the `rust-toolchain.toml` file

--- a/.github/actions/init_rust_job/action.yml
+++ b/.github/actions/init_rust_job/action.yml
@@ -25,7 +25,7 @@ runs:
       continue-on-error: false
       with:
         key: ${{ inputs.cache-key }}
-        restore-keys: ${{ runner.os }}-${{ runner.arch }}-cargo-
+        restore-keys: ${{ inputs.restore-key }}
         path: |
           ~/.cargo/
           !~/.cargo/registry/src

--- a/.github/actions/sanitize/action.yml
+++ b/.github/actions/sanitize/action.yml
@@ -30,7 +30,7 @@ runs:
       shell: bash
       run: |
         cd ${{ inputs.working-directory }}
-        cargo clippy --locked --all-targets --tests --release -- -D warnings
+        cargo clippy --locked --all-targets --tests -- -D warnings
 
     - name: Setup Node.js
       uses: actions/setup-node@v3
@@ -49,4 +49,4 @@ runs:
       shell: bash
       run: |
         cd ${{ inputs.working-directory }}
-        RUST_BACKTRACE=1 cargo nextest run --release --profile ci
+        RUST_BACKTRACE=1 cargo nextest run --profile ci

--- a/.github/actions/sanitize/action.yml
+++ b/.github/actions/sanitize/action.yml
@@ -30,7 +30,7 @@ runs:
       shell: bash
       run: |
         cd ${{ inputs.working-directory }}
-        cargo clippy --locked --all-targets --tests -- -D warnings
+        cargo clippy --locked --all-targets --tests --release -- -D warnings
 
     - name: Setup Node.js
       uses: actions/setup-node@v3
@@ -49,4 +49,4 @@ runs:
       shell: bash
       run: |
         cd ${{ inputs.working-directory }}
-        RUST_BACKTRACE=1 cargo nextest run --profile ci
+        RUST_BACKTRACE=1 cargo nextest run --release --profile ci

--- a/.github/workflows/cli-partial-release.yml
+++ b/.github/workflows/cli-partial-release.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           platform: linux
           cache-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release-${{ hashFiles('cli/Cargo.lock') }}
+          restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release
 
       - name: Download darwin-x86_64 artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -17,8 +17,10 @@ permissions:
 
 env:
   GRAFBASE_SKIP_ASSET_VERSION_CHECK: 'true'
-  ASSETS_VERSION: 'release/2ad2c2a-2023-05-12'
-  PROD_ASSETS: assets.grafbase.com
+  #ASSETS_VERSION: 'release/2ad2c2a-2023-05-12'
+  ASSETS_VERSION: 'graeme-playing-around/98fa98d-2023-05-13'
+    #PROD_ASSETS: assets.grafbase.com
+  PROD_ASSETS: assets.grafbase.dev
   CARGO_TERM_COLOR: 'always'
   CARGO_INCREMENTAL: 0
 

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -17,10 +17,8 @@ permissions:
 
 env:
   GRAFBASE_SKIP_ASSET_VERSION_CHECK: 'true'
-  #ASSETS_VERSION: 'release/2ad2c2a-2023-05-12'
-  ASSETS_VERSION: 'graeme-playing-around/98fa98d-2023-05-13'
-    #PROD_ASSETS: assets.grafbase.com
-  PROD_ASSETS: assets.grafbase.dev
+  ASSETS_VERSION: 'release/f0516a0-2023-05-16'
+  PROD_ASSETS: assets.grafbase.com
   CARGO_TERM_COLOR: 'always'
   CARGO_PROFILE_DEV_DEBUG: 0
   CARGO_PROFILE_TEST_DEBUG: 0

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -22,6 +22,8 @@ env:
     #PROD_ASSETS: assets.grafbase.com
   PROD_ASSETS: assets.grafbase.dev
   CARGO_TERM_COLOR: 'always'
+  CARGO_PROFILE_DEV_DEBUG: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -92,10 +92,10 @@ jobs:
           # However, each package is published individually, so we're checking that all packages compile
           # with only their defined features.
           # See: https://github.com/rust-lang/cargo/issues/4463
-          (cd common && cargo check)
-          (cd server && cargo check)
-          (cd backend && cargo check)
-          (cd cli && cargo check)
+          (cd common && cargo check --release)
+          (cd server && cargo check --release)
+          (cd backend && cargo check --release)
+          (cd cli && cargo check --release)
 
   windows:
     needs: [lint]

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -20,6 +20,7 @@ env:
   ASSETS_VERSION: 'release/2ad2c2a-2023-05-12'
   PROD_ASSETS: assets.grafbase.com
   CARGO_TERM_COLOR: 'always'
+  CARGO_INCREMENTAL: 0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -148,7 +148,12 @@ jobs:
       - name: Build release
         run: |
           cd cli
-          cargo build --release --target x86_64-pc-windows-msvc
+          cargo build --release --target x86_64-pc-windows-msvc --timings
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: windows-release-timings.html
+          path: cli/target/cargo-timings/cargo-timing.html
 
       - if: startsWith(github.ref, 'refs/tags/')
         name: Upload binaries
@@ -186,7 +191,12 @@ jobs:
       - name: Build release
         run: |
           cd cli
-          cargo build --release --target x86_64-unknown-linux-musl
+          cargo build --release --target x86_64-unknown-linux-musl --timings
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: linux-release-timings.html
+          path: cli/target/cargo-timings/cargo-timing.html
 
       - if: startsWith(github.ref, 'refs/tags/')
         name: Upload binaries
@@ -228,7 +238,12 @@ jobs:
       - name: Build ${{ matrix.target }} release
         run: |
           cd cli
-          cargo build --release --target ${{ matrix.target }}
+          cargo build --release --target ${{ matrix.target }} --timings
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.target }}-release-timings.html
+          path: cli/target/cargo-timings/cargo-timing.html
 
       - if: startsWith(github.ref, 'refs/tags/')
         name: Upload ${{ matrix.target }} binary

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -22,7 +22,6 @@ env:
     #PROD_ASSETS: assets.grafbase.com
   PROD_ASSETS: assets.grafbase.dev
   CARGO_TERM_COLOR: 'always'
-  CARGO_INCREMENTAL: 0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -83,6 +83,30 @@ jobs:
         with:
           test: false
 
+  individual-builds:
+    needs: [detect-change-type]
+    if: ${{ needs.detect-change-type.outputs.build == 'true' || startsWith(github.ref, 'refs/tags/') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [common, server, backend, cli]
+    runs-on: ubuntu-latest-8-cores
+    steps:
+      - name: Get sources
+        uses: actions/checkout@v3
+
+      - name: Rust job init
+        uses: ./.github/actions/init_rust_job
+        with:
+          platform: linux
+          cache-key: ${{ runner.os }}-${{ runner.arch }}-build-${{ matrix.package }}-${{ hashFiles('cli/Cargo.lock') }}
+
+      - name: Fetch CDN assets
+        uses: ./.github/actions/cdn_assets
+        with:
+          cdn: ${{ env.PROD_ASSETS }}
+          assets_version: ${{ env.ASSETS_VERSION }}
+
       - name: Individual package build
         shell: bash
         run: |
@@ -92,10 +116,7 @@ jobs:
           # However, each package is published individually, so we're checking that all packages compile
           # with only their defined features.
           # See: https://github.com/rust-lang/cargo/issues/4463
-          (cd common && cargo check --release)
-          (cd server && cargo check --release)
-          (cd backend && cargo check --release)
-          (cd cli && cargo check --release)
+          cd ${{ matrix.package }} && cargo check
 
   windows:
     needs: [lint]

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -219,7 +219,7 @@ jobs:
           cdn: ${{ env.PROD_ASSETS }}
           assets_version: ${{ env.ASSETS_VERSION }}
 
-      - if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+      - if: ${{ !startsWith(github.ref, 'refs/tags/') && matrix.target == 'x86_64-apple-darwin' }}
         name: Sanitize
         uses: ./.github/actions/sanitize
         with:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           platform: linux
           cache-key: ${{ runner.os }}-${{ runner.arch }}-cargo-dev-${{ hashFiles('cli/Cargo.lock') }}
+          restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-dev
 
       - name: Fetch CDN assets
         uses: ./.github/actions/cdn_assets
@@ -101,7 +102,8 @@ jobs:
         uses: ./.github/actions/init_rust_job
         with:
           platform: linux
-          cache-key: ${{ runner.os }}-${{ runner.arch }}-build-${{ matrix.package }}-${{ hashFiles('cli/Cargo.lock') }}
+          cache-key: ${{ runner.os }}-${{ runner.arch }}-cargo-build-${{ matrix.package }}-${{ hashFiles('cli/Cargo.lock') }}
+          restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-build
 
       - name: Fetch CDN assets
         uses: ./.github/actions/cdn_assets
@@ -132,6 +134,7 @@ jobs:
         with:
           platform: windows
           cache-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release-${{ hashFiles('cli/Cargo.lock') }}
+          restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release
 
       - name: Fetch CDN assets
         uses: ./.github/actions/cdn_assets
@@ -175,6 +178,7 @@ jobs:
         with:
           platform: linux
           cache-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release-${{ hashFiles('cli/Cargo.lock') }}
+          restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release
 
       - name: Fetch CDN assets
         uses: ./.github/actions/cdn_assets
@@ -222,6 +226,7 @@ jobs:
         with:
           platform: macos
           cache-key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-cargo-release-${{ hashFiles('cli/Cargo.lock') }}
+          restore-key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}
 
       - name: Fetch CDN assets
         uses: ./.github/actions/cdn_assets

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -221,7 +221,7 @@ jobs:
         uses: ./.github/actions/init_rust_job
         with:
           platform: macos
-          cache-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release-${{ hashFiles('cli/Cargo.lock') }}
+          cache-key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-cargo-release-${{ hashFiles('cli/Cargo.lock') }}
 
       - name: Fetch CDN assets
         uses: ./.github/actions/cdn_assets

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1284,16 +1284,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2309,12 +2299,6 @@ checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
  "hashbrown",
 ]
-
-[[package]]
-name = "lz4_flex"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a8cbbb2831780bc3b9c15a41f5b49222ef756b6730a95f3decfdd15903eb5a3"
 
 [[package]]
 name = "malloc_buf"
@@ -3881,15 +3865,12 @@ dependencies = [
  "fail",
  "fastdivide",
  "fastfield_codecs",
- "fs2",
  "htmlescape",
  "itertools",
  "levenshtein_automata",
  "log",
  "lru",
- "lz4_flex",
  "measure_time",
- "memmap2",
  "murmurhash32",
  "num_cpus",
  "once_cell",
@@ -3907,7 +3888,6 @@ dependencies = [
  "tantivy-common",
  "tantivy-fst",
  "tantivy-query-grammar",
- "tempfile",
  "thiserror",
  "time 0.3.20",
  "uuid",
@@ -4174,7 +4154,6 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
 ]
 
 [[package]]
@@ -4184,19 +4163,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.19.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]
@@ -4878,15 +4844,6 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
-
-[[package]]
-name = "winnow"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winreg"

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1598,6 +1598,7 @@ dependencies = [
  "dotenv",
  "exitcode",
  "filetime",
+ "flate2",
  "futures-util",
  "grafbase-local-common",
  "hyper",
@@ -1610,7 +1611,6 @@ dependencies = [
  "once_cell",
  "regex",
  "reqwest",
- "rust-embed",
  "serde",
  "serde_json",
  "slug",
@@ -1618,6 +1618,7 @@ dependencies = [
  "strip-ansi-escapes",
  "strum",
  "tantivy",
+ "tar",
  "tempfile",
  "thiserror",
  "tokio",
@@ -3248,40 +3249,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-embed"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b68543d5527e158213414a92832d2aab11a84d2571a5eb021ebe22c43aab066"
-dependencies = [
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "6.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4e0f0ced47ded9a68374ac145edd65a6c1fa13a96447b873660b2a568a0fd7"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "syn 1.0.109",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "7.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512b0ab6853f7e14e3c8754acb43d6f748bb9ced66aa5915a6553ac8213f7731"
-dependencies = [
- "sha2 0.10.6",
- "walkdir",
-]
-
-[[package]]
 name = "rust-stemmers"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3983,6 +3950,17 @@ dependencies = [
  "combine 4.6.6",
  "once_cell",
  "regex",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1528,7 +1528,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "toml",
  "tracing-subscriber",
  "uuid",
  "webbrowser",
@@ -3437,15 +3436,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4143,26 +4133,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "toml"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -18,12 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1969,40 +1963,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "include-flate"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfdcb449c721557c1cf89bbd3412bf33fa963289e26e9badbd824a960912e148"
-dependencies = [
- "include-flate-codegen-exports",
- "lazy_static",
- "libflate",
-]
-
-[[package]]
-name = "include-flate-codegen"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a7d6e1419fa3129eb0802b4c99603c0d425c79fb5d76191d5a20d0ab0d664e8"
-dependencies = [
- "libflate",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "include-flate-codegen-exports"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75657043ffe3d8280f1cb8aef0f505532b392ed7758e0baeac22edadcee31a03"
-dependencies = [
- "include-flate-codegen",
- "proc-macro-hack",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2273,26 +2233,6 @@ name = "libc"
 version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
-
-[[package]]
-name = "libflate"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97822bf791bd4d5b403713886a5fbe8bf49520fe78e323b0dc480ca1a03e50b0"
-dependencies = [
- "adler32",
- "crc32fast",
- "libflate_lz77",
-]
-
-[[package]]
-name = "libflate_lz77"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a52d3a8bfc85f250440e4424db7d857e241a3aebbbe301f3eb606ab15c39acbf"
-dependencies = [
- "rle-decode-fast",
-]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2949,12 +2889,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3205,12 +3139,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rle-decode-fast"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
-
-[[package]]
 name = "rstest"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3325,7 +3253,6 @@ version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b68543d5527e158213414a92832d2aab11a84d2571a5eb021ebe22c43aab066"
 dependencies = [
- "include-flate",
  "rust-embed-impl",
  "rust-embed-utils",
  "walkdir",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,18 +1,6 @@
 [workspace]
 members = ["crates/*"]
 
-# TODO: Probably only do these on CI if they work
-
-[profile.dev]
-# Disabling debug info speeds up builds a bunch,
-# and we don't rely on it for debugging that much.
-debug = 0
-
-[profile.test]
-# Disabling debug info speeds up builds a bunch,
-# and we don't rely on it for debugging that much.
-debug = 0
-
 [profile.release]
 strip = "symbols"
 lto = false

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,4 +3,4 @@ members = ["crates/*"]
 
 [profile.release]
 strip = "symbols"
-lto = "thin"
+lto = false

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,5 +3,4 @@ members = ["crates/*"]
 
 [profile.release]
 strip = "symbols"
-lto = true
-codegen-units = 1
+lto = "thin"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,18 @@
 [workspace]
 members = ["crates/*"]
 
+# TODO: Probably only do these on CI if they work
+
+[profile.dev]
+# Disabling debug info speeds up builds a bunch,
+# and we don't rely on it for debugging that much.
+debug = 0
+
+[profile.test]
+# Disabling debug info speeds up builds a bunch,
+# and we don't rely on it for debugging that much.
+debug = 0
+
 [profile.release]
 strip = "symbols"
 lto = false

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -32,7 +32,6 @@ serde_derive = "1"
 serde_json = "1"
 slugify = "0.1.0"
 thiserror = "1"
-toml = { version = "0.7", default-features = false }
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -29,9 +29,10 @@ once_cell = "1"
 os_type = "2"
 serde = "1"
 serde_derive = "1"
+serde_json = "1"
 slugify = "0.1.0"
 thiserror = "1"
-toml = "0.7"
+toml = { version = "0.7", default-features = false }
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
@@ -56,7 +57,6 @@ reqwest = { version = "0.11", features = [
   "blocking",
 ], default-features = false }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 sysinfo = "0.28"
 tempfile = "3"
 tokio = { version = "1", features = ["full"] }

--- a/cli/crates/cli/src/panic_hook/mod.rs
+++ b/cli/crates/cli/src/panic_hook/mod.rs
@@ -136,7 +136,7 @@ pub fn handle_dump(meta: &Metadata, panic_info: &PanicInfo<'_>) -> Option<PathBu
             "{}",
             report
                 .serialize()
-                .unwrap_or_else(|| "<Could not serialize report TOML>".to_string())
+                .unwrap_or_else(|| "<Could not serialize report JSON>".to_string())
         );
         None
     }

--- a/cli/crates/cli/src/panic_hook/report.rs
+++ b/cli/crates/cli/src/panic_hook/report.rs
@@ -124,8 +124,8 @@ impl Report {
         let file_name = format!("report-{}.json", &uuid);
         let file_path = Path::new(&tmp_dir).join(file_name);
         let mut file = File::create(&file_path)?;
-        let toml = self.serialize().unwrap();
-        file.write_all(toml.as_bytes())?;
+        let json = self.serialize().unwrap();
+        file.write_all(json.as_bytes())?;
         Ok(file_path)
     }
 }

--- a/cli/crates/cli/src/panic_hook/report.rs
+++ b/cli/crates/cli/src/panic_hook/report.rs
@@ -112,16 +112,16 @@ impl Report {
         }
     }
 
-    /// Serialize the `Report` to a TOML string.
+    /// Serialize the `Report` to a JSON string.
     pub fn serialize(&self) -> Option<String> {
-        toml::to_string_pretty(&self).ok()
+        serde_json::to_string_pretty(&self).ok()
     }
 
     /// Write a file to disk.
     pub fn persist(&self) -> Result<PathBuf, Box<dyn Error + 'static>> {
         let uuid = Uuid::new_v4().as_hyphenated().to_string();
         let tmp_dir = env::temp_dir();
-        let file_name = format!("report-{}.toml", &uuid);
+        let file_name = format!("report-{}.json", &uuid);
         let file_path = Path::new(&tmp_dir).join(file_name);
         let mut file = File::create(&file_path)?;
         let toml = self.serialize().unwrap();

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -36,7 +36,7 @@ reqwest = { version = "0.11", features = [
   "rustls-tls",
   "json",
 ], default-features = false }
-rust-embed = { version = "6", features = ["compression"] }
+rust-embed = { version = "6" }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 slug = "0.1"

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -47,7 +47,7 @@ sqlx = { version = "0.6", features = [
 ] }
 strip-ansi-escapes = "0.1"
 strum = { version = "0.24", features = ["derive"] }
-tantivy = "0.19"
+tantivy = { version = "0.19", default-features = false }
 tar = "0.4"
 tempfile = "3"
 thiserror = "1"

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -20,6 +20,7 @@ combine = "4"
 dotenv = "0.15"
 exitcode = "1"
 filetime = "0.2"
+flate2 = "1.0"
 futures-util = "0.3"
 hyper = "0.14"
 integer-encoding = "3"
@@ -36,7 +37,6 @@ reqwest = { version = "0.11", features = [
   "rustls-tls",
   "json",
 ], default-features = false }
-rust-embed = { version = "6" }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 slug = "0.1"
@@ -48,6 +48,7 @@ sqlx = { version = "0.6", features = [
 strip-ansi-escapes = "0.1"
 strum = { version = "0.24", features = ["derive"] }
 tantivy = "0.19"
+tar = "0.4"
 tempfile = "3"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -6,7 +6,7 @@ use crate::custom_resolvers::build_resolvers;
 use crate::error_server;
 use crate::event::{wait_for_event, wait_for_event_and_match, Event};
 use crate::file_watcher::start_watcher;
-use crate::types::{Assets, ServerMessage};
+use crate::types::{Assets, ServerMessage, MY_DATA};
 use crate::{bridge, errors::ServerError};
 use common::consts::{EPHEMERAL_PORT_RANGE, GRAFBASE_DIRECTORY_NAME, GRAFBASE_SCHEMA_FILE_NAME};
 use common::environment::{Environment, SchemaLocation};
@@ -323,6 +323,12 @@ fn export_embedded_files() -> Result<(), ServerError> {
         fs::write(gitignore_path, GIT_IGNORE_CONTENTS)
             .map_err(|_| ServerError::WriteFile(gitignore_path.to_string_lossy().into_owned()))?;
 
+        // TODO: write a build.rs to tar & gzip
+        // Update this code to ungzip & untar.
+        // Publish: profit.
+        fs::write("whatever.tar.gz", MY_DATA);
+
+        #[cfg(goaway)]
         let mut write_results = Assets::iter().map(|path| {
             let file = Assets::get(path.as_ref());
 
@@ -337,6 +343,7 @@ fn export_embedded_files() -> Result<(), ServerError> {
             (write_result, full_path)
         });
 
+        #[cfg(goaway)]
         if let Some((_, path)) = write_results.find(|(result, _)| result.is_err()) {
             let error_path_string = path.to_string_lossy().into_owned();
             return Err(ServerError::WriteFile(error_path_string));

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -14,6 +14,7 @@ use common::types::LocalAddressType;
 use common::utils::find_available_port_in_range;
 use futures_util::FutureExt;
 
+use flate2::read::GzDecoder;
 use std::borrow::Cow;
 use std::env;
 use std::path::Path;
@@ -323,39 +324,12 @@ fn export_embedded_files() -> Result<(), ServerError> {
         fs::write(gitignore_path, GIT_IGNORE_CONTENTS)
             .map_err(|_| ServerError::WriteFile(gitignore_path.to_string_lossy().into_owned()))?;
 
-        // TODO: write a build.rs to tar & gzip
-        // Update this code to ungzip & untar.
-        // Publish: profit.
-        {
-            use flate2::read::GzDecoder;
-            let reader = GzDecoder::new(ASSETS_GZIP);
-            let mut archive = tar::Archive::new(reader);
-            let full_path = &environment.user_dot_grafbase_path;
-            fs::create_dir_all(full_path).unwrap();
-
-            archive.unpack(full_path).unwrap();
-        }
-
-        #[cfg(goaway)]
-        let mut write_results = Assets::iter().map(|path| {
-            let file = Assets::get(path.as_ref());
-
-            let full_path = environment.user_dot_grafbase_path.join(path.as_ref());
-
-            let parent = full_path.parent().expect("must have a parent");
-            let create_dir_result = fs::create_dir_all(parent);
-
-            // must be Some(file) since we're iterating over existing paths
-            let write_result = create_dir_result.and_then(|_| fs::write(&full_path, file.unwrap().data));
-
-            (write_result, full_path)
-        });
-
-        #[cfg(goaway)]
-        if let Some((_, path)) = write_results.find(|(result, _)| result.is_err()) {
-            let error_path_string = path.to_string_lossy().into_owned();
-            return Err(ServerError::WriteFile(error_path_string));
-        }
+        let reader = GzDecoder::new(ASSETS_GZIP);
+        let mut archive = tar::Archive::new(reader);
+        let full_path = &environment.user_dot_grafbase_path;
+        fs::create_dir_all(full_path)
+            .and_then(|_| archive.unpack(full_path))
+            .map_err(|_| ServerError::WriteFile(full_path.to_string_lossy().into_owned()))?;
 
         if fs::write(&version_path, current_version).is_err() {
             let version_path_string = version_path.to_string_lossy().into_owned();

--- a/cli/crates/server/src/types.rs
+++ b/cli/crates/server/src/types.rs
@@ -2,8 +2,10 @@ use common::types::ResolverMessageLevel;
 use rust_embed::RustEmbed;
 use std::path::PathBuf;
 
-#[derive(RustEmbed)]
-#[folder = "assets/"]
+pub const MY_DATA: &[u8] = include_bytes!("../assets.tar.gz");
+
+// #[derive(RustEmbed)]
+// #[folder = "assets/"]
 pub struct Assets;
 
 #[derive(Clone, Debug)]

--- a/cli/crates/server/src/types.rs
+++ b/cli/crates/server/src/types.rs
@@ -1,12 +1,7 @@
 use common::types::ResolverMessageLevel;
-use rust_embed::RustEmbed;
 use std::path::PathBuf;
 
-pub const MY_DATA: &[u8] = include_bytes!("../assets.tar.gz");
-
-// #[derive(RustEmbed)]
-// #[folder = "assets/"]
-pub struct Assets;
+pub const ASSETS_GZIP: &[u8] = include_bytes!("../assets.tar.gz");
 
 #[derive(Clone, Debug)]
 pub enum ServerMessage {


### PR DESCRIPTION
CI for the CLI seems to take 25-30 minutes _most of the time_.  It's a bit
ridiculous.  This PR has a bunch of changes that seem to improve things:

1. Release builds on my laptop are also excruciatingly slow.  From some testing
   this seems to be related to `RustEmbed` - I'm not sure whether it's the
   compression rust embed is doing or the fact that it's including every binary
   blob separately, but embedding a single `.tar.gz` manually halved release
   compile time on my laptop.
2. The size of the assets we're embedding seem to have a direct impact on
   compile times (probably due to [this rust issue](https://github.com/rust-lang/rust/issues/65818)).  A `.tar.gz` was a
   good 30% smaller than a `.zip` so I'll have a separate PR to the `api` repo
   to output one of these.  We could get some more improvements by bundling
   less things - I accidentally tried a build without `typescript` in it and
   shaved another 20-30 seconds off my build.
3. `lto` & `codegen-units = 1` were also slowing things down a bit.  Shaved
    another 25 seconds off builds on my machine.   Suspect we can live without
    them.
4. I've split the individual package builds out so they can be parallelised,
   and also to improve the `lint` cache (I _suspect_ some stuff in `target` was
   being clobbered by the individual builds, forcing any `lint` builds that use
   the cache to repeat more work than otherwise.  Not certain though, it's very
   slow to test all this stuff)
5. I've disabled the sanitize step for `aarch64` builds - it's not actually
   testing on `aarch64` so seemed a bit pointless when we've already got an
   `x86_64` build doing the same thing.
6. Disabled debug artifacts, because they go in the cache and we don't need
   them on CI.
7. Adjusted cache keys & cache prefixes a bit to try and improve things.
8. Updated the builds to record timings and push them as artifacts, so we can
   see more details about why it's slow.
9. After I'd done that, I noticed:
   - Tantivy was taking several minutes to compile.  Disabling it's default
     features improved this somewhat.
   - TOML was taking about a minute to compile.  Looking into this it was only
     used for panic reports, which could easily be JSON.  So I made that
     change.

This seems to have reduced an uncached CI run to about 20 minutes, and so far
I've been hitting caches fairly consistently and getting builds of 9-15
minutes (though it's possible that's because I was the only person doing things
at the weekend):

<img width="207" alt="CleanShot 2023-05-15 at 12 27 39@2x" src="https://github.com/grafbase/grafbase/assets/556490/3cdec3d1-6c88-4ea3-8eb4-f776023af26e">
