### PR TITLE
GB-3774: Implement OpenAPI connector(s) in the SDK

### DIFF
--- a/packages/grafbase-sdk/README.md
+++ b/packages/grafbase-sdk/README.md
@@ -329,9 +329,14 @@ const openai = connector.OpenAPI({
 const stripe = connector
   .OpenAPI({
     schema: 'https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json',
-    url: 'https://api.stripe.com'
+    url: 'https://api.stripe.com',
+    headers: (headers) => {
+      // used in client and introspection requests
+      headers.static('Authorization', 'Bearer {{ env.STRIPE_API_KEY }}')
+      // used only in introspection requests
+      headers.introspection('foo', 'bar')
+    }
   })
-  .header('Authorization', 'Bearer {{ env.STRIPE_API_KEY }}')
 ```
 
 Introspecting the connector namespace to the schema happens with the `introspect` method of the schema:

--- a/packages/grafbase-sdk/README.md
+++ b/packages/grafbase-sdk/README.md
@@ -308,3 +308,35 @@ const user = g.model("User", {
   age: g.int()
 }).search()
 ```
+
+## Connectors
+
+Connectors are created through the connector interface:
+
+```typescript
+import { connector } from '../../src/index'
+```
+
+### OpenAPI
+
+The OpenAPI connector can be created with the `OpenAPI` method:
+
+```typescript
+const openai = connector.OpenAPI({
+  schema: 'https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml'
+})
+
+const stripe = connector
+  .OpenAPI({
+    schema: 'https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json',
+    url: 'https://api.stripe.com'
+  })
+  .header('Authorization', 'Bearer {{ env.STRIPE_API_KEY }}')
+```
+
+Introspecting the connector namespace to the schema happens with the `introspect` method of the schema:
+
+```typescript
+g.introspect(stripe, { namespace: 'Stripe' })
+g.introspect(openai, { namespace: 'OpenAI' })
+```

--- a/packages/grafbase-sdk/README.md
+++ b/packages/grafbase-sdk/README.md
@@ -329,7 +329,6 @@ const openai = connector.OpenAPI({
 const stripe = connector
   .OpenAPI({
     schema: 'https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json',
-    url: 'https://api.stripe.com',
     headers: (headers) => {
       // used in client and introspection requests
       headers.static('Authorization', 'Bearer {{ env.STRIPE_API_KEY }}')

--- a/packages/grafbase-sdk/README.md
+++ b/packages/grafbase-sdk/README.md
@@ -339,9 +339,9 @@ const stripe = connector
   })
 ```
 
-Introspecting the connector namespace to the schema happens with the `introspect` method of the schema:
+Introspecting the connector namespace to the schema happens with the `datasource` method of the schema:
 
 ```typescript
-g.introspect(stripe, { namespace: 'Stripe' })
-g.introspect(openai, { namespace: 'OpenAI' })
+g.datasource(stripe, { namespace: 'Stripe' })
+g.datasource(openai, { namespace: 'OpenAI' })
 ```

--- a/packages/grafbase-sdk/src/grafbase-schema.ts
+++ b/packages/grafbase-sdk/src/grafbase-schema.ts
@@ -37,9 +37,8 @@ export class Datasources {
     if (this.inner.length > 0) {
       const header = 'extend schema'
       const datasources = this.inner.map(String).join('\n')
-      const footer = ' {\n  query: Query\n}'
 
-      return `${header}\n${datasources}${footer}`
+      return `${header}\n${datasources}`
     } else {
       return ''
     }

--- a/packages/grafbase-sdk/src/grafbase-schema.ts
+++ b/packages/grafbase-sdk/src/grafbase-schema.ts
@@ -71,6 +71,12 @@ export class GrafbaseSchema {
     this.datasources = new Datasources()
   }
 
+  public datasource(datasource: PartialDatasource, params: IntrospectParams) {
+    if (datasource instanceof PartialOpenAPI) {
+      this.datasources.push(datasource.finalize(params.namespace))
+    }
+  }
+
   public model(name: string, fields: Record<string, FieldShape>): Model {
     const model = Object.entries(fields).reduce(
       (model, [name, definition]) => model.field(name, definition),
@@ -159,12 +165,6 @@ export class GrafbaseSchema {
     this.enums.push(e)
 
     return e
-  }
-
-  public introspect(datasource: PartialDatasource, params: IntrospectParams) {
-    if (datasource instanceof PartialOpenAPI) {
-      this.datasources.push(datasource.finalize(params.namespace))
-    }
   }
 
   public string(): StringDefinition {

--- a/packages/grafbase-sdk/src/index.ts
+++ b/packages/grafbase-sdk/src/index.ts
@@ -39,6 +39,6 @@ export function config(input: ConfigInput): Config {
 
 export const connector = {
   OpenAPI: (params: OpenAPIParams): PartialOpenAPI => {
-    return new PartialOpenAPI(params.schema, params.url)
+    return new PartialOpenAPI(params)
   }
 }

--- a/packages/grafbase-sdk/src/index.ts
+++ b/packages/grafbase-sdk/src/index.ts
@@ -11,6 +11,7 @@ import { ReferenceDefinition } from './reference'
 import { RelationDefinition } from './relation'
 import { GrafbaseSchema } from './grafbase-schema'
 import { Config, ConfigInput } from './config'
+import { OpenAPIParams, PartialOpenAPI } from './openapi'
 
 export type FieldShape =
   | ScalarDefinition
@@ -34,4 +35,10 @@ export const g = new GrafbaseSchema()
 
 export function config(input: ConfigInput): Config {
   return new Config(input)
+}
+
+export const connector = {
+  OpenAPI: (params: OpenAPIParams): PartialOpenAPI => {
+    return new PartialOpenAPI(params.schema, params.url)
+  }
 }

--- a/packages/grafbase-sdk/src/openapi.ts
+++ b/packages/grafbase-sdk/src/openapi.ts
@@ -8,34 +8,69 @@ export class Header {
   }
 
   public toString(): string {
-    return `{ name: "${this.name}", value: "${this.value}"}`
+    return `{ name: "${this.name}", value: "${this.value}" }`
   }
 }
+
+export class Headers {
+  headers: Header[]
+  introspectionHeaders: Header[]
+
+  constructor() {
+    this.headers = []
+    this.introspectionHeaders = []
+  }
+
+  /**
+  * Creates a header used in client and introspection requests.
+  *
+  * @param name - The name of the header
+  * @param value - The value of the header
+  */
+  public static(name: string, value: string) {
+    this.headers.push(new Header(name, value))
+  }
+
+  /**
+  * Creates a header used only in introspection requests.
+  *
+  * @param name - The name of the header
+  * @param value - The value of the header
+  */
+  public introspection(name: string, value: string) {
+    this.introspectionHeaders.push(new Header(name, value))
+  }
+}
+
+export type HeaderGenerator = (headers: Headers) => any
 
 export interface OpenAPIParams {
   schema: string
   url?: string
+  headers?: HeaderGenerator
 }
 
 export class PartialOpenAPI {
   schema: string
   apiUrl?: string
   headers: Header[]
+  introspectionHeaders: Header[]
+  
+  constructor(params: OpenAPIParams) {
+    const headers = new Headers()
 
-  constructor(schema: string, url?: string) {
-    this.schema = schema
-    this.apiUrl = url
-    this.headers = []
-  }
-
-  public header(name: string, value: string): PartialOpenAPI {
-    this.headers.push(new Header(name, value))
-
-    return this
+    if (params.headers) {
+      params.headers(headers)
+    }
+    
+    this.schema = params.schema
+    this.apiUrl = params.url
+    this.headers = headers.headers
+    this.introspectionHeaders = headers.introspectionHeaders
   }
 
   finalize(namespace: string): OpenAPI {
-    return new OpenAPI(namespace, this.schema, this.headers, this.apiUrl)
+    return new OpenAPI(namespace, this.schema, this.headers, this.introspectionHeaders, this.apiUrl)
   }
 }
 
@@ -44,30 +79,30 @@ export class OpenAPI {
   schema: string
   apiUrl?: string
   headers: Header[]
+  introspectionHeaders: Header[]
 
-  constructor(
-    namespace: string,
-    schema: string,
-    headers: Header[],
-    url?: string
-  ) {
+  constructor(namespace: string, schema: string, headers: Header[], introspectionHeaders: Header[], url?: string) {
     this.namespace = namespace
     this.schema = schema
     this.apiUrl = url
     this.headers = headers
+    this.introspectionHeaders = introspectionHeaders
   }
 
   public toString(): string {
-    const header = '  @openapi(\n'
-    const namespace = this.namespace ? `    name: "${this.namespace}"\n` : ''
-    const url = this.apiUrl ? `    url: "${this.apiUrl}"\n` : ''
+    const header = "  @openapi(\n"
+    const namespace = this.namespace ? `    name: "${this.namespace}"\n` : ""
+    const url = this.apiUrl ? `    url: "${this.apiUrl}"\n` : ""
     const schema = `    schema: "${this.schema}"\n`
 
-    var headers = this.headers.map((header) => `      ${header}`).join('\n')
-    headers = headers ? `    headers: [\n${headers}\n    ]\n` : ''
+    var headers = this.headers.map((header) => `      ${header}`).join("\n")
+    headers = headers ? `    headers: [\n${headers}\n    ]\n`: ""
 
-    const footer = '  )'
+    var introspectionHeaders = this.introspectionHeaders.map((header) => `      ${header}`).join("\n")
+    introspectionHeaders = headers ? `    introspectionHeaders: [\n${introspectionHeaders}\n    ]\n`: ""
 
-    return `${header}${namespace}${url}${schema}${headers}${footer}`
+    const footer = "  )"
+
+    return `${header}${namespace}${url}${schema}${headers}${introspectionHeaders}${footer}`
   }
 }

--- a/packages/grafbase-sdk/src/openapi.ts
+++ b/packages/grafbase-sdk/src/openapi.ts
@@ -22,55 +22,66 @@ export class Headers {
   }
 
   /**
-  * Creates a header used in client and introspection requests.
-  *
-  * @param name - The name of the header
-  * @param value - The value of the header
-  */
+   * Creates a header used in client and introspection requests.
+   *
+   * @param name - The name of the header
+   * @param value - The value of the header
+   */
   public static(name: string, value: string) {
     this.headers.push(new Header(name, value))
   }
 
   /**
-  * Creates a header used only in introspection requests.
-  *
-  * @param name - The name of the header
-  * @param value - The value of the header
-  */
+   * Creates a header used only in introspection requests.
+   *
+   * @param name - The name of the header
+   * @param value - The value of the header
+   */
   public introspection(name: string, value: string) {
     this.introspectionHeaders.push(new Header(name, value))
   }
 }
 
 export type HeaderGenerator = (headers: Headers) => any
+export type OpenApiTransforms = 'OPERATION_ID' | 'SCHEMA_NAME'
 
 export interface OpenAPIParams {
   schema: string
   url?: string
+  transforms?: OpenApiTransforms
   headers?: HeaderGenerator
 }
 
 export class PartialOpenAPI {
   schema: string
   apiUrl?: string
+  transforms?: OpenApiTransforms
   headers: Header[]
   introspectionHeaders: Header[]
-  
+
   constructor(params: OpenAPIParams) {
     const headers = new Headers()
 
     if (params.headers) {
       params.headers(headers)
     }
-    
+
     this.schema = params.schema
     this.apiUrl = params.url
+    this.transforms = params.transforms
     this.headers = headers.headers
     this.introspectionHeaders = headers.introspectionHeaders
   }
 
   finalize(namespace: string): OpenAPI {
-    return new OpenAPI(namespace, this.schema, this.headers, this.introspectionHeaders, this.apiUrl)
+    return new OpenAPI(
+      namespace,
+      this.schema,
+      this.headers,
+      this.introspectionHeaders,
+      this.transforms,
+      this.apiUrl
+    )
   }
 }
 
@@ -78,31 +89,49 @@ export class OpenAPI {
   namespace: string
   schema: string
   apiUrl?: string
+  transforms?: OpenApiTransforms
   headers: Header[]
   introspectionHeaders: Header[]
 
-  constructor(namespace: string, schema: string, headers: Header[], introspectionHeaders: Header[], url?: string) {
+  constructor(
+    namespace: string,
+    schema: string,
+    headers: Header[],
+    introspectionHeaders: Header[],
+    transforms?: OpenApiTransforms,
+    url?: string
+  ) {
     this.namespace = namespace
     this.schema = schema
     this.apiUrl = url
+    this.transforms = transforms
     this.headers = headers
     this.introspectionHeaders = introspectionHeaders
   }
 
   public toString(): string {
-    const header = "  @openapi(\n"
-    const namespace = this.namespace ? `    name: "${this.namespace}"\n` : ""
-    const url = this.apiUrl ? `    url: "${this.apiUrl}"\n` : ""
+    const header = '  @openapi(\n'
+    const namespace = this.namespace ? `    name: "${this.namespace}"\n` : ''
+    const url = this.apiUrl ? `    url: "${this.apiUrl}"\n` : ''
     const schema = `    schema: "${this.schema}"\n`
 
-    var headers = this.headers.map((header) => `      ${header}`).join("\n")
-    headers = headers ? `    headers: [\n${headers}\n    ]\n`: ""
+    const transforms = this.transforms
+      ? `    transforms: ${this.transforms}\n`
+      : ''
 
-    var introspectionHeaders = this.introspectionHeaders.map((header) => `      ${header}`).join("\n")
-    introspectionHeaders = headers ? `    introspectionHeaders: [\n${introspectionHeaders}\n    ]\n`: ""
+    var headers = this.headers.map((header) => `      ${header}`).join('\n')
+    headers = headers ? `    headers: [\n${headers}\n    ]\n` : ''
 
-    const footer = "  )"
+    var introspectionHeaders = this.introspectionHeaders
+      .map((header) => `      ${header}`)
+      .join('\n')
 
-    return `${header}${namespace}${url}${schema}${headers}${introspectionHeaders}${footer}`
+    introspectionHeaders = headers
+      ? `    introspectionHeaders: [\n${introspectionHeaders}\n    ]\n`
+      : ''
+
+    const footer = '  )'
+
+    return `${header}${namespace}${url}${schema}${transforms}${headers}${introspectionHeaders}${footer}`
   }
 }

--- a/packages/grafbase-sdk/src/openapi.ts
+++ b/packages/grafbase-sdk/src/openapi.ts
@@ -1,0 +1,73 @@
+export class Header {
+  name: string
+  value: string
+
+  constructor(name: string, value: string) {
+    this.name = name
+    this.value = value
+  }
+
+  public toString(): string {
+    return `{ name: "${this.name}", value: "${this.value}"}`
+  }
+}
+
+export interface OpenAPIParams {
+  schema: string
+  url?: string
+}
+
+export class PartialOpenAPI {
+  schema: string
+  apiUrl?: string
+  headers: Header[]
+
+  constructor(schema: string, url?: string) {
+    this.schema = schema
+    this.apiUrl = url
+    this.headers = []
+  }
+
+  public header(name: string, value: string): PartialOpenAPI {
+    this.headers.push(new Header(name, value))
+
+    return this
+  }
+
+  finalize(namespace: string): OpenAPI {
+    return new OpenAPI(namespace, this.schema, this.headers, this.apiUrl)
+  }
+}
+
+export class OpenAPI {
+  namespace: string
+  schema: string
+  apiUrl?: string
+  headers: Header[]
+
+  constructor(
+    namespace: string,
+    schema: string,
+    headers: Header[],
+    url?: string
+  ) {
+    this.namespace = namespace
+    this.schema = schema
+    this.apiUrl = url
+    this.headers = headers
+  }
+
+  public toString(): string {
+    const header = '  @openapi(\n'
+    const namespace = this.namespace ? `    name: "${this.namespace}"\n` : ''
+    const url = this.apiUrl ? `    url: "${this.apiUrl}"\n` : ''
+    const schema = `    schema: "${this.schema}"\n`
+
+    var headers = this.headers.map((header) => `      ${header}`).join('\n')
+    headers = headers ? `    headers: [\n${headers}\n    ]\n` : ''
+
+    const footer = '  )'
+
+    return `${header}${namespace}${url}${schema}${headers}${footer}`
+  }
+}

--- a/packages/grafbase-sdk/tests/unit/defaults.test.ts
+++ b/packages/grafbase-sdk/tests/unit/defaults.test.ts
@@ -148,7 +148,10 @@ describe('Default value generation', () => {
 
   it('generates URL list default', () => {
     const model = g.model('User', {
-      name: g.url().list().default(['https://github.com', 'https://codeberg.org'])
+      name: g
+        .url()
+        .list()
+        .default(['https://github.com', 'https://codeberg.org'])
     })
 
     expect(model.toString()).toMatchInlineSnapshot(`

--- a/packages/grafbase-sdk/tests/unit/interface.test.ts
+++ b/packages/grafbase-sdk/tests/unit/interface.test.ts
@@ -65,9 +65,9 @@ describe('Interface generator', () => {
     })
 
     g.type('Fruit', {
-        isSeedless: g.boolean().optional(),
-        ripenessIndicators: g.string().optional().list().optional()
-      })
+      isSeedless: g.boolean().optional(),
+      ripenessIndicators: g.string().optional().list().optional()
+    })
       .implements(produce)
       .implements(sweets)
 

--- a/packages/grafbase-sdk/tests/unit/openapi.test.ts
+++ b/packages/grafbase-sdk/tests/unit/openapi.test.ts
@@ -17,9 +17,7 @@ describe('OpenAPI generator', () => {
         @openapi(
           name: "Stripe"
           schema: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json"
-        ) {
-        query: Query
-      }"
+        )"
     `)
   })
 
@@ -28,6 +26,7 @@ describe('OpenAPI generator', () => {
       schema:
         'https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json',
       url: 'https://api.stripe.com',
+      transforms: 'SCHEMA_NAME',
       headers: (headers) => {
         headers.static('Authorization', 'Bearer {{ env.STRIPE_API_KEY }}')
         headers.static('Method', 'POST')
@@ -44,6 +43,7 @@ describe('OpenAPI generator', () => {
           name: "Stripe"
           url: "https://api.stripe.com"
           schema: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json"
+          transforms: SCHEMA_NAME
           headers: [
             { name: "Authorization", value: "Bearer {{ env.STRIPE_API_KEY }}" }
             { name: "Method", value: "POST" }
@@ -51,9 +51,7 @@ describe('OpenAPI generator', () => {
           introspectionHeaders: [
             { name: "foo", value: "bar" }
           ]
-        ) {
-        query: Query
-      }"
+        )"
     `)
   })
 
@@ -80,9 +78,7 @@ describe('OpenAPI generator', () => {
         @openapi(
           name: "OpenAI"
           schema: "https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml"
-        ) {
-        query: Query
-      }"
+        )"
     `)
   })
 })

--- a/packages/grafbase-sdk/tests/unit/openapi.test.ts
+++ b/packages/grafbase-sdk/tests/unit/openapi.test.ts
@@ -1,0 +1,80 @@
+import { config, g, connector } from '../../src/index'
+import { describe, expect, it, beforeEach } from '@jest/globals'
+
+describe('OpenAPI generator', () => {
+  beforeEach(() => g.clear())
+
+  it('generates the minimum possible OpenAPI datasource', () => {
+    const stripe = connector.OpenAPI({
+      schema:
+        'https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json'
+    })
+
+    g.introspect(stripe, { namespace: 'Stripe' })
+
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+      "extend schema
+        @openapi(
+          name: "Stripe"
+          schema: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json"
+        ) {
+        query: Query
+      }"
+    `)
+  })
+
+  it('generates the maximum possible OpenAPI datasource', () => {
+    const stripe = connector
+      .OpenAPI({
+        schema:
+          'https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json',
+        url: 'https://api.stripe.com'
+      })
+      .header('Authorization', 'Bearer {{ env.STRIPE_API_KEY }}')
+
+    g.introspect(stripe, { namespace: 'Stripe' })
+
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+      "extend schema
+        @openapi(
+          name: "Stripe"
+          url: "https://api.stripe.com"
+          schema: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json"
+          headers: [
+            { name: "Authorization", value: "Bearer {{ env.STRIPE_API_KEY }}"}
+          ]
+        ) {
+        query: Query
+      }"
+    `)
+  })
+
+  it('combines multiple apis into one extension', () => {
+    const stripe = connector.OpenAPI({
+      schema:
+        'https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json'
+    })
+
+    const openai = connector.OpenAPI({
+      schema:
+        'https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml'
+    })
+
+    g.introspect(stripe, { namespace: 'Stripe' })
+    g.introspect(openai, { namespace: 'OpenAI' })
+
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+      "extend schema
+        @openapi(
+          name: "Stripe"
+          schema: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json"
+        )
+        @openapi(
+          name: "OpenAI"
+          schema: "https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml"
+        ) {
+        query: Query
+      }"
+    `)
+  })
+})

--- a/packages/grafbase-sdk/tests/unit/openapi.test.ts
+++ b/packages/grafbase-sdk/tests/unit/openapi.test.ts
@@ -10,7 +10,7 @@ describe('OpenAPI generator', () => {
         'https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json'
     })
 
-    g.introspect(stripe, { namespace: 'Stripe' })
+    g.datasource(stripe, { namespace: 'Stripe' })
 
     expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "extend schema
@@ -24,15 +24,19 @@ describe('OpenAPI generator', () => {
   })
 
   it('generates the maximum possible OpenAPI datasource', () => {
-    const stripe = connector
-      .OpenAPI({
-        schema:
-          'https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json',
-        url: 'https://api.stripe.com'
-      })
-      .header('Authorization', 'Bearer {{ env.STRIPE_API_KEY }}')
+    const stripe = connector.OpenAPI({
+      schema:
+        'https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json',
+      url: 'https://api.stripe.com',
+      headers: (headers) => {
+        headers.static('Authorization', 'Bearer {{ env.STRIPE_API_KEY }}')
+        headers.static('Method', 'POST')
 
-    g.introspect(stripe, { namespace: 'Stripe' })
+        headers.introspection('foo', 'bar')
+      }
+    })
+
+    g.datasource(stripe, { namespace: 'Stripe' })
 
     expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "extend schema
@@ -41,7 +45,11 @@ describe('OpenAPI generator', () => {
           url: "https://api.stripe.com"
           schema: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json"
           headers: [
-            { name: "Authorization", value: "Bearer {{ env.STRIPE_API_KEY }}"}
+            { name: "Authorization", value: "Bearer {{ env.STRIPE_API_KEY }}" }
+            { name: "Method", value: "POST" }
+          ]
+          introspectionHeaders: [
+            { name: "foo", value: "bar" }
           ]
         ) {
         query: Query
@@ -60,8 +68,8 @@ describe('OpenAPI generator', () => {
         'https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml'
     })
 
-    g.introspect(stripe, { namespace: 'Stripe' })
-    g.introspect(openai, { namespace: 'OpenAI' })
+    g.datasource(stripe, { namespace: 'Stripe' })
+    g.datasource(openai, { namespace: 'OpenAI' })
 
     expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "extend schema

--- a/packages/grafbase-sdk/tests/unit/relation.test.ts
+++ b/packages/grafbase-sdk/tests/unit/relation.test.ts
@@ -66,7 +66,10 @@ describe('Relations generator', () => {
 
   it('generates 1:m relations with nullable content', () => {
     const user = g.model('User', {
-      posts: g.relation(() => post).optional().list()
+      posts: g
+        .relation(() => post)
+        .optional()
+        .list()
     })
 
     const post = g.model('Post', {
@@ -86,7 +89,10 @@ describe('Relations generator', () => {
 
   it('generates 1:m relations with nullable list', () => {
     const user = g.model('User', {
-      posts: g.relation(() => post).list().optional()
+      posts: g
+        .relation(() => post)
+        .list()
+        .optional()
     })
 
     const post = g.model('Post', {
@@ -106,7 +112,11 @@ describe('Relations generator', () => {
 
   it('generates 1:m relations with nullable list and content', () => {
     const user = g.model('User', {
-      posts: g.relation(() => post).optional().list().optional()
+      posts: g
+        .relation(() => post)
+        .optional()
+        .list()
+        .optional()
     })
 
     const post = g.model('Post', {


### PR DESCRIPTION
# Description

Allows creating OpenAPI connectors in the SDK config generator.

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [x] 📖 Requires documentation update
