### PR TITLE
Gather all queries and mutations in one extend block per query type

### DIFF
--- a/packages/grafbase-sdk/src/query.ts
+++ b/packages/grafbase-sdk/src/query.ts
@@ -25,29 +25,17 @@ export class QueryArgument {
   }
 }
 
-export enum QueryType {
-  Query = 'Query',
-  Mutation = 'Mutation'
-}
-
 export class Query {
   name: string
   arguments: QueryArgument[]
   returns: OutputType
   resolver: string
-  type: QueryType
 
-  constructor(
-    name: string,
-    type: QueryType,
-    returnType: OutputType,
-    resolverName: string
-  ) {
+  constructor(name: string, returnType: OutputType, resolverName: string) {
     this.name = name
     this.arguments = []
     this.returns = returnType
     this.resolver = resolverName
-    this.type = type
   }
 
   public pushArgument(name: string, type: InputType): Query {
@@ -57,12 +45,9 @@ export class Query {
   }
 
   public toString(): string {
-    const header = `extend type ${this.type} {`
     const args = this.arguments.map(String).join(', ')
     const argsStr = args ? `(${args})` : ''
-    const query = `  ${this.name}${argsStr}: ${this.returns} @resolver(name: "${this.resolver}")`
-    const footer = '}'
 
-    return `${header}\n${query}\n${footer}`
+    return `  ${this.name}${argsStr}: ${this.returns} @resolver(name: "${this.resolver}")`
   }
 }

--- a/packages/grafbase-sdk/tests/unit/queries.test.ts
+++ b/packages/grafbase-sdk/tests/unit/queries.test.ts
@@ -5,13 +5,12 @@ describe('Query generator', () => {
   beforeEach(() => g.clear())
 
   it('generates a resolver with empty args', () => {
-    const greetQuery = g
-      .query('greet', {
-        returns: g.string(),
-        resolver: 'hello'
-      })
+    g.query('greet', {
+      returns: g.string(),
+      resolver: 'hello'
+    })
 
-    expect(greetQuery.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "extend type Query {
         greet: String! @resolver(name: "hello")
       }"
@@ -19,14 +18,13 @@ describe('Query generator', () => {
   })
 
   it('generates a resolver with required input and output', () => {
-    const greetQuery = g
-      .query('greet', {
-        args: { name: g.string() },
-        returns: g.string(),
-        resolver: 'hello'
-      })
+    g.query('greet', {
+      args: { name: g.string() },
+      returns: g.string(),
+      resolver: 'hello'
+    })
 
-    expect(greetQuery.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "extend type Query {
         greet(name: String!): String! @resolver(name: "hello")
       }"
@@ -34,14 +32,13 @@ describe('Query generator', () => {
   })
 
   it('generates a resolver with optional input', () => {
-    const greetQuery = g
-      .query('greet', {
-        args: { name: g.string().optional() },
-        returns: g.string(),
-        resolver: 'hello'
-      })
+    g.query('greet', {
+      args: { name: g.string().optional() },
+      returns: g.string(),
+      resolver: 'hello'
+    })
 
-    expect(greetQuery.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "extend type Query {
         greet(name: String): String! @resolver(name: "hello")
       }"
@@ -49,14 +46,13 @@ describe('Query generator', () => {
   })
 
   it('generates a resolver with optional input and output', () => {
-    const greetQuery = g
-      .query('greet', {
-        args: { name: g.string().optional() },
-        returns: g.string().optional(),
-        resolver: 'hello',
-      })
+    g.query('greet', {
+      args: { name: g.string().optional() },
+      returns: g.string().optional(),
+      resolver: 'hello'
+    })
 
-    expect(greetQuery.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "extend type Query {
         greet(name: String): String @resolver(name: "hello")
       }"
@@ -64,14 +60,13 @@ describe('Query generator', () => {
   })
 
   it('generates a resolver with list input', () => {
-    const greetQuery = g
-      .query('greet', {
-        args: { name: g.string().list() },
-        returns: g.string(),
-        resolver: 'hello'
-      })
+    g.query('greet', {
+      args: { name: g.string().list() },
+      returns: g.string(),
+      resolver: 'hello'
+    })
 
-    expect(greetQuery.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "extend type Query {
         greet(name: [String!]!): String! @resolver(name: "hello")
       }"
@@ -79,14 +74,13 @@ describe('Query generator', () => {
   })
 
   it('generates a resolver with list output', () => {
-    const greetQuery = g
-      .query('greet', {
-        args: { name: g.string() },
-        returns: g.string().list(),
-        resolver: 'hello'
-      })
+    g.query('greet', {
+      args: { name: g.string() },
+      returns: g.string().list(),
+      resolver: 'hello'
+    })
 
-    expect(greetQuery.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "extend type Query {
         greet(name: String!): [String!]! @resolver(name: "hello")
       }"
@@ -94,14 +88,13 @@ describe('Query generator', () => {
   })
 
   it('generates a resolver with list output', () => {
-    const greetQuery = g
-      .query('greet', {
-        args: { name: g.string() },
-        returns: g.string().list(),
-        resolver: 'hello'
-      })
+    g.query('greet', {
+      args: { name: g.string() },
+      returns: g.string().list(),
+      resolver: 'hello'
+    })
 
-    expect(greetQuery.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "extend type Query {
         greet(name: String!): [String!]! @resolver(name: "hello")
       }"
@@ -118,11 +111,7 @@ describe('Query generator', () => {
       resolver: 'checkout'
     })
 
-    const cfg = config({
-      schema: g
-    })
-
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "type CheckoutSessionInput {
         name: String!
       }
@@ -146,17 +135,13 @@ describe('Query generator', () => {
       resolver: 'hello'
     })
 
-    g.query('greet', {
+    g.query('sweet', {
       args: { game: g.int().optional() },
       returns: g.ref(enm).list(),
-      resolver: 'hello'
+      resolver: 'jello'
     })
 
-    const cfg = config({
-      schema: g
-    })
-
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "enum Foo {
         Bar,
         Baz
@@ -164,10 +149,7 @@ describe('Query generator', () => {
 
       extend type Query {
         greet(name: String!): [String!]! @resolver(name: "hello")
-      }
-
-      extend type Query {
-        greet(game: Int): [Foo!]! @resolver(name: "hello")
+        sweet(game: Int): [Foo!]! @resolver(name: "jello")
       }"
     `)
   })


### PR DESCRIPTION
# Description

Instead of having one block such as:

```graphql
extend type Query {
  greet(name: String!): String! @resolver(name: "hello")
}

extend type Query {
  sweet(name: String!): String! @resolver(name: "jello")
}
```

We should render them in one extend block:

```graphql
extend type Query {
  greet(name: String!): String! @resolver(name: "hello")
  sweet(name: String!): String! @resolver(name: "jello")
}
```

Same with mutations.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [x] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
