### PR TITLE
Fetch the CLI assets prior to release

### DIFF
--- a/.github/workflows/cli-partial-release.yml
+++ b/.github/workflows/cli-partial-release.yml
@@ -33,6 +33,27 @@ jobs:
           cache-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release-${{ hashFiles('cli/Cargo.lock') }}
           restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release
 
+      # This is annoying, but github doesn't pass env vars down to child workflows,
+      # and you can't use them as input parameters either so lets read them out the
+      # YAML
+      - name: Get PROD_ASSETS from cli workflow
+        id: lookup-prod-assets
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq '.env.PROD_ASSETS' './.github/workflows/cli.yml'
+
+      - name: Get ASSETS_VERSION from cli workflow
+        id: lookup-assets-version
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq '.env.ASSETS_VERSION' './.github/workflows/cli.yml'
+
+      - name: Fetch CDN assets
+        uses: ./.github/actions/cdn_assets
+        with:
+          cdn: ${{ steps.lookup-prod-assets.outputs.result }}
+          assets_version: ${{ steps.lookup-assets-version.outputs.result }}
+
       - name: Download darwin-x86_64 artifact
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
This (hopefully) fixes the longstanding issue where crates.io builds don't get the assets embedded into them.

#363 updated the build in such a way that this was a fatal error rather than just silently making a broken build.