### PR TITLE
GB-3775: Implement GraphQL connector(s) in the SDK

### DIFF
--- a/packages/grafbase-sdk/README.md
+++ b/packages/grafbase-sdk/README.md
@@ -344,3 +344,28 @@ Introspecting the connector namespace to the schema happens with the `datasource
 g.datasource(stripe, { namespace: 'Stripe' })
 g.datasource(openai, { namespace: 'OpenAI' })
 ```
+
+### GraphQL
+
+The GraphQL connector can be created with the `GraphQL` method:
+
+```typescript
+const contentful = connector.GraphQL({
+  url: 'https://graphql.contentful.com/content/v1/spaces/{{ env.CONTENTFUL_SPACE_ID }}/environments/{{ env.CONTENTFUL_ENVIRONMENT }}',
+  headers: (headers) => {
+    headers.static('Authorization', 'Bearer {{ env.STRIPE_API_KEY }}')
+    headers.static('Method', 'POST')
+  }
+})
+
+const github = connector.GraphQL({
+  url: 'https://api.github.com/graphql'
+})
+```
+
+Introspecting the connector namespace to the schema happens with the `introspect` method of the schema:
+
+```typescript
+g.datasource(contentful, { namespace: 'Contentful' })
+g.datasource(github, { namespace: 'GitHub' })
+```

--- a/packages/grafbase-sdk/src/connector/graphql.ts
+++ b/packages/grafbase-sdk/src/connector/graphql.ts
@@ -1,0 +1,51 @@
+import { Header, PartialHeaderGenerator, PartialHeaders } from './header'
+
+export interface GraphQLParams {
+  url: string
+  headers?: PartialHeaderGenerator
+}
+
+export class PartialGraphQLAPI {
+  apiUrl: string
+  headers: Header[]
+
+  constructor(params: GraphQLParams) {
+    const headers = new PartialHeaders()
+
+    if (params.headers) {
+      params.headers(headers)
+    }
+
+    this.apiUrl = params.url
+    this.headers = headers.headers
+  }
+
+  finalize(namespace: string): GraphQLAPI {
+    return new GraphQLAPI(namespace, this.apiUrl, this.headers)
+  }
+}
+
+export class GraphQLAPI {
+  namespace: string
+  url: string
+  headers: Header[]
+
+  constructor(namespace: string, url: string, headers: Header[]) {
+    this.namespace = namespace
+    this.url = url
+    this.headers = headers
+  }
+
+  public toString(): string {
+    const header = '  @graphql(\n'
+    const namespace = this.namespace ? `    name: "${this.namespace}"\n` : ''
+    const url = this.url ? `    url: "${this.url}"\n` : ''
+
+    var headers = this.headers.map((header) => `      ${header}`).join('\n')
+    headers = headers ? `    headers: [\n${headers}\n    ]\n` : ''
+
+    const footer = '  )'
+
+    return `${header}${namespace}${url}${headers}${footer}`
+  }
+}

--- a/packages/grafbase-sdk/src/connector/header.ts
+++ b/packages/grafbase-sdk/src/connector/header.ts
@@ -1,0 +1,63 @@
+export type HeaderGenerator = (headers: Headers) => any
+export type PartialHeaderGenerator = (headers: PartialHeaders) => any /**
+
+/**
+* Header used in connector calls.
+*/
+export class Header {
+  name: string
+  value: string
+
+  constructor(name: string, value: string) {
+    this.name = name
+    this.value = value
+  }
+
+  public toString(): string {
+    return `{ name: "${this.name}", value: "${this.value}" }`
+  }
+}
+
+/**
+ * An accumulator class to gather headers for a connector.
+ */
+export class PartialHeaders {
+  headers: Header[]
+
+  constructor() {
+    this.headers = []
+  }
+
+  /**
+   * Creates a header used in client and introspection requests.
+   *
+   * @param name - The name of the header
+   * @param value - The value of the header
+   */
+  public static(name: string, value: string) {
+    this.headers.push(new Header(name, value))
+  }
+}
+
+/**
+ * An accumulator class to gather headers for a connector which supports
+ * introspection headers.
+ */
+export class Headers extends PartialHeaders {
+  introspectionHeaders: Header[]
+
+  constructor() {
+    super()
+    this.introspectionHeaders = []
+  }
+
+  /**
+   * Creates a header used only in introspection requests.
+   *
+   * @param name - The name of the header
+   * @param value - The value of the header
+   */
+  public introspection(name: string, value: string) {
+    this.introspectionHeaders.push(new Header(name, value))
+  }
+}

--- a/packages/grafbase-sdk/src/connector/openapi.ts
+++ b/packages/grafbase-sdk/src/connector/openapi.ts
@@ -1,48 +1,5 @@
-export class Header {
-  name: string
-  value: string
+import { Header, Headers, HeaderGenerator } from "./header"
 
-  constructor(name: string, value: string) {
-    this.name = name
-    this.value = value
-  }
-
-  public toString(): string {
-    return `{ name: "${this.name}", value: "${this.value}" }`
-  }
-}
-
-export class Headers {
-  headers: Header[]
-  introspectionHeaders: Header[]
-
-  constructor() {
-    this.headers = []
-    this.introspectionHeaders = []
-  }
-
-  /**
-   * Creates a header used in client and introspection requests.
-   *
-   * @param name - The name of the header
-   * @param value - The value of the header
-   */
-  public static(name: string, value: string) {
-    this.headers.push(new Header(name, value))
-  }
-
-  /**
-   * Creates a header used only in introspection requests.
-   *
-   * @param name - The name of the header
-   * @param value - The value of the header
-   */
-  public introspection(name: string, value: string) {
-    this.introspectionHeaders.push(new Header(name, value))
-  }
-}
-
-export type HeaderGenerator = (headers: Headers) => any
 export type OpenApiTransforms = 'OPERATION_ID' | 'SCHEMA_NAME'
 
 export interface OpenAPIParams {

--- a/packages/grafbase-sdk/src/grafbase-schema.ts
+++ b/packages/grafbase-sdk/src/grafbase-schema.ts
@@ -17,10 +17,11 @@ import { Union } from './union'
 import { Interface } from './interface'
 import { Query, QueryInput } from './query'
 import { EnumShape, FieldShape, RelationRef } from '.'
-import { OpenAPI, PartialOpenAPI } from './openapi'
+import { OpenAPI, PartialOpenAPI } from './connector/openapi'
+import { GraphQLAPI, PartialGraphQLAPI } from './connector/graphql'
 
-export type PartialDatasource = PartialOpenAPI
-export type Datasource = OpenAPI
+export type PartialDatasource = PartialOpenAPI | PartialGraphQLAPI
+export type Datasource = OpenAPI | GraphQLAPI
 
 export class Datasources {
   inner: Datasource[]
@@ -71,9 +72,7 @@ export class GrafbaseSchema {
   }
 
   public datasource(datasource: PartialDatasource, params: IntrospectParams) {
-    if (datasource instanceof PartialOpenAPI) {
-      this.datasources.push(datasource.finalize(params.namespace))
-    }
+    this.datasources.push(datasource.finalize(params.namespace))
   }
 
   public model(name: string, fields: Record<string, FieldShape>): Model {

--- a/packages/grafbase-sdk/src/index.ts
+++ b/packages/grafbase-sdk/src/index.ts
@@ -11,7 +11,8 @@ import { ReferenceDefinition } from './reference'
 import { RelationDefinition } from './relation'
 import { GrafbaseSchema } from './grafbase-schema'
 import { Config, ConfigInput } from './config'
-import { OpenAPIParams, PartialOpenAPI } from './openapi'
+import { OpenAPIParams, PartialOpenAPI } from './connector/openapi'
+import { GraphQLParams, PartialGraphQLAPI } from './connector/graphql'
 
 export type FieldShape =
   | ScalarDefinition
@@ -40,5 +41,8 @@ export function config(input: ConfigInput): Config {
 export const connector = {
   OpenAPI: (params: OpenAPIParams): PartialOpenAPI => {
     return new PartialOpenAPI(params)
+  },
+  GraphQL: (params: GraphQLParams): PartialGraphQLAPI => {
+    return new PartialGraphQLAPI(params)
   }
 }

--- a/packages/grafbase-sdk/tests/unit/graphql.test.ts
+++ b/packages/grafbase-sdk/tests/unit/graphql.test.ts
@@ -1,0 +1,71 @@
+import { config, g, connector } from '../../src/index'
+import { describe, expect, it, beforeEach } from '@jest/globals'
+
+describe('GraphQL connector', () => {
+  beforeEach(() => g.clear())
+
+  it('generates the minimum possible GraphQL datasource', () => {
+    const contentful = connector.GraphQL({
+      url: 'https://graphql.contentful.com/content/v1/spaces/{{ env.CONTENTFUL_SPACE_ID }}/environments/{{ env.CONTENTFUL_ENVIRONMENT }}'
+    })
+
+    g.datasource(contentful, { namespace: 'Contentful' })
+
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+      "extend schema
+        @graphql(
+          name: "Contentful"
+          url: "https://graphql.contentful.com/content/v1/spaces/{{ env.CONTENTFUL_SPACE_ID }}/environments/{{ env.CONTENTFUL_ENVIRONMENT }}"
+        )"
+    `)
+  })
+
+  it('generates the maximum possible GraphQL datasource', () => {
+    const contentful = connector.GraphQL({
+      url: 'https://graphql.contentful.com/content/v1/spaces/{{ env.CONTENTFUL_SPACE_ID }}/environments/{{ env.CONTENTFUL_ENVIRONMENT }}',
+      headers: (headers) => {
+        headers.static('Authorization', 'Bearer {{ env.STRIPE_API_KEY }}')
+        headers.static('Method', 'POST')
+      }
+    })
+
+    g.datasource(contentful, { namespace: 'Contentful' })
+
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+      "extend schema
+        @graphql(
+          name: "Contentful"
+          url: "https://graphql.contentful.com/content/v1/spaces/{{ env.CONTENTFUL_SPACE_ID }}/environments/{{ env.CONTENTFUL_ENVIRONMENT }}"
+          headers: [
+            { name: "Authorization", value: "Bearer {{ env.STRIPE_API_KEY }}" }
+            { name: "Method", value: "POST" }
+          ]
+        )"
+    `)
+  })
+
+  it('combines multiple apis into one extension', () => {
+    const contentful = connector.GraphQL({
+      url: 'https://graphql.contentful.com/content/v1/spaces/{{ env.CONTENTFUL_SPACE_ID }}/environments/{{ env.CONTENTFUL_ENVIRONMENT }}'
+    })
+
+    const github = connector.GraphQL({
+      url: 'https://api.github.com/graphql'
+    })
+
+    g.datasource(contentful, { namespace: 'Contentful' })
+    g.datasource(github, { namespace: 'GitHub' })
+
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+      "extend schema
+        @graphql(
+          name: "Contentful"
+          url: "https://graphql.contentful.com/content/v1/spaces/{{ env.CONTENTFUL_SPACE_ID }}/environments/{{ env.CONTENTFUL_ENVIRONMENT }}"
+        )
+        @graphql(
+          name: "GitHub"
+          url: "https://api.github.com/graphql"
+        )"
+    `)
+  })
+})


### PR DESCRIPTION
# Description

Allows creating GraphQL connectors in the SDK config generator.

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [x] 📖 Requires documentation update
