### PR TITLE
Release 0.20.0-rc.2

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.20.0-rc.1"
+version = "0.20.0-rc.2"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.20.0-rc.1"
+version = "0.20.0-rc.2"
 dependencies = [
  "async-compression",
  "async-tar",
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.20.0-rc.1"
+version = "0.20.0-rc.2"
 dependencies = [
  "dirs 5.0.0",
  "exitcode",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.20.0-rc.1"
+version = "0.20.0-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cli/changelog/0.20.0-rc.2.md
+++ b/cli/changelog/0.20.0-rc.2.md
@@ -1,0 +1,7 @@
+A re-release of 0.20.0-rc.1
+
+### Features
+
+- Adds a `@graphql` directive to support generating queries and mutations from upstream GraphQL APIs
+- Adds a `JWKS` auth provider
+- Adds initial support for TypeScript configurations

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-local-backend"
-version = "0.20.0-rc.1"
+version = "0.20.0-rc.2"
 edition = "2021"
 description = "The local backend for grafbase developer tools"
 license = "Apache-2.0"
@@ -36,8 +36,8 @@ url = "2"
 urlencoding = "2"
 webbrowser = "0.8"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.20.0-rc.1" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.20.0-rc.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.20.0-rc.2" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.20.0-rc.2" }
 
 [features]
 dynamodb = ["server/dynamodb"]

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase"
-version = "0.20.0-rc.1"
+version = "0.20.0-rc.2"
 edition = "2021"
 description = "The Grafbase command line interface"
 license = "Apache-2.0"
@@ -37,8 +37,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
 webbrowser = "0.8"
 
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.20.0-rc.1" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.20.0-rc.1" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.20.0-rc.2" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.20.0-rc.2" }
 
 [dev-dependencies]
 chrono = "0.4"

--- a/cli/crates/common/Cargo.toml
+++ b/cli/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-local-common"
-version = "0.20.0-rc.1"
+version = "0.20.0-rc.2"
 edition = "2021"
 description = "Common code used in multiple crates in the CLI workspace"
 license = "Apache-2.0"

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-local-server"
-version = "0.20.0-rc.1"
+version = "0.20.0-rc.2"
 edition = "2021"
 description = "A wrapper for the grafbase worker"
 license = "Apache-2.0"
@@ -59,7 +59,7 @@ uuid = { version = "1", features = ["v4"] }
 version-compare = "0.1"
 which = "4"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.20.0-rc.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.20.0-rc.2" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.20.0-rc.1",
+  "version": "0.20.0-rc.2",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.20.0-rc.1",
+  "version": "0.20.0-rc.2",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,9 +27,9 @@
     "jest": "29.4.3"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.20.0-rc.1",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.20.0-rc.1",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.20.0-rc.1",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.20.0-rc.1"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.20.0-rc.2",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.20.0-rc.2",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.20.0-rc.2",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.20.0-rc.2"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.20.0-rc.1",
+  "version": "0.20.0-rc.2",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.20.0-rc.1",
+  "version": "0.20.0-rc.2",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.20.0-rc.1",
+  "version": "0.20.0-rc.2",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
A re-release of 0.20.0-rc.1

### Features

- Adds a `@graphql` directive to support generating queries and mutations from upstream GraphQL APIs
- Adds a `JWKS` auth provider
- Adds initial support for TypeScript configurations