### PR TITLE
Pull in tar-rs fork to work around startup issue.

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -4069,8 +4069,7 @@ dependencies = [
 [[package]]
 name = "tar"
 version = "0.4.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+source = "git+https://github.com/obmarg/tar-rs.git?rev=bffee32190d531c03d806680daebd89cb1544be1#bffee32190d531c03d806680daebd89cb1544be1"
 dependencies = [
  "filetime",
  "libc",

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -48,7 +48,8 @@ sqlx = { version = "0.6", features = [
 strip-ansi-escapes = "0.1"
 strum = { version = "0.24", features = ["derive"] }
 tantivy = { version = "0.19", default-features = false }
-tar = "0.4"
+# Temporary change till https://github.com/alexcrichton/tar-rs/pull/319 is release
+tar = { git = "https://github.com/obmarg/tar-rs.git", rev = "bffee32190d531c03d806680daebd89cb1544be1" }
 tempfile = "3"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -333,7 +333,7 @@ fn export_embedded_files() -> Result<(), ServerError> {
         let full_path = &environment.user_dot_grafbase_path;
         archive
             .unpack(full_path)
-            .map_err(|e| ServerError::WriteFile(full_path.to_string_lossy().into_owned()))?;
+            .map_err(|_| ServerError::WriteFile(full_path.to_string_lossy().into_owned()))?;
 
         if fs::write(&version_path, current_version).is_err() {
             let version_path_string = version_path.to_string_lossy().into_owned();

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -331,9 +331,9 @@ fn export_embedded_files() -> Result<(), ServerError> {
         let reader = GzDecoder::new(ASSETS_GZIP);
         let mut archive = tar::Archive::new(reader);
         let full_path = &environment.user_dot_grafbase_path;
-        fs::create_dir_all(full_path)
-            .and_then(|_| archive.unpack(full_path))
-            .map_err(|_| ServerError::WriteFile(full_path.to_string_lossy().into_owned()))?;
+        archive
+            .unpack(full_path)
+            .map_err(|e| ServerError::WriteFile(full_path.to_string_lossy().into_owned()))?;
 
         if fs::write(&version_path, current_version).is_err() {
             let version_path_string = version_path.to_string_lossy().into_owned();


### PR DESCRIPTION
# Description

`tar-rs` has an issue where it won't overwrite files if they're stored as hard links in the tar.  We install our asset `node_modules` with pnpm, which uses hard links to deduplicate content.  This means `grafbase dev` will refuse to overwrite some existing files on startup.

I've [fixed this and PRd it](https://github.com/alexcrichton/tar-rs/pull/319), this pulls the fix in the meantime.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
