### PR TITLE
Pin wrangler to 2.x

### DIFF
--- a/cli/crates/server/src/custom_resolvers.rs
+++ b/cli/crates/server/src/custom_resolvers.rs
@@ -198,10 +198,10 @@ async fn build_resolver(
                 artifact_directory_path_string,
                 "add",
                 "--save-dev",
-                "wrangler",
+                "wrangler@2",
             ],
             JavaScriptPackageManager::Pnpm => {
-                vec!["add", "-D", "wrangler"]
+                vec!["add", "-D", "wrangler@2"]
             }
             JavaScriptPackageManager::Yarn => {
                 vec![
@@ -209,7 +209,7 @@ async fn build_resolver(
                     "--modules-folder",
                     artifact_directory_modules_path_string,
                     "-D",
-                    "wrangler",
+                    "wrangler@2",
                 ]
             }
         };


### PR DESCRIPTION
# Description

Ensures the wrangler installation in Grafbase.com doesn't pull in 3.x.
This will go away when and if we drop the wrangler dependency.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
