### PR TITLE
Render relation name correctly outside of the list

### DIFF
--- a/packages/grafbase-sdk/src/connector/openapi.ts
+++ b/packages/grafbase-sdk/src/connector/openapi.ts
@@ -1,4 +1,4 @@
-import { Header, Headers, HeaderGenerator } from "./header"
+import { Header, Headers, HeaderGenerator } from './header'
 
 export type OpenApiTransforms = 'OPERATION_ID' | 'SCHEMA_NAME'
 

--- a/packages/grafbase-sdk/src/field/list.ts
+++ b/packages/grafbase-sdk/src/field/list.ts
@@ -41,6 +41,40 @@ export class ListDefinition {
   }
 }
 
+export class RelationListDefinition {
+  relation: RelationDefinition
+  isOptional: boolean
+
+  constructor(fieldDefinition: RelationDefinition) {
+    this.relation = fieldDefinition
+    this.isOptional = false
+  }
+
+  public optional(): RelationListDefinition {
+    this.isOptional = true
+
+    return this
+  }
+
+  public toString(): string {
+    let modelName
+    if (typeof this.relation.referencedModel === 'function') {
+      modelName = this.relation.referencedModel().name
+    } else {
+      modelName = this.relation.referencedModel.name
+    }
+
+    const relationRequired = this.relation.isOptional ? '' : '!'
+    const listRequired = this.isOptional ? '' : '!'
+
+    const relationAttribute = this.relation.relationName
+      ? ` @relation(name: ${this.relation.relationName})`
+      : ''
+
+    return `[${modelName}${relationRequired}]${listRequired}${relationAttribute}`
+  }
+}
+
 class ListWithDefaultDefinition extends ListDefinition {
   fieldType: FieldType
 

--- a/packages/grafbase-sdk/src/index.ts
+++ b/packages/grafbase-sdk/src/index.ts
@@ -1,4 +1,4 @@
-import { ListDefinition } from './field/list'
+import { ListDefinition, RelationListDefinition } from './field/list'
 import {
   DefaultDefinition,
   LengthLimitedStringDefinition,
@@ -18,6 +18,7 @@ export type FieldShape =
   | ScalarDefinition
   | RelationDefinition
   | ListDefinition
+  | RelationListDefinition
   | SearchDefinition
   | ReferenceDefinition
   | UniqueDefinition

--- a/packages/grafbase-sdk/src/relation.ts
+++ b/packages/grafbase-sdk/src/relation.ts
@@ -1,5 +1,5 @@
 import { RelationRef } from '.'
-import { ListDefinition } from './field/list'
+import { ListDefinition, RelationListDefinition } from './field/list'
 
 export class RelationDefinition {
   relationName?: string
@@ -17,8 +17,8 @@ export class RelationDefinition {
     return this
   }
 
-  public list(): ListDefinition {
-    return new ListDefinition(this)
+  public list(): RelationListDefinition {
+    return new RelationListDefinition(this)
   }
 
   public name(name: string): RelationDefinition {

--- a/packages/grafbase-sdk/tests/unit/relation.test.ts
+++ b/packages/grafbase-sdk/tests/unit/relation.test.ts
@@ -189,4 +189,26 @@ describe('Relations generator', () => {
       }"
     `)
   })
+
+  it('generates named 1:m relations', () => {
+    const address = g.model('Address', {
+      line1: g.string()
+    })
+
+    g.model('Order', {
+      billingAddresses: g.relation(address).name('billing').list(),
+      shippingAddresses: g.relation(address).name('shipping').list()
+    })
+
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+      "type Address @model {
+        line1: String!
+      }
+
+      type Order @model {
+        billingAddresses: [Address!]! @relation(name: billing)
+        shippingAddresses: [Address!]! @relation(name: shipping)
+      }"
+    `)
+  })
 })


### PR DESCRIPTION
# Description

With the following config:

```typescript
const post = g.model('Post', {
    title: g.string(),
    content: g.string(),
    author: g.relation(user).name('userPosts'),
    comments: g.relation(() => comment).name('postComments').list()
})

const comment = g.model('Comment', {
    comment: g.string(),
    post: g.relation(post).name('postComments'),
    author: g.relation(user).name('userComments')
})
```

The `comments` relation in the `Post` model rendered wrong SDL:

```graphql
comments: [Comment! @relation(name: "postComments")]!
```

This patch will render the `@relation` attribute correctly outside of the list.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
