### PR TITLE
fix(sdk): Enable introspectionHeaders on GraphQL connector

### DIFF
--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",

--- a/packages/grafbase-sdk/src/connector/graphql.ts
+++ b/packages/grafbase-sdk/src/connector/graphql.ts
@@ -1,16 +1,17 @@
-import { Header, PartialHeaderGenerator, PartialHeaders } from './header'
+import { Header, Headers, HeaderGenerator } from './header'
 
 export interface GraphQLParams {
   url: string
-  headers?: PartialHeaderGenerator
+  headers?: HeaderGenerator
 }
 
 export class PartialGraphQLAPI {
   apiUrl: string
   headers: Header[]
+  introspectionHeaders: Header[]
 
   constructor(params: GraphQLParams) {
-    const headers = new PartialHeaders()
+    const headers = new Headers()
 
     if (params.headers) {
       params.headers(headers)
@@ -18,10 +19,16 @@ export class PartialGraphQLAPI {
 
     this.apiUrl = params.url
     this.headers = headers.headers
+    this.introspectionHeaders = headers.introspectionHeaders
   }
 
   finalize(namespace: string): GraphQLAPI {
-    return new GraphQLAPI(namespace, this.apiUrl, this.headers)
+    return new GraphQLAPI(
+      namespace,
+      this.apiUrl,
+      this.headers,
+      this.introspectionHeaders
+    )
   }
 }
 
@@ -29,11 +36,18 @@ export class GraphQLAPI {
   namespace: string
   url: string
   headers: Header[]
+  introspectionHeaders: Header[]
 
-  constructor(namespace: string, url: string, headers: Header[]) {
+  constructor(
+    namespace: string,
+    url: string,
+    headers: Header[],
+    introspectionHeaders: Header[]
+  ) {
     this.namespace = namespace
     this.url = url
     this.headers = headers
+    this.introspectionHeaders = introspectionHeaders
   }
 
   public toString(): string {
@@ -44,8 +58,16 @@ export class GraphQLAPI {
     var headers = this.headers.map((header) => `      ${header}`).join('\n')
     headers = headers ? `    headers: [\n${headers}\n    ]\n` : ''
 
+    var introspectionHeaders = this.introspectionHeaders
+      .map((header) => `      ${header}`)
+      .join('\n')
+
+    introspectionHeaders = headers
+      ? `    introspectionHeaders: [\n${introspectionHeaders}\n    ]\n`
+      : ''
+
     const footer = '  )'
 
-    return `${header}${namespace}${url}${headers}${footer}`
+    return `${header}${namespace}${url}${headers}${introspectionHeaders}${footer}`
   }
 }

--- a/packages/grafbase-sdk/src/connector/header.ts
+++ b/packages/grafbase-sdk/src/connector/header.ts
@@ -1,9 +1,8 @@
 export type HeaderGenerator = (headers: Headers) => any
-export type PartialHeaderGenerator = (headers: PartialHeaders) => any /**
 
 /**
-* Header used in connector calls.
-*/
+ * Header used in connector calls.
+ */
 export class Header {
   name: string
   value: string
@@ -19,13 +18,16 @@ export class Header {
 }
 
 /**
- * An accumulator class to gather headers for a connector.
+ * An accumulator class to gather headers for a connector which supports
+ * introspection headers.
  */
-export class PartialHeaders {
+export class Headers {
   headers: Header[]
+  introspectionHeaders: Header[]
 
   constructor() {
     this.headers = []
+    this.introspectionHeaders = []
   }
 
   /**
@@ -36,19 +38,6 @@ export class PartialHeaders {
    */
   public static(name: string, value: string) {
     this.headers.push(new Header(name, value))
-  }
-}
-
-/**
- * An accumulator class to gather headers for a connector which supports
- * introspection headers.
- */
-export class Headers extends PartialHeaders {
-  introspectionHeaders: Header[]
-
-  constructor() {
-    super()
-    this.introspectionHeaders = []
   }
 
   /**

--- a/packages/grafbase-sdk/tests/unit/graphql.test.ts
+++ b/packages/grafbase-sdk/tests/unit/graphql.test.ts
@@ -26,6 +26,7 @@ describe('GraphQL connector', () => {
       headers: (headers) => {
         headers.static('Authorization', 'Bearer {{ env.STRIPE_API_KEY }}')
         headers.static('Method', 'POST')
+        headers.introspection('Foo', 'BAR')
       }
     })
 
@@ -39,6 +40,9 @@ describe('GraphQL connector', () => {
           headers: [
             { name: "Authorization", value: "Bearer {{ env.STRIPE_API_KEY }}" }
             { name: "Method", value: "POST" }
+          ]
+          introspectionHeaders: [
+            { name: "Foo", value: "BAR" }
           ]
         )"
     `)


### PR DESCRIPTION
# Description

We should have introspection headers available for the GrapQL connector too.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [x] 📖 Requires documentation update
