### PR TITLE
GB-3801: Support @resolver attribute in model/type fields

### DIFF
--- a/packages/grafbase-sdk/src/auth.ts
+++ b/packages/grafbase-sdk/src/auth.ts
@@ -3,8 +3,19 @@ import { JWKSAuth } from './auth/jwks'
 import { JWTAuth } from './auth/jwt'
 import { OpenIDAuth } from './auth/openid'
 
+/**
+* A list of authentication providers which can be used in the configuration.
+*/
 export type AuthProvider = OpenIDAuth | JWTAuth | JWKSAuth
+
+/**
+* A closure to define authentication rules.
+*/
 export type AuthRuleF = (rules: AuthRules) => any
+
+/**
+* A list of supported authenticated operations.
+*/
 export type AuthOperation =
   | 'get'
   | 'list'
@@ -13,6 +24,14 @@ export type AuthOperation =
   | 'update'
   | 'delete'
 
+/**
+* A list of supported authentication strategies.
+*/
+export type AuthStrategy = 'private' | 'owner' | AuthGroups
+
+/**
+* A builder to greate auth groups.
+*/
 export class AuthGroups {
   groups: string[]
 
@@ -26,8 +45,9 @@ export class AuthGroups {
   }
 }
 
-export type AuthStrategy = 'private' | 'owner' | AuthGroups
-
+/**
+* A builder to create a rule to the auth attribute.
+*/
 export class AuthRule {
   strategy: AuthStrategy
   operations: AuthOperation[]
@@ -37,26 +57,32 @@ export class AuthRule {
     this.operations = []
   }
 
+  /** Allows the `get` operation for the given strategy. */
   public get(): AuthRule {
     return this.operation('get')
   }
 
+  /** Allows the `list` operation for the given strategy. */
   public list(): AuthRule {
     return this.operation('list')
   }
 
+  /** Allows the `read` operation for the given strategy. */
   public read(): AuthRule {
     return this.operation('read')
   }
 
+  /** Allows the `create` operation for the given strategy. */
   public create(): AuthRule {
     return this.operation('create')
   }
 
+  /** Allows the `update` operation for the given strategy. */
   public update(): AuthRule {
     return this.operation('update')
   }
 
+  /** Allows the `delete` operation for the given strategy. */
   public delete(): AuthRule {
     return this.operation('delete')
   }
@@ -77,6 +103,9 @@ export class AuthRule {
   }
 }
 
+/**
+* A builder to generate a set of rules to the auth attribute.
+*/
 export class AuthRules {
   rules: AuthRule[]
 
@@ -84,6 +113,9 @@ export class AuthRules {
     this.rules = []
   }
 
+  /**
+  * Allow access to any signed-in user.
+  */
   public private(): AuthRule {
     const rule = new AuthRule('private')
 
@@ -92,6 +124,9 @@ export class AuthRules {
     return rule
   }
 
+  /**
+  * Allow access to the owner only.
+  */
   public owner(): AuthRule {
     const rule = new AuthRule('owner')
 
@@ -100,6 +135,9 @@ export class AuthRules {
     return rule
   }
 
+  /**
+  * Allow access to users of a group.
+  */
   public groups(groups: string[]): AuthRule {
     const rule = new AuthRule(new AuthGroups(groups))
 

--- a/packages/grafbase-sdk/src/auth/jwt.ts
+++ b/packages/grafbase-sdk/src/auth/jwt.ts
@@ -1,3 +1,15 @@
+/**
+* Input parameters to define a JWT auth provider. Requres `issuer` and `secret`
+* to be defined, and optionally supports the `clientId` and `groupsClaim`
+* definitions.
+*
+* `clientId` should be defined for providers that sign tokens with the same
+* `iss` value. The value of `clientId` is checked against the `aud` claim
+* inside the JWT.
+*
+* `groupsClaim` should be defined for group-based auth to use a custom claim
+* path.
+*/
 export interface JWTParams {
   issuer: string
   secret: string
@@ -5,6 +17,10 @@ export interface JWTParams {
   groupsClaim?: string
 }
 
+/**
+* Grafbase supports a symmetric JWT provider that you can use to authorize
+* requests using a JWT signed by yourself or a third-party service.
+*/
 export class JWTAuth {
   issuer: string
   secret: string

--- a/packages/grafbase-sdk/src/config.ts
+++ b/packages/grafbase-sdk/src/config.ts
@@ -1,11 +1,17 @@
 import { AuthParams, Authentication } from './auth'
 import { GrafbaseSchema } from './grafbase-schema'
 
+/**
+* An interface to create the complete config definition.
+*/
 export interface ConfigInput {
   schema: GrafbaseSchema
   auth?: AuthParams
 }
 
+/**
+* Defines the complete Grafbase configuration.
+*/
 export class Config {
   schema: GrafbaseSchema
   auth?: Authentication

--- a/packages/grafbase-sdk/src/enum.ts
+++ b/packages/grafbase-sdk/src/enum.ts
@@ -1,5 +1,9 @@
 import { AtLeastOne } from '.'
 
+/**
+* Defines how an input enum can look like. Either an array of
+* strings with at least one item, or a TypeScript enum definition.
+*/
 export type EnumShape = AtLeastOne<string> | { [s: number]: string }
 
 export class Enum {

--- a/packages/grafbase-sdk/src/field/list.ts
+++ b/packages/grafbase-sdk/src/field/list.ts
@@ -18,6 +18,7 @@ export class ListDefinition {
   isOptional: boolean
   defaultValue?: DefaultValueType[]
   authRules?: AuthRules
+  resolverName?: string
 
   constructor(
     fieldDefinition: ScalarDefinition | RelationDefinition | ReferenceDefinition
@@ -45,6 +46,12 @@ export class ListDefinition {
     return this
   }
 
+  public resolver(name: string): ListDefinition {
+    this.resolverName = name
+
+    return this
+  }
+
   public toString(): string {
     const required = this.isOptional ? '' : '!'
 
@@ -52,7 +59,11 @@ export class ListDefinition {
       ? ` @auth(rules: ${this.authRules.toString().replace(/\s\s+/g, ' ')})`
       : ''
 
-    return `[${this.fieldDefinition}]${required}${rules}`
+    const resolver = this.resolverName
+      ? ` @resolver(name: "${this.resolverName}")`
+      : ''
+
+    return `[${this.fieldDefinition}]${required}${rules}${resolver}`
   }
 }
 

--- a/packages/grafbase-sdk/src/grafbase-schema.ts
+++ b/packages/grafbase-sdk/src/grafbase-schema.ts
@@ -121,7 +121,7 @@ export class GrafbaseSchema {
 
     if (definition.args != null) {
       Object.entries(definition.args).forEach(([name, type]) =>
-        query.pushArgument(name, type)
+        query.argument(name, type)
       )
     }
 
@@ -135,7 +135,7 @@ export class GrafbaseSchema {
 
     if (definition.args != null) {
       Object.entries(definition.args).forEach(
-        ([name, type]) => query.pushArgument(name, type),
+        ([name, type]) => query.argument(name, type),
         query
       )
     }

--- a/packages/grafbase-sdk/src/model.ts
+++ b/packages/grafbase-sdk/src/model.ts
@@ -6,6 +6,7 @@ import { RelationDefinition } from './relation'
 import { AuthDefinition } from './typedefs/auth'
 import { DefaultDefinition } from './typedefs/default'
 import { LengthLimitedStringDefinition } from './typedefs/length-limited-string'
+import { ResolverDefinition } from './typedefs/resolver'
 import { ScalarDefinition } from './typedefs/scalar'
 import { SearchDefinition } from './typedefs/search'
 import { UniqueDefinition } from './typedefs/unique'
@@ -29,6 +30,7 @@ export type ModelFieldShape =
   | DefaultDefinition
   | LengthLimitedStringDefinition
   | AuthDefinition
+  | ResolverDefinition
 
 export class Model {
   name: string

--- a/packages/grafbase-sdk/src/model.ts
+++ b/packages/grafbase-sdk/src/model.ts
@@ -46,24 +46,36 @@ export class Model {
     this.isLive = false
   }
 
+  /**
+  * Pushes a field to the model definition.
+  */
   public field(name: string, definition: ModelFieldShape): Model {
     this.fields.push(new Field(name, definition))
 
     return this
   }
 
+  /**
+  * Makes the model searchable.
+  */
   public search(): Model {
     this.isSearch = true
 
     return this
   }
 
+  /**
+  * Enables live queries to the model.
+  */
   public live(): Model {
     this.isLive = true
 
     return this
   }
 
+  /**
+  * Sets the per-model `@auth` directive.
+  */
   public auth(rules: AuthRuleF): Model {
     const authRules = new AuthRules()
     rules(authRules)

--- a/packages/grafbase-sdk/src/query.ts
+++ b/packages/grafbase-sdk/src/query.ts
@@ -2,15 +2,24 @@ import { ListDefinition } from './field/list'
 import { ReferenceDefinition } from './reference'
 import { ScalarDefinition } from './typedefs/scalar'
 
+/** The possible types of an input parameters of a query. */
 export type InputType = ScalarDefinition | ListDefinition | ReferenceDefinition
+
+/** The possible types of an output parameters of a query. */
 export type OutputType = ScalarDefinition | ListDefinition | ReferenceDefinition
 
+/**
+* Parameters to create a new query definition.
+*/
 export interface QueryInput {
   args?: Record<string, InputType>
   returns: OutputType
   resolver: string
 }
 
+/**
+* An input argument shape of a query.
+*/
 export class QueryArgument {
   name: string
   type: InputType
@@ -25,6 +34,9 @@ export class QueryArgument {
   }
 }
 
+/**
+* An edge resolver query definition.
+*/
 export class Query {
   name: string
   arguments: QueryArgument[]
@@ -38,7 +50,10 @@ export class Query {
     this.resolver = resolverName
   }
 
-  public pushArgument(name: string, type: InputType): Query {
+  /**
+  * Pushes a new input argument to the query.
+  */
+  public argument(name: string, type: InputType): Query {
     this.arguments.push(new QueryArgument(name, type))
 
     return this

--- a/packages/grafbase-sdk/src/reference.ts
+++ b/packages/grafbase-sdk/src/reference.ts
@@ -3,6 +3,7 @@ import { Enum } from './enum'
 import { ListDefinition } from './field/list'
 import { Type } from './type'
 import { AuthDefinition } from './typedefs/auth'
+import { ResolverDefinition } from './typedefs/resolver'
 
 export class ReferenceDefinition {
   referencedType: string
@@ -25,6 +26,10 @@ export class ReferenceDefinition {
 
   public auth(rules: AuthRuleF): AuthDefinition {
     return new AuthDefinition(this, rules)
+  }
+
+  public resolver(name: string): ResolverDefinition {
+    return new ResolverDefinition(this, name)
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/type.ts
+++ b/packages/grafbase-sdk/src/type.ts
@@ -25,19 +25,24 @@ export class Type {
   fields: Field[]
   interfaces: Interface[]
 
-  /** @param {string} name */
   constructor(name: string) {
     this.name = name
     this.fields = []
     this.interfaces = []
   }
 
+  /**
+  * Pushes a field to the type definition.
+  */
   public field(name: string, definition: TypeFieldShape): Type {
     this.fields.push(new Field(name, definition))
 
     return this
   }
 
+  /**
+  * Pushes an interface implemented by the type.
+  */
   public implements(i: Interface): Type {
     this.interfaces.push(i)
 

--- a/packages/grafbase-sdk/src/typedefs/default.ts
+++ b/packages/grafbase-sdk/src/typedefs/default.ts
@@ -3,6 +3,7 @@ import { Enum } from '../enum'
 import { FieldType } from '../field/typedefs'
 import { AuthDefinition } from './auth'
 import { LengthLimitedStringDefinition } from './length-limited-string'
+import { ResolverDefinition } from './resolver'
 import { ScalarDefinition, DefaultValueType } from './scalar'
 import { UniqueDefinition } from './unique'
 
@@ -29,6 +30,10 @@ export class DefaultDefinition {
 
   public auth(rules: AuthRuleF): AuthDefinition {
     return new AuthDefinition(this, rules)
+  }
+
+  public resolver(name: string): ResolverDefinition {
+    return new ResolverDefinition(this, name)
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/resolver.ts
+++ b/packages/grafbase-sdk/src/typedefs/resolver.ts
@@ -1,0 +1,26 @@
+import { ReferenceDefinition } from "../reference"
+import { DefaultDefinition } from "./default"
+import { ScalarDefinition } from "./scalar"
+import { UniqueDefinition } from "./unique"
+
+/**
+ * A list of field types that can hold a `@resolver` attribute.
+ */
+export type Resolvable = ScalarDefinition
+  | UniqueDefinition
+  | DefaultDefinition
+  | ReferenceDefinition
+
+export class ResolverDefinition {
+  field: Resolvable
+  resolver: string
+
+  constructor(field: Resolvable, resolver: string) {
+    this.field = field
+    this.resolver = resolver
+  }
+
+  public toString(): string {
+    return `${this.field} @resolver(name: "${this.resolver}")`
+  }
+}

--- a/packages/grafbase-sdk/src/typedefs/scalar.ts
+++ b/packages/grafbase-sdk/src/typedefs/scalar.ts
@@ -17,6 +17,7 @@ import { SearchDefinition } from './search'
 import { UniqueDefinition } from './unique'
 import { AuthDefinition } from './auth'
 import { AuthRuleF } from '../auth'
+import { ResolverDefinition } from './resolver'
 
 export type DefaultValueType = string | number | Date | object | boolean
 
@@ -50,6 +51,10 @@ export class ScalarDefinition {
 
   public auth(rules: AuthRuleF): AuthDefinition {
     return new AuthDefinition(this, rules)
+  }
+
+  public resolver(name: string): ResolverDefinition {
+    return new ResolverDefinition(this, name)
   }
 
   fieldTypeVal(): FieldType | Enum {

--- a/packages/grafbase-sdk/src/typedefs/unique.ts
+++ b/packages/grafbase-sdk/src/typedefs/unique.ts
@@ -2,6 +2,7 @@ import { AuthRuleF } from '../auth'
 import { AuthDefinition } from './auth'
 import { DefaultDefinition } from './default'
 import { LengthLimitedStringDefinition } from './length-limited-string'
+import { ResolverDefinition } from './resolver'
 import { ScalarDefinition } from './scalar'
 import { SearchDefinition } from './search'
 
@@ -26,6 +27,10 @@ export class UniqueDefinition {
 
   public auth(rules: AuthRuleF): AuthDefinition {
     return new AuthDefinition(this, rules)
+  }
+
+  public resolver(name: string): ResolverDefinition {
+    return new ResolverDefinition(this, name)
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/union.ts
+++ b/packages/grafbase-sdk/src/union.ts
@@ -1,5 +1,8 @@
 import { Type } from './type'
 
+/**
+* A builder to create a GraphQL union.
+*/
 export class Union {
   name: string
   types: string[]
@@ -9,6 +12,7 @@ export class Union {
     this.types = []
   }
 
+  /** Pushes a new type to the union definition. */
   public type(type: Type): Union {
     this.types.push(type.name)
 

--- a/packages/grafbase-sdk/tests/unit/model.test.ts
+++ b/packages/grafbase-sdk/tests/unit/model.test.ts
@@ -650,4 +650,72 @@ describe('Model generator', () => {
       }"
     `)
   })
+
+  it('generates a resolver to a field', () => {
+    g.model('User', {
+      name: g.string().resolver('a-field')
+    })
+
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String! @resolver(name: "a-field")
+      }"
+    `)
+  })
+
+  it('generates a unique field with a resolver', () => {
+    g.model('User', {
+      name: g.string().unique().resolver('a-field')
+    })
+
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String! @unique @resolver(name: "a-field")
+      }"
+    `)
+  })
+
+  it('generates a field with a default value and a resolver', () => {
+    g.model('User', {
+      name: g.string().default('Bob').resolver('a-field')
+    })
+
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String! @default(value: "Bob") @resolver(name: "a-field")
+      }"
+    `)
+  })
+
+  it('generates a composite type field with a resolver', () => {
+    const address = g.type('Address', {
+      street: g.string().optional()
+    })
+
+    g.model('User', {
+      name: g.ref(address).resolver('a-field')
+    })
+
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+      "type Address {
+        street: String
+      }
+
+      type User @model {
+        name: Address! @resolver(name: "a-field")
+      }"
+    `)
+  })
+
+  it('generates a list field with a resolver', () => {
+    g.model('User', {
+      name: g.string().list().resolver('a-field')
+    })
+
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+      "type User @model {
+        name: [String!]! @resolver(name: "a-field")
+      }"
+    `)
+  })
 })


### PR DESCRIPTION
# Description

Adds support to resolver attribute on fields:

```ts
type A @model {
  b: String @resolver(name: "some-resolver")
}

type B {
  c: String @resolver(name: "other-resolver")
}
```

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [x] 📖 Requires documentation update
