### PR TITLE
add introspection headers to contentful example

### DIFF
--- a/templates/graphql-contentful/grafbase/schema.graphql
+++ b/templates/graphql-contentful/grafbase/schema.graphql
@@ -5,4 +5,7 @@ extend schema
     headers: [
       { name: "Authorization", value: "Bearer {{ env.CONTENTFUL_API_TOKEN }}" }
     ]
+    introspectionHeaders: [
+      { name: "Authorization", value: "Bearer {{ env.CONTENTFUL_API_TOKEN }}" }
+    ]
   )


### PR DESCRIPTION
# Description

Contentful requires you to be authenticated for introspection queries. We don't send `headers` with that request but require the `introspectionHeaders` to be set. This PR fixes that.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
