### PR TITLE
feat(sdk): Caches

### DIFF
--- a/packages/grafbase-sdk/jest.config.js
+++ b/packages/grafbase-sdk/jest.config.js
@@ -1,5 +1,5 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'node',
+  testEnvironment: 'node'
 }

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -37,6 +37,7 @@
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
     "eslint": "^8.39.0",
+    "graphql": "^16.6.0",
     "jest": "=29.5.0",
     "npm-watch": "^0.11.0",
     "ts-jest": "=29.1.0",

--- a/packages/grafbase-sdk/src/auth.ts
+++ b/packages/grafbase-sdk/src/auth.ts
@@ -4,18 +4,18 @@ import { JWTAuth } from './auth/jwt'
 import { OpenIDAuth } from './auth/openid'
 
 /**
-* A list of authentication providers which can be used in the configuration.
-*/
+ * A list of authentication providers which can be used in the configuration.
+ */
 export type AuthProvider = OpenIDAuth | JWTAuth | JWKSAuth
 
 /**
-* A closure to define authentication rules.
-*/
+ * A closure to define authentication rules.
+ */
 export type AuthRuleF = (rules: AuthRules) => any
 
 /**
-* A list of supported authenticated operations.
-*/
+ * A list of supported authenticated operations.
+ */
 export type AuthOperation =
   | 'get'
   | 'list'
@@ -25,13 +25,13 @@ export type AuthOperation =
   | 'delete'
 
 /**
-* A list of supported authentication strategies.
-*/
+ * A list of supported authentication strategies.
+ */
 export type AuthStrategy = 'private' | 'owner' | AuthGroups
 
 /**
-* A builder to greate auth groups.
-*/
+ * A builder to greate auth groups.
+ */
 export class AuthGroups {
   groups: string[]
 
@@ -46,8 +46,8 @@ export class AuthGroups {
 }
 
 /**
-* A builder to create a rule to the auth attribute.
-*/
+ * A builder to create a rule to the auth attribute.
+ */
 export class AuthRule {
   strategy: AuthStrategy
   operations: AuthOperation[]
@@ -104,8 +104,8 @@ export class AuthRule {
 }
 
 /**
-* A builder to generate a set of rules to the auth attribute.
-*/
+ * A builder to generate a set of rules to the auth attribute.
+ */
 export class AuthRules {
   rules: AuthRule[]
 
@@ -114,8 +114,8 @@ export class AuthRules {
   }
 
   /**
-  * Allow access to any signed-in user.
-  */
+   * Allow access to any signed-in user.
+   */
   public private(): AuthRule {
     const rule = new AuthRule('private')
 
@@ -125,8 +125,8 @@ export class AuthRules {
   }
 
   /**
-  * Allow access to the owner only.
-  */
+   * Allow access to the owner only.
+   */
   public owner(): AuthRule {
     const rule = new AuthRule('owner')
 
@@ -136,8 +136,8 @@ export class AuthRules {
   }
 
   /**
-  * Allow access to users of a group.
-  */
+   * Allow access to users of a group.
+   */
   public groups(groups: string[]): AuthRule {
     const rule = new AuthRule(new AuthGroups(groups))
 

--- a/packages/grafbase-sdk/src/auth/jwt.ts
+++ b/packages/grafbase-sdk/src/auth/jwt.ts
@@ -1,15 +1,15 @@
 /**
-* Input parameters to define a JWT auth provider. Requres `issuer` and `secret`
-* to be defined, and optionally supports the `clientId` and `groupsClaim`
-* definitions.
-*
-* `clientId` should be defined for providers that sign tokens with the same
-* `iss` value. The value of `clientId` is checked against the `aud` claim
-* inside the JWT.
-*
-* `groupsClaim` should be defined for group-based auth to use a custom claim
-* path.
-*/
+ * Input parameters to define a JWT auth provider. Requres `issuer` and `secret`
+ * to be defined, and optionally supports the `clientId` and `groupsClaim`
+ * definitions.
+ *
+ * `clientId` should be defined for providers that sign tokens with the same
+ * `iss` value. The value of `clientId` is checked against the `aud` claim
+ * inside the JWT.
+ *
+ * `groupsClaim` should be defined for group-based auth to use a custom claim
+ * path.
+ */
 export interface JWTParams {
   issuer: string
   secret: string
@@ -18,9 +18,9 @@ export interface JWTParams {
 }
 
 /**
-* Grafbase supports a symmetric JWT provider that you can use to authorize
-* requests using a JWT signed by yourself or a third-party service.
-*/
+ * Grafbase supports a symmetric JWT provider that you can use to authorize
+ * requests using a JWT signed by yourself or a third-party service.
+ */
 export class JWTAuth {
   issuer: string
   secret: string

--- a/packages/grafbase-sdk/src/cache.ts
+++ b/packages/grafbase-sdk/src/cache.ts
@@ -1,0 +1,63 @@
+import util from 'node:util'
+
+/**
+* Defines a cached type with fields.
+*/
+export interface StructuredCacheRuleType {
+  name: string
+  fields: string[]  
+}
+
+/**
+* Defines a type to be cached. Can be a single type, multiple types
+* or more granularly types with specific fields.
+*/
+export type CachedType = string | string[] | StructuredCacheRuleType[]
+
+/**
+* Defines a single global cache rule.
+*/
+export interface CacheRuleParam {
+  types: CachedType
+  maxAge: number
+  staleWhileRevalidate: number
+}
+
+/**
+* Defines global cache rules.
+*/
+export interface CacheParams {
+  rules: CacheRuleParam[]
+}
+
+export class GlobalCache {
+  params: CacheParams
+
+  constructor(params: CacheParams) {
+    this.params = params
+  }
+
+  public toString(): string {
+    const rules = this.params.rules.map((rule) => {
+      var types
+      if (typeof rule.types === 'string') {
+        types = `"${rule.types}"`
+      } else {
+        const inner = rule.types.map((type) => {
+          if (typeof type === 'string') {
+            return `"${type}"`
+          } else {
+            const fields = type.fields.map((field) => `"${field}"`).join(',')
+            return `{\n        name: "${type.name}",\n        fields: [${fields}]\n      }`
+          }
+        }).join(', ')
+
+        types = `[${inner}]`
+      }
+
+      return `    {\n      types: ${types},\n      maxAge: ${rule.maxAge},\n      staleWhileRevalidate: ${rule.staleWhileRevalidate}\n    }`
+    })
+
+    return `extend schema\n  @cache(rules: [\n${rules}\n  ])\n\n`
+  }
+}

--- a/packages/grafbase-sdk/src/cache.ts
+++ b/packages/grafbase-sdk/src/cache.ts
@@ -1,22 +1,22 @@
 import util from 'node:util'
 
 /**
-* Defines a cached type with fields.
-*/
+ * Defines a cached type with fields.
+ */
 export interface StructuredCacheRuleType {
   name: string
-  fields: string[]  
+  fields: string[]
 }
 
 /**
-* Defines a type to be cached. Can be a single type, multiple types
-* or more granularly types with specific fields.
-*/
+ * Defines a type to be cached. Can be a single type, multiple types
+ * or more granularly types with specific fields.
+ */
 export type CachedType = string | string[] | StructuredCacheRuleType[]
 
 /**
-* Defines a single global cache rule.
-*/
+ * Defines a single global cache rule.
+ */
 export interface CacheRuleParam {
   types: CachedType
   maxAge: number
@@ -24,8 +24,8 @@ export interface CacheRuleParam {
 }
 
 /**
-* Defines global cache rules.
-*/
+ * Defines global cache rules.
+ */
 export interface CacheParams {
   rules: CacheRuleParam[]
 }
@@ -43,14 +43,16 @@ export class GlobalCache {
       if (typeof rule.types === 'string') {
         types = `"${rule.types}"`
       } else {
-        const inner = rule.types.map((type) => {
-          if (typeof type === 'string') {
-            return `"${type}"`
-          } else {
-            const fields = type.fields.map((field) => `"${field}"`).join(',')
-            return `{\n        name: "${type.name}",\n        fields: [${fields}]\n      }`
-          }
-        }).join(', ')
+        const inner = rule.types
+          .map((type) => {
+            if (typeof type === 'string') {
+              return `"${type}"`
+            } else {
+              const fields = type.fields.map((field) => `"${field}"`).join(',')
+              return `{\n        name: "${type.name}",\n        fields: [${fields}]\n      }`
+            }
+          })
+          .join(', ')
 
         types = `[${inner}]`
       }

--- a/packages/grafbase-sdk/src/config.ts
+++ b/packages/grafbase-sdk/src/config.ts
@@ -1,4 +1,5 @@
 import { AuthParams, Authentication } from './auth'
+import { CacheParams, GlobalCache } from './cache'
 import { GrafbaseSchema } from './grafbase-schema'
 
 /**
@@ -7,6 +8,7 @@ import { GrafbaseSchema } from './grafbase-schema'
 export interface ConfigInput {
   schema: GrafbaseSchema
   auth?: AuthParams
+  cache?: CacheParams
 }
 
 /**
@@ -15,6 +17,7 @@ export interface ConfigInput {
 export class Config {
   schema: GrafbaseSchema
   auth?: Authentication
+  cache?: GlobalCache
 
   constructor(input: ConfigInput) {
     this.schema = input.schema
@@ -22,12 +25,17 @@ export class Config {
     if (input.auth) {
       this.auth = new Authentication(input.auth)
     }
+
+    if (input.cache) {
+      this.cache = new GlobalCache(input.cache)
+    }
   }
 
   public toString(): string {
     const schema = this.schema.toString()
     const auth = this.auth ? this.auth.toString() : ''
+    const cache = this.cache ? this.cache.toString() : ''
 
-    return `${auth}${schema}`
+    return `${auth}${cache}${schema}`
   }
 }

--- a/packages/grafbase-sdk/src/config.ts
+++ b/packages/grafbase-sdk/src/config.ts
@@ -3,8 +3,8 @@ import { CacheParams, GlobalCache } from './cache'
 import { GrafbaseSchema } from './grafbase-schema'
 
 /**
-* An interface to create the complete config definition.
-*/
+ * An interface to create the complete config definition.
+ */
 export interface ConfigInput {
   schema: GrafbaseSchema
   auth?: AuthParams
@@ -12,8 +12,8 @@ export interface ConfigInput {
 }
 
 /**
-* Defines the complete Grafbase configuration.
-*/
+ * Defines the complete Grafbase configuration.
+ */
 export class Config {
   schema: GrafbaseSchema
   auth?: Authentication

--- a/packages/grafbase-sdk/src/enum.ts
+++ b/packages/grafbase-sdk/src/enum.ts
@@ -1,9 +1,9 @@
 import { AtLeastOne } from '.'
 
 /**
-* Defines how an input enum can look like. Either an array of
-* strings with at least one item, or a TypeScript enum definition.
-*/
+ * Defines how an input enum can look like. Either an array of
+ * strings with at least one item, or a TypeScript enum definition.
+ */
 export type EnumShape = AtLeastOne<string> | { [s: number]: string }
 
 export class Enum {

--- a/packages/grafbase-sdk/src/model.ts
+++ b/packages/grafbase-sdk/src/model.ts
@@ -4,6 +4,7 @@ import { ListDefinition, RelationListDefinition } from './field/list'
 import { ReferenceDefinition } from './reference'
 import { RelationDefinition } from './relation'
 import { AuthDefinition } from './typedefs/auth'
+import { CacheDefinition, CacheParams, TypeLevelCache } from './typedefs/cache'
 import { DefaultDefinition } from './typedefs/default'
 import { LengthLimitedStringDefinition } from './typedefs/length-limited-string'
 import { ResolverDefinition } from './typedefs/resolver'
@@ -31,6 +32,7 @@ export type ModelFieldShape =
   | LengthLimitedStringDefinition
   | AuthDefinition
   | ResolverDefinition
+  | CacheDefinition
 
 export class Model {
   name: string
@@ -38,6 +40,7 @@ export class Model {
   authRules?: AuthRules
   isSearch: boolean
   isLive: boolean
+  cacheDirective?: TypeLevelCache
 
   constructor(name: string) {
     this.name = name
@@ -47,8 +50,8 @@ export class Model {
   }
 
   /**
-  * Pushes a field to the model definition.
-  */
+   * Pushes a field to the model definition.
+   */
   public field(name: string, definition: ModelFieldShape): Model {
     this.fields.push(new Field(name, definition))
 
@@ -56,8 +59,8 @@ export class Model {
   }
 
   /**
-  * Makes the model searchable.
-  */
+   * Makes the model searchable.
+   */
   public search(): Model {
     this.isSearch = true
 
@@ -65,8 +68,8 @@ export class Model {
   }
 
   /**
-  * Enables live queries to the model.
-  */
+   * Enables live queries to the model.
+   */
   public live(): Model {
     this.isLive = true
 
@@ -74,8 +77,8 @@ export class Model {
   }
 
   /**
-  * Sets the per-model `@auth` directive.
-  */
+   * Sets the per-model `@auth` directive.
+   */
   public auth(rules: AuthRuleF): Model {
     const authRules = new AuthRules()
     rules(authRules)
@@ -84,11 +87,21 @@ export class Model {
     return this
   }
 
+  /**
+   * Sets the model `@cache` directive.
+   */
+  public cache(params: CacheParams): Model {
+    this.cacheDirective = new TypeLevelCache(params)
+
+    return this
+  }
+
   public toString(): string {
     const search = this.isSearch ? ' @search' : ''
     const live = this.isLive ? ' @live' : ''
     const auth = this.authRules ? ` @auth(\n    rules: ${this.authRules})` : ''
-    const header = `type ${this.name} @model${search}${live}${auth} {`
+    const cache = this.cacheDirective ? ` ${this.cacheDirective}` : ''
+    const header = `type ${this.name} @model${search}${live}${auth}${cache} {`
 
     const fields = this.fields.map((field) => `  ${field}`).join('\n')
 

--- a/packages/grafbase-sdk/src/query.ts
+++ b/packages/grafbase-sdk/src/query.ts
@@ -9,8 +9,8 @@ export type InputType = ScalarDefinition | ListDefinition | ReferenceDefinition
 export type OutputType = ScalarDefinition | ListDefinition | ReferenceDefinition
 
 /**
-* Parameters to create a new query definition.
-*/
+ * Parameters to create a new query definition.
+ */
 export interface QueryInput {
   args?: Record<string, InputType>
   returns: OutputType
@@ -18,8 +18,8 @@ export interface QueryInput {
 }
 
 /**
-* An input argument shape of a query.
-*/
+ * An input argument shape of a query.
+ */
 export class QueryArgument {
   name: string
   type: InputType
@@ -35,8 +35,8 @@ export class QueryArgument {
 }
 
 /**
-* An edge resolver query definition.
-*/
+ * An edge resolver query definition.
+ */
 export class Query {
   name: string
   arguments: QueryArgument[]
@@ -51,8 +51,8 @@ export class Query {
   }
 
   /**
-  * Pushes a new input argument to the query.
-  */
+   * Pushes a new input argument to the query.
+   */
   public argument(name: string, type: InputType): Query {
     this.arguments.push(new QueryArgument(name, type))
 

--- a/packages/grafbase-sdk/src/type.ts
+++ b/packages/grafbase-sdk/src/type.ts
@@ -2,6 +2,7 @@ import { Field } from './field'
 import { ListDefinition } from './field/list'
 import { Interface } from './interface'
 import { ReferenceDefinition } from './reference'
+import { CacheDefinition, CacheParams, TypeLevelCache } from './typedefs/cache'
 import { ScalarDefinition } from './typedefs/scalar'
 
 /**
@@ -16,6 +17,7 @@ export type TypeFieldShape =
   | ScalarDefinition
   | ListDefinition
   | ReferenceDefinition
+  | CacheDefinition
 
 /**
  * A composite type definition (e.g. not a model).
@@ -24,6 +26,7 @@ export class Type {
   name: string
   fields: Field[]
   interfaces: Interface[]
+  cacheDirective?: TypeLevelCache
 
   constructor(name: string) {
     this.name = name
@@ -32,27 +35,37 @@ export class Type {
   }
 
   /**
-  * Pushes a field to the type definition.
-  */
-  public field(name: string, definition: TypeFieldShape): Type {
+   * Pushes a field to the type definition.
+   */
+  public field(name: string, definition: TypeFieldShape): this {
     this.fields.push(new Field(name, definition))
 
     return this
   }
 
   /**
-  * Pushes an interface implemented by the type.
-  */
-  public implements(i: Interface): Type {
+   * Pushes an interface implemented by the type.
+   */
+  public implements(i: Interface): this {
     this.interfaces.push(i)
+
+    return this
+  }
+
+  /**
+   * Sets the type `@cache` directive.
+   */
+  public cache(params: CacheParams): this {
+    this.cacheDirective = new TypeLevelCache(params)
 
     return this
   }
 
   public toString(): string {
     const interfaces = this.interfaces.map((i) => i.name).join(' & ')
+    const cache = this.cacheDirective ? ` ${this.cacheDirective}` : ''
     const impl = interfaces ? ` implements ${interfaces}` : ''
-    const header = `type ${this.name}${impl} {`
+    const header = `type ${this.name}${cache}${impl} {`
 
     const fields = distinct(
       (this.interfaces.flatMap((i) => i.fields) ?? []).concat(this.fields)

--- a/packages/grafbase-sdk/src/typedefs/auth.ts
+++ b/packages/grafbase-sdk/src/typedefs/auth.ts
@@ -1,8 +1,10 @@
 import { AuthRuleF, AuthRules } from '../auth'
 import { ReferenceDefinition } from '../reference'
 import { RelationDefinition } from '../relation'
+import { CacheDefinition, CacheParams, TypeLevelCache } from './cache'
 import { DefaultDefinition } from './default'
 import { LengthLimitedStringDefinition } from './length-limited-string'
+import { ResolverDefinition } from './resolver'
 import { ScalarDefinition } from './scalar'
 import { SearchDefinition } from './search'
 import { UniqueDefinition } from './unique'
@@ -15,6 +17,8 @@ export type Authenticable =
   | ReferenceDefinition
   | LengthLimitedStringDefinition
   | RelationDefinition
+  | CacheDefinition
+  | ResolverDefinition
 
 export class AuthDefinition {
   field: Authenticable
@@ -26,6 +30,18 @@ export class AuthDefinition {
 
     this.authRules = authRules
     this.field = field
+  }
+
+  public search(): SearchDefinition {
+    return new SearchDefinition(this)
+  }
+
+  public unique(scope?: string[]): UniqueDefinition {
+    return new UniqueDefinition(this, scope)
+  }
+
+  public cache(params: CacheParams): CacheDefinition {
+    return new CacheDefinition(this, new TypeLevelCache(params))
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/cache.ts
+++ b/packages/grafbase-sdk/src/typedefs/cache.ts
@@ -1,0 +1,56 @@
+import { AuthRuleF } from '../auth'
+import { AuthDefinition } from './auth'
+import { DefaultDefinition } from './default'
+import { LengthLimitedStringDefinition } from './length-limited-string'
+import { ResolverDefinition } from './resolver'
+import { ScalarDefinition } from './scalar'
+import { SearchDefinition } from './search'
+import { UniqueDefinition } from './unique'
+
+export type Cacheable =
+  | ScalarDefinition
+  | AuthDefinition
+  | DefaultDefinition
+  | ResolverDefinition
+  | LengthLimitedStringDefinition
+  | SearchDefinition
+  | UniqueDefinition
+
+export interface CacheParams {
+  maxAge: number
+  staleWhileRevalidate: number
+}
+
+export class TypeLevelCache {
+  params: CacheParams
+
+  constructor(params: CacheParams) {
+    this.params = params
+  }
+
+  public toString(): string {
+    return `@cache(maxAge: ${this.params.maxAge}, staleWhileRevalidate: ${this.params.staleWhileRevalidate})`
+  }
+}
+
+export class CacheDefinition {
+  attribute: TypeLevelCache
+  field: Cacheable
+
+  constructor(field: Cacheable, attribute: TypeLevelCache) {
+    this.attribute = attribute
+    this.field = field
+  }
+
+  public auth(rules: AuthRuleF): AuthDefinition {
+    return new AuthDefinition(this, rules)
+  }
+
+  public search(): SearchDefinition {
+    return new SearchDefinition(this)
+  }
+
+  public toString(): string {
+    return `${this.field} ${this.attribute}`
+  }
+}

--- a/packages/grafbase-sdk/src/typedefs/default.ts
+++ b/packages/grafbase-sdk/src/typedefs/default.ts
@@ -2,10 +2,12 @@ import { AuthRuleF } from '../auth'
 import { Enum } from '../enum'
 import { FieldType } from '../field/typedefs'
 import { AuthDefinition } from './auth'
+import { CacheDefinition, TypeLevelCache, CacheParams } from './cache'
 import { LengthLimitedStringDefinition } from './length-limited-string'
-import { ResolverDefinition } from './resolver'
 import { ScalarDefinition, DefaultValueType } from './scalar'
 import { UniqueDefinition } from './unique'
+
+export type DefaultAllowed = ScalarDefinition | LengthLimitedStringDefinition
 
 export class DefaultDefinition {
   defaultValue: DefaultValueType
@@ -32,8 +34,8 @@ export class DefaultDefinition {
     return new AuthDefinition(this, rules)
   }
 
-  public resolver(name: string): ResolverDefinition {
-    return new ResolverDefinition(this, name)
+  public cache(params: CacheParams): CacheDefinition {
+    return new CacheDefinition(this, new TypeLevelCache(params))
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/length-limited-string.ts
+++ b/packages/grafbase-sdk/src/typedefs/length-limited-string.ts
@@ -7,6 +7,7 @@ import { StringDefinition } from './scalar'
 import { SearchDefinition } from './search'
 import { AuthRuleF } from '../auth'
 import { AuthDefinition } from './auth'
+import { CacheDefinition, CacheParams, TypeLevelCache } from './cache'
 
 export interface FieldLength {
   min?: number
@@ -45,6 +46,10 @@ export class LengthLimitedStringDefinition {
 
   public auth(rules: AuthRuleF): AuthDefinition {
     return new AuthDefinition(this, rules)
+  }
+
+  public cache(params: CacheParams): CacheDefinition {
+    return new CacheDefinition(this, new TypeLevelCache(params))
   }
 
   fieldTypeVal(): FieldType | Enum {

--- a/packages/grafbase-sdk/src/typedefs/resolver.ts
+++ b/packages/grafbase-sdk/src/typedefs/resolver.ts
@@ -1,15 +1,20 @@
-import { ReferenceDefinition } from "../reference"
-import { DefaultDefinition } from "./default"
-import { ScalarDefinition } from "./scalar"
-import { UniqueDefinition } from "./unique"
+import { AuthRuleF } from '../auth'
+import { ReferenceDefinition } from '../reference'
+import { AuthDefinition } from './auth'
+import { CacheDefinition, CacheParams, TypeLevelCache } from './cache'
+import { DefaultDefinition } from './default'
+import { ScalarDefinition } from './scalar'
+import { SearchDefinition } from './search'
+import { UniqueDefinition } from './unique'
 
 /**
  * A list of field types that can hold a `@resolver` attribute.
  */
-export type Resolvable = ScalarDefinition
-  | UniqueDefinition
+export type Resolvable =
+  | ScalarDefinition
   | DefaultDefinition
   | ReferenceDefinition
+  | CacheDefinition
 
 export class ResolverDefinition {
   field: Resolvable
@@ -18,6 +23,22 @@ export class ResolverDefinition {
   constructor(field: Resolvable, resolver: string) {
     this.field = field
     this.resolver = resolver
+  }
+
+  public auth(rules: AuthRuleF): AuthDefinition {
+    return new AuthDefinition(this, rules)
+  }
+
+  public search(): SearchDefinition {
+    return new SearchDefinition(this)
+  }
+
+  public unique(scope?: string[]): UniqueDefinition {
+    return new UniqueDefinition(this, scope)
+  }
+
+  public cache(params: CacheParams): CacheDefinition {
+    return new CacheDefinition(this, new TypeLevelCache(params))
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/scalar.ts
+++ b/packages/grafbase-sdk/src/typedefs/scalar.ts
@@ -18,6 +18,7 @@ import { UniqueDefinition } from './unique'
 import { AuthDefinition } from './auth'
 import { AuthRuleF } from '../auth'
 import { ResolverDefinition } from './resolver'
+import { CacheDefinition, CacheParams, TypeLevelCache } from './cache'
 
 export type DefaultValueType = string | number | Date | object | boolean
 
@@ -31,7 +32,7 @@ export class ScalarDefinition {
     this.isOptional = false
   }
 
-  public optional(): ScalarDefinition {
+  public optional(): this {
     this.isOptional = true
 
     return this
@@ -55,6 +56,10 @@ export class ScalarDefinition {
 
   public resolver(name: string): ResolverDefinition {
     return new ResolverDefinition(this, name)
+  }
+
+  public cache(params: CacheParams): CacheDefinition {
+    return new CacheDefinition(this, new TypeLevelCache(params))
   }
 
   fieldTypeVal(): FieldType | Enum {

--- a/packages/grafbase-sdk/src/typedefs/search.ts
+++ b/packages/grafbase-sdk/src/typedefs/search.ts
@@ -1,7 +1,9 @@
 import { AuthRuleF } from '../auth'
 import { ListDefinition } from '../field/list'
 import { AuthDefinition } from './auth'
+import { CacheDefinition, CacheParams, TypeLevelCache } from './cache'
 import { LengthLimitedStringDefinition } from './length-limited-string'
+import { ResolverDefinition } from './resolver'
 import { ScalarDefinition } from './scalar'
 import { UniqueDefinition } from './unique'
 
@@ -13,6 +15,9 @@ export type Searchable =
   | ListDefinition
   | UniqueDefinition
   | LengthLimitedStringDefinition
+  | CacheDefinition
+  | AuthDefinition
+  | ResolverDefinition
 
 export class SearchDefinition {
   field: Searchable
@@ -23,6 +28,14 @@ export class SearchDefinition {
 
   public auth(rules: AuthRuleF): AuthDefinition {
     return new AuthDefinition(this, rules)
+  }
+
+  public cache(params: CacheParams): CacheDefinition {
+    return new CacheDefinition(this, new TypeLevelCache(params))
+  }
+
+  public unique(scope?: string[]): UniqueDefinition {
+    return new UniqueDefinition(this, scope)
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/unique.ts
+++ b/packages/grafbase-sdk/src/typedefs/unique.ts
@@ -1,5 +1,6 @@
 import { AuthRuleF } from '../auth'
 import { AuthDefinition } from './auth'
+import { CacheDefinition, CacheParams, TypeLevelCache } from './cache'
 import { DefaultDefinition } from './default'
 import { LengthLimitedStringDefinition } from './length-limited-string'
 import { ResolverDefinition } from './resolver'
@@ -11,6 +12,9 @@ type UniqueScalarType =
   | DefaultDefinition
   | SearchDefinition
   | LengthLimitedStringDefinition
+  | AuthDefinition
+  | ResolverDefinition
+  | CacheDefinition
 
 export class UniqueDefinition {
   compoundScope?: string[]
@@ -29,8 +33,8 @@ export class UniqueDefinition {
     return new AuthDefinition(this, rules)
   }
 
-  public resolver(name: string): ResolverDefinition {
-    return new ResolverDefinition(this, name)
+  public cache(params: CacheParams): CacheDefinition {
+    return new CacheDefinition(this, new TypeLevelCache(params))
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/union.ts
+++ b/packages/grafbase-sdk/src/union.ts
@@ -1,8 +1,8 @@
 import { Type } from './type'
 
 /**
-* A builder to create a GraphQL union.
-*/
+ * A builder to create a GraphQL union.
+ */
 export class Union {
   name: string
   types: string[]

--- a/packages/grafbase-sdk/tests/unit/auth.jwks.test.ts
+++ b/packages/grafbase-sdk/tests/unit/auth.jwks.test.ts
@@ -1,5 +1,6 @@
 import { config, g, auth } from '../../src/index'
 import { describe, expect, it, beforeEach } from '@jest/globals'
+import { renderGraphQL } from '../utils'
 
 describe('OpenID auth provider', () => {
   beforeEach(() => g.clear())
@@ -19,7 +20,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [
@@ -47,7 +48,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [
@@ -76,7 +77,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [
@@ -105,7 +106,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [
@@ -134,7 +135,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [

--- a/packages/grafbase-sdk/tests/unit/auth.jwt.test.ts
+++ b/packages/grafbase-sdk/tests/unit/auth.jwt.test.ts
@@ -1,5 +1,6 @@
 import { config, g, auth } from '../../src/index'
 import { describe, expect, it, beforeEach } from '@jest/globals'
+import { renderGraphQL } from '../utils'
 
 describe('OpenID auth provider', () => {
   beforeEach(() => g.clear())
@@ -20,7 +21,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [
@@ -50,7 +51,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [
@@ -80,7 +81,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [

--- a/packages/grafbase-sdk/tests/unit/auth.openid.test.ts
+++ b/packages/grafbase-sdk/tests/unit/auth.openid.test.ts
@@ -1,5 +1,6 @@
 import { config, g, auth } from '../../src/index'
 import { describe, expect, it, beforeEach } from '@jest/globals'
+import { renderGraphQL } from '../utils'
 
 describe('OpenID auth provider', () => {
   beforeEach(() => g.clear())
@@ -19,7 +20,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [
@@ -48,7 +49,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [
@@ -77,7 +78,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [
@@ -105,7 +106,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [
@@ -133,7 +134,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [
@@ -161,7 +162,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [
@@ -189,7 +190,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [
@@ -217,7 +218,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [
@@ -245,7 +246,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [
@@ -273,7 +274,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [
@@ -301,7 +302,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [
@@ -329,7 +330,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [
@@ -357,7 +358,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [
@@ -385,7 +386,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [
@@ -415,7 +416,7 @@ describe('OpenID auth provider', () => {
       }
     })
 
-    expect(cfg.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
           providers: [

--- a/packages/grafbase-sdk/tests/unit/cache.test.ts
+++ b/packages/grafbase-sdk/tests/unit/cache.test.ts
@@ -1,0 +1,118 @@
+import { config, g } from '../../src/index'
+import { describe, expect, it, beforeEach } from '@jest/globals'
+import { renderGraphQL } from '../utils'
+
+describe('Cache generator', () => {
+  beforeEach(() => g.clear())
+
+  it('renders single type global cache', async () => {
+    g.type('A', {
+      b: g.int().optional()
+    })
+
+    const cfg = config({
+      schema: g,
+      cache: {
+        rules: [
+          {
+            types: 'Query',
+            maxAge: 60,
+            staleWhileRevalidate: 60
+          }
+        ]
+      }
+    })
+
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
+      "extend schema
+        @cache(rules: [
+          {
+            types: "Query",
+            maxAge: 60,
+            staleWhileRevalidate: 60
+          }
+        ])
+
+      type A {
+        b: Int
+      }"
+    `)
+  })
+
+  it('renders multi-type global cache', async () => {
+    g.type('A', {
+      b: g.int().optional()
+    })
+
+    const cfg = config({
+      schema: g,
+      cache: {
+        rules: [
+          {
+            types: ['Query', 'Schwuery'],
+            maxAge: 60,
+            staleWhileRevalidate: 60
+          }
+        ]
+      }
+    })
+
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
+      "extend schema
+        @cache(rules: [
+          {
+            types: ["Query", "Schwuery"],
+            maxAge: 60,
+            staleWhileRevalidate: 60
+          }
+        ])
+
+      type A {
+        b: Int
+      }"
+    `)
+  })
+
+  it('renders complex multi-type global cache', async () => {
+    g.type('A', {
+      b: g.int().optional()
+    })
+
+    const cfg = config({
+      schema: g,
+      cache: {
+        rules: [
+          {
+            types: [
+              { name: 'User', fields: ['name', 'age'] },
+              { name: 'Address', fields: ['street', 'city'] }
+            ],
+            maxAge: 60,
+            staleWhileRevalidate: 60
+          }
+        ]
+      }
+    })
+
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
+      "extend schema
+        @cache(rules: [
+          {
+            types: [{
+              name: "User",
+              fields: ["name","age"]
+            }, {
+              name: "Address",
+              fields: ["street","city"]
+            }],
+            maxAge: 60,
+            staleWhileRevalidate: 60
+          }
+        ])
+
+      type A {
+        b: Int
+      }"
+    `)
+  })
+})

--- a/packages/grafbase-sdk/tests/unit/defaults.test.ts
+++ b/packages/grafbase-sdk/tests/unit/defaults.test.ts
@@ -1,5 +1,6 @@
 import { g } from '../../src/index'
 import { describe, expect, it } from '@jest/globals'
+import { renderGraphQL } from '../utils'
 
 describe('Default value generation', () => {
   it('generates String default', () => {
@@ -7,7 +8,7 @@ describe('Default value generation', () => {
       name: g.string().default('Bob')
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: String! @default(value: "Bob")
       }"
@@ -19,7 +20,7 @@ describe('Default value generation', () => {
       name: g.string().default('Bob').optional()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: String @default(value: "Bob")
       }"
@@ -31,7 +32,7 @@ describe('Default value generation', () => {
       name: g.string().list().default(['Bob'])
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: [String!]! @default(value: ["Bob"])
       }"
@@ -43,7 +44,7 @@ describe('Default value generation', () => {
       name: g.id().default('asdf123')
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: ID! @default(value: "asdf123")
       }"
@@ -55,7 +56,7 @@ describe('Default value generation', () => {
       name: g.id().list().default(['asdf123', 'omg123'])
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: [ID!]! @default(value: ["asdf123", "omg123"])
       }"
@@ -67,7 +68,7 @@ describe('Default value generation', () => {
       name: g.phoneNumber().default('555 123 123')
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: PhoneNumber! @default(value: "555 123 123")
       }"
@@ -79,7 +80,7 @@ describe('Default value generation', () => {
       name: g.phoneNumber().list().default(['555 123 123', '555 432 432'])
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: [PhoneNumber!]! @default(value: ["555 123 123", "555 432 432"])
       }"
@@ -91,7 +92,7 @@ describe('Default value generation', () => {
       name: g.ipAddress().default('0.0.0.0')
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: IPAddress! @default(value: "0.0.0.0")
       }"
@@ -103,7 +104,7 @@ describe('Default value generation', () => {
       name: g.ipAddress().list().default(['0.0.0.0', '1.1.1.1'])
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: [IPAddress!]! @default(value: ["0.0.0.0", "1.1.1.1"])
       }"
@@ -115,7 +116,7 @@ describe('Default value generation', () => {
       name: g.email().default('foo@bar.lol')
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: Email! @default(value: "foo@bar.lol")
       }"
@@ -127,7 +128,7 @@ describe('Default value generation', () => {
       name: g.email().list().default(['foo@bar.lol'])
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: [Email!]! @default(value: ["foo@bar.lol"])
       }"
@@ -139,7 +140,7 @@ describe('Default value generation', () => {
       name: g.url().default('https://github.com')
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: URL! @default(value: "https://github.com")
       }"
@@ -154,7 +155,7 @@ describe('Default value generation', () => {
         .default(['https://github.com', 'https://codeberg.org'])
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: [URL!]! @default(value: ["https://github.com", "https://codeberg.org"])
       }"
@@ -166,7 +167,7 @@ describe('Default value generation', () => {
       name: g.int().default(2)
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: Int! @default(value: 2)
       }"
@@ -178,7 +179,7 @@ describe('Default value generation', () => {
       name: g.int().list().default([2])
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: [Int!]! @default(value: [2])
       }"
@@ -190,7 +191,7 @@ describe('Default value generation', () => {
       name: g.float().default(1.337)
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: Float! @default(value: 1.337)
       }"
@@ -202,7 +203,7 @@ describe('Default value generation', () => {
       name: g.float().list().default([1.337, 2.32])
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: [Float!]! @default(value: [1.337, 2.32])
       }"
@@ -214,7 +215,7 @@ describe('Default value generation', () => {
       name: g.boolean().default(false)
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: Boolean! @default(value: false)
       }"
@@ -226,7 +227,7 @@ describe('Default value generation', () => {
       name: g.boolean().list().default([true, false])
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: [Boolean!]! @default(value: [true, false])
       }"
@@ -238,7 +239,7 @@ describe('Default value generation', () => {
       date: g.date().default(new Date('1995-12-17'))
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         date: Date! @default(value: "1995-12-17")
       }"
@@ -253,7 +254,7 @@ describe('Default value generation', () => {
         .default([new Date('1995-12-17'), new Date('2002-01-01')])
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         date: [Date!]! @default(value: ["1995-12-17", "2002-01-01"])
       }"
@@ -265,7 +266,7 @@ describe('Default value generation', () => {
       date: g.datetime().default(new Date('1995-12-17T04:20:00Z'))
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         date: DateTime! @default(value: "1995-12-17T04:20:00Z")
       }"
@@ -283,7 +284,7 @@ describe('Default value generation', () => {
         ])
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         date: [DateTime!]! @default(value: ["1995-12-17T04:20:00Z", "2002-12-17T04:20:00Z"])
       }"
@@ -295,7 +296,7 @@ describe('Default value generation', () => {
       date: g.timestamp().default(1683644443566)
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         date: Timestamp! @default(value: 1683644443566)
       }"
@@ -307,7 +308,7 @@ describe('Default value generation', () => {
       date: g.timestamp().list().default([1683644443566, 1683644443569])
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         date: [Timestamp!]! @default(value: [1683644443566, 1683644443569])
       }"

--- a/packages/grafbase-sdk/tests/unit/enum.test.ts
+++ b/packages/grafbase-sdk/tests/unit/enum.test.ts
@@ -1,5 +1,6 @@
 import { config, g } from '../../src/index'
 import { describe, expect, it, beforeEach } from '@jest/globals'
+import { renderGraphQL } from '../utils'
 
 describe('Enum generator', () => {
   beforeEach(() => {
@@ -9,7 +10,7 @@ describe('Enum generator', () => {
   it('generates an enum from an array of strings', () => {
     const e = g.enum('Fruits', ['Apples', 'Oranges'])
 
-    expect(e.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(e)).toMatchInlineSnapshot(`
       "enum Fruits {
         Apples,
         Oranges
@@ -25,7 +26,7 @@ describe('Enum generator', () => {
 
     const e = g.enum('Fruits', Fruits)
 
-    expect(e.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(e)).toMatchInlineSnapshot(`
       "enum Fruits {
         Apples,
         Oranges
@@ -40,7 +41,7 @@ describe('Enum generator', () => {
       fruitType: g.ref(e)
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "enum Fruits {
         Apples,
         Oranges

--- a/packages/grafbase-sdk/tests/unit/graphql.test.ts
+++ b/packages/grafbase-sdk/tests/unit/graphql.test.ts
@@ -1,5 +1,6 @@
 import { config, g, connector } from '../../src/index'
 import { describe, expect, it, beforeEach } from '@jest/globals'
+import { renderGraphQL } from '../utils'
 
 describe('GraphQL connector', () => {
   beforeEach(() => g.clear())
@@ -11,7 +12,7 @@ describe('GraphQL connector', () => {
 
     g.datasource(contentful, { namespace: 'Contentful' })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend schema
         @graphql(
           name: "Contentful"
@@ -32,7 +33,7 @@ describe('GraphQL connector', () => {
 
     g.datasource(contentful, { namespace: 'Contentful' })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend schema
         @graphql(
           name: "Contentful"
@@ -60,7 +61,7 @@ describe('GraphQL connector', () => {
     g.datasource(contentful, { namespace: 'Contentful' })
     g.datasource(github, { namespace: 'GitHub' })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend schema
         @graphql(
           name: "Contentful"

--- a/packages/grafbase-sdk/tests/unit/interface.test.ts
+++ b/packages/grafbase-sdk/tests/unit/interface.test.ts
@@ -1,5 +1,6 @@
 import { config, g } from '../../src/index'
 import { describe, expect, it, beforeEach } from '@jest/globals'
+import { renderGraphQL } from '../utils'
 
 describe('Interface generator', () => {
   beforeEach(() => g.clear())
@@ -12,7 +13,7 @@ describe('Interface generator', () => {
       nutrients: g.string().optional().list().optional()
     })
 
-    expect(i.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(i)).toMatchInlineSnapshot(`
       "interface Produce {
         name: String!
         quantity: Int!
@@ -35,7 +36,7 @@ describe('Interface generator', () => {
       ripenessIndicators: g.string().optional().list().optional()
     }).implements(produce)
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "interface Produce {
         name: String!
         quantity: Int!
@@ -71,7 +72,7 @@ describe('Interface generator', () => {
       .implements(produce)
       .implements(sweets)
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "interface Produce {
         name: String!
       }

--- a/packages/grafbase-sdk/tests/unit/model.test.ts
+++ b/packages/grafbase-sdk/tests/unit/model.test.ts
@@ -395,7 +395,7 @@ describe('Model generator', () => {
       address: g.ref(address).optional()
     })
 
-    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type Address {
         street: String
       }
@@ -411,6 +411,7 @@ describe('Model generator', () => {
     const user = g.model('User', {
       name: g
         .string()
+        .optional()
         .length({ min: 2 })
         .default('foo')
         .unique()
@@ -418,11 +419,12 @@ describe('Model generator', () => {
         .auth((rules) => {
           rules.private()
         })
+        .cache({ maxAge: 10, staleWhileRevalidate: 5 })
     })
 
-    expect(user.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(user)).toMatchInlineSnapshot(`
       "type User @model {
-        name: String! @length(min: 2) @default(value: "foo") @unique @search @auth(rules: [ { allow: private } ])
+        name: String @length(min: 2) @default(value: "foo") @unique @search @auth(rules: [ { allow: private } ]) @cache(maxAge: 10, staleWhileRevalidate: 5)
       }"
     `)
   })
@@ -437,7 +439,7 @@ describe('Model generator', () => {
       address: g.ref(address).optional()
     })
 
-    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type Address {
         street: String
       }
@@ -459,7 +461,7 @@ describe('Model generator', () => {
       addresses: g.ref(address).list()
     })
 
-    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type Address {
         street: String
       }
@@ -478,7 +480,7 @@ describe('Model generator', () => {
       rules.private().read()
     })
 
-    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User @model @auth(
           rules: [
             { allow: private, operations: [read] }
@@ -496,7 +498,7 @@ describe('Model generator', () => {
       rules.groups(['admin'])
     })
 
-    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User @model @auth(
           rules: [
             { allow: private, operations: [read] }
@@ -514,7 +516,7 @@ describe('Model generator', () => {
       })
     })
 
-    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User @model {
         name: String! @auth(rules: [ { allow: groups, groups: ["admin"] } ])
       }"
@@ -531,7 +533,7 @@ describe('Model generator', () => {
         })
     })
 
-    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User @model {
         name: String! @unique @auth(rules: [ { allow: groups, groups: ["admin"] } ])
       }"
@@ -548,7 +550,7 @@ describe('Model generator', () => {
         })
     })
 
-    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User @model {
         age: Int! @default(value: 1) @auth(rules: [ { allow: private } ])
       }"
@@ -565,7 +567,7 @@ describe('Model generator', () => {
         })
     })
 
-    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User @model {
         name: String! @search @auth(rules: [ { allow: private } ])
       }"
@@ -583,7 +585,7 @@ describe('Model generator', () => {
       })
     })
 
-    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type Address {
         street: String
       }
@@ -603,7 +605,7 @@ describe('Model generator', () => {
         .auth((rules) => rules.private())
     })
 
-    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User @model {
         cats: [String!] @auth(rules: [ { allow: private } ])
       }"
@@ -618,7 +620,7 @@ describe('Model generator', () => {
         .auth((rules) => rules.private())
     })
 
-    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User @model {
         cats: String! @length(min: 2) @auth(rules: [ { allow: private } ])
       }"
@@ -630,7 +632,7 @@ describe('Model generator', () => {
       self: g.relation(() => model).auth((rules) => rules.private())
     })
 
-    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User @model {
         self: User! @auth(rules: [ { allow: private } ])
       }"
@@ -645,7 +647,7 @@ describe('Model generator', () => {
         .auth((rules) => rules.private())
     })
 
-    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User @model {
         self: [User!]! @auth(rules: [ { allow: private } ])
       }"
@@ -657,33 +659,9 @@ describe('Model generator', () => {
       name: g.string().resolver('a-field')
     })
 
-    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User @model {
         name: String! @resolver(name: "a-field")
-      }"
-    `)
-  })
-
-  it('generates a unique field with a resolver', () => {
-    g.model('User', {
-      name: g.string().unique().resolver('a-field')
-    })
-
-    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
-      "type User @model {
-        name: String! @unique @resolver(name: "a-field")
-      }"
-    `)
-  })
-
-  it('generates a field with a default value and a resolver', () => {
-    g.model('User', {
-      name: g.string().default('Bob').resolver('a-field')
-    })
-
-    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
-      "type User @model {
-        name: String! @default(value: "Bob") @resolver(name: "a-field")
       }"
     `)
   })
@@ -697,7 +675,7 @@ describe('Model generator', () => {
       name: g.ref(address).resolver('a-field')
     })
 
-    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type Address {
         street: String
       }
@@ -713,9 +691,116 @@ describe('Model generator', () => {
       name: g.string().list().resolver('a-field')
     })
 
-    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User @model {
         name: [String!]! @resolver(name: "a-field")
+      }"
+    `)
+  })
+
+  it('generates a model level cache', () => {
+    g.model('User', {
+      name: g.string().optional()
+    }).cache({ maxAge: 60, staleWhileRevalidate: 50 })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "type User @model @cache(maxAge: 60, staleWhileRevalidate: 50) {
+        name: String
+      }"
+    `)
+  })
+
+  it('generates a field level cache', () => {
+    g.model('User', {
+      name: g
+        .string()
+        .optional()
+        .cache({ maxAge: 60, staleWhileRevalidate: 50 })
+    })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String @cache(maxAge: 60, staleWhileRevalidate: 50)
+      }"
+    `)
+  })
+
+  it('generates a cache with unique', () => {
+    g.model('User', {
+      name: g
+        .string()
+        .optional()
+        .unique()
+        .cache({ maxAge: 60, staleWhileRevalidate: 50 })
+    })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String @unique @cache(maxAge: 60, staleWhileRevalidate: 50)
+      }"
+    `)
+  })
+
+  it('generates a cache with default', () => {
+    g.model('User', {
+      name: g
+        .string()
+        .optional()
+        .default('Bob')
+        .cache({ maxAge: 60, staleWhileRevalidate: 50 })
+    })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String @default(value: "Bob") @cache(maxAge: 60, staleWhileRevalidate: 50)
+      }"
+    `)
+  })
+
+  it('generates a cache with length-limited string', () => {
+    g.model('User', {
+      name: g
+        .string()
+        .optional()
+        .length({ min: 1 })
+        .cache({ maxAge: 60, staleWhileRevalidate: 50 })
+    })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String @length(min: 1) @cache(maxAge: 60, staleWhileRevalidate: 50)
+      }"
+    `)
+  })
+
+  it('generates a cache with resolver', () => {
+    g.model('User', {
+      name: g
+        .string()
+        .optional()
+        .resolver('a-field')
+        .cache({ maxAge: 60, staleWhileRevalidate: 50 })
+    })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String @resolver(name: "a-field") @cache(maxAge: 60, staleWhileRevalidate: 50)
+      }"
+    `)
+  })
+
+  it('generates a cache with search', () => {
+    g.model('User', {
+      name: g
+        .string()
+        .optional()
+        .search()
+        .cache({ maxAge: 60, staleWhileRevalidate: 50 })
+    })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String @search @cache(maxAge: 60, staleWhileRevalidate: 50)
       }"
     `)
   })

--- a/packages/grafbase-sdk/tests/unit/model.test.ts
+++ b/packages/grafbase-sdk/tests/unit/model.test.ts
@@ -1,5 +1,6 @@
 import { config, g } from '../../src/index'
 import { describe, expect, it, beforeEach } from '@jest/globals'
+import { renderGraphQL } from '../utils'
 
 describe('Model generator', () => {
   beforeEach(() => g.clear())
@@ -9,7 +10,7 @@ describe('Model generator', () => {
       name: g.string()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: String!
       }"
@@ -21,7 +22,7 @@ describe('Model generator', () => {
       identifier: g.id()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         identifier: ID!
       }"
@@ -33,7 +34,7 @@ describe('Model generator', () => {
       age: g.int()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         age: Int!
       }"
@@ -45,7 +46,7 @@ describe('Model generator', () => {
       weight: g.float()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         weight: Float!
       }"
@@ -57,7 +58,7 @@ describe('Model generator', () => {
       registered: g.boolean()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         registered: Boolean!
       }"
@@ -69,7 +70,7 @@ describe('Model generator', () => {
       birthday: g.date()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         birthday: Date!
       }"
@@ -81,7 +82,7 @@ describe('Model generator', () => {
       registerationDate: g.datetime()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         registerationDate: DateTime!
       }"
@@ -93,7 +94,7 @@ describe('Model generator', () => {
       email: g.email()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         email: Email!
       }"
@@ -105,7 +106,7 @@ describe('Model generator', () => {
       ipAddress: g.ipAddress()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         ipAddress: IPAddress!
       }"
@@ -117,7 +118,7 @@ describe('Model generator', () => {
       lastSeen: g.timestamp()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         lastSeen: Timestamp!
       }"
@@ -129,7 +130,7 @@ describe('Model generator', () => {
       fediverseInstance: g.url()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         fediverseInstance: URL!
       }"
@@ -141,7 +142,7 @@ describe('Model generator', () => {
       customData: g.json()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         customData: JSON!
       }"
@@ -153,7 +154,7 @@ describe('Model generator', () => {
       phoneNumber: g.phoneNumber()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         phoneNumber: PhoneNumber!
       }"
@@ -166,7 +167,7 @@ describe('Model generator', () => {
       age: g.int()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: String!
         age: Int!
@@ -179,7 +180,7 @@ describe('Model generator', () => {
       name: g.string().optional()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: String
       }"
@@ -191,7 +192,7 @@ describe('Model generator', () => {
       name: g.string().list()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: [String!]!
       }"
@@ -203,7 +204,7 @@ describe('Model generator', () => {
       name: g.string().list().search()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: [String!]! @search
       }"
@@ -215,7 +216,7 @@ describe('Model generator', () => {
       name: g.string().list().optional().search()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: [String!] @search
       }"
@@ -227,7 +228,7 @@ describe('Model generator', () => {
       name: g.string().optional().list().optional().search()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: [String] @search
       }"
@@ -239,7 +240,7 @@ describe('Model generator', () => {
       name: g.string().list().optional()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: [String!]
       }"
@@ -251,7 +252,7 @@ describe('Model generator', () => {
       name: g.string().optional().list().optional()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: [String]
       }"
@@ -263,7 +264,7 @@ describe('Model generator', () => {
       name: g.string().optional().list()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: [String]!
       }"
@@ -277,7 +278,7 @@ describe('Model generator', () => {
       })
       .search()
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model @search {
         name: String!
       }"
@@ -289,7 +290,7 @@ describe('Model generator', () => {
       name: g.string().search()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: String! @search
       }"
@@ -301,7 +302,7 @@ describe('Model generator', () => {
       name: g.string().unique()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: String! @unique
       }"
@@ -314,7 +315,7 @@ describe('Model generator', () => {
       age: g.int()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: String! @unique(fields: ["age"])
         age: Int!
@@ -329,7 +330,7 @@ describe('Model generator', () => {
       })
       .live()
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model @live {
         name: String!
       }"
@@ -341,7 +342,7 @@ describe('Model generator', () => {
       name: g.string().length({ min: 2 })
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: String! @length(min: 2)
       }"
@@ -353,7 +354,7 @@ describe('Model generator', () => {
       name: g.string().length({ min: 2 }).unique().search()
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: String! @length(min: 2) @unique @search
       }"
@@ -365,7 +366,7 @@ describe('Model generator', () => {
       name: g.string().length({ max: 255 })
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: String! @length(max: 255)
       }"
@@ -377,7 +378,7 @@ describe('Model generator', () => {
       name: g.string().length({ min: 2, max: 255 })
     })
 
-    expect(model.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: String! @length(min: 2, max: 255)
       }"
@@ -394,7 +395,7 @@ describe('Model generator', () => {
       address: g.ref(address).optional()
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
       "type Address {
         street: String
       }
@@ -436,7 +437,7 @@ describe('Model generator', () => {
       address: g.ref(address).optional()
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
       "type Address {
         street: String
       }
@@ -458,7 +459,7 @@ describe('Model generator', () => {
       addresses: g.ref(address).list()
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
       "type Address {
         street: String
       }
@@ -477,7 +478,7 @@ describe('Model generator', () => {
       rules.private().read()
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
       "type User @model @auth(
           rules: [
             { allow: private, operations: [read] }
@@ -495,7 +496,7 @@ describe('Model generator', () => {
       rules.groups(['admin'])
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
       "type User @model @auth(
           rules: [
             { allow: private, operations: [read] }
@@ -513,7 +514,7 @@ describe('Model generator', () => {
       })
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
       "type User @model {
         name: String! @auth(rules: [ { allow: groups, groups: ["admin"] } ])
       }"
@@ -530,7 +531,7 @@ describe('Model generator', () => {
         })
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
       "type User @model {
         name: String! @unique @auth(rules: [ { allow: groups, groups: ["admin"] } ])
       }"
@@ -547,7 +548,7 @@ describe('Model generator', () => {
         })
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
       "type User @model {
         age: Int! @default(value: 1) @auth(rules: [ { allow: private } ])
       }"
@@ -564,7 +565,7 @@ describe('Model generator', () => {
         })
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
       "type User @model {
         name: String! @search @auth(rules: [ { allow: private } ])
       }"
@@ -582,7 +583,7 @@ describe('Model generator', () => {
       })
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
       "type Address {
         street: String
       }
@@ -602,7 +603,7 @@ describe('Model generator', () => {
         .auth((rules) => rules.private())
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
       "type User @model {
         cats: [String!] @auth(rules: [ { allow: private } ])
       }"
@@ -617,7 +618,7 @@ describe('Model generator', () => {
         .auth((rules) => rules.private())
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
       "type User @model {
         cats: String! @length(min: 2) @auth(rules: [ { allow: private } ])
       }"
@@ -629,7 +630,7 @@ describe('Model generator', () => {
       self: g.relation(() => model).auth((rules) => rules.private())
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
       "type User @model {
         self: User! @auth(rules: [ { allow: private } ])
       }"
@@ -644,7 +645,7 @@ describe('Model generator', () => {
         .auth((rules) => rules.private())
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
       "type User @model {
         self: [User!]! @auth(rules: [ { allow: private } ])
       }"
@@ -656,7 +657,7 @@ describe('Model generator', () => {
       name: g.string().resolver('a-field')
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
       "type User @model {
         name: String! @resolver(name: "a-field")
       }"
@@ -668,7 +669,7 @@ describe('Model generator', () => {
       name: g.string().unique().resolver('a-field')
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
       "type User @model {
         name: String! @unique @resolver(name: "a-field")
       }"
@@ -680,7 +681,7 @@ describe('Model generator', () => {
       name: g.string().default('Bob').resolver('a-field')
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
       "type User @model {
         name: String! @default(value: "Bob") @resolver(name: "a-field")
       }"
@@ -696,7 +697,7 @@ describe('Model generator', () => {
       name: g.ref(address).resolver('a-field')
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
       "type Address {
         street: String
       }
@@ -712,7 +713,7 @@ describe('Model generator', () => {
       name: g.string().list().resolver('a-field')
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g}))).toMatchInlineSnapshot(`
       "type User @model {
         name: [String!]! @resolver(name: "a-field")
       }"

--- a/packages/grafbase-sdk/tests/unit/openapi.test.ts
+++ b/packages/grafbase-sdk/tests/unit/openapi.test.ts
@@ -1,5 +1,6 @@
 import { config, g, connector } from '../../src/index'
 import { describe, expect, it, beforeEach } from '@jest/globals'
+import { renderGraphQL } from '../utils'
 
 describe('OpenAPI generator', () => {
   beforeEach(() => g.clear())
@@ -12,7 +13,7 @@ describe('OpenAPI generator', () => {
 
     g.datasource(stripe, { namespace: 'Stripe' })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend schema
         @openapi(
           name: "Stripe"
@@ -37,7 +38,7 @@ describe('OpenAPI generator', () => {
 
     g.datasource(stripe, { namespace: 'Stripe' })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend schema
         @openapi(
           name: "Stripe"
@@ -69,7 +70,7 @@ describe('OpenAPI generator', () => {
     g.datasource(stripe, { namespace: 'Stripe' })
     g.datasource(openai, { namespace: 'OpenAI' })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend schema
         @openapi(
           name: "Stripe"

--- a/packages/grafbase-sdk/tests/unit/queries.test.ts
+++ b/packages/grafbase-sdk/tests/unit/queries.test.ts
@@ -1,5 +1,6 @@
 import { config, g } from '../../src/index'
 import { describe, expect, it, beforeEach } from '@jest/globals'
+import { renderGraphQL } from '../utils'
 
 describe('Query generator', () => {
   beforeEach(() => g.clear())
@@ -10,7 +11,7 @@ describe('Query generator', () => {
       resolver: 'hello'
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend type Query {
         greet: String! @resolver(name: "hello")
       }"
@@ -24,7 +25,7 @@ describe('Query generator', () => {
       resolver: 'hello'
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend type Query {
         greet(name: String!): String! @resolver(name: "hello")
       }"
@@ -38,7 +39,7 @@ describe('Query generator', () => {
       resolver: 'hello'
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend type Query {
         greet(name: String): String! @resolver(name: "hello")
       }"
@@ -52,7 +53,7 @@ describe('Query generator', () => {
       resolver: 'hello'
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend type Query {
         greet(name: String): String @resolver(name: "hello")
       }"
@@ -66,7 +67,7 @@ describe('Query generator', () => {
       resolver: 'hello'
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend type Query {
         greet(name: [String!]!): String! @resolver(name: "hello")
       }"
@@ -80,7 +81,7 @@ describe('Query generator', () => {
       resolver: 'hello'
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend type Query {
         greet(name: String!): [String!]! @resolver(name: "hello")
       }"
@@ -94,7 +95,7 @@ describe('Query generator', () => {
       resolver: 'hello'
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend type Query {
         greet(name: String!): [String!]! @resolver(name: "hello")
       }"
@@ -111,7 +112,7 @@ describe('Query generator', () => {
       resolver: 'checkout'
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type CheckoutSessionInput {
         name: String!
       }
@@ -141,7 +142,7 @@ describe('Query generator', () => {
       resolver: 'jello'
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "enum Foo {
         Bar,
         Baz

--- a/packages/grafbase-sdk/tests/unit/relation.test.ts
+++ b/packages/grafbase-sdk/tests/unit/relation.test.ts
@@ -1,5 +1,6 @@
 import { g, config } from '../../src/index'
 import { describe, expect, it, beforeEach } from '@jest/globals'
+import { renderGraphQL } from '../utils'
 
 describe('Relations generator', () => {
   beforeEach(() => g.clear())
@@ -13,7 +14,7 @@ describe('Relations generator', () => {
       user: g.relation(user)
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User @model {
         profile: Profile!
       }
@@ -33,7 +34,7 @@ describe('Relations generator', () => {
       user: g.relation(user)
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User @model {
         profile: Profile
       }
@@ -53,7 +54,7 @@ describe('Relations generator', () => {
       author: g.relation(user)
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User @model {
         posts: [Post!]!
       }
@@ -76,7 +77,7 @@ describe('Relations generator', () => {
       author: g.relation(user)
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User @model {
         posts: [Post]!
       }
@@ -99,7 +100,7 @@ describe('Relations generator', () => {
       author: g.relation(user)
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User @model {
         posts: [Post!]
       }
@@ -123,7 +124,7 @@ describe('Relations generator', () => {
       author: g.relation(user)
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User @model {
         posts: [Post]
       }
@@ -143,7 +144,7 @@ describe('Relations generator', () => {
       author: g.relation(user).list()
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User @model {
         posts: [Post!]!
       }
@@ -160,7 +161,7 @@ describe('Relations generator', () => {
       parent: g.relation(() => human).optional()
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type Human @model {
         children: [Human!]!
         parent: Human
@@ -178,7 +179,7 @@ describe('Relations generator', () => {
       shippingAddress: g.relation(address).name('shipping')
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type Address @model {
         line1: String!
       }
@@ -200,7 +201,7 @@ describe('Relations generator', () => {
       shippingAddresses: g.relation(address).name('shipping').list()
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type Address @model {
         line1: String!
       }

--- a/packages/grafbase-sdk/tests/unit/types.test.ts
+++ b/packages/grafbase-sdk/tests/unit/types.test.ts
@@ -1,5 +1,6 @@
 import { g, config } from '../../src/index'
 import { describe, expect, it, beforeEach } from '@jest/globals'
+import { renderGraphQL } from '../utils'
 
 describe('Type generator', () => {
   beforeEach(() => {
@@ -11,7 +12,7 @@ describe('Type generator', () => {
       name: g.string()
     })
 
-    expect(t.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(t)).toMatchInlineSnapshot(`
       "type User {
         name: String!
       }"
@@ -24,7 +25,7 @@ describe('Type generator', () => {
       age: g.int().optional()
     })
 
-    expect(t.toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(t)).toMatchInlineSnapshot(`
       "type User {
         name: String!
         age: Int
@@ -44,7 +45,7 @@ describe('Type generator', () => {
 
     g.union('UserOrAddress', { user, address })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User {
         name: String!
         age: Int
@@ -73,7 +74,7 @@ describe('Type generator', () => {
       city: g.ref(city)
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User {
         name: String!
         age: Int
@@ -103,7 +104,7 @@ describe('Type generator', () => {
       color: g.ref(enm).optional()
     })
 
-    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "enum Color {
         Red,
         Green

--- a/packages/grafbase-sdk/tests/unit/types.test.ts
+++ b/packages/grafbase-sdk/tests/unit/types.test.ts
@@ -33,6 +33,20 @@ describe('Type generator', () => {
     `)
   })
 
+  it('generates one with cache', () => {
+    const t = g
+      .type('User', {
+        name: g.string().cache({ maxAge: 10, staleWhileRevalidate: 20 })
+      })
+      .cache({ maxAge: 10, staleWhileRevalidate: 20 })
+
+    expect(renderGraphQL(t)).toMatchInlineSnapshot(`
+      "type User @cache(maxAge: 10, staleWhileRevalidate: 20) {
+        name: String! @cache(maxAge: 10, staleWhileRevalidate: 20)
+      }"
+    `)
+  })
+
   it('generates a union of multiple types', () => {
     const user = g.type('User', {
       name: g.string(),

--- a/packages/grafbase-sdk/tests/utils.ts
+++ b/packages/grafbase-sdk/tests/utils.ts
@@ -2,7 +2,7 @@ import { parse } from 'graphql'
 
 export function renderGraphQL(obj: any): string {
   const stringified = obj.toString()
-  try { 
+  try {
     // check if it's valid graphql
     parse(stringified)
 

--- a/packages/grafbase-sdk/tests/utils.ts
+++ b/packages/grafbase-sdk/tests/utils.ts
@@ -1,0 +1,14 @@
+import { parse } from 'graphql'
+
+export function renderGraphQL(obj: any): string {
+  const stringified = obj.toString()
+  try { 
+    // check if it's valid graphql
+    parse(stringified)
+
+    return stringified
+  } catch (e: any) {
+    console.log(stringified)
+    throw e
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         version: 2.8.8
       turbo:
         specifier: latest
-        version: 1.9.3
+        version: 1.9.9
 
   packages/eslint-config-grafbase:
     dependencies:
@@ -27,7 +27,7 @@ importers:
         version: 8.3.0(eslint@8.35.0)
       eslint-config-turbo:
         specifier: latest
-        version: 1.9.3(eslint@8.35.0)
+        version: 1.9.9(eslint@8.35.0)
       eslint-plugin-react:
         specifier: 7.32.2
         version: 7.32.2(eslint@8.35.0)
@@ -232,6 +232,9 @@ importers:
       eslint:
         specifier: ^8.39.0
         version: 8.39.0
+      graphql:
+        specifier: ^16.6.0
+        version: 16.6.0
       jest:
         specifier: '=29.5.0'
         version: 29.5.0(@types/node@18.14.2)(ts-node@10.9.1)
@@ -3223,13 +3226,13 @@ packages:
       eslint: 8.35.0
     dev: false
 
-  /eslint-config-turbo@1.9.3(eslint@8.35.0):
-    resolution: {integrity: sha512-QG6jxFQkrGSpQqlFKefPdtgUfr20EbU0s4tGGIuGFOcPuJEdsY6VYZpZUxNJvmMcTGqPgMyOPjAFBKhy/DPHLA==}
+  /eslint-config-turbo@1.9.9(eslint@8.35.0):
+    resolution: {integrity: sha512-OQLvRK9Ej/8HIEAW6e9hPu3nk1nCYWJ76voB4eOIaI2fYeIKC++0/r0zJPMOD8puo5V1DH+Gkd0XioKpL14ncg==}
     peerDependencies:
       eslint: '>6.6.0'
     dependencies:
       eslint: 8.35.0
-      eslint-plugin-turbo: 1.9.3(eslint@8.35.0)
+      eslint-plugin-turbo: 1.9.9(eslint@8.35.0)
     dev: false
 
   /eslint-import-resolver-node@0.3.7:
@@ -3387,8 +3390,8 @@ packages:
       string.prototype.matchall: 4.0.8
     dev: false
 
-  /eslint-plugin-turbo@1.9.3(eslint@8.35.0):
-    resolution: {integrity: sha512-ZsRtksdzk3v+z5/I/K4E50E4lfZ7oYmLX395gkrUMBz4/spJlYbr+GC8hP9oVNLj9s5Pvnm9rLv/zoj5PVYaVw==}
+  /eslint-plugin-turbo@1.9.9(eslint@8.35.0):
+    resolution: {integrity: sha512-BgtBMcgNd2YKiHbn1clRiEAmnlpSl19kt9yfIhFEsNIVPg2Gx0O1H++vWXGzMtT19mjHG4Unx0uIMRENKnDYLg==}
     peerDependencies:
       eslint: '>6.6.0'
     dependencies:
@@ -6295,65 +6298,65 @@ packages:
       typescript: 5.0.4
     dev: false
 
-  /turbo-darwin-64@1.9.3:
-    resolution: {integrity: sha512-0dFc2cWXl82kRE4Z+QqPHhbEFEpUZho1msHXHWbz5+PqLxn8FY0lEVOHkq5tgKNNEd5KnGyj33gC/bHhpZOk5g==}
+  /turbo-darwin-64@1.9.9:
+    resolution: {integrity: sha512-UDGM9E21eCDzF5t1F4rzrjwWutcup33e7ZjNJcW/mJDPorazZzqXGKEPIy9kXwKhamUUXfC7668r6ZuA1WXF2Q==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64@1.9.3:
-    resolution: {integrity: sha512-1cYbjqLBA2zYE1nbf/qVnEkrHa4PkJJbLo7hnuMuGM0bPzh4+AnTNe98gELhqI1mkTWBu/XAEeF5u6dgz0jLNA==}
+  /turbo-darwin-arm64@1.9.9:
+    resolution: {integrity: sha512-VyfkXzTJpYLTAQ9krq2myyEq7RPObilpS04lgJ4OO1piq76RNmSpX9F/t9JCaY9Pj/4TL7i0d8PM7NGhwEA5Ag==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64@1.9.3:
-    resolution: {integrity: sha512-UuBPFefawEwpuxh5pM9Jqq3q4C8M0vYxVYlB3qea/nHQ80pxYq7ZcaLGEpb10SGnr3oMUUs1zZvkXWDNKCJb8Q==}
+  /turbo-linux-64@1.9.9:
+    resolution: {integrity: sha512-Fu1MY29Odg8dHOqXcpIIGC3T63XLOGgnGfbobXMKdrC7JQDvtJv8TUCYciRsyknZYjyyKK1z6zKuYIiDjf3KeQ==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64@1.9.3:
-    resolution: {integrity: sha512-vUrNGa3hyDtRh9W0MkO+l1dzP8Co2gKnOVmlJQW0hdpOlWlIh22nHNGGlICg+xFa2f9j4PbQlWTsc22c019s8Q==}
+  /turbo-linux-arm64@1.9.9:
+    resolution: {integrity: sha512-50LI8NafPuJxdnMCBeDdzgyt1cgjQG7FwkyY336v4e95WJPUVjrHdrKH6jYXhOUyrv9+jCJxwX1Yrg02t5yJ1g==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64@1.9.3:
-    resolution: {integrity: sha512-0BZ7YaHs6r+K4ksqWus1GKK3W45DuDqlmfjm/yuUbTEVc8szmMCs12vugU2Zi5GdrdJSYfoKfEJ/PeegSLIQGQ==}
+  /turbo-windows-64@1.9.9:
+    resolution: {integrity: sha512-9IsTReoLmQl1IRsy3WExe2j2RKWXQyXujfJ4fXF+jp08KxjVF4/tYP2CIRJx/A7UP/7keBta27bZqzAjsmbSTA==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-arm64@1.9.3:
-    resolution: {integrity: sha512-QJUYLSsxdXOsR1TquiOmLdAgtYcQ/RuSRpScGvnZb1hY0oLc7JWU0llkYB81wVtWs469y8H9O0cxbKwCZGR4RQ==}
+  /turbo-windows-arm64@1.9.9:
+    resolution: {integrity: sha512-CUu4hpeQo68JjDr0V0ygTQRLbS+/sNfdqEVV+Xz9136vpKn2WMQLAuUBVZV0Sp0S/7i+zGnplskT0fED+W46wQ==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo@1.9.3:
-    resolution: {integrity: sha512-ID7mxmaLUPKG/hVkp+h0VuucB1U99RPCJD9cEuSEOdIPoSIuomcIClEJtKamUsdPLhLCud+BvapBNnhgh58Nzw==}
+  /turbo@1.9.9:
+    resolution: {integrity: sha512-+ZS66LOT7ahKHxh6XrIdcmf2Yk9mNpAbPEj4iF2cs0cAeaDU3xLVPZFF0HbSho89Uxwhx7b5HBgPbdcjQTwQkg==}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      turbo-darwin-64: 1.9.3
-      turbo-darwin-arm64: 1.9.3
-      turbo-linux-64: 1.9.3
-      turbo-linux-arm64: 1.9.3
-      turbo-windows-64: 1.9.3
-      turbo-windows-arm64: 1.9.3
+      turbo-darwin-64: 1.9.9
+      turbo-darwin-arm64: 1.9.9
+      turbo-linux-64: 1.9.9
+      turbo-linux-arm64: 1.9.9
+      turbo-windows-64: 1.9.9
+      turbo-windows-arm64: 1.9.9
     dev: true
 
   /type-check@0.4.0:


### PR DESCRIPTION
# Description

Closes: GB-3776

Implements the cache directive APIs to the SDK.

## Global cache

```ts
const cfg = config({
  schema: g,
  cache: {
    rules: [
      {
        types: 'Query',
        maxAge: 60,
        staleWhileRevalidate: 60
      }
    ]
  }
})

// or

const cfg = config({
  schema: g,
  cache: {
    rules: [
      {
        types: ['Query', 'Schwuery'],
        maxAge: 60,
        staleWhileRevalidate: 60
      }
    ]
  }
})

// or

const cfg = config({
  schema: g,
  cache: {
    rules: [
      {
        types: [
          { name: 'User', fields: ['name', 'age'] },
          { name: 'Address', fields: ['street', 'city'] }
        ],
        maxAge: 60,
        staleWhileRevalidate: 60
      }
    ]
  }
})
```

## Type-level

```ts
const t = g
  .type('User', {
    name: g.string()
  })
  .cache({ maxAge: 10, staleWhileRevalidate: 20 })
```

## Model-level

```ts
g.model('User', {
  name: g.string().optional()
}).cache({ maxAge: 60, staleWhileRevalidate: 50 })
```

## Field-level

```ts
g.model('User', {
  name: g
    .string()
    .optional()
    .cache({ maxAge: 60, staleWhileRevalidate: 50 })
})
```

Additionally adds GraphQL validation to every test to see if we generate correct syntax.

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [x] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [x] 📖 Requires documentation update
