### PR TITLE
fix(sdk): Make fields and staleWhileRevalidate optional in global cache, introduce invalidation params

### DIFF
--- a/packages/grafbase-sdk/README.md
+++ b/packages/grafbase-sdk/README.md
@@ -532,7 +532,8 @@ config({
         staleWhileRevalidate: 60
       },
       {
-        types: [{ name: 'Query' }, { name: 'GitHub', fields: ['name'] }]
+        types: [{ name: 'Query' }, { name: 'GitHub', fields: ['name'] }],
+        maxAge: 60
       }
     ]
   }

--- a/packages/grafbase-sdk/README.md
+++ b/packages/grafbase-sdk/README.md
@@ -512,3 +512,49 @@ g.model('User', {
   })
 })
 ```
+
+## Caching
+
+Caching can be defined globally, per type or per field.
+
+```ts
+config({
+  schema: g,
+  cache: {
+    rules: [
+      {
+        types: 'Query',
+        maxAge: 60
+      },
+      {
+        types: ['GitHub', 'Strava'],
+        maxAge: 60,
+        staleWhileRevalidate: 60
+      },
+      {
+        types: [{ name: 'Query' }, { name: 'GitHub', fields: ['name'] }]
+      }
+    ]
+  }
+})
+
+g.model('User', {
+  name: g.string().optional()
+}).cache({
+  maxAge: 60,
+  staleWhileRevalidate: 60,
+  mutationInvalidation: 'entity'
+})
+
+g.type('User', {
+  name: g.string().optional()
+}).cache({
+  maxAge: 60,
+  staleWhileRevalidate: 60,
+  mutationInvalidation: 'type'
+})
+
+g.model('User', {
+  name: g.string().cache({ maxAge: 60, staleWhileRevalidate: 60 })
+})
+```

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",

--- a/packages/grafbase-sdk/src/cache.ts
+++ b/packages/grafbase-sdk/src/cache.ts
@@ -10,15 +10,15 @@ export interface StructuredCacheRuleType {
  * Defines a type to be cached. Can be a single type, multiple types
  * or more granularly types with specific fields.
  */
-export type CachedType = string | string[] | StructuredCacheRuleType[]
+export type CachedTypes = string | string[] | StructuredCacheRuleType[]
 
 /**
  * Defines a single global cache rule.
  */
 export interface CacheRuleParam {
-  types: CachedType
+  types: CachedTypes
   maxAge: number
-  staleWhileRevalidate: number
+  staleWhileRevalidate?: number
 }
 
 /**
@@ -37,29 +37,37 @@ export class GlobalCache {
 
   public toString(): string {
     const rules = this.params.rules.map((rule) => {
-      var types
-      if (typeof rule.types === 'string') {
-        types = `"${rule.types}"`
-      } else {
-        const inner = rule.types
-          .map((type) => {
-            if (typeof type === 'string') {
-              return `"${type}"`
-            } else {
-              var fields = type.fields ? type.fields.map((field) => `"${field}"`).join(',') : ''
-              fields = fields ? `,\n        fields: [${fields}]\n` : '\n'
+      const types = `\n      types: ${renderTypes(rule.types)}`
+      const maxAge = `,\n      maxAge: ${rule.maxAge}`
 
-              return `{\n        name: "${type.name}"${fields}      }`
-            }
-          })
-          .join(', ')
+      const staleWhileRevalidate = rule.staleWhileRevalidate
+        ? `,\n      staleWhileRevalidate: ${rule.staleWhileRevalidate}`
+        : ''
 
-        types = `[${inner}]`
-      }
-
-      return `    {\n      types: ${types},\n      maxAge: ${rule.maxAge},\n      staleWhileRevalidate: ${rule.staleWhileRevalidate}\n    }`
+      return `    {${types}${maxAge}${staleWhileRevalidate}\n    }`
     })
 
     return `extend schema\n  @cache(rules: [\n${rules}\n  ])\n\n`
+  }
+}
+
+function renderTypes(types: CachedTypes): string {
+  if (typeof types === 'string') {
+    return `"${types}"`
+  } else {
+    const inner = types
+      .map((type) => {
+        if (typeof type === 'string') {
+          return `"${type}"`
+        } else {
+          var fields = type.fields ? type.fields.map((field) => `"${field}"`).join(',') : ''
+          fields = fields ? `,\n        fields: [${fields}]\n` : '\n'
+
+          return `{\n        name: "${type.name}"${fields}      }`
+        }
+      })
+      .join(', ')
+
+    return `[${inner}]`
   }
 }

--- a/packages/grafbase-sdk/src/cache.ts
+++ b/packages/grafbase-sdk/src/cache.ts
@@ -1,11 +1,9 @@
-import util from 'node:util'
-
 /**
  * Defines a cached type with fields.
  */
 export interface StructuredCacheRuleType {
   name: string
-  fields: string[]
+  fields?: string[]
 }
 
 /**
@@ -48,8 +46,10 @@ export class GlobalCache {
             if (typeof type === 'string') {
               return `"${type}"`
             } else {
-              const fields = type.fields.map((field) => `"${field}"`).join(',')
-              return `{\n        name: "${type.name}",\n        fields: [${fields}]\n      }`
+              var fields = type.fields ? type.fields.map((field) => `"${field}"`).join(',') : ''
+              fields = fields ? `,\n        fields: [${fields}]\n` : '\n'
+
+              return `{\n        name: "${type.name}"${fields}      }`
             }
           })
           .join(', ')

--- a/packages/grafbase-sdk/src/model.ts
+++ b/packages/grafbase-sdk/src/model.ts
@@ -4,7 +4,11 @@ import { ListDefinition, RelationListDefinition } from './typedefs/list'
 import { ReferenceDefinition } from './typedefs/reference'
 import { RelationDefinition } from './relation'
 import { AuthDefinition } from './typedefs/auth'
-import { CacheDefinition, CacheParams, TypeLevelCache } from './typedefs/cache'
+import {
+  CacheDefinition,
+  TypeCacheParams,
+  TypeLevelCache
+} from './typedefs/cache'
 import { DefaultDefinition } from './typedefs/default'
 import { LengthLimitedStringDefinition } from './typedefs/length-limited-string'
 import { ResolverDefinition } from './typedefs/resolver'
@@ -92,7 +96,7 @@ export class Model {
   /**
    * Sets the model `@cache` directive.
    */
-  public cache(params: CacheParams): Model {
+  public cache(params: TypeCacheParams): Model {
     this.cacheDirective = new TypeLevelCache(params)
 
     return this

--- a/packages/grafbase-sdk/src/type.ts
+++ b/packages/grafbase-sdk/src/type.ts
@@ -1,7 +1,11 @@
 import { Field } from './field'
 import { ListDefinition } from './typedefs/list'
 import { Interface } from './interface'
-import { CacheDefinition, CacheParams, TypeLevelCache } from './typedefs/cache'
+import {
+  CacheDefinition,
+  TypeCacheParams,
+  TypeLevelCache
+} from './typedefs/cache'
 import { ReferenceDefinition } from './typedefs/reference'
 import { ScalarDefinition } from './typedefs/scalar'
 import { EnumDefinition } from './typedefs/enum'
@@ -57,7 +61,7 @@ export class Type {
   /**
    * Sets the type `@cache` directive.
    */
-  public cache(params: CacheParams): this {
+  public cache(params: TypeCacheParams): this {
     this.cacheDirective = new TypeLevelCache(params)
 
     return this

--- a/packages/grafbase-sdk/src/typedefs/auth.ts
+++ b/packages/grafbase-sdk/src/typedefs/auth.ts
@@ -1,7 +1,7 @@
 import { AuthRuleF, AuthRules } from '../auth'
 import { ReferenceDefinition } from './reference'
 import { RelationDefinition } from '../relation'
-import { CacheDefinition, CacheParams, TypeLevelCache } from './cache'
+import { CacheDefinition, FieldCacheParams, FieldLevelCache } from './cache'
 import { DefaultDefinition } from './default'
 import { LengthLimitedStringDefinition } from './length-limited-string'
 import { ResolverDefinition } from './resolver'
@@ -42,8 +42,8 @@ export class AuthDefinition {
     return new UniqueDefinition(this, scope)
   }
 
-  public cache(params: CacheParams): CacheDefinition {
-    return new CacheDefinition(this, new TypeLevelCache(params))
+  public cache(params: FieldCacheParams): CacheDefinition {
+    return new CacheDefinition(this, new FieldLevelCache(params))
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/cache.ts
+++ b/packages/grafbase-sdk/src/typedefs/cache.ts
@@ -18,7 +18,7 @@ export type Cacheable =
 
 export interface CacheParams {
   maxAge: number
-  staleWhileRevalidate: number
+  staleWhileRevalidate?: number
 }
 
 export class TypeLevelCache {
@@ -29,7 +29,13 @@ export class TypeLevelCache {
   }
 
   public toString(): string {
-    return `@cache(maxAge: ${this.params.maxAge}, staleWhileRevalidate: ${this.params.staleWhileRevalidate})`
+    let maxAge = `maxAge: ${this.params.maxAge}`
+
+    let staleWhileRevalidate = this.params.staleWhileRevalidate
+      ? `, staleWhileRevalidate: ${this.params.staleWhileRevalidate}`
+      : ''
+
+    return `@cache(${maxAge}${staleWhileRevalidate})`
   }
 }
 

--- a/packages/grafbase-sdk/src/typedefs/cache.ts
+++ b/packages/grafbase-sdk/src/typedefs/cache.ts
@@ -1,4 +1,5 @@
 import { AuthRuleF } from '../auth'
+import { MutationInvalidation, renderMutationInvalidation } from '../cache'
 import { AuthDefinition } from './auth'
 import { DefaultDefinition } from './default'
 import { LengthLimitedStringDefinition } from './length-limited-string'
@@ -16,15 +17,45 @@ export type Cacheable =
   | SearchDefinition
   | UniqueDefinition
 
-export interface CacheParams {
+export interface TypeCacheParams {
+  maxAge: number
+  staleWhileRevalidate?: number
+  mutationInvalidation?: MutationInvalidation
+}
+
+export interface FieldCacheParams {
   maxAge: number
   staleWhileRevalidate?: number
 }
 
 export class TypeLevelCache {
-  params: CacheParams
+  params: TypeCacheParams
 
-  constructor(params: CacheParams) {
+  constructor(params: TypeCacheParams) {
+    this.params = params
+  }
+
+  public toString(): string {
+    let maxAge = `maxAge: ${this.params.maxAge}`
+
+    let staleWhileRevalidate = this.params.staleWhileRevalidate
+      ? `, staleWhileRevalidate: ${this.params.staleWhileRevalidate}`
+      : ''
+
+    let mutationInvalidation = this.params.mutationInvalidation
+      ? `, mutationInvalidation: ${renderMutationInvalidation(
+          this.params.mutationInvalidation
+        )}`
+      : ''
+
+    return `@cache(${maxAge}${staleWhileRevalidate}${mutationInvalidation})`
+  }
+}
+
+export class FieldLevelCache {
+  params: FieldCacheParams
+
+  constructor(params: FieldCacheParams) {
     this.params = params
   }
 

--- a/packages/grafbase-sdk/src/typedefs/default.ts
+++ b/packages/grafbase-sdk/src/typedefs/default.ts
@@ -2,7 +2,7 @@ import { AuthRuleF } from '../auth'
 import { Enum } from '../enum'
 import { FieldType } from '../typedefs'
 import { AuthDefinition } from './auth'
-import { CacheDefinition, TypeLevelCache, CacheParams } from './cache'
+import { CacheDefinition, FieldCacheParams, FieldLevelCache } from './cache'
 import { LengthLimitedStringDefinition } from './length-limited-string'
 import { ScalarDefinition } from './scalar'
 import { UniqueDefinition } from './unique'
@@ -37,8 +37,8 @@ export class DefaultDefinition {
     return new AuthDefinition(this, rules)
   }
 
-  public cache(params: CacheParams): CacheDefinition {
-    return new CacheDefinition(this, new TypeLevelCache(params))
+  public cache(params: FieldCacheParams): CacheDefinition {
+    return new CacheDefinition(this, new FieldLevelCache(params))
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/length-limited-string.ts
+++ b/packages/grafbase-sdk/src/typedefs/length-limited-string.ts
@@ -7,7 +7,7 @@ import { StringDefinition } from './scalar'
 import { SearchDefinition } from './search'
 import { AuthRuleF } from '../auth'
 import { AuthDefinition } from './auth'
-import { CacheDefinition, CacheParams, TypeLevelCache } from './cache'
+import { CacheDefinition, FieldCacheParams, FieldLevelCache } from './cache'
 
 export interface FieldLength {
   min?: number
@@ -48,8 +48,8 @@ export class LengthLimitedStringDefinition {
     return new AuthDefinition(this, rules)
   }
 
-  public cache(params: CacheParams): CacheDefinition {
-    return new CacheDefinition(this, new TypeLevelCache(params))
+  public cache(params: FieldCacheParams): CacheDefinition {
+    return new CacheDefinition(this, new FieldLevelCache(params))
   }
 
   fieldTypeVal(): FieldType | Enum<any, any> {

--- a/packages/grafbase-sdk/src/typedefs/resolver.ts
+++ b/packages/grafbase-sdk/src/typedefs/resolver.ts
@@ -1,6 +1,6 @@
 import { AuthRuleF } from '../auth'
 import { AuthDefinition } from './auth'
-import { CacheDefinition, CacheParams, TypeLevelCache } from './cache'
+import { CacheDefinition, FieldCacheParams, FieldLevelCache } from './cache'
 import { SearchDefinition } from './search'
 import { DefaultDefinition } from './default'
 import { ReferenceDefinition } from './reference'
@@ -38,8 +38,8 @@ export class ResolverDefinition {
     return new UniqueDefinition(this, scope)
   }
 
-  public cache(params: CacheParams): CacheDefinition {
-    return new CacheDefinition(this, new TypeLevelCache(params))
+  public cache(params: FieldCacheParams): CacheDefinition {
+    return new CacheDefinition(this, new FieldLevelCache(params))
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/scalar.ts
+++ b/packages/grafbase-sdk/src/typedefs/scalar.ts
@@ -18,7 +18,7 @@ import { UniqueDefinition } from './unique'
 import { AuthDefinition } from './auth'
 import { AuthRuleF } from '../auth'
 import { ResolverDefinition } from './resolver'
-import { CacheDefinition, CacheParams, TypeLevelCache } from './cache'
+import { CacheDefinition, FieldCacheParams, FieldLevelCache } from './cache'
 
 export class ScalarDefinition {
   fieldType: FieldType | Enum<any, any>
@@ -56,8 +56,8 @@ export class ScalarDefinition {
     return new ResolverDefinition(this, name)
   }
 
-  public cache(params: CacheParams): CacheDefinition {
-    return new CacheDefinition(this, new TypeLevelCache(params))
+  public cache(params: FieldCacheParams): CacheDefinition {
+    return new CacheDefinition(this, new FieldLevelCache(params))
   }
 
   fieldTypeVal(): FieldType | Enum<any, any> {

--- a/packages/grafbase-sdk/src/typedefs/search.ts
+++ b/packages/grafbase-sdk/src/typedefs/search.ts
@@ -1,7 +1,7 @@
 import { AuthRuleF } from '../auth'
 import { ListDefinition } from './list'
 import { AuthDefinition } from './auth'
-import { CacheDefinition, CacheParams, TypeLevelCache } from './cache'
+import { CacheDefinition, FieldCacheParams, FieldLevelCache } from './cache'
 import { LengthLimitedStringDefinition } from './length-limited-string'
 import { ResolverDefinition } from './resolver'
 import { ScalarDefinition } from './scalar'
@@ -32,8 +32,8 @@ export class SearchDefinition {
     return new AuthDefinition(this, rules)
   }
 
-  public cache(params: CacheParams): CacheDefinition {
-    return new CacheDefinition(this, new TypeLevelCache(params))
+  public cache(params: FieldCacheParams): CacheDefinition {
+    return new CacheDefinition(this, new FieldLevelCache(params))
   }
 
   public unique(scope?: string[]): UniqueDefinition {

--- a/packages/grafbase-sdk/src/typedefs/unique.ts
+++ b/packages/grafbase-sdk/src/typedefs/unique.ts
@@ -1,6 +1,6 @@
 import { AuthRuleF } from '../auth'
 import { AuthDefinition } from './auth'
-import { CacheDefinition, CacheParams, TypeLevelCache } from './cache'
+import { CacheDefinition, FieldCacheParams, FieldLevelCache } from './cache'
 import { DefaultDefinition } from './default'
 import { EnumDefinition } from './enum'
 import { LengthLimitedStringDefinition } from './length-limited-string'
@@ -35,8 +35,8 @@ export class UniqueDefinition {
     return new AuthDefinition(this, rules)
   }
 
-  public cache(params: CacheParams): CacheDefinition {
-    return new CacheDefinition(this, new TypeLevelCache(params))
+  public cache(params: FieldCacheParams): CacheDefinition {
+    return new CacheDefinition(this, new FieldLevelCache(params))
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/tests/unit/cache.test.ts
+++ b/packages/grafbase-sdk/tests/unit/cache.test.ts
@@ -37,6 +37,142 @@ describe('Cache generator', () => {
     `)
   })
 
+  it('renders type invalidation strategy', async () => {
+    g.type('A', {
+      b: g.int().optional()
+    })
+
+    const cfg = config({
+      schema: g,
+      cache: {
+        rules: [
+          {
+            types: 'Query',
+            maxAge: 60,
+            mutationInvalidation: 'type'
+          }
+        ]
+      }
+    })
+
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
+      "extend schema
+        @cache(rules: [
+          {
+            types: "Query",
+            maxAge: 60,
+            mutationInvalidation: type
+          }
+        ])
+
+      type A {
+        b: Int
+      }"
+    `)
+  })
+
+  it('renders entity invalidation strategy', async () => {
+    g.type('A', {
+      b: g.int().optional()
+    })
+
+    const cfg = config({
+      schema: g,
+      cache: {
+        rules: [
+          {
+            types: 'Query',
+            maxAge: 60,
+            mutationInvalidation: 'entity'
+          }
+        ]
+      }
+    })
+
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
+      "extend schema
+        @cache(rules: [
+          {
+            types: "Query",
+            maxAge: 60,
+            mutationInvalidation: entity
+          }
+        ])
+
+      type A {
+        b: Int
+      }"
+    `)
+  })
+
+  it('renders list invalidation strategy', async () => {
+    g.type('A', {
+      b: g.int().optional()
+    })
+
+    const cfg = config({
+      schema: g,
+      cache: {
+        rules: [
+          {
+            types: 'Query',
+            maxAge: 60,
+            mutationInvalidation: 'list'
+          }
+        ]
+      }
+    })
+
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
+      "extend schema
+        @cache(rules: [
+          {
+            types: "Query",
+            maxAge: 60,
+            mutationInvalidation: list
+          }
+        ])
+
+      type A {
+        b: Int
+      }"
+    `)
+  })
+
+  it('renders custom field invalidation strategy', async () => {
+    g.type('A', {
+      b: g.int().optional()
+    })
+
+    const cfg = config({
+      schema: g,
+      cache: {
+        rules: [
+          {
+            types: 'Query',
+            maxAge: 60,
+            mutationInvalidation: { field: 'name' }
+          }
+        ]
+      }
+    })
+
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
+      "extend schema
+        @cache(rules: [
+          {
+            types: "Query",
+            maxAge: 60,
+            mutationInvalidation: { field: "name" }
+          }
+        ])
+
+      type A {
+        b: Int
+      }"
+    `)
+  })
+
   it('renders multi-type global cache', async () => {
     g.type('A', {
       b: g.int().optional()

--- a/packages/grafbase-sdk/tests/unit/cache.test.ts
+++ b/packages/grafbase-sdk/tests/unit/cache.test.ts
@@ -84,7 +84,7 @@ describe('Cache generator', () => {
         rules: [
           {
             types: [
-              { name: 'User', fields: ['name', 'age'] },
+              { name: 'User' },
               { name: 'Address', fields: ['street', 'city'] }
             ],
             maxAge: 60,
@@ -99,8 +99,7 @@ describe('Cache generator', () => {
         @cache(rules: [
           {
             types: [{
-              name: "User",
-              fields: ["name","age"]
+              name: "User"
             }, {
               name: "Address",
               fields: ["street","city"]

--- a/packages/grafbase-sdk/tests/unit/cache.test.ts
+++ b/packages/grafbase-sdk/tests/unit/cache.test.ts
@@ -16,8 +16,7 @@ describe('Cache generator', () => {
         rules: [
           {
             types: 'Query',
-            maxAge: 60,
-            staleWhileRevalidate: 60
+            maxAge: 60
           }
         ]
       }
@@ -28,8 +27,7 @@ describe('Cache generator', () => {
         @cache(rules: [
           {
             types: "Query",
-            maxAge: 60,
-            staleWhileRevalidate: 60
+            maxAge: 60
           }
         ])
 

--- a/packages/grafbase-sdk/tests/unit/model.test.ts
+++ b/packages/grafbase-sdk/tests/unit/model.test.ts
@@ -701,6 +701,18 @@ describe('Model generator', () => {
   it('generates a model level cache', () => {
     g.model('User', {
       name: g.string().optional()
+    }).cache({ maxAge: 60 })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "type User @model @cache(maxAge: 60) {
+        name: String
+      }"
+    `)
+  })
+
+  it('generates a model level cache with staleWhileRevalidate', () => {
+    g.model('User', {
+      name: g.string().optional()
     }).cache({ maxAge: 60, staleWhileRevalidate: 50 })
 
     expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
@@ -731,12 +743,12 @@ describe('Model generator', () => {
         .string()
         .optional()
         .unique()
-        .cache({ maxAge: 60, staleWhileRevalidate: 50 })
+        .cache({ maxAge: 60 })
     })
 
     expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "type User @model {
-        name: String @unique @cache(maxAge: 60, staleWhileRevalidate: 50)
+        name: String @unique @cache(maxAge: 60)
       }"
     `)
   })

--- a/packages/grafbase-sdk/tests/unit/model.test.ts
+++ b/packages/grafbase-sdk/tests/unit/model.test.ts
@@ -722,6 +722,54 @@ describe('Model generator', () => {
     `)
   })
 
+  it('generates a model level cache with type mutation invalidation', () => {
+    g.model('User', {
+      name: g.string().optional()
+    }).cache({ maxAge: 60, mutationInvalidation: 'type' })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "type User @model @cache(maxAge: 60, mutationInvalidation: type) {
+        name: String
+      }"
+    `)
+  })
+
+  it('generates a model level cache with entity mutation invalidation', () => {
+    g.model('User', {
+      name: g.string().optional()
+    }).cache({ maxAge: 60, mutationInvalidation: 'entity' })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "type User @model @cache(maxAge: 60, mutationInvalidation: entity) {
+        name: String
+      }"
+    `)
+  })
+
+  it('generates a model level cache with list mutation invalidation', () => {
+    g.model('User', {
+      name: g.string().optional()
+    }).cache({ maxAge: 60, mutationInvalidation: 'list' })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "type User @model @cache(maxAge: 60, mutationInvalidation: list) {
+        name: String
+      }"
+    `)
+  })
+
+  it('generates a model level cache with custom field mutation invalidation', () => {
+    g.model('User', {
+      name: g.string().optional()
+    }).cache({ maxAge: 60, mutationInvalidation: { field: 'name' } })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "type User @model @cache(maxAge: 60, mutationInvalidation: { field: "name" }) {
+        name: String
+      }"
+    `)
+  })
+
   it('generates a field level cache', () => {
     g.model('User', {
       name: g
@@ -739,11 +787,7 @@ describe('Model generator', () => {
 
   it('generates a cache with unique', () => {
     g.model('User', {
-      name: g
-        .string()
-        .optional()
-        .unique()
-        .cache({ maxAge: 60 })
+      name: g.string().optional().unique().cache({ maxAge: 60 })
     })
 
     expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`

--- a/packages/grafbase-sdk/tests/unit/types.test.ts
+++ b/packages/grafbase-sdk/tests/unit/types.test.ts
@@ -47,6 +47,62 @@ describe('Type generator', () => {
     `)
   })
 
+  it('generates one with cache using type mutation invalidation', () => {
+    const t = g
+      .type('User', {
+        name: g.string()
+      })
+      .cache({ maxAge: 10, mutationInvalidation: 'type' })
+
+    expect(renderGraphQL(t)).toMatchInlineSnapshot(`
+      "type User @cache(maxAge: 10, mutationInvalidation: type) {
+        name: String!
+      }"
+    `)
+  })
+
+  it('generates one with cache using entity mutation invalidation', () => {
+    const t = g
+      .type('User', {
+        name: g.string()
+      })
+      .cache({ maxAge: 10, mutationInvalidation: 'entity' })
+
+    expect(renderGraphQL(t)).toMatchInlineSnapshot(`
+      "type User @cache(maxAge: 10, mutationInvalidation: entity) {
+        name: String!
+      }"
+    `)
+  })
+
+  it('generates one with cache using list mutation invalidation', () => {
+    const t = g
+      .type('User', {
+        name: g.string()
+      })
+      .cache({ maxAge: 10, mutationInvalidation: 'list' })
+
+    expect(renderGraphQL(t)).toMatchInlineSnapshot(`
+      "type User @cache(maxAge: 10, mutationInvalidation: list) {
+        name: String!
+      }"
+    `)
+  })
+
+  it('generates one with cache using custom field mutation invalidation', () => {
+    const t = g
+      .type('User', {
+        name: g.string()
+      })
+      .cache({ maxAge: 10, mutationInvalidation: { field: 'name' } })
+
+    expect(renderGraphQL(t)).toMatchInlineSnapshot(`
+      "type User @cache(maxAge: 10, mutationInvalidation: { field: "name" }) {
+        name: String!
+      }"
+    `)
+  })
+
   it('generates a union of multiple types', () => {
     const user = g.type('User', {
       name: g.string(),


### PR DESCRIPTION
# Description

Adds and fixes a few things in SDK caches:

- `fields` and `staleWhileRevalidate` are now optional
- Introduces `mutationInvalidation` param to global and type-level caches

Examples can be read from the [README](https://github.com/grafbase/grafbase/blob/sdk/cache-fixes/packages/grafbase-sdk/README.md#caching).

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [x] 📖 Requires documentation update
