### PR TITLE
fix(sdk): Relation name should be quoted, indentifiers should be validated

### DIFF
--- a/packages/grafbase-sdk/src/enum.ts
+++ b/packages/grafbase-sdk/src/enum.ts
@@ -1,3 +1,5 @@
+import { validateIdentifier } from "./validation"
+
 /**
  * Defines how an input enum can look like. Either an array of
  * strings with at least one item, or a TypeScript enum definition.
@@ -9,6 +11,9 @@ export class Enum<T extends string, U extends EnumShape<T>> {
   variants: U
 
   constructor(name: string, variants: U) {
+    validateIdentifier(name)
+    variants.forEach((variant) => validateIdentifier(variant))
+
     this.name = name
     this.variants = variants
   }

--- a/packages/grafbase-sdk/src/field.ts
+++ b/packages/grafbase-sdk/src/field.ts
@@ -1,10 +1,13 @@
 import { ModelFieldShape } from './model'
+import { validateIdentifier } from './validation'
 
 export class Field {
   name: string
   shape: ModelFieldShape
 
   constructor(name: string, shape: ModelFieldShape) {
+    validateIdentifier(name)
+
     this.name = name
     this.shape = shape
   }

--- a/packages/grafbase-sdk/src/interface.ts
+++ b/packages/grafbase-sdk/src/interface.ts
@@ -1,6 +1,7 @@
 import { Field } from './field'
 import { ListDefinition } from './typedefs/list'
 import { ScalarDefinition } from './typedefs/scalar'
+import { validateIdentifier } from './validation'
 
 /**
  * A collection of fields in an interface.
@@ -17,6 +18,8 @@ export class Interface {
   fields: Field[]
 
   constructor(name: string) {
+    validateIdentifier(name)
+
     this.name = name
     this.fields = []
   }

--- a/packages/grafbase-sdk/src/model.ts
+++ b/packages/grafbase-sdk/src/model.ts
@@ -12,6 +12,7 @@ import { ScalarDefinition } from './typedefs/scalar'
 import { SearchDefinition } from './typedefs/search'
 import { UniqueDefinition } from './typedefs/unique'
 import { EnumDefinition } from './typedefs/enum'
+import { validateIdentifier } from './validation'
 
 /**
  * A collection of fields in a model.
@@ -45,6 +46,8 @@ export class Model {
   cacheDirective?: TypeLevelCache
 
   constructor(name: string) {
+    validateIdentifier(name)
+
     this.name = name
     this.fields = []
     this.isSearch = false

--- a/packages/grafbase-sdk/src/query.ts
+++ b/packages/grafbase-sdk/src/query.ts
@@ -1,6 +1,7 @@
 import { ListDefinition } from './typedefs/list'
 import { ReferenceDefinition } from './typedefs/reference'
 import { ScalarDefinition } from './typedefs/scalar'
+import { validateIdentifier } from './validation'
 
 /** The possible types of an input parameters of a query. */
 export type InputType = ScalarDefinition | ListDefinition | ReferenceDefinition
@@ -25,6 +26,8 @@ export class QueryArgument {
   type: InputType
 
   constructor(name: string, type: InputType) {
+    validateIdentifier(name)
+
     this.name = name
     this.type = type
   }
@@ -44,6 +47,8 @@ export class Query {
   resolver: string
 
   constructor(name: string, returnType: OutputType, resolverName: string) {
+    validateIdentifier(name)
+
     this.name = name
     this.arguments = []
     this.returns = returnType

--- a/packages/grafbase-sdk/src/relation.ts
+++ b/packages/grafbase-sdk/src/relation.ts
@@ -69,7 +69,7 @@ export class RelationDefinition {
 
     const required = this.isOptional ? '' : '!'
     const relationAttribute = this.relationName
-      ? ` @relation(name: ${this.relationName})`
+      ? ` @relation(name: "${this.relationName}")`
       : ''
 
     return `${modelName}${required}${relationAttribute}`

--- a/packages/grafbase-sdk/src/type.ts
+++ b/packages/grafbase-sdk/src/type.ts
@@ -5,6 +5,7 @@ import { CacheDefinition, CacheParams, TypeLevelCache } from './typedefs/cache'
 import { ReferenceDefinition } from './typedefs/reference'
 import { ScalarDefinition } from './typedefs/scalar'
 import { EnumDefinition } from './typedefs/enum'
+import { validateIdentifier } from './validation'
 
 /**
  * A collection of fields in a model.
@@ -31,6 +32,8 @@ export class Type {
   cacheDirective?: TypeLevelCache
 
   constructor(name: string) {
+    validateIdentifier(name)
+
     this.name = name
     this.fields = []
     this.interfaces = []

--- a/packages/grafbase-sdk/src/union.ts
+++ b/packages/grafbase-sdk/src/union.ts
@@ -1,4 +1,5 @@
 import { Type } from './type'
+import { validateIdentifier } from './validation'
 
 /**
  * A builder to create a GraphQL union.
@@ -8,6 +9,8 @@ export class Union {
   types: string[]
 
   constructor(name: string) {
+    validateIdentifier(name)
+
     this.name = name
     this.types = []
   }

--- a/packages/grafbase-sdk/src/validation.ts
+++ b/packages/grafbase-sdk/src/validation.ts
@@ -1,0 +1,10 @@
+/**
+ * Throws, if given input value is a valid GraphQL and JavaScript identifier.
+ */
+export function validateIdentifier(identifier: string) {
+  const identifierRE = new RegExp(/^[_a-zA-Z][_a-zA-Z0-9]*$/)
+
+  if (!identifierRE.test(identifier)) {
+    throw `Given name "${identifier}" is not a valid TypeScript identifier.`
+  }
+}

--- a/packages/grafbase-sdk/tests/unit/enum.test.ts
+++ b/packages/grafbase-sdk/tests/unit/enum.test.ts
@@ -55,4 +55,40 @@ describe('Enum generator', () => {
       }"
     `)
   })
+
+  it('prevents using of whitespaced identifier as the name', () => {
+    expect(() => g.enum('white space', ["Foo", "Bar"])).toThrow(
+      'Given name "white space" is not a valid TypeScript identifier.'
+    )
+  })
+
+  it('prevents using of number-prefixed identifier as the name', () => {
+    expect(() => g.enum('0User', ["Foo", "Bar"])).toThrow(
+      'Given name "0User" is not a valid TypeScript identifier.'
+    )
+  })
+
+  it('prevents using of weird characters identifier as the name', () => {
+    expect(() => g.enum('!@#$%^&*()+|~`\=-', ["Foo", "Bar"])).toThrow(
+      'Given name "!@#$%^&*()+|~`\=-" is not a valid TypeScript identifier.'
+    )
+  })
+
+  it('prevents using of whitespaced identifier as a variant name', () => {
+    expect(() => g.enum('A', ["white space"])).toThrow(
+      'Given name "white space" is not a valid TypeScript identifier.'
+    )
+  })
+
+  it('prevents using of number-prefixed identifier as a variant name', () => {
+    expect(() => g.enum('A', ["0User"])).toThrow(
+      'Given name "0User" is not a valid TypeScript identifier.'
+    )
+  })
+
+  it('prevents using of weird characters identifier as a variant name', () => {
+    expect(() => g.enum('A', ["!@#$%^&*()+|~`\=-"])).toThrow(
+      'Given name "!@#$%^&*()+|~`\=-" is not a valid TypeScript identifier.'
+    )
+  })
 })

--- a/packages/grafbase-sdk/tests/unit/interface.test.ts
+++ b/packages/grafbase-sdk/tests/unit/interface.test.ts
@@ -23,6 +23,24 @@ describe('Interface generator', () => {
     `)
   })
 
+  it('prevents using of whitespaced identifier as the name', () => {
+    expect(() => g.interface('white space', { name: g.string() })).toThrow(
+      'Given name "white space" is not a valid TypeScript identifier.'
+    )
+  })
+
+  it('prevents using of number-prefixed identifier as the name', () => {
+    expect(() => g.interface('0User', { name: g.string() })).toThrow(
+      'Given name "0User" is not a valid TypeScript identifier.'
+    )
+  })
+
+  it('prevents using of weird characters identifier as the name', () => {
+    expect(() => g.interface('!@#$%^&*()+|~`\=-', { name: g.string() })).toThrow(
+      'Given name "!@#$%^&*()+|~`\=-" is not a valid TypeScript identifier.'
+    )
+  })
+
   it('generates a type implementing an interface', () => {
     const produce = g.interface('Produce', {
       name: g.string(),

--- a/packages/grafbase-sdk/tests/unit/model.test.ts
+++ b/packages/grafbase-sdk/tests/unit/model.test.ts
@@ -804,4 +804,40 @@ describe('Model generator', () => {
       }"
     `)
   })
+
+  it('prevents using of whitespaced identifier as the name', () => {
+    expect(() => g.model('white space', { name: g.string() })).toThrow(
+      'Given name "white space" is not a valid TypeScript identifier.'
+    )
+  })
+
+  it('prevents using of number-prefixed identifier as the name', () => {
+    expect(() => g.model('0User', { name: g.string() })).toThrow(
+      'Given name "0User" is not a valid TypeScript identifier.'
+    )
+  })
+
+  it('prevents using of weird characters identifier as the name', () => {
+    expect(() => g.model('!@#$%^&*()+|~`\=-', { name: g.string() })).toThrow(
+      'Given name "!@#$%^&*()+|~`\=-" is not a valid TypeScript identifier.'
+    )
+  })
+
+  it('prevents using of whitespaced identifier as a field name', () => {
+    expect(() => g.model('A', { 'white space': g.string() })).toThrow(
+      'Given name "white space" is not a valid TypeScript identifier.'
+    )
+  })
+
+  it('prevents using of number-prefixed identifier as a field name', () => {
+    expect(() => g.model('A', { '0name': g.string() })).toThrow(
+      'Given name "0name" is not a valid TypeScript identifier.'
+    )
+  })
+
+  it('prevents using of weird characters identifier as a field name', () => {
+    expect(() => g.model('A', { '!@#$%^&*()+|~`\=-': g.string() })).toThrow(
+      'Given name "!@#$%^&*()+|~`\=-" is not a valid TypeScript identifier.'
+    )
+  })
 })

--- a/packages/grafbase-sdk/tests/unit/queries.test.ts
+++ b/packages/grafbase-sdk/tests/unit/queries.test.ts
@@ -154,4 +154,68 @@ describe('Query generator', () => {
       }"
     `)
   })
+
+  it('prevents using of whitespaced identifier as the name', () => {
+    expect(() =>
+      g.query('white space', {
+        args: { name: g.string() },
+        returns: g.string(),
+        resolver: 'hello'
+      })
+    ).toThrow('Given name "white space" is not a valid TypeScript identifier.')
+  })
+
+  it('prevents using of number-prefixed identifier as the name', () => {
+    expect(() =>
+      g.query('0User', {
+        args: { name: g.string() },
+        returns: g.string(),
+        resolver: 'hello'
+      })
+    ).toThrow('Given name "0User" is not a valid TypeScript identifier.')
+  })
+
+  it('prevents using of weird characters identifier as the name', () => {
+    expect(() =>
+      g.query('!@#$%^&*()+|~`=-', {
+        args: { name: g.string() },
+        returns: g.string(),
+        resolver: 'hello'
+      })
+    ).toThrow(
+      'Given name "!@#$%^&*()+|~`=-" is not a valid TypeScript identifier.'
+    )
+  })
+
+  it('prevents using of whitespaced identifier an argument name', () => {
+    expect(() =>
+      g.query('Test', {
+        args: { 'white space': g.string() },
+        returns: g.string(),
+        resolver: 'hello'
+      })
+    ).toThrow('Given name "white space" is not a valid TypeScript identifier.')
+  })
+
+  it('prevents using of number-prefixed identifier as an argument name', () => {
+    expect(() =>
+      g.query('Test', {
+        args: { '0name': g.string() },
+        returns: g.string(),
+        resolver: 'hello'
+      })
+    ).toThrow('Given name "0name" is not a valid TypeScript identifier.')
+  })
+
+  it('prevents using of weird characters identifier as an argument name', () => {
+    expect(() =>
+      g.query('Test', {
+        args: { '!@#$%^&*()+|~`=-': g.string() },
+        returns: g.string(),
+        resolver: 'hello'
+      })
+    ).toThrow(
+      'Given name "!@#$%^&*()+|~`=-" is not a valid TypeScript identifier.'
+    )
+  })
 })

--- a/packages/grafbase-sdk/tests/unit/relation.test.ts
+++ b/packages/grafbase-sdk/tests/unit/relation.test.ts
@@ -185,8 +185,8 @@ describe('Relations generator', () => {
       }
 
       type Order @model {
-        billingAddress: Address! @relation(name: billing)
-        shippingAddress: Address! @relation(name: shipping)
+        billingAddress: Address! @relation(name: "billing")
+        shippingAddress: Address! @relation(name: "shipping")
       }"
     `)
   })

--- a/packages/grafbase-sdk/tests/unit/types.test.ts
+++ b/packages/grafbase-sdk/tests/unit/types.test.ts
@@ -73,6 +73,51 @@ describe('Type generator', () => {
     `)
   })
 
+  it('prevents using of whitespaced identifier as a union name', () => {
+    const user = g.type('User', {
+      name: g.string(),
+      age: g.int().optional()
+    })
+
+    const address = g.type('Address', {
+      street: g.string().optional()
+    })
+
+    expect(() => g.union('white space', { user, address })).toThrow(
+      'Given name "white space" is not a valid TypeScript identifier.'
+    )
+  })
+
+  it('prevents using of number-prefixed identifier as a union name', () => {
+    const user = g.type('User', {
+      name: g.string(),
+      age: g.int().optional()
+    })
+
+    const address = g.type('Address', {
+      street: g.string().optional()
+    })
+
+    expect(() => g.union('0User', { user, address })).toThrow(
+      'Given name "0User" is not a valid TypeScript identifier.'
+    )
+  })
+
+  it('prevents using of weird characters identifier as a union name', () => {
+    const user = g.type('User', {
+      name: g.string(),
+      age: g.int().optional()
+    })
+
+    const address = g.type('Address', {
+      street: g.string().optional()
+    })
+
+    expect(() => g.union('!@#$%^&*()+|~`\=-', { user, address })).toThrow(
+      'Given name "!@#$%^&*()+|~`\=-" is not a valid TypeScript identifier.'
+    )
+  })
+
   it('references another type', () => {
     g.type('User', {
       name: g.string(),
@@ -134,5 +179,23 @@ describe('Type generator', () => {
         color: Color
       }"
     `)
+  })
+
+  it('prevents using of whitespaced identifier as the name', () => {
+    expect(() => g.type('white space', { name: g.string() })).toThrow(
+      'Given name "white space" is not a valid TypeScript identifier.'
+    )
+  })
+
+  it('prevents using of number-prefixed identifier as the name', () => {
+    expect(() => g.type('0User', { name: g.string() })).toThrow(
+      'Given name "0User" is not a valid TypeScript identifier.'
+    )
+  })
+
+  it('prevents using of weird characters identifier as the name', () => {
+    expect(() => g.type('!@#$%^&*()+|~`\=-', { name: g.string() })).toThrow(
+      'Given name "!@#$%^&*()+|~`\=-" is not a valid TypeScript identifier.'
+    )
   })
 })


### PR DESCRIPTION
# Description

Closes: GB-3828

Fixes relation names that should be quoted.

Adds a validation for names that are rendered as identifiers in GraphQL and used as identifiers in the upcoming TypeScript client API. Uses the validation rules in http://spec.graphql.org/October2021/#sec-Names

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
