### PR TITLE
feat(sdk): Extending internal and external types

### DIFF
--- a/packages/grafbase-sdk/README.md
+++ b/packages/grafbase-sdk/README.md
@@ -559,3 +559,35 @@ g.model('User', {
   name: g.string().cache({ maxAge: 60, staleWhileRevalidate: 60 })
 })
 ```
+
+### Extending Types
+
+Types can be extended with extra queries, handled with resolvers.
+
+To extend a type that is defined in the Grafbase schema, define the type first and extend it by using the type as the parameter:
+
+```ts
+const user = g.type('User', {
+  name: g.string()
+})
+
+g.extend(user, {
+  myField: {
+    args: { myArg: g.string() },
+    returns: g.string(),
+    resolver: 'file'
+  }
+})
+```
+
+Sometimes a type is not defined directly in the schema, but instead introspected from an external connector. In these cases passing a string as the first argument allows extending the type with custom queries. Keep in mind that in these cases it is not validated in compile-time if the type exist.
+
+```ts
+g.extend('StripeCustomer', {
+  myField: {
+    args: { myArg: g.string() },
+    returns: g.string(),
+    resolver: 'file'
+  }
+})
+```

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",

--- a/packages/grafbase-sdk/src/type.ts
+++ b/packages/grafbase-sdk/src/type.ts
@@ -10,6 +10,7 @@ import { ReferenceDefinition } from './typedefs/reference'
 import { ScalarDefinition } from './typedefs/scalar'
 import { EnumDefinition } from './typedefs/enum'
 import { validateIdentifier } from './validation'
+import { InputType, OutputType, Query, QueryArgument } from './query'
 
 /**
  * A collection of fields in a model.
@@ -92,6 +93,43 @@ export class Type {
     const footer = '}'
 
     return `${header}\n${fields}\n${footer}`
+  }
+}
+
+export class TypeExtension {
+  name: string
+  queries: Query[]
+
+  constructor(type: string | Type) {
+    if (type instanceof Type) {
+      this.name = type.name
+    } else {
+      validateIdentifier(type)
+      this.name = type
+    }
+
+    this.queries = []
+  }
+
+  /**
+   * Pushes a query to the extension.
+   *
+   * @param query - The query to be added.
+   */
+  public query(query: Query): this {
+    this.queries.push(query)
+
+    return this
+  }
+
+  public toString(): string {
+    if (this.queries.length > 0) {
+      const queries = this.queries.map(String).join('\n')
+
+      return `extend type ${this.name} {\n${queries}\n}`
+    } else {
+      return ''
+    }
   }
 }
 

--- a/packages/grafbase-sdk/tests/unit/enum.test.ts
+++ b/packages/grafbase-sdk/tests/unit/enum.test.ts
@@ -57,38 +57,38 @@ describe('Enum generator', () => {
   })
 
   it('prevents using of whitespaced identifier as the name', () => {
-    expect(() => g.enum('white space', ["Foo", "Bar"])).toThrow(
+    expect(() => g.enum('white space', ['Foo', 'Bar'])).toThrow(
       'Given name "white space" is not a valid TypeScript identifier.'
     )
   })
 
   it('prevents using of number-prefixed identifier as the name', () => {
-    expect(() => g.enum('0User', ["Foo", "Bar"])).toThrow(
+    expect(() => g.enum('0User', ['Foo', 'Bar'])).toThrow(
       'Given name "0User" is not a valid TypeScript identifier.'
     )
   })
 
   it('prevents using of weird characters identifier as the name', () => {
-    expect(() => g.enum('!@#$%^&*()+|~`\=-', ["Foo", "Bar"])).toThrow(
-      'Given name "!@#$%^&*()+|~`\=-" is not a valid TypeScript identifier.'
+    expect(() => g.enum('!@#$%^&*()+|~`=-', ['Foo', 'Bar'])).toThrow(
+      'Given name "!@#$%^&*()+|~`=-" is not a valid TypeScript identifier.'
     )
   })
 
   it('prevents using of whitespaced identifier as a variant name', () => {
-    expect(() => g.enum('A', ["white space"])).toThrow(
+    expect(() => g.enum('A', ['white space'])).toThrow(
       'Given name "white space" is not a valid TypeScript identifier.'
     )
   })
 
   it('prevents using of number-prefixed identifier as a variant name', () => {
-    expect(() => g.enum('A', ["0User"])).toThrow(
+    expect(() => g.enum('A', ['0User'])).toThrow(
       'Given name "0User" is not a valid TypeScript identifier.'
     )
   })
 
   it('prevents using of weird characters identifier as a variant name', () => {
-    expect(() => g.enum('A', ["!@#$%^&*()+|~`\=-"])).toThrow(
-      'Given name "!@#$%^&*()+|~`\=-" is not a valid TypeScript identifier.'
+    expect(() => g.enum('A', ['!@#$%^&*()+|~`=-'])).toThrow(
+      'Given name "!@#$%^&*()+|~`=-" is not a valid TypeScript identifier.'
     )
   })
 })

--- a/packages/grafbase-sdk/tests/unit/interface.test.ts
+++ b/packages/grafbase-sdk/tests/unit/interface.test.ts
@@ -36,8 +36,8 @@ describe('Interface generator', () => {
   })
 
   it('prevents using of weird characters identifier as the name', () => {
-    expect(() => g.interface('!@#$%^&*()+|~`\=-', { name: g.string() })).toThrow(
-      'Given name "!@#$%^&*()+|~`\=-" is not a valid TypeScript identifier.'
+    expect(() => g.interface('!@#$%^&*()+|~`=-', { name: g.string() })).toThrow(
+      'Given name "!@#$%^&*()+|~`=-" is not a valid TypeScript identifier.'
     )
   })
 

--- a/packages/grafbase-sdk/tests/unit/model.test.ts
+++ b/packages/grafbase-sdk/tests/unit/model.test.ts
@@ -874,8 +874,8 @@ describe('Model generator', () => {
   })
 
   it('prevents using of weird characters identifier as the name', () => {
-    expect(() => g.model('!@#$%^&*()+|~`\=-', { name: g.string() })).toThrow(
-      'Given name "!@#$%^&*()+|~`\=-" is not a valid TypeScript identifier.'
+    expect(() => g.model('!@#$%^&*()+|~`=-', { name: g.string() })).toThrow(
+      'Given name "!@#$%^&*()+|~`=-" is not a valid TypeScript identifier.'
     )
   })
 
@@ -892,8 +892,8 @@ describe('Model generator', () => {
   })
 
   it('prevents using of weird characters identifier as a field name', () => {
-    expect(() => g.model('A', { '!@#$%^&*()+|~`\=-': g.string() })).toThrow(
-      'Given name "!@#$%^&*()+|~`\=-" is not a valid TypeScript identifier.'
+    expect(() => g.model('A', { '!@#$%^&*()+|~`=-': g.string() })).toThrow(
+      'Given name "!@#$%^&*()+|~`=-" is not a valid TypeScript identifier.'
     )
   })
 })

--- a/packages/grafbase-sdk/tests/unit/types.test.ts
+++ b/packages/grafbase-sdk/tests/unit/types.test.ts
@@ -169,8 +169,8 @@ describe('Type generator', () => {
       street: g.string().optional()
     })
 
-    expect(() => g.union('!@#$%^&*()+|~`\=-', { user, address })).toThrow(
-      'Given name "!@#$%^&*()+|~`\=-" is not a valid TypeScript identifier.'
+    expect(() => g.union('!@#$%^&*()+|~`=-', { user, address })).toThrow(
+      'Given name "!@#$%^&*()+|~`=-" is not a valid TypeScript identifier.'
     )
   })
 
@@ -250,8 +250,48 @@ describe('Type generator', () => {
   })
 
   it('prevents using of weird characters identifier as the name', () => {
-    expect(() => g.type('!@#$%^&*()+|~`\=-', { name: g.string() })).toThrow(
-      'Given name "!@#$%^&*()+|~`\=-" is not a valid TypeScript identifier.'
+    expect(() => g.type('!@#$%^&*()+|~`=-', { name: g.string() })).toThrow(
+      'Given name "!@#$%^&*()+|~`=-" is not a valid TypeScript identifier.'
     )
+  })
+
+  it('extends an internal type', () => {
+    const t = g.type('User', {
+      name: g.string()
+    })
+
+    g.extend(t, {
+      myField: {
+        args: { myArg: g.string() },
+        returns: g.string(),
+        resolver: 'file'
+      }
+    })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "type User {
+        name: String!
+      }
+
+      extend type User {
+        myField(myArg: String!): String! @resolver(name: "file")
+      }"
+    `)
+  })
+
+  it('extends an external type', () => {
+    g.extend('StripeCustomer', {
+      myField: {
+        args: { myArg: g.string() },
+        returns: g.string(),
+        resolver: 'file'
+      }
+    })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "extend type StripeCustomer {
+        myField(myArg: String!): String! @resolver(name: "file")
+      }"
+    `)
   })
 })


### PR DESCRIPTION
# Description

Closes: GB-3817

Allows extending types with custom resolvers. Either types that exist in the schema, or types introspected from connectors.

See README for usage.

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [x] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [x] 📖 Requires documentation update
