### PR TITLE
chore: Split cli and sdk tags. Implement sdk publish pipeline

### DIFF
--- a/.github/workflows/cli-partial-release.yml
+++ b/.github/workflows/cli-partial-release.yml
@@ -23,6 +23,11 @@ jobs:
     name: Release CLI
     runs-on: ubuntu-latest-8-cores
     steps:
+      - name: Parse version tag
+        run: |
+          VERSION_BUMP="${{ inputs.tag }}"
+          VERSION_BUMP=${VERSION_BUMP//cli-} # remove the cli prefix from the tag
+          echo VERSION_BUMP=${VERSION_BUMP} >> $GITHUB_ENV
       - name: Get sources
         uses: actions/checkout@v3
 
@@ -57,25 +62,25 @@ jobs:
       - name: Download darwin-x86_64 artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ inputs.tag }}-x86_64-apple-darwin
+          name: ${{ env.VERSION_BUMP }}-x86_64-apple-darwin
           path: cli/npm/x86_64-apple-darwin
 
       - name: Download darwin-aarch64 artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ inputs.tag }}-aarch64-apple-darwin
+          name: ${{ env.VERSION_BUMP }}-aarch64-apple-darwin
           path: cli/npm/aarch64-apple-darwin
 
       - name: Download linux artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ inputs.tag }}-linux
+          name: ${{ env.VERSION_BUMP }}-linux
           path: cli/npm/x86_64-unknown-linux-musl
 
       - name: Download windows artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ inputs.tag }}-windows
+          name: ${{ env.VERSION_BUMP }}-windows
           path: cli/npm/x86_64-pc-windows-msvc
 
       - name: Process artifacts

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -255,9 +255,9 @@ jobs:
           name: ${{ github.ref_name }}-${{ matrix.target }}
           path: cli/target/${{ matrix.target }}/release/grafbase
 
-  release:
+  release-cli:
     needs: [windows, linux, darwin]
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') && startsWith(github.ref_name, 'cli-')
     uses: ./.github/workflows/cli-partial-release.yml
     with:
       draft: false

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -116,3 +116,53 @@ jobs:
 
       - name: Run tests
         run: pnpm turbo test
+
+    release-sdk:
+      name: Release @grafbase/sdk
+      needs: [build-and-test]
+      runs-on: ubuntu-latest-8-cores
+      if: startsWith(github.ref, 'refs/tags/') && startsWith(github.ref_name, 'sdk-')
+      steps:
+        - name: Get sources
+          uses: actions/checkout@v3
+
+        - name: Setup Node.js
+          uses: actions/setup-node@v3
+          with:
+            node-version: 18
+
+        - name: Install pnpm
+          uses: pnpm/action-setup@v2
+          id: pnpm-install
+          with:
+            version: 8
+            run_install: false
+
+        - name: Get pnpm store directory
+          id: pnpm-cache
+          shell: bash
+          run: |
+            echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+        - uses: actions/cache@v3
+          name: Setup pnpm cache
+          with:
+            path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+            key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+            restore-keys: |
+              ${{ runner.os }}-pnpm-store-
+
+        - name: Install dependencies
+          run: |
+            pnpm install --ignore-scripts --frozen-lockfile
+
+        - name: Build @grafbase/sdk
+          working-directory: ./packages/grafbase-sdk
+          run: |
+            pnpm build
+
+        - name: Publish @grafbase/sdk
+          working-directory: ./packages/grafbase-sdk
+          run: |
+            npm set "//registry.npmjs.org/:_authToken" ${{ secrets.NPM_ACCESS_TOKEN }}
+            npm publish

--- a/cli/Makefile.toml
+++ b/cli/Makefile.toml
@@ -64,7 +64,7 @@ git pull
 cd crates/cli
 VERSION=$(cargo pkgid | rev | cut -d '@' -f 1 | rev)
 cd ../..
-git tag $VERSION
+git tag cli-$VERSION
 git push --tags
 '''
 

--- a/packages/grafbase-sdk/CHANGELOG.md
+++ b/packages/grafbase-sdk/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [0.0.15] - Wed May 31 2023
+
+[CHANGELOG](changelog/0.0.15.md)
+

--- a/packages/grafbase-sdk/RELEASING.md
+++ b/packages/grafbase-sdk/RELEASING.md
@@ -1,0 +1,11 @@
+# Release
+
+Start with bumping the version:
+
+```bash
+> npm run bump-(patch|minor|major)
+```
+
+Edit the `changelog/version.md` with the changes added. Commit with the message `chore(sdk): Bump to version VERSION`, push and create a new pull request.
+
+When the pull request is merged, run `npm run release`. Monitor the deployment on GitHub Actions.

--- a/packages/grafbase-sdk/changelog/0.0.15.md
+++ b/packages/grafbase-sdk/changelog/0.0.15.md
@@ -1,0 +1,3 @@
+## Features
+
+- Added release pipeline

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",
@@ -19,7 +19,11 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "pnpm exec jest"
+    "test": "pnpm exec jest",
+    "bump-patch": "node scripts/bump-version.js patch",
+    "bump-minor": "node scripts/bump-version.js minor",
+    "bump-major": "node scripts/bump-version.js major",
+    "release": "node scripts/release.js"
   },
   "watch": {
     "build": {
@@ -43,7 +47,8 @@
     "ts-jest": "=29.1.0",
     "ts-node": "^10.9.1",
     "tsconfig": "workspace:*",
-    "typescript": "^5.0.2"
+    "typescript": "^5.0.2",
+    "semver": "^7.5.1"
   },
   "dependencies": {
     "type-fest": "^3.9.0"

--- a/packages/grafbase-sdk/scripts/bump-version.js
+++ b/packages/grafbase-sdk/scripts/bump-version.js
@@ -1,0 +1,33 @@
+const fs = require('fs')
+const semver = require('semver')
+
+const pkg = JSON.parse(fs.readFileSync('package.json'))
+pkg.version = semver.inc(pkg.version, process.argv.slice(2)[0])
+fs.writeFileSync('package.json', `${JSON.stringify(pkg, null, 2)}\n`)
+
+const changelog = `## Breaking
+
+TODO
+
+## Features
+
+TODO
+
+## Fixes
+
+TODO
+`
+
+fs.writeFileSync(`changelog/${pkg.version}.md`, changelog)
+
+var fullChangelog = "# Changelog\n\n"
+
+fs.readdirSync('changelog/').sort().reverse().forEach(file => {
+  const stat = fs.statSync(`changelog/${file}`)
+  const modified = stat.mtime.toDateString()
+  const version = file.replace('.md', '')
+
+  fullChangelog += `## [${version}] - ${modified}\n\n[CHANGELOG](changelog/${file})\n\n`
+})
+
+fs.writeFileSync('CHANGELOG.md', fullChangelog)

--- a/packages/grafbase-sdk/scripts/release.js
+++ b/packages/grafbase-sdk/scripts/release.js
@@ -1,0 +1,5 @@
+const fs = require('fs')
+const childProcess = require('node:child_process')
+const pkg = JSON.parse(fs.readFileSync('package.json'))
+
+childProcess.execSync(`git switch main && git pull && git tag sdk-${pkg.version} && git push --tags`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,9 @@ importers:
       npm-watch:
         specifier: ^0.11.0
         version: 0.11.0
+      semver:
+        specifier: ^7.5.1
+        version: 7.5.1
       ts-jest:
         specifier: '=29.1.0'
         version: 29.1.0(@babel/core@7.21.8)(jest@29.5.0)(typescript@5.0.2)
@@ -1974,7 +1977,7 @@ packages:
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
-      semver: 7.5.0
+      semver: 7.5.1
       tsutils: 3.21.0(typescript@5.0.2)
       typescript: 5.0.2
     transitivePeerDependencies:
@@ -2066,7 +2069,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.0
+      semver: 7.5.1
       tsutils: 3.21.0(typescript@5.0.2)
       typescript: 5.0.2
     transitivePeerDependencies:
@@ -2087,7 +2090,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.0
+      semver: 7.5.1
       tsutils: 3.21.0(typescript@5.0.4)
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -2108,7 +2111,7 @@ packages:
       '@typescript-eslint/typescript-estree': 5.59.2(typescript@5.0.2)
       eslint: 8.39.0
       eslint-scope: 5.1.1
-      semver: 7.5.0
+      semver: 7.5.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -2472,7 +2475,7 @@ packages:
   /builtins@5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
     dependencies:
-      semver: 7.5.0
+      semver: 7.5.1
     dev: false
 
   /bundle-name@3.0.0:
@@ -4737,7 +4740,7 @@ packages:
       jest-util: 29.5.0
       natural-compare: 1.4.0
       pretty-format: 29.5.0
-      semver: 7.5.0
+      semver: 7.5.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5201,7 +5204,7 @@ packages:
     dependencies:
       execa: 6.1.0
       parse-package-name: 1.0.0
-      semver: 7.5.0
+      semver: 7.5.1
       validate-npm-package-name: 4.0.0
     dev: false
 
@@ -5777,8 +5780,8 @@ packages:
     hasBin: true
     dev: true
 
-  /semver@7.5.0:
-    resolution: {integrity: sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==}
+  /semver@7.5.1:
+    resolution: {integrity: sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -6154,7 +6157,7 @@ packages:
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.5.0
+      semver: 7.5.1
       typescript: 5.0.2
       yargs-parser: 21.1.1
     dev: true


### PR DESCRIPTION
# Description

Closes: GB-3871

To bump `@grafbase/sdk`:

- `cd packages/grafbase-sdk`
- `npm run bump-patch|minor|major`
- `git commit -m "chore(sdk): Bump to version X.X.X`
- `git push`

To release `@grafbase/sdk`:

- `cd packages/grafbase/sdk`
- `npm run release`

The tags are now split into two:

- `cli-0.x.x` triggers CLI deployments
- `sdk-0.x.x` triggers SDK deployments

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [x] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
