### PR TITLE
fix(sdk): Release SDK always on tag pushes (skip dependencies)

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -122,7 +122,7 @@ jobs:
 
   release-sdk:
     name: Release @grafbase/sdk
-    needs: [build-and-test]
+    needs: []
     runs-on: ubuntu-latest-8-cores
     if: startsWith(github.ref, 'refs/tags/') && startsWith(github.ref_name, 'sdk-')
     steps:

--- a/packages/grafbase-sdk/CHANGELOG.md
+++ b/packages/grafbase-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.17] - Wed May 31 2023
+
+[CHANGELOG](changelog/0.0.17.md)
+
 ## [0.0.16] - Wed May 31 2023
 
 [CHANGELOG](changelog/0.0.16.md)

--- a/packages/grafbase-sdk/changelog/0.0.17.md
+++ b/packages/grafbase-sdk/changelog/0.0.17.md
@@ -1,0 +1,3 @@
+## Fixes
+
+Publish SDK always on tag changes

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

When pushing a tag, we skip the test/lint pipelines and go directly to releasing the SDK.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
