### PR TITLE
fix(sdk): Run npm authentication in project root

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -57,12 +57,14 @@ jobs:
           pnpm install --ignore-scripts --frozen-lockfile
 
       - name: Build @grafbase/sdk
+        shell: bash
         working-directory: ./packages/grafbase-sdk
         run: |
           pnpm build
 
       - name: Publish @grafbase/sdk
-        working-directory: ./packages/grafbase-sdk
+        shell: bash
         run: |
           npm set "//registry.npmjs.org/:_authToken" ${{ secrets.NPM_ACCESS_TOKEN }}
+          cd packages/grafbase-sdk
           npm publish

--- a/packages/grafbase-sdk/CHANGELOG.md
+++ b/packages/grafbase-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.18] - Wed May 31 2023
+
+[CHANGELOG](changelog/0.0.18.md)
+
 ## [0.0.17] - Wed May 31 2023
 
 [CHANGELOG](changelog/0.0.17.md)

--- a/packages/grafbase-sdk/changelog/0.0.18.md
+++ b/packages/grafbase-sdk/changelog/0.0.18.md
@@ -1,0 +1,3 @@
+## Fixes
+
+Run npm authentication on project root

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

Authentication should be run in the project root for it to work.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
