### PR TITLE
chore(cli): Bump to 0.22.0-rc.1

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   GRAFBASE_SKIP_ASSET_VERSION_CHECK: 'true'
-  ASSETS_VERSION: release/af360d1-2023-05-25
+  ASSETS_VERSION: release/1d8d52e-2023-05-31
   PROD_ASSETS: assets.grafbase.com
   CARGO_TERM_COLOR: 'always'
   CARGO_PROFILE_DEV_DEBUG: 0

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.21.0] - 2023-05-22
+
+[CHANGELOG](changelog/0.21.0.md)
+
 ## [0.20.0] - 2023-05-22
 
 [CHANGELOG](changelog/0.20.0.md)

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.21.1"
+version = "0.22.0-pre.1"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.21.1"
+version = "0.22.0-pre.1"
 dependencies = [
  "async-compression",
  "async-tar",
@@ -1646,7 +1646,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.21.1"
+version = "0.22.0-pre.1"
 dependencies = [
  "chrono",
  "derivative",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.21.1"
+version = "0.22.0-pre.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cli/changelog/0.22.0-pre.1.md
+++ b/cli/changelog/0.22.0-pre.1.md
@@ -1,0 +1,69 @@
+## Features
+
+Adds support for privacy preserving anonymous analytics
+
+- Does not include or store any PII
+- Compile time checks
+  - Checks for `GRAFBASE_RUDDERSTACK_WRITE_KEY` and `GRAFBASE_RUDDERSTACK_DATAPLANE_URL` (will be set as CI secrets) to enable analytics
+- Runtime checks
+  - Checks for `DO_NOT_TRACK` and disables analytics if found with any value
+  - Checks `$HOME/.grafbase/config.json` and disables analytics if enableAnalytics is set to false
+- Added context:
+
+  ```js
+  {
+   "anonymousId": "..." // anonymous ULID, stored between sessions. not linked to anything.
+   "sessionId": "...", // anonymous ULID, generated once per session. not linked to anything.
+   "startTime": "...", // ISO 8601 timestamp
+   "version": "..." // semantic version
+  }
+  ```
+
+- Current events:
+
+  - "Command Executed" - Sends the name and arguments (argument names only, omits values!) of the currently used command. We use this to understand which features are being used.
+  - Example payload (sent for `gb dev --port 3999`)
+
+    ```json
+    {
+      "anonymousId": "01H1M2NKXQZC0XYK7NAFYBK6JZ",
+      "channel": "server",
+      "context": {
+        "library": {
+          "name": "RudderStack Rust SDK",
+          "version": "1.0.0"
+        },
+        "sessionId": "01H1M2Y2SBSCVA3WMYNTNRTNFR",
+        "startTime": "2023-05-29T15:44:53.547629Z",
+        "version": "0.21.1"
+      },
+      "event": "Command Executed",
+      "messageId": "0b4c14a8-39ac-45ed-b0d3-61d534b22149",
+      "originalTimestamp": "2023-05-29T15:44:53.548544Z",
+      "properties": {
+        "arguments": ["port"],
+        "name": "dev"
+      },
+      "rudderId": "1a0dfe06-e5aa-4762-8a55-bc039327cb13",
+      "sentAt": "2023-05-29T15:44:53.548544Z",
+      "type": "track"
+    }
+    ```
+
+- Opting out (may be a command later on):
+
+  - _Option 1_: Write / modify the following properties in `$HOME/.grafbase/config.json`:
+
+    ```json
+    {
+      "analyticsEnabled": false,
+      "anonymousId": null
+    }
+    ```
+
+  - _Option 2_: Set the `DO_NOT_TRACK` environment variable with any value (this may affect other tooling that checks for `DO_NOT_TRACK`)
+
+## Fixes
+
+- Fixes an issue where `login` and `logout` could only be run in projects.
+- Fixes an issue where `create` would not ask project info if run without parameters.

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-local-backend"
-version = "0.21.1"
+version = "0.22.0-pre.1"
 edition = "2021"
 description = "The local backend for grafbase developer tools"
 license = "Apache-2.0"
@@ -36,8 +36,8 @@ url = "2"
 urlencoding = "2"
 webbrowser = "0.8"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.21.1" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.21.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.22.0-pre.1" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.22.0-pre.1" }
 
 [features]
 dynamodb = ["server/dynamodb"]

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase"
-version = "0.21.1"
+version = "0.22.0-pre.1"
 edition = "2021"
 description = "The Grafbase command line interface"
 license = "Apache-2.0"
@@ -37,8 +37,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
 webbrowser = "0.8"
 
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.21.1" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.21.1" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.22.0-pre.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.22.0-pre.1" }
 
 [dev-dependencies]
 chrono = "0.4"

--- a/cli/crates/common/Cargo.toml
+++ b/cli/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-local-common"
-version = "0.21.1"
+version = "0.22.0-pre.1"
 edition = "2021"
 description = "Common code used in multiple crates in the CLI workspace"
 license = "Apache-2.0"

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-local-server"
-version = "0.21.1"
+version = "0.22.0-pre.1"
 edition = "2021"
 description = "A wrapper for the grafbase worker"
 license = "Apache-2.0"
@@ -61,7 +61,7 @@ uuid = { version = "1", features = ["v4"] }
 version-compare = "0.1"
 which = "4"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.21.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.22.0-pre.1" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.21.1",
+  "version": "0.22.0-pre.1",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.21.1",
+  "version": "0.22.0-pre.1",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,9 +27,9 @@
     "jest": "29.4.3"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.21.1",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.21.1",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.21.1",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.21.1"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.22.0-pre.1",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.22.0-pre.1",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.22.0-pre.1",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.22.0-pre.1"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.21.1",
+  "version": "0.22.0-pre.1",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.21.1",
+  "version": "0.22.0-pre.1",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.21.1",
+  "version": "0.22.0-pre.1",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
# Description

[Changelog](https://github.com/grafbase/grafbase/blob/release/1d8d52e-2023-05-31/cli/changelog/0.22.0-pre.1.md)
