### PR TITLE
fix(ci): Changelog name should be taken without the cli- prefix

### DIFF
--- a/.github/workflows/cli-partial-release.yml
+++ b/.github/workflows/cli-partial-release.yml
@@ -133,7 +133,7 @@ jobs:
         id: gh-release
         uses: softprops/action-gh-release@v1
         with:
-          body_path: cli/changelog/${{ inputs.tag }}.md
+          body_path: cli/changelog/${{ env.VERSION_BUMP }}.md
           draft: ${{ inputs.draft }}
           prerelease: ${{ inputs.prerelease }}
           files: |


### PR DESCRIPTION
# Description

It tries to find it from `changelog/cli-version.md` instead of `changelog/version.md`.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
