### PR TITLE
Event-field-naming

### DIFF
--- a/cli/crates/common/src/analytics.rs
+++ b/cli/crates/common/src/analytics.rs
@@ -167,10 +167,10 @@ impl Analytics {
             });
     }
 
-    pub fn command_executed(name: &str, arguments: &Option<Vec<&'static str>>) {
+    pub fn command_executed(command_name: &str, command_arguments: &Option<Vec<&'static str>>) {
         Self::track(
             "Command Executed",
-            Some(json!({ "name": name, "arguments": arguments })),
+            Some(json!({ "commandName": command_name, "commandArguments": command_arguments })),
         );
     }
 }


### PR DESCRIPTION
# Description

## Fixes

- Fixes the naming of the "Command Executed" event fields

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
