### PR TITLE
fix(search): Did not trim whitespace in the query

### DIFF
--- a/cli/crates/cli/tests/search.rs
+++ b/cli/crates/cli/tests/search.rs
@@ -268,6 +268,11 @@ fn basic_search(#[case] name: &str, #[case] create_query: &str, #[case] search_q
     assert_hits_unordered!(search_text("Dogs best"), dog_id);
     assert_hits_unordered!(search_text("\"Dogs are the best\""), dog_id);
 
+    // Trims whitespace
+    assert_hits_unordered!(search_text("the "), dog_id, cat_id);
+    assert_hits_unordered!(search_text(" the"), dog_id, cat_id);
+    assert_hits_unordered!(search_text("  the  "), dog_id, cat_id);
+
     // URL / Email
     assert_hits_unordered!(search_text("bestfriends"), dog_id);
     assert_hits_unordered!(search_text("domination"), cat_id);

--- a/cli/crates/server/src/bridge/api_counterfeit/search/query_builder.rs
+++ b/cli/crates/server/src/bridge/api_counterfeit/search/query_builder.rs
@@ -318,14 +318,14 @@ fn parser<'a>() -> impl Parser<&'a str, Output = Vec<Text>> {
     use combine::{
         many1,
         parser::char::{char, spaces},
-        satisfy, sep_by,
+        satisfy, sep_end_by,
     };
     let word = many1(satisfy(|c: char| !c.is_whitespace())).map(Text::Word);
     let phrase = char('"')
         .with(many1(satisfy(|c: char| c != '"')))
         .skip(char('"'))
         .map(Text::Phrase);
-    sep_by(phrase.or(word), spaces())
+    spaces().with(sep_end_by(phrase.or(word), spaces()))
 }
 
 fn to_term(field: Field, value: ScalarValue) -> Term {


### PR DESCRIPTION
# Description

## Fixes

- Fixes an issue resulting in failed searches when whitespace was present at the beginning or end of a query string

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
