### PR TITLE
Turn event args to a comma separated string

### DIFF
--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -70,7 +70,7 @@ fn try_main(args: Args) -> Result<(), CliError> {
     }
 
     Analytics::init().map_err(CliError::CommonError)?;
-    Analytics::command_executed(args.command.as_ref(), &args.command.argument_names());
+    Analytics::command_executed(args.command.as_ref(), args.command.argument_names());
 
     report::warnings(&Environment::get().warnings);
 

--- a/cli/crates/common/src/analytics.rs
+++ b/cli/crates/common/src/analytics.rs
@@ -167,7 +167,8 @@ impl Analytics {
             });
     }
 
-    pub fn command_executed(command_name: &str, command_arguments: &Option<Vec<&'static str>>) {
+    pub fn command_executed(command_name: &str, command_arguments: Option<Vec<&'static str>>) {
+        let command_arguments = command_arguments.map(|arguments| arguments.join(","));
         Self::track(
             "Command Executed",
             Some(json!({ "commandName": command_name, "commandArguments": command_arguments })),


### PR DESCRIPTION
# Description

## Fix

- Turns `commandArguments` in the `"Command Executed"` event to a comma separated string

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
