### PR TITLE
Updates for cynic 3.0.0

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -439,6 +439,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +487,28 @@ name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "byteorder"
@@ -968,6 +1002,7 @@ dependencies = [
  "ouroboros",
  "proc-macro2",
  "quote",
+ "rkyv",
  "strsim",
  "syn 1.0.109",
  "thiserror",
@@ -1398,6 +1433,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,6 +1682,7 @@ dependencies = [
  "axum",
  "const_format",
  "cynic",
+ "cynic-codegen",
  "dirs 5.0.0",
  "exitcode",
  "grafbase-local-common",
@@ -3101,6 +3143,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3108,6 +3170,12 @@ checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3284,6 +3352,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
+name = "rend"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3359,6 +3436,34 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0200c8230b013893c0b2d6213d6ec64ed2b9be2e0e016682b7224ff82cff5c58"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "hashbrown",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2e06b915b5c230a17d7a736d1e2e63ee753c256a8614ef3f5147b13a4f5541d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3630,6 +3735,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "security-framework"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3831,6 +3942,12 @@ dependencies = [
  "digest 0.10.6",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "similar"
@@ -4227,6 +4344,12 @@ dependencies = [
  "once_cell",
  "regex",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -5159,6 +5282,15 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -39,5 +39,8 @@ webbrowser = "0.8"
 common = { package = "grafbase-local-common", path = "../common", version = "0.22.0-rc.7" }
 server = { package = "grafbase-local-server", path = "../server", version = "0.22.0-rc.7" }
 
+[build-dependencies]
+cynic-codegen = { version = "3", features = ["rkyv"]}
+
 [features]
 dynamodb = ["server/dynamodb"]

--- a/cli/crates/backend/build.rs
+++ b/cli/crates/backend/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    cynic_codegen::register_schema("grafbase")
+        .from_sdl_file("src/api/graphql/api.graphql")
+        .unwrap()
+        .as_default()
+        .unwrap();
+}

--- a/cli/crates/backend/src/api/create.rs
+++ b/cli/crates/backend/src/api/create.rs
@@ -90,8 +90,8 @@ pub async fn create(
     let operation = ProjectCreate::build(ProjectCreateArguments {
         input: ProjectCreateInput {
             account_id: Id::new(account_id),
-            database_regions: database_regions.iter().map(ToString::to_string).collect(),
-            project_slug: project_slug.to_owned(),
+            database_regions,
+            project_slug,
         },
     });
 

--- a/cli/crates/backend/src/api/graphql/types.rs
+++ b/cli/crates/backend/src/api/graphql/types.rs
@@ -1,17 +1,16 @@
-#[cynic::schema_for_derives(file = r#"src/api/graphql/api.graphql"#, module = "schema")]
 pub mod mutations {
     use super::schema;
 
     #[derive(cynic::InputObject, Clone, Debug)]
-    pub struct ProjectCreateInput {
+    pub struct ProjectCreateInput<'a> {
         pub account_id: cynic::Id,
-        pub project_slug: String,
-        pub database_regions: Vec<String>,
+        pub project_slug: &'a str,
+        pub database_regions: &'a [String],
     }
 
     #[derive(cynic::QueryVariables)]
-    pub struct ProjectCreateArguments {
-        pub input: ProjectCreateInput,
+    pub struct ProjectCreateArguments<'a> {
+        pub input: ProjectCreateInput<'a>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
@@ -118,15 +117,15 @@ pub mod mutations {
 
     #[derive(cynic::InputObject, Clone, Debug)]
     #[cynic(rename_all = "camelCase")]
-    pub struct DeploymentCreateInput {
+    pub struct DeploymentCreateInput<'a> {
         pub archive_file_size: i32,
-        pub branch: Option<String>,
+        pub branch: Option<&'a str>,
         pub project_id: cynic::Id,
     }
 
     #[derive(cynic::QueryVariables)]
-    pub struct DeploymentCreateArguments {
-        pub input: DeploymentCreateInput,
+    pub struct DeploymentCreateArguments<'a> {
+        pub input: DeploymentCreateInput<'a>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
@@ -166,7 +165,6 @@ pub mod mutations {
 }
 
 pub mod queries {
-    #[cynic::schema_for_derives(file = r#"src/api/graphql/api.graphql"#, module = "schema")]
     pub mod viewer_and_regions {
         use super::super::schema;
 
@@ -218,7 +216,6 @@ pub mod queries {
         }
     }
 
-    #[cynic::schema_for_derives(file = r#"src/api/graphql/api.graphql"#, module = "schema")]
     pub mod viewer {
         use super::super::schema;
 
@@ -285,7 +282,5 @@ pub mod queries {
     }
 }
 
-#[allow(non_snake_case, non_camel_case_types)]
-mod schema {
-    cynic::use_schema!(r#"src/api/graphql/api.graphql"#);
-}
+#[cynic::schema("grafbase")]
+mod schema {}


### PR DESCRIPTION
# Description

I released a new version of cynic over the weekend.  Renovate has already pulled in the code, but it enables a few bits of cleanup in our code.

1. I added the a concept of "registering" a schema in `build.rs` which can save you passing the path to the schema file to every single derive.
2. Related to the above there's an rkyv feature flag that speeds up the derives somewhat (they don't have to parse the schema over and over again).
3. Most of the derives support generic params now, so you can use reference types for variables.  Simplifies the code in a few places.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [x] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
