### PR TITLE
feat(sdk): Input types

### DIFF
--- a/packages/grafbase-sdk/CHANGELOG.md
+++ b/packages/grafbase-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.19] - Tue Jun 06 2023
+
+[CHANGELOG](changelog/0.0.19.md)
+
 ## [0.0.18] - Wed May 31 2023
 
 [CHANGELOG](changelog/0.0.18.md)

--- a/packages/grafbase-sdk/README.md
+++ b/packages/grafbase-sdk/README.md
@@ -110,11 +110,11 @@ g.query('greet', {
   resolver: 'hello'
 })
 
-const input = g.type('CheckoutSessionInput', { name: g.string() })
+const input = g.input('CheckoutSessionInput', { name: g.string() })
 const output = g.type('CheckoutSessionOutput', { successful: g.boolean() })
 
 g.mutation('checkout', {
-  args: { input: g.ref(input) },
+  args: { input: g.inputRef(input) },
   returns: g.ref(output),
   resolver: 'checkout'
 })

--- a/packages/grafbase-sdk/changelog/0.0.19.md
+++ b/packages/grafbase-sdk/changelog/0.0.19.md
@@ -1,0 +1,7 @@
+## Breaking
+
+- A `type` cannot be part of an input parameter. Use `input` instead.
+
+## Fixes
+
+- Everything that does not need to be public is now private.

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",

--- a/packages/grafbase-sdk/src/auth.ts
+++ b/packages/grafbase-sdk/src/auth.ts
@@ -33,7 +33,7 @@ export type AuthStrategy = 'private' | 'owner' | AuthGroups
  * A builder to greate auth groups.
  */
 export class AuthGroups {
-  groups: string[]
+  private groups: string[]
 
   constructor(groups: string[]) {
     this.groups = groups
@@ -49,8 +49,8 @@ export class AuthGroups {
  * A builder to create a rule to the auth attribute.
  */
 export class AuthRule {
-  strategy: AuthStrategy
-  operations: AuthOperation[]
+  private strategy: AuthStrategy
+  private operations: AuthOperation[]
 
   constructor(strategy: AuthStrategy) {
     this.strategy = strategy
@@ -96,7 +96,7 @@ export class AuthRule {
     return `{ ${allow}${ops} }`
   }
 
-  operation(op: AuthOperation): AuthRule {
+  private operation(op: AuthOperation): AuthRule {
     this.operations.push(op)
 
     return this
@@ -107,7 +107,7 @@ export class AuthRule {
  * A builder to generate a set of rules to the auth attribute.
  */
 export class AuthRules {
-  rules: AuthRule[]
+  private rules: AuthRule[]
 
   constructor() {
     this.rules = []
@@ -167,8 +167,8 @@ export interface AuthParams {
 }
 
 export class Authentication {
-  providers: FixedLengthArray<AuthProvider, 1>
-  rules: AuthRules
+  private providers: FixedLengthArray<AuthProvider, 1>
+  private rules: AuthRules
 
   constructor(params: AuthParams) {
     this.providers = params.providers

--- a/packages/grafbase-sdk/src/auth/jwks.ts
+++ b/packages/grafbase-sdk/src/auth/jwks.ts
@@ -21,10 +21,10 @@ export type JWKSParams = {
 }
 
 export class JWKSAuth {
-  issuer?: string
-  jwksEndpoint?: string
-  clientId?: string
-  groupsClaim?: string
+  private issuer?: string
+  private jwksEndpoint?: string
+  private clientId?: string
+  private groupsClaim?: string
 
   constructor(
     params: RequireAtLeastOne<JWKSParams, 'issuer' | 'jwksEndpoint'>

--- a/packages/grafbase-sdk/src/auth/jwt.ts
+++ b/packages/grafbase-sdk/src/auth/jwt.ts
@@ -22,10 +22,10 @@ export interface JWTParams {
  * requests using a JWT signed by yourself or a third-party service.
  */
 export class JWTAuth {
-  issuer: string
-  secret: string
-  clientId?: string
-  groupsClaim?: string
+  private issuer: string
+  private secret: string
+  private clientId?: string
+  private groupsClaim?: string
 
   constructor(params: JWTParams) {
     this.issuer = params.issuer

--- a/packages/grafbase-sdk/src/auth/openid.ts
+++ b/packages/grafbase-sdk/src/auth/openid.ts
@@ -17,9 +17,9 @@ export interface OpenIDParams {
 }
 
 export class OpenIDAuth {
-  issuer: string
-  clientId?: string
-  groupsClaim?: string
+  private issuer: string
+  private clientId?: string
+  private groupsClaim?: string
 
   constructor(params: OpenIDParams) {
     this.issuer = params.issuer

--- a/packages/grafbase-sdk/src/cache.ts
+++ b/packages/grafbase-sdk/src/cache.ts
@@ -45,7 +45,7 @@ export interface CacheParams {
 }
 
 export class GlobalCache {
-  params: CacheParams
+  private params: CacheParams
 
   constructor(params: CacheParams) {
     this.params = params

--- a/packages/grafbase-sdk/src/config.ts
+++ b/packages/grafbase-sdk/src/config.ts
@@ -15,9 +15,9 @@ export interface ConfigInput {
  * Defines the complete Grafbase configuration.
  */
 export class Config {
-  schema: GrafbaseSchema
-  auth?: Authentication
-  cache?: GlobalCache
+  private schema: GrafbaseSchema
+  private auth?: Authentication
+  private cache?: GlobalCache
 
   constructor(input: ConfigInput) {
     this.schema = input.schema

--- a/packages/grafbase-sdk/src/connector/graphql.ts
+++ b/packages/grafbase-sdk/src/connector/graphql.ts
@@ -6,9 +6,9 @@ export interface GraphQLParams {
 }
 
 export class PartialGraphQLAPI {
-  apiUrl: string
-  headers: Header[]
-  introspectionHeaders: Header[]
+  private apiUrl: string
+  private headers: Header[]
+  private introspectionHeaders: Header[]
 
   constructor(params: GraphQLParams) {
     const headers = new Headers()
@@ -33,10 +33,10 @@ export class PartialGraphQLAPI {
 }
 
 export class GraphQLAPI {
-  namespace: string
-  url: string
-  headers: Header[]
-  introspectionHeaders: Header[]
+  private namespace: string
+  private url: string
+  private headers: Header[]
+  private introspectionHeaders: Header[]
 
   constructor(
     namespace: string,

--- a/packages/grafbase-sdk/src/connector/header.ts
+++ b/packages/grafbase-sdk/src/connector/header.ts
@@ -4,8 +4,8 @@ export type HeaderGenerator = (headers: Headers) => any
  * Header used in connector calls.
  */
 export class Header {
-  name: string
-  value: string
+  private name: string
+  private value: string
 
   constructor(name: string, value: string) {
     this.name = name
@@ -22,16 +22,30 @@ export class Header {
  * introspection headers.
  */
 export class Headers {
-  headers: Header[]
-  introspectionHeaders: Header[]
+  private _headers: Header[]
+  private _introspectionHeaders: Header[]
 
   constructor() {
-    this.headers = []
-    this.introspectionHeaders = []
+    this._headers = []
+    this._introspectionHeaders = []
   }
 
   /**
-   * Creates a header used in client and introspection requests.
+   * All headers used in client requests.
+   */
+  public get headers(): Header[] {
+    return this._headers
+  }
+
+  /**
+   * All headers used in introspection requests.
+   */
+  public get introspectionHeaders(): Header[] {
+    return this._introspectionHeaders
+  }
+
+  /**
+   * Creates a header used in client requests.
    *
    * @param name - The name of the header
    * @param value - The value of the header
@@ -41,7 +55,7 @@ export class Headers {
   }
 
   /**
-   * Creates a header used only in introspection requests.
+   * Creates a header used in introspection requests.
    *
    * @param name - The name of the header
    * @param value - The value of the header

--- a/packages/grafbase-sdk/src/connector/openapi.ts
+++ b/packages/grafbase-sdk/src/connector/openapi.ts
@@ -10,11 +10,11 @@ export interface OpenAPIParams {
 }
 
 export class PartialOpenAPI {
-  schema: string
-  apiUrl?: string
-  transforms?: OpenApiTransforms
-  headers: Header[]
-  introspectionHeaders: Header[]
+  private schema: string
+  private apiUrl?: string
+  private transforms?: OpenApiTransforms
+  private headers: Header[]
+  private introspectionHeaders: Header[]
 
   constructor(params: OpenAPIParams) {
     const headers = new Headers()
@@ -43,12 +43,12 @@ export class PartialOpenAPI {
 }
 
 export class OpenAPI {
-  namespace: string
-  schema: string
-  apiUrl?: string
-  transforms?: OpenApiTransforms
-  headers: Header[]
-  introspectionHeaders: Header[]
+  private namespace: string
+  private schema: string
+  private apiUrl?: string
+  private transforms?: OpenApiTransforms
+  private headers: Header[]
+  private introspectionHeaders: Header[]
 
   constructor(
     namespace: string,

--- a/packages/grafbase-sdk/src/enum.ts
+++ b/packages/grafbase-sdk/src/enum.ts
@@ -7,15 +7,29 @@ import { validateIdentifier } from './validation'
 export type EnumShape<T> = [T, ...Array<T>]
 
 export class Enum<T extends string, U extends EnumShape<T>> {
-  name: string
-  variants: U
+  private _name: string
+  private _variants: U
 
   constructor(name: string, variants: U) {
     validateIdentifier(name)
     variants.forEach((variant) => validateIdentifier(variant))
 
-    this.name = name
-    this.variants = variants
+    this._name = name
+    this._variants = variants
+  }
+
+  /**
+   * The name of the enum.
+   */
+  public get name(): string {
+    return this._name
+  }
+
+  /**
+   * A list of variants in the enum.
+   */
+  public get variants(): U {
+    return this._variants
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/field.ts
+++ b/packages/grafbase-sdk/src/field.ts
@@ -2,14 +2,18 @@ import { ModelFieldShape } from './model'
 import { validateIdentifier } from './validation'
 
 export class Field {
-  name: string
-  shape: ModelFieldShape
+  private _name: string
+  private shape: ModelFieldShape
 
   constructor(name: string, shape: ModelFieldShape) {
     validateIdentifier(name)
 
-    this.name = name
+    this._name = name
     this.shape = shape
+  }
+
+  public get name(): string {
+    return this._name
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/grafbase-schema.ts
+++ b/packages/grafbase-sdk/src/grafbase-schema.ts
@@ -24,7 +24,7 @@ export type PartialDatasource = PartialOpenAPI | PartialGraphQLAPI
 export type Datasource = OpenAPI | GraphQLAPI
 
 export class Datasources {
-  inner: Datasource[]
+  private inner: Datasource[]
 
   constructor() {
     this.inner = []
@@ -51,16 +51,16 @@ export interface IntrospectParams {
 }
 
 export class GrafbaseSchema {
-  enums: Enum<any, any>[]
-  types: Type[]
-  unions: Union[]
-  models: Model[]
-  interfaces: Interface[]
-  queries?: TypeExtension
-  mutations?: TypeExtension
-  datasources: Datasources
-  extendedTypes: TypeExtension[]
-  inputs: Input[]
+  private enums: Enum<any, any>[]
+  private types: Type[]
+  private unions: Union[]
+  private models: Model[]
+  private interfaces: Interface[]
+  private queries?: TypeExtension
+  private mutations?: TypeExtension
+  private datasources: Datasources
+  private extendedTypes: TypeExtension[]
+  private inputs: Input[]
 
   constructor() {
     this.enums = []

--- a/packages/grafbase-sdk/src/grafbase-schema.ts
+++ b/packages/grafbase-sdk/src/grafbase-schema.ts
@@ -17,6 +17,8 @@ import {
 } from './typedefs/scalar'
 import { FieldType } from './typedefs'
 import { EnumDefinition } from './typedefs/enum'
+import { Input, InputFields } from './input_type'
+import { InputDefinition } from './typedefs/input'
 
 export type PartialDatasource = PartialOpenAPI | PartialGraphQLAPI
 export type Datasource = OpenAPI | GraphQLAPI
@@ -58,6 +60,7 @@ export class GrafbaseSchema {
   mutations?: TypeExtension
   datasources: Datasources
   extendedTypes: TypeExtension[]
+  inputs: Input[]
 
   constructor() {
     this.enums = []
@@ -67,6 +70,7 @@ export class GrafbaseSchema {
     this.interfaces = []
     this.datasources = new Datasources()
     this.extendedTypes = []
+    this.inputs = []
   }
 
   /**
@@ -195,6 +199,25 @@ export class GrafbaseSchema {
 
     return query
   }
+
+  /**
+   * Add a new input to the schema.
+   *
+   * @param name = The name of the input.
+   * @param fields = The input definition.
+   */
+  public input(name: string, definition: InputFields): Input {
+    var input = new Input(name)
+
+    Object.entries(definition).forEach(([name, type]) => {
+      input.field(name, type)
+    })
+
+    this.inputs.push(input)
+
+    return input
+  }
+
 
   /**
    * Add a new enum to the schema.
@@ -333,6 +356,15 @@ export class GrafbaseSchema {
   }
 
   /**
+   * Create a new field from an input object reference.
+   *
+   * @param input - The input object reference.
+   */
+  public inputRef(input: Input): InputDefinition {
+    return new InputDefinition(input)
+  }
+
+  /**
    * Extends an existing type with the given queries.
    *
    * @param type - Either a type if the given type is directly in the schema,
@@ -371,12 +403,14 @@ export class GrafbaseSchema {
     this.models = []
     this.datasources = new Datasources()
     this.extendedTypes = []
+    this.inputs = []
   }
 
   public toString(): string {
     const datasources = this.datasources.toString()
     const interfaces = this.interfaces.map(String).join('\n\n')
     const types = this.types.map(String).join('\n\n')
+    const inputs = this.inputs.map(String).join('\n\n')
     const queries = this.queries ? this.queries.toString() : ''
     const mutations = this.mutations ? this.mutations.toString() : ''
     const extendedTypes = this.extendedTypes.map(String).join('\n\n')
@@ -388,6 +422,7 @@ export class GrafbaseSchema {
       datasources,
       interfaces,
       enums,
+      inputs,
       types,
       extendedTypes,
       queries,

--- a/packages/grafbase-sdk/src/grafbase-schema.ts
+++ b/packages/grafbase-sdk/src/grafbase-schema.ts
@@ -218,7 +218,6 @@ export class GrafbaseSchema {
     return input
   }
 
-
   /**
    * Add a new enum to the schema.
    *

--- a/packages/grafbase-sdk/src/input_type.ts
+++ b/packages/grafbase-sdk/src/input_type.ts
@@ -1,12 +1,13 @@
-import { EnumDefinition } from "./typedefs/enum";
-import { InputDefinition } from "./typedefs/input";
-import { ListDefinition } from "./typedefs/list";
-import { ScalarDefinition } from "./typedefs/scalar";
-import { validateIdentifier } from "./validation";
+import { EnumDefinition } from './typedefs/enum'
+import { InputDefinition } from './typedefs/input'
+import { ListDefinition } from './typedefs/list'
+import { ScalarDefinition } from './typedefs/scalar'
+import { validateIdentifier } from './validation'
 
 export type InputFields = Record<string, InputFieldShape>
 
-export type InputFieldShape = ScalarDefinition
+export type InputFieldShape =
+  | ScalarDefinition
   | ListDefinition
   | EnumDefinition<any, any>
   | InputDefinition
@@ -31,7 +32,7 @@ export class Input {
   public get name(): string {
     return this._name
   }
- 
+
   /**
    * Pushes a field to the input definition.
    *

--- a/packages/grafbase-sdk/src/input_type.ts
+++ b/packages/grafbase-sdk/src/input_type.ts
@@ -15,14 +15,21 @@ export type InputFieldShape = ScalarDefinition
  * A GraphQL Input Object defines a set of input fields, used in queries and mutations.
  */
 export class Input {
-  public name: string
+  private _name: string
   private fields: InputField[]
 
   constructor(name: string) {
     validateIdentifier(name)
 
-    this.name = name
+    this._name = name
     this.fields = []
+  }
+
+  /**
+   * The name of the input.
+   */
+  public get name(): string {
+    return this._name
   }
  
   /**

--- a/packages/grafbase-sdk/src/input_type.ts
+++ b/packages/grafbase-sdk/src/input_type.ts
@@ -1,0 +1,63 @@
+import { EnumDefinition } from "./typedefs/enum";
+import { InputDefinition } from "./typedefs/input";
+import { ListDefinition } from "./typedefs/list";
+import { ScalarDefinition } from "./typedefs/scalar";
+import { validateIdentifier } from "./validation";
+
+export type InputFields = Record<string, InputFieldShape>
+
+export type InputFieldShape = ScalarDefinition
+  | ListDefinition
+  | EnumDefinition<any, any>
+  | InputDefinition
+
+/**
+ * A GraphQL Input Object defines a set of input fields, used in queries and mutations.
+ */
+export class Input {
+  public name: string
+  private fields: InputField[]
+
+  constructor(name: string) {
+    validateIdentifier(name)
+
+    this.name = name
+    this.fields = []
+  }
+ 
+  /**
+   * Pushes a field to the input definition.
+   *
+   * @param name - The name of the field.
+   * @param definition - The type definition.
+   */
+  public field(name: string, definition: InputFieldShape): this {
+    this.fields.push(new InputField(name, definition))
+
+    return this
+  }
+
+  public toString(): string {
+    const header = `input ${this.name} {`
+    const fields = this.fields.map((f) => `  ${f}`).join('\n')
+    const footer = '}'
+
+    return `${header}\n${fields}\n${footer}`
+  }
+}
+
+class InputField {
+  private name: string
+  private shape: InputFieldShape
+
+  constructor(name: string, shape: InputFieldShape) {
+    validateIdentifier(name)
+
+    this.name = name
+    this.shape = shape
+  }
+
+  public toString(): string {
+    return `${this.name}: ${this.shape}`
+  }
+}

--- a/packages/grafbase-sdk/src/interface.ts
+++ b/packages/grafbase-sdk/src/interface.ts
@@ -14,14 +14,14 @@ export type InterfaceFields = Record<string, InterfaceFieldShape>
 export type InterfaceFieldShape = ScalarDefinition | ListDefinition
 
 export class Interface {
-  name: string
-  fields: Field[]
+  private _name: string
+  private _fields: Field[]
 
   constructor(name: string) {
     validateIdentifier(name)
 
-    this.name = name
-    this.fields = []
+    this._name = name
+    this._fields = []
   }
 
   /**
@@ -34,6 +34,20 @@ export class Interface {
     this.fields.push(new Field(name, definition))
 
     return this
+  }
+
+  /**
+   * All fields that belong to the interface.
+   */
+  public get fields(): Field[] {
+    return this._fields
+  }
+
+  /**
+   * The name of the interface.
+   */
+  public get name(): string {
+    return this._name
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/model.ts
+++ b/packages/grafbase-sdk/src/model.ts
@@ -42,20 +42,27 @@ export type ModelFieldShape =
   | EnumDefinition<any, any>
 
 export class Model {
-  name: string
-  fields: Field[]
-  authRules?: AuthRules
-  isSearch: boolean
-  isLive: boolean
-  cacheDirective?: TypeLevelCache
+  private _name: string
+  private fields: Field[]
+  private authRules?: AuthRules
+  private isSearch: boolean
+  private isLive: boolean
+  private cacheDirective?: TypeLevelCache
 
   constructor(name: string) {
     validateIdentifier(name)
 
-    this.name = name
+    this._name = name
     this.fields = []
     this.isSearch = false
     this.isLive = false
+  }
+
+  /**
+   * Get the name of the model.
+   */
+  public get name(): string {
+    return this._name
   }
 
   /**

--- a/packages/grafbase-sdk/src/query.ts
+++ b/packages/grafbase-sdk/src/query.ts
@@ -1,10 +1,11 @@
+import { InputDefinition } from './typedefs/input'
 import { ListDefinition } from './typedefs/list'
 import { ReferenceDefinition } from './typedefs/reference'
 import { ScalarDefinition } from './typedefs/scalar'
 import { validateIdentifier } from './validation'
 
 /** The possible types of an input parameters of a query. */
-export type InputType = ScalarDefinition | ListDefinition | ReferenceDefinition
+export type InputType = ScalarDefinition | ListDefinition | InputDefinition
 
 /** The possible types of an output parameters of a query. */
 export type OutputType = ScalarDefinition | ListDefinition | ReferenceDefinition

--- a/packages/grafbase-sdk/src/query.ts
+++ b/packages/grafbase-sdk/src/query.ts
@@ -23,8 +23,8 @@ export interface QueryInput {
  * An input argument shape of a query.
  */
 export class QueryArgument {
-  name: string
-  type: InputType
+  private name: string
+  private type: InputType
 
   constructor(name: string, type: InputType) {
     validateIdentifier(name)
@@ -42,10 +42,10 @@ export class QueryArgument {
  * An edge resolver query definition.
  */
 export class Query {
-  name: string
-  arguments: QueryArgument[]
-  returns: OutputType
-  resolver: string
+  private name: string
+  private arguments: QueryArgument[]
+  private returns: OutputType
+  private resolver: string
 
   constructor(name: string, returnType: OutputType, resolverName: string) {
     validateIdentifier(name)

--- a/packages/grafbase-sdk/src/relation.ts
+++ b/packages/grafbase-sdk/src/relation.ts
@@ -22,21 +22,21 @@ type RelationF = () => Model
 export class RelationDefinition {
   // For ambivalent relations, a name makes them distinct.
   // Rendered as `@relation(name: "relationName")`.
-  relationName?: string
+  private _relationName?: string
   // The model we refer from this field.
-  referencedModel: RelationRef
+  private _referencedModel: RelationRef
   // True, if the field can hold a null value.
-  isOptional: boolean
+  private _isOptional: boolean
 
   /** @param {RelationRef} referencedModel */
   constructor(referencedModel: RelationRef) {
-    this.referencedModel = referencedModel
-    this.isOptional = false
+    this._referencedModel = referencedModel
+    this._isOptional = false
   }
 
   /** Make the field nullable. */
   public optional(): RelationDefinition {
-    this.isOptional = true
+    this._isOptional = true
 
     return this
   }
@@ -52,7 +52,7 @@ export class RelationDefinition {
    * @param name - The name of the relation.
    */
   public name(name: string): RelationDefinition {
-    this.relationName = name
+    this._relationName = name
 
     return this
   }
@@ -66,18 +66,36 @@ export class RelationDefinition {
     return new AuthDefinition(this, rules)
   }
 
+  /**
+   * Gets the relations name
+   */
+  public get relationName(): string | undefined {
+    return this._relationName
+  }
+
+  /**
+   * Gets the referenced model
+   */
+  public get referencedModel(): RelationRef {
+    return this._referencedModel
+  }
+
+  public get isOptional(): boolean {
+    return this._isOptional
+  }
+
   public toString(): string {
     let modelName
 
-    if (typeof this.referencedModel === 'function') {
-      modelName = this.referencedModel().name
+    if (typeof this._referencedModel === 'function') {
+      modelName = this._referencedModel().name
     } else {
-      modelName = this.referencedModel.name
+      modelName = this._referencedModel.name
     }
 
     const required = this.isOptional ? '' : '!'
-    const relationAttribute = this.relationName
-      ? ` @relation(name: "${this.relationName}")`
+    const relationAttribute = this._relationName
+      ? ` @relation(name: "${this._relationName}")`
       : ''
 
     return `${modelName}${required}${relationAttribute}`

--- a/packages/grafbase-sdk/src/type.ts
+++ b/packages/grafbase-sdk/src/type.ts
@@ -31,17 +31,24 @@ export type TypeFieldShape =
  * A composite type definition (e.g. not a model).
  */
 export class Type {
-  name: string
-  fields: Field[]
-  interfaces: Interface[]
-  cacheDirective?: TypeLevelCache
+  private _name: string
+  private fields: Field[]
+  private interfaces: Interface[]
+  private cacheDirective?: TypeLevelCache
 
   constructor(name: string) {
     validateIdentifier(name)
 
-    this.name = name
+    this._name = name
     this.fields = []
     this.interfaces = []
+  }
+
+  /**
+   * The name of the type.
+   */
+  public get name(): string {
+    return this._name
   }
 
   /**
@@ -97,8 +104,8 @@ export class Type {
 }
 
 export class TypeExtension {
-  name: string
-  queries: Query[]
+  private name: string
+  private queries: Query[]
 
   constructor(type: string | Type) {
     if (type instanceof Type) {

--- a/packages/grafbase-sdk/src/typedefs/auth.ts
+++ b/packages/grafbase-sdk/src/typedefs/auth.ts
@@ -23,8 +23,8 @@ export type Authenticable =
   | EnumDefinition<any, any>
 
 export class AuthDefinition {
-  field: Authenticable
-  authRules: AuthRules
+  private field: Authenticable
+  private authRules: AuthRules
 
   constructor(field: Authenticable, rules: AuthRuleF) {
     const authRules = new AuthRules()

--- a/packages/grafbase-sdk/src/typedefs/cache.ts
+++ b/packages/grafbase-sdk/src/typedefs/cache.ts
@@ -31,7 +31,7 @@ export interface FieldCacheParams {
 }
 
 export class TypeLevelCache {
-  params: TypeCacheParams
+  private params: TypeCacheParams
 
   constructor(params: TypeCacheParams) {
     this.params = params
@@ -55,7 +55,7 @@ export class TypeLevelCache {
 }
 
 export class FieldLevelCache {
-  params: FieldCacheParams
+  private params: FieldCacheParams
 
   constructor(params: FieldCacheParams) {
     this.params = params
@@ -73,10 +73,10 @@ export class FieldLevelCache {
 }
 
 export class CacheDefinition {
-  attribute: TypeLevelCache
-  field: Cacheable
+  private attribute: FieldLevelCache
+  private field: Cacheable
 
-  constructor(field: Cacheable, attribute: TypeLevelCache) {
+  constructor(field: Cacheable, attribute: FieldLevelCache) {
     this.attribute = attribute
     this.field = field
   }

--- a/packages/grafbase-sdk/src/typedefs/default.ts
+++ b/packages/grafbase-sdk/src/typedefs/default.ts
@@ -16,8 +16,8 @@ export type DefaultFieldShape =
   | EnumDefinition<any, any>
 
 export class DefaultDefinition {
-  defaultValue: DefaultValueType
-  scalar: DefaultFieldShape
+  private defaultValue: DefaultValueType
+  private scalar: DefaultFieldShape
 
   constructor(scalar: DefaultFieldShape, defaultValue: DefaultValueType) {
     this.defaultValue = defaultValue

--- a/packages/grafbase-sdk/src/typedefs/enum.ts
+++ b/packages/grafbase-sdk/src/typedefs/enum.ts
@@ -9,9 +9,9 @@ import { SearchDefinition } from './search'
 import { UniqueDefinition } from './unique'
 
 export class EnumDefinition<T extends string, U extends EnumShape<T>> {
-  enumName: string
-  enumVariants: U
-  isOptional: boolean
+  private enumName: string
+  private enumVariants: U
+  private isOptional: boolean
 
   constructor(referencedEnum: Enum<T, U>) {
     this.enumName = referencedEnum.name

--- a/packages/grafbase-sdk/src/typedefs/input.ts
+++ b/packages/grafbase-sdk/src/typedefs/input.ts
@@ -1,5 +1,5 @@
-import { Input } from "../input_type"
-import { ListDefinition } from "./list"
+import { Input } from '../input_type'
+import { ListDefinition } from './list'
 
 /**
  * Defines a reference to an input object

--- a/packages/grafbase-sdk/src/typedefs/input.ts
+++ b/packages/grafbase-sdk/src/typedefs/input.ts
@@ -1,0 +1,37 @@
+import { Input } from "../input_type"
+import { ListDefinition } from "./list"
+
+/**
+ * Defines a reference to an input object
+ */
+export class InputDefinition {
+  name: string
+  isOptional: boolean
+
+  constructor(input: Input) {
+    this.name = input.name
+    this.isOptional = false
+  }
+
+  /**
+   * Set the field optional.
+   */
+  public optional(): this {
+    this.isOptional = true
+
+    return this
+  }
+
+  /**
+   * Allow multiple scalars to be used as values for the field.
+   */
+  public list(): ListDefinition {
+    return new ListDefinition(this)
+  }
+
+  public toString(): string {
+    const required = this.isOptional ? '' : '!'
+
+    return `${this.name}${required}`
+  }
+}

--- a/packages/grafbase-sdk/src/typedefs/input.ts
+++ b/packages/grafbase-sdk/src/typedefs/input.ts
@@ -5,8 +5,8 @@ import { ListDefinition } from "./list"
  * Defines a reference to an input object
  */
 export class InputDefinition {
-  name: string
-  isOptional: boolean
+  private name: string
+  private isOptional: boolean
 
   constructor(input: Input) {
     this.name = input.name

--- a/packages/grafbase-sdk/src/typedefs/length-limited-string.ts
+++ b/packages/grafbase-sdk/src/typedefs/length-limited-string.ts
@@ -15,8 +15,8 @@ export interface FieldLength {
 }
 
 export class LengthLimitedStringDefinition {
-  fieldLength: RequireAtLeastOne<FieldLength, 'min' | 'max'>
-  scalar: StringDefinition
+  private fieldLength: RequireAtLeastOne<FieldLength, 'min' | 'max'>
+  private scalar: StringDefinition
 
   constructor(
     scalar: StringDefinition,

--- a/packages/grafbase-sdk/src/typedefs/list.ts
+++ b/packages/grafbase-sdk/src/typedefs/list.ts
@@ -22,11 +22,11 @@ export type ListScalarType =
   | InputDefinition
 
 export class ListDefinition {
-  fieldDefinition: ListScalarType
-  isOptional: boolean
-  defaultValue?: DefaultValueType[]
-  authRules?: AuthRules
-  resolverName?: string
+  private fieldDefinition: ListScalarType
+  private isOptional: boolean
+  protected defaultValue?: DefaultValueType[]
+  private authRules?: AuthRules
+  private resolverName?: string
 
   constructor(fieldDefinition: ListScalarType) {
     this.fieldDefinition = fieldDefinition
@@ -90,9 +90,9 @@ export class ListDefinition {
 }
 
 export class RelationListDefinition {
-  relation: RelationDefinition
-  isOptional: boolean
-  authRules?: AuthRules
+  private relation: RelationDefinition
+  private isOptional: boolean
+  private authRules?: AuthRules
 
   constructor(fieldDefinition: RelationDefinition) {
     this.relation = fieldDefinition
@@ -146,7 +146,7 @@ export class RelationListDefinition {
 }
 
 class ListWithDefaultDefinition extends ListDefinition {
-  fieldType: FieldType
+  private fieldType: FieldType
 
   constructor(fieldDefinition: ScalarDefinition) {
     super(fieldDefinition)

--- a/packages/grafbase-sdk/src/typedefs/list.ts
+++ b/packages/grafbase-sdk/src/typedefs/list.ts
@@ -12,12 +12,14 @@ import {
 import { SearchDefinition } from './search'
 import { FieldType } from '../typedefs'
 import { EnumDefinition } from './enum'
+import { InputDefinition } from './input'
 
 export type ListScalarType =
   | ScalarDefinition
   | RelationDefinition
   | ReferenceDefinition
   | EnumDefinition<any, any>
+  | InputDefinition
 
 export class ListDefinition {
   fieldDefinition: ListScalarType

--- a/packages/grafbase-sdk/src/typedefs/reference.ts
+++ b/packages/grafbase-sdk/src/typedefs/reference.ts
@@ -5,8 +5,8 @@ import { AuthDefinition } from './auth'
 import { ResolverDefinition } from './resolver'
 
 export class ReferenceDefinition {
-  referencedType: string
-  isOptional: boolean
+  private referencedType: string
+  private isOptional: boolean
 
   constructor(referencedType: Type) {
     this.referencedType = referencedType.name

--- a/packages/grafbase-sdk/src/typedefs/resolver.ts
+++ b/packages/grafbase-sdk/src/typedefs/resolver.ts
@@ -20,8 +20,8 @@ export type Resolvable =
   | EnumDefinition<any, any>
 
 export class ResolverDefinition {
-  field: Resolvable
-  resolver: string
+  private field: Resolvable
+  private resolver: string
 
   constructor(field: Resolvable, resolver: string) {
     this.field = field

--- a/packages/grafbase-sdk/src/typedefs/scalar.ts
+++ b/packages/grafbase-sdk/src/typedefs/scalar.ts
@@ -21,15 +21,25 @@ import { ResolverDefinition } from './resolver'
 import { CacheDefinition, FieldCacheParams, FieldLevelCache } from './cache'
 
 export class ScalarDefinition {
-  fieldType: FieldType | Enum<any, any>
-  isOptional: boolean
-  defaultValue?: DefaultValueType
+  private _fieldType: FieldType | Enum<any, any>
+  private isOptional: boolean
+  protected defaultValue?: DefaultValueType
 
   constructor(fieldType: FieldType | Enum<any, any>) {
-    this.fieldType = fieldType
+    this._fieldType = fieldType
     this.isOptional = false
   }
 
+  /**
+   * The type of the field
+   */
+  public get fieldType(): FieldType | Enum<any, any> {
+    return this._fieldType
+  }
+
+  /**
+   * Make the field optional.
+   */
   public optional(): this {
     this.isOptional = true
 

--- a/packages/grafbase-sdk/src/typedefs/search.ts
+++ b/packages/grafbase-sdk/src/typedefs/search.ts
@@ -22,7 +22,7 @@ export type Searchable =
   | EnumDefinition<any, any>
 
 export class SearchDefinition {
-  field: Searchable
+  private field: Searchable
 
   constructor(field: Searchable) {
     this.field = field

--- a/packages/grafbase-sdk/src/typedefs/unique.ts
+++ b/packages/grafbase-sdk/src/typedefs/unique.ts
@@ -19,8 +19,8 @@ type UniqueScalarType =
   | EnumDefinition<any, any>
 
 export class UniqueDefinition {
-  compoundScope?: string[]
-  scalar: UniqueScalarType
+  private compoundScope?: string[]
+  private scalar: UniqueScalarType
 
   constructor(scalar: UniqueScalarType, scope?: string[]) {
     this.scalar = scalar

--- a/packages/grafbase-sdk/src/union.ts
+++ b/packages/grafbase-sdk/src/union.ts
@@ -5,8 +5,8 @@ import { validateIdentifier } from './validation'
  * A builder to create a GraphQL union.
  */
 export class Union {
-  name: string
-  types: string[]
+  private name: string
+  private types: string[]
 
   constructor(name: string) {
     validateIdentifier(name)

--- a/packages/grafbase-sdk/tests/unit/queries.test.ts
+++ b/packages/grafbase-sdk/tests/unit/queries.test.ts
@@ -103,17 +103,17 @@ describe('Query generator', () => {
   })
 
   it('generates a mutation resolver with required input and output', () => {
-    const input = g.type('CheckoutSessionInput', { name: g.string() })
+    const input = g.input('CheckoutSessionInput', { name: g.string() })
     const output = g.type('CheckoutSessionOutput', { successful: g.boolean() })
 
     g.mutation('checkout', {
-      args: { input: g.ref(input) },
+      args: { input: g.inputRef(input) },
       returns: g.ref(output),
       resolver: 'checkout'
     })
 
     expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
-      "type CheckoutSessionInput {
+      "input CheckoutSessionInput {
         name: String!
       }
 
@@ -217,5 +217,91 @@ describe('Query generator', () => {
     ).toThrow(
       'Given name "!@#$%^&*()+|~`=-" is not a valid TypeScript identifier.'
     )
+  })
+
+  it('generates a basic input type', () => {
+    g.input('Point2D', {
+      x: g.float(),
+      y: g.float()
+    })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "input Point2D {
+        x: Float!
+        y: Float!
+      }"
+    `)
+  })
+
+  it('generates an input type with an enum field', () => {
+    const color = g.enum('Color', ['Red', 'Green', 'Blue'])
+
+    g.input('Data', {
+      color: g.enumRef(color).optional()
+    })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "enum Color {
+        Red,
+        Green,
+        Blue
+      }
+
+      input Data {
+        color: Color
+      }"
+    `)
+  })
+
+  it('generates an input type with a list field', () => {
+    g.input('Data', {
+      color: g.int().list()
+    })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "input Data {
+        color: [Int!]!
+      }"
+    `)
+  })
+
+  it('generates an input type with a nested input field', () => {
+    const nested = g.input('Nested', {
+      x: g.boolean()
+    })
+
+    g.input('Data', {
+      color: g.inputRef(nested)
+    })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "input Nested {
+        x: Boolean!
+      }
+
+      input Data {
+        color: Nested!
+      }"
+    `)
+  })
+
+  it('generates an input type with a nested list input field', () => {
+    const nested = g.input('Nested', {
+      x: g.boolean()
+    })
+
+    g.input('Data', {
+      color: g.inputRef(nested).list()
+    })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "input Nested {
+        x: Boolean!
+      }
+
+      input Data {
+        color: [Nested!]!
+      }"
+    `)
   })
 })


### PR DESCRIPTION
# Description

Closes: GB-3898

A query input parameter cannot be referencing a `type`, using `input` instead. Inputs can be created with the `input` method:

```ts
const point = g.input('Point2D', {
  x: g.float(),
  y: g.float()
})

g.query('LoadData', {
  args: { point: g.inputRef(point) },
  returns: g.boolean(),
  resolver: 'load_data'
})
``` 

# Type of change

- [x] 💔 Breaking
- [x] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [x] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [x] 📖 Requires documentation update
