### PR TITLE
GB-3734 - Ignore deployment files from blacklist

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1700,6 +1700,7 @@ dependencies = [
  "tower-http",
  "url",
  "urlencoding",
+ "walkdir",
  "webbrowser",
 ]
 

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -34,13 +34,14 @@ tokio-util = { version = "0.7", features = ["futures-io", "compat"] }
 tower-http = { version = "0.4", features = ["trace"] }
 url = "2"
 urlencoding = "2"
+walkdir = "2"
 webbrowser = "0.8"
 
 common = { package = "grafbase-local-common", path = "../common", version = "0.22.0" }
 server = { package = "grafbase-local-server", path = "../server", version = "0.22.0" }
 
 [build-dependencies]
-cynic-codegen = { version = "3", features = ["rkyv"]}
+cynic-codegen = { version = "3", features = ["rkyv"] }
 
 [features]
 dynamodb = ["server/dynamodb"]

--- a/cli/crates/backend/src/api/deploy.rs
+++ b/cli/crates/backend/src/api/deploy.rs
@@ -72,7 +72,6 @@ pub async fn deploy() -> Result<(), ApiError> {
         );
         let entry_metadata = entry.metadata().map_err(ApiError::ReadProjectFile)?;
         if entry_metadata.is_file() {
-            println!("appending file {entry:#?}");
             tar.append_path_with_name(entry_path, path_in_tar)
                 .await
                 .map_err(ApiError::AppendToArchive)?;

--- a/cli/crates/backend/src/api/deploy.rs
+++ b/cli/crates/backend/src/api/deploy.rs
@@ -12,9 +12,14 @@ use common::environment::Project;
 use cynic::http::ReqwestExt;
 use cynic::{Id, MutationBuilder};
 use reqwest::{header, Body, Client};
+use std::ffi::OsStr;
+use std::path::PathBuf;
 use tokio::fs::read_to_string;
 use tokio_util::codec::{BytesCodec, FramedRead};
 use tokio_util::compat::TokioAsyncReadCompatExt;
+use walkdir::{DirEntry, WalkDir};
+
+const ENTRY_BLACKLIST: [&str; 2] = ["node_modules", ".env"];
 
 /// # Errors
 ///
@@ -53,9 +58,33 @@ pub async fn deploy() -> Result<(), ApiError> {
             .map_err(ApiError::AppendToArchive)?;
     }
 
-    tar.append_dir_all(GRAFBASE_DIRECTORY_NAME, &project.grafbase_directory_path)
-        .await
-        .map_err(ApiError::AppendToArchive)?;
+    let walker = WalkDir::new(&project.grafbase_directory_path).into_iter();
+    for entry in walker.filter_entry(|entry| entry_not_in_blacklist(entry, &project.path)) {
+        let entry = entry.map_err(ApiError::ReadProjectFile)?;
+
+        let entry_path = entry.path().to_owned();
+        let path_in_tar = PathBuf::from(GRAFBASE_DIRECTORY_NAME).join(
+            entry_path
+                .strip_prefix(&project.path)
+                .expect("must include prefix")
+                .strip_prefix(GRAFBASE_DIRECTORY_NAME)
+                .expect("must include grafbase dir name"),
+        );
+        let entry_metadata = entry.metadata().map_err(ApiError::ReadProjectFile)?;
+        if entry_metadata.is_file() {
+            println!("appending file {entry:#?}");
+            tar.append_path_with_name(entry_path, path_in_tar)
+                .await
+                .map_err(ApiError::AppendToArchive)?;
+        } else {
+            // as we don't follow links, anything else will be a directory
+            tar.append_dir(path_in_tar, entry_path)
+                .await
+                .map_err(ApiError::AppendToArchive)?;
+        }
+    }
+
+    tar.finish().await.map_err(ApiError::WriteArchive)?;
 
     let tar_file = tokio::fs::File::open(&tar_file_path)
         .await
@@ -110,4 +139,14 @@ pub async fn deploy() -> Result<(), ApiError> {
         }) => Err(DeployError::DailyDeploymentCountLimitExceeded { limit }.into()),
         DeploymentCreatePayload::Unknown => Err(DeployError::Unknown.into()),
     }
+}
+
+fn entry_not_in_blacklist(entry: &DirEntry, root_path: &PathBuf) -> bool {
+    entry
+        .path()
+        .strip_prefix(root_path)
+        .expect("must contain the project directory")
+        .file_name()
+        .and_then(OsStr::to_str)
+        .is_some_and(|entry_name| !ENTRY_BLACKLIST.contains(&entry_name))
 }

--- a/cli/crates/backend/src/api/errors.rs
+++ b/cli/crates/backend/src/api/errors.rs
@@ -108,9 +108,21 @@ pub enum ApiError {
     #[error("could not read the upload archive\ncaused by: {0}")]
     ReadArchive(io::Error),
 
+    /// returned if a project file could not be read
+    #[error("could not read a project file\ncaused by: {0}")]
+    ReadProjectFile(walkdir::Error),
+
+    /// returned if a project file could not be opened
+    #[error("could not open a project file\ncaused by: {0}")]
+    OpenProjectFile(io::Error),
+
     /// returned if a file or directory could not be appended to the upload archive
     #[error("could not append a file or directory to the upload archive\ncaused by: {0}")]
     AppendToArchive(io::Error),
+
+    /// returned if the upload archive could not be written
+    #[error("could not write the upload archive\ncaused by: {0}")]
+    WriteArchive(io::Error),
 
     /// returned if a temporary file for the upload archive could not be created
     #[error("could not create a temporary file\ncaused by: {0}")]

--- a/cli/crates/backend/src/api/errors.rs
+++ b/cli/crates/backend/src/api/errors.rs
@@ -109,11 +109,11 @@ pub enum ApiError {
     ReadArchive(io::Error),
 
     /// returned if a project file could not be read
-    #[error("could not read a project file\ncaused by: {0}")]
+    #[error("could not read a project file\nCaused by: {0}")]
     ReadProjectFile(walkdir::Error),
 
     /// returned if a project file could not be opened
-    #[error("could not open a project file\ncaused by: {0}")]
+    #[error("could not open a project file\nCaused by: {0}")]
     OpenProjectFile(io::Error),
 
     /// returned if a file or directory could not be appended to the upload archive
@@ -121,7 +121,7 @@ pub enum ApiError {
     AppendToArchive(io::Error),
 
     /// returned if the upload archive could not be written
-    #[error("could not write the upload archive\ncaused by: {0}")]
+    #[error("could not write the upload archive\nCaused by: {0}")]
     WriteArchive(io::Error),
 
     /// returned if a temporary file for the upload archive could not be created


### PR DESCRIPTION
# Description

## Fixes

- Ignores blacklisted files when building the deployment archive

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
