### PR TITLE
fix(sdk): Length should be allowed on string list fields

### DIFF
--- a/packages/grafbase-sdk/CHANGELOG.md
+++ b/packages/grafbase-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.20] - Mon Jun 12 2023
+
+[CHANGELOG](changelog/0.0.20.md)
+
 ## [0.0.19] - Tue Jun 06 2023
 
 [CHANGELOG](changelog/0.0.19.md)

--- a/packages/grafbase-sdk/changelog/0.0.20.md
+++ b/packages/grafbase-sdk/changelog/0.0.20.md
@@ -1,0 +1,3 @@
+## Fixes
+
+- Allow setting length limit for string list fields

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",

--- a/packages/grafbase-sdk/src/typedefs/length-limited-string.ts
+++ b/packages/grafbase-sdk/src/typedefs/length-limited-string.ts
@@ -8,18 +8,21 @@ import { SearchDefinition } from './search'
 import { AuthRuleF } from '../auth'
 import { AuthDefinition } from './auth'
 import { CacheDefinition, FieldCacheParams, FieldLevelCache } from './cache'
+import { StringListDefinition } from './list'
 
 export interface FieldLength {
   min?: number
   max?: number
 }
 
+export type LengthLimitedField = StringDefinition | StringListDefinition
+
 export class LengthLimitedStringDefinition {
   private fieldLength: RequireAtLeastOne<FieldLength, 'min' | 'max'>
-  private scalar: StringDefinition
+  private scalar: LengthLimitedField
 
   constructor(
-    scalar: StringDefinition,
+    scalar: LengthLimitedField,
     fieldLength: RequireAtLeastOne<FieldLength, 'min' | 'max'>
   ) {
     this.fieldLength = fieldLength

--- a/packages/grafbase-sdk/src/typedefs/list.ts
+++ b/packages/grafbase-sdk/src/typedefs/list.ts
@@ -13,6 +13,9 @@ import { SearchDefinition } from './search'
 import { FieldType } from '../typedefs'
 import { EnumDefinition } from './enum'
 import { InputDefinition } from './input'
+import { RequireAtLeastOne } from 'type-fest'
+import { FieldLength } from './length-limited-string'
+import { LengthLimitedStringDefinition } from './length-limited-string'
 
 export type ListScalarType =
   | ScalarDefinition
@@ -146,19 +149,19 @@ export class RelationListDefinition {
 }
 
 class ListWithDefaultDefinition extends ListDefinition {
-  private fieldType: FieldType
+  protected _fieldType: FieldType
 
   constructor(fieldDefinition: ScalarDefinition) {
     super(fieldDefinition)
 
-    this.fieldType = fieldDefinition.fieldType as FieldType
+    this._fieldType = fieldDefinition.fieldType as FieldType
   }
 
   public toString(): string {
     const defaultValue =
       this.defaultValue != null
         ? ` @default(value: [${this.defaultValue
-            .map((v) => renderDefault(v, this.fieldType))
+            .map((v) => renderDefault(v, this._fieldType))
             .join(', ')}])`
         : ''
 
@@ -169,6 +172,25 @@ class ListWithDefaultDefinition extends ListDefinition {
 export class StringListDefinition extends ListWithDefaultDefinition {
   constructor(fieldDefinition: StringDefinition) {
     super(fieldDefinition)
+  }
+
+  /**
+   * The type of the field
+   */
+  public get fieldType(): FieldType {
+    return this._fieldType
+  }
+
+
+  /**
+   * Specify a minimum or a maximum (or both) length of the field.
+   *
+   * @param fieldLength - Either `min`, `max` or both.
+   */
+  public length(
+    fieldLength: RequireAtLeastOne<FieldLength, 'min' | 'max'>
+  ): LengthLimitedStringDefinition {
+    return new LengthLimitedStringDefinition(this, fieldLength)
   }
 
   /**

--- a/packages/grafbase-sdk/src/typedefs/list.ts
+++ b/packages/grafbase-sdk/src/typedefs/list.ts
@@ -181,7 +181,6 @@ export class StringListDefinition extends ListWithDefaultDefinition {
     return this._fieldType
   }
 
-
   /**
    * Specify a minimum or a maximum (or both) length of the field.
    *

--- a/packages/grafbase-sdk/tests/unit/model.test.ts
+++ b/packages/grafbase-sdk/tests/unit/model.test.ts
@@ -337,18 +337,6 @@ describe('Model generator', () => {
     `)
   })
 
-  it('generates a length with minimum', () => {
-    const model = g.model('User', {
-      name: g.string().length({ min: 2 })
-    })
-
-    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
-      "type User @model {
-        name: String! @length(min: 2)
-      }"
-    `)
-  })
-
   it('generates a length with minimum and unique + search', () => {
     const model = g.model('User', {
       name: g.string().length({ min: 2 }).unique().search()
@@ -357,6 +345,18 @@ describe('Model generator', () => {
     expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: String! @length(min: 2) @unique @search
+      }"
+    `)
+  })
+
+  it('generates a length with minimum', () => {
+    const model = g.model('User', {
+      name: g.string().length({ min: 2 })
+    })
+
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
+      "type User @model {
+        name: String! @length(min: 2)
       }"
     `)
   })
@@ -381,6 +381,42 @@ describe('Model generator', () => {
     expect(renderGraphQL(model)).toMatchInlineSnapshot(`
       "type User @model {
         name: String! @length(min: 2, max: 255)
+      }"
+    `)
+  })
+
+  it('generates a list length with minimum', () => {
+    const model = g.model('User', {
+      name: g.string().list().length({ min: 2 })
+    })
+
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
+      "type User @model {
+        name: [String!]! @length(min: 2)
+      }"
+    `)
+  })
+
+  it('generates a list length with maximum', () => {
+    const model = g.model('User', {
+      name: g.string().list().length({ max: 255 })
+    })
+
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
+      "type User @model {
+        name: [String!]! @length(max: 255)
+      }"
+    `)
+  })
+
+  it('generates a list length with minimum and maximum', () => {
+    const model = g.model('User', {
+      name: g.string().list().length({ min: 2, max: 255 })
+    })
+
+    expect(renderGraphQL(model)).toMatchInlineSnapshot(`
+      "type User @model {
+        name: [String!]! @length(min: 2, max: 255)
       }"
     `)
   })


### PR DESCRIPTION
# Description

Fixes: GB-3924

```ts
g.model('User', {
  name: g.string().list().length({ min: 2, max: 255 })
})
```

```graphql
type User @model {
  name: [String!]! @length(min: 2, max: 255)
}
```

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [x] 📖 Requires documentation update
