### PR TITLE
feat(cli): Init workflow for TypeScript config

### DIFF
--- a/cli/.prettierignore
+++ b/cli/.prettierignore
@@ -1,3 +1,4 @@
 target
 crates/cli/tests/graphql/compilation_error/schema.graphql
+crates/backend/assets/grafbase.default.config.ts
 about.hbs

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1715,6 +1715,7 @@ dependencies = [
  "rudderanalytics",
  "serde",
  "serde_json",
+ "strum",
  "thiserror",
  "ulid",
 ]
@@ -3796,6 +3797,7 @@ version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/cli/crates/backend/assets/grafbase.default.config.ts
+++ b/cli/crates/backend/assets/grafbase.default.config.ts
@@ -1,0 +1,54 @@
+import { g, auth, config } from '@grafbase/sdk'
+
+// Welcome to Grafbase!
+// Define your data models, integrate auth, permission rules, custom resolvers, search, and more with Grafbase.
+// Integrate Auth
+// https://grafbase.com/docs/auth
+//
+// const authProvider = auth.OpenIDConnect({
+//   issuer: process.env.ISSUER_URL ?? ''
+// })
+//
+// Define Data Models
+// https://grafbase.com/docs/database
+
+const post = g.model('Post', {
+  title: g.string(),
+  slug: g.string().unique(),
+  content: g.string().optional(),
+  publishedAt: g.datetime().optional(),
+  comments: g.relation(() => comment).optional().list().optional(),
+  likes: g.int().default(0),
+  tags: g.string().optional().list().length({ max: 5 }),
+  author: g.relation(() => user).optional()
+}).search()
+
+const comment = g.model('Comment', {
+  post: g.relation(post),
+  body: g.string(),
+  likes: g.int().default(0),
+  author: g.relation(() => user).optional()
+})
+
+const user = g.model('User', {
+  name: g.string(),
+  email: g.email().optional(),
+  posts: g.relation(post).optional().list(),
+  comments: g.relation(comment).optional().list()
+
+  // Extend models with resolvers
+  // https://grafbase.com/docs/edge-gateway/resolvers
+  // gravatar: g.url().resolver('user/gravatar')
+})
+
+export default config({
+  schema: g
+  // Integrate Auth
+  // https://grafbase.com/docs/auth
+  // auth: {
+  //   providers: [authProvider],
+  //   rules: (rules) => {
+  //     rules.private()
+  //   }
+  // }
+})

--- a/cli/crates/backend/src/consts.rs
+++ b/cli/crates/backend/src/consts.rs
@@ -1,5 +1,6 @@
 use const_format::formatcp;
 
-pub const DEFAULT_SCHEMA: &str = include_str!("../assets/default-schema.graphql");
+pub const DEFAULT_SCHEMA_SDL: &str = include_str!("../assets/default-schema.graphql");
+pub const DEFAULT_SCHEMA_TS: &str = include_str!("../assets/grafbase.default.config.ts");
 pub const DEFAULT_DOT_ENV: &str = include_str!("../assets/default.env");
 pub const USER_AGENT: &str = formatcp!("Grafbase-CLI-{}", env!("CARGO_PKG_VERSION"));

--- a/cli/crates/backend/src/errors.rs
+++ b/cli/crates/backend/src/errors.rs
@@ -107,6 +107,6 @@ pub enum BackendError {
     #[error("could not read the repository information for {0}")]
     ReadRepositoryInformation(String),
 
-    #[error("could not add required dependency to project 'package.json': {0}")]
+    #[error("could not add required dependency to project 'package.json':\nCaused by: {0}")]
     DependencyInstallFailure(io::Error),
 }

--- a/cli/crates/backend/src/errors.rs
+++ b/cli/crates/backend/src/errors.rs
@@ -1,3 +1,4 @@
+use common::errors::CommonError;
 pub use server::errors::ServerError;
 use std::{io, path::PathBuf};
 use thiserror::Error;
@@ -107,6 +108,7 @@ pub enum BackendError {
     #[error("could not read the repository information for {0}")]
     ReadRepositoryInformation(String),
 
-    #[error("could not add required dependency to project 'package.json':\nCaused by: {0}")]
-    DependencyInstallFailure(io::Error),
+    // wraps a [`CommonError`]
+    #[error(transparent)]
+    CommonError(#[from] CommonError),
 }

--- a/cli/crates/backend/src/errors.rs
+++ b/cli/crates/backend/src/errors.rs
@@ -106,4 +106,7 @@ pub enum BackendError {
     /// returned if the request to get the information for a repository returned a response that could not be parsed
     #[error("could not read the repository information for {0}")]
     ReadRepositoryInformation(String),
+
+    #[error("could not add required dependency to project 'package.json': {0}")]
+    DependencyInstallFailure(io::Error),
 }

--- a/cli/crates/backend/src/project.rs
+++ b/cli/crates/backend/src/project.rs
@@ -1,22 +1,59 @@
-use crate::consts::{DEFAULT_DOT_ENV, DEFAULT_SCHEMA, USER_AGENT};
+use crate::consts::{DEFAULT_DOT_ENV, DEFAULT_SCHEMA_SDL, DEFAULT_SCHEMA_TS, USER_AGENT};
 use crate::errors::BackendError;
 use async_compression::tokio::bufread::GzipDecoder;
 use async_tar::Archive;
-use common::consts::{GRAFBASE_DIRECTORY_NAME, GRAFBASE_ENV_FILE_NAME, GRAFBASE_SCHEMA_FILE_NAME};
-use common::environment::Project;
+use common::consts::{
+    GRAFBASE_DIRECTORY_NAME, GRAFBASE_ENV_FILE_NAME, GRAFBASE_SCHEMA_FILE_NAME, GRAFBASE_SDK_PACKAGE_NAME,
+    GRAFBASE_SDK_PACKAGE_VERSION, GRAFBASE_TS_CONFIG_FILE_NAME,
+};
+use common::environment::{self, Project};
 use http_cache_reqwest::{CACacheManager, Cache, CacheMode, HttpCache};
 use reqwest::{header, Client};
 use reqwest_middleware::ClientBuilder;
 use serde::Deserialize;
-use std::env;
 use std::fs;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::iter::Iterator;
 use std::path::PathBuf;
+use std::{env, fmt};
 use tokio_stream::StreamExt;
 use tokio_util::compat::TokioAsyncReadCompatExt;
 use tokio_util::io::StreamReader;
 use url::Url;
+
+#[derive(Debug, Clone, Copy)]
+pub enum ConfigType {
+    TypeScript,
+    GraphQL,
+}
+
+impl AsRef<str> for ConfigType {
+    fn as_ref(&self) -> &str {
+        match self {
+            ConfigType::TypeScript => "typescript",
+            ConfigType::GraphQL => "graphql",
+        }
+    }
+}
+
+impl fmt::Display for ConfigType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConfigType::TypeScript => f.write_str("TypeScript"),
+            ConfigType::GraphQL => f.write_str("GraphQL"),
+        }
+    }
+}
+
+impl ConfigType {
+    pub const VARIANTS: &'static [ConfigType] = &[Self::TypeScript, Self::GraphQL];
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ProjectTemplate<'a> {
+    FromUrl(&'a str),
+    FromDefault(ConfigType),
+}
 
 /// initializes a new project in the current or a new directory, optionally from a template
 ///
@@ -60,53 +97,78 @@ use url::Url;
 ///
 /// - returns [`BackendError::ReadRepositoryInformation`] if the request to get the information for a repository returned a response that could not be parsed
 #[tokio::main]
-pub async fn init(name: Option<&str>, template: Option<&str>) -> Result<(), BackendError> {
+pub async fn init(name: Option<&str>, template: ProjectTemplate<'_>) -> Result<(), BackendError> {
     let project_path = to_project_path(name)?;
     let grafbase_path = project_path.join(GRAFBASE_DIRECTORY_NAME);
-    let schema_path = grafbase_path.join(GRAFBASE_SCHEMA_FILE_NAME);
 
     if grafbase_path.exists() {
-        Err(BackendError::AlreadyAProject(grafbase_path))
-    } else if let Some(template) = template {
-        // as directory names cannot contain slashes, and URLs with no scheme or path cannot
-        // be differentiated from a valid template name,
-        // anything with a slash is treated as a URL
-        if template.contains('/') {
-            if let Ok(repo_url) = Url::parse(template) {
-                match repo_url.host_str() {
-                    Some("github.com") => handle_github_repo_url(grafbase_path, &repo_url).await,
-                    _ => Err(BackendError::UnsupportedTemplateURL(template.to_string())),
+        return Err(BackendError::AlreadyAProject(grafbase_path));
+    }
+
+    match template {
+        ProjectTemplate::FromUrl(template) => {
+            // as directory names cannot contain slashes, and URLs with no scheme or path cannot
+            // be differentiated from a valid template name,
+            // anything with a slash is treated as a URL
+            if template.contains('/') {
+                if let Ok(repo_url) = Url::parse(template) {
+                    match repo_url.host_str() {
+                        Some("github.com") => handle_github_repo_url(grafbase_path, &repo_url).await?,
+                        _ => return Err(BackendError::UnsupportedTemplateURL(template.to_string())),
+                    }
+                } else {
+                    return Err(BackendError::MalformedTemplateURL(template.to_owned()));
                 }
             } else {
-                return Err(BackendError::MalformedTemplateURL(template.to_owned()));
+                download_github_template(
+                    grafbase_path,
+                    GitHubTemplate::Grafbase(GrafbaseGithubTemplate { path: template }),
+                )
+                .await?;
             }
-        } else {
-            download_github_template(
-                grafbase_path,
-                GitHubTemplate::Grafbase(GrafbaseGithubTemplate { path: template }),
-            )
-            .await
         }
-    } else {
-        tokio::fs::create_dir_all(&grafbase_path)
-            .await
-            .map_err(BackendError::CreateGrafbaseDirectory)?;
-
-        let dot_env_path = grafbase_path.join(GRAFBASE_ENV_FILE_NAME);
-        let schema_write_result = fs::write(schema_path, DEFAULT_SCHEMA).map_err(BackendError::WriteSchema);
-        let dot_env_write_result = fs::write(dot_env_path, DEFAULT_DOT_ENV).map_err(BackendError::WriteSchema);
-
-        if schema_write_result.is_err() || dot_env_write_result.is_err() {
-            tokio::fs::remove_dir_all(&grafbase_path)
+        ProjectTemplate::FromDefault(config_type) => {
+            tokio::fs::create_dir_all(&grafbase_path)
                 .await
-                .map_err(BackendError::DeleteGrafbaseDirectory)?;
+                .map_err(BackendError::CreateGrafbaseDirectory)?;
+
+            let dot_env_path = grafbase_path.join(GRAFBASE_ENV_FILE_NAME);
+
+            let schema_write_result = match config_type {
+                ConfigType::TypeScript => {
+                    let schema_path = grafbase_path.join(GRAFBASE_TS_CONFIG_FILE_NAME);
+
+                    let add_sdk = environment::add_dev_dependency_to_package_json(
+                        &project_path,
+                        GRAFBASE_SDK_PACKAGE_NAME,
+                        GRAFBASE_SDK_PACKAGE_VERSION,
+                    )
+                    .map_err(BackendError::DependencyInstallFailure);
+
+                    let write_schema = fs::write(schema_path, DEFAULT_SCHEMA_TS).map_err(BackendError::WriteSchema);
+
+                    add_sdk.and_then(|_| write_schema)
+                }
+                ConfigType::GraphQL => {
+                    let schema_path = grafbase_path.join(GRAFBASE_SCHEMA_FILE_NAME);
+                    fs::write(schema_path, DEFAULT_SCHEMA_SDL).map_err(BackendError::WriteSchema)
+                }
+            };
+
+            let dot_env_write_result = fs::write(dot_env_path, DEFAULT_DOT_ENV).map_err(BackendError::WriteSchema);
+
+            if schema_write_result.is_err() || dot_env_write_result.is_err() {
+                tokio::fs::remove_dir_all(&grafbase_path)
+                    .await
+                    .map_err(BackendError::DeleteGrafbaseDirectory)?;
+            }
+
+            schema_write_result?;
+            dot_env_write_result?;
         }
+    };
 
-        schema_write_result?;
-        dot_env_write_result?;
-
-        Ok(())
-    }
+    Ok(())
 }
 
 async fn handle_github_repo_url(grafbase_path: PathBuf, repo_url: &Url) -> Result<(), BackendError> {

--- a/cli/crates/backend/src/project.rs
+++ b/cli/crates/backend/src/project.rs
@@ -143,7 +143,7 @@ pub async fn init(name: Option<&str>, template: ProjectTemplate<'_>) -> Result<(
                         GRAFBASE_SDK_PACKAGE_NAME,
                         GRAFBASE_SDK_PACKAGE_VERSION,
                     )
-                    .map_err(BackendError::DependencyInstallFailure);
+                    .map_err(Into::into);
 
                     let write_schema = fs::write(schema_path, DEFAULT_SCHEMA_TS).map_err(BackendError::WriteSchema);
 

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -29,7 +29,7 @@ once_cell = "1"
 os_type = "2"
 serde = "1"
 serde_derive = "1"
-serde_json = "1"
+serde_json = { version = "1", features = ["preserve_order"] }
 slugify = "0.1.0"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }

--- a/cli/crates/cli/src/cli_input.rs
+++ b/cli/crates/cli/src/cli_input.rs
@@ -59,11 +59,11 @@ pub struct CompletionsCommand {
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum ConfigFormat {
-    /// The configuration is written in TypeScript, using the '@grafbase/sdk' library
+    /// Adds a TypeScript configuration file
     #[value(name = "typescript")]
     TypeScript,
     #[value(name = "graphql")]
-    /// The configuration is written in GraphQL SDL
+    /// Adds a GraphQL configuration file
     GraphQL,
 }
 
@@ -74,7 +74,7 @@ pub struct InitCommand {
     /// The name or GitHub URL of the template to use for the new project
     #[arg(short, long)]
     pub template: Option<String>,
-    /// The format the Grafbase config is written
+    /// The format used for the Grafbase configuration file
     #[arg(short, long)]
     pub config_format: Option<ConfigFormat>,
 }

--- a/cli/crates/cli/src/cli_input.rs
+++ b/cli/crates/cli/src/cli_input.rs
@@ -1,5 +1,5 @@
 use crate::create::CreateArguments;
-use clap::{arg, command, CommandFactory, Parser};
+use clap::{arg, command, CommandFactory, Parser, ValueEnum};
 use clap_complete::{shells, Generator};
 use common::consts::{DEFAULT_LOG_FILTER, TRACE_LOG_FILTER};
 use std::{fmt, path::PathBuf};
@@ -57,6 +57,16 @@ pub struct CompletionsCommand {
     pub shell: Shell,
 }
 
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum ConfigFormat {
+    /// The configuration is written in TypeScript, using the '@grafbase/sdk' library
+    #[value(name = "typescript")]
+    TypeScript,
+    #[value(name = "graphql")]
+    /// The configuration is written in GraphQL SDL
+    GraphQL,
+}
+
 #[derive(Debug, Parser)]
 pub struct InitCommand {
     /// The name of the project to create
@@ -64,6 +74,9 @@ pub struct InitCommand {
     /// The name or GitHub URL of the template to use for the new project
     #[arg(short, long)]
     pub template: Option<String>,
+    /// The format the Grafbase config is written
+    #[arg(short, long)]
+    pub config_format: Option<ConfigFormat>,
 }
 
 impl InitCommand {

--- a/cli/crates/cli/src/init.rs
+++ b/cli/crates/cli/src/init.rs
@@ -9,7 +9,7 @@ pub fn init(name: Option<&str>, template: Option<&str>, config_format: Option<Co
         (None, Some(ConfigFormat::GraphQL)) => ProjectTemplate::FromDefault(ConfigType::GraphQL),
         (None, None) => {
             let config_type = Select::new(
-                "In which format the project schema and configuration should be written?",
+                "What configuration format would you like to use?",
                 ConfigType::VARIANTS.to_vec(),
             )
             .prompt()

--- a/cli/crates/cli/src/init.rs
+++ b/cli/crates/cli/src/init.rs
@@ -1,12 +1,12 @@
 use crate::{cli_input::ConfigFormat, errors::CliError, output::report, prompts::handle_inquire_error};
-use backend::project::{self, ConfigType, ProjectTemplate};
+use backend::project::{self, ConfigType, Template};
 use inquire::Select;
 
 pub fn init(name: Option<&str>, template: Option<&str>, config_format: Option<ConfigFormat>) -> Result<(), CliError> {
     let template = match (template, config_format) {
-        (Some(template), _) => ProjectTemplate::FromUrl(template),
-        (None, Some(ConfigFormat::TypeScript)) => ProjectTemplate::FromDefault(ConfigType::TypeScript),
-        (None, Some(ConfigFormat::GraphQL)) => ProjectTemplate::FromDefault(ConfigType::GraphQL),
+        (Some(template), _) => Template::FromUrl(template),
+        (None, Some(ConfigFormat::TypeScript)) => Template::FromDefault(ConfigType::TypeScript),
+        (None, Some(ConfigFormat::GraphQL)) => Template::FromDefault(ConfigType::GraphQL),
         (None, None) => {
             let config_type = Select::new(
                 "What configuration format would you like to use?",
@@ -15,7 +15,7 @@ pub fn init(name: Option<&str>, template: Option<&str>, config_format: Option<Co
             .prompt()
             .map_err(handle_inquire_error)?;
 
-            ProjectTemplate::FromDefault(config_type)
+            Template::FromDefault(config_type)
         }
     };
 

--- a/cli/crates/cli/src/init.rs
+++ b/cli/crates/cli/src/init.rs
@@ -1,8 +1,26 @@
-use crate::{errors::CliError, output::report};
-use backend::project;
+use crate::{cli_input::ConfigFormat, errors::CliError, output::report, prompts::handle_inquire_error};
+use backend::project::{self, ConfigType, ProjectTemplate};
+use inquire::Select;
 
-pub fn init(name: Option<&str>, template: Option<&str>) -> Result<(), CliError> {
+pub fn init(name: Option<&str>, template: Option<&str>, config_format: Option<ConfigFormat>) -> Result<(), CliError> {
+    let template = match (template, config_format) {
+        (Some(template), _) => ProjectTemplate::FromUrl(template),
+        (None, Some(ConfigFormat::TypeScript)) => ProjectTemplate::FromDefault(ConfigType::TypeScript),
+        (None, Some(ConfigFormat::GraphQL)) => ProjectTemplate::FromDefault(ConfigType::GraphQL),
+        (None, None) => {
+            let config_type = Select::new(
+                "In which format the project schema and configuration should be written?",
+                ConfigType::VARIANTS.to_vec(),
+            )
+            .prompt()
+            .map_err(handle_inquire_error)?;
+
+            ProjectTemplate::FromDefault(config_type)
+        }
+    };
+
     project::init(name, template).map_err(CliError::BackendError)?;
-    report::project_created(name);
+    report::project_created(name, template);
+
     Ok(())
 }

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -89,7 +89,7 @@ fn try_main(args: Args) -> Result<(), CliError> {
 
             dev(cmd.search, !cmd.disable_watch, cmd.port, args.trace >= 2)
         }
-        SubCommand::Init(cmd) => init(cmd.name(), cmd.template()),
+        SubCommand::Init(cmd) => init(cmd.name(), cmd.template(), cmd.config_format),
         SubCommand::Reset => reset(),
         SubCommand::Login => login(),
         SubCommand::Logout => logout(),

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -2,8 +2,9 @@ use crate::{
     errors::CliError,
     watercolor::{self, watercolor},
 };
+use backend::project::{ConfigType, ProjectTemplate};
 use colored::Colorize;
-use common::types::ResolverMessageLevel;
+use common::{consts::GRAFBASE_TS_CONFIG_FILE_NAME, types::ResolverMessageLevel};
 use common::{
     consts::{GRAFBASE_DIRECTORY_NAME, GRAFBASE_SCHEMA_FILE_NAME, LOCALHOST},
     environment::Warning,
@@ -41,12 +42,18 @@ pub fn start_server(resolvers_reported: bool, port: u16, start_port: u16) {
     );
 }
 
-pub fn project_created(name: Option<&str>) {
+pub fn project_created(name: Option<&str>, template: ProjectTemplate<'_>) {
     let slash = std::path::MAIN_SEPARATOR.to_string();
+
+    let schema_file_name = match template {
+        ProjectTemplate::FromDefault(ConfigType::TypeScript) => GRAFBASE_TS_CONFIG_FILE_NAME,
+        _ => GRAFBASE_SCHEMA_FILE_NAME,
+    };
+
     if let Some(name) = name {
         watercolor::output!(r#"✨ {name} was successfully initialized!"#, @BrightBlue);
 
-        let schema_path = &[".", name, GRAFBASE_DIRECTORY_NAME, GRAFBASE_SCHEMA_FILE_NAME].join(&slash);
+        let schema_path = &[".", name, GRAFBASE_DIRECTORY_NAME, schema_file_name].join(&slash);
 
         println!(
             "The schema for your new project can be found at {}",
@@ -55,12 +62,16 @@ pub fn project_created(name: Option<&str>) {
     } else {
         watercolor::output!(r#"✨ Your project was successfully set up for Grafbase!"#, @BrightBlue);
 
-        let schema_path = &[".", GRAFBASE_DIRECTORY_NAME, GRAFBASE_SCHEMA_FILE_NAME].join(&slash);
+        let schema_path = &[".", GRAFBASE_DIRECTORY_NAME, schema_file_name].join(&slash);
 
         println!(
             "Your new schema can be found at {}",
             watercolor!("{schema_path}", @BrightBlue)
         );
+    }
+
+    if let ProjectTemplate::FromDefault(ConfigType::TypeScript) = template {
+        println!("Install the added dependencies by running your project's package manager.");
     }
 }
 

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -71,7 +71,10 @@ pub fn project_created(name: Option<&str>, template: ProjectTemplate<'_>) {
     }
 
     if let ProjectTemplate::FromDefault(ConfigType::TypeScript) = template {
-        println!("Install the added dependencies by running your project's package manager.");
+        println!(
+            "We've added our SDK to your {}, make sure to install dependencies before continuing.",
+            watercolor!("package.json", @BrightBlue)
+        );
     }
 }
 

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -2,7 +2,7 @@ use crate::{
     errors::CliError,
     watercolor::{self, watercolor},
 };
-use backend::project::{ConfigType, ProjectTemplate};
+use backend::project::{ConfigType, Template};
 use colored::Colorize;
 use common::{consts::GRAFBASE_TS_CONFIG_FILE_NAME, types::ResolverMessageLevel};
 use common::{
@@ -42,11 +42,11 @@ pub fn start_server(resolvers_reported: bool, port: u16, start_port: u16) {
     );
 }
 
-pub fn project_created(name: Option<&str>, template: ProjectTemplate<'_>) {
+pub fn project_created(name: Option<&str>, template: Template<'_>) {
     let slash = std::path::MAIN_SEPARATOR.to_string();
 
     let schema_file_name = match template {
-        ProjectTemplate::FromDefault(ConfigType::TypeScript) => GRAFBASE_TS_CONFIG_FILE_NAME,
+        Template::FromDefault(ConfigType::TypeScript) => GRAFBASE_TS_CONFIG_FILE_NAME,
         _ => GRAFBASE_SCHEMA_FILE_NAME,
     };
 
@@ -70,7 +70,7 @@ pub fn project_created(name: Option<&str>, template: ProjectTemplate<'_>) {
         );
     }
 
-    if let ProjectTemplate::FromDefault(ConfigType::TypeScript) = template {
+    if let Template::FromDefault(ConfigType::TypeScript) = template {
         println!(
             "We've added our SDK to your {}, make sure to install dependencies before continuing.",
             watercolor!("package.json", @BrightBlue)

--- a/cli/crates/cli/tests/auth.rs
+++ b/cli/crates/cli/tests/auth.rs
@@ -1,5 +1,6 @@
 mod utils;
 
+use backend::project::ConfigType;
 use jwt_compact::alg::{Hs512, Hs512Key};
 use jwt_compact::alg::{Rsa, RsaPrivateKey, RsaPublicKey, StrongAlg, StrongKey};
 use jwt_compact::jwk::JsonWebKey;
@@ -26,7 +27,7 @@ const JWT_SECRET: &str = "topsecret";
 #[test]
 fn jwt_provider() {
     let mut env = Environment::init();
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(JWT_PROVIDER_SCHEMA);
     env.set_variables(HashMap::from([
         ("ISSUER_URL".to_string(), JWT_ISSUER_URL.to_string()),
@@ -216,7 +217,7 @@ async fn set_up_oidc_with_path(path: Option<&str>) -> SetUpOidc {
     };
     set_up_oidc_server(&issuer_url, &server, key_set).await;
     let mut env = Environment::init_async().await;
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(OIDC_PROVIDER_SCHEMA);
     env.set_variables(HashMap::from([("ISSUER_URL".to_string(), issuer_url.to_string())]));
     env.grafbase_dev();
@@ -244,7 +245,7 @@ async fn set_up_jwks<F: Fn(&Url) -> HashMap<String, String>>(
     let jwks_uri = issuer_url.join(jwks_path).unwrap();
     set_up_jwks_server(jwks_uri.path(), &server, key_set).await;
     let mut env = Environment::init_async().await;
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(schema);
     env.set_variables(variables_fn(&issuer_url));
     env.grafbase_dev();

--- a/cli/crates/cli/tests/coercion.rs
+++ b/cli/crates/cli/tests/coercion.rs
@@ -1,5 +1,6 @@
 mod utils;
 
+use backend::project::ConfigType;
 use serde_json::{json, Value};
 use utils::consts::{COERCION_CREATE_DUMMY, COERCION_SCHEMA};
 use utils::environment::Environment;
@@ -7,7 +8,7 @@ use utils::environment::Environment;
 #[test]
 fn coercion() {
     let mut env = Environment::init();
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(COERCION_SCHEMA);
     env.grafbase_dev();
     let client = env.create_client().with_api_key();

--- a/cli/crates/cli/tests/compilation_error.rs
+++ b/cli/crates/cli/tests/compilation_error.rs
@@ -2,6 +2,7 @@ mod utils;
 
 use std::collections::HashMap;
 
+use backend::project::ConfigType;
 use serde_json::Value;
 use utils::consts::{
     COMPILATION_ERROR_QUERY, COMPILATION_ERROR_RESOLVER_MUTATION, COMPILATION_ERROR_RESOLVER_SCHEMA,
@@ -13,7 +14,7 @@ use utils::environment::Environment;
 #[cfg_attr(target_os = "windows", ignore)]
 fn compilation_error() {
     let mut env = Environment::init();
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(COMPILATION_ERROR_SCHEMA);
     env.grafbase_dev_watch();
     let mut client = env.create_client().with_api_key();

--- a/cli/crates/cli/tests/concurrency_process.rs
+++ b/cli/crates/cli/tests/concurrency_process.rs
@@ -2,6 +2,7 @@ mod utils;
 
 use std::future::IntoFuture;
 
+use backend::project::ConfigType;
 use serde_json::Value;
 use utils::consts::{CONCURRENCY_MUTATION, CONCURRENCY_QUERY, CONCURRENCY_SCHEMA};
 use utils::environment::Environment;
@@ -11,7 +12,7 @@ async fn concurrency_process() {
     let mut env1 = Environment::init_async().await;
     let mut env2 = Environment::from(&env1);
 
-    env1.grafbase_init();
+    env1.grafbase_init(ConfigType::GraphQL);
     env1.write_schema(CONCURRENCY_SCHEMA);
     env1.grafbase_dev();
 

--- a/cli/crates/cli/tests/concurrency_thread.rs
+++ b/cli/crates/cli/tests/concurrency_thread.rs
@@ -2,6 +2,7 @@ mod utils;
 
 use std::future::IntoFuture;
 
+use backend::project::ConfigType;
 use serde_json::Value;
 use utils::consts::{CONCURRENCY_MUTATION, CONCURRENCY_QUERY, CONCURRENCY_SCHEMA};
 use utils::environment::Environment;
@@ -10,7 +11,7 @@ use utils::environment::Environment;
 async fn concurrency_thread() {
     let mut env = Environment::init_async().await;
 
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(CONCURRENCY_SCHEMA);
     env.grafbase_dev();
 

--- a/cli/crates/cli/tests/custom_resolvers.rs
+++ b/cli/crates/cli/tests/custom_resolvers.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::too_many_lines)]
 mod utils;
 
+use backend::project::ConfigType;
 use serde_json::Value;
 use utils::environment::Environment;
 
@@ -265,7 +266,7 @@ fn test_field_resolver(
     #[case] package_json: Option<&str>,
 ) {
     let mut env = Environment::init();
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
     std::fs::write(env.directory.join("grafbase/.env"), "MY_OWN_VARIABLE=test_value").unwrap();
     env.write_schema(schema);
     env.write_resolver(resolver_name, resolver_contents);
@@ -373,7 +374,7 @@ fn test_query_mutation_resolver(
     #[case] queries: &[(&str, &str)],
 ) {
     let mut env = Environment::init();
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(schema);
     env.write_resolver(resolver_name, resolver_contents);
     env.grafbase_dev();

--- a/cli/crates/cli/tests/default_directive.rs
+++ b/cli/crates/cli/tests/default_directive.rs
@@ -1,13 +1,14 @@
 mod utils;
 
 use crate::utils::consts::{DEFAULT_DIRECTIVE_CREATE_USER1, DEFAULT_DIRECTIVE_CREATE_USER2, DEFAULT_DIRECTIVE_SCHEMA};
+use backend::project::ConfigType;
 use serde_json::Value;
 use utils::environment::Environment;
 
 #[test]
 fn default_directive() {
     let mut env = Environment::init();
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(DEFAULT_DIRECTIVE_SCHEMA);
     env.grafbase_dev();
     let client = env.create_client().with_api_key();

--- a/cli/crates/cli/tests/dev.rs
+++ b/cli/crates/cli/tests/dev.rs
@@ -1,5 +1,6 @@
 mod utils;
 
+use backend::project::ConfigType;
 use serde_json::{json, Value};
 use utils::consts::{DEFAULT_CREATE, DEFAULT_QUERY, DEFAULT_SCHEMA, DEFAULT_UPDATE};
 use utils::environment::Environment;
@@ -7,7 +8,7 @@ use utils::environment::Environment;
 #[test]
 fn dev() {
     let mut env = Environment::init();
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(DEFAULT_SCHEMA);
     env.grafbase_dev();
     let client = env.create_client().with_api_key();

--- a/cli/crates/cli/tests/dev_watch.rs
+++ b/cli/crates/cli/tests/dev_watch.rs
@@ -1,5 +1,6 @@
 mod utils;
 
+use backend::project::ConfigType;
 use json_dotpath::DotPaths;
 use serde_json::Value;
 use utils::consts::{DEFAULT_QUERY, DEFAULT_SCHEMA, UPDATED_MUTATION, UPDATED_QUERY, UPDATED_SCHEMA};
@@ -9,7 +10,7 @@ use utils::environment::Environment;
 fn dev_watch() {
     let mut env = Environment::init();
 
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
 
     env.write_schema(DEFAULT_SCHEMA);
 

--- a/cli/crates/cli/tests/environment_file.rs
+++ b/cli/crates/cli/tests/environment_file.rs
@@ -1,5 +1,6 @@
 mod utils;
 
+use backend::project::ConfigType;
 use std::collections::HashMap;
 use utils::consts::ENVIRONMENT_SCHEMA;
 use utils::environment::Environment;
@@ -8,7 +9,7 @@ use utils::environment::Environment;
 fn environment_file() {
     let mut env = Environment::init();
 
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
 
     env.write_schema(ENVIRONMENT_SCHEMA);
 

--- a/cli/crates/cli/tests/environment_process.rs
+++ b/cli/crates/cli/tests/environment_process.rs
@@ -1,5 +1,6 @@
 mod utils;
 
+use backend::project::ConfigType;
 use utils::consts::ENVIRONMENT_SCHEMA;
 use utils::environment::Environment;
 
@@ -7,7 +8,7 @@ use utils::environment::Environment;
 fn environment_process() {
     let mut env = Environment::init();
 
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
 
     env.write_schema(ENVIRONMENT_SCHEMA);
 

--- a/cli/crates/cli/tests/home.rs
+++ b/cli/crates/cli/tests/home.rs
@@ -1,5 +1,6 @@
 mod utils;
 
+use backend::project::ConfigType;
 use std::path::PathBuf;
 use utils::environment::Environment;
 
@@ -35,7 +36,7 @@ fn env_var(#[case] case_path: PathBuf) {
     std::env::set_var("GRAFBASE_HOME", case_path.as_os_str());
 
     let mut env = Environment::init();
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(
         r#" 
         type Post @model {

--- a/cli/crates/cli/tests/init.rs
+++ b/cli/crates/cli/tests/init.rs
@@ -1,21 +1,23 @@
 mod utils;
 
+use backend::project::ConfigType;
 use utils::environment::Environment;
 
 #[test]
 fn init() {
     let env = Environment::init();
 
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
 
     assert!(env.directory.join("grafbase").exists());
     assert!(env.directory.join("grafbase").join("schema.graphql").exists());
 
-    let output = env.grafbase_init_output();
+    let output = env.grafbase_init_output(ConfigType::GraphQL);
 
     assert!(!output.stderr.is_empty());
     assert!(std::str::from_utf8(&output.stderr).unwrap().contains("already exists"));
 
+    env.remove_grafbase_dir(None);
     env.remove_grafbase_dir(None);
 
     env.grafbase_init_template(None, "todo");

--- a/cli/crates/cli/tests/init.rs
+++ b/cli/crates/cli/tests/init.rs
@@ -18,7 +18,6 @@ fn init() {
     assert!(std::str::from_utf8(&output.stderr).unwrap().contains("already exists"));
 
     env.remove_grafbase_dir(None);
-    env.remove_grafbase_dir(None);
 
     env.grafbase_init_template(None, "todo");
 

--- a/cli/crates/cli/tests/init_ts.rs
+++ b/cli/crates/cli/tests/init_ts.rs
@@ -1,0 +1,45 @@
+mod utils;
+
+use backend::project::ConfigType;
+use serde_json::json;
+use utils::environment::Environment;
+
+#[test]
+fn init_ts() {
+    let env = Environment::init();
+
+    env.write_json_file_to_project(
+        "package.json",
+        &json!({
+          "name": "test",
+          "version": "1.0.0",
+          "description": "",
+          "main": "index.js",
+          "keywords": [],
+          "author": "",
+          "license": "ISC"
+        }),
+    );
+
+    env.grafbase_init_output(ConfigType::TypeScript);
+
+    assert!(env.directory.join("grafbase").exists());
+    assert!(env.directory.join("grafbase").join("grafbase.config.ts").exists());
+
+    let package_json = env.load_file_from_project("package.json");
+
+    insta::assert_snapshot!(&package_json, @r###"
+    {
+      "name": "test",
+      "version": "1.0.0",
+      "description": "",
+      "main": "index.js",
+      "keywords": [],
+      "author": "",
+      "license": "ISC",
+      "devDependencies": {
+        "@grafbase/sdk": "~0.0.20"
+      }
+    }
+    "###);
+}

--- a/cli/crates/cli/tests/length.rs
+++ b/cli/crates/cli/tests/length.rs
@@ -1,5 +1,6 @@
 mod utils;
 
+use backend::project::ConfigType;
 use json_dotpath::DotPaths;
 use serde_json::{json, Value};
 use utils::consts::{LENGTH_CREATE_MUTATION, LENGTH_SCHEMA, LENGTH_UPDATE_MUTATION};
@@ -9,7 +10,7 @@ use utils::environment::Environment;
 fn length() {
     let mut env = Environment::init();
 
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
 
     env.write_schema(LENGTH_SCHEMA);
 

--- a/cli/crates/cli/tests/openapi/main.rs
+++ b/cli/crates/cli/tests/openapi/main.rs
@@ -6,6 +6,7 @@ mod remote_unions;
 
 use std::net::SocketAddr;
 
+use backend::project::ConfigType;
 use crossbeam_channel::{Receiver, Sender};
 use serde_json::{json, Value};
 use utils::{async_client::AsyncClient, environment::Environment};
@@ -139,7 +140,7 @@ impl Match for RequestBodySpy {
 }
 
 async fn start_grafbase(env: &mut Environment, schema: impl AsRef<str>) -> AsyncClient {
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(schema);
     env.set_variables([("API_KEY", "BLAH")]);
     env.grafbase_dev_watch();

--- a/cli/crates/cli/tests/owner.rs
+++ b/cli/crates/cli/tests/owner.rs
@@ -62,13 +62,14 @@ mod global {
         };
         use crate::utils::environment::Environment;
         use crate::{ADMIN, USER1, USER2, USER3};
+        use backend::project::ConfigType;
         use json_dotpath::DotPaths;
         use serde_json::{json, Value};
 
         #[test]
         fn entity_should_be_visible_only_to_the_owner() {
             let mut env = Environment::init();
-            env.grafbase_init();
+            env.grafbase_init(ConfigType::GraphQL);
             env.write_schema(OWNER_TODO_SCHEMA);
             env.grafbase_dev();
             let client = env.create_client();
@@ -158,7 +159,7 @@ mod global {
         #[test]
         fn owner_create_group_all_should_work() {
             let mut env = Environment::init();
-            env.grafbase_init();
+            env.grafbase_init(ConfigType::GraphQL);
             env.write_schema(OWNER_TODO_OWNER_CREATE_SCHEMA);
             env.grafbase_dev();
             let client = env.create_client();
@@ -226,7 +227,7 @@ mod global {
         #[test]
         fn group_should_supercede_owner_when_listing_entities() {
             let mut env = Environment::init();
-            env.grafbase_init();
+            env.grafbase_init(ConfigType::GraphQL);
             env.write_schema(OWNER_TODO_MIXED_SCHEMA);
             env.grafbase_dev();
             let client = env.create_client();
@@ -299,13 +300,14 @@ mod global {
         };
         use crate::utils::environment::Environment;
         use crate::{USER1, USER2};
+        use backend::project::ConfigType;
         use json_dotpath::DotPaths;
         use serde_json::{json, Value};
 
         #[test]
         fn get_by_id_should_be_filtered_by_the_owner() {
             let mut env = Environment::init();
-            env.grafbase_init();
+            env.grafbase_init(ConfigType::GraphQL);
             env.write_schema(OWNER_TWITTER_SCHEMA);
             env.grafbase_dev();
             let client = env.create_client();
@@ -349,7 +351,7 @@ mod global {
         #[test]
         fn get_by_email_should_be_filtered_by_the_owner() {
             let mut env = Environment::init();
-            env.grafbase_init();
+            env.grafbase_init(ConfigType::GraphQL);
             env.write_schema(OWNER_TWITTER_SCHEMA);
             env.grafbase_dev();
             let client = env.create_client();
@@ -389,7 +391,7 @@ mod global {
         #[test]
         fn test_linking() {
             let mut env = Environment::init();
-            env.grafbase_init();
+            env.grafbase_init(ConfigType::GraphQL);
             env.write_schema(OWNER_TWITTER_SCHEMA);
             env.grafbase_dev();
             let client = env.create_client();

--- a/cli/crates/cli/tests/pagination.rs
+++ b/cli/crates/cli/tests/pagination.rs
@@ -2,6 +2,7 @@
 
 mod utils;
 
+use backend::project::ConfigType;
 use serde_json::{json, Value};
 use utils::client::Client;
 use utils::consts::{
@@ -54,7 +55,7 @@ fn generate_todos(client: &Client, n: usize) -> Vec<Todo> {
 #[test]
 fn pagination() {
     let mut env = Environment::init();
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(PAGINATION_SCHEMA);
     env.grafbase_dev();
     let client = env.create_client().with_api_key();
@@ -214,7 +215,7 @@ macro_rules! assert_same_todos {
 #[test]
 fn pagination_order() {
     let mut env = Environment::init();
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(PAGINATION_SCHEMA);
     env.grafbase_dev();
     let client = env.create_client().with_api_key();

--- a/cli/crates/cli/tests/relations.rs
+++ b/cli/crates/cli/tests/relations.rs
@@ -1,5 +1,6 @@
 mod utils;
 
+use backend::project::ConfigType;
 use serde_json::{json, Value};
 use utils::consts::{
     REALTIONS_LINK_SECONDARY_AUTHOR_TO_BLOG, REALTIONS_RENAME_AUTHOR, RELATIONS_LINK_BLOG_TO_AUTHOR,
@@ -12,7 +13,7 @@ use utils::environment::Environment;
 fn relations() {
     let mut env = Environment::init();
 
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
 
     env.write_schema(RELATIONS_SCHEMA);
 
@@ -122,7 +123,7 @@ fn test_relation_unlinking() {
 
     let mut env = Environment::init();
 
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
 
     env.write_schema(SCHEMA);
 
@@ -228,7 +229,7 @@ fn test_relation_unlink_and_create() {
 
     let mut env = Environment::init();
 
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
 
     env.write_schema(SCHEMA);
 

--- a/cli/crates/cli/tests/reserved_dates.rs
+++ b/cli/crates/cli/tests/reserved_dates.rs
@@ -3,6 +3,7 @@ mod utils;
 use crate::utils::consts::{
     RESERVED_DATES_CREATE_TODO, RESERVED_DATES_CREATE_TODO_LIST, RESERVED_DATES_NESTED_CREATION, RESERVED_DATES_SCHEMA,
 };
+use backend::project::ConfigType;
 use chrono::{DateTime, Duration, Utc};
 use serde_json::{json, Value};
 use utils::environment::Environment;
@@ -11,7 +12,7 @@ use utils::environment::Environment;
 fn reserved_dates() {
     // TODO: Create simpler client setup (one-line)
     let mut env = Environment::init();
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(RESERVED_DATES_SCHEMA);
     env.grafbase_dev();
     let client = env.create_client().with_api_key();

--- a/cli/crates/cli/tests/reset.rs
+++ b/cli/crates/cli/tests/reset.rs
@@ -1,12 +1,13 @@
 mod utils;
 
+use backend::project::ConfigType;
 use utils::environment::Environment;
 
 #[test]
 fn reset() {
     let mut env = Environment::init();
 
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
     env.grafbase_dev();
 
     let client = env.create_client();

--- a/cli/crates/cli/tests/scalars.rs
+++ b/cli/crates/cli/tests/scalars.rs
@@ -1,5 +1,6 @@
 mod utils;
 
+use backend::project::ConfigType;
 use regex::Regex;
 use serde_json::{json, Value};
 use utils::client::Client;
@@ -52,7 +53,7 @@ fn error_matching(pattern: &str) -> Result<Value, Regex> {
 #[test]
 fn scalars() {
     let mut env = Environment::init();
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(SCALARS_SCHEMA);
     env.grafbase_dev();
     let client = env.create_client().with_api_key();

--- a/cli/crates/cli/tests/search.rs
+++ b/cli/crates/cli/tests/search.rs
@@ -118,8 +118,10 @@ struct Edge<N> {
 #[cfg(not(feature = "dynamodb"))] // GB-3636
 #[test]
 fn search_enums() {
+    use backend::project::ConfigType;
+
     let mut env = Environment::init();
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(SEARCH_SCHEMA);
     env.grafbase_dev();
     let client = env.create_client().with_api_key();
@@ -175,8 +177,10 @@ fn search_enums() {
 #[case("requiredFields", SEARCH_CREATE_REQUIRED, SEARCH_SEARCH_REQUIRED)]
 #[case("listFields", SEARCH_CREATE_LIST, SEARCH_SEARCH_LIST)]
 fn basic_search(#[case] name: &str, #[case] create_query: &str, #[case] search_query: &str) {
+    use backend::project::ConfigType;
+
     let mut env = Environment::init();
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(SEARCH_SCHEMA);
     env.grafbase_dev();
     let client = env.create_client().with_api_key();
@@ -453,8 +457,10 @@ fn basic_search(#[case] name: &str, #[case] create_query: &str, #[case] search_q
 #[cfg(not(feature = "dynamodb"))] // GB-3636
 #[test]
 fn search_created_updated_at() {
+    use backend::project::ConfigType;
+
     let mut env = Environment::init();
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(SEARCH_SCHEMA);
     env.grafbase_dev();
     let client = env.create_client().with_api_key();
@@ -515,8 +521,10 @@ fn search_created_updated_at() {
 #[cfg(not(feature = "dynamodb"))] // GB-3636
 #[test]
 fn search_pagination_and_total_hits() {
+    use backend::project::ConfigType;
+
     let mut env = Environment::init();
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(SEARCH_SCHEMA);
     env.grafbase_dev();
     let client = env.create_client().with_api_key();

--- a/cli/crates/cli/tests/snapshots/auth__introspection.snap
+++ b/cli/crates/cli/tests/snapshots/auth__introspection.snap
@@ -1,146 +1,80 @@
 ---
 source: crates/cli/tests/auth.rs
-expression: "client.gql::<Value>(INTROSPECTION_QUERY).send()"
+expression: "set_up.client.gql::<Value>(INTROSPECTION_QUERY).await"
 ---
 {
   "data": {
     "__schema": {
-      "directives": [
-        {
-          "args": [
-            {
-              "defaultValue": null,
-              "description": "Included when true.",
-              "name": "if",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
-          "locations": [
-            "FIELD",
-            "FRAGMENT_SPREAD",
-            "INLINE_FRAGMENT"
-          ],
-          "name": "include"
-        },
-        {
-          "args": [],
-          "description": "Directs the executor to return values as a Streaming response.",
-          "locations": [
-            "QUERY"
-          ],
-          "name": "live"
-        },
-        {
-          "args": [],
-          "description": "Indicates that an input object is a oneOf input object",
-          "locations": [
-            "INPUT_OBJECT"
-          ],
-          "name": "oneOf"
-        },
-        {
-          "args": [
-            {
-              "defaultValue": null,
-              "description": "Skipped when true.",
-              "name": "if",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
-          "locations": [
-            "FIELD",
-            "FRAGMENT_SPREAD",
-            "INLINE_FRAGMENT"
-          ],
-          "name": "skip"
-        }
-      ],
-      "mutationType": {
-        "name": "Mutation"
-      },
       "queryType": {
         "name": "Query"
+      },
+      "mutationType": {
+        "name": "Mutation"
       },
       "subscriptionType": null,
       "types": [
         {
-          "description": "The `Boolean` scalar type represents `true` or `false`.",
-          "enumValues": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
           "kind": "SCALAR",
           "name": "Boolean",
-          "possibleTypes": null
-        },
-        {
-          "description": "A date-time string at UTC, such as 2007-12-03T10:15:30Z, is compliant with the date-time format outlined in section 5.6 of the RFC 3339\nprofile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.\n\nThis scalar is a description of an exact instant on the timeline such as the instant that a user account was created.\n\n# Input Coercion\n\nWhen expected as an input type, only RFC 3339 compliant date-time strings are accepted. All other input values raise a query error indicating an incorrect type.\n\n# Result Coercion\n\nWhere an RFC 3339 compliant date-time string has a time-zone other than UTC, it is shifted to UTC.\nFor example, the date-time string 2016-01-01T14:10:20+01:00 is shifted to 2016-01-01T13:10:20Z.",
-          "enumValues": null,
+          "description": "The `Boolean` scalar type represents `true` or `false`.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "SCALAR",
           "name": "DateTime",
-          "possibleTypes": null
-        },
-        {
-          "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
-          "enumValues": null,
+          "description": "A date-time string at UTC, such as 2007-12-03T10:15:30Z, is compliant with the date-time format outlined in section 5.6 of the RFC 3339\nprofile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.\n\nThis scalar is a description of an exact instant on the timeline such as the instant that a user account was created.\n\n# Input Coercion\n\nWhen expected as an input type, only RFC 3339 compliant date-time strings are accepted. All other input values raise a query error indicating an incorrect type.\n\n# Result Coercion\n\nWhere an RFC 3339 compliant date-time string has a time-zone other than UTC, it is shifted to UTC.\nFor example, the date-time string 2016-01-01T14:10:20+01:00 is shifted to 2016-01-01T13:10:20Z.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "SCALAR",
           "name": "Float",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
+          "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "SCALAR",
           "name": "ID",
-          "possibleTypes": null
-        },
-        {
-          "description": "The `Int` scalar type represents non-fractional whole numeric values.",
-          "enumValues": null,
+          "description": null,
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "kind": "SCALAR",
-          "name": "Int",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "description": null,
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": "The `Int` scalar type represents non-fractional whole numeric values.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Mutation",
+          "description": null,
           "fields": [
             {
+              "name": "todoCreate",
+              "description": "Create a Todo",
               "args": [
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "input",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -149,52 +83,25 @@ expression: "client.gql::<Value>(INTROSPECTION_QUERY).send()"
                       "name": "TodoCreateInput",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": null
                 }
               ],
-              "deprecationReason": null,
-              "description": "Create a Todo",
-              "isDeprecated": false,
-              "name": "todoCreate",
               "type": {
                 "kind": "OBJECT",
                 "name": "TodoCreatePayload",
                 "ofType": null
-              }
-            },
-            {
-              "args": [
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "by",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "TodoByInput",
-                      "ofType": null
-                    }
-                  }
-                }
-              ],
-              "deprecationReason": null,
-              "description": "Delete a Todo by ID or unique field",
+              },
               "isDeprecated": false,
-              "name": "todoDelete",
-              "type": {
-                "kind": "OBJECT",
-                "name": "TodoDeletePayload",
-                "ofType": null
-              }
+              "deprecationReason": null
             },
             {
+              "name": "todoUpdate",
+              "description": "Update a Todo",
               "args": [
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "by",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -203,12 +110,12 @@ expression: "client.gql::<Value>(INTROSPECTION_QUERY).send()"
                       "name": "TodoByInput",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": null
                 },
                 {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "input",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -217,126 +124,25 @@ expression: "client.gql::<Value>(INTROSPECTION_QUERY).send()"
                       "name": "TodoUpdateInput",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": null
                 }
               ],
-              "deprecationReason": null,
-              "description": "Update a Todo",
-              "isDeprecated": false,
-              "name": "todoUpdate",
               "type": {
                 "kind": "OBJECT",
                 "name": "TodoUpdatePayload",
                 "ofType": null
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "Mutation",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": [
-            {
-              "deprecationReason": null,
-              "description": null,
+              },
               "isDeprecated": false,
-              "name": "ASC"
+              "deprecationReason": null
             },
             {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "DESC"
-            }
-          ],
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "ENUM",
-          "name": "OrderByDirection",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "endCursor",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "hasNextPage",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "hasPreviousPage",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "startCursor",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "PageInfo",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
+              "name": "todoDelete",
+              "description": "Delete a Todo by ID or unique field",
               "args": [
                 {
-                  "defaultValue": null,
-                  "description": "The field and value by which to query the Todo",
                   "name": "by",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -345,467 +151,56 @@ expression: "client.gql::<Value>(INTROSPECTION_QUERY).send()"
                       "name": "TodoByInput",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": null
                 }
               ],
-              "deprecationReason": null,
-              "description": "Query a single Todo by an ID or a unique field",
-              "isDeprecated": false,
-              "name": "todo",
               "type": {
                 "kind": "OBJECT",
-                "name": "Todo",
+                "name": "TodoDeletePayload",
                 "ofType": null
-              }
-            },
-            {
-              "args": [
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "after",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "before",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "first",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "last",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "orderBy",
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "TodoOrderByInput",
-                    "ofType": null
-                  }
-                }
-              ],
-              "deprecationReason": null,
-              "description": "Paginated query to fetch the whole list of `Todo`.",
+              },
               "isDeprecated": false,
-              "name": "todoCollection",
-              "type": {
-                "kind": "OBJECT",
-                "name": "TodoConnection",
-                "ofType": null
-              }
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "Query",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
-          "enumValues": null,
+          "kind": "ENUM",
+          "name": "OrderByDirection",
+          "description": null,
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "kind": "SCALAR",
-          "name": "String",
+          "enumValues": [
+            {
+              "name": "ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "when the model was created",
-              "isDeprecated": false,
-              "name": "createdAt",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "DateTime",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Unique identifier",
-              "isDeprecated": false,
-              "name": "id",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "title",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "when the model was updated",
-              "isDeprecated": false,
-              "name": "updatedAt",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "DateTime",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
           "kind": "OBJECT",
-          "name": "Todo",
-          "possibleTypes": null
-        },
-        {
+          "name": "PageInfo",
           "description": null,
-          "enumValues": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "id",
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            }
-          ],
-          "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "TodoByInput",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
           "fields": [
             {
+              "name": "hasPreviousPage",
+              "description": null,
               "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "edges",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "TodoEdge",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Information to aid in pagination",
-              "isDeprecated": false,
-              "name": "pageInfo",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PageInfo",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "TodoConnection",
-          "possibleTypes": null
-        },
-        {
-          "description": "Input to create a Todo",
-          "enumValues": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "title",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "TodoCreateInput",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "todo",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Todo",
-                "ofType": null
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "TodoCreatePayload",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "deletedId",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "TodoDeletePayload",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "cursor",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "node",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Todo",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "TodoEdge",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "createdAt",
-              "type": {
-                "kind": "ENUM",
-                "name": "OrderByDirection",
-                "ofType": null
-              }
-            }
-          ],
-          "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "TodoOrderByInput",
-          "possibleTypes": null
-        },
-        {
-          "description": "Input to update a Todo",
-          "enumValues": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "title",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            }
-          ],
-          "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "TodoUpdateInput",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "todo",
-              "type": {
-                "kind": "OBJECT",
-                "name": "Todo",
-                "ofType": null
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "TodoUpdatePayload",
-          "possibleTypes": null
-        },
-        {
-          "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "args",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "__InputValue",
-                      "ofType": null
-                    }
-                  }
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "description",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "isRepeatable",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -814,14 +209,526 @@ expression: "client.gql::<Value>(INTROSPECTION_QUERY).send()"
                   "name": "Boolean",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
+              "name": "hasNextPage",
               "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
               "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startCursor",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "endCursor",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Query",
+          "description": null,
+          "fields": [
+            {
+              "name": "todo",
+              "description": "Query a single Todo by an ID or a unique field",
+              "args": [
+                {
+                  "name": "by",
+                  "description": "The field and value by which to query the Todo",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "TodoByInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Todo",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "todoCollection",
+              "description": "Paginated query to fetch the whole list of `Todo`.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "TodoOrderByInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "TodoConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Todo",
+          "description": null,
+          "fields": [
+            {
+              "name": "title",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "Unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": "when the model was updated",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": "when the model was created",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "TodoByInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TodoConnection",
+          "description": null,
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TodoEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "TodoCreateInput",
+          "description": "Input to create a Todo",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "title",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TodoCreatePayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "todo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Todo",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TodoDeletePayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "deletedId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TodoEdge",
+          "description": null,
+          "fields": [
+            {
+              "name": "node",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Todo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "TodoOrderByInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "OrderByDirection",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "TodoUpdateInput",
+          "description": "Input to update a Todo",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "title",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TodoUpdatePayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "todo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Todo",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Directive",
+          "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "locations",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -838,233 +745,14 @@ expression: "client.gql::<Value>(INTROSPECTION_QUERY).send()"
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "name",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "__Directive",
-          "possibleTypes": null
-        },
-        {
-          "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
-          "enumValues": [
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to an argument definition.",
-              "isDeprecated": false,
-              "name": "ARGUMENT_DEFINITION"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to an enum definition.",
-              "isDeprecated": false,
-              "name": "ENUM"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to an enum value definition.",
-              "isDeprecated": false,
-              "name": "ENUM_VALUE"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a field.",
-              "isDeprecated": false,
-              "name": "FIELD"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a field definition.",
-              "isDeprecated": false,
-              "name": "FIELD_DEFINITION"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a fragment definition.",
-              "isDeprecated": false,
-              "name": "FRAGMENT_DEFINITION"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a fragment spread.",
-              "isDeprecated": false,
-              "name": "FRAGMENT_SPREAD"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to an inline fragment.",
-              "isDeprecated": false,
-              "name": "INLINE_FRAGMENT"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to an input object field definition.",
-              "isDeprecated": false,
-              "name": "INPUT_FIELD_DEFINITION"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to an input object type definition.",
-              "isDeprecated": false,
-              "name": "INPUT_OBJECT"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to an interface definition.",
-              "isDeprecated": false,
-              "name": "INTERFACE"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a mutation operation.",
-              "isDeprecated": false,
-              "name": "MUTATION"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to an object type definition.",
-              "isDeprecated": false,
-              "name": "OBJECT"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a query operation.",
-              "isDeprecated": false,
-              "name": "QUERY"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a scalar definition.",
-              "isDeprecated": false,
-              "name": "SCALAR"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a schema definition.",
-              "isDeprecated": false,
-              "name": "SCHEMA"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a subscription operation.",
-              "isDeprecated": false,
-              "name": "SUBSCRIPTION"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a union definition.",
-              "isDeprecated": false,
-              "name": "UNION"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Location adjacent to a variable definition.",
-              "isDeprecated": false,
-              "name": "VARIABLE_DEFINITION"
-            }
-          ],
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "ENUM",
-          "name": "__DirectiveLocation",
-          "possibleTypes": null
-        },
-        {
-          "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "deprecationReason",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "description",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "isDeprecated",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "name",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "__EnumValue",
-          "possibleTypes": null
-        },
-        {
-          "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "args",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1081,38 +769,14 @@ expression: "client.gql::<Value>(INTROSPECTION_QUERY).send()"
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
+              "name": "isRepeatable",
               "description": null,
-              "isDeprecated": false,
-              "name": "deprecationReason",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
               "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "description",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "isDeprecated",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1121,14 +785,150 @@ expression: "client.gql::<Value>(INTROSPECTION_QUERY).send()"
                   "name": "Boolean",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "__DirectiveLocation",
+          "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "QUERY",
+              "description": "Location adjacent to a query operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
+              "name": "MUTATION",
+              "description": "Location adjacent to a mutation operation.",
               "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SUBSCRIPTION",
+              "description": "Location adjacent to a subscription operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD",
+              "description": "Location adjacent to a field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_DEFINITION",
+              "description": "Location adjacent to a fragment definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_SPREAD",
+              "description": "Location adjacent to a fragment spread.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INLINE_FRAGMENT",
+              "description": "Location adjacent to an inline fragment.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "VARIABLE_DEFINITION",
+              "description": "Location adjacent to a variable definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCHEMA",
+              "description": "Location adjacent to a schema definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCALAR",
+              "description": "Location adjacent to a scalar definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Location adjacent to an object type definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD_DEFINITION",
+              "description": "Location adjacent to a field definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ARGUMENT_DEFINITION",
+              "description": "Location adjacent to an argument definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Location adjacent to an interface definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Location adjacent to a union definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Location adjacent to an enum definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM_VALUE",
+              "description": "Location adjacent to an enum value definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Location adjacent to an input object type definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_FIELD_DEFINITION",
+              "description": "Location adjacent to an input object field definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__EnumValue",
+          "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+          "fields": [
+            {
               "name": "name",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1137,65 +937,65 @@ expression: "client.gql::<Value>(INTROSPECTION_QUERY).send()"
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
+              "name": "description",
               "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
               "isDeprecated": false,
-              "name": "type",
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "__Type",
+                  "kind": "SCALAR",
+                  "name": "Boolean",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
           "name": "__Field",
-          "possibleTypes": null
-        },
-        {
-          "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
-          "enumValues": null,
+          "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "defaultValue",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "description",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "name",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1204,41 +1004,26 @@ expression: "client.gql::<Value>(INTROSPECTION_QUERY).send()"
                   "name": "String",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
+              "name": "description",
               "description": null,
-              "isDeprecated": false,
-              "name": "type",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "__Type",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "__InputValue",
-          "possibleTypes": null
-        },
-        {
-          "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
-          "enumValues": null,
-          "fields": [
-            {
               "args": [],
-              "deprecationReason": null,
-              "description": "A list of all directives supported by this server.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
               "isDeprecated": false,
-              "name": "directives",
+              "deprecationReason": null
+            },
+            {
+              "name": "args",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1250,31 +1035,19 @@ expression: "client.gql::<Value>(INTROSPECTION_QUERY).send()"
                     "name": null,
                     "ofType": {
                       "kind": "OBJECT",
-                      "name": "__Directive",
+                      "name": "__InputValue",
                       "ofType": null
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "type",
+              "description": null,
               "args": [],
-              "deprecationReason": null,
-              "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
-              "isDeprecated": false,
-              "name": "mutationType",
-              "type": {
-                "kind": "OBJECT",
-                "name": "__Type",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The type that query operations will be rooted at.",
-              "isDeprecated": false,
-              "name": "queryType",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1283,26 +1056,120 @@ expression: "client.gql::<Value>(INTROSPECTION_QUERY).send()"
                   "name": "__Type",
                   "ofType": null
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "isDeprecated",
+              "description": null,
               "args": [],
-              "deprecationReason": null,
-              "description": "If this server support subscription, the type that subscription operations will be rooted at.",
-              "isDeprecated": false,
-              "name": "subscriptionType",
               "type": {
-                "kind": "OBJECT",
-                "name": "__Type",
-                "ofType": null
-              }
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "deprecationReason",
+              "description": null,
               "args": [],
-              "deprecationReason": null,
-              "description": "A list of all types supported by this server.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
               "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__InputValue",
+          "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "defaultValue",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Schema",
+          "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+          "fields": [
+            {
               "name": "types",
+              "description": "A list of all types supported by this server.",
+              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1319,72 +1186,132 @@ expression: "client.gql::<Value>(INTROSPECTION_QUERY).send()"
                     }
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "queryType",
+              "description": "The type that query operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mutationType",
+              "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscriptionType",
+              "description": "If this server support subscription, the type that subscription operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "directives",
+              "description": "A list of all directives supported by this server.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Directive",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "__Schema",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "__Type",
           "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
-          "enumValues": null,
           "fields": [
             {
-              "args": [],
-              "deprecationReason": null,
+              "name": "kind",
               "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "__TypeKind",
+                  "ofType": null
+                }
+              },
               "isDeprecated": false,
-              "name": "description",
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [
-                {
-                  "defaultValue": "false",
-                  "description": null,
-                  "name": "includeDeprecated",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Boolean",
-                      "ofType": null
-                    }
-                  }
-                }
-              ],
-              "deprecationReason": null,
+              "name": "description",
               "description": null,
-              "isDeprecated": false,
-              "name": "enumValues",
+              "args": [],
               "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "__EnumValue",
-                    "ofType": null
-                  }
-                }
-              }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
+              "name": "fields",
+              "description": null,
               "args": [
                 {
-                  "defaultValue": "false",
-                  "description": null,
                   "name": "includeDeprecated",
+                  "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -1393,13 +1320,10 @@ expression: "client.gql::<Value>(INTROSPECTION_QUERY).send()"
                       "name": "Boolean",
                       "ofType": null
                     }
-                  }
+                  },
+                  "defaultValue": "false"
                 }
               ],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "fields",
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -1412,14 +1336,89 @@ expression: "client.gql::<Value>(INTROSPECTION_QUERY).send()"
                     "ofType": null
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
+              "name": "interfaces",
               "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
               "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "possibleTypes",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "enumValues",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Boolean",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__EnumValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "inputFields",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -1432,177 +1431,178 @@ expression: "client.gql::<Value>(INTROSPECTION_QUERY).send()"
                     "ofType": null
                   }
                 }
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "interfaces",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "__Type",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "isOneOf",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "kind",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "__TypeKind",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "name",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "ofType",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "OBJECT",
                 "name": "__Type",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "possibleTypes",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "__Type",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "specifiedByURL",
+              "description": null,
+              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isOneOf",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "kind": "OBJECT",
-          "name": "__Type",
+          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "__TypeKind",
           "description": "An enum describing what kind of type a given `__Type` is.",
-          "enumValues": [
-            {
-              "deprecationReason": null,
-              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
-              "isDeprecated": false,
-              "name": "ENUM"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
-              "isDeprecated": false,
-              "name": "INPUT_OBJECT"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
-              "isDeprecated": false,
-              "name": "INTERFACE"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Indicates this type is a list. `ofType` is a valid field.",
-              "isDeprecated": false,
-              "name": "LIST"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
-              "isDeprecated": false,
-              "name": "NON_NULL"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
-              "isDeprecated": false,
-              "name": "OBJECT"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Indicates this type is a scalar.",
-              "isDeprecated": false,
-              "name": "SCALAR"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
-              "isDeprecated": false,
-              "name": "UNION"
-            }
-          ],
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "kind": "ENUM",
-          "name": "__TypeKind",
+          "enumValues": [
+            {
+              "name": "SCALAR",
+              "description": "Indicates this type is a scalar.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LIST",
+              "description": "Indicates this type is a list. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NON_NULL",
+              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
+        }
+      ],
+      "directives": [
+        {
+          "name": "include",
+          "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Included when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "live",
+          "description": "Directs the executor to return values as a Streaming response.",
+          "locations": [
+            "QUERY"
+          ],
+          "args": []
+        },
+        {
+          "name": "oneOf",
+          "description": "Indicates that an input object is a oneOf input object",
+          "locations": [
+            "INPUT_OBJECT"
+          ],
+          "args": []
+        },
+        {
+          "name": "skip",
+          "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Skipped when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
         }
       ]
     }

--- a/cli/crates/cli/tests/snapshots/owner__global__todo__get.snap
+++ b/cli/crates/cli/tests/snapshots/owner__global__todo__get.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/cli/tests/owner.rs
-expression: "client.gql::<Value>(OWNER_TODO_GET).bearer(ADMIN).variables(json!({\n                \"id\" : id\n            })).send()"
+expression: "client.gql::<Value>(OWNER_TODO_GET).bearer(USER1).variables(json!({\n                \"id\" : id\n            })).send()"
 ---
 {
   "data": {
     "todo": {
-      "complete": false,
-      "title": "1"
+      "title": "1",
+      "complete": false
     }
   }
 }

--- a/cli/crates/cli/tests/snapshots/owner__global__todo__list.snap
+++ b/cli/crates/cli/tests/snapshots/owner__global__todo__list.snap
@@ -8,8 +8,8 @@ expression: "client.gql::<Value>(OWNER_TODO_LIST).bearer(ADMIN).send()"
       "edges": [
         {
           "node": {
-            "complete": false,
-            "title": "1"
+            "title": "1",
+            "complete": false
           }
         }
       ]

--- a/cli/crates/cli/tests/snapshots/owner__global__todo__user1-create.snap
+++ b/cli/crates/cli/tests/snapshots/owner__global__todo__user1-create.snap
@@ -6,9 +6,9 @@ expression: todo_created
   "data": {
     "todoCreate": {
       "todo": {
-        "complete": false,
         "id": "[id]",
-        "title": "1"
+        "title": "1",
+        "complete": false
       }
     }
   }

--- a/cli/crates/cli/tests/snapshots/owner__global__todo__user1-get.snap
+++ b/cli/crates/cli/tests/snapshots/owner__global__todo__user1-get.snap
@@ -5,8 +5,8 @@ expression: "client.gql::<Value>(OWNER_TODO_GET).bearer(USER1).variables(json!({
 {
   "data": {
     "todo": {
-      "complete": false,
-      "title": "1"
+      "title": "1",
+      "complete": false
     }
   }
 }

--- a/cli/crates/cli/tests/snapshots/owner__global__todo__user1-list-2.snap
+++ b/cli/crates/cli/tests/snapshots/owner__global__todo__user1-list-2.snap
@@ -8,8 +8,8 @@ expression: "client.gql::<Value>(OWNER_TODO_LIST).bearer(USER1).send()"
       "edges": [
         {
           "node": {
-            "complete": true,
-            "title": "1"
+            "title": "1",
+            "complete": true
           }
         }
       ]

--- a/cli/crates/cli/tests/snapshots/owner__global__todo__user1-list.snap
+++ b/cli/crates/cli/tests/snapshots/owner__global__todo__user1-list.snap
@@ -8,8 +8,8 @@ expression: "client.gql::<Value>(OWNER_TODO_LIST).bearer(USER1).send()"
       "edges": [
         {
           "node": {
-            "complete": false,
-            "title": "1"
+            "title": "1",
+            "complete": false
           }
         }
       ]

--- a/cli/crates/cli/tests/snapshots/owner__global__todo__user1-update.snap
+++ b/cli/crates/cli/tests/snapshots/owner__global__todo__user1-update.snap
@@ -6,8 +6,8 @@ expression: "client.gql::<Value>(OWNER_TODO_UPDATE).bearer(USER1).variables(json
   "data": {
     "todoUpdate": {
       "todo": {
-        "complete": true,
-        "title": "1"
+        "title": "1",
+        "complete": true
       }
     }
   }

--- a/cli/crates/cli/tests/snapshots/owner__global__twitter__user1-create.snap
+++ b/cli/crates/cli/tests/snapshots/owner__global__twitter__user1-create.snap
@@ -6,11 +6,11 @@ expression: user_created
   "data": {
     "userCreate": {
       "user": {
-        "avatar": "http://example.com/",
-        "email": "user1@example.com",
         "id": "[id]",
-        "url": "http://example.com/",
-        "username": "user1"
+        "username": "user1",
+        "email": "user1@example.com",
+        "avatar": "http://example.com/",
+        "url": "http://example.com/"
       }
     }
   }

--- a/cli/crates/cli/tests/snapshots/owner__global__twitter__user2-create-tweet-fail.snap
+++ b/cli/crates/cli/tests/snapshots/owner__global__twitter__user2-create-tweet-fail.snap
@@ -6,13 +6,13 @@ expression: "client.gql::<Value>(OWNER_TWITTER_TWEET_CREATE).bearer(USER2).varia
   "data": null,
   "errors": [
     {
+      "message": "An issue happened while applying the transaction.",
       "locations": [
         {
-          "column": 3,
-          "line": 2
+          "line": 2,
+          "column": 3
         }
       ],
-      "message": "An issue happened while applying the transaction.",
       "path": [
         "tweetCreate"
       ]

--- a/cli/crates/cli/tests/unique.rs
+++ b/cli/crates/cli/tests/unique.rs
@@ -1,5 +1,6 @@
 mod utils;
 
+use backend::project::ConfigType;
 use json_dotpath::DotPaths;
 use serde_json::{json, Value};
 use utils::consts::{
@@ -14,7 +15,7 @@ use utils::{client::Client, environment::Environment};
 fn unique() {
     let mut env = Environment::init();
 
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
 
     env.write_schema(UNIQUE_SCHEMA);
 
@@ -196,7 +197,7 @@ pub const ACCOUNT_QUERY_PAGINATED: &str = include_str!("graphql/unique/multiple-
 fn unique_with_multiple_fields() {
     let mut env = Environment::init();
 
-    env.grafbase_init();
+    env.grafbase_init(ConfigType::GraphQL);
 
     env.write_schema(UNIQUE_SCHEMA);
 

--- a/cli/crates/common/Cargo.toml
+++ b/cli/crates/common/Cargo.toml
@@ -18,6 +18,7 @@ rudderanalytics = { version = "1", features = [
     "rustls-tls",
 ], default-features = false }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["preserve_order"] }
+strum = { version = "0.24", features = ["derive"] }
 thiserror = "1"
 ulid = { version = "1", features = ["serde"] }

--- a/cli/crates/common/src/consts.rs
+++ b/cli/crates/common/src/consts.rs
@@ -36,3 +36,5 @@ pub const GRAFBASE_HOME: &str = "GRAFBASE_HOME";
 pub const GRAFBASE_SDK_PACKAGE_NAME: &str = "@grafbase/sdk";
 /// the version string of the Grafbase SDK npm package
 pub const GRAFBASE_SDK_PACKAGE_VERSION: &str = "~0.0.20";
+/// the package.json file name
+pub const PACKAGE_JSON_NAME: &str = "package.json";

--- a/cli/crates/common/src/consts.rs
+++ b/cli/crates/common/src/consts.rs
@@ -32,3 +32,7 @@ pub const EPHEMERAL_PORT_RANGE: Range<u16> = 49152..65535;
 pub const DATABASE_DIRECTORY: &str = "database";
 /// an environment variable that sets the path of the home directory
 pub const GRAFBASE_HOME: &str = "GRAFBASE_HOME";
+/// the name of the Grafbase SDK npm package
+pub const GRAFBASE_SDK_PACKAGE_NAME: &str = "@grafbase/sdk";
+/// the version string of the Grafbase SDK npm package
+pub const GRAFBASE_SDK_PACKAGE_VERSION: &str = "~0.0.20";

--- a/cli/crates/common/src/consts.rs
+++ b/cli/crates/common/src/consts.rs
@@ -38,3 +38,5 @@ pub const GRAFBASE_SDK_PACKAGE_NAME: &str = "@grafbase/sdk";
 pub const GRAFBASE_SDK_PACKAGE_VERSION: &str = "~0.0.20";
 /// the package.json file name
 pub const PACKAGE_JSON_NAME: &str = "package.json";
+/// the package.json dev dependencies key
+pub const PACKAGE_JSON_DEV_DEPENDENCIES: &str = "devDependencies";

--- a/cli/crates/common/src/environment.rs
+++ b/cli/crates/common/src/environment.rs
@@ -40,11 +40,6 @@ impl GrafbaseSchemaPath {
         &self.location
     }
 
-    /// True, if the project uses typescript config
-    pub fn uses_typescript_config(&self) -> bool {
-        matches!(&self.location, SchemaLocation::TsConfig(_))
-    }
-
     fn ts_config(path: PathBuf) -> Self {
         Self {
             location: SchemaLocation::TsConfig(path),
@@ -330,14 +325,11 @@ pub fn add_dev_dependency_to_package_json(project_dir: &Path, package: &str, ver
     let package_json_path = project_dir.join(PACKAGE_JSON_NAME);
     let file = fs::File::open(&package_json_path).map_err(CommonError::AccessPackageJson)?;
 
-    let mut package_json = match serde_json::from_reader(&file) {
-        Ok(Value::Object(obj)) => obj,
-        _ => {
-            return Err(CommonError::AccessPackageJson(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "the file is not a JSON object",
-            )));
-        }
+    let Ok(Value::Object(mut package_json)) = serde_json::from_reader(&file) else {
+        return Err(CommonError::AccessPackageJson(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "the file is not a JSON object",
+        )));
     };
 
     match package_json

--- a/cli/crates/common/src/environment.rs
+++ b/cli/crates/common/src/environment.rs
@@ -1,14 +1,14 @@
 #![allow(dead_code)]
 
-use serde_json::{Map, Value};
-
 use crate::{
     consts::{
         DATABASE_DIRECTORY, DOT_GRAFBASE_DIRECTORY, GRAFBASE_DIRECTORY_NAME, GRAFBASE_HOME, GRAFBASE_SCHEMA_FILE_NAME,
-        GRAFBASE_TS_CONFIG_FILE_NAME, REGISTRY_FILE, RESOLVERS_DIRECTORY_NAME, WRANGLER_DIRECTORY_NAME,
+        GRAFBASE_TS_CONFIG_FILE_NAME, PACKAGE_JSON_NAME, REGISTRY_FILE, RESOLVERS_DIRECTORY_NAME,
+        WRANGLER_DIRECTORY_NAME,
     },
     errors::CommonError,
 };
+use serde_json::{Map, Value};
 use std::{
     borrow::Cow,
     env, fs, io,
@@ -327,7 +327,7 @@ fn find_grafbase_configuration(path: &Path, warnings: &mut Vec<Warning>) -> Opti
 }
 
 pub fn add_dev_dependency_to_package_json(project_dir: &Path, package: &str, version: &str) -> Result<(), io::Error> {
-    let package_json_path = project_dir.join("package.json");
+    let package_json_path = project_dir.join(PACKAGE_JSON_NAME);
     let file = fs::File::open(&package_json_path)?;
 
     let mut package_json = match serde_json::from_reader(&file) {
@@ -335,7 +335,7 @@ pub fn add_dev_dependency_to_package_json(project_dir: &Path, package: &str, ver
         _ => {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                "data in package.json is in a wrong format",
+                "the given package.json file is in an incorrect format",
             ));
         }
     };

--- a/cli/crates/common/src/errors.rs
+++ b/cli/crates/common/src/errors.rs
@@ -25,4 +25,8 @@ pub enum CommonError {
     /// returned if ~/.grafbase could not be created
     #[error("could not create '~/.grafbase'\nCaused by: {0}")]
     CreateUserDotGrafbaseFolder(std::io::Error),
+    #[error("could not open the project 'package.json':\nCaused by: {0}")]
+    AccessPackageJson(std::io::Error),
+    #[error("could not serialize the project 'package.json':\nCaused by: {0}")]
+    SerializePackageJson(serde_json::Error),
 }

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,7 @@
             rustup
             sccache
             pkg-config
+            openssl.dev
             # for sqlx-macros
             libiconv
 


### PR DESCRIPTION
# Description

Closes: GB-3883

Support for TypeScript configuration in the `init` workflow:

```sh
❯ ~/code/grafbase/grafbase/cli/target/debug/grafbase init
Grafbase CLI 0.22.0

? In which format the project schema and configuration should be written?  
> TypeScript
  GraphQL
[↑↓ to move, enter to select, type to filter]
```

```sh
❯ ~/code/grafbase/grafbase/cli/target/debug/grafbase init --help
Sets up the current or a new project for Grafbase

Usage: grafbase init [OPTIONS] [NAME]

Arguments:
  [NAME]
          The name of the project to create

Options:
  -t, --template <TEMPLATE>
          The name or GitHub URL of the template to use for the new project

  -c, --config-format <CONFIG_FORMAT>
          The format the Grafbase config is written

          Possible values:
          - typescript: The configuration is written in TypeScript, using the '@grafbase/sdk' library
          - graphql:    The configuration is written in GraphQL SDL

  -h, --help
          Print help (see a summary with '-h')
```

```sh
❯ ~/code/grafbase/grafbase/cli/target/debug/grafbase init -c typescript
Grafbase CLI 0.22.0

✨ Your project was successfully set up for Grafbase!
Your new schema can be found at ./grafbase/grafbase.config.ts
Install the added dependencies by running your project's package manager.
```

```ts
❯ cat grafbase/grafbase.config.ts
import { g, auth, config } from '@grafbase/sdk'

// Welcome to Grafbase!
// Define your data models, integrate auth, permission rules, custom resolvers, search, and more with Grafbase.
// Integrate Auth
// https://grafbase.com/docs/auth
//
// const authProvider = auth.OpenIDConnect({
//   issuer: process.env.ISSUER_URL ?? ''
// })
//
// Define Data Models
// https://grafbase.com/docs/database

const post = g.model('Post', {
  title: g.string(),
  slug: g.string().unique(),
  content: g.string().optional(),
  publishedAt: g.datetime().optional(),
  comments: g.relation(() => comment).optional().list().optional(),
  likes: g.int().default(0),
  tags: g.string().optional().list().length({ max: 5 }),
  author: g.relation(() => user).optional()
}).search()

const comment = g.model('Comment', {
  post: g.relation(post),
  body: g.string(),
  likes: g.int().default(0),
  author: g.relation(() => user).optional()
})

const user = g.model('User', {
  name: g.string(),
  email: g.email().optional(),
  posts: g.relation(post).optional().list(),
  comments: g.relation(comment).optional().list()

  // Extend models with resolvers
  // https://grafbase.com/docs/edge-gateway/resolvers
  // gravatar: g.url().resolver('user/gravatar')
})

export default config({
  schema: g
  // Integrate Auth
  // https://grafbase.com/docs/auth
  // auth: {
  //   providers: [authProvider],
  //   rules: (rules) => {
  //     rules.private()
  //   }
  // }
})
```

The command adds `@grafbase/sdk` to the `package.json` if it's missing from there:

```json
❯ cat package.json 
{
  "name": "dev-test-project",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "keywords": [],
  "author": "",
  "license": "ISC",
  "devDependencies": {
    "@types/node": "^20.3.0",
    "ts-node": "^10.9.1",
    "typescript": "^5.1.3",
    "@grafbase/sdk": "~0.0.20"
  }
}⏎                                                                                                        
```

After `grafbase init`, if using the TypeScript config, the user must run `npm install`, `yarn install` or `pnpm install` depending on which package manager they use.

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [x] 📖 Requires documentation update
