### PR TITLE
feat(sdk): Add a convenient way to use env vars

### DIFF
--- a/packages/grafbase-sdk/README.md
+++ b/packages/grafbase-sdk/README.md
@@ -591,3 +591,16 @@ g.extend('StripeCustomer', {
   }
 })
 ```
+
+### Environment variables
+
+Node's `process.env` return nullable strings, which are a bit annoying to use in fields requiring non-nullable values. The schema has a helper `g.env()` that throws if the variable is not set, and returns a guaranteed string.
+
+```ts
+const github = connector.GraphQL({
+  url: 'https://api.github.com/graphql',
+  headers: (headers) => {
+    headers.static('Authorization', `Bearer ${g.env('GITHUB_TOKEN')}`)
+  }
+})
+```

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -51,7 +51,8 @@
     "semver": "^7.5.1"
   },
   "dependencies": {
-    "type-fest": "^3.9.0"
+    "type-fest": "^3.9.0",
+    "dotenv": "^16.1.4"
   },
   "engines": {
     "node": ">=16.13.0"

--- a/packages/grafbase-sdk/src/connector/graphql.ts
+++ b/packages/grafbase-sdk/src/connector/graphql.ts
@@ -62,7 +62,7 @@ export class GraphQLAPI {
       .map((header) => `      ${header}`)
       .join('\n')
 
-    introspectionHeaders = headers
+    introspectionHeaders = introspectionHeaders
       ? `    introspectionHeaders: [\n${introspectionHeaders}\n    ]\n`
       : ''
 

--- a/packages/grafbase-sdk/src/grafbase-schema.ts
+++ b/packages/grafbase-sdk/src/grafbase-schema.ts
@@ -398,7 +398,7 @@ export class GrafbaseSchema {
   public env(variableName: string): string {
     const value = process.env[variableName]
 
-    if (!value) {
+    if (value === undefined || value === null) {
       throw `Environment variable ${variableName} is not set`
     }
 

--- a/packages/grafbase-sdk/src/grafbase-schema.ts
+++ b/packages/grafbase-sdk/src/grafbase-schema.ts
@@ -390,6 +390,22 @@ export class GrafbaseSchema {
   }
 
   /**
+   * Returns the environment variable with the given variableName.
+   * Throws, if the variable is not set.
+   *
+   * @param variableName - The name of the environment variable.
+   */
+  public env(variableName: string): string {
+    const value = process.env[variableName]
+
+    if (!value) {
+      throw `Environment variable ${variableName} is not set`
+    }
+
+    return value
+  }
+
+  /**
    * Empty the schema.
    */
   public clear() {

--- a/packages/grafbase-sdk/src/index.ts
+++ b/packages/grafbase-sdk/src/index.ts
@@ -6,6 +6,9 @@ import { OpenIDAuth, OpenIDParams } from './auth/openid'
 import { JWTAuth, JWTParams } from './auth/jwt'
 import { JWKSAuth, JWKSParams } from './auth/jwks'
 import { RequireAtLeastOne } from 'type-fest'
+import dotenv from "dotenv"
+
+dotenv.config()
 
 export type AtLeastOne<T> = [T, ...T[]]
 

--- a/packages/grafbase-sdk/tests/unit/env.test.ts
+++ b/packages/grafbase-sdk/tests/unit/env.test.ts
@@ -1,0 +1,46 @@
+import { g, connector, config } from '../../src/index'
+import { describe, expect, it, beforeEach } from '@jest/globals'
+
+describe('Env var accessor', () => {
+  beforeEach(() => g.clear())
+
+  it('returns the value of the variable if set', () => {
+    process.env.TEST_VAL = 'test'
+
+    expect(g.env('TEST_VAL')).toBe('test')
+
+    delete process.env.TEST_VAL
+  })
+
+  it('throws if the variable is not set', () => {
+    expect(() => g.env('TEST_VAL')).toThrow(
+      'Environment variable TEST_VAL is not set'
+    )
+  })
+
+  it('adds the variable to the SDL', () => {
+    process.env.GITHUB_TOKEN = 'test_token'
+
+    const github = connector.GraphQL({
+      url: 'https://api.github.com/graphql',
+      headers: (headers) => {
+        headers.static('Authorization', `Bearer ${g.env('GITHUB_TOKEN')}`)
+      }
+    })
+
+    g.datasource(github, { namespace: 'GitHub' })
+
+    expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
+      "extend schema
+        @graphql(
+          name: "GitHub"
+          url: "https://api.github.com/graphql"
+          headers: [
+            { name: "Authorization", value: "Bearer test_token" }
+          ]
+        )"
+    `)
+
+    delete process.env.GITHUB_TOKEN
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,9 @@ importers:
 
   packages/grafbase-sdk:
     dependencies:
+      dotenv:
+        specifier: ^16.1.4
+        version: 16.1.4
       type-fest:
         specifier: ^3.9.0
         version: 3.9.0
@@ -2815,6 +2818,11 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       esutils: 2.0.3
+
+  /dotenv@16.1.4:
+    resolution: {integrity: sha512-m55RtE8AsPeJBpOIFKihEmqUcoVncQIwo7x9U8ZwLEZw9ZpXboz2c+rvog+jUaJvVrZ5kBOeYQBX5+8Aa/OZQw==}
+    engines: {node: '>=12'}
+    dev: false
 
   /electron-to-chromium@1.4.384:
     resolution: {integrity: sha512-I97q0MmRAAqj53+a8vZsDkEXBZki+ehYAOPzwtQzALip52aEp2+BJqHFtTlsfjoqVZYwPpHC8wM6MbsSZQ/Eqw==}


### PR DESCRIPTION
# Description

Adds `g.env()` for easy env var support. In addition of the unit tests, also tested manually by generating a GitHub token, and then running a project with the following config:

```ts
import { g, config, connector } from '@grafbase/sdk'

const github = connector.GraphQL({
  url: 'https://api.github.com/graphql',
  headers: (headers) => {
    headers.static('Authorization', `Bearer ${g.env('GITHUB_TOKEN')}`),
    headers.introspection('Authorization', `Bearer ${g.env('GITHUB_TOKEN')}`)
  }
})

g.datasource(github, { namespace: 'GitHub' })

export default config({ schema: g })
```

```fish
❯ env GITHUB_TOKEN="<REDACTED>" npx grafbase dev
```

And it works as it should. If using bash, go with:

```bash
❯ GITHUB_TOKEN="<REDACTED>" npx grafbase dev
```

Also adds support for `.env` file, which should now work.

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [x] 📖 Requires documentation update
