### PR TITLE
fix(sdk): Make transforms to take an object instead of a string

### DIFF
--- a/packages/grafbase-sdk/CHANGELOG.md
+++ b/packages/grafbase-sdk/CHANGELOG.md
@@ -4,27 +4,27 @@
 
 [CHANGELOG](changelog/0.0.21.md)
 
-## [0.0.20] - Wed Jun 14 2023
+## [0.0.20] - Tue Jun 13 2023
 
 [CHANGELOG](changelog/0.0.20.md)
 
-## [0.0.19] - Wed Jun 14 2023
+## [0.0.19] - Tue Jun 06 2023
 
 [CHANGELOG](changelog/0.0.19.md)
 
-## [0.0.18] - Wed Jun 14 2023
+## [0.0.18] - Wed May 31 2023
 
 [CHANGELOG](changelog/0.0.18.md)
 
-## [0.0.17] - Wed Jun 14 2023
+## [0.0.17] - Wed May 31 2023
 
 [CHANGELOG](changelog/0.0.17.md)
 
-## [0.0.16] - Wed Jun 14 2023
+## [0.0.16] - Wed May 31 2023
 
 [CHANGELOG](changelog/0.0.16.md)
 
-## [0.0.15] - Wed Jun 14 2023
+## [0.0.15] - Wed May 31 2023
 
 [CHANGELOG](changelog/0.0.15.md)
 

--- a/packages/grafbase-sdk/CHANGELOG.md
+++ b/packages/grafbase-sdk/CHANGELOG.md
@@ -1,26 +1,30 @@
 # Changelog
 
-## [0.0.20] - Mon Jun 12 2023
+## [0.0.21] - Wed Jun 14 2023
+
+[CHANGELOG](changelog/0.0.21.md)
+
+## [0.0.20] - Wed Jun 14 2023
 
 [CHANGELOG](changelog/0.0.20.md)
 
-## [0.0.19] - Tue Jun 06 2023
+## [0.0.19] - Wed Jun 14 2023
 
 [CHANGELOG](changelog/0.0.19.md)
 
-## [0.0.18] - Wed May 31 2023
+## [0.0.18] - Wed Jun 14 2023
 
 [CHANGELOG](changelog/0.0.18.md)
 
-## [0.0.17] - Wed May 31 2023
+## [0.0.17] - Wed Jun 14 2023
 
 [CHANGELOG](changelog/0.0.17.md)
 
-## [0.0.16] - Wed May 31 2023
+## [0.0.16] - Wed Jun 14 2023
 
 [CHANGELOG](changelog/0.0.16.md)
 
-## [0.0.15] - Wed May 31 2023
+## [0.0.15] - Wed Jun 14 2023
 
 [CHANGELOG](changelog/0.0.15.md)
 

--- a/packages/grafbase-sdk/changelog/0.0.21.md
+++ b/packages/grafbase-sdk/changelog/0.0.21.md
@@ -2,3 +2,7 @@
 
 - Add `g.env()` for easy env var handling
 - Support `.env` to define env vars
+
+## Fixes
+
+- `transforms: 'OPERATION_ID'` -> `transforms: { queryNaming: 'OPERATION_ID'}`

--- a/packages/grafbase-sdk/changelog/0.0.21.md
+++ b/packages/grafbase-sdk/changelog/0.0.21.md
@@ -1,0 +1,4 @@
+## Features
+
+- Add `g.env()` for easy env var handling
+- Support `.env` to define env vars

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",

--- a/packages/grafbase-sdk/scripts/bump-version.js
+++ b/packages/grafbase-sdk/scripts/bump-version.js
@@ -27,7 +27,7 @@ var fullChangelog = "# Changelog\n\n"
 
 fs.readdirSync('changelog/').sort().reverse().forEach(file => {
   const stat = fs.statSync(`changelog/${file}`)
-  const modified = stat.mtime.toDateString()
+  const modified = stat.ctime.toDateString()
   const version = file.replace('.md', '')
 
   fullChangelog += `## [${version}] - ${modified}\n\n[CHANGELOG](changelog/${file})\n\n`

--- a/packages/grafbase-sdk/src/connector/openapi.ts
+++ b/packages/grafbase-sdk/src/connector/openapi.ts
@@ -1,12 +1,30 @@
 import { Header, Headers, HeaderGenerator } from './header'
 
-export type OpenApiTransforms = 'OPERATION_ID' | 'SCHEMA_NAME'
+export type OpenApiQueryNamingStrategy = 'OPERATION_ID' | 'SCHEMA_NAME'
+
+export interface OpenApiTransformParams {
+  queryNaming: OpenApiQueryNamingStrategy
+}
 
 export interface OpenAPIParams {
   schema: string
   url?: string
-  transforms?: OpenApiTransforms
+  transforms?: OpenApiTransformParams
   headers?: HeaderGenerator
+}
+
+export class OpenApiTransforms {
+  private params: OpenApiTransformParams
+
+  constructor(params: OpenApiTransformParams) {
+    this.params = params
+  }
+
+  public toString(): string {
+    return Object.entries(this.params)
+      .map(([key, value]) => `${key}: ${value}`)
+      .join(', ')
+  }
 }
 
 export class PartialOpenAPI {
@@ -26,6 +44,8 @@ export class PartialOpenAPI {
     this.schema = params.schema
     this.apiUrl = params.url
     this.transforms = params.transforms
+      ? new OpenApiTransforms(params.transforms)
+      : undefined
     this.headers = headers.headers
     this.introspectionHeaders = headers.introspectionHeaders
   }
@@ -73,7 +93,7 @@ export class OpenAPI {
     const schema = `    schema: "${this.schema}"\n`
 
     const transforms = this.transforms
-      ? `    transforms: { queryNaming: ${this.transforms} }\n`
+      ? `    transforms: { ${this.transforms} }\n`
       : ''
 
     var headers = this.headers.map((header) => `      ${header}`).join('\n')

--- a/packages/grafbase-sdk/src/index.ts
+++ b/packages/grafbase-sdk/src/index.ts
@@ -6,7 +6,7 @@ import { OpenIDAuth, OpenIDParams } from './auth/openid'
 import { JWTAuth, JWTParams } from './auth/jwt'
 import { JWKSAuth, JWKSParams } from './auth/jwks'
 import { RequireAtLeastOne } from 'type-fest'
-import dotenv from "dotenv"
+import dotenv from 'dotenv'
 
 dotenv.config()
 

--- a/packages/grafbase-sdk/tests/unit/openapi.test.ts
+++ b/packages/grafbase-sdk/tests/unit/openapi.test.ts
@@ -27,7 +27,7 @@ describe('OpenAPI generator', () => {
       schema:
         'https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json',
       url: 'https://api.stripe.com',
-      transforms: 'SCHEMA_NAME',
+      transforms: { queryNaming: 'OPERATION_ID' },
       headers: (headers) => {
         headers.static('Authorization', 'Bearer {{ env.STRIPE_API_KEY }}')
         headers.static('Method', 'POST')
@@ -44,7 +44,7 @@ describe('OpenAPI generator', () => {
           name: "Stripe"
           url: "https://api.stripe.com"
           schema: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json"
-          transforms: { queryNaming: SCHEMA_NAME }
+          transforms: { queryNaming: OPERATION_ID }
           headers: [
             { name: "Authorization", value: "Bearer {{ env.STRIPE_API_KEY }}" }
             { name: "Method", value: "POST" }


### PR DESCRIPTION
# Description

```ts
transforms: 'OPERATION_ID'
```

to

```ts
transforms: { queryNaming: 'OPERATION_ID' }
```

Bump to 0.0.21.
