### PR TITLE
chore: Add `additionalBranchPrefix` to renovate.json to force separate PRs for the CLI & the rest

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,20 @@
 {
+  "additionalBranchPrefix": "{{parentDir}}-",
   "branchPrefix": "renovate-",
-  "extends": ["config:base", ":disableDependencyDashboard", "schedule:weekly"],
+  "extends": [
+    "config:base",
+    ":disableDependencyDashboard",
+    "schedule:weekly"
+  ],
   "packageRules": [
     {
       "groupName": "dependencies-non-major",
-      "matchUpdateTypes": ["digest", "minor", "patch", "pin"]
+      "matchUpdateTypes": [
+        "digest",
+        "minor",
+        "patch",
+        "pin"
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Description

This change to the Renovate configuration will allow us to track updates to the CLI dependencies & the other things located in this repository separately.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [X] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
