### PR TITLE
fix(sdk): Input type default values

### DIFF
--- a/packages/grafbase-sdk/src/query.ts
+++ b/packages/grafbase-sdk/src/query.ts
@@ -1,3 +1,4 @@
+import { DefaultDefinition, DefaultFieldShape, DefaultValueType, renderDefault } from './typedefs/default'
 import { InputDefinition } from './typedefs/input'
 import { ListDefinition } from './typedefs/list'
 import { ReferenceDefinition } from './typedefs/reference'
@@ -5,10 +6,24 @@ import { ScalarDefinition } from './typedefs/scalar'
 import { validateIdentifier } from './validation'
 
 /** The possible types of an input parameters of a query. */
-export type InputType = ScalarDefinition | ListDefinition | InputDefinition
+export type InputType = ScalarDefinition | ListDefinition | InputDefinition | InputDefaultDefinition
 
 /** The possible types of an output parameters of a query. */
 export type OutputType = ScalarDefinition | ListDefinition | ReferenceDefinition
+
+/**
+ * Defaults are rendered differently in input types, which we do in this specialization
+ */
+export class InputDefaultDefinition extends DefaultDefinition {
+  constructor(scalar: DefaultFieldShape, defaultValue: DefaultValueType) {
+    super(scalar, defaultValue)
+  }
+
+  public toString(): string {
+    const defaultValue = renderDefault(this._defaultValue, this._scalar.fieldTypeVal())
+    return `${this._scalar} = ${defaultValue}`
+  }
+}
 
 /**
  * Parameters to create a new query definition.
@@ -30,7 +45,12 @@ export class QueryArgument {
     validateIdentifier(name)
 
     this.name = name
-    this.type = type
+
+    if ('scalar' in type && 'defaultValue' in type) {
+      this.type = new InputDefaultDefinition(type.scalar, type.defaultValue)
+    } else {
+      this.type = type
+    }
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/default.ts
+++ b/packages/grafbase-sdk/src/typedefs/default.ts
@@ -16,12 +16,26 @@ export type DefaultFieldShape =
   | EnumDefinition<any, any>
 
 export class DefaultDefinition {
-  private defaultValue: DefaultValueType
-  private scalar: DefaultFieldShape
+  protected _defaultValue: DefaultValueType
+  protected _scalar: DefaultFieldShape
 
   constructor(scalar: DefaultFieldShape, defaultValue: DefaultValueType) {
-    this.defaultValue = defaultValue
-    this.scalar = scalar
+    this._defaultValue = defaultValue
+    this._scalar = scalar
+  }
+
+  /**
+   * The default value.
+   */
+  public get defaultValue(): DefaultValueType {
+    return this._defaultValue
+  }
+
+  /**
+   * The default type of the default value.
+   */
+  public get scalar(): DefaultFieldShape {
+    return this._scalar
   }
 
   /**
@@ -50,9 +64,9 @@ export class DefaultDefinition {
   }
 
   public toString(): string {
-    return `${this.scalar} @default(value: ${renderDefault(
-      this.defaultValue,
-      this.scalar.fieldTypeVal()
+    return `${this._scalar} @default(value: ${renderDefault(
+      this._defaultValue,
+      this._scalar.fieldTypeVal()
     )})`
   }
 }

--- a/packages/grafbase-sdk/tests/unit/queries.test.ts
+++ b/packages/grafbase-sdk/tests/unit/queries.test.ts
@@ -46,6 +46,20 @@ describe('Query generator', () => {
     `)
   })
 
+  it('generates a resolver with input default value', () => {
+    g.query('greet', {
+      args: { name: g.string().default('Bob') },
+      returns: g.string(),
+      resolver: 'hello'
+    })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "extend type Query {
+        greet(name: String! = "Bob"): String! @resolver(name: "hello")
+      }"
+    `)
+  })
+
   it('generates a resolver with optional input and output', () => {
     g.query('greet', {
       args: { name: g.string().optional() },


### PR DESCRIPTION
# Description

```ts
it('generates a resolver with input default value', () => {
  g.query('greet', {
    args: { name: g.string().default('Bob') },
    returns: g.string(),
    resolver: 'hello'
  })

  expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
    "extend type Query {
      greet(name: String! = "Bob"): String! @resolver(name: "hello")
    }"
  `)
})
```

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [x] 📖 Requires documentation update
