### PR TITLE
release 0.23.0-rc.1

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   GRAFBASE_SKIP_ASSET_VERSION_CHECK: 'true'
-  ASSETS_VERSION: release/dcaabc5-2023-06-08
+  ASSETS_VERSION: XXX
   PROD_ASSETS: assets.grafbase.com
   CARGO_TERM_COLOR: 'always'
   CARGO_PROFILE_DEV_DEBUG: 0

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   GRAFBASE_SKIP_ASSET_VERSION_CHECK: 'true'
-  ASSETS_VERSION: XXX
+  ASSETS_VERSION: release/1ecb302-2023-06-14
   PROD_ASSETS: assets.grafbase.com
   CARGO_TERM_COLOR: 'always'
   CARGO_PROFILE_DEV_DEBUG: 0

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.22.0"
+version = "0.23.0-rc.1"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.22.0"
+version = "0.23.0-rc.1"
 dependencies = [
  "async-compression",
  "async-tar",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.22.0"
+version = "0.23.0-rc.1"
 dependencies = [
  "chrono",
  "derivative",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.22.0"
+version = "0.23.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.22.0"
+version = "0.23.0-rc.1"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://grafbase.com"

--- a/cli/changelog/0.23.0-rc.1.md
+++ b/cli/changelog/0.23.0-rc.1.md
@@ -1,0 +1,9 @@
+## Features
+
+- Make GraphQL Connector namespacing optional
+- Add replace payment method endpoint to allow clients to change their payment
+  method
+
+## Fixes
+
+- Add an error message if package.json missing while grafbase.config.ts present

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -37,8 +37,8 @@ urlencoding = "2"
 walkdir = "2"
 webbrowser = "0.8"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.22.0" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.22.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.23.0-rc.1" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.23.0-rc.1" }
 
 [build-dependencies]
 cynic-codegen = { version = "3", features = ["rkyv"] }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -37,8 +37,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
 webbrowser = "0.8"
 
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.22.0" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.22.0" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.23.0-rc.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.23.0-rc.1" }
 
 [dev-dependencies]
 chrono = "0.4"

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -60,7 +60,7 @@ uuid = { version = "1", features = ["v4"] }
 version-compare = "0.1"
 which = "4"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.22.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.23.0-rc.1" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.22.0",
+  "version": "0.23.0-rc.1",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.22.0",
+  "version": "0.23.0-rc.1",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,9 +27,9 @@
     "jest": "29.4.3"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.22.0",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.22.0",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.22.0",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.22.0"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.23.0-rc.1",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.23.0-rc.1",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.23.0-rc.1",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.23.0-rc.1"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.22.0",
+  "version": "0.23.0-rc.1",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.22.0",
+  "version": "0.23.0-rc.1",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.22.0",
+  "version": "0.23.0-rc.1",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
Allows for customers to omit GraphQL connector namespacing. Proper changelog will follow once we're done with the RC process.