### PR TITLE
fix(sdk): Resolver fields are _not_ searchable or unique. Make openapi/graphql namespace optional and rename it to namespace

### DIFF
--- a/packages/grafbase-sdk/CHANGELOG.md
+++ b/packages/grafbase-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.23] - Wed Jun 14 2023
+
+[CHANGELOG](changelog/0.0.23.md)
+
 ## [0.0.22] - Wed Jun 14 2023
 
 [CHANGELOG](changelog/0.0.22.md)

--- a/packages/grafbase-sdk/changelog/0.0.23.md
+++ b/packages/grafbase-sdk/changelog/0.0.23.md
@@ -1,0 +1,5 @@
+## Breaking
+
+## Fixes
+
+- Do not allow using search on resolved fields

--- a/packages/grafbase-sdk/changelog/0.0.23.md
+++ b/packages/grafbase-sdk/changelog/0.0.23.md
@@ -3,3 +3,5 @@
 ## Fixes
 
 - Do not allow using search on resolved fields
+- Do not allow using unique on resolved fields
+- Rename openapi/graphql name to namespace, make it optional

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",

--- a/packages/grafbase-sdk/src/connector/graphql.ts
+++ b/packages/grafbase-sdk/src/connector/graphql.ts
@@ -22,27 +22,27 @@ export class PartialGraphQLAPI {
     this.introspectionHeaders = headers.introspectionHeaders
   }
 
-  finalize(namespace: string): GraphQLAPI {
+  finalize(namespace?: string): GraphQLAPI {
     return new GraphQLAPI(
-      namespace,
       this.apiUrl,
       this.headers,
-      this.introspectionHeaders
+      this.introspectionHeaders,
+      namespace
     )
   }
 }
 
 export class GraphQLAPI {
-  private namespace: string
+  private namespace?: string
   private url: string
   private headers: Header[]
   private introspectionHeaders: Header[]
 
   constructor(
-    namespace: string,
     url: string,
     headers: Header[],
-    introspectionHeaders: Header[]
+    introspectionHeaders: Header[],
+    namespace?: string
   ) {
     this.namespace = namespace
     this.url = url
@@ -52,7 +52,7 @@ export class GraphQLAPI {
 
   public toString(): string {
     const header = '  @graphql(\n'
-    const namespace = this.namespace ? `    name: "${this.namespace}"\n` : ''
+    const namespace = this.namespace ? `    namespace: "${this.namespace}"\n` : ''
     const url = this.url ? `    url: "${this.url}"\n` : ''
 
     var headers = this.headers.map((header) => `      ${header}`).join('\n')

--- a/packages/grafbase-sdk/src/connector/openapi.ts
+++ b/packages/grafbase-sdk/src/connector/openapi.ts
@@ -50,20 +50,20 @@ export class PartialOpenAPI {
     this.introspectionHeaders = headers.introspectionHeaders
   }
 
-  finalize(namespace: string): OpenAPI {
+  finalize(namespace?: string): OpenAPI {
     return new OpenAPI(
-      namespace,
       this.schema,
       this.headers,
       this.introspectionHeaders,
       this.transforms,
-      this.apiUrl
+      this.apiUrl,
+      namespace
     )
   }
 }
 
 export class OpenAPI {
-  private namespace: string
+  private namespace?: string
   private schema: string
   private apiUrl?: string
   private transforms?: OpenApiTransforms
@@ -71,12 +71,12 @@ export class OpenAPI {
   private introspectionHeaders: Header[]
 
   constructor(
-    namespace: string,
     schema: string,
     headers: Header[],
     introspectionHeaders: Header[],
     transforms?: OpenApiTransforms,
-    url?: string
+    url?: string,
+    namespace?: string
   ) {
     this.namespace = namespace
     this.schema = schema
@@ -88,7 +88,7 @@ export class OpenAPI {
 
   public toString(): string {
     const header = '  @openapi(\n'
-    const namespace = this.namespace ? `    name: "${this.namespace}"\n` : ''
+    const namespace = this.namespace ? `    namespace: "${this.namespace}"\n` : ''
     const url = this.apiUrl ? `    url: "${this.apiUrl}"\n` : ''
     const schema = `    schema: "${this.schema}"\n`
 

--- a/packages/grafbase-sdk/src/grafbase-schema.ts
+++ b/packages/grafbase-sdk/src/grafbase-schema.ts
@@ -47,7 +47,7 @@ export class Datasources {
 }
 
 export interface IntrospectParams {
-  namespace: string
+  namespace?: string
 }
 
 export class GrafbaseSchema {
@@ -79,8 +79,8 @@ export class GrafbaseSchema {
    * @param datasource - The datasource to add.
    * @param params - The introspection parameters.
    */
-  public datasource(datasource: PartialDatasource, params: IntrospectParams) {
-    this.datasources.push(datasource.finalize(params.namespace))
+  public datasource(datasource: PartialDatasource, params?: IntrospectParams) {
+    this.datasources.push(datasource.finalize(params?.namespace))
   }
 
   /**

--- a/packages/grafbase-sdk/src/query.ts
+++ b/packages/grafbase-sdk/src/query.ts
@@ -1,4 +1,9 @@
-import { DefaultDefinition, DefaultFieldShape, DefaultValueType, renderDefault } from './typedefs/default'
+import {
+  DefaultDefinition,
+  DefaultFieldShape,
+  DefaultValueType,
+  renderDefault
+} from './typedefs/default'
 import { InputDefinition } from './typedefs/input'
 import { ListDefinition } from './typedefs/list'
 import { ReferenceDefinition } from './typedefs/reference'
@@ -6,7 +11,11 @@ import { ScalarDefinition } from './typedefs/scalar'
 import { validateIdentifier } from './validation'
 
 /** The possible types of an input parameters of a query. */
-export type InputType = ScalarDefinition | ListDefinition | InputDefinition | InputDefaultDefinition
+export type InputType =
+  | ScalarDefinition
+  | ListDefinition
+  | InputDefinition
+  | InputDefaultDefinition
 
 /** The possible types of an output parameters of a query. */
 export type OutputType = ScalarDefinition | ListDefinition | ReferenceDefinition
@@ -20,7 +29,10 @@ export class InputDefaultDefinition extends DefaultDefinition {
   }
 
   public toString(): string {
-    const defaultValue = renderDefault(this._defaultValue, this._scalar.fieldTypeVal())
+    const defaultValue = renderDefault(
+      this._defaultValue,
+      this._scalar.fieldTypeVal()
+    )
     return `${this._scalar} = ${defaultValue}`
   }
 }

--- a/packages/grafbase-sdk/src/typedefs/resolver.ts
+++ b/packages/grafbase-sdk/src/typedefs/resolver.ts
@@ -4,7 +4,6 @@ import { CacheDefinition, FieldCacheParams, FieldLevelCache } from './cache'
 import { DefaultDefinition } from './default'
 import { ReferenceDefinition } from './reference'
 import { ScalarDefinition } from './scalar'
-import { UniqueDefinition } from './unique'
 import { EnumDefinition } from './enum'
 
 /**
@@ -12,7 +11,6 @@ import { EnumDefinition } from './enum'
  */
 export type Resolvable =
   | ScalarDefinition
-  | UniqueDefinition
   | DefaultDefinition
   | ReferenceDefinition
   | CacheDefinition
@@ -34,15 +32,6 @@ export class ResolverDefinition {
    */
   public auth(rules: AuthRuleF): AuthDefinition {
     return new AuthDefinition(this, rules)
-  }
-
-  /**
-   * Make the field unique.
-   *
-   * @param scope - Additional fields to be added to the constraint.
-   */
-  public unique(scope?: string[]): UniqueDefinition {
-    return new UniqueDefinition(this, scope)
   }
 
   /**

--- a/packages/grafbase-sdk/src/typedefs/resolver.ts
+++ b/packages/grafbase-sdk/src/typedefs/resolver.ts
@@ -1,7 +1,6 @@
 import { AuthRuleF } from '../auth'
 import { AuthDefinition } from './auth'
 import { CacheDefinition, FieldCacheParams, FieldLevelCache } from './cache'
-import { SearchDefinition } from './search'
 import { DefaultDefinition } from './default'
 import { ReferenceDefinition } from './reference'
 import { ScalarDefinition } from './scalar'
@@ -35,13 +34,6 @@ export class ResolverDefinition {
    */
   public auth(rules: AuthRuleF): AuthDefinition {
     return new AuthDefinition(this, rules)
-  }
-
-  /**
-   * Make the field searchable.
-   */
-  public search(): SearchDefinition {
-    return new SearchDefinition(this)
   }
 
   /**

--- a/packages/grafbase-sdk/src/typedefs/search.ts
+++ b/packages/grafbase-sdk/src/typedefs/search.ts
@@ -3,7 +3,6 @@ import { ListDefinition } from './list'
 import { AuthDefinition } from './auth'
 import { CacheDefinition, FieldCacheParams, FieldLevelCache } from './cache'
 import { LengthLimitedStringDefinition } from './length-limited-string'
-import { ResolverDefinition } from './resolver'
 import { ScalarDefinition } from './scalar'
 import { UniqueDefinition } from './unique'
 import { EnumDefinition } from './enum'
@@ -18,7 +17,6 @@ export type Searchable =
   | LengthLimitedStringDefinition
   | CacheDefinition
   | AuthDefinition
-  | ResolverDefinition
   | EnumDefinition<any, any>
 
 export class SearchDefinition {

--- a/packages/grafbase-sdk/tests/unit/env.test.ts
+++ b/packages/grafbase-sdk/tests/unit/env.test.ts
@@ -33,7 +33,7 @@ describe('Env var accessor', () => {
     expect(config({ schema: g }).toString()).toMatchInlineSnapshot(`
       "extend schema
         @graphql(
-          name: "GitHub"
+          namespace: "GitHub"
           url: "https://api.github.com/graphql"
           headers: [
             { name: "Authorization", value: "Bearer test_token" }

--- a/packages/grafbase-sdk/tests/unit/graphql.test.ts
+++ b/packages/grafbase-sdk/tests/unit/graphql.test.ts
@@ -10,12 +10,11 @@ describe('GraphQL connector', () => {
       url: 'https://graphql.contentful.com/content/v1/spaces/{{ env.CONTENTFUL_SPACE_ID }}/environments/{{ env.CONTENTFUL_ENVIRONMENT }}'
     })
 
-    g.datasource(contentful, { namespace: 'Contentful' })
+    g.datasource(contentful)
 
     expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend schema
         @graphql(
-          name: "Contentful"
           url: "https://graphql.contentful.com/content/v1/spaces/{{ env.CONTENTFUL_SPACE_ID }}/environments/{{ env.CONTENTFUL_ENVIRONMENT }}"
         )"
     `)
@@ -36,7 +35,7 @@ describe('GraphQL connector', () => {
     expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend schema
         @graphql(
-          name: "Contentful"
+          namespace: "Contentful"
           url: "https://graphql.contentful.com/content/v1/spaces/{{ env.CONTENTFUL_SPACE_ID }}/environments/{{ env.CONTENTFUL_ENVIRONMENT }}"
           headers: [
             { name: "Authorization", value: "Bearer {{ env.STRIPE_API_KEY }}" }
@@ -64,11 +63,11 @@ describe('GraphQL connector', () => {
     expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend schema
         @graphql(
-          name: "Contentful"
+          namespace: "Contentful"
           url: "https://graphql.contentful.com/content/v1/spaces/{{ env.CONTENTFUL_SPACE_ID }}/environments/{{ env.CONTENTFUL_ENVIRONMENT }}"
         )
         @graphql(
-          name: "GitHub"
+          namespace: "GitHub"
           url: "https://api.github.com/graphql"
         )"
     `)

--- a/packages/grafbase-sdk/tests/unit/openapi.test.ts
+++ b/packages/grafbase-sdk/tests/unit/openapi.test.ts
@@ -11,12 +11,11 @@ describe('OpenAPI generator', () => {
         'https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json'
     })
 
-    g.datasource(stripe, { namespace: 'Stripe' })
+    g.datasource(stripe)
 
     expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend schema
         @openapi(
-          name: "Stripe"
           schema: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json"
         )"
     `)
@@ -41,7 +40,7 @@ describe('OpenAPI generator', () => {
     expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend schema
         @openapi(
-          name: "Stripe"
+          namespace: "Stripe"
           url: "https://api.stripe.com"
           schema: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json"
           transforms: { queryNaming: OPERATION_ID }
@@ -73,11 +72,11 @@ describe('OpenAPI generator', () => {
     expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend schema
         @openapi(
-          name: "Stripe"
+          namespace: "Stripe"
           schema: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json"
         )
         @openapi(
-          name: "OpenAI"
+          namespace: "OpenAI"
           schema: "https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml"
         )"
     `)


### PR DESCRIPTION
# Description

If a field is using a resolver, you can't use the search attribute to it or the field cannot be unique. We prevent this in type-level.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
