### PR TITLE
fix(cli): grafbase init should run 'npm init' if 'package.json' not found

### DIFF
--- a/cli/crates/cli/tests/init_ts.rs
+++ b/cli/crates/cli/tests/init_ts.rs
@@ -5,7 +5,7 @@ use serde_json::json;
 use utils::environment::Environment;
 
 #[test]
-fn init_ts() {
+fn init_ts_existing_package_json() {
     let env = Environment::init();
 
     env.write_json_file_to_project(
@@ -41,5 +41,26 @@ fn init_ts() {
         "@grafbase/sdk": "~0.0.20"
       }
     }
+    "###);
+}
+
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn init_ts_new_project() {
+    let env = Environment::init();
+
+    env.grafbase_init_output(ConfigType::TypeScript);
+
+    assert!(env.directory.join("grafbase").exists());
+    assert!(env.directory.join("grafbase").join("grafbase.config.ts").exists());
+    assert!(env.directory.join("package.json").exists());
+
+    let package_json: serde_json::Value = serde_json::from_str(&env.load_file_from_project("package.json")).unwrap();
+    let package_json = package_json.as_object().unwrap().get("devDependencies").unwrap();
+
+    insta::assert_json_snapshot!(&package_json, @r###"
+        {
+          "@grafbase/sdk": "~0.0.20"
+        }
     "###);
 }

--- a/cli/crates/common/src/errors.rs
+++ b/cli/crates/common/src/errors.rs
@@ -29,4 +29,6 @@ pub enum CommonError {
     AccessPackageJson(std::io::Error),
     #[error("could not serialize the project 'package.json':\nCaused by: {0}")]
     SerializePackageJson(serde_json::Error),
+    #[error("could not execute 'npm init':\nCaused by: {0}")]
+    NpmInitError(std::io::Error),
 }


### PR DESCRIPTION
# Description

When running `grafbase init` for the first time, and choosing `TypeScript` as the config type. If `package.json` is not found from the current directory, it will run `npm init -y` before continuing.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [x] 📖 Requires documentation update
