### PR TITLE
chore(cli): Bump to 0.23.0

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   GRAFBASE_SKIP_ASSET_VERSION_CHECK: 'true'
-  ASSETS_VERSION: release/b609bf1-2023-06-15
+  ASSETS_VERSION: release/f7f8871-2023-06-16
   PROD_ASSETS: assets.grafbase.com
   CARGO_TERM_COLOR: 'always'
   CARGO_PROFILE_DEV_DEBUG: 0

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## [0.21.0] - 2023-05-22
+## [0.23.0] - 2023-06-16
+
+[CHANGELOG](changelog/0.23.0.md)
+
+## [0.22.0] - 2023-06-06
+
+[CHANGELOG](changelog/0.22.0.md)
+
+## [0.21.0] - 2023-05-25
 
 [CHANGELOG](changelog/0.21.0.md)
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1655,7 +1655,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.23.0-rc.2"
+version = "0.23.0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.23.0-rc.2"
+version = "0.23.0"
 dependencies = [
  "async-compression",
  "async-tar",
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.23.0-rc.2"
+version = "0.23.0"
 dependencies = [
  "chrono",
  "derivative",
@@ -1749,7 +1749,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.23.0-rc.2"
+version = "0.23.0"
 dependencies = [
  "axum",
  "base64 0.21.0",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.23.0-rc.2"
+version = "0.23.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://grafbase.com"

--- a/cli/changelog/0.23.0.md
+++ b/cli/changelog/0.23.0.md
@@ -1,0 +1,16 @@
+## Features
+
+- Make GraphQL Connector namespacing optional
+- Add replace payment method endpoint to allow clients to change their payment
+  method
+- Move to lazy compilation of resolvers in local dev
+
+## Fixes
+
+- Add an error message if package.json missing while grafbase.config.ts present
+- Resolve issues with namespace-less GraphQL connector queries
+- Make error message verification more generic
+- Fix custom resolvers on Windows
+- Ignore deployment files from blacklist
+- Adds new error variants to the create operation
+- Output the name of unknown API errors

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -35,8 +35,8 @@ url = "2"
 urlencoding = "2"
 walkdir = "2"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.23.0-rc.2" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.23.0-rc.2" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.23.0" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.23.0" }
 
 [build-dependencies]
 cynic-codegen = { version = "3", features = ["rkyv"] }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -34,8 +34,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
 webbrowser = "0.8"
 
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.23.0-rc.2" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.23.0-rc.2" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.23.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.23.0" }
 
 [dev-dependencies]
 cfg-if = "1"

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -56,7 +56,7 @@ uuid = { version = "1", features = ["v4"] }
 version-compare = "0.1"
 which = "4"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.23.0-rc.2" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.23.0" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.23.0-rc.2",
+  "version": "0.23.0",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.23.0-rc.2",
+  "version": "0.23.0",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,9 +27,9 @@
     "jest": "29.4.3"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.23.0-rc.2",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.23.0-rc.2",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.23.0-rc.2",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.23.0-rc.2"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.23.0",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.23.0",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.23.0",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.23.0"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.23.0-rc.2",
+  "version": "0.23.0",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.23.0-rc.2",
+  "version": "0.23.0",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.23.0-rc.2",
+  "version": "0.23.0",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
## Features

- Make GraphQL Connector namespacing optional
- Add replace payment method endpoint to allow clients to change their payment
  method
- Move to lazy compilation of resolvers in local dev

## Fixes

- Add an error message if package.json missing while grafbase.config.ts present
- Resolve issues with namespace-less GraphQL connector queries
- Make error message verification more generic
- Fix custom resolvers on Windows
- Ignore deployment files from blacklist
- Adds new error variants to the create operation
- Output the name of unknown API errors