### PR TITLE
fix(sdk): Make auth provider optional (for public rules)

### DIFF
--- a/packages/grafbase-sdk/CHANGELOG.md
+++ b/packages/grafbase-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.24] - Fri Jun 16 2023
+
+[CHANGELOG](changelog/0.0.24.md)
+
 ## [0.0.23] - Wed Jun 14 2023
 
 [CHANGELOG](changelog/0.0.23.md)

--- a/packages/grafbase-sdk/changelog/0.0.24.md
+++ b/packages/grafbase-sdk/changelog/0.0.24.md
@@ -1,0 +1,3 @@
+## Fixes
+
+- Do not enforce auth providers for public rules

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",

--- a/packages/grafbase-sdk/src/auth.ts
+++ b/packages/grafbase-sdk/src/auth.ts
@@ -173,12 +173,12 @@ export class AuthRules {
 }
 
 export interface AuthParams {
-  providers: FixedLengthArray<AuthProvider, 1>
+  providers?: FixedLengthArray<AuthProvider, 1>
   rules: AuthRuleF
 }
 
 export class Authentication {
-  private providers: FixedLengthArray<AuthProvider, 1>
+  private providers?: FixedLengthArray<AuthProvider, 1>
   private rules: AuthRules
 
   constructor(params: AuthParams) {
@@ -191,15 +191,18 @@ export class Authentication {
   }
 
   public toString(): string {
-    const providers = this.providers.map(String).join('\n      ')
+    var providers = this.providers ? this.providers.map(String).join('\n      ') : ''
+
+    if (providers) {
+      providers = `\n    providers: [\n      ${providers}\n    ]`
+    }
+
     var rules = this.rules.toString()
 
     if (rules) {
       rules = `\n    rules: ${rules}`
-    } else {
-      rules = ''
     }
 
-    return `extend schema\n  @auth(\n    providers: [\n      ${providers}\n    ]${rules}\n  )`
+    return `extend schema\n  @auth(${providers}${rules}\n  )`
   }
 }

--- a/packages/grafbase-sdk/tests/unit/auth.openid.test.ts
+++ b/packages/grafbase-sdk/tests/unit/auth.openid.test.ts
@@ -5,17 +5,12 @@ import { renderGraphQL } from '../utils'
 describe('OpenID auth provider', () => {
   beforeEach(() => g.clear())
 
-  it('renders a provider with public access', () => {
-    const clerk = auth.OpenIDConnect({
-      issuer: '{{ env.ISSUER_URL }}'
-    })
-
+  it('public access', () => {
     const cfg = config({
       schema: g,
       auth: {
-        providers: [clerk],
         rules: (rules) => {
-          rules.public().read()
+          rules.public()
         }
       }
     })
@@ -23,11 +18,8 @@ describe('OpenID auth provider', () => {
     expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
         @auth(
-          providers: [
-            { type: oidc, issuer: "{{ env.ISSUER_URL }}" }
-          ]
           rules: [
-            { allow: public, operations: [read] }
+            { allow: public }
           ]
         )"
     `)


### PR DESCRIPTION
# Description

If having a public auth rule, there is no reason to enforce a provider.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [x] 📖 Requires documentation update
