### PR TITLE
fix(resolvers): Ensure resolvers get compiled concurrently when multiple fields are queried

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1779,6 +1779,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tower-http",
  "tracing",
  "unicode-normalization",

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -48,6 +48,7 @@ tar = { git = "https://github.com/obmarg/tar-rs.git", rev = "bffee32190d531c03d8
 tempfile = "3"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
+tokio-stream = { version = "0.1", features = ["io-util"] }
 tower-http = { version = "0.4", features = ["trace"] }
 tracing = "0.1"
 unicode-normalization = "0.1"

--- a/cli/crates/server/src/bridge/errors.rs
+++ b/cli/crates/server/src/bridge/errors.rs
@@ -23,8 +23,6 @@ pub enum ApiError {
     ServerError,
     #[error("resolver {0} is invalid")]
     ResolverInvalid(String),
-    #[error("could not find a free point for a resolver worker")]
-    CouldNotFindPortForResolverWorker,
     /// returned if the miniflare command returns an error
     #[error("resolver could not be spawned")]
     ResolverSpawnError,
@@ -57,7 +55,6 @@ impl IntoResponse for ApiError {
             ApiError::SqlError(_)
             | ApiError::ServerError
             | ApiError::ResolverInvalid(_)
-            | ApiError::CouldNotFindPortForResolverWorker
             | ApiError::ResolverSpawnError => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
         }
     }

--- a/cli/crates/server/src/bridge/resolvers.rs
+++ b/cli/crates/server/src/bridge/resolvers.rs
@@ -121,9 +121,7 @@ pub async fn spawn_miniflare(
                 futures_util::future::ready(Ok(line
                     .split("Listening on")
                     .skip(1)
-                    .flat_map(|bound_address| bound_address.split(':'))
-                    .skip(1)
-                    .next()
+                    .flat_map(|bound_address| bound_address.split(':')).nth(1)
                     .and_then(|value| value.trim().parse::<u16>().ok())))
             });
             pin_mut!(filtered_lines_stream);

--- a/cli/crates/server/src/bridge/resolvers.rs
+++ b/cli/crates/server/src/bridge/resolvers.rs
@@ -121,7 +121,8 @@ pub async fn spawn_miniflare(
                 futures_util::future::ready(Ok(line
                     .split("Listening on")
                     .skip(1)
-                    .flat_map(|bound_address| bound_address.split(':')).nth(1)
+                    .flat_map(|bound_address| bound_address.split(':'))
+                    .nth(1)
                     .and_then(|value| value.trim().parse::<u16>().ok())))
             });
             pin_mut!(filtered_lines_stream);

--- a/cli/crates/server/src/bridge/server.rs
+++ b/cli/crates/server/src/bridge/server.rs
@@ -41,7 +41,6 @@ enum ResolverBuild {
 }
 
 struct HandlerState {
-    worker_port: u16,
     pool: SqlitePool,
     bridge_sender: tokio::sync::mpsc::Sender<ServerMessage>,
     resolver_builds: Mutex<std::collections::HashMap<String, ResolverBuild>>,
@@ -197,7 +196,6 @@ async fn invoke_resolver_endpoint(
         {
             let (miniflare_handle, worker_port) = super::resolvers::spawn_miniflare(
                 &payload.resolver_name,
-                handler_state.worker_port,
                 package_json_path,
                 wrangler_toml_path,
                 tracing,
@@ -283,7 +281,6 @@ pub async fn start(
     query(PREPARE).execute(&pool).await?;
 
     let handler_state = Arc::new(HandlerState {
-        worker_port,
         pool,
         bridge_sender,
         resolver_builds: Mutex::default(),

--- a/cli/crates/server/src/bridge/server.rs
+++ b/cli/crates/server/src/bridge/server.rs
@@ -148,32 +148,34 @@ async fn invoke_resolver_endpoint(
     let environment = Environment::get();
 
     let resolver_worker_port = loop {
-        let mut resolver_builds = handler_state.resolver_builds.lock().await;
+        let notify = {
+            let mut resolver_builds = handler_state.resolver_builds.lock().await;
 
-        let notify = if let Some(resolver_build) = resolver_builds.get(&payload.resolver_name) {
-            match resolver_build {
-                ResolverBuild::Succeeded { worker_port, .. } => break *worker_port,
-                ResolverBuild::Failed => return Err(ApiError::ResolverSpawnError),
-                ResolverBuild::InProgress { notify } => {
-                    // If the resolver build happening within another invocation has been cancelled
-                    // due to the invocation having been interrupted by the HTTP client, start a new build.
-                    if Arc::strong_count(notify) == 1 {
-                        notify.clone()
-                    } else {
-                        let notify = notify.clone();
-                        drop(resolver_builds);
-                        notify.notified().await;
-                        continue;
+            if let Some(resolver_build) = resolver_builds.get(&payload.resolver_name) {
+                match resolver_build {
+                    ResolverBuild::Succeeded { worker_port, .. } => break *worker_port,
+                    ResolverBuild::Failed => return Err(ApiError::ResolverSpawnError),
+                    ResolverBuild::InProgress { notify } => {
+                        // If the resolver build happening within another invocation has been cancelled
+                        // due to the invocation having been interrupted by the HTTP client, start a new build.
+                        if Arc::strong_count(notify) == 1 {
+                            notify.clone()
+                        } else {
+                            let notify = notify.clone();
+                            drop(resolver_builds);
+                            notify.notified().await;
+                            continue;
+                        }
                     }
                 }
+            } else {
+                let notify = Arc::new(Notify::new());
+                resolver_builds.insert(
+                    payload.resolver_name.clone(),
+                    ResolverBuild::InProgress { notify: notify.clone() },
+                );
+                notify
             }
-        } else {
-            let notify = Arc::new(Notify::new());
-            resolver_builds.insert(
-                payload.resolver_name.clone(),
-                ResolverBuild::InProgress { notify: notify.clone() },
-            );
-            notify
         };
 
         let start = std::time::Instant::now();
@@ -202,7 +204,7 @@ async fn invoke_resolver_endpoint(
             )
             .await?;
 
-            resolver_builds.insert(
+            handler_state.resolver_builds.lock().await.insert(
                 payload.resolver_name.clone(),
                 ResolverBuild::Succeeded {
                     miniflare_handle,
@@ -223,7 +225,11 @@ async fn invoke_resolver_endpoint(
             break worker_port;
         }
 
-        resolver_builds.insert(payload.resolver_name.clone(), ResolverBuild::Failed);
+        handler_state
+            .resolver_builds
+            .lock()
+            .await
+            .insert(payload.resolver_name.clone(), ResolverBuild::Failed);
         notify.notify_waiters();
         return Err(ApiError::ResolverSpawnError);
     };

--- a/cli/crates/server/src/custom_resolvers.rs
+++ b/cli/crates/server/src/custom_resolvers.rs
@@ -400,7 +400,9 @@ pub async fn install_wrangler(environment: &Environment, tracing: bool) -> Resul
     )
     .await?;
 
-    tokio::task::spawn_blocking(move || lock_file.unlock());
+    tokio::task::spawn_blocking(move || lock_file.unlock())
+        .await?
+        .map_err(ServerError::Unlock)?;
 
     Ok(())
 }

--- a/cli/crates/server/src/errors.rs
+++ b/cli/crates/server/src/errors.rs
@@ -162,7 +162,10 @@ pub enum ServerError {
     FileWatcher(#[from] NotifyError),
 
     #[error("Could not create a lock for the wrangler installation: {0}")]
-    Lock(#[from] fslock::Error),
+    Lock(fslock::Error),
+
+    #[error("Could not release the lock for the wrangler installation: {0}")]
+    Unlock(fslock::Error),
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
# Description

This removes a single point of locking that was mistakenly introduced in https://github.com/grafbase/grafbase/pull/357.
Also, let miniflare pick the port for a worker on its own (--port 0) rather than speculatively pick a port from a range which is racy with multiple miniflare instances starting concurrently.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
