### PR TITLE
fix(sdk): Do not render empty introspectionHeaders, name/namespace (openapi)

### DIFF
--- a/packages/grafbase-sdk/CHANGELOG.md
+++ b/packages/grafbase-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.25] - Mon Jun 19 2023
+
+[CHANGELOG](changelog/0.0.25.md)
+
 ## [0.0.24] - Fri Jun 16 2023
 
 [CHANGELOG](changelog/0.0.24.md)

--- a/packages/grafbase-sdk/changelog/0.0.25.md
+++ b/packages/grafbase-sdk/changelog/0.0.25.md
@@ -1,0 +1,4 @@
+## Fixes
+
+- OpenAPI renders name for now for namespace
+- OpenAPI should not render empty introspectionHeaders

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",

--- a/packages/grafbase-sdk/src/connector/openapi.ts
+++ b/packages/grafbase-sdk/src/connector/openapi.ts
@@ -103,7 +103,7 @@ export class OpenAPI {
       .map((header) => `      ${header}`)
       .join('\n')
 
-    introspectionHeaders = headers
+    introspectionHeaders = introspectionHeaders
       ? `    introspectionHeaders: [\n${introspectionHeaders}\n    ]\n`
       : ''
 

--- a/packages/grafbase-sdk/src/connector/openapi.ts
+++ b/packages/grafbase-sdk/src/connector/openapi.ts
@@ -88,7 +88,7 @@ export class OpenAPI {
 
   public toString(): string {
     const header = '  @openapi(\n'
-    const namespace = this.namespace ? `    namespace: "${this.namespace}"\n` : ''
+    const namespace = this.namespace ? `    name: "${this.namespace}"\n` : ''
     const url = this.apiUrl ? `    url: "${this.apiUrl}"\n` : ''
     const schema = `    schema: "${this.schema}"\n`
 

--- a/packages/grafbase-sdk/tests/unit/openapi.test.ts
+++ b/packages/grafbase-sdk/tests/unit/openapi.test.ts
@@ -40,7 +40,7 @@ describe('OpenAPI generator', () => {
     expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend schema
         @openapi(
-          namespace: "Stripe"
+          name: "Stripe"
           url: "https://api.stripe.com"
           schema: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json"
           transforms: { queryNaming: OPERATION_ID }
@@ -72,11 +72,11 @@ describe('OpenAPI generator', () => {
     expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend schema
         @openapi(
-          namespace: "Stripe"
+          name: "Stripe"
           schema: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json"
         )
         @openapi(
-          namespace: "OpenAI"
+          name: "OpenAI"
           schema: "https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml"
         )"
     `)


### PR DESCRIPTION
# Description

Closes: GB-3963

A few OpenAPI fixes:

- Do not render empty introspectionHeaders
- Render namespace as name until we change that in the backend

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
