### PR TITLE
Fix grafbase init -c typescript on folders starting with a dot

### DIFF
--- a/cli/crates/cli/tests/init.rs
+++ b/cli/crates/cli/tests/init.rs
@@ -14,7 +14,7 @@ fn init() {
     assert!(env.directory.join("grafbase").join("schema.graphql").exists());
 
     let output = env.grafbase_init_output(ConfigType::GraphQL);
-
+    assert!(!output.status.success());
     assert!(!output.stderr.is_empty());
     assert!(std::str::from_utf8(&output.stderr).unwrap().contains("already exists"));
 

--- a/cli/crates/cli/tests/init_ts.rs
+++ b/cli/crates/cli/tests/init_ts.rs
@@ -22,7 +22,14 @@ fn init_ts_existing_package_json() {
         }),
     );
 
-    env.grafbase_init_output(ConfigType::TypeScript);
+    let output = env.grafbase_init_output(ConfigType::TypeScript);
+    println!("stdout: `{}`", String::from_utf8_lossy(&output.stdout));
+    assert!(
+        output.stderr.is_empty(),
+        "stderr should be empty, got: `{}`",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.status.success());
 
     assert!(env.directory.join("grafbase").exists());
     assert!(env.directory.join("grafbase").join("grafbase.config.ts").exists());
@@ -49,8 +56,14 @@ fn init_ts_existing_package_json() {
 #[cfg_attr(target_os = "windows", ignore)]
 fn init_ts_new_project() {
     let env = Environment::init();
-
-    env.grafbase_init_output(ConfigType::TypeScript);
+    let output = env.grafbase_init_output(ConfigType::TypeScript);
+    println!("stdout: `{}`", String::from_utf8_lossy(&output.stdout));
+    assert!(
+        output.stderr.is_empty(),
+        "stderr should be empty, got: `{}`",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.status.success());
 
     assert!(env.directory.join("grafbase").exists());
     assert!(env.directory.join("grafbase").join("grafbase.config.ts").exists());

--- a/cli/crates/common/src/environment.rs
+++ b/cli/crates/common/src/environment.rs
@@ -13,7 +13,6 @@ use std::{
     borrow::Cow,
     env, fs, io,
     path::{Path, PathBuf},
-    process::Command,
     sync::OnceLock,
 };
 
@@ -325,17 +324,37 @@ fn find_grafbase_configuration(path: &Path, warnings: &mut Vec<Warning>) -> Opti
 pub fn add_dev_dependency_to_package_json(project_dir: &Path, package: &str, version: &str) -> Result<(), CommonError> {
     let package_json_path = project_dir.join(PACKAGE_JSON_NAME);
 
-    if !package_json_path.exists() {
-        run_npm_init(project_dir)?;
-    }
-
-    let file = fs::File::open(&package_json_path).map_err(CommonError::AccessPackageJson)?;
-
-    let Ok(Value::Object(mut package_json)) = serde_json::from_reader(&file) else {
+    let mut package_json = if !package_json_path.exists() {
+        let name = project_dir
+            .file_name()
+            .map(|it| it.to_string_lossy())
+            .unwrap_or(Cow::Borrowed("grafbase-project"));
+        match serde_json::json!(
+        {
+          "name": name,
+          "version": "1.0.0",
+          "description": "",
+          "main": "index.js",
+          "scripts": {
+            "test": "echo \"Error: no test specified\" && exit 1"
+          },
+          "keywords": [],
+          "author": "",
+          "license": "ISC",
+        }
+        ) {
+            Value::Object(package_json) => package_json,
+            _ => unreachable!("must be an object"),
+        }
+    } else {
+        let file = fs::File::open(&package_json_path).map_err(CommonError::AccessPackageJson)?;
+        let Ok(Value::Object(package_json)) = serde_json::from_reader(&file) else {
         return Err(CommonError::AccessPackageJson(io::Error::new(
             io::ErrorKind::InvalidData,
             "the file is not a JSON object",
         )));
+    };
+        package_json
     };
 
     match package_json
@@ -358,13 +377,4 @@ pub fn add_dev_dependency_to_package_json(project_dir: &Path, package: &str, ver
     serde_json::to_writer_pretty(&file, &package_json).map_err(CommonError::SerializePackageJson)?;
 
     Ok(())
-}
-
-fn run_npm_init(project_dir: &Path) -> Result<(), CommonError> {
-    Command::new("npm")
-        .args(["init", "-y"])
-        .current_dir(project_dir)
-        .output()
-        .map_err(CommonError::NpmInitError)
-        .map(|_| ())
 }

--- a/cli/crates/common/src/errors.rs
+++ b/cli/crates/common/src/errors.rs
@@ -25,9 +25,9 @@ pub enum CommonError {
     /// returned if ~/.grafbase could not be created
     #[error("could not create '~/.grafbase'\nCaused by: {0}")]
     CreateUserDotGrafbaseFolder(std::io::Error),
-    #[error("could not open the project 'package.json':\nCaused by: {0}")]
+    #[error("could not open the project's 'package.json':\nCaused by: {0}")]
     AccessPackageJson(std::io::Error),
-    #[error("could not serialize the project 'package.json':\nCaused by: {0}")]
+    #[error("could not serialize the project's 'package.json':\nCaused by: {0}")]
     SerializePackageJson(serde_json::Error),
     #[error("could not execute 'npm init':\nCaused by: {0}")]
     NpmInitError(std::io::Error),


### PR DESCRIPTION
# Description
Steps to reproduce:
```
$ mkdir .some
$ cd .some
$ grafbase --trace 2 init -c typescript
2023-06-20T08:04:17.108970Z TRACE grafbase: subcommand: init
Grafbase CLI 0.23.0

Error: could not open the project 'package.json':
Caused by: No such file or directory (os error 2)
```

The problem is that `npm init -y` inside of such folders fails.
This fix replaces the npm call with the package json content taken from a successful call.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
