### PR TITLE
chore: Add dynein for nix users

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "dynein-nixpkgs": {
+      "locked": {
+        "lastModified": 1687268242,
+        "narHash": "sha256-0gYllY4mfZZvo215N2WjYTTvTd8TXxxi68cpUDerGa0=",
+        "owner": "pimeys",
+        "repo": "nixpkgs",
+        "rev": "160d929d06fd4c29c3f82b441aa5b335002231cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pimeys",
+        "ref": "dynein-0.2.1",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,6 +52,7 @@
     },
     "root": {
       "inputs": {
+        "dynein-nixpkgs": "dynein-nixpkgs",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    dynein-nixpkgs.url = "github:pimeys/nixpkgs/dynein-0.2.1";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs = {
@@ -28,6 +29,7 @@
     nixpkgs,
     flake-utils,
     rust-overlay,
+    dynein-nixpkgs,
     ...
   }: let
     inherit
@@ -35,12 +37,18 @@
       optional
       ;
     systems = flake-utils.lib.system;
+    
   in
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = import nixpkgs {
         inherit system;
         overlays = [(import rust-overlay)];
       };
+
+      dyneinPkgs = import dynein-nixpkgs {
+        inherit system;
+      };
+
       x86_64LinuxPkgs = import nixpkgs {
         inherit system;
         crossSystem = {
@@ -77,6 +85,9 @@
 
             # Versioning
             nodePackages.semver
+
+            # Local DynamoDB handling
+            dyneinPkgs.dynein
           ]
           ++ optional (system == systems.aarch64-darwin) [
             darwin.apple_sdk.frameworks.Security
@@ -121,3 +132,4 @@
       };
     });
 }
+


### PR DESCRIPTION
# Description

The local development workflow needs dynein for database handling. This was not available in nixpkgs, so I added that in this PR:

https://github.com/NixOS/nixpkgs/pull/238762

We should switch using it from master or unstable when it's merged and available.
