### PR TITLE
fix(api): OpenAPI name renamed to namespace (and made optional)

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   GRAFBASE_SKIP_ASSET_VERSION_CHECK: 'true'
-  ASSETS_VERSION: release/f7f8871-2023-06-16
+  ASSETS_VERSION: release/8f8e3bc-2023-06-21
   PROD_ASSETS: assets.grafbase.com
   CARGO_TERM_COLOR: 'always'
   CARGO_PROFILE_DEV_DEBUG: 0

--- a/cli/crates/cli/tests/openapi/introspection_headers.rs
+++ b/cli/crates/cli/tests/openapi/introspection_headers.rs
@@ -34,7 +34,7 @@ fn schema(address: &SocketAddr) -> String {
         r#"
           extend schema
           @openapi(
-            name: "petstore",
+            namespace: "petstore",
             url: "http://{address}",
             schema: "http://{address}/spec.json",
             introspectionHeaders: [{{ name: "day", value: "friday" }}]

--- a/cli/crates/cli/tests/openapi/remote_unions.rs
+++ b/cli/crates/cli/tests/openapi/remote_unions.rs
@@ -109,7 +109,7 @@ fn schema(address: &SocketAddr) -> String {
         r#"
           extend schema
           @openapi(
-            name: "petstore",
+            namespace: "petstore",
             url: "http://{address}",
             schema: "http://{address}/spec.json",
           )

--- a/packages/grafbase-sdk/CHANGELOG.md
+++ b/packages/grafbase-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.26] - Wed Jun 21 2023
+
+[CHANGELOG](changelog/0.0.26.md)
+
 ## [0.0.25] - Mon Jun 19 2023
 
 [CHANGELOG](changelog/0.0.25.md)

--- a/packages/grafbase-sdk/changelog/0.0.26.md
+++ b/packages/grafbase-sdk/changelog/0.0.26.md
@@ -1,0 +1,3 @@
+## Fixes
+
+- OpenAPI namespace renders as namespace, and is optional

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",

--- a/packages/grafbase-sdk/src/connector/openapi.ts
+++ b/packages/grafbase-sdk/src/connector/openapi.ts
@@ -88,7 +88,7 @@ export class OpenAPI {
 
   public toString(): string {
     const header = '  @openapi(\n'
-    const namespace = this.namespace ? `    name: "${this.namespace}"\n` : ''
+    const namespace = this.namespace ? `    namespace: "${this.namespace}"\n` : ''
     const url = this.apiUrl ? `    url: "${this.apiUrl}"\n` : ''
     const schema = `    schema: "${this.schema}"\n`
 

--- a/packages/grafbase-sdk/tests/unit/openapi.test.ts
+++ b/packages/grafbase-sdk/tests/unit/openapi.test.ts
@@ -40,7 +40,7 @@ describe('OpenAPI generator', () => {
     expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend schema
         @openapi(
-          name: "Stripe"
+          namespace: "Stripe"
           url: "https://api.stripe.com"
           schema: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json"
           transforms: { queryNaming: OPERATION_ID }
@@ -72,11 +72,11 @@ describe('OpenAPI generator', () => {
     expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend schema
         @openapi(
-          name: "Stripe"
+          namespace: "Stripe"
           schema: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json"
         )
         @openapi(
-          name: "OpenAI"
+          namespace: "OpenAI"
           schema: "https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml"
         )"
     `)

--- a/templates/openapi-github/grafbase/schema.graphql
+++ b/templates/openapi-github/grafbase/schema.graphql
@@ -1,6 +1,6 @@
 extend schema
   @openapi(
-    name: "GitHub"
+    namespace: "GitHub"
     url: "https://api.github.com/"
     schema: "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/ghes-3.0/ghes-3.0.json"
     headers: [

--- a/templates/openapi-mux/grafbase/schema.graphql
+++ b/templates/openapi-mux/grafbase/schema.graphql
@@ -1,6 +1,6 @@
 extend schema
   @openapi(
-    name: "Mux"
+    namespace: "Mux"
     schema: "https://docs.mux.com/api-spec.json"
     headers: [{ name: "Authorization", value: "Basic {{ env.MUX_BASE64 }}" }]
     transforms: { queryNaming: OPERATION_ID }

--- a/templates/openapi-neon/grafbase/schema.graphql
+++ b/templates/openapi-neon/grafbase/schema.graphql
@@ -1,6 +1,6 @@
 extend schema
   @openapi(
-    name: "Neon"
+    namespace: "Neon"
     schema: "https://console.neon.tech/api/v2/"
     headers: [{ name: "Authorization", value: "Bearer {{ env.NEON_API_KEY }}" }]
   )

--- a/templates/openapi-openai/grafbase/schema.graphql
+++ b/templates/openapi-openai/grafbase/schema.graphql
@@ -1,6 +1,6 @@
 extend schema
   @openapi(
-    name: "OpenAI"
+    namespace: "OpenAI"
     url: "https://api.openai.com/v1/"
     schema: "https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml"
     headers: [

--- a/templates/openapi-stripe/grafbase/schema.graphql
+++ b/templates/openapi-stripe/grafbase/schema.graphql
@@ -1,6 +1,6 @@
 extend schema
   @openapi(
-    name: "Stripe"
+    namespace: "Stripe"
     url: "https://api.stripe.com/"
     schema: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json"
     headers: [

--- a/templates/openapi-tinybird/grafbase/schema.graphql
+++ b/templates/openapi-tinybird/grafbase/schema.graphql
@@ -1,6 +1,6 @@
 extend schema
   @openapi(
-    name: "Tinybird"
+    namespace: "Tinybird"
     url: "{{ env.TINYBIRD_API_URL }}"
     schema: "{{ env.TINYBIRD_API_SCHEMA }}"
     headers: [


### PR DESCRIPTION
# Description

OpenAPI SDL name is renamed to namespace, and it's now optional.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
