### PR TITLE
chore(cli): Bump to 0.24.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.24.0] - 2023-06-22
+
+[CHANGELOG](changelog/0.24.0.md)
+
 ## [0.23.0] - 2023-06-16
 
 [CHANGELOG](changelog/0.23.0.md)

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -1655,7 +1655,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-compression",
  "async-tar",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "chrono",
  "derivative",
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "axum",
  "base64 0.21.2",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://grafbase.com"

--- a/cli/changelog/0.24.0.md
+++ b/cli/changelog/0.24.0.md
@@ -1,0 +1,6 @@
+## Fixes
+
+- OpenAPI name attribute is now namespace, and is optional
+- Update crates
+- Fix grafbase init -c typescript on folders starting with a dot
+- Fix the CLI failing to start in server mode on some Windows installations

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -38,8 +38,8 @@ url = "2"
 urlencoding = "2"
 walkdir = "2"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.23.0" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.23.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.24.0" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.24.0" }
 
 [build-dependencies]
 cynic-codegen = { version = "3", features = ["rkyv"] }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -34,8 +34,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
 webbrowser = "0.8"
 
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.23.0" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.23.0" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.24.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.24.0" }
 
 [dev-dependencies]
 cfg-if = "1"

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -56,7 +56,7 @@ uuid = { version = "1", features = ["v4"] }
 version-compare = "0.1"
 which = "4"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.23.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.24.0" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,9 +27,9 @@
     "jest": "29.5.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.23.0",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.23.0",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.23.0",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.23.0"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.24.0",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.24.0",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.24.0",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.24.0"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
## Fixes

- OpenAPI name attribute is now namespace, and is optional
- Fix grafbase init -c typescript on folders starting with a dot
- Fix the CLI failing to start in server mode on some Windows installations
