### PR TITLE
feat(auth): GB-3994: Add authorizer runtime

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   GRAFBASE_SKIP_ASSET_VERSION_CHECK: 'true'
-  ASSETS_VERSION: release/8f8e3bc-2023-06-21
+  ASSETS_VERSION: release/630328e-2023-06-23
   PROD_ASSETS: assets.grafbase.com
   CARGO_TERM_COLOR: 'always'
   CARGO_PROFILE_DEV_DEBUG: 0

--- a/cli/crates/cli/tests/auth.rs
+++ b/cli/crates/cli/tests/auth.rs
@@ -583,7 +583,7 @@ async fn authorizer_with_no_headers_should_work() {
     env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(AUTHORIZER_SCHEMA);
     let authorizer_name = "a1";
-    let authorizer_content = r#"export default function(parent, args, context, info) {
+    let authorizer_content = r#"export default function(context) {
         return { identity: { sub:'user1', groups: ['backend'] } };
     }"#;
 
@@ -607,7 +607,7 @@ async fn authorizer_with_headers_should_work() {
     env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(AUTHORIZER_SCHEMA);
     let authorizer_name = "a1";
-    let authorizer_content = r#"export default function(parent, args, context, info) {
+    let authorizer_content = r#"export default function(context) {
         return { identity: { groups: [context.request.headers['h1']] } };
     }"#;
 
@@ -631,7 +631,7 @@ async fn authorizer_with_public_access_should_work() {
     env.grafbase_init(ConfigType::GraphQL);
     env.write_schema(AUTHORIZER_SCHEMA);
     let authorizer_name = "a1";
-    let authorizer_content = r#"export default function(parent, args, context, info) {
+    let authorizer_content = r#"export default function(context) {
         const grp = context.request.headers['h1']
         if (grp) {
             return { identity: { groups: [grp] } };

--- a/cli/crates/cli/tests/auth.rs
+++ b/cli/crates/cli/tests/auth.rs
@@ -582,7 +582,7 @@ async fn authorizer_with_no_headers_should_work() {
         return { identity: { sub:'user1', groups: ['backend'] } };
     }"#;
 
-    env.write_resolver(format!("{authorizer_name}.js"), authorizer_content);
+    env.write_authorizer(format!("{authorizer_name}.js"), authorizer_content);
     env.set_variables(HashMap::from([(
         "AUTHORIZER_NAME".to_string(),
         authorizer_name.to_string(),
@@ -606,7 +606,7 @@ async fn authorizer_with_headers_should_work() {
         return { identity: { groups: [context.request.headers['h1']] } };
     }"#;
 
-    env.write_resolver(format!("{authorizer_name}.js"), authorizer_content);
+    env.write_authorizer(format!("{authorizer_name}.js"), authorizer_content);
     env.set_variables(HashMap::from([(
         "AUTHORIZER_NAME".to_string(),
         authorizer_name.to_string(),

--- a/cli/crates/cli/tests/auth.rs
+++ b/cli/crates/cli/tests/auth.rs
@@ -14,9 +14,10 @@ use std::collections::HashMap;
 use url::Url;
 use utils::async_client::AsyncClient;
 use utils::consts::{
-    AUTH_PUBLIC_GLOBAL_SCHEMA, AUTH_PUBLIC_TYPE_SCHEMA, AUTH_TYPE_FIELD_RESOLVER_SCHEMA, INTROSPECTION_QUERY,
-    JWKS_PROVIDER_WITH_ENDPOINT_SCHEMA, JWKS_PROVIDER_WITH_ISSUER_ENDPOINT_SCHEMA, JWKS_PROVIDER_WITH_ISSUER_SCHEMA,
-    JWT_PROVIDER_QUERY, JWT_PROVIDER_SCHEMA, OIDC_PROVIDER_SCHEMA,
+    AUTH_JWKS_PROVIDER_WITH_ENDPOINT_SCHEMA, AUTH_JWKS_PROVIDER_WITH_ISSUER_ENDPOINT_SCHEMA,
+    AUTH_JWKS_PROVIDER_WITH_ISSUER_SCHEMA, AUTH_JWT_PROVIDER_SCHEMA, AUTH_OIDC_PROVIDER_SCHEMA,
+    AUTH_PUBLIC_GLOBAL_SCHEMA, AUTH_PUBLIC_TYPE_SCHEMA, AUTH_QUERY_TODOS, AUTH_TYPE_FIELD_RESOLVER_SCHEMA,
+    INTROSPECTION_QUERY,
 };
 use utils::environment::Environment;
 use wiremock::matchers::{method, path};
@@ -34,7 +35,7 @@ const JWT_SECRET: &str = "topsecret";
 fn jwt_provider() {
     let mut env = Environment::init();
     env.grafbase_init(ConfigType::GraphQL);
-    env.write_schema(JWT_PROVIDER_SCHEMA);
+    env.write_schema(AUTH_JWT_PROVIDER_SCHEMA);
     env.set_variables(HashMap::from([
         ("ISSUER_URL".to_string(), JWT_ISSUER_URL.to_string()),
         ("JWT_SECRET".to_string(), JWT_SECRET.to_string()),
@@ -45,7 +46,7 @@ fn jwt_provider() {
     client.poll_endpoint(30, 300);
 
     // No auth header -> fail
-    let resp = client.gql::<Value>(JWT_PROVIDER_QUERY).send();
+    let resp = client.gql::<Value>(AUTH_QUERY_TODOS).send();
     let error: String = dot_get_opt!(resp, "errors.0.message").expect("should end with an auth failure");
     assert!(error.contains("Unauthorized"), "error: {error:#?}");
 
@@ -54,27 +55,27 @@ fn jwt_provider() {
 
     // Reject invalid token
     let client = client.with_header("Authorization", "Bearer invalid-token");
-    let resp = client.gql::<Value>(JWT_PROVIDER_QUERY).send();
+    let resp = client.gql::<Value>(AUTH_QUERY_TODOS).send();
     let error: Option<String> = dot_get_opt!(resp, "errors.0.message");
     assert_eq!(error, Some("Unauthorized".to_string()), "error: {error:#?}");
 
     // Reject valid token with wrong group
     let token = generate_hs512_token("cli_user", &["some-group"]);
     let client = client.with_header("Authorization", &format!("Bearer {token}"));
-    let resp = client.gql::<Value>(JWT_PROVIDER_QUERY).send();
+    let resp = client.gql::<Value>(AUTH_QUERY_TODOS).send();
     let error: String = dot_get_opt!(resp, "errors.0.message").expect("should end with an auth failure");
     assert!(error.contains("Unauthorized"), "error: {error:#?}");
 
     // Accept valid token with correct group
     let token = generate_hs512_token("cli_user", &["backend"]);
     let client = client.with_header("Authorization", &format!("Bearer {token}"));
-    let resp = client.gql::<Value>(JWT_PROVIDER_QUERY).send();
+    let resp = client.gql::<Value>(AUTH_QUERY_TODOS).send();
     let errors: Option<Value> = dot_get_opt!(resp, "errors");
     assert!(errors.is_none(), "errors: {errors:#?}");
 
     // accept authorization via an API key
     let client = client.with_cleared_headers().with_api_key();
-    let resp = client.gql::<Value>(JWT_PROVIDER_QUERY).send();
+    let resp = client.gql::<Value>(AUTH_QUERY_TODOS).send();
     let errors: Option<Value> = dot_get_opt!(resp, "errors");
     assert!(errors.is_none(), "errors: {errors:#?}");
 }
@@ -225,7 +226,7 @@ async fn set_up_oidc_with_path(path: Option<&str>) -> SetUpOidc {
     set_up_oidc_server(&issuer_url, &server, key_set).await;
     let mut env = Environment::init_async().await;
     env.grafbase_init(ConfigType::GraphQL);
-    env.write_schema(OIDC_PROVIDER_SCHEMA);
+    env.write_schema(AUTH_OIDC_PROVIDER_SCHEMA);
     env.set_variables(HashMap::from([("ISSUER_URL".to_string(), issuer_url.to_string())]));
     env.grafbase_dev();
     let client = env.create_async_client();
@@ -271,7 +272,7 @@ async fn oidc_without_token_should_only_allow_introspection() {
     let set_up = set_up_oidc().await;
 
     // No auth header -> fail
-    let resp = set_up.client.gql::<Value>(JWT_PROVIDER_QUERY).await;
+    let resp = set_up.client.gql::<Value>(AUTH_QUERY_TODOS).await;
     let error: String = dot_get_opt!(resp, "errors.0.message").expect("response should contain an error");
     assert!(error.contains("Unauthorized"), "error: {error:#?}");
 
@@ -291,7 +292,7 @@ async fn oidc_token_with_valid_group_should_work() {
         KEY_ID,
     );
     let client = set_up.client.with_header("Authorization", &format!("Bearer {token}"));
-    let resp = client.gql::<Value>(JWT_PROVIDER_QUERY).await;
+    let resp = client.gql::<Value>(AUTH_QUERY_TODOS).await;
     let errors: Option<Value> = dot_get_opt!(resp, "errors");
     assert!(errors.is_none(), "errors: {errors:#?}");
 }
@@ -307,7 +308,7 @@ async fn oidc_with_path_with_trailing_slash_should_work() {
         KEY_ID,
     );
     let client = set_up.client.with_header("Authorization", &format!("Bearer {token}"));
-    let resp = client.gql::<Value>(JWT_PROVIDER_QUERY).await;
+    let resp = client.gql::<Value>(AUTH_QUERY_TODOS).await;
     let errors: Option<Value> = dot_get_opt!(resp, "errors");
     assert!(errors.is_none(), "errors: {errors:#?}");
 }
@@ -323,7 +324,7 @@ async fn oidc_with_path_without_trailing_slash_should_work() {
         KEY_ID,
     );
     let client = set_up.client.with_header("Authorization", &format!("Bearer {token}"));
-    let resp = client.gql::<Value>(JWT_PROVIDER_QUERY).await;
+    let resp = client.gql::<Value>(AUTH_QUERY_TODOS).await;
     let errors: Option<Value> = dot_get_opt!(resp, "errors");
     assert!(errors.is_none(), "errors: {errors:#?}");
 }
@@ -340,7 +341,7 @@ async fn oidc_token_with_wrong_group_should_fail() {
         KEY_ID,
     );
     let client = set_up.client.with_header("Authorization", &format!("Bearer {token}"));
-    let resp = client.gql::<Value>(JWT_PROVIDER_QUERY).await;
+    let resp = client.gql::<Value>(AUTH_QUERY_TODOS).await;
     let error: Option<String> = dot_get_opt!(resp, "errors.0.message");
     assert_eq!(
         error,
@@ -361,14 +362,14 @@ async fn oidc_token_with_wrong_kid_should_fail() {
         "other-id",
     );
     let client = set_up.client.with_header("Authorization", &format!("Bearer {token}"));
-    let resp = client.gql::<Value>(JWT_PROVIDER_QUERY).await;
+    let resp = client.gql::<Value>(AUTH_QUERY_TODOS).await;
     let error: Option<String> = dot_get_opt!(resp, "errors.0.message");
     assert_eq!(error, Some("Unauthorized".to_string()));
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn jwks_issuer_token_with_valid_group_should_work() {
-    let set_up = set_up_jwks(JWKS_PROVIDER_WITH_ISSUER_SCHEMA, JWKS_PATH, |issuer_url: &Url| {
+    let set_up = set_up_jwks(AUTH_JWKS_PROVIDER_WITH_ISSUER_SCHEMA, JWKS_PATH, |issuer_url: &Url| {
         HashMap::from([("ISSUER_URL".to_string(), issuer_url.to_string())])
     })
     .await;
@@ -381,7 +382,7 @@ async fn jwks_issuer_token_with_valid_group_should_work() {
         KEY_ID,
     );
     let client = set_up.client.with_header("Authorization", &format!("Bearer {token}"));
-    let resp = client.gql::<Value>(JWT_PROVIDER_QUERY).await;
+    let resp = client.gql::<Value>(AUTH_QUERY_TODOS).await;
     let errors: Option<Value> = dot_get_opt!(resp, "errors");
     assert!(errors.is_none(), "errors: {errors:#?}");
 }
@@ -389,12 +390,16 @@ async fn jwks_issuer_token_with_valid_group_should_work() {
 #[tokio::test(flavor = "multi_thread")]
 async fn jwks_endoint_token_with_valid_group_should_work() {
     const ENDPOINT_PATH: &str = "custom/jwks.json";
-    let set_up = set_up_jwks(JWKS_PROVIDER_WITH_ENDPOINT_SCHEMA, ENDPOINT_PATH, |issuer_url: &Url| {
-        HashMap::from([(
-            "JWKS_ENDPOINT_URL".to_string(),
-            issuer_url.join(ENDPOINT_PATH).unwrap().to_string(),
-        )])
-    })
+    let set_up = set_up_jwks(
+        AUTH_JWKS_PROVIDER_WITH_ENDPOINT_SCHEMA,
+        ENDPOINT_PATH,
+        |issuer_url: &Url| {
+            HashMap::from([(
+                "JWKS_ENDPOINT_URL".to_string(),
+                issuer_url.join(ENDPOINT_PATH).unwrap().to_string(),
+            )])
+        },
+    )
     .await;
 
     let token = generate_rs256_token(
@@ -405,7 +410,7 @@ async fn jwks_endoint_token_with_valid_group_should_work() {
         KEY_ID,
     );
     let client = set_up.client.with_header("Authorization", &format!("Bearer {token}"));
-    let resp = client.gql::<Value>(JWT_PROVIDER_QUERY).await;
+    let resp = client.gql::<Value>(AUTH_QUERY_TODOS).await;
     let errors: Option<Value> = dot_get_opt!(resp, "errors");
     assert!(errors.is_none(), "errors: {errors:#?}");
 }
@@ -414,7 +419,7 @@ async fn jwks_endoint_token_with_valid_group_should_work() {
 async fn jwks_endoint_and_issuer_token_with_valid_group_should_work() {
     const ENDPOINT_PATH: &str = "custom/jwks.json";
     let set_up = set_up_jwks(
-        JWKS_PROVIDER_WITH_ISSUER_ENDPOINT_SCHEMA,
+        AUTH_JWKS_PROVIDER_WITH_ISSUER_ENDPOINT_SCHEMA,
         ENDPOINT_PATH,
         |issuer_url: &Url| {
             HashMap::from([
@@ -436,7 +441,7 @@ async fn jwks_endoint_and_issuer_token_with_valid_group_should_work() {
         KEY_ID,
     );
     let client = set_up.client.with_header("Authorization", &format!("Bearer {token}"));
-    let resp = client.gql::<Value>(JWT_PROVIDER_QUERY).await;
+    let resp = client.gql::<Value>(AUTH_QUERY_TODOS).await;
     let errors: Option<Value> = dot_get_opt!(resp, "errors");
     assert!(errors.is_none(), "errors: {errors:#?}");
 }
@@ -453,7 +458,7 @@ async fn public_global() {
     env.grafbase_dev();
     let client = env.create_async_client();
     client.poll_endpoint(30, 300).await;
-    let resp = client.gql::<Value>(JWT_PROVIDER_QUERY).await;
+    let resp = client.gql::<Value>(AUTH_QUERY_TODOS).await;
     insta::assert_json_snapshot!("public_global", resp);
 }
 
@@ -469,7 +474,7 @@ async fn public_type() {
     env.grafbase_dev();
     let client = env.create_async_client();
     client.poll_endpoint(30, 300).await;
-    let resp = client.gql::<Value>(JWT_PROVIDER_QUERY).await;
+    let resp = client.gql::<Value>(AUTH_QUERY_TODOS).await;
     insta::assert_json_snapshot!("public_type", resp);
 }
 
@@ -514,7 +519,7 @@ async fn type_field_resolver_mixed() {
     );
     insta::assert_json_snapshot!(
         "type_field_resolver_mixed__public_partial_query_should_succeed",
-        public_client.gql::<Value>(JWT_PROVIDER_QUERY).await
+        public_client.gql::<Value>(AUTH_QUERY_TODOS).await
     );
 }
 
@@ -617,5 +622,47 @@ async fn authorizer_with_headers_should_work() {
     insta::assert_json_snapshot!(
         "authorizer_with_headers_should_work__todo_creation_should_succeed",
         client.gql::<Value>(AUTH_CREATE_MUTATION).await
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn authorizer_with_public_access_should_work() {
+    let mut env = Environment::init_async().await;
+    env.grafbase_init(ConfigType::GraphQL);
+    env.write_schema(AUTHORIZER_SCHEMA);
+    let authorizer_name = "a1";
+    let authorizer_content = r#"export default function(parent, args, context, info) {
+        const grp = context.request.headers['h1']
+        if (grp) {
+            return { identity: { groups: [grp] } };
+        } else {
+            return {}; // missing identity = public access
+        }
+    }"#;
+
+    env.write_authorizer(format!("{authorizer_name}.js"), authorizer_content);
+    env.set_variables(HashMap::from([(
+        "AUTHORIZER_NAME".to_string(),
+        authorizer_name.to_string(),
+    )]));
+    env.grafbase_dev();
+    let private_client = env.create_async_client().with_header("h1", "backend");
+    private_client.poll_endpoint(30, 300).await;
+    insta::assert_json_snapshot!(
+        "authorizer_with_public_access_should_work__todo_creation_should_succeed",
+        private_client.gql::<Value>(AUTH_CREATE_MUTATION).await
+    );
+    insta::assert_json_snapshot!(
+        "authorizer_with_public_access_should_work__todo_list_should_succeed",
+        private_client.gql::<Value>(AUTH_QUERY_TODOS).await
+    );
+    let public_client = env.create_async_client();
+    insta::assert_json_snapshot!(
+        "authorizer_with_public_access_should_work__todo_creation_with_public_access_should_fail",
+        public_client.gql::<Value>(AUTH_CREATE_MUTATION).await
+    );
+    insta::assert_json_snapshot!(
+        "authorizer_with_public_access_should_work__todo_list_should_succeed",
+        private_client.gql::<Value>(AUTH_QUERY_TODOS).await
     );
 }

--- a/cli/crates/cli/tests/graphql/auth/authorizer/authorizer.graphql
+++ b/cli/crates/cli/tests/graphql/auth/authorizer/authorizer.graphql
@@ -1,0 +1,13 @@
+schema
+  @auth(
+    providers: [{ type: authorizer, name: "{{ env.AUTHORIZER_NAME }}" }]
+    rules: [{ allow: groups, groups: ["backend"] }]
+  ) {
+  query: Query
+}
+
+type Todo @model {
+  id: ID!
+  title: String!
+  complete: Boolean!
+}

--- a/cli/crates/cli/tests/graphql/auth/authorizer/authorizer.graphql
+++ b/cli/crates/cli/tests/graphql/auth/authorizer/authorizer.graphql
@@ -1,7 +1,7 @@
 schema
   @auth(
     providers: [{ type: authorizer, name: "{{ env.AUTHORIZER_NAME }}" }]
-    rules: [{ allow: groups, groups: ["backend"] }]
+    rules: [{ allow: groups, groups: ["backend"] }, { allow: public, operations: [read] }]
   ) {
   query: Query
 }

--- a/cli/crates/cli/tests/snapshots/auth__authorizer_with_headers_should_work__todo_creation_should_succeed.snap
+++ b/cli/crates/cli/tests/snapshots/auth__authorizer_with_headers_should_work__todo_creation_should_succeed.snap
@@ -1,0 +1,14 @@
+---
+source: crates/cli/tests/auth.rs
+expression: "client.gql::<Value>(AUTH_CREATE_MUTATION).await"
+---
+{
+  "data": {
+    "todoCreate": {
+      "__typename": "TodoCreatePayload",
+      "todo": {
+        "title": "1"
+      }
+    }
+  }
+}

--- a/cli/crates/cli/tests/snapshots/auth__authorizer_with_no_headers_should_work__todo_creation_should_succeed.snap
+++ b/cli/crates/cli/tests/snapshots/auth__authorizer_with_no_headers_should_work__todo_creation_should_succeed.snap
@@ -1,0 +1,14 @@
+---
+source: crates/cli/tests/auth.rs
+expression: "client.gql::<Value>(AUTH_CREATE_MUTATION).await"
+---
+{
+  "data": {
+    "todoCreate": {
+      "__typename": "TodoCreatePayload",
+      "todo": {
+        "title": "1"
+      }
+    }
+  }
+}

--- a/cli/crates/cli/tests/snapshots/auth__authorizer_with_public_access_should_work__todo_creation_should_succeed.snap
+++ b/cli/crates/cli/tests/snapshots/auth__authorizer_with_public_access_should_work__todo_creation_should_succeed.snap
@@ -1,0 +1,14 @@
+---
+source: crates/cli/tests/auth.rs
+expression: "private_client.gql::<Value>(AUTH_CREATE_MUTATION).await"
+---
+{
+  "data": {
+    "todoCreate": {
+      "__typename": "TodoCreatePayload",
+      "todo": {
+        "title": "1"
+      }
+    }
+  }
+}

--- a/cli/crates/cli/tests/snapshots/auth__authorizer_with_public_access_should_work__todo_creation_with_public_access_should_fail.snap
+++ b/cli/crates/cli/tests/snapshots/auth__authorizer_with_public_access_should_work__todo_creation_with_public_access_should_fail.snap
@@ -1,0 +1,12 @@
+---
+source: crates/cli/tests/auth.rs
+expression: "public_client.gql::<Value>(AUTH_CREATE_MUTATION).await"
+---
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "Unauthorized to access Mutation.todoCreate (missing create operation)"
+    }
+  ]
+}

--- a/cli/crates/cli/tests/snapshots/auth__authorizer_with_public_access_should_work__todo_list_should_succeed.snap
+++ b/cli/crates/cli/tests/snapshots/auth__authorizer_with_public_access_should_work__todo_list_should_succeed.snap
@@ -1,0 +1,18 @@
+---
+source: crates/cli/tests/auth.rs
+expression: "private_client.gql::<Value>(AUTH_QUERY_TODOS).await"
+---
+{
+  "data": {
+    "todoCollection": {
+      "__typename": "TodoConnection",
+      "edges": [
+        {
+          "node": {
+            "title": "1"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/cli/crates/cli/tests/utils/consts.rs
+++ b/cli/crates/cli/tests/utils/consts.rs
@@ -68,14 +68,13 @@ pub const SEARCH_SEARCH_PERSON: &str = include_str!("../graphql/search/search-pe
 
 pub const ENVIRONMENT_SCHEMA: &str = include_str!("../graphql/environment/schema.graphql");
 
-pub const JWT_PROVIDER_SCHEMA: &str = include_str!("../graphql/auth/jwt.graphql");
-pub const JWT_PROVIDER_QUERY: &str = include_str!("../graphql/auth/query.graphql");
-pub const OIDC_PROVIDER_SCHEMA: &str = include_str!("../graphql/auth/oidc.graphql");
-pub const JWKS_PROVIDER_WITH_ISSUER_SCHEMA: &str = include_str!("../graphql/auth/jwks-issuer.graphql");
-pub const JWKS_PROVIDER_WITH_ENDPOINT_SCHEMA: &str = include_str!("../graphql/auth/jwks-endpoint.graphql");
-pub const JWKS_PROVIDER_WITH_ISSUER_ENDPOINT_SCHEMA: &str =
+pub const AUTH_JWT_PROVIDER_SCHEMA: &str = include_str!("../graphql/auth/jwt.graphql");
+pub const AUTH_QUERY_TODOS: &str = include_str!("../graphql/auth/query.graphql");
+pub const AUTH_OIDC_PROVIDER_SCHEMA: &str = include_str!("../graphql/auth/oidc.graphql");
+pub const AUTH_JWKS_PROVIDER_WITH_ISSUER_SCHEMA: &str = include_str!("../graphql/auth/jwks-issuer.graphql");
+pub const AUTH_JWKS_PROVIDER_WITH_ENDPOINT_SCHEMA: &str = include_str!("../graphql/auth/jwks-endpoint.graphql");
+pub const AUTH_JWKS_PROVIDER_WITH_ISSUER_ENDPOINT_SCHEMA: &str =
     include_str!("../graphql/auth/jwks-issuer-endpoint.graphql");
-
 pub const AUTH_PUBLIC_GLOBAL_SCHEMA: &str = include_str!("../graphql/auth/public-global.graphql");
 pub const AUTH_PUBLIC_TYPE_SCHEMA: &str = include_str!("../graphql/auth/public-type.graphql");
 pub const AUTH_TYPE_FIELD_RESOLVER_SCHEMA: &str = include_str!("../graphql/auth/type-field-resolver.graphql");

--- a/cli/crates/cli/tests/utils/consts.rs
+++ b/cli/crates/cli/tests/utils/consts.rs
@@ -86,6 +86,8 @@ pub const AUTH_ENTRYPOINT_FIELD_RESOLVER_SCHEMA: &str =
 pub const AUTH_ENTRYPOINT_QUERY_TEXT: &str = include_str!("../graphql/auth/entrypoint-query-text.graphql");
 pub const AUTH_ENTRYPOINT_MUTATION_TEXT: &str = include_str!("../graphql/auth/entrypoint-mutation-text.graphql");
 
+pub const AUTHORIZER_SCHEMA: &str = include_str!("../graphql/auth/authorizer/authorizer.graphql");
+
 pub const INTROSPECTION_QUERY: &str = include_str!("../graphql/introspection.graphql");
 
 pub const RESERVED_DATES_SCHEMA: &str = include_str!("../graphql/reserved_dates/schema.graphql");

--- a/cli/crates/cli/tests/utils/environment.rs
+++ b/cli/crates/cli/tests/utils/environment.rs
@@ -190,6 +190,11 @@ impl Environment {
     }
 
     #[track_caller]
+    pub fn write_authorizer(&self, path: impl AsRef<Path>, contents: impl AsRef<str>) {
+        self.write_file(Path::new("auth").join(path.as_ref()), contents);
+    }
+
+    #[track_caller]
     pub fn write_file(&self, path: impl AsRef<Path>, contents: impl AsRef<str>) {
         let target_path = self.schema_path.parent().unwrap().join(path.as_ref());
         fs::create_dir_all(target_path.parent().unwrap()).unwrap();

--- a/cli/crates/common/src/consts.rs
+++ b/cli/crates/common/src/consts.rs
@@ -20,6 +20,8 @@ pub const DOT_GRAFBASE_DIRECTORY: &str = ".grafbase";
 pub const REGISTRY_FILE: &str = "registry.json";
 /// the /resolvers directory containing resolver implementations
 pub const RESOLVERS_DIRECTORY_NAME: &str = "resolvers";
+/// the /auth directory containing custom authorizers
+pub const AUTHORIZERS_DIRECTORY_NAME: &str = "auth";
 /// the wrangler installation directory within ~/.grafbase
 pub const WRANGLER_DIRECTORY_NAME: &str = "wrangler";
 /// the tracing filter to be used when tracing is on

--- a/cli/crates/common/src/environment.rs
+++ b/cli/crates/common/src/environment.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use crate::consts::AUTHORIZERS_DIRECTORY_NAME;
 use crate::{
     consts::{
         DATABASE_DIRECTORY, DOT_GRAFBASE_DIRECTORY, GRAFBASE_DIRECTORY_NAME, GRAFBASE_HOME, GRAFBASE_SCHEMA_FILE_NAME,
@@ -113,6 +114,10 @@ pub struct Project {
     pub resolvers_source_path: PathBuf,
     /// the path within `$PROJECT/.grafbase/` containing build artifacts for custom resolvers.
     pub resolvers_build_artifact_path: PathBuf,
+    /// the path of the `grafbase/auth` directory.
+    pub authorizers_source_path: PathBuf,
+    /// the path within `$PROJECT/.grafbase/` containing build artifacts for custom resolvers.
+    pub authorizers_build_artifact_path: PathBuf,
     /// the path within '$PROJECT/.grafbase' containing the database
     pub database_directory_path: PathBuf,
 }
@@ -172,6 +177,8 @@ impl Project {
         let registry_path = dot_grafbase_directory_path.join(REGISTRY_FILE);
         let resolvers_source_path = grafbase_directory_path.join(RESOLVERS_DIRECTORY_NAME);
         let resolvers_build_artifact_path = dot_grafbase_directory_path.join(RESOLVERS_DIRECTORY_NAME);
+        let authorizers_source_path = grafbase_directory_path.join(AUTHORIZERS_DIRECTORY_NAME);
+        let authorizers_build_artifact_path = dot_grafbase_directory_path.join(AUTHORIZERS_DIRECTORY_NAME);
         let database_directory_path = dot_grafbase_directory_path.join(DATABASE_DIRECTORY);
 
         Ok(Project {
@@ -182,6 +189,8 @@ impl Project {
             registry_path,
             resolvers_source_path,
             resolvers_build_artifact_path,
+            authorizers_source_path,
+            authorizers_build_artifact_path,
             database_directory_path,
         })
     }

--- a/cli/crates/common/src/types.rs
+++ b/cli/crates/common/src/types.rs
@@ -30,6 +30,7 @@ impl LocalAddressType {
 #[derive(Clone, Copy, Debug, serde::Deserialize, strum::Display)]
 pub enum UdfKind {
     Resolver,
+    Authorizer,
 }
 
 // FIXME: remove after api repo is updated

--- a/cli/crates/server/src/bridge/udf.rs
+++ b/cli/crates/server/src/bridge/udf.rs
@@ -108,7 +108,7 @@ pub async fn spawn_miniflare(
             let lines_stream = LinesStream::new(tokio::io::BufReader::new(stdout).lines())
                 .inspect_ok(|line| trace!("miniflare: {line}"));
 
-            let filtered_lines_stream = lines_stream.try_filter_map(|line| {
+            let filtered_lines_stream = lines_stream.try_filter_map(|line: String| {
                 futures_util::future::ready(Ok(line
                     .split("Listening on")
                     .skip(1)

--- a/cli/crates/server/src/bridge/udf.rs
+++ b/cli/crates/server/src/bridge/udf.rs
@@ -156,7 +156,7 @@ pub async fn invoke(
     payload: &serde_json::Value,
 ) -> Result<serde_json::Value, ApiError> {
     use futures_util::TryFutureExt;
-    trace!("Invocation of {udf_kind} '{udf_name}'");
+    trace!("Invocation of {udf_kind} '{udf_name}' with payload {payload}");
     let json_string = reqwest::Client::new()
         .post(format!("http://127.0.0.1:{udf_worker_port}/invoke"))
         .json(&payload)

--- a/cli/crates/server/src/errors.rs
+++ b/cli/crates/server/src/errors.rs
@@ -17,8 +17,8 @@ use crate::udf_builder::JavaScriptPackageManager;
 #[derive(Error, Debug)]
 pub enum JavascriptPackageManagerComamndError {
     /// returned if npm/pnpm/yarn cannot be found
-    #[error("could not find {0}: {1}")]
-    NotFound(JavaScriptPackageManager, which::Error),
+    #[error("could not find {0:?}: {1}")]
+    NotFound(Option<JavaScriptPackageManager>, String),
 
     /// returned if any of the npm/pnpm/yarn commands exits unsuccessfully
     #[error("{0} encountered an error: {1}")]

--- a/cli/crates/server/src/errors.rs
+++ b/cli/crates/server/src/errors.rs
@@ -18,9 +18,11 @@ use crate::udf_builder::JavaScriptPackageManager;
 pub enum JavascriptPackageManagerComamndError {
     #[error("working directory '{0}' not found")]
     WorkingDirectoryNotFound(PathBuf),
+    #[error("working directory '{0}' cannot be read.\nCaused by: {1}")]
+    WorkingDirectoryCannotBeRead(PathBuf, std::io::Error),
     /// returned if npm/pnpm/yarn cannot be found
     #[error("could not find {0}: {1}")]
-    NotFound(JavaScriptPackageManager, String),
+    NotFound(JavaScriptPackageManager, which::Error),
 
     /// returned if any of the npm/pnpm/yarn commands exits unsuccessfully
     #[error("{0} encountered an error: {1}")]

--- a/cli/crates/server/src/errors.rs
+++ b/cli/crates/server/src/errors.rs
@@ -16,9 +16,11 @@ use crate::udf_builder::JavaScriptPackageManager;
 
 #[derive(Error, Debug)]
 pub enum JavascriptPackageManagerComamndError {
+    #[error("working directory '{0}' not found")]
+    WorkingDirectoryNotFound(PathBuf),
     /// returned if npm/pnpm/yarn cannot be found
-    #[error("could not find {0:?}: {1}")]
-    NotFound(Option<JavaScriptPackageManager>, String),
+    #[error("could not find {0}: {1}")]
+    NotFound(JavaScriptPackageManager, String),
 
     /// returned if any of the npm/pnpm/yarn commands exits unsuccessfully
     #[error("{0} encountered an error: {1}")]

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -6,7 +6,7 @@ use crate::error_server;
 use crate::event::{wait_for_event, wait_for_event_and_match, Event};
 use crate::file_watcher::start_watcher;
 use crate::types::{ServerMessage, ASSETS_GZIP};
-use crate::udf_builder::maybe_install_wrangler;
+use crate::udf_builder::install_wrangler;
 use crate::{bridge, errors::ServerError};
 use common::consts::{
     EPHEMERAL_PORT_RANGE, GRAFBASE_DIRECTORY_NAME, GRAFBASE_SCHEMA_FILE_NAME, GRAFBASE_TS_CONFIG_FILE_NAME,
@@ -135,7 +135,10 @@ async fn spawn_servers(
 
     let environment_variables: std::collections::HashMap<_, _> = crate::environment::variables().collect();
 
-    let mut resolvers = match run_schema_parser(&environment_variables).await {
+    let ParsingResponse {
+        mut detected_resolvers,
+        requires_udf,
+    } = match run_schema_parser(&environment_variables).await {
         Ok(resolvers) => resolvers,
         Err(error) => {
             let _: Result<_, _> = sender.send(ServerMessage::CompilationError(error.to_string()));
@@ -158,7 +161,7 @@ async fn spawn_servers(
         .filter(|(dir, path)| path != &dir.join(GRAFBASE_TS_CONFIG_FILE_NAME))
         .is_some()
     {
-        for resolver in &mut resolvers {
+        for resolver in &mut detected_resolvers {
             resolver.fresh = false;
         }
     }
@@ -166,15 +169,19 @@ async fn spawn_servers(
     let environment = Environment::get();
     let project = Project::get();
 
-    if let Err(error) = maybe_install_wrangler(environment, resolvers, tracing).await {
-        let _: Result<_, _> = sender.send(ServerMessage::CompilationError(error.to_string()));
-        // TODO consider disabling colored output from wrangler
-        let error = strip_ansi_escapes::strip(error.to_string().as_bytes())
-            .ok()
-            .and_then(|stripped| String::from_utf8(stripped).ok())
-            .unwrap_or_else(|| error.to_string());
-        tokio::spawn(async move { error_server::start(worker_port, error, bridge_event_bus).await }).await??;
-        return Ok(());
+    if requires_udf {
+        if let Err(error) = install_wrangler(environment, tracing).await {
+            let _: Result<_, _> = sender.send(ServerMessage::CompilationError(error.to_string()));
+            // TODO consider disabling colored output from wrangler
+            let error = strip_ansi_escapes::strip(error.to_string().as_bytes())
+                .ok()
+                .and_then(|stripped| String::from_utf8(stripped).ok())
+                .unwrap_or_else(|| error.to_string());
+            tokio::spawn(async move { error_server::start(worker_port, error, bridge_event_bus).await }).await??;
+            return Ok(());
+        }
+    } else {
+        trace!("Skipping wrangler installation");
     }
 
     let (bridge_sender, mut bridge_receiver) = tokio::sync::mpsc::channel(128);
@@ -349,6 +356,7 @@ struct SchemaParserResult {
     #[allow(dead_code)]
     required_resolvers: Vec<String>,
     versioned_registry: serde_json::Value,
+    requires_udf: bool,
 }
 
 pub struct DetectedResolver {
@@ -356,11 +364,16 @@ pub struct DetectedResolver {
     pub fresh: bool,
 }
 
-// schema-parser is run via NodeJS due to it being built to run in a Wasm (via wasm-bindgen) environement
+pub struct ParsingResponse {
+    detected_resolvers: Vec<DetectedResolver>,
+    requires_udf: bool,
+}
+
+// schema-parser is run via NodeJS due to it being built to run in a Wasm (via wasm-bindgen) environment
 // and due to schema-parser not being open source
 async fn run_schema_parser(
     environment_variables: &std::collections::HashMap<String, String>,
-) -> Result<Vec<DetectedResolver>, ServerError> {
+) -> Result<ParsingResponse, ServerError> {
     trace!("parsing schema");
     let environment = Environment::get();
     let project = Project::get();
@@ -421,9 +434,11 @@ async fn run_schema_parser(
     let parser_result_string = tokio::fs::read_to_string(&parser_result_path)
         .await
         .map_err(ServerError::SchemaParserResultRead)?;
+
     let SchemaParserResult {
         versioned_registry,
         required_resolvers,
+        requires_udf,
     } = serde_json::from_str(&parser_result_string).map_err(ServerError::SchemaParserResultJson)?;
 
     let registry_mtime = tokio::fs::metadata(&project.registry_path)
@@ -457,8 +472,10 @@ async fn run_schema_parser(
     )
     .await
     .map_err(ServerError::SchemaRegistryWrite)?;
-
-    Ok(detected_resolvers)
+    Ok(ParsingResponse {
+        detected_resolvers,
+        requires_udf,
+    })
 }
 
 /// Parses a TypeScript Grafbase configuration and generates a GraphQL schema

--- a/cli/crates/server/src/udf_builder.rs
+++ b/cli/crates/server/src/udf_builder.rs
@@ -148,10 +148,12 @@ pub async fn build(
     let package_root_path = project.grafbase_directory_path.as_path();
     let udf_input_file_path_without_extension = match udf_kind {
         UdfKind::Resolver => project.resolvers_source_path.join(udf_name),
+        UdfKind::Authorizer => project.authorizers_source_path.join(udf_name),
     };
 
     let udf_build_artifact_directory_path = match udf_kind {
         UdfKind::Resolver => project.resolvers_build_artifact_path.join(udf_name),
+        UdfKind::Authorizer => project.authorizers_build_artifact_path.join(udf_name),
     };
 
     let mut udf_input_file_path = None;
@@ -247,6 +249,9 @@ pub async fn build(
         UdfKind::Resolver => udf_build_artifact_directory_path
             .join("resolver")
             .with_extension(udf_input_file_path.extension().unwrap()),
+        UdfKind::Authorizer => udf_build_artifact_directory_path
+            .join("auth")
+            .with_extension(udf_input_file_path.extension().unwrap()),
     };
 
     trace!("Copying the main file of the {udf_kind}");
@@ -257,11 +262,6 @@ pub async fn build(
 
     let udf_wrapper_worker_contents = udf_wrapper_worker_contents.replace(
         "${UDF_MAIN_FILE_PATH}",
-        udf_js_file_path.to_slash().expect("must be valid UTF-8").as_ref(),
-    );
-    // TODO: remove after wrapper-worker.js in api repo is updated.
-    let udf_wrapper_worker_contents = udf_wrapper_worker_contents.replace(
-        "${RESOLVER_MAIN_FILE_PATH}",
         udf_js_file_path.to_slash().expect("must be valid UTF-8").as_ref(),
     );
     tokio::fs::write(&udf_build_entrypoint_path, udf_wrapper_worker_contents)

--- a/cli/crates/server/src/udf_builder.rs
+++ b/cli/crates/server/src/udf_builder.rs
@@ -20,9 +20,8 @@ async fn run_command<P: AsRef<Path>>(
     let command_string = format!("{command_type} {}", arguments.iter().format(" "));
     let current_directory = current_directory.as_ref();
     if !current_directory.exists() {
-        return Err(JavascriptPackageManagerComamndError::NotFound(
-            None,
-            format!("Working directory not found: {current_directory:?}"),
+        return Err(JavascriptPackageManagerComamndError::WorkingDirectoryNotFound(
+            current_directory.to_owned(),
         ));
     }
     debug!("running '{command_string}'");
@@ -30,7 +29,7 @@ async fn run_command<P: AsRef<Path>>(
     // Use `which` to work-around weird path search issues on Windows.
     // See https://github.com/rust-lang/rust/issues/37519.
     let program_path = which::which(command_type.to_string())
-        .map_err(|err| JavascriptPackageManagerComamndError::NotFound(Some(command_type), err.to_string()))?;
+        .map_err(|err| JavascriptPackageManagerComamndError::NotFound(command_type, err.to_string()))?;
 
     let mut command = Command::new(program_path);
     command


### PR DESCRIPTION
# Description

Add new UdfKind::Authorizer, running the custom auth provider. Use `requires_udf` flag to install wrangler. Add tests for authorizer.

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [x] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
