### PR TITLE
feat(cli): Init installs dependencies, if using npm

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1843,6 +1843,7 @@ dependencies = [
  "strum",
  "thiserror",
  "ulid",
+ "which",
 ]
 
 [[package]]
@@ -1871,7 +1872,6 @@ dependencies = [
  "slug",
  "sqlx",
  "strip-ansi-escapes",
- "strum",
  "tantivy",
  "tar",
  "tempfile",

--- a/cli/crates/backend/src/errors.rs
+++ b/cli/crates/backend/src/errors.rs
@@ -108,6 +108,9 @@ pub enum BackendError {
     #[error("could not read the repository information for {0}")]
     ReadRepositoryInformation(String),
 
+    #[error("could not find 'npm':\nCaused by: {0}")]
+    NpmNotFound(Box<dyn std::error::Error + Send>),
+
     // wraps a [`CommonError`]
     #[error(transparent)]
     CommonError(#[from] CommonError),

--- a/cli/crates/cli/src/init.rs
+++ b/cli/crates/cli/src/init.rs
@@ -1,5 +1,10 @@
-use crate::{cli_input::ConfigFormat, errors::CliError, output::report, prompts::handle_inquire_error};
-use backend::project::{self, ConfigType, Template};
+use crate::{
+    cli_input::ConfigFormat, errors::CliError, output::report, prompts::handle_inquire_error, watercolor::watercolor,
+};
+use backend::{
+    errors::BackendError,
+    project::{self, ConfigType, Template},
+};
 use inquire::Select;
 
 pub fn init(name: Option<&str>, template: Option<&str>, config_format: Option<ConfigFormat>) -> Result<(), CliError> {
@@ -19,8 +24,18 @@ pub fn init(name: Option<&str>, template: Option<&str>, config_format: Option<Co
         }
     };
 
-    project::init(name, template).map_err(CliError::BackendError)?;
-    report::project_created(name, template);
+    match project::init(name, template) {
+        Ok(_) => report::project_created(name, template),
+        Err(BackendError::NpmNotFound(_)) => {
+            report::project_created(name, template);
+
+            println!(
+                "We've added our SDK to your {}, make sure to install dependencies before continuing.",
+                watercolor!("package.json", @BrightBlue)
+            );
+        }
+        Err(e) => return Err(CliError::BackendError(e)),
+    }
 
     Ok(())
 }

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -70,13 +70,6 @@ pub fn project_created(name: Option<&str>, template: Template<'_>) {
             watercolor!("{schema_path}", @BrightBlue)
         );
     }
-
-    if let Template::FromDefault(ConfigType::TypeScript) = template {
-        println!(
-            "We've added our SDK to your {}, make sure to install dependencies before continuing.",
-            watercolor!("package.json", @BrightBlue)
-        );
-    }
 }
 
 /// reports an error to stderr

--- a/cli/crates/cli/tests/init_ts.rs
+++ b/cli/crates/cli/tests/init_ts.rs
@@ -34,6 +34,113 @@ fn init_ts_existing_package_json() {
     assert!(env.directory.join("grafbase").exists());
     assert!(env.directory.join("grafbase").join("grafbase.config.ts").exists());
 
+    assert!(env.directory.join("package-lock.json").exists());
+    assert!(env.directory.join("node_modules").exists());
+
+    let package_json = env.load_file_from_project("package.json");
+
+    insta::assert_snapshot!(&package_json, @r###"
+    {
+      "name": "test",
+      "version": "1.0.0",
+      "description": "",
+      "main": "index.js",
+      "keywords": [],
+      "author": "",
+      "license": "ISC",
+      "devDependencies": {
+        "@grafbase/sdk": "~0.1.0"
+      }
+    }
+    "###);
+}
+
+#[test]
+fn init_ts_existing_package_json_pnpm_project() {
+    let env = Environment::init();
+
+    env.write_json_file_to_project(
+        "package.json",
+        &json!({
+          "name": "test",
+          "version": "1.0.0",
+          "description": "",
+          "main": "index.js",
+          "keywords": [],
+          "author": "",
+          "license": "ISC"
+        }),
+    );
+
+    env.write_file_to_project("pnpm-lock.yaml", "");
+
+    let output = env.grafbase_init_output(ConfigType::TypeScript);
+    println!("stdout: `{}`", String::from_utf8_lossy(&output.stdout));
+    assert!(
+        output.stderr.is_empty(),
+        "stderr should be empty, got: `{}`",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.status.success());
+
+    assert!(env.directory.join("grafbase").exists());
+    assert!(env.directory.join("grafbase").join("grafbase.config.ts").exists());
+
+    assert!(!env.directory.join("package-lock.json").exists());
+    assert!(!env.directory.join("node_modules").exists());
+
+    let package_json = env.load_file_from_project("package.json");
+
+    insta::assert_snapshot!(&package_json, @r###"
+    {
+      "name": "test",
+      "version": "1.0.0",
+      "description": "",
+      "main": "index.js",
+      "keywords": [],
+      "author": "",
+      "license": "ISC",
+      "devDependencies": {
+        "@grafbase/sdk": "~0.1.0"
+      }
+    }
+    "###);
+}
+
+#[test]
+fn init_ts_existing_package_json_yarn_project() {
+    let env = Environment::init();
+
+    env.write_json_file_to_project(
+        "package.json",
+        &json!({
+          "name": "test",
+          "version": "1.0.0",
+          "description": "",
+          "main": "index.js",
+          "keywords": [],
+          "author": "",
+          "license": "ISC"
+        }),
+    );
+
+    env.write_file_to_project("yarn.lock", "");
+
+    let output = env.grafbase_init_output(ConfigType::TypeScript);
+    println!("stdout: `{}`", String::from_utf8_lossy(&output.stdout));
+    assert!(
+        output.stderr.is_empty(),
+        "stderr should be empty, got: `{}`",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.status.success());
+
+    assert!(env.directory.join("grafbase").exists());
+    assert!(env.directory.join("grafbase").join("grafbase.config.ts").exists());
+
+    assert!(!env.directory.join("package-lock.json").exists());
+    assert!(!env.directory.join("node_modules").exists());
+
     let package_json = env.load_file_from_project("package.json");
 
     insta::assert_snapshot!(&package_json, @r###"
@@ -68,6 +175,8 @@ fn init_ts_new_project() {
     assert!(env.directory.join("grafbase").exists());
     assert!(env.directory.join("grafbase").join("grafbase.config.ts").exists());
     assert!(env.directory.join("package.json").exists());
+    assert!(env.directory.join("package-lock.json").exists());
+    assert!(env.directory.join("node_modules").exists());
 
     let package_json: serde_json::Value = serde_json::from_str(&env.load_file_from_project("package.json")).unwrap();
     let package_json = package_json.as_object().unwrap().get("devDependencies").unwrap();

--- a/cli/crates/cli/tests/utils/environment.rs
+++ b/cli/crates/cli/tests/utils/environment.rs
@@ -202,6 +202,13 @@ impl Environment {
     }
 
     #[track_caller]
+    pub fn write_file_to_project(&self, path: impl AsRef<Path>, contents: impl AsRef<str>) {
+        let target_path = self.directory.join(path.as_ref());
+        fs::create_dir_all(target_path.parent().unwrap()).unwrap();
+        fs::write(target_path, contents.as_ref()).unwrap();
+    }
+
+    #[track_caller]
     pub fn write_json_file_to_project(&self, path: impl AsRef<Path>, contents: &serde_json::Value) {
         let contents = serde_json::to_string_pretty(contents).unwrap();
         let target_path = self.directory.join(path.as_ref());

--- a/cli/crates/common/Cargo.toml
+++ b/cli/crates/common/Cargo.toml
@@ -21,3 +21,4 @@ serde_json = { version = "1", features = ["preserve_order"] }
 strum = { version = "0.24", features = ["derive"] }
 thiserror = "1"
 ulid = { version = "1", features = ["serde"] }
+which = "4.4.0"

--- a/cli/crates/common/src/consts.rs
+++ b/cli/crates/common/src/consts.rs
@@ -42,3 +42,7 @@ pub const GRAFBASE_SDK_PACKAGE_VERSION: &str = "~0.1.0";
 pub const PACKAGE_JSON_NAME: &str = "package.json";
 /// the package.json dev dependencies key
 pub const PACKAGE_JSON_DEV_DEPENDENCIES: &str = "devDependencies";
+/// the name of the pnpm lock file
+pub const PNPM_LOCK_FILE: &str = "pnpm-lock.yaml";
+/// the name of the yarn lock file
+pub const YARN_LOCK_FILE: &str = "yarn.lock";

--- a/cli/crates/common/src/environment.rs
+++ b/cli/crates/common/src/environment.rs
@@ -398,7 +398,7 @@ pub fn install_dependencies(project_root: &Path) -> Result<(), CommonError> {
 }
 
 pub fn guess_project_package_manager(project_root: &Path, package_json: &Path) -> Option<NodePackageManager> {
-    const LOCK_FILES: &[(&str, NodePackageManager)] = &[
+    const LOCK_FILE_NAMES: &[(&str, NodePackageManager)] = &[
         (PNPM_LOCK_FILE, NodePackageManager::Pnpm),
         (YARN_LOCK_FILE, NodePackageManager::Yarn),
     ];
@@ -417,7 +417,7 @@ pub fn guess_project_package_manager(project_root: &Path, package_json: &Path) -
         return Some(package_manager);
     };
 
-    for (file_name, package_manager) in LOCK_FILES.iter() {
+    for (file_name, package_manager) in LOCK_FILE_NAMES.iter() {
         let path_to_check = project_root.join(file_name);
 
         if Path::exists(&path_to_check) {

--- a/cli/crates/common/src/environment.rs
+++ b/cli/crates/common/src/environment.rs
@@ -370,14 +370,7 @@ impl FromStr for NodePackageManager {
             "npm" => Ok(NodePackageManager::Npm),
             "pnpm" => Ok(NodePackageManager::Pnpm),
             "yarn" => Ok(NodePackageManager::Yarn),
-            _ => {
-                let inner = io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("Unsupported package manager in package.json: {s}"),
-                );
-
-                Err(CommonError::AccessPackageJson(inner))
-            }
+            _ => Err(CommonError::UnsupportedNodePackageManager(s.to_string())),
         }
     }
 }

--- a/cli/crates/common/src/errors.rs
+++ b/cli/crates/common/src/errors.rs
@@ -31,4 +31,8 @@ pub enum CommonError {
     SerializePackageJson(serde_json::Error),
     #[error("could not execute 'npm init':\nCaused by: {0}")]
     NpmInitError(std::io::Error),
+    #[error("could not execute 'npm install':\nCaused by: {0}")]
+    NpmInstall(std::io::Error),
+    #[error("could not find 'npm':\nCaused by: {0}")]
+    NpmNotFound(Box<dyn std::error::Error + Send>),
 }

--- a/cli/crates/common/src/errors.rs
+++ b/cli/crates/common/src/errors.rs
@@ -27,6 +27,8 @@ pub enum CommonError {
     CreateUserDotGrafbaseFolder(std::io::Error),
     #[error("could not open the project's 'package.json':\nCaused by: {0}")]
     AccessPackageJson(std::io::Error),
+    #[error("unsupported package manager in project's 'package.json': {0}")]
+    UnsupportedNodePackageManager(String),
     #[error("could not serialize the project's 'package.json':\nCaused by: {0}")]
     SerializePackageJson(serde_json::Error),
     #[error("could not execute 'npm init':\nCaused by: {0}")]

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -41,7 +41,6 @@ sqlx = { version = "0.6", features = [
   "json",
 ] }
 strip-ansi-escapes = "0.1"
-strum = { version = "0.24", features = ["derive"] }
 tantivy = { version = "0.19", default-features = false }
 # Temporary change till https://github.com/alexcrichton/tar-rs/pull/319 is release
 tar = { git = "https://github.com/obmarg/tar-rs.git", rev = "bffee32190d531c03d806680daebd89cb1544be1" }

--- a/cli/crates/server/src/errors.rs
+++ b/cli/crates/server/src/errors.rs
@@ -2,6 +2,7 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::response::Response;
 use axum::Json;
+use common::environment::NodePackageManager;
 use common::types::UdfKind;
 use hyper::Error as HyperError;
 use notify::Error as NotifyError;
@@ -12,25 +13,25 @@ use std::path::PathBuf;
 use thiserror::Error;
 use tokio::task::JoinError;
 
-use crate::udf_builder::JavaScriptPackageManager;
-
 #[derive(Error, Debug)]
-pub enum JavascriptPackageManagerComamndError {
+pub enum JavascriptPackageManagerCommandError {
     #[error("working directory '{0}' not found")]
     WorkingDirectoryNotFound(PathBuf),
+
     #[error("working directory '{0}' cannot be read.\nCaused by: {1}")]
     WorkingDirectoryCannotBeRead(PathBuf, std::io::Error),
+
     /// returned if npm/pnpm/yarn cannot be found
     #[error("could not find {0}: {1}")]
-    NotFound(JavaScriptPackageManager, which::Error),
+    NotFound(NodePackageManager, which::Error),
 
     /// returned if any of the npm/pnpm/yarn commands exits unsuccessfully
     #[error("{0} encountered an error: {1}")]
-    CommandError(JavaScriptPackageManager, IoError),
+    CommandError(NodePackageManager, IoError),
 
     /// returned if any of the npm/pnpm/yarn commands exits unsuccessfully
     #[error("{0} failed with output:\n{1}")]
-    OutputError(JavaScriptPackageManager, String),
+    OutputError(NodePackageManager, String),
 }
 
 #[derive(Error, Debug)]
@@ -116,7 +117,7 @@ pub enum ServerError {
 
     /// returned if any of the package manager commands ran during resolver build exits unsuccessfully
     #[error("command error: {0}")]
-    WranglerInstallPackageManagerCommandError(#[from] JavascriptPackageManagerComamndError),
+    WranglerInstallPackageManagerCommandError(#[from] JavascriptPackageManagerCommandError),
 
     /// returned if any of the npm commands ran during resolver build exits unsuccessfully
     #[error("resolver {0} failed to build:\n{1}")]
@@ -208,7 +209,7 @@ pub enum UdfBuildError {
 
     /// returned if any of the package manager commands ran during resolver build exits unsuccessfully
     #[error("command error: {0}")]
-    WranglerInstallPackageManagerCommandError(#[from] JavascriptPackageManagerComamndError),
+    WranglerInstallPackageManagerCommandError(#[from] JavascriptPackageManagerCommandError),
 
     /// returned if any of the npm commands ran during resolver build exits unsuccessfully
     #[error("{0} {1} failed to build:\n{2}")]


### PR DESCRIPTION
# Description

If initializing a new project with a TypeScript config, and we find out the project uses `npm` and we can find `npm` executable, we run `npm install` to install `@grafbase/sdk` to the project. If the project uses some other package manager, or we can't find `npm` executable, we ask the user to install dependencies.

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [x] 📖 Requires documentation update
