### PR TITLE
chore(ci): GB-4011: Add nextest configuration to terminate slow tests after 1 minute

### DIFF
--- a/cli/.config/nextest.toml
+++ b/cli/.config/nextest.toml
@@ -2,6 +2,7 @@
 fail-fast = false
 failure-output = "immediate"
 retries = 2
+slow-timeout = { period = "30s", terminate-after = 2 }
 
 [profile.ci.junit]
 path = "junit.xml"


### PR DESCRIPTION
# Description

Allow restarting tests that get stuck for any reason.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
