### PR TITLE
Add type conversion between InquireError and CliError

### DIFF
--- a/cli/crates/cli/src/create.rs
+++ b/cli/crates/cli/src/create.rs
@@ -1,4 +1,4 @@
-use crate::{errors::CliError, output::report, prompts::handle_inquire_error};
+use crate::{errors::CliError, output::report};
 use backend::api::{
     create,
     types::{Account, DatabaseRegion},
@@ -87,12 +87,10 @@ async fn interactive() -> Result<(), CliError> {
                 ))
             }
         })
-        .prompt()
-        .map_err(handle_inquire_error)?;
+        .prompt()?;
 
-    let AccountSelection(selected_account) = Select::new("In which account should the project be created?", options)
-        .prompt()
-        .map_err(handle_inquire_error)?;
+    let AccountSelection(selected_account) =
+        Select::new("In which account should the project be created?", options).prompt()?;
 
     let selected_region = Select::new(
         "In which region should your database be created?",
@@ -104,13 +102,11 @@ async fn interactive() -> Result<(), CliError> {
             .position(|region| region.name == closest_region.name)
             .unwrap_or_default(),
     )
-    .prompt()
-    .map_err(handle_inquire_error)?;
+    .prompt()?;
 
     let confirm = Confirm::new("Please confirm the above to create and deploy your new project")
         .with_default(true)
-        .prompt()
-        .map_err(handle_inquire_error)?;
+        .prompt()?;
 
     if confirm {
         let domains = create::create(&selected_account.id, &project_name, &[selected_region.0.name.clone()])

--- a/cli/crates/cli/src/init.rs
+++ b/cli/crates/cli/src/init.rs
@@ -1,4 +1,4 @@
-use crate::{cli_input::ConfigFormat, errors::CliError, output::report, prompts::handle_inquire_error};
+use crate::{cli_input::ConfigFormat, errors::CliError, output::report};
 use backend::project::{self, ConfigType, Template};
 use inquire::Select;
 
@@ -12,8 +12,7 @@ pub fn init(name: Option<&str>, template: Option<&str>, config_format: Option<Co
                 "What configuration format would you like to use?",
                 ConfigType::VARIANTS.to_vec(),
             )
-            .prompt()
-            .map_err(handle_inquire_error)?;
+            .prompt()?;
 
             Template::FromDefault(config_type)
         }

--- a/cli/crates/cli/src/link.rs
+++ b/cli/crates/cli/src/link.rs
@@ -1,4 +1,4 @@
-use crate::{errors::CliError, output::report, prompts::handle_inquire_error};
+use crate::{errors::CliError, output::report};
 use backend::api::{
     link,
     types::{AccountWithProjects, Project},
@@ -32,9 +32,7 @@ pub async fn link() -> Result<(), CliError> {
     let options: Vec<AccountSelection> = accounts.into_iter().map(AccountSelection).collect();
 
     let AccountSelection(selected_account) =
-        Select::new("Which account owns the project you'd like to link to?", options)
-            .prompt()
-            .map_err(handle_inquire_error)?;
+        Select::new("Which account owns the project you'd like to link to?", options).prompt()?;
 
     if selected_account.projects.is_empty() {
         return Err(CliError::AccountWithNoProjects);
@@ -42,9 +40,8 @@ pub async fn link() -> Result<(), CliError> {
 
     let options: Vec<ProjectSelection> = selected_account.projects.into_iter().map(ProjectSelection).collect();
 
-    let ProjectSelection(selected_project) = Select::new("Which project would you like to link to?", options)
-        .prompt()
-        .map_err(handle_inquire_error)?;
+    let ProjectSelection(selected_project) =
+        Select::new("Which project would you like to link to?", options).prompt()?;
 
     link::link_project(selected_account.id, selected_project.id)
         .await

--- a/cli/crates/cli/src/prompts.rs
+++ b/cli/crates/cli/src/prompts.rs
@@ -2,12 +2,14 @@ use crate::errors::CliError;
 use inquire::InquireError;
 use std::process;
 
-pub fn handle_inquire_error(error: InquireError) -> CliError {
-    match error {
-        InquireError::NotTTY => CliError::PromptNotTTY,
-        InquireError::IO(error) => CliError::PromptIoError(error),
-        // exit normally without panicking on ESC or CTRL+C
-        InquireError::OperationCanceled | InquireError::OperationInterrupted => process::exit(0),
-        InquireError::InvalidConfiguration(_) | InquireError::Custom(_) => unreachable!(),
+impl From<InquireError> for CliError {
+    fn from(error: InquireError) -> Self {
+        match error {
+            InquireError::NotTTY => CliError::PromptNotTTY,
+            InquireError::IO(error) => CliError::PromptIoError(error),
+            // exit normally without panicking on ESC or CTRL+C
+            InquireError::OperationCanceled | InquireError::OperationInterrupted => process::exit(0),
+            InquireError::InvalidConfiguration(_) | InquireError::Custom(_) => unreachable!(),
+        }
     }
 }


### PR DESCRIPTION
# Description

I noticed InquireError was being manually mapped to CliError on every prompt call, a conversion 
that can be made implicit if the resulting type implements From<E> where E is the source type.

So, I thought of creating this PR to simplify the code a little bit in case there isn't a 
reason/context I'm missing.

# Type of change

- [x] 🔨 Refactoring
