### PR TITLE
Release 0.25.3

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   GRAFBASE_SKIP_ASSET_VERSION_CHECK: 'true'
-  ASSETS_VERSION: release/9f510c1-2023-06-30
+  ASSETS_VERSION: release/55cc068-2023-07-04
   PROD_ASSETS: assets.grafbase.com
   CARGO_TERM_COLOR: 'always'
   CARGO_PROFILE_DEV_DEBUG: 0

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.25.3] - 2023-07-04
+
+[CHANGELOG](changelog/0.25.3.md)
+
 ## [0.25.2] - 2023-06-30
 
 [CHANGELOG](changelog/0.25.2.md)

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "async-compression",
  "async-tar",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "chrono",
  "derivative",
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "axum",
  "base64 0.21.2",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.25.2"
+version = "0.25.3"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://grafbase.com"

--- a/cli/changelog/0.25.3.md
+++ b/cli/changelog/0.25.3.md
@@ -1,0 +1,4 @@
+### Bug Fixes
+
+- Fixed `allOf` schema support in `@openapi`
+- JSON scalars will now accept any literal `Value` in documents

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -38,8 +38,8 @@ url = "2"
 urlencoding = "2"
 walkdir = "2"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.25.2" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.25.2" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.25.3" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.25.3" }
 
 [build-dependencies]
 cynic-codegen = { version = "3", features = ["rkyv"] }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -34,8 +34,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
 webbrowser = "0.8"
 
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.25.2" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.25.2" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.25.3" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.25.3" }
 
 [dev-dependencies]
 async-graphql = "5"

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -56,7 +56,7 @@ uuid = { version = "1", features = ["v4"] }
 version-compare = "0.1"
 which = "4"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.25.2" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.25.3" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.5.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.25.2",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.25.2",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.25.2",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.25.2",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.25.2"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.25.3",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.25.3",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.25.3",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.25.3",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.25.3"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
Contains a few fixes I've made:

- Fixed `allOf` schema support in `@openapi`
- `JSON` scalars will now accept any literal `Value` in documents