### PR TITLE
fix(udf): Fix the way we compile UDFs to ensure you can import from local modules defined in separate files

### DIFF
--- a/cli/crates/cli/src/dev.rs
+++ b/cli/crates/cli/src/dev.rs
@@ -30,6 +30,10 @@ pub fn dev(search: bool, watch: bool, external_port: u16, tracing: bool) -> Resu
                     READY.call_once(|| report::start_server(resolvers_reported, port, external_port));
                 }
                 ServerMessage::Reload(path) => report::reload(path),
+                ServerMessage::InstallUdfDependencies => report::install_udf_dependencies(),
+                ServerMessage::CompleteInstallingUdfDependencies { duration } => {
+                    report::complete_installing_udf_dependencies(duration)
+                }
                 ServerMessage::StartUdfBuild { udf_kind, udf_name } => {
                     report::start_udf_build(udf_kind, &udf_name);
                 }

--- a/cli/crates/cli/src/dev.rs
+++ b/cli/crates/cli/src/dev.rs
@@ -32,7 +32,7 @@ pub fn dev(search: bool, watch: bool, external_port: u16, tracing: bool) -> Resu
                 ServerMessage::Reload(path) => report::reload(path),
                 ServerMessage::InstallUdfDependencies => report::install_udf_dependencies(),
                 ServerMessage::CompleteInstallingUdfDependencies { duration } => {
-                    report::complete_installing_udf_dependencies(duration)
+                    report::complete_installing_udf_dependencies(duration);
                 }
                 ServerMessage::StartUdfBuild { udf_kind, udf_name } => {
                     report::start_udf_build(udf_kind, &udf_name);

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -105,6 +105,25 @@ pub fn goodbye() {
     watercolor::output!("\n👋 See you next time!", @BrightBlue);
 }
 
+pub fn install_udf_dependencies() {
+    println!(
+        "{}  - installing dependencies from package.json…",
+        watercolor!("wait", @Blue)
+    );
+}
+
+pub fn complete_installing_udf_dependencies(duration: std::time::Duration) {
+    let formatted_duration = if duration < std::time::Duration::from_secs(1) {
+        format!("{}ms", duration.as_millis())
+    } else {
+        format!("{:.1}s", duration.as_secs_f64())
+    };
+    println!(
+        "{} - installed successfully in {formatted_duration}",
+        watercolor!("event", @Green)
+    );
+}
+
 pub fn start_udf_build(udf_kind: UdfKind, udf_name: &str) {
     println!("{}  - compiling {udf_kind} '{udf_name}'…", watercolor!("wait", @Blue));
 }

--- a/cli/crates/cli/tests/snapshots/custom_resolvers__query_mutation_resolver_3_1.snap
+++ b/cli/crates/cli/tests/snapshots/custom_resolvers__query_mutation_resolver_3_1.snap
@@ -1,0 +1,5 @@
+---
+source: crates/cli/tests/custom_resolvers.rs
+expression: value
+---
+Hello World!

--- a/cli/crates/common/src/consts.rs
+++ b/cli/crates/common/src/consts.rs
@@ -39,6 +39,6 @@ pub const GRAFBASE_SDK_PACKAGE_NAME: &str = "@grafbase/sdk";
 /// the version string of the Grafbase SDK npm package
 pub const GRAFBASE_SDK_PACKAGE_VERSION: &str = "~0.1.0";
 /// the package.json file name
-pub const PACKAGE_JSON_NAME: &str = "package.json";
+pub const PACKAGE_JSON_FILE_NAME: &str = "package.json";
 /// the package.json dev dependencies key
 pub const PACKAGE_JSON_DEV_DEPENDENCIES: &str = "devDependencies";

--- a/cli/crates/common/src/environment.rs
+++ b/cli/crates/common/src/environment.rs
@@ -1,10 +1,11 @@
 #![allow(dead_code)]
 
 use crate::consts::AUTHORIZERS_DIRECTORY_NAME;
+use crate::types::UdfKind;
 use crate::{
     consts::{
         DATABASE_DIRECTORY, DOT_GRAFBASE_DIRECTORY, GRAFBASE_DIRECTORY_NAME, GRAFBASE_HOME, GRAFBASE_SCHEMA_FILE_NAME,
-        GRAFBASE_TS_CONFIG_FILE_NAME, PACKAGE_JSON_DEV_DEPENDENCIES, PACKAGE_JSON_NAME, REGISTRY_FILE,
+        GRAFBASE_TS_CONFIG_FILE_NAME, PACKAGE_JSON_DEV_DEPENDENCIES, PACKAGE_JSON_FILE_NAME, REGISTRY_FILE,
         RESOLVERS_DIRECTORY_NAME, WRANGLER_DIRECTORY_NAME,
     },
     errors::CommonError,
@@ -110,16 +111,30 @@ pub struct Project {
     /// the path of `$PROJECT/.grafbase/registry.json`, the registry derived from `schema.graphql`,
     /// in the nearest ancestor directory with a `grabase/schema.graphql` file
     pub registry_path: PathBuf,
-    /// the path of the `grafbase/resolvers` directory.
-    pub resolvers_source_path: PathBuf,
-    /// the path within `$PROJECT/.grafbase/` containing build artifacts for custom resolvers.
-    pub resolvers_build_artifact_path: PathBuf,
-    /// the path of the `grafbase/auth` directory.
-    pub authorizers_source_path: PathBuf,
-    /// the path within `$PROJECT/.grafbase/` containing build artifacts for custom resolvers.
-    pub authorizers_build_artifact_path: PathBuf,
     /// the path within '$PROJECT/.grafbase' containing the database
     pub database_directory_path: PathBuf,
+    /// the location of package.json either in '$PROJECT/grafbase' or '$PROJECT'
+    pub package_json_path: Option<PathBuf>,
+}
+
+impl Project {
+    /// the path of the directory containing the sources corresponding to the UDF type (resolvers, authorizers).
+    pub fn udfs_source_path(&self, kind: UdfKind) -> std::path::PathBuf {
+        let subdirectory_name = match kind {
+            UdfKind::Resolver => RESOLVERS_DIRECTORY_NAME,
+            UdfKind::Authorizer => AUTHORIZERS_DIRECTORY_NAME,
+        };
+        self.grafbase_directory_path.join(subdirectory_name)
+    }
+
+    /// the path of the directory containing the build artifacts corresponding to the UDF type (resolvers, authorizers).
+    pub fn udfs_build_artifact_path(&self, kind: UdfKind) -> std::path::PathBuf {
+        let subdirectory_name = match kind {
+            UdfKind::Resolver => RESOLVERS_DIRECTORY_NAME,
+            UdfKind::Authorizer => AUTHORIZERS_DIRECTORY_NAME,
+        };
+        self.dot_grafbase_directory_path.join(subdirectory_name)
+    }
 }
 
 /// a static representation of the current environment
@@ -175,11 +190,11 @@ impl Project {
 
         let dot_grafbase_directory_path = path.join(DOT_GRAFBASE_DIRECTORY);
         let registry_path = dot_grafbase_directory_path.join(REGISTRY_FILE);
-        let resolvers_source_path = grafbase_directory_path.join(RESOLVERS_DIRECTORY_NAME);
-        let resolvers_build_artifact_path = dot_grafbase_directory_path.join(RESOLVERS_DIRECTORY_NAME);
-        let authorizers_source_path = grafbase_directory_path.join(AUTHORIZERS_DIRECTORY_NAME);
-        let authorizers_build_artifact_path = dot_grafbase_directory_path.join(AUTHORIZERS_DIRECTORY_NAME);
         let database_directory_path = dot_grafbase_directory_path.join(DATABASE_DIRECTORY);
+        let package_json_path = [grafbase_directory_path.as_path(), path.as_path()]
+            .into_iter()
+            .map(|candidate| candidate.join(PACKAGE_JSON_FILE_NAME))
+            .find(|candidate| candidate.exists());
 
         Ok(Project {
             path,
@@ -187,11 +202,8 @@ impl Project {
             dot_grafbase_directory_path,
             grafbase_directory_path,
             registry_path,
-            resolvers_source_path,
-            resolvers_build_artifact_path,
-            authorizers_source_path,
-            authorizers_build_artifact_path,
             database_directory_path,
+            package_json_path,
         })
     }
 
@@ -331,7 +343,7 @@ fn find_grafbase_configuration(path: &Path, warnings: &mut Vec<Warning>) -> Opti
 }
 
 pub fn add_dev_dependency_to_package_json(project_dir: &Path, package: &str, version: &str) -> Result<(), CommonError> {
-    let package_json_path = project_dir.join(PACKAGE_JSON_NAME);
+    let package_json_path = project_dir.join(PACKAGE_JSON_FILE_NAME);
 
     let mut package_json = if package_json_path.exists() {
         let file = fs::File::open(&package_json_path).map_err(CommonError::AccessPackageJson)?;

--- a/cli/crates/common/src/environment.rs
+++ b/cli/crates/common/src/environment.rs
@@ -119,6 +119,7 @@ pub struct Project {
 
 impl Project {
     /// the path of the directory containing the sources corresponding to the UDF type (resolvers, authorizers).
+    #[must_use]
     pub fn udfs_source_path(&self, kind: UdfKind) -> std::path::PathBuf {
         let subdirectory_name = match kind {
             UdfKind::Resolver => RESOLVERS_DIRECTORY_NAME,
@@ -128,6 +129,7 @@ impl Project {
     }
 
     /// the path of the directory containing the build artifacts corresponding to the UDF type (resolvers, authorizers).
+    #[must_use]
     pub fn udfs_build_artifact_path(&self, kind: UdfKind) -> std::path::PathBuf {
         let subdirectory_name = match kind {
             UdfKind::Resolver => RESOLVERS_DIRECTORY_NAME,

--- a/cli/crates/common/src/types.rs
+++ b/cli/crates/common/src/types.rs
@@ -27,7 +27,7 @@ impl LocalAddressType {
     }
 }
 
-#[derive(Clone, Copy, Debug, serde::Deserialize, strum::Display)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Deserialize, strum::Display)]
 pub enum UdfKind {
     Resolver,
     Authorizer,

--- a/cli/crates/server/src/types.rs
+++ b/cli/crates/server/src/types.rs
@@ -7,6 +7,10 @@ pub const ASSETS_GZIP: &[u8] = include_bytes!("../assets/assets.tar.gz");
 pub enum ServerMessage {
     Ready(u16),
     Reload(PathBuf),
+    InstallUdfDependencies,
+    CompleteInstallingUdfDependencies {
+        duration: std::time::Duration,
+    },
     StartUdfBuild {
         udf_kind: UdfKind,
         udf_name: String,


### PR DESCRIPTION
# Description

This eliminates the needless copying of the UDFs entrypoint files that we were doing prior to compiling them. Moving the entrypoint module to another directory would break the imports of files relative to the entrypoint module. This PR fixes that by compiling UDFs in-place, which is also more intuitive.

We've also decided to share the dependency installation step and let it happen synchronously rather than lazily to avoid needless locking of one UDF build against another. In the future we may merge this installation step with that required for the support of TypeScript config.

# Type of change

- [ ] 💔 Breaking
- [X] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
