### PR TITLE
Fix the file watcher rules to avoid the infinite loop on dependency installation when package.json is located in grafbase

### DIFF
--- a/cli/crates/server/src/consts.rs
+++ b/cli/crates/server/src/consts.rs
@@ -1,6 +1,6 @@
 pub const ASSET_VERSION_FILE: &str = "version.txt";
 pub const CONFIG_PARSER_SCRIPT: &str = "parse-config.ts";
-pub const DOT_ENV_FILE: &str = ".env";
+pub const DOT_ENV_FILE_NAME: &str = ".env";
 pub const GENERATED_SCHEMAS_DIR: &str = "generated/schemas";
 pub const GIT_IGNORE_CONTENTS: &str = "*\n";
 pub const GIT_IGNORE_FILE: &str = ".gitignore";

--- a/cli/crates/server/src/environment.rs
+++ b/cli/crates/server/src/environment.rs
@@ -1,11 +1,11 @@
 use common::environment::Project;
 
-use crate::consts::DOT_ENV_FILE;
+use crate::consts::DOT_ENV_FILE_NAME;
 
 #[allow(deprecated)] // https://github.com/dotenv-rs/dotenv/pull/54
 pub fn variables() -> impl Iterator<Item = (String, String)> {
     let project = Project::get();
-    let dot_env_file_path = project.grafbase_directory_path.join(DOT_ENV_FILE);
+    let dot_env_file_path = project.grafbase_directory_path.join(DOT_ENV_FILE_NAME);
     // We don't use dotenv::dotenv() as we don't want to pollute the process' environment.
     // Doing otherwise would make us unable to properly refresh it whenever any of the .env files
     // changes which is something we may want to do in the future.

--- a/cli/crates/server/src/file_watcher.rs
+++ b/cli/crates/server/src/file_watcher.rs
@@ -90,7 +90,7 @@ fn in_blacklisted_directory(path: &Path, root: &Path) -> bool {
     path.strip_prefix(root)
         .expect("must contain root directory")
         .iter()
-        .filter_map(|path_part| path_part.to_str())
+        .filter_map(std::ffi::OsStr::to_str)
         .any(|path_part| DIRECTORY_BLACKLIST.contains(&path_part))
 }
 

--- a/cli/crates/server/src/udf_builder.rs
+++ b/cli/crates/server/src/udf_builder.rs
@@ -92,7 +92,7 @@ async fn guess_package_manager_from_package_json(path: impl AsRef<Path>) -> Opti
         .and_then(|value| value.trim_start_matches('^').split('@').next().unwrap().parse().ok())
 }
 
-pub const LOCK_FILES: &[(&str, JavaScriptPackageManager)] = &[
+pub const LOCK_FILE_NAMES: &[(&str, JavaScriptPackageManager)] = &[
     ("package-lock.json", JavaScriptPackageManager::Npm),
     ("pnpm-lock.yaml", JavaScriptPackageManager::Pnpm),
     ("yarn.lock", JavaScriptPackageManager::Yarn),
@@ -101,7 +101,7 @@ pub const LOCK_FILES: &[(&str, JavaScriptPackageManager)] = &[
 async fn guess_package_manager_from_package_root(path: impl AsRef<Path>) -> Option<JavaScriptPackageManager> {
     let package_root = path.as_ref();
 
-    futures_util::future::join_all(LOCK_FILES.iter().map(|(file_name, package_manager)| {
+    futures_util::future::join_all(LOCK_FILE_NAMES.iter().map(|(file_name, package_manager)| {
         let path_to_check = package_root.join(file_name);
         async move {
             let file_exists = tokio::fs::try_exists(&path_to_check).await.ok().unwrap_or_default();


### PR DESCRIPTION
# Description

Fix an issue with the file watcher picking up changes in the lock file. I've added the lock file names to the blocklists and redid the inclusion/exclusion logic a bit for more clarity.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
