### PR TITLE
CLI: Print out the new operation-related events logged through the bridge to the stdout

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   GRAFBASE_SKIP_ASSET_VERSION_CHECK: 'true'
-  ASSETS_VERSION: release/e4b391a-2023-07-12
+  ASSETS_VERSION: release/19d76c2-2023-07-12
   PROD_ASSETS: assets.grafbase.com
   CARGO_TERM_COLOR: 'always'
   CARGO_PROFILE_DEV_DEBUG: 0

--- a/cli/.cargo/config.toml
+++ b/cli/.cargo/config.toml
@@ -7,6 +7,7 @@ rustflags = [
     "-Drust-2018-idioms",
     "-Dunused-crate-dependencies",
     "-Aclippy::missing-errors-doc",
+    "-Aclippy::module-name-repetitions",
 ]
 
 [net]

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1875,6 +1875,7 @@ dependencies = [
  "rudderanalytics",
  "serde",
  "serde_json",
+ "serde_with",
  "strum",
  "thiserror",
  "ulid",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1875,7 +1875,6 @@ dependencies = [
  "rudderanalytics",
  "serde",
  "serde_json",
- "serde_with",
  "strum",
  "thiserror",
  "ulid",
@@ -4498,24 +4497,24 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "6069ca09d878a33f883cc06aaa9718ede171841d3832450354410b718b097232"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "1a0f6ceed3640b4825424da70a5107e79d48d9b2bc6318dfc666b2fc4777f8c4"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
- "darling",
+ "darling 0.14.4",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -1094,7 +1094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bae9fba24ecfe751572a782cabff22d1290eccf04495d2eaadb514f2ccf6fb6"
 dependencies = [
  "counter",
- "darling",
+ "darling 0.14.4",
  "graphql-parser",
  "once_cell",
  "ouroboros",
@@ -1123,8 +1123,18 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0558d22a7b463ed0241e993f76f09f30b126687447751a8638587b864e4b3944"
+dependencies = [
+ "darling_core 0.20.1",
+ "darling_macro 0.20.1",
 ]
 
 [[package]]
@@ -1142,14 +1152,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
+dependencies = [
+ "darling_core 0.20.1",
+ "quote",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1208,7 +1243,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
- "darling",
+ "darling 0.14.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1868,6 +1903,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_with",
  "slug",
  "sqlx",
  "strip-ansi-escapes",
@@ -4085,6 +4121,34 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f02d8aa6e3c385bf084924f660ce2a3a6bd333ba55b35e8590b321f35d88513"
+dependencies = [
+ "base64 0.21.2",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time 0.3.22",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc7d5d3932fb12ce722ee5e64dd38c504efba37567f0c402f6ca728c3b8b070"
+dependencies = [
+ "darling 0.20.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
 members = ["crates/*"]
 
+resolver = "2"
+
 [workspace.package]
 version = "0.27.0-rc.1"
 edition = "2021"

--- a/cli/crates/cli/src/cli_input.rs
+++ b/cli/crates/cli/src/cli_input.rs
@@ -17,6 +17,9 @@ pub struct DevCommand {
     /// Do not listen for schema changes and reload
     #[arg(long)]
     pub disable_watch: bool,
+    /// Log more events taking place such as introspection queries
+    #[arg(short, long)]
+    pub debug: bool,
 }
 
 #[derive(Debug, Parser, Clone, Copy)]

--- a/cli/crates/cli/src/dev.rs
+++ b/cli/crates/cli/src/dev.rs
@@ -15,6 +15,7 @@ static READY: Once = Once::new();
 /// returns [`CliError::BackendError`] if the the local gateway returns an error
 ///
 /// returns [`CliError::ServerPanic`] if the development server panics
+#[allow(clippy::fn_params_excessive_bools)]
 pub fn dev(search: bool, watch: bool, external_port: u16, debug: bool, tracing: bool) -> Result<(), CliError> {
     trace!("attempting to start server");
 

--- a/cli/crates/cli/src/dev.rs
+++ b/cli/crates/cli/src/dev.rs
@@ -54,7 +54,7 @@ pub fn dev(search: bool, watch: bool, external_port: u16, tracing: bool) -> Resu
                     report::udf_message(udf_kind, &udf_name, &message, level);
                 }
                 ServerMessage::OperationStarted { request_id, name } => {
-                    report::operation_started(request_id, name);
+                    report::operation_started(&request_id, &name);
                 }
                 ServerMessage::OperationCompleted {
                     request_id,
@@ -62,7 +62,7 @@ pub fn dev(search: bool, watch: bool, external_port: u16, tracing: bool) -> Resu
                     duration,
                     r#type,
                 } => {
-                    report::operation_completed(request_id, name, r#type, duration);
+                    report::operation_completed(&request_id, name, r#type, duration);
                 }
                 ServerMessage::CompilationError(error) => report::error(&CliError::CompilationError(error)),
             }

--- a/cli/crates/cli/src/dev.rs
+++ b/cli/crates/cli/src/dev.rs
@@ -53,6 +53,16 @@ pub fn dev(search: bool, watch: bool, external_port: u16, tracing: bool) -> Resu
                 } => {
                     report::udf_message(udf_kind, &udf_name, &message, level);
                 }
+                ServerMessage::OperationStarted { request_id, name } => {
+                    report::operation_started(request_id, name);
+                }
+                ServerMessage::OperationCompleted {
+                    request_id,
+                    name,
+                    duration,
+                } => {
+                    report::operation_completed(request_id, name, duration);
+                }
                 ServerMessage::CompilationError(error) => report::error(&CliError::CompilationError(error)),
             }
         }

--- a/cli/crates/cli/src/dev.rs
+++ b/cli/crates/cli/src/dev.rs
@@ -15,7 +15,7 @@ static READY: Once = Once::new();
 /// returns [`CliError::BackendError`] if the the local gateway returns an error
 ///
 /// returns [`CliError::ServerPanic`] if the development server panics
-pub fn dev(search: bool, watch: bool, external_port: u16, tracing: bool) -> Result<(), CliError> {
+pub fn dev(search: bool, watch: bool, external_port: u16, debug: bool, tracing: bool) -> Result<(), CliError> {
     trace!("attempting to start server");
 
     let (server_handle, receiver) =
@@ -62,7 +62,7 @@ pub fn dev(search: bool, watch: bool, external_port: u16, tracing: bool) -> Resu
                     duration,
                     r#type,
                 } => {
-                    report::operation_completed(&request_id, name, r#type, duration);
+                    report::operation_completed(&request_id, name, r#type, duration, debug);
                 }
                 ServerMessage::CompilationError(error) => report::error(&CliError::CompilationError(error)),
             }

--- a/cli/crates/cli/src/dev.rs
+++ b/cli/crates/cli/src/dev.rs
@@ -60,8 +60,9 @@ pub fn dev(search: bool, watch: bool, external_port: u16, tracing: bool) -> Resu
                     request_id,
                     name,
                     duration,
+                    r#type,
                 } => {
-                    report::operation_completed(request_id, name, duration);
+                    report::operation_completed(request_id, name, r#type, duration);
                 }
                 ServerMessage::CompilationError(error) => report::error(&CliError::CompilationError(error)),
             }

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -88,7 +88,7 @@ fn try_main(args: Args) -> Result<(), CliError> {
                 process::exit(exitcode::OK);
             });
 
-            dev(cmd.search, !cmd.disable_watch, cmd.port, args.trace >= 2)
+            dev(cmd.search, !cmd.disable_watch, cmd.port, cmd.debug, args.trace >= 2)
         }
         SubCommand::Init(cmd) => init(cmd.name(), cmd.template(), cmd.config_format),
         SubCommand::Reset => reset(),

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -157,9 +157,15 @@ pub fn operation_completed(
     r#type: common::types::OperationType,
     duration: std::time::Duration,
 ) {
+    let formatted_duration = if duration < std::time::Duration::from_secs(1) {
+        format!("{}ms", duration.as_millis())
+    } else {
+        format!("{:.1}s", duration.as_secs_f64())
+    };
+
     // FIXME: Add operation type.
     let formatted_name = name.map(|name| format!(" {name}")).unwrap_or_default();
-    println!("→ {type}{formatted_name}  🕑 {}ms", duration.as_millis());
+    println!("→ {type}{formatted_name}  🕑 {formatted_duration}");
 }
 
 pub fn reload<P: AsRef<Path>>(path: P) {

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -10,7 +10,7 @@ use common::{
     consts::{GRAFBASE_DIRECTORY_NAME, GRAFBASE_SCHEMA_FILE_NAME, LOCALHOST},
     environment::Warning,
 };
-use std::{path::Path, fmt::Debug};
+use std::{path::Path};
 
 /// reports to stdout that the server has started
 pub fn cli_header() {

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -151,10 +151,15 @@ pub fn udf_message(udf_kind: UdfKind, udf_name: &str, message: &str, level: UdfM
 
 pub fn operation_started(_request_id: String, _name: Option<String>) {}
 
-pub fn operation_completed(_request_id: String, name: Option<String>, duration: std::time::Duration) {
+pub fn operation_completed(
+    _request_id: String,
+    name: Option<String>,
+    r#type: common::types::OperationType,
+    duration: std::time::Duration,
+) {
     // FIXME: Add operation type.
     let formatted_name = name.map(|name| format!(" {name}")).unwrap_or_default();
-    println!("→{formatted_name}  {}ms", duration.as_millis());
+    println!("→ {type}{formatted_name}  🕑 {}ms", duration.as_millis());
 }
 
 pub fn reload<P: AsRef<Path>>(path: P) {

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -149,6 +149,14 @@ pub fn udf_message(udf_kind: UdfKind, udf_name: &str, message: &str, level: UdfM
     }
 }
 
+pub fn operation_started(_request_id: String, _name: Option<String>) {}
+
+pub fn operation_completed(_request_id: String, name: Option<String>, duration: std::time::Duration) {
+    // FIXME: Add operation type.
+    let formatted_name = name.map(|name| format!(" {name}")).unwrap_or_default();
+    println!("→{formatted_name}  {}ms", duration.as_millis());
+}
+
 pub fn reload<P: AsRef<Path>>(path: P) {
     println!(
         "🔄 Detected a change in {path}, reloading",

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -10,7 +10,7 @@ use common::{
     consts::{GRAFBASE_DIRECTORY_NAME, GRAFBASE_SCHEMA_FILE_NAME, LOCALHOST},
     environment::Warning,
 };
-use std::{path::Path};
+use std::path::Path;
 
 /// reports to stdout that the server has started
 pub fn cli_header() {

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -163,9 +163,9 @@ pub fn operation_completed(
     }
 
     let formatted_duration = if duration < std::time::Duration::from_secs(1) {
-        format!("{}ms", duration.as_millis())
+        format!("{:.2}ms", duration.as_secs_f64() / 1000.0)
     } else {
-        format!("{:.1}s", duration.as_secs_f64())
+        format!("{:.2}s", duration.as_secs_f64())
     };
 
     // FIXME: Add operation type.

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -149,10 +149,10 @@ pub fn udf_message(udf_kind: UdfKind, udf_name: &str, message: &str, level: UdfM
     }
 }
 
-pub fn operation_started(_request_id: String, _name: Option<String>) {}
+pub fn operation_started(_request_id: &str, _name: &Option<String>) {}
 
 pub fn operation_completed(
-    _request_id: String,
+    _request_id: &str,
     name: Option<String>,
     r#type: common::types::OperationType,
     duration: std::time::Duration,

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -10,7 +10,7 @@ use common::{
     consts::{GRAFBASE_DIRECTORY_NAME, GRAFBASE_SCHEMA_FILE_NAME, LOCALHOST},
     environment::Warning,
 };
-use std::path::Path;
+use std::{path::Path, fmt::Debug};
 
 /// reports to stdout that the server has started
 pub fn cli_header() {
@@ -156,10 +156,12 @@ pub fn operation_completed(
     name: Option<String>,
     r#type: common::types::OperationType,
     duration: std::time::Duration,
+    debug: bool,
 ) {
-    // FIXME: Put under the `--debug` mode rather than ignoring altogether.
     if let common::types::OperationType::Query { is_introspection: true } = r#type {
-        return;
+        if !debug {
+            return;
+        }
     }
 
     let formatted_duration = if duration < std::time::Duration::from_secs(1) {

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -155,8 +155,14 @@ pub fn format_duration(duration: std::time::Duration) -> String {
     [
         ("ns", duration.as_nanos()),
         ("μs", duration.as_micros()),
-        ("ms", duration.as_millis())
-    ].into_iter().find(|(_, value)| *value < 1000).map_or_else(|| format!("{:.2}s", duration.as_secs_f64()), |(suffix, value)| format!("{value}{suffix}"))
+        ("ms", duration.as_millis()),
+    ]
+    .into_iter()
+    .find(|(_, value)| *value < 1000)
+    .map_or_else(
+        || format!("{:.2}s", duration.as_secs_f64()),
+        |(suffix, value)| format!("{value}{suffix}"),
+    )
 }
 
 pub fn operation_completed(
@@ -172,22 +178,20 @@ pub fn operation_completed(
                 return;
             }
             watercolor::colored::Color::Green
-        },
+        }
         // Pink.
-        common::types::OperationType::Mutation => watercolor::colored::Color::TrueColor {
-            r: 255,
-            g: 105,
-            b: 180
-        },
+        common::types::OperationType::Mutation => watercolor::colored::Color::TrueColor { r: 255, g: 105, b: 180 },
         common::types::OperationType::Subscription => {
             return;
         }
     };
 
-
     let formatted_duration = format_duration(duration);
     let formatted_name = name.map(|name| format!(" {name}")).unwrap_or_default();
-    println!("- {type}{formatted_name} {formatted_duration}", r#type = r#type.to_string().color(colour));
+    println!(
+        "- {type}{formatted_name} {formatted_duration}",
+        r#type = r#type.to_string().color(colour)
+    );
 }
 
 pub fn reload<P: AsRef<Path>>(path: P) {

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -135,7 +135,7 @@ pub fn complete_udf_build(udf_kind: UdfKind, udf_name: &str, duration: std::time
         format!("{:.1}s", duration.as_secs_f64())
     };
     println!(
-        "- {} {udf_kind} {udf_name} compiled successfully in {formatted_duration}",
+        "- {} compiled {udf_kind} {udf_name} successfully in {formatted_duration}",
         watercolor!("event", @BrightMagenta)
     );
 }

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -157,6 +157,11 @@ pub fn operation_completed(
     r#type: common::types::OperationType,
     duration: std::time::Duration,
 ) {
+    // FIXME: Put under the `--debug` mode rather than ignoring altogether.
+    if let common::types::OperationType::Query { is_introspection: true } = r#type {
+        return;
+    }
+
     let formatted_duration = if duration < std::time::Duration::from_secs(1) {
         format!("{}ms", duration.as_millis())
     } else {

--- a/cli/crates/common/Cargo.toml
+++ b/cli/crates/common/Cargo.toml
@@ -18,6 +18,7 @@ rudderanalytics = { version = "1", features = [
 ], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
+serde_with = "3"
 strum = { version = "0.24", features = ["derive"] }
 thiserror = "1"
 ulid = { version = "1", features = ["serde"] }

--- a/cli/crates/common/Cargo.toml
+++ b/cli/crates/common/Cargo.toml
@@ -18,7 +18,6 @@ rudderanalytics = { version = "1", features = [
 ], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
-serde_with = "3"
-strum = { version = "0.24", features = ["derive"] }
+strum = { version = "0.25", features = ["derive"] }
 thiserror = "1"
 ulid = { version = "1", features = ["serde"] }

--- a/cli/crates/common/src/types.rs
+++ b/cli/crates/common/src/types.rs
@@ -28,6 +28,7 @@ impl LocalAddressType {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Deserialize, strum::Display)]
+#[strum(serialize_all = "lowercase")]
 pub enum UdfKind {
     Resolver,
     Authorizer,

--- a/cli/crates/common/src/types.rs
+++ b/cli/crates/common/src/types.rs
@@ -40,10 +40,10 @@ impl Default for UdfKind {
     }
 }
 
-#[derive(Clone, Copy, Debug, serde_with::DeserializeFromStr, strum::Display, strum::EnumString)]
+#[derive(serde::Deserialize, Clone, Copy, Debug, strum::Display)]
 #[strum(serialize_all = "lowercase")]
 pub enum OperationType {
-    Query,
+    Query { is_introspection: bool },
     Mutation,
     Subscription,
 }

--- a/cli/crates/common/src/types.rs
+++ b/cli/crates/common/src/types.rs
@@ -39,3 +39,11 @@ impl Default for UdfKind {
         Self::Resolver
     }
 }
+
+#[derive(Clone, Copy, Debug, serde_with::DeserializeFromStr, strum::Display, strum::EnumString)]
+#[strum(serialize_all = "lowercase")]
+pub enum OperationType {
+    Query,
+    Mutation,
+    Subscription,
+}

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -42,7 +42,7 @@ sqlx = { version = "0.6", features = [
   "json",
 ] }
 strip-ansi-escapes = "0.1"
-strum = { version = "0.24", features = ["derive"] }
+strum = { version = "0.25", features = ["derive"] }
 tantivy = { version = "0.19", default-features = false }
 # Temporary change till https://github.com/alexcrichton/tar-rs/pull/319 is release
 tar = { git = "https://github.com/obmarg/tar-rs.git", rev = "bffee32190d531c03d806680daebd89cb1544be1" }

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -34,6 +34,7 @@ reqwest = { version = "0.11", features = [
 ], default-features = false }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
+serde_with = "3"
 slug = "0.1"
 sqlx = { version = "0.6", features = [
   "runtime-tokio-rustls",

--- a/cli/crates/server/src/bridge/log.rs
+++ b/cli/crates/server/src/bridge/log.rs
@@ -17,10 +17,11 @@ pub async fn log_event_endpoint(
     let LogEvent { request_id, r#type } = request;
     let message = match r#type {
         LogEventType::OperationStarted { name } => ServerMessage::OperationStarted { request_id, name },
-        LogEventType::OperationCompleted { name, duration } => ServerMessage::OperationCompleted {
+        LogEventType::OperationCompleted { name, duration, r#type } => ServerMessage::OperationCompleted {
             request_id,
             name,
             duration,
+            r#type,
         },
     };
 

--- a/cli/crates/server/src/bridge/log.rs
+++ b/cli/crates/server/src/bridge/log.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+
+use axum::{extract::State, Json};
+
+use crate::types::ServerMessage;
+
+use super::{
+    errors::ApiError,
+    server::HandlerState,
+    types::{LogEvent, LogEventType},
+};
+
+pub async fn log_event_endpoint(
+    State(handler_state): State<Arc<HandlerState>>,
+    Json(request): Json<LogEvent>,
+) -> Result<(), ApiError> {
+    let LogEvent { request_id, r#type } = request;
+    let message = match r#type {
+        LogEventType::OperationStarted { name } => ServerMessage::OperationStarted { request_id, name },
+        LogEventType::OperationCompleted { name, duration } => ServerMessage::OperationCompleted {
+            request_id,
+            name,
+            duration,
+        },
+    };
+
+    handler_state.bridge_sender.send(message).await.unwrap();
+
+    Ok(())
+}

--- a/cli/crates/server/src/bridge/mod.rs
+++ b/cli/crates/server/src/bridge/mod.rs
@@ -1,6 +1,7 @@
 mod api_counterfeit;
 mod consts;
 mod listener;
+mod log;
 mod search;
 mod server;
 mod sqlite;

--- a/cli/crates/server/src/bridge/server.rs
+++ b/cli/crates/server/src/bridge/server.rs
@@ -1,52 +1,38 @@
-use super::api_counterfeit::registry::Registry;
-use super::api_counterfeit::search::{QueryExecutionRequest, QueryExecutionResponse};
 use super::consts::{DATABASE_FILE, DATABASE_URL_PREFIX, PREPARE};
-use super::search::Index;
-use super::types::{Mutation, Operation, Record, UdfInvocation};
-use crate::bridge::api_counterfeit::registry::VersionedRegistry;
+use super::types::{Mutation, Operation, Record};
+use super::udf::UdfBuild;
 use crate::bridge::errors::ApiError;
 use crate::bridge::listener;
+use crate::bridge::log::log_event_endpoint;
+use crate::bridge::search::search_endpoint;
 use crate::bridge::types::{Constraint, ConstraintKind, OperationKind};
+use crate::bridge::udf::invoke_udf_endpoint;
 use crate::errors::ServerError;
 use crate::event::{wait_for_event, Event};
 use crate::types::ServerMessage;
 use axum::extract::State;
 use axum::Json;
 use axum::{http::StatusCode, routing::post, Router};
-use common::environment::{Environment, Project};
+use common::environment::Project;
 
 use common::types::UdfKind;
 use sqlx::query::{Query, QueryAs};
 use sqlx::{migrate::MigrateDatabase, query, query_as, sqlite::SqlitePoolOptions, Sqlite, SqlitePool};
 use tokio::fs;
-use tokio::sync::{Mutex, Notify};
+use tokio::sync::Mutex;
 
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::BufReader;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
 use tower_http::trace::TraceLayer;
 
-pub enum UdfBuild {
-    InProgress {
-        notify: Arc<Notify>,
-    },
-    Succeeded {
-        #[allow(dead_code)]
-        miniflare_handle: tokio::task::JoinHandle<()>,
-        worker_port: u16,
-    },
-    Failed,
-}
-
-struct HandlerState {
-    pool: SqlitePool,
-    bridge_sender: tokio::sync::mpsc::Sender<ServerMessage>,
-    udf_builds: Mutex<std::collections::HashMap<(String, UdfKind), UdfBuild>>,
-    environment_variables: HashMap<String, String>,
-    tracing: bool,
+pub struct HandlerState {
+    pub pool: SqlitePool,
+    pub bridge_sender: tokio::sync::mpsc::Sender<ServerMessage>,
+    pub udf_builds: Mutex<std::collections::HashMap<(String, UdfKind), UdfBuild>>,
+    pub environment_variables: HashMap<String, String>,
+    pub tracing: bool,
 }
 
 async fn query_endpoint(
@@ -112,157 +98,6 @@ async fn mutation_endpoint(
     Ok(StatusCode::OK)
 }
 
-async fn search_endpoint(
-    State(handler_state): State<Arc<HandlerState>>,
-    Json(request): Json<QueryExecutionRequest>,
-) -> Result<Json<QueryExecutionResponse>, ApiError> {
-    let project = Project::get();
-
-    let registry: Registry = {
-        let path = &project.registry_path;
-        let file = File::open(path).map_err(|err| {
-            error!("Failed to open {path:?}: {err:?}");
-            ApiError::ServerError
-        })?;
-        let reader = BufReader::new(file);
-        let versioned: VersionedRegistry = serde_json::from_reader(reader).map_err(|err| {
-            error!("Failed to deserialize registry: {err:?}");
-            ApiError::ServerError
-        })?;
-        versioned.registry
-    };
-
-    let response = Index::build(&handler_state.pool, &request.entity_type, &registry.search_config)
-        .await?
-        .search(request.query, request.pagination)?;
-    Ok(Json(response))
-}
-
-#[allow(clippy::too_many_lines)]
-async fn invoke_udf_endpoint(
-    State(handler_state): State<Arc<HandlerState>>,
-    Json(payload): Json<UdfInvocation>,
-) -> Result<Json<serde_json::Value>, ApiError> {
-    use futures_util::TryFutureExt;
-
-    trace!("UDF invocation\n\n{:#?}\n", payload);
-
-    let environment = Environment::get();
-    let udf_kind = payload.udf_kind;
-
-    let udf_worker_port = loop {
-        let notify = {
-            let mut udf_builds: tokio::sync::MutexGuard<'_, _> = handler_state.udf_builds.lock().await;
-
-            if let Some(udf_build) = udf_builds.get(&(payload.name.clone(), udf_kind)) {
-                match udf_build {
-                    UdfBuild::Succeeded { worker_port, .. } => break *worker_port,
-                    UdfBuild::Failed => return Err(ApiError::UdfInvocation),
-                    UdfBuild::InProgress { notify } => {
-                        // If the resolver build happening within another invocation has been cancelled
-                        // due to the invocation having been interrupted by the HTTP client, start a new build.
-                        if Arc::strong_count(notify) == 1 {
-                            notify.clone()
-                        } else {
-                            let notify = notify.clone();
-                            drop(udf_builds);
-                            notify.notified().await;
-                            continue;
-                        }
-                    }
-                }
-            } else {
-                let notify = Arc::new(Notify::new());
-                udf_builds.insert(
-                    (payload.name.clone(), udf_kind),
-                    UdfBuild::InProgress { notify: notify.clone() },
-                );
-                notify
-            }
-        };
-
-        let start = std::time::Instant::now();
-        handler_state
-            .bridge_sender
-            .send(ServerMessage::StartUdfBuild {
-                udf_kind,
-                udf_name: payload.name.clone(),
-            })
-            .await
-            .unwrap();
-
-        let tracing = handler_state.tracing;
-
-        match crate::udf_builder::build(
-            environment,
-            &handler_state.environment_variables,
-            udf_kind,
-            &payload.name,
-            tracing,
-        )
-        .and_then(|(package_json_path, wrangler_toml_path)| {
-            super::udf::spawn_miniflare(udf_kind, &payload.name, package_json_path, wrangler_toml_path, tracing)
-        })
-        .await
-        {
-            Ok((miniflare_handle, worker_port)) => {
-                handler_state.udf_builds.lock().await.insert(
-                    (payload.name.clone(), udf_kind),
-                    UdfBuild::Succeeded {
-                        miniflare_handle,
-                        worker_port,
-                    },
-                );
-                notify.notify_waiters();
-
-                handler_state
-                    .bridge_sender
-                    .send(ServerMessage::CompleteUdfBuild {
-                        udf_kind,
-                        udf_name: payload.name.clone(),
-                        duration: start.elapsed(),
-                    })
-                    .await
-                    .unwrap();
-
-                break worker_port;
-            }
-            Err(err) => {
-                error!(
-                    "Build of {udf_kind} '{udf_name}' failed: {err:?}",
-                    udf_name = payload.name
-                );
-                handler_state
-                    .bridge_sender
-                    .send(ServerMessage::CompilationError(format!(
-                        "{udf_kind} '{udf_name}' failed to build: {err}",
-                        udf_name = payload.name
-                    )))
-                    .await
-                    .unwrap();
-            }
-        };
-
-        handler_state
-            .udf_builds
-            .lock()
-            .await
-            .insert((payload.name.clone(), udf_kind), UdfBuild::Failed);
-        notify.notify_waiters();
-        return Err(ApiError::UdfInvocation);
-    };
-
-    super::udf::invoke(
-        &handler_state.bridge_sender,
-        udf_worker_port,
-        udf_kind,
-        &payload.name,
-        &payload.payload,
-    )
-    .await
-    .map(Json)
-}
-
 pub async fn start(
     port: u16,
     worker_port: u16,
@@ -312,8 +147,8 @@ pub async fn start(
         .route("/query", post(query_endpoint))
         .route("/mutation", post(mutation_endpoint))
         .route("/search", post(search_endpoint))
-        .route("/invoke-resolver", post(invoke_udf_endpoint)) // FIXME: remove after API repo is switched.
         .route("/invoke-udf", post(invoke_udf_endpoint))
+        .route("/log-event", post(log_event_endpoint))
         .with_state(handler_state.clone())
         .layer(TraceLayer::new_for_http());
 

--- a/cli/crates/server/src/bridge/types.rs
+++ b/cli/crates/server/src/bridge/types.rs
@@ -70,9 +70,26 @@ pub struct RecordDocument {
 
 #[derive(Deserialize, Debug)]
 pub struct UdfInvocation {
-    #[serde(alias = "resolver_name")] // FIXME: remove after api repo is updated
     pub name: String,
     pub payload: serde_json::Value,
-    #[serde(default)] // FIXME: remove after api repo is updated
     pub udf_kind: UdfKind,
+}
+
+#[serde_with::serde_as]
+#[derive(Deserialize, Debug)]
+pub enum LogEventType {
+    OperationStarted {
+        name: Option<String>,
+    },
+    OperationCompleted {
+        name: Option<String>,
+        #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
+        duration: std::time::Duration,
+    },
+}
+
+#[derive(Deserialize, Debug)]
+pub struct LogEvent {
+    pub request_id: String,
+    pub r#type: LogEventType,
 }

--- a/cli/crates/server/src/bridge/types.rs
+++ b/cli/crates/server/src/bridge/types.rs
@@ -85,6 +85,7 @@ pub enum LogEventType {
         name: Option<String>,
         #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
         duration: std::time::Duration,
+        r#type: common::types::OperationType,
     },
 }
 

--- a/cli/crates/server/src/bridge/udf.rs
+++ b/cli/crates/server/src/bridge/udf.rs
@@ -1,14 +1,20 @@
 use std::process::Stdio;
+use std::sync::Arc;
 
 use crate::errors::UdfBuildError;
 use crate::types::ServerMessage;
 
+use axum::extract::State;
+use axum::Json;
 use common::types::UdfKind;
 use common::{environment::Environment, types::UdfMessageLevel};
 use futures_util::{pin_mut, TryFutureExt, TryStreamExt};
 use tokio::process::Command;
+use tokio::sync::Notify;
 
 use super::errors::ApiError;
+use super::server::HandlerState;
+use super::types::UdfInvocation;
 
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -23,6 +29,141 @@ struct UdfResponse {
     log_entries: Vec<UdfMessage>,
     #[serde(flatten)]
     rest: serde_json::Value,
+}
+
+pub enum UdfBuild {
+    InProgress {
+        notify: Arc<Notify>,
+    },
+    Succeeded {
+        #[allow(dead_code)]
+        miniflare_handle: tokio::task::JoinHandle<()>,
+        worker_port: u16,
+    },
+    Failed,
+}
+
+#[allow(clippy::too_many_lines)]
+pub async fn invoke_udf_endpoint(
+    State(handler_state): State<Arc<HandlerState>>,
+    Json(payload): Json<UdfInvocation>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    trace!("UDF invocation\n\n{:#?}\n", payload);
+
+    let environment = Environment::get();
+    let udf_kind = payload.udf_kind;
+
+    let udf_worker_port = loop {
+        let notify = {
+            let mut udf_builds: tokio::sync::MutexGuard<'_, _> = handler_state.udf_builds.lock().await;
+
+            if let Some(udf_build) = udf_builds.get(&(payload.name.clone(), udf_kind)) {
+                match udf_build {
+                    UdfBuild::Succeeded { worker_port, .. } => break *worker_port,
+                    UdfBuild::Failed => return Err(ApiError::UdfInvocation),
+                    UdfBuild::InProgress { notify } => {
+                        // If the resolver build happening within another invocation has been cancelled
+                        // due to the invocation having been interrupted by the HTTP client, start a new build.
+                        if Arc::strong_count(notify) == 1 {
+                            notify.clone()
+                        } else {
+                            let notify = notify.clone();
+                            drop(udf_builds);
+                            notify.notified().await;
+                            continue;
+                        }
+                    }
+                }
+            } else {
+                let notify = Arc::new(Notify::new());
+                udf_builds.insert(
+                    (payload.name.clone(), udf_kind),
+                    UdfBuild::InProgress { notify: notify.clone() },
+                );
+                notify
+            }
+        };
+
+        let start = std::time::Instant::now();
+        handler_state
+            .bridge_sender
+            .send(ServerMessage::StartUdfBuild {
+                udf_kind,
+                udf_name: payload.name.clone(),
+            })
+            .await
+            .unwrap();
+
+        let tracing = handler_state.tracing;
+
+        match crate::udf_builder::build(
+            environment,
+            &handler_state.environment_variables,
+            udf_kind,
+            &payload.name,
+            tracing,
+        )
+        .and_then(|(package_json_path, wrangler_toml_path)| {
+            super::udf::spawn_miniflare(udf_kind, &payload.name, package_json_path, wrangler_toml_path, tracing)
+        })
+        .await
+        {
+            Ok((miniflare_handle, worker_port)) => {
+                handler_state.udf_builds.lock().await.insert(
+                    (payload.name.clone(), udf_kind),
+                    UdfBuild::Succeeded {
+                        miniflare_handle,
+                        worker_port,
+                    },
+                );
+                notify.notify_waiters();
+
+                handler_state
+                    .bridge_sender
+                    .send(ServerMessage::CompleteUdfBuild {
+                        udf_kind,
+                        udf_name: payload.name.clone(),
+                        duration: start.elapsed(),
+                    })
+                    .await
+                    .unwrap();
+
+                break worker_port;
+            }
+            Err(err) => {
+                error!(
+                    "Build of {udf_kind} '{udf_name}' failed: {err:?}",
+                    udf_name = payload.name
+                );
+                handler_state
+                    .bridge_sender
+                    .send(ServerMessage::CompilationError(format!(
+                        "{udf_kind} '{udf_name}' failed to build: {err}",
+                        udf_name = payload.name
+                    )))
+                    .await
+                    .unwrap();
+            }
+        };
+
+        handler_state
+            .udf_builds
+            .lock()
+            .await
+            .insert((payload.name.clone(), udf_kind), UdfBuild::Failed);
+        notify.notify_waiters();
+        return Err(ApiError::UdfInvocation);
+    };
+
+    super::udf::invoke(
+        &handler_state.bridge_sender,
+        udf_worker_port,
+        udf_kind,
+        &payload.name,
+        &payload.payload,
+    )
+    .await
+    .map(Json)
 }
 
 async fn wait_until_udf_ready(worker_port: u16, udf_kind: UdfKind, udf_name: &str) -> Result<bool, reqwest::Error> {

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -180,14 +180,7 @@ async fn spawn_servers(
             return Ok(());
         }
 
-        let start = std::time::Instant::now();
-        sender.send(ServerMessage::InstallUdfDependencies).unwrap();
-        crate::udf_builder::install_dependencies(project, tracing).await?;
-        sender
-            .send(ServerMessage::CompleteInstallingUdfDependencies {
-                duration: start.elapsed(),
-            })
-            .unwrap();
+        crate::udf_builder::install_dependencies(project, &sender, tracing).await?;
     }
 
     let (bridge_sender, mut bridge_receiver) = tokio::sync::mpsc::channel(128);

--- a/cli/crates/server/src/types.rs
+++ b/cli/crates/server/src/types.rs
@@ -26,5 +26,14 @@ pub enum ServerMessage {
         level: UdfMessageLevel,
         message: String,
     },
+    OperationStarted {
+        request_id: String,
+        name: Option<String>,
+    },
+    OperationCompleted {
+        request_id: String,
+        name: Option<String>,
+        duration: std::time::Duration,
+    },
     CompilationError(String),
 }

--- a/cli/crates/server/src/types.rs
+++ b/cli/crates/server/src/types.rs
@@ -34,6 +34,7 @@ pub enum ServerMessage {
         request_id: String,
         name: Option<String>,
         duration: std::time::Duration,
+        r#type: common::types::OperationType,
     },
     CompilationError(String),
 }


### PR DESCRIPTION
# Description

This introduces an initial logging of operation-related log events (operation start and completion) that get posted through the bridge.

This also adds a '--debug' argument to the 'dev' command that for now enables logging of introspection queries.

# Type of change

- [ ] 💔 Breaking
- [X] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update

![image](https://github.com/grafbase/grafbase/assets/14150873/bc7c770d-fa85-4575-880e-abab88cb7e22)

![image](https://github.com/grafbase/grafbase/assets/14150873/04a84392-3079-4bb8-903a-ccf5b3cb7bd6)
