### PR TITLE
feat: pull in header forwarding, add a test.

### DIFF
--- a/cli/crates/cli/tests/graphql-directive/headers.rs
+++ b/cli/crates/cli/tests/graphql-directive/headers.rs
@@ -1,0 +1,89 @@
+use backend::project::ConfigType;
+use serde_json::Value;
+
+use crate::{
+    server,
+    utils::{async_client::AsyncClient, environment::Environment},
+};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_header_forwarding() {
+    server::run(54303).await;
+
+    let mut env = Environment::init_async().await;
+    let client = start_grafbase(&mut env, schema(54303)).await;
+
+    let response = client
+        .gql::<Value>(
+            r#"
+                query {
+                    headers {
+                        name
+                        value
+                    }
+                }
+        "#,
+        )
+        .header("wow-what-a-header", "isn't it the best")
+        .header("and-another-one", "yes")
+        .header("a-header-that-shouldnt-be-forwarded", "ok")
+        .header("Authorization", "Basic XYZ")
+        .await;
+
+    insta::assert_yaml_snapshot!(response, @r###"
+    ---
+    data:
+      headers:
+        - name: host
+          value: "127.0.0.1:54303"
+        - name: connection
+          value: keep-alive
+        - name: another-one
+          value: "yes"
+        - name: authorization
+          value: Bearer BLAH
+        - name: content-type
+          value: application/json
+        - name: user-agent
+          value: Grafbase
+        - name: wow-what-a-header
+          value: "isn't it the best"
+        - name: mf-loop
+          value: "1"
+        - name: accept-encoding
+          value: "gzip, deflate"
+        - name: content-length
+          value: "96"
+    "###);
+}
+
+async fn start_grafbase(env: &mut Environment, schema: impl AsRef<str>) -> AsyncClient {
+    env.grafbase_init(ConfigType::GraphQL);
+    env.write_schema(schema);
+    env.set_variables([("API_KEY", "BLAH")]);
+    env.grafbase_dev_watch();
+
+    let client = env.create_async_client().with_api_key();
+
+    client.poll_endpoint(30, 300).await;
+
+    client
+}
+
+fn schema(port: u16) -> String {
+    format!(
+        r#"
+          extend schema
+          @graphql(
+            url: "http://127.0.0.1:{port}",
+            schema: "http://127.0.0.1:{port}/spec.json",
+            headers: [
+                {{ name: "authorization", value: "Bearer {{{{ env.API_KEY }}}}" }}
+                {{ name: "wow-what-a-header", forward: "wow-what-a-header" }}
+                {{ name: "another-one", forward: "and-another-one" }}
+                {{ name: "secret-third-header", forward: "secret-third-header" }}
+            ],
+          )
+        "#
+    )
+}

--- a/cli/crates/cli/tests/graphql-directive/main.rs
+++ b/cli/crates/cli/tests/graphql-directive/main.rs
@@ -8,6 +8,7 @@ use crate::utils::environment::Environment;
 #[path = "../utils/mod.rs"]
 mod utils;
 
+mod headers;
 mod server;
 
 const NAMESPACED_QUERY: &str = "
@@ -119,6 +120,43 @@ async fn graphql_test_without_namespace() {
 
     let mut env = Environment::init_async().await;
     let client = start_grafbase(&mut env, schema(54301, false)).await;
+
+    insta::assert_yaml_snapshot!(
+        "unnamespaced-pull-request-with-user",
+        client
+            .gql::<Value>(UNNAMESPACED_QUERY)
+            .variables(json!({"id": "1"}))
+            .await
+    );
+    insta::assert_yaml_snapshot!(
+        "unnamespaced-pull-request-with-bot",
+        client
+            .gql::<Value>(UNNAMESPACED_QUERY)
+            .variables(json!({"id": "2"}))
+            .await
+    );
+    insta::assert_yaml_snapshot!(
+        "unnamespaced-issue",
+        client
+            .gql::<Value>(UNNAMESPACED_QUERY)
+            .variables(json!({"id": "3"}))
+            .await
+    );
+    insta::assert_yaml_snapshot!(
+        "unnamespaced-null",
+        client
+            .gql::<Value>(UNNAMESPACED_QUERY)
+            .variables(json!({"id": "4"}))
+            .await
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_header_forwarding() {
+    server::run(54302).await;
+
+    let mut env = Environment::init_async().await;
+    let client = start_grafbase(&mut env, schema(54302, false)).await;
 
     insta::assert_yaml_snapshot!(
         "unnamespaced-pull-request-with-user",

--- a/cli/crates/cli/tests/graphql-directive/server.rs
+++ b/cli/crates/cli/tests/graphql-directive/server.rs
@@ -2,20 +2,25 @@ use std::net::SocketAddr;
 
 use async_graphql::{EmptyMutation, EmptySubscription, Interface, Object, Schema, SimpleObject, Union, ID};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
-use axum::{extract::Extension, routing::post, Router};
+use axum::{http::HeaderMap, routing::post, Router};
 
-type TestSchema = Schema<Query, EmptyMutation, EmptySubscription>;
+async fn graphql_handler(headers: HeaderMap, req: GraphQLRequest) -> GraphQLResponse {
+    let headers = headers
+        .into_iter()
+        .map(|(name, value)| {
+            (
+                name.map(|name| name.to_string()).unwrap_or_default(),
+                String::from_utf8_lossy(value.as_bytes()).to_string(),
+            )
+        })
+        .collect();
+    let schema = Schema::build(Query { headers }, EmptyMutation, EmptySubscription).finish();
 
-async fn graphql_handler(schema: Extension<TestSchema>, req: GraphQLRequest) -> GraphQLResponse {
     schema.execute(req.into_inner()).await.into()
 }
 
 pub(crate) async fn run(port: u16) {
-    let schema = Schema::build(Query, EmptyMutation, EmptySubscription)
-        .data(TestSchema::new(Query, EmptyMutation, EmptySubscription))
-        .finish();
-
-    let app = Router::new().route("/", post(graphql_handler)).layer(Extension(schema));
+    let app = Router::new().route("/", post(graphql_handler));
 
     tokio::spawn(async move {
         let addr = SocketAddr::from(([127, 0, 0, 1], port));
@@ -23,7 +28,9 @@ pub(crate) async fn run(port: u16) {
     });
 }
 
-struct Query;
+struct Query {
+    headers: Vec<(String, String)>,
+}
 
 #[Object]
 impl Query {
@@ -54,6 +61,20 @@ impl Query {
         }
         None
     }
+
+    async fn headers(&self) -> Vec<Header> {
+        self.headers
+            .clone()
+            .into_iter()
+            .map(|(name, value)| Header { name, value })
+            .collect()
+    }
+}
+
+#[derive(SimpleObject)]
+struct Header {
+    name: String,
+    value: String,
 }
 
 #[derive(SimpleObject)]

--- a/cli/crates/cli/tests/openapi/headers.rs
+++ b/cli/crates/cli/tests/openapi/headers.rs
@@ -1,0 +1,100 @@
+//! Tests of passing through headers
+
+use std::{collections::BTreeMap, net::SocketAddr};
+
+use serde_json::Value;
+use wiremock::{
+    matchers::{method, path},
+    Mock, ResponseTemplate,
+};
+
+use crate::{http_spy::HttpSpy, utils::environment::Environment};
+
+use super::{doggie, mount_petstore_spec, start_grafbase};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_header_passthrough() {
+    let mock_server = wiremock::MockServer::start().await;
+    mount_petstore_spec(&mock_server).await;
+
+    let mut env = Environment::init_async().await;
+    let client = start_grafbase(&mut env, petstore_schema_with_header_forwarding(mock_server.address())).await;
+
+    let http_spy = HttpSpy::new();
+
+    Mock::given(method("GET"))
+        .and(path("/pet/123"))
+        .and(http_spy.clone())
+        .respond_with(ResponseTemplate::new(200).set_body_json(doggie()))
+        .mount(&mock_server)
+        .await;
+
+    insta::assert_yaml_snapshot!(
+        client
+            .gql::<Value>(
+                r#"
+                    query {
+                        petstore {
+                            pet(petId: 123) {
+                                id
+                            }
+                        }
+                    }
+                "#,
+            )
+            .header("wow-what-a-header", "isn't it the best")
+            .header("and-another-one", "yes")
+            .header("a-header-that-shouldnt-be-forwarded", "ok")
+            .header("Authorization", "Basic XYZ")
+            .await,
+        @r###"
+    ---
+    data:
+      petstore:
+        pet:
+          id: 123
+    "###
+    );
+
+    let headers = http_spy
+        .drain_requests()
+        .into_iter()
+        .map(|request| {
+            // Wow, this is annoying...
+            request
+                .headers
+                .into_iter()
+                .map(|(name, value)| (name.to_string(), value.to_string()))
+                .filter(|(name, _)| {
+                    name != "host" && name != "connection" && name != "accept-encoding" && name != "mf-loop"
+                })
+                .collect::<BTreeMap<_, _>>()
+        })
+        .collect::<Vec<_>>();
+
+    insta::assert_yaml_snapshot!(headers, @r###"
+    ---
+    - another-one: "[\"yes\"]"
+      authorization: "[\"Bearer BLAH\"]"
+      wow-what-a-header: "[\"isn't it the best\"]"
+    "###);
+}
+
+fn petstore_schema_with_header_forwarding(address: &SocketAddr) -> String {
+    format!(
+        r#"
+          extend schema
+          @openapi(
+            namespace: "petstore",
+            url: "http://{address}",
+            schema: "http://{address}/spec.json",
+            headers: [
+                {{ name: "authorization", value: "Bearer {{{{ env.API_KEY }}}}" }}
+                {{ name: "wow-what-a-header", forward: "wow-what-a-header" }}
+                {{ name: "another-one", forward: "and-another-one" }}
+                {{ name: "secret-third-header", forward: "secret-third-header" }}
+            ],
+          )
+        "#
+    )
+}

--- a/cli/crates/cli/tests/openapi/http_spy.rs
+++ b/cli/crates/cli/tests/openapi/http_spy.rs
@@ -1,0 +1,36 @@
+use crossbeam_channel::{Receiver, Sender};
+use serde_json::Value;
+use wiremock::{Match, Request};
+
+#[derive(Clone)]
+/// An impl of `wiremock::Match` that lets you see what requests were made
+pub struct HttpSpy {
+    receiver: Receiver<Request>,
+    sender: Sender<Request>,
+}
+
+impl HttpSpy {
+    pub fn new() -> Self {
+        let (sender, receiver) = crossbeam_channel::unbounded();
+        HttpSpy { receiver, sender }
+    }
+
+    pub fn drain_requests(&self) -> Vec<Request> {
+        self.receiver.try_iter().collect()
+    }
+
+    pub fn drain_json_bodies(&self) -> Vec<Value> {
+        self.receiver
+            .try_iter()
+            .map(|request| request.body_json().expect("Expected JSON body"))
+            .collect()
+    }
+}
+
+impl Match for HttpSpy {
+    fn matches(&self, request: &wiremock::Request) -> bool {
+        self.sender.send(request.clone()).expect("channel to be open");
+
+        true
+    }
+}

--- a/cli/crates/cli/tests/openapi/main.rs
+++ b/cli/crates/cli/tests/openapi/main.rs
@@ -2,19 +2,22 @@
 #[path = "../utils/mod.rs"]
 mod utils;
 
+mod headers;
+mod http_spy;
 mod introspection_headers;
 mod remote_unions;
 
 use std::net::SocketAddr;
 
 use backend::project::ConfigType;
-use crossbeam_channel::{Receiver, Sender};
 use serde_json::{json, Value};
 use utils::{async_client::AsyncClient, environment::Environment};
 use wiremock::{
     matchers::{header, method, path},
-    Match, Mock, ResponseTemplate,
+    Mock, ResponseTemplate,
 };
+
+use self::http_spy::HttpSpy;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn openapi_test() {
@@ -58,12 +61,12 @@ async fn openapi_test() {
     "###
     );
 
-    let request_body_spy = RequestBodySpy::new();
+    let http_spy = HttpSpy::new();
 
     Mock::given(method("PUT"))
         .and(path("/pet"))
         .and(header("authorization", "Bearer BLAH"))
-        .and(request_body_spy.clone())
+        .and(http_spy.clone())
         .respond_with(ResponseTemplate::new(200).set_body_json(doggie()))
         .mount(&mock_server)
         .await;
@@ -102,7 +105,7 @@ async fn openapi_test() {
     "###
     );
 
-    insta::assert_yaml_snapshot!(request_body_spy.drain_requests(), @r###"
+    insta::assert_yaml_snapshot!(http_spy.drain_json_bodies(), @r###"
     ---
     - category: {}
       id: 123
@@ -152,12 +155,12 @@ async fn openapi_flat_namespace() {
     "###
     );
 
-    let request_body_spy = RequestBodySpy::new();
+    let http_spy = HttpSpy::new();
 
     Mock::given(method("PUT"))
         .and(path("/pet"))
         .and(header("authorization", "Bearer BLAH"))
-        .and(request_body_spy.clone())
+        .and(http_spy.clone())
         .respond_with(ResponseTemplate::new(200).set_body_json(doggie()))
         .mount(&mock_server)
         .await;
@@ -193,7 +196,7 @@ async fn openapi_flat_namespace() {
     "###
     );
 
-    insta::assert_yaml_snapshot!(request_body_spy.drain_requests(), @r###"
+    insta::assert_yaml_snapshot!(http_spy.drain_json_bodies(), @r###"
     ---
     - category: {}
       id: 123
@@ -202,33 +205,6 @@ async fn openapi_flat_namespace() {
       status: available
       tags: []
     "###);
-}
-
-#[derive(Clone)]
-struct RequestBodySpy {
-    receiver: Receiver<Value>,
-    sender: Sender<Value>,
-}
-
-impl RequestBodySpy {
-    pub fn new() -> Self {
-        let (sender, receiver) = crossbeam_channel::unbounded();
-        RequestBodySpy { receiver, sender }
-    }
-
-    pub fn drain_requests(&self) -> Vec<Value> {
-        self.receiver.try_iter().collect()
-    }
-}
-
-impl Match for RequestBodySpy {
-    fn matches(&self, request: &wiremock::Request) -> bool {
-        self.sender
-            .send(request.body_json().expect("A JSON Body"))
-            .expect("channel to be open");
-
-        true
-    }
 }
 
 async fn start_grafbase(env: &mut Environment, schema: impl AsRef<str>) -> AsyncClient {

--- a/cli/crates/cli/tests/utils/async_client.rs
+++ b/cli/crates/cli/tests/utils/async_client.rs
@@ -164,6 +164,11 @@ pub struct GqlRequestBuilder<Response> {
 }
 
 impl<Response> GqlRequestBuilder<Response> {
+    pub fn header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.reqwest_builder = self.reqwest_builder.header(name.into(), value.into());
+        self
+    }
+
     pub fn variables(mut self, variables: impl serde::Serialize) -> Self {
         self.variables = Some(serde_json::to_value(variables).expect("to be able to serialize variables"));
         self


### PR DESCRIPTION
# Description

Users would like to be able to forward headers from the incoming request to connectors.  This pulls in that functionality and adds a test.

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
