### PR TITLE
feat: update tsconfig with support for header forwarding.

### DIFF
--- a/packages/grafbase-sdk/tests/unit/graphql.test.ts
+++ b/packages/grafbase-sdk/tests/unit/graphql.test.ts
@@ -27,6 +27,9 @@ describe('GraphQL connector', () => {
         headers.static('Authorization', 'Bearer {{ env.STRIPE_API_KEY }}')
         headers.static('Method', 'POST')
         headers.introspection('Foo', 'BAR')
+
+        headers.set('X-Features', 'Foo,Bar')
+        headers.set('Foo', { forward: 'Bar' })
       }
     })
 
@@ -40,6 +43,8 @@ describe('GraphQL connector', () => {
           headers: [
             { name: "Authorization", value: "Bearer {{ env.STRIPE_API_KEY }}" }
             { name: "Method", value: "POST" }
+            { name: "X-Features", value: "Foo,Bar" }
+            { name: "Foo", forward: "Bar" }
           ]
           introspectionHeaders: [
             { name: "Foo", value: "BAR" }

--- a/packages/grafbase-sdk/tests/unit/openapi.test.ts
+++ b/packages/grafbase-sdk/tests/unit/openapi.test.ts
@@ -32,6 +32,9 @@ describe('OpenAPI generator', () => {
         headers.static('Method', 'POST')
 
         headers.introspection('foo', 'bar')
+
+        headers.set('X-Features', 'Foo,Bar')
+        headers.set('Foo', { forward: 'Bar' })
       }
     })
 
@@ -47,6 +50,8 @@ describe('OpenAPI generator', () => {
           headers: [
             { name: "Authorization", value: "Bearer {{ env.STRIPE_API_KEY }}" }
             { name: "Method", value: "POST" }
+            { name: "X-Features", value: "Foo,Bar" }
+            { name: "Foo", forward: "Bar" }
           ]
           introspectionHeaders: [
             { name: "foo", value: "bar" }

--- a/packages/grafbase-sdk/tsconfig.json
+++ b/packages/grafbase-sdk/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/base.json",
+  "extends": "../tsconfig/base.json",
   "compilerOptions": {
     "outDir": "./dist"
   },


### PR DESCRIPTION
# Description

We're adding the ability to forward headers from a users request to openapi & graphql connectors.  This adds support for these to TS config.

As part of this we've deprecated the old `headers.static` method in favour of a new `headers.set` method that supports static headers and forwarded headers.

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
