### PR TITLE
Fix the way we handle miniflare's output to ensure we expose errors happening at spawn time

### DIFF
--- a/cli/crates/server/src/bridge/errors.rs
+++ b/cli/crates/server/src/bridge/errors.rs
@@ -23,9 +23,6 @@ pub enum ApiError {
     ServerError,
     #[error("user-defined function invocation error")]
     UdfInvocation,
-    /// returned if the miniflare command returns an error
-    #[error("user-defined function could not be spawned")]
-    UdfSpawnError,
 }
 
 #[derive(Serialize, Debug)]
@@ -52,7 +49,7 @@ impl IntoResponse for ApiError {
         match self {
             ApiError::User(user_error) => (StatusCode::CONFLICT, Json(user_error)).into_response(),
 
-            ApiError::SqlError(_) | ApiError::ServerError | ApiError::UdfInvocation | ApiError::UdfSpawnError => {
+            ApiError::SqlError(_) | ApiError::ServerError | ApiError::UdfInvocation => {
                 StatusCode::INTERNAL_SERVER_ERROR.into_response()
             }
         }

--- a/cli/crates/server/src/errors.rs
+++ b/cli/crates/server/src/errors.rs
@@ -210,9 +210,17 @@ pub enum UdfBuildError {
     #[error("command error: {0}")]
     WranglerInstallPackageManagerCommandError(#[from] JavascriptPackageManagerComamndError),
 
-    /// returned if any of the npm commands ran during resolver build exits unsuccessfully
-    #[error("{0} {1} failed to build:\n{2}")]
-    UdfBuild(UdfKind, String, String),
+    /// returned if the wrangler build step failed
+    #[error("\n{output}")]
+    WranglerBuildFailed { output: String },
+
+    // returned if miniflare for a given UDF fails to spawn
+    #[error("unknown spawn error")]
+    MiniflareSpawnFailed,
+
+    // returned if miniflare for a given UDF fails to spawn, with more details
+    #[error("\n{output}")]
+    MiniflareSpawnFailedWithOutput { output: String },
 
     /// returned if a spawned task panics
     #[error(transparent)]

--- a/cli/crates/server/src/udf_builder.rs
+++ b/cli/crates/server/src/udf_builder.rs
@@ -285,7 +285,7 @@ pub async fn build(
         .await
         .map_err(|err| match err {
             JavascriptPackageManagerComamndError::OutputError(_, output) => {
-                UdfBuildError::UdfBuild(udf_kind, udf_name.to_owned(), output)
+                UdfBuildError::WranglerBuildFailed { output }
             }
             other => other.into(),
         })?;


### PR DESCRIPTION
# Description

When we introduced lazy loading for resolvers – the inner workings of which include spawning a separate miniflare instance for each resolver – we started allocating ports to miniflare instances dynamically by passing `--port 0` to spawn command. Later, we would parse the miniflare output to look for a line containing the port the instance is bound to, to establish the mapping between resolver names and port numbers.

This has broken our handling of errors happening at miniflare spawn time, including errors related to initialisation of the resolver module or any code running in the initialisation of dependencies in the global scope.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
