### PR TITLE
feat: Add regex filter in search query

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   GRAFBASE_SKIP_ASSET_VERSION_CHECK: 'true'
-  ASSETS_VERSION: release/9d65ad1-2023-07-19
+  ASSETS_VERSION: release/10fea4b-2023-07-21
   PROD_ASSETS: assets.grafbase.com
   CARGO_TERM_COLOR: 'always'
   CARGO_PROFILE_DEV_DEBUG: 0

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1585,6 +1585,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,6 +1933,7 @@ dependencies = [
  "strip-ansi-escapes",
  "strum",
  "tantivy",
+ "tantivy-fst",
  "tar",
  "tempfile",
  "thiserror",
@@ -4617,12 +4628,14 @@ dependencies = [
  "fail",
  "fastdivide",
  "fastfield_codecs",
+ "fs2",
  "htmlescape",
  "itertools",
  "levenshtein_automata",
  "log",
  "lru",
  "measure_time",
+ "memmap2",
  "murmurhash32",
  "num_cpus",
  "once_cell",
@@ -4640,6 +4653,7 @@ dependencies = [
  "tantivy-common",
  "tantivy-fst",
  "tantivy-query-grammar",
+ "tempfile",
  "thiserror",
  "time 0.3.22",
  "uuid",

--- a/cli/changelog/0.28.0.md
+++ b/cli/changelog/0.28.0.md
@@ -1,0 +1,4 @@
+### Features
+
+- Add `id` filter to the collection query.
+- Add `regex` filter to the search query.

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -43,7 +43,7 @@ sqlx = { version = "0.6", features = [
 ] }
 strip-ansi-escapes = "0.1"
 strum = { version = "0.25", features = ["derive"] }
-tantivy = { version = "0.19", default-features = false }
+tantivy = { version = "0.19", default-features = false, features = ["mmap"] }
 # Temporary change till https://github.com/alexcrichton/tar-rs/pull/319 is release
 tar = { git = "https://github.com/obmarg/tar-rs.git", rev = "bffee32190d531c03d806680daebd89cb1544be1" }
 tempfile = "3"
@@ -56,6 +56,10 @@ unicode-normalization = "0.1"
 uuid = { version = "1", features = ["v4"] }
 version-compare = "0.1"
 which = "4"
+
+# Same version as Tantivy
+tantivy-fst = "0.4.0"
+
 
 common = { package = "grafbase-local-common", path = "../common", version = "0.27.0" }
 

--- a/cli/crates/server/src/bridge/api_counterfeit/search/protocol.rs
+++ b/cli/crates/server/src/bridge/api_counterfeit/search/protocol.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use super::{cursor::Cursor, query::Query};
+use super::{cursor::Cursor, query::Query, SearchError};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct QueryExecutionRequest {
@@ -10,7 +10,7 @@ pub struct QueryExecutionRequest {
     pub database: String,
 }
 
-pub type QueryExecutionResponse = PaginatedHits<String>;
+pub type QueryExecutionResponse = Result<PaginatedHits<String>, SearchError>;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Pagination {


### PR DESCRIPTION
Adding regex filter, it's actually relatively limited by tantivy in terms of regex complexity, but better than nothing.
I'm also now handling user errors a bit better (invalid regex/cursor) a bit better instead of just saying "Search failed".

# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
