### PR TITLE
chore(test): Extend entrypoint resolver auth tests

### DIFF
--- a/cli/crates/cli/tests/graphql/auth/entrypoint-field-resolver.graphql
+++ b/cli/crates/cli/tests/graphql/auth/entrypoint-field-resolver.graphql
@@ -1,7 +1,10 @@
 schema
   @auth(
     providers: [{ type: jwt, issuer: "{{ env.ISSUER_URL }}", secret: "{{ env.JWT_SECRET }}" }]
-    rules: [{ allow: private }]
+    rules: [
+      { allow: groups, groups: ["reader"], operations: [read] }
+      { allow: groups, groups: ["writer"], operations: [create, update, delete] }
+    ]
   ) {
   query: Query
 }

--- a/cli/crates/cli/tests/snapshots/auth__entrypoint_mutation_field_resolver_mixed___writer_with_entrypoint_field_mutation_should_succeed.snap
+++ b/cli/crates/cli/tests/snapshots/auth__entrypoint_mutation_field_resolver_mixed___writer_with_entrypoint_field_mutation_should_succeed.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/cli/tests/auth.rs
-expression: "private_client.gql::<Value>(AUTH_ENTRYPOINT_QUERY_TEXT).await"
+expression: "writer_client.gql::<Value>(AUTH_ENTRYPOINT_MUTATION_TEXT).await"
 ---
 {
   "data": {

--- a/cli/crates/cli/tests/snapshots/auth__entrypoint_mutation_field_resolver_mixed__reader_entrypoint_field_mutation_should_fail.snap
+++ b/cli/crates/cli/tests/snapshots/auth__entrypoint_mutation_field_resolver_mixed__reader_entrypoint_field_mutation_should_fail.snap
@@ -1,0 +1,12 @@
+---
+source: crates/cli/tests/auth.rs
+expression: "reader_client.gql::<Value>(AUTH_ENTRYPOINT_MUTATION_TEXT).await"
+---
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "Unauthorized to access Mutation.text (missing create | update | delete operation)"
+    }
+  ]
+}

--- a/cli/crates/cli/tests/snapshots/auth__entrypoint_query_field_resolver__reader_with_entrypoint_field_query_should_succeed.snap
+++ b/cli/crates/cli/tests/snapshots/auth__entrypoint_query_field_resolver__reader_with_entrypoint_field_query_should_succeed.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/cli/tests/auth.rs
-expression: "private_client.gql::<Value>(AUTH_ENTRYPOINT_MUTATION_TEXT).await"
+expression: "reader_client.gql::<Value>(AUTH_ENTRYPOINT_QUERY_TEXT).await"
 ---
 {
   "data": {

--- a/cli/crates/cli/tests/snapshots/auth__entrypoint_query_field_resolver__writer_with_entrypoint_field_query_should_fail.snap
+++ b/cli/crates/cli/tests/snapshots/auth__entrypoint_query_field_resolver__writer_with_entrypoint_field_query_should_fail.snap
@@ -1,0 +1,12 @@
+---
+source: crates/cli/tests/auth.rs
+expression: "writer_client.gql::<Value>(AUTH_ENTRYPOINT_QUERY_TEXT).await"
+---
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "Unauthorized to access Query.text (missing get | list operation)"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Add auth tests for top level query and mutation resolvers.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
