### PR TITLE
fix: console.log not working

### DIFF
--- a/cli/crates/cli/tests/custom_resolvers.rs
+++ b/cli/crates/cli/tests/custom_resolvers.rs
@@ -414,6 +414,35 @@ fn test_field_resolver(
         ),
     ],
 )]
+#[case(
+    4,
+    r#"
+        extend type Query {
+            hello: String @resolver(name: "hello")
+        }
+    "#,
+    &[
+        (
+            "hello.js",
+            r#"
+                export default function Resolver(parent, args, context, info) {
+                    console.log("Hello")
+                    return "Hello"
+                }
+            "#,
+        )
+    ],
+    &[
+        (
+            r#"
+                {
+                    hello
+                }
+            "#,
+            "data.hello"
+        ),
+    ],
+)]
 fn test_query_mutation_resolver(
     #[case] case_index: usize,
     #[case] schema: &str,

--- a/cli/crates/cli/tests/snapshots/custom_resolvers__query_mutation_resolver_4_1.snap
+++ b/cli/crates/cli/tests/snapshots/custom_resolvers__query_mutation_resolver_4_1.snap
@@ -1,0 +1,5 @@
+---
+source: crates/cli/tests/custom_resolvers.rs
+expression: value
+---
+Hello

--- a/cli/crates/common/src/types.rs
+++ b/cli/crates/common/src/types.rs
@@ -9,6 +9,7 @@ pub enum LocalAddressType {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum LogLevel {
     Error,
     Warn,


### PR DESCRIPTION
We had a case mismatch on log levels between our JS and Rust.

Also added a test to make sure we don't regress.

Fixes GB-4406