### PR TITLE
refactor(templates): use new set header method in templates

### DIFF
--- a/packages/grafbase-sdk/README.md
+++ b/packages/grafbase-sdk/README.md
@@ -354,7 +354,7 @@ const stripe = connector.OpenAPI({
     'https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json',
   headers: (headers) => {
     // used in client and introspection requests
-    headers.static('Authorization', `Bearer ${g.env('STRIPE_API_KEY')}`)
+    headers.set('Authorization', `Bearer ${g.env('STRIPE_API_KEY')}`)
     // used only in introspection requests
     headers.introspection('foo', 'bar')
   }
@@ -376,8 +376,8 @@ The GraphQL connector can be created with the `GraphQL` method:
 const contentful = connector.GraphQL({
   url: g.env('CONTENTFUL_API_URL'),
   headers: (headers) => {
-    headers.static('Authorization', `Bearer ${g.env('CONTENTFUL_API_KEY')}`)
-    headers.static('Method', 'POST')
+    headers.set('Authorization', `Bearer ${g.env('CONTENTFUL_API_KEY')}`)
+    headers.set('Method', 'POST')
   }
 })
 
@@ -628,7 +628,7 @@ Node's `process.env` return nullable strings, which are a bit annoying to use in
 const github = connector.GraphQL({
   url: 'https://api.github.com/graphql',
   headers: (headers) => {
-    headers.static('Authorization', `Bearer ${g.env('GITHUB_TOKEN')}`)
+    headers.set('Authorization', `Bearer ${g.env('GITHUB_TOKEN')}`)
   }
 })
 ```

--- a/templates/blog/package-lock.json
+++ b/templates/blog/package-lock.json
@@ -5,11 +5,8 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "blog",
-      "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
-        "@grafbase/sdk": "~0.3.0"
+        "@grafbase/sdk": "^0.3.0"
       }
     },
     "node_modules/@grafbase/sdk": {

--- a/templates/blog/package.json
+++ b/templates/blog/package.json
@@ -1,15 +1,6 @@
 {
-  "name": "blog",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "~0.3.0"
+    "@grafbase/sdk": "^0.3.0"
   }
 }

--- a/templates/chatroom/package-lock.json
+++ b/templates/chatroom/package-lock.json
@@ -5,11 +5,8 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "chatroom",
-      "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
-        "@grafbase/sdk": "~0.3.0"
+        "@grafbase/sdk": "^0.3.0"
       }
     },
     "node_modules/@grafbase/sdk": {

--- a/templates/chatroom/package.json
+++ b/templates/chatroom/package.json
@@ -1,15 +1,6 @@
 {
-  "name": "chatroom",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "~0.3.0"
+    "@grafbase/sdk": "^0.3.0"
   }
 }

--- a/templates/commerce/package-lock.json
+++ b/templates/commerce/package-lock.json
@@ -5,11 +5,8 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "commerce",
-      "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
-        "@grafbase/sdk": "~0.3.0"
+        "@grafbase/sdk": "^0.3.0"
       }
     },
     "node_modules/@grafbase/sdk": {

--- a/templates/commerce/package.json
+++ b/templates/commerce/package.json
@@ -1,15 +1,6 @@
 {
-  "name": "commerce",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "~0.3.0"
+    "@grafbase/sdk": "^0.3.0"
   }
 }

--- a/templates/graphql-cloudflare-analytics/grafbase/grafbase.config.ts
+++ b/templates/graphql-cloudflare-analytics/grafbase/grafbase.config.ts
@@ -3,7 +3,7 @@ import { g, connector, config } from '@grafbase/sdk'
 const cloudflare = connector.GraphQL({
   url: 'https://api.cloudflare.com/client/v4/graphql',
   headers: (headers) => {
-    headers.static('Authorization', `Bearer ${g.env('API_TOKEN')}`)
+    headers.set('Authorization', `Bearer ${g.env('API_TOKEN')}`)
   }
 })
 

--- a/templates/graphql-cloudflare-analytics/package-lock.json
+++ b/templates/graphql-cloudflare-analytics/package-lock.json
@@ -5,17 +5,14 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "graphql-cloudflare-analytics",
-      "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
-        "@grafbase/sdk": "^0.1.1"
+        "@grafbase/sdk": "^0.3.0"
       }
     },
     "node_modules/@grafbase/sdk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.1.1.tgz",
-      "integrity": "sha512-tfIitoX4TdnY9pu2Z2ro6pzL6F0iMDWFfi0OqBQz9ldKUb6zB1LvCb/cs5DRRnr3YV9M1fVXDcLIO3u6//+9fA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.3.0.tgz",
+      "integrity": "sha512-kvpNPbtHwVr1EDcY3nv5dQH98+M/9dM8Sp8Lcd9tc2Ayi3/12CkJCxSKBDaYf4MA5e8e05DGmfo+CRTTP1rsAQ==",
       "dev": true,
       "dependencies": {
         "dotenv": "^16.1.4",

--- a/templates/graphql-cloudflare-analytics/package.json
+++ b/templates/graphql-cloudflare-analytics/package.json
@@ -1,15 +1,6 @@
 {
-  "name": "graphql-cloudflare-analytics",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "~0.1.0"
+    "@grafbase/sdk": "^0.3.0"
   }
 }

--- a/templates/graphql-contentful/package.json
+++ b/templates/graphql-contentful/package.json
@@ -1,15 +1,6 @@
 {
-  "name": "graphql-contentful",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "~0.1.0"
+    "@grafbase/sdk": "^0.3.0"
   }
 }

--- a/templates/graphql-github/grafbase/grafbase.config.ts
+++ b/templates/graphql-github/grafbase/grafbase.config.ts
@@ -3,7 +3,7 @@ import { g, connector, config } from '@grafbase/sdk'
 const github = connector.GraphQL({
   url: 'https://api.github.com/graphql',
   headers: (headers) => {
-    headers.static('Authorization', `Bearer ${g.env('GITHUB_ACCESS_TOKEN')}`)
+    headers.set('Authorization', `Bearer ${g.env('GITHUB_ACCESS_TOKEN')}`)
   }
 })
 

--- a/templates/graphql-github/package-lock.json
+++ b/templates/graphql-github/package-lock.json
@@ -5,17 +5,14 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "graphql-github",
-      "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
-        "@grafbase/sdk": "~0.1.0"
+        "@grafbase/sdk": "^0.3.0"
       }
     },
     "node_modules/@grafbase/sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.1.0.tgz",
-      "integrity": "sha512-ERXhlUHoeW0cZZe2gPnSKffihVkUwGApqkYS2jeieYhzNWhUH+tnds/7wFqKMKer54kOkllb7bZuDkw35rbG2w==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.3.0.tgz",
+      "integrity": "sha512-kvpNPbtHwVr1EDcY3nv5dQH98+M/9dM8Sp8Lcd9tc2Ayi3/12CkJCxSKBDaYf4MA5e8e05DGmfo+CRTTP1rsAQ==",
       "dev": true,
       "dependencies": {
         "dotenv": "^16.1.4",

--- a/templates/graphql-github/package.json
+++ b/templates/graphql-github/package.json
@@ -1,15 +1,6 @@
 {
-  "name": "graphql-github",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "~0.1.0"
+    "@grafbase/sdk": "^0.3.0"
   }
 }

--- a/templates/graphql-saleor/grafbase/grafbase.config.ts
+++ b/templates/graphql-saleor/grafbase/grafbase.config.ts
@@ -3,7 +3,7 @@ import { g, connector, config } from '@grafbase/sdk'
 const saleor = connector.GraphQL({
   url: g.env('ENVIRONMENT_DOMAIN'),
   headers: (headers) => {
-    headers.static('Authorization', `Bearer ${g.env('ACCESS_TOKEN')}`)
+    headers.set('Authorization', `Bearer ${g.env('ACCESS_TOKEN')}`)
   }
 })
 

--- a/templates/graphql-saleor/package-lock.json
+++ b/templates/graphql-saleor/package-lock.json
@@ -5,17 +5,14 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "graphql-saleor",
-      "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
-        "@grafbase/sdk": "~0.1.0"
+        "@grafbase/sdk": "^0.3.0"
       }
     },
     "node_modules/@grafbase/sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.1.0.tgz",
-      "integrity": "sha512-ERXhlUHoeW0cZZe2gPnSKffihVkUwGApqkYS2jeieYhzNWhUH+tnds/7wFqKMKer54kOkllb7bZuDkw35rbG2w==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.3.0.tgz",
+      "integrity": "sha512-kvpNPbtHwVr1EDcY3nv5dQH98+M/9dM8Sp8Lcd9tc2Ayi3/12CkJCxSKBDaYf4MA5e8e05DGmfo+CRTTP1rsAQ==",
       "dev": true,
       "dependencies": {
         "dotenv": "^16.1.4",

--- a/templates/graphql-saleor/package.json
+++ b/templates/graphql-saleor/package.json
@@ -1,15 +1,6 @@
 {
-  "name": "graphql-saleor",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "~0.1.0"
+    "@grafbase/sdk": "^0.3.0"
   }
 }

--- a/templates/graphql-shopify-storefront/grafbase/grafbase.config.ts
+++ b/templates/graphql-shopify-storefront/grafbase/grafbase.config.ts
@@ -5,7 +5,7 @@ const shopify = connector.GraphQL({
     'SHOPIFY_STORE_NAME'
   )}.myshopify.com/api/2023-04/graphql.json`,
   headers: (headers) => {
-    headers.static(
+    headers.set(
       'X-Shopify-Storefront-Access-Token',
       g.env('SHOPIFY_STOREFRONT_ACCESS_TOKEN')
     )

--- a/templates/graphql-shopify-storefront/package-lock.json
+++ b/templates/graphql-shopify-storefront/package-lock.json
@@ -5,17 +5,14 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "graphql-shopify-storefront",
-      "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
-        "@grafbase/sdk": "~0.1.0"
+        "@grafbase/sdk": "^0.3.0"
       }
     },
     "node_modules/@grafbase/sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.1.0.tgz",
-      "integrity": "sha512-ERXhlUHoeW0cZZe2gPnSKffihVkUwGApqkYS2jeieYhzNWhUH+tnds/7wFqKMKer54kOkllb7bZuDkw35rbG2w==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.3.0.tgz",
+      "integrity": "sha512-kvpNPbtHwVr1EDcY3nv5dQH98+M/9dM8Sp8Lcd9tc2Ayi3/12CkJCxSKBDaYf4MA5e8e05DGmfo+CRTTP1rsAQ==",
       "dev": true,
       "dependencies": {
         "dotenv": "^16.1.4",

--- a/templates/graphql-shopify-storefront/package.json
+++ b/templates/graphql-shopify-storefront/package.json
@@ -1,15 +1,6 @@
 {
-  "name": "graphql-shopify-storefront",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "~0.1.0"
+    "@grafbase/sdk": "^0.3.0"
   }
 }

--- a/templates/hackernews/package-lock.json
+++ b/templates/hackernews/package-lock.json
@@ -5,17 +5,14 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "hackernews",
-      "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
-        "@grafbase/sdk": "~0.1.0"
+        "@grafbase/sdk": "^0.3.0"
       }
     },
     "node_modules/@grafbase/sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.1.0.tgz",
-      "integrity": "sha512-ERXhlUHoeW0cZZe2gPnSKffihVkUwGApqkYS2jeieYhzNWhUH+tnds/7wFqKMKer54kOkllb7bZuDkw35rbG2w==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.3.0.tgz",
+      "integrity": "sha512-kvpNPbtHwVr1EDcY3nv5dQH98+M/9dM8Sp8Lcd9tc2Ayi3/12CkJCxSKBDaYf4MA5e8e05DGmfo+CRTTP1rsAQ==",
       "dev": true,
       "dependencies": {
         "dotenv": "^16.1.4",

--- a/templates/hackernews/package.json
+++ b/templates/hackernews/package.json
@@ -1,15 +1,6 @@
 {
-  "name": "hackernews",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "~0.1.0"
+    "@grafbase/sdk": "^0.3.0"
   }
 }

--- a/templates/openapi-github/grafbase/grafbase.config.ts
+++ b/templates/openapi-github/grafbase/grafbase.config.ts
@@ -4,7 +4,7 @@ const github = connector.OpenAPI({
   schema:
     'https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/ghes-3.0/ghes-3.0.json',
   headers: (headers) => {
-    headers.static('Authorization', `Bearer ${g.env('GITHUB_ACCESS_TOKEN')}`)
+    headers.set('Authorization', `Bearer ${g.env('GITHUB_ACCESS_TOKEN')}`)
   }
 })
 

--- a/templates/openapi-github/package-lock.json
+++ b/templates/openapi-github/package-lock.json
@@ -5,17 +5,14 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "openapi-github",
-      "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
-        "@grafbase/sdk": "~0.1.0"
+        "@grafbase/sdk": "^0.3.0"
       }
     },
     "node_modules/@grafbase/sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.1.0.tgz",
-      "integrity": "sha512-ERXhlUHoeW0cZZe2gPnSKffihVkUwGApqkYS2jeieYhzNWhUH+tnds/7wFqKMKer54kOkllb7bZuDkw35rbG2w==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.3.0.tgz",
+      "integrity": "sha512-kvpNPbtHwVr1EDcY3nv5dQH98+M/9dM8Sp8Lcd9tc2Ayi3/12CkJCxSKBDaYf4MA5e8e05DGmfo+CRTTP1rsAQ==",
       "dev": true,
       "dependencies": {
         "dotenv": "^16.1.4",

--- a/templates/openapi-github/package.json
+++ b/templates/openapi-github/package.json
@@ -1,15 +1,6 @@
 {
-  "name": "openapi-github",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "~0.1.0"
+    "@grafbase/sdk": "^0.3.0"
   }
 }

--- a/templates/openapi-mux/grafbase/grafbase.config.ts
+++ b/templates/openapi-mux/grafbase/grafbase.config.ts
@@ -3,7 +3,7 @@ import { g, connector, config } from '@grafbase/sdk'
 const mux = connector.OpenAPI({
   schema: 'https://docs.mux.com/api-spec.json',
   headers: (headers) => {
-    headers.static('Authorization', `Basic ${g.env('MUX_BASE64')}`)
+    headers.set('Authorization', `Basic ${g.env('MUX_BASE64')}`)
   },
   transforms: { queryNaming: 'OPERATION_ID' }
 })

--- a/templates/openapi-mux/package-lock.json
+++ b/templates/openapi-mux/package-lock.json
@@ -5,17 +5,14 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "openapi-mux",
-      "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
-        "@grafbase/sdk": "~0.1.0"
+        "@grafbase/sdk": "^0.3.0"
       }
     },
     "node_modules/@grafbase/sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.1.0.tgz",
-      "integrity": "sha512-ERXhlUHoeW0cZZe2gPnSKffihVkUwGApqkYS2jeieYhzNWhUH+tnds/7wFqKMKer54kOkllb7bZuDkw35rbG2w==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.3.0.tgz",
+      "integrity": "sha512-kvpNPbtHwVr1EDcY3nv5dQH98+M/9dM8Sp8Lcd9tc2Ayi3/12CkJCxSKBDaYf4MA5e8e05DGmfo+CRTTP1rsAQ==",
       "dev": true,
       "dependencies": {
         "dotenv": "^16.1.4",

--- a/templates/openapi-mux/package.json
+++ b/templates/openapi-mux/package.json
@@ -1,15 +1,6 @@
 {
-  "name": "openapi-mux",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "~0.1.0"
+    "@grafbase/sdk": "^0.3.0"
   }
 }

--- a/templates/openapi-neon/grafbase/grafbase.config.ts
+++ b/templates/openapi-neon/grafbase/grafbase.config.ts
@@ -3,7 +3,7 @@ import { g, connector, config } from '@grafbase/sdk'
 const neon = connector.OpenAPI({
   schema: 'https://console.neon.tech/api/v2/',
   headers: (headers) => {
-    headers.static('Authorization', `Bearer ${g.env('NEON_API_KEY')}`)
+    headers.set('Authorization', `Bearer ${g.env('NEON_API_KEY')}`)
   },
   transforms: { queryNaming: 'OPERATION_ID' }
 })

--- a/templates/openapi-neon/package-lock.json
+++ b/templates/openapi-neon/package-lock.json
@@ -5,17 +5,14 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "openapi-neon",
-      "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
-        "@grafbase/sdk": "~0.1.0"
+        "@grafbase/sdk": "^0.3.0"
       }
     },
     "node_modules/@grafbase/sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.1.0.tgz",
-      "integrity": "sha512-ERXhlUHoeW0cZZe2gPnSKffihVkUwGApqkYS2jeieYhzNWhUH+tnds/7wFqKMKer54kOkllb7bZuDkw35rbG2w==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.3.0.tgz",
+      "integrity": "sha512-kvpNPbtHwVr1EDcY3nv5dQH98+M/9dM8Sp8Lcd9tc2Ayi3/12CkJCxSKBDaYf4MA5e8e05DGmfo+CRTTP1rsAQ==",
       "dev": true,
       "dependencies": {
         "dotenv": "^16.1.4",

--- a/templates/openapi-neon/package.json
+++ b/templates/openapi-neon/package.json
@@ -1,15 +1,6 @@
 {
-  "name": "openapi-neon",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "~0.1.0"
+    "@grafbase/sdk": "^0.3.0"
   }
 }

--- a/templates/openapi-openai/grafbase/grafbase.config.ts
+++ b/templates/openapi-openai/grafbase/grafbase.config.ts
@@ -4,7 +4,7 @@ const openai = connector.OpenAPI({
   schema:
     'https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml',
   headers: (headers) => {
-    headers.static('Authorization', `Bearer ${g.env('OPENAI_API_KEY')}`)
+    headers.set('Authorization', `Bearer ${g.env('OPENAI_API_KEY')}`)
   },
   transforms: { queryNaming: 'OPERATION_ID' }
 })

--- a/templates/openapi-openai/package-lock.json
+++ b/templates/openapi-openai/package-lock.json
@@ -5,17 +5,14 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "openapi-openai",
-      "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
-        "@grafbase/sdk": "~0.1.0"
+        "@grafbase/sdk": "^0.3.0"
       }
     },
     "node_modules/@grafbase/sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.1.0.tgz",
-      "integrity": "sha512-ERXhlUHoeW0cZZe2gPnSKffihVkUwGApqkYS2jeieYhzNWhUH+tnds/7wFqKMKer54kOkllb7bZuDkw35rbG2w==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.3.0.tgz",
+      "integrity": "sha512-kvpNPbtHwVr1EDcY3nv5dQH98+M/9dM8Sp8Lcd9tc2Ayi3/12CkJCxSKBDaYf4MA5e8e05DGmfo+CRTTP1rsAQ==",
       "dev": true,
       "dependencies": {
         "dotenv": "^16.1.4",

--- a/templates/openapi-openai/package.json
+++ b/templates/openapi-openai/package.json
@@ -1,15 +1,6 @@
 {
-  "name": "openapi-openai",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "~0.1.0"
+    "@grafbase/sdk": "^0.3.0"
   }
 }

--- a/templates/openapi-stripe/grafbase/grafbase.config.ts
+++ b/templates/openapi-stripe/grafbase/grafbase.config.ts
@@ -4,7 +4,7 @@ const stripe = connector.OpenAPI({
   schema:
     'https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json',
   headers: (headers) => {
-    headers.static('Authorization', `Bearer ${g.env('STRIPE_API_KEY')}`)
+    headers.set('Authorization', `Bearer ${g.env('STRIPE_API_KEY')}`)
   },
   transforms: { queryNaming: 'OPERATION_ID' }
 })

--- a/templates/openapi-stripe/package-lock.json
+++ b/templates/openapi-stripe/package-lock.json
@@ -5,17 +5,14 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "openapi-stripe",
-      "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
-        "@grafbase/sdk": "~0.1.0"
+        "@grafbase/sdk": "^0.3.0"
       }
     },
     "node_modules/@grafbase/sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.1.0.tgz",
-      "integrity": "sha512-ERXhlUHoeW0cZZe2gPnSKffihVkUwGApqkYS2jeieYhzNWhUH+tnds/7wFqKMKer54kOkllb7bZuDkw35rbG2w==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.3.0.tgz",
+      "integrity": "sha512-kvpNPbtHwVr1EDcY3nv5dQH98+M/9dM8Sp8Lcd9tc2Ayi3/12CkJCxSKBDaYf4MA5e8e05DGmfo+CRTTP1rsAQ==",
       "dev": true,
       "dependencies": {
         "dotenv": "^16.1.4",

--- a/templates/openapi-stripe/package.json
+++ b/templates/openapi-stripe/package.json
@@ -1,15 +1,6 @@
 {
-  "name": "openapi-stripe",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "~0.1.0"
+    "@grafbase/sdk": "^0.3.0"
   }
 }

--- a/templates/openapi-tinybird/grafbase/grafbase.config.ts
+++ b/templates/openapi-tinybird/grafbase/grafbase.config.ts
@@ -3,7 +3,7 @@ import { g, connector, config } from '@grafbase/sdk'
 const tinybird = connector.OpenAPI({
   schema: g.env('TINYBIRD_API_SCHEMA'),
   headers: (headers) => {
-    headers.static('Authorization', `Bearer ${g.env('TINYBIRD_API_TOKEN')}`)
+    headers.set('Authorization', `Bearer ${g.env('TINYBIRD_API_TOKEN')}`)
   },
   transforms: { queryNaming: 'OPERATION_ID' }
 })

--- a/templates/openapi-tinybird/package-lock.json
+++ b/templates/openapi-tinybird/package-lock.json
@@ -5,17 +5,14 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "openapi-tinybird",
-      "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
-        "@grafbase/sdk": "~0.1.0"
+        "@grafbase/sdk": "^0.3.0"
       }
     },
     "node_modules/@grafbase/sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.1.0.tgz",
-      "integrity": "sha512-ERXhlUHoeW0cZZe2gPnSKffihVkUwGApqkYS2jeieYhzNWhUH+tnds/7wFqKMKer54kOkllb7bZuDkw35rbG2w==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.3.0.tgz",
+      "integrity": "sha512-kvpNPbtHwVr1EDcY3nv5dQH98+M/9dM8Sp8Lcd9tc2Ayi3/12CkJCxSKBDaYf4MA5e8e05DGmfo+CRTTP1rsAQ==",
       "dev": true,
       "dependencies": {
         "dotenv": "^16.1.4",

--- a/templates/openapi-tinybird/package.json
+++ b/templates/openapi-tinybird/package.json
@@ -1,15 +1,6 @@
 {
-  "name": "openapi-tinybird",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "~0.1.0"
+    "@grafbase/sdk": "^0.3.0"
   }
 }

--- a/templates/todo/package-lock.json
+++ b/templates/todo/package-lock.json
@@ -5,17 +5,14 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "todo",
-      "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
-        "@grafbase/sdk": "~0.1.0"
+        "@grafbase/sdk": "^0.3.0"
       }
     },
     "node_modules/@grafbase/sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.1.0.tgz",
-      "integrity": "sha512-ERXhlUHoeW0cZZe2gPnSKffihVkUwGApqkYS2jeieYhzNWhUH+tnds/7wFqKMKer54kOkllb7bZuDkw35rbG2w==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.3.0.tgz",
+      "integrity": "sha512-kvpNPbtHwVr1EDcY3nv5dQH98+M/9dM8Sp8Lcd9tc2Ayi3/12CkJCxSKBDaYf4MA5e8e05DGmfo+CRTTP1rsAQ==",
       "dev": true,
       "dependencies": {
         "dotenv": "^16.1.4",

--- a/templates/todo/package.json
+++ b/templates/todo/package.json
@@ -1,15 +1,6 @@
 {
-  "name": "todo",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "~0.1.0"
+    "@grafbase/sdk": "^0.3.0"
   }
 }

--- a/templates/twitter/package-lock.json
+++ b/templates/twitter/package-lock.json
@@ -5,17 +5,14 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "twitter",
-      "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
-        "@grafbase/sdk": "~0.1.0"
+        "@grafbase/sdk": "^0.3.0"
       }
     },
     "node_modules/@grafbase/sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.1.0.tgz",
-      "integrity": "sha512-ERXhlUHoeW0cZZe2gPnSKffihVkUwGApqkYS2jeieYhzNWhUH+tnds/7wFqKMKer54kOkllb7bZuDkw35rbG2w==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.3.0.tgz",
+      "integrity": "sha512-kvpNPbtHwVr1EDcY3nv5dQH98+M/9dM8Sp8Lcd9tc2Ayi3/12CkJCxSKBDaYf4MA5e8e05DGmfo+CRTTP1rsAQ==",
       "dev": true,
       "dependencies": {
         "dotenv": "^16.1.4",

--- a/templates/twitter/package.json
+++ b/templates/twitter/package.json
@@ -1,15 +1,6 @@
 {
-  "name": "twitter",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "~0.1.0"
+    "@grafbase/sdk": "^0.3.0"
   }
 }


### PR DESCRIPTION
# Description

Replaces `headers.static` with `headers.set` in TS templates.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [x] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
