### PR TITLE
feat(logs): GB-4411: Nest all request-scoped log events under the operation completion entry

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   GRAFBASE_SKIP_ASSET_VERSION_CHECK: 'true'
-  ASSETS_VERSION: release/7fb3f6c-2023-08-03
+  ASSETS_VERSION: release/d53ed4e-2023-08-04
   PROD_ASSETS: assets.grafbase.com
   CARGO_TERM_COLOR: 'always'
   CARGO_PROFILE_DEV_DEBUG: 0

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1151,12 +1151,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0558d22a7b463ed0241e993f76f09f30b126687447751a8638587b864e4b3944"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
 dependencies = [
- "darling_core 0.20.1",
- "darling_macro 0.20.1",
+ "darling_core 0.20.3",
+ "darling_macro 0.20.3",
 ]
 
 [[package]]
@@ -1175,9 +1175,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1200,11 +1200,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
- "darling_core 0.20.1",
+ "darling_core 0.20.3",
  "quote",
  "syn 2.0.18",
 ]
@@ -4199,9 +4199,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02d8aa6e3c385bf084924f660ce2a3a6bd333ba55b35e8590b321f35d88513"
+checksum = "21e47d95bc83ed33b2ecf84f4187ad1ab9685d18ff28db000c99deac8ce180e3"
 dependencies = [
  "base64 0.21.2",
  "chrono",
@@ -4215,11 +4215,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc7d5d3932fb12ce722ee5e64dd38c504efba37567f0c402f6ca728c3b8b070"
+checksum = "ea3cee93715c2e266b9338b7544da68a9f24e227722ba482bd1c024367c77c65"
 dependencies = [
- "darling 0.20.1",
+ "darling 0.20.3",
  "proc-macro2",
  "quote",
  "syn 2.0.18",

--- a/cli/crates/backend/src/types.rs
+++ b/cli/crates/backend/src/types.rs
@@ -1,1 +1,1 @@
-pub use server::types::{LogEventType, ServerMessage};
+pub use server::types::{LogEventType, NestedRequestScopedMessage, RequestCompletedOutcome, ServerMessage};

--- a/cli/crates/cli/src/dev.rs
+++ b/cli/crates/cli/src/dev.rs
@@ -35,7 +35,7 @@ pub fn dev(
         let mut resolvers_reported = false;
 
         // We group messages by operation (request ID). Because messages come in as a stream of events,
-        // we need to group them on the fly and "flush" as a tree only when the final operation completion
+        // we need to group them on the fly and “flush” as a tree only when the final operation completion
         // event is observed.
         let mut message_group_buffer = std::collections::HashMap::new();
 
@@ -79,7 +79,7 @@ pub fn dev(
                 ServerMessage::CompilationError(error) => report::error(&CliError::CompilationError(error)),
             }
 
-            // Flush nested events that are really old – if a user interrupt a request, we will not see an operation completion event.
+            // Flush nested events that are really old – if a user interrupts a request, we will not see an operation completion event.
             message_group_buffer.retain(|_, (created, _)| created.elapsed() < EXPIRY_TIME);
         }
     });

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -110,7 +110,11 @@ pub fn goodbye() {
 }
 
 pub fn start_udf_build(udf_kind: UdfKind, udf_name: &str) {
-    println!("{} compiling {udf_kind} {udf_name}...", watercolor!("wait", @Cyan));
+    println!(
+        "{} compiling {udf_kind} {udf_name}...",
+        watercolor!("wait", @Cyan),
+        udf_name = format!("{udf_name}").bold()
+    );
 }
 
 pub fn complete_udf_build(udf_kind: UdfKind, udf_name: &str, duration: std::time::Duration) {
@@ -121,7 +125,8 @@ pub fn complete_udf_build(udf_kind: UdfKind, udf_name: &str, duration: std::time
     };
     println!(
         "{} compiled {udf_kind} {udf_name} successfully in {formatted_duration}",
-        watercolor!("event", @BrightMagenta)
+        watercolor!("event", @BrightMagenta),
+        udf_name = format!("{udf_name}").bold()
     );
 }
 

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -113,7 +113,7 @@ pub fn start_udf_build(udf_kind: UdfKind, udf_name: &str) {
     println!(
         "{} compiling {udf_kind} {udf_name}...",
         watercolor!("wait", @Cyan),
-        udf_name = format!("{udf_name}").bold()
+        udf_name = udf_name.to_string().bold()
     );
 }
 
@@ -126,7 +126,7 @@ pub fn complete_udf_build(udf_kind: UdfKind, udf_name: &str, duration: std::time
     println!(
         "{} compiled {udf_kind} {udf_name} successfully in {formatted_duration}",
         watercolor!("event", @BrightMagenta),
-        udf_name = format!("{udf_name}").bold()
+        udf_name = udf_name.to_string().bold()
     );
 }
 
@@ -162,9 +162,9 @@ pub fn operation_log(
 
     let formatted_duration = format_duration(duration);
     let formatted_name = name
-        .map(|name| format!(" {}", format!("{name}").bold()))
+        .map(|name| format!(" {}", name.to_string().bold()))
         .unwrap_or_default();
-    let formatted_type = r#type.map_or_else(|| "operation".to_owned(), |r#type| r#type.to_string());
+    let formatted_type = r#type.map_or_else(|| "operation".to_owned(), |value| value.to_string());
     println!(
         "{formatted_type}{formatted_name} {formatted_duration}",
         formatted_type = formatted_type.color(colour)
@@ -194,7 +194,7 @@ pub fn operation_log(
                     "{indent}{} {} {}",
                     watercolor!("{udf_kind}", @Blue),
                     udf_name.bold(),
-                    format!("{message}").color(message_colour)
+                    message.to_string().color(message_colour)
                 );
             }
         }

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -1,10 +1,11 @@
 use crate::{
+    cli_input::LogLevelFilters,
     errors::CliError,
     watercolor::{self, watercolor},
 };
 use backend::{
     project::{ConfigType, Template},
-    types::LogEventType,
+    types::{NestedRequestScopedMessage, RequestCompletedOutcome},
 };
 use colored::Colorize;
 use common::consts::GRAFBASE_TS_CONFIG_FILE_NAME;
@@ -109,7 +110,7 @@ pub fn goodbye() {
 }
 
 pub fn start_udf_build(udf_kind: UdfKind, udf_name: &str) {
-    println!("- {} compiling {udf_kind} {udf_name}...", watercolor!("wait", @Cyan));
+    println!("{} compiling {udf_kind} {udf_name}...", watercolor!("wait", @Cyan));
 }
 
 pub fn complete_udf_build(udf_kind: UdfKind, udf_name: &str, duration: std::time::Duration) {
@@ -119,48 +120,27 @@ pub fn complete_udf_build(udf_kind: UdfKind, udf_name: &str, duration: std::time
         format!("{:.1}s", duration.as_secs_f64())
     };
     println!(
-        "- {} compiled {udf_kind} {udf_name} successfully in {formatted_duration}",
+        "{} compiled {udf_kind} {udf_name} successfully in {formatted_duration}",
         watercolor!("event", @BrightMagenta)
     );
 }
 
-pub fn udf_message(
-    udf_kind: UdfKind,
-    udf_name: &str,
-    message: &str,
-    message_level: LogLevel,
-    log_level_filter: Option<LogLevel>,
+pub fn operation_log(
+    name: Option<String>,
+    duration: std::time::Duration,
+    request_completed: RequestCompletedOutcome,
+    nested_events: Vec<NestedRequestScopedMessage>,
+    log_level_filters: LogLevelFilters,
 ) {
-    let Some(log_level_filter) = log_level_filter else {
-        return;
-    };
-    if message_level > log_level_filter {
+    if log_level_filters.graphql_operations < Some(LogLevel::Info) {
         return;
     }
 
-    let colour = match message_level {
-        LogLevel::Debug => watercolor::colored::Color::BrightBlack,
-        LogLevel::Error => watercolor::colored::Color::Red,
-        LogLevel::Info => watercolor::colored::Color::Cyan,
-        LogLevel::Warn => watercolor::colored::Color::Yellow,
-    };
-    println!("{}", format!("[{udf_kind} '{udf_name}'] {message}").color(colour));
-}
-
-pub fn operation_log(log_event_type: LogEventType, log_level_filter: Option<LogLevel>) {
-    let Some(log_level_filter) = log_level_filter else {
-        return;
-    };
-    if log_level_filter < LogLevel::Info {
-        return;
-    }
-
-    let (name, r#type, colour, duration) = match log_event_type {
-        LogEventType::OperationStarted { .. } => return,
-        LogEventType::OperationCompleted { name, duration, r#type } => {
+    let (name, r#type, colour, duration) = match request_completed {
+        RequestCompletedOutcome::Success { r#type } => {
             let colour = match r#type {
                 common::types::OperationType::Query { is_introspection } => {
-                    if is_introspection && log_level_filter < LogLevel::Debug {
+                    if is_introspection && log_level_filters.graphql_operations < Some(LogLevel::Debug) {
                         return;
                     }
                     watercolor::colored::Color::Green
@@ -172,16 +152,48 @@ pub fn operation_log(log_event_type: LogEventType, log_level_filter: Option<LogL
             };
             (name, Some(r#type), colour, duration)
         }
-        LogEventType::BadRequest { name, duration } => (name, None, watercolor::colored::Color::Red, duration),
+        RequestCompletedOutcome::BadRequest => (name, None, watercolor::colored::Color::Red, duration),
     };
 
     let formatted_duration = format_duration(duration);
-    let formatted_name = name.map(|name| format!(" {name}")).unwrap_or_default();
+    let formatted_name = name
+        .map(|name| format!(" {}", format!("{name}").bold()))
+        .unwrap_or_default();
     let formatted_type = r#type.map_or_else(|| "operation".to_owned(), |r#type| r#type.to_string());
     println!(
-        "- {formatted_type}{formatted_name} {formatted_duration}",
+        "{formatted_type}{formatted_name} {formatted_duration}",
         formatted_type = formatted_type.color(colour)
     );
+
+    let indent = "  ";
+
+    for nested_event in nested_events {
+        match nested_event {
+            NestedRequestScopedMessage::UdfMessage {
+                udf_kind,
+                udf_name,
+                level,
+                message,
+            } => {
+                if log_level_filters.functions < Some(level) {
+                    continue;
+                }
+
+                let message_colour = match level {
+                    LogLevel::Debug => watercolor::colored::Color::BrightBlack,
+                    LogLevel::Error => watercolor::colored::Color::Red,
+                    LogLevel::Info => watercolor::colored::Color::Cyan,
+                    LogLevel::Warn => watercolor::colored::Color::Yellow,
+                };
+                println!(
+                    "{indent}{} {} {}",
+                    watercolor!("{udf_kind}", @Blue),
+                    udf_name.bold(),
+                    format!("{message}").color(message_colour)
+                );
+            }
+        }
+    }
 }
 
 pub fn format_duration(duration: std::time::Duration) -> String {

--- a/cli/crates/server/src/bridge/types.rs
+++ b/cli/crates/server/src/bridge/types.rs
@@ -70,13 +70,33 @@ pub struct RecordDocument {
 
 #[derive(Deserialize, Debug)]
 pub struct UdfInvocation {
+    pub request_id: String,
     pub name: String,
     pub payload: serde_json::Value,
     pub udf_kind: UdfKind,
 }
 
+#[serde_with::serde_as]
+#[derive(Deserialize, Debug)]
+pub enum LogEventType {
+    OperationStarted {
+        name: Option<String>,
+    },
+    OperationCompleted {
+        name: Option<String>,
+        #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
+        duration: std::time::Duration,
+        r#type: common::types::OperationType,
+    },
+    BadRequest {
+        name: Option<String>,
+        #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
+        duration: std::time::Duration,
+    },
+}
+
 #[derive(Deserialize, Debug)]
 pub struct LogEvent {
     pub request_id: String,
-    pub r#type: crate::types::LogEventType,
+    pub r#type: LogEventType,
 }

--- a/cli/crates/server/src/bridge/udf.rs
+++ b/cli/crates/server/src/bridge/udf.rs
@@ -50,13 +50,18 @@ pub async fn invoke_udf_endpoint(
     trace!("UDF invocation\n\n{:#?}\n", payload);
 
     let environment = Environment::get();
-    let udf_kind = payload.udf_kind;
+    let UdfInvocation {
+        request_id,
+        name: udf_name,
+        payload,
+        udf_kind,
+    } = payload;
 
     let udf_worker_port = loop {
         let notify = {
             let mut udf_builds: tokio::sync::MutexGuard<'_, _> = handler_state.udf_builds.lock().await;
 
-            if let Some(udf_build) = udf_builds.get(&(payload.name.clone(), udf_kind)) {
+            if let Some(udf_build) = udf_builds.get(&(udf_name.clone(), udf_kind)) {
                 match udf_build {
                     UdfBuild::Succeeded { worker_port, .. } => break *worker_port,
                     UdfBuild::Failed => return Err(ApiError::UdfInvocation),
@@ -76,7 +81,7 @@ pub async fn invoke_udf_endpoint(
             } else {
                 let notify = Arc::new(Notify::new());
                 udf_builds.insert(
-                    (payload.name.clone(), udf_kind),
+                    (udf_name.clone(), udf_kind),
                     UdfBuild::InProgress { notify: notify.clone() },
                 );
                 notify
@@ -88,7 +93,7 @@ pub async fn invoke_udf_endpoint(
             .bridge_sender
             .send(ServerMessage::StartUdfBuild {
                 udf_kind,
-                udf_name: payload.name.clone(),
+                udf_name: udf_name.clone(),
             })
             .await
             .unwrap();
@@ -99,17 +104,17 @@ pub async fn invoke_udf_endpoint(
             environment,
             &handler_state.environment_variables,
             udf_kind,
-            &payload.name,
+            &udf_name,
             tracing,
         )
         .and_then(|(package_json_path, wrangler_toml_path)| {
-            super::udf::spawn_miniflare(udf_kind, &payload.name, package_json_path, wrangler_toml_path, tracing)
+            super::udf::spawn_miniflare(udf_kind, &udf_name, package_json_path, wrangler_toml_path, tracing)
         })
         .await
         {
             Ok((miniflare_handle, worker_port)) => {
                 handler_state.udf_builds.lock().await.insert(
-                    (payload.name.clone(), udf_kind),
+                    (udf_name.clone(), udf_kind),
                     UdfBuild::Succeeded {
                         miniflare_handle,
                         worker_port,
@@ -121,7 +126,7 @@ pub async fn invoke_udf_endpoint(
                     .bridge_sender
                     .send(ServerMessage::CompleteUdfBuild {
                         udf_kind,
-                        udf_name: payload.name.clone(),
+                        udf_name: udf_name.clone(),
                         duration: start.elapsed(),
                     })
                     .await
@@ -130,15 +135,11 @@ pub async fn invoke_udf_endpoint(
                 break worker_port;
             }
             Err(err) => {
-                error!(
-                    "Build of {udf_kind} '{udf_name}' failed: {err:?}",
-                    udf_name = payload.name
-                );
+                error!("Build of {udf_kind} '{udf_name}' failed: {err:?}");
                 handler_state
                     .bridge_sender
                     .send(ServerMessage::CompilationError(format!(
-                        "{udf_kind} '{udf_name}' failed to build: {err}",
-                        udf_name = payload.name
+                        "{udf_kind} '{udf_name}' failed to build: {err}"
                     )))
                     .await
                     .unwrap();
@@ -149,17 +150,18 @@ pub async fn invoke_udf_endpoint(
             .udf_builds
             .lock()
             .await
-            .insert((payload.name.clone(), udf_kind), UdfBuild::Failed);
+            .insert((udf_name.clone(), udf_kind), UdfBuild::Failed);
         notify.notify_waiters();
         return Err(ApiError::UdfInvocation);
     };
 
     super::udf::invoke(
         &handler_state.bridge_sender,
+        &request_id,
         udf_worker_port,
         udf_kind,
-        &payload.name,
-        &payload.payload,
+        &udf_name,
+        &payload,
     )
     .await
     .map(Json)
@@ -294,6 +296,7 @@ pub async fn spawn_miniflare(
 
 pub async fn invoke(
     bridge_sender: &tokio::sync::mpsc::Sender<ServerMessage>,
+    request_id: &str,
     udf_worker_port: u16,
     udf_kind: UdfKind,
     udf_name: &str,
@@ -319,11 +322,16 @@ pub async fn invoke(
 
     for UdfMessage { level, message } in log_entries {
         bridge_sender
-            .send(ServerMessage::UdfMessage {
-                udf_kind,
-                udf_name: udf_name.to_owned(),
-                level,
-                message,
+            .send(ServerMessage::RequestScopedMessage {
+                request_id: request_id.to_owned(),
+                event_type: crate::types::LogEventType::NestedEvent(
+                    crate::types::NestedRequestScopedMessage::UdfMessage {
+                        udf_kind,
+                        udf_name: udf_name.to_owned(),
+                        level,
+                        message,
+                    },
+                ),
             })
             .await
             .unwrap();

--- a/cli/crates/server/src/types.rs
+++ b/cli/crates/server/src/types.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 pub const ASSETS_GZIP: &[u8] = include_bytes!("../assets/assets.tar.gz");
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum RequestCompletedOutcome {
     Success { r#type: common::types::OperationType },
     BadRequest,


### PR DESCRIPTION
# Description

This adds more clarity to the log stream in the CLI.

![image](https://github.com/grafbase/grafbase/assets/14150873/f98b1883-6684-450e-8bb0-9eda2abb78d4)

# Type of change

- [ ] 💔 Breaking
- [X] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
