### PR TITLE
Redefine the `--verbose` flag not to log introspection queries.

### DIFF
--- a/cli/crates/cli/src/cli_input.rs
+++ b/cli/crates/cli/src/cli_input.rs
@@ -83,15 +83,13 @@ impl DevCommand {
             }
         };
         LogLevelFilters {
-            functions: self.log_level_functions.unwrap_or(default_log_levels.functions).into(),
+            functions: self.log_level_functions.unwrap_or(default_log_levels.functions),
             graphql_operations: self
                 .log_level_graphql_operations
-                .unwrap_or(default_log_levels.graphql_operations)
-                .into(),
+                .unwrap_or(default_log_levels.graphql_operations),
             fetch_requests: self
                 .log_level_fetch_requests
-                .unwrap_or(default_log_levels.fetch_requests)
-                .into(),
+                .unwrap_or(default_log_levels.fetch_requests),
         }
     }
 }

--- a/cli/crates/cli/src/cli_input.rs
+++ b/cli/crates/cli/src/cli_input.rs
@@ -63,7 +63,7 @@ pub struct DevCommand {
     #[arg(long)]
     pub log_level: Option<LogLevelFilter>,
     /// A shortcut to enable fairly detailed logging
-    #[arg(short, long)]
+    #[arg(short, long, conflicts_with = "log_level")]
     pub verbose: bool,
 }
 
@@ -77,9 +77,9 @@ impl DevCommand {
             }
         } else {
             LogLevelFilters {
-                functions: LogLevelFilter::Info,
-                graphql_operations: LogLevelFilter::Info,
-                fetch_requests: LogLevelFilter::Info,
+                functions: self.log_level.unwrap_or(LogLevelFilter::Info),
+                graphql_operations: self.log_level.unwrap_or(LogLevelFilter::Info),
+                fetch_requests: self.log_level.unwrap_or(LogLevelFilter::Info),
             }
         };
         LogLevelFilters {

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -158,7 +158,7 @@ pub fn operation_log(
     nested_events: Vec<NestedRequestScopedMessage>,
     log_level_filters: LogLevelFilters,
 ) {
-    if log_level_filters.graphql_operations < Some(LogLevel::Info) {
+    if !log_level_filters.graphql_operations.should_display(LogLevel::Info) {
         return;
     }
 
@@ -166,7 +166,7 @@ pub fn operation_log(
         RequestCompletedOutcome::Success { r#type } => {
             let colour = match r#type {
                 common::types::OperationType::Query { is_introspection } => {
-                    if is_introspection && log_level_filters.graphql_operations < Some(LogLevel::Debug) {
+                    if is_introspection && !log_level_filters.graphql_operations.should_display(LogLevel::Debug) {
                         return;
                     }
                     watercolor::colored::Color::Green
@@ -201,7 +201,7 @@ pub fn operation_log(
                 level,
                 message,
             } => {
-                if log_level_filters.functions < Some(level) {
+                if !log_level_filters.functions.should_display(level) {
                     continue;
                 }
 
@@ -231,7 +231,7 @@ pub fn operation_log(
                 } else {
                     LogLevel::Info
                 };
-                if log_level_filters.fetch_requests < Some(required_log_level) {
+                if !log_level_filters.fetch_requests.should_display(required_log_level) {
                     continue;
                 }
 
@@ -243,7 +243,7 @@ pub fn operation_log(
                     url.bold(),
                 );
 
-                if log_level_filters.fetch_requests >= Some(LogLevel::Debug) {
+                if log_level_filters.fetch_requests.should_display(LogLevel::Debug) {
                     if let Some(formatted_body) = format_response_body(indent, body, content_type) {
                         println!("{formatted_body}");
                     }


### PR DESCRIPTION
# Description

This is a slight tweak of the definition of the `--verbose` flag. We don't want it to enable logging of introspection queries. For that you'll need an explicit `--log-level-graphql-operations=debug` or the all-encompassing `--log-level=debug`.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
