### PR TITLE
GB-4562 - Non-interactive link

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1885,6 +1885,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing-subscriber",
+ "ulid",
  "url",
  "uuid",
  "webbrowser",

--- a/cli/crates/backend/src/api/create.rs
+++ b/cli/crates/backend/src/api/create.rs
@@ -106,7 +106,6 @@ pub async fn create(
             tokio::fs::write(
                 &project_metadata_path,
                 ProjectMetadata {
-                    account_id: account_id.to_owned(),
                     project_id: project_create_success.project.id.into_inner().clone(),
                 }
                 .to_string(),

--- a/cli/crates/backend/src/api/types.rs
+++ b/cli/crates/backend/src/api/types.rs
@@ -46,7 +46,6 @@ impl<'a> ToString for Credentials<'a> {
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProjectMetadata {
-    pub account_id: String,
     pub project_id: String,
 }
 

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -32,12 +32,14 @@ slugify = "0.1.0"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+ulid = "1"
 uuid = { version = "1", features = ["v4"] }
 url = "2"
 webbrowser = "0.8"
 
 backend = { package = "grafbase-local-backend", path = "../backend", version = "0.32.1" }
 common = { package = "grafbase-local-common", path = "../common", version = "0.32.1" }
+
 
 [dev-dependencies]
 async-graphql = "5"

--- a/cli/crates/cli/src/cli_input.rs
+++ b/cli/crates/cli/src/cli_input.rs
@@ -6,6 +6,7 @@ use common::{
     types::LogLevel,
 };
 use std::{fmt, path::PathBuf};
+use ulid::Ulid;
 
 const DEFAULT_PORT: u16 = 4000;
 
@@ -195,7 +196,7 @@ impl CreateCommand {
 pub struct LinkCommand {
     /// The id of the linked project
     #[arg(short, long, value_name = "PROJECT_ID")]
-    pub project: Option<String>,
+    pub project: Option<Ulid>,
 }
 
 #[derive(Debug, Parser)]

--- a/cli/crates/cli/src/cli_input.rs
+++ b/cli/crates/cli/src/cli_input.rs
@@ -165,6 +165,13 @@ impl CreateCommand {
     }
 }
 
+#[derive(Debug, clap::Args)]
+pub struct LinkCommand {
+    /// The id of the linked project
+    #[arg(short, long, value_name = "PROJECT_ID")]
+    pub project: Option<String>,
+}
+
 #[derive(Debug, Parser)]
 pub enum SubCommand {
     /// Run your Grafbase project locally
@@ -185,7 +192,7 @@ pub enum SubCommand {
     /// Deploy your project
     Deploy,
     /// Connect a local project to a remote project
-    Link,
+    Link(LinkCommand),
     /// Disconnect a local project from a remote project
     Unlink,
 }
@@ -250,7 +257,7 @@ impl ArgumentNames for SubCommand {
             | SubCommand::Login
             | SubCommand::Logout
             | SubCommand::Deploy
-            | SubCommand::Link
+            | SubCommand::Link(_)
             | SubCommand::Unlink
             | SubCommand::Completions(_) => None,
         }
@@ -261,7 +268,7 @@ impl SubCommand {
     pub(crate) fn in_project_context(&self) -> bool {
         matches!(
             self,
-            Self::Dev(_) | Self::Create(_) | Self::Deploy | Self::Link | Self::Unlink | Self::Reset
+            Self::Dev(_) | Self::Create(_) | Self::Deploy | Self::Link(_) | Self::Unlink | Self::Reset
         )
     }
 }
@@ -277,7 +284,7 @@ impl AsRef<str> for SubCommand {
             SubCommand::Logout => "logout",
             SubCommand::Create(_) => "create",
             SubCommand::Deploy => "deploy",
-            SubCommand::Link => "link",
+            SubCommand::Link(_) => "link",
             SubCommand::Unlink => "unlink",
         }
     }

--- a/cli/crates/cli/src/link.rs
+++ b/cli/crates/cli/src/link.rs
@@ -5,6 +5,7 @@ use backend::api::{
 };
 use inquire::Select;
 use std::fmt::Display;
+use ulid::Ulid;
 
 #[derive(Debug)]
 struct AccountSelection(AccountWithProjects);
@@ -24,11 +25,11 @@ impl Display for ProjectSelection {
 }
 
 #[tokio::main]
-pub async fn link(project_id: Option<String>) -> Result<(), CliError> {
+pub async fn link(project_id: Option<Ulid>) -> Result<(), CliError> {
     project_link_validations().await.map_err(CliError::BackendApiError)?;
 
     if let Some(project_id) = project_id {
-        link::link_project(project_id)
+        link::link_project(project_id.to_string())
             .await
             .map_err(CliError::BackendApiError)?;
 

--- a/cli/crates/cli/src/link.rs
+++ b/cli/crates/cli/src/link.rs
@@ -1,6 +1,6 @@
 use crate::{errors::CliError, output::report, prompts::handle_inquire_error};
 use backend::api::{
-    link,
+    link::{self, project_link_validations},
     types::{AccountWithProjects, Project},
 };
 use inquire::Select;
@@ -24,7 +24,19 @@ impl Display for ProjectSelection {
 }
 
 #[tokio::main]
-pub async fn link() -> Result<(), CliError> {
+pub async fn link(project_id: Option<String>) -> Result<(), CliError> {
+    project_link_validations().await.map_err(CliError::BackendApiError)?;
+
+    if let Some(project_id) = project_id {
+        link::link_project(project_id)
+            .await
+            .map_err(CliError::BackendApiError)?;
+
+        report::linked_non_interactive();
+
+        return Ok(());
+    }
+
     let accounts = link::get_viewer_data_for_link()
         .await
         .map_err(CliError::BackendApiError)?;
@@ -46,7 +58,7 @@ pub async fn link() -> Result<(), CliError> {
         .prompt()
         .map_err(handle_inquire_error)?;
 
-    link::link_project(selected_account.id, selected_project.id)
+    link::link_project(selected_project.id)
         .await
         .map_err(CliError::BackendApiError)?;
 

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -102,7 +102,7 @@ fn try_main(args: Args) -> Result<(), CliError> {
         SubCommand::Logout => logout(),
         SubCommand::Create(cmd) => create(&cmd.create_arguments()),
         SubCommand::Deploy => deploy(),
-        SubCommand::Link(cmd) => link(cmd.project.map(|ulid| ulid.to_string())),
+        SubCommand::Link(cmd) => link(cmd.project),
         SubCommand::Unlink => unlink(),
     }
 }

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -102,7 +102,7 @@ fn try_main(args: Args) -> Result<(), CliError> {
         SubCommand::Logout => logout(),
         SubCommand::Create(cmd) => create(&cmd.create_arguments()),
         SubCommand::Deploy => deploy(),
-        SubCommand::Link => link(),
+        SubCommand::Link(cmd) => link(cmd.project),
         SubCommand::Unlink => unlink(),
     }
 }

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -102,7 +102,7 @@ fn try_main(args: Args) -> Result<(), CliError> {
         SubCommand::Logout => logout(),
         SubCommand::Create(cmd) => create(&cmd.create_arguments()),
         SubCommand::Deploy => deploy(),
-        SubCommand::Link(cmd) => link(cmd.project),
+        SubCommand::Link(cmd) => link(cmd.project.map(|ulid| ulid.to_string())),
         SubCommand::Unlink => unlink(),
     }
 }

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -269,6 +269,10 @@ pub fn linked(name: &str) {
     watercolor::output!("\n✨ Successfully linked your local project to {name}!", @BrightBlue);
 }
 
+pub fn linked_non_interactive() {
+    watercolor::output!("✨ Successfully linked your local project!", @BrightBlue);
+}
+
 pub fn unlinked() {
     watercolor::output!("✨ Successfully unlinked your project!", @BrightBlue);
 }

--- a/cli/crates/cli/tests/link.rs
+++ b/cli/crates/cli/tests/link.rs
@@ -1,0 +1,48 @@
+#![allow(unused_crate_dependencies)]
+mod utils;
+
+use backend::{api::consts::PROJECT_METADATA_FILE, project::ConfigType};
+use common::consts::DOT_GRAFBASE_DIRECTORY;
+use utils::environment::Environment;
+
+#[test]
+fn link_success() {
+    let env = Environment::init();
+    env.grafbase_init(ConfigType::GraphQL);
+
+    let correct_ulid = "11H70FF572W29JXMG77JAB4KK0";
+
+    let link_output = env.grafbase_link_non_interactive(correct_ulid);
+
+    assert!(link_output.status.success());
+
+    assert!(env
+        .directory
+        .join(DOT_GRAFBASE_DIRECTORY)
+        .join(PROJECT_METADATA_FILE)
+        .exists());
+
+    assert!(
+        std::fs::read_to_string(env.directory.join(DOT_GRAFBASE_DIRECTORY).join(PROJECT_METADATA_FILE))
+            .unwrap()
+            .contains(correct_ulid)
+    );
+}
+
+#[test]
+fn link_invalid_ulid() {
+    let env = Environment::init();
+    env.grafbase_init(ConfigType::GraphQL);
+
+    let link_output = env.grafbase_link_non_interactive("*1H70FF572W29JXMG77JAB4KK0");
+
+    assert!(!link_output.status.success());
+
+    assert!(std::str::from_utf8(&link_output.stderr).unwrap().contains("character"));
+
+    let link_output = env.grafbase_link_non_interactive("11H7");
+
+    assert!(!link_output.status.success());
+
+    assert!(std::str::from_utf8(&link_output.stderr).unwrap().contains("length"));
+}

--- a/cli/crates/cli/tests/utils/environment.rs
+++ b/cli/crates/cli/tests/utils/environment.rs
@@ -260,6 +260,16 @@ impl Environment {
         .unwrap()
     }
 
+    pub fn grafbase_link_non_interactive(&self, project: &str) -> Output {
+        cmd!(cargo_bin("grafbase"), "link", "--project", project)
+            .dir(&self.directory)
+            .stdout_capture()
+            .stderr_capture()
+            .unchecked()
+            .run()
+            .unwrap()
+    }
+
     pub fn grafbase_init_template(&self, name: Option<&str>, template: &str) {
         if let Some(name) = name {
             cmd!(cargo_bin("grafbase"), "init", name, "--template", template)


### PR DESCRIPTION
# Description

## Features 

- Adds the ability to pass a `project` argument to `link` which makes `link` run non-interactively (and without any external calls), validates that the passed argument is a valid ULID

## Fixes

- Does not store the account ID when linking as it's not needed

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
