### PR TITLE
fix(sdk): GB-4552: Allow enum refs in mutation/query extends

### DIFF
--- a/packages/grafbase-sdk/src/query.ts
+++ b/packages/grafbase-sdk/src/query.ts
@@ -4,6 +4,7 @@ import {
   DefaultValueType,
   renderDefault
 } from './typedefs/default'
+import { EnumDefinition } from './typedefs/enum'
 import { InputDefinition } from './typedefs/input'
 import { ListDefinition } from './typedefs/list'
 import { ReferenceDefinition } from './typedefs/reference'
@@ -16,6 +17,7 @@ export type InputType =
   | ListDefinition
   | InputDefinition
   | InputDefaultDefinition
+  | EnumDefinition<any, any>
 
 /** The possible types of an output parameters of a query. */
 export type OutputType = ScalarDefinition | ListDefinition | ReferenceDefinition

--- a/packages/grafbase-sdk/tests/unit/queries.test.ts
+++ b/packages/grafbase-sdk/tests/unit/queries.test.ts
@@ -141,6 +141,60 @@ describe('Query generator', () => {
     `)
   })
 
+  it('generates a mutation resolver with enum input and output', () => {
+    const output = g.type('CheckoutSessionOutput', { successful: g.boolean() })
+
+    const enm = g.enum('Foo', ['A', 'B'])
+
+    g.mutation('checkout', {
+      args: { input: g.enumRef(enm) },
+      returns: g.ref(output),
+      resolver: 'checkout'
+    })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "enum Foo {
+        A,
+        B
+      }
+
+      type CheckoutSessionOutput {
+        successful: Boolean!
+      }
+
+      extend type Mutation {
+        checkout(input: Foo!): CheckoutSessionOutput! @resolver(name: "checkout")
+      }"
+    `)
+  })
+
+  it('generates a query resolver with enum input and output', () => {
+    const output = g.type('CheckoutSessionOutput', { successful: g.boolean() })
+
+    const enm = g.enum('Foo', ['A', 'B'])
+
+    g.query('checkout', {
+      args: { input: g.enumRef(enm) },
+      returns: g.ref(output),
+      resolver: 'checkout'
+    })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "enum Foo {
+        A,
+        B
+      }
+
+      type CheckoutSessionOutput {
+        successful: Boolean!
+      }
+
+      extend type Query {
+        checkout(input: Foo!): CheckoutSessionOutput! @resolver(name: "checkout")
+      }"
+    `)
+  })
+
   it('generates a query as part of the full SDL', () => {
     const enm = g.enum('Foo', ['Bar', 'Baz'])
 


### PR DESCRIPTION
# Description

![2023-08-16_14-08-1692190353](https://github.com/grafbase/grafbase/assets/34967/6e37e355-d96b-4f01-8630-13f73dbc1de8)

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
