### PR TITLE
fix(sdk): Allow setting the Atlas Data API URL for MongoDB

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -19,7 +19,7 @@ permissions:
 
 env:
   GRAFBASE_SKIP_ASSET_VERSION_CHECK: 'true'
-  ASSETS_VERSION: release/431d243-2023-08-14
+  ASSETS_VERSION: release/770b775-2023-08-18
   PROD_ASSETS: assets.grafbase.com
   CARGO_TERM_COLOR: 'always'
   CARGO_PROFILE_DEV_DEBUG: 0

--- a/cli/crates/cli/tests/mongodb/main.rs
+++ b/cli/crates/cli/tests/mongodb/main.rs
@@ -24,8 +24,8 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate, Times,
 };
 
+const MONGODB_PATH: &str = "/app/data-asdf/endpoint/data/v1";
 const MONGODB_API_KEY: &str = "FAKE KEY";
-const MONGODB_APP_ID: &str = "data-asdf";
 const MONGODB_DATA_SOURCE: &str = "grafbase";
 const MONGODB_DATABASE: &str = "test";
 const MONGODB_CONNECTOR: &str = "mongo";
@@ -269,7 +269,7 @@ impl Server {
 
     /// Send a query or mutation to the server, returning JSON response.
     pub async fn request(&self, request: &str) -> Value {
-        let request_path = format!("/app/{MONGODB_APP_ID}/endpoint/data/v1/action/{}", self.action);
+        let request_path = format!("{MONGODB_PATH}/action/{}", self.action);
 
         Mock::given(method("POST"))
             .and(path(&request_path))
@@ -324,11 +324,10 @@ impl Server {
             extend schema
               @mongodb(
                 name: "{MONGODB_CONNECTOR}",
+                url: "http://{address}{MONGODB_PATH}"
                 apiKey: "{MONGODB_API_KEY}"
-                appId: "{MONGODB_APP_ID}"
                 dataSource: "{MONGODB_DATA_SOURCE}"
                 database: "{MONGODB_DATABASE}"
-                hostUrl: "http://{address}"
               )
 
             {config} 

--- a/packages/grafbase-sdk/src/connector/mongodb.ts
+++ b/packages/grafbase-sdk/src/connector/mongodb.ts
@@ -2,24 +2,24 @@ import { ModelFields, MongoDBModel } from './mongodb/model'
 
 export interface MongoDBParams {
   name: string
+  url: string,
   apiKey: string
-  appId: string
   dataSource: string
   database: string
 }
 
 export class PartialMongoDBAPI {
   private name: string
+  private url: string
   private apiKey: string
-  private appId: string
   private dataSource: string
   private database: string
   private models: MongoDBModel[]
 
   constructor(params: MongoDBParams) {
     this.name = params.name
+    this.url = params.url
     this.apiKey = params.apiKey
-    this.appId = params.appId
     this.dataSource = params.dataSource
     this.database = params.database
     this.models = []
@@ -46,7 +46,7 @@ export class PartialMongoDBAPI {
     return new MongoDBAPI(
       this.name,
       this.apiKey,
-      this.appId,
+      this.url,
       this.dataSource,
       this.database,
       this.models,
@@ -58,7 +58,7 @@ export class PartialMongoDBAPI {
 export class MongoDBAPI {
   private name: string
   private apiKey: string
-  private appId: string
+  private url: string
   private dataSource: string
   private database: string
   private namespace?: string
@@ -67,7 +67,7 @@ export class MongoDBAPI {
   constructor(
     name: string,
     apiKey: string,
-    appId: string,
+    url: string,
     dataSource: string,
     database: string,
     models: MongoDBModel[],
@@ -75,7 +75,7 @@ export class MongoDBAPI {
   ) {
     this.name = name
     this.apiKey = apiKey
-    this.appId = appId
+    this.url = url
     this.dataSource = dataSource
     this.database = database
     this.namespace = namespace
@@ -85,8 +85,8 @@ export class MongoDBAPI {
   public toString(): string {
     const header = '  @mongodb(\n'
     const name = `    name: "${this.name}"\n`
+    const url = `    url: "${this.url}"\n`
     const apiKey = `    apiKey: "${this.apiKey}"\n`
-    const appId = `    appId: "${this.appId}"\n`
     const dataSource = `    dataSource: "${this.dataSource}"\n`
     const database = `    database: "${this.database}"\n`
 
@@ -96,6 +96,6 @@ export class MongoDBAPI {
 
     const footer = '  )'
 
-    return `${header}${namespace}${name}${apiKey}${appId}${dataSource}${database}${footer}`
+    return `${header}${namespace}${name}${url}${apiKey}${dataSource}${database}${footer}`
   }
 }

--- a/packages/grafbase-sdk/tests/unit/mongodb.test.ts
+++ b/packages/grafbase-sdk/tests/unit/mongodb.test.ts
@@ -5,8 +5,8 @@ import { renderGraphQL } from '../utils'
 describe('MongoDB generator', () => {
   const mongoParams = {
     name: 'Test',
+    url: 'https://data.mongodb-api.com/app/data-test/endpoint/data/v1',
     apiKey: 'SOME_KEY',
-    appId: 'test',
     dataSource: 'data',
     database: 'tables'
   }
@@ -21,8 +21,8 @@ describe('MongoDB generator', () => {
       "extend schema
         @mongodb(
           name: "Test"
+          url: "https://data.mongodb-api.com/app/data-test/endpoint/data/v1"
           apiKey: "SOME_KEY"
-          appId: "test"
           dataSource: "data"
           database: "tables"
         )"
@@ -45,8 +45,8 @@ describe('MongoDB generator', () => {
       "extend schema
         @mongodb(
           name: "Test"
+          url: "https://data.mongodb-api.com/app/data-test/endpoint/data/v1"
           apiKey: "SOME_KEY"
-          appId: "test"
           dataSource: "data"
           database: "tables"
         )
@@ -72,8 +72,8 @@ describe('MongoDB generator', () => {
       "extend schema
         @mongodb(
           name: "Test"
+          url: "https://data.mongodb-api.com/app/data-test/endpoint/data/v1"
           apiKey: "SOME_KEY"
-          appId: "test"
           dataSource: "data"
           database: "tables"
         )
@@ -101,8 +101,8 @@ describe('MongoDB generator', () => {
       "extend schema
         @mongodb(
           name: "Test"
+          url: "https://data.mongodb-api.com/app/data-test/endpoint/data/v1"
           apiKey: "SOME_KEY"
-          appId: "test"
           dataSource: "data"
           database: "tables"
         )
@@ -130,8 +130,8 @@ describe('MongoDB generator', () => {
       "extend schema
         @mongodb(
           name: "Test"
+          url: "https://data.mongodb-api.com/app/data-test/endpoint/data/v1"
           apiKey: "SOME_KEY"
-          appId: "test"
           dataSource: "data"
           database: "tables"
         )
@@ -159,8 +159,8 @@ describe('MongoDB generator', () => {
       "extend schema
         @mongodb(
           name: "Test"
+          url: "https://data.mongodb-api.com/app/data-test/endpoint/data/v1"
           apiKey: "SOME_KEY"
-          appId: "test"
           dataSource: "data"
           database: "tables"
         )
@@ -191,8 +191,8 @@ describe('MongoDB generator', () => {
       "extend schema
         @mongodb(
           name: "Test"
+          url: "https://data.mongodb-api.com/app/data-test/endpoint/data/v1"
           apiKey: "SOME_KEY"
-          appId: "test"
           dataSource: "data"
           database: "tables"
         )
@@ -224,8 +224,8 @@ describe('MongoDB generator', () => {
       "extend schema
         @mongodb(
           name: "Test"
+          url: "https://data.mongodb-api.com/app/data-test/endpoint/data/v1"
           apiKey: "SOME_KEY"
-          appId: "test"
           dataSource: "data"
           database: "tables"
         )
@@ -242,8 +242,8 @@ describe('MongoDB generator', () => {
 
     const another = connector.MongoDB({
       name: 'Another',
+      url: 'https://data.mongodb-api.com/app/data-jest/endpoint/data/v1',
       apiKey: 'OTHER_KEY',
-      appId: 'foo',
       dataSource: 'bar',
       database: 'something'
     })
@@ -267,15 +267,15 @@ describe('MongoDB generator', () => {
       "extend schema
         @mongodb(
           name: "Test"
+          url: "https://data.mongodb-api.com/app/data-test/endpoint/data/v1"
           apiKey: "SOME_KEY"
-          appId: "test"
           dataSource: "data"
           database: "tables"
         )
         @mongodb(
           name: "Another"
+          url: "https://data.mongodb-api.com/app/data-jest/endpoint/data/v1"
           apiKey: "OTHER_KEY"
-          appId: "foo"
           dataSource: "bar"
           database: "something"
         )


### PR DESCRIPTION
# Description

Data API URL can be set directly in the connector.

API counterpart: https://github.com/grafbase/api/pull/2651

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
