### PR TITLE
fix(sdk): GB-4630: Do not lose models if MongoDB datasource is added too early

### DIFF
--- a/packages/grafbase-sdk/src/grafbase-schema.ts
+++ b/packages/grafbase-sdk/src/grafbase-schema.ts
@@ -31,7 +31,7 @@ export type PartialDatasource =
 export type Datasource = OpenAPI | GraphQLAPI | MongoDBAPI
 
 export class Datasources {
-  private inner: Datasource[]
+  inner: Datasource[]
 
   constructor() {
     this.inner = []
@@ -88,10 +88,6 @@ export class GrafbaseSchema {
    */
   public datasource(datasource: PartialDatasource, params?: IntrospectParams) {
     const finalDatasource = datasource.finalize(params?.namespace)
-
-    if (finalDatasource instanceof MongoDBAPI) {
-      this.models = this.models.concat(finalDatasource.models)
-    }
 
     this.datasources.push(finalDatasource)
   }
@@ -456,6 +452,12 @@ export class GrafbaseSchema {
   }
 
   public toString(): string {
+    this.datasources.inner.forEach((datasource) => {
+      if (datasource instanceof MongoDBAPI) {
+        this.models = this.models.concat(datasource.models)
+      }
+    })
+
     const datasources = this.datasources.toString()
     const interfaces = this.interfaces.map(String).join('\n\n')
     const types = this.types.map(String).join('\n\n')

--- a/packages/grafbase-sdk/tests/unit/mongodb.test.ts
+++ b/packages/grafbase-sdk/tests/unit/mongodb.test.ts
@@ -32,14 +32,14 @@ describe('MongoDB generator', () => {
   it('generates a simple model', () => {
     const mongo = connector.MongoDB(mongoParams)
 
+    g.datasource(mongo)
+
     mongo
       .model('User', {
         id: g.id().unique().mapped('_id'),
         field: g.string()
       })
       .collection('users')
-
-    g.datasource(mongo)
 
     expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
       "extend schema


### PR DESCRIPTION
# Description

If calling `g.datasource` too early with a MongoDB connector, the models are lost. This won't do.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
