### PR TITLE
GB-4644 - Add .ignore hardlink for .gitignore

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,52 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+node_modules
+.pnp
+.pnp.js
+
+# testing
+coverage
+
+# build output
+.next/
+out/
+build
+dist
+target
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# local env files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# turbo
+.turbo
+
+# ide
+.idea
+.vscode
+.now
+
+# direnv
+.envrc
+.direnv/
+
+# Jujutsu
+.jj/
+
+# Direnv
+.envrc
+.env


### PR DESCRIPTION
# Description

## Tooling

- Add .ignore hardlink for .gitignore

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [x] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
