### PR TITLE
fix(args): Fix a mislabeled value name for the --log-level-fetch-requests argument

### DIFF
--- a/cli/crates/cli/src/cli_input.rs
+++ b/cli/crates/cli/src/cli_input.rs
@@ -58,7 +58,7 @@ pub struct DevCommand {
     #[arg(long, value_name = "GRAPHQL_OPERATION_LOG_LEVEL")]
     pub log_level_graphql_operations: Option<LogLevelFilter>,
     /// Log level to print for fetch requests, defaults to 'log-level'
-    #[arg(long, value_name = "GRAPHQL_OPERATION_LOG_LEVEL")]
+    #[arg(long, value_name = "FETCH_REQUEST_LOG_LEVEL")]
     pub log_level_fetch_requests: Option<LogLevelFilter>,
     /// Default log level to print
     #[arg(long)]


### PR DESCRIPTION
# Description

Fix a mislabeled value name resulting from a copy paste gone wrong.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
