### PR TITLE
chore: Bump CLI to 0.33.0-rc.1, SDK to 0.6.0

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1835,7 +1835,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.32.4"
+version = "0.33.0-rc.1"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.32.4"
+version = "0.33.0-rc.1"
 dependencies = [
  "async-compression",
  "async-tar",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.32.4"
+version = "0.33.0-rc.1"
 dependencies = [
  "chrono",
  "derivative",
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.32.4"
+version = "0.33.0-rc.1"
 dependencies = [
  "axum",
  "base64 0.21.2",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.32.4"
+version = "0.33.0-rc.1"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://grafbase.com"

--- a/cli/changelog/0.33.0-rc.1.md
+++ b/cli/changelog/0.33.0-rc.1.md
@@ -1,0 +1,4 @@
+# Breaking
+
+- `name` is now a mandatory param to all connectors
+- `namespace` is a boolean parameter, if `true`, all queries of the connector are namespaced with `name`

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -38,8 +38,8 @@ url = "2"
 urlencoding = "2"
 walkdir = "2"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.32.4" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.32.4" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.33.0-rc.1" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.33.0-rc.1" }
 
 [build-dependencies]
 cynic-codegen = { version = "3", features = ["rkyv"] }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -37,8 +37,8 @@ uuid = { version = "1", features = ["v4"] }
 url = "2"
 webbrowser = "0.8"
 
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.32.4" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.32.4" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.33.0-rc.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.33.0-rc.1" }
 
 
 [dev-dependencies]

--- a/cli/crates/cli/tests/init_ts.rs
+++ b/cli/crates/cli/tests/init_ts.rs
@@ -46,7 +46,7 @@ fn init_ts_existing_package_json() {
       "author": "",
       "license": "ISC",
       "devDependencies": {
-        "@grafbase/sdk": "~0.5.0"
+        "@grafbase/sdk": "~0.6.0"
       }
     }
     "###);
@@ -74,7 +74,7 @@ fn init_ts_new_project() {
 
     insta::assert_json_snapshot!(&package_json, @r###"
         {
-          "@grafbase/sdk": "~0.5.0"
+          "@grafbase/sdk": "~0.6.0"
         }
     "###);
 }

--- a/cli/crates/common/src/consts.rs
+++ b/cli/crates/common/src/consts.rs
@@ -33,7 +33,7 @@ pub const GRAFBASE_HOME: &str = "GRAFBASE_HOME";
 /// the name of the Grafbase SDK npm package
 pub const GRAFBASE_SDK_PACKAGE_NAME: &str = "@grafbase/sdk";
 /// the version string of the Grafbase SDK npm package
-pub const GRAFBASE_SDK_PACKAGE_VERSION: &str = "~0.5.0";
+pub const GRAFBASE_SDK_PACKAGE_VERSION: &str = "~0.6.0";
 /// the package.json file name
 pub const PACKAGE_JSON_FILE_NAME: &str = "package.json";
 /// the package.json dev dependencies key

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -62,7 +62,7 @@ which = "4"
 # Same version as Tantivy
 tantivy-fst = "0.4.0"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.32.4" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.33.0-rc.1" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.32.4",
+  "version": "0.33.0-rc.1",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.32.4",
+  "version": "0.33.0-rc.1",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.32.4",
+  "version": "0.33.0-rc.1",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.6.2"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.32.4",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.32.4",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.32.4",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.32.4",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.32.4"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.33.0-rc.1",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.33.0-rc.1",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.33.0-rc.1",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.33.0-rc.1",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.33.0-rc.1"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.32.4",
+  "version": "0.33.0-rc.1",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.32.4",
+  "version": "0.33.0-rc.1",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.32.4",
+  "version": "0.33.0-rc.1",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/examples/resolvers-couchbase/package.json
+++ b/examples/resolvers-couchbase/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@grafbase/sdk": "^0.5.2",
+    "@grafbase/sdk": "^0.6.0",
     "nanoid": "4.0.2"
   }
 }

--- a/examples/resolvers-fauna/package.json
+++ b/examples/resolvers-fauna/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@grafbase/sdk": "^0.3.0",
+    "@grafbase/sdk": "^0.6.0",
     "dotenv": "^16.3.1",
     "fauna": "^0.9.4",
     "graphql": "^16.7.1",

--- a/examples/resolvers-planetscale/package.json
+++ b/examples/resolvers-planetscale/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@grafbase/sdk": "0.5.0",
+    "@grafbase/sdk": "0.6.0",
     "@planetscale/database": "^1.8.0",
     "graphql": "^16.7.1"
   }

--- a/packages/grafbase-sdk/CHANGELOG.md
+++ b/packages/grafbase-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.6.0] - Thu Aug 24 2023
+
+[CHANGELOG](changelog/0.6.0.md)
+
 ## [0.5.2] - Fri Aug 18 2023
 
 [CHANGELOG](changelog/0.5.2.md)

--- a/packages/grafbase-sdk/README.md
+++ b/packages/grafbase-sdk/README.md
@@ -383,8 +383,8 @@ const stripe = connector.OpenAPI("Stripe", {
 Connectors can be added to the schema using `g.datasource()`, including an optional `namespace`:
 
 ```typescript
-g.datasource(stripe, { namespace: 'Stripe' })
-g.datasource(openai, { namespace: 'OpenAI' })
+g.datasource(stripe)
+g.datasource(openai)
 ```
 
 ### GraphQL
@@ -409,8 +409,8 @@ const github = connector.GraphQL('GitHub', {
 Connectors can be added to the schema using `g.datasource()`, including an optional `namespace`:
 
 ```typescript
-g.datasource(contentful, { namespace: 'Contentful' })
-g.datasource(github, { namespace: 'GitHub' })
+g.datasource(contentful)
+g.datasource(github)
 ```
 
 ### MongoDB
@@ -426,15 +426,9 @@ const mongodb = connector.MongoDB('MongoDB', {
 })
 
 // Models must be added manually for this connector.
+mongodb.model('User', { field: g.string() }).collection('users')
 
-mongodb
-  .model('User', {
-    id: g.id().unique().mapped('_id'),
-    field: g.string()
-  })
-  .collection('users')
-
-g.datasource(mongodb, { namespace: 'MongoDB' })
+g.datasource(mongodb)
 ```
 
 ### Authentication

--- a/packages/grafbase-sdk/changelog/0.6.0.md
+++ b/packages/grafbase-sdk/changelog/0.6.0.md
@@ -1,0 +1,4 @@
+## Breaking
+
+- Connectors take two parameters: name, followed with the options object
+- The namespace parameter when adding a datasource is now boolean: if omitted or true, the queries are namespaced with the connector name.

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",

--- a/packages/grafbase-sdk/src/connector/graphql.ts
+++ b/packages/grafbase-sdk/src/connector/graphql.ts
@@ -77,8 +77,8 @@ export class GraphQLAPI {
     const header = '  @graphql(\n'
     const name = `    name: "${this.name}"\n`
 
-    let namespace;
-    if (this.namespace === undefined || this.namespace === true)  {
+    let namespace
+    if (this.namespace === undefined || this.namespace === true) {
       namespace = `    namespace: true\n`
     } else {
       namespace = ''

--- a/packages/grafbase-sdk/src/connector/mongodb.ts
+++ b/packages/grafbase-sdk/src/connector/mongodb.ts
@@ -88,9 +88,9 @@ export class MongoDBAPI {
     const apiKey = `    apiKey: "${this.apiKey}"\n`
     const dataSource = `    dataSource: "${this.dataSource}"\n`
     const database = `    database: "${this.database}"\n`
-    
-    let namespace;
-    if (this.namespace === undefined || this.namespace === true)  {
+
+    let namespace
+    if (this.namespace === undefined || this.namespace === true) {
       namespace = `    namespace: true\n`
     } else {
       namespace = ''

--- a/packages/grafbase-sdk/src/connector/openapi.ts
+++ b/packages/grafbase-sdk/src/connector/openapi.ts
@@ -94,8 +94,8 @@ export class OpenAPI {
     const header = '  @openapi(\n'
     const name = `    name: "${this.name}"\n`
 
-    let namespace;
-    if (this.namespace === undefined || this.namespace === true)  {
+    let namespace
+    if (this.namespace === undefined || this.namespace === true) {
       namespace = `    namespace: true\n`
     } else {
       namespace = ''

--- a/packages/grafbase-sdk/src/index.ts
+++ b/packages/grafbase-sdk/src/index.ts
@@ -10,6 +10,7 @@ import dotenv from 'dotenv'
 import { Authorizer, AuthorizerParams } from './auth/authorizer'
 import { MongoDBParams, PartialMongoDBAPI } from './connector/mongodb'
 import path from 'path'
+import { validateIdentifier } from './validation'
 
 dotenv.config({
   // must exist, defined by "~/.grafbase/parser/parse-config.ts"
@@ -35,25 +36,34 @@ export const connector = {
   /**
    * Create a new OpenAPI connector object.
    *
+   * @param name - A unique name for the connector.
    * @param params - The configuration parameters.
    */
   OpenAPI: (name: string, params: OpenAPIParams): PartialOpenAPI => {
+    validateIdentifier(name)
+
     return new PartialOpenAPI(name, params)
   },
   /**
    * Create a new GraphQL connector object.
    *
+   * @param name - A unique name for the connector.
    * @param params - The configuration parameters.
    */
   GraphQL: (name: string, params: GraphQLParams): PartialGraphQLAPI => {
+    validateIdentifier(name)
+
     return new PartialGraphQLAPI(name, params)
   },
   /**
    * Create a new MongoDB connector object.
    *
-   * @param params = The configuration parameters.
+   * @param name - A unique name for the connector.
+   * @param params - The configuration parameters.
    */
   MongoDB: (name: string, params: MongoDBParams): PartialMongoDBAPI => {
+    validateIdentifier(name)
+
     return new PartialMongoDBAPI(name, params)
   }
 }

--- a/packages/grafbase-sdk/tests/unit/mongodb.test.ts
+++ b/packages/grafbase-sdk/tests/unit/mongodb.test.ts
@@ -59,6 +59,48 @@ describe('MongoDB generator', () => {
     `)
   })
 
+  it('expects a valid identifier as a name', () => {
+    expect(() => connector.MongoDB('Nest Test', mongoParams)).toThrow(
+      'Given name "Nest Test" is not a valid TypeScript identifier.'
+    )
+  })
+
+  it('generates a simple model with a nested type', () => {
+    const mongo = connector.MongoDB('Test', mongoParams)
+
+    g.datasource(mongo)
+
+    const address = g.type('Address', {
+      street: g.string().mapped('street_name')
+    })
+
+    mongo
+      .model('User', {
+        address: g.ref(address)
+      })
+      .collection('users')
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "extend schema
+        @mongodb(
+          namespace: true
+          name: "Test"
+          url: "https://data.mongodb-api.com/app/data-test/endpoint/data/v1"
+          apiKey: "SOME_KEY"
+          dataSource: "data"
+          database: "tables"
+        )
+
+      type Address {
+        street: String! @map(name: "street_name")
+      }
+
+      type User @model(connector: "Test", collection: "users") {
+        address: Address!
+      }"
+    `)
+  })
+
   it('generates a simple model with no specified collection', () => {
     const mongo = connector.MongoDB('Test', mongoParams)
 

--- a/templates/blog/package.json
+++ b/templates/blog/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "^0.5.0"
+    "@grafbase/sdk": "^0.6.0"
   }
 }

--- a/templates/chatroom/package.json
+++ b/templates/chatroom/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "^0.5.0"
+    "@grafbase/sdk": "^0.6.0"
   }
 }

--- a/templates/commerce/package.json
+++ b/templates/commerce/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "^0.5.0"
+    "@grafbase/sdk": "^0.6.0"
   }
 }

--- a/templates/graphql-cloudflare-analytics/package.json
+++ b/templates/graphql-cloudflare-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "^0.5.0"
+    "@grafbase/sdk": "^0.6.0"
   }
 }

--- a/templates/graphql-contentful/package.json
+++ b/templates/graphql-contentful/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "^0.5.0"
+    "@grafbase/sdk": "^0.6.0"
   }
 }

--- a/templates/graphql-dgraph/package.json
+++ b/templates/graphql-dgraph/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "^0.5.0"
+    "@grafbase/sdk": "^0.6.0"
   }
 }

--- a/templates/graphql-fauna/package.json
+++ b/templates/graphql-fauna/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "^0.5.0"
+    "@grafbase/sdk": "^0.6.0"
   }
 }

--- a/templates/graphql-github/package.json
+++ b/templates/graphql-github/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "^0.5.0"
+    "@grafbase/sdk": "^0.6.0"
   }
 }

--- a/templates/graphql-saleor/package.json
+++ b/templates/graphql-saleor/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "^0.5.0"
+    "@grafbase/sdk": "^0.6.0"
   }
 }

--- a/templates/graphql-shopify-storefront/package.json
+++ b/templates/graphql-shopify-storefront/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "^0.5.0"
+    "@grafbase/sdk": "^0.6.0"
   }
 }

--- a/templates/graphql-strapi/package.json
+++ b/templates/graphql-strapi/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "^0.5.0"
+    "@grafbase/sdk": "^0.6.0"
   }
 }

--- a/templates/hackernews/package.json
+++ b/templates/hackernews/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "^0.5.0"
+    "@grafbase/sdk": "^0.6.0"
   }
 }

--- a/templates/openapi-github/package.json
+++ b/templates/openapi-github/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "^0.5.0"
+    "@grafbase/sdk": "^0.6.0"
   }
 }

--- a/templates/openapi-mux/package.json
+++ b/templates/openapi-mux/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "^0.5.0"
+    "@grafbase/sdk": "^0.6.0"
   }
 }

--- a/templates/openapi-neon/package.json
+++ b/templates/openapi-neon/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "^0.5.0"
+    "@grafbase/sdk": "^0.6.0"
   }
 }

--- a/templates/openapi-openai/package.json
+++ b/templates/openapi-openai/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "^0.5.0"
+    "@grafbase/sdk": "^0.6.0"
   }
 }

--- a/templates/openapi-stripe/package.json
+++ b/templates/openapi-stripe/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "^0.5.0"
+    "@grafbase/sdk": "^0.6.0"
   }
 }

--- a/templates/openapi-tinybird/package.json
+++ b/templates/openapi-tinybird/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "^0.5.0"
+    "@grafbase/sdk": "^0.6.0"
   }
 }

--- a/templates/todo/package.json
+++ b/templates/todo/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "^0.5.0"
+    "@grafbase/sdk": "^0.6.0"
   }
 }

--- a/templates/twitter/package.json
+++ b/templates/twitter/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@grafbase/sdk": "^0.5.0"
+    "@grafbase/sdk": "^0.6.0"
   }
 }


### PR DESCRIPTION
Breaking things in this release: the mandatory connector name, and namespace as a boolean.
