### PR TITLE
fix(sdk): Always render namespace in SDK connectors

### DIFF
--- a/packages/grafbase-sdk/CHANGELOG.md
+++ b/packages/grafbase-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.6.1] - Mon Aug 28 2023
+
+[CHANGELOG](changelog/0.6.1.md)
+
 ## [0.6.0] - Thu Aug 24 2023
 
 [CHANGELOG](changelog/0.6.0.md)

--- a/packages/grafbase-sdk/changelog/0.6.1.md
+++ b/packages/grafbase-sdk/changelog/0.6.1.md
@@ -1,0 +1,3 @@
+## Fixes
+
+- Always render namespace in SDK connectors

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",

--- a/packages/grafbase-sdk/src/connector/graphql.ts
+++ b/packages/grafbase-sdk/src/connector/graphql.ts
@@ -81,7 +81,7 @@ export class GraphQLAPI {
     if (this.namespace === undefined || this.namespace === true) {
       namespace = `    namespace: true\n`
     } else {
-      namespace = ''
+      namespace = '    namespace: false\n'
     }
 
     const url = this.url ? `    url: "${this.url}"\n` : ''

--- a/packages/grafbase-sdk/src/connector/mongodb.ts
+++ b/packages/grafbase-sdk/src/connector/mongodb.ts
@@ -93,7 +93,7 @@ export class MongoDBAPI {
     if (this.namespace === undefined || this.namespace === true) {
       namespace = `    namespace: true\n`
     } else {
-      namespace = ''
+      namespace = '    namespace: false\n'
     }
 
     const footer = '  )'

--- a/packages/grafbase-sdk/src/connector/openapi.ts
+++ b/packages/grafbase-sdk/src/connector/openapi.ts
@@ -98,7 +98,7 @@ export class OpenAPI {
     if (this.namespace === undefined || this.namespace === true) {
       namespace = `    namespace: true\n`
     } else {
-      namespace = ''
+      namespace = '    namespace: false\n'
     }
 
     const url = this.apiUrl ? `    url: "${this.apiUrl}"\n` : ''

--- a/packages/grafbase-sdk/tests/unit/graphql.test.ts
+++ b/packages/grafbase-sdk/tests/unit/graphql.test.ts
@@ -33,6 +33,7 @@ describe('GraphQL connector', () => {
       "extend schema
         @graphql(
           name: "Contentful"
+          namespace: false
           url: "https://graphql.contentful.com/content/v1/spaces/{{ env.CONTENTFUL_SPACE_ID }}/environments/{{ env.CONTENTFUL_ENVIRONMENT }}"
         )"
     `)

--- a/packages/grafbase-sdk/tests/unit/mongodb.test.ts
+++ b/packages/grafbase-sdk/tests/unit/mongodb.test.ts
@@ -29,6 +29,23 @@ describe('MongoDB generator', () => {
     `)
   })
 
+  it('generates the minimum possible MongoDB datasource, namespace: false', () => {
+    const mongo = connector.MongoDB('Test', mongoParams)
+    g.datasource(mongo, { namespace: false })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "extend schema
+        @mongodb(
+          namespace: false
+          name: "Test"
+          url: "https://data.mongodb-api.com/app/data-test/endpoint/data/v1"
+          apiKey: "SOME_KEY"
+          dataSource: "data"
+          database: "tables"
+        )"
+    `)
+  })
+
   it('generates a simple model', () => {
     const mongo = connector.MongoDB('Test', mongoParams)
 

--- a/packages/grafbase-sdk/tests/unit/openapi.test.ts
+++ b/packages/grafbase-sdk/tests/unit/openapi.test.ts
@@ -35,6 +35,7 @@ describe('OpenAPI generator', () => {
       "extend schema
         @openapi(
           name: "Stripe"
+          namespace: false
           schema: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json"
         )"
     `)


### PR DESCRIPTION
# Description

Previously, `{ namespace: false }` rendered nothing, which is wrong.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [x] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
