### PR TITLE
feat(cli): create default resolver files

### DIFF
--- a/cli/crates/backend/assets/default-schema.graphql
+++ b/cli/crates/backend/assets/default-schema.graphql
@@ -1,44 +1,11 @@
 # Welcome to Grafbase!
-# Define your data models, integrate auth, permission rules, custom resolvers, search, and more with Grafbase.
+# Instant GraphQL APIs for your data
+# https://grafbase.com
 
-# Integrate Auth
-# https://grafbase.com/docs/auth
-#
-# schema @auth(providers: [{ type: oidc, issuer: "{{ env.ISSUER_URL }}" }], rules: [{ allow: private }]) {
-#   query: Query
-# }
-
-# Define Data Models
-# https://grafbase.com/docs/database
-type Post @model @search {
-  title: String!
-  slug: String! @unique
-  content: String
-  publishedAt: DateTime
-  comments: [Comment]
-  likes: Int @default(value: 0)
-  tags: [String] @length(max: 5)
-  author: User
-}
-
-type Comment @model @search {
-  post: Post!
-  body: String!
-  likes: Int @default(value: 0)
-  author: User
-}
-
-type User @model {
-  name: String!
-  email: Email
-  posts: [Post]
-  comments: [Comment]
-
-  # Extend models with resolvers
-  # https://grafbase.com/docs/edge-gateway/resolvers
-  # gravatar: URL @resolver(name: "user/gravatar")
-}
-
-# Start your backend
-# https://grafbase.com/docs/cli
-# npx grafbase dev
+# TODO
+# MongoDB Connector (2 models)
+# OpenAPI Connector (header forwarding)
+# Extended OpenAPI Connector (+ resolver)
+# Custom query resolver
+# Caching config
+# Public auth rule

--- a/cli/crates/backend/assets/grafbase.default.config.ts
+++ b/cli/crates/backend/assets/grafbase.default.config.ts
@@ -1,54 +1,17 @@
-import { g, auth, config } from '@grafbase/sdk'
-
 // Welcome to Grafbase!
-// Define your data models, integrate auth, permission rules, custom resolvers, search, and more with Grafbase.
-// Integrate Auth
-// https://grafbase.com/docs/auth
-//
-// const authProvider = auth.OpenIDConnect({
-//   issuer: process.env.ISSUER_URL ?? ''
-// })
-//
-// Define Data Models
-// https://grafbase.com/docs/database
+// Instant GraphQL APIs for your data
+// https://grafbase.com
 
-const post = g.model('Post', {
-  title: g.string(),
-  slug: g.string().unique(),
-  content: g.string().optional(),
-  publishedAt: g.datetime().optional(),
-  comments: g.relation(() => comment).optional().list().optional(),
-  likes: g.int().default(0),
-  tags: g.string().optional().list().length({ max: 5 }),
-  author: g.relation(() => user).optional()
-}).search()
+import { g, auth, connector, config } from '@grafbase/sdk';
 
-const comment = g.model('Comment', {
-  post: g.relation(post),
-  body: g.string(),
-  likes: g.int().default(0),
-  author: g.relation(() => user).optional()
-})
-
-const user = g.model('User', {
-  name: g.string(),
-  email: g.email().optional(),
-  posts: g.relation(post).optional().list(),
-  comments: g.relation(comment).optional().list()
-
-  // Extend models with resolvers
-  // https://grafbase.com/docs/edge-gateway/resolvers
-  // gravatar: g.url().resolver('user/gravatar')
-})
+// TODO
+// MongoDB Connector (2 models)
+// OpenAPI Connector (header forwarding)
+// Extended OpenAPI Connector (+ resolver)
+// Custom query resolver
+// Caching config
+// Public auth rule
 
 export default config({
-  schema: g
-  // Integrate Auth
-  // https://grafbase.com/docs/auth
-  // auth: {
-  //   providers: [authProvider],
-  //   rules: (rules) => {
-  //     rules.private()
-  //   }
-  // }
-})
+  schema: g,
+});

--- a/cli/crates/backend/assets/gravatar.ts
+++ b/cli/crates/backend/assets/gravatar.ts
@@ -1,0 +1,3 @@
+export default function GravatarResolver({ email }) {
+  return 'https://toupdatewithcode.com/image.png';
+}

--- a/cli/crates/backend/assets/hello.ts
+++ b/cli/crates/backend/assets/hello.ts
@@ -1,0 +1,5 @@
+export default function HelloResolver(_, { name = 'world' }) {
+  return {
+    name,
+  };
+}

--- a/cli/crates/backend/src/consts.rs
+++ b/cli/crates/backend/src/consts.rs
@@ -2,5 +2,6 @@ use const_format::formatcp;
 
 pub const DEFAULT_SCHEMA_SDL: &str = include_str!("../assets/default-schema.graphql");
 pub const DEFAULT_SCHEMA_TS: &str = include_str!("../assets/grafbase.default.config.ts");
+pub const DEFAULT_RESOLVER: &str = include_str!("../assets/hello.ts");
 pub const DEFAULT_DOT_ENV: &str = include_str!("../assets/default.env");
 pub const USER_AGENT: &str = formatcp!("Grafbase-CLI-{}", env!("CARGO_PKG_VERSION"));

--- a/cli/crates/backend/src/errors.rs
+++ b/cli/crates/backend/src/errors.rs
@@ -33,6 +33,18 @@ pub enum BackendError {
     #[error("could not create a schema.graphql file\nCaused by: {0}")]
     WriteSchema(io::Error),
 
+    /// returned if a resolvers folder could not be created
+    #[error("could not create the folder resolvers\nCaused by: {0}")]
+    WriteDefaultResolverFolder(io::Error),
+
+    /// returned if a resolvers/hello.ts file could not be created
+    #[error("could not create the file resolvers/hello.ts\nCaused by: {0}")]
+    WriteDefaultHelloResolver(io::Error),
+
+    /// returned if a resolvers/gravatar.ts file could not be created
+    #[error("could not create the file resolvers/gravatar.ts\nCaused by: {0}")]
+    WriteDefaultGravatarResolver(io::Error),
+
     /// returned if a .env file could not be created
     #[error("could not create a .env file\nCaused by: {0}")]
     WriteEnvFile(io::Error),


### PR DESCRIPTION
# Description

This PR attempts to create 2 new files when you run `init`.

First I created each file but then attempted to be a bit smarter by using `iter()` to go through a list of files to make but I now have some questions and errors.

Also the files `hello.ts` and `gravatar.ts` are not final, these might be named something else.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
