### PR TITLE
feat(resolvers): optionally create symlink to grafbase-wasm-sdk

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1944,6 +1944,7 @@ version = "0.33.2"
 dependencies = [
  "axum",
  "base64 0.21.2",
+ "cfg-if",
  "chrono",
  "combine 4.6.6",
  "dotenv",

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -57,6 +57,7 @@ unicode-normalization = "0.1"
 ulid = "1"
 version-compare = "0.1"
 which = "4"
+cfg-if = "1"
 
 # Same version as Tantivy
 tantivy-fst = "0.4.0"

--- a/cli/crates/server/src/consts.rs
+++ b/cli/crates/server/src/consts.rs
@@ -10,3 +10,5 @@ pub const SCHEMA_PARSER_DIR: &str = "parser";
 pub const SCHEMA_PARSER_INDEX: &str = "index.js";
 pub const TS_NODE_SCRIPT_PATH: &str = "node_modules/ts-node/dist/bin.js";
 pub const WRAPPER_WORKER_JS_PATH: &str = "custom-resolvers/wrapper-worker.js";
+pub const GRAFBASE_WASM_SDK_NAME: &str = "grafbase-wasm-sdk_bg.wasm";
+pub const GRAFBASE_WASM_SDK_PATH: &str = "custom-resolvers/grafbase-wasm-sdk_bg.wasm";

--- a/cli/crates/server/src/errors.rs
+++ b/cli/crates/server/src/errors.rs
@@ -216,6 +216,10 @@ pub enum UdfBuildError {
     #[error("could not write to a temporary file '{0}': {1}")]
     CreateNotWriteToTemporaryFile(PathBuf, IoError),
 
+    /// returned if creating symlink to a file fails.
+    #[error("could not link to file: {0}")]
+    SymlinkFailure(IoError),
+
     #[error("could not find a {0} referenced in the schema under the path {1}.{{js,ts}}")]
     UdfDoesNotExist(UdfKind, PathBuf),
 


### PR DESCRIPTION
# Description

This PR adds a symlink to grafbase-wasm-sdk and updates the wrangler.toml used on resolvers to use a rule that makes this wasm available when uploading the worker.

The symlink is required because wrangler build rules use relative paths.

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
