### PR TITLE
fix: error propagation & nested list resolution

### DIFF
--- a/engine/crates/grafbase-engine-integration-tests/tests/errors/mod.rs
+++ b/engine/crates/grafbase-engine-integration-tests/tests/errors/mod.rs
@@ -1,0 +1,283 @@
+//! Various tests of errors during execution
+
+use std::net::SocketAddr;
+
+use grafbase_engine_integration_tests::{runtime, udfs::RustUdfs, Engine, EngineBuilder, ResponseExt};
+use grafbase_runtime::udf::{CustomResolverRequestPayload, CustomResolverResponse};
+use serde_json::json;
+use wiremock::{
+    matchers::{method, path},
+    Mock, MockServer, ResponseTemplate,
+};
+
+#[test]
+fn error_propagation_openapi() {
+    runtime().block_on(async {
+        let mock_server = wiremock::MockServer::start().await;
+        let engine = build_petstore_engine(petstore_schema(mock_server.address())).await;
+
+        // We only set up one the pets we request, so we should get
+        // one pet back and a null on the other (with an error explaining why)
+        mock_doggo(&mock_server, 123, "Immediate Doggo").await;
+
+        insta::assert_json_snapshot!(
+            engine
+                .execute(
+                r#"
+                    query {
+                        petstore {
+                            goodDoggo: pet(petId: 123) {
+                                id
+                                name
+                            }
+                            veryGoodDoggo: pet(petId: 456) {
+                                id
+                                name
+                            }
+                        }
+                    }
+                "#,
+                )
+                .await
+                .into_value(),
+            @r###"
+        {
+          "data": {
+            "petstore": {
+              "goodDoggo": {
+                "id": 123,
+                "name": "Immediate Doggo"
+              },
+              "veryGoodDoggo": null
+            }
+          },
+          "errors": [
+            {
+              "locations": [
+                {
+                  "column": 29,
+                  "line": 8
+                }
+              ],
+              "message": "Received an unexpected status from the downstream server: 404 Not Found",
+              "path": [
+                "petstore",
+                "veryGoodDoggo"
+              ]
+            }
+          ]
+        }
+        "###
+        );
+    });
+}
+
+#[test]
+fn error_handling_scalar_custom_resolver() {
+    runtime().block_on(async {
+        let schema = r#"
+            type Query {
+                error: String @resolver(name: "error")
+            }
+        "#;
+        let engine = EngineBuilder::new(schema)
+            .with_custom_resolvers(RustUdfs::new().resolver(
+                "error",
+                CustomResolverResponse::GraphQLError {
+                    message: "Shits on fire yo".into(),
+                    extensions: None,
+                },
+            ))
+            .build()
+            .await;
+
+        insta::assert_json_snapshot!(
+            engine.execute("query { error }",).await.into_value(),
+            @r###"
+        {
+          "data": {
+            "error": null
+          },
+          "errors": [
+            {
+              "locations": [
+                {
+                  "column": 9,
+                  "line": 1
+                }
+              ],
+              "message": "Shits on fire yo",
+              "path": [
+                "error"
+              ]
+            }
+          ]
+        }
+        "###
+        );
+    });
+}
+
+#[test]
+fn error_handling_list_custom_resolver() {
+    // Tests handling of errors on list fields
+    runtime().block_on(async {
+        let schema = r#"
+            type Query {
+                error: [String] @resolver(name: "error")
+            }
+        "#;
+        let engine = EngineBuilder::new(schema)
+            .with_custom_resolvers(RustUdfs::new().resolver(
+                "error",
+                CustomResolverResponse::GraphQLError {
+                    message: "Shits on fire yo".into(),
+                    extensions: None,
+                },
+            ))
+            .build()
+            .await;
+
+        insta::assert_json_snapshot!(
+            engine.execute("query { error }",).await.into_value(),
+            @r###"
+        {
+          "data": {
+            "error": null
+          },
+          "errors": [
+            {
+              "locations": [
+                {
+                  "column": 9,
+                  "line": 1
+                }
+              ],
+              "message": "Shits on fire yo",
+              "path": [
+                "error"
+              ]
+            }
+          ]
+        }
+        "###
+        );
+    });
+}
+
+#[test]
+fn error_handling_list_propagation() {
+    // Tests that errors inside list items propagate to the list item and not the list
+    runtime().block_on(async {
+        let schema = r#"
+          type Query {
+              list: [ObjectWithErrors]! @resolver(name: "list")
+          }
+
+          type ObjectWithErrors {
+              hello: String! @resolver(name: "item")
+          }
+        "#;
+        let engine = EngineBuilder::new(schema)
+            .with_custom_resolvers(
+                RustUdfs::new()
+                    .resolver("list", CustomResolverResponse::Success(json!([{"id": 1}, {"id": 2}])))
+                    .resolver("item", |payload: CustomResolverRequestPayload| {
+                        if payload.parent.unwrap()["id"] == json!(1) {
+                            Ok(CustomResolverResponse::Success(json!("world")))
+                        } else {
+                            Ok(CustomResolverResponse::GraphQLError {
+                                message: "get out of my pub".into(),
+                                extensions: None,
+                            })
+                        }
+                    }),
+            )
+            .build()
+            .await;
+
+        insta::assert_json_snapshot!(
+            engine.execute("query { list { hello }}",).await.into_value(),
+            @r###"
+        {
+          "data": {
+            "list": [
+              {
+                "hello": "world"
+              },
+              null
+            ]
+          },
+          "errors": [
+            {
+              "locations": [
+                {
+                  "column": 16,
+                  "line": 1
+                }
+              ],
+              "message": "get out of my pub",
+              "path": [
+                "list",
+                1,
+                "hello"
+              ]
+            }
+          ]
+        }
+        "###
+        );
+    });
+}
+
+async fn build_petstore_engine(schema: String) -> Engine {
+    EngineBuilder::new(schema)
+        .with_openapi_schema(
+            "http://example.com/petstore.json",
+            include_str!("../openapi/petstore.json"),
+        )
+        .build()
+        .await
+}
+
+fn petstore_schema(address: &SocketAddr) -> String {
+    format!(
+        r#"
+          extend schema
+          @openapi(
+            name: "petstore",
+            url: "http://{address}",
+            schema: "http://example.com/petstore.json",
+          )
+        "#
+    )
+}
+
+async fn mock_doggo(mock_server: &MockServer, id: u32, name: &str) {
+    Mock::given(method("GET"))
+        .and(path(format!("/pet/{id}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(doggo(id, name)))
+        .mount(mock_server)
+        .await;
+}
+
+fn doggo(id: u32, name: &str) -> serde_json::Value {
+    json!({
+        "id": id,
+        "name": name,
+        "category": {
+            "id": 1,
+            "name": "Dogs"
+        },
+        "photoUrls": [
+            "string"
+        ],
+        "tags": [
+            {
+            "id": 0,
+            "name": "string"
+            }
+        ],
+        "status": "available"
+    })
+}

--- a/engine/crates/grafbase-engine-integration-tests/tests/integration_tests.rs
+++ b/engine/crates/grafbase-engine-integration-tests/tests/integration_tests.rs
@@ -2,6 +2,7 @@
 
 mod custom_resolvers;
 mod defer;
+mod errors;
 mod execution;
 mod mongodb;
 mod openapi;

--- a/engine/crates/grafbase-engine-integration-tests/tests/mongodb/find_many.rs
+++ b/engine/crates/grafbase-engine-integration-tests/tests/mongodb/find_many.rs
@@ -17,7 +17,7 @@ fn empty() {
         let query = indoc! {r#"
             query {
               userCollection(first: 10, filter: { age: { eq: 39 } }) {
-                edges { node { age } }  
+                edges { node { age } }
               }
             }
         "#};
@@ -50,7 +50,7 @@ fn namespaced() {
             query {
               myMongo {
                 userCollection(first: 10, filter: { age: { eq: 39 } }) {
-                  edges { node { age } }  
+                  edges { node { age } }
                 }
               }
             }
@@ -85,7 +85,7 @@ fn missing_first_or_last() {
         let query = indoc! {r#"
             query {
               userCollection(filter: { age: { eq: 39 } }) {
-                edges { node { age } }  
+                edges { node { age } }
               }
             }
         "#};
@@ -95,7 +95,9 @@ fn missing_first_or_last() {
 
     let expected = expect![[r#"
         {
-          "data": null,
+          "data": {
+            "userCollection": null
+          },
           "errors": [
             {
               "message": "please limit your selection by setting either the first or last parameter",
@@ -135,7 +137,7 @@ fn eq() {
         let query = indoc! {r#"
             query {
               userCollection(first: 10, filter: { age: { eq: 39 } }) {
-                edges { node { age } }  
+                edges { node { age } }
               }
             }
         "#};
@@ -172,7 +174,7 @@ fn nested_eq() {
           b: B
           d: String
         }
-        
+
         type User @model(connector: "test", collection: "users") {
           data: A
           other: Int
@@ -257,7 +259,7 @@ fn ne() {
         let query = indoc! {r#"
             query {
               userCollection(first: 10, filter: { age: { ne: 39 } }) {
-                edges { node { age } }  
+                edges { node { age } }
               }
             }
         "#};
@@ -308,7 +310,7 @@ fn gt() {
         let query = indoc! {r#"
             query {
               userCollection(first: 10, filter: { age: { gt: 39 } }) {
-                edges { node { age } }  
+                edges { node { age } }
               }
             }
         "#};
@@ -354,7 +356,7 @@ fn lt() {
         let query = indoc! {r#"
             query {
               userCollection(first: 10, filter: { age: { lt: 39 } }) {
-                edges { node { age } }  
+                edges { node { age } }
               }
             }
         "#};
@@ -400,7 +402,7 @@ fn gte() {
         let query = indoc! {r#"
             query {
               userCollection(first: 10, filter: { age: { gte: 39 } }) {
-                edges { node { age } }  
+                edges { node { age } }
               }
             }
         "#};
@@ -451,7 +453,7 @@ fn lte() {
         let query = indoc! {r#"
             query {
               userCollection(first: 10, filter: { age: { lte: 39 } }) {
-                edges { node { age } }  
+                edges { node { age } }
               }
             }
         "#};
@@ -502,7 +504,7 @@ fn r#in() {
         let query = indoc! {r#"
             query {
               userCollection(first: 10, filter: { age: { in: [38, 40] } }) {
-                edges { node { age } }  
+                edges { node { age } }
               }
             }
         "#};
@@ -553,7 +555,7 @@ fn nin() {
         let query = indoc! {r#"
             query {
               userCollection(first: 10, filter: { age: { nin: [38, 40] } }) {
-                edges { node { age } }  
+                edges { node { age } }
               }
             }
         "#};
@@ -603,7 +605,7 @@ fn all() {
                 { age: { eq: 39 } },
                 { name: { eq: "Alice" } }
               ]}) {
-                edges { node { name age } }  
+                edges { node { name age } }
               }
             }
         "#};
@@ -654,7 +656,7 @@ fn none() {
                 { age: { eq: 38 } },
                 { name: { eq: "Alice" } }
               ]}) {
-                edges { node { name age } }  
+                edges { node { name age } }
               }
             }
         "#};
@@ -705,7 +707,7 @@ fn any() {
                 { age: { eq: 39 } },
                 { name: { eq: "Bob" } }
               ]}) {
-                edges { node { name age } }  
+                edges { node { name age } }
               }
             }
         "#};
@@ -767,7 +769,7 @@ fn not() {
               userCollection(first: 10, filter: {
                 age: { not: { eq: 39 } }
               }) {
-                edges { node { name age } }  
+                edges { node { name age } }
               }
             }
         "#};
@@ -827,7 +829,7 @@ fn date_eq() {
               userCollection(first: 10, filter: {
                 birthday: { eq: "2022-01-12" }
               }) {
-                edges { node { birthday } }  
+                edges { node { birthday } }
               }
             }
         "#};
@@ -882,7 +884,7 @@ fn datetime_eq() {
               userCollection(first: 10, filter: {
                 birthday: { eq: "2022-01-12T02:33:23.067+04:00" }
               }) {
-                edges { node { birthday } }  
+                edges { node { birthday } }
               }
             }
         "#};
@@ -943,7 +945,7 @@ fn timestamp_eq() {
               userCollection(first: 10, filter: {
                 registered: { eq: 1565545684 }
               }) {
-                edges { node { registered } }  
+                edges { node { registered } }
               }
             }
         "#};
@@ -991,7 +993,7 @@ fn simple_array_all() {
               userCollection(first: 10, filter: {
                 data: { all: [2, 3, 4] }
               }) {
-                edges { node { data } }  
+                edges { node { data } }
               }
             }
         "#};
@@ -1043,7 +1045,7 @@ fn simple_array_size() {
               userCollection(first: 10, filter: {
                 data: { size: 2 }
               }) {
-                edges { node { data } }  
+                edges { node { data } }
               }
             }
         "#};
@@ -1094,7 +1096,7 @@ fn simple_array_elemmatch() {
               userCollection(first: 10, filter: {
                 data: { elemMatch: { eq: 2 } }
               }) {
-                edges { node { data } }  
+                edges { node { data } }
               }
             }
         "#};
@@ -1158,7 +1160,7 @@ fn complex_array_elemmatch() {
               userCollection(first: 10, filter: {
                 data: { elemMatch: { street: { eq: "Wall" } } }
               }) {
-                edges { node { data { street }} }  
+                edges { node { data { street }} }
               }
             }
         "#};
@@ -1192,7 +1194,7 @@ fn complex_array_elemmatch() {
 fn complex_double_nested_array_elemmatch() {
     let schema = indoc! {r#"
         type Street {
-          name: String @map(name: "street_name")            
+          name: String @map(name: "street_name")
         }
 
         type Address {
@@ -1218,7 +1220,7 @@ fn complex_double_nested_array_elemmatch() {
               userCollection(first: 10, filter: {
                 data: { elemMatch: { street: { name: { eq: "Wall" } } } }
               }) {
-                edges { node { data { street { name } } } }  
+                edges { node { data { street { name } } } }
               }
             }
         "#};
@@ -1274,7 +1276,7 @@ fn simple_sort_asc() {
                 filter: { age: { gt: 38 } },
                 orderBy: [{ age: ASC }]
               ) {
-                edges { node { age } }  
+                edges { node { age } }
               }
             }
         "#};
@@ -1329,7 +1331,7 @@ fn simple_sort_desc() {
                 filter: { age: { gt: 38 } },
                 orderBy: [{ age: DESC }]
               ) {
-                edges { node { age } }  
+                edges { node { age } }
               }
             }
         "#};
@@ -1388,7 +1390,7 @@ fn nested_sort() {
                 filter: { age: { number: { gt: 38 } } },
                 orderBy: [{ age: { number: ASC } }]
               ) {
-                edges { node { age { number } } }  
+                edges { node { age { number } } }
               }
             }
         "#};

--- a/engine/crates/grafbase-engine/src/context.rs
+++ b/engine/crates/grafbase-engine/src/context.rs
@@ -520,6 +520,11 @@ impl<'a, T> ContextBase<'a, T> {
 
     #[doc(hidden)]
     pub fn set_error_path(&self, error: ServerError) -> ServerError {
+        if !error.path.is_empty() {
+            // If the error already has a path we don't want to overwrite it.
+            return error;
+        }
+
         if let Some(node) = self.path_node {
             let path = node.to_owned_segments();
             ServerError { path, ..error }

--- a/engine/crates/grafbase-engine/src/registry/mod.rs
+++ b/engine/crates/grafbase-engine/src/registry/mod.rs
@@ -37,7 +37,10 @@ pub use self::{
         CacheAccessScope, CacheConfig, CacheControl, CacheControlError, CacheInvalidation, CacheInvalidationPolicy,
     },
     connector_headers::{ConnectorHeaderValue, ConnectorHeaders},
-    type_names::{InputValueType, MetaFieldType, ModelName, NamedType, TypeCondition, TypeReference},
+    type_names::{
+        InputValueType, MetaFieldType, ModelName, NamedType, TypeCondition, TypeReference, WrappingType,
+        WrappingTypeIter,
+    },
     union_discriminator::UnionDiscriminator,
 };
 use self::{relations::MetaRelation, resolvers::Resolver, type_kinds::TypeKind};

--- a/engine/crates/grafbase-engine/src/registry/type_names.rs
+++ b/engine/crates/grafbase-engine/src/registry/type_names.rs
@@ -79,6 +79,10 @@ impl MetaFieldType {
     pub fn base_type_name(&self) -> &str {
         named_type_from_type_str(&self.0)
     }
+
+    pub fn wrapping_types(&self) -> WrappingTypeIter<'_> {
+        WrappingTypeIter(self.as_str().chars())
+    }
 }
 
 impl TypeReference for MetaFieldType {
@@ -219,4 +223,53 @@ fn named_type_from_type_str(meta: &str) -> &str {
     }
 
     nested.expect("Can't fail")
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum WrappingType {
+    NonNull,
+    List,
+}
+
+pub struct WrappingTypeIter<'a>(std::str::Chars<'a>);
+
+impl Iterator for WrappingTypeIter<'_> {
+    type Item = WrappingType;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.0.next_back()? {
+            '!' => Some(WrappingType::NonNull),
+            ']' => Some(WrappingType::List),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_wrapping_type_iter() {
+        let wrapping_types = |s: &str| WrappingTypeIter(s.chars()).collect::<Vec<_>>();
+        assert_eq!(wrapping_types("String"), vec![]);
+        assert_eq!(wrapping_types("String!"), vec![WrappingType::NonNull]);
+        assert_eq!(
+            wrapping_types("[String]!"),
+            vec![WrappingType::NonNull, WrappingType::List]
+        );
+        assert_eq!(wrapping_types("[String]"), vec![WrappingType::List]);
+        assert_eq!(
+            wrapping_types("[String!]"),
+            vec![WrappingType::List, WrappingType::NonNull]
+        );
+        assert_eq!(
+            wrapping_types("[String!]!"),
+            vec![WrappingType::NonNull, WrappingType::List, WrappingType::NonNull]
+        );
+        assert_eq!(
+            wrapping_types("[[String!]]"),
+            vec![WrappingType::List, WrappingType::List, WrappingType::NonNull]
+        );
+    }
 }

--- a/engine/crates/grafbase-engine/src/registry/type_names.rs
+++ b/engine/crates/grafbase-engine/src/registry/type_names.rs
@@ -70,6 +70,11 @@ impl MetaFieldType {
         self.0.ends_with('!')
     }
 
+    pub fn is_nullable(&self) -> bool {
+        // This makes me sad, but for now lets live with it
+        !self.0.ends_with('!')
+    }
+
     pub fn is_list(&self) -> bool {
         // Note that we do starts_with here to include both nullable and non-nullable
         // lists.

--- a/engine/crates/grafbase-engine/src/resolver_utils/field.rs
+++ b/engine/crates/grafbase-engine/src/resolver_utils/field.rs
@@ -59,7 +59,7 @@ pub async fn resolve_field(
 
     match result {
         Ok(result) => Ok(Some(result)),
-        Err(e) if !field.ty.is_non_null() => {
+        Err(e) if field.ty.is_nullable() => {
             ctx.add_error(e);
             Ok(Some(ctx.response_graph.write().await.insert_node(CompactValue::Null)))
         }

--- a/engine/crates/grafbase-engine/src/resolver_utils/list.rs
+++ b/engine/crates/grafbase-engine/src/resolver_utils/list.rs
@@ -1,5 +1,7 @@
+use std::{future::Future, iter::Peekable};
+
 use grafbase_engine_value::Name;
-use graph_entities::{ResponseList, ResponseNodeId, ResponsePrimitive};
+use graph_entities::{CompactValue, QueryResponseNode, ResponseList, ResponseNodeId, ResponsePrimitive};
 
 use crate::{
     extensions::ResolveInfo,
@@ -7,123 +9,193 @@ use crate::{
     registry::{
         resolvers::ResolvedValue,
         scalars::{DynamicScalar, PossibleScalar},
-        MetaType,
+        MetaFieldType, MetaType, WrappingType, WrappingTypeIter,
     },
     resolver_utils::resolve_container,
     ContextSelectionSet, Error, LegacyOutputType, Positioned, ServerError, ServerResult, Value,
 };
 
-/// Resolve an list by executing each of the items concurrently.
+/// Resolve a list by executing each of the items concurrently.
 pub async fn resolve_list<'a>(
-    ctx: &ContextSelectionSet<'a>,
+    ctx: ContextSelectionSet<'a>,
     field: &Positioned<Field>,
-    ty: &'a MetaType,
-    values: Vec<ResolvedValue>,
+    field_ty: &MetaFieldType,
+    inner_ty: &'a MetaType,
+    value: ResolvedValue,
 ) -> ServerResult<ResponseNodeId> {
-    let extensions = &ctx.query_env.extensions;
-    if !extensions.is_empty() {
-        let mut futures = Vec::with_capacity(values.len());
-        for (idx, item) in values.into_iter().enumerate() {
-            futures.push({
-                let ctx = ctx.clone();
-                let type_name = ty.name();
-                async move {
-                    let ctx_idx = ctx.with_index(idx, Some(&ctx.item.node));
-                    let extensions = &ctx.query_env.extensions;
+    #[async_recursion::async_recursion]
+    async fn inner(
+        ctx: ContextSelectionSet<'async_recursion>,
+        field: &Positioned<Field>,
+        list_kinds: &[ListKind],
+        ty: &MetaType,
+        value: ResolvedValue,
+    ) -> Result<ResponseNodeId, ServerError> {
+        let Some(list_kind) = list_kinds.first() else {
+            // If there's no list_kind then we've reached the innermost item and should resolve that
+            return resolve_item(ctx, field, ty, value).await;
+        };
 
-                    let ctx_field = ctx.with_field(field, None, Some(&ctx.item.node));
-                    let meta_field = ctx_field
-                        .schema_env
-                        .registry
-                        .types
-                        .get(type_name)
-                        .and_then(|ty| ty.field_by_name(field.node.name.node.as_str()));
+        // First we need to make sure our parent resolve data actually has a list
+        // (or return null early if we're on a nullable list)
+        let items = match (list_kind, value.data_resolved()) {
+            (ListKind::NullableList(_), serde_json::Value::Null) => {
+                return Ok(ctx.response_graph.write().await.insert_node(CompactValue::Null));
+            }
+            (ListKind::NonNullList(_), serde_json::Value::Null) => {
+                return Err(ctx.set_error_path(ServerError::new(
+                    format!(
+                        "An error occurred while fetching `{}`, a non-nullable value was expected but no value was found.",
+                        field.node.name.node
+                    ),
+                    Some(ctx.item.pos),
+                )));
+            }
+            (_, serde_json::Value::Array(_)) => value.item_iter().expect("we checked its an array").collect::<Vec<_>>(),
+            (_, value) => {
+                return Err(ctx.set_error_path(ServerError::new(
+                    format!("Encountered a {} where we expected a list", json_kind_str(value)),
+                    Some(ctx.item.pos),
+                )));
+            }
+        };
 
-                    let parent_type = format!("[{type_name}]");
-                    let return_type = format!("{type_name}!").into();
-                    let args_values: Vec<(Positioned<Name>, Option<Value>)> = ctx_field
-                        .item
-                        .node
-                        .arguments
-                        .clone()
-                        .into_iter()
-                        .map(|(key, val)| (key, ctx_field.resolve_input_value(val).ok()))
-                        .collect();
-
-                    let resolve_info = ResolveInfo {
-                        path_node: ctx_idx.path_node.as_ref().unwrap(),
-                        parent_type: &parent_type,
-                        return_type: &return_type,
-                        name: field.node.name.node.as_str(),
-                        alias: field.node.alias.as_ref().map(|alias| alias.node.as_str()),
-                        required_operation: meta_field.and_then(|f| f.required_operation),
-                        auth: meta_field.and_then(|f| f.auth.as_ref()),
-                        input_values: args_values,
-                    };
-
-                    let resolve_fut = async {
-                        match ty {
-                            MetaType::Scalar(_) | MetaType::Enum(_) => {
-                                let mut result = Value::try_from(item.take()).map_err(|err| {
-                                    ctx_idx.set_error_path(ServerError::new(format!("{err:?}"), Some(field.pos)))
-                                })?;
-                                // Yes it's ugly...
-                                if let MetaType::Scalar(_) = ty {
-                                    result = resolve_scalar(result, type_name)
-                                        .map_err(|err| err.into_server_error(field.pos))?;
-                                }
-                                Ok(Some(
-                                    ctx_idx
-                                        .response_graph
-                                        .write()
-                                        .await
-                                        .insert_node(ResponsePrimitive::new(result.into())),
-                                ))
-                            }
-                            _ => resolve_container(&ctx_idx, ty, None, Some(item))
-                                .await
-                                .map(Option::Some)
-                                .map_err(|err| ctx_idx.set_error_path(err)),
-                        }
-                    };
-                    futures_util::pin_mut!(resolve_fut);
-                    extensions
-                        .resolve(resolve_info, &mut resolve_fut)
-                        .await
-                        .map(|value| value.expect("You definitely encountered a bug!"))
-                }
-            });
-        }
-        let node = ResponseList::with_children(futures_util::future::try_join_all(futures).await?);
-
-        Ok(ctx.response_graph.write().await.insert_node(node))
-    } else {
-        let mut futures = Vec::with_capacity(values.len());
-        for (idx, item) in values.into_iter().enumerate() {
+        let futures = items.into_iter().enumerate().map(|(idx, item)| {
             let ctx_idx = ctx.with_index(idx, Some(&ctx.item.node));
-            futures.push(async move {
-                match ty {
-                    MetaType::Scalar { .. } | MetaType::Enum { .. } => {
-                        let result = Value::try_from(item.take()).map_err(|err| {
-                            ctx_idx.set_error_path(ServerError::new(format!("{err:?}"), Some(field.pos)))
-                        })?;
+            let resolve_future = inner(ctx_idx.clone(), field, &list_kinds[1..], ty, item);
 
-                        Ok(ctx_idx
-                            .response_graph
-                            .write()
-                            .await
-                            .insert_node(ResponsePrimitive::new(result.into())))
+            if ctx.query_env.extensions.is_empty() {
+                resolve_future
+            } else {
+                Box::pin(apply_extensions(ctx_idx, field, ty, resolve_future))
+            }
+        });
+
+        let mut children = vec![];
+        for result in futures_util::future::join_all(futures).await {
+            // Now we need to handle error propagation and validate the nullability
+            // of each of the list items
+            match result {
+                Ok(id) if list_kind.inner_nullablity() == ListInner::NonNullable => {
+                    let found_null = match ctx.response_graph.read().await.get_node(id) {
+                        Some(QueryResponseNode::Primitive(value)) if value.is_null() => true,
+                        None => true,
+                        _ => false,
+                    };
+                    if found_null {
+                        ctx.add_error(ServerError::new(
+                            format!(
+                                "An error occurred while fetching `{}`, a non-nullable value was expected but nm value was found.",
+                                field.node.name.node
+                            ),
+                            Some(ctx.item.pos),
+                        ));
+                        children.push(ctx.response_graph.write().await.insert_node(CompactValue::Null));
+                    } else {
+                        children.push(id);
                     }
-                    _ => resolve_container(&ctx_idx, ty, None, Some(item))
-                        .await
-                        .map_err(|err| ctx_idx.set_error_path(err)),
                 }
-            });
+                Ok(id) => children.push(id),
+                Err(error) if list_kind.inner_nullablity() == ListInner::Nullable => {
+                    ctx.add_error(error);
+                    children.push(ctx.response_graph.write().await.insert_node(CompactValue::Null));
+                }
+                Err(error) => return Err(error),
+            }
         }
 
-        let node = ResponseList::with_children(futures_util::future::try_join_all(futures).await?);
+        Ok(ctx
+            .response_graph
+            .write()
+            .await
+            .insert_node(ResponseList::with_children(children)))
+    }
 
-        Ok(ctx.response_graph.write().await.insert_node(node))
+    inner(
+        ctx,
+        field,
+        &ListNullabilityIter::new(field_ty).collect::<Vec<_>>(),
+        inner_ty,
+        value,
+    )
+    .await
+}
+
+fn apply_extensions<'a>(
+    ctx: ContextSelectionSet<'a>,
+    field: &'a Positioned<Field>,
+    inner_ty: &'a MetaType,
+    resolve_fut: impl Future<Output = Result<ResponseNodeId, ServerError>> + Send + 'a,
+) -> impl Future<Output = Result<ResponseNodeId, ServerError>> + 'a {
+    let ctx = ctx.clone();
+    let type_name = inner_ty.name();
+    async move {
+        let ctx_field = ctx.with_field(field, None, Some(&ctx.item.node));
+        let meta_field = ctx_field
+            .schema_env
+            .registry
+            .types
+            .get(type_name)
+            .and_then(|ty| ty.field_by_name(field.node.name.node.as_str()));
+
+        let parent_type = format!("[{type_name}]");
+        let return_type = format!("{type_name}!").into();
+        let args_values: Vec<(Positioned<Name>, Option<Value>)> = ctx_field
+            .item
+            .node
+            .arguments
+            .clone()
+            .into_iter()
+            .map(|(key, val)| (key, ctx_field.resolve_input_value(val).ok()))
+            .collect();
+
+        let resolve_info = ResolveInfo {
+            path_node: ctx.path_node.as_ref().unwrap(),
+            parent_type: &parent_type,
+            return_type: &return_type,
+            name: field.node.name.node.as_str(),
+            alias: field.node.alias.as_ref().map(|alias| alias.node.as_str()),
+            required_operation: meta_field.and_then(|f| f.required_operation),
+            auth: meta_field.and_then(|f| f.auth.as_ref()),
+            input_values: args_values,
+        };
+
+        let resolve_fut = async move { Ok(Some(resolve_fut.await?)) };
+        futures_util::pin_mut!(resolve_fut);
+        ctx.query_env
+            .extensions
+            .resolve(resolve_info, &mut resolve_fut)
+            .await
+            .map(|value| value.expect("You definitely encountered a bug!"))
+    }
+}
+
+async fn resolve_item(
+    ctx_idx: ContextSelectionSet<'_>,
+    field: &Positioned<Field>,
+    ty: &MetaType,
+    item: ResolvedValue,
+) -> Result<ResponseNodeId, ServerError> {
+    match ty {
+        MetaType::Scalar(_) | MetaType::Enum(_) => {
+            let mut result = Value::try_from(item.take()).map_err(|err| Error::new(format!("{err:?}")));
+
+            // Yes it's ugly...
+            if let MetaType::Scalar(_) = ty {
+                result = result.and_then(|value| resolve_scalar(value, ty.name()));
+            }
+
+            let item = result.map_err(|error| ctx_idx.set_error_path(error.into_server_error(field.pos)))?;
+
+            Ok(ctx_idx
+                .response_graph
+                .write()
+                .await
+                .insert_node(ResponsePrimitive::new(item.into())))
+        }
+        _ => resolve_container(&ctx_idx, ty, None, Some(item))
+            .await
+            .map_err(|err| ctx_idx.set_error_path(err)),
     }
 }
 
@@ -224,5 +296,124 @@ pub async fn resolve_list_native<'a, T: LegacyOutputType + 'a>(
             .insert_node(ResponseList::with_children(children));
 
         Ok(node_id)
+    }
+}
+
+/// An iterator over the nullability of lists in a type string
+struct ListNullabilityIter<'a>(Peekable<WrappingTypeIter<'a>>);
+
+impl<'a> ListNullabilityIter<'a> {
+    pub fn new(ty: &'a MetaFieldType) -> Self {
+        ListNullabilityIter(ty.wrapping_types().peekable())
+    }
+}
+
+/// The nullability of a list _and_ its contents
+#[derive(Debug, PartialEq, Clone, Copy)]
+enum ListKind {
+    NullableList(ListInner),
+    NonNullList(ListInner),
+}
+
+impl ListKind {
+    pub fn inner_nullablity(self) -> ListInner {
+        match self {
+            ListKind::NullableList(inner) => inner,
+            ListKind::NonNullList(inner) => inner,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+enum ListInner {
+    Nullable,
+    NonNullable,
+}
+
+impl Iterator for ListNullabilityIter<'_> {
+    type Item = ListKind;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut nullable = true;
+        loop {
+            match self.0.next()? {
+                WrappingType::NonNull => {
+                    nullable = false;
+                    continue;
+                }
+                WrappingType::List if nullable => {
+                    return Some(ListKind::NullableList(match self.0.peek() {
+                        Some(WrappingType::NonNull) => ListInner::NonNullable,
+                        _ => ListInner::Nullable,
+                    }))
+                }
+                WrappingType::List => {
+                    return Some(ListKind::NonNullList(match self.0.peek() {
+                        Some(WrappingType::NonNull) => ListInner::NonNullable,
+                        _ => ListInner::Nullable,
+                    }))
+                }
+            }
+        }
+    }
+}
+
+fn json_kind_str(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "bool",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "list",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn list_nullability(ty: &str) -> Vec<ListKind> {
+        ListNullabilityIter::new(&ty.into()).collect::<Vec<_>>()
+    }
+
+    #[test]
+    fn test_list_nullability_iter() {
+        assert_eq!(list_nullability("String"), vec![]);
+        assert_eq!(list_nullability("String!"), vec![]);
+        assert_eq!(
+            list_nullability("[String!]"),
+            vec![ListKind::NullableList(ListInner::NonNullable)]
+        );
+        assert_eq!(
+            list_nullability("[String!]!"),
+            vec![ListKind::NonNullList(ListInner::NonNullable)]
+        );
+        assert_eq!(
+            list_nullability("[String]!"),
+            vec![ListKind::NonNullList(ListInner::Nullable)]
+        );
+        assert_eq!(
+            list_nullability("[[String!]!]"),
+            vec![
+                ListKind::NullableList(ListInner::NonNullable),
+                ListKind::NonNullList(ListInner::NonNullable)
+            ]
+        );
+        assert_eq!(
+            list_nullability("[[String!]]!"),
+            vec![
+                ListKind::NonNullList(ListInner::Nullable),
+                ListKind::NullableList(ListInner::NonNullable)
+            ]
+        );
+        assert_eq!(
+            list_nullability("[[[String]]!]"),
+            vec![
+                ListKind::NullableList(ListInner::NonNullable),
+                ListKind::NonNullList(ListInner::Nullable),
+                ListKind::NullableList(ListInner::Nullable)
+            ]
+        );
     }
 }

--- a/engine/crates/graph-entities/src/response/mod.rs
+++ b/engine/crates/graph-entities/src/response/mod.rs
@@ -487,6 +487,10 @@ impl ResponsePrimitive {
     pub fn new(value: CompactValue) -> Box<Self> {
         Box::new(ResponsePrimitive(value))
     }
+
+    pub fn is_null(&self) -> bool {
+        matches!(self.0, CompactValue::Null)
+    }
 }
 
 impl Default for ResponsePrimitive {


### PR DESCRIPTION
While testing `@defer` I've discovered a few bugs: 

1. We were propagating errors up to the top level of a response rather than the nearest nullable field.
2. We weren't reporting the path correctly on errors.
3. Nested lists would get flattened into a single level of list.
4. Nullability validation at the various levels of the list (and of items in lists) was also pretty sketchy.

This PR fixes those:

1. We were being a bit overzealous with the question mark operator.  I've replaced one or two points with proper error->null conversion to fix this.
2. Was because we called `set_error_path` all over the place which overwrote the path with a less specific path.  I've updated `set_error_path` to only set the path if there's not one already, which fixes that.
3. Our list resolver code just didn't take nested lists into account properly. I've rewritten it with that in mind.
4. Fixed as part of 3 - specifically had to track the nullability of various parts of the list to do this.

I'm not certain this is perfect but it's a lot better than it was - added a bunch of tests to verify various cases I could think of.

Fixes GB-4761
Fixes GB-4769