### PR TITLE
feat: error handling for @defer

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -333,6 +333,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1368,6 +1377,7 @@ dependencies = [
  "grafbase-types",
  "graph-entities",
  "http",
+ "im",
  "indexmap 2.0.0-pre",
  "indoc",
  "insta",
@@ -1786,6 +1796,20 @@ name = "if_chain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
+
+[[package]]
+name = "im"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+dependencies = [
+ "bitmaps",
+ "rand_core 0.6.4",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "indenter"
@@ -2685,6 +2709,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3444,6 +3477,16 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
 
 [[package]]
 name = "slab"

--- a/engine/crates/grafbase-engine/Cargo.toml
+++ b/engine/crates/grafbase-engine/Cargo.toml
@@ -37,6 +37,7 @@ fnv = "1"
 futures = { workspace = true }
 futures-util = { workspace = true, features = ["io", "sink"] }
 http = "0.2"
+im = "15"
 indexmap = { git = "https://github.com/bluss/indexmap.git", rev = "eedabaca9f84e520eab01325b305c08f3773e66c" }
 indoc = "2"
 Inflector = { version = "0.11" }

--- a/engine/crates/grafbase-engine/src/context.rs
+++ b/engine/crates/grafbase-engine/src/context.rs
@@ -321,7 +321,7 @@ impl<'a, T> ContextBase<'a, T> {
         ContextBase {
             resolver_node: Some(ResolverChainNode {
                 parent: self.resolver_node.as_ref(),
-                segment: path.last_segment().unwrap().clone(),
+                segment: path.last().unwrap().clone(),
                 ty: meta,
                 field: meta_field,
                 executable_field: Some(field),
@@ -364,7 +364,7 @@ impl<'a, T> ContextBase<'a, T> {
         }
 
         ServerError {
-            path: self.path.iter_segments().cloned().collect(),
+            path: self.path.iter().cloned().collect(),
             ..error
         }
     }
@@ -596,7 +596,7 @@ impl<'a> ContextBase<'a, &'a Positioned<SelectionSet>> {
         ContextBase {
             resolver_node: Some(ResolverChainNode {
                 parent: self.resolver_node.as_ref(),
-                segment: path.last_segment().cloned().unwrap(),
+                segment: path.last().cloned().unwrap(),
                 field: self.resolver_node.as_ref().and_then(|x| x.field),
                 executable_field: self.resolver_node.as_ref().and_then(|x| x.executable_field),
                 ty: self.resolver_node.as_ref().and_then(|x| x.ty),

--- a/engine/crates/grafbase-engine/src/deferred.rs
+++ b/engine/crates/grafbase-engine/src/deferred.rs
@@ -45,11 +45,7 @@ impl DeferredWorkload {
         ContextSelectionSet {
             path: self.path.clone(),
             resolver_node: Some(ResolverChainNode {
-                segment: self
-                    .path
-                    .last_segment()
-                    .cloned()
-                    .expect("to always have one path element"),
+                segment: self.path.last().cloned().expect("to always have one path element"),
                 parent: None,
                 field: None,
                 executable_field: None,

--- a/engine/crates/grafbase-engine/src/error.rs
+++ b/engine/crates/grafbase-engine/src/error.rs
@@ -9,7 +9,7 @@ use std::{
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{parser, LegacyInputType, Pos, Value};
+use crate::{parser, LegacyInputType, Pos, QueryPathSegment, Value};
 
 /// Extensions to the error.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -41,7 +41,7 @@ pub struct ServerError {
     pub locations: Vec<Pos>,
     /// If the error occurred in a resolver, the path to the error.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub path: Vec<PathSegment>,
+    pub path: Vec<QueryPathSegment>,
     /// Extensions to the error.
     #[serde(skip_serializing_if = "error_extensions_is_empty", default)]
     pub extensions: Option<ErrorExtensionValues>,
@@ -124,7 +124,7 @@ impl ServerError {
 
     #[doc(hidden)]
     #[must_use]
-    pub fn with_path(self, path: Vec<PathSegment>) -> Self {
+    pub fn with_path(self, path: Vec<QueryPathSegment>) -> Self {
         Self { path, ..self }
     }
 }
@@ -151,19 +151,6 @@ impl From<parser::Error> for ServerError {
             extensions: None,
         }
     }
-}
-
-/// A segment of path to a resolver.
-///
-/// This is like [`QueryPathSegment`](enum.QueryPathSegment.html), but owned and used as a part of
-/// errors instead of during execution.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum PathSegment {
-    /// A field in an object.
-    Field(String),
-    /// An index in a list.
-    Index(usize),
 }
 
 /// Alias for `Result<T, ServerError>`.

--- a/engine/crates/grafbase-engine/src/extensions/mod.rs
+++ b/engine/crates/grafbase-engine/src/extensions/mod.rs
@@ -12,8 +12,8 @@ use grafbase_types::auth::Operations;
 use graph_entities::ResponseNodeId;
 
 use crate::{
-    parser::types::ExecutableDocument, registry::MetaFieldType, Data, DataContext, Error, QueryPathNode, Request,
-    Response, Result, SchemaEnv, ServerError, ServerResult, ValidationResult, Value, Variables,
+    parser::types::ExecutableDocument, registry::MetaFieldType, Data, DataContext, Error, QueryPath, Request, Response,
+    Result, SchemaEnv, ServerError, ServerResult, ValidationResult, Value, Variables,
 };
 
 /// Context for extension
@@ -88,8 +88,8 @@ impl<'a> ExtensionContext<'a> {
 /// Parameters for `Extension::resolve_field_start`
 #[derive(Debug)]
 pub struct ResolveInfo<'a> {
-    /// Current path node, You can go through the entire path.
-    pub path_node: &'a QueryPathNode<'a>,
+    /// Current path within the query
+    pub path: QueryPath,
 
     /// Parent type
     pub parent_type: &'a str,

--- a/engine/crates/grafbase-engine/src/lib.rs
+++ b/engine/crates/grafbase-engine/src/lib.rs
@@ -51,6 +51,7 @@ mod look_ahead;
 #[doc(hidden)]
 pub mod model;
 pub mod names;
+mod query_path;
 mod request;
 mod response;
 mod schema;
@@ -86,8 +87,8 @@ pub use context::ContextSelectionSet;
 pub use context::*;
 pub use custom_directive::{CustomDirective, CustomDirectiveFactory};
 pub use error::{
-    Error, ErrorExtensionValues, ErrorExtensions, InputValueError, InputValueResult, ParseRequestError, PathSegment,
-    Result, ResultExt, ServerError, ServerResult,
+    Error, ErrorExtensionValues, ErrorExtensions, InputValueError, InputValueResult, ParseRequestError, Result,
+    ResultExt, ServerError, ServerResult,
 };
 pub use extensions::ResolveFut;
 #[doc(hidden)]
@@ -106,6 +107,7 @@ pub use indexmap;
 pub use look_ahead::Lookahead;
 #[doc(no_inline)]
 pub use parser::{Pos, Positioned};
+pub use query_path::{QueryPath, QueryPathSegment};
 pub use registry::{CacheControl, CacheInvalidation};
 pub use request::{BatchRequest, Request};
 #[doc(no_inline)]

--- a/engine/crates/grafbase-engine/src/query_path.rs
+++ b/engine/crates/grafbase-engine/src/query_path.rs
@@ -23,7 +23,7 @@ impl QueryPath {
         self.0.push_back(segment.into());
     }
 
-    pub fn last_segment(&self) -> Option<&QueryPathSegment> {
+    pub fn last(&self) -> Option<&QueryPathSegment> {
         self.0.last()
     }
 
@@ -33,8 +33,18 @@ impl QueryPath {
         child
     }
 
-    pub fn iter_segments(&self) -> impl DoubleEndedIterator<Item = &QueryPathSegment> {
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &QueryPathSegment> {
         self.0.iter()
+    }
+}
+
+impl IntoIterator for QueryPath {
+    type Item = QueryPathSegment;
+
+    type IntoIter = im::vector::ConsumingIter<QueryPathSegment>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 

--- a/engine/crates/grafbase-engine/src/query_path.rs
+++ b/engine/crates/grafbase-engine/src/query_path.rs
@@ -1,0 +1,83 @@
+use std::fmt;
+
+use internment::ArcIntern;
+use serde::{Deserialize, Serialize};
+
+/// A path to the current location in a query
+///
+/// We use `im::Vector` to store this as we'll be making a ton of these with slight
+/// changes, and its structural sharing should make that more efficient with memory.
+///
+/// At one point this was just a reverse linked-list of references, but that was a
+/// real pain to integrate with defer & stream as the lifetimes wouldn't last long
+/// enough.
+#[derive(Debug, Default, Clone)]
+pub struct QueryPath(im::Vector<QueryPathSegment>);
+
+impl QueryPath {
+    pub fn empty() -> Self {
+        QueryPath::default()
+    }
+
+    pub fn push(&mut self, segment: impl Into<QueryPathSegment>) {
+        self.0.push_back(segment.into());
+    }
+
+    pub fn last_segment(&self) -> Option<&QueryPathSegment> {
+        self.0.last()
+    }
+
+    pub fn child(self, segment: impl Into<QueryPathSegment>) -> Self {
+        let mut child = self.clone();
+        child.push(segment.into());
+        child
+    }
+
+    pub fn iter_segments(&self) -> impl DoubleEndedIterator<Item = &QueryPathSegment> {
+        self.0.iter()
+    }
+}
+
+impl fmt::Display for QueryPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (i, segment) in self.0.iter().enumerate() {
+            if i != 0 {
+                write!(f, ".")?;
+            }
+            write!(f, "{segment}")?;
+        }
+        Ok(())
+    }
+}
+
+/// A segment in the path to the current query.
+///
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum QueryPathSegment {
+    /// We are currently resolving an element in a list.
+    Index(usize),
+    // We are currently resolving a field in an object.
+    Field(ArcIntern<String>),
+}
+
+impl fmt::Display for QueryPathSegment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            QueryPathSegment::Index(idx) => write!(f, "{idx}"),
+            QueryPathSegment::Field(name) => write!(f, "{name}"),
+        }
+    }
+}
+
+impl From<usize> for QueryPathSegment {
+    fn from(value: usize) -> Self {
+        QueryPathSegment::Index(value)
+    }
+}
+
+impl From<&str> for QueryPathSegment {
+    fn from(value: &str) -> Self {
+        QueryPathSegment::Field(ArcIntern::from_ref(value))
+    }
+}

--- a/engine/crates/grafbase-engine/src/resolver_utils/container.rs
+++ b/engine/crates/grafbase-engine/src/resolver_utils/container.rs
@@ -388,7 +388,7 @@ impl<'a> FieldExecutionSet<'a> {
                     .and_then(|ty| ty.field_by_name(field.node.name.node.as_str()));
 
                 let resolve_info = ResolveInfo {
-                    path_node: ctx_field.path_node.as_ref().unwrap(),
+                    path: ctx_field.path.clone(),
                     parent_type: &type_name,
                     return_type: match meta_field.map(|field| &field.ty) {
                         Some(ty) => &ty,
@@ -425,7 +425,7 @@ impl<'a> FieldExecutionSet<'a> {
                         ctx.schema_env.custom_directives.get(directive.node.name.node.as_str())
                     {
                         let ctx_directive = ContextBase {
-                            path_node: ctx_field.path_node,
+                            path: ctx_field.path.clone(),
                             resolver_node: ctx_field.resolver_node.clone(),
                             item: directive,
                             schema_env: ctx_field.schema_env,
@@ -515,9 +515,7 @@ fn defer_fragment(
 
     let workload = DeferredWorkload::new(
         fragment_details.selection_set.clone(),
-        ctx.path_node
-            .map(|path_node| path_node.to_owned_segments())
-            .unwrap_or_default(),
+        ctx.path.clone(),
         root.name().to_string().into(),
         parent_resolver_value.clone(),
     );
@@ -616,7 +614,7 @@ impl<'a> Fields<'a> {
                                     .and_then(|ty| ty.field_by_name(field.node.name.node.as_str()));
 
                                 let resolve_info = ResolveInfo {
-                                    path_node: ctx_field.path_node.as_ref().unwrap(),
+                                    path: ctx_field.path.clone(),
                                     parent_type: &type_name,
                                     return_type: match meta_field.map(|field| &field.ty) {
                                         Some(ty) => &ty,
@@ -657,7 +655,7 @@ impl<'a> Fields<'a> {
                                             ctx.schema_env.custom_directives.get(directive.node.name.node.as_str())
                                         {
                                             let ctx_directive = ContextBase {
-                                                path_node: ctx_field.path_node,
+                                                path: ctx_field.path.clone(),
                                                 resolver_node: ctx_field.resolver_node.clone(),
                                                 item: directive,
                                                 schema_env: ctx_field.schema_env,

--- a/engine/crates/grafbase-engine/src/resolver_utils/field.rs
+++ b/engine/crates/grafbase-engine/src/resolver_utils/field.rs
@@ -278,7 +278,7 @@ async fn run_field_resolver(
 ) -> Result<ResolvedValue, Error> {
     let mut final_result = parent_resolver_value.unwrap_or_default();
 
-    if let Some(QueryPathSegment::Index(idx)) = ctx.path.last_segment() {
+    if let Some(QueryPathSegment::Index(idx)) = ctx.path.last() {
         // If we are in an index segment, it means we do not have a current resolver (YET).
         final_result = final_result.get_index(*idx).unwrap_or_default();
     } else if let Some(resolver) = resolver_node.resolver {

--- a/engine/crates/grafbase-engine/src/resolver_utils/field.rs
+++ b/engine/crates/grafbase-engine/src/resolver_utils/field.rs
@@ -91,7 +91,7 @@ async fn resolve_primitive_field(
                     serde_json::to_string_pretty(&serde_json::json!({
                         "message": "Something went wrong here",
                         "expected": serde_json::Value::String(field.ty.to_string()),
-                        "path": serde_json::Value::String(resolver_node.clone().to_string()),
+                        "path": serde_json::Value::String(ctx.path.to_string()),
                     }))
                     .unwrap(),
                 );
@@ -278,9 +278,9 @@ async fn run_field_resolver(
 ) -> Result<ResolvedValue, Error> {
     let mut final_result = parent_resolver_value.unwrap_or_default();
 
-    if let QueryPathSegment::Index(idx) = resolver_node.segment {
-        // If we are in a segment, it means we do not have a current resolver (YET).
-        final_result = final_result.get_index(idx).unwrap_or_default();
+    if let Some(QueryPathSegment::Index(idx)) = ctx.path.last_segment() {
+        // If we are in an index segment, it means we do not have a current resolver (YET).
+        final_result = final_result.get_index(*idx).unwrap_or_default();
     } else if let Some(resolver) = resolver_node.resolver {
         // Avoiding the early return when we're just propagating downwards data. Container
         // fields used as namespaces have no value (so Null) but their fields have resolvers.

--- a/engine/crates/grafbase-engine/src/resolver_utils/list.rs
+++ b/engine/crates/grafbase-engine/src/resolver_utils/list.rs
@@ -18,7 +18,7 @@ use crate::{
 /// Resolve a list by executing each of the items concurrently.
 pub async fn resolve_list<'a>(
     ctx: ContextSelectionSet<'a>,
-    field: &Positioned<Field>,
+    field: &'a Positioned<Field>,
     field_ty: &MetaFieldType,
     inner_ty: &'a MetaType,
     value: ResolvedValue,
@@ -157,7 +157,7 @@ fn apply_extensions<'a>(
             .collect();
 
         let resolve_info = ResolveInfo {
-            path_node: ctx.path_node.as_ref().unwrap(),
+            path: ctx.path.clone(),
             parent_type: &parent_type,
             return_type: &return_type,
             name: field.node.name.node.as_str(),
@@ -251,7 +251,7 @@ pub async fn resolve_list_native<'a, T: LegacyOutputType + 'a>(
                         .and_then(|ty| ty.field_by_name(field.node.name.node.as_str()));
 
                     let resolve_info = ResolveInfo {
-                        path_node: ctx_idx.path_node.as_ref().unwrap(),
+                        path: ctx_idx.path.clone(),
                         parent_type: &Vec::<T>::type_name(),
                         return_type: &T::qualified_type_name(),
                         name: field.node.name.node.as_str(),

--- a/engine/crates/grafbase-engine/src/resolver_utils/list.rs
+++ b/engine/crates/grafbase-engine/src/resolver_utils/list.rs
@@ -92,11 +92,7 @@ pub async fn resolve_list<'a>(
                                 Some(ctx.item.pos),
                             );
 
-                        if let Some(path) = ctx.path_node {
-                            let mut path = path.to_owned_segments();
-                            path.push(crate::PathSegment::Index(index));
-                            error.path = path;
-                        }
+                        error.path = ctx.path.child(index).into_iter().collect();
 
                         return Err(error);
                     }

--- a/engine/crates/grafbase-engine/src/response/streaming.rs
+++ b/engine/crates/grafbase-engine/src/response/streaming.rs
@@ -1,7 +1,7 @@
 use graph_entities::QueryResponse;
 use serde::ser::SerializeMap;
 
-use crate::{PathSegment, Response, ServerError};
+use crate::{QueryPath, Response, ServerError};
 
 /// If a user makes a streaming request, this is the set of different response payloads
 /// they can received.  The first payload will always be a `Response` - followed by
@@ -36,7 +36,7 @@ impl serde::Serialize for StreamingPayload {
 pub struct IncrementalPayload {
     pub label: Option<String>,
     pub data: QueryResponse,
-    pub path: Vec<PathSegment>,
+    pub path: QueryPath,
     pub has_next: bool,
     pub errors: Vec<ServerError>,
 }
@@ -72,7 +72,7 @@ impl serde::Serialize for GraphqlIncrementalPayload<'_> {
         // 2. It calls `self.0.data.as_graphql_data()`
         let mut map = serializer.serialize_map(Some(5))?;
         map.serialize_entry("data", &self.0.data.as_graphql_data())?;
-        map.serialize_entry("path", &self.0.path)?;
+        map.serialize_entry("path", &self.0.path.iter_segments().collect::<Vec<_>>())?;
         map.serialize_entry("hasNext", &self.0.has_next)?;
         if let Some(label) = &self.0.label {
             map.serialize_entry("label", &label)?;

--- a/engine/crates/grafbase-engine/src/response/streaming.rs
+++ b/engine/crates/grafbase-engine/src/response/streaming.rs
@@ -72,7 +72,7 @@ impl serde::Serialize for GraphqlIncrementalPayload<'_> {
         // 2. It calls `self.0.data.as_graphql_data()`
         let mut map = serializer.serialize_map(Some(5))?;
         map.serialize_entry("data", &self.0.data.as_graphql_data())?;
-        map.serialize_entry("path", &self.0.path.iter_segments().collect::<Vec<_>>())?;
+        map.serialize_entry("path", &self.0.path.iter().collect::<Vec<_>>())?;
         map.serialize_entry("hasNext", &self.0.has_next)?;
         if let Some(label) = &self.0.label {
             map.serialize_entry("label", &label)?;

--- a/engine/crates/grafbase-engine/src/subscription.rs
+++ b/engine/crates/grafbase-engine/src/subscription.rs
@@ -7,7 +7,7 @@ use crate::{
     parser::types::{Selection, TypeCondition},
     registry,
     registry::Registry,
-    Context, ContextSelectionSet, PathSegment, Response, ServerError, ServerResult,
+    Context, ContextSelectionSet, Response, ServerError, ServerResult,
 };
 
 /// A GraphQL subscription object
@@ -57,7 +57,7 @@ pub(crate) fn collect_subscription_streams<'a, T: SubscriptionType + 'static>(
                         }
                     } else {
                         let err = ServerError::new(format!(r#"Cannot query field "{}" on type "{}"."#, field_name, T::type_name()), Some(ctx.item.pos))
-                            .with_path(vec![PathSegment::Field(field_name.to_string())]);
+                            .with_path(vec![field_name.as_str().into()]);
                         yield Response::from_errors(vec![err], OperationType::Subscription);
                     }
                 }

--- a/engine/crates/grafbase-engine/src/validation/rules/arguments_of_correct_type.rs
+++ b/engine/crates/grafbase-engine/src/validation/rules/arguments_of_correct_type.rs
@@ -2,14 +2,13 @@ use grafbase_engine_value::Value;
 use indexmap::map::IndexMap;
 
 use crate::{
-    context::QueryPathNode,
     parser::types::{Directive, Field},
     registry::MetaInputValue,
     validation::{
         utils::is_valid_input_value,
         visitor::{Visitor, VisitorContext},
     },
-    Name, Positioned, QueryPathSegment,
+    Name, Positioned, QueryPath,
 };
 
 #[derive(Default)]
@@ -49,15 +48,10 @@ impl<'a> Visitor<'a> for ArgumentsOfCorrectType<'a> {
                 .ok();
 
             if let Some(reason) = value.and_then(|value| {
-                is_valid_input_value(
-                    ctx.registry,
-                    arg.ty.as_str(),
-                    &value,
-                    QueryPathNode {
-                        parent: None,
-                        segment: QueryPathSegment::Name(&arg.name),
-                    },
-                )
+                let mut query_path = QueryPath::empty();
+                query_path.push(arg.name.as_str());
+
+                is_valid_input_value(ctx.registry, arg.ty.as_str(), &value, query_path)
             }) {
                 ctx.report_error(vec![name.pos], format!("Invalid value for argument {reason}"));
             }

--- a/engine/crates/grafbase-engine/src/validation/rules/default_values_of_correct_type.rs
+++ b/engine/crates/grafbase-engine/src/validation/rules/default_values_of_correct_type.rs
@@ -1,13 +1,12 @@
 use grafbase_engine_parser::types::BaseType;
 
 use crate::{
-    context::QueryPathNode,
     parser::types::VariableDefinition,
     validation::{
         utils::is_valid_input_value,
         visitor::{Visitor, VisitorContext},
     },
-    Positioned, QueryPathSegment,
+    Positioned, QueryPath,
 };
 
 pub struct DefaultValuesOfCorrectType;
@@ -38,10 +37,7 @@ impl<'a> Visitor<'a> for DefaultValuesOfCorrectType {
                 ctx.registry,
                 &variable_definition.node.var_type.to_string(),
                 &value.node,
-                QueryPathNode {
-                    parent: None,
-                    segment: QueryPathSegment::Name(&variable_definition.node.name.node),
-                },
+                QueryPath::empty().child(variable_definition.node.name.node.as_str()),
             ) {
                 ctx.report_error(
                     vec![variable_definition.pos],

--- a/engine/crates/sdl-parser/src/rules/default_directive_types.rs
+++ b/engine/crates/sdl-parser/src/rules/default_directive_types.rs
@@ -1,4 +1,4 @@
-use grafbase_engine::Positioned;
+use grafbase_engine::{Positioned, QueryPath};
 use grafbase_engine_parser::types::{FieldDefinition, TypeDefinition};
 
 use super::{
@@ -52,10 +52,7 @@ impl<'a> Visitor<'a> for DefaultDirectiveTypes {
                         &ctx_registry,
                         &field.node.ty.node.to_string(),
                         &default_value,
-                        grafbase_engine::QueryPathNode {
-                            parent: None,
-                            segment: grafbase_engine::QueryPathSegment::Name(&field.node.name.node),
-                        },
+                        QueryPath::empty().child(field.node.name.node.as_str()),
                     )
                 };
                 if let Some(err) = error {


### PR DESCRIPTION
I introduced basic `@defer` support to grafbase-engine in #2696.  One of the things I skipped was error handling.  

This was trickier than you might expect because error handling requires the path to be set correctly in the `Context`, but `Context.path_node` made heavy use of references in a way that made it really hard to defer.  I've ended up re-working it to a `Vector` of `ArcIntern<String>` instead of a reverse linked list.  It's much easier to make use of.  I'm using `im::Vector` instead of just a `Vec` to theoretically make cloning slightly cheaper, though I've been careful to hide that detail so we can swap it out if it proves to be a waste of time.