### PR TITLE
feat: set hasNext correctly in `@defer`

### DIFF
--- a/engine/crates/grafbase-engine-integration-tests/tests/defer/mod.rs
+++ b/engine/crates/grafbase-engine-integration-tests/tests/defer/mod.rs
@@ -61,7 +61,7 @@ fn simple_defer_test() {
                 "name": "Deferred Doggo"
               }
             },
-            "hasNext": true,
+            "hasNext": false,
             "path": [
               "petstore"
             ]
@@ -215,7 +215,7 @@ fn test_defer_on_named_fragment() {
                 "name": "Deferred Doggo"
               }
             },
-            "hasNext": true,
+            "hasNext": false,
             "path": [
               "petstore"
             ]
@@ -286,7 +286,7 @@ fn test_nested_defers() {
                 "name": "Second Deferred Doggo"
               }
             },
-            "hasNext": true,
+            "hasNext": false,
             "path": [
               "petstore"
             ]
@@ -373,7 +373,7 @@ fn test_defer_with_errors() {
                 ]
               }
             ],
-            "hasNext": true,
+            "hasNext": false,
             "path": [
               "petstore"
             ]

--- a/engine/crates/grafbase-engine-integration-tests/tests/defer/type_conditions.rs
+++ b/engine/crates/grafbase-engine-integration-tests/tests/defer/type_conditions.rs
@@ -58,7 +58,7 @@ fn test_defer_on_matching_typecondition() {
             "data": {
               "data": "A PetstoreString"
             },
-            "hasNext": true,
+            "hasNext": false,
             "path": [
               "petstore",
               "pets",
@@ -177,7 +177,7 @@ fn test_defer_on_multiple_fragments_with_one_match() {
             "data": {
               "data": "A PetstoreString"
             },
-            "hasNext": true,
+            "hasNext": false,
             "path": [
               "petstore",
               "pets",
@@ -232,7 +232,7 @@ fn test_defer_with_typecondition_on_concrete_type() {
                 }
               ]
             },
-            "hasNext": true,
+            "hasNext": false,
             "path": [
               "petstore"
             ]

--- a/engine/crates/grafbase-engine/src/schema.rs
+++ b/engine/crates/grafbase-engine/src/schema.rs
@@ -727,7 +727,7 @@ async fn process_deferred_workload(
         label: workload.label,
         data,
         path: workload.path,
-        has_next: true, // We hardcode this to true here, the function calling us should override
+        has_next: false, // We hardcode this to false here, the function calling us should override
         errors,
     }
 }


### PR DESCRIPTION
Incremental payloads as used by `@defer` have a `hasNext` property that tells you whether to expect any more payloads after the current one.  I skipped over setting this correctly when I first implemented defer - just setting it to true all the time.  This PR fixes that.