### PR TITLE
chore: simplify ExecutionEngine trait

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1251,7 +1251,6 @@ dependencies = [
  "cfg-if",
  "dynamodb",
  "gateway-protocol",
- "gateway-types",
  "grafbase-engine",
  "grafbase-local",
  "grafbase-runtime",
@@ -1266,6 +1265,7 @@ dependencies = [
 name = "gateway-protocol"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "grafbase-engine",
  "grafbase-types",
  "rusoto_core",
@@ -1274,16 +1274,8 @@ dependencies = [
  "serde_with",
  "sha2",
  "strum",
- "ulid",
- "worker",
-]
-
-[[package]]
-name = "gateway-types"
-version = "0.1.0"
-dependencies = [
- "async-trait",
  "thiserror",
+ "ulid",
  "worker",
 ]
 

--- a/engine/crates/gateway-local/Cargo.toml
+++ b/engine/crates/gateway-local/Cargo.toml
@@ -14,7 +14,6 @@ dynamodb = { path = "../dynamodb", features = ["tracing"] }
 grafbase-engine = { path = "../grafbase-engine", features = ["tracing_worker"], default-features = false }
 grafbase-local = { path = "../grafbase-runtime/local" }
 grafbase-runtime = { path = "../grafbase-runtime" }
-gateway-types = { path = "../gateway-types" }
 
 # TODO: these are private dependencies, that must be removed.
 worker-env = { path = "../worker-env" }

--- a/engine/crates/gateway-protocol/Cargo.toml
+++ b/engine/crates/gateway-protocol/Cargo.toml
@@ -4,10 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+async-trait = "0.1"
 rusoto_core = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_with = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
 ulid = { workspace = true }
 worker = { workspace = true }
 

--- a/engine/crates/gateway-protocol/src/execution_engine.rs
+++ b/engine/crates/gateway-protocol/src/execution_engine.rs
@@ -1,8 +1,6 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use worker::{self, Env};
 
 #[derive(Debug, thiserror::Error)]
 #[allow(dead_code)]
@@ -18,23 +16,16 @@ pub type ExecutionResult<T> = Result<T, ExecutionError>;
 /// Owned trait with 'static in mind
 #[async_trait(?Send)]
 pub trait ExecutionEngine {
-    type Fetcher;
     type ConfigType;
-    type HealthRequest;
-    type HealthResponse;
-    type ExecutionRequest;
-    type ExecutionResponse;
-
-    fn from_env(env: &Env) -> worker::Result<HashMap<String, String>>;
+    type ExecutionResponse; // This is always grafbase_engine::Response (but is needed for tests)
 
     async fn execute(
-        fetch: Arc<Option<Self::Fetcher>>,
-        env: Arc<HashMap<String, String>>,
-        execution_request: Self::ExecutionRequest,
+        self: Arc<Self>,
+        execution_request: crate::ExecutionRequest<Self::ConfigType>,
     ) -> ExecutionResult<Self::ExecutionResponse>;
 
     async fn health(
-        fetch: Arc<Option<Self::Fetcher>>,
-        health_request: Self::HealthRequest,
-    ) -> ExecutionResult<Self::HealthResponse>;
+        self: Arc<Self>,
+        health_request: crate::ExecutionHealthRequest<Self::ConfigType>,
+    ) -> ExecutionResult<crate::ExecutionHealthResponse>;
 }

--- a/engine/crates/gateway-protocol/src/lib.rs
+++ b/engine/crates/gateway-protocol/src/lib.rs
@@ -1,7 +1,11 @@
 use std::collections::HashMap;
 
-pub use customer_deployment_config::local::LocalSpecificConfig;
-pub use customer_deployment_config::{CommonCustomerDeploymentConfig, CustomerDeploymentConfig};
+pub use self::{
+    customer_deployment_config::{
+        local::LocalSpecificConfig, CommonCustomerDeploymentConfig, CustomerDeploymentConfig,
+    },
+    execution_engine::{ExecutionEngine, ExecutionError, ExecutionResult},
+};
 
 use grafbase_engine::{registry::CacheControlError, CacheControl};
 use grafbase_types::{auth::ExecutionAuth, UdfKind};
@@ -10,6 +14,7 @@ use worker::{js_sys::Uint8Array, Headers, Method, RequestInit};
 pub use grafbase_engine::registry::VersionedRegistry;
 
 mod customer_deployment_config;
+mod execution_engine;
 #[cfg(test)]
 mod tests;
 

--- a/engine/crates/gateway-types/Cargo.toml
+++ b/engine/crates/gateway-types/Cargo.toml
@@ -1,9 +1,0 @@
-[package]
-name = "gateway-types"
-version = "0.1.0"
-edition = "2021"
-
-[dependencies]
-thiserror = "1"
-worker = "0.0.18"
-async-trait = "0.1"


### PR DESCRIPTION
I'm likely going to have to add another method or two to the ExecutionEngine trait soon, as well as updating a few places that it's used.  But it seemed quite difficult to work with, so I've tried to simplify it a bit first:

1. It had a ton of associated types that really only seem to exist because it doesn't have access to gateway-protocol types.  I've just moved it into `gateway-protocol` to fix this.  Not sure if it really needed to be in it's own crate.  Now that I'm typing this I'm wondering if I could have just added a dep between on `gateway-protocol` instead.  Not sure if that's any better though, let me know in the comments.
2. Updated it to take `self: Arc<Self>` so we don't need to pass a bunch of context to each function that could just live on self.
3. Tried to simplify the construction of ExecutionUpstream a bit, deduplicating the `local` & `not(local)` branches a bit.

This work has already happened in the `api` repo, just moving the relevant bits over here now.