### PR TITLE
feat: add SSE & incremental delivery to local gateway

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -244,6 +244,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-sse"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e6fa871e4334a622afd6bb2f611635e8083a6f5e2936c0f90f37c7ef9856298"
+dependencies = [
+ "async-channel",
+ "futures-lite",
+ "http-types",
+ "log 0.4.20",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,6 +2023,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "multipart-stream"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70b4619423c3ca07881bd4d62bb853d447a63253901bee471e0b832c3e37e505"
+dependencies = [
+ "bytes",
+ "futures",
+ "http",
+ "httparse",
+ "pin-project",
+]
+
+[[package]]
 name = "names"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2959,6 +2986,7 @@ dependencies = [
  "async-trait",
  "common-types",
  "engine",
+ "futures-util",
  "rusoto_core",
  "serde",
  "serde_json",
@@ -2974,15 +3002,21 @@ dependencies = [
 name = "runtime-protocol-local"
 version = "0.1.0"
 dependencies = [
+ "async-sse",
  "async-trait",
+ "bytes",
  "cfg-if",
  "dynamodb",
  "engine",
+ "futures-channel",
+ "futures-util",
  "graphql-extensions",
+ "multipart-stream",
  "runtime",
  "runtime-local",
  "runtime-protocol",
  "serde_json",
+ "tracing",
  "ulid",
  "worker",
  "worker-env",

--- a/engine/crates/engine/Cargo.toml
+++ b/engine/crates/engine/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["graphql", "engine", "grafbase"]
 [features]
 default = []
 tracing_worker = ["logworker", "dynamodb/tracing", "tracing"]
-defer = []
 
 [dependencies]
 async-lock = "2"

--- a/engine/crates/engine/src/deferred.rs
+++ b/engine/crates/engine/src/deferred.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use async_lock::RwLock;
-use futures::channel::mpsc::{UnboundedReceiver, UnboundedSender};
 use engine_parser::{types::SelectionSet, Positioned};
+use futures::channel::mpsc::{UnboundedReceiver, UnboundedSender};
 use graph_entities::QueryResponse;
 use ulid::Ulid;
 
@@ -16,7 +16,7 @@ pub struct DeferredWorkload {
     pub label: Option<String>,
     selection_set: Positioned<SelectionSet>,
     pub path: QueryPath,
-    current_type_name: NamedType<'static>,
+    pub current_type_name: NamedType<'static>,
     pub parent_resolver_value: Option<ResolvedValue>,
 }
 
@@ -44,8 +44,8 @@ impl DeferredWorkload {
     ) -> ContextSelectionSet<'a> {
         ContextSelectionSet {
             path: self.path.clone(),
-            resolver_node: Some(ResolverChainNode {
-                segment: self.path.last().cloned().expect("to always have one path element"),
+            resolver_node: self.path.last().cloned().map(|segment| ResolverChainNode {
+                segment,
                 parent: None,
                 field: None,
                 executable_field: None,
@@ -53,7 +53,7 @@ impl DeferredWorkload {
                     schema_env
                         .registry
                         .lookup(&self.current_type_name)
-                        .expect("TODO: handle errors"),
+                        .expect("current type name to exist"),
                 ),
                 selections: Some(&self.selection_set),
                 execution_id: Ulid::new(),

--- a/engine/crates/engine/src/response/streaming.rs
+++ b/engine/crates/engine/src/response/streaming.rs
@@ -9,6 +9,7 @@ use crate::{QueryPath, Response, ServerError};
 ///
 /// At some point we might add support for subscriptions in which case a user will probably
 /// see multiple Response entries.
+#[derive(Debug)]
 pub enum StreamingPayload {
     Response(Response),
     Incremental(IncrementalPayload),

--- a/engine/crates/engine/src/schema.rs
+++ b/engine/crates/engine/src/schema.rs
@@ -374,7 +374,6 @@ impl Schema {
             visible: None,
         });
 
-        #[cfg(feature = "defer")]
         registry.add_directive(MetaDirective {
             name: "defer".to_string(),
             description: Some("De-prioritizes a fragment, causing the fragment to be omitted in the initial response and delivered as a subsequent response afterward.".to_string()),
@@ -705,7 +704,10 @@ async fn process_deferred_workload(
     let context = workload.to_context(&schema.env, env, sender.clone());
     let result = resolver_utils::resolve_deferred_container(
         &context,
-        context.resolver_node.as_ref().unwrap().ty.as_ref().unwrap(),
+        context
+            .registry()
+            .lookup(&workload.current_type_name)
+            .expect("the current type name to exist"),
         workload.parent_resolver_value.clone(),
     )
     .await;

--- a/engine/crates/engine/src/validation/rules/overlapping_fields_can_be_merged.rs
+++ b/engine/crates/engine/src/validation/rules/overlapping_fields_can_be_merged.rs
@@ -71,8 +71,8 @@ impl<'a, 'ctx> FindConflicts<'a, 'ctx> {
                     format!("Fields \"{name}\" conflict because they have differing arguments. Use different aliases on the fields to fetch both if this was intentional."));
             }
 
-            for (name, value) in &prev_field.node.arguments {
-                match field.node.get_argument(&name.node) {
+            for (arg_name, value) in &prev_field.node.arguments {
+                match field.node.get_argument(&arg_name.node) {
                     Some(other_value) if value == other_value => {}
                     _=> self.ctx.report_error(
                         vec![prev_field.pos, field.pos],

--- a/engine/crates/gateway-local/Cargo.toml
+++ b/engine/crates/gateway-local/Cargo.toml
@@ -14,6 +14,7 @@ dynamodb = { path = "../dynamodb", features = ["tracing"] }
 engine = { path = "../engine", features = [
     "tracing_worker",
 ], default-features = false }
+graphql-extensions = { path = "../graphql-extensions" }
 runtime-local = { path = "../runtime/local" }
 runtime = { path = "../runtime" }
 
@@ -21,12 +22,18 @@ runtime = { path = "../runtime" }
 worker-env = { path = "../worker-env" }
 runtime-protocol = { path = "../runtime-protocol" }
 
+async-sse = "5"
 async-trait = "0.1"
-worker = "0.0.18"
+bytes = "1"
 cfg-if = "1"
-ulid = "1"
-graphql-extensions = { path = "../graphql-extensions" }
+futures-channel = "0.3"
+futures-util = { workspace = true }
+multipart-stream = "0.1"
 serde_json = "1"
+tracing = { workspace = true }
+ulid = "1"
+worker = "0.0.18"
+
 
 [features]
 sqlite = ["dynamodb/sqlite"]

--- a/engine/crates/gateway-local/src/execution.rs
+++ b/engine/crates/gateway-local/src/execution.rs
@@ -1,14 +1,16 @@
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use dynamodb::{DynamoDBBatchersData, DynamoDBContext};
+use engine::{registry::resolvers::graphql, RequestHeaders, Response, StreamingPayload};
+use futures_util::{future::BoxFuture, stream::BoxStream, AsyncBufReadExt, SinkExt, Stream, StreamExt};
+use runtime_local::{Bridge, LocalSearchEngine, UdfInvokerImpl};
 use runtime_protocol::{
     ExecutionEngine, ExecutionError, ExecutionHealthRequest, ExecutionHealthResponse, ExecutionRequest,
-    ExecutionResult, LocalSpecificConfig, VersionedRegistry,
+    ExecutionResult, LocalSpecificConfig, StreamingFormat, VersionedRegistry,
 };
-use engine::{registry::resolvers::graphql, RequestHeaders, Response};
-use runtime_local::{Bridge, LocalSearchEngine, UdfInvokerImpl};
-use worker::Env;
+use worker::{js_sys, Env};
 use worker_env::{EnvExt, VarType};
 
 pub const REGISTRY_ENV_VAR: &str = "REGISTRY";
@@ -26,6 +28,7 @@ const RAY_ID_HEADER: &str = "ray-id";
 
 pub struct LocalExecution {
     env: HashMap<String, String>,
+    bridge_port: u16,
 }
 
 #[allow(unused_variables, clippy::expect_fun_call)]
@@ -76,7 +79,7 @@ impl LocalExecution {
     #[allow(clippy::expect_fun_call)]
     pub fn from_env(env: &Env) -> worker::Result<Self> {
         let bridge_port = env
-            .var_get(VarType::Var, BRIDGE_PORT_ENV_VAR)
+            .var_get::<String>(VarType::Var, BRIDGE_PORT_ENV_VAR)
             .expect(&format!("Missing env var {BRIDGE_PORT_ENV_VAR}"));
 
         let registry = env
@@ -84,7 +87,7 @@ impl LocalExecution {
             .expect(&format!("Missing env var {REGISTRY_ENV_VAR}"));
 
         let mut local_env = HashMap::from([
-            (BRIDGE_PORT_ENV_VAR.to_string(), bridge_port),
+            (BRIDGE_PORT_ENV_VAR.to_string(), bridge_port.clone()),
             (REGISTRY_ENV_VAR.to_string(), registry),
         ]);
 
@@ -105,50 +108,43 @@ impl LocalExecution {
             local_env.insert(DYNAMODB_TABLE_NAME_ENV_VAR.to_string(), dynamodb_table);
         }
 
-        Ok(Self { env: local_env })
-    }
-}
-
-#[async_trait(? Send)]
-impl ExecutionEngine for LocalExecution {
-    type ConfigType = LocalSpecificConfig;
-    type ExecutionResponse = Response;
-
-    #[allow(clippy::expect_fun_call)]
-    async fn execute(
-        self: Arc<Self>,
-        mut execution_request: ExecutionRequest<runtime_protocol::LocalSpecificConfig>,
-    ) -> ExecutionResult<Response> {
-        use worker::js_sys;
-
-        let db_context = get_db_context(&execution_request, &self.env);
-
-        let bridge_port = self
-            .env
-            .get(BRIDGE_PORT_ENV_VAR)
-            .expect(&format!("Missing env var {BRIDGE_PORT_ENV_VAR}"));
-        let dynamodb_batchers_data = DynamoDBBatchersData::new(
-            &Arc::new(db_context.clone()),
-            #[cfg(feature = "sqlite")]
-            &Arc::new(dynamodb::LocalContext {
-                bridge_port: bridge_port.to_string(),
-            }),
-        );
         let bridge_port = bridge_port
             .parse()
             .expect(&format!("{BRIDGE_PORT_ENV_VAR} should be an integer"));
 
-        let fetch_log_endpoint = format!("http://{}:{}", std::net::Ipv4Addr::LOCALHOST, bridge_port);
+        Ok(Self {
+            env: local_env,
+            bridge_port,
+        })
+    }
+
+    #[allow(clippy::expect_fun_call)]
+    pub fn build_schema(
+        &self,
+        execution_request: &ExecutionRequest<runtime_protocol::LocalSpecificConfig>,
+    ) -> ExecutionResult<engine::Schema> {
+        let db_context = get_db_context(execution_request, &self.env);
+
+        let dynamodb_batchers_data = DynamoDBBatchersData::new(
+            &Arc::new(db_context.clone()),
+            #[cfg(feature = "sqlite")]
+            &Arc::new(dynamodb::LocalContext {
+                bridge_port: self.bridge_port.to_string(),
+            }),
+        );
+
+        let fetch_log_endpoint = format!("http://{}:{}", std::net::Ipv4Addr::LOCALHOST, self.bridge_port);
         let global: worker::wasm_bindgen::JsValue = js_sys::global().into();
         js_sys::Reflect::set(&global, &"fetchLogEndpoint".into(), &fetch_log_endpoint.into()).unwrap();
 
-        let search_engine = LocalSearchEngine::new(bridge_port);
+        let search_engine = LocalSearchEngine::new(self.bridge_port);
         let versioned_registry: VersionedRegistry<'_> = serde_json::from_str(
             self.env
                 .get(REGISTRY_ENV_VAR)
                 .expect("should have REGISTRY env var defined"),
         )
         .map_err(|e| ExecutionError::InternalError(e.to_string()))?;
+
         let registry = versioned_registry.registry.into_owned();
 
         let ray_id = execution_request
@@ -157,14 +153,14 @@ impl ExecutionEngine for LocalExecution {
             .map(|v| v.to_string())
             .unwrap_or_else(|| ulid::Ulid::new().to_string()); // Random one in local.
 
-        let bridge = Bridge::new(bridge_port);
+        let bridge = Bridge::new(self.bridge_port);
         let resolver_engine = UdfInvokerImpl::create_engine(bridge.clone());
         let gql_request_exec_context = runtime::GraphqlRequestExecutionContext {
             ray_id: ray_id.clone(),
             headers: execution_request.execution_headers.clone(),
         };
 
-        let schema = engine::Schema::build(registry)
+        Ok(engine::Schema::build(registry)
             .data(dynamodb_batchers_data)
             .data(graphql::QueryBatcher::new())
             .data(search_engine)
@@ -175,12 +171,54 @@ impl ExecutionEngine for LocalExecution {
                 runtime_local::LogEventReceiverImpl::new(bridge),
             )))
             .extension(graphql_extensions::authorization::AuthExtension::new(ray_id.clone()))
-            .finish();
+            .finish())
+    }
+}
+
+#[async_trait(? Send)]
+impl ExecutionEngine for LocalExecution {
+    type ConfigType = LocalSpecificConfig;
+    type ExecutionResponse = Response;
+
+    async fn execute(
+        self: Arc<Self>,
+        mut execution_request: ExecutionRequest<runtime_protocol::LocalSpecificConfig>,
+    ) -> ExecutionResult<Response> {
+        let schema = self.build_schema(&execution_request)?;
 
         // decorate the graphql request context with auth data for extension
         execution_request.request.data.insert(execution_request.auth);
 
         Ok(schema.execute(execution_request.request).await)
+    }
+
+    async fn execute_stream(
+        self: Arc<Self>,
+        mut execution_request: ExecutionRequest<Self::ConfigType>,
+        streaming_format: StreamingFormat,
+    ) -> ExecutionResult<(worker::Response, Option<BoxFuture<'static, ()>>)> {
+        let schema = self.build_schema(&execution_request)?;
+
+        // decorate the graphql request context with auth data for extension
+        execution_request.request.data.insert(execution_request.auth);
+
+        let payload_stream = schema.execute_stream(execution_request.request);
+
+        let (response_stream, process_future) = into_byte_stream_and_future(payload_stream, streaming_format);
+
+        let mut response = worker::Response::from_stream(response_stream)?;
+
+        let headers = response.headers_mut();
+        headers.set("Cache-Control", "no-cache")?;
+        headers.set(
+            "Content-Type",
+            match streaming_format {
+                StreamingFormat::IncrementalDelivery => "multipart/mixed; boundary=\"-\"",
+                StreamingFormat::GraphQLOverSSE => "text/event-stream",
+            },
+        )?;
+
+        return Ok((response, Some(process_future)));
     }
 
     async fn health(
@@ -192,5 +230,80 @@ impl ExecutionEngine for LocalExecution {
             ready: true,
             udf_results: vec![],
         })
+    }
+}
+
+fn into_byte_stream_and_future(
+    payload_stream: impl Stream<Item = StreamingPayload> + Send + 'static,
+    streaming_format: StreamingFormat,
+) -> (BoxStream<'static, Result<Bytes, String>>, BoxFuture<'static, ()>) {
+    match streaming_format {
+        StreamingFormat::IncrementalDelivery => {
+            let mut byte_stream = Box::pin(multipart_stream::serialize(
+                payload_stream.map(|payload| {
+                    Ok(multipart_stream::Part {
+                        headers: Default::default(),
+                        body: Bytes::from(serde_json::to_vec(&payload).map_err(|e| e.to_string())?),
+                    })
+                }),
+                "-",
+            ));
+
+            // We should be able to just return the above stream,  but miniflare as run
+            // in the CLI has an issue where _sometimes_ code run inside a response stream
+            // is considered outside of the request context and we get panics when doing I/O etc.
+            //
+            // We work around this by returning a future that does the work, which can
+            // be resolved inside a wait_until, guaranteeing it's inside the request context.
+            //
+            // Miniflare 3 doesn't appear to have this problem so we can probably get
+            // rid of this hack when/if we upgrade
+            let (mut tx, rx) = futures_channel::mpsc::channel(10);
+            let process_stream = Box::pin(async move {
+                while let Some(bytes) = byte_stream.next().await {
+                    tx.send(bytes).await.ok();
+                }
+            });
+
+            (Box::pin(rx), process_stream)
+        }
+        StreamingFormat::GraphQLOverSSE => {
+            let mut payload_stream = Box::pin(payload_stream);
+
+            let (sse_sender, sse_encoder) = async_sse::encode();
+            let response_stream = sse_encoder.lines().map(|line| {
+                line.map(|mut line| {
+                    line.push_str("\r\n");
+                    line.into()
+                })
+                .map_err(|e| e.to_string())
+            });
+
+            let sender_future = Box::pin(async move {
+                while let Some(payload) = payload_stream.next().await {
+                    let payload_json = match serde_json::to_string(&payload) {
+                        Ok(json) => json,
+                        Err(error) => {
+                            tracing::error!("Could not encode StreamingPayload as JSON: {error:?}");
+                            return;
+                        }
+                    };
+
+                    if let Err(error) = sse_sender.send("next", &payload_json, None).await {
+                        tracing::error!("Could not send next payload via sse_sender: {error}");
+                        return;
+                    }
+                }
+
+                // The GraphQLOverSSE spec suggests we just need the event name on the complete
+                // event but the SSE spec says that you should drop events with an empty data
+                // buffer.  So I'm just putting complete in the data buffer as well for now.
+                if let Err(error) = sse_sender.send("complete", "complete", None).await {
+                    tracing::error!("Could not send complete payload via sse_sender: {error}");
+                }
+            });
+
+            (Box::pin(response_stream), sender_future)
+        }
     }
 }

--- a/engine/crates/integration-tests/Cargo.toml
+++ b/engine/crates/integration-tests/Cargo.toml
@@ -27,7 +27,7 @@ features = ["json"]
 [dependencies.engine]
 path = "../engine"
 default-features = false
-features = ["tracing_worker", "defer"]
+features = ["tracing_worker"]
 
 [dependencies.parser-sdl]
 path = "../parser-sdl"

--- a/engine/crates/runtime-protocol/Cargo.toml
+++ b/engine/crates/runtime-protocol/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1"
+futures-util = { workspace = true }
 rusoto_core = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_with = { workspace = true }

--- a/engine/crates/runtime-protocol/src/execution_engine.rs
+++ b/engine/crates/runtime-protocol/src/execution_engine.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use futures_util::future::BoxFuture;
 
 #[derive(Debug, thiserror::Error)]
 #[allow(dead_code)]
@@ -13,16 +14,55 @@ pub enum ExecutionError {
 
 pub type ExecutionResult<T> = Result<T, ExecutionError>;
 
+/// The format execute_stream should return
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StreamingFormat {
+    /// Follow the [incremental delivery spec][1]
+    ///
+    /// [1]: https://github.com/graphql/graphql-over-http/blob/main/rfcs/IncrementalDelivery.md
+    IncrementalDelivery,
+    /// Follow the [GraphQL over SSE spec][1]
+    ///
+    /// [1]: https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverSSE.md
+    GraphQLOverSSE,
+}
+
+impl StreamingFormat {
+    pub fn from_accept_header(header: &str) -> Option<Self> {
+        // Note: This is not even close to the correct way to parse the Accept header.
+        // Going to improve apon this in GB-4878
+        match header {
+            "multipart/mixed" => Some(Self::IncrementalDelivery),
+            "text/event-stream" => Some(Self::GraphQLOverSSE),
+            _ => None,
+        }
+    }
+}
+
 /// Owned trait with 'static in mind
 #[async_trait(?Send)]
 pub trait ExecutionEngine {
     type ConfigType;
-    type ExecutionResponse; // This is always engine::Response (but is needed for tests)
+    type ExecutionResponse; // This is always grafbase_engine::Response (but is needed for tests)
 
     async fn execute(
         self: Arc<Self>,
         execution_request: crate::ExecutionRequest<Self::ConfigType>,
     ) -> ExecutionResult<Self::ExecutionResponse>;
+
+    /// Executes a streaming request from the engine.
+    ///
+    /// For streaming requests we current expect to just return the Response from upstream directly
+    /// without any caching etc.  At some point we might want to consider caching for streamed requests
+    /// but it's not straightforward and requires some thought.
+    ///
+    /// Note that this returns a Response _and_ an optional future.  That future (if provided) needs to
+    /// be polled within a request context.
+    async fn execute_stream(
+        self: Arc<Self>,
+        execution_request: crate::ExecutionRequest<Self::ConfigType>,
+        streaming_format: StreamingFormat,
+    ) -> ExecutionResult<(worker::Response, Option<BoxFuture<'static, ()>>)>;
 
     async fn health(
         self: Arc<Self>,

--- a/engine/crates/runtime-protocol/src/lib.rs
+++ b/engine/crates/runtime-protocol/src/lib.rs
@@ -4,11 +4,11 @@ pub use self::{
     customer_deployment_config::{
         local::LocalSpecificConfig, CommonCustomerDeploymentConfig, CustomerDeploymentConfig,
     },
-    execution_engine::{ExecutionEngine, ExecutionError, ExecutionResult},
+    execution_engine::{ExecutionEngine, ExecutionError, ExecutionResult, StreamingFormat},
 };
 
-use engine::{registry::CacheControlError, CacheControl};
 use common_types::{auth::ExecutionAuth, UdfKind};
+use engine::{registry::CacheControlError, CacheControl};
 use worker::{js_sys::Uint8Array, Headers, Method, RequestInit};
 
 pub use engine::registry::VersionedRegistry;


### PR DESCRIPTION
The engine currently has support for `@defer` but it's useless without some sort of streaming transport.  This adds support for the [GraphQLOverSSE][1] & [Incremental Delivery][2] transports into the `gateway-local` crate.  Though I'll still need to make another PR in `api` followed by a PR here before this is functional.

While testing this I found that doing a `@defer` at the top level of the query was causing a panic because of some mismatched exepctations around `resolver_chain_node`.  So I've also fixed that in this PR

[1]: https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverSSE.md
[2]: https://github.com/graphql/graphql-over-http/blob/main/rfcs/IncrementalDelivery.md