### PR TITLE
fix(udf): GB-4829: Avoid installing wrangler when it's already installed with the right version

### DIFF
--- a/cli/crates/server/src/udf_builder.rs
+++ b/cli/crates/server/src/udf_builder.rs
@@ -317,7 +317,7 @@ async fn symlink_grafbase_wasm_sdk(
     Ok(())
 }
 
-async fn installed_wrangler_version(wrangler_installation_path: impl AsRef<Path>, tracing: bool) -> Option<String> {
+async fn installed_wrangler_version(wrangler_installation_path: impl AsRef<Path>) -> Option<String> {
     let wrangler_installation_path = wrangler_installation_path.as_ref();
     let wrangler_arguments = &[
         "exec",
@@ -331,7 +331,7 @@ async fn installed_wrangler_version(wrangler_installation_path: impl AsRef<Path>
         JavaScriptPackageManager::Npm,
         wrangler_arguments,
         wrangler_installation_path,
-        tracing,
+        false,
         &[],
     )
     .await
@@ -351,8 +351,7 @@ pub async fn install_wrangler(environment: &Environment, tracing: bool) -> Resul
     .await?
     .map_err(ServerError::Lock)?;
 
-    if let Some(installed_wrangler_version) =
-        installed_wrangler_version(&environment.wrangler_installation_path, tracing).await
+    if let Some(installed_wrangler_version) = installed_wrangler_version(&environment.wrangler_installation_path).await
     {
         info!("Installed wrangler version: {installed_wrangler_version}");
         if installed_wrangler_version == WRANGLER_VERSION {
@@ -377,14 +376,6 @@ pub async fn install_wrangler(environment: &Environment, tracing: bool) -> Resul
             "--prefix",
             wrangler_installation_path_str,
         ],
-        wrangler_installation_path_str,
-        tracing,
-        &[],
-    )
-    .await?;
-    run_command(
-        JavaScriptPackageManager::Npm,
-        &["install", "--prefix", wrangler_installation_path_str],
         wrangler_installation_path_str,
         tracing,
         &[],

--- a/cli/crates/server/src/udf_builder.rs
+++ b/cli/crates/server/src/udf_builder.rs
@@ -179,6 +179,7 @@ pub async fn build(
     {
         let wrangler_arguments = &[
             "exec",
+            "--no",
             "--prefix",
             environment.wrangler_installation_path.to_str().expect("must be valid"),
             "--",
@@ -321,6 +322,7 @@ async fn installed_wrangler_version(wrangler_installation_path: impl AsRef<Path>
     let wrangler_installation_path = wrangler_installation_path.as_ref();
     let wrangler_arguments = &[
         "exec",
+        "--no",
         "--prefix",
         wrangler_installation_path.to_str().expect("must be valid"),
         "--",

--- a/cli/crates/server/src/udf_builder.rs
+++ b/cli/crates/server/src/udf_builder.rs
@@ -16,7 +16,7 @@ async fn run_command<P: AsRef<Path>>(
     current_directory: P,
     tracing: bool,
     environment: &[(&'static str, &str)],
-) -> Result<Vec<u8>, JavascriptPackageManagerComamndError> {
+) -> Result<Option<Vec<u8>>, JavascriptPackageManagerComamndError> {
     let command_string = format!("{command_type} {}", arguments.iter().format(" "));
     let current_directory = current_directory.as_ref();
     match current_directory.try_exists() {
@@ -56,7 +56,7 @@ async fn run_command<P: AsRef<Path>>(
 
     if output.status.success() {
         trace!("'{command_string}' succeeded");
-        Ok(output.stdout)
+        Ok(Some(output.stdout).filter(|output| !output.is_empty()))
     } else {
         trace!("'{command_string}' failed");
         Err(JavascriptPackageManagerComamndError::OutputError(
@@ -335,7 +335,7 @@ async fn installed_wrangler_version(wrangler_installation_path: impl AsRef<Path>
         &[],
     )
     .await
-    .ok()?;
+    .ok()??;
     Some(String::from_utf8(output_bytes).ok()?.trim().to_owned())
 }
 


### PR DESCRIPTION
# Description

This PR introduces a check ensuring that we don't reinstall wrangler excessively. If we find a valid wrangler already installed in ~/.grafbase/wrangler – by trying to invoke it through `npm exec` – and it's of the right version, no attempt to install it again will be carried out. Even if `npm install` itself for the existing package would already have been fairly quick.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
