### PR TITLE
fix: send valid json in the complete body

### DIFF
--- a/engine/crates/gateway-adapter-local/src/execution.rs
+++ b/engine/crates/gateway-adapter-local/src/execution.rs
@@ -297,8 +297,8 @@ fn into_byte_stream_and_future(
 
                 // The GraphQLOverSSE spec suggests we just need the event name on the complete
                 // event but the SSE spec says that you should drop events with an empty data
-                // buffer.  So I'm just putting complete in the data buffer as well for now.
-                if let Err(error) = sse_sender.send("complete", "complete", None).await {
+                // buffer.  So I'm just putting null in the data buffer for now.
+                if let Err(error) = sse_sender.send("complete", "null", None).await {
                     tracing::error!("Could not send complete payload via sse_sender: {error}");
                 }
             });


### PR DESCRIPTION
I noticed when writing tests of SSE that a naive client implementation might assume `body` is always JSON, but I was sending the word `complete` in the body of the complete event.  I don't think it's wrong, but might as well make it valid JSON.