### PR TITLE
feat: @experimental

### DIFF
--- a/engine/crates/engine/src/registry/mod.rs
+++ b/engine/crates/engine/src/registry/mod.rs
@@ -1391,6 +1391,8 @@ pub struct Registry {
     pub search_config: runtime::search::Config,
     #[serde(default)]
     pub enable_caching: bool,
+    #[serde(default)]
+    pub enable_kv: bool,
 }
 
 impl Default for Registry {
@@ -1411,6 +1413,7 @@ impl Default for Registry {
             postgres_databases: Default::default(),
             search_config: Default::default(),
             enable_caching: false,
+            enable_kv: false,
         }
     }
 }

--- a/engine/crates/engine/src/registry/resolvers/mod.rs
+++ b/engine/crates/engine/src/registry/resolvers/mod.rs
@@ -266,7 +266,7 @@ impl Resolver {
                 );
 
                 #[cfg(feature = "tracing_worker")]
-                let future = future.instrument(info_span!("http_resolver", name = resolver.name().as_ref()));
+                let future = future.instrument(info_span!("graphql_resolver", name = resolver.name().as_ref()));
 
                 future.await.map_err(Into::into)
             }

--- a/engine/crates/parser-sdl/src/lib.rs
+++ b/engine/crates/parser-sdl/src/lib.rs
@@ -60,6 +60,7 @@ pub use rules::{
 
 use crate::rules::{
     cache_directive::{visitor::CacheVisitor, CacheDirective},
+    experimental::ExperimentalDirectiveVisitor,
     mongodb_directive::MongoDBVisitor,
     scalar_hydratation::ScalarHydratation,
 };
@@ -289,6 +290,7 @@ fn parse_types<'a>(schema: &'a ServiceDocument, ctx: &mut VisitorContext<'a>) {
         .with(AuthDirective)
         .with(ResolverDirective)
         .with(CacheVisitor)
+        .with(ExperimentalDirectiveVisitor)
         .with(InputObjectVisitor)
         .with(BasicType)
         .with(ExtendQueryAndMutationTypes)

--- a/engine/crates/parser-sdl/src/rules/experimental.rs
+++ b/engine/crates/parser-sdl/src/rules/experimental.rs
@@ -14,7 +14,7 @@ const EXPERIMENTAL_DIRECTIVE_NAME: &str = "experimental";
 
 #[derive(Debug, thiserror::Error)]
 pub enum ExperimentalDirectiveError {
-    #[error("@experimental error: Unable to parse - {0}")]
+    #[error("Unable to parse @experiment - {0}")]
     Parsing(RuleError),
 }
 

--- a/engine/crates/parser-sdl/src/rules/experimental.rs
+++ b/engine/crates/parser-sdl/src/rules/experimental.rs
@@ -1,0 +1,98 @@
+use std::collections::HashMap;
+
+use engine_parser::{types::SchemaDefinition, Positioned};
+
+use crate::{
+    directive_de::parse_directive,
+    rules::{
+        directive::Directive,
+        visitor::{RuleError, Visitor, VisitorContext},
+    },
+};
+
+const EXPERIMENTAL_DIRECTIVE_NAME: &str = "experimental";
+
+#[derive(Debug, thiserror::Error)]
+pub enum ExperimentalDirectiveError {
+    #[error("@experimental error: Unable to parse - {0}")]
+    Parsing(RuleError),
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExperimentalDirective {
+    pub kv: bool,
+}
+
+pub struct ExperimentalDirectiveVisitor;
+impl<'a> Visitor<'a> for ExperimentalDirectiveVisitor {
+    fn enter_schema(&mut self, ctx: &mut VisitorContext<'a>, doc: &'a Positioned<SchemaDefinition>) {
+        let directives = doc
+            .directives
+            .iter()
+            .filter(|d| d.node.name.node == EXPERIMENTAL_DIRECTIVE_NAME)
+            .collect::<Vec<_>>();
+
+        let Some(experimental_directive) = directives.first() else {
+            return;
+        };
+
+        match parse_directive::<ExperimentalDirective>(experimental_directive, &HashMap::default()) {
+            Ok(experimental_directive) => {
+                ctx.registry.get_mut().enable_kv = experimental_directive.kv;
+            }
+            Err(err) => {
+                ctx.report_error(
+                    vec![experimental_directive.pos],
+                    ExperimentalDirectiveError::Parsing(err).to_string(),
+                );
+            }
+        };
+    }
+}
+
+impl Directive for ExperimentalDirective {
+    fn definition() -> String {
+        r#"
+        directive @experimental(
+          """
+          Enable experimental usage of KV in resolvers.
+          """
+          kv: Boolean
+        ) on SCHEMA
+        "#
+        .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        parse_schema,
+        rules::{
+            experimental::ExperimentalDirectiveVisitor,
+            visitor::{visit, VisitorContext},
+        },
+    };
+
+    #[rstest::rstest]
+    #[case::error_parsing_unknown_field(r#"
+        extend schema @experimental(random: true)
+    "#, &["@experimental error: Unable to parse - [2:37] unknown field `random`, expected `kv`"], false)]
+    #[case::successful_parsing_kv_enabled(r#"
+        extend schema @experimental(kv: true)
+    "#, &[], true)]
+    #[case::successful_parsing_kv_disabled(r#"
+        extend schema @experimental(kv: false)
+    "#, &[], false)]
+    fn test_parsing(#[case] schema: &str, #[case] expected_messages: &[&str], #[case] expected_kv_enabled: bool) {
+        let schema = parse_schema(schema).unwrap();
+        let mut ctx = VisitorContext::new(&schema);
+        visit(&mut ExperimentalDirectiveVisitor, &mut ctx, &schema);
+
+        let actual_messages: Vec<_> = ctx.errors.iter().map(|error| error.message.as_str()).collect();
+        assert_eq!(actual_messages.as_slice(), expected_messages);
+
+        assert_eq!(ctx.registry.borrow().enable_kv, expected_kv_enabled);
+    }
+}

--- a/engine/crates/parser-sdl/src/rules/experimental.rs
+++ b/engine/crates/parser-sdl/src/rules/experimental.rs
@@ -14,7 +14,7 @@ const EXPERIMENTAL_DIRECTIVE_NAME: &str = "experimental";
 
 #[derive(Debug, thiserror::Error)]
 pub enum ExperimentalDirectiveError {
-    #[error("Unable to parse @experiment - {0}")]
+    #[error("Unable to parse @experimental - {0}")]
     Parsing(RuleError),
 }
 
@@ -27,12 +27,11 @@ pub struct ExperimentalDirective {
 pub struct ExperimentalDirectiveVisitor;
 impl<'a> Visitor<'a> for ExperimentalDirectiveVisitor {
     fn enter_schema(&mut self, ctx: &mut VisitorContext<'a>, doc: &'a Positioned<SchemaDefinition>) {
-        let directive = doc
+        let Some(experimental_directive) = doc
             .directives
             .iter()
-            .find(|d| d.node.name.node == EXPERIMENTAL_DIRECTIVE_NAME);
-
-        let Some(experimental_directive) = directive else {
+            .find(|d| d.node.name.node == EXPERIMENTAL_DIRECTIVE_NAME)
+        else {
             return;
         };
 
@@ -77,7 +76,7 @@ mod tests {
     #[rstest::rstest]
     #[case::error_parsing_unknown_field(r#"
         extend schema @experimental(random: true)
-    "#, &["@experimental error: Unable to parse - [2:37] unknown field `random`, expected `kv`"], false)]
+    "#, &["Unable to parse @experimental - [2:37] unknown field `random`, expected `kv`"], false)]
     #[case::successful_parsing_kv_enabled(r#"
         extend schema @experimental(kv: true)
     "#, &[], true)]

--- a/engine/crates/parser-sdl/src/rules/experimental.rs
+++ b/engine/crates/parser-sdl/src/rules/experimental.rs
@@ -27,13 +27,12 @@ pub struct ExperimentalDirective {
 pub struct ExperimentalDirectiveVisitor;
 impl<'a> Visitor<'a> for ExperimentalDirectiveVisitor {
     fn enter_schema(&mut self, ctx: &mut VisitorContext<'a>, doc: &'a Positioned<SchemaDefinition>) {
-        let directives = doc
+        let directive = doc
             .directives
             .iter()
-            .filter(|d| d.node.name.node == EXPERIMENTAL_DIRECTIVE_NAME)
-            .collect::<Vec<_>>();
+            .find(|d| d.node.name.node == EXPERIMENTAL_DIRECTIVE_NAME);
 
-        let Some(experimental_directive) = directives.first() else {
+        let Some(experimental_directive) = directive else {
             return;
         };
 

--- a/engine/crates/parser-sdl/src/rules/mod.rs
+++ b/engine/crates/parser-sdl/src/rules/mod.rs
@@ -12,6 +12,7 @@ pub mod default_directive;
 pub mod default_directive_types;
 pub mod directive;
 pub mod enum_type;
+pub mod experimental;
 pub mod extend_connector_types;
 pub mod extend_query_and_mutation_types;
 pub mod graphql_directive;

--- a/engine/crates/parser-sdl/src/rules/mongodb_directive/model_directive/types/input.rs
+++ b/engine/crates/parser-sdl/src/rules/mongodb_directive/model_directive/types/input.rs
@@ -2,12 +2,11 @@ use case::CaseExt;
 use engine::registry::{InputObjectType, MetaInputValue};
 use engine_parser::types::{BaseType, ObjectType, Type, TypeDefinition};
 
+use super::generic::{self, filter_type_name, MONGO_POP_POSITION};
 use crate::{
     registry::names::MetaNames,
     rules::{mongodb_directive::CreateTypeContext, visitor::VisitorContext},
 };
-
-use super::generic::{self, filter_type_name, MONGO_POP_POSITION};
 
 pub(crate) fn register_input(visitor_ctx: &mut VisitorContext<'_>, create_ctx: &CreateTypeContext<'_>) -> String {
     register_type_input(visitor_ctx, create_ctx.object, create_ctx.r#type)

--- a/engine/crates/parser-sdl/src/rules/neon_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/neon_directive.rs
@@ -1,12 +1,11 @@
 use engine::Positioned;
 use engine_parser::types::SchemaDefinition;
 
-use crate::directive_de::parse_directive;
-
 use super::{
     directive::Directive,
     visitor::{Visitor, VisitorContext},
 };
+use crate::directive_de::parse_directive;
 
 const NEON_DIRECTIVE_NAME: &str = "neon";
 


### PR DESCRIPTION
# Description

Adds a new directive `@experimental` parsed only at the global level (or at schema level).

```graphql

schema @experimental(kv: true)

```

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
