### PR TITLE
Drop the `#[serde(default)]` annotations from the fields in `CommonCustomerDeploymentConfig`

### DIFF
--- a/engine/crates/gateway-adapter/src/customer_deployment_config/mod.rs
+++ b/engine/crates/gateway-adapter/src/customer_deployment_config/mod.rs
@@ -29,10 +29,8 @@ pub enum BranchEnvironment {
 #[derive(Clone, Default, serde::Deserialize, serde::Serialize)]
 pub struct CommonCustomerDeploymentConfig {
     /// Grafbase Gateway Version
-    #[serde(default)]
     pub gateway_version: String,
     /// Grafbase Deployment ID where this config was generated
-    #[serde(default)]
     pub deployment_id: String,
     /// Branch of the project this deployment belongs to
     pub github_ref_name: Option<String>,
@@ -43,18 +41,12 @@ pub struct CommonCustomerDeploymentConfig {
     /// Grafbase project ID this deployment belongs to
     pub project_id: String,
     /// UDF service names
-    #[serde(default)]
     #[serde_as(as = "Vec<(_, _)>")]
     pub udf_bindings: std::collections::HashMap<(UdfKind, String), String>,
-    #[serde(default)]
     /// Customer's dedicated subdomain
     pub subdomain: String,
-    // FIXME: 2023-04-05: Optional for now until legacy projects are redeployed.
-    #[serde(default)]
     pub account_id: Option<String>,
-    #[serde(default)]
     pub auth_config: AuthConfig,
-    #[serde(default)]
     pub cache_config: CacheConfig,
 }
 


### PR DESCRIPTION
# Description

These aren't necessary any more after upstream changes in the platform.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
