### PR TITLE
fix: parse accept header properly

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1384,6 +1384,7 @@ dependencies = [
  "common-types",
  "engine",
  "futures-util",
+ "mediatype",
  "rusoto_core",
  "serde",
  "serde_json",
@@ -2008,6 +2009,12 @@ checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
 dependencies = [
  "digest",
 ]
+
+[[package]]
+name = "mediatype"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c408dc227d302f1496c84d9dc68c00fec6f56f9228a18f3023f976f3ca7c945"
 
 [[package]]
 name = "memchr"

--- a/engine/crates/gateway-adapter/Cargo.toml
+++ b/engine/crates/gateway-adapter/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1"
 futures-util = { workspace = true }
+mediatype = "0.19"
 rusoto_core = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_with = { workspace = true }

--- a/engine/crates/gateway-adapter/src/execution_engine.rs
+++ b/engine/crates/gateway-adapter/src/execution_engine.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures_util::future::BoxFuture;
 
+use crate::StreamingFormat;
+
 #[derive(Debug, thiserror::Error)]
 #[allow(dead_code)]
 pub enum ExecutionError {
@@ -13,31 +15,6 @@ pub enum ExecutionError {
 }
 
 pub type ExecutionResult<T> = Result<T, ExecutionError>;
-
-/// The format execute_stream should return
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum StreamingFormat {
-    /// Follow the [incremental delivery spec][1]
-    ///
-    /// [1]: https://github.com/graphql/graphql-over-http/blob/main/rfcs/IncrementalDelivery.md
-    IncrementalDelivery,
-    /// Follow the [GraphQL over SSE spec][1]
-    ///
-    /// [1]: https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverSSE.md
-    GraphQLOverSSE,
-}
-
-impl StreamingFormat {
-    pub fn from_accept_header(header: &str) -> Option<Self> {
-        // Note: This is not even close to the correct way to parse the Accept header.
-        // Going to improve apon this in GB-4878
-        match header {
-            "multipart/mixed" => Some(Self::IncrementalDelivery),
-            "text/event-stream" => Some(Self::GraphQLOverSSE),
-            _ => None,
-        }
-    }
-}
 
 /// Owned trait with 'static in mind
 #[async_trait(?Send)]

--- a/engine/crates/gateway-adapter/src/lib.rs
+++ b/engine/crates/gateway-adapter/src/lib.rs
@@ -4,8 +4,9 @@ pub use self::{
     customer_deployment_config::{
         local::LocalSpecificConfig, CommonCustomerDeploymentConfig, CustomerDeploymentConfig,
     },
-    execution_engine::{ExecutionEngine, ExecutionError, ExecutionResult, StreamingFormat},
+    execution_engine::{ExecutionEngine, ExecutionError, ExecutionResult},
     registry::{RegistryError, RegistryProvider, RegistryResult},
+    streaming_format::StreamingFormat,
 };
 pub use engine::registry::VersionedRegistry;
 
@@ -16,6 +17,7 @@ use worker::{js_sys::Uint8Array, Headers, Method, RequestInit};
 mod customer_deployment_config;
 mod execution_engine;
 mod registry;
+mod streaming_format;
 
 #[cfg(test)]
 mod tests;

--- a/engine/crates/gateway-adapter/src/streaming_format.rs
+++ b/engine/crates/gateway-adapter/src/streaming_format.rs
@@ -1,0 +1,109 @@
+use mediatype::{MediaType, MediaTypeList, Name};
+
+/// The format ExecutionEngine::execute_stream should return
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StreamingFormat {
+    /// Follow the [incremental delivery spec][1]
+    ///
+    /// [1]: https://github.com/graphql/graphql-over-http/blob/main/rfcs/IncrementalDelivery.md
+    IncrementalDelivery,
+    /// Follow the [GraphQL over SSE spec][1]
+    ///
+    /// [1]: https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverSSE.md
+    GraphQLOverSSE,
+}
+
+const INCREMENTAL_MEDIA_TYPE: MediaType =
+    MediaType::new(Name::new_unchecked("multipart"), Name::new_unchecked("mixed"));
+const SSE_MEDIA_TYPE: MediaType = MediaType::new(Name::new_unchecked("text"), Name::new_unchecked("event-stream"));
+
+impl StreamingFormat {
+    pub fn from_accept_header(header: &str) -> Option<Self> {
+        let (mediatype, _) = MediaTypeList::new(header)
+            .filter_map(Result::ok)
+            .filter(|mediatype| {
+                // Get the mediatype without parameters
+                let essence = mediatype.essence();
+
+                essence == INCREMENTAL_MEDIA_TYPE || essence == SSE_MEDIA_TYPE
+            })
+            .map(|mediatype| {
+                let quality_value = mediatype
+                    .params
+                    .iter()
+                    .find(|(name, _)| name == "q")
+                    .and_then(|(_, value)| value.as_str().parse::<f32>().ok())
+                    .unwrap_or(1.0);
+
+                (mediatype, quality_value)
+            })
+            .max_by(|(_, lhs), (_, rhs)| lhs.total_cmp(rhs))?;
+
+        let mediatype = mediatype.essence();
+
+        if mediatype == INCREMENTAL_MEDIA_TYPE {
+            Some(Self::IncrementalDelivery)
+        } else if mediatype == SSE_MEDIA_TYPE {
+            Some(Self::GraphQLOverSSE)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::StreamingFormat;
+
+    #[test]
+    fn test_accept_header_parsing() {
+        assert_eq!(
+            StreamingFormat::from_accept_header("multipart/mixed"),
+            Some(StreamingFormat::IncrementalDelivery)
+        );
+        assert_eq!(
+            StreamingFormat::from_accept_header("multipart/mixed,application/json;q=0.9"),
+            Some(StreamingFormat::IncrementalDelivery)
+        );
+        assert_eq!(
+            StreamingFormat::from_accept_header("*/*,multipart/mixed;q=0.9,application/json;q=0.8"),
+            Some(StreamingFormat::IncrementalDelivery)
+        );
+        assert_eq!(
+            StreamingFormat::from_accept_header(
+                "*/*,multipart/mixed;q=0.9,text/event-stream=0.8;application/json;q=0.8"
+            ),
+            Some(StreamingFormat::IncrementalDelivery)
+        );
+
+        assert_eq!(
+            StreamingFormat::from_accept_header("text/event-stream"),
+            Some(StreamingFormat::GraphQLOverSSE)
+        );
+        assert_eq!(
+            StreamingFormat::from_accept_header("text/event-stream,application/json;q=0.9"),
+            Some(StreamingFormat::GraphQLOverSSE)
+        );
+        assert_eq!(
+            StreamingFormat::from_accept_header("*/*,text/event-stream;q=0.9,application/json;q=0.8"),
+            Some(StreamingFormat::GraphQLOverSSE)
+        );
+        assert_eq!(
+            StreamingFormat::from_accept_header(
+                "*/*,text/event-stream;q=0.9,multipart/mixed=0.8;application/json;q=0.8"
+            ),
+            Some(StreamingFormat::GraphQLOverSSE)
+        );
+
+        assert_eq!(
+            StreamingFormat::from_accept_header("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"),
+            None
+        );
+        assert_eq!(StreamingFormat::from_accept_header("application/json"), None);
+        assert_eq!(StreamingFormat::from_accept_header("*/*"), None);
+        assert_eq!(
+            StreamingFormat::from_accept_header("application/graphql-response+json"),
+            None
+        );
+    }
+}


### PR DESCRIPTION
We're using the HTTP Accept header to determine which transport we use to reply to incoming requests.  I couldn't find an obvious way to parse the `Accept` header properly at the time I was writing the code, so I temporarily did the dumbest thing I could to not get blocked.

Came back to it today and this time I managed to find a crate that does the trick.  So this PR pulls that in and fixes that issue.