### PR TITLE
feat(connector): Neon findMany

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1566,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sql-ast"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e85914cf77b743c12e6eda54c452974f9de60acd818be754e7a63de4942346dd"
+checksum = "29aa39c93553fc933094f7b15d92a6a96956e944760f5c061e527482e7ac24e3"
 dependencies = [
  "serde_json",
 ]

--- a/engine/crates/engine/Cargo.toml
+++ b/engine/crates/engine/Cargo.toml
@@ -20,7 +20,7 @@ async-recursion = "1"
 async-stream = "0.3"
 async-trait = "0.1"
 common-types = { path = "../common-types" }
-grafbase-sql-ast = "0.1"
+grafbase-sql-ast = "0.1.1"
 postgresql-types = { path = "../postgresql-types" }
 bytes = { version = "1", features = ["serde"] }
 case = "1"

--- a/engine/crates/engine/src/registry/resolvers/postgresql.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql.rs
@@ -10,12 +10,14 @@ use std::{future::Future, pin::Pin};
 #[serde(rename_all = "camelCase")]
 pub enum Operation {
     FindOne,
+    FindMany,
 }
 
 impl AsRef<str> for Operation {
     fn as_ref(&self) -> &str {
         match self {
             Self::FindOne => "findOne",
+            Self::FindMany => "findMany",
         }
     }
 }

--- a/engine/crates/engine/src/registry/resolvers/postgresql/context.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql/context.rs
@@ -1,18 +1,20 @@
 mod filter;
 mod selection;
 
-pub(super) use filter::SimpleFilterIterator;
+pub(super) use filter::FilterIterator;
 pub(super) use selection::{CollectionArgs, SelectionIterator, TableSelection};
 
 use crate::{
-    registry::{resolvers::ResolverContext, Registry},
-    Context, Error, ServerResult,
+    registry::{resolvers::ResolverContext, type_kinds::SelectionSetTarget, Registry},
+    Context, Error, SelectionField, ServerResult,
 };
 use postgresql_types::{
     database_definition::{DatabaseDefinition, TableWalker},
     transport::NeonTransport,
 };
 use serde_json::{Map, Value};
+
+use self::filter::{ByFilterIterator, ComplexFilterIterator};
 
 /// The API to access the request parameters, such as filters and selection, and map that together with
 /// the database types.
@@ -52,17 +54,48 @@ impl<'a> PostgresContext<'a> {
             .expect("could not find table for client type")
     }
 
+    /// The first field of the query, e.g. the query.
+    pub fn root_field(&self) -> SelectionField<'a> {
+        self.context
+            .look_ahead()
+            .iter_selection_fields()
+            .next()
+            .expect("we always have at least one field in the query")
+    }
+
     /// The selection of fields in the request.
     pub fn selection(&'a self) -> SelectionIterator<'a> {
         let selection = self
             .context
             .look_ahead()
-            .selection_fields()
-            .into_iter()
+            .iter_selection_fields()
             .flat_map(|selection| selection.selection_set())
             .collect();
 
         let meta_type = self.resolver_context.ty.unwrap();
+        SelectionIterator::new(self, meta_type, selection)
+    }
+
+    pub fn collection_selection(&'a self) -> SelectionIterator<'a> {
+        let selection = self
+            .context
+            .look_ahead()
+            .field("edges")
+            .field("node")
+            .iter_selection_fields()
+            .flat_map(|selection| selection.selection_set())
+            .collect();
+
+        let target: SelectionSetTarget = self.resolver_context.ty.unwrap().try_into().unwrap();
+
+        let meta_type = target
+            .field("edges")
+            .and_then(|field| self.registry().lookup(&field.ty).ok())
+            .as_ref()
+            .and_then(|output| output.field("node"))
+            .and_then(|field| self.registry().lookup_by_str(field.ty.base_type_name()).ok())
+            .expect("couldn't fiind a meta type for a collection selection");
+
         SelectionIterator::new(self, meta_type, selection)
     }
 
@@ -72,12 +105,20 @@ impl<'a> PostgresContext<'a> {
     }
 
     /// A simple `user(by: { id: 1 })` filter, that has exactly one equals operation.
-    pub fn by_filter(&self) -> ServerResult<SimpleFilterIterator<'a>> {
+    pub fn by_filter(&self) -> ServerResult<FilterIterator<'a>> {
         let filter_map: Map<String, Value> = self.context.input_by_name("by")?;
         let input_type = self.context.find_argument_type("by")?;
-        let iterator = SimpleFilterIterator::new(self.database_definition, input_type, filter_map);
+        let iterator = ByFilterIterator::new(self.database_definition, input_type, filter_map);
 
-        Ok(iterator)
+        Ok(FilterIterator::By(iterator))
+    }
+
+    pub fn filter(&'a self) -> ServerResult<FilterIterator<'a>> {
+        let filter_map: Map<String, Value> = self.context.input_by_name("filter")?;
+        let input_type = self.context.find_argument_type("filter")?;
+        let iterator = ComplexFilterIterator::new(self, input_type, filter_map);
+
+        Ok(FilterIterator::Complex(iterator))
     }
 
     /// The database connection.

--- a/engine/crates/engine/src/registry/resolvers/postgresql/context/filter/complex.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql/context/filter/complex.rs
@@ -1,0 +1,171 @@
+use std::collections::VecDeque;
+
+use grafbase_sql_ast::ast::{Column, Comparable, ConditionTree, Expression, Row, Select};
+use postgresql_types::database_definition::TableColumnWalker;
+use serde_json::{Map, Value};
+
+use crate::registry::{resolvers::postgresql::context::PostgresContext, type_kinds::InputType};
+
+#[derive(Clone)]
+pub struct ComplexFilterIterator<'a> {
+    context: &'a PostgresContext<'a>,
+    input_type: InputType<'a>,
+    filter: VecDeque<(String, Value)>,
+}
+
+impl<'a> ComplexFilterIterator<'a> {
+    pub fn new(
+        context: &'a PostgresContext<'a>,
+        input_type: InputType<'a>,
+        filter: impl IntoIterator<Item = (String, Value)>,
+    ) -> Self {
+        Self {
+            context,
+            input_type,
+            filter: VecDeque::from_iter(filter),
+        }
+    }
+}
+
+impl<'a> Iterator for ComplexFilterIterator<'a> {
+    type Item = ConditionTree<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let Some((field, value)) = self.filter.pop_front() else { return None };
+
+        let table = self
+            .context
+            .database_definition
+            .find_table_for_client_type(self.input_type.name())
+            .expect("table for input type not found");
+
+        // filtering from a related table.
+        if let Some(relation) = self
+            .context
+            .database_definition
+            .find_relation_for_client_field(&field, table.id())
+        {
+            let input_type: InputType<'_> = self
+                .input_type
+                .field(&field)
+                .and_then(|field| self.context.registry().lookup(&field.ty).ok())
+                .unwrap();
+
+            let object = if !relation.is_referenced_row_unique() {
+                match value {
+                    Value::Object(mut object) => match object.remove("contains") {
+                        Some(Value::Object(object)) => object,
+                        _ => unreachable!("nested filters must be objects"),
+                    },
+                    _ => unreachable!("nested filters must be objects"),
+                }
+            } else {
+                match value {
+                    Value::Object(object) => object,
+                    _ => unreachable!("nested filters must be objects"),
+                }
+            };
+
+            let mut conditions = Vec::new();
+
+            for (referenced, referencing) in relation.referenced_columns().zip(relation.referencing_columns()) {
+                let referencing = Column::from((referencing.table().database_name(), referencing.database_name()));
+                conditions.push(Expression::from(referenced.database_name().equals(referencing)));
+            }
+
+            let nested = Self::new(self.context, input_type, object);
+
+            for condition in nested {
+                conditions.push(Expression::from(condition))
+            }
+
+            let table = relation.referenced_table();
+
+            let mut select = Select::from_table((table.schema(), table.database_name()));
+            select.value(1);
+            select.so_that(ConditionTree::And(conditions));
+
+            return Some(ConditionTree::exists(select));
+        }
+
+        let operations = match value {
+            Value::Object(operations) => operations,
+            Value::Array(values) => {
+                let mut operations = Vec::with_capacity(values.len());
+
+                for operation in values.into_iter().flat_map(|operation| match operation {
+                    Value::Object(obj) => Some(obj),
+                    _ => None,
+                }) {
+                    let nested = Self::new(self.context, self.input_type, operation);
+
+                    for operation in nested {
+                        operations.push(Expression::from(operation));
+                    }
+                }
+
+                let tree = match field.as_str() {
+                    "ALL" => ConditionTree::And(operations),
+                    "ANY" => ConditionTree::Or(operations),
+                    "NONE" => ConditionTree::not(ConditionTree::Or(operations)),
+                    _ => unreachable!(),
+                };
+
+                return Some(tree);
+            }
+            _ => return None,
+        };
+
+        let column = self
+            .context
+            .database_definition
+            .find_column_for_client_field(&field, table.id())
+            .expect("column for input field not found");
+
+        Some(generate_conditions(operations, column))
+    }
+}
+
+fn generate_conditions(operations: Map<String, Value>, column: TableColumnWalker<'_>) -> ConditionTree<'_> {
+    let mut compares = Vec::with_capacity(operations.len());
+
+    for (key, value) in operations.into_iter() {
+        let table_column = (column.table().database_name(), column.database_name());
+
+        let compare = match key.as_str() {
+            "eq" => match value {
+                Value::Null => table_column.is_null(),
+                value => table_column.equals(value),
+            },
+            "ne" => match value {
+                Value::Null => table_column.is_not_null(),
+                value => table_column.not_equals(value),
+            },
+            "gt" => table_column.greater_than(value),
+            "lt" => table_column.less_than(value),
+            "gte" => table_column.greater_than_or_equals(value),
+            "lte" => table_column.less_than_or_equals(value),
+            "in" => table_column.in_selection(Row::from(value)),
+            "nin" => table_column.not_in_selection(Row::from(value)),
+            "contains" => table_column.array_contains(value),
+            "contained" => table_column.array_contained(value),
+            "overlaps" => table_column.array_overlaps(value),
+            "not" => {
+                let operations = match value {
+                    Value::Object(obj) => obj,
+                    _ => unreachable!("non-object not filter"),
+                };
+
+                let expression = Expression::from(ConditionTree::not(generate_conditions(operations, column)));
+                compares.push(expression);
+
+                continue;
+            }
+            _ => todo!(),
+        };
+
+        compares.push(Expression::from(compare));
+    }
+
+    ConditionTree::And(compares)
+}

--- a/engine/crates/engine/src/registry/resolvers/postgresql/context/filter/simple.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql/context/filter/simple.rs
@@ -1,0 +1,73 @@
+use crate::registry::type_kinds::InputType;
+use grafbase_sql_ast::ast::Comparable;
+use postgresql_types::database_definition::DatabaseDefinition;
+use serde_json::Value;
+use std::{collections::VecDeque, iter::Iterator};
+
+/// An iterator for a "simple" filter, e.g. a filter that's defined
+/// as `by` argument from the client, and has at most one unique equality
+/// check.
+#[derive(Debug, Clone)]
+pub struct ByFilterIterator<'a> {
+    database_definition: &'a DatabaseDefinition,
+    input_type: InputType<'a>,
+    filter: VecDeque<(String, Value)>,
+    nested: Option<Box<ByFilterIterator<'a>>>,
+}
+
+impl<'a> ByFilterIterator<'a> {
+    pub fn new(
+        database_definition: &'a DatabaseDefinition,
+        input_type: InputType<'a>,
+        filter: impl IntoIterator<Item = (String, Value)>,
+    ) -> Self {
+        Self {
+            database_definition,
+            input_type,
+            filter: VecDeque::from_iter(filter),
+            nested: None,
+        }
+    }
+}
+
+impl<'a> Iterator for ByFilterIterator<'a> {
+    type Item = grafbase_sql_ast::ast::Compare<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // We are having a nested input type, which we iterate over.
+        if let Some(item) = self.nested.as_mut().and_then(Iterator::next) {
+            return Some(item);
+        }
+
+        let Some((field, value)) = self.filter.pop_front() else { return None };
+
+        // If selecting an object, we don't care about the name of the object, but selecting the
+        // fields defined in the input.
+        //
+        // E.g. in `user(by: { nameEmail: { name: "foo", email: "bar" }})`, we do not care about `nameEmail`,
+        // but the nested values `name` and `email` are used in the query filters.
+        if let Value::Object(map) = value {
+            let mut nested = ByFilterIterator::new(self.database_definition, self.input_type, map);
+
+            let item = nested.next();
+            self.nested = Some(Box::new(nested));
+
+            return item;
+        };
+
+        let table = self
+            .database_definition
+            .find_table_for_client_type(self.input_type.name())
+            .expect("table for input type not found");
+
+        let column = self
+            .database_definition
+            .find_column_for_client_field(&field, table.id())
+            .expect("column for input field not found");
+
+        match value {
+            Value::Null => Some((table.database_name(), column.database_name()).is_null()),
+            _ => Some((table.database_name(), column.database_name()).equals(value)),
+        }
+    }
+}

--- a/engine/crates/engine/src/registry/resolvers/postgresql/context/selection/collection_args.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql/context/selection/collection_args.rs
@@ -17,7 +17,7 @@ pub struct CollectionArgs {
 }
 
 impl CollectionArgs {
-    pub(super) fn new(ctx: &PostgresContext<'_>, table: TableWalker<'_>, value: &SelectionField<'_>) -> Self {
+    pub(crate) fn new(ctx: &PostgresContext<'_>, table: TableWalker<'_>, value: &SelectionField<'_>) -> Self {
         let first = value.field.get_argument("first").and_then(|value| value.as_u64());
         let last = value.field.get_argument("last").and_then(|value| value.as_u64());
         let before = value.field.get_argument("before").and_then(|value| value.as_string());

--- a/engine/crates/engine/src/registry/resolvers/postgresql/request.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql/request.rs
@@ -1,3 +1,4 @@
+mod find_many;
 mod find_one;
 mod query;
 
@@ -7,5 +8,6 @@ use crate::{registry::resolvers::ResolvedValue, Error};
 pub(super) async fn execute(ctx: PostgresContext<'_>, operation: Operation) -> Result<ResolvedValue, Error> {
     match operation {
         Operation::FindOne => find_one::execute(ctx).await,
+        Operation::FindMany => find_many::execute(ctx).await,
     }
 }

--- a/engine/crates/engine/src/registry/resolvers/postgresql/request/find_many.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql/request/find_many.rs
@@ -1,0 +1,41 @@
+use super::query::{self, SelectBuilder};
+use crate::{
+    registry::resolvers::{
+        postgresql::context::{CollectionArgs, PostgresContext},
+        ResolvedValue,
+    },
+    Error,
+};
+use grafbase_sql_ast::renderer::{self, Renderer};
+use postgresql_types::transport::Transport;
+use serde_json::Value;
+
+#[derive(Debug, serde::Deserialize)]
+struct Response {
+    root: Value,
+}
+
+pub(crate) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, Error> {
+    let mut builder = SelectBuilder::new(ctx.table(), ctx.collection_selection(), "root");
+
+    builder.set_collection_args(CollectionArgs::new(&ctx, ctx.table(), &ctx.root_field()));
+
+    if let Ok(filter) = ctx.filter() {
+        builder.set_filter(filter);
+    }
+
+    let (sql, params) = renderer::Postgres::build(query::build(builder));
+
+    let response = ctx
+        .transport()
+        .parameterized_query::<Response>(&sql, params)
+        .await
+        .map_err(|error| Error::new(error.to_string()))?;
+
+    Ok(ResolvedValue::new(
+        response
+            .into_single_row()
+            .map(|row| row.root)
+            .unwrap_or(Value::Array(Vec::new())),
+    ))
+}

--- a/engine/crates/engine/src/registry/resolvers/postgresql/request/query.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql/request/query.rs
@@ -20,7 +20,7 @@ pub fn build<'a>(builder: SelectBuilder<'a>) -> Select<'a> {
     let mut inner_nested = Select::from_table(sql_table);
 
     if let Some(filters) = builder.filter() {
-        for filter in filters.clone() {
+        for filter in filters {
             inner_nested.and_where(filter);
         }
     }
@@ -108,14 +108,12 @@ pub fn build<'a>(builder: SelectBuilder<'a>) -> Select<'a> {
     let mut json_select = Select::from_table(Table::from(collecting_select).alias(builder.table().database_name()));
     json_select.value(row_to_json(builder.table().database_name(), false).alias(builder.field_name().to_string()));
 
-    if let Some(args) = builder.collection_args() {
-        for column in args.extra_columns() {
-            json_select.column(column.clone());
-        }
-    }
-
     match builder.collection_args() {
         Some(args) => {
+            for column in args.extra_columns() {
+                json_select.column(column.clone());
+            }
+
             // SQL doesn't guarantee ordering if it's not defined in the query.
             // we'll reuse the nested ordering here.
             if let Some((_, order_by)) = args.order_by() {

--- a/engine/crates/engine/src/registry/resolvers/postgresql/request/query/builder.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql/request/query/builder.rs
@@ -1,4 +1,4 @@
-use crate::registry::resolvers::postgresql::context::{CollectionArgs, SelectionIterator, SimpleFilterIterator};
+use crate::registry::resolvers::postgresql::context::{CollectionArgs, FilterIterator, SelectionIterator};
 use postgresql_types::database_definition::{RelationWalker, TableWalker};
 use std::borrow::Cow;
 
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 pub struct SelectBuilder<'a> {
     table: TableWalker<'a>,
     selection: SelectionIterator<'a>,
-    filter: Option<SimpleFilterIterator<'a>>,
+    filter: Option<FilterIterator<'a>>,
     collection_args: Option<CollectionArgs>,
     field_name: Cow<'static, str>,
     relation: Option<RelationWalker<'a>>,
@@ -32,7 +32,7 @@ impl<'a> SelectBuilder<'a> {
     }
 
     /// Adds a `WHERE` clause to the statement.
-    pub fn set_filter(&mut self, filter: SimpleFilterIterator<'a>) {
+    pub fn set_filter(&mut self, filter: FilterIterator<'a>) {
         self.filter = Some(filter);
     }
 
@@ -70,7 +70,7 @@ impl<'a> SelectBuilder<'a> {
     }
 
     /// The `WHERE` statement for this select.
-    pub fn filter(&self) -> Option<SimpleFilterIterator<'a>> {
+    pub fn filter(&self) -> Option<FilterIterator<'a>> {
         self.filter.clone()
     }
 

--- a/engine/crates/integration-tests/src/postgresql.rs
+++ b/engine/crates/integration-tests/src/postgresql.rs
@@ -192,6 +192,8 @@ impl TestApi {
     pub async fn execute(&self, operation: impl AsRef<str>) -> Response {
         self.inner
             .engine
+            // this prevents a race. we initialize the engine only when executing the first request,
+            // so the introspection runs only after we've modified the database schema.
             .get_or_init(async { Engine::new(self.inner.schema.clone()).await })
             .await
             .execute(operation.as_ref())

--- a/engine/crates/integration-tests/tests/postgresql/find_many.rs
+++ b/engine/crates/integration-tests/tests/postgresql/find_many.rs
@@ -1,0 +1,1541 @@
+use expect_test::expect;
+use indoc::indoc;
+use integration_tests::postgresql::{query_namespaced_neon, query_neon};
+
+#[test]
+fn eq_pk() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { id: { eq: 1 } }) {
+                edges { node { id name } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 1,
+                    "name": "Musti"
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn first() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(first: 1) {
+                edges { node { id name } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 1,
+                    "name": "Musti"
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn last() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(last: 1) {
+                edges { node { id name } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 2,
+                    "name": "Naukio"
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn order_by() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(orderBy: [{ name: DESC }]) {
+                edges { node { id name } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 2,
+                    "name": "Naukio"
+                  }
+                },
+                {
+                  "node": {
+                    "id": 1,
+                    "name": "Musti"
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn namespaced() {
+    let response = query_namespaced_neon("pg", |api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              pg {
+                userCollection(filter: { id: { eq: 1 } }) {
+                  edges { node { id name } }  
+                }
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "pg": {
+              "userCollection": {
+                "edges": [
+                  {
+                    "node": {
+                      "id": 1,
+                      "name": "Musti"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn eq_pk_rename() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id_field INT PRIMARY KEY,
+                name_field VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id_field, name_field) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { idField: { eq: 1 } }) {
+                edges { node { idField nameField } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "idField": 1,
+                    "nameField": "Musti"
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn string_eq() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { name: { eq: "Musti" } }) {
+                edges { node { id name } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 1,
+                    "name": "Musti"
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn array_eq() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                numbers INT[] NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, numbers) VALUES (1, '{1, 2}'), (2, '{3, 4}')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { numbers: { eq: [3, 4] } }) {
+                edges { node { id numbers } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 2,
+                    "numbers": [
+                      3,
+                      4
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn array_ne() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                numbers INT[] NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, numbers) VALUES (1, '{1, 2}'), (2, '{3, 4}')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { numbers: { ne: [3, 4] } }) {
+                edges { node { id numbers } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 1,
+                    "numbers": [
+                      1,
+                      2
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn array_gt() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                numbers INT[] NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, numbers) VALUES (1, '{1, 2}'), (2, '{3, 4}')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { numbers: { gt: [1, 2] } }) {
+                edges { node { id numbers } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 2,
+                    "numbers": [
+                      3,
+                      4
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn array_contains() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                numbers INT[] NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, numbers) VALUES (1, '{1, 2}'), (2, '{3, 4}')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { numbers: { contains: [1, 2, 2, 1] } }) {
+                edges { node { id numbers } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 1,
+                    "numbers": [
+                      1,
+                      2
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn array_contained() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                numbers INT[] NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, numbers) VALUES (1, '{1, 2}'), (2, '{3, 4}')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { numbers: { contained: [3, 6, 4, 7] } }) {
+                edges { node { id numbers } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 2,
+                    "numbers": [
+                      3,
+                      4
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn array_overlaps() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                numbers INT[] NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, numbers) VALUES (1, '{1, 2}'), (2, '{3, 4}')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { numbers: { overlaps: [1, 5, 5, 6] } }) {
+                edges { node { id numbers } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 1,
+                    "numbers": [
+                      1,
+                      2
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn two_field_eq() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL,
+                age INT NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name, age) VALUES (1, 'Musti', 11), (2, 'Musti', 12)
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { name: { eq: "Musti" }, age: { eq: 11 } }) {
+                edges { node { id name age } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 1,
+                    "name": "Musti",
+                    "age": 11
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn string_ne() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { name: { ne: "Musti" } }) {
+                edges { node { id name } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 2,
+                    "name": "Naukio"
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn string_gt() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { name: { gt: "Musti" } }) {
+                edges { node { id name } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 2,
+                    "name": "Naukio"
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn string_lt() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { name: { lt: "Naukio" } }) {
+                edges { node { id name } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 1,
+                    "name": "Musti"
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn string_gte() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { name: { gte: "Musti" } }) {
+                edges { node { id name } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 1,
+                    "name": "Musti"
+                  }
+                },
+                {
+                  "node": {
+                    "id": 2,
+                    "name": "Naukio"
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn string_lte() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { name: { lte: "Naukio" } }) {
+                edges { node { id name } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 1,
+                    "name": "Musti"
+                  }
+                },
+                {
+                  "node": {
+                    "id": 2,
+                    "name": "Naukio"
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn string_in() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { name: { in: ["Musti", "Naukio"] } }) {
+                edges { node { id name } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 1,
+                    "name": "Musti"
+                  }
+                },
+                {
+                  "node": {
+                    "id": 2,
+                    "name": "Naukio"
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn string_nin() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { name: { nin: ["Musti", "Naukio"] } }) {
+                edges { node { id name } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": []
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn all() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL,
+                age INT NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name, age) VALUES (1, 'Musti', 11), (2, 'Musti', 12)
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { ALL: [
+                { name: { eq: "Musti" } },
+                { age: { eq: 11 } }
+              ]}) {
+                edges { node { id name age } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 1,
+                    "name": "Musti",
+                    "age": 11
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn any() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL,
+                age INT NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name, age) VALUES (1, 'Musti', 12), (2, 'Naukio', 11)
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { ANY: [
+                { name: { eq: "Musti" } },
+                { age: { eq: 11 } }
+              ]}) {
+                edges { node { id name age } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 1,
+                    "name": "Musti",
+                    "age": 12
+                  }
+                },
+                {
+                  "node": {
+                    "id": 2,
+                    "name": "Naukio",
+                    "age": 11
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn none() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL,
+                age INT NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name, age) VALUES
+              (1, 'Musti', 11),
+              (2, 'Naukio', 12),
+              (3, 'Pentti', 13)
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { NONE: [
+                { name: { eq: "Musti" } },
+                { age: { eq: 13 } }
+              ]}) {
+                edges { node { id name age } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 2,
+                    "name": "Naukio",
+                    "age": 12
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn not() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL,
+                age INT NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name, age) VALUES
+              (1, 'Musti', 11),
+              (2, 'Naukio', 12),
+              (3, 'Pentti', 13)
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { name: { not: { eq: "Pentti" } } }) {
+                edges { node { id name age } }  
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 1,
+                    "name": "Musti",
+                    "age": 11
+                  }
+                },
+                {
+                  "node": {
+                    "id": 2,
+                    "name": "Naukio",
+                    "age": 12
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn one_to_one_relation_filter() {
+    let response = query_neon(|api| async move {
+        let user_table = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            );
+        "#};
+
+        api.execute_sql(user_table).await;
+
+        let profile_table = indoc! {r#"
+            CREATE TABLE "Profile" (
+                id INT PRIMARY KEY,
+                user_id INT NULL UNIQUE,
+                description TEXT NOT NULL,
+                CONSTRAINT Profile_User_fkey FOREIGN KEY (user_id) REFERENCES "User" (id)
+            )  
+        "#};
+
+        api.execute_sql(profile_table).await;
+
+        let insert_users = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES
+              (1, 'Musti'),
+              (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert_users).await;
+
+        let insert_profiles = indoc! {r#"
+            INSERT INTO "Profile" (id, user_id, description) VALUES
+              (1, 1, 'meowmeowmeow'),
+              (2, 2, 'purrpurrpurr')
+        "#};
+
+        api.execute_sql(insert_profiles).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { profile: { description: { eq: "purrpurrpurr" } } }) {
+                edges {
+                  node {
+                    id
+                    name
+                    profile { description }
+                  }
+                }
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 2,
+                    "name": "Naukio",
+                    "profile": {
+                      "description": "purrpurrpurr"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn one_to_many_relation_filter_child_side() {
+    let response = query_neon(|api| async move {
+        let user_table = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            );
+        "#};
+
+        api.execute_sql(user_table).await;
+
+        let profile_table = indoc! {r#"
+            CREATE TABLE "Blog" (
+                id INT PRIMARY KEY,
+                user_id INT NOT NULL,
+                title VARCHAR(255) NOT NULL,
+                CONSTRAINT Blog_User_fkey FOREIGN KEY (user_id) REFERENCES "User" (id)
+            )  
+        "#};
+
+        api.execute_sql(profile_table).await;
+
+        let insert_users = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES
+              (1, 'Musti'),
+              (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert_users).await;
+
+        let insert_profiles = indoc! {r#"
+            INSERT INTO "Blog" (id, user_id, title) VALUES
+              (1, 1, 'Hello, world!'),
+              (2, 1, 'Sayonara...'),
+              (3, 2, 'Meow meow?')
+        "#};
+
+        api.execute_sql(insert_profiles).await;
+
+        let query = indoc! {r#"
+            query {
+              blogCollection(filter: { user: { id: { eq: 1 } } }) {
+                edges {
+                  node {
+                    id
+                    title
+                    user { id name }
+                  }
+                }
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "blogCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 1,
+                    "title": "Hello, world!",
+                    "user": {
+                      "id": 1,
+                      "name": "Musti"
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "id": 2,
+                    "title": "Sayonara...",
+                    "user": {
+                      "id": 1,
+                      "name": "Musti"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn one_to_many_relation_filter_parent_side() {
+    let response = query_neon(|api| async move {
+        let user_table = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            );
+        "#};
+
+        api.execute_sql(user_table).await;
+
+        let profile_table = indoc! {r#"
+            CREATE TABLE "Blog" (
+                id INT PRIMARY KEY,
+                user_id INT NOT NULL,
+                title VARCHAR(255) NOT NULL,
+                CONSTRAINT Blog_User_fkey FOREIGN KEY (user_id) REFERENCES "User" (id)
+            )  
+        "#};
+
+        api.execute_sql(profile_table).await;
+
+        let insert_users = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES
+              (1, 'Musti'),
+              (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert_users).await;
+
+        let insert_profiles = indoc! {r#"
+            INSERT INTO "Blog" (id, user_id, title) VALUES
+              (1, 1, 'Hello, world!'),
+              (2, 1, 'Sayonara...'),
+              (3, 2, 'Meow meow?')
+        "#};
+
+        api.execute_sql(insert_profiles).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { blogs: { contains: { id: { eq: 1 } } } }) {
+                edges {
+                  node {
+                    id
+                    name
+                    blogs { edges { node { id title } } }
+                  }
+                }
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 1,
+                    "name": "Musti",
+                    "blogs": {
+                      "edges": [
+                        {
+                          "node": {
+                            "id": 1,
+                            "title": "Hello, world!"
+                          }
+                        },
+                        {
+                          "node": {
+                            "id": 2,
+                            "title": "Sayonara..."
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}

--- a/engine/crates/integration-tests/tests/postgresql/introspection.rs
+++ b/engine/crates/integration-tests/tests/postgresql/introspection.rs
@@ -15,11 +15,58 @@ fn table_with_serial_primary_key() {
     });
 
     let expected = expect![[r#"
+        """
+          Search filter input for Int type.
+        """
+        input IntSearchFilterInput {
+          """
+            The value is exactly the one given
+          """ eq: Int
+          """
+            The value is not the one given
+          """ ne: Int
+          """
+            The value is greater than the one given
+          """ gt: Int
+          """
+            The value is less than the one given
+          """ lt: Int
+          """
+            The value is greater than, or equal to the one given
+          """ gte: Int
+          """
+            The value is less than, or equal to the one given
+          """ lte: Int
+          """
+            The value is in the given array of values
+          """ in: [Int]
+          """
+            The value is not in the given array of values
+          """ nin: [Int]
+          not: IntSearchFilterInput
+        }
+
+        enum OrderByDirection {
+          ASC
+          DESC
+        }
+
+        type PageInfo {
+          hasNextPage: Boolean!
+          hasPreviousPage: Boolean!
+          startCursor: String
+          endCursor: String
+        }
+
         type Query {
           """
             Query a single User by a field
           """
           user(by: UserByInput!): User
+          """
+            Paginated query to fetch the whole list of User
+          """
+          userCollection(filter: UserCollection, first: Int, last: Int, before: String, after: String, orderBy: [UserOrderByInput]): UserConnection
         }
 
         type User {
@@ -28,6 +75,33 @@ fn table_with_serial_primary_key() {
 
         input UserByInput {
           id: Int
+        }
+
+        input UserCollection {
+          id: IntSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [UserCollection]
+          """
+            None of the filters must match
+          """ NONE: [UserCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [UserCollection]
+        }
+
+        type UserConnection {
+          edges: [UserEdge]!
+          pageInfo: PageInfo!
+        }
+
+        type UserEdge {
+          node: User!
+          cursor: String!
+        }
+
+        input UserOrderByInput {
+          id: OrderByDirection
         }
 
         schema {
@@ -67,11 +141,87 @@ fn table_with_enum_field() {
           id: Int
         }
 
+        input ACollection {
+          id: IntSearchFilterInput
+          val: StreetLightSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [ACollection]
+          """
+            None of the filters must match
+          """ NONE: [ACollection]
+          """
+            At least one of the filters must match
+          """ ANY: [ACollection]
+        }
+
+        type AConnection {
+          edges: [AEdge]!
+          pageInfo: PageInfo!
+        }
+
+        type AEdge {
+          node: A!
+          cursor: String!
+        }
+
+        input AOrderByInput {
+          id: OrderByDirection
+          val: OrderByDirection
+        }
+
+        """
+          Search filter input for Int type.
+        """
+        input IntSearchFilterInput {
+          """
+            The value is exactly the one given
+          """ eq: Int
+          """
+            The value is not the one given
+          """ ne: Int
+          """
+            The value is greater than the one given
+          """ gt: Int
+          """
+            The value is less than the one given
+          """ lt: Int
+          """
+            The value is greater than, or equal to the one given
+          """ gte: Int
+          """
+            The value is less than, or equal to the one given
+          """ lte: Int
+          """
+            The value is in the given array of values
+          """ in: [Int]
+          """
+            The value is not in the given array of values
+          """ nin: [Int]
+          not: IntSearchFilterInput
+        }
+
+        enum OrderByDirection {
+          ASC
+          DESC
+        }
+
+        type PageInfo {
+          hasNextPage: Boolean!
+          hasPreviousPage: Boolean!
+          startCursor: String
+          endCursor: String
+        }
+
         type Query {
           """
             Query a single A by a field
           """
           a(by: AByInput!): A
+          """
+            Paginated query to fetch the whole list of A
+          """
+          aCollection(filter: ACollection, first: Int, last: Int, before: String, after: String, orderBy: [AOrderByInput]): AConnection
         }
 
         enum StreetLight {
@@ -101,11 +251,58 @@ fn table_with_int_primary_key() {
     });
 
     let expected = expect![[r#"
+        """
+          Search filter input for Int type.
+        """
+        input IntSearchFilterInput {
+          """
+            The value is exactly the one given
+          """ eq: Int
+          """
+            The value is not the one given
+          """ ne: Int
+          """
+            The value is greater than the one given
+          """ gt: Int
+          """
+            The value is less than the one given
+          """ lt: Int
+          """
+            The value is greater than, or equal to the one given
+          """ gte: Int
+          """
+            The value is less than, or equal to the one given
+          """ lte: Int
+          """
+            The value is in the given array of values
+          """ in: [Int]
+          """
+            The value is not in the given array of values
+          """ nin: [Int]
+          not: IntSearchFilterInput
+        }
+
+        enum OrderByDirection {
+          ASC
+          DESC
+        }
+
+        type PageInfo {
+          hasNextPage: Boolean!
+          hasPreviousPage: Boolean!
+          startCursor: String
+          endCursor: String
+        }
+
         type Query {
           """
             Query a single User by a field
           """
           user(by: UserByInput!): User
+          """
+            Paginated query to fetch the whole list of User
+          """
+          userCollection(filter: UserCollection, first: Int, last: Int, before: String, after: String, orderBy: [UserOrderByInput]): UserConnection
         }
 
         type User {
@@ -114,6 +311,33 @@ fn table_with_int_primary_key() {
 
         input UserByInput {
           id: Int
+        }
+
+        input UserCollection {
+          id: IntSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [UserCollection]
+          """
+            None of the filters must match
+          """ NONE: [UserCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [UserCollection]
+        }
+
+        type UserConnection {
+          edges: [UserEdge]!
+          pageInfo: PageInfo!
+        }
+
+        type UserEdge {
+          node: User!
+          cursor: String!
+        }
+
+        input UserOrderByInput {
+          id: OrderByDirection
         }
 
         schema {
@@ -137,11 +361,58 @@ fn table_with_int_unique() {
     });
 
     let expected = expect![[r#"
+        """
+          Search filter input for Int type.
+        """
+        input IntSearchFilterInput {
+          """
+            The value is exactly the one given
+          """ eq: Int
+          """
+            The value is not the one given
+          """ ne: Int
+          """
+            The value is greater than the one given
+          """ gt: Int
+          """
+            The value is less than the one given
+          """ lt: Int
+          """
+            The value is greater than, or equal to the one given
+          """ gte: Int
+          """
+            The value is less than, or equal to the one given
+          """ lte: Int
+          """
+            The value is in the given array of values
+          """ in: [Int]
+          """
+            The value is not in the given array of values
+          """ nin: [Int]
+          not: IntSearchFilterInput
+        }
+
+        enum OrderByDirection {
+          ASC
+          DESC
+        }
+
+        type PageInfo {
+          hasNextPage: Boolean!
+          hasPreviousPage: Boolean!
+          startCursor: String
+          endCursor: String
+        }
+
         type Query {
           """
             Query a single User by a field
           """
           user(by: UserByInput!): User
+          """
+            Paginated query to fetch the whole list of User
+          """
+          userCollection(filter: UserCollection, first: Int, last: Int, before: String, after: String, orderBy: [UserOrderByInput]): UserConnection
         }
 
         type User {
@@ -150,6 +421,33 @@ fn table_with_int_unique() {
 
         input UserByInput {
           id: Int
+        }
+
+        input UserCollection {
+          id: IntSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [UserCollection]
+          """
+            None of the filters must match
+          """ NONE: [UserCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [UserCollection]
+        }
+
+        type UserConnection {
+          edges: [UserEdge]!
+          pageInfo: PageInfo!
+        }
+
+        type UserEdge {
+          node: User!
+          cursor: String!
+        }
+
+        input UserOrderByInput {
+          id: OrderByDirection
         }
 
         schema {
@@ -174,11 +472,89 @@ fn table_with_serial_primary_key_string_unique() {
     });
 
     let expected = expect![[r#"
+        """
+          Search filter input for Int type.
+        """
+        input IntSearchFilterInput {
+          """
+            The value is exactly the one given
+          """ eq: Int
+          """
+            The value is not the one given
+          """ ne: Int
+          """
+            The value is greater than the one given
+          """ gt: Int
+          """
+            The value is less than the one given
+          """ lt: Int
+          """
+            The value is greater than, or equal to the one given
+          """ gte: Int
+          """
+            The value is less than, or equal to the one given
+          """ lte: Int
+          """
+            The value is in the given array of values
+          """ in: [Int]
+          """
+            The value is not in the given array of values
+          """ nin: [Int]
+          not: IntSearchFilterInput
+        }
+
+        enum OrderByDirection {
+          ASC
+          DESC
+        }
+
+        type PageInfo {
+          hasNextPage: Boolean!
+          hasPreviousPage: Boolean!
+          startCursor: String
+          endCursor: String
+        }
+
         type Query {
           """
             Query a single User by a field
           """
           user(by: UserByInput!): User
+          """
+            Paginated query to fetch the whole list of User
+          """
+          userCollection(filter: UserCollection, first: Int, last: Int, before: String, after: String, orderBy: [UserOrderByInput]): UserConnection
+        }
+
+        """
+          Search filter input for String type.
+        """
+        input StringSearchFilterInput {
+          """
+            The value is exactly the one given
+          """ eq: String
+          """
+            The value is not the one given
+          """ ne: String
+          """
+            The value is greater than the one given
+          """ gt: String
+          """
+            The value is less than the one given
+          """ lt: String
+          """
+            The value is greater than, or equal to the one given
+          """ gte: String
+          """
+            The value is less than, or equal to the one given
+          """ lte: String
+          """
+            The value is in the given array of values
+          """ in: [String]
+          """
+            The value is not in the given array of values
+          """ nin: [String]
+          not: StringSearchFilterInput
         }
 
         type User {
@@ -189,6 +565,35 @@ fn table_with_serial_primary_key_string_unique() {
         input UserByInput {
           email: String
           id: Int
+        }
+
+        input UserCollection {
+          id: IntSearchFilterInput
+          email: StringSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [UserCollection]
+          """
+            None of the filters must match
+          """ NONE: [UserCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [UserCollection]
+        }
+
+        type UserConnection {
+          edges: [UserEdge]!
+          pageInfo: PageInfo!
+        }
+
+        type UserEdge {
+          node: User!
+          cursor: String!
+        }
+
+        input UserOrderByInput {
+          id: OrderByDirection
+          email: OrderByDirection
         }
 
         schema {
@@ -214,11 +619,58 @@ fn table_with_composite_primary_key() {
     });
 
     let expected = expect![[r#"
+        enum OrderByDirection {
+          ASC
+          DESC
+        }
+
+        type PageInfo {
+          hasNextPage: Boolean!
+          hasPreviousPage: Boolean!
+          startCursor: String
+          endCursor: String
+        }
+
         type Query {
           """
             Query a single User by a field
           """
           user(by: UserByInput!): User
+          """
+            Paginated query to fetch the whole list of User
+          """
+          userCollection(filter: UserCollection, first: Int, last: Int, before: String, after: String, orderBy: [UserOrderByInput]): UserConnection
+        }
+
+        """
+          Search filter input for String type.
+        """
+        input StringSearchFilterInput {
+          """
+            The value is exactly the one given
+          """ eq: String
+          """
+            The value is not the one given
+          """ ne: String
+          """
+            The value is greater than the one given
+          """ gt: String
+          """
+            The value is less than the one given
+          """ lt: String
+          """
+            The value is greater than, or equal to the one given
+          """ gte: String
+          """
+            The value is less than, or equal to the one given
+          """ lte: String
+          """
+            The value is in the given array of values
+          """ in: [String]
+          """
+            The value is not in the given array of values
+          """ nin: [String]
+          not: StringSearchFilterInput
         }
 
         type User {
@@ -230,9 +682,38 @@ fn table_with_composite_primary_key() {
           nameEmail: UserNameEmailInput
         }
 
+        input UserCollection {
+          name: StringSearchFilterInput
+          email: StringSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [UserCollection]
+          """
+            None of the filters must match
+          """ NONE: [UserCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [UserCollection]
+        }
+
+        type UserConnection {
+          edges: [UserEdge]!
+          pageInfo: PageInfo!
+        }
+
+        type UserEdge {
+          node: User!
+          cursor: String!
+        }
+
         input UserNameEmailInput {
           name: String!
           email: String!
+        }
+
+        input UserOrderByInput {
+          name: OrderByDirection
+          email: OrderByDirection
         }
 
         schema {
@@ -266,12 +747,82 @@ fn two_schemas_same_table_name() {
     });
 
     let expected = expect![[r#"
+        """
+          Search filter input for Int type.
+        """
+        input IntSearchFilterInput {
+          """
+            The value is exactly the one given
+          """ eq: Int
+          """
+            The value is not the one given
+          """ ne: Int
+          """
+            The value is greater than the one given
+          """ gt: Int
+          """
+            The value is less than the one given
+          """ lt: Int
+          """
+            The value is greater than, or equal to the one given
+          """ gte: Int
+          """
+            The value is less than, or equal to the one given
+          """ lte: Int
+          """
+            The value is in the given array of values
+          """ in: [Int]
+          """
+            The value is not in the given array of values
+          """ nin: [Int]
+          not: IntSearchFilterInput
+        }
+
+        enum OrderByDirection {
+          ASC
+          DESC
+        }
+
+        type PageInfo {
+          hasNextPage: Boolean!
+          hasPreviousPage: Boolean!
+          startCursor: String
+          endCursor: String
+        }
+
         type PrivateUser {
           id: Int!
         }
 
         input PrivateUserByInput {
           id: Int
+        }
+
+        input PrivateUserCollection {
+          id: IntSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [PrivateUserCollection]
+          """
+            None of the filters must match
+          """ NONE: [PrivateUserCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [PrivateUserCollection]
+        }
+
+        type PrivateUserConnection {
+          edges: [PrivateUserEdge]!
+          pageInfo: PageInfo!
+        }
+
+        type PrivateUserEdge {
+          node: PrivateUser!
+          cursor: String!
+        }
+
+        input PrivateUserOrderByInput {
+          id: OrderByDirection
         }
 
         type PublicUser {
@@ -282,15 +833,50 @@ fn two_schemas_same_table_name() {
           id: Int
         }
 
+        input PublicUserCollection {
+          id: IntSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [PublicUserCollection]
+          """
+            None of the filters must match
+          """ NONE: [PublicUserCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [PublicUserCollection]
+        }
+
+        type PublicUserConnection {
+          edges: [PublicUserEdge]!
+          pageInfo: PageInfo!
+        }
+
+        type PublicUserEdge {
+          node: PublicUser!
+          cursor: String!
+        }
+
+        input PublicUserOrderByInput {
+          id: OrderByDirection
+        }
+
         type Query {
           """
             Query a single PrivateUser by a field
           """
           privateUser(by: PrivateUserByInput!): PrivateUser
           """
+            Paginated query to fetch the whole list of PrivateUser
+          """
+          privateUserCollection(filter: PrivateUserCollection, first: Int, last: Int, before: String, after: String, orderBy: [PrivateUserOrderByInput]): PrivateUserConnection
+          """
             Query a single PublicUser by a field
           """
           publicUser(by: PublicUserByInput!): PublicUser
+          """
+            Paginated query to fetch the whole list of PublicUser
+          """
+          publicUserCollection(filter: PublicUserCollection, first: Int, last: Int, before: String, after: String, orderBy: [PublicUserOrderByInput]): PublicUserConnection
         }
 
         schema {
@@ -314,11 +900,51 @@ fn table_with_serial_primary_key_namespaced() {
     });
 
     let expected = expect![[r#"
+        """
+          Search filter input for Int type.
+        """
+        input NeonIntSearchFilterInput {
+          """
+            The value is exactly the one given
+          """ eq: Int
+          """
+            The value is not the one given
+          """ ne: Int
+          """
+            The value is greater than the one given
+          """ gt: Int
+          """
+            The value is less than the one given
+          """ lt: Int
+          """
+            The value is greater than, or equal to the one given
+          """ gte: Int
+          """
+            The value is less than, or equal to the one given
+          """ lte: Int
+          """
+            The value is in the given array of values
+          """ in: [Int]
+          """
+            The value is not in the given array of values
+          """ nin: [Int]
+          not: NeonIntSearchFilterInput
+        }
+
+        enum NeonOrderByDirection {
+          ASC
+          DESC
+        }
+
         type NeonQuery {
           """
             Query a single NeonUser by a field
           """
           user(by: NeonUserByInput!): NeonUser
+          """
+            Paginated query to fetch the whole list of User
+          """
+          userCollection(filter: NeonUserCollection, first: Int, last: Int, before: String, after: String, orderBy: [NeonUserOrderByInput]): NeonUserConnection
         }
 
         type NeonUser {
@@ -327,6 +953,40 @@ fn table_with_serial_primary_key_namespaced() {
 
         input NeonUserByInput {
           id: Int
+        }
+
+        input NeonUserCollection {
+          id: NeonIntSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [NeonUserCollection]
+          """
+            None of the filters must match
+          """ NONE: [NeonUserCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [NeonUserCollection]
+        }
+
+        type NeonUserConnection {
+          edges: [NeonUserEdge]!
+          pageInfo: PageInfo!
+        }
+
+        type NeonUserEdge {
+          node: NeonUser!
+          cursor: String!
+        }
+
+        input NeonUserOrderByInput {
+          id: NeonOrderByDirection
+        }
+
+        type PageInfo {
+          hasNextPage: Boolean!
+          hasPreviousPage: Boolean!
+          startCursor: String
+          endCursor: String
         }
 
         type Query {
@@ -379,6 +1039,27 @@ fn two_tables_with_single_column_foreign_key() {
           id: Int
         }
 
+        input BlogCollection {
+          id: IntSearchFilterInput
+          title: StringSearchFilterInput
+          content: StringSearchFilterInput
+          userId: IntSearchFilterInput
+          user: UserCollection
+          """
+            All of the filters must match
+          """ ALL: [BlogCollection]
+          """
+            None of the filters must match
+          """ NONE: [BlogCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [BlogCollection]
+        }
+
+        input BlogCollectionContains {
+          contains: BlogCollection
+        }
+
         type BlogConnection {
           edges: [BlogEdge]!
           pageInfo: PageInfo!
@@ -394,6 +1075,37 @@ fn two_tables_with_single_column_foreign_key() {
           title: OrderByDirection
           content: OrderByDirection
           userId: OrderByDirection
+        }
+
+        """
+          Search filter input for Int type.
+        """
+        input IntSearchFilterInput {
+          """
+            The value is exactly the one given
+          """ eq: Int
+          """
+            The value is not the one given
+          """ ne: Int
+          """
+            The value is greater than the one given
+          """ gt: Int
+          """
+            The value is less than the one given
+          """ lt: Int
+          """
+            The value is greater than, or equal to the one given
+          """ gte: Int
+          """
+            The value is less than, or equal to the one given
+          """ lte: Int
+          """
+            The value is in the given array of values
+          """ in: [Int]
+          """
+            The value is not in the given array of values
+          """ nin: [Int]
+          not: IntSearchFilterInput
         }
 
         enum OrderByDirection {
@@ -414,9 +1126,48 @@ fn two_tables_with_single_column_foreign_key() {
           """
           blog(by: BlogByInput!): Blog
           """
+            Paginated query to fetch the whole list of Blog
+          """
+          blogCollection(filter: BlogCollection, first: Int, last: Int, before: String, after: String, orderBy: [BlogOrderByInput]): BlogConnection
+          """
             Query a single User by a field
           """
           user(by: UserByInput!): User
+          """
+            Paginated query to fetch the whole list of User
+          """
+          userCollection(filter: UserCollection, first: Int, last: Int, before: String, after: String, orderBy: [UserOrderByInput]): UserConnection
+        }
+
+        """
+          Search filter input for String type.
+        """
+        input StringSearchFilterInput {
+          """
+            The value is exactly the one given
+          """ eq: String
+          """
+            The value is not the one given
+          """ ne: String
+          """
+            The value is greater than the one given
+          """ gt: String
+          """
+            The value is less than the one given
+          """ lt: String
+          """
+            The value is greater than, or equal to the one given
+          """ gte: String
+          """
+            The value is less than, or equal to the one given
+          """ lte: String
+          """
+            The value is in the given array of values
+          """ in: [String]
+          """
+            The value is not in the given array of values
+          """ nin: [String]
+          not: StringSearchFilterInput
         }
 
         type User {
@@ -427,6 +1178,36 @@ fn two_tables_with_single_column_foreign_key() {
 
         input UserByInput {
           id: Int
+        }
+
+        input UserCollection {
+          id: IntSearchFilterInput
+          name: StringSearchFilterInput
+          blogs: BlogCollectionContains
+          """
+            All of the filters must match
+          """ ALL: [UserCollection]
+          """
+            None of the filters must match
+          """ NONE: [UserCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [UserCollection]
+        }
+
+        type UserConnection {
+          edges: [UserEdge]!
+          pageInfo: PageInfo!
+        }
+
+        type UserEdge {
+          node: User!
+          cursor: String!
+        }
+
+        input UserOrderByInput {
+          id: OrderByDirection
+          name: OrderByDirection
         }
 
         schema {

--- a/engine/crates/integration-tests/tests/postgresql/mod.rs
+++ b/engine/crates/integration-tests/tests/postgresql/mod.rs
@@ -1,2 +1,3 @@
+mod find_many;
 mod find_one;
 mod introspection;

--- a/engine/crates/parser-postgresql/src/registry/context/input.rs
+++ b/engine/crates/parser-postgresql/src/registry/context/input.rs
@@ -29,6 +29,15 @@ impl<'a> InputContext<'a> {
         }
     }
 
+    pub(crate) fn filter_type_name(&self, scalar: &str) -> String {
+        let base = format!("{scalar}_search_filter_input");
+
+        match self.namespace {
+            Some(namespace) => format!("{namespace}_{base}").to_pascal_case(),
+            None => base.to_pascal_case(),
+        }
+    }
+
     pub(crate) fn connection_type_name(&self, name: &str) -> String {
         let base_name = format!("{name}Connection");
 
@@ -36,6 +45,10 @@ impl<'a> InputContext<'a> {
             Some(namespace) => format!("{namespace}_{base_name}").to_pascal_case(),
             None => base_name,
         }
+    }
+
+    pub(crate) fn collection_query_name(&self, type_name: &str) -> String {
+        format!("{type_name}_Collection").to_camel_case()
     }
 
     pub(crate) fn edge_type_name(&self, name: &str) -> String {

--- a/engine/crates/parser-postgresql/src/registry/context/output.rs
+++ b/engine/crates/parser-postgresql/src/registry/context/output.rs
@@ -83,6 +83,7 @@ impl OutputContext {
 
         self.type_mapping.extend(builder.type_mapping);
         self.field_mapping.extend(builder.field_mapping);
+        self.relation_mapping.extend(builder.relation_mapping);
 
         self.registry
             .create_type(|_| builder.input_object_type.into(), name, name);

--- a/engine/crates/parser-postgresql/src/registry/context/output/builders.rs
+++ b/engine/crates/parser-postgresql/src/registry/context/output/builders.rs
@@ -23,6 +23,10 @@ impl ObjectTypeBuilder {
 
     pub(crate) fn push_scalar_field(&mut self, field: MetaField, column_id: TableColumnId) {
         self.field_mapping.push((field.name.to_string(), column_id));
+        self.push_non_mapped_scalar_field(field);
+    }
+
+    pub(crate) fn push_non_mapped_scalar_field(&mut self, field: MetaField) {
         self.object_type.fields.insert(field.name.to_string(), field);
     }
 
@@ -41,6 +45,7 @@ pub struct InputTypeBuilder {
     pub(super) input_object_type: InputObjectType,
     pub(super) type_mapping: Vec<(String, TableId)>,
     pub(super) field_mapping: Vec<(String, TableColumnId)>,
+    pub(super) relation_mapping: Vec<(String, RelationId)>,
     pub(super) nested: Vec<InputObjectType>,
 }
 
@@ -52,12 +57,17 @@ impl InputTypeBuilder {
             input_object_type: InputObjectType::new(name.clone(), []),
             type_mapping: vec![(name, table_id)],
             field_mapping: Vec::new(),
+            relation_mapping: Vec::new(),
             nested: Vec::new(),
         }
     }
 
     pub(crate) fn push_input_column(&mut self, value: MetaInputValue, column_id: TableColumnId) {
         self.field_mapping.push((value.name.to_string(), column_id));
+        self.push_non_mapped_input_column(value);
+    }
+
+    pub(crate) fn push_non_mapped_input_column(&mut self, value: MetaInputValue) {
         self.push_input_value(value);
     }
 
@@ -65,6 +75,11 @@ impl InputTypeBuilder {
         self.input_object_type
             .input_fields
             .insert(value.name.to_string(), value);
+    }
+
+    pub(crate) fn push_input_relation(&mut self, value: MetaInputValue, id: RelationId) {
+        self.relation_mapping.push((value.name.clone(), id));
+        self.push_non_mapped_input_column(value);
     }
 
     pub(crate) fn oneof(&mut self, value: bool) {

--- a/engine/crates/parser-postgresql/src/registry/queries.rs
+++ b/engine/crates/parser-postgresql/src/registry/queries.rs
@@ -1,3 +1,4 @@
+mod find_many;
 mod find_one;
 mod input;
 
@@ -10,8 +11,10 @@ pub(super) fn generate(input_ctx: &InputContext<'_>, output_ctx: &mut OutputCont
         .filter(|table| table.allowed_in_client());
 
     for table in tables {
-        let filter_oneof_type = input::register_oneof_filter(input_ctx, table, output_ctx);
+        let filter_oneof_type = input::oneof::register(input_ctx, table, output_ctx);
+        let filter_type = input::filter::register(input_ctx, table, output_ctx);
 
         find_one::register(input_ctx, table, &filter_oneof_type, output_ctx);
+        find_many::register(input_ctx, table, &filter_type, output_ctx);
     }
 }

--- a/engine/crates/parser-postgresql/src/registry/queries/find_many.rs
+++ b/engine/crates/parser-postgresql/src/registry/queries/find_many.rs
@@ -1,0 +1,45 @@
+use common_types::auth::Operations;
+use engine::{
+    indexmap::IndexMap,
+    registry::{
+        resolvers::{
+            postgresql::{Operation, PostgresResolver},
+            Resolver,
+        },
+        MetaField, MetaInputValue,
+    },
+};
+use postgresql_types::database_definition::TableWalker;
+
+use crate::registry::context::{InputContext, OutputContext};
+
+pub(crate) fn register(
+    input_ctx: &InputContext<'_>,
+    table: TableWalker<'_>,
+    filter_type: &str,
+    output_ctx: &mut OutputContext,
+) {
+    let type_name = table.client_name();
+    let field_name = input_ctx.collection_query_name(type_name);
+    let output_type = input_ctx.connection_type_name(type_name);
+
+    let mut field = MetaField::new(field_name, output_type.as_str());
+    field.description = Some(format!("Paginated query to fetch the whole list of {type_name}"));
+
+    field.args = IndexMap::from([
+        ("filter".to_string(), MetaInputValue::new("filter", filter_type)),
+        ("first".to_string(), MetaInputValue::new("first", "Int")),
+        ("last".to_string(), MetaInputValue::new("last", "Int")),
+        ("before".to_string(), MetaInputValue::new("before", "String")),
+        ("after".to_string(), MetaInputValue::new("after", "String")),
+    ]);
+
+    let order_by_type = input_ctx.orderby_input_type_name(type_name);
+    let order_by_value = MetaInputValue::new("orderBy", format!("[{order_by_type}]"));
+    field.args.insert("orderBy".to_string(), order_by_value);
+
+    field.resolver = Resolver::PostgresResolver(PostgresResolver::new(Operation::FindMany, input_ctx.directive_name()));
+    field.required_operation = Some(Operations::LIST);
+
+    output_ctx.push_query(field);
+}

--- a/engine/crates/parser-postgresql/src/registry/queries/input.rs
+++ b/engine/crates/parser-postgresql/src/registry/queries/input.rs
@@ -1,54 +1,9 @@
-use std::borrow::Cow;
+pub(super) mod filter;
+pub(super) mod oneof;
 
 use engine::registry::MetaInputValue;
-use inflector::Inflector;
-use itertools::Itertools;
-use postgresql_types::database_definition::{TableColumnWalker, TableWalker};
-
-use crate::registry::context::{InputContext, OutputContext};
-
-pub(super) fn register_oneof_filter(
-    input_ctx: &InputContext<'_>,
-    table: TableWalker<'_>,
-    output_ctx: &mut OutputContext,
-) -> String {
-    let type_name = input_ctx.type_name(table.client_name());
-    let input_type_name = format!("{type_name}ByInput");
-
-    output_ctx.with_input_type(&input_type_name, table.id(), move |builder| {
-        builder.oneof(true);
-
-        for constraint in table.unique_constraints() {
-            if constraint.columns().len() > 1 {
-                let type_prefix = constraint
-                    .columns()
-                    .map(|column| column.table_column().client_name())
-                    .join("_");
-
-                let input_type_name = format!("{type_name}_{type_prefix}_Input").to_pascal_case();
-
-                builder.with_input_type(&input_type_name, table.id(), move |builder| {
-                    for column in constraint.columns() {
-                        let column = column.table_column();
-                        let input_value = input_value_from_column(column, false);
-                        builder.push_input_column(input_value, column.id());
-                    }
-                });
-
-                let query_name = type_prefix.to_camel_case();
-
-                builder.push_input_value(MetaInputValue::new(query_name, input_type_name));
-            } else if let Some(column) = constraint.columns().next() {
-                let input_value = input_value_from_column(column.table_column(), true);
-                builder.push_input_column(input_value, column.table_column().id());
-            } else {
-                continue;
-            }
-        }
-    });
-
-    input_type_name
-}
+use postgresql_types::database_definition::TableColumnWalker;
+use std::borrow::Cow;
 
 fn input_value_from_column(column: TableColumnWalker<'_>, oneof: bool) -> MetaInputValue {
     let mut client_type = column

--- a/engine/crates/parser-postgresql/src/registry/queries/input/filter.rs
+++ b/engine/crates/parser-postgresql/src/registry/queries/input/filter.rs
@@ -1,0 +1,64 @@
+use engine::registry::MetaInputValue;
+use postgresql_types::database_definition::TableWalker;
+
+use crate::registry::context::{InputContext, OutputContext};
+
+const LOGICAL_OPERATIONS: &[(&str, &str)] = &[
+    ("ALL", "All of the filters must match"),
+    ("NONE", "None of the filters must match"),
+    ("ANY", "At least one of the filters must match"),
+];
+
+pub(crate) fn register(input_ctx: &InputContext<'_>, table: TableWalker<'_>, output_ctx: &mut OutputContext) -> String {
+    let type_name = input_ctx.type_name(table.client_name());
+    let input_type_name = format!("{type_name}Collection");
+
+    output_ctx.with_input_type(&input_type_name, table.id(), |builder| {
+        for column in table.columns() {
+            let scalar = column
+                .graphql_base_type()
+                .expect("unsupported types are filtered out at this point");
+
+            let type_name = if column.is_array() {
+                input_ctx.filter_type_name(&format!("{scalar}Array"))
+            } else {
+                input_ctx.filter_type_name(&scalar)
+            };
+
+            let input = MetaInputValue::new(column.client_name(), type_name.as_ref())
+                .with_rename(Some(column.database_name().to_string()));
+
+            builder.push_input_column(input, column.id());
+        }
+
+        for relation in table.relations() {
+            let mut type_name = format!(
+                "{}Collection",
+                input_ctx.type_name(relation.referenced_table().client_name())
+            );
+
+            if !relation.is_referenced_row_unique() {
+                type_name = format!("{type_name}Contains");
+            }
+
+            let input = MetaInputValue::new(relation.client_field_name(), type_name.as_ref());
+
+            builder.push_input_relation(input, relation.id());
+        }
+
+        for (name, description) in LOGICAL_OPERATIONS {
+            let r#type = format!("[{input_type_name}]");
+            let input = MetaInputValue::new(*name, r#type).with_description(*description);
+
+            builder.push_non_mapped_input_column(input);
+        }
+
+        let contains_type_name = format!("{input_type_name}Contains");
+        builder.with_input_type(&contains_type_name, table.id(), |builder| {
+            let value = MetaInputValue::new("contains", input_type_name.as_ref());
+            builder.push_non_mapped_input_column(value);
+        })
+    });
+
+    input_type_name
+}

--- a/engine/crates/parser-postgresql/src/registry/queries/input/oneof.rs
+++ b/engine/crates/parser-postgresql/src/registry/queries/input/oneof.rs
@@ -1,0 +1,44 @@
+use crate::registry::context::{InputContext, OutputContext};
+use engine::registry::MetaInputValue;
+use inflector::Inflector;
+use itertools::Itertools;
+use postgresql_types::database_definition::TableWalker;
+
+pub(crate) fn register(input_ctx: &InputContext<'_>, table: TableWalker<'_>, output_ctx: &mut OutputContext) -> String {
+    let type_name = input_ctx.type_name(table.client_name());
+    let input_type_name = format!("{type_name}ByInput");
+
+    output_ctx.with_input_type(&input_type_name, table.id(), move |builder| {
+        builder.oneof(true);
+
+        for constraint in table.unique_constraints() {
+            if constraint.columns().len() > 1 {
+                let type_prefix = constraint
+                    .columns()
+                    .map(|column| column.table_column().client_name())
+                    .join("_");
+
+                let input_type_name = format!("{type_name}_{type_prefix}_Input").to_pascal_case();
+
+                builder.with_input_type(&input_type_name, table.id(), move |builder| {
+                    for column in constraint.columns() {
+                        let column = column.table_column();
+                        let input_value = super::input_value_from_column(column, false);
+                        builder.push_input_column(input_value, column.id());
+                    }
+                });
+
+                let query_name = type_prefix.to_camel_case();
+
+                builder.push_input_value(MetaInputValue::new(query_name, input_type_name));
+            } else if let Some(column) = constraint.columns().next() {
+                let input_value = super::input_value_from_column(column.table_column(), true);
+                builder.push_input_column(input_value, column.table_column().id());
+            } else {
+                continue;
+            }
+        }
+    });
+
+    input_type_name
+}

--- a/engine/crates/parser-postgresql/src/registry/types/scalar.rs
+++ b/engine/crates/parser-postgresql/src/registry/types/scalar.rs
@@ -1,0 +1,125 @@
+use engine::registry::{InputObjectType, MetaInputValue};
+
+use crate::registry::context::{InputContext, OutputContext};
+
+static SCALARS: &[&str] = &[
+    "Boolean",
+    "BigInt",
+    "UnsignedBigInt",
+    "Bytes",
+    "Decimal",
+    "Date",
+    "DateTime",
+    "Float",
+    "ID",
+    "Int",
+    "JSON",
+    "PhoneNumber",
+    "String",
+    "URL",
+    "Uuid",
+    "IPAddress",
+    "NaiveDateTime",
+    "Time",
+];
+
+pub(super) fn register(input_ctx: &InputContext<'_>, output_ctx: &mut OutputContext) {
+    static SCALAR_FILTERS: &[(&str, &str, &str)] = &[
+        ("eq", "=", "The value is exactly the one given"),
+        ("ne", "<>", "The value is not the one given"),
+        ("gt", ">", "The value is greater than the one given"),
+        ("lt", "<", "The value is less than the one given"),
+        ("gte", ">=", "The value is greater than, or equal to the one given"),
+        ("lte", "<=", "The value is less than, or equal to the one given"),
+    ];
+
+    for scalar in SCALARS {
+        let type_name = input_ctx.filter_type_name(scalar);
+        let mut fields = Vec::with_capacity(SCALAR_FILTERS.len() + 2);
+
+        for (filter, mapped_name, description) in SCALAR_FILTERS {
+            let mut input = MetaInputValue::new(*filter, *scalar);
+            input.description = Some(String::from(*description));
+            input.rename = Some((*mapped_name).to_string());
+
+            fields.push(input);
+        }
+
+        fields.push({
+            let mut input = MetaInputValue::new("in", format!("[{scalar}]"));
+            input.description = Some(String::from("The value is in the given array of values"));
+
+            input
+        });
+
+        fields.push({
+            let mut input = MetaInputValue::new("nin", format!("[{scalar}]"));
+            input.description = Some(String::from("The value is not in the given array of values"));
+
+            input
+        });
+
+        fields.push(MetaInputValue::new("not", type_name.as_str()));
+
+        let description = format!("Search filter input for {scalar} type.");
+        let input_type = InputObjectType::new(type_name.clone(), fields).with_description(Some(description));
+
+        output_ctx.create_input_type(input_type);
+    }
+
+    // arrays
+    for scalar in SCALARS {
+        let type_name = input_ctx.filter_type_name(&format!("{scalar}Array"));
+        let mut fields = Vec::with_capacity(SCALAR_FILTERS.len() + 2);
+
+        for (filter, mapped_name, description) in SCALAR_FILTERS {
+            let mut input = MetaInputValue::new(*filter, format!("[{scalar}]"));
+            input.description = Some(String::from(*description));
+            input.rename = Some((*mapped_name).to_string());
+
+            fields.push(input);
+        }
+
+        fields.push({
+            let mut input = MetaInputValue::new("in", format!("[[{scalar}]]"));
+            input.description = Some(String::from("The value is in the given array of values"));
+
+            input
+        });
+
+        fields.push({
+            let mut input = MetaInputValue::new("nin", format!("[[{scalar}]]"));
+            input.description = Some(String::from("The value is not in the given array of values"));
+
+            input
+        });
+
+        fields.push({
+            let mut input = MetaInputValue::new("contains", format!("[{scalar}]"));
+            input.description = Some(String::from("The column contains all elements from the given array."));
+
+            input
+        });
+
+        fields.push({
+            let mut input = MetaInputValue::new("contained", format!("[{scalar}]"));
+            input.description = Some(String::from("The given array contains all elements from the column."));
+
+            input
+        });
+
+        fields.push({
+            let mut input = MetaInputValue::new("overlaps", format!("[{scalar}]"));
+            input.description = Some(String::from("Do the arrays have any elements in common."));
+
+            input
+        });
+
+        fields.push(MetaInputValue::new("not", type_name.as_str()));
+
+        let description = format!("Search filter input for {scalar} type.");
+        let input_type = InputObjectType::new(type_name.clone(), fields).with_description(Some(description));
+
+        output_ctx.create_input_type(input_type);
+    }
+}

--- a/engine/crates/postgresql-types/src/database_definition/walkers/table_column.rs
+++ b/engine/crates/postgresql-types/src/database_definition/walkers/table_column.rs
@@ -30,6 +30,12 @@ impl<'a> TableColumnWalker<'a> {
         }
     }
 
+    /// The base type without possible array notation.
+    pub fn graphql_base_type(self) -> Option<String> {
+        self.graphql_type()
+            .map(|graphql_type| graphql_type.trim_start_matches('[').trim_end_matches(']').to_string())
+    }
+
     /// The type of this column in the GraphQL APIs.
     ///
     /// Returns `None`, if we don't support the database type yet.


### PR DESCRIPTION
Tests are over 2k lines, so this one is finally under 1k for the feature :)

```graphql
query {
  userCollection(filter: { id: { eq: 1 } }) {
    edges { node { id name } }  
  }
}
```

Nested filters from n:1 side:

```graphql
query {
  userCollection(filter: { profile: { id: { eq: 1 } } }) {
    edges {
      node {
        id
        name
        profile { description }
      }
    }
  }
}
```

And from 1:n side:

```graphql
query {
  userCollection(filter: { blogs: { contains: { id: { eq: 1 } } } }) {
    edges {
      node {
        id
        name
        blogs { edges { node { id title } } }
      }
    }
  }
}
```

Arrays have few postgres-specific operations:

- `contains`: if the column array contains all the elements from the given array
- `contained`: if the given array contains all the elements from the column
- `overlaps`: if the given array overlaps with any of the elements from the column

## Known issues

Everything related to pagination, e.g. before, after, cursors and the page info leads to crashes or weird behavior. Follow the [issue](https://linear.app/grafbase/issue/GB-4677/query-support-pagination) to see when they're implemented.

Closes: GB-4676