### PR TITLE
fix(connector): Convert MongoDB timestamps to standard format in a transformer

### DIFF
--- a/engine/crates/engine/src/registry/scalars/timestamp.rs
+++ b/engine/crates/engine/src/registry/scalars/timestamp.rs
@@ -40,10 +40,6 @@ impl DynamicParse for TimestampScalar {
 
     fn to_value(value: serde_json::Value) -> Result<ConstValue, Error> {
         match value {
-            serde_json::Value::Object(object) => match object.get("T") {
-                Some(serde_json::Value::Number(ms)) if ms.is_u64() => Ok(ConstValue::Number(ms.clone())),
-                _ => Err(Error::new("Cannot coerce the initial value into a valid Timestamp")),
-            },
             serde_json::Value::Number(ms) => {
                 if ms.is_u64() {
                     Ok(ConstValue::Number(ms))

--- a/engine/crates/parser-sdl/src/rules/mongodb_directive/model_directive/model_type/resolver_data.rs
+++ b/engine/crates/parser-sdl/src/rules/mongodb_directive/model_directive/model_type/resolver_data.rs
@@ -52,7 +52,12 @@ impl ResolverData {
             .map(ToString::to_string)
             .unwrap_or_else(|| field.name().to_string());
 
-        let resolver = Resolver::Transformer(Transformer::Select { key });
+        let mut resolver = Resolver::Transformer(Transformer::Select { key });
+
+        if let "Timestamp" = field.ty.base.to_base_type_str() {
+            resolver = resolver.and_then(Transformer::MongoTimestamp)
+        }
+
         let field_type = field.ty.node.to_string();
         let cache_control = CacheDirective::parse(&field.directives);
 


### PR DESCRIPTION
This is much better than doing stupid conversions for all connectors.
