### PR TITLE
fix: use SendWrapper in less places

### DIFF
--- a/engine/crates/engine/Cargo.toml
+++ b/engine/crates/engine/Cargo.toml
@@ -52,7 +52,6 @@ once_cell = "1"
 pin-project-lite = "0.2"
 regex = { workspace = true }
 secrecy = { version = "0.8", features = ["serde"] }
-send_wrapper = { version = "0.6", features = ["futures"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
@@ -85,6 +84,7 @@ time = { version = "0.3.28", features = ["parsing"] }
 uuid.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+send_wrapper = { version = "0.6", features = ["futures"] }
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/engine/crates/engine/src/lib.rs
+++ b/engine/crates/engine/src/lib.rs
@@ -73,6 +73,7 @@ pub mod graph;
 mod deferred;
 mod directive;
 pub mod registry;
+mod send_wrapper;
 
 #[doc(hidden)]
 pub use async_stream;

--- a/engine/crates/engine/src/registry/resolvers/atlas_data_api.rs
+++ b/engine/crates/engine/src/registry/resolvers/atlas_data_api.rs
@@ -9,10 +9,9 @@ mod request;
 mod value;
 
 use super::{ResolvedValue, ResolverContext};
-use crate::{Context, Error};
+use crate::{send_wrapper::make_send_on_wasm, Context, Error};
 use futures_util::Future;
 pub use operation::OperationType;
-use send_wrapper::SendWrapper;
 use std::pin::Pin;
 
 type JsonMap = serde_json::Map<String, serde_json::Value>;
@@ -41,7 +40,7 @@ impl AtlasDataApiResolver {
             .get_mongodb_config(&self.directive_name)
             .expect("directive must exist");
 
-        Box::pin(SendWrapper::new(async move {
+        Box::pin(make_send_on_wasm(async move {
             request::execute(ctx, resolver_ctx, &config, &self.collection, self.operation_type).await
         }))
     }

--- a/engine/crates/engine/src/registry/resolvers/http/mod.rs
+++ b/engine/crates/engine/src/registry/resolvers/http/mod.rs
@@ -2,11 +2,12 @@ use std::{collections::BTreeMap, pin::Pin};
 
 use futures_util::Future;
 use reqwest::Url;
-use send_wrapper::SendWrapper;
 
 use self::parameters::ParamApply;
 use super::{ResolvedValue, ResolverContext};
-use crate::{registry::variables::VariableResolveDefinition, Context, Error, RequestHeaders};
+use crate::{
+    registry::variables::VariableResolveDefinition, send_wrapper::make_send_on_wasm, Context, Error, RequestHeaders,
+};
 
 mod parameters;
 
@@ -79,7 +80,7 @@ impl HttpResolver {
             .map(|(connector_headers, request_headers)| connector_headers.build_header_vec(request_headers))
             .unwrap_or_default();
 
-        Box::pin(SendWrapper::new(async move {
+        Box::pin(make_send_on_wasm(async move {
             let ray_id = &ctx.data::<runtime::GraphqlRequestExecutionContext>()?.ray_id;
             let url = self.build_url(ctx, last_resolver_value)?;
             let mut request_builder = reqwest::Client::new()

--- a/engine/crates/engine/src/registry/resolvers/postgresql.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql.rs
@@ -2,9 +2,8 @@ mod context;
 mod request;
 
 use super::{ResolvedValue, ResolverContext};
-use crate::{Context, Error};
+use crate::{send_wrapper::make_send_on_wasm, Context, Error};
 use context::PostgresContext;
-use send_wrapper::SendWrapper;
 use std::{future::Future, pin::Pin};
 
 #[derive(Clone, Copy, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq, Hash)]
@@ -41,7 +40,7 @@ impl PostgresResolver {
         ctx: &'a Context<'_>,
         resolver_ctx: &'a ResolverContext<'_>,
     ) -> Pin<Box<dyn Future<Output = Result<ResolvedValue, Error>> + Send + 'a>> {
-        Box::pin(SendWrapper::new(async move {
+        Box::pin(make_send_on_wasm(async move {
             let context = PostgresContext::new(ctx, resolver_ctx, &self.directive_name)?;
             request::execute(context, self.operation).await
         }))

--- a/engine/crates/engine/src/send_wrapper.rs
+++ b/engine/crates/engine/src/send_wrapper.rs
@@ -1,0 +1,14 @@
+use futures_util::Future;
+
+#[cfg(target_arch = "wasm32")]
+pub fn make_send_on_wasm<T>(future: impl Future<Output = T>) -> impl Future<Output = T> + Send {
+    send_wrapper::SendWrapper::new(future)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn make_send_on_wasm<F>(future: F) -> F
+where
+    F: Future + Send,
+{
+    future
+}

--- a/engine/crates/integration-tests/src/udfs.rs
+++ b/engine/crates/integration-tests/src/udfs.rs
@@ -30,7 +30,7 @@ impl RustUdfs {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl runtime::udf::UdfInvoker<CustomResolverRequestPayload> for RustUdfs {
     async fn invoke(
         &self,

--- a/engine/crates/runtime-local/src/ufd_invoker.rs
+++ b/engine/crates/runtime-local/src/ufd_invoker.rs
@@ -21,8 +21,8 @@ impl UdfInvokerImpl {
     }
 }
 
-#[async_trait::async_trait(?Send)]
-impl<Payload: Serialize> UdfInvoker<Payload> for UdfInvokerImpl {
+#[async_trait::async_trait]
+impl<Payload: Serialize + Send> UdfInvoker<Payload> for UdfInvokerImpl {
     async fn invoke(
         &self,
         ray_id: &str,

--- a/engine/crates/runtime/src/udf.rs
+++ b/engine/crates/runtime/src/udf.rs
@@ -32,7 +32,7 @@ pub enum CustomResolverResponse {
     },
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 pub trait UdfInvoker<Payload: Serialize> {
     async fn invoke(
         &self,


### PR DESCRIPTION
I've was adding some GraphQL connector tests into the integration-tests today, when I ran into some panics from our use of `SendWrapper`.  It was safe to use `SendWrapper` in wasm because it's inherently single threaded - less so in native code.

Thankfully we generally only need SendWrapper when we're building for wasm.  So I've updated all the places we use it to only do so on WASM.