### PR TITLE
chore: port GraphQL connector tests into integration tests

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -174,6 +174,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-graphql-axum"
+version = "6.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c70544e827f6fcfcb6e8bafaf2e3db030dbda35b74504ea7a6b2c70e531e2d83"
+dependencies = [
+ "async-graphql",
+ "async-trait",
+ "axum",
+ "bytes",
+ "futures-util",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+]
+
+[[package]]
 name = "async-graphql-derive"
 version = "6.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +330,59 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "base64 0.21.4",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "headers",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit 0.7.2",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "backtrace"
@@ -812,6 +883,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "dataloader"
@@ -1594,6 +1671,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
+name = "headers"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+dependencies = [
+ "base64 0.21.4",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,8 +1971,11 @@ dependencies = [
 name = "integration-tests"
 version = "0.1.0"
 dependencies = [
+ "async-graphql",
+ "async-graphql-axum",
  "async-once-cell",
  "async-trait",
+ "axum",
  "cynic",
  "cynic-introspection",
  "engine",
@@ -1881,6 +1985,7 @@ dependencies = [
  "indoc",
  "insta",
  "names",
+ "parser-graphql",
  "parser-openapi",
  "parser-postgresql",
  "parser-sdl",
@@ -2021,6 +2126,12 @@ name = "matchit"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9376a4f0340565ad675d11fc1419227faf5f60cd7ac9cb2e7185a471f30af833"
+
+[[package]]
+name = "matchit"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed1202b2a6f884ae56f04cff409ab315c5ce26b5e58d7412e484f01fd52f52ef"
 
 [[package]]
 name = "md-5"
@@ -3411,6 +3522,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4beec8bce849d58d06238cb50db2e1c417cfeafa4c63f692b15c82b7c80f8335"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_qs"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3484,6 +3605,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3648,6 +3780,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
@@ -3817,6 +3955,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2dbec703c26b00d74844519606ef15d09a7d6857860f84ad223dec002ddea2"
+dependencies = [
+ "futures-util",
+ "log 0.4.20",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3824,6 +3985,7 @@ checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -3857,6 +4019,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3869,6 +4053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log 0.4.20",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3929,6 +4114,25 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "tungstenite"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e862a1c4128df0112ab625f55cd5c934bcb4312ba80b39ae4b4835a3fd58e649"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log 0.4.20",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
 
 [[package]]
 name = "tuple"
@@ -4028,6 +4232,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
@@ -4421,7 +4631,7 @@ dependencies = [
  "futures-util",
  "http",
  "js-sys",
- "matchit",
+ "matchit 0.4.6",
  "pin-project",
  "serde",
  "serde-wasm-bindgen",

--- a/engine/crates/integration-tests/Cargo.toml
+++ b/engine/crates/integration-tests/Cargo.toml
@@ -4,8 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+async-graphql = "6"
+async-graphql-axum = "6"
 async-once-cell = "0.5.3"
 async-trait = "0.1"
+axum = "0.6"
 cynic = "3"
 cynic-introspection = "3"
 expect-test = "1.4"
@@ -31,6 +34,9 @@ features = ["json"]
 path = "../engine"
 default-features = false
 features = ["tracing_worker"]
+
+[dependencies.parser-graphql]
+path = "../parser-graphql"
 
 [dependencies.parser-sdl]
 path = "../parser-sdl"

--- a/engine/crates/integration-tests/src/engine/builder.rs
+++ b/engine/crates/integration-tests/src/engine/builder.rs
@@ -97,8 +97,17 @@ impl ConnectorParsers for EngineBuilder {
         Ok(registry)
     }
 
-    async fn fetch_and_parse_graphql(&self, _directive: GraphqlDirective) -> Result<Registry, Vec<String>> {
-        todo!("someone should implement this sometime, similar to the above")
+    async fn fetch_and_parse_graphql(&self, directive: GraphqlDirective) -> Result<Registry, Vec<String>> {
+        parser_graphql::parse_schema(
+            reqwest::Client::new(),
+            &directive.name,
+            directive.namespace,
+            &directive.url,
+            directive.headers(),
+            directive.introspection_headers(),
+        )
+        .await
+        .map_err(|errors| errors.into_iter().map(|error| error.to_string()).collect::<Vec<_>>())
     }
 
     async fn fetch_and_parse_neon(&self, directive: &NeonDirective) -> Result<Registry, Vec<String>> {

--- a/engine/crates/integration-tests/src/engine/mod.rs
+++ b/engine/crates/integration-tests/src/engine/mod.rs
@@ -52,6 +52,13 @@ impl ExecutionRequest<'_> {
         self.headers.insert(name.into(), value.into());
         self
     }
+
+    pub fn variables(mut self, variables: impl serde::Serialize) -> Self {
+        self.graphql.variables = Some(Variables::from_json(
+            serde_json::to_value(variables).expect("variables to be serializable"),
+        ));
+        self
+    }
 }
 
 impl<'a> IntoFuture for ExecutionRequest<'a> {

--- a/engine/crates/integration-tests/src/lib.rs
+++ b/engine/crates/integration-tests/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod engine;
 pub mod helpers;
+mod mocks;
 pub mod mongodb;
 pub mod postgresql;
 pub mod types;
@@ -9,6 +10,7 @@ pub mod udfs;
 
 pub use crate::engine::{Engine, EngineBuilder};
 pub use helpers::{GetPath, ResponseExt};
+pub use mocks::graphql::MockGraphQlServer;
 pub use mongodb::{with_mongodb, with_namespaced_mongodb};
 pub use types::{Error, ResponseData};
 

--- a/engine/crates/integration-tests/src/mocks.rs
+++ b/engine/crates/integration-tests/src/mocks.rs
@@ -1,0 +1,1 @@
+pub mod graphql;

--- a/engine/crates/integration-tests/src/mocks/graphql.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql.rs
@@ -1,0 +1,166 @@
+//! A mock GraphQL server for testing the GraphQL connector
+
+use std::{net::TcpListener, time::Duration};
+
+use async_graphql::{EmptyMutation, EmptySubscription, Interface, Object, Schema, SimpleObject, Union, ID};
+use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
+use axum::{http::HeaderMap, routing::post, Router};
+
+pub struct MockGraphQlServer {
+    shutdown: Option<tokio::sync::oneshot::Sender<()>>,
+    port: u16,
+}
+
+impl Drop for MockGraphQlServer {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            shutdown.send(()).ok();
+        }
+    }
+}
+
+impl MockGraphQlServer {
+    pub async fn new() -> MockGraphQlServer {
+        let app = Router::new().route("/", post(graphql_handler));
+
+        let socket = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = socket.local_addr().unwrap().port();
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+
+        tokio::spawn(async move {
+            axum::Server::from_tcp(socket)
+                .unwrap()
+                .serve(app.into_make_service())
+                .with_graceful_shutdown(async move {
+                    shutdown_rx.await.ok();
+                })
+                .await
+                .unwrap();
+        });
+
+        // Give the server time to start
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        MockGraphQlServer {
+            shutdown: Some(shutdown_tx),
+            port,
+        }
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+}
+
+async fn graphql_handler(headers: HeaderMap, req: GraphQLRequest) -> GraphQLResponse {
+    let headers = headers
+        .into_iter()
+        .map(|(name, value)| {
+            (
+                name.map(|name| name.to_string()).unwrap_or_default(),
+                String::from_utf8_lossy(value.as_bytes()).to_string(),
+            )
+        })
+        .collect();
+    let schema = Schema::build(Query { headers }, EmptyMutation, EmptySubscription).finish();
+
+    schema.execute(req.into_inner()).await.into()
+}
+
+struct Query {
+    headers: Vec<(String, String)>,
+}
+
+#[Object]
+impl Query {
+    // A top level scalar field for testing
+    async fn server_version(&self) -> &str {
+        "1"
+    }
+
+    async fn pull_request_or_issue(&self, id: ID) -> Option<PullRequestOrIssue> {
+        if id == "1" {
+            return Some(PullRequestOrIssue::PullRequest(PullRequest {
+                title: "Creating the thing".into(),
+                checks: vec!["Success!".into()],
+                author: UserOrBot::User(User {
+                    name: "Jim".into(),
+                    email: "jim@example.com".into(),
+                }),
+            }));
+        } else if id == "2" {
+            return Some(PullRequestOrIssue::PullRequest(PullRequest {
+                title: "Some bot PR".into(),
+                checks: vec!["Success!".into()],
+                author: UserOrBot::Bot(Bot { id: "123".into() }),
+            }));
+        } else if id == "3" {
+            return Some(PullRequestOrIssue::Issue(Issue {
+                title: "Everythings fucked".into(),
+                author: UserOrBot::User(User {
+                    name: "The Pessimist".into(),
+                    email: "pessimist@example.com".into(),
+                }),
+            }));
+        }
+        None
+    }
+
+    async fn headers(&self) -> Vec<Header> {
+        self.headers
+            .clone()
+            .into_iter()
+            .map(|(name, value)| Header { name, value })
+            .collect()
+    }
+}
+
+#[derive(SimpleObject)]
+struct Header {
+    name: String,
+    value: String,
+}
+
+#[derive(SimpleObject)]
+struct PullRequest {
+    title: String,
+    checks: Vec<String>,
+    author: UserOrBot,
+}
+
+#[derive(SimpleObject)]
+struct Issue {
+    title: String,
+    author: UserOrBot,
+}
+
+#[derive(Interface)]
+#[graphql(field(name = "title", ty = "String"), field(name = "author", ty = "UserOrBot"))]
+enum PullRequestOrIssue {
+    PullRequest(PullRequest),
+    Issue(Issue),
+}
+
+#[derive(Union, Clone)]
+enum UserOrBot {
+    User(User),
+    Bot(Bot),
+}
+
+#[derive(SimpleObject, Clone)]
+struct User {
+    name: String,
+    email: String,
+}
+
+#[derive(SimpleObject, Clone)]
+struct Bot {
+    id: ID,
+}
+
+impl From<&UserOrBot> for UserOrBot {
+    fn from(value: &UserOrBot) -> Self {
+        value.clone()
+    }
+}

--- a/engine/crates/integration-tests/tests/graphql_connector/basic.rs
+++ b/engine/crates/integration-tests/tests/graphql_connector/basic.rs
@@ -1,0 +1,168 @@
+use integration_tests::{runtime, EngineBuilder, MockGraphQlServer, ResponseExt};
+use serde_json::json;
+
+const NAMESPACED_QUERY: &str = "
+    query($id: ID!) {
+        gothub {
+            serverVersion
+            pullRequestOrIssue(id: $id) {
+                __typename
+                title
+                ... on GothubPullRequest {
+                    checks
+                    author {
+                        __typename
+                        ...AuthorFragment
+                    }
+                }
+                ... on GothubIssue {
+                    title
+                    author {
+                        __typename
+                        ...AuthorFragment
+                    }
+                }
+            }
+        }
+    }
+
+    fragment AuthorFragment on GothubUserOrBot {
+        ... on GothubUser {
+            email
+        }
+        ... on GothubBot {
+            id
+        }
+    }
+";
+
+#[test]
+fn graphql_test_with_namespace() {
+    runtime().block_on(async {
+        let graphql_mock = MockGraphQlServer::new().await;
+
+        let engine = EngineBuilder::new(schema(graphql_mock.port(), true)).build().await;
+
+        insta::assert_json_snapshot!(
+            "namespaced-pull-request-with-user",
+            engine
+                .execute(NAMESPACED_QUERY)
+                .variables(json!({"id": "1"}))
+                .await
+                .into_value()
+        );
+        insta::assert_json_snapshot!(
+            "namespaced-pull-request-with-bot",
+            engine
+                .execute(NAMESPACED_QUERY)
+                .variables(json!({"id": "2"}))
+                .await
+                .into_value()
+        );
+        insta::assert_json_snapshot!(
+            "namespaced-issue",
+            engine
+                .execute(NAMESPACED_QUERY)
+                .variables(json!({"id": "3"}))
+                .await
+                .into_value()
+        );
+        insta::assert_json_snapshot!(
+            "namespaced-null",
+            engine
+                .execute(NAMESPACED_QUERY)
+                .variables(json!({"id": "4"}))
+                .await
+                .into_value()
+        );
+    })
+}
+
+const UNNAMESPACED_QUERY: &str = "
+    query($id: ID!) {
+        serverVersion
+        pullRequestOrIssue(id: $id) {
+            __typename
+            title
+            ... on PullRequest {
+                checks
+                author {
+                    __typename
+                    ...AuthorFragment
+                }
+            }
+            ... on Issue {
+                title
+                author {
+                    __typename
+                    ...AuthorFragment
+                }
+            }
+        }
+    }
+
+    fragment AuthorFragment on UserOrBot {
+        ... on User {
+            email
+        }
+        ... on Bot {
+            id
+        }
+    }
+";
+
+#[test]
+fn graphql_test_without_namespace() {
+    runtime().block_on(async {
+        let graphql_mock = MockGraphQlServer::new().await;
+
+        let engine = EngineBuilder::new(schema(graphql_mock.port(), false)).build().await;
+
+        insta::assert_json_snapshot!(
+            "unnamespaced-pull-request-with-user",
+            engine
+                .execute(UNNAMESPACED_QUERY)
+                .variables(json!({"id": "1"}))
+                .await
+                .into_value()
+        );
+        insta::assert_json_snapshot!(
+            "unnamespaced-pull-request-with-bot",
+            engine
+                .execute(UNNAMESPACED_QUERY)
+                .variables(json!({"id": "2"}))
+                .await
+                .into_value()
+        );
+        insta::assert_json_snapshot!(
+            "unnamespaced-issue",
+            engine
+                .execute(UNNAMESPACED_QUERY)
+                .variables(json!({"id": "3"}))
+                .await
+                .into_value()
+        );
+        insta::assert_json_snapshot!(
+            "unnamespaced-null",
+            engine
+                .execute(UNNAMESPACED_QUERY)
+                .variables(json!({"id": "4"}))
+                .await
+                .into_value()
+        );
+    });
+}
+
+fn schema(port: u16, namespace: bool) -> String {
+    format!(
+        r#"
+          extend schema
+          @graphql(
+            name: "gothub",
+            namespace: {namespace},
+            url: "http://127.0.0.1:{port}",
+            schema: "http://127.0.0.1:{port}/spec.json",
+          )
+        "#
+    )
+}

--- a/engine/crates/integration-tests/tests/graphql_connector/headers.rs
+++ b/engine/crates/integration-tests/tests/graphql_connector/headers.rs
@@ -1,0 +1,108 @@
+use integration_tests::{runtime, EngineBuilder, MockGraphQlServer, ResponseExt};
+use serde_json::json;
+
+#[test]
+fn test_header_forwarding() {
+    runtime().block_on(async {
+        let graphql_mock = MockGraphQlServer::new().await;
+
+        let engine = EngineBuilder::new(schema(graphql_mock.port()))
+            .with_env_var("API_KEY", "BLAH")
+            .build()
+            .await;
+
+        let mut response = engine
+            .execute(
+                r#"
+                query {
+                    headers {
+                        name
+                        value
+                    }
+                }
+				"#,
+            )
+            .header("wow-what-a-header", "isn't it the best")
+            .header("and-another-one", "yes")
+            .header("a-header-that-shouldnt-be-forwarded", "ok")
+            .header("Authorization", "Basic XYZ")
+            .await
+            .into_value();
+
+        // Remove the host header because it's dynamic
+        response.get_mut("data").and_then(|data| {
+            let headers = data.get_mut("headers")?;
+
+            let host_header_index = headers
+                .as_array()?
+                .iter()
+                .enumerate()
+                .find(|(_, header)| header.get("name") == Some(&json!("host")))?
+                .0;
+
+            headers.as_array_mut()?.remove(host_header_index);
+            Some(())
+        });
+
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "headers": [
+              {
+                "name": "user-agent",
+                "value": "Grafbase"
+              },
+              {
+                "name": "authorization",
+                "value": "Bearer BLAH"
+              },
+              {
+                "name": "wow-what-a-header",
+                "value": "isn't it the best"
+              },
+              {
+                "name": "another-one",
+                "value": "yes"
+              },
+              {
+                "name": "x-grafbase-fetch-trace-id",
+                "value": ""
+              },
+              {
+                "name": "content-type",
+                "value": "application/json"
+              },
+              {
+                "name": "accept",
+                "value": "*/*"
+              },
+              {
+                "name": "content-length",
+                "value": "96"
+              }
+            ]
+          }
+        }
+        "###);
+    });
+}
+
+fn schema(port: u16) -> String {
+    format!(
+        r#"
+          extend schema
+          @graphql(
+            name: "Test",
+            namespace: false,
+            url: "http://127.0.0.1:{port}",
+            schema: "http://127.0.0.1:{port}/spec.json",
+            headers: [
+                {{ name: "authorization", value: "Bearer {{{{ env.API_KEY }}}}" }}
+                {{ name: "Wow-what-a-header", forward: "Wow-what-a-header" }}
+                {{ name: "another-one", forward: "and-another-one" }}
+                {{ name: "secret-third-header", forward: "secret-third-header" }}
+            ],
+          )
+        "#
+    )
+}

--- a/engine/crates/integration-tests/tests/graphql_connector/mod.rs
+++ b/engine/crates/integration-tests/tests/graphql_connector/mod.rs
@@ -1,0 +1,3 @@
+mod basic;
+mod headers;
+mod transforms;

--- a/engine/crates/integration-tests/tests/graphql_connector/snapshots/integration_tests__graphql_connector__basic__namespaced-issue.snap
+++ b/engine/crates/integration-tests/tests/graphql_connector/snapshots/integration_tests__graphql_connector__basic__namespaced-issue.snap
@@ -1,0 +1,19 @@
+---
+source: crates/integration-tests/tests/graphql_connector/basic.rs
+expression: "engine.execute(NAMESPACED_QUERY).variables(json!({\n                    \"id\" : \"3\"\n                })).await.into_value()"
+---
+{
+  "data": {
+    "gothub": {
+      "pullRequestOrIssue": {
+        "__typename": "GothubIssue",
+        "author": {
+          "__typename": "GothubUser",
+          "email": "pessimist@example.com"
+        },
+        "title": "Everythings fucked"
+      },
+      "serverVersion": "1"
+    }
+  }
+}

--- a/engine/crates/integration-tests/tests/graphql_connector/snapshots/integration_tests__graphql_connector__basic__namespaced-null.snap
+++ b/engine/crates/integration-tests/tests/graphql_connector/snapshots/integration_tests__graphql_connector__basic__namespaced-null.snap
@@ -1,0 +1,12 @@
+---
+source: crates/integration-tests/tests/graphql_connector/basic.rs
+expression: "engine.execute(NAMESPACED_QUERY).variables(json!({\n                    \"id\" : \"4\"\n                })).await.into_value()"
+---
+{
+  "data": {
+    "gothub": {
+      "pullRequestOrIssue": null,
+      "serverVersion": "1"
+    }
+  }
+}

--- a/engine/crates/integration-tests/tests/graphql_connector/snapshots/integration_tests__graphql_connector__basic__namespaced-pull-request-with-bot.snap
+++ b/engine/crates/integration-tests/tests/graphql_connector/snapshots/integration_tests__graphql_connector__basic__namespaced-pull-request-with-bot.snap
@@ -1,0 +1,22 @@
+---
+source: crates/integration-tests/tests/graphql_connector/basic.rs
+expression: "engine.execute(NAMESPACED_QUERY).variables(json!({\n                    \"id\" : \"2\"\n                })).await.into_value()"
+---
+{
+  "data": {
+    "gothub": {
+      "pullRequestOrIssue": {
+        "__typename": "GothubPullRequest",
+        "author": {
+          "__typename": "GothubBot",
+          "id": "123"
+        },
+        "checks": [
+          "Success!"
+        ],
+        "title": "Some bot PR"
+      },
+      "serverVersion": "1"
+    }
+  }
+}

--- a/engine/crates/integration-tests/tests/graphql_connector/snapshots/integration_tests__graphql_connector__basic__namespaced-pull-request-with-user.snap
+++ b/engine/crates/integration-tests/tests/graphql_connector/snapshots/integration_tests__graphql_connector__basic__namespaced-pull-request-with-user.snap
@@ -1,0 +1,22 @@
+---
+source: crates/integration-tests/tests/graphql_connector/basic.rs
+expression: "engine.execute(NAMESPACED_QUERY).variables(json!({\n                    \"id\" : \"1\"\n                })).await.into_value()"
+---
+{
+  "data": {
+    "gothub": {
+      "pullRequestOrIssue": {
+        "__typename": "GothubPullRequest",
+        "author": {
+          "__typename": "GothubUser",
+          "email": "jim@example.com"
+        },
+        "checks": [
+          "Success!"
+        ],
+        "title": "Creating the thing"
+      },
+      "serverVersion": "1"
+    }
+  }
+}

--- a/engine/crates/integration-tests/tests/graphql_connector/snapshots/integration_tests__graphql_connector__basic__unnamespaced-issue.snap
+++ b/engine/crates/integration-tests/tests/graphql_connector/snapshots/integration_tests__graphql_connector__basic__unnamespaced-issue.snap
@@ -1,0 +1,17 @@
+---
+source: crates/integration-tests/tests/graphql_connector/basic.rs
+expression: "engine.execute(UNNAMESPACED_QUERY).variables(json!({\n                    \"id\" : \"3\"\n                })).await.into_value()"
+---
+{
+  "data": {
+    "pullRequestOrIssue": {
+      "__typename": "Issue",
+      "author": {
+        "__typename": "User",
+        "email": "pessimist@example.com"
+      },
+      "title": "Everythings fucked"
+    },
+    "serverVersion": "1"
+  }
+}

--- a/engine/crates/integration-tests/tests/graphql_connector/snapshots/integration_tests__graphql_connector__basic__unnamespaced-null.snap
+++ b/engine/crates/integration-tests/tests/graphql_connector/snapshots/integration_tests__graphql_connector__basic__unnamespaced-null.snap
@@ -1,0 +1,10 @@
+---
+source: crates/integration-tests/tests/graphql_connector/basic.rs
+expression: "engine.execute(UNNAMESPACED_QUERY).variables(json!({\n                    \"id\" : \"4\"\n                })).await.into_value()"
+---
+{
+  "data": {
+    "pullRequestOrIssue": null,
+    "serverVersion": "1"
+  }
+}

--- a/engine/crates/integration-tests/tests/graphql_connector/snapshots/integration_tests__graphql_connector__basic__unnamespaced-pull-request-with-bot.snap
+++ b/engine/crates/integration-tests/tests/graphql_connector/snapshots/integration_tests__graphql_connector__basic__unnamespaced-pull-request-with-bot.snap
@@ -1,0 +1,20 @@
+---
+source: crates/integration-tests/tests/graphql_connector/basic.rs
+expression: "engine.execute(UNNAMESPACED_QUERY).variables(json!({\n                    \"id\" : \"2\"\n                })).await.into_value()"
+---
+{
+  "data": {
+    "pullRequestOrIssue": {
+      "__typename": "PullRequest",
+      "author": {
+        "__typename": "Bot",
+        "id": "123"
+      },
+      "checks": [
+        "Success!"
+      ],
+      "title": "Some bot PR"
+    },
+    "serverVersion": "1"
+  }
+}

--- a/engine/crates/integration-tests/tests/graphql_connector/snapshots/integration_tests__graphql_connector__basic__unnamespaced-pull-request-with-user.snap
+++ b/engine/crates/integration-tests/tests/graphql_connector/snapshots/integration_tests__graphql_connector__basic__unnamespaced-pull-request-with-user.snap
@@ -1,0 +1,20 @@
+---
+source: crates/integration-tests/tests/graphql_connector/basic.rs
+expression: "engine.execute(UNNAMESPACED_QUERY).variables(json!({\n                    \"id\" : \"1\"\n                })).await.into_value()"
+---
+{
+  "data": {
+    "pullRequestOrIssue": {
+      "__typename": "PullRequest",
+      "author": {
+        "__typename": "User",
+        "email": "jim@example.com"
+      },
+      "checks": [
+        "Success!"
+      ],
+      "title": "Creating the thing"
+    },
+    "serverVersion": "1"
+  }
+}

--- a/engine/crates/integration-tests/tests/graphql_connector/transforms.rs
+++ b/engine/crates/integration-tests/tests/graphql_connector/transforms.rs
@@ -1,0 +1,65 @@
+use cynic::QueryBuilder;
+use cynic_introspection::IntrospectionQuery;
+use integration_tests::{runtime, EngineBuilder, MockGraphQlServer, ResponseExt};
+
+#[test]
+fn graphql_test_with_transforms() {
+    runtime().block_on(async {
+        let graphql_mock = MockGraphQlServer::new().await;
+
+        let engine = EngineBuilder::new(schema(graphql_mock.port())).build().await;
+
+        let introspection_query = IntrospectionQuery::build(());
+        let response = engine
+            .execute(introspection_query)
+            .await
+            .into_data::<IntrospectionQuery>();
+
+        insta::assert_snapshot!(response.into_schema().unwrap().to_sdl(), @r###"
+        type Header {
+          name: String!
+          value: String!
+        }
+
+        type Issue implements PullRequestOrIssue {
+          title: String!
+        }
+
+        type PullRequest implements PullRequestOrIssue {
+          checks: [String!]!
+          title: String!
+        }
+
+        interface PullRequestOrIssue {
+          title: String!
+        }
+
+        type Query {
+          headers: [Header!]!
+          pullRequestOrIssue(id: ID!): PullRequestOrIssue
+          serverVersion: String!
+        }
+
+        "###);
+    });
+}
+
+fn schema(port: u16) -> String {
+    format!(
+        r#"
+          extend schema
+          @graphql(
+            name: "test",
+            namespace: false,
+            url: "http://127.0.0.1:{port}",
+            schema: "http://127.0.0.1:{port}/spec.json",
+            transforms: {{
+              exclude: [
+                "PullRequest.author",
+                "Issue.author"
+              ]
+            }}
+          )
+        "#
+    )
+}

--- a/engine/crates/integration-tests/tests/integration_tests.rs
+++ b/engine/crates/integration-tests/tests/integration_tests.rs
@@ -3,6 +3,7 @@
 mod custom_resolvers;
 mod defer;
 mod execution;
+mod graphql_connector;
 mod mongodb;
 mod openapi;
 mod postgresql;


### PR DESCRIPTION
I'm adding some functionality that affects the GraphQL connector so figured this was as good a time as any to port the tests from the CLI over to the integration tests.