### PR TITLE
fix: dont forward `@defer` to connected gql apis

### DIFF
--- a/engine/crates/engine/src/registry/resolvers/graphql/serializer.rs
+++ b/engine/crates/engine/src/registry/resolvers/graphql/serializer.rs
@@ -555,9 +555,9 @@ mod tests {
     #[rstest]
     #[case::one_bare("query { foo @include }")]
     #[case::one_arguments("query { foo @include(if: true) }")]
-    #[case::many_bare("query { foo @include @deprecated }")]
-    #[case::many_arguments("query { foo @include(if: true) @exclude(if: 42) }")]
-    #[case::many_mixed("query { foo @include(if: true) @deprecated @exclude(if: 42) }")]
+    #[case::many_bare("query { foo @include @skip }")]
+    #[case::many_arguments("query { foo @include(if: true) @skip(if: 42) }")]
+    #[case::many_mixed("query { foo @include(if: true) @skip @skip(if: 42) }")]
     fn field_directives(#[case] input: &str) {
         set_snapshot_suffix!("{}", input);
         insta::assert_snapshot!(serialize(input));
@@ -573,7 +573,7 @@ mod tests {
 
     #[rstest]
     #[case::one("query { ... foo }")]
-    #[case::many("query { ... fooBar @deprecated }")]
+    #[case::many("query { ... fooBar @skip }")]
     fn fragment_spread(#[case] input: &str) {
         set_snapshot_suffix!("{}", input);
         insta::assert_snapshot!(serialize(input));
@@ -582,7 +582,7 @@ mod tests {
     #[rstest]
     #[case::cond("query { ... on Foo { bar baz } }")]
     #[case::directive("query { ... @include(if: $foo) { bar } }")]
-    #[case::cond_and_directive("query { ... on Foo @deprecated { baz } }")]
+    #[case::cond_and_directive("query { ... on Foo @skip { baz } }")]
     fn inline_fragment(#[case] input: &str) {
         set_snapshot_suffix!("{}", input);
         insta::assert_snapshot!(serialize(input));

--- a/engine/crates/engine/src/registry/resolvers/graphql/serializer.rs
+++ b/engine/crates/engine/src/registry/resolvers/graphql/serializer.rs
@@ -508,7 +508,7 @@ impl From<crate::Error> for Error {
 }
 
 fn should_forward_directive(name: &str) -> bool {
-    // For now we only support forwarding the skip & defer directives.
+    // For now we only support forwarding the skip & include directives.
     //
     // defer would need some implementation work to support forwarding
     matches!(name, "skip" | "include")

--- a/engine/crates/engine/src/registry/resolvers/graphql/serializer.rs
+++ b/engine/crates/engine/src/registry/resolvers/graphql/serializer.rs
@@ -254,6 +254,10 @@ impl<'a: 'b, 'b: 'a, 'c: 'a> Serializer<'a, 'b> {
 
     fn serialize_directives(&mut self, directives: impl Iterator<Item = Directive>) -> Result<(), Error> {
         for directive in directives {
+            if !should_forward_directive(directive.name.as_str()) {
+                continue;
+            }
+
             self.write_str(" @")?;
             self.write_str(directive.name.as_str())?;
             self.serialize_arguments(&directive.arguments)?;
@@ -501,6 +505,13 @@ impl From<crate::Error> for Error {
     fn from(value: crate::Error) -> Self {
         Error::RegistryError(value)
     }
+}
+
+fn should_forward_directive(name: &str) -> bool {
+    // For now we only support forwarding the skip & defer directives.
+    //
+    // defer would need some implementation work to support forwarding
+    matches!(name, "skip" | "include")
 }
 
 #[cfg(test)]

--- a/engine/crates/engine/src/registry/resolvers/graphql/snapshots/engine__registry__resolvers__graphql__serializer__tests__field_directives@query { foo @include @skip }.snap
+++ b/engine/crates/engine/src/registry/resolvers/graphql/snapshots/engine__registry__resolvers__graphql__serializer__tests__field_directives@query { foo @include @skip }.snap
@@ -1,0 +1,8 @@
+---
+source: crates/engine/src/registry/resolvers/graphql/serializer.rs
+expression: serialize(input)
+---
+query {
+	foo @include @skip
+}
+

--- a/engine/crates/engine/src/registry/resolvers/graphql/snapshots/engine__registry__resolvers__graphql__serializer__tests__field_directives@query { foo @include(if true) @skip @skip(if 42) }.snap
+++ b/engine/crates/engine/src/registry/resolvers/graphql/snapshots/engine__registry__resolvers__graphql__serializer__tests__field_directives@query { foo @include(if true) @skip @skip(if 42) }.snap
@@ -1,0 +1,8 @@
+---
+source: crates/engine/src/registry/resolvers/graphql/serializer.rs
+expression: serialize(input)
+---
+query {
+	foo @include(if: true) @skip @skip(if: 42)
+}
+

--- a/engine/crates/engine/src/registry/resolvers/graphql/snapshots/engine__registry__resolvers__graphql__serializer__tests__field_directives@query { foo @include(if true) @skip(if 42) }.snap
+++ b/engine/crates/engine/src/registry/resolvers/graphql/snapshots/engine__registry__resolvers__graphql__serializer__tests__field_directives@query { foo @include(if true) @skip(if 42) }.snap
@@ -1,0 +1,8 @@
+---
+source: crates/engine/src/registry/resolvers/graphql/serializer.rs
+expression: serialize(input)
+---
+query {
+	foo @include(if: true) @skip(if: 42)
+}
+

--- a/engine/crates/engine/src/registry/resolvers/graphql/snapshots/engine__registry__resolvers__graphql__serializer__tests__fragment_spread@query { ... fooBar @skip }.snap
+++ b/engine/crates/engine/src/registry/resolvers/graphql/snapshots/engine__registry__resolvers__graphql__serializer__tests__fragment_spread@query { ... fooBar @skip }.snap
@@ -1,0 +1,8 @@
+---
+source: crates/engine/src/registry/resolvers/graphql/serializer.rs
+expression: serialize(input)
+---
+query {
+	... fooBar @skip
+}
+

--- a/engine/crates/engine/src/registry/resolvers/graphql/snapshots/engine__registry__resolvers__graphql__serializer__tests__inline_fragment@query { ... on Foo @skip { baz } }.snap
+++ b/engine/crates/engine/src/registry/resolvers/graphql/snapshots/engine__registry__resolvers__graphql__serializer__tests__inline_fragment@query { ... on Foo @skip { baz } }.snap
@@ -1,0 +1,11 @@
+---
+source: crates/engine/src/registry/resolvers/graphql/serializer.rs
+expression: serialize(input)
+---
+query {
+	... on Foo @skip {
+		__typename
+		baz
+	}
+}
+

--- a/engine/crates/integration-tests/src/helpers.rs
+++ b/engine/crates/integration-tests/src/helpers.rs
@@ -71,7 +71,6 @@ impl GetPath for Response {
 
 pub trait ResponseExt: Sized {
     /// Asserts that there are no errors in this Response
-    #[must_use]
     fn assert_success(self) -> Self;
 
     /// Converts the response into a serde_json Value

--- a/engine/crates/integration-tests/tests/graphql_connector/defer.rs
+++ b/engine/crates/integration-tests/tests/graphql_connector/defer.rs
@@ -1,0 +1,42 @@
+use integration_tests::{runtime, EngineBuilder, MockGraphQlServer, ResponseExt};
+
+#[test]
+fn test_defer_on_graphql_connector() {
+    // Note: this test relies on async-graphql not supporting @defer
+    // When that changes we might need to re-think this
+    runtime().block_on(async {
+        let graphql_mock = MockGraphQlServer::new().await;
+
+        let engine = EngineBuilder::new(schema(graphql_mock.port())).build().await;
+
+        engine
+            .execute(
+                r#"
+                query {
+                    pullRequestOrIssue(id: "1") {
+                        ... @defer {
+                            __typename
+                            title
+                        }
+                    }
+                }
+                "#,
+            )
+            .await
+            .assert_success();
+    });
+}
+
+fn schema(port: u16) -> String {
+    format!(
+        r#"
+          extend schema
+          @graphql(
+            name: "gothub",
+            namespace: false
+            url: "http://127.0.0.1:{port}",
+            schema: "http://127.0.0.1:{port}/spec.json",
+          )
+        "#
+    )
+}

--- a/engine/crates/integration-tests/tests/graphql_connector/mod.rs
+++ b/engine/crates/integration-tests/tests/graphql_connector/mod.rs
@@ -1,3 +1,4 @@
 mod basic;
+mod defer;
 mod headers;
 mod transforms;


### PR DESCRIPTION
Now that we support `@defer` we need to be careful to not send it to connected GraphQL APIs.  They might well not support the directive, and even if they do we don't have any support for streaming responses from connected APIs.

This filters out the directive to handle this.  We can maybe do something better in the future/