### PR TITLE
fix: handle variables inside inputs in graphql connector

### DIFF
--- a/engine/crates/engine/src/registry/resolvers/graphql/serializer.rs
+++ b/engine/crates/engine/src/registry/resolvers/graphql/serializer.rs
@@ -211,11 +211,9 @@ impl<'a: 'b, 'b: 'a, 'c: 'a> Serializer<'a, 'b> {
             .peekable();
 
         while let Some((name, value)) = arguments.next() {
-            // If the argument references a variable, we track it so that the caller knows which
+            // If the argument references variables, we track them so that the caller knows which
             // variable values are needed to execute the document.
-            if let Value::Variable(name) = value.clone() {
-                self.variable_references.insert(name);
-            }
+            self.variable_references.extend(value.variables_used().cloned());
 
             self.write_str(name)?;
             self.write_str(": ")?;

--- a/engine/crates/integration-tests/src/mocks/graphql.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql.rs
@@ -2,7 +2,9 @@
 
 use std::{net::TcpListener, time::Duration};
 
-use async_graphql::{EmptyMutation, EmptySubscription, Interface, Object, Schema, SimpleObject, Union, ID};
+use async_graphql::{
+    EmptyMutation, EmptySubscription, InputObject, Interface, Object, Schema, SimpleObject, Union, ID,
+};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::{http::HeaderMap, routing::post, Router};
 
@@ -77,6 +79,32 @@ impl Query {
     // A top level scalar field for testing
     async fn server_version(&self) -> &str {
         "1"
+    }
+
+    async fn pull_requests_and_issues(&self, _filter: PullRequestsAndIssuesFilters) -> Vec<PullRequestOrIssue> {
+        // This doesn't actually filter anything because I don't need that for my test.
+        vec![
+            PullRequestOrIssue::PullRequest(PullRequest {
+                title: "Creating the thing".into(),
+                checks: vec!["Success!".into()],
+                author: UserOrBot::User(User {
+                    name: "Jim".into(),
+                    email: "jim@example.com".into(),
+                }),
+            }),
+            PullRequestOrIssue::PullRequest(PullRequest {
+                title: "Some bot PR".into(),
+                checks: vec!["Success!".into()],
+                author: UserOrBot::Bot(Bot { id: "123".into() }),
+            }),
+            PullRequestOrIssue::Issue(Issue {
+                title: "Everythings fucked".into(),
+                author: UserOrBot::User(User {
+                    name: "The Pessimist".into(),
+                    email: "pessimist@example.com".into(),
+                }),
+            }),
+        ]
     }
 
     async fn pull_request_or_issue(&self, id: ID) -> Option<PullRequestOrIssue> {
@@ -163,4 +191,9 @@ impl From<&UserOrBot> for UserOrBot {
     fn from(value: &UserOrBot) -> Self {
         value.clone()
     }
+}
+
+#[derive(Debug, InputObject)]
+struct PullRequestsAndIssuesFilters {
+    search: String,
 }

--- a/engine/crates/integration-tests/tests/graphql_connector/basic.rs
+++ b/engine/crates/integration-tests/tests/graphql_connector/basic.rs
@@ -153,6 +153,29 @@ fn graphql_test_without_namespace() {
     });
 }
 
+#[test]
+fn test_nested_variable_forwarding() {
+    runtime().block_on(async {
+        let graphql_mock = MockGraphQlServer::new().await;
+
+        let engine = EngineBuilder::new(schema(graphql_mock.port(), false)).build().await;
+
+        engine
+            .execute(
+                r#"
+                    query ($search: String!) {
+                        pullRequestsAndIssues(filter: {search: $search}) {
+                            __typename
+                        }
+                    }
+                "#,
+            )
+            .variables(json!({"search": "1"}))
+            .await
+            .assert_success();
+    });
+}
+
 fn schema(port: u16, namespace: bool) -> String {
     format!(
         r#"

--- a/engine/crates/integration-tests/tests/graphql_connector/transforms.rs
+++ b/engine/crates/integration-tests/tests/graphql_connector/transforms.rs
@@ -34,9 +34,14 @@ fn graphql_test_with_transforms() {
           title: String!
         }
 
+        input PullRequestsAndIssuesFilters {
+          search: String!
+        }
+
         type Query {
           headers: [Header!]!
           pullRequestOrIssue(id: ID!): PullRequestOrIssue
+          pullRequestsAndIssues(filter: PullRequestsAndIssuesFilters!): [PullRequestOrIssue!]!
           serverVersion: String!
         }
 


### PR DESCRIPTION
The GraphQL connector needs to track which variables are used inside a query in order to know which variables to send to the downstream API.  It was doing this, but it was only pulling top-level variables rather than any nested inside a `Value`.  This PR fixes that and adds a test that catches the failure.