### PR TITLE
fix(neon): Add `x-grafbase-fetch-trace-id` header to the Neon requests to ensure they get logged properly

### DIFF
--- a/engine/crates/engine/src/registry/resolvers/postgresql/context.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql/context.rs
@@ -35,7 +35,8 @@ impl<'a> PostgresContext<'a> {
             .get_postgresql_definition(directive_name)
             .expect("directive must exist");
 
-        let transport = NeonTransport::new(database_definition.connection_string())
+        let ray_id = &context.data::<runtime::GraphqlRequestExecutionContext>()?.ray_id;
+        let transport = NeonTransport::new(ray_id, database_definition.connection_string())
             .map_err(|error| Error::new(error.to_string()))?;
 
         Ok(Self {

--- a/engine/crates/integration-tests/src/engine/builder.rs
+++ b/engine/crates/integration-tests/src/engine/builder.rs
@@ -111,7 +111,8 @@ impl ConnectorParsers for EngineBuilder {
     }
 
     async fn fetch_and_parse_neon(&self, directive: &NeonDirective) -> Result<Registry, Vec<String>> {
-        let transport = NeonTransport::new(directive.connection_string()).map_err(|error| vec![error.to_string()])?;
+        let transport = NeonTransport::new("dummy-ray-id", directive.connection_string())
+            .map_err(|error| vec![error.to_string()])?;
 
         parser_postgresql::introspect(&transport, directive.name(), directive.namespace())
             .await

--- a/engine/crates/integration-tests/src/postgresql.rs
+++ b/engine/crates/integration-tests/src/postgresql.rs
@@ -67,7 +67,7 @@ where
     T: Future<Output = TestApi>,
 {
     super::runtime().block_on(async {
-        let admin = NeonTransport::new(ADMIN_CONNECTION_STRING).unwrap();
+        let admin = NeonTransport::new("dummy-ray-id", ADMIN_CONNECTION_STRING).unwrap();
 
         admin
             .execute(&format!("DROP DATABASE IF EXISTS {database}"))
@@ -102,7 +102,7 @@ where
     R: Future<Output = TestApi>,
 {
     super::runtime().block_on(async {
-        let admin = NeonTransport::new(ADMIN_CONNECTION_STRING).unwrap();
+        let admin = NeonTransport::new("dummy-ray-id", ADMIN_CONNECTION_STRING).unwrap();
 
         admin
             .execute(&format!("DROP DATABASE IF EXISTS {database}"))
@@ -170,7 +170,7 @@ impl TestApi {
 
     async fn new_inner(schema: String, connection_string: String) -> Self {
         let engine = OnceCell::new();
-        let connection = NeonTransport::new(&connection_string).unwrap();
+        let connection = NeonTransport::new("dummy-ray-id", &connection_string).unwrap();
 
         let inner = Inner {
             engine,

--- a/engine/crates/postgresql-types/src/transport/neon.rs
+++ b/engine/crates/postgresql-types/src/transport/neon.rs
@@ -61,7 +61,7 @@ pub struct NeonError {
 }
 
 impl NeonTransport {
-    pub fn new(connection_string: &str) -> crate::Result<Self> {
+    pub fn new(ray_id: &str, connection_string: &str) -> crate::Result<Self> {
         let url = Url::parse(connection_string)?;
 
         let http_host = match url.host_str() {
@@ -79,7 +79,10 @@ impl NeonTransport {
             HeaderValue::from_str(connection_string)
                 .map_err(|_| Error::InvalidConnectionString("the URL must only use ASCII characeters".to_string()))?,
         );
-
+        headers.insert(
+            "x-grafbase-fetch-trace-id",
+            HeaderValue::from_str(ray_id).expect("must be valid"),
+        );
         headers.insert("Neon-Raw-Text-Output", HeaderValue::from_static("false"));
         headers.insert("Neon-Array-Mode", HeaderValue::from_static("false"));
         headers.insert("Neon-Pool-Opt-In", HeaderValue::from_static("false"));


### PR DESCRIPTION
# Description

A small tweak ensuring requests to Neon will get logged.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
