### PR TITLE
feat(connector): Neon pagination

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1616,9 +1616,9 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sql-ast"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29aa39c93553fc933094f7b15d92a6a96956e944760f5c061e527482e7ac24e3"
+checksum = "d051b841d94e5716c3fdf21eed72031010958a8bf57c07149c0519d42cc7a9b2"
 dependencies = [
  "serde_json",
 ]

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -2879,9 +2879,11 @@ version = "0.1.0"
 dependencies = [
  "Inflector",
  "async-trait",
+ "flexbuffers",
  "indexmap 1.9.3",
  "itertools",
  "reqwest",
+ "search-protocol",
  "serde",
  "serde_json",
  "thiserror",

--- a/engine/crates/engine/Cargo.toml
+++ b/engine/crates/engine/Cargo.toml
@@ -20,7 +20,7 @@ async-recursion = "1"
 async-stream = "0.3"
 async-trait = "0.1"
 common-types = { path = "../common-types" }
-grafbase-sql-ast = "0.1.1"
+grafbase-sql-ast = "0.1.2"
 postgresql-types = { path = "../postgresql-types" }
 bytes = { version = "1", features = ["serde"] }
 case = "1"

--- a/engine/crates/engine/src/registry/resolvers/postgresql.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql.rs
@@ -1,6 +1,8 @@
 mod context;
 mod request;
 
+pub use context::CollectionArgs;
+
 use super::{ResolvedValue, ResolverContext};
 use crate::{send_wrapper::make_send_on_wasm, Context, Error};
 use context::PostgresContext;

--- a/engine/crates/engine/src/registry/resolvers/postgresql/context.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql/context.rs
@@ -1,8 +1,10 @@
 mod filter;
-mod selection;
+pub mod selection;
+
+pub use selection::CollectionArgs;
 
 pub(super) use filter::FilterIterator;
-pub(super) use selection::{CollectionArgs, SelectionIterator, TableSelection};
+pub(super) use selection::{SelectionIterator, TableSelection};
 
 use crate::{
     registry::{resolvers::ResolverContext, type_kinds::SelectionSetTarget, Registry},
@@ -47,6 +49,10 @@ impl<'a> PostgresContext<'a> {
         })
     }
 
+    pub fn database_definition(&self) -> &DatabaseDefinition {
+        self.database_definition
+    }
+
     /// The main table accessed by this request.
     pub fn table(&self) -> TableWalker<'a> {
         self.resolver_context
@@ -74,7 +80,7 @@ impl<'a> PostgresContext<'a> {
             .collect();
 
         let meta_type = self.resolver_context.ty.unwrap();
-        SelectionIterator::new(self, meta_type, selection)
+        SelectionIterator::new(self, meta_type, &self.root_field(), selection)
     }
 
     pub fn collection_selection(&'a self) -> SelectionIterator<'a> {
@@ -97,7 +103,7 @@ impl<'a> PostgresContext<'a> {
             .and_then(|field| self.registry().lookup_by_str(field.ty.base_type_name()).ok())
             .expect("couldn't fiind a meta type for a collection selection");
 
-        SelectionIterator::new(self, meta_type, selection)
+        SelectionIterator::new(self, meta_type, &self.root_field(), selection)
     }
 
     /// Access to the schema registry.

--- a/engine/crates/engine/src/registry/resolvers/postgresql/context/selection.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql/context/selection.rs
@@ -1,4 +1,4 @@
-mod collection_args;
+pub mod collection_args;
 
 use super::PostgresContext;
 use crate::{
@@ -6,7 +6,7 @@ use crate::{
     Lookahead, SelectionField,
 };
 pub use collection_args::CollectionArgs;
-use postgresql_types::database_definition::{RelationWalker, TableColumnWalker};
+use postgresql_types::database_definition::{RelationWalker, TableColumnWalker, TableWalker};
 
 pub enum TableSelection<'a> {
     /// Selects a single column.
@@ -22,20 +22,81 @@ pub enum TableSelection<'a> {
 #[derive(Clone)]
 pub struct SelectionIterator<'a> {
     ctx: &'a PostgresContext<'a>,
+    table: TableWalker<'a>,
     selection: Vec<SelectionField<'a>>,
+    extra_columns: Vec<TableColumnWalker<'a>>,
     target: SelectionSetTarget<'a>,
     index: usize,
+    extra_column_index: usize,
 }
 
 impl<'a> SelectionIterator<'a> {
-    pub fn new(ctx: &'a PostgresContext<'a>, meta_type: &'a MetaType, selection: Vec<SelectionField<'a>>) -> Self {
-        let target = meta_type.try_into().unwrap();
+    pub fn new(
+        ctx: &'a PostgresContext<'a>,
+        meta_type: &'a MetaType,
+        selection_field: &SelectionField<'_>,
+        selection: Vec<SelectionField<'a>>,
+    ) -> Self {
+        let target: SelectionSetTarget<'a> = meta_type.try_into().unwrap();
+
+        let table = ctx
+            .database_definition
+            .find_table_for_client_type(target.name())
+            .expect("table for client type not found");
+
+        let mut extra_columns = Vec::new();
+
+        match selection_field
+            .field
+            .get_argument("orderBy")
+            .and_then(|value| value.as_slice())
+        {
+            Some(order_by) => {
+                for value in order_by {
+                    let object = match value {
+                        engine_value::Value::Object(obj) => obj,
+                        _ => continue,
+                    };
+
+                    for field in object.keys() {
+                        if selection
+                            .iter()
+                            .any(|select| select.field.name.as_str() == field.as_str())
+                        {
+                            continue;
+                        }
+
+                        let column = ctx
+                            .database_definition
+                            .find_column_for_client_field(&field, table.id())
+                            .expect("ordering with non-existing column");
+
+                        extra_columns.push(column);
+                    }
+                }
+            }
+            None => {
+                for column in table.implicit_ordering_key().unwrap().columns() {
+                    if selection
+                        .iter()
+                        .any(|select| select.field.name.as_str() == column.table_column().client_name())
+                    {
+                        continue;
+                    }
+
+                    extra_columns.push(column.table_column());
+                }
+            }
+        }
 
         Self {
             ctx,
+            table,
             selection,
+            extra_columns,
             target,
             index: 0,
+            extra_column_index: 0,
         }
     }
 }
@@ -44,21 +105,20 @@ impl<'a> Iterator for SelectionIterator<'a> {
     type Item = TableSelection<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let Some(selection_field) = self.selection.get(self.index) else { return None };
+        let Some(selection_field) = self.selection.get(self.index) else {
+            let extra = self.extra_columns.get(self.extra_column_index);
+            self.extra_column_index += 1;
+
+            return extra.map(|column| TableSelection::Column(*column));
+        };
 
         self.index += 1;
-
-        let table = self
-            .ctx
-            .database_definition
-            .find_table_for_client_type(self.target.name())
-            .expect("table for client type not found");
 
         // Selecting a column.
         if let Some(column) = self
             .ctx
             .database_definition
-            .find_column_for_client_field(selection_field.name(), table.id())
+            .find_column_for_client_field(selection_field.name(), self.table.id())
         {
             return Some(TableSelection::Column(column));
         }
@@ -67,7 +127,7 @@ impl<'a> Iterator for SelectionIterator<'a> {
         let relation = match self
             .ctx
             .database_definition
-            .find_relation_for_client_field(selection_field.name(), table.id())
+            .find_relation_for_client_field(selection_field.name(), self.table.id())
         {
             Some(relation) => relation,
             None => return self.next(),
@@ -83,7 +143,7 @@ impl<'a> Iterator for SelectionIterator<'a> {
         if relation.is_referenced_row_unique() {
             // The other side has a unique constraint, so our join must return at most one row.
             let selection_set = selection_field.selection_set().collect();
-            let iterator = Self::new(self.ctx, meta_type, selection_set);
+            let iterator = Self::new(self.ctx, meta_type, selection_field, selection_set);
 
             Some(TableSelection::JoinUnique(relation, iterator))
         } else {
@@ -107,10 +167,14 @@ impl<'a> Iterator for SelectionIterator<'a> {
                 .and_then(|field| self.ctx.registry().lookup_expecting(&field.ty).ok())
                 .expect("couldn't find a meta type for a collection selection");
 
-            let iterator = Self::new(self.ctx, meta_type, selection_set);
+            let iterator = Self::new(self.ctx, meta_type, selection_field, selection_set);
 
             // By defining this, we mark the next select to return a collecton.
-            let args = CollectionArgs::new(self.ctx, relation.referenced_table(), selection_field);
+            let args = CollectionArgs::new(
+                self.ctx.database_definition,
+                relation.referenced_table(),
+                selection_field,
+            );
 
             Some(TableSelection::JoinMany(relation, iterator, args))
         }

--- a/engine/crates/engine/src/registry/resolvers/postgresql/context/selection/collection_args.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql/context/selection/collection_args.rs
@@ -1,23 +1,51 @@
-use crate::{registry::resolvers::postgresql::context::PostgresContext, SelectionField};
+use crate::SelectionField;
 use engine_value::{Name, Value};
 use grafbase_sql_ast::ast::{Aliasable, Column, Order, OrderDefinition};
 use indexmap::IndexMap;
-use postgresql_types::database_definition::TableWalker;
-use std::borrow::Cow;
+use postgresql_types::database_definition::{DatabaseDefinition, TableWalker};
+
+#[derive(Debug, Clone, Default)]
+pub struct CollectionOrdering {
+    inner: Vec<((String, String), Option<Order>)>,
+    outer: Vec<(String, Option<Order>)>,
+}
+
+impl CollectionOrdering {
+    pub fn raw_order(&self) -> impl ExactSizeIterator<Item = (&str, Option<Order>)> + '_ {
+        self.inner.iter().map(|((_, column), order)| (column.as_str(), *order))
+    }
+
+    pub fn inner(&self) -> impl ExactSizeIterator<Item = OrderDefinition<'static>> + '_ {
+        self.inner
+            .iter()
+            .map(|((table, column), order)| (Column::from((table.clone(), column.clone())).into(), *order))
+    }
+
+    pub fn outer(&self) -> impl ExactSizeIterator<Item = OrderDefinition<'static>> + '_ {
+        self.outer.iter().map(|(column, order)| {
+            let column = Column::from(column.clone());
+            (column.into(), *order)
+        })
+    }
+}
 
 /// Argument defining a relay-style GraphQL collection.
 #[derive(Debug, Clone)]
 pub struct CollectionArgs {
     first: Option<u64>,
     last: Option<u64>,
-    order_by: Option<(Vec<OrderDefinition<'static>>, Vec<OrderDefinition<'static>>)>,
+    order_by: CollectionOrdering,
     extra_columns: Vec<Column<'static>>,
     before: Option<String>,
     after: Option<String>,
 }
 
 impl CollectionArgs {
-    pub(crate) fn new(ctx: &PostgresContext<'_>, table: TableWalker<'_>, value: &SelectionField<'_>) -> Self {
+    pub(crate) fn new(
+        database_definition: &DatabaseDefinition,
+        table: TableWalker<'_>,
+        value: &SelectionField<'_>,
+    ) -> Self {
         let first = value.field.get_argument("first").and_then(|value| value.as_u64());
         let last = value.field.get_argument("last").and_then(|value| value.as_u64());
         let before = value.field.get_argument("before").and_then(|value| value.as_string());
@@ -27,90 +55,74 @@ impl CollectionArgs {
             .field
             .get_argument("orderBy")
             .and_then(|value| value.as_slice())
-            .map(Cow::from);
+            .map(<[engine_value::Value]>::to_vec)
+            .unwrap_or_default();
 
-        // For `last` to work, we need some known order for the inner query.
-        // If no `orderBy` is set, we order the inner selection with the first unique constraint,
-        // so we can select the `FIRST` n items from the reversed inner selection, and then
-        // reverse again in the outer queries.
-        //
-        // We first try to order with the primary key, and if the table has no primary keys, we use the
-        // first secondary key we find.
-        if let (None, Some(_)) = (&order_by_argument, last) {
-            let constraint = table
-                .primary_key()
-                .or_else(|| table.unique_constraints().next())
-                .expect("tables at this point must have at least one unique constraint");
+        let constraint = table
+            .implicit_ordering_key()
+            .expect("tables at this point must have at least one unique constraint");
 
-            let mut implicit_fields = Vec::with_capacity(constraint.columns().len());
-
-            for column in constraint.columns() {
-                let mut object = IndexMap::new();
-
-                object.insert(
-                    Name::new(column.table_column().database_name()),
-                    Value::String("ASC".into()),
-                );
-
-                implicit_fields.push(Value::Object(object));
+        for column in constraint.columns() {
+            if order_by_argument.iter().any(|value| match value {
+                Value::Object(ref obj) => obj.keys().any(|key| key == column.table_column().client_name()),
+                _ => false,
+            }) {
+                continue;
             }
 
-            order_by_argument = Some(Cow::from(implicit_fields))
-        };
+            let mut object = IndexMap::new();
 
-        let order_by = order_by_argument.map(|slice| {
-            // ordering the innermost query
-            let mut inner_order = Vec::new();
+            object.insert(
+                Name::new(column.table_column().client_name()),
+                Value::String("ASC".into()),
+            );
 
-            // the variables used for ordering the json queries
-            let mut outer_order = Vec::new();
+            order_by_argument.push(engine_value::Value::Object(object))
+        }
 
-            // extra columns we have to select (based on ordering)
-            let mut extra_columns = Vec::new();
+        // ordering the innermost query
+        let mut order_by = CollectionOrdering::default();
 
-            for value in slice.as_ref() {
-                let Some((field, value)) = value.as_object().and_then(IndexMap::first) else { continue };
-                let Some(direction) = value.as_str() else { continue };
+        // extra columns we have to select (based on ordering)
+        let mut extra_columns = Vec::new();
 
-                // For `last` to work, we must reverse the order of the inner query.
-                let inner_direction = match direction {
-                    "DESC" if last.is_some() => Order::Asc,
-                    "DESC" => Order::Desc,
-                    _ if last.is_some() => Order::Desc,
-                    _ => Order::Asc,
-                };
+        for value in order_by_argument.into_iter() {
+            let Some((field, value)) = value.as_object().and_then(IndexMap::first) else { continue };
+            let Some(direction) = value.as_str() else { continue };
 
-                // and then reverse the order again for the outer query.
-                let outer_direction = match inner_direction {
-                    Order::Desc if last.is_some() => Order::Asc,
-                    Order::Asc if last.is_some() => Order::Desc,
-                    _ => inner_direction,
-                };
+            // For `last` to work, we must reverse the order of the inner query.
+            let inner_direction = match direction {
+                "DESC" if last.is_some() => Order::Asc,
+                "DESC" => Order::Desc,
+                _ if last.is_some() => Order::Desc,
+                _ => Order::Asc,
+            };
 
-                let column = ctx
-                    .database_definition
-                    .find_column_for_client_field(&field, table.id())
-                    .expect("ordering with non-existing column");
+            // and then reverse the order again for the outer query.
+            let outer_direction = match inner_direction {
+                Order::Desc if last.is_some() => Order::Asc,
+                Order::Asc if last.is_some() => Order::Desc,
+                _ => inner_direction,
+            };
 
-                let sql_column = Column::from((table.database_name().to_string(), column.database_name().to_string()));
+            let column = database_definition
+                .find_column_for_client_field(&field, table.id())
+                .expect("ordering with non-existing column");
 
-                // We must name our order columns for them to be visible in the order by statement of the
-                // outer queries.
-                let order_alias = format!("{}_{}", table.database_name(), column.database_name());
-                extra_columns.push(sql_column.clone().alias(order_alias.clone()));
-                inner_order.push((sql_column.into(), Some(inner_direction)));
+            let sql_column = Column::from((table.database_name().to_string(), column.database_name().to_string()));
 
-                let column = Column::from(order_alias);
-                outer_order.push((column.into(), Some(outer_direction)));
-            }
+            // We must name our order columns for them to be visible in the order by statement of the
+            // outer queries.
+            let alias = format!("{}_{}", table.database_name(), column.database_name());
+            extra_columns.push(sql_column.clone().alias(alias.clone()));
 
-            (inner_order, outer_order, extra_columns)
-        });
+            order_by.inner.push((
+                (table.database_name().to_string(), column.database_name().to_string()),
+                Some(inner_direction),
+            ));
 
-        let (order_by, extra_columns) = match order_by {
-            Some((inner_order, outer_order, extra_columns)) => (Some((inner_order, outer_order)), extra_columns),
-            None => (None, Vec::new()),
-        };
+            order_by.outer.push((alias, Some(outer_direction)));
+        }
 
         Self {
             first,
@@ -147,10 +159,8 @@ impl CollectionArgs {
     /// Defines the ordering of the collection. The first item in a tuple is the ordering for the innermost
     /// query, and the second one of all the outer queries. An example GraphQL definition:
     /// `userCollection(orderBy: [{ name: DESC }])`.
-    pub(crate) fn order_by(&self) -> Option<(&[OrderDefinition<'static>], &[OrderDefinition<'static>])> {
-        self.order_by
-            .as_ref()
-            .map(|(left, right)| (left.as_slice(), right.as_slice()))
+    pub(crate) fn order_by(&self) -> &CollectionOrdering {
+        &self.order_by
     }
 
     /// A set of extra columns needing to select in the collecting query. Needed to handle the ordering of the outer

--- a/engine/crates/engine/src/registry/resolvers/postgresql/request/find_many.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql/request/find_many.rs
@@ -22,7 +22,7 @@ struct Response {
 pub(crate) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, Error> {
     let mut builder = SelectBuilder::new(ctx.table(), ctx.collection_selection(), "root");
 
-    let args = CollectionArgs::new(&ctx.database_definition(), ctx.table(), &ctx.root_field());
+    let args = CollectionArgs::new(&ctx.database_definition(), ctx.table(), &ctx.root_field())?;
     let mut selection_data = SelectionData::default();
 
     if let Some(first) = args.first() {
@@ -38,7 +38,7 @@ pub(crate) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, E
         .raw_order()
         .map(|(column, order)| {
             let order = order.map(|order| match order {
-                Order::Desc => "DESC",
+                Order::DescNullsFirst => "DESC",
                 _ => "ASC",
             });
 
@@ -53,7 +53,7 @@ pub(crate) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, E
         builder.set_filter(filter);
     }
 
-    let (sql, params) = renderer::Postgres::build(query::build(builder));
+    let (sql, params) = renderer::Postgres::build(query::build(builder)?);
 
     let response = ctx
         .transport()

--- a/engine/crates/engine/src/registry/resolvers/postgresql/request/find_many.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql/request/find_many.rs
@@ -2,11 +2,15 @@ use super::query::{self, SelectBuilder};
 use crate::{
     registry::resolvers::{
         postgresql::context::{CollectionArgs, PostgresContext},
+        resolved_value::SelectionData,
         ResolvedValue,
     },
     Error,
 };
-use grafbase_sql_ast::renderer::{self, Renderer};
+use grafbase_sql_ast::{
+    ast::Order,
+    renderer::{self, Renderer},
+};
 use postgresql_types::transport::Transport;
 use serde_json::Value;
 
@@ -18,7 +22,32 @@ struct Response {
 pub(crate) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, Error> {
     let mut builder = SelectBuilder::new(ctx.table(), ctx.collection_selection(), "root");
 
-    builder.set_collection_args(CollectionArgs::new(&ctx, ctx.table(), &ctx.root_field()));
+    let args = CollectionArgs::new(&ctx.database_definition(), ctx.table(), &ctx.root_field());
+    let mut selection_data = SelectionData::default();
+
+    if let Some(first) = args.first() {
+        selection_data.set_first(first);
+    }
+
+    if let Some(last) = args.last() {
+        selection_data.set_last(last);
+    }
+
+    let explicit_order = args
+        .order_by()
+        .raw_order()
+        .map(|(column, order)| {
+            let order = order.map(|order| match order {
+                Order::Desc => "DESC",
+                _ => "ASC",
+            });
+
+            (column.to_string(), order)
+        })
+        .collect();
+
+    selection_data.set_order_by(explicit_order);
+    builder.set_collection_args(args);
 
     if let Ok(filter) = ctx.filter() {
         builder.set_filter(filter);
@@ -32,10 +61,12 @@ pub(crate) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, E
         .await
         .map_err(|error| Error::new(error.to_string()))?;
 
-    Ok(ResolvedValue::new(
-        response
-            .into_single_row()
-            .map(|row| row.root)
-            .unwrap_or(Value::Array(Vec::new())),
-    ))
+    let response_data = response
+        .into_single_row()
+        .map(|row| row.root)
+        .unwrap_or(Value::Array(Vec::new()));
+
+    let resolved_value = ResolvedValue::new(response_data).with_selection_data(selection_data);
+
+    Ok(resolved_value)
 }

--- a/engine/crates/engine/src/registry/resolvers/postgresql/request/find_one.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql/request/find_one.rs
@@ -24,7 +24,7 @@ pub(super) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, E
         builder.set_filter(filter);
     }
 
-    let (sql, params) = renderer::Postgres::build(query::build(builder));
+    let (sql, params) = renderer::Postgres::build(query::build(builder)?);
 
     let response = ctx
         .transport()

--- a/engine/crates/engine/src/registry/resolvers/postgresql/request/query.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql/request/query.rs
@@ -31,13 +31,13 @@ pub fn build<'a>(builder: SelectBuilder<'a>) -> Select<'a> {
         }
 
         if let Some(limit) = args.first() {
-            inner_nested.limit(limit as u32);
+            inner_nested.limit(limit as u32 + 1); // we load one extra for pagination
         }
 
         // There's no `LAST` in PostgreSQL, so we limit the inner selection which is ordered in an opposite way,
         // and re-order it in the outer query.
         if let Some(limit) = args.last() {
-            inner_nested.limit(limit as u32);
+            inner_nested.limit(limit as u32 + 1); // we load one extra for pagination
         }
 
         if args.before().is_some() {

--- a/engine/crates/engine/src/registry/resolvers/transformer.rs
+++ b/engine/crates/engine/src/registry/resolvers/transformer.rs
@@ -167,7 +167,7 @@ impl Transformer {
                 Ok(new_value)
             }
             Transformer::PaginationData => {
-                let pagination = dbg!(last_resolver_value)
+                let pagination = last_resolver_value
                     .and_then(|x| x.pagination.as_ref())
                     .map(ResolvedPaginationInfo::output);
                 Ok(ResolvedValue::new(serde_json::to_value(pagination)?))
@@ -428,7 +428,7 @@ impl Transformer {
                     .next()
                     .expect("we always have at least one field in the query");
 
-                let args = CollectionArgs::new(database_definition, table, &root_field);
+                let args = CollectionArgs::new(database_definition, table, &root_field)?;
                 let mut selection_data = SelectionData::default();
 
                 if let Some(first) = args.first() {
@@ -444,7 +444,7 @@ impl Transformer {
                     .raw_order()
                     .map(|(column, order)| {
                         let order = order.map(|order| match order {
-                            Order::Desc => "DESC",
+                            Order::DescNullsFirst => "DESC",
                             _ => "ASC",
                         });
 

--- a/engine/crates/engine/src/registry/resolvers/transformer.rs
+++ b/engine/crates/engine/src/registry/resolvers/transformer.rs
@@ -159,10 +159,7 @@ impl Transformer {
                 let resolved_value =
                     last_resolver_value.ok_or_else(|| Error::new("Internal error resolving remote enum"))?;
 
-                let mut new_value =
-                    ResolvedValue::new(resolve_enum_value(resolved_value.data_resolved(), enum_values)?);
-
-                new_value.selection_data = resolved_value.selection_data.clone();
+                let new_value = ResolvedValue::new(resolve_enum_value(resolved_value.data_resolved(), enum_values)?);
 
                 Ok(new_value)
             }
@@ -334,10 +331,7 @@ impl Transformer {
                     _ => return Err(Error::new("The resolved value is not a bytes string")),
                 };
 
-                let mut new_value = ResolvedValue::new(new_value);
-                new_value.selection_data = resolved_value.selection_data.clone();
-
-                Ok(new_value)
+                Ok(ResolvedValue::new(new_value))
             }
             Transformer::MongoTimestamp => {
                 let resolved_value =
@@ -353,10 +347,7 @@ impl Transformer {
                     _ => return Err(Error::new("Cannot coerce the initial value into a valid Timestamp")),
                 };
 
-                let mut new_value = ResolvedValue::new(value);
-                new_value.selection_data = resolved_value.selection_data.clone();
-
-                Ok(new_value)
+                Ok(ResolvedValue::new(value))
             }
             Transformer::PostgresPageInfo => {
                 let resolved_value =

--- a/engine/crates/integration-tests/src/postgresql.rs
+++ b/engine/crates/integration-tests/src/postgresql.rs
@@ -200,6 +200,18 @@ impl TestApi {
             .await
     }
 
+    pub async fn execute_as<T>(&self, operation: impl AsRef<str>) -> T
+    where
+        T: DeserializeOwned + Send,
+    {
+        let result = self.execute(operation).await;
+        let response = serde_json::to_string(&result.to_graphql_response()).unwrap();
+
+        println!("{response}");
+
+        serde_json::from_str(&response).unwrap()
+    }
+
     pub async fn query_sql<T>(&self, query: &str) -> QueryResponse<T>
     where
         T: DeserializeOwned + Send,

--- a/engine/crates/integration-tests/tests/postgresql/find_many.rs
+++ b/engine/crates/integration-tests/tests/postgresql/find_many.rs
@@ -1,3 +1,5 @@
+mod pagination;
+
 use expect_test::expect;
 use indoc::indoc;
 use integration_tests::postgresql::{query_namespaced_neon, query_neon};

--- a/engine/crates/integration-tests/tests/postgresql/find_many.rs
+++ b/engine/crates/integration-tests/tests/postgresql/find_many.rs
@@ -24,7 +24,7 @@ fn eq_pk() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { id: { eq: 1 } }) {
+              userCollection(first: 10, filter: { id: { eq: 1 } }) {
                 edges { node { id name } }  
               }
             }
@@ -168,7 +168,7 @@ fn order_by() {
 
         let query = indoc! {r#"
             query {
-              userCollection(orderBy: [{ name: DESC }]) {
+              userCollection(first: 10, orderBy: [{ name: DESC }]) {
                 edges { node { id name } }  
               }
             }
@@ -223,7 +223,7 @@ fn namespaced() {
         let query = indoc! {r#"
             query {
               pg {
-                userCollection(filter: { id: { eq: 1 } }) {
+                userCollection(first: 10, filter: { id: { eq: 1 } }) {
                   edges { node { id name } }  
                 }
               }
@@ -274,7 +274,7 @@ fn eq_pk_rename() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { idField: { eq: 1 } }) {
+              userCollection(first: 10, filter: { idField: { eq: 1 } }) {
                 edges { node { idField nameField } }  
               }
             }
@@ -322,7 +322,7 @@ fn string_eq() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { name: { eq: "Musti" } }) {
+              userCollection(first: 10, filter: { name: { eq: "Musti" } }) {
                 edges { node { id name } }  
               }
             }
@@ -370,7 +370,7 @@ fn array_eq() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { numbers: { eq: [3, 4] } }) {
+              userCollection(first: 10, filter: { numbers: { eq: [3, 4] } }) {
                 edges { node { id numbers } }  
               }
             }
@@ -421,7 +421,7 @@ fn array_ne() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { numbers: { ne: [3, 4] } }) {
+              userCollection(first: 10, filter: { numbers: { ne: [3, 4] } }) {
                 edges { node { id numbers } }  
               }
             }
@@ -472,7 +472,7 @@ fn array_gt() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { numbers: { gt: [1, 2] } }) {
+              userCollection(first: 10, filter: { numbers: { gt: [1, 2] } }) {
                 edges { node { id numbers } }  
               }
             }
@@ -523,7 +523,7 @@ fn array_contains() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { numbers: { contains: [1, 2, 2, 1] } }) {
+              userCollection(first: 10, filter: { numbers: { contains: [1, 2, 2, 1] } }) {
                 edges { node { id numbers } }  
               }
             }
@@ -574,7 +574,7 @@ fn array_contained() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { numbers: { contained: [3, 6, 4, 7] } }) {
+              userCollection(first: 10, filter: { numbers: { contained: [3, 6, 4, 7] } }) {
                 edges { node { id numbers } }  
               }
             }
@@ -625,7 +625,7 @@ fn array_overlaps() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { numbers: { overlaps: [1, 5, 5, 6] } }) {
+              userCollection(first: 10, filter: { numbers: { overlaps: [1, 5, 5, 6] } }) {
                 edges { node { id numbers } }  
               }
             }
@@ -677,7 +677,7 @@ fn two_field_eq() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { name: { eq: "Musti" }, age: { eq: 11 } }) {
+              userCollection(first: 10, filter: { name: { eq: "Musti" }, age: { eq: 11 } }) {
                 edges { node { id name age } }  
               }
             }
@@ -726,7 +726,7 @@ fn string_ne() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { name: { ne: "Musti" } }) {
+              userCollection(first: 10, filter: { name: { ne: "Musti" } }) {
                 edges { node { id name } }  
               }
             }
@@ -774,7 +774,7 @@ fn string_gt() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { name: { gt: "Musti" } }) {
+              userCollection(first: 10, filter: { name: { gt: "Musti" } }) {
                 edges { node { id name } }  
               }
             }
@@ -822,7 +822,7 @@ fn string_lt() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { name: { lt: "Naukio" } }) {
+              userCollection(first: 10, filter: { name: { lt: "Naukio" } }) {
                 edges { node { id name } }  
               }
             }
@@ -870,7 +870,7 @@ fn string_gte() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { name: { gte: "Musti" } }) {
+              userCollection(first: 10, filter: { name: { gte: "Musti" } }) {
                 edges { node { id name } }  
               }
             }
@@ -924,7 +924,7 @@ fn string_lte() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { name: { lte: "Naukio" } }) {
+              userCollection(first: 10, filter: { name: { lte: "Naukio" } }) {
                 edges { node { id name } }  
               }
             }
@@ -978,7 +978,7 @@ fn string_in() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { name: { in: ["Musti", "Naukio"] } }) {
+              userCollection(first: 10, filter: { name: { in: ["Musti", "Naukio"] } }) {
                 edges { node { id name } }  
               }
             }
@@ -1032,7 +1032,7 @@ fn string_nin() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { name: { nin: ["Musti", "Naukio"] } }) {
+              userCollection(first: 10, filter: { name: { nin: ["Musti", "Naukio"] } }) {
                 edges { node { id name } }  
               }
             }
@@ -1074,7 +1074,7 @@ fn all() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { ALL: [
+              userCollection(first: 10, filter: { ALL: [
                 { name: { eq: "Musti" } },
                 { age: { eq: 11 } }
               ]}) {
@@ -1127,7 +1127,7 @@ fn any() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { ANY: [
+              userCollection(first: 10, filter: { ANY: [
                 { name: { eq: "Musti" } },
                 { age: { eq: 11 } }
               ]}) {
@@ -1190,7 +1190,7 @@ fn none() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { NONE: [
+              userCollection(first: 10, filter: { NONE: [
                 { name: { eq: "Musti" } },
                 { age: { eq: 13 } }
               ]}) {
@@ -1246,7 +1246,7 @@ fn not() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { name: { not: { eq: "Pentti" } } }) {
+              userCollection(first: 10, filter: { name: { not: { eq: "Pentti" } } }) {
                 edges { node { id name age } }  
               }
             }
@@ -1323,7 +1323,7 @@ fn one_to_one_relation_filter() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { profile: { description: { eq: "purrpurrpurr" } } }) {
+              userCollection(first: 10, filter: { profile: { description: { eq: "purrpurrpurr" } } }) {
                 edges {
                   node {
                     id
@@ -1402,7 +1402,7 @@ fn one_to_many_relation_filter_child_side() {
 
         let query = indoc! {r#"
             query {
-              blogCollection(filter: { user: { id: { eq: 1 } } }) {
+              blogCollection(first: 10, filter: { user: { id: { eq: 1 } } }) {
                 edges {
                   node {
                     id
@@ -1492,12 +1492,12 @@ fn one_to_many_relation_filter_parent_side() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { blogs: { contains: { id: { eq: 1 } } } }) {
+              userCollection(first: 10, filter: { blogs: { contains: { id: { eq: 1 } } } }) {
                 edges {
                   node {
                     id
                     name
-                    blogs { edges { node { id title } } }
+                    blogs(first: 10) { edges { node { id title } } }
                   }
                 }
               }

--- a/engine/crates/integration-tests/tests/postgresql/find_many/pagination.rs
+++ b/engine/crates/integration-tests/tests/postgresql/find_many/pagination.rs
@@ -1,4 +1,5 @@
 mod cursors;
+mod filters;
 
 use expect_test::expect;
 use indoc::indoc;
@@ -24,7 +25,7 @@ fn page_info_no_nesting() {
 
         let query = indoc! {r#"
             query {
-              userCollection {
+              userCollection(first: 10) {
                 edges { node { name } cursor }
                 pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
               }
@@ -217,10 +218,10 @@ fn nested_page_info_no_limit() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { id: { eq: 1 } }) {
+              userCollection(first: 10, filter: { id: { eq: 1 } }) {
                 edges {
                   node {
-                    blogs {
+                    blogs(first: 10) {
                       edges { node { id title } cursor }
                       pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
                     }
@@ -325,7 +326,7 @@ fn nested_page_info_with_first() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { id: { eq: 1 } }) {
+              userCollection(first: 10, filter: { id: { eq: 1 } }) {
                 edges {
                   node {
                     blogs(first: 1) {
@@ -426,7 +427,7 @@ fn nested_page_info_with_last() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { id: { eq: 1 } }) {
+              userCollection(first: 10, filter: { id: { eq: 1 } }) {
                 edges {
                   node {
                     blogs(last: 1) {

--- a/engine/crates/integration-tests/tests/postgresql/find_many/pagination.rs
+++ b/engine/crates/integration-tests/tests/postgresql/find_many/pagination.rs
@@ -1,0 +1,459 @@
+use expect_test::expect;
+use indoc::indoc;
+use integration_tests::postgresql::query_neon;
+
+#[test]
+fn root_level_implicit_order_with_single_pk() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(first: 2) {
+                edges { node { name } cursor }
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "name": "Musti"
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB"
+                },
+                {
+                  "node": {
+                    "name": "Naukio"
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgIUFAgBByQBPAEBAQcoAiQB"
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn root_level_implicit_order_with_compound_pk() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                name VARCHAR(255) NOT NULL,
+                email VARCHAR(255) NOT NULL,
+                CONSTRAINT "User_pkey" PRIMARY KEY (name, email)
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (name, email) VALUES ('Musti', 'murr@purr.com'), ('Naukio', 'purr@murr.com')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(first: 2) {
+                edges { node { name } cursor }
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "name": "Musti"
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABU11c3RpAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWLyUDAQMRLyQUFBQFZW1haWwADW11cnJAcHVyci5jb20ACUFzY2VuZGluZwADRF1TAwEDESgiFBQUAjUIJCQBdQEBAQkoAiQB"
+                },
+                {
+                  "node": {
+                    "name": "Naukio"
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABk5hdWtpbwBkaXJlY3Rpb24ACUFzY2VuZGluZwADFjAmAwEDETAlFBQUBWVtYWlsAA1wdXJyQG11cnIuY29tAAlBc2NlbmRpbmcAA0ReVAMBAxEoIhQUFAI1CCQkAXYBAQEJKAIkAQ"
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn root_level_implicit_order_with_nullable_compound_key() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                name VARCHAR(255) NOT NULL,
+                email VARCHAR(255) NULL,
+                CONSTRAINT "User_pkey" UNIQUE (name, email)
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (name, email) VALUES ('Musti', NULL), ('Naukio', 'purr@murr.com')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(first: 2) {
+                edges { node { name } cursor }
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "name": "Musti"
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABU11c3RpAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWLyUDAQMRLyQUFBQFZW1haWwACUFzY2VuZGluZwADNU5EAwEDERkAFBQAAiYIJCQBZgEBAQkoAiQB"
+                },
+                {
+                  "node": {
+                    "name": "Naukio"
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABk5hdWtpbwBkaXJlY3Rpb24ACUFzY2VuZGluZwADFjAmAwEDETAlFBQUBWVtYWlsAA1wdXJyQG11cnIuY29tAAlBc2NlbmRpbmcAA0ReVAMBAxEoIhQUFAI1CCQkAXYBAQEJKAIkAQ"
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn root_level_explicit_order() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(first: 2, orderBy: [{ name: DESC }]) {
+                edges { node { id } cursor }
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 2
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABk5hdWtpbwBkaXJlY3Rpb24ACkRlc2NlbmRpbmcAAxcxJwMBAxIxJhQUFAJpZAAJQXNjZW5kaW5nAAMzTUMDAQMRFgIUFAgCIwgkJAFlAQEBCSgCJAE"
+                },
+                {
+                  "node": {
+                    "id": 1
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABU11c3RpAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFzAmAwEDEjAlFBQUAmlkAAlBc2NlbmRpbmcAAzNMQgMBAxEWARQUCAIjCCQkAWQBAQEJKAIkAQ"
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn root_level_explicit_order_two_columns() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(first: 2, orderBy: [{ name: DESC }, { id: DESC }]) {
+                edges { node { id } cursor }
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 2
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABk5hdWtpbwBkaXJlY3Rpb24ACkRlc2NlbmRpbmcAAxcxJwMBAxIxJhQUFAJpZAAKRGVzY2VuZGluZwADNE5EAwEDEhcCFBQIAiQIJCQBZgEBAQkoAiQB"
+                },
+                {
+                  "node": {
+                    "id": 1
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABU11c3RpAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFzAmAwEDEjAlFBQUAmlkAApEZXNjZW5kaW5nAAM0TUMDAQMSFwEUFAgCJAgkJAFlAQEBCSgCJAE"
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn nested_ordering_cursors_implicit_order() {
+    let response = query_neon(|api| async move {
+        let user_table = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            );
+        "#};
+
+        api.execute_sql(user_table).await;
+
+        let profile_table = indoc! {r#"
+            CREATE TABLE "Blog" (
+                id INT PRIMARY KEY,
+                user_id INT NOT NULL,
+                title VARCHAR(255) NOT NULL,
+                CONSTRAINT Blog_User_fkey FOREIGN KEY (user_id) REFERENCES "User" (id)
+            )  
+        "#};
+
+        api.execute_sql(profile_table).await;
+
+        let insert_users = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES
+              (1, 'Musti'),
+              (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert_users).await;
+
+        let insert_profiles = indoc! {r#"
+            INSERT INTO "Blog" (id, user_id, title) VALUES
+              (1, 1, 'Hello, world!'),
+              (2, 1, 'Sayonara...'),
+              (3, 2, 'Meow meow?')
+        "#};
+
+        api.execute_sql(insert_profiles).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { id: { eq: 1 } }) {
+                edges {
+                  node {
+                    blogs(first: 2) { edges { node { id title } cursor } }
+                  }
+                  cursor
+                }
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "blogs": {
+                      "edges": [
+                        {
+                          "node": {
+                            "id": 1,
+                            "title": "Hello, world!"
+                          },
+                          "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB"
+                        },
+                        {
+                          "node": {
+                            "id": 2,
+                            "title": "Sayonara..."
+                          },
+                          "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgIUFAgBByQBPAEBAQcoAiQB"
+                        }
+                      ]
+                    }
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB"
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn nested_ordering_cursors_explicit_order() {
+    let response = query_neon(|api| async move {
+        let user_table = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            );
+        "#};
+
+        api.execute_sql(user_table).await;
+
+        let profile_table = indoc! {r#"
+            CREATE TABLE "Blog" (
+                id INT PRIMARY KEY,
+                user_id INT NOT NULL,
+                title VARCHAR(255) NOT NULL,
+                CONSTRAINT Blog_User_fkey FOREIGN KEY (user_id) REFERENCES "User" (id)
+            )  
+        "#};
+
+        api.execute_sql(profile_table).await;
+
+        let insert_users = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES
+              (1, 'Musti'),
+              (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert_users).await;
+
+        let insert_profiles = indoc! {r#"
+            INSERT INTO "Blog" (id, user_id, title) VALUES
+              (1, 1, 'Hello, world!'),
+              (2, 1, 'Sayonara...'),
+              (3, 2, 'Meow meow?')
+        "#};
+
+        api.execute_sql(insert_profiles).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(filter: { id: { eq: 1 } }) {
+                edges {
+                  node {
+                    blogs(first: 2, orderBy: [{ title: DESC }]) { edges { node { id title } cursor } }
+                  }
+                  cursor
+                }
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "blogs": {
+                      "edges": [
+                        {
+                          "node": {
+                            "id": 2,
+                            "title": "Sayonara..."
+                          },
+                          "cursor": "ZmllbGRzAG5hbWUABXRpdGxlAHZhbHVlAAtTYXlvbmFyYS4uLgBkaXJlY3Rpb24ACkRlc2NlbmRpbmcAAxc3LAMBAxI3KxQUFAJpZAAJQXNjZW5kaW5nAAMzU0gDAQMRFgIUFAgCIwgkJAFrAQEBCSgCJAE"
+                        },
+                        {
+                          "node": {
+                            "id": 1,
+                            "title": "Hello, world!"
+                          },
+                          "cursor": "ZmllbGRzAG5hbWUABXRpdGxlAHZhbHVlAA1IZWxsbywgd29ybGQhAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFzkuAwEDEjktFBQUAmlkAAlBc2NlbmRpbmcAAzNVSgMBAxEWARQUCAIjCCQkAW0BAQEJKAIkAQ"
+                        }
+                      ]
+                    }
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB"
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}

--- a/engine/crates/integration-tests/tests/postgresql/find_many/pagination/cursors.rs
+++ b/engine/crates/integration-tests/tests/postgresql/find_many/pagination/cursors.rs
@@ -1,11 +1,9 @@
-mod cursors;
-
 use expect_test::expect;
 use indoc::indoc;
 use integration_tests::postgresql::query_neon;
 
 #[test]
-fn page_info_no_nesting() {
+fn root_level_implicit_order_with_single_pk() {
     let response = query_neon(|api| async move {
         let schema = indoc! {r#"
             CREATE TABLE "User" (
@@ -24,9 +22,8 @@ fn page_info_no_nesting() {
 
         let query = indoc! {r#"
             query {
-              userCollection {
+              userCollection(first: 2) {
                 edges { node { name } cursor }
-                pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
               }
             }
         "#};
@@ -51,13 +48,7 @@ fn page_info_no_nesting() {
                   },
                   "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgIUFAgBByQBPAEBAQcoAiQB"
                 }
-              ],
-              "pageInfo": {
-                "hasNextPage": false,
-                "hasPreviousPage": false,
-                "startCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB",
-                "endCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgIUFAgBByQBPAEBAQcoAiQB"
-              }
+              ]
             }
           }
         }"#]];
@@ -66,28 +57,28 @@ fn page_info_no_nesting() {
 }
 
 #[test]
-fn page_info_first_has_more_data() {
+fn root_level_implicit_order_with_compound_pk() {
     let response = query_neon(|api| async move {
         let schema = indoc! {r#"
             CREATE TABLE "User" (
-                id INT PRIMARY KEY,
-                name VARCHAR(255) NOT NULL
+                name VARCHAR(255) NOT NULL,
+                email VARCHAR(255) NOT NULL,
+                CONSTRAINT "User_pkey" PRIMARY KEY (name, email)
             )    
         "#};
 
         api.execute_sql(schema).await;
 
         let insert = indoc! {r#"
-            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+            INSERT INTO "User" (name, email) VALUES ('Musti', 'murr@purr.com'), ('Naukio', 'purr@murr.com')
         "#};
 
         api.execute_sql(insert).await;
 
         let query = indoc! {r#"
             query {
-              userCollection(first: 1) {
+              userCollection(first: 2) {
                 edges { node { name } cursor }
-                pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
               }
             }
         "#};
@@ -104,15 +95,15 @@ fn page_info_first_has_more_data() {
                   "node": {
                     "name": "Musti"
                   },
-                  "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB"
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABU11c3RpAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWLyUDAQMRLyQUFBQFZW1haWwADW11cnJAcHVyci5jb20ACUFzY2VuZGluZwADRF1TAwEDESgiFBQUAjUIJCQBdQEBAQkoAiQB"
+                },
+                {
+                  "node": {
+                    "name": "Naukio"
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABk5hdWtpbwBkaXJlY3Rpb24ACUFzY2VuZGluZwADFjAmAwEDETAlFBQUBWVtYWlsAA1wdXJyQG11cnIuY29tAAlBc2NlbmRpbmcAA0ReVAMBAxEoIhQUFAI1CCQkAXYBAQEJKAIkAQ"
                 }
-              ],
-              "pageInfo": {
-                "hasNextPage": true,
-                "hasPreviousPage": false,
-                "startCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB",
-                "endCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB"
-              }
+              ]
             }
           }
         }"#]];
@@ -121,7 +112,62 @@ fn page_info_first_has_more_data() {
 }
 
 #[test]
-fn page_info_last_has_more_data() {
+fn root_level_implicit_order_with_nullable_compound_key() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                name VARCHAR(255) NOT NULL,
+                email VARCHAR(255) NULL,
+                CONSTRAINT "User_pkey" UNIQUE (name, email)
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (name, email) VALUES ('Musti', NULL), ('Naukio', 'purr@murr.com')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(first: 2) {
+                edges { node { name } cursor }
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "name": "Musti"
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABU11c3RpAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWLyUDAQMRLyQUFBQFZW1haWwACUFzY2VuZGluZwADNU5EAwEDERkAFBQAAiYIJCQBZgEBAQkoAiQB"
+                },
+                {
+                  "node": {
+                    "name": "Naukio"
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABk5hdWtpbwBkaXJlY3Rpb24ACUFzY2VuZGluZwADFjAmAwEDETAlFBQUBWVtYWlsAA1wdXJyQG11cnIuY29tAAlBc2NlbmRpbmcAA0ReVAMBAxEoIhQUFAI1CCQkAXYBAQEJKAIkAQ"
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn root_level_explicit_order() {
     let response = query_neon(|api| async move {
         let schema = indoc! {r#"
             CREATE TABLE "User" (
@@ -140,9 +186,8 @@ fn page_info_last_has_more_data() {
 
         let query = indoc! {r#"
             query {
-              userCollection(last: 1) {
-                edges { node { name } cursor }
-                pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
+              userCollection(first: 2, orderBy: [{ name: DESC }]) {
+                edges { node { id } cursor }
               }
             }
         "#};
@@ -157,17 +202,17 @@ fn page_info_last_has_more_data() {
               "edges": [
                 {
                   "node": {
-                    "name": "Naukio"
+                    "id": 2
                   },
-                  "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFycfAwEDEicCFBQIAQckAT0BAQEHKAIkAQ"
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABk5hdWtpbwBkaXJlY3Rpb24ACkRlc2NlbmRpbmcAAxcxJwMBAxIxJhQUFAJpZAAJQXNjZW5kaW5nAAMzTUMDAQMRFgIUFAgCIwgkJAFlAQEBCSgCJAE"
+                },
+                {
+                  "node": {
+                    "id": 1
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABU11c3RpAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFzAmAwEDEjAlFBQUAmlkAAlBc2NlbmRpbmcAAzNMQgMBAxEWARQUCAIjCCQkAWQBAQEJKAIkAQ"
                 }
-              ],
-              "pageInfo": {
-                "hasNextPage": false,
-                "hasPreviousPage": true,
-                "startCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFycfAwEDEicCFBQIAQckAT0BAQEHKAIkAQ",
-                "endCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFycfAwEDEicCFBQIAQckAT0BAQEHKAIkAQ"
-              }
+              ]
             }
           }
         }"#]];
@@ -176,7 +221,61 @@ fn page_info_last_has_more_data() {
 }
 
 #[test]
-fn nested_page_info_no_limit() {
+fn root_level_explicit_order_two_columns() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(first: 2, orderBy: [{ name: DESC }, { id: DESC }]) {
+                edges { node { id } cursor }
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 2
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABk5hdWtpbwBkaXJlY3Rpb24ACkRlc2NlbmRpbmcAAxcxJwMBAxIxJhQUFAJpZAAKRGVzY2VuZGluZwADNE5EAwEDEhcCFBQIAiQIJCQBZgEBAQkoAiQB"
+                },
+                {
+                  "node": {
+                    "id": 1
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABU11c3RpAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFzAmAwEDEjAlFBQUAmlkAApEZXNjZW5kaW5nAAM0TUMDAQMSFwEUFAgCJAgkJAFlAQEBCSgCJAE"
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn nested_ordering_cursors_implicit_order() {
     let response = query_neon(|api| async move {
         let user_table = indoc! {r#"
             CREATE TABLE "User" (
@@ -220,14 +319,10 @@ fn nested_page_info_no_limit() {
               userCollection(filter: { id: { eq: 1 } }) {
                 edges {
                   node {
-                    blogs {
-                      edges { node { id title } cursor }
-                      pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
-                    }
+                    blogs(first: 2) { edges { node { id title } cursor } }
                   }
                   cursor
                 }
-                pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
               }
             }
         "#};
@@ -258,24 +353,12 @@ fn nested_page_info_no_limit() {
                           },
                           "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgIUFAgBByQBPAEBAQcoAiQB"
                         }
-                      ],
-                      "pageInfo": {
-                        "hasNextPage": false,
-                        "hasPreviousPage": false,
-                        "startCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB",
-                        "endCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgIUFAgBByQBPAEBAQcoAiQB"
-                      }
+                      ]
                     }
                   },
                   "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB"
                 }
-              ],
-              "pageInfo": {
-                "hasNextPage": false,
-                "hasPreviousPage": false,
-                "startCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB",
-                "endCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB"
-              }
+              ]
             }
           }
         }"#]];
@@ -284,7 +367,7 @@ fn nested_page_info_no_limit() {
 }
 
 #[test]
-fn nested_page_info_with_first() {
+fn nested_ordering_cursors_explicit_order() {
     let response = query_neon(|api| async move {
         let user_table = indoc! {r#"
             CREATE TABLE "User" (
@@ -328,115 +411,10 @@ fn nested_page_info_with_first() {
               userCollection(filter: { id: { eq: 1 } }) {
                 edges {
                   node {
-                    blogs(first: 1) {
-                      edges { node { id title } cursor }
-                      pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
-                    }
+                    blogs(first: 2, orderBy: [{ title: DESC }]) { edges { node { id title } cursor } }
                   }
                   cursor
                 }
-                pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
-              }
-            }
-        "#};
-
-        api.execute(query).await
-    });
-
-    let expected = expect![[r#"
-        {
-          "data": {
-            "userCollection": {
-              "edges": [
-                {
-                  "node": {
-                    "blogs": {
-                      "edges": [
-                        {
-                          "node": {
-                            "id": 1,
-                            "title": "Hello, world!"
-                          },
-                          "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB"
-                        }
-                      ],
-                      "pageInfo": {
-                        "hasNextPage": true,
-                        "hasPreviousPage": false,
-                        "startCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB",
-                        "endCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB"
-                      }
-                    }
-                  },
-                  "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB"
-                }
-              ],
-              "pageInfo": {
-                "hasNextPage": false,
-                "hasPreviousPage": false,
-                "startCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB",
-                "endCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB"
-              }
-            }
-          }
-        }"#]];
-
-    expected.assert_eq(&response);
-}
-
-#[test]
-fn nested_page_info_with_last() {
-    let response = query_neon(|api| async move {
-        let user_table = indoc! {r#"
-            CREATE TABLE "User" (
-                id INT PRIMARY KEY,
-                name VARCHAR(255) NOT NULL
-            );
-        "#};
-
-        api.execute_sql(user_table).await;
-
-        let profile_table = indoc! {r#"
-            CREATE TABLE "Blog" (
-                id INT PRIMARY KEY,
-                user_id INT NOT NULL,
-                title VARCHAR(255) NOT NULL,
-                CONSTRAINT Blog_User_fkey FOREIGN KEY (user_id) REFERENCES "User" (id)
-            )  
-        "#};
-
-        api.execute_sql(profile_table).await;
-
-        let insert_users = indoc! {r#"
-            INSERT INTO "User" (id, name) VALUES
-              (1, 'Musti'),
-              (2, 'Naukio')
-        "#};
-
-        api.execute_sql(insert_users).await;
-
-        let insert_profiles = indoc! {r#"
-            INSERT INTO "Blog" (id, user_id, title) VALUES
-              (1, 1, 'Hello, world!'),
-              (2, 1, 'Sayonara...'),
-              (3, 2, 'Meow meow?')
-        "#};
-
-        api.execute_sql(insert_profiles).await;
-
-        let query = indoc! {r#"
-            query {
-              userCollection(filter: { id: { eq: 1 } }) {
-                edges {
-                  node {
-                    blogs(last: 1) {
-                      edges { node { id title } cursor }
-                      pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
-                    }
-                  }
-                  cursor
-                }
-                pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
               }
             }
         "#};
@@ -458,26 +436,21 @@ fn nested_page_info_with_last() {
                             "id": 2,
                             "title": "Sayonara..."
                           },
-                          "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFycfAwEDEicCFBQIAQckAT0BAQEHKAIkAQ"
+                          "cursor": "ZmllbGRzAG5hbWUABXRpdGxlAHZhbHVlAAtTYXlvbmFyYS4uLgBkaXJlY3Rpb24ACkRlc2NlbmRpbmcAAxc3LAMBAxI3KxQUFAJpZAAJQXNjZW5kaW5nAAMzU0gDAQMRFgIUFAgCIwgkJAFrAQEBCSgCJAE"
+                        },
+                        {
+                          "node": {
+                            "id": 1,
+                            "title": "Hello, world!"
+                          },
+                          "cursor": "ZmllbGRzAG5hbWUABXRpdGxlAHZhbHVlAA1IZWxsbywgd29ybGQhAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFzkuAwEDEjktFBQUAmlkAAlBc2NlbmRpbmcAAzNVSgMBAxEWARQUCAIjCCQkAW0BAQEJKAIkAQ"
                         }
-                      ],
-                      "pageInfo": {
-                        "hasNextPage": false,
-                        "hasPreviousPage": true,
-                        "startCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFycfAwEDEicCFBQIAQckAT0BAQEHKAIkAQ",
-                        "endCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFycfAwEDEicCFBQIAQckAT0BAQEHKAIkAQ"
-                      }
+                      ]
                     }
                   },
                   "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB"
                 }
-              ],
-              "pageInfo": {
-                "hasNextPage": false,
-                "hasPreviousPage": false,
-                "startCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB",
-                "endCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB"
-              }
+              ]
             }
           }
         }"#]];

--- a/engine/crates/integration-tests/tests/postgresql/find_many/pagination/cursors.rs
+++ b/engine/crates/integration-tests/tests/postgresql/find_many/pagination/cursors.rs
@@ -316,7 +316,7 @@ fn nested_ordering_cursors_implicit_order() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { id: { eq: 1 } }) {
+              userCollection(first: 1000, filter: { id: { eq: 1 } }) {
                 edges {
                   node {
                     blogs(first: 2) { edges { node { id title } cursor } }
@@ -408,7 +408,7 @@ fn nested_ordering_cursors_explicit_order() {
 
         let query = indoc! {r#"
             query {
-              userCollection(filter: { id: { eq: 1 } }) {
+              userCollection(first: 1000, filter: { id: { eq: 1 } }) {
                 edges {
                   node {
                     blogs(first: 2, orderBy: [{ title: DESC }]) { edges { node { id title } cursor } }

--- a/engine/crates/integration-tests/tests/postgresql/find_many/pagination/filters.rs
+++ b/engine/crates/integration-tests/tests/postgresql/find_many/pagination/filters.rs
@@ -1,0 +1,869 @@
+mod nested;
+
+use expect_test::expect;
+use indoc::{formatdoc, indoc};
+use integration_tests::postgresql::query_neon;
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UserCollection {
+    page_info: PageInfo,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PageInfo {
+    has_next_page: bool,
+    has_previous_page: bool,
+    start_cursor: String,
+    end_cursor: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ResponseData {
+    user_collection: UserCollection,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Response {
+    data: ResponseData,
+}
+
+#[test]
+fn id_pk_implicit_order_with_after() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(first: 1) {
+                edges { node { name } cursor }
+                pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
+              }
+            }
+        "#};
+
+        let response: Response = api.execute_as(query).await;
+        let page_info = response.data.user_collection.page_info;
+        let cursor = page_info.end_cursor;
+
+        assert!(page_info.has_next_page);
+
+        let query = formatdoc! {r#"
+            query {{
+              userCollection(first: 1, after: "{cursor}") {{
+                edges {{ node {{ name }} cursor }}
+                pageInfo {{ hasNextPage hasPreviousPage startCursor endCursor }}
+              }}
+            }}
+        "#};
+
+        api.execute(&query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "name": "Naukio"
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgIUFAgBByQBPAEBAQcoAiQB"
+                }
+              ],
+              "pageInfo": {
+                "hasNextPage": false,
+                "hasPreviousPage": false,
+                "startCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgIUFAgBByQBPAEBAQcoAiQB",
+                "endCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgIUFAgBByQBPAEBAQcoAiQB"
+              }
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response)
+}
+
+#[test]
+fn id_pk_implicit_order_with_before() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(last: 1) {
+                edges { node { name } cursor }
+                pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
+              }
+            }
+        "#};
+
+        let response: Response = api.execute_as(query).await;
+        let page_info = response.data.user_collection.page_info;
+        let cursor = page_info.start_cursor;
+
+        assert!(page_info.has_previous_page);
+
+        let query = formatdoc! {r#"
+            query {{
+              userCollection(last: 1, before: "{cursor}") {{
+                edges {{ node {{ name }} cursor }}
+                pageInfo {{ hasNextPage hasPreviousPage startCursor endCursor }}
+              }}
+            }}
+        "#};
+
+        api.execute(&query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "name": "Musti"
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFycfAwEDEicBFBQIAQckAT0BAQEHKAIkAQ"
+                }
+              ],
+              "pageInfo": {
+                "hasNextPage": false,
+                "hasPreviousPage": false,
+                "startCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFycfAwEDEicBFBQIAQckAT0BAQEHKAIkAQ",
+                "endCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFycfAwEDEicBFBQIAQckAT0BAQEHKAIkAQ"
+              }
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response)
+}
+
+#[test]
+fn id_pk_explicit_order_with_after() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(first: 1, orderBy: [{ id: DESC }]) {
+                edges { node { name } cursor }
+                pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
+              }
+            }
+        "#};
+
+        let response: Response = api.execute_as(query).await;
+        let page_info = response.data.user_collection.page_info;
+        let cursor = page_info.end_cursor;
+
+        assert!(page_info.has_next_page);
+
+        let query = formatdoc! {r#"
+            query {{
+              userCollection(first: 1, orderBy: [{{ id: DESC }}], after: "{cursor}") {{
+                edges {{ node {{ name }} cursor }}
+                pageInfo {{ hasNextPage hasPreviousPage startCursor endCursor }}
+              }}
+            }}
+        "#};
+
+        api.execute(&query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "name": "Musti"
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFycfAwEDEicBFBQIAQckAT0BAQEHKAIkAQ"
+                }
+              ],
+              "pageInfo": {
+                "hasNextPage": false,
+                "hasPreviousPage": false,
+                "startCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFycfAwEDEicBFBQIAQckAT0BAQEHKAIkAQ",
+                "endCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFycfAwEDEicBFBQIAQckAT0BAQEHKAIkAQ"
+              }
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response)
+}
+
+#[test]
+fn id_pk_explicit_order_with_before() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )    
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti'), (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(last: 1, orderBy: [{ id: DESC }]) {
+                edges { node { name } cursor }
+                pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
+              }
+            }
+        "#};
+
+        let response: Response = api.execute_as(query).await;
+        let page_info = response.data.user_collection.page_info;
+        let cursor = page_info.start_cursor;
+
+        assert!(page_info.has_previous_page);
+
+        let query = formatdoc! {r#"
+            query {{
+              userCollection(last: 1, before: "{cursor}", orderBy: [{{ id: DESC }}]) {{
+                edges {{ node {{ name }} cursor }}
+                pageInfo {{ hasNextPage hasPreviousPage startCursor endCursor }}
+              }}
+            }}
+        "#};
+
+        api.execute(&query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "name": "Naukio"
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgIUFAgBByQBPAEBAQcoAiQB"
+                }
+              ],
+              "pageInfo": {
+                "hasNextPage": false,
+                "hasPreviousPage": false,
+                "startCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgIUFAgBByQBPAEBAQcoAiQB",
+                "endCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgIUFAgBByQBPAEBAQcoAiQB"
+              }
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response)
+}
+
+#[test]
+fn compound_pk_implicit_order_with_after() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                name VARCHAR(255) NOT NULL,
+                email VARCHAR(255) NOT NULL,
+                CONSTRAINT "User_pkey" PRIMARY KEY (name, email)
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (name, email) VALUES
+                ('Musti', 'meow1@example.com'),
+                ('Musti', 'meow2@example.com'),
+                ('Naukio', 'meow3@example.com')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(first: 1) {
+                edges { node { name email } cursor }
+                pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
+              }
+            }
+        "#};
+
+        let response: Response = api.execute_as(query).await;
+        let page_info = response.data.user_collection.page_info;
+        let cursor = page_info.end_cursor;
+
+        assert!(page_info.has_next_page);
+
+        let query = formatdoc! {r#"
+            query {{
+              userCollection(first: 1, after: "{cursor}") {{
+                edges {{ node {{ name email }} cursor }}
+                pageInfo {{ hasNextPage hasPreviousPage startCursor endCursor }}
+              }}
+            }}
+        "#};
+
+        api.execute(&query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "name": "Musti",
+                    "email": "meow2@example.com"
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABU11c3RpAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWLyUDAQMRLyQUFBQFZW1haWwAEW1lb3cyQGV4YW1wbGUuY29tAAlBc2NlbmRpbmcAA0hhVwMBAxEsJhQUFAI5CCQkAXkBAQEJKAIkAQ"
+                }
+              ],
+              "pageInfo": {
+                "hasNextPage": true,
+                "hasPreviousPage": false,
+                "startCursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABU11c3RpAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWLyUDAQMRLyQUFBQFZW1haWwAEW1lb3cyQGV4YW1wbGUuY29tAAlBc2NlbmRpbmcAA0hhVwMBAxEsJhQUFAI5CCQkAXkBAQEJKAIkAQ",
+                "endCursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABU11c3RpAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWLyUDAQMRLyQUFBQFZW1haWwAEW1lb3cyQGV4YW1wbGUuY29tAAlBc2NlbmRpbmcAA0hhVwMBAxEsJhQUFAI5CCQkAXkBAQEJKAIkAQ"
+              }
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response)
+}
+
+#[test]
+fn compound_pk_implicit_order_with_before() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                name VARCHAR(255) NOT NULL,
+                email VARCHAR(255) NOT NULL,
+                CONSTRAINT "User_pkey" PRIMARY KEY (name, email)
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (name, email) VALUES
+                ('Musti', 'meow1@example.com'),
+                ('Naukio', 'meow3@example.com')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(last: 1) {
+                edges { node { name email } cursor }
+                pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
+              }
+            }
+        "#};
+
+        let response: Response = api.execute_as(query).await;
+        let page_info = response.data.user_collection.page_info;
+        let cursor = page_info.start_cursor;
+
+        assert!(page_info.has_previous_page);
+
+        let query = formatdoc! {r#"
+            query {{
+              userCollection(last: 1, before: "{cursor}") {{
+                edges {{ node {{ name email }} cursor }}
+                pageInfo {{ hasNextPage hasPreviousPage startCursor endCursor }}
+              }}
+            }}
+        "#};
+
+        api.execute(&query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "name": "Musti",
+                    "email": "meow1@example.com"
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABU11c3RpAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFzAmAwEDEjAlFBQUBWVtYWlsABFtZW93MUBleGFtcGxlLmNvbQAKRGVzY2VuZGluZwADSmNZAwEDEi0nFBQUAjoIJCQBewEBAQkoAiQB"
+                }
+              ],
+              "pageInfo": {
+                "hasNextPage": false,
+                "hasPreviousPage": false,
+                "startCursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABU11c3RpAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFzAmAwEDEjAlFBQUBWVtYWlsABFtZW93MUBleGFtcGxlLmNvbQAKRGVzY2VuZGluZwADSmNZAwEDEi0nFBQUAjoIJCQBewEBAQkoAiQB",
+                "endCursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABU11c3RpAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFzAmAwEDEjAlFBQUBWVtYWlsABFtZW93MUBleGFtcGxlLmNvbQAKRGVzY2VuZGluZwADSmNZAwEDEi0nFBQUAjoIJCQBewEBAQkoAiQB"
+              }
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response)
+}
+
+#[test]
+fn compound_pk_explicit_order_with_after() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                name VARCHAR(255) NOT NULL,
+                email VARCHAR(255) NOT NULL,
+                CONSTRAINT "User_pkey" PRIMARY KEY (name, email)
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (name, email) VALUES
+                ('Musti', 'meow1@example.com'),
+                ('Musti', 'meow2@example.com'),
+                ('Naukio', 'meow3@example.com')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(first: 1, orderBy: [{ name: ASC }, { email: DESC }]) {
+                edges { node { name email } cursor }
+                pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
+              }
+            }
+        "#};
+
+        let response: Response = api.execute_as(query).await;
+        let page_info = response.data.user_collection.page_info;
+        let cursor = page_info.end_cursor;
+
+        assert!(page_info.has_next_page);
+
+        let query = formatdoc! {r#"
+            query {{
+              userCollection(first: 1, orderBy: [{{ name: ASC }}, {{ email: DESC }}], after: "{cursor}") {{
+                edges {{ node {{ name email }} cursor }}
+                pageInfo {{ hasNextPage hasPreviousPage startCursor endCursor }}
+              }}
+            }}
+        "#};
+
+        api.execute(&query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "name": "Musti",
+                    "email": "meow1@example.com"
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABU11c3RpAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWLyUDAQMRLyQUFBQFZW1haWwAEW1lb3cxQGV4YW1wbGUuY29tAApEZXNjZW5kaW5nAANJYlgDAQMSLScUFBQCOggkJAF6AQEBCSgCJAE"
+                }
+              ],
+              "pageInfo": {
+                "hasNextPage": true,
+                "hasPreviousPage": false,
+                "startCursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABU11c3RpAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWLyUDAQMRLyQUFBQFZW1haWwAEW1lb3cxQGV4YW1wbGUuY29tAApEZXNjZW5kaW5nAANJYlgDAQMSLScUFBQCOggkJAF6AQEBCSgCJAE",
+                "endCursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABU11c3RpAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWLyUDAQMRLyQUFBQFZW1haWwAEW1lb3cxQGV4YW1wbGUuY29tAApEZXNjZW5kaW5nAANJYlgDAQMSLScUFBQCOggkJAF6AQEBCSgCJAE"
+              }
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response)
+}
+
+#[test]
+fn compound_pk_explicit_order_with_before() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                name VARCHAR(255) NOT NULL,
+                email VARCHAR(255) NOT NULL,
+                CONSTRAINT "User_pkey" PRIMARY KEY (name, email)
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (name, email) VALUES
+                ('Musti', 'meow1@example.com'),
+                ('Musti', 'meow2@example.com'),
+                ('Naukio', 'meow3@example.com')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(last: 1, orderBy: [{ name: ASC }, { email: DESC }]) {
+                edges { node { name email } cursor }
+                pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
+              }
+            }
+        "#};
+
+        let response: Response = api.execute_as(query).await;
+        let page_info = response.data.user_collection.page_info;
+        let cursor = page_info.start_cursor;
+
+        assert!(page_info.has_previous_page);
+
+        let query = formatdoc! {r#"
+            query {{
+              userCollection(last: 1, orderBy: [{{ name: ASC }}, {{ email: DESC }}], before: "{cursor}") {{
+                edges {{ node {{ name email }} cursor }}
+                pageInfo {{ hasNextPage hasPreviousPage startCursor endCursor }}
+              }}
+            }}
+        "#};
+
+        api.execute(&query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "name": "Musti",
+                    "email": "meow1@example.com"
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABU11c3RpAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFzAmAwEDEjAlFBQUBWVtYWlsABFtZW93MUBleGFtcGxlLmNvbQAJQXNjZW5kaW5nAANJYlgDAQMRLCYUFBQCOQgkJAF6AQEBCSgCJAE"
+                }
+              ],
+              "pageInfo": {
+                "hasNextPage": false,
+                "hasPreviousPage": true,
+                "startCursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABU11c3RpAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFzAmAwEDEjAlFBQUBWVtYWlsABFtZW93MUBleGFtcGxlLmNvbQAJQXNjZW5kaW5nAANJYlgDAQMRLCYUFBQCOQgkJAF6AQEBCSgCJAE",
+                "endCursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABU11c3RpAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFzAmAwEDEjAlFBQUBWVtYWlsABFtZW93MUBleGFtcGxlLmNvbQAJQXNjZW5kaW5nAANJYlgDAQMRLCYUFBQCOQgkJAF6AQEBCSgCJAE"
+              }
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response)
+}
+
+#[test]
+fn compound_pk_implicit_order_with_nulls_and_after() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                name VARCHAR(255) NOT NULL,
+                email VARCHAR(255) NULL,
+                CONSTRAINT "User_key" UNIQUE (name, email)
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (name, email) VALUES
+                ('Musti', NULL),
+                ('Naukio', NULL),
+                ('Naukio', 'meow3@example.com')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(first: 1) {
+                edges { node { name email } cursor }
+                pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
+              }
+            }
+        "#};
+
+        let response: Response = api.execute_as(query).await;
+        let page_info = response.data.user_collection.page_info;
+        let cursor = page_info.end_cursor;
+
+        assert!(page_info.has_next_page);
+
+        let query = formatdoc! {r#"
+            query {{
+              userCollection(first: 1, after: "{cursor}") {{
+                edges {{ node {{ name email }} cursor }}
+                pageInfo {{ hasNextPage hasPreviousPage startCursor endCursor }}
+              }}
+            }}
+        "#};
+
+        api.execute(&query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "name": "Naukio",
+                    "email": null
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABk5hdWtpbwBkaXJlY3Rpb24ACUFzY2VuZGluZwADFjAmAwEDETAlFBQUBWVtYWlsAAlBc2NlbmRpbmcAAzVPRQMBAxEZABQUAAImCCQkAWcBAQEJKAIkAQ"
+                }
+              ],
+              "pageInfo": {
+                "hasNextPage": true,
+                "hasPreviousPage": false,
+                "startCursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABk5hdWtpbwBkaXJlY3Rpb24ACUFzY2VuZGluZwADFjAmAwEDETAlFBQUBWVtYWlsAAlBc2NlbmRpbmcAAzVPRQMBAxEZABQUAAImCCQkAWcBAQEJKAIkAQ",
+                "endCursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABk5hdWtpbwBkaXJlY3Rpb24ACUFzY2VuZGluZwADFjAmAwEDETAlFBQUBWVtYWlsAAlBc2NlbmRpbmcAAzVPRQMBAxEZABQUAAImCCQkAWcBAQEJKAIkAQ"
+              }
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response)
+}
+
+#[test]
+fn compound_pk_implicit_order_with_nulls_and_before() {
+    let response = query_neon(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                name VARCHAR(255) NOT NULL,
+                email VARCHAR(255) NULL,
+                CONSTRAINT "User_key" UNIQUE (name, email)
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (name, email) VALUES
+                ('Musti', NULL),
+                ('Naukio', NULL),
+                ('Naukio', 'meow3@example.com')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(last: 1) {
+                edges { node { name email } cursor }
+                pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
+              }
+            }
+        "#};
+
+        let response: Response = api.execute_as(query).await;
+        let page_info = response.data.user_collection.page_info;
+        let cursor = page_info.start_cursor;
+
+        assert!(page_info.has_previous_page);
+
+        let query = formatdoc! {r#"
+            query {{
+              userCollection(last: 1, before: "{cursor}") {{
+                edges {{ node {{ name email }} cursor }}
+                pageInfo {{ hasNextPage hasPreviousPage startCursor endCursor }}
+              }}
+            }}
+        "#};
+
+        api.execute(&query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "name": "Naukio",
+                    "email": null
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABk5hdWtpbwBkaXJlY3Rpb24ACkRlc2NlbmRpbmcAAxcxJwMBAxIxJhQUFAVlbWFpbAAKRGVzY2VuZGluZwADN1FHAwEDEhoAFBQAAicIJCQBaQEBAQkoAiQB"
+                }
+              ],
+              "pageInfo": {
+                "hasNextPage": false,
+                "hasPreviousPage": true,
+                "startCursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABk5hdWtpbwBkaXJlY3Rpb24ACkRlc2NlbmRpbmcAAxcxJwMBAxIxJhQUFAVlbWFpbAAKRGVzY2VuZGluZwADN1FHAwEDEhoAFBQAAicIJCQBaQEBAQkoAiQB",
+                "endCursor": "ZmllbGRzAG5hbWUABG5hbWUAdmFsdWUABk5hdWtpbwBkaXJlY3Rpb24ACkRlc2NlbmRpbmcAAxcxJwMBAxIxJhQUFAVlbWFpbAAKRGVzY2VuZGluZwADN1FHAwEDEhoAFBQAAicIJCQBaQEBAQkoAiQB"
+              }
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response)
+}
+
+#[test]
+fn nested_page_info_no_limit() {
+    let response = query_neon(|api| async move {
+        let user_table = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            );
+        "#};
+
+        api.execute_sql(user_table).await;
+
+        let profile_table = indoc! {r#"
+            CREATE TABLE "Blog" (
+                id INT PRIMARY KEY,
+                user_id INT NOT NULL,
+                title VARCHAR(255) NOT NULL,
+                CONSTRAINT Blog_User_fkey FOREIGN KEY (user_id) REFERENCES "User" (id)
+            )  
+        "#};
+
+        api.execute_sql(profile_table).await;
+
+        let insert_users = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES
+              (1, 'Musti'),
+              (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert_users).await;
+
+        let insert_profiles = indoc! {r#"
+            INSERT INTO "Blog" (id, user_id, title) VALUES
+              (1, 1, 'Hello, world!'),
+              (2, 1, 'Sayonara...'),
+              (3, 2, 'Meow meow?')
+        "#};
+
+        api.execute_sql(insert_profiles).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(first: 1000, filter: { id: { eq: 1 } }) {
+                edges {
+                  node {
+                    blogs(first: 1000) {
+                      edges { node { id title } cursor }
+                      pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
+                    }
+                  }
+                  cursor
+                }
+                pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "blogs": {
+                      "edges": [
+                        {
+                          "node": {
+                            "id": 1,
+                            "title": "Hello, world!"
+                          },
+                          "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB"
+                        },
+                        {
+                          "node": {
+                            "id": 2,
+                            "title": "Sayonara..."
+                          },
+                          "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgIUFAgBByQBPAEBAQcoAiQB"
+                        }
+                      ],
+                      "pageInfo": {
+                        "hasNextPage": false,
+                        "hasPreviousPage": false,
+                        "startCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB",
+                        "endCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgIUFAgBByQBPAEBAQcoAiQB"
+                      }
+                    }
+                  },
+                  "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB"
+                }
+              ],
+              "pageInfo": {
+                "hasNextPage": false,
+                "hasPreviousPage": false,
+                "startCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB",
+                "endCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgEUFAgBByQBPAEBAQcoAiQB"
+              }
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}

--- a/engine/crates/integration-tests/tests/postgresql/find_many/pagination/filters/nested.rs
+++ b/engine/crates/integration-tests/tests/postgresql/find_many/pagination/filters/nested.rs
@@ -1,0 +1,273 @@
+use expect_test::expect;
+use indoc::{formatdoc, indoc};
+use integration_tests::postgresql::query_neon;
+use serde_json::Value;
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UserNode {
+    blogs: Collection<Edge<Value>>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Edge<T> {
+    node: T,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Collection<T> {
+    edges: Vec<T>,
+    page_info: PageInfo,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PageInfo {
+    has_next_page: bool,
+    has_previous_page: bool,
+    start_cursor: String,
+    end_cursor: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ResponseData {
+    user_collection: Collection<Edge<UserNode>>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Response {
+    data: ResponseData,
+}
+
+#[test]
+fn single_pk_implicit_order_after() {
+    let response = query_neon(|api| async move {
+        let user_table = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            );
+        "#};
+
+        api.execute_sql(user_table).await;
+
+        let profile_table = indoc! {r#"
+            CREATE TABLE "Blog" (
+                id INT PRIMARY KEY,
+                user_id INT NOT NULL,
+                title VARCHAR(255) NOT NULL,
+                CONSTRAINT Blog_User_fkey FOREIGN KEY (user_id) REFERENCES "User" (id)
+            )  
+        "#};
+
+        api.execute_sql(profile_table).await;
+
+        let insert_users = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES
+              (1, 'Musti'),
+              (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert_users).await;
+
+        let insert_profiles = indoc! {r#"
+            INSERT INTO "Blog" (id, user_id, title) VALUES
+              (1, 1, 'Hello, world!'),
+              (2, 1, 'Sayonara...'),
+              (3, 1, 'Meow meow?')
+        "#};
+
+        api.execute_sql(insert_profiles).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(first: 10, filter: { id: { eq: 1 } }) {
+                edges {
+                  node {
+                    blogs(first: 1) {
+                      edges { node { id title } cursor }
+                      pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
+                    }
+                  }
+                }
+                pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
+              }
+            }
+        "#};
+
+        let response: Response = api.execute_as(query).await;
+        let page_info = &response.data.user_collection.edges[0].node.blogs.page_info;
+        let cursor = &page_info.end_cursor;
+
+        assert!(page_info.has_next_page);
+
+        let query = formatdoc! {r#"
+            query {{
+              userCollection(first: 10, filter: {{ id: {{ eq: 1 }} }}) {{
+                edges {{
+                  node {{
+                    blogs(first: 1, after: "{cursor}") {{
+                      edges {{ node {{ id title }} cursor }}
+                      pageInfo {{ hasNextPage hasPreviousPage startCursor endCursor }}
+                    }}
+                  }}
+                }}
+              }}
+            }}
+        "#};
+
+        api.execute(&query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "blogs": {
+                      "edges": [
+                        {
+                          "node": {
+                            "id": 2,
+                            "title": "Sayonara..."
+                          },
+                          "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgIUFAgBByQBPAEBAQcoAiQB"
+                        }
+                      ],
+                      "pageInfo": {
+                        "hasNextPage": true,
+                        "hasPreviousPage": false,
+                        "startCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgIUFAgBByQBPAEBAQcoAiQB",
+                        "endCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAJQXNjZW5kaW5nAAMWJh4DAQMRJgIUFAgBByQBPAEBAQcoAiQB"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn single_pk_implicit_order_before() {
+    let response = query_neon(|api| async move {
+        let user_table = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            );
+        "#};
+
+        api.execute_sql(user_table).await;
+
+        let profile_table = indoc! {r#"
+            CREATE TABLE "Blog" (
+                id INT PRIMARY KEY,
+                user_id INT NOT NULL,
+                title VARCHAR(255) NOT NULL,
+                CONSTRAINT Blog_User_fkey FOREIGN KEY (user_id) REFERENCES "User" (id)
+            )  
+        "#};
+
+        api.execute_sql(profile_table).await;
+
+        let insert_users = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES
+              (1, 'Musti'),
+              (2, 'Naukio')
+        "#};
+
+        api.execute_sql(insert_users).await;
+
+        let insert_profiles = indoc! {r#"
+            INSERT INTO "Blog" (id, user_id, title) VALUES
+              (1, 1, 'Hello, world!'),
+              (2, 1, 'Sayonara...'),
+              (3, 1, 'Meow meow?')
+        "#};
+
+        api.execute_sql(insert_profiles).await;
+
+        let query = indoc! {r#"
+            query {
+              userCollection(first: 10, filter: { id: { eq: 1 } }) {
+                edges {
+                  node {
+                    blogs(last: 1) {
+                      edges { node { id title } cursor }
+                      pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
+                    }
+                  }
+                  cursor
+                }
+                pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
+              }
+            }
+        "#};
+
+        let response: Response = api.execute_as(query).await;
+        let page_info = &response.data.user_collection.edges[0].node.blogs.page_info;
+        let cursor = &page_info.start_cursor;
+
+        assert!(page_info.has_previous_page);
+
+        let query = formatdoc! {r#"
+            query {{
+              userCollection(first: 10, filter: {{ id: {{ eq: 1 }} }}) {{
+                edges {{
+                  node {{
+                    blogs(last: 1, before: "{cursor}") {{
+                      edges {{ node {{ id title }} cursor }}
+                      pageInfo {{ hasNextPage hasPreviousPage startCursor endCursor }}
+                    }}
+                  }}
+                }}
+              }}
+            }}
+        "#};
+
+        api.execute(&query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "blogs": {
+                      "edges": [
+                        {
+                          "node": {
+                            "id": 2,
+                            "title": "Sayonara..."
+                          },
+                          "cursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFycfAwEDEicCFBQIAQckAT0BAQEHKAIkAQ"
+                        }
+                      ],
+                      "pageInfo": {
+                        "hasNextPage": false,
+                        "hasPreviousPage": true,
+                        "startCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFycfAwEDEicCFBQIAQckAT0BAQEHKAIkAQ",
+                        "endCursor": "ZmllbGRzAG5hbWUAAmlkAHZhbHVlAGRpcmVjdGlvbgAKRGVzY2VuZGluZwADFycfAwEDEicCFBQIAQckAT0BAQEHKAIkAQ"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}

--- a/engine/crates/integration-tests/tests/postgresql/find_one/joins.rs
+++ b/engine/crates/integration-tests/tests/postgresql/find_one/joins.rs
@@ -270,7 +270,7 @@ fn one_to_many_join_between_schemas() {
               publicUser(by: { id: 1 }) {
                 id
                 name
-                privateUsers { edges { node { secretName } } }
+                privateUsers(first: 1000) { edges { node { secretName } } }
               }
             }
         "#};
@@ -644,7 +644,7 @@ fn one_to_many_join_parent_side() {
             query {
               user(by: { id: 1 }) {
                 name
-                blogs { edges { node { id title } } }
+                blogs(first: 10000) { edges { node { id title } } }
               }
             }
         "#};
@@ -744,12 +744,12 @@ fn nested_one_to_many_joins_parent_side() {
             query {
               user(by: { id: 1 }) {
                 name
-                blogs { 
+                blogs(first: 1000) { 
                   edges {
                     node {
                       id
                       title
-                      posts {
+                      posts(first: 1000) {
                         edges {
                           node {
                             id
@@ -1007,7 +1007,7 @@ fn one_to_many_join_parent_side_with_single_column_descending_order() {
             query {
               user(by: { id: 1 }) {
                 name
-                blogs(orderBy: [{ id: DESC }]) { edges { node { id title } } }
+                blogs(first: 10, orderBy: [{ id: DESC }]) { edges { node { id title } } }
               }
             }
         "#};
@@ -1275,8 +1275,8 @@ fn two_one_to_many_joins_parent_side() {
             query {
               user(by: { id: 1 }) {
                 name
-                blogs { edges { node { id title } } }
-                cats { edges { node { id name } } }
+                blogs(first: 1000) { edges { node { id title } } }
+                cats(first: 100) { edges { node { id name } } }
               }
             }
         "#};
@@ -1391,7 +1391,7 @@ fn one_to_one_with_one_to_many_joins_parent_side() {
             query {
               user(by: { id: 1 }) {
                 name
-                blogs { edges { node { id title } } }
+                blogs(first: 10) { edges { node { id title } } }
                 profile { description }
               }
             }

--- a/engine/crates/integration-tests/tests/postgresql/introspection.rs
+++ b/engine/crates/integration-tests/tests/postgresql/introspection.rs
@@ -52,8 +52,8 @@ fn table_with_serial_primary_key() {
         }
 
         type PageInfo {
-          hasNextPage: Boolean!
           hasPreviousPage: Boolean!
+          hasNextPage: Boolean!
           startCursor: String
           endCursor: String
         }
@@ -207,8 +207,8 @@ fn table_with_enum_field() {
         }
 
         type PageInfo {
-          hasNextPage: Boolean!
           hasPreviousPage: Boolean!
+          hasNextPage: Boolean!
           startCursor: String
           endCursor: String
         }
@@ -288,8 +288,8 @@ fn table_with_int_primary_key() {
         }
 
         type PageInfo {
-          hasNextPage: Boolean!
           hasPreviousPage: Boolean!
+          hasNextPage: Boolean!
           startCursor: String
           endCursor: String
         }
@@ -398,8 +398,8 @@ fn table_with_int_unique() {
         }
 
         type PageInfo {
-          hasNextPage: Boolean!
           hasPreviousPage: Boolean!
+          hasNextPage: Boolean!
           startCursor: String
           endCursor: String
         }
@@ -509,8 +509,8 @@ fn table_with_serial_primary_key_string_unique() {
         }
 
         type PageInfo {
-          hasNextPage: Boolean!
           hasPreviousPage: Boolean!
+          hasNextPage: Boolean!
           startCursor: String
           endCursor: String
         }
@@ -625,8 +625,8 @@ fn table_with_composite_primary_key() {
         }
 
         type PageInfo {
-          hasNextPage: Boolean!
           hasPreviousPage: Boolean!
+          hasNextPage: Boolean!
           startCursor: String
           endCursor: String
         }
@@ -784,8 +784,8 @@ fn two_schemas_same_table_name() {
         }
 
         type PageInfo {
-          hasNextPage: Boolean!
           hasPreviousPage: Boolean!
+          hasNextPage: Boolean!
           startCursor: String
           endCursor: String
         }
@@ -937,8 +937,8 @@ fn table_with_serial_primary_key_namespaced() {
         }
 
         type NeonPageInfo {
-          hasNextPage: Boolean!
           hasPreviousPage: Boolean!
+          hasNextPage: Boolean!
           startCursor: String
           endCursor: String
         }
@@ -1114,8 +1114,8 @@ fn two_tables_with_single_column_foreign_key() {
         }
 
         type PageInfo {
-          hasNextPage: Boolean!
           hasPreviousPage: Boolean!
+          hasNextPage: Boolean!
           startCursor: String
           endCursor: String
         }

--- a/engine/crates/integration-tests/tests/postgresql/introspection.rs
+++ b/engine/crates/integration-tests/tests/postgresql/introspection.rs
@@ -936,6 +936,13 @@ fn table_with_serial_primary_key_namespaced() {
           DESC
         }
 
+        type NeonPageInfo {
+          hasNextPage: Boolean!
+          hasPreviousPage: Boolean!
+          startCursor: String
+          endCursor: String
+        }
+
         type NeonQuery {
           """
             Query a single NeonUser by a field
@@ -970,7 +977,7 @@ fn table_with_serial_primary_key_namespaced() {
 
         type NeonUserConnection {
           edges: [NeonUserEdge]!
-          pageInfo: PageInfo!
+          pageInfo: NeonPageInfo!
         }
 
         type NeonUserEdge {
@@ -980,13 +987,6 @@ fn table_with_serial_primary_key_namespaced() {
 
         input NeonUserOrderByInput {
           id: NeonOrderByDirection
-        }
-
-        type PageInfo {
-          hasNextPage: Boolean!
-          hasPreviousPage: Boolean!
-          startCursor: String
-          endCursor: String
         }
 
         type Query {

--- a/engine/crates/parser-postgresql/src/registry/queries/find_many.rs
+++ b/engine/crates/parser-postgresql/src/registry/queries/find_many.rs
@@ -35,6 +35,7 @@ pub(crate) fn register(
     ]);
 
     let order_by_type = input_ctx.orderby_input_type_name(type_name);
+
     let order_by_value = MetaInputValue::new("orderBy", format!("[{order_by_type}]"));
     field.args.insert("orderBy".to_string(), order_by_value);
 

--- a/engine/crates/parser-postgresql/src/registry/queries/find_many.rs
+++ b/engine/crates/parser-postgresql/src/registry/queries/find_many.rs
@@ -4,6 +4,7 @@ use engine::{
     registry::{
         resolvers::{
             postgresql::{Operation, PostgresResolver},
+            transformer::Transformer,
             Resolver,
         },
         MetaField, MetaInputValue,
@@ -39,7 +40,9 @@ pub(crate) fn register(
     let order_by_value = MetaInputValue::new("orderBy", format!("[{order_by_type}]"));
     field.args.insert("orderBy".to_string(), order_by_value);
 
-    field.resolver = Resolver::PostgresResolver(PostgresResolver::new(Operation::FindMany, input_ctx.directive_name()));
+    field.resolver = Resolver::PostgresResolver(PostgresResolver::new(Operation::FindMany, input_ctx.directive_name()))
+        .and_then(Transformer::PostgresPageInfo);
+
     field.required_operation = Some(Operations::LIST);
 
     output_ctx.push_query(field);

--- a/engine/crates/parser-postgresql/src/registry/types.rs
+++ b/engine/crates/parser-postgresql/src/registry/types.rs
@@ -1,13 +1,10 @@
+mod order_direction;
+mod page_info;
 mod scalar;
-
-use std::borrow::Cow;
+mod table;
 
 use super::context::{InputContext, OutputContext};
-use engine::registry::{
-    resolvers::{transformer::Transformer, Resolver},
-    Constraint, EnumType, InputObjectType, MetaEnumValue, MetaField, MetaInputValue, ObjectType,
-};
-use postgresql_types::database_definition::{DatabaseType, ScalarType, TableWalker};
+use engine::registry::MetaEnumValue;
 
 pub(super) fn generate(input_ctx: &InputContext<'_>, output_ctx: &mut OutputContext) {
     let tables = input_ctx
@@ -15,13 +12,13 @@ pub(super) fn generate(input_ctx: &InputContext<'_>, output_ctx: &mut OutputCont
         .tables()
         .filter(|table| table.allowed_in_client());
 
-    register_page_info(output_ctx);
+    page_info::register(input_ctx, output_ctx);
     scalar::register(input_ctx, output_ctx);
 
-    let direction_type = register_order_direction(input_ctx, output_ctx);
+    let direction_type = order_direction::register(input_ctx, output_ctx);
 
     for table in tables {
-        generate_types(input_ctx, table, &direction_type, output_ctx);
+        table::generate(input_ctx, table, &direction_type, output_ctx);
     }
 
     for r#enum in input_ctx.database_definition().enums() {
@@ -36,194 +33,4 @@ pub(super) fn generate(input_ctx: &InputContext<'_>, output_ctx: &mut OutputCont
             }
         })
     }
-}
-
-fn generate_types(
-    input_ctx: &InputContext<'_>,
-    table: TableWalker<'_>,
-    direction_type: &str,
-    output_ctx: &mut OutputContext,
-) {
-    let type_name = input_ctx.type_name(table.client_name());
-    let edge_type_name = register_edge_type(input_ctx, table, &type_name, output_ctx);
-
-    register_orderby_input(input_ctx, direction_type, table, output_ctx);
-    register_connection_type(input_ctx, table, &edge_type_name, output_ctx);
-
-    output_ctx.with_object_type(&type_name, table.id(), |builder| {
-        for column in table.columns() {
-            let client_type = column
-                .graphql_type()
-                .expect("forgot to filter unsupported types before generating");
-
-            let client_type = if column.nullable() {
-                client_type.to_string()
-            } else {
-                format!("{client_type}!")
-            };
-
-            let mut field = MetaField::new(column.client_name(), client_type.as_ref());
-            field.mapped_name = Some(column.database_name().to_string());
-
-            field.resolver = Resolver::Transformer(Transformer::Select {
-                key: column.database_name().to_string(),
-            });
-
-            let extra_transformer = match column.database_type() {
-                DatabaseType::Scalar(ScalarType::Bytea) => Some(Transformer::BytesToBase64),
-                DatabaseType::Scalar(ScalarType::ByteaArray) => Some(Transformer::ByteArrayToBase64Array),
-                DatabaseType::Enum(_) => Some(Transformer::RemoteEnum),
-                _ => None,
-            };
-
-            if let Some(transformer) = extra_transformer {
-                field.resolver = field.resolver.and_then(transformer);
-            }
-
-            builder.push_scalar_field(field, column.id());
-        }
-
-        for relation in table.relations() {
-            let field = if !relation.is_referenced_row_unique() {
-                let connection_type_name = input_ctx.connection_type_name(relation.referenced_table().client_name());
-
-                let mut field = MetaField::new(relation.client_field_name(), connection_type_name);
-
-                field
-                    .args
-                    .insert(String::from("first"), MetaInputValue::new("first", "Int"));
-
-                field
-                    .args
-                    .insert(String::from("last"), MetaInputValue::new("last", "Int"));
-
-                field
-                    .args
-                    .insert(String::from("before"), MetaInputValue::new("before", "String"));
-
-                field
-                    .args
-                    .insert(String::from("after"), MetaInputValue::new("after", "String"));
-
-                let order_by_type = input_ctx.orderby_input_type_name(relation.referenced_table().client_name());
-
-                field.args.insert(
-                    String::from("orderBy"),
-                    MetaInputValue::new("orderBy", format!("[{order_by_type}!]")),
-                );
-
-                field.resolver = Resolver::Transformer(Transformer::Select {
-                    key: relation.client_field_name(),
-                });
-
-                field
-            } else {
-                let client_type = relation.client_type();
-                let client_type = input_ctx.type_name(&client_type);
-
-                let client_type = if relation.nullable() {
-                    client_type
-                } else {
-                    Cow::Owned(format!("{client_type}!"))
-                };
-
-                let mut field = MetaField::new(relation.client_field_name(), client_type.as_ref());
-
-                field.resolver = Resolver::Transformer(Transformer::Select {
-                    key: relation.client_field_name(),
-                });
-
-                field
-            };
-
-            builder.push_relation_field(field, relation.id());
-        }
-
-        for constraint in table.unique_constraints() {
-            let fields = constraint
-                .columns()
-                .map(|column| column.table_column().client_name().to_string())
-                .collect();
-
-            builder.push_constraint(Constraint::unique(constraint.name().to_string(), fields));
-        }
-    });
-}
-
-fn register_order_direction(input_ctx: &InputContext<'_>, output_ctx: &mut OutputContext) -> String {
-    let type_name = input_ctx.type_name("OrderByDirection");
-
-    let variants = ["ASC", "DESC"].iter().map(|name| {
-        let mut variant = MetaEnumValue::new((*name).to_string());
-        variant.value = Some((*name).to_string());
-
-        variant
-    });
-
-    let r#enum = EnumType::new(type_name.to_string(), variants);
-
-    output_ctx.create_enum_type(r#enum);
-    type_name.into_owned()
-}
-
-fn register_page_info(output_ctx: &mut OutputContext) {
-    output_ctx.create_object_type(ObjectType::new(
-        "PageInfo",
-        [
-            MetaField::new("hasNextPage", "Boolean!"),
-            MetaField::new("hasPreviousPage", "Boolean!"),
-            MetaField::new("startCursor", "String"),
-            MetaField::new("endCursor", "String"),
-        ],
-    ));
-}
-
-fn register_connection_type(
-    input_ctx: &InputContext<'_>,
-    table: TableWalker<'_>,
-    edge_type_name: &str,
-    output_ctx: &mut OutputContext,
-) {
-    let connection_type_name = input_ctx.connection_type_name(table.client_name());
-
-    output_ctx.with_object_type(&connection_type_name, table.id(), |builder| {
-        builder.push_non_mapped_scalar_field(MetaField::new("edges", format!("[{edge_type_name}]!")));
-        builder.push_non_mapped_scalar_field(MetaField::new("pageInfo", String::from("PageInfo!")));
-    })
-}
-
-fn register_edge_type(
-    input_ctx: &InputContext<'_>,
-    table: TableWalker<'_>,
-    type_name: &str,
-    output_ctx: &mut OutputContext,
-) -> String {
-    let edge_type_name = input_ctx.edge_type_name(table.client_name());
-
-    output_ctx.create_object_type(ObjectType::new(
-        edge_type_name.to_owned(),
-        [
-            MetaField::new("node", format!("{type_name}!")),
-            MetaField::new("cursor", String::from("String!")),
-        ],
-    ));
-
-    edge_type_name.to_owned()
-}
-
-fn register_orderby_input(
-    input_ctx: &InputContext<'_>,
-    direction_type: &str,
-    table: TableWalker<'_>,
-    output_ctx: &mut OutputContext,
-) {
-    let type_name = input_ctx.orderby_input_type_name(table.client_name());
-
-    let input_fields = table
-        .columns()
-        .map(|column| MetaInputValue::new(column.client_name().to_string(), direction_type));
-
-    let input_object = InputObjectType::new(type_name.to_string(), input_fields).with_oneof(true);
-
-    output_ctx.create_input_type(input_object);
 }

--- a/engine/crates/parser-postgresql/src/registry/types/order_direction.rs
+++ b/engine/crates/parser-postgresql/src/registry/types/order_direction.rs
@@ -1,0 +1,19 @@
+use engine::registry::{EnumType, MetaEnumValue};
+
+use crate::registry::context::{InputContext, OutputContext};
+
+pub(super) fn register(input_ctx: &InputContext<'_>, output_ctx: &mut OutputContext) -> String {
+    let type_name = input_ctx.type_name("OrderByDirection");
+
+    let variants = ["ASC", "DESC"].iter().map(|name| {
+        let mut variant = MetaEnumValue::new((*name).to_string());
+        variant.value = Some((*name).to_string());
+
+        variant
+    });
+
+    let r#enum = EnumType::new(type_name.to_string(), variants);
+
+    output_ctx.create_enum_type(r#enum);
+    type_name.into_owned()
+}

--- a/engine/crates/parser-postgresql/src/registry/types/page_info.rs
+++ b/engine/crates/parser-postgresql/src/registry/types/page_info.rs
@@ -1,14 +1,39 @@
 use crate::registry::context::{InputContext, OutputContext};
-use engine::registry::{MetaField, ObjectType};
+use common_types::auth::Operations;
+use engine::registry::{resolvers::transformer::Transformer, MetaField, ObjectType};
 
 pub(super) fn register(input_ctx: &InputContext<'_>, output_ctx: &mut OutputContext) {
     let object = ObjectType::new(
         input_ctx.type_name("PageInfo"),
         [
-            MetaField::new("hasNextPage", "Boolean!"),
-            MetaField::new("hasPreviousPage", "Boolean!"),
-            MetaField::new("startCursor", "String"),
-            MetaField::new("endCursor", "String"),
+            MetaField {
+                name: "hasPreviousPage".to_string(),
+                ty: "Boolean!".into(),
+                resolver: Transformer::PaginationData.and_then(Transformer::select("has_previous_page")),
+                required_operation: Some(Operations::LIST),
+                ..Default::default()
+            },
+            MetaField {
+                name: "hasNextPage".to_string(),
+                ty: "Boolean!".into(),
+                resolver: Transformer::PaginationData.and_then(Transformer::select("has_next_page")),
+                required_operation: Some(Operations::LIST),
+                ..Default::default()
+            },
+            MetaField {
+                name: "startCursor".to_string(),
+                ty: "String".into(),
+                resolver: Transformer::PaginationData.and_then(Transformer::select("start_cursor")),
+                required_operation: Some(Operations::LIST),
+                ..Default::default()
+            },
+            MetaField {
+                name: "endCursor".to_string(),
+                ty: "String".into(),
+                resolver: Transformer::PaginationData.and_then(Transformer::select("end_cursor")),
+                required_operation: Some(Operations::LIST),
+                ..Default::default()
+            },
         ],
     );
 

--- a/engine/crates/parser-postgresql/src/registry/types/page_info.rs
+++ b/engine/crates/parser-postgresql/src/registry/types/page_info.rs
@@ -1,0 +1,16 @@
+use crate::registry::context::{InputContext, OutputContext};
+use engine::registry::{MetaField, ObjectType};
+
+pub(super) fn register(input_ctx: &InputContext<'_>, output_ctx: &mut OutputContext) {
+    let object = ObjectType::new(
+        input_ctx.type_name("PageInfo"),
+        [
+            MetaField::new("hasNextPage", "Boolean!"),
+            MetaField::new("hasPreviousPage", "Boolean!"),
+            MetaField::new("startCursor", "String"),
+            MetaField::new("endCursor", "String"),
+        ],
+    );
+
+    output_ctx.create_object_type(object);
+}

--- a/engine/crates/parser-postgresql/src/registry/types/table.rs
+++ b/engine/crates/parser-postgresql/src/registry/types/table.rs
@@ -86,7 +86,8 @@ pub(super) fn generate(
                 .and_then(Transformer::PostgresSelectionData {
                     directive_name: input_ctx.directive_name().to_string(),
                     table_id: relation.referenced_table().id(),
-                });
+                })
+                .and_then(Transformer::PostgresPageInfo);
 
                 field
             } else {
@@ -131,10 +132,12 @@ fn register_connection_type(
     let connection_type_name = input_ctx.connection_type_name(table.client_name());
 
     output_ctx.with_object_type(&connection_type_name, table.id(), |builder| {
-        builder.push_non_mapped_scalar_field(MetaField::new("edges", format!("[{edge_type_name}]!")));
+        let field = MetaField::new("edges", format!("[{edge_type_name}]!"));
 
-        let mut page_info = MetaField::new("pageInfo", String::from("PageInfo!"));
-        page_info.resolver = Resolver::Transformer(Transformer::PostgresPageInfo);
+        builder.push_non_mapped_scalar_field(field);
+
+        let type_name = input_ctx.type_name("PageInfo");
+        let page_info = MetaField::new("pageInfo", format!("{type_name}!"));
 
         builder.push_non_mapped_scalar_field(page_info);
     })

--- a/engine/crates/parser-postgresql/src/registry/types/table.rs
+++ b/engine/crates/parser-postgresql/src/registry/types/table.rs
@@ -1,0 +1,175 @@
+use crate::registry::context::{InputContext, OutputContext};
+use engine::registry::{
+    resolvers::{transformer::Transformer, Resolver},
+    Constraint, InputObjectType, MetaField, MetaInputValue, ObjectType,
+};
+use postgresql_types::database_definition::{DatabaseType, ScalarType, TableWalker};
+use std::borrow::Cow;
+
+pub(super) fn generate(
+    input_ctx: &InputContext<'_>,
+    table: TableWalker<'_>,
+    direction_type: &str,
+    output_ctx: &mut OutputContext,
+) {
+    let type_name = input_ctx.type_name(table.client_name());
+    let edge_type_name = register_edge_type(input_ctx, table, &type_name, output_ctx);
+
+    register_orderby_input(input_ctx, direction_type, table, output_ctx);
+    register_connection_type(input_ctx, table, &edge_type_name, output_ctx);
+
+    output_ctx.with_object_type(&type_name, table.id(), |builder| {
+        for column in table.columns() {
+            let client_type = column
+                .graphql_type()
+                .expect("forgot to filter unsupported types before generating");
+
+            let client_type = if column.nullable() {
+                client_type.to_string()
+            } else {
+                format!("{client_type}!")
+            };
+
+            let mut field = MetaField::new(column.client_name(), client_type.as_ref());
+            field.mapped_name = Some(column.database_name().to_string());
+
+            field.resolver = Resolver::Transformer(Transformer::Select {
+                key: column.database_name().to_string(),
+            });
+
+            let extra_transformer = match column.database_type() {
+                DatabaseType::Scalar(ScalarType::Bytea) => Some(Transformer::BytesToBase64),
+                DatabaseType::Scalar(ScalarType::ByteaArray) => Some(Transformer::ByteArrayToBase64Array),
+                DatabaseType::Enum(_) => Some(Transformer::RemoteEnum),
+                _ => None,
+            };
+
+            if let Some(transformer) = extra_transformer {
+                field.resolver = field.resolver.and_then(transformer);
+            }
+
+            builder.push_scalar_field(field, column.id());
+        }
+
+        for relation in table.relations() {
+            let field = if !relation.is_referenced_row_unique() {
+                let connection_type_name = input_ctx.connection_type_name(relation.referenced_table().client_name());
+
+                let mut field = MetaField::new(relation.client_field_name(), connection_type_name);
+
+                field
+                    .args
+                    .insert(String::from("first"), MetaInputValue::new("first", "Int"));
+
+                field
+                    .args
+                    .insert(String::from("last"), MetaInputValue::new("last", "Int"));
+
+                field
+                    .args
+                    .insert(String::from("before"), MetaInputValue::new("before", "String"));
+
+                field
+                    .args
+                    .insert(String::from("after"), MetaInputValue::new("after", "String"));
+
+                let order_by_type = input_ctx.orderby_input_type_name(relation.referenced_table().client_name());
+
+                field.args.insert(
+                    String::from("orderBy"),
+                    MetaInputValue::new("orderBy", format!("[{order_by_type}!]")),
+                );
+
+                field.resolver = Resolver::Transformer(Transformer::Select {
+                    key: relation.client_field_name(),
+                })
+                .and_then(Transformer::PostgresSelectionData {
+                    directive_name: input_ctx.directive_name().to_string(),
+                    table_id: relation.referenced_table().id(),
+                });
+
+                field
+            } else {
+                let client_type = relation.client_type();
+                let client_type = input_ctx.type_name(&client_type);
+
+                let client_type = if relation.nullable() {
+                    client_type
+                } else {
+                    Cow::Owned(format!("{client_type}!"))
+                };
+
+                let mut field = MetaField::new(relation.client_field_name(), client_type.as_ref());
+
+                field.resolver = Resolver::Transformer(Transformer::Select {
+                    key: relation.client_field_name(),
+                });
+
+                field
+            };
+
+            builder.push_relation_field(field, relation.id());
+        }
+
+        for constraint in table.unique_constraints() {
+            let fields = constraint
+                .columns()
+                .map(|column| column.table_column().client_name().to_string())
+                .collect();
+
+            builder.push_constraint(Constraint::unique(constraint.name().to_string(), fields));
+        }
+    });
+}
+
+fn register_connection_type(
+    input_ctx: &InputContext<'_>,
+    table: TableWalker<'_>,
+    edge_type_name: &str,
+    output_ctx: &mut OutputContext,
+) {
+    let connection_type_name = input_ctx.connection_type_name(table.client_name());
+
+    output_ctx.with_object_type(&connection_type_name, table.id(), |builder| {
+        builder.push_non_mapped_scalar_field(MetaField::new("edges", format!("[{edge_type_name}]!")));
+
+        let mut page_info = MetaField::new("pageInfo", String::from("PageInfo!"));
+        page_info.resolver = Resolver::Transformer(Transformer::PostgresPageInfo);
+
+        builder.push_non_mapped_scalar_field(page_info);
+    })
+}
+
+fn register_edge_type(
+    input_ctx: &InputContext<'_>,
+    table: TableWalker<'_>,
+    type_name: &str,
+    output_ctx: &mut OutputContext,
+) -> String {
+    let edge_type_name = input_ctx.edge_type_name(table.client_name());
+    let node = MetaField::new("node", format!("{type_name}!"));
+
+    let mut cursor = MetaField::new("cursor", String::from("String!"));
+    cursor.resolver = Resolver::Transformer(Transformer::PostgresCursor);
+
+    output_ctx.create_object_type(ObjectType::new(edge_type_name.to_owned(), [node, cursor]));
+
+    edge_type_name.to_owned()
+}
+
+fn register_orderby_input(
+    input_ctx: &InputContext<'_>,
+    direction_type: &str,
+    table: TableWalker<'_>,
+    output_ctx: &mut OutputContext,
+) {
+    let type_name = input_ctx.orderby_input_type_name(table.client_name());
+
+    let input_fields = table
+        .columns()
+        .map(|column| MetaInputValue::new(column.client_name().to_string(), direction_type));
+
+    let input_object = InputObjectType::new(type_name.to_string(), input_fields).with_oneof(true);
+
+    output_ctx.create_input_type(input_object);
+}

--- a/engine/crates/postgresql-types/Cargo.toml
+++ b/engine/crates/postgresql-types/Cargo.toml
@@ -12,8 +12,10 @@ keywords = ["graphql", "postgresql", "grafbase"]
 [dependencies]
 Inflector = "0.11.4"
 async-trait = "0.1.73"
+flexbuffers.workspace = true
 indexmap = { version = "1", features = ["serde"] }
 itertools.workspace = true
+search-protocol.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/engine/crates/postgresql-types/src/cursor.rs
+++ b/engine/crates/postgresql-types/src/cursor.rs
@@ -1,0 +1,88 @@
+use crate::error::Error;
+use search_protocol::query::GraphqlCursor;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum OrderDirection {
+    #[default]
+    Ascending,
+    Descending,
+}
+
+impl FromStr for OrderDirection {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let result = match s {
+            "DESC" => Self::Descending,
+            _ => Self::Ascending,
+        };
+
+        Ok(result)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct CursorField {
+    pub(super) name: String,
+    pub(super) value: Value,
+    pub(super) direction: OrderDirection,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct SQLCursor {
+    fields: Vec<CursorField>,
+}
+
+impl SQLCursor {
+    pub fn new(row: Map<String, Value>, order_by: Option<&[(String, Option<&'static str>)]>) -> Self {
+        let mut fields = Vec::new();
+
+        if let Some(order_by) = order_by {
+            for (column, order) in order_by {
+                let value = row
+                    .get(column)
+                    .expect("must select the field we're ordering with")
+                    .clone();
+
+                let direction = order.and_then(|order| order.parse().ok()).unwrap_or_default();
+
+                fields.push(CursorField {
+                    name: column.clone(),
+                    value,
+                    direction,
+                });
+            }
+        };
+
+        Self { fields }
+    }
+}
+
+impl TryFrom<SQLCursor> for GraphqlCursor {
+    type Error = Error;
+
+    fn try_from(value: SQLCursor) -> Result<Self, Self::Error> {
+        let mut serializer = flexbuffers::FlexbufferSerializer::new();
+
+        value
+            .serialize(&mut serializer)
+            .map_err(|error| Error::Internal(format!("invalid cursor: {error}")))?;
+
+        Ok(GraphqlCursor::from_bytes(serializer.take_buffer()))
+    }
+}
+
+impl TryFrom<GraphqlCursor> for SQLCursor {
+    type Error = Error;
+
+    fn try_from(value: GraphqlCursor) -> Result<Self, Self::Error> {
+        let reader = flexbuffers::Reader::get_root(value.as_slice())
+            .map_err(|error| Error::Internal(format!("invalid cursor: {error}")))?;
+
+        Self::deserialize(reader).map_err(|error| Error::Internal(format!("invalid cursor: {error}")))
+    }
+}

--- a/engine/crates/postgresql-types/src/cursor.rs
+++ b/engine/crates/postgresql-types/src/cursor.rs
@@ -60,6 +60,12 @@ impl SQLCursor {
 
         Self { fields }
     }
+
+    pub fn fields(&self) -> impl ExactSizeIterator<Item = (&str, &Value, OrderDirection)> + '_ {
+        self.fields
+            .iter()
+            .map(|field| (field.name.as_str(), &field.value, field.direction))
+    }
 }
 
 impl TryFrom<SQLCursor> for GraphqlCursor {

--- a/engine/crates/postgresql-types/src/database_definition/names.rs
+++ b/engine/crates/postgresql-types/src/database_definition/names.rs
@@ -17,6 +17,8 @@ pub(super) struct Names {
     #[serde(with = "super::vectorize")]
     table_columns: HashMap<(TableId, StringId), TableColumnId>,
     #[serde(with = "super::vectorize")]
+    client_columns: HashMap<(TableId, StringId), TableColumnId>,
+    #[serde(with = "super::vectorize")]
     enums: HashMap<(SchemaId, StringId), EnumId>,
     #[serde(with = "super::vectorize")]
     enum_variants: HashMap<(EnumId, StringId), EnumVariantId>,
@@ -43,6 +45,9 @@ impl Names {
     pub(super) fn intern_table_column(&mut self, column: &TableColumn<String>, column_id: TableColumnId) {
         let string_id = self.interner.intern(column.database_name());
         self.table_columns.insert((column.table_id(), string_id), column_id);
+
+        let string_id = self.interner.intern(column.client_name());
+        self.client_columns.insert((column.table_id(), string_id), column_id);
     }
 
     pub(super) fn intern_enum(&mut self, r#enum: &Enum<String>, enum_id: EnumId) {
@@ -127,6 +132,12 @@ impl Names {
     pub(super) fn get_table_column_id(&self, table_id: TableId, column_name: &str) -> Option<TableColumnId> {
         self.lookup_name(column_name)
             .and_then(|string_id| self.table_columns.get(&(table_id, string_id)))
+            .copied()
+    }
+
+    pub(super) fn get_table_client_column_id(&self, table_id: TableId, column_name: &str) -> Option<TableColumnId> {
+        self.lookup_name(column_name)
+            .and_then(|string_id| self.client_columns.get(&(table_id, string_id)))
             .copied()
     }
 

--- a/engine/crates/postgresql-types/src/database_definition/names.rs
+++ b/engine/crates/postgresql-types/src/database_definition/names.rs
@@ -17,8 +17,6 @@ pub(super) struct Names {
     #[serde(with = "super::vectorize")]
     table_columns: HashMap<(TableId, StringId), TableColumnId>,
     #[serde(with = "super::vectorize")]
-    client_columns: HashMap<(TableId, StringId), TableColumnId>,
-    #[serde(with = "super::vectorize")]
     enums: HashMap<(SchemaId, StringId), EnumId>,
     #[serde(with = "super::vectorize")]
     enum_variants: HashMap<(EnumId, StringId), EnumVariantId>,
@@ -45,9 +43,6 @@ impl Names {
     pub(super) fn intern_table_column(&mut self, column: &TableColumn<String>, column_id: TableColumnId) {
         let string_id = self.interner.intern(column.database_name());
         self.table_columns.insert((column.table_id(), string_id), column_id);
-
-        let string_id = self.interner.intern(column.client_name());
-        self.client_columns.insert((column.table_id(), string_id), column_id);
     }
 
     pub(super) fn intern_enum(&mut self, r#enum: &Enum<String>, enum_id: EnumId) {
@@ -132,12 +127,6 @@ impl Names {
     pub(super) fn get_table_column_id(&self, table_id: TableId, column_name: &str) -> Option<TableColumnId> {
         self.lookup_name(column_name)
             .and_then(|string_id| self.table_columns.get(&(table_id, string_id)))
-            .copied()
-    }
-
-    pub(super) fn get_table_client_column_id(&self, table_id: TableId, column_name: &str) -> Option<TableColumnId> {
-        self.lookup_name(column_name)
-            .and_then(|string_id| self.client_columns.get(&(table_id, string_id)))
             .copied()
     }
 

--- a/engine/crates/postgresql-types/src/database_definition/walkers/table.rs
+++ b/engine/crates/postgresql-types/src/database_definition/walkers/table.rs
@@ -70,14 +70,6 @@ impl<'a> TableWalker<'a> {
             .map(|id| self.walk(id))
     }
 
-    /// Find a column by client name.
-    pub fn find_client_column(self, name: &str) -> Option<TableColumnWalker<'a>> {
-        self.database_definition
-            .names
-            .get_table_client_column_id(self.id, name)
-            .map(|id| self.walk(id))
-    }
-
     /// Find a unique constraint by name.
     pub fn find_unique_constraint(self, constraint_name: &str) -> Option<UniqueConstraintWalker<'a>> {
         self.database_definition

--- a/engine/crates/postgresql-types/src/database_definition/walkers/table.rs
+++ b/engine/crates/postgresql-types/src/database_definition/walkers/table.rs
@@ -41,8 +41,14 @@ impl<'a> TableWalker<'a> {
         self.columns().next().is_some() && self.unique_constraints().next().is_some()
     }
 
+    /// A special unique index that acts as the primary key of the column.
     pub fn primary_key(self) -> Option<UniqueConstraintWalker<'a>> {
         self.unique_constraints().find(|constraint| constraint.is_primary())
+    }
+
+    /// The key used to implicitly order a result set if no order defined by the user.
+    pub fn implicit_ordering_key(self) -> Option<UniqueConstraintWalker<'a>> {
+        self.primary_key().or_else(|| self.unique_constraints().next())
     }
 
     /// An iterator over all the unqiue constraints, including the primary key.
@@ -56,11 +62,19 @@ impl<'a> TableWalker<'a> {
             .filter(|constraint| constraint.all_columns_use_supported_types())
     }
 
-    /// Find a column by name.
-    pub fn find_column(self, name: &str) -> Option<TableColumnWalker<'a>> {
+    /// Find a column by database name.
+    pub fn find_database_column(self, name: &str) -> Option<TableColumnWalker<'a>> {
         self.database_definition
             .names
             .get_table_column_id(self.id, name)
+            .map(|id| self.walk(id))
+    }
+
+    /// Find a column by client name.
+    pub fn find_client_column(self, name: &str) -> Option<TableColumnWalker<'a>> {
+        self.database_definition
+            .names
+            .get_table_client_column_id(self.id, name)
             .map(|id| self.walk(id))
     }
 

--- a/engine/crates/postgresql-types/src/lib.rs
+++ b/engine/crates/postgresql-types/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cursor;
 pub mod database_definition;
 pub mod error;
 pub mod transport;


### PR DESCRIPTION
Implements cursors, page infos and before/after filters for Neon/PostgreSQL. Again, about 2k lines of this PR are tests, so the actual feature should be about 1k lines to read.

Some weird things: we load all the data, even nested data, in one query. This kind of puts us implementing page infos in resolvers, and additionally the cursors are resolved values, so they are also handled in special resolvers. This required me to add some query-specific data to the resolved value, which allows cursor calculation if needed. This whole thing has a bit too much copying we should maybe address later.

Another one that will bring questions is our ordering preference. MongoDB has nulls first _always_, but PostgreSQL has this as a server setting, or nulls last when ascending. For the first iteration, we take a stance to have nulls _always first_ no matter what is the order. This simplifies the pagination code, and we can extend it later to let user to choose `ASC`, `DESC`, `ASC_NULLS_LAST`, `ASC_NULLS_FIRST`, `DESC_NULLS_LAST` or `DESC_NULLS_FIRST`.

Closes: GB-4677
