### PR TITLE
chore: Use same clippy as api

### DIFF
--- a/engine/.cargo/config.toml
+++ b/engine/.cargo/config.toml
@@ -1,0 +1,44 @@
+[target.'cfg(all())']
+rustflags = [
+  "--cfg=web_sys_unstable_apis",
+  "-Dclippy::all",
+  "-Dclippy::panic",
+  "-Dclippy::pedantic",
+  "-Dnonstandard-style",
+  "-Drust-2018-idioms",
+  "-Dunused-crate-dependencies",
+  # Opt out of lints that have too many false positives or are yet to be addressed.
+  "-Alet-underscore-drop",
+  "-Aclippy::bool-to-int-with-if",
+  "-Aclippy::cast-possible-truncation",
+  "-Aclippy::default-trait-access",
+  "-Aclippy::derive-partial-eq-without-eq",
+  "-Aclippy::doc-markdown",
+  "-Aclippy::enum-glob-use",
+  "-Aclippy::implicit-hasher",
+  "-Aclippy::items-after-statements",
+  "-Aclippy::large-digit-groups",
+  "-Aclippy::let-underscore-untyped",
+  "-Aclippy::let-with-type-underscore",
+  "-Aclippy::manual-assert",
+  "-Aclippy::map-unwrap-or",
+  "-Aclippy::match-wildcard-for-single-variants",
+  "-Aclippy::missing-errors-doc",
+  "-Aclippy::missing-panics-doc",
+  "-Aclippy::module-name-repetitions",
+  "-Aclippy::must-use-candidate",
+  "-Aclippy::needless-pass-by-value",
+  "-Aclippy::redundant-closure-for-method-calls",
+  "-Aclippy::single-match-else",
+  "-Aclippy::struct-excessive-bools",
+  "-Aclippy::too-many-lines",
+  "-Aclippy::unused-async",
+  "-Aclippy::unused-self",
+  "-Aclippy::wildcard-imports",
+]
+
+[net]
+git-fetch-with-cli = true
+
+[registries.crates-io]
+protocol = "sparse"

--- a/engine/crates/engine/src/registry/resolvers/postgresql/context/filter/complex.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql/context/filter/complex.rs
@@ -93,7 +93,7 @@ impl<'a> Iterator for ComplexFilterIterator<'a> {
             Value::Array(values) => {
                 let mut operations = Vec::with_capacity(values.len());
 
-                for operation in values.into_iter().flat_map(|operation| match operation {
+                for operation in values.into_iter().filter_map(|operation| match operation {
                     Value::Object(obj) => Some(obj),
                     _ => None,
                 }) {
@@ -129,7 +129,7 @@ impl<'a> Iterator for ComplexFilterIterator<'a> {
 fn generate_conditions(operations: Map<String, Value>, column: TableColumnWalker<'_>) -> ConditionTree<'_> {
     let mut compares = Vec::with_capacity(operations.len());
 
-    for (key, value) in operations.into_iter() {
+    for (key, value) in operations {
         let table_column = (column.table().database_name(), column.database_name());
 
         let compare = match key.as_str() {

--- a/engine/crates/engine/src/registry/resolvers/postgresql/context/selection/collection_args.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql/context/selection/collection_args.rs
@@ -133,7 +133,7 @@ impl CollectionArgs {
         // extra columns we have to select (based on ordering)
         let mut extra_columns = Vec::new();
 
-        for value in order_by_argument.into_iter() {
+        for value in order_by_argument {
             let Some((field, value)) = value.as_object().and_then(IndexMap::first) else { continue };
             let Some(direction) = value.as_str() else { continue };
 

--- a/engine/crates/integration-tests/src/helpers.rs
+++ b/engine/crates/integration-tests/src/helpers.rs
@@ -71,6 +71,7 @@ impl GetPath for Response {
 
 pub trait ResponseExt: Sized {
     /// Asserts that there are no errors in this Response
+    #[allow(clippy::return_self_not_must_use)]
     fn assert_success(self) -> Self;
 
     /// Converts the response into a serde_json Value

--- a/engine/crates/integration-tests/src/postgresql.rs
+++ b/engine/crates/integration-tests/src/postgresql.rs
@@ -190,14 +190,16 @@ impl TestApi {
     }
 
     pub async fn execute(&self, operation: impl AsRef<str>) -> Response {
-        self.inner
-            .engine
-            // this prevents a race. we initialize the engine only when executing the first request,
-            // so the introspection runs only after we've modified the database schema.
-            .get_or_init(async { Engine::new(self.inner.schema.clone()).await })
-            .await
-            .execute(operation.as_ref())
-            .await
+        Box::pin(
+            self.inner
+                .engine
+                // this prevents a race. we initialize the engine only when executing the first request,
+                // so the introspection runs only after we've modified the database schema.
+                .get_or_init(async { Engine::new(self.inner.schema.clone()).await }),
+        )
+        .await
+        .execute(operation.as_ref())
+        .await
     }
 
     pub async fn execute_as<T>(&self, operation: impl AsRef<str>) -> T

--- a/engine/crates/integration-tests/tests/graphql_connector/basic.rs
+++ b/engine/crates/integration-tests/tests/graphql_connector/basic.rs
@@ -75,7 +75,7 @@ fn graphql_test_with_namespace() {
                 .await
                 .into_value()
         );
-    })
+    });
 }
 
 const UNNAMESPACED_QUERY: &str = "

--- a/engine/crates/integration-tests/tests/postgresql/find_many/pagination/filters.rs
+++ b/engine/crates/integration-tests/tests/postgresql/find_many/pagination/filters.rs
@@ -98,7 +98,7 @@ fn id_pk_implicit_order_with_after() {
           }
         }"#]];
 
-    expected.assert_eq(&response)
+    expected.assert_eq(&response);
 }
 
 #[test]
@@ -168,7 +168,7 @@ fn id_pk_implicit_order_with_before() {
           }
         }"#]];
 
-    expected.assert_eq(&response)
+    expected.assert_eq(&response);
 }
 
 #[test]
@@ -238,7 +238,7 @@ fn id_pk_explicit_order_with_after() {
           }
         }"#]];
 
-    expected.assert_eq(&response)
+    expected.assert_eq(&response);
 }
 
 #[test]
@@ -308,7 +308,7 @@ fn id_pk_explicit_order_with_before() {
           }
         }"#]];
 
-    expected.assert_eq(&response)
+    expected.assert_eq(&response);
 }
 
 #[test]
@@ -383,7 +383,7 @@ fn compound_pk_implicit_order_with_after() {
           }
         }"#]];
 
-    expected.assert_eq(&response)
+    expected.assert_eq(&response);
 }
 
 #[test]
@@ -457,7 +457,7 @@ fn compound_pk_implicit_order_with_before() {
           }
         }"#]];
 
-    expected.assert_eq(&response)
+    expected.assert_eq(&response);
 }
 
 #[test]
@@ -532,7 +532,7 @@ fn compound_pk_explicit_order_with_after() {
           }
         }"#]];
 
-    expected.assert_eq(&response)
+    expected.assert_eq(&response);
 }
 
 #[test]
@@ -607,7 +607,7 @@ fn compound_pk_explicit_order_with_before() {
           }
         }"#]];
 
-    expected.assert_eq(&response)
+    expected.assert_eq(&response);
 }
 
 #[test]
@@ -682,7 +682,7 @@ fn compound_pk_implicit_order_with_nulls_and_after() {
           }
         }"#]];
 
-    expected.assert_eq(&response)
+    expected.assert_eq(&response);
 }
 
 #[test]
@@ -757,7 +757,7 @@ fn compound_pk_implicit_order_with_nulls_and_before() {
           }
         }"#]];
 
-    expected.assert_eq(&response)
+    expected.assert_eq(&response);
 }
 
 #[test]

--- a/engine/crates/parser-postgresql/src/registry/queries/input.rs
+++ b/engine/crates/parser-postgresql/src/registry/queries/input.rs
@@ -13,7 +13,7 @@ fn input_value_from_column(column: TableColumnWalker<'_>, oneof: bool) -> MetaIn
     // Oneof types can't enforce arguments, the runtime expects one of the arguments to be
     // defined. For nested input types, we must enforce any argument that cannot be null.
     if !oneof && !column.nullable() {
-        client_type = Cow::from(format!("{client_type}!"))
+        client_type = Cow::from(format!("{client_type}!"));
     }
 
     MetaInputValue::new(column.client_name(), client_type.as_ref())

--- a/engine/crates/parser-postgresql/src/registry/queries/input/filter.rs
+++ b/engine/crates/parser-postgresql/src/registry/queries/input/filter.rs
@@ -57,7 +57,7 @@ pub(crate) fn register(input_ctx: &InputContext<'_>, table: TableWalker<'_>, out
         builder.with_input_type(&contains_type_name, table.id(), |builder| {
             let value = MetaInputValue::new("contains", input_type_name.as_ref());
             builder.push_non_mapped_input_column(value);
-        })
+        });
     });
 
     input_type_name

--- a/engine/crates/parser-postgresql/src/registry/types.rs
+++ b/engine/crates/parser-postgresql/src/registry/types.rs
@@ -31,6 +31,6 @@ pub(super) fn generate(input_ctx: &InputContext<'_>, output_ctx: &mut OutputCont
 
                 builder.push_variant(meta_value);
             }
-        })
+        });
     }
 }

--- a/engine/crates/parser-postgresql/src/registry/types/table.rs
+++ b/engine/crates/parser-postgresql/src/registry/types/table.rs
@@ -52,6 +52,7 @@ pub(super) fn generate(
         }
 
         for relation in table.relations() {
+            #[allow(clippy::if_not_else)]
             let field = if !relation.is_referenced_row_unique() {
                 let connection_type_name = input_ctx.connection_type_name(relation.referenced_table().client_name());
 
@@ -140,7 +141,7 @@ fn register_connection_type(
         let page_info = MetaField::new("pageInfo", format!("{type_name}!"));
 
         builder.push_non_mapped_scalar_field(page_info);
-    })
+    });
 }
 
 fn register_edge_type(
@@ -155,9 +156,9 @@ fn register_edge_type(
     let mut cursor = MetaField::new("cursor", String::from("String!"));
     cursor.resolver = Resolver::Transformer(Transformer::PostgresCursor);
 
-    output_ctx.create_object_type(ObjectType::new(edge_type_name.to_owned(), [node, cursor]));
+    output_ctx.create_object_type(ObjectType::new(edge_type_name.clone(), [node, cursor]));
 
-    edge_type_name.to_owned()
+    edge_type_name.clone()
 }
 
 fn register_orderby_input(

--- a/engine/crates/parser-sdl/src/rules/mongodb_directive/model_directive/model_type/resolver_data.rs
+++ b/engine/crates/parser-sdl/src/rules/mongodb_directive/model_directive/model_type/resolver_data.rs
@@ -55,7 +55,7 @@ impl ResolverData {
         let mut resolver = Resolver::Transformer(Transformer::Select { key });
 
         if let "Timestamp" = field.ty.base.to_base_type_str() {
-            resolver = resolver.and_then(Transformer::MongoTimestamp)
+            resolver = resolver.and_then(Transformer::MongoTimestamp);
         }
 
         let field_type = field.ty.node.to_string();

--- a/engine/crates/parser-sdl/src/tests.rs
+++ b/engine/crates/parser-sdl/src/tests.rs
@@ -732,5 +732,5 @@ fn test_experimental() {
     )
     .unwrap();
 
-    assert!(!result.enable_kv)
+    assert!(!result.enable_kv);
 }

--- a/engine/crates/postgresql-types/src/database_definition/postgres_type.rs
+++ b/engine/crates/postgresql-types/src/database_definition/postgres_type.rs
@@ -12,10 +12,7 @@ impl<'a> DatabaseType<'a> {
     }
 
     pub fn is_binary(&self) -> bool {
-        matches!(
-            self,
-            DatabaseType::Scalar(ScalarType::Bytea) | DatabaseType::Scalar(ScalarType::ByteaArray)
-        )
+        matches!(self, DatabaseType::Scalar(ScalarType::Bytea | ScalarType::ByteaArray))
     }
 }
 


### PR DESCRIPTION
When using those crates with inside api I had clippy complaining about unused dependencies... So could have just added that check, but thought might as well have the same clippy configuration.
