### PR TITLE
fix: stop breaking graphql-codegen

### DIFF
--- a/engine/crates/gateway-adapter/src/streaming_format.rs
+++ b/engine/crates/gateway-adapter/src/streaming_format.rs
@@ -20,6 +20,10 @@ const SSE_MEDIA_TYPE: MediaType<'static> =
 
 impl StreamingFormat {
     pub fn from_accept_header(header: &str) -> Option<Self> {
+        if header.contains("application/graphql-response+json") {
+            // Temporarily default to graphql JSON if its present in the headers
+            return None;
+        }
         let (mediatype, _) = MediaTypeList::new(header)
             .filter_map(Result::ok)
             .filter(|mediatype| {


### PR DESCRIPTION
graphql-codegen sends an accept header with `multipart/mixed` in it, so we're responding with `multipart/mixed`. However it doesn't like our multipart mixed responses and crashes.

I'm investigating the problem but in the meantime I'm putting this in so we just do a normal JSON reply to graphql-codegen