### PR TITLE
chore: merge ResolverChainNode into Context

### DIFF
--- a/engine/crates/engine/derive/src/complex_object.rs
+++ b/engine/crates/engine/derive/src/complex_object.rs
@@ -54,7 +54,7 @@ pub fn generate(object_args: &args::ComplexObject, item_impl: &mut ItemImpl) -> 
                             if let FnArg::Typed(pat) = x {
                                 if let Type::Reference(TypeReference { elem, .. }) = &*pat.ty {
                                     if let Type::Path(path) = elem.as_ref() {
-                                        return path.path.segments.last().unwrap().ident != "Context";
+                                        return path.path.segments.last().unwrap().ident != "ContextField";
                                     }
                                 }
                             };
@@ -63,7 +63,8 @@ pub fn generate(object_args: &args::ComplexObject, item_impl: &mut ItemImpl) -> 
                         .unwrap_or(true);
 
                     if should_create_context {
-                        let arg_ctx = syn::parse2::<FnArg>(quote! { ctx: &Context<'_> }).expect("invalid arg type");
+                        let arg_ctx =
+                            syn::parse2::<FnArg>(quote! { ctx: &ContextField<'_> }).expect("invalid arg type");
                         new_impl.sig.inputs.insert(1, arg_ctx);
                     }
 
@@ -398,7 +399,7 @@ pub fn generate(object_args: &args::ComplexObject, item_impl: &mut ItemImpl) -> 
                 fields
             }
 
-            async fn resolve_field(&self, ctx: &#crate_name::Context<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::ResponseNodeId>> {
+            async fn resolve_field(&self, ctx: &#crate_name::ContextField<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::ResponseNodeId>> {
                 #(#resolvers)*
                 ::std::result::Result::Ok(::std::option::Option::None)
             }

--- a/engine/crates/engine/derive/src/enum.rs
+++ b/engine/crates/engine/derive/src/enum.rs
@@ -180,7 +180,7 @@ pub fn generate(enum_args: &args::Enum) -> GeneratorResult<TokenStream> {
                 Self::__create_type_info(registry).as_str().into()
             }
 
-            async fn resolve(&self, ctx: &#crate_name::ContextSelectionSet<'_>, _field: &#crate_name::Positioned<#crate_name::parser::types::Field>) -> #crate_name::ServerResult<#crate_name::ResponseNodeId> {
+            async fn resolve(&self, ctx: &#crate_name::ContextSelectionSetLegacy<'_>, _field: &#crate_name::Positioned<#crate_name::parser::types::Field>) -> #crate_name::ServerResult<#crate_name::ResponseNodeId> {
                 ::std::result::Result::Ok(#crate_name::resolver_utils::enum_value_node(ctx, *self).await)
             }
         }

--- a/engine/crates/engine/derive/src/interface.rs
+++ b/engine/crates/engine/derive/src/interface.rs
@@ -148,7 +148,7 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
             None => quote! { ::std::option::Option::None },
         };
 
-        decl_params.push(quote! { ctx: &'ctx #crate_name::Context<'ctx> });
+        decl_params.push(quote! { ctx: &'ctx #crate_name::ContextField<'ctx> });
         use_params.push(quote! { ctx });
 
         for InterfaceFieldArgument {
@@ -274,7 +274,7 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
         resolvers.push(quote! {
             if ctx.item.node.name.node == #name {
                 #(#get_params)*
-                let ctx_obj = ctx.with_selection_set(&ctx.item.node.selection_set);
+                let ctx_obj = ctx.with_selection_set_legacy(&ctx.item.node.selection_set);
                 return #crate_name::LegacyOutputType::resolve(&#resolve_obj, &ctx_obj, ctx.item).await.map(::std::option::Option::Some);
             }
         });
@@ -302,12 +302,12 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
         #[allow(clippy::all, clippy::pedantic)]
         #[#crate_name::async_trait::async_trait]
         impl #impl_generics #crate_name::resolver_utils::ContainerType for #ident #ty_generics #where_clause {
-            async fn resolve_field(&self, ctx: &#crate_name::Context<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::ResponseNodeId>> {
+            async fn resolve_field(&self, ctx: &#crate_name::ContextField<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::ResponseNodeId>> {
                 #(#resolvers)*
                 ::std::result::Result::Ok(::std::option::Option::None)
             }
 
-            fn collect_all_fields_native<'__life>(&'__life self, ctx: &#crate_name::ContextSelectionSet<'__life>, fields: &mut #crate_name::resolver_utils::Fields<'__life>) -> #crate_name::ServerResult<()> {
+            fn collect_all_fields_native<'__life>(&'__life self, ctx: &#crate_name::ContextSelectionSetLegacy<'__life>, fields: &mut #crate_name::resolver_utils::Fields<'__life>) -> #crate_name::ServerResult<()> {
                 match self {
                     #(#collect_all_fields),*
                 }
@@ -352,7 +352,7 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
 
             async fn resolve(
                 &self,
-                ctx: &#crate_name::ContextSelectionSet<'_>,
+                ctx: &#crate_name::ContextSelectionSetLegacy<'_>,
                 _field: &#crate_name::Positioned<#crate_name::parser::types::Field>,
             ) -> #crate_name::ServerResult<#crate_name::ResponseNodeId> {
                 #crate_name::resolver_utils::resolve_container_native(ctx, self).await

--- a/engine/crates/engine/derive/src/merged_object.rs
+++ b/engine/crates/engine/derive/src/merged_object.rs
@@ -63,11 +63,11 @@ pub fn generate(object_args: &args::MergedObject) -> GeneratorResult<TokenStream
         #[allow(clippy::all, clippy::pedantic)]
         #[#crate_name::async_trait::async_trait]
         impl #impl_generics #crate_name::resolver_utils::ContainerType for #ident #ty_generics #where_clause {
-            async fn resolve_field(&self, ctx: &#crate_name::Context<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::ResponseNodeId>> {
+            async fn resolve_field(&self, ctx: &#crate_name::ContextField<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::ResponseNodeId>> {
                 #create_merged_obj.resolve_field(ctx).await
             }
 
-            async fn find_entity(&self, ctx: &#crate_name::Context<'_>, params: &#crate_name::Value) ->  #crate_name::ServerResult<::std::option::Option<#crate_name::Value>> {
+            async fn find_entity(&self, ctx: &#crate_name::ContextField<'_>, params: &#crate_name::Value) ->  #crate_name::ServerResult<::std::option::Option<#crate_name::Value>> {
                #create_merged_obj.find_entity(ctx, params).await
             }
         }
@@ -108,7 +108,7 @@ pub fn generate(object_args: &args::MergedObject) -> GeneratorResult<TokenStream
                 })
             }
 
-            async fn resolve(&self, ctx: &#crate_name::ContextSelectionSet<'_>, _field: &#crate_name::Positioned<#crate_name::parser::types::Field>) -> #crate_name::ServerResult<#crate_name::ResponseNodeId> {
+            async fn resolve(&self, ctx: &#crate_name::ContextSelectionSetLegacy<'_>, _field: &#crate_name::Positioned<#crate_name::parser::types::Field>) -> #crate_name::ServerResult<#crate_name::ResponseNodeId> {
                 #resolve_container
             }
         }

--- a/engine/crates/engine/derive/src/merged_subscription.rs
+++ b/engine/crates/engine/derive/src/merged_subscription.rs
@@ -77,7 +77,7 @@ pub fn generate(object_args: &args::MergedSubscription) -> GeneratorResult<Token
 
             fn create_field_stream<'__life>(
                 &'__life self,
-                ctx: &'__life #crate_name::Context<'__life>
+                ctx: &'__life #crate_name::ContextField<'__life>
             ) -> ::std::option::Option<::std::pin::Pin<::std::boxed::Box<dyn #crate_name::futures_util::stream::Stream<Item = #crate_name::Response> + ::std::marker::Send + '__life>>> {
                 ::std::option::Option::None #create_field_stream
             }

--- a/engine/crates/engine/derive/src/newtype.rs
+++ b/engine/crates/engine/derive/src/newtype.rs
@@ -119,7 +119,7 @@ pub fn generate(newtype_args: &args::NewType) -> GeneratorResult<TokenStream> {
 
             async fn resolve(
                 &self,
-                _: &#crate_name::ContextSelectionSet<'_>,
+                _: &#crate_name::ContextSelectionSetLegacy<'_>,
                 _field: &#crate_name::Positioned<#crate_name::parser::types::Field>
             ) -> #crate_name::ServerResult<#crate_name::ResponseNodeId> {
                 Ok(#crate_name::LegacyScalarType::to_value(self))

--- a/engine/crates/engine/derive/src/scalar.rs
+++ b/engine/crates/engine/derive/src/scalar.rs
@@ -93,7 +93,7 @@ pub fn generate(scalar_args: &args::Scalar, item_impl: &mut ItemImpl) -> Generat
 
             async fn resolve(
                 &self,
-                ctx: &#crate_name::ContextSelectionSet<'_>,
+                ctx: &#crate_name::ContextSelectionSetLegacy<'_>,
                 _field: &#crate_name::Positioned<#crate_name::parser::types::Field>
             ) -> #crate_name::ServerResult<#crate_name::ResponseNodeId> {
                 #crate_name::resolver_utils::resolve_scalar_native(

--- a/engine/crates/engine/derive/src/simple_object.rs
+++ b/engine/crates/engine/derive/src/simple_object.rs
@@ -224,7 +224,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
             getters.push(quote! {
                  #[inline]
                  #[allow(missing_docs)]
-                 #vis async fn #ident(&self, ctx: &#crate_name::Context<'_>) -> #crate_name::Result<#ty> {
+                 #vis async fn #ident(&self, ctx: &#crate_name::ContextField<'_>) -> #crate_name::Result<#ty> {
                      ::std::result::Result::Ok(#block)
                  }
             });
@@ -236,7 +236,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
                         self.#ident(ctx).await.map_err(|err| err.into_server_error(ctx.item.pos))
                     };
                     let obj = f.await.map_err(|err| ctx.set_error_path(err))?;
-                    let ctx_obj = ctx.with_selection_set(&ctx.item.node.selection_set);
+                    let ctx_obj = ctx.with_selection_set_legacy(&ctx.item.node.selection_set);
                     return #crate_name::LegacyOutputType::resolve(&obj, &ctx_obj, ctx.item).await.map(::std::option::Option::Some);
                 }
             });
@@ -295,7 +295,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
             #[#crate_name::async_trait::async_trait]
 
             impl #impl_generics #crate_name::resolver_utils::ContainerType for #ident #ty_generics #where_clause {
-                async fn resolve_field(&self, ctx: &#crate_name::Context<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::ResponseNodeId>> {
+                async fn resolve_field(&self, ctx: &#crate_name::ContextField<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::ResponseNodeId>> {
                     #(#resolvers)*
                     #complex_resolver
                     ::std::result::Result::Ok(::std::option::Option::None)
@@ -332,7 +332,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
                     )
                 }
 
-                async fn resolve(&self, ctx: &#crate_name::ContextSelectionSet<'_>, _field: &#crate_name::Positioned<#crate_name::parser::types::Field>) -> #crate_name::ServerResult<#crate_name::ResponseNodeId> {
+                async fn resolve(&self, ctx: &#crate_name::ContextSelectionSetLegacy<'_>, _field: &#crate_name::Positioned<#crate_name::parser::types::Field>) -> #crate_name::ServerResult<#crate_name::ResponseNodeId> {
                     #resolve_container
                 }
             }
@@ -403,7 +403,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
                     )
                 }
 
-                async fn __internal_resolve_field(&self, ctx: &#crate_name::Context<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::ResponseNodeId>> where Self: #crate_name::ContainerType {
+                async fn __internal_resolve_field(&self, ctx: &#crate_name::ContextField<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::ResponseNodeId>> where Self: #crate_name::ContainerType {
                     #(#resolvers)*
                     ::std::result::Result::Ok(::std::option::Option::None)
                 }
@@ -419,7 +419,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
                 #[allow(clippy::all, clippy::pedantic)]
                 #[#crate_name::async_trait::async_trait]
                 impl #def_lifetimes #crate_name::resolver_utils::ContainerType for #concrete_type {
-                    async fn resolve_field(&self, ctx: &#crate_name::Context<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::ResponseNodeId>> {
+                    async fn resolve_field(&self, ctx: &#crate_name::ContextField<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::ResponseNodeId>> {
                         #complex_resolver
                         self.__internal_resolve_field(ctx).await
                     }
@@ -438,7 +438,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
                         Self::__internal_create_type_info(registry, #gql_typename, fields)
                     }
 
-                    async fn resolve(&self, ctx: &#crate_name::ContextSelectionSet<'_>, _field: &#crate_name::Positioned<#crate_name::parser::types::Field>) -> #crate_name::ServerResult<#crate_name::ResponseNodeId> {
+                    async fn resolve(&self, ctx: &#crate_name::ContextSelectionSetLegacy<'_>, _field: &#crate_name::Positioned<#crate_name::parser::types::Field>) -> #crate_name::ServerResult<#crate_name::ResponseNodeId> {
                         #resolve_container
                     }
                 }

--- a/engine/crates/engine/derive/src/union.rs
+++ b/engine/crates/engine/derive/src/union.rs
@@ -133,11 +133,11 @@ pub fn generate(union_args: &args::Union) -> GeneratorResult<TokenStream> {
         #[#crate_name::async_trait::async_trait]
 
         impl #impl_generics #crate_name::resolver_utils::ContainerType for #ident #ty_generics #where_clause {
-            async fn resolve_field(&self, ctx: &#crate_name::Context<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::ResponseNodeId>> {
+            async fn resolve_field(&self, ctx: &#crate_name::ContextField<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::ResponseNodeId>> {
                 ::std::result::Result::Ok(::std::option::Option::None)
             }
 
-            fn collect_all_fields_native<'__life>(&'__life self, ctx: &#crate_name::ContextSelectionSet<'__life>, fields: &mut #crate_name::resolver_utils::Fields<'__life>) -> #crate_name::ServerResult<()> {
+            fn collect_all_fields_native<'__life>(&'__life self, ctx: &#crate_name::ContextSelectionSetLegacy<'__life>, fields: &mut #crate_name::resolver_utils::Fields<'__life>) -> #crate_name::ServerResult<()> {
                 match self {
                     #(#collect_all_fields),*
                 }
@@ -176,7 +176,7 @@ pub fn generate(union_args: &args::Union) -> GeneratorResult<TokenStream> {
                 })
             }
 
-            async fn resolve(&self, ctx: &#crate_name::ContextSelectionSet<'_>, _field: &#crate_name::Positioned<#crate_name::parser::types::Field>) -> #crate_name::ServerResult<#crate_name::ResponseNodeId> {
+            async fn resolve(&self, ctx: &#crate_name::ContextSelectionSetLegacy<'_>, _field: &#crate_name::Positioned<#crate_name::parser::types::Field>) -> #crate_name::ServerResult<#crate_name::ResponseNodeId> {
                 #crate_name::resolver_utils::resolve_container_native(ctx, self).await
             }
         }

--- a/engine/crates/engine/derive/src/utils.rs
+++ b/engine/crates/engine/derive/src/utils.rs
@@ -241,7 +241,7 @@ pub fn extract_input_args(
             match (&*pat.pat, &*pat.ty) {
                 (Pat::Ident(arg_ident), Type::Reference(TypeReference { elem, .. })) => {
                     if let Type::Path(path) = elem.as_ref() {
-                        if idx != 1 || path.path.segments.last().unwrap().ident != "Context" {
+                        if idx != 1 || path.path.segments.last().unwrap().ident != "ContextField" {
                             args.push((
                                 arg_ident.clone(),
                                 pat.ty.as_ref().clone(),
@@ -268,7 +268,7 @@ pub fn extract_input_args(
     }
 
     if create_ctx {
-        let arg = syn::parse2::<FnArg>(quote! { _: &#crate_name::Context<'_> }).unwrap();
+        let arg = syn::parse2::<FnArg>(quote! { _: &#crate_name::ContextField<'_> }).unwrap();
         method.sig.inputs.insert(1, arg);
     }
 

--- a/engine/crates/engine/src/context/legacy.rs
+++ b/engine/crates/engine/src/context/legacy.rs
@@ -1,0 +1,110 @@
+//! Contexts for resolving the legacy async_graphql derive based stuff...
+//!
+//! Hopefully one day we can delete this
+
+use engine_parser::{
+    types::{Field, SelectionSet},
+    Positioned,
+};
+use ulid::Ulid;
+
+use crate::{
+    registry::type_kinds::OutputType, Context, ContextField, QueryEnv, QueryPath, QueryPathSegment, SchemaEnv,
+};
+
+#[derive(Clone)]
+pub struct ContextSelectionSetLegacy<'a> {
+    /// The type our selection set applies to
+    pub ty: OutputType<'a>,
+
+    /// The current path being resolved.
+    pub path: QueryPath,
+    /// The selection set being resolved
+    pub item: &'a Positioned<SelectionSet>,
+    /// Context scoped to the current schema
+    pub schema_env: &'a SchemaEnv,
+    /// Context scoped to the current query
+    pub query_env: &'a QueryEnv,
+}
+
+impl<'a> ContextSelectionSetLegacy<'a> {
+    pub fn with_field(&'a self, field: &'a Positioned<Field>) -> ContextField<'a> {
+        let meta_field = self.ty.field(&field.node.name.node);
+
+        let mut path = self.path.clone();
+        path.push(field.node.response_key().node.as_str());
+
+        ContextField {
+            field: meta_field.expect("malformed query that should be validated before here"),
+            parent_type: self
+                .ty
+                .try_into()
+                .expect("have to be a selection set if were going into a field"),
+            execution_id: Ulid::from_datetime(self.query_env.current_datetime.clone().into()),
+            path,
+            item: field,
+            schema_env: self.schema_env,
+            query_env: self.query_env,
+        }
+    }
+
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_index(&'a self, idx: usize) -> ContextSelectionSetLegacy<'a> {
+        let mut path = self.path.clone();
+        path.push(QueryPathSegment::Index(idx));
+        ContextSelectionSetLegacy {
+            ty: self.ty,
+            path,
+            item: self.item,
+            schema_env: self.schema_env,
+            query_env: self.query_env,
+        }
+    }
+
+    /// Makes a ContextSelection for the given selection set.
+    ///
+    /// This should be used on spreads
+    pub fn with_selection_set(
+        &self,
+        selection_set: &'a Positioned<SelectionSet>,
+        new_target: OutputType<'a>,
+    ) -> ContextSelectionSetLegacy<'a> {
+        ContextSelectionSetLegacy {
+            ty: new_target,
+            path: self.path.clone(),
+            item: selection_set,
+            schema_env: self.schema_env,
+            query_env: self.query_env,
+        }
+    }
+}
+
+impl<'a> ContextField<'a> {
+    pub fn with_selection_set_legacy(
+        &self,
+        selection_set: &'a Positioned<SelectionSet>,
+    ) -> ContextSelectionSetLegacy<'a> {
+        ContextSelectionSetLegacy {
+            ty: self.field_base_type(),
+            path: self.path.clone(),
+            item: selection_set,
+            schema_env: self.schema_env,
+            query_env: self.query_env,
+        }
+    }
+}
+
+impl<'a> Context<'a> for ContextSelectionSetLegacy<'a> {
+    fn path(&self) -> &QueryPath {
+        &self.path
+    }
+
+    fn query_env(&self) -> &'a QueryEnv {
+        self.query_env
+    }
+
+    fn schema_env(&self) -> &'a SchemaEnv {
+        self.schema_env
+    }
+}

--- a/engine/crates/engine/src/context/list.rs
+++ b/engine/crates/engine/src/context/list.rs
@@ -1,0 +1,118 @@
+use std::borrow::Cow;
+
+use engine_parser::{types::Type, Pos};
+use ulid::Ulid;
+
+use crate::{
+    registry::type_kinds::OutputType, Context, ContextField, ContextSelectionSet, QueryEnv, QueryPath,
+    QueryPathSegment, SchemaEnv,
+};
+
+/// Context when we're resolving a list field
+///
+/// This is likely to be less widely used than the other contexts - it's mostly an
+/// intermediate type for the resolver_utils
+#[derive(Clone, Debug)]
+pub struct ContextList<'a> {
+    /// The current type we are resolving.
+    ///
+    /// I'm using the parser::Type here because it's well suited for recursing through lists
+    pub current_type: Cow<'a, Type>,
+
+    /// The context of the field that contains the list
+    pub field_context: &'a ContextField<'a>,
+
+    /// The current path within query
+    pub path: QueryPath,
+}
+
+/// The result of indexing into a ContextList
+#[derive(Clone, Debug)]
+pub enum ContextWithIndex<'a> {
+    List(ContextList<'a>),
+    Field(ContextField<'a>),
+    SelectionSet(ContextSelectionSet<'a>),
+}
+
+impl<'a> ContextList<'a> {
+    pub fn pos(&self) -> Pos {
+        self.field_context.item.pos
+    }
+
+    pub fn list_is_nullable(&self) -> bool {
+        self.current_type.nullable
+    }
+
+    pub fn contents_are_non_null(&self) -> Option<bool> {
+        match &self.current_type.base {
+            engine_parser::types::BaseType::Named(_) => None,
+            engine_parser::types::BaseType::List(inner) => Some(!inner.nullable),
+        }
+    }
+
+    #[must_use]
+    pub fn with_index(&'a self, idx: usize) -> ContextWithIndex<'a> {
+        let mut path = self.path.clone();
+        path.push(QueryPathSegment::Index(idx));
+        let engine_parser::types::BaseType::List(next) = &self.current_type.base else {
+            unreachable!("We shouldn't have a ContextList if we're not a list");
+        };
+        let next = next.as_ref();
+        if let engine_parser::types::BaseType::List(_) = &next.base {
+            return ContextWithIndex::List(ContextList {
+                current_type: Cow::Borrowed(next),
+                path,
+                field_context: self.field_context,
+            });
+        }
+
+        // If we get here we've reached the end of the lists and need to return a field/selection set context
+        match self.field_context.field_base_type() {
+            OutputType::Scalar(_) | OutputType::Enum(_) => ContextWithIndex::Field(ContextField {
+                path,
+                execution_id: Ulid::from_datetime(self.field_context.query_env.current_datetime.clone().into()),
+                field: self.field_context.field,
+                item: self.field_context.item,
+                parent_type: self.field_context.parent_type,
+                schema_env: self.field_context.schema_env,
+                query_env: self.field_context.query_env,
+            }),
+            ty @ (OutputType::Object(_) | OutputType::Interface(_) | OutputType::Union(_)) => {
+                ContextWithIndex::SelectionSet(ContextSelectionSet {
+                    ty: ty.try_into().expect("already verified it's a selection target"),
+                    path,
+                    item: &self.field_context.item.selection_set,
+                    schema_env: self.field_context.schema_env,
+                    query_env: self.field_context.query_env,
+                })
+            }
+        }
+    }
+}
+
+impl<'a> super::ContextField<'a> {
+    /// Converts this into a ContextList
+    pub fn to_list_context(&'a self) -> ContextList<'a> {
+        ContextList {
+            current_type: Cow::Owned(
+                engine_parser::types::Type::new(self.field.ty.as_str()).expect("type names to be well formed"),
+            ),
+            path: self.path.clone(),
+            field_context: self,
+        }
+    }
+}
+
+impl<'a> Context<'a> for ContextList<'a> {
+    fn path(&self) -> &QueryPath {
+        &self.path
+    }
+
+    fn query_env(&self) -> &'a QueryEnv {
+        &self.field_context.query_env()
+    }
+
+    fn schema_env(&self) -> &'a SchemaEnv {
+        &self.field_context.schema_env()
+    }
+}

--- a/engine/crates/engine/src/context/resolver_chain.rs
+++ b/engine/crates/engine/src/context/resolver_chain.rs
@@ -5,8 +5,8 @@ use engine_parser::{
 use ulid::Ulid;
 
 use crate::{
-    registry::{resolvers::Resolver, MetaField, MetaType},
-    QueryPathSegment,
+    registry::{resolvers::Resolver, type_kinds::OutputType, MetaField, MetaType, NamedType},
+    ContextExt, QueryPathSegment,
 };
 
 /// Holds some metadata about the current node in the query.
@@ -42,13 +42,6 @@ pub struct ResolverChainNode<'a> {
     /// The current resolver to apply, if it exists.
     /// There is no resolvers on QueryPathSegment::Index for instance.
     pub resolver: Option<&'a Resolver>,
-}
-
-#[derive(serde::Serialize)]
-pub struct ResponsePath<'a> {
-    key: &'a str,
-    prev: Option<Box<ResponsePath<'a>>>,
-    typename: Option<&'a str>,
 }
 
 impl<'a> ResolverChainNode<'a> {

--- a/engine/crates/engine/src/context/selection_set.rs
+++ b/engine/crates/engine/src/context/selection_set.rs
@@ -5,19 +5,20 @@ use ulid::Ulid;
 use crate::{
     parser::types::{Field, SelectionSet},
     query_path::QueryPath,
-    registry::{MetaType, TypeReference},
+    registry::type_kinds::SelectionSetTarget,
     schema::SchemaEnv,
-    ContextField, Positioned, QueryEnv, QueryPathSegment, ResolverChainNode,
+    ContextField, Positioned, QueryEnv,
 };
 
-use super::ContextExt;
+use super::ext::Context;
 
 #[derive(Clone)]
 pub struct ContextSelectionSet<'a> {
+    /// The type our selection set applies to
+    pub ty: SelectionSetTarget<'a>,
+
     /// The current path being resolved.
     pub path: QueryPath,
-    /// The current resolver path being resolved.
-    pub resolver_node: Option<ResolverChainNode<'a>>,
     /// The selection set being resolved
     pub item: &'a Positioned<SelectionSet>,
     /// Context scoped to the current schema
@@ -28,32 +29,16 @@ pub struct ContextSelectionSet<'a> {
 
 impl<'a> ContextSelectionSet<'a> {
     /// We add a new field with the Context with the proper execution_id generated.
-    pub fn with_field(
-        &'a self,
-        field: &'a Positioned<Field>,
-        ty: Option<&'a MetaType>,
-        selections: Option<&'a SelectionSet>,
-    ) -> ContextField<'a> {
-        let registry = &self.schema_env.registry;
-
-        let meta_field = ty.and_then(|ty| ty.field_by_name(&field.node.name.node));
-
-        let meta = meta_field.and_then(|field| registry.types.get(field.ty.named_type().as_str()));
+    pub fn with_field(&'a self, field: &'a Positioned<Field>) -> ContextField<'a> {
+        let meta_field = self.ty.field(&field.node.name.node);
 
         let mut path = self.path.clone();
         path.push(field.node.response_key().node.as_str());
 
         ContextField {
-            resolver_node: Some(ResolverChainNode {
-                parent: self.resolver_node.as_ref(),
-                segment: path.last().unwrap().clone(),
-                ty: meta,
-                field: meta_field,
-                executable_field: Some(field),
-                resolver: meta_field.map(|x| &x.resolver),
-                execution_id: Ulid::from_datetime(self.query_env.current_datetime.clone().into()),
-                selections,
-            }),
+            field: meta_field.expect("query to be validated before this point"),
+            parent_type: self.ty,
+            execution_id: Ulid::from_datetime(self.query_env.current_datetime.clone().into()),
             path,
             item: field,
             schema_env: self.schema_env,
@@ -61,34 +46,17 @@ impl<'a> ContextSelectionSet<'a> {
         }
     }
 
-    #[doc(hidden)]
-    #[must_use]
-    pub fn with_index(&'a self, idx: usize, selections: Option<&'a SelectionSet>) -> ContextSelectionSet<'a> {
-        let mut path = self.path.clone();
-        path.push(QueryPathSegment::Index(idx));
+    /// Makes a ContextSelection for the given selection set.
+    ///
+    /// This should be used on spreads
+    pub fn with_selection_set(
+        &self,
+        selection_set: &'a Positioned<SelectionSet>,
+        new_target: SelectionSetTarget<'a>,
+    ) -> ContextSelectionSet<'a> {
         ContextSelectionSet {
-            resolver_node: Some(ResolverChainNode {
-                parent: self.resolver_node.as_ref(),
-                segment: path.last().cloned().unwrap(),
-                field: self.resolver_node.as_ref().and_then(|x| x.field),
-                executable_field: self.resolver_node.as_ref().and_then(|x| x.executable_field),
-                ty: self.resolver_node.as_ref().and_then(|x| x.ty),
-                resolver: self.resolver_node.as_ref().and_then(|x| x.resolver),
-                execution_id: Ulid::from_datetime(self.query_env.current_datetime.clone().into()),
-                selections,
-            }),
-            path,
-            item: self.item,
-            schema_env: self.schema_env,
-            query_env: self.query_env,
-        }
-    }
-
-    #[doc(hidden)]
-    pub fn with_selection_set(&self, selection_set: &'a Positioned<SelectionSet>) -> ContextSelectionSet<'a> {
-        ContextSelectionSet {
+            ty: new_target,
             path: self.path.clone(),
-            resolver_node: self.resolver_node.clone(),
             item: selection_set,
             schema_env: self.schema_env,
             query_env: self.query_env,
@@ -96,16 +64,16 @@ impl<'a> ContextSelectionSet<'a> {
     }
 }
 
-impl ContextExt for ContextSelectionSet<'_> {
+impl<'a> Context<'a> for ContextSelectionSet<'a> {
     fn path(&self) -> &QueryPath {
         &self.path
     }
 
-    fn query_env(&self) -> &QueryEnv {
+    fn query_env(&self) -> &'a QueryEnv {
         self.query_env
     }
 
-    fn schema_env(&self) -> &SchemaEnv {
+    fn schema_env(&self) -> &'a SchemaEnv {
         self.schema_env
     }
 }

--- a/engine/crates/engine/src/deferred.rs
+++ b/engine/crates/engine/src/deferred.rs
@@ -1,10 +1,9 @@
 use engine_parser::{types::SelectionSet, Positioned};
 use futures::channel::mpsc::{UnboundedReceiver, UnboundedSender};
-use ulid::Ulid;
 
 use crate::{
     registry::{resolvers::ResolvedValue, NamedType},
-    ContextSelectionSet, Error, QueryEnv, QueryPath, ResolverChainNode, SchemaEnv,
+    ContextSelectionSet, Error, QueryEnv, QueryPath, SchemaEnv,
 };
 
 #[derive(Debug)]
@@ -36,21 +35,10 @@ impl DeferredWorkload {
     pub fn to_context<'a>(&'a self, schema_env: &'a SchemaEnv, query_env: &'a QueryEnv) -> ContextSelectionSet<'a> {
         ContextSelectionSet {
             path: self.path.clone(),
-            resolver_node: self.path.last().cloned().map(|segment| ResolverChainNode {
-                segment,
-                parent: None,
-                field: None,
-                executable_field: None,
-                ty: Some(
-                    schema_env
-                        .registry
-                        .lookup(&self.current_type_name)
-                        .expect("current type name to exist"),
-                ),
-                selections: Some(&self.selection_set),
-                execution_id: Ulid::new(),
-                resolver: None,
-            }),
+            ty: schema_env
+                .registry
+                .lookup_expecting(&self.current_type_name)
+                .expect("current type name to exist"),
             item: &self.selection_set,
             schema_env,
             query_env,

--- a/engine/crates/engine/src/graph.rs
+++ b/engine/crates/engine/src/graph.rs
@@ -1,41 +1,27 @@
 use engine_value::ConstValue;
 use graph_entities::{ResponseContainer, ResponseList, ResponseNodeId, ResponseNodeRelation, ResponsePrimitive};
 
-use crate::{registry::MetaType, relations_edges, Context, ContextExt, ContextSelectionSet};
+use crate::{ContextExt, ContextField, ContextSelectionSetLegacy};
 
 #[async_recursion::async_recursion]
-pub async fn selection_set_into_node<'a>(
-    value: ConstValue,
-    ctx: &ContextSelectionSet<'a>,
-    root: &MetaType,
-) -> ResponseNodeId {
+pub async fn selection_set_into_node<'a>(value: ConstValue, ctx: &ContextSelectionSetLegacy<'a>) -> ResponseNodeId {
     match value {
         ConstValue::List(list) => {
             let mut container = ResponseList::default();
             for value in list {
-                let id = selection_set_into_node(value, ctx, root).await;
+                let id = selection_set_into_node(value, ctx).await;
                 container.push(id);
             }
             ctx.response().await.insert_node(Box::new(container))
         }
         ConstValue::Object(value) => {
             let mut container = ResponseContainer::new_container();
-            let relations = relations_edges(ctx, root);
             for (name, value) in value {
-                let id = selection_set_into_node(value, ctx, root).await;
+                let id = selection_set_into_node(value, ctx).await;
                 let relation = name.to_string();
-                let rel = if let Some(rel) = relations.get(name.as_str()) {
-                    ResponseNodeRelation::relation(
-                        relation,
-                        rel.name.clone(),
-                        rel.relation.0.as_ref().map(ToString::to_string),
-                        rel.relation.1.to_string(),
-                    )
-                } else {
-                    ResponseNodeRelation::NotARelation {
-                        field: relation.into(),
-                        response_key: None,
-                    }
+                let rel = ResponseNodeRelation::NotARelation {
+                    field: relation.into(),
+                    response_key: None,
                 };
                 container.insert(rel, id);
             }
@@ -50,7 +36,7 @@ pub async fn selection_set_into_node<'a>(
 
 // TODO: Function is not proper, but own't really matter in the usage, still should be fixed later.
 #[async_recursion::async_recursion]
-pub async fn field_into_node<'a>(value: ConstValue, ctx: &Context<'a>) -> ResponseNodeId {
+pub async fn field_into_node<'a>(value: ConstValue, ctx: &ContextField<'a>) -> ResponseNodeId {
     match value {
         ConstValue::List(list) => {
             let mut container = ResponseList::default();

--- a/engine/crates/engine/src/guard.rs
+++ b/engine/crates/engine/src/guard.rs
@@ -1,6 +1,6 @@
 //! Field guards
 
-use crate::{Context, Result};
+use crate::{ContextField, Result};
 
 /// Field guard
 ///
@@ -8,7 +8,7 @@ use crate::{Context, Result};
 #[async_trait::async_trait]
 pub trait Guard {
     /// Check whether the guard will allow access to the field.
-    async fn check(&self, ctx: &Context<'_>) -> Result<()>;
+    async fn check(&self, ctx: &ContextField<'_>) -> Result<()>;
 }
 
 /// An extension trait for `Guard`.
@@ -31,7 +31,7 @@ pub struct And<A: Guard, B: Guard>(A, B);
 
 #[async_trait::async_trait]
 impl<A: Guard + Send + Sync, B: Guard + Send + Sync> Guard for And<A, B> {
-    async fn check(&self, ctx: &Context<'_>) -> Result<()> {
+    async fn check(&self, ctx: &ContextField<'_>) -> Result<()> {
         self.0.check(ctx).await?;
         self.1.check(ctx).await
     }
@@ -42,7 +42,7 @@ pub struct Or<A: Guard, B: Guard>(A, B);
 
 #[async_trait::async_trait]
 impl<A: Guard + Send + Sync, B: Guard + Send + Sync> Guard for Or<A, B> {
-    async fn check(&self, ctx: &Context<'_>) -> Result<()> {
+    async fn check(&self, ctx: &ContextField<'_>) -> Result<()> {
         if self.0.check(ctx).await.is_ok() {
             return Ok(());
         }

--- a/engine/crates/engine/src/look_ahead.rs
+++ b/engine/crates/engine/src/look_ahead.rs
@@ -2,21 +2,21 @@ use std::collections::HashMap;
 
 use crate::{
     parser::types::{Field, FragmentDefinition, Selection, SelectionSet},
-    Context, Name, Positioned, SelectionField,
+    ContextField, Name, Positioned, SelectionField,
 };
 
 /// A selection performed by a query.
 pub struct Lookahead<'a> {
     fragments: &'a HashMap<Name, Positioned<FragmentDefinition>>,
     fields: Vec<&'a Field>,
-    context: &'a Context<'a>,
+    context: &'a ContextField<'a>,
 }
 
 impl<'a> Lookahead<'a> {
     pub(crate) fn new(
         fragments: &'a HashMap<Name, Positioned<FragmentDefinition>>,
         field: &'a Field,
-        context: &'a Context<'a>,
+        context: &'a ContextField<'a>,
     ) -> Self {
         Self {
             fragments,
@@ -121,7 +121,7 @@ fn filter<'a>(
     fragments: &'a HashMap<Name, Positioned<FragmentDefinition>>,
     selection_set: &'a SelectionSet,
     name: &str,
-    _context: &'a Context<'a>,
+    _context: &'a ContextField<'a>,
 ) {
     for item in &selection_set.items {
         match &item.node {

--- a/engine/crates/engine/src/model/field.rs
+++ b/engine/crates/engine/src/model/field.rs
@@ -4,7 +4,7 @@ use crate::{
     model::{__InputValue, __Type},
     registry,
     registry::is_visible,
-    Context, Object,
+    ContextField, Object,
 };
 
 pub struct __Field<'a> {
@@ -26,7 +26,7 @@ impl<'a> __Field<'a> {
         self.field.description.as_deref()
     }
 
-    async fn args(&self, ctx: &Context<'_>) -> Vec<__InputValue<'a>> {
+    async fn args(&self, ctx: &ContextField<'_>) -> Vec<__InputValue<'a>> {
         self.field
             .args
             .values()

--- a/engine/crates/engine/src/model/type.rs
+++ b/engine/crates/engine/src/model/type.rs
@@ -4,7 +4,7 @@ use crate::{
     model::{__EnumValue, __Field, __InputValue, __TypeKind},
     registry,
     registry::{is_visible, ObjectType},
-    Context, Object,
+    ContextField, Object,
 };
 
 enum TypeDetail<'a> {
@@ -108,7 +108,7 @@ impl<'a> __Type<'a> {
 
     async fn fields(
         &self,
-        ctx: &Context<'_>,
+        ctx: &ContextField<'_>,
         #[graphql(default = false)] include_deprecated: bool,
     ) -> Option<Vec<__Field<'a>>> {
         if let TypeDetail::Named(ty) = &self.detail {
@@ -168,7 +168,7 @@ impl<'a> __Type<'a> {
 
     async fn enum_values(
         &self,
-        ctx: &Context<'_>,
+        ctx: &ContextField<'_>,
         #[graphql(default = false)] include_deprecated: bool,
     ) -> Option<Vec<__EnumValue<'a>>> {
         if let TypeDetail::Named(registry::MetaType::Enum(enum_type)) = &self.detail {
@@ -189,7 +189,7 @@ impl<'a> __Type<'a> {
         }
     }
 
-    async fn input_fields(&self, ctx: &Context<'_>) -> Option<Vec<__InputValue<'a>>> {
+    async fn input_fields(&self, ctx: &ContextField<'_>) -> Option<Vec<__InputValue<'a>>> {
         if let TypeDetail::Named(registry::MetaType::InputObject(input_object)) = &self.detail {
             Some(
                 input_object

--- a/engine/crates/engine/src/registry/resolvers/atlas_data_api.rs
+++ b/engine/crates/engine/src/registry/resolvers/atlas_data_api.rs
@@ -9,7 +9,7 @@ mod request;
 mod value;
 
 use super::{ResolvedValue, ResolverContext};
-use crate::{send_wrapper::make_send_on_wasm, Context, ContextExt, Error};
+use crate::{send_wrapper::make_send_on_wasm, ContextExt, ContextField, Error};
 use futures_util::Future;
 pub use operation::OperationType;
 use std::pin::Pin;
@@ -33,7 +33,7 @@ pub struct AtlasDataApiResolver {
 impl AtlasDataApiResolver {
     pub fn resolve<'a>(
         &'a self,
-        ctx: &'a Context<'_>,
+        ctx: &'a ContextField<'_>,
         resolver_ctx: &'a ResolverContext<'_>,
     ) -> Pin<Box<dyn Future<Output = Result<ResolvedValue, Error>> + Send + 'a>> {
         let config = ctx

--- a/engine/crates/engine/src/registry/resolvers/atlas_data_api/cursor.rs
+++ b/engine/crates/engine/src/registry/resolvers/atlas_data_api/cursor.rs
@@ -6,7 +6,7 @@ use crate::{
         type_kinds::{OutputType, SelectionSetTarget},
         MetaField, MetaType, TypeReference,
     },
-    Context, ContextExt, ServerError, ServerResult,
+    Context, ContextExt, ContextField, ServerError, ServerResult,
 };
 use indexmap::IndexMap;
 use runtime::search::GraphqlCursor;
@@ -47,7 +47,7 @@ pub(super) struct AtlasCursor {
 
 impl AtlasCursor {
     pub(super) fn new(
-        ctx: &Context<'_>,
+        ctx: &ContextField<'_>,
         resolver_ctx: &ResolverContext<'_>,
         order_by: Option<&[JsonMap]>,
         document: &JsonMap,
@@ -68,14 +68,14 @@ impl AtlasCursor {
     }
 
     fn from_ordering(
-        ctx: &Context<'_>,
+        ctx: &ContextField<'_>,
         resolver_ctx: &ResolverContext<'_>,
         order_by: &[JsonMap],
         document: &JsonMap,
     ) -> ServerResult<Self> {
         let mut fields = Vec::new();
 
-        let selection_target: SelectionSetTarget<'_> = resolver_ctx.ty.unwrap().try_into().unwrap();
+        let selection_target: SelectionSetTarget<'_> = resolver_ctx.ty.try_into().unwrap();
 
         let selection_edges = selection_target
             .field("edges")
@@ -162,7 +162,7 @@ impl TryFrom<GraphqlCursor> for AtlasCursor {
     }
 }
 
-fn embed_type_info(ctx: &Context<'_>, map: &JsonMap, type_info: &IndexMap<String, MetaField>) -> JsonMap {
+fn embed_type_info(ctx: &ContextField<'_>, map: &JsonMap, type_info: &IndexMap<String, MetaField>) -> JsonMap {
     let mut result = JsonMap::new();
 
     for (key, value) in map {

--- a/engine/crates/engine/src/registry/resolvers/atlas_data_api/input.rs
+++ b/engine/crates/engine/src/registry/resolvers/atlas_data_api/input.rs
@@ -10,12 +10,12 @@ use crate::{
         consts::{TYPE, TYPE_DATE, TYPE_TIMESTAMP},
         normalize,
     },
-    Context, ServerResult,
+    ContextField, ServerResult,
 };
 use indexmap::IndexMap;
 use serde_json::{json, Value};
 
-pub(super) fn by(ctx: &Context<'_>) -> ServerResult<JsonMap> {
+pub(super) fn by(ctx: &ContextField<'_>) -> ServerResult<JsonMap> {
     let map = ctx.input_by_name("by")?;
     let input_type = ctx.find_argument_type("by")?;
     let map = normalize::keys_and_values(ctx, map, input_type);
@@ -23,7 +23,7 @@ pub(super) fn by(ctx: &Context<'_>) -> ServerResult<JsonMap> {
     Ok(map)
 }
 
-pub(super) fn filter(ctx: &Context<'_>) -> ServerResult<JsonMap> {
+pub(super) fn filter(ctx: &ContextField<'_>) -> ServerResult<JsonMap> {
     let map = ctx.input_by_name("filter")?;
     let input_type = ctx.find_argument_type("filter")?;
     let map = normalize::flatten_keys(normalize::keys_and_values(ctx, map, input_type));
@@ -55,7 +55,7 @@ pub(super) fn filter(ctx: &Context<'_>) -> ServerResult<JsonMap> {
     Ok(map)
 }
 
-pub(super) fn input(ctx: &Context<'_>) -> ServerResult<JsonMap> {
+pub(super) fn input(ctx: &ContextField<'_>) -> ServerResult<JsonMap> {
     let map = ctx.input_by_name("input")?;
     let input_type = ctx.find_argument_type("input")?;
     let map = normalize::keys_and_values(ctx, map, input_type);
@@ -63,7 +63,7 @@ pub(super) fn input(ctx: &Context<'_>) -> ServerResult<JsonMap> {
     Ok(map)
 }
 
-pub(super) fn input_many(ctx: &Context<'_>) -> ServerResult<Vec<JsonMap>> {
+pub(super) fn input_many(ctx: &ContextField<'_>) -> ServerResult<Vec<JsonMap>> {
     let maps: Vec<JsonMap> = ctx.input_by_name("input")?;
     let input_type = ctx.find_argument_type("input")?;
 
@@ -75,11 +75,14 @@ pub(super) fn input_many(ctx: &Context<'_>) -> ServerResult<Vec<JsonMap>> {
     Ok(result)
 }
 
-pub(super) fn order_by(ctx: &Context<'_>) -> Option<Vec<JsonMap>> {
+pub(super) fn order_by(ctx: &ContextField<'_>) -> Option<Vec<JsonMap>> {
     ctx.input_by_name("orderBy").ok()
 }
 
-pub(super) fn sort(ctx: &Context<'_>, definition: Option<&[JsonMap]>) -> ServerResult<Option<IndexMap<String, Value>>> {
+pub(super) fn sort(
+    ctx: &ContextField<'_>,
+    definition: Option<&[JsonMap]>,
+) -> ServerResult<Option<IndexMap<String, Value>>> {
     let last = last(ctx);
 
     match definition {
@@ -129,15 +132,15 @@ pub(super) fn sort(ctx: &Context<'_>, definition: Option<&[JsonMap]>) -> ServerR
     }
 }
 
-pub(super) fn first(ctx: &Context<'_>) -> Option<usize> {
+pub(super) fn first(ctx: &ContextField<'_>) -> Option<usize> {
     ctx.input_by_name("first").ok()
 }
 
-pub(super) fn last(ctx: &Context<'_>) -> Option<usize> {
+pub(super) fn last(ctx: &ContextField<'_>) -> Option<usize> {
     ctx.input_by_name("last").ok()
 }
 
-pub(super) fn update(ctx: &Context<'_>) -> ServerResult<JsonMap> {
+pub(super) fn update(ctx: &ContextField<'_>) -> ServerResult<JsonMap> {
     let input: JsonMap = ctx.input_by_name("input")?;
     let input_type = ctx.find_argument_type("input")?;
     let input = normalize::keys_and_values(ctx, input, input_type);

--- a/engine/crates/engine/src/registry/resolvers/atlas_data_api/input/pagination.rs
+++ b/engine/crates/engine/src/registry/resolvers/atlas_data_api/input/pagination.rs
@@ -7,7 +7,7 @@ use crate::{
         cursor::{AtlasCursor, CursorField, OrderByDirection},
         JsonMap,
     },
-    Context, ServerResult,
+    ContextField, ServerResult,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -28,15 +28,15 @@ impl ValueIncrement {
     }
 }
 
-pub(crate) fn before_definition(ctx: &Context) -> Option<GraphqlCursor> {
+pub(crate) fn before_definition(ctx: &ContextField) -> Option<GraphqlCursor> {
     ctx.input_by_name("before").ok()
 }
 
-pub(crate) fn after_definition(ctx: &Context) -> Option<GraphqlCursor> {
+pub(crate) fn after_definition(ctx: &ContextField) -> Option<GraphqlCursor> {
     ctx.input_by_name("after").ok()
 }
 
-pub(super) fn before(ctx: &Context<'_>) -> ServerResult<Option<JsonMap>> {
+pub(super) fn before(ctx: &ContextField<'_>) -> ServerResult<Option<JsonMap>> {
     let cursor = before_definition(ctx);
 
     let mut before = match cursor {
@@ -70,7 +70,7 @@ pub(super) fn before(ctx: &Context<'_>) -> ServerResult<Option<JsonMap>> {
     Ok(Some(filter))
 }
 
-pub(super) fn after(ctx: &Context<'_>) -> ServerResult<Option<JsonMap>> {
+pub(super) fn after(ctx: &ContextField<'_>) -> ServerResult<Option<JsonMap>> {
     let cursor = after_definition(ctx);
 
     let mut after = match cursor {

--- a/engine/crates/engine/src/registry/resolvers/atlas_data_api/normalize.rs
+++ b/engine/crates/engine/src/registry/resolvers/atlas_data_api/normalize.rs
@@ -3,14 +3,14 @@ use crate::{
     registry::{
         resolvers::atlas_data_api::consts::OP_ELEM_MATCH, type_kinds::InputType, MetaInputValue, TypeReference,
     },
-    Context,
+    ContextField,
 };
 use serde_json::Value;
 
 /// Given the input keys, converts them to the names on MongoDB.
 ///
 /// Has any effect if a field in the data model is having a `@map` directive.
-pub(super) fn keys(ctx: &Context<'_>, map: JsonMap, input_type: InputType<'_>) -> JsonMap {
+pub(super) fn keys(ctx: &ContextField<'_>, map: JsonMap, input_type: InputType<'_>) -> JsonMap {
     let mut result = JsonMap::new();
 
     for (key, value) in map {
@@ -26,7 +26,7 @@ pub(super) fn keys(ctx: &Context<'_>, map: JsonMap, input_type: InputType<'_>) -
 
 /// Given the input values, converts them to the extended JSON format
 /// on MongoDB.
-pub(super) fn values(ctx: &Context<'_>, map: JsonMap, input_type: InputType<'_>) -> JsonMap {
+pub(super) fn values(ctx: &ContextField<'_>, map: JsonMap, input_type: InputType<'_>) -> JsonMap {
     let mut result = JsonMap::new();
 
     for (key, value) in map {
@@ -43,7 +43,7 @@ pub(super) fn values(ctx: &Context<'_>, map: JsonMap, input_type: InputType<'_>)
 
 /// Given the input, converts the keys to the mapped variants in MongoDB,
 /// and values to the extended JSON format.
-pub(super) fn keys_and_values(ctx: &Context<'_>, map: JsonMap, input_type: InputType<'_>) -> JsonMap {
+pub(super) fn keys_and_values(ctx: &ContextField<'_>, map: JsonMap, input_type: InputType<'_>) -> JsonMap {
     let map = values(ctx, map, input_type);
     keys(ctx, map, input_type)
 }
@@ -114,9 +114,9 @@ pub(super) fn flatten_keys(input: JsonMap) -> JsonMap {
     result
 }
 
-fn normalize<F>(normalize: F, ctx: &Context<'_>, value: Value, input_meta: &MetaInputValue) -> Value
+fn normalize<F>(normalize: F, ctx: &ContextField<'_>, value: Value, input_meta: &MetaInputValue) -> Value
 where
-    F: Fn(&Context<'_>, JsonMap, InputType<'_>) -> JsonMap,
+    F: Fn(&ContextField<'_>, JsonMap, InputType<'_>) -> JsonMap,
 {
     let nested_type = ctx
         .schema_env

--- a/engine/crates/engine/src/registry/resolvers/atlas_data_api/pagination.rs
+++ b/engine/crates/engine/src/registry/resolvers/atlas_data_api/pagination.rs
@@ -1,19 +1,19 @@
 use super::{cursor::AtlasCursor, input::first, JsonMap};
 use crate::{
     registry::resolvers::{ResolvedPaginationInfo, ResolverContext},
-    Context, Error,
+    ContextField, Error,
 };
 use runtime::search::GraphqlCursor;
 
 #[derive(Debug, Clone, Copy)]
 pub(super) struct PaginationContext<'a> {
-    context: &'a Context<'a>,
+    context: &'a ContextField<'a>,
     resolver_context: &'a ResolverContext<'a>,
     forward: bool,
 }
 
 impl<'a> PaginationContext<'a> {
-    pub(super) fn new(context: &'a Context<'a>, resolver_context: &'a ResolverContext<'a>) -> Self {
+    pub(super) fn new(context: &'a ContextField<'a>, resolver_context: &'a ResolverContext<'a>) -> Self {
         let forward = first(context).is_some();
 
         Self {

--- a/engine/crates/engine/src/registry/resolvers/atlas_data_api/projection.rs
+++ b/engine/crates/engine/src/registry/resolvers/atlas_data_api/projection.rs
@@ -5,11 +5,11 @@ use super::{normalize, JsonMap};
 use crate::{
     names::MONGODB_OUTPUT_FIELD_ID,
     registry::{MetaField, MetaType},
-    Context, ContextExt, Error, SelectionField,
+    ContextExt, ContextField, Error, SelectionField,
 };
 
 pub(super) fn project<'a>(
-    ctx: &'a Context<'a>,
+    ctx: &'a ContextField<'a>,
     selection: impl Iterator<Item = SelectionField<'a>> + 'a,
     target: &IndexMap<String, MetaField>,
 ) -> Result<JsonMap, Error> {
@@ -26,7 +26,7 @@ pub(super) fn project<'a>(
 }
 
 fn recurse<'a>(
-    ctx: &Context<'a>,
+    ctx: &ContextField<'a>,
     selection: impl Iterator<Item = SelectionField<'a>> + 'a,
     target: &IndexMap<String, MetaField>,
     output: &mut JsonMap,

--- a/engine/crates/engine/src/registry/resolvers/atlas_data_api/request.rs
+++ b/engine/crates/engine/src/registry/resolvers/atlas_data_api/request.rs
@@ -6,7 +6,7 @@ use crate::{
         resolvers::{ResolvedValue, ResolverContext},
         MongoDBConfiguration,
     },
-    Context, ContextExt, Error,
+    ContextExt, ContextField, Error,
 };
 use http::{
     header::{ACCEPT, CONTENT_TYPE, USER_AGENT},
@@ -23,7 +23,7 @@ mod headers {
 }
 
 pub(super) async fn execute(
-    ctx: &Context<'_>,
+    ctx: &ContextField<'_>,
     resolver_ctx: &ResolverContext<'_>,
     config: &MongoDBConfiguration,
     collection: &str,
@@ -96,7 +96,7 @@ struct AtlasRequest<'a> {
 impl<'a> AtlasRequest<'a> {
     fn convert_result(
         &self,
-        ctx: &Context<'_>,
+        ctx: &ContextField<'_>,
         resolver_ctx: &ResolverContext<'_>,
         mut value: Value,
     ) -> Result<ResolvedValue, Error> {

--- a/engine/crates/engine/src/registry/resolvers/atlas_data_api/request/query/delete_many.rs
+++ b/engine/crates/engine/src/registry/resolvers/atlas_data_api/request/query/delete_many.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     registry::resolvers::atlas_data_api::{input, JsonMap},
-    Context, Error,
+    ContextField, Error,
 };
 
 use super::AtlasQuery;
@@ -14,7 +14,7 @@ pub struct DeleteMany {
 }
 
 impl DeleteMany {
-    pub fn new(ctx: &Context<'_>) -> Result<Self, Error> {
+    pub fn new(ctx: &ContextField<'_>) -> Result<Self, Error> {
         let filter = input::filter(ctx)?;
 
         Ok(Self { filter })

--- a/engine/crates/engine/src/registry/resolvers/atlas_data_api/request/query/delete_one.rs
+++ b/engine/crates/engine/src/registry/resolvers/atlas_data_api/request/query/delete_one.rs
@@ -1,7 +1,7 @@
 use super::AtlasQuery;
 use crate::{
     registry::resolvers::atlas_data_api::{input, JsonMap},
-    Context, Error,
+    ContextField, Error,
 };
 use serde::Serialize;
 
@@ -12,7 +12,7 @@ pub struct DeleteOne {
 }
 
 impl DeleteOne {
-    pub fn new(ctx: &Context<'_>) -> Result<Self, Error> {
+    pub fn new(ctx: &ContextField<'_>) -> Result<Self, Error> {
         let filter = input::by(ctx)?;
 
         Ok(Self { filter })

--- a/engine/crates/engine/src/registry/resolvers/atlas_data_api/request/query/find_many.rs
+++ b/engine/crates/engine/src/registry/resolvers/atlas_data_api/request/query/find_many.rs
@@ -13,7 +13,7 @@ use crate::{
         },
         type_kinds::{OutputType, SelectionSetTarget},
     },
-    Context, ContextExt, Error,
+    Context, ContextField, Error,
 };
 use indexmap::IndexMap;
 use runtime::search::GraphqlCursor;
@@ -38,7 +38,7 @@ pub struct FindMany {
 }
 
 impl FindMany {
-    pub fn new(ctx: &Context<'_>, resolver_ctx: &ResolverContext<'_>) -> Result<Self, Error> {
+    pub fn new(ctx: &ContextField<'_>, resolver_ctx: &ResolverContext<'_>) -> Result<Self, Error> {
         match (input::first(ctx), input::last(ctx)) {
             (Some(_), Some(_)) => {
                 return Err(Error::new("first and last parameters can't be both defined"));
@@ -51,7 +51,7 @@ impl FindMany {
             _ => (),
         }
 
-        let selection_target: SelectionSetTarget<'_> = resolver_ctx.ty.unwrap().try_into().unwrap();
+        let selection_target: SelectionSetTarget<'_> = resolver_ctx.ty.try_into().unwrap();
 
         let selection_type = selection_target
             .field("edges")
@@ -83,7 +83,7 @@ impl FindMany {
 
     pub fn convert_result(
         &self,
-        ctx: &Context<'_>,
+        ctx: &ContextField<'_>,
         resolver_ctx: &ResolverContext<'_>,
         result: &mut serde_json::Value,
     ) -> Result<ResolvedValue, Error> {

--- a/engine/crates/engine/src/registry/resolvers/atlas_data_api/request/query/find_one.rs
+++ b/engine/crates/engine/src/registry/resolvers/atlas_data_api/request/query/find_one.rs
@@ -8,7 +8,7 @@ use crate::{
         },
         type_kinds::SelectionSetTarget,
     },
-    Context, Error,
+    ContextField, Error,
 };
 
 use super::AtlasQuery;
@@ -21,8 +21,8 @@ pub struct FindOne {
 }
 
 impl FindOne {
-    pub fn new(ctx: &Context<'_>, resolver_ctx: &ResolverContext<'_>) -> Result<Self, Error> {
-        let selection_set: SelectionSetTarget<'_> = resolver_ctx.ty.unwrap().try_into().unwrap();
+    pub fn new(ctx: &ContextField<'_>, resolver_ctx: &ResolverContext<'_>) -> Result<Self, Error> {
+        let selection_set: SelectionSetTarget<'_> = resolver_ctx.ty.try_into().unwrap();
         let available_fields = selection_set.field_map().unwrap();
         let selection = ctx.look_ahead().selection_fields();
 

--- a/engine/crates/engine/src/registry/resolvers/atlas_data_api/request/query/insert_many.rs
+++ b/engine/crates/engine/src/registry/resolvers/atlas_data_api/request/query/insert_many.rs
@@ -1,7 +1,7 @@
 use super::AtlasQuery;
 use crate::{
     registry::resolvers::atlas_data_api::{input, JsonMap},
-    Context, Error,
+    ContextField, Error,
 };
 use serde::Serialize;
 
@@ -12,7 +12,7 @@ pub struct InsertMany {
 }
 
 impl InsertMany {
-    pub fn new(ctx: &Context<'_>) -> Result<Self, Error> {
+    pub fn new(ctx: &ContextField<'_>) -> Result<Self, Error> {
         let documents = input::input_many(ctx)?;
 
         Ok(Self { documents })

--- a/engine/crates/engine/src/registry/resolvers/atlas_data_api/request/query/insert_one.rs
+++ b/engine/crates/engine/src/registry/resolvers/atlas_data_api/request/query/insert_one.rs
@@ -1,7 +1,7 @@
 use super::AtlasQuery;
 use crate::{
     registry::resolvers::atlas_data_api::{input, JsonMap},
-    Context, Error,
+    ContextField, Error,
 };
 use serde::Serialize;
 
@@ -12,7 +12,7 @@ pub struct InsertOne {
 }
 
 impl InsertOne {
-    pub fn new(ctx: &Context<'_>) -> Result<Self, Error> {
+    pub fn new(ctx: &ContextField<'_>) -> Result<Self, Error> {
         let document = input::input(ctx)?;
 
         Ok(Self { document })

--- a/engine/crates/engine/src/registry/resolvers/atlas_data_api/request/query/update_many.rs
+++ b/engine/crates/engine/src/registry/resolvers/atlas_data_api/request/query/update_many.rs
@@ -1,7 +1,7 @@
 use super::AtlasQuery;
 use crate::{
     registry::resolvers::atlas_data_api::{input, JsonMap},
-    Context, Error,
+    ContextField, Error,
 };
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -14,7 +14,7 @@ pub struct UpdateMany {
 }
 
 impl UpdateMany {
-    pub fn new(ctx: &Context<'_>) -> Result<Self, Error> {
+    pub fn new(ctx: &ContextField<'_>) -> Result<Self, Error> {
         let filter = input::filter(ctx)?;
         let update = input::update(ctx)?;
 

--- a/engine/crates/engine/src/registry/resolvers/atlas_data_api/request/query/update_one.rs
+++ b/engine/crates/engine/src/registry/resolvers/atlas_data_api/request/query/update_one.rs
@@ -1,7 +1,7 @@
 use super::AtlasQuery;
 use crate::{
     registry::resolvers::atlas_data_api::{input, JsonMap},
-    Context, Error,
+    ContextField, Error,
 };
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -14,7 +14,7 @@ pub struct UpdateOne {
 }
 
 impl UpdateOne {
-    pub fn new(ctx: &Context<'_>) -> Result<Self, Error> {
+    pub fn new(ctx: &ContextField<'_>) -> Result<Self, Error> {
         let filter = input::by(ctx)?;
         let update = input::update(ctx)?;
 

--- a/engine/crates/engine/src/registry/resolvers/dynamo_mutation.rs
+++ b/engine/crates/engine/src/registry/resolvers/dynamo_mutation.rs
@@ -25,7 +25,7 @@ use crate::{
         variables::{id::ObfuscatedID, VariableResolveDefinition},
         ConstraintType, MetaFieldType, ModelName, ObjectType, TypeReference,
     },
-    Context, ContextExt, Error, ServerError, Value,
+    Context, ContextExt, ContextField, Error, ServerError, Value,
 };
 
 mod create;
@@ -265,7 +265,7 @@ impl<'a> Add<RecursiveCreation<'a>> for RecursiveCreation<'a> {
 /// Return a flattened version of Vec<Future> for every transactions which will
 /// need to be run.
 fn node_create<'a>(
-    ctx: &'a Context<'a>,
+    ctx: &'a ContextField<'a>,
     node_ty: &'a ObjectType,
     execution_id: Ulid,
     increment: Arc<AtomicUsize>,
@@ -386,7 +386,7 @@ fn node_create<'a>(
 /// So we get, the first relation & the second one
 /// Then we remove those
 async fn relation_remove<'a>(
-    ctx: &'a Context<'a>,
+    ctx: &'a ContextField<'a>,
     from: SharedSelectionType<'a>,
     to: String,
     relation_name: &'a str,
@@ -443,7 +443,7 @@ pub const NUMERICAL_TYPES: &[&str] = &["Int", "Int!", "Float", "Float!"];
 ///   - Create new linked entity if needed
 ///   - Remove old entity linked if needed
 fn node_update<'a>(
-    ctx: &'a Context<'a>,
+    ctx: &'a ContextField<'a>,
     node_ty: &'a ObjectType,
     execution_id: Ulid,
     increment: Arc<AtomicUsize>,
@@ -654,7 +654,7 @@ fn inputs(parent_input: &Value) -> Option<Vec<&IndexMap<Name, Value>>> {
 
 /// Create a relation node only if needed
 async fn create_relation_node<'a>(
-    ctx: &'a Context<'a>,
+    ctx: &'a ContextField<'a>,
     to_ty: &ObjectType,
     parent_value: SharedSelectionType<'a>,
     selected_value: SharedSelectionType<'a>,
@@ -714,7 +714,7 @@ async fn create_relation_node<'a>(
 }
 
 fn internal_node_linking<'a>(
-    ctx: &'a Context<'a>,
+    ctx: &'a ContextField<'a>,
     parent_ty: &'a ObjectType,
     child_ty: &'a ObjectType,
     parent_value: SharedSelectionType<'a>,
@@ -769,7 +769,7 @@ fn internal_node_linking<'a>(
 }
 
 fn internal_node_unlinking<'a>(
-    ctx: &'a Context<'a>,
+    ctx: &'a ContextField<'a>,
     parent_value: SharedSelectionType<'a>,
     relation_name: &'a str,
     unlinking_input: &Value,
@@ -854,7 +854,7 @@ fn internal_node_unlinking<'a>(
 ///
 #[allow(clippy::too_many_arguments)]
 fn relation_handle<'a>(
-    ctx: &'a Context<'a>,
+    ctx: &'a ContextField<'a>,
     parent_ty: &'a ObjectType,
     parent_value: SharedSelectionType<'a>,
     relation_field: &'a str,
@@ -969,7 +969,7 @@ fn relation_handle<'a>(
 impl DynamoMutationResolver {
     pub(super) async fn resolve(
         &self,
-        ctx: &Context<'_>,
+        ctx: &ContextField<'_>,
         resolver_ctx: &ResolverContext<'_>,
         last_resolver_value: Option<&ResolvedValue>,
     ) -> Result<ResolvedValue, Error> {

--- a/engine/crates/engine/src/registry/resolvers/dynamo_mutation/create.rs
+++ b/engine/crates/engine/src/registry/resolvers/dynamo_mutation/create.rs
@@ -9,7 +9,7 @@ use crate::{
         variables::VariableResolveDefinition,
         ModelName,
     },
-    Context, ContextExt, Error,
+    Context, ContextField, Error,
 };
 
 #[derive(serde::Deserialize)]
@@ -18,7 +18,7 @@ struct CreateInput {
 }
 
 pub(super) async fn batch(
-    ctx: &Context<'_>,
+    ctx: &ContextField<'_>,
     resolver_ctx: &ResolverContext<'_>,
     last_resolver_value: Option<&ResolvedValue>,
     input: &VariableResolveDefinition,

--- a/engine/crates/engine/src/registry/resolvers/dynamo_mutation/delete.rs
+++ b/engine/crates/engine/src/registry/resolvers/dynamo_mutation/delete.rs
@@ -9,7 +9,7 @@ use crate::{
         variables::{id::ObfuscatedID, oneof::OneOf, VariableResolveDefinition},
         ModelName,
     },
-    Context, ContextExt, Error,
+    Context, ContextExt, ContextField, Error,
 };
 
 #[derive(serde::Deserialize)]
@@ -18,7 +18,7 @@ struct PostDeleteManyInput {
 }
 
 pub(super) async fn resolve_delete_nodes(
-    ctx: &Context<'_>,
+    ctx: &ContextField<'_>,
     last_resolver_value: Option<&ResolvedValue>,
     input: &VariableResolveDefinition,
     ty: &ModelName,
@@ -39,7 +39,11 @@ struct Parsed {
     deleted_ids: HashSet<String>,
 }
 
-async fn generate_changes(ctx: &Context<'_>, input: Vec<PostDeleteManyInput>, ty: &ModelName) -> Result<Parsed, Error> {
+async fn generate_changes(
+    ctx: &ContextField<'_>,
+    input: Vec<PostDeleteManyInput>,
+    ty: &ModelName,
+) -> Result<Parsed, Error> {
     let batchers = &ctx.data::<Arc<DynamoDBBatchersData>>()?;
     let meta_type = ctx.registry().lookup(ty)?;
 

--- a/engine/crates/engine/src/registry/resolvers/dynamo_mutation/update.rs
+++ b/engine/crates/engine/src/registry/resolvers/dynamo_mutation/update.rs
@@ -12,7 +12,7 @@ use crate::{
         variables::{id::ObfuscatedID, oneof::OneOf},
         ModelName, ObjectType,
     },
-    Context, ContextExt, Error, ServerError,
+    Context, ContextExt, ContextField, Error, ServerError,
 };
 
 #[derive(serde::Deserialize)]
@@ -49,7 +49,7 @@ struct Update {
 }
 
 pub(super) async fn batch(
-    ctx: &Context<'_>,
+    ctx: &ContextField<'_>,
     resolver_ctx: &ResolverContext<'_>,
     input: Vec<ParsedUpdateInput>,
     ty: &ModelName,
@@ -93,7 +93,7 @@ pub(super) async fn batch(
 }
 
 fn partition_by_identifier(
-    ctx: &Context<'_>,
+    ctx: &ContextField<'_>,
     meta_type: &ObjectType,
     input: Vec<ParsedUpdateInput>,
 ) -> Result<(Vec<ById>, Vec<ByConstraint>), ServerError> {
@@ -141,7 +141,7 @@ fn partition_by_identifier(
 }
 
 async fn generate_updates(
-    ctx: &Context<'_>,
+    ctx: &ContextField<'_>,
     by_ids: Vec<ById>,
     by_constraints: Vec<ByConstraint>,
 ) -> Result<Vec<Update>, Error> {

--- a/engine/crates/engine/src/registry/resolvers/dynamo_querying.rs
+++ b/engine/crates/engine/src/registry/resolvers/dynamo_querying.rs
@@ -19,9 +19,9 @@ use crate::{
         relations::{MetaRelation, MetaRelationKind},
         resolvers::ResolverContext,
         variables::{oneof::OneOf, VariableResolveDefinition},
-        MetaType, ModelName, SchemaID,
+        ModelName, SchemaID,
     },
-    Context, ContextExt, Error, Value,
+    ContextExt, ContextField, Error, Value,
 };
 
 mod get;
@@ -208,7 +208,7 @@ struct IdScalarFilter {
 impl DynamoResolver {
     pub(super) async fn resolve(
         &self,
-        ctx: &Context<'_>,
+        ctx: &ContextField<'_>,
         resolver_ctx: &ResolverContext<'_>,
         last_resolver_value: Option<&ResolvedValue>,
     ) -> Result<ResolvedValue, Error> {
@@ -220,7 +220,7 @@ impl DynamoResolver {
 
         let ctx_ty = resolver_ctx
             .ty
-            .and_then(MetaType::object)
+            .object()
             .ok_or_else(|| Error::new("Internal Error: Failed process the associated schema."))?;
         let current_ty = ctx_ty.name.as_str();
 

--- a/engine/crates/engine/src/registry/resolvers/dynamo_querying/get.rs
+++ b/engine/crates/engine/src/registry/resolvers/dynamo_querying/get.rs
@@ -8,10 +8,10 @@ use crate::{
         resolvers::{ResolvedPaginationDirection, ResolvedPaginationInfo, ResolvedValue},
         ModelName,
     },
-    Context, ContextExt, Error,
+    ContextExt, ContextField, Error,
 };
 
-pub(super) async fn by_ids(ctx: &Context<'_>, ids: &[String], ty: &ModelName) -> Result<ResolvedValue, Error> {
+pub(super) async fn by_ids(ctx: &ContextField<'_>, ids: &[String], ty: &ModelName) -> Result<ResolvedValue, Error> {
     let keys = ids.iter().map(|id| (id.clone(), id.clone())).collect::<Vec<_>>();
     let mut db_result = ctx
         .data::<Arc<DynamoDBBatchersData>>()?
@@ -33,7 +33,7 @@ pub(super) async fn by_ids(ctx: &Context<'_>, ids: &[String], ty: &ModelName) ->
 }
 
 pub(super) async fn paginated_by_ids(
-    ctx: &Context<'_>,
+    ctx: &ContextField<'_>,
     ids: HashSet<String>,
     cursor: PaginatedCursor,
     ordering: PaginationOrdering,

--- a/engine/crates/engine/src/registry/resolvers/http/mod.rs
+++ b/engine/crates/engine/src/registry/resolvers/http/mod.rs
@@ -6,8 +6,8 @@ use reqwest::Url;
 use self::parameters::ParamApply;
 use super::{ResolvedValue, ResolverContext};
 use crate::{
-    registry::variables::VariableResolveDefinition, send_wrapper::make_send_on_wasm, Context, ContextExt, Error,
-    RequestHeaders,
+    registry::variables::VariableResolveDefinition, send_wrapper::make_send_on_wasm, Context, ContextExt, ContextField,
+    Error, RequestHeaders,
 };
 
 mod parameters;
@@ -65,7 +65,7 @@ pub enum ExpectedStatusCode {
 impl HttpResolver {
     pub fn resolve<'a>(
         &'a self,
-        ctx: &'a Context<'_>,
+        ctx: &'a ContextField<'_>,
         _resolver_ctx: &ResolverContext<'a>,
         last_resolver_value: Option<&'a ResolvedValue>,
     ) -> Pin<Box<dyn Future<Output = Result<ResolvedValue, Error>> + Send + 'a>> {
@@ -135,7 +135,11 @@ impl HttpResolver {
         }))
     }
 
-    fn build_url(&self, ctx: &Context<'_>, last_resolver_value: Option<&serde_json::Value>) -> Result<String, Error> {
+    fn build_url(
+        &self,
+        ctx: &ContextField<'_>,
+        last_resolver_value: Option<&serde_json::Value>,
+    ) -> Result<String, Error> {
         let mut url = self.url.clone();
 
         for param in &self.path_parameters {

--- a/engine/crates/engine/src/registry/resolvers/postgresql.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql.rs
@@ -4,7 +4,7 @@ mod request;
 pub use context::CollectionArgs;
 
 use super::{ResolvedValue, ResolverContext};
-use crate::{send_wrapper::make_send_on_wasm, Context, Error};
+use crate::{send_wrapper::make_send_on_wasm, ContextField, Error};
 use context::PostgresContext;
 use std::{future::Future, pin::Pin};
 
@@ -41,7 +41,7 @@ impl PostgresResolver {
 
     pub fn resolve<'a>(
         &'a self,
-        ctx: &'a Context<'_>,
+        ctx: &'a ContextField<'_>,
         resolver_ctx: &'a ResolverContext<'_>,
     ) -> Pin<Box<dyn Future<Output = Result<ResolvedValue, Error>> + Send + 'a>> {
         Box::pin(make_send_on_wasm(async move {

--- a/engine/crates/engine/src/registry/resolvers/postgresql/context/selection.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql/context/selection.rs
@@ -2,7 +2,7 @@ pub mod collection_args;
 
 use super::PostgresContext;
 use crate::{
-    registry::{type_kinds::SelectionSetTarget, MetaType},
+    registry::type_kinds::{OutputType, SelectionSetTarget},
     Error, Lookahead, SelectionField,
 };
 pub use collection_args::CollectionArgs;
@@ -33,7 +33,7 @@ pub struct SelectionIterator<'a> {
 impl<'a> SelectionIterator<'a> {
     pub fn new(
         ctx: &'a PostgresContext<'a>,
-        meta_type: &'a MetaType,
+        meta_type: OutputType<'a>,
         selection_field: &SelectionField<'_>,
         selection: Vec<SelectionField<'a>>,
     ) -> Self {
@@ -160,7 +160,7 @@ impl<'a> Iterator for SelectionIterator<'a> {
 
             // `userCollection { edges { node { field } } }`, the type part.
             let meta_type = meta_type
-                .field_by_name("edges")
+                .field("edges")
                 .and_then(|field| self.ctx.registry().lookup(&field.ty).ok())
                 .as_ref()
                 .and_then(|output| output.field("node"))

--- a/engine/crates/engine/src/registry/resolvers/query/mod.rs
+++ b/engine/crates/engine/src/registry/resolvers/query/mod.rs
@@ -9,7 +9,7 @@ use super::{
 use crate::{
     names::OUTPUT_EDGE_CURSOR,
     registry::{variables::VariableResolveDefinition, ModelName},
-    Context, ContextExt, Error,
+    Context, ContextExt, ContextField, Error,
 };
 
 mod search_parser;
@@ -36,7 +36,7 @@ pub enum QueryResolver {
 impl QueryResolver {
     pub async fn resolve(
         &self,
-        ctx: &Context<'_>,
+        ctx: &ContextField<'_>,
         resolver_ctx: &ResolverContext<'_>,
         last_resolver_value: Option<&ResolvedValue>,
     ) -> Result<ResolvedValue, Error> {

--- a/engine/crates/engine/src/registry/resolvers/transformer.rs
+++ b/engine/crates/engine/src/registry/resolvers/transformer.rs
@@ -17,10 +17,11 @@ use super::{
 use crate::{
     registry::{
         resolvers::{postgresql::CollectionArgs, resolved_value::SelectionData, ResolverContext},
+        type_kinds::OutputType,
         variables::VariableResolveDefinition,
-        MetaEnumValue, MetaType, UnionDiscriminator,
+        MetaEnumValue, UnionDiscriminator,
     },
-    Context, ContextExt, Error,
+    ContextExt, ContextField, Error,
 };
 
 #[non_exhaustive]
@@ -124,7 +125,7 @@ impl Transformer {
 
     pub(super) async fn resolve(
         &self,
-        ctx: &Context<'_>,
+        ctx: &ContextField<'_>,
         resolver_ctx: &ResolverContext<'_>,
         last_resolver_value: Option<&ResolvedValue>,
     ) -> Result<ResolvedValue, Error> {
@@ -483,17 +484,17 @@ impl Transformer {
     }
 }
 
-impl Context<'_> {
+impl ContextField<'_> {
     fn current_enum_values(&self) -> Option<&IndexMap<String, MetaEnumValue>> {
-        match self.resolver_node.as_ref()?.ty? {
-            MetaType::Enum(enum_type) => Some(&enum_type.enum_values),
+        match self.field_base_type() {
+            OutputType::Enum(enum_type) => Some(&enum_type.enum_values),
             _ => None,
         }
     }
 
     fn current_discriminators(&self) -> Option<&Vec<(String, UnionDiscriminator)>> {
-        match self.resolver_node.as_ref()?.ty? {
-            MetaType::Union(union_type) => union_type.discriminators.as_ref(),
+        match self.field_base_type() {
+            OutputType::Union(union_type) => union_type.discriminators.as_ref(),
             _ => None,
         }
     }

--- a/engine/crates/engine/src/registry/type_names.rs
+++ b/engine/crates/engine/src/registry/type_names.rs
@@ -2,6 +2,8 @@
 
 use std::borrow::{Borrow, Cow};
 
+use engine_value::Name;
+
 use super::{
     type_kinds::{InputType, OutputType, SelectionSetTarget},
     MetaType, ObjectType,
@@ -208,6 +210,12 @@ impl<'a> From<&'a String> for NamedType<'a> {
 impl std::fmt::Display for NamedType<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+impl<'a> From<&'a Name> for NamedType<'a> {
+    fn from(value: &'a Name) -> Self {
+        NamedType(Cow::Borrowed(value.as_str()))
     }
 }
 

--- a/engine/crates/engine/src/registry/variables/mod.rs
+++ b/engine/crates/engine/src/registry/variables/mod.rs
@@ -13,7 +13,7 @@ use runtime::search::GraphqlCursor;
 use serde::{de::DeserializeOwned, Serialize};
 
 use self::oneof::OneOf;
-use crate::{resolver_utils::InputResolveMode, Context, Error, ServerError, ServerResult, Value};
+use crate::{resolver_utils::InputResolveMode, ContextField, Error, ServerError, ServerResult, Value};
 
 pub mod id;
 pub mod oneof;
@@ -60,7 +60,7 @@ impl VariableResolveDefinition {
     /// Resolve the first variable with this definition
     pub fn param<'a>(
         &self,
-        ctx: &'a Context<'a>,
+        ctx: &'a ContextField<'a>,
         last_resolver_value: Option<&'a serde_json::Value>,
     ) -> Result<Option<Value>, ServerError> {
         match self {
@@ -84,7 +84,7 @@ impl VariableResolveDefinition {
 
     pub fn resolve<T: DeserializeOwned>(
         &self,
-        ctx: &Context<'_>,
+        ctx: &ContextField<'_>,
         last_resolver_value: Option<impl Borrow<serde_json::Value>>,
     ) -> ServerResult<T> {
         let param = match last_resolver_value {
@@ -97,7 +97,7 @@ impl VariableResolveDefinition {
 
     pub fn expect_string<'a>(
         &self,
-        ctx: &'a Context<'a>,
+        ctx: &'a ContextField<'a>,
         last_resolver_value: Option<&'a serde_json::Value>,
     ) -> Result<String, ServerError> {
         match self.param(ctx, last_resolver_value)? {
@@ -108,7 +108,7 @@ impl VariableResolveDefinition {
 
     pub fn expect_obj<'a>(
         &self,
-        ctx: &'a Context<'a>,
+        ctx: &'a ContextField<'a>,
         last_resolver_value: Option<&'a serde_json::Value>,
     ) -> Result<IndexMap<Name, Value>, ServerError> {
         match self.param(ctx, last_resolver_value)? {
@@ -119,7 +119,7 @@ impl VariableResolveDefinition {
 
     pub fn expect_op_obj<'a>(
         &self,
-        ctx: &'a Context<'a>,
+        ctx: &'a ContextField<'a>,
         last_resolver_value: Option<&'a serde_json::Value>,
     ) -> Result<Option<IndexMap<Name, Value>>, ServerError> {
         match self.param(ctx, last_resolver_value)? {
@@ -131,7 +131,7 @@ impl VariableResolveDefinition {
 
     pub fn expect_opt_string<'a>(
         &self,
-        ctx: &'a Context<'a>,
+        ctx: &'a ContextField<'a>,
         last_resolver_value: Option<&'a serde_json::Value>,
     ) -> Result<Option<String>, ServerError> {
         match self.param(ctx, last_resolver_value)? {
@@ -144,7 +144,7 @@ impl VariableResolveDefinition {
 
     pub fn expect_opt_int<'a>(
         &self,
-        ctx: &'a Context<'a>,
+        ctx: &'a ContextField<'a>,
         last_resolver_value: Option<&'a serde_json::Value>,
         limit: Option<usize>,
     ) -> Result<Option<usize>, ServerError> {
@@ -167,7 +167,7 @@ impl VariableResolveDefinition {
 
     pub fn expect_opt_cursor<'a>(
         &self,
-        ctx: &'a Context<'a>,
+        ctx: &'a ContextField<'a>,
         last_resolver_value: Option<&'a serde_json::Value>,
     ) -> Result<Option<String>, ServerError> {
         match self.expect_opt_string(ctx, last_resolver_value)? {
@@ -181,7 +181,7 @@ impl VariableResolveDefinition {
 
     pub fn expect_oneof<'a, T>(
         &self,
-        ctx: &'a Context<'a>,
+        ctx: &'a ContextField<'a>,
         last_resolver_value: Option<&'a serde_json::Value>,
     ) -> Result<Option<OneOf<T>>, ServerError>
     where

--- a/engine/crates/engine/src/registry/walker.rs
+++ b/engine/crates/engine/src/registry/walker.rs
@@ -1,0 +1,8 @@
+pub struct OutputTypeWalker<'a> {
+    registry: &'a Registry,
+    ty: &'a OutputType,
+}
+
+impl OutputTypeWalker {
+    pub fn field(&self, name: &str) -> OutputTypeWalker {}
+}

--- a/engine/crates/engine/src/resolver_utils/dynamic.rs
+++ b/engine/crates/engine/src/resolver_utils/dynamic.rs
@@ -6,7 +6,7 @@ use crate::{
         scalars::{DynamicScalar, PossibleScalar},
         MetaEnumValue, MetaInputValue, MetaType, MetaTypeName,
     },
-    Context, Error, ServerResult,
+    ContextField, Error, ServerResult,
 };
 
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
@@ -17,7 +17,7 @@ pub enum InputResolveMode {
 }
 
 pub fn resolve_input(
-    ctx_field: &Context<'_>,
+    ctx_field: &ContextField<'_>,
     arg_name: &str,
     meta_input_value: &MetaInputValue,
     value: Option<ConstValue>,
@@ -64,7 +64,7 @@ impl<'a> PathNode<'a> {
 }
 
 struct ResolveContext<'a> {
-    ctx: &'a Context<'a>,
+    ctx: &'a ContextField<'a>,
     path: PathNode<'a>,
     /// Expected GraphQL type
     ty: &'a str,

--- a/engine/crates/engine/src/resolver_utils/enum.rs
+++ b/engine/crates/engine/src/resolver_utils/enum.rs
@@ -1,9 +1,7 @@
 use graph_entities::{CompactValue, ResponseNodeId};
 use internment::ArcIntern;
 
-use crate::{
-    context::ContextSelectionSet, ContextExt, InputValueError, InputValueResult, LegacyInputType, Name, Value,
-};
+use crate::{ContextExt, ContextSelectionSetLegacy, InputValueError, InputValueResult, LegacyInputType, Name, Value};
 
 /// A variant of an enum.
 pub struct EnumItem<T> {
@@ -44,7 +42,7 @@ pub fn enum_value<T: LegacyEnumType>(value: T) -> Value {
     Value::Enum(Name::new(item.name))
 }
 
-pub async fn enum_value_node<'a, T: LegacyEnumType>(ctx: &ContextSelectionSet<'a>, value: T) -> ResponseNodeId {
+pub async fn enum_value_node<'a, T: LegacyEnumType>(ctx: &ContextSelectionSetLegacy<'a>, value: T) -> ResponseNodeId {
     let item = T::items().iter().find(|item| item.value == value).unwrap();
 
     let mut response_graph = ctx.response().await;

--- a/engine/crates/engine/src/resolver_utils/introspection.rs
+++ b/engine/crates/engine/src/resolver_utils/introspection.rs
@@ -11,7 +11,7 @@ use crate::{
 /// remove sometime.
 pub async fn resolve_type_field(ctx: &ContextField<'_>) -> Result<Option<ResponseNodeId>, ServerError> {
     let (_, type_name) = ctx.param_value::<String>("name", None)?;
-    let ctx_obj = ctx.with_selection_set(&ctx.item.node.selection_set);
+    let ctx_obj = ctx.with_selection_set_legacy(&ctx.item.node.selection_set);
     let visible_types = ctx.schema_env.registry.find_visible_types(ctx);
     let resolved = LegacyOutputType::resolve(
         &ctx.schema_env
@@ -33,7 +33,7 @@ pub async fn resolve_type_field(ctx: &ContextField<'_>) -> Result<Option<Respons
 /// This calls into some legacy resolution stuff that we should definitely
 /// remove sometime.
 pub async fn resolve_schema_field(ctx: &ContextField<'_>) -> Result<Option<ResponseNodeId>, ServerError> {
-    let ctx_obj = ctx.with_selection_set(&ctx.item.node.selection_set);
+    let ctx_obj = ctx.with_selection_set_legacy(&ctx.item.node.selection_set);
     let visible_types = ctx.schema_env.registry.find_visible_types(ctx);
     let resolved = LegacyOutputType::resolve(
         &__Schema::new(&ctx.schema_env.registry, &visible_types),

--- a/engine/crates/engine/src/resolver_utils/list.rs
+++ b/engine/crates/engine/src/resolver_utils/list.rs
@@ -1,82 +1,89 @@
-use std::{future::Future, iter::Peekable};
+use std::future::Future;
 
 use engine_value::Name;
+use futures_util::future::BoxFuture;
 use graph_entities::{CompactValue, QueryResponseNode, ResponseList, ResponseNodeId, ResponsePrimitive};
 
 use crate::{
     extensions::ResolveInfo,
     parser::types::Field,
     registry::{
-        resolvers::ResolvedValue,
-        scalars::{DynamicScalar, PossibleScalar},
-        MetaFieldType, MetaType, WrappingType, WrappingTypeIter,
+        resolvers::ResolvedValue, scalars::DynamicScalar, scalars::PossibleScalar, type_kinds::OutputType, MetaType,
     },
     resolver_utils::resolve_container,
-    ContextExt, ContextSelectionSet, Error, LegacyOutputType, Positioned, ServerError, ServerResult, Value,
+    Context, ContextExt, ContextField, ContextList, ContextSelectionSetLegacy, ContextWithIndex, Error,
+    LegacyOutputType, Positioned, ServerError, ServerResult, Value,
 };
 
 /// Resolve a list by executing each of the items concurrently.
 pub async fn resolve_list<'a>(
-    ctx: ContextSelectionSet<'a>,
+    ctx: ContextList<'a>,
     field: &'a Positioned<Field>,
-    field_ty: &MetaFieldType,
     inner_ty: &'a MetaType,
     value: ResolvedValue,
 ) -> ServerResult<ResponseNodeId> {
     #[async_recursion::async_recursion]
     async fn inner(
-        ctx: ContextSelectionSet<'async_recursion>,
+        ctx: ContextList<'async_recursion>,
         field: &Positioned<Field>,
-        list_kinds: &[ListKind],
         ty: &MetaType,
         value: ResolvedValue,
     ) -> Result<ResponseNodeId, ServerError> {
-        let Some(list_kind) = list_kinds.first() else {
-            // If there's no list_kind then we've reached the innermost item and should resolve that
-            return resolve_item(ctx, field, ty, value).await;
-        };
-
         // First we need to make sure our parent resolve data actually has a list
         // (or return null early if we're on a nullable list)
-        let items = match (list_kind, value.data_resolved()) {
-            (ListKind::NullableList(_), serde_json::Value::Null) => {
+        let items = match value.data_resolved() {
+            serde_json::Value::Null if ctx.list_is_nullable() => {
                 return Ok(ctx.response().await.insert_node(CompactValue::Null));
             }
-            (ListKind::NonNullList(_), serde_json::Value::Null) => {
+            serde_json::Value::Null => {
                 return Err(ctx.set_error_path(ServerError::new(
                     format!(
                         "An error occurred while fetching `{}`, a non-nullable value was expected but no value was found.",
                         field.node.name.node
                     ),
-                    Some(ctx.item.pos),
+                    Some(ctx.pos()),
                 )));
             }
-            (_, serde_json::Value::Array(_)) => value.item_iter().expect("we checked its an array").collect::<Vec<_>>(),
-            (_, value) => {
+            serde_json::Value::Array(_) => value.item_iter().expect("we checked its an array").collect::<Vec<_>>(),
+            value => {
                 return Err(ctx.set_error_path(ServerError::new(
                     format!("Encountered a {} where we expected a list", json_kind_str(value)),
-                    Some(ctx.item.pos),
+                    Some(ctx.pos()),
                 )));
             }
         };
 
-        let futures = items.into_iter().enumerate().map(|(idx, item)| {
-            let ctx_idx = ctx.with_index(idx, Some(&ctx.item.node));
-            let resolve_future = inner(ctx_idx.clone(), field, &list_kinds[1..], ty, item);
+        let futures = items.into_iter().enumerate().map(|(idx, item)| -> BoxFuture<'_, _> {
+            match ctx.with_index(idx) {
+                ContextWithIndex::Field(field_ctx) => {
+                    Box::pin(async move { resolve_leaf_field(field_ctx, item).await })
+                }
+                ContextWithIndex::SelectionSet(selection_ctx) => {
+                    Box::pin(async move { resolve_container(&selection_ctx, None, item).await })
+                }
+                ContextWithIndex::List(list_context) => {
+                    let resolve_future = inner(list_context.clone(), field, ty, item);
 
-            if ctx.query_env.extensions.is_empty() {
-                resolve_future
-            } else {
-                Box::pin(apply_extensions(ctx_idx, field, ty, resolve_future))
+                    if ctx.query_env().extensions.is_empty() {
+                        Box::pin(resolve_future)
+                    } else {
+                        Box::pin(apply_extensions(list_context, field, ty, resolve_future))
+                    }
+                }
             }
         });
 
         let mut children = vec![];
+        let contents_are_non_null = ctx
+            .contents_are_non_null()
+            .expect("only returns none if we're not a list and we definitely are here");
+        let contents_are_nullable = !contents_are_non_null;
+
         for (index, result) in futures_util::future::join_all(futures).await.into_iter().enumerate() {
             // Now we need to handle error propagation and validate the nullability
             // of each of the list items
             match result {
-                Ok(id) if list_kind.has_non_null_item() => {
+                Ok(id) if contents_are_non_null => {
                     let found_null = match ctx.response().await.get_node(id) {
                         Some(QueryResponseNode::Primitive(value)) if value.is_null() => true,
                         None => true,
@@ -89,7 +96,7 @@ pub async fn resolve_list<'a>(
                                     "An error occurred while fetching `{}`, a non-nullable value was expected but no value was found.",
                                     field.node.name.node
                                 ),
-                                Some(ctx.item.pos),
+                                Some(ctx.pos()),
                             );
 
                         error.path = ctx.path.child(index).into_iter().collect();
@@ -99,7 +106,7 @@ pub async fn resolve_list<'a>(
                     children.push(id);
                 }
                 Ok(id) => children.push(id),
-                Err(error) if list_kind.has_nullable_item() => {
+                Err(error) if contents_are_nullable => {
                     ctx.add_error(error);
                     children.push(ctx.response().await.insert_node(CompactValue::Null));
                 }
@@ -110,18 +117,11 @@ pub async fn resolve_list<'a>(
         Ok(ctx.response().await.insert_node(ResponseList::with_children(children)))
     }
 
-    inner(
-        ctx,
-        field,
-        &ListNullabilityIter::new(field_ty).collect::<Vec<_>>(),
-        inner_ty,
-        value,
-    )
-    .await
+    inner(ctx, field, inner_ty, value).await
 }
 
 fn apply_extensions<'a>(
-    ctx: ContextSelectionSet<'a>,
+    ctx: ContextList<'a>,
     field: &'a Positioned<Field>,
     inner_ty: &'a MetaType,
     resolve_fut: impl Future<Output = Result<ResponseNodeId, ServerError>> + Send + 'a,
@@ -129,7 +129,7 @@ fn apply_extensions<'a>(
     let ctx = ctx.clone();
     let type_name = inner_ty.name();
     async move {
-        let ctx_field = ctx.with_field(field, None, Some(&ctx.item.node));
+        let ctx_field = ctx.field_context;
         let meta_field = ctx_field
             .schema_env
             .registry
@@ -161,7 +161,7 @@ fn apply_extensions<'a>(
 
         let resolve_fut = async move { Ok(Some(resolve_fut.await?)) };
         futures_util::pin_mut!(resolve_fut);
-        ctx.query_env
+        ctx.query_env()
             .extensions
             .resolve(resolve_info, &mut resolve_fut)
             .await
@@ -169,32 +169,17 @@ fn apply_extensions<'a>(
     }
 }
 
-async fn resolve_item(
-    ctx_idx: ContextSelectionSet<'_>,
-    field: &Positioned<Field>,
-    ty: &MetaType,
-    item: ResolvedValue,
-) -> Result<ResponseNodeId, ServerError> {
-    match ty {
-        MetaType::Scalar(_) | MetaType::Enum(_) => {
-            let mut result = Value::try_from(item.take()).map_err(|err| Error::new(format!("{err:?}")));
+async fn resolve_leaf_field(ctx: ContextField<'_>, item: ResolvedValue) -> Result<ResponseNodeId, ServerError> {
+    let mut result = Value::try_from(item.take()).map_err(|err| Error::new(format!("{err:?}")));
 
-            // Yes it's ugly...
-            if let MetaType::Scalar(_) = ty {
-                result = result.and_then(|value| resolve_scalar(value, ty.name()));
-            }
-
-            let item = result.map_err(|error| ctx_idx.set_error_path(error.into_server_error(field.pos)))?;
-
-            Ok(ctx_idx
-                .response()
-                .await
-                .insert_node(ResponsePrimitive::new(item.into())))
-        }
-        _ => resolve_container(&ctx_idx, ty, None, Some(item))
-            .await
-            .map_err(|err| ctx_idx.set_error_path(err)),
+    // Yes it's ugly...
+    if let OutputType::Scalar(scalar) = ctx.field_base_type() {
+        result = result.and_then(|value| resolve_scalar(value, &scalar.name));
     }
+
+    let item = result.map_err(|error| ctx.set_error_path(error.into_server_error(ctx.item.pos)))?;
+
+    Ok(ctx.response().await.insert_node(ResponsePrimitive::new(item.into())))
 }
 
 fn resolve_scalar(value: Value, base_type_name: &str) -> Result<Value, Error> {
@@ -217,143 +202,26 @@ fn resolve_scalar(value: Value, base_type_name: &str) -> Result<Value, Error> {
 
 /// Resolve an list by executing each of the items concurrently.
 pub async fn resolve_list_native<'a, T: LegacyOutputType + 'a>(
-    ctx: &ContextSelectionSet<'a>,
+    ctx: &ContextSelectionSetLegacy<'a>,
     field: &Positioned<Field>,
     iter: impl IntoIterator<Item = T>,
     len: Option<usize>,
 ) -> ServerResult<ResponseNodeId> {
-    let extensions = &ctx.query_env.extensions;
-    if !extensions.is_empty() {
-        let mut futures = len.map(Vec::with_capacity).unwrap_or_default();
-        for (idx, item) in iter.into_iter().enumerate() {
-            futures.push({
-                let ctx = ctx.clone();
-                async move {
-                    let ctx_idx = ctx.with_index(idx, Some(&ctx.item.node));
-                    let extensions = &ctx.query_env.extensions;
-
-                    let type_name = <T>::type_name();
-                    let ctx_field = ctx.with_field(field, None, Some(&ctx.item.node));
-                    let meta_field = ctx_field
-                        .schema_env
-                        .registry
-                        .types
-                        .get(type_name.as_ref())
-                        .and_then(|ty| ty.field_by_name(field.node.name.node.as_str()));
-
-                    let resolve_info = ResolveInfo {
-                        path: ctx_idx.path.clone(),
-                        parent_type: &Vec::<T>::type_name(),
-                        return_type: &T::qualified_type_name(),
-                        name: field.node.name.node.as_str(),
-                        alias: field.node.alias.as_ref().map(|alias| alias.node.as_str()),
-                        required_operation: meta_field.and_then(|f| f.required_operation),
-                        auth: meta_field.and_then(|f| f.auth.as_ref()),
-                        input_values: Vec::new(), // Isn't needed for static resolve
-                    };
-                    let resolve_fut = async {
-                        LegacyOutputType::resolve(&item, &ctx_idx, field)
-                            .await
-                            .map(Option::Some)
-                            .map_err(|err| ctx_idx.set_error_path(err))
-                    };
-                    futures_util::pin_mut!(resolve_fut);
-                    extensions
-                        .resolve(resolve_info, &mut resolve_fut)
-                        .await
-                        .map(|value| value.expect("You definitely encountered a bug!"))
-                }
-            });
-        }
-        let children = futures_util::future::try_join_all(futures).await?;
-
-        let node_id = ctx.response().await.insert_node(ResponseList::with_children(children));
-
-        Ok(node_id)
-    } else {
-        let mut futures = len.map(Vec::with_capacity).unwrap_or_default();
-        for (idx, item) in iter.into_iter().enumerate() {
-            let ctx_idx = ctx.with_index(idx, Some(&ctx.item.node));
-            futures.push(async move {
-                LegacyOutputType::resolve(&item, &ctx_idx, field)
-                    .await
-                    .map_err(|err| ctx_idx.set_error_path(err))
-            });
-        }
-
-        let children = futures_util::future::try_join_all(futures).await?;
-
-        let node_id = ctx.response().await.insert_node(ResponseList::with_children(children));
-
-        Ok(node_id)
-    }
-}
-
-/// An iterator over the nullability of lists in a type string
-struct ListNullabilityIter<'a>(Peekable<WrappingTypeIter<'a>>);
-
-impl<'a> ListNullabilityIter<'a> {
-    pub fn new(ty: &'a MetaFieldType) -> Self {
-        ListNullabilityIter(ty.wrapping_types().peekable())
-    }
-}
-
-/// The nullability of a list _and_ its contents
-#[derive(Debug, PartialEq, Clone, Copy)]
-enum ListKind {
-    NullableList(ListInner),
-    NonNullList(ListInner),
-}
-
-impl ListKind {
-    pub fn has_nullable_item(self) -> bool {
-        matches!(self.inner_nullablity(), ListInner::Nullable)
+    let mut futures = len.map(Vec::with_capacity).unwrap_or_default();
+    for (idx, item) in iter.into_iter().enumerate() {
+        let ctx_idx = ctx.with_index(idx);
+        futures.push(async move {
+            LegacyOutputType::resolve(&item, &ctx_idx, field)
+                .await
+                .map_err(|err| ctx_idx.set_error_path(err))
+        });
     }
 
-    pub fn has_non_null_item(self) -> bool {
-        matches!(self.inner_nullablity(), ListInner::NonNullable)
-    }
+    let children = futures_util::future::try_join_all(futures).await?;
 
-    fn inner_nullablity(self) -> ListInner {
-        match self {
-            ListKind::NullableList(inner) => inner,
-            ListKind::NonNullList(inner) => inner,
-        }
-    }
-}
+    let node_id = ctx.response().await.insert_node(ResponseList::with_children(children));
 
-#[derive(Debug, PartialEq, Clone, Copy)]
-enum ListInner {
-    Nullable,
-    NonNullable,
-}
-
-impl Iterator for ListNullabilityIter<'_> {
-    type Item = ListKind;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let mut nullable = true;
-        loop {
-            match self.0.next()? {
-                WrappingType::NonNull => {
-                    nullable = false;
-                    continue;
-                }
-                WrappingType::List if nullable => {
-                    return Some(ListKind::NullableList(match self.0.peek() {
-                        Some(WrappingType::NonNull) => ListInner::NonNullable,
-                        _ => ListInner::Nullable,
-                    }))
-                }
-                WrappingType::List => {
-                    return Some(ListKind::NonNullList(match self.0.peek() {
-                        Some(WrappingType::NonNull) => ListInner::NonNullable,
-                        _ => ListInner::Nullable,
-                    }))
-                }
-            }
-        }
-    }
+    Ok(node_id)
 }
 
 fn json_kind_str(value: &serde_json::Value) -> &'static str {
@@ -364,54 +232,5 @@ fn json_kind_str(value: &serde_json::Value) -> &'static str {
         serde_json::Value::String(_) => "string",
         serde_json::Value::Array(_) => "list",
         serde_json::Value::Object(_) => "object",
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn list_nullability(ty: &str) -> Vec<ListKind> {
-        ListNullabilityIter::new(&ty.into()).collect::<Vec<_>>()
-    }
-
-    #[test]
-    fn test_list_nullability_iter() {
-        assert_eq!(list_nullability("String"), vec![]);
-        assert_eq!(list_nullability("String!"), vec![]);
-        assert_eq!(
-            list_nullability("[String!]"),
-            vec![ListKind::NullableList(ListInner::NonNullable)]
-        );
-        assert_eq!(
-            list_nullability("[String!]!"),
-            vec![ListKind::NonNullList(ListInner::NonNullable)]
-        );
-        assert_eq!(
-            list_nullability("[String]!"),
-            vec![ListKind::NonNullList(ListInner::Nullable)]
-        );
-        assert_eq!(
-            list_nullability("[[String!]!]"),
-            vec![
-                ListKind::NullableList(ListInner::NonNullable),
-                ListKind::NonNullList(ListInner::NonNullable)
-            ]
-        );
-        assert_eq!(
-            list_nullability("[[String!]]!"),
-            vec![
-                ListKind::NonNullList(ListInner::Nullable),
-                ListKind::NullableList(ListInner::NonNullable)
-            ]
-        );
-        assert_eq!(
-            list_nullability("[[[String]]!]"),
-            vec![
-                ListKind::NullableList(ListInner::NonNullable),
-                ListKind::NonNullList(ListInner::Nullable),
-                ListKind::NullableList(ListInner::Nullable)
-            ]
-        );
     }
 }

--- a/engine/crates/engine/src/resolver_utils/scalar.rs
+++ b/engine/crates/engine/src/resolver_utils/scalar.rs
@@ -1,6 +1,6 @@
 use graph_entities::{ResponseNodeId, ResponsePrimitive};
 
-use crate::{ContextExt, ContextSelectionSet, InputValueResult, ServerResult, Value};
+use crate::{ContextExt, ContextSelectionSetLegacy, InputValueResult, ServerResult, Value};
 
 /// A GraphQL scalar.
 ///
@@ -216,7 +216,10 @@ macro_rules! scalar_internal {
     };
 }
 
-pub async fn resolve_scalar_native<'a>(ctx: &ContextSelectionSet<'a>, value: Value) -> ServerResult<ResponseNodeId> {
+pub async fn resolve_scalar_native<'a>(
+    ctx: &ContextSelectionSetLegacy<'a>,
+    value: Value,
+) -> ServerResult<ResponseNodeId> {
     let mut response_graph = ctx.response().await;
     Ok(response_graph.insert_node(ResponsePrimitive::new(value.into())))
 }

--- a/engine/crates/engine/src/types/empty_mutation.rs
+++ b/engine/crates/engine/src/types/empty_mutation.rs
@@ -3,8 +3,8 @@ use std::borrow::Cow;
 use graph_entities::ResponseNodeId;
 
 use crate::{
-    parser::types::Field, registry, resolver_utils::ContainerType, Context, ContextSelectionSet, LegacyOutputType,
-    ObjectType, Positioned, ServerError, ServerResult,
+    parser::types::Field, registry, resolver_utils::ContainerType, ContextField, ContextSelectionSetLegacy,
+    LegacyOutputType, ObjectType, Positioned, ServerError, ServerResult,
 };
 
 /// Empty mutation
@@ -37,7 +37,7 @@ impl ContainerType for EmptyMutation {
         true
     }
 
-    async fn resolve_field(&self, _ctx: &Context<'_>) -> ServerResult<Option<ResponseNodeId>> {
+    async fn resolve_field(&self, _ctx: &ContextField<'_>) -> ServerResult<Option<ResponseNodeId>> {
         Ok(None)
     }
 }
@@ -69,7 +69,7 @@ impl LegacyOutputType for EmptyMutation {
 
     async fn resolve(
         &self,
-        _ctx: &ContextSelectionSet<'_>,
+        _ctx: &ContextSelectionSetLegacy<'_>,
         _field: &Positioned<Field>,
     ) -> ServerResult<ResponseNodeId> {
         Err(ServerError::new("Schema is not configured for mutations.", None))

--- a/engine/crates/engine/src/types/empty_subscription.rs
+++ b/engine/crates/engine/src/types/empty_subscription.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, pin::Pin};
 use engine_parser::types::OperationType;
 use futures_util::stream::{self, Stream};
 
-use crate::{registry, Context, Response, ServerError, SubscriptionType};
+use crate::{registry, ContextField, Response, ServerError, SubscriptionType};
 
 /// Empty subscription
 ///
@@ -28,7 +28,7 @@ impl SubscriptionType for EmptySubscription {
 
     fn create_field_stream<'a>(
         &'a self,
-        _ctx: &'a Context<'_>,
+        _ctx: &'a ContextField<'_>,
     ) -> Option<Pin<Box<dyn Stream<Item = Response> + Send + 'a>>>
     where
         Self: Send + Sync + 'static + Sized,

--- a/engine/crates/engine/src/types/external/cow.rs
+++ b/engine/crates/engine/src/types/external/cow.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use engine_parser::types::Field;
 use graph_entities::ResponseNodeId;
 
-use crate::{registry, ContextSelectionSet, LegacyOutputType, Positioned, ServerResult};
+use crate::{registry, ContextSelectionSetLegacy, LegacyOutputType, Positioned, ServerResult};
 
 #[async_trait::async_trait]
 impl<'a, T> LegacyOutputType for Cow<'a, T>
@@ -19,7 +19,11 @@ where
         <T as LegacyOutputType>::create_type_info(registry)
     }
 
-    async fn resolve(&self, ctx: &ContextSelectionSet<'_>, field: &Positioned<Field>) -> ServerResult<ResponseNodeId> {
+    async fn resolve(
+        &self,
+        ctx: &ContextSelectionSetLegacy<'_>,
+        field: &Positioned<Field>,
+    ) -> ServerResult<ResponseNodeId> {
         self.as_ref().resolve(ctx, field).await
     }
 }

--- a/engine/crates/engine/src/types/external/json_object/hashmap.rs
+++ b/engine/crates/engine/src/types/external/json_object/hashmap.rs
@@ -9,8 +9,8 @@ use serde::{de::DeserializeOwned, Serialize};
 use crate::{
     graph::selection_set_into_node,
     registry::{self, MetaType, Registry, ScalarType},
-    ContextSelectionSet, InputValueError, InputValueResult, LegacyInputType, LegacyOutputType, Name, ServerResult,
-    Value,
+    ContextSelectionSetLegacy, InputValueError, InputValueResult, LegacyInputType, LegacyOutputType, Name,
+    ServerResult, Value,
 };
 
 impl<K, V> LegacyInputType for HashMap<K, V>
@@ -92,19 +92,16 @@ where
         })
     }
 
-    async fn resolve(&self, ctx: &ContextSelectionSet<'_>, field: &Positioned<Field>) -> ServerResult<ResponseNodeId> {
+    async fn resolve(
+        &self,
+        ctx: &ContextSelectionSetLegacy<'_>,
+        _field: &Positioned<Field>,
+    ) -> ServerResult<ResponseNodeId> {
         let mut map = IndexMap::new();
         for (name, value) in self {
             map.insert(Name::new(name.to_string()), to_value(value).unwrap_or_default());
         }
-        let ctx_field = ctx.with_field(field, None, Some(&ctx.item.node));
-        let ty = ctx_field
-            .schema_env
-            .registry
-            .types
-            .get(Self::type_name().as_ref())
-            .expect("If this type is used it should be in the registry");
 
-        Ok(selection_set_into_node(Value::Object(map), ctx, ty).await)
+        Ok(selection_set_into_node(Value::Object(map), ctx).await)
     }
 }

--- a/engine/crates/engine/src/types/external/list/array.rs
+++ b/engine/crates/engine/src/types/external/list/array.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use graph_entities::ResponseNodeId;
 
 use crate::{
-    parser::types::Field, registry, resolver_utils::resolve_list_native, ContextSelectionSet, InputValueError,
+    parser::types::Field, registry, resolver_utils::resolve_list_native, ContextSelectionSetLegacy, InputValueError,
     InputValueResult, LegacyInputType, LegacyOutputType, Positioned, ServerResult, Value,
 };
 
@@ -69,7 +69,11 @@ impl<T: LegacyOutputType, const N: usize> LegacyOutputType for [T; N] {
         Self::qualified_type_name()
     }
 
-    async fn resolve(&self, ctx: &ContextSelectionSet<'_>, field: &Positioned<Field>) -> ServerResult<ResponseNodeId> {
+    async fn resolve(
+        &self,
+        ctx: &ContextSelectionSetLegacy<'_>,
+        field: &Positioned<Field>,
+    ) -> ServerResult<ResponseNodeId> {
         resolve_list_native(ctx, field, self.iter(), Some(self.len())).await
     }
 }

--- a/engine/crates/engine/src/types/external/list/btree_set.rs
+++ b/engine/crates/engine/src/types/external/list/btree_set.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, collections::BTreeSet};
 use graph_entities::ResponseNodeId;
 
 use crate::{
-    parser::types::Field, registry, resolver_utils::resolve_list_native, ContextSelectionSet, InputValueError,
+    parser::types::Field, registry, resolver_utils::resolve_list_native, ContextSelectionSetLegacy, InputValueError,
     InputValueResult, LegacyInputType, LegacyOutputType, Positioned, ServerResult, Value,
 };
 
@@ -62,7 +62,11 @@ impl<T: LegacyOutputType + Ord> LegacyOutputType for BTreeSet<T> {
         Self::qualified_type_name()
     }
 
-    async fn resolve(&self, ctx: &ContextSelectionSet<'_>, field: &Positioned<Field>) -> ServerResult<ResponseNodeId> {
+    async fn resolve(
+        &self,
+        ctx: &ContextSelectionSetLegacy<'_>,
+        field: &Positioned<Field>,
+    ) -> ServerResult<ResponseNodeId> {
         resolve_list_native(ctx, field, self, Some(self.len())).await
     }
 }

--- a/engine/crates/engine/src/types/external/list/hash_set.rs
+++ b/engine/crates/engine/src/types/external/list/hash_set.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, cmp::Eq, collections::HashSet, hash::Hash};
 use graph_entities::ResponseNodeId;
 
 use crate::{
-    parser::types::Field, registry, resolver_utils::resolve_list_native, ContextSelectionSet, InputValueError,
+    parser::types::Field, registry, resolver_utils::resolve_list_native, ContextSelectionSetLegacy, InputValueError,
     InputValueResult, LegacyInputType, LegacyOutputType, Positioned, Result, ServerResult, Value,
 };
 
@@ -62,7 +62,11 @@ impl<T: LegacyOutputType + Hash + Eq> LegacyOutputType for HashSet<T> {
         Self::qualified_type_name()
     }
 
-    async fn resolve(&self, ctx: &ContextSelectionSet<'_>, field: &Positioned<Field>) -> ServerResult<ResponseNodeId> {
+    async fn resolve(
+        &self,
+        ctx: &ContextSelectionSetLegacy<'_>,
+        field: &Positioned<Field>,
+    ) -> ServerResult<ResponseNodeId> {
         resolve_list_native(ctx, field, self, Some(self.len())).await
     }
 }

--- a/engine/crates/engine/src/types/external/list/linked_list.rs
+++ b/engine/crates/engine/src/types/external/list/linked_list.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, collections::LinkedList};
 use graph_entities::ResponseNodeId;
 
 use crate::{
-    parser::types::Field, registry, resolver_utils::resolve_list_native, ContextSelectionSet, InputValueError,
+    parser::types::Field, registry, resolver_utils::resolve_list_native, ContextSelectionSetLegacy, InputValueError,
     InputValueResult, LegacyInputType, LegacyOutputType, Positioned, ServerResult, Value,
 };
 
@@ -62,7 +62,11 @@ impl<T: LegacyOutputType> LegacyOutputType for LinkedList<T> {
         Self::qualified_type_name()
     }
 
-    async fn resolve(&self, ctx: &ContextSelectionSet<'_>, field: &Positioned<Field>) -> ServerResult<ResponseNodeId> {
+    async fn resolve(
+        &self,
+        ctx: &ContextSelectionSetLegacy<'_>,
+        field: &Positioned<Field>,
+    ) -> ServerResult<ResponseNodeId> {
         resolve_list_native(ctx, field, self, Some(self.len())).await
     }
 }

--- a/engine/crates/engine/src/types/external/list/slice.rs
+++ b/engine/crates/engine/src/types/external/list/slice.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, sync::Arc};
 use graph_entities::ResponseNodeId;
 
 use crate::{
-    parser::types::Field, registry, resolver_utils::resolve_list_native, ContextSelectionSet, InputValueError,
+    parser::types::Field, registry, resolver_utils::resolve_list_native, ContextSelectionSetLegacy, InputValueError,
     InputValueResult, LegacyInputType, LegacyOutputType, Positioned, ServerResult, Value,
 };
 
@@ -22,7 +22,11 @@ impl<'a, T: LegacyOutputType + 'a> LegacyOutputType for &'a [T] {
         Self::qualified_type_name()
     }
 
-    async fn resolve(&self, ctx: &ContextSelectionSet<'_>, field: &Positioned<Field>) -> ServerResult<ResponseNodeId> {
+    async fn resolve(
+        &self,
+        ctx: &ContextSelectionSetLegacy<'_>,
+        field: &Positioned<Field>,
+    ) -> ServerResult<ResponseNodeId> {
         resolve_list_native(ctx, field, self.iter(), Some(self.len())).await
     }
 }
@@ -46,7 +50,7 @@ macro_rules! impl_output_slice_for_smart_ptr {
 
             async fn resolve(
                 &self,
-                ctx: &ContextSelectionSet<'_>,
+                ctx: &ContextSelectionSetLegacy<'_>,
                 field: &Positioned<Field>,
             ) -> ServerResult<ResponseNodeId> {
                 resolve_list_native(ctx, field, self.iter(), Some(self.len())).await

--- a/engine/crates/engine/src/types/external/list/vec.rs
+++ b/engine/crates/engine/src/types/external/list/vec.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use graph_entities::ResponseNodeId;
 
 use crate::{
-    parser::types::Field, registry, resolver_utils::resolve_list_native, ContextSelectionSet, InputValueError,
+    parser::types::Field, registry, resolver_utils::resolve_list_native, ContextSelectionSetLegacy, InputValueError,
     InputValueResult, LegacyInputType, LegacyOutputType, Positioned, Result, ServerResult, Value,
 };
 
@@ -60,7 +60,11 @@ impl<T: LegacyOutputType> LegacyOutputType for Vec<T> {
         Self::qualified_type_name()
     }
 
-    async fn resolve(&self, ctx: &ContextSelectionSet<'_>, field: &Positioned<Field>) -> ServerResult<ResponseNodeId> {
+    async fn resolve(
+        &self,
+        ctx: &ContextSelectionSetLegacy<'_>,
+        field: &Positioned<Field>,
+    ) -> ServerResult<ResponseNodeId> {
         resolve_list_native(ctx, field, self, Some(self.len())).await
     }
 }

--- a/engine/crates/engine/src/types/external/list/vec_deque.rs
+++ b/engine/crates/engine/src/types/external/list/vec_deque.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, collections::VecDeque};
 use graph_entities::ResponseNodeId;
 
 use crate::{
-    parser::types::Field, registry, resolver_utils::resolve_list_native, ContextSelectionSet, InputValueError,
+    parser::types::Field, registry, resolver_utils::resolve_list_native, ContextSelectionSetLegacy, InputValueError,
     InputValueResult, LegacyInputType, LegacyOutputType, Positioned, ServerResult, Value,
 };
 
@@ -62,7 +62,11 @@ impl<T: LegacyOutputType> LegacyOutputType for VecDeque<T> {
         Self::qualified_type_name()
     }
 
-    async fn resolve(&self, ctx: &ContextSelectionSet<'_>, field: &Positioned<Field>) -> ServerResult<ResponseNodeId> {
+    async fn resolve(
+        &self,
+        ctx: &ContextSelectionSetLegacy<'_>,
+        field: &Positioned<Field>,
+    ) -> ServerResult<ResponseNodeId> {
         resolve_list_native(ctx, field, self, Some(self.len())).await
     }
 }

--- a/engine/crates/engine/src/types/external/optional.rs
+++ b/engine/crates/engine/src/types/external/optional.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use graph_entities::{CompactValue, ResponseNodeId};
 
 use crate::{
-    parser::types::Field, registry, ContextExt, ContextSelectionSet, InputValueError, InputValueResult,
+    parser::types::Field, registry, ContextExt, ContextSelectionSetLegacy, InputValueError, InputValueResult,
     LegacyInputType, LegacyOutputType, Positioned, ServerResult, Value,
 };
 
@@ -60,7 +60,11 @@ impl<T: LegacyOutputType + Sync> LegacyOutputType for Option<T> {
         T::type_name().as_ref().into()
     }
 
-    async fn resolve(&self, ctx: &ContextSelectionSet<'_>, field: &Positioned<Field>) -> ServerResult<ResponseNodeId> {
+    async fn resolve(
+        &self,
+        ctx: &ContextSelectionSetLegacy<'_>,
+        field: &Positioned<Field>,
+    ) -> ServerResult<ResponseNodeId> {
         if let Some(inner) = self {
             match LegacyOutputType::resolve(inner, ctx, field).await {
                 Ok(value) => Ok(value),

--- a/engine/crates/engine/src/types/external/string.rs
+++ b/engine/crates/engine/src/types/external/string.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use graph_entities::{CompactValue, ResponseNodeId};
 
 use crate::{
-    parser::types::Field, registry, registry::Registry, ContextExt, ContextSelectionSet, InputValueError,
+    parser::types::Field, registry, registry::Registry, ContextExt, ContextSelectionSetLegacy, InputValueError,
     InputValueResult, LegacyInputType, LegacyOutputType, LegacyScalarType, Positioned, Scalar, ServerResult, Value,
 };
 
@@ -72,7 +72,11 @@ impl LegacyOutputType for str {
         <String as LegacyOutputType>::create_type_info(registry)
     }
 
-    async fn resolve(&self, ctx: &ContextSelectionSet<'_>, _field: &Positioned<Field>) -> ServerResult<ResponseNodeId> {
+    async fn resolve(
+        &self,
+        ctx: &ContextSelectionSetLegacy<'_>,
+        _field: &Positioned<Field>,
+    ) -> ServerResult<ResponseNodeId> {
         let mut graph = ctx.response().await;
         Ok(graph.insert_node(CompactValue::String(self.to_string())))
     }

--- a/engine/crates/engine/src/types/merged_object.rs
+++ b/engine/crates/engine/src/types/merged_object.rs
@@ -7,8 +7,8 @@ use crate::{
     futures_util::Stream,
     parser::types::Field,
     registry::{MetaType, ObjectType, Registry},
-    CacheControl, ContainerType, Context, ContextSelectionSet, LegacyOutputType, Positioned, Response, ServerResult,
-    SimpleObject, SubscriptionType, Value,
+    CacheControl, ContainerType, ContextField, ContextSelectionSetLegacy, LegacyOutputType, Positioned, Response,
+    ServerResult, SimpleObject, SubscriptionType, Value,
 };
 
 #[doc(hidden)]
@@ -20,7 +20,7 @@ where
     A: ContainerType,
     B: ContainerType,
 {
-    async fn resolve_field(&self, ctx: &Context<'_>) -> ServerResult<Option<ResponseNodeId>> {
+    async fn resolve_field(&self, ctx: &ContextField<'_>) -> ServerResult<Option<ResponseNodeId>> {
         match self.0.resolve_field(ctx).await {
             Ok(Some(value)) => Ok(Some(value)),
             Ok(None) => self.1.resolve_field(ctx).await,
@@ -28,7 +28,7 @@ where
         }
     }
 
-    async fn find_entity(&self, ctx: &Context<'_>, params: &Value) -> ServerResult<Option<Value>> {
+    async fn find_entity(&self, ctx: &ContextField<'_>, params: &Value) -> ServerResult<Option<Value>> {
         match self.0.find_entity(ctx, params).await {
             Ok(Some(value)) => Ok(Some(value)),
             Ok(None) => self.1.find_entity(ctx, params).await,
@@ -81,7 +81,7 @@ where
 
     async fn resolve(
         &self,
-        _ctx: &ContextSelectionSet<'_>,
+        _ctx: &ContextSelectionSetLegacy<'_>,
         _field: &Positioned<Field>,
     ) -> ServerResult<ResponseNodeId> {
         unreachable!()
@@ -134,7 +134,7 @@ where
 
     fn create_field_stream<'a>(
         &'a self,
-        _ctx: &'a Context<'_>,
+        _ctx: &'a ContextField<'_>,
     ) -> Option<Pin<Box<dyn Stream<Item = Response> + Send + 'a>>> {
         unreachable!()
     }
@@ -162,7 +162,7 @@ impl SubscriptionType for MergedObjectTail {
 
     fn create_field_stream<'a>(
         &'a self,
-        _ctx: &'a Context<'_>,
+        _ctx: &'a ContextField<'_>,
     ) -> Option<Pin<Box<dyn Stream<Item = Response> + Send + 'a>>> {
         unreachable!()
     }

--- a/engine/crates/engine/src/types/upload.rs
+++ b/engine/crates/engine/src/types/upload.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, fs::File, io::Read};
 
-use crate::{registry, Context, InputValueError, InputValueResult, LegacyInputType, Value};
+use crate::{registry, ContextField, InputValueError, InputValueResult, LegacyInputType, Value};
 
 /// A file upload value.
 pub struct UploadValue {
@@ -83,7 +83,7 @@ pub struct Upload(usize);
 
 impl Upload {
     /// Get the upload value.
-    pub fn value(&self, ctx: &Context<'_>) -> std::io::Result<UploadValue> {
+    pub fn value(&self, ctx: &ContextField<'_>) -> std::io::Result<UploadValue> {
         ctx.query_env.uploads[self.0].try_clone()
     }
 }

--- a/engine/crates/integration-tests/tests/execution/mod.rs
+++ b/engine/crates/integration-tests/tests/execution/mod.rs
@@ -109,7 +109,7 @@ fn test_nullable_list_validation() {
             {
               "locations": [
                 {
-                  "column": 14,
+                  "column": 9,
                   "line": 1
                 }
               ],

--- a/engine/crates/integration-tests/tests/integration_tests.rs
+++ b/engine/crates/integration-tests/tests/integration_tests.rs
@@ -2,6 +2,7 @@
 
 mod custom_resolvers;
 mod defer;
+mod errors;
 mod execution;
 mod graphql_connector;
 mod mongodb;


### PR DESCRIPTION
I'm working on GB-4762.  This issue is caused by the ResolverChainNode not being set up correctly in deferred contexts.  It's quite hard to do this correctly in a deferred context because it contains references to its parent, and without running a bunch of execution calls again it's hard to get the lifetimes to line up.

It is also a bit of a mess of a struct -  it's got a bunch of Options that are always set depending on the context (which isn't documented so you just sort of have to know) and it's got a lot of overlap with `ContextBase`.  So I've removed it and merged the relevant bits into the respective Context structs.

This results in a lot less Options, and some more specific types.  Other changes I needed to make:

- Got rid of the `Context` alias for `ContextField` so I could create a `Context` trait.
- Added ContextList for resolving lists (it was using ContextSelectionSet before, but there might not actually be a selection set)
- Made a `ContextSelectionSetLegacy` for the legacy async_graphql resolution stuff, because `ContextSelectionSet` didn't _quite_ work for it.
- Probably some other stuff I've forgotten to mention.