### PR TITLE
chore: fix incremental delivery implementation

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2943,8 +2943,7 @@ dependencies = [
 [[package]]
 name = "multipart-stream"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b4619423c3ca07881bd4d62bb853d447a63253901bee471e0b832c3e37e505"
+source = "git+https://github.com/grafbase/multipart-stream-rs.git?branch=fix-multipart-mixed#96eaebfcd0f8101bc834ddc405f69f28dbf1e559"
 dependencies = [
  "bytes",
  "futures",

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -61,7 +61,7 @@ jwt-compact = { version = "0.8.0-beta.1", default-features = false, features = [
   "clock",
   "rsa",
 ] }
-multipart-stream = "0.1"
+multipart-stream = { git = "https://github.com/grafbase/multipart-stream-rs.git", branch = "fix-multipart-mixed" }
 rand = "0.8"
 reqwest = { version = "0.11", features = [
   "rustls-tls",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1161,7 +1161,6 @@ dependencies = [
  "rust_decimal",
  "sanitize-filename",
  "secrecy",
- "send_wrapper 0.6.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1515,6 +1514,7 @@ dependencies = [
  "gateway-adapter",
  "gateway-core",
  "graphql-extensions",
+ "http",
  "multipart-stream",
  "runtime",
  "runtime-local",
@@ -2319,8 +2319,7 @@ dependencies = [
 [[package]]
 name = "multipart-stream"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b4619423c3ca07881bd4d62bb853d447a63253901bee471e0b832c3e37e505"
+source = "git+https://github.com/grafbase/multipart-stream-rs.git?branch=fix-multipart-mixed#96eaebfcd0f8101bc834ddc405f69f28dbf1e559"
 dependencies = [
  "bytes",
  "futures",

--- a/engine/crates/engine/Cargo.toml
+++ b/engine/crates/engine/Cargo.toml
@@ -77,7 +77,6 @@ time = { version = "0.3.28", features = ["parsing"] }
 uuid.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-send_wrapper = { version = "0.6", features = ["futures"] }
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/engine/crates/gateway-adapter-local/Cargo.toml
+++ b/engine/crates/gateway-adapter-local/Cargo.toml
@@ -27,7 +27,8 @@ bytes = "1"
 cfg-if = "1"
 futures-channel = "0.3"
 futures-util = { workspace = true }
-multipart-stream = "0.1"
+http = "0.2"
+multipart-stream = { git = "https://github.com/grafbase/multipart-stream-rs.git", branch = "fix-multipart-mixed" }
 serde_json = "1"
 tracing = { workspace = true }
 ulid = "1"

--- a/engine/crates/gateway-adapter-local/src/execution.rs
+++ b/engine/crates/gateway-adapter-local/src/execution.rs
@@ -218,8 +218,10 @@ fn into_byte_stream_and_future(
         StreamingFormat::IncrementalDelivery => {
             let mut byte_stream = Box::pin(multipart_stream::serialize(
                 payload_stream.map(|payload| {
+                    let mut headers = http::HeaderMap::new();
+                    headers.insert("content-type", http::HeaderValue::from_str("application/json").unwrap());
                     Ok(multipart_stream::Part {
-                        headers: Default::default(),
+                        headers,
                         body: Bytes::from(serde_json::to_vec(&payload).map_err(|e| e.to_string())?),
                     })
                 }),

--- a/engine/crates/gateway-core/src/streaming_format.rs
+++ b/engine/crates/gateway-core/src/streaming_format.rs
@@ -20,10 +20,6 @@ const SSE_MEDIA_TYPE: MediaType<'static> =
 
 impl StreamingFormat {
     pub fn from_accept_header(header: &str) -> Option<Self> {
-        if header.contains("application/graphql-response+json") {
-            // Temporarily default to graphql JSON if its present in the headers
-            return None;
-        }
         let (mediatype, _) = MediaTypeList::new(header)
             .filter_map(Result::ok)
             .filter(|mediatype| {


### PR DESCRIPTION
GraphQL codegen supports using the incremental delivery transport, and uncovered a few problems in our implementation.  Tricky to find these, but easy enough to fix.

1. Each part has to contain a content-type header.
2. The multipart-stream library we're using wasn't sending a trailing boundary, so I've forked to fix that.
3. The multipart-stream library we're using wasn't putting boundaries on their own line, so I've also fixed that in our fork.