### PR TITLE
fix: add hasNext into the initial response when streaming

### DIFF
--- a/cli/crates/cli/tests/defer/main.rs
+++ b/cli/crates/cli/tests/defer/main.rs
@@ -90,7 +90,8 @@ async fn defer_multipart_test() {
               }
             ]
           }
-        }
+        },
+        "hasNext": true
       },
       {
         "data": {
@@ -184,7 +185,7 @@ async fn defer_sse_test() {
         Message(
             Event {
                 event: "next",
-                data: "{\"data\":{\"todoCollection\":{\"__typename\":\"TodoConnection\",\"edges\":[{\"node\":{\"title\":\"Defer Things\"}}]}}}",
+                data: "{\"data\":{\"todoCollection\":{\"__typename\":\"TodoConnection\",\"edges\":[{\"node\":{\"title\":\"Defer Things\"}}]}},\"hasNext\":true}",
                 id: "",
                 retry: None,
             },

--- a/engine/crates/engine/src/lib.rs
+++ b/engine/crates/engine/src/lib.rs
@@ -115,7 +115,7 @@ pub use registry::{CacheControl, CacheInvalidation, Registry};
 pub use request::{BatchRequest, Request};
 #[doc(no_inline)]
 pub use resolver_utils::{ContainerType, LegacyEnumType, LegacyScalarType};
-pub use response::{BatchResponse, GraphQlResponse, IncrementalPayload, Response, StreamingPayload};
+pub use response::{BatchResponse, GraphQlResponse, IncrementalPayload, InitialResponse, Response, StreamingPayload};
 pub use schema::{Schema, SchemaBuilder, SchemaEnv};
 #[doc(hidden)]
 pub use static_assertions;

--- a/engine/crates/integration-tests/src/helpers.rs
+++ b/engine/crates/integration-tests/src/helpers.rs
@@ -1,4 +1,4 @@
-use engine::{Response, StreamingPayload};
+use engine::{InitialResponse, Response, StreamingPayload};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 
@@ -100,7 +100,10 @@ impl ResponseExt for Response {
 impl ResponseExt for StreamingPayload {
     fn assert_success(self) -> Self {
         match self {
-            StreamingPayload::Response(response) => StreamingPayload::Response(response.assert_success()),
+            StreamingPayload::InitialResponse(InitialResponse { response, has_next }) => {
+                let response = response.assert_success();
+                StreamingPayload::InitialResponse(InitialResponse { response, has_next })
+            }
             StreamingPayload::Incremental(incremental) => {
                 assert_eq!(incremental.errors, vec![]);
                 StreamingPayload::Incremental(incremental)

--- a/engine/crates/integration-tests/tests/defer/mod.rs
+++ b/engine/crates/integration-tests/tests/defer/mod.rs
@@ -53,7 +53,8 @@ fn simple_defer_test() {
                   "name": "Immediate Doggo"
                 }
               }
-            }
+            },
+            "hasNext": true
           },
           {
             "data": {
@@ -207,7 +208,8 @@ fn test_defer_on_named_fragment() {
                   "name": "Immediate Doggo"
                 }
               }
-            }
+            },
+            "hasNext": true
           },
           {
             "data": {
@@ -266,7 +268,8 @@ fn test_nested_defers() {
           {
             "data": {
               "petstore": {}
-            }
+            },
+            "hasNext": true
           },
           {
             "data": {
@@ -353,7 +356,8 @@ fn test_defer_with_errors() {
                   "pet"
                 ]
               }
-            ]
+            ],
+            "hasNext": true
           },
           {
             "data": {
@@ -430,7 +434,8 @@ fn test_defer_at_root() {
                   "name": "Immediate Doggo"
                 }
               }
-            }
+            },
+            "hasNext": true
           },
           {
             "data": {
@@ -490,7 +495,8 @@ fn test_defer_with_labels() {
           {
             "data": {
               "petstore": {}
-            }
+            },
+            "hasNext": true
           },
           {
             "data": {
@@ -567,7 +573,8 @@ fn test_defer_with_if_true() {
                   "name": "Immediate Doggo"
                 }
               }
-            }
+            },
+            "hasNext": true
           },
           {
             "data": {
@@ -634,7 +641,8 @@ fn test_defer_with_if_false() {
                   "name": "Immediate Doggo"
                 }
               }
-            }
+            },
+            "hasNext": false
           }
         ]
         "###
@@ -682,7 +690,8 @@ fn test_invalid_defer_parameters() {
                 ],
                 "message": "Invalid value for argument \"if\", expected type \"Boolean\""
               }
-            ]
+            ],
+            "hasNext": false
           }
         ]
         "###
@@ -728,7 +737,8 @@ fn defer_a_custom_resolver() {
                 {},
                 {}
               ]
-            }
+            },
+            "hasNext": true
           },
           {
             "data": {
@@ -798,7 +808,8 @@ fn defer_a_custom_resolver_that_errors() {
                 {},
                 {}
               ]
-            }
+            },
+            "hasNext": true
           },
           {
             "data": null,

--- a/engine/crates/integration-tests/tests/defer/type_conditions.rs
+++ b/engine/crates/integration-tests/tests/defer/type_conditions.rs
@@ -52,7 +52,8 @@ fn test_defer_on_matching_typecondition() {
                   }
                 ]
               }
-            }
+            },
+            "hasNext": true
           },
           {
             "data": {
@@ -116,7 +117,8 @@ fn test_defer_on_unmatching_typecondition() {
                   }
                 ]
               }
-            }
+            },
+            "hasNext": false
           }
         ]
         "###);
@@ -171,7 +173,8 @@ fn test_defer_on_multiple_fragments_with_one_match() {
                   }
                 ]
               }
-            }
+            },
+            "hasNext": true
           },
           {
             "data": {
@@ -222,7 +225,8 @@ fn test_defer_with_typecondition_on_concrete_type() {
           {
             "data": {
               "petstore": {}
-            }
+            },
+            "hasNext": true
           },
           {
             "data": {


### PR DESCRIPTION
The [defer & stream RFC][1] says "The first payload is the same shape as a standard GraphQL response.".  Which is what I implemented. 

But, if you look at it's examples they all have `hasNext` in the first payload.  This PR updates the initial response to contain `hasNext`.

[1]: https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md#payload-format