### PR TITLE
fix(connector): Reduce allocations for PostgreSQL pagination

### DIFF
--- a/engine/crates/engine/src/resolver_utils/field.rs
+++ b/engine/crates/engine/src/resolver_utils/field.rs
@@ -277,7 +277,7 @@ async fn run_field_resolver(
         if !resolver.is_parent() {
             let resolver_context = ResolverContext::new(ctx);
 
-            final_result = resolver.resolve(ctx, &resolver_context, Some(&final_result)).await?;
+            final_result = resolver.resolve(ctx, &resolver_context, Some(final_result)).await?;
 
             if final_result.data_resolved().is_null() {
                 final_result = final_result.with_early_return();


### PR DESCRIPTION
Instead of calling `data_resolved()` and then cloning the `&Value`, we get the resolved value by-value, then `take()` the data out. Calling `take()` will only allocate if we have no other references to the data.

Tested this with some scenarios, and it will skip allocations in most cases. Nested page infos are still cloning the underlying data sadly, and we should consider finding a better solution for that in the future.

But. This PR will still reduce allocations, and that's a net-positive anyhow so let's go with this?

Closes: GB-5032