### PR TITLE
fix(connector): Allow emitting input field for nullable composite key

### DIFF
--- a/engine/crates/engine/src/registry/resolvers/postgresql/context/filter/simple.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgresql/context/filter/simple.rs
@@ -1,6 +1,7 @@
 use crate::registry::type_kinds::InputType;
-use grafbase_sql_ast::ast::Comparable;
-use postgresql_types::database_definition::DatabaseDefinition;
+use grafbase_sql_ast::ast::{Comparable, Compare};
+use indexmap::IndexSet;
+use postgresql_types::database_definition::{DatabaseDefinition, TableColumnId};
 use serde_json::Value;
 use std::{collections::VecDeque, iter::Iterator};
 
@@ -13,6 +14,7 @@ pub struct ByFilterIterator<'a> {
     input_type: InputType<'a>,
     filter: VecDeque<(String, Value)>,
     nested: Option<Box<ByFilterIterator<'a>>>,
+    constrained_columns: IndexSet<TableColumnId>,
 }
 
 impl<'a> ByFilterIterator<'a> {
@@ -26,12 +28,17 @@ impl<'a> ByFilterIterator<'a> {
             input_type,
             filter: VecDeque::from_iter(filter),
             nested: None,
+            constrained_columns: IndexSet::new(),
         }
+    }
+
+    fn push_constrained_column(&mut self, column_id: TableColumnId) {
+        self.constrained_columns.insert(column_id);
     }
 }
 
 impl<'a> Iterator for ByFilterIterator<'a> {
-    type Item = grafbase_sql_ast::ast::Compare<'a>;
+    type Item = Compare<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // We are having a nested input type, which we iterate over.
@@ -39,7 +46,18 @@ impl<'a> Iterator for ByFilterIterator<'a> {
             return Some(item);
         }
 
-        let Some((field, value)) = self.filter.pop_front() else { return None };
+        let table = self
+            .database_definition
+            .find_table_for_client_type(self.input_type.name())
+            .expect("table for input type not found");
+
+        let Some((field, value)) = self.filter.pop_front() else {
+            // solves the issue where user emits a value for a nullable composite unique.
+            return self.constrained_columns.pop().map(|column_id| {
+                let column = self.database_definition.walk(column_id);
+                (table.database_name(), column.database_name()).is_null()
+            });
+        };
 
         // If selecting an object, we don't care about the name of the object, but selecting the
         // fields defined in the input.
@@ -49,21 +67,27 @@ impl<'a> Iterator for ByFilterIterator<'a> {
         if let Value::Object(map) = value {
             let mut nested = ByFilterIterator::new(self.database_definition, self.input_type, map);
 
+            let constraint = self
+                .database_definition
+                .find_unique_constraint_for_client_field(&field, table.id())
+                .expect("constraint for input field not found");
+
+            for column in constraint.columns() {
+                nested.push_constrained_column(column.table_column().id());
+            }
+
             let item = nested.next();
             self.nested = Some(Box::new(nested));
 
             return item;
         };
 
-        let table = self
-            .database_definition
-            .find_table_for_client_type(self.input_type.name())
-            .expect("table for input type not found");
-
         let column = self
             .database_definition
             .find_column_for_client_field(&field, table.id())
             .expect("column for input field not found");
+
+        self.constrained_columns.remove(&column.id());
 
         match value {
             Value::Null => Some((table.database_name(), column.database_name()).is_null()),

--- a/engine/crates/parser-postgresql/src/registry/queries/input/filter.rs
+++ b/engine/crates/parser-postgresql/src/registry/queries/input/filter.rs
@@ -50,13 +50,13 @@ pub(crate) fn register(input_ctx: &InputContext<'_>, table: TableWalker<'_>, out
             let r#type = format!("[{input_type_name}]");
             let input = MetaInputValue::new(*name, r#type).with_description(*description);
 
-            builder.push_non_mapped_input_column(input);
+            builder.push_input_value(input);
         }
 
         let contains_type_name = format!("{input_type_name}Contains");
         builder.with_input_type(&contains_type_name, table.id(), |builder| {
             let value = MetaInputValue::new("contains", input_type_name.as_ref());
-            builder.push_non_mapped_input_column(value);
+            builder.push_input_value(value);
         });
     });
 

--- a/engine/crates/parser-postgresql/src/registry/queries/input/oneof.rs
+++ b/engine/crates/parser-postgresql/src/registry/queries/input/oneof.rs
@@ -30,6 +30,7 @@ pub(crate) fn register(input_ctx: &InputContext<'_>, table: TableWalker<'_>, out
 
                 let query_name = type_prefix.to_camel_case();
 
+                builder.map_unique_constraint(&query_name, constraint.id());
                 builder.push_input_value(MetaInputValue::new(query_name, input_type_name));
             } else if let Some(column) = constraint.columns().next() {
                 let input_value = super::input_value_from_column(column.table_column(), true);

--- a/engine/crates/postgresql-types/src/database_definition.rs
+++ b/engine/crates/postgresql-types/src/database_definition.rs
@@ -146,6 +146,17 @@ impl DatabaseDefinition {
             .map(|relation_id| self.walk(relation_id))
     }
 
+    /// Find a unique constraint that represents the given client field.
+    pub fn find_unique_constraint_for_client_field(
+        &self,
+        client_field: &str,
+        table_id: TableId,
+    ) -> Option<UniqueConstraintWalker<'_>> {
+        self.names
+            .get_unique_constraint_id_for_client_field(client_field, table_id)
+            .map(|constraint_id| self.walk(constraint_id))
+    }
+
     /// Adds a schema to the definition.
     pub fn push_schema(&mut self, schema: String) -> SchemaId {
         let id = self.next_schema_id();
@@ -275,6 +286,17 @@ impl DatabaseDefinition {
     /// Adds an index from client field name and table id to table column id.
     pub fn push_client_field_mapping(&mut self, field_name: &str, table_id: TableId, column_id: TableColumnId) {
         self.names.intern_client_field(field_name, table_id, column_id);
+    }
+
+    /// Adds an index from client field name and table id to unique constraint id.
+    pub fn push_client_field_unique_constraint_mapping(
+        &mut self,
+        field_name: &str,
+        table_id: TableId,
+        constraint_id: UniqueConstraintId,
+    ) {
+        self.names
+            .intern_client_unique_constraint(field_name, table_id, constraint_id);
     }
 
     /// Adds an index from client enum name to the corresponding enum id.


### PR DESCRIPTION
This fixes an edge case that might seem small, but would lead to catastrophic results in the worst case. Let's imagine a table:

```sql
CREATE TABLE "user" (
  name VARCHAR(255) NOT NULL,
  email VARCHAR(255) NULL,
  CONSTRAINT foo_key UNIQUE (name, email)
);
```

The input type would be something like this:

```graphql
query {
  user(by: { nameEmail: { name: "Naukio", email: null } }) {
    name
    email
  }
}
```

This would trigger a query with `WHERE name = 'Naukio' AND email IS NULL`. Now, the column being nullable, the generated graphql type allows one to emit the value completely, so this is also allowed:

```graphql
query {
  user(by: { nameEmail: { name: "Naukio" } }) {
    name
    email
  }
}
```

Before the fix, it renders a query `WHERE name = 'Naukio'`, which then could return more than one rows, leading to  undefined behavior. And what's worse, when we implement the deletion or updates of one item, this would delete/update more than one item in the database.

The fix maps all fields _not defined_ in the query that are part of the constraint, and adds `AND field IS NULL` for the fields missing in the input.

Closes: GB-4909