### PR TITLE
chore: Bump CLI to 0.37.1 and bump SDK to 0.6.4

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.37.1] - 2023-10-05
+
+[CHANGELOG](changelog/0.37.1.md)
+
 ## [0.37.0] - 2023-10-03
 
 [CHANGELOG](changelog/0.37.0.md)

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "async-graphql 6.0.6",
  "async-trait",
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "async-graphql 5.0.10",
  "async-graphql-axum",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "async-compression",
  "async-tar",
@@ -2403,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "chrono",
  "common-types",
@@ -2419,7 +2419,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,7 +15,7 @@ ulid = { git = "https://github.com/grafbase/ulid-rs", rev = "6d06156193d51a2db32
 
 
 [workspace.package]
-version = "0.37.0"
+version = "0.37.1"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://grafbase.com"

--- a/cli/changelog/0.37.1.md
+++ b/cli/changelog/0.37.1.md
@@ -1,0 +1,9 @@
+### Fixes
+
+- Reduce allocations for PostgreSQL pagination
+- Add `url` to `LogEventType::UdfMessage`
+- Emit inpuit field for nullable PostgreSQL composite key
+
+### Breaking
+
+- Rename `@neon` directive to `@postgresql`

--- a/cli/changelog/0.37.1.md
+++ b/cli/changelog/0.37.1.md
@@ -1,9 +1,9 @@
 ### Fixes
 
-- Reduce allocations for PostgreSQL pagination
+- Reduce allocations for Postgres pagination
 - Add `url` to `LogEventType::UdfMessage`
-- Emit inpuit field for nullable PostgreSQL composite key
+- Emit input field for nullable Postgres composite key
 
 ### Breaking
 
-- Rename `@neon` directive to `@postgresql`
+- Rename `@neon` directive to `@postgres`

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -38,8 +38,8 @@ url = "2"
 urlencoding = "2"
 walkdir = "2"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.37.0" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.37.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.37.1" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.37.1" }
 
 [build-dependencies]
 cynic-codegen = { version = "3", features = ["rkyv"] }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -37,8 +37,8 @@ uuid = { version = "1", features = ["v4"] }
 url = "2"
 webbrowser = "0.8"
 
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.37.0" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.37.0" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.37.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.37.1" }
 
 
 [dev-dependencies]

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -63,7 +63,7 @@ cfg-if = "1"
 # Same version as Tantivy
 tantivy-fst = "0.4.0"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.37.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.37.1" }
 gateway = { path = "../gateway" }
 engine = { path = "../../../engine/crates/engine" }
 runtime = { path = "../../../engine/crates/runtime" }

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.6.4"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.37.0",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.37.0",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.37.0",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.37.0",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.37.0"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.37.1",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.37.1",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.37.1",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.37.1",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.37.1"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/packages/grafbase-sdk/CHANGELOG.md
+++ b/packages/grafbase-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.6.4] - Thu Oct 05 2023
+
+[CHANGELOG](changelog/0.6.4.md)
+
 ## [0.6.3] - Tue Sep 26 2023
 
 [CHANGELOG](changelog/0.6.3.md)

--- a/packages/grafbase-sdk/changelog/0.6.4.md
+++ b/packages/grafbase-sdk/changelog/0.6.4.md
@@ -1,0 +1,3 @@
+## Breaking
+
+- Rename `Neon` connector to `Postgres`

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Releasing the Postgres renames.