### PR TITLE
fix(gateway): Drop the `log::error!()` from the branch when a UDF invocation fails

### DIFF
--- a/engine/crates/engine/src/registry/resolvers/custom.rs
+++ b/engine/crates/engine/src/registry/resolvers/custom.rs
@@ -88,12 +88,7 @@ impl CustomResolver {
                 });
                 Err(error)
             }
-            #[allow(unused_variables)]
-            CustomResolverResponse::Error(err) => {
-                log::error!(ctx.trace_id(), "UDF error: {err}");
-
-                Err(CustomResolverError::InvocationError.into())
-            }
+            CustomResolverResponse::Error(_err) => Err(CustomResolverError::InvocationError.into()),
         }
     }
 }


### PR DESCRIPTION

# Description

We've got it covered with runtime logs now.


# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
