### PR TITLE
chore(ci): Downgrade Windows runner to 2019 version (should be faster)

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -132,7 +132,7 @@ jobs:
 
   windows:
     needs: [lint]
-    runs-on: windows-latest-8-cores
+    runs-on: windows-2019-8-cores
     steps:
       - name: Get sources
         uses: actions/checkout@v3


### PR DESCRIPTION
# Description

See: https://github.com/actions/checkout/issues/1186
