### PR TITLE
fix(logs): Runtime logs: Change the timezone of the timestamp printed to local.

### DIFF
--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -353,6 +353,8 @@ pub fn print_log_entry(
         ..
     }: LogEvent,
 ) {
+    let created_at: chrono::DateTime<chrono::Local> = chrono::DateTime::from(created_at);
+
     let extra_properties = match log_event_type {
         crate::logs::LogEventType::Request {
             http_method,


### PR DESCRIPTION
# Description

Now it'll be:
```
2023-10-09T16:00:59.459+02:00 POST /graphql 200 | query IntrospectionQuery
2023-10-09T16:01:10.472+02:00 POST /graphql 200 | query IntrospectionQuery
2023-10-09T16:01:19.264+02:00 POST /graphql 200 | query Test34124
2023-10-09T16:01:19.281+02:00 [ERROR] resolver return-string | HELLO WORLD!
```

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
