### PR TITLE
sdk: allow attaching resolvers on fields of types

### DIFF
--- a/packages/grafbase-sdk/src/type.ts
+++ b/packages/grafbase-sdk/src/type.ts
@@ -9,8 +9,9 @@ import {
 import { ReferenceDefinition } from './typedefs/reference'
 import { ScalarDefinition } from './typedefs/scalar'
 import { EnumDefinition } from './typedefs/enum'
+import { ResolverDefinition } from './typedefs/resolver'
 import { validateIdentifier } from './validation'
-import { InputType, OutputType, Query, QueryArgument } from './query'
+import { Query } from './query'
 import { MapDefinition } from './typedefs/map'
 
 /**
@@ -28,6 +29,7 @@ export type TypeFieldShape =
   | CacheDefinition
   | MapDefinition
   | EnumDefinition<any, any>
+  | ResolverDefinition
 
 /**
  * A composite type definition (e.g. not a model).

--- a/packages/grafbase-sdk/tests/unit/types.test.ts
+++ b/packages/grafbase-sdk/tests/unit/types.test.ts
@@ -316,4 +316,16 @@ describe('Type generator', () => {
       }"
     `)
   })
+
+  it('supports field resolvers', () => {
+    g.type('User', {
+      name: g.string().resolver('a-field')
+    })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "type User {
+        name: String! @resolver(name: "a-field")
+      }"
+    `)
+  })
 })


### PR DESCRIPTION
Before this commit, this typechecks:

```typescript
g.model('Repository', {
    id: g.id(),
    license: g.string().resolver('repository/license')
});
```

but the same declaration with g.type() does not:

```typescript
g.type('Repository', {
    id: g.id(),
    license: g.string().resolver('repository/license')
});
```

This commit corrects that discrepancy.

Closes GB-5080

# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
