### PR TITLE
chore(sdk): bump to 0.6.5

### DIFF
--- a/packages/grafbase-sdk/CHANGELOG.md
+++ b/packages/grafbase-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.6.5] - Tue Oct 10 2023
+
+[CHANGELOG](changelog/0.6.5.md)
+
 ## [0.6.4] - Thu Oct 05 2023
 
 [CHANGELOG](changelog/0.6.4.md)

--- a/packages/grafbase-sdk/changelog/0.6.5.md
+++ b/packages/grafbase-sdk/changelog/0.6.5.md
@@ -1,0 +1,5 @@
+## Fixes
+
+- It is now possible to define resolvers on fields of output types (`g.type()`)
+  the same as on the fields of models (`g.model()`). This was an omission. See
+  [the PR](https://github.com/grafbase/grafbase/pull/785) for an example.

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

Following https://github.com/grafbase/grafbase/pull/785

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
