### PR TITLE
feat(connector): Postgres update mutations

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2477,9 +2477,9 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sql-ast"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d39c76dd44c3cec2c81e527770394ac6371da5883454addcedafae5470bd98"
+checksum = "c3aac7444d8a2748651d0ad4b7f27dc08b616b2babfe0ebe2656b2ee82463396"
 dependencies = [
  "anyhow",
  "serde_json",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2477,9 +2477,9 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sql-ast"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0f9b4ca8baa35c2988ea3b900d470e1cd80faa5aff94953cea6267f43d4c36"
+checksum = "80d39c76dd44c3cec2c81e527770394ac6371da5883454addcedafae5470bd98"
 dependencies = [
  "anyhow",
  "serde_json",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1603,9 +1603,9 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sql-ast"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d39c76dd44c3cec2c81e527770394ac6371da5883454addcedafae5470bd98"
+checksum = "c3aac7444d8a2748651d0ad4b7f27dc08b616b2babfe0ebe2656b2ee82463396"
 dependencies = [
  "anyhow",
  "serde_json",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1603,9 +1603,9 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sql-ast"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0f9b4ca8baa35c2988ea3b900d470e1cd80faa5aff94953cea6267f43d4c36"
+checksum = "80d39c76dd44c3cec2c81e527770394ac6371da5883454addcedafae5470bd98"
 dependencies = [
  "anyhow",
  "serde_json",

--- a/engine/crates/engine/Cargo.toml
+++ b/engine/crates/engine/Cargo.toml
@@ -16,7 +16,7 @@ async-recursion = "1"
 async-stream = "0.3"
 async-trait = "0.1"
 common-types = { workspace = true }
-grafbase-sql-ast = "0.1.8"
+grafbase-sql-ast = "0.1.9"
 postgres-types = { path = "../postgres-types" }
 bytes = { version = "1", features = ["serde"] }
 case = "1"

--- a/engine/crates/engine/Cargo.toml
+++ b/engine/crates/engine/Cargo.toml
@@ -16,7 +16,7 @@ async-recursion = "1"
 async-stream = "0.3"
 async-trait = "0.1"
 common-types = { workspace = true }
-grafbase-sql-ast = "0.1.6"
+grafbase-sql-ast = "0.1.8"
 postgres-types = { path = "../postgres-types" }
 bytes = { version = "1", features = ["serde"] }
 case = "1"

--- a/engine/crates/engine/src/registry/resolvers/postgres.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres.rs
@@ -18,6 +18,7 @@ pub enum Operation {
     DeleteMany,
     CreateOne,
     CreateMany,
+    UpdateOne,
 }
 
 impl AsRef<str> for Operation {
@@ -29,6 +30,7 @@ impl AsRef<str> for Operation {
             Self::DeleteMany => "deleteMany",
             Self::CreateOne => "createOne",
             Self::CreateMany => "createMany",
+            Self::UpdateOne => "updateOne",
         }
     }
 }

--- a/engine/crates/engine/src/registry/resolvers/postgres.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres.rs
@@ -19,6 +19,7 @@ pub enum Operation {
     CreateOne,
     CreateMany,
     UpdateOne,
+    UpdateMany,
 }
 
 impl AsRef<str> for Operation {
@@ -31,6 +32,7 @@ impl AsRef<str> for Operation {
             Self::CreateOne => "createOne",
             Self::CreateMany => "createMany",
             Self::UpdateOne => "updateOne",
+            Self::UpdateMany => "updateMany",
         }
     }
 }

--- a/engine/crates/engine/src/registry/resolvers/postgres/context.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/context.rs
@@ -1,12 +1,14 @@
+mod create_input;
 mod filter;
-mod input;
 pub mod selection;
+mod update_input;
 
 pub use selection::CollectionArgs;
 
+pub(super) use create_input::{CreateInputItem, CreateInputIterator};
 pub(super) use filter::FilterIterator;
-pub(super) use input::{InputItem, InputIterator};
 pub(super) use selection::{SelectionIterator, TableSelection};
+pub(super) use update_input::{UpdateInputItem, UpdateInputIterator};
 
 use crate::{
     registry::{resolvers::ResolverContext, type_kinds::SelectionSetTarget, Registry},
@@ -129,26 +131,35 @@ impl<'a> PostgresContext<'a> {
         Ok(FilterIterator::Complex(iterator))
     }
 
-    /// An iterator for input value definition.
-    pub fn input(&'a self) -> ServerResult<InputIterator<'a>> {
+    /// An iterator for create input value definition.
+    pub fn create_input(&'a self) -> ServerResult<CreateInputIterator<'a>> {
         let input_map: Map<String, Value> = self.context.input_by_name("input")?;
         let input_type = self.context.find_argument_type("input")?;
-        let iterator = InputIterator::new(self.database_definition(), input_type, input_map);
+        let iterator = CreateInputIterator::new(self.database_definition(), input_type, input_map);
 
         Ok(iterator)
     }
 
-    /// A collection of iterators for multiple input value definitions.
-    pub fn many_input(&'a self) -> ServerResult<Vec<InputIterator<'a>>> {
+    /// A collection of iterators for multiple create input value definitions.
+    pub fn create_many_input(&'a self) -> ServerResult<Vec<CreateInputIterator<'a>>> {
         let input_map: Vec<Map<String, Value>> = self.context.input_by_name("input")?;
         let input_type = self.context.find_argument_type("input")?;
 
         let iterators = input_map
             .into_iter()
-            .map(|input_map| InputIterator::new(self.database_definition(), input_type, input_map))
+            .map(|input_map| CreateInputIterator::new(self.database_definition(), input_type, input_map))
             .collect();
 
         Ok(iterators)
+    }
+
+    /// An iterator for update value definition.
+    pub fn update_input(&'a self) -> ServerResult<UpdateInputIterator<'a>> {
+        let input_map: Map<String, Value> = self.context.input_by_name("input")?;
+        let input_type = self.context.find_argument_type("input")?;
+        let iterator = UpdateInputIterator::new(self.database_definition(), input_type, input_map);
+
+        Ok(iterator)
     }
 
     /// The database connection.

--- a/engine/crates/engine/src/registry/resolvers/postgres/context/create_input.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/context/create_input.rs
@@ -7,18 +7,18 @@ use serde_json::Value;
 
 use crate::registry::type_kinds::InputType;
 
-pub enum InputItem<'a> {
+pub enum CreateInputItem<'a> {
     /// Inserts a single column value.
     Column(TableColumnWalker<'a>, Value),
 }
 
-pub struct InputIterator<'a> {
+pub struct CreateInputIterator<'a> {
     database_definition: &'a DatabaseDefinition,
     table: TableWalker<'a>,
     input: VecDeque<(String, Value)>,
 }
 
-impl<'a> InputIterator<'a> {
+impl<'a> CreateInputIterator<'a> {
     pub fn new(
         database_definition: &'a DatabaseDefinition,
         input_type: InputType<'a>,
@@ -36,8 +36,8 @@ impl<'a> InputIterator<'a> {
     }
 }
 
-impl<'a> Iterator for InputIterator<'a> {
-    type Item = InputItem<'a>;
+impl<'a> Iterator for CreateInputIterator<'a> {
+    type Item = CreateInputItem<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let (field, value) = self.input.pop_front()?;
@@ -69,7 +69,7 @@ impl<'a> Iterator for InputIterator<'a> {
             (value, _) => value,
         };
 
-        Some(InputItem::Column(column, value))
+        Some(CreateInputItem::Column(column, value))
     }
 }
 

--- a/engine/crates/engine/src/registry/resolvers/postgres/context/update_input.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/context/update_input.rs
@@ -1,0 +1,96 @@
+use std::collections::VecDeque;
+
+use grafbase_sql_ast::ast::{Column, Expression, SqlOp};
+use postgres_types::database_definition::{DatabaseDefinition, TableColumnWalker, TableWalker};
+use serde_json::Value;
+
+use crate::registry::type_kinds::InputType;
+
+pub enum UpdateInputItem<'a> {
+    /// Updates a single column value.
+    Column(TableColumnWalker<'a>, Expression<'a>),
+}
+
+pub struct UpdateInputIterator<'a> {
+    database_definition: &'a DatabaseDefinition,
+    table: TableWalker<'a>,
+    input: VecDeque<(String, Value)>,
+}
+
+impl<'a> UpdateInputIterator<'a> {
+    pub fn new(
+        database_definition: &'a DatabaseDefinition,
+        input_type: InputType<'a>,
+        input: impl IntoIterator<Item = (String, Value)>,
+    ) -> Self {
+        let table = database_definition
+            .find_table_for_client_type(input_type.name())
+            .expect("table for client type not found");
+
+        Self {
+            database_definition,
+            table,
+            input: input.into_iter().collect(),
+        }
+    }
+}
+
+impl<'a> Iterator for UpdateInputIterator<'a> {
+    type Item = UpdateInputItem<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (field, value) = self.input.pop_front()?;
+
+        let column = self
+            .database_definition
+            .find_column_for_client_field(&field, self.table.id())
+            .expect("column for client field not found");
+
+        let sql_column = Column::from(column.database_name());
+
+        let value = match value {
+            Value::Object(value) => value,
+            _ => unreachable!("our schema prevents non-object values here"),
+        };
+
+        // the type is oneOf, so we always have at most one operation in the object
+        let expression = match value.into_iter().next() {
+            Some((key, value)) if key == "set" => Expression::from(value),
+            Some((key, value)) if key == "increment" => Expression::from(sql_column) + Expression::from(value),
+            Some((key, value)) if key == "decrement" || key == "deleteKey" => {
+                Expression::from(sql_column) - Expression::from(value)
+            }
+            Some((key, value)) if key == "multiply" => Expression::from(sql_column) * Expression::from(value),
+            Some((key, value)) if key == "divide" => Expression::from(sql_column) / Expression::from(value),
+            Some((key, value)) if key == "append" => {
+                let value = if column.database_type().is_jsonb() {
+                    Value::String(serde_json::to_string(&value).unwrap())
+                } else {
+                    value
+                };
+
+                let op = SqlOp::Append(Expression::from(sql_column), Expression::from(value));
+                Expression::from(op)
+            }
+            Some((key, value)) if key == "prepend" => {
+                let value = if column.database_type().is_jsonb() {
+                    Value::String(serde_json::to_string(&value).unwrap())
+                } else {
+                    value
+                };
+
+                let op = SqlOp::Append(Expression::from(value), Expression::from(sql_column));
+                Expression::from(op)
+            }
+            Some((key, value)) if key == "deleteAtPath" => {
+                let op = SqlOp::JsonDeleteAtPath(Expression::from(sql_column), Expression::from(value));
+
+                Expression::from(op)
+            }
+            Some((key, _)) => todo!("operation {key}"),
+            None => unreachable!("oneOf type prevents this"),
+        };
+
+        Some(UpdateInputItem::Column(column, expression))
+    }
+}

--- a/engine/crates/engine/src/registry/resolvers/postgres/request.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request.rs
@@ -5,6 +5,7 @@ mod delete_one;
 mod find_many;
 mod find_one;
 mod query;
+mod update_many;
 mod update_one;
 
 use super::{context::PostgresContext, Operation};
@@ -19,5 +20,6 @@ pub(super) async fn execute(ctx: PostgresContext<'_>, operation: Operation) -> R
         Operation::CreateOne => create_one::execute(ctx).await,
         Operation::CreateMany => create_many::execute(ctx).await,
         Operation::UpdateOne => update_one::execute(ctx).await,
+        Operation::UpdateMany => update_many::execute(ctx).await,
     }
 }

--- a/engine/crates/engine/src/registry/resolvers/postgres/request.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request.rs
@@ -5,6 +5,7 @@ mod delete_one;
 mod find_many;
 mod find_one;
 mod query;
+mod update_one;
 
 use super::{context::PostgresContext, Operation};
 use crate::{registry::resolvers::ResolvedValue, Error};
@@ -17,5 +18,6 @@ pub(super) async fn execute(ctx: PostgresContext<'_>, operation: Operation) -> R
         Operation::DeleteMany => delete_many::execute(ctx).await,
         Operation::CreateOne => create_one::execute(ctx).await,
         Operation::CreateMany => create_many::execute(ctx).await,
+        Operation::UpdateOne => update_one::execute(ctx).await,
     }
 }

--- a/engine/crates/engine/src/registry/resolvers/postgres/request/create_one.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request/create_one.rs
@@ -13,7 +13,7 @@ struct Response {
 }
 
 pub(crate) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, crate::Error> {
-    let (sql, params) = renderer::Postgres::build(query::insert::build(&ctx, [ctx.input()?])?);
+    let (sql, params) = renderer::Postgres::build(query::insert::build(&ctx, [ctx.create_input()?])?);
 
     let response = ctx
         .transport()

--- a/engine/crates/engine/src/registry/resolvers/postgres/request/query.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request/query.rs
@@ -2,5 +2,6 @@ mod builder;
 pub mod delete;
 pub mod insert;
 pub mod select;
+pub mod update;
 
 pub use builder::SelectBuilder;

--- a/engine/crates/engine/src/registry/resolvers/postgres/request/query/update.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request/query/update.rs
@@ -1,0 +1,46 @@
+use grafbase_sql_ast::ast::{
+    json_build_object, Aliasable, Column, CommonTableExpression, ConditionTree, Select, Update,
+};
+
+use crate::registry::resolvers::postgres::context::{FilterIterator, PostgresContext, TableSelection, UpdateInputItem};
+
+pub fn build<'a>(ctx: &'a PostgresContext<'a>, filter: FilterIterator<'a>) -> Result<Select<'a>, crate::Error> {
+    let mut update = Update::table(ctx.table().database_name());
+    update.so_that(filter.fold(ConditionTree::NoCondition, ConditionTree::and));
+
+    for item in ctx.update_input()? {
+        match item {
+            UpdateInputItem::Column(column, expression) => update.set(column.database_name(), expression),
+        }
+    }
+
+    let update_name = format!("{}_{}_update", ctx.table().schema(), ctx.table().database_name());
+
+    let mut returning = Vec::new();
+    let mut selected_data = Vec::new();
+
+    for selection in ctx.selection() {
+        match selection? {
+            TableSelection::Column(column) => {
+                selected_data.push((
+                    column.database_name(),
+                    Column::from((update_name.clone(), column.database_name())),
+                ));
+
+                returning.push(column.database_name());
+            }
+            // we will not have relations in the first phase
+            TableSelection::JoinUnique(..) | TableSelection::JoinMany(..) => {
+                todo!("we'll get back to this with nested updates")
+            }
+        }
+    }
+
+    update.returning(returning);
+
+    let mut select = Select::from_table(update_name.clone());
+    select.with(CommonTableExpression::new(update_name, update));
+    select.value(json_build_object(selected_data).alias("root"));
+
+    Ok(select)
+}

--- a/engine/crates/engine/src/registry/resolvers/postgres/request/update_many.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request/update_many.rs
@@ -1,0 +1,28 @@
+use grafbase_sql_ast::renderer::{self, Renderer};
+use postgres_types::transport::Transport;
+use serde_json::Value;
+
+use crate::registry::resolvers::{
+    postgres::{context::PostgresContext, request::query},
+    ResolvedValue,
+};
+
+#[derive(Debug, serde::Deserialize)]
+struct Response {
+    root: Value,
+}
+
+pub(crate) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, crate::Error> {
+    let (sql, params) = renderer::Postgres::build(query::update::build(&ctx, ctx.filter()?)?);
+
+    println!("{sql}");
+
+    let response = ctx
+        .transport()
+        .parameterized_query::<Response>(&sql, params)
+        .await
+        .map_err(|error| crate::Error::new(error.to_string()))?;
+
+    let rows = response.into_rows().map(|row| row.root).collect();
+    Ok(ResolvedValue::new(Value::Array(rows)))
+}

--- a/engine/crates/engine/src/registry/resolvers/postgres/request/update_one.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request/update_one.rs
@@ -1,8 +1,11 @@
-use super::query;
-use crate::registry::resolvers::{postgres::context::PostgresContext, ResolvedValue};
 use grafbase_sql_ast::renderer::{self, Renderer};
 use postgres_types::transport::Transport;
 use serde_json::Value;
+
+use crate::registry::resolvers::{
+    postgres::{context::PostgresContext, request::query},
+    ResolvedValue,
+};
 
 #[derive(Debug, serde::Deserialize)]
 struct Response {
@@ -10,7 +13,7 @@ struct Response {
 }
 
 pub(crate) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, crate::Error> {
-    let (sql, params) = renderer::Postgres::build(query::insert::build(&ctx, ctx.create_many_input()?)?);
+    let (sql, params) = renderer::Postgres::build(query::update::build(&ctx, ctx.by_filter()?)?);
 
     let response = ctx
         .transport()
@@ -18,7 +21,7 @@ pub(crate) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, c
         .await
         .map_err(|error| crate::Error::new(error.to_string()))?;
 
-    let rows = response.into_rows().map(|row| row.root).collect();
-
-    Ok(ResolvedValue::new(Value::Array(rows)))
+    Ok(ResolvedValue::new(
+        response.into_single_row().map(|row| row.root).unwrap_or(Value::Null),
+    ))
 }

--- a/engine/crates/integration-tests/tests/postgres/introspection.rs
+++ b/engine/crates/integration-tests/tests/postgres/introspection.rs
@@ -46,6 +46,27 @@ fn table_with_serial_primary_key() {
           not: IntSearchFilterInput
         }
 
+        """
+          Update input for Int type.
+        """
+        input IntUpdateInput {
+          """
+            Replaces the value of a field with the specified value.
+          """ set: Int
+          """
+            Increments the value of the field by the specified amount.
+          """ increment: Int
+          """
+            Decrements the value of the field by the specified amount.
+          """ decrement: Int
+          """
+            Multiplies the value of the field by the specified amount.
+          """ multiply: Int
+          """
+            Divides the value of the field with the given value.
+          """ divide: Int
+        }
+
         type Mutation {
           """
             Delete a unique User by a field or combination of fields
@@ -63,6 +84,10 @@ fn table_with_serial_primary_key() {
             Create multiple Users
           """
           userCreateMany(input: [UserInput!]!): [UserReduced!]!
+          """
+            Update a unique User
+          """
+          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
         }
 
         enum OrderByDirection {
@@ -142,6 +167,10 @@ fn table_with_serial_primary_key() {
           """
             At least one of the filters must match
           """ ANY: [UserReducedCollection]
+        }
+
+        input UserUpdateInput {
+          id: IntUpdateInput
         }
 
         schema {
@@ -235,6 +264,11 @@ fn table_with_enum_field() {
           """ ANY: [AReducedCollection]
         }
 
+        input AUpdateInput {
+          id: IntUpdateInput
+          val: StreetLightUpdateInput
+        }
+
         """
           Search filter input for Int type.
         """
@@ -266,6 +300,27 @@ fn table_with_enum_field() {
           not: IntSearchFilterInput
         }
 
+        """
+          Update input for Int type.
+        """
+        input IntUpdateInput {
+          """
+            Replaces the value of a field with the specified value.
+          """ set: Int
+          """
+            Increments the value of the field by the specified amount.
+          """ increment: Int
+          """
+            Decrements the value of the field by the specified amount.
+          """ decrement: Int
+          """
+            Multiplies the value of the field by the specified amount.
+          """ multiply: Int
+          """
+            Divides the value of the field with the given value.
+          """ divide: Int
+        }
+
         type Mutation {
           """
             Delete a unique A by a field or combination of fields
@@ -283,6 +338,10 @@ fn table_with_enum_field() {
             Create multiple As
           """
           aCreateMany(input: [AInput!]!): [AReduced!]!
+          """
+            Update a unique A
+          """
+          aUpdate(by: AByInput!, input: AUpdateInput!): AReduced
         }
 
         enum OrderByDirection {
@@ -367,6 +426,27 @@ fn table_with_int_primary_key() {
           not: IntSearchFilterInput
         }
 
+        """
+          Update input for Int type.
+        """
+        input IntUpdateInput {
+          """
+            Replaces the value of a field with the specified value.
+          """ set: Int
+          """
+            Increments the value of the field by the specified amount.
+          """ increment: Int
+          """
+            Decrements the value of the field by the specified amount.
+          """ decrement: Int
+          """
+            Multiplies the value of the field by the specified amount.
+          """ multiply: Int
+          """
+            Divides the value of the field with the given value.
+          """ divide: Int
+        }
+
         type Mutation {
           """
             Delete a unique User by a field or combination of fields
@@ -384,6 +464,10 @@ fn table_with_int_primary_key() {
             Create multiple Users
           """
           userCreateMany(input: [UserInput!]!): [UserReduced!]!
+          """
+            Update a unique User
+          """
+          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
         }
 
         enum OrderByDirection {
@@ -463,6 +547,10 @@ fn table_with_int_primary_key() {
           """
             At least one of the filters must match
           """ ANY: [UserReducedCollection]
+        }
+
+        input UserUpdateInput {
+          id: IntUpdateInput
         }
 
         schema {
@@ -518,6 +606,27 @@ fn table_with_int_unique() {
           not: IntSearchFilterInput
         }
 
+        """
+          Update input for Int type.
+        """
+        input IntUpdateInput {
+          """
+            Replaces the value of a field with the specified value.
+          """ set: Int
+          """
+            Increments the value of the field by the specified amount.
+          """ increment: Int
+          """
+            Decrements the value of the field by the specified amount.
+          """ decrement: Int
+          """
+            Multiplies the value of the field by the specified amount.
+          """ multiply: Int
+          """
+            Divides the value of the field with the given value.
+          """ divide: Int
+        }
+
         type Mutation {
           """
             Delete a unique User by a field or combination of fields
@@ -535,6 +644,10 @@ fn table_with_int_unique() {
             Create multiple Users
           """
           userCreateMany(input: [UserInput!]!): [UserReduced!]!
+          """
+            Update a unique User
+          """
+          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
         }
 
         enum OrderByDirection {
@@ -614,6 +727,10 @@ fn table_with_int_unique() {
           """
             At least one of the filters must match
           """ ANY: [UserReducedCollection]
+        }
+
+        input UserUpdateInput {
+          id: IntUpdateInput
         }
 
         schema {
@@ -670,6 +787,27 @@ fn table_with_serial_primary_key_string_unique() {
           not: IntSearchFilterInput
         }
 
+        """
+          Update input for Int type.
+        """
+        input IntUpdateInput {
+          """
+            Replaces the value of a field with the specified value.
+          """ set: Int
+          """
+            Increments the value of the field by the specified amount.
+          """ increment: Int
+          """
+            Decrements the value of the field by the specified amount.
+          """ decrement: Int
+          """
+            Multiplies the value of the field by the specified amount.
+          """ multiply: Int
+          """
+            Divides the value of the field with the given value.
+          """ divide: Int
+        }
+
         type Mutation {
           """
             Delete a unique User by a field or combination of fields
@@ -687,6 +825,10 @@ fn table_with_serial_primary_key_string_unique() {
             Create multiple Users
           """
           userCreateMany(input: [UserInput!]!): [UserReduced!]!
+          """
+            Update a unique User
+          """
+          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
         }
 
         enum OrderByDirection {
@@ -741,6 +883,15 @@ fn table_with_serial_primary_key_string_unique() {
             The value is not in the given array of values
           """ nin: [String]
           not: StringSearchFilterInput
+        }
+
+        """
+          Update input for String type.
+        """
+        input StringUpdateInput {
+          """
+            Replaces the value of a field with the specified value.
+          """ set: String
         }
 
         type User {
@@ -806,6 +957,11 @@ fn table_with_serial_primary_key_string_unique() {
           """ ANY: [UserReducedCollection]
         }
 
+        input UserUpdateInput {
+          id: IntUpdateInput
+          email: StringUpdateInput
+        }
+
         schema {
           query: Query
           mutation: Mutation
@@ -847,6 +1003,10 @@ fn table_with_composite_primary_key() {
             Create multiple Users
           """
           userCreateMany(input: [UserInput!]!): [UserReduced!]!
+          """
+            Update a unique User
+          """
+          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
         }
 
         enum OrderByDirection {
@@ -901,6 +1061,15 @@ fn table_with_composite_primary_key() {
             The value is not in the given array of values
           """ nin: [String]
           not: StringSearchFilterInput
+        }
+
+        """
+          Update input for String type.
+        """
+        input StringUpdateInput {
+          """
+            Replaces the value of a field with the specified value.
+          """ set: String
         }
 
         type User {
@@ -970,6 +1139,11 @@ fn table_with_composite_primary_key() {
           """ ANY: [UserReducedCollection]
         }
 
+        input UserUpdateInput {
+          name: StringUpdateInput
+          email: StringUpdateInput
+        }
+
         schema {
           query: Query
           mutation: Mutation
@@ -1033,6 +1207,27 @@ fn two_schemas_same_table_name() {
           not: IntSearchFilterInput
         }
 
+        """
+          Update input for Int type.
+        """
+        input IntUpdateInput {
+          """
+            Replaces the value of a field with the specified value.
+          """ set: Int
+          """
+            Increments the value of the field by the specified amount.
+          """ increment: Int
+          """
+            Decrements the value of the field by the specified amount.
+          """ decrement: Int
+          """
+            Multiplies the value of the field by the specified amount.
+          """ multiply: Int
+          """
+            Divides the value of the field with the given value.
+          """ divide: Int
+        }
+
         type Mutation {
           """
             Delete a unique PrivateUser by a field or combination of fields
@@ -1051,6 +1246,10 @@ fn two_schemas_same_table_name() {
           """
           privateUserCreateMany(input: [PrivateUserInput!]!): [PrivateUserReduced!]!
           """
+            Update a unique PrivateUser
+          """
+          privateUserUpdate(by: PrivateUserByInput!, input: PrivateUserUpdateInput!): PrivateUserReduced
+          """
             Delete a unique PublicUser by a field or combination of fields
           """
           publicUserDelete(by: PublicUserByInput!): PublicUserReduced
@@ -1066,6 +1265,10 @@ fn two_schemas_same_table_name() {
             Create multiple PublicUsers
           """
           publicUserCreateMany(input: [PublicUserInput!]!): [PublicUserReduced!]!
+          """
+            Update a unique PublicUser
+          """
+          publicUserUpdate(by: PublicUserByInput!, input: PublicUserUpdateInput!): PublicUserReduced
         }
 
         enum OrderByDirection {
@@ -1136,6 +1339,10 @@ fn two_schemas_same_table_name() {
           """ ANY: [PrivateUserReducedCollection]
         }
 
+        input PrivateUserUpdateInput {
+          id: IntUpdateInput
+        }
+
         type PublicUser {
           id: Int!
         }
@@ -1190,6 +1397,10 @@ fn two_schemas_same_table_name() {
           """
             At least one of the filters must match
           """ ANY: [PublicUserReducedCollection]
+        }
+
+        input PublicUserUpdateInput {
+          id: IntUpdateInput
         }
 
         type Query {
@@ -1268,6 +1479,27 @@ fn table_with_serial_primary_key_namespaced() {
           not: NeonIntSearchFilterInput
         }
 
+        """
+          Update input for Int type.
+        """
+        input NeonIntUpdateInput {
+          """
+            Replaces the value of a field with the specified value.
+          """ set: Int
+          """
+            Increments the value of the field by the specified amount.
+          """ increment: Int
+          """
+            Decrements the value of the field by the specified amount.
+          """ decrement: Int
+          """
+            Multiplies the value of the field by the specified amount.
+          """ multiply: Int
+          """
+            Divides the value of the field with the given value.
+          """ divide: Int
+        }
+
         type NeonMutation {
           """
             Delete a unique User by a field or combination of fields
@@ -1285,6 +1517,10 @@ fn table_with_serial_primary_key_namespaced() {
             Create multiple Users
           """
           userCreateMany(input: [NeonUserInput!]!): [NeonUserReduced!]!
+          """
+            Update a unique User
+          """
+          userUpdate(by: NeonUserByInput!, input: NeonUserUpdateInput!): NeonUserReduced
         }
 
         enum NeonOrderByDirection {
@@ -1364,6 +1600,10 @@ fn table_with_serial_primary_key_namespaced() {
           """
             At least one of the filters must match
           """ ANY: [NeonUserReducedCollection]
+        }
+
+        input NeonUserUpdateInput {
+          id: NeonIntUpdateInput
         }
 
         type Query {
@@ -1485,6 +1725,13 @@ fn two_tables_with_single_column_foreign_key() {
           """ ANY: [BlogReducedCollection]
         }
 
+        input BlogUpdateInput {
+          id: IntUpdateInput
+          title: StringUpdateInput
+          content: StringUpdateInput
+          userId: IntUpdateInput
+        }
+
         """
           Search filter input for Int type.
         """
@@ -1516,6 +1763,27 @@ fn two_tables_with_single_column_foreign_key() {
           not: IntSearchFilterInput
         }
 
+        """
+          Update input for Int type.
+        """
+        input IntUpdateInput {
+          """
+            Replaces the value of a field with the specified value.
+          """ set: Int
+          """
+            Increments the value of the field by the specified amount.
+          """ increment: Int
+          """
+            Decrements the value of the field by the specified amount.
+          """ decrement: Int
+          """
+            Multiplies the value of the field by the specified amount.
+          """ multiply: Int
+          """
+            Divides the value of the field with the given value.
+          """ divide: Int
+        }
+
         type Mutation {
           """
             Delete a unique Blog by a field or combination of fields
@@ -1534,6 +1802,10 @@ fn two_tables_with_single_column_foreign_key() {
           """
           blogCreateMany(input: [BlogInput!]!): [BlogReduced!]!
           """
+            Update a unique Blog
+          """
+          blogUpdate(by: BlogByInput!, input: BlogUpdateInput!): BlogReduced
+          """
             Delete a unique User by a field or combination of fields
           """
           userDelete(by: UserByInput!): UserReduced
@@ -1549,6 +1821,10 @@ fn two_tables_with_single_column_foreign_key() {
             Create multiple Users
           """
           userCreateMany(input: [UserInput!]!): [UserReduced!]!
+          """
+            Update a unique User
+          """
+          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
         }
 
         enum OrderByDirection {
@@ -1613,6 +1889,15 @@ fn two_tables_with_single_column_foreign_key() {
           not: StringSearchFilterInput
         }
 
+        """
+          Update input for String type.
+        """
+        input StringUpdateInput {
+          """
+            Replaces the value of a field with the specified value.
+          """ set: String
+        }
+
         type User {
           id: Int!
           name: String!
@@ -1675,6 +1960,11 @@ fn two_tables_with_single_column_foreign_key() {
           """
             At least one of the filters must match
           """ ANY: [UserReducedCollection]
+        }
+
+        input UserUpdateInput {
+          id: IntUpdateInput
+          name: StringUpdateInput
         }
 
         schema {

--- a/engine/crates/integration-tests/tests/postgres/introspection.rs
+++ b/engine/crates/integration-tests/tests/postgres/introspection.rs
@@ -88,6 +88,10 @@ fn table_with_serial_primary_key() {
             Update a unique User
           """
           userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
+          """
+            Update multiple Users
+          """
+          userUpdateMany(filter: UserReducedCollection!, input: UserUpdateInput!): [UserReduced]!
         }
 
         enum OrderByDirection {
@@ -342,6 +346,10 @@ fn table_with_enum_field() {
             Update a unique A
           """
           aUpdate(by: AByInput!, input: AUpdateInput!): AReduced
+          """
+            Update multiple As
+          """
+          aUpdateMany(filter: AReducedCollection!, input: AUpdateInput!): [AReduced]!
         }
 
         enum OrderByDirection {
@@ -468,6 +476,10 @@ fn table_with_int_primary_key() {
             Update a unique User
           """
           userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
+          """
+            Update multiple Users
+          """
+          userUpdateMany(filter: UserReducedCollection!, input: UserUpdateInput!): [UserReduced]!
         }
 
         enum OrderByDirection {
@@ -648,6 +660,10 @@ fn table_with_int_unique() {
             Update a unique User
           """
           userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
+          """
+            Update multiple Users
+          """
+          userUpdateMany(filter: UserReducedCollection!, input: UserUpdateInput!): [UserReduced]!
         }
 
         enum OrderByDirection {
@@ -829,6 +845,10 @@ fn table_with_serial_primary_key_string_unique() {
             Update a unique User
           """
           userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
+          """
+            Update multiple Users
+          """
+          userUpdateMany(filter: UserReducedCollection!, input: UserUpdateInput!): [UserReduced]!
         }
 
         enum OrderByDirection {
@@ -1007,6 +1027,10 @@ fn table_with_composite_primary_key() {
             Update a unique User
           """
           userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
+          """
+            Update multiple Users
+          """
+          userUpdateMany(filter: UserReducedCollection!, input: UserUpdateInput!): [UserReduced]!
         }
 
         enum OrderByDirection {
@@ -1250,6 +1274,10 @@ fn two_schemas_same_table_name() {
           """
           privateUserUpdate(by: PrivateUserByInput!, input: PrivateUserUpdateInput!): PrivateUserReduced
           """
+            Update multiple PrivateUsers
+          """
+          privateUserUpdateMany(filter: PrivateUserReducedCollection!, input: PrivateUserUpdateInput!): [PrivateUserReduced]!
+          """
             Delete a unique PublicUser by a field or combination of fields
           """
           publicUserDelete(by: PublicUserByInput!): PublicUserReduced
@@ -1269,6 +1297,10 @@ fn two_schemas_same_table_name() {
             Update a unique PublicUser
           """
           publicUserUpdate(by: PublicUserByInput!, input: PublicUserUpdateInput!): PublicUserReduced
+          """
+            Update multiple PublicUsers
+          """
+          publicUserUpdateMany(filter: PublicUserReducedCollection!, input: PublicUserUpdateInput!): [PublicUserReduced]!
         }
 
         enum OrderByDirection {
@@ -1521,6 +1553,10 @@ fn table_with_serial_primary_key_namespaced() {
             Update a unique User
           """
           userUpdate(by: NeonUserByInput!, input: NeonUserUpdateInput!): NeonUserReduced
+          """
+            Update multiple Users
+          """
+          userUpdateMany(filter: NeonUserReducedCollection!, input: NeonUserUpdateInput!): [NeonUserReduced]!
         }
 
         enum NeonOrderByDirection {
@@ -1608,6 +1644,742 @@ fn table_with_serial_primary_key_namespaced() {
 
         type Query {
           neon: NeonQuery
+        }
+
+        schema {
+          query: Query
+          mutation: Mutation
+        }
+    "#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn table_with_an_array_column() {
+    let response = introspect_postgres(|api| async move {
+        let schema = indoc! {r#"
+           CREATE TABLE "User" (
+               id SERIAL PRIMARY KEY,
+               name INT[] NOT NULL 
+           );
+       "#};
+
+        api.execute_sql(schema).await;
+    });
+
+    let expected = expect![[r#"
+        """
+          Search filter input for Int type.
+        """
+        input IntArraySearchFilterInput {
+          """
+            The value is exactly the one given
+          """ eq: [Int]
+          """
+            The value is not the one given
+          """ ne: [Int]
+          """
+            The value is greater than the one given
+          """ gt: [Int]
+          """
+            The value is less than the one given
+          """ lt: [Int]
+          """
+            The value is greater than, or equal to the one given
+          """ gte: [Int]
+          """
+            The value is less than, or equal to the one given
+          """ lte: [Int]
+          """
+            The value is in the given array of values
+          """ in: [[Int]]
+          """
+            The value is not in the given array of values
+          """ nin: [[Int]]
+          """
+            The column contains all elements from the given array.
+          """ contains: [Int]
+          """
+            The given array contains all elements from the column.
+          """ contained: [Int]
+          """
+            Do the arrays have any elements in common.
+          """ overlaps: [Int]
+          not: IntArraySearchFilterInput
+        }
+
+        """
+          Update input for Int array type.
+        """
+        input IntArrayUpdateInput {
+          """
+            Replaces the value of a field with the specified value.
+          """ set: [Int]
+          """
+            Append an array value to the column.
+          """ append: [Int]
+          """
+            Prepend an array value to the column.
+          """ prepend: [Int]
+        }
+
+        """
+          Search filter input for Int type.
+        """
+        input IntSearchFilterInput {
+          """
+            The value is exactly the one given
+          """ eq: Int
+          """
+            The value is not the one given
+          """ ne: Int
+          """
+            The value is greater than the one given
+          """ gt: Int
+          """
+            The value is less than the one given
+          """ lt: Int
+          """
+            The value is greater than, or equal to the one given
+          """ gte: Int
+          """
+            The value is less than, or equal to the one given
+          """ lte: Int
+          """
+            The value is in the given array of values
+          """ in: [Int]
+          """
+            The value is not in the given array of values
+          """ nin: [Int]
+          not: IntSearchFilterInput
+        }
+
+        """
+          Update input for Int type.
+        """
+        input IntUpdateInput {
+          """
+            Replaces the value of a field with the specified value.
+          """ set: Int
+          """
+            Increments the value of the field by the specified amount.
+          """ increment: Int
+          """
+            Decrements the value of the field by the specified amount.
+          """ decrement: Int
+          """
+            Multiplies the value of the field by the specified amount.
+          """ multiply: Int
+          """
+            Divides the value of the field with the given value.
+          """ divide: Int
+        }
+
+        type Mutation {
+          """
+            Delete a unique User by a field or combination of fields
+          """
+          userDelete(by: UserByInput!): UserReduced
+          """
+            Delete multiple rows of User by a filter
+          """
+          userDeleteMany(filter: UserReducedCollection!): [UserReduced]!
+          """
+            Create a User
+          """
+          userCreate(input: UserInput!): UserReduced
+          """
+            Create multiple Users
+          """
+          userCreateMany(input: [UserInput!]!): [UserReduced!]!
+          """
+            Update a unique User
+          """
+          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
+          """
+            Update multiple Users
+          """
+          userUpdateMany(filter: UserReducedCollection!, input: UserUpdateInput!): [UserReduced]!
+        }
+
+        enum OrderByDirection {
+          ASC
+          DESC
+        }
+
+        type PageInfo {
+          hasPreviousPage: Boolean!
+          hasNextPage: Boolean!
+          startCursor: String
+          endCursor: String
+        }
+
+        type Query {
+          """
+            Query a single User by a field
+          """
+          user(by: UserByInput!): User
+          """
+            Paginated query to fetch the whole list of User
+          """
+          userCollection(filter: UserCollection, first: Int, last: Int, before: String, after: String, orderBy: [UserOrderByInput]): UserConnection
+        }
+
+        type User {
+          id: Int!
+          name: [Int]!
+        }
+
+        input UserByInput {
+          id: Int
+        }
+
+        input UserCollection {
+          id: IntSearchFilterInput
+          name: IntArraySearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [UserCollection]
+          """
+            None of the filters must match
+          """ NONE: [UserCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [UserCollection]
+        }
+
+        type UserConnection {
+          edges: [UserEdge]!
+          pageInfo: PageInfo!
+        }
+
+        type UserEdge {
+          node: User!
+          cursor: String!
+        }
+
+        input UserInput {
+          id: Int
+          name: [Int]!
+        }
+
+        input UserOrderByInput {
+          id: OrderByDirection
+          name: OrderByDirection
+        }
+
+        type UserReduced {
+          id: Int!
+          name: [Int]!
+        }
+
+        input UserReducedCollection {
+          id: IntSearchFilterInput
+          name: IntArraySearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [UserReducedCollection]
+          """
+            None of the filters must match
+          """ NONE: [UserReducedCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [UserReducedCollection]
+        }
+
+        input UserUpdateInput {
+          id: IntUpdateInput
+          name: IntArrayUpdateInput
+        }
+
+        schema {
+          query: Query
+          mutation: Mutation
+        }
+    "#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn table_with_jsonb_column() {
+    let response = introspect_postgres(|api| async move {
+        let schema = indoc! {r#"
+           CREATE TABLE "User" (
+               id SERIAL PRIMARY KEY,
+               name JSONB NOT NULL 
+           );
+       "#};
+
+        api.execute_sql(schema).await;
+    });
+
+    let expected = expect![[r#"
+        """
+          Search filter input for Int type.
+        """
+        input IntSearchFilterInput {
+          """
+            The value is exactly the one given
+          """ eq: Int
+          """
+            The value is not the one given
+          """ ne: Int
+          """
+            The value is greater than the one given
+          """ gt: Int
+          """
+            The value is less than the one given
+          """ lt: Int
+          """
+            The value is greater than, or equal to the one given
+          """ gte: Int
+          """
+            The value is less than, or equal to the one given
+          """ lte: Int
+          """
+            The value is in the given array of values
+          """ in: [Int]
+          """
+            The value is not in the given array of values
+          """ nin: [Int]
+          not: IntSearchFilterInput
+        }
+
+        """
+          Update input for Int type.
+        """
+        input IntUpdateInput {
+          """
+            Replaces the value of a field with the specified value.
+          """ set: Int
+          """
+            Increments the value of the field by the specified amount.
+          """ increment: Int
+          """
+            Decrements the value of the field by the specified amount.
+          """ decrement: Int
+          """
+            Multiplies the value of the field by the specified amount.
+          """ multiply: Int
+          """
+            Divides the value of the field with the given value.
+          """ divide: Int
+        }
+
+        """
+          A JSON Value
+        """
+        scalar JSON
+
+        """
+          Search filter input for JSON type.
+        """
+        input JsonSearchFilterInput {
+          """
+            The value is exactly the one given
+          """ eq: JSON
+          """
+            The value is not the one given
+          """ ne: JSON
+          """
+            The value is greater than the one given
+          """ gt: JSON
+          """
+            The value is less than the one given
+          """ lt: JSON
+          """
+            The value is greater than, or equal to the one given
+          """ gte: JSON
+          """
+            The value is less than, or equal to the one given
+          """ lte: JSON
+          """
+            The value is in the given array of values
+          """ in: [JSON]
+          """
+            The value is not in the given array of values
+          """ nin: [JSON]
+          not: JsonSearchFilterInput
+        }
+
+        """
+          Update input for JSON type.
+        """
+        input JsonUpdateInput {
+          """
+            Replaces the value of a field with the specified value.
+          """ set: JSON
+          """
+            Append JSON value to the column.
+          """ append: JSON
+          """
+            Prepend JSON value to the column.
+          """ prepend: JSON
+          """
+            Deletes a key (and its value) from a JSON object, or matching string value(s) from a JSON array.
+          """ deleteKey: String
+          """
+            Deletes the array element with specified index (negative integers count from the end). Throws an error if JSON value is not an array.
+          """ deleteElem: Int
+          """
+            Deletes the field or array element at the specified path, where path elements can be either field keys or array indexes.
+          """ deleteAtPath: [String!]
+        }
+
+        type Mutation {
+          """
+            Delete a unique User by a field or combination of fields
+          """
+          userDelete(by: UserByInput!): UserReduced
+          """
+            Delete multiple rows of User by a filter
+          """
+          userDeleteMany(filter: UserReducedCollection!): [UserReduced]!
+          """
+            Create a User
+          """
+          userCreate(input: UserInput!): UserReduced
+          """
+            Create multiple Users
+          """
+          userCreateMany(input: [UserInput!]!): [UserReduced!]!
+          """
+            Update a unique User
+          """
+          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
+          """
+            Update multiple Users
+          """
+          userUpdateMany(filter: UserReducedCollection!, input: UserUpdateInput!): [UserReduced]!
+        }
+
+        enum OrderByDirection {
+          ASC
+          DESC
+        }
+
+        type PageInfo {
+          hasPreviousPage: Boolean!
+          hasNextPage: Boolean!
+          startCursor: String
+          endCursor: String
+        }
+
+        type Query {
+          """
+            Query a single User by a field
+          """
+          user(by: UserByInput!): User
+          """
+            Paginated query to fetch the whole list of User
+          """
+          userCollection(filter: UserCollection, first: Int, last: Int, before: String, after: String, orderBy: [UserOrderByInput]): UserConnection
+        }
+
+        type User {
+          id: Int!
+          name: JSON!
+        }
+
+        input UserByInput {
+          id: Int
+        }
+
+        input UserCollection {
+          id: IntSearchFilterInput
+          name: JsonSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [UserCollection]
+          """
+            None of the filters must match
+          """ NONE: [UserCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [UserCollection]
+        }
+
+        type UserConnection {
+          edges: [UserEdge]!
+          pageInfo: PageInfo!
+        }
+
+        type UserEdge {
+          node: User!
+          cursor: String!
+        }
+
+        input UserInput {
+          id: Int
+          name: JSON!
+        }
+
+        input UserOrderByInput {
+          id: OrderByDirection
+          name: OrderByDirection
+        }
+
+        type UserReduced {
+          id: Int!
+          name: JSON!
+        }
+
+        input UserReducedCollection {
+          id: IntSearchFilterInput
+          name: JsonSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [UserReducedCollection]
+          """
+            None of the filters must match
+          """ NONE: [UserReducedCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [UserReducedCollection]
+        }
+
+        input UserUpdateInput {
+          id: IntUpdateInput
+          name: JsonUpdateInput
+        }
+
+        schema {
+          query: Query
+          mutation: Mutation
+        }
+    "#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn table_with_json_column() {
+    let response = introspect_postgres(|api| async move {
+        let schema = indoc! {r#"
+           CREATE TABLE "User" (
+               id SERIAL PRIMARY KEY,
+               name JSON NOT NULL 
+           );
+       "#};
+
+        api.execute_sql(schema).await;
+    });
+
+    let expected = expect![[r#"
+        """
+          Search filter input for Int type.
+        """
+        input IntSearchFilterInput {
+          """
+            The value is exactly the one given
+          """ eq: Int
+          """
+            The value is not the one given
+          """ ne: Int
+          """
+            The value is greater than the one given
+          """ gt: Int
+          """
+            The value is less than the one given
+          """ lt: Int
+          """
+            The value is greater than, or equal to the one given
+          """ gte: Int
+          """
+            The value is less than, or equal to the one given
+          """ lte: Int
+          """
+            The value is in the given array of values
+          """ in: [Int]
+          """
+            The value is not in the given array of values
+          """ nin: [Int]
+          not: IntSearchFilterInput
+        }
+
+        """
+          Update input for Int type.
+        """
+        input IntUpdateInput {
+          """
+            Replaces the value of a field with the specified value.
+          """ set: Int
+          """
+            Increments the value of the field by the specified amount.
+          """ increment: Int
+          """
+            Decrements the value of the field by the specified amount.
+          """ decrement: Int
+          """
+            Multiplies the value of the field by the specified amount.
+          """ multiply: Int
+          """
+            Divides the value of the field with the given value.
+          """ divide: Int
+        }
+
+        """
+          A JSON Value
+        """
+        scalar JSON
+
+        """
+          Search filter input for JSON type.
+        """
+        input JsonSearchFilterInput {
+          """
+            The value is exactly the one given
+          """ eq: JSON
+          """
+            The value is not the one given
+          """ ne: JSON
+          """
+            The value is greater than the one given
+          """ gt: JSON
+          """
+            The value is less than the one given
+          """ lt: JSON
+          """
+            The value is greater than, or equal to the one given
+          """ gte: JSON
+          """
+            The value is less than, or equal to the one given
+          """ lte: JSON
+          """
+            The value is in the given array of values
+          """ in: [JSON]
+          """
+            The value is not in the given array of values
+          """ nin: [JSON]
+          not: JsonSearchFilterInput
+        }
+
+        type Mutation {
+          """
+            Delete a unique User by a field or combination of fields
+          """
+          userDelete(by: UserByInput!): UserReduced
+          """
+            Delete multiple rows of User by a filter
+          """
+          userDeleteMany(filter: UserReducedCollection!): [UserReduced]!
+          """
+            Create a User
+          """
+          userCreate(input: UserInput!): UserReduced
+          """
+            Create multiple Users
+          """
+          userCreateMany(input: [UserInput!]!): [UserReduced!]!
+          """
+            Update a unique User
+          """
+          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
+          """
+            Update multiple Users
+          """
+          userUpdateMany(filter: UserReducedCollection!, input: UserUpdateInput!): [UserReduced]!
+        }
+
+        enum OrderByDirection {
+          ASC
+          DESC
+        }
+
+        type PageInfo {
+          hasPreviousPage: Boolean!
+          hasNextPage: Boolean!
+          startCursor: String
+          endCursor: String
+        }
+
+        type Query {
+          """
+            Query a single User by a field
+          """
+          user(by: UserByInput!): User
+          """
+            Paginated query to fetch the whole list of User
+          """
+          userCollection(filter: UserCollection, first: Int, last: Int, before: String, after: String, orderBy: [UserOrderByInput]): UserConnection
+        }
+
+        """
+          Update input for SimpleJSON type.
+        """
+        input SimpleJSONUpdateInput {
+          """
+            Replaces the value of a field with the specified value.
+          """ set: SimpleJSON
+        }
+
+        type User {
+          id: Int!
+          name: JSON!
+        }
+
+        input UserByInput {
+          id: Int
+        }
+
+        input UserCollection {
+          id: IntSearchFilterInput
+          name: JsonSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [UserCollection]
+          """
+            None of the filters must match
+          """ NONE: [UserCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [UserCollection]
+        }
+
+        type UserConnection {
+          edges: [UserEdge]!
+          pageInfo: PageInfo!
+        }
+
+        type UserEdge {
+          node: User!
+          cursor: String!
+        }
+
+        input UserInput {
+          id: Int
+          name: JSON!
+        }
+
+        input UserOrderByInput {
+          id: OrderByDirection
+          name: OrderByDirection
+        }
+
+        type UserReduced {
+          id: Int!
+          name: JSON!
+        }
+
+        input UserReducedCollection {
+          id: IntSearchFilterInput
+          name: JsonSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [UserReducedCollection]
+          """
+            None of the filters must match
+          """ NONE: [UserReducedCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [UserReducedCollection]
+        }
+
+        input UserUpdateInput {
+          id: IntUpdateInput
+          name: SimpleJSONUpdateInput
         }
 
         schema {
@@ -1806,6 +2578,10 @@ fn two_tables_with_single_column_foreign_key() {
           """
           blogUpdate(by: BlogByInput!, input: BlogUpdateInput!): BlogReduced
           """
+            Update multiple Blogs
+          """
+          blogUpdateMany(filter: BlogReducedCollection!, input: BlogUpdateInput!): [BlogReduced]!
+          """
             Delete a unique User by a field or combination of fields
           """
           userDelete(by: UserByInput!): UserReduced
@@ -1825,6 +2601,10 @@ fn two_tables_with_single_column_foreign_key() {
             Update a unique User
           """
           userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
+          """
+            Update multiple Users
+          """
+          userUpdateMany(filter: UserReducedCollection!, input: UserUpdateInput!): [UserReduced]!
         }
 
         enum OrderByDirection {

--- a/engine/crates/integration-tests/tests/postgres/mod.rs
+++ b/engine/crates/integration-tests/tests/postgres/mod.rs
@@ -5,3 +5,4 @@ mod delete_one;
 mod find_many;
 mod find_one;
 mod introspection;
+mod update_one;

--- a/engine/crates/integration-tests/tests/postgres/mod.rs
+++ b/engine/crates/integration-tests/tests/postgres/mod.rs
@@ -5,4 +5,5 @@ mod delete_one;
 mod find_many;
 mod find_one;
 mod introspection;
+mod update_many;
 mod update_one;

--- a/engine/crates/integration-tests/tests/postgres/update_many.rs
+++ b/engine/crates/integration-tests/tests/postgres/update_many.rs
@@ -1,0 +1,102 @@
+use expect_test::expect;
+use indoc::indoc;
+use integration_tests::postgres::query_postgres;
+
+#[test]
+fn smoke() {
+    let response = query_postgres(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL,
+                age INT NOT NULL
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name, age) VALUES
+                (1, 'Musti', 11),
+                (2, 'Naukio', 11),
+                (3, 'Pertti', 12)
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let mutation = indoc! {r#"
+            mutation {
+              userUpdateMany(filter: { age: { eq: 11 } }, input: { age: { set: 10 } }) {
+                id
+                name
+                age
+              }
+            }
+        "#};
+
+        let result = serde_json::to_string_pretty(&api.execute(mutation).await.to_graphql_response()).unwrap();
+
+        let expected = expect![[r#"
+            {
+              "data": {
+                "userUpdateMany": [
+                  {
+                    "id": 1,
+                    "name": "Musti",
+                    "age": 10
+                  },
+                  {
+                    "id": 2,
+                    "name": "Naukio",
+                    "age": 10
+                  }
+                ]
+              }
+            }"#]];
+
+        expected.assert_eq(&result);
+
+        let query = indoc! {r#"
+            query {
+              userCollection(first: 10) {
+                edges { node { id name age } }
+              }
+            }    
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
+                    "id": 1,
+                    "name": "Musti",
+                    "age": 10
+                  }
+                },
+                {
+                  "node": {
+                    "id": 2,
+                    "name": "Naukio",
+                    "age": 10
+                  }
+                },
+                {
+                  "node": {
+                    "id": 3,
+                    "name": "Pertti",
+                    "age": 12
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}

--- a/engine/crates/integration-tests/tests/postgres/update_one.rs
+++ b/engine/crates/integration-tests/tests/postgres/update_one.rs
@@ -655,6 +655,120 @@ fn array_set() {
 }
 
 #[test]
+fn array_append() {
+    let response = query_postgres(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                val INT[] NOT NULL
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, val) VALUES (1, '{1}')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let mutation = indoc! {r#"
+            mutation {
+              userUpdate(by: { id: 1 }, input: { val: { append: [2, 3] } }) {
+                id
+              }
+            }
+        "#};
+
+        api.execute(mutation).await;
+
+        let query = indoc! {r#"
+            query {
+              user(by: { id: 1 }) {
+                id
+                val
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "user": {
+              "id": 1,
+              "val": [
+                1,
+                2,
+                3
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn array_prepend() {
+    let response = query_postgres(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                val INT[] NOT NULL
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, val) VALUES (1, '{1}')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let mutation = indoc! {r#"
+            mutation {
+              userUpdate(by: { id: 1 }, input: { val: { prepend: [2, 3] } }) {
+                id
+              }
+            }
+        "#};
+
+        api.execute(mutation).await;
+
+        let query = indoc! {r#"
+            query {
+              user(by: { id: 1 }) {
+                id
+                val
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "user": {
+              "id": 1,
+              "val": [
+                2,
+                3,
+                1
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
 fn jsonb_append() {
     let response = query_postgres(|api| async move {
         let schema = indoc! {r#"

--- a/engine/crates/integration-tests/tests/postgres/update_one.rs
+++ b/engine/crates/integration-tests/tests/postgres/update_one.rs
@@ -1,0 +1,935 @@
+use expect_test::expect;
+use indoc::indoc;
+use integration_tests::postgres::query_postgres;
+
+#[test]
+fn string_set_with_returning() {
+    let response = query_postgres(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name) VALUES (1, 'Musti')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let mutation = indoc! {r#"
+            mutation {
+              userUpdate(by: { id: 1 }, input: { name: { set: "Naukio" } }) {
+                id
+                name
+              }
+            }
+        "#};
+
+        let result = serde_json::to_string_pretty(&api.execute(mutation).await.to_graphql_response()).unwrap();
+
+        let expected = expect![[r#"
+            {
+              "data": {
+                "userUpdate": {
+                  "id": 1,
+                  "name": "Naukio"
+                }
+              }
+            }"#]];
+
+        expected.assert_eq(&result);
+
+        let query = indoc! {r#"
+            query {
+              user(by: { id: 1 }) {
+                id
+                name
+              }
+            }    
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "user": {
+              "id": 1,
+              "name": "Naukio"
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn int2_increment() {
+    let response = query_postgres(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                val INT2 NOT NULL
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, val) VALUES (1, 1)
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let mutation = indoc! {r#"
+            mutation {
+              userUpdate(by: { id: 1 }, input: { val: { increment: 68 } }) {
+                id
+              }
+            }
+        "#};
+
+        api.execute(mutation).await;
+
+        let query = indoc! {r#"
+            query {
+              user(by: { id: 1 }) {
+                id
+                val
+              }
+            }    
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "user": {
+              "id": 1,
+              "val": 69
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn int2_decrement() {
+    let response = query_postgres(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                val INT2 NOT NULL
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, val) VALUES (1, 70)
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let mutation = indoc! {r#"
+            mutation {
+              userUpdate(by: { id: 1 }, input: { val: { decrement: 1 } }) {
+                id
+              }
+            }
+        "#};
+
+        api.execute(mutation).await;
+
+        let query = indoc! {r#"
+            query {
+              user(by: { id: 1 }) {
+                id
+                val
+              }
+            }    
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "user": {
+              "id": 1,
+              "val": 69
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn int2_multiply() {
+    let response = query_postgres(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                val INT2 NOT NULL
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, val) VALUES (1, 6)
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let mutation = indoc! {r#"
+            mutation {
+              userUpdate(by: { id: 1 }, input: { val: { multiply: 8 } }) {
+                id
+              }
+            }
+        "#};
+
+        api.execute(mutation).await;
+
+        let query = indoc! {r#"
+            query {
+              user(by: { id: 1 }) {
+                id
+                val
+              }
+            }    
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "user": {
+              "id": 1,
+              "val": 48
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn int2_divide() {
+    let response = query_postgres(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                val INT2 NOT NULL
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, val) VALUES (1, 138)
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let mutation = indoc! {r#"
+            mutation {
+              userUpdate(by: { id: 1 }, input: { val: { divide: 2 } }) {
+                id
+              }
+            }
+        "#};
+
+        api.execute(mutation).await;
+
+        let query = indoc! {r#"
+            query {
+              user(by: { id: 1 }) {
+                id
+                val
+              }
+            }    
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "user": {
+              "id": 1,
+              "val": 69
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn int4_increment() {
+    let response = query_postgres(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                val INT4 NOT NULL
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, val) VALUES (1, 1)
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let mutation = indoc! {r#"
+            mutation {
+              userUpdate(by: { id: 1 }, input: { val: { increment: 68 } }) {
+                id
+              }
+            }
+        "#};
+
+        api.execute(mutation).await;
+
+        let query = indoc! {r#"
+            query {
+              user(by: { id: 1 }) {
+                id
+                val
+              }
+            }    
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "user": {
+              "id": 1,
+              "val": 69
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn int8_increment() {
+    let response = query_postgres(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                val INT8 NOT NULL
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, val) VALUES (1, 1)
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let mutation = indoc! {r#"
+            mutation {
+              userUpdate(by: { id: 1 }, input: { val: { increment: "68" } }) {
+                id
+              }
+            }
+        "#};
+
+        api.execute(mutation).await;
+
+        let query = indoc! {r#"
+            query {
+              user(by: { id: 1 }) {
+                id
+                val
+              }
+            }    
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "user": {
+              "id": 1,
+              "val": "69"
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn float_increment() {
+    let response = query_postgres(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                val FLOAT4 NOT NULL
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, val) VALUES (1, 1.0)
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let mutation = indoc! {r#"
+            mutation {
+              userUpdate(by: { id: 1 }, input: { val: { increment: 68.0 } }) {
+                id
+              }
+            }
+        "#};
+
+        api.execute(mutation).await;
+
+        let query = indoc! {r#"
+            query {
+              user(by: { id: 1 }) {
+                id
+                val
+              }
+            }    
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "user": {
+              "id": 1,
+              "val": 69.0
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn double_increment() {
+    let response = query_postgres(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                val FLOAT8 NOT NULL
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, val) VALUES (1, 1.0)
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let mutation = indoc! {r#"
+            mutation {
+              userUpdate(by: { id: 1 }, input: { val: { increment: 68.0 } }) {
+                id
+              }
+            }
+        "#};
+
+        api.execute(mutation).await;
+
+        let query = indoc! {r#"
+            query {
+              user(by: { id: 1 }) {
+                id
+                val
+              }
+            }    
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "user": {
+              "id": 1,
+              "val": 69.0
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn numeric_increment() {
+    let response = query_postgres(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                val NUMERIC NOT NULL
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, val) VALUES (1, 1.0)
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let mutation = indoc! {r#"
+            mutation {
+              userUpdate(by: { id: 1 }, input: { val: { increment: "68.0" } }) {
+                id
+              }
+            }
+        "#};
+
+        api.execute(mutation).await;
+
+        let query = indoc! {r#"
+            query {
+              user(by: { id: 1 }) {
+                id
+                val
+              }
+            }    
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "user": {
+              "id": 1,
+              "val": "69.0"
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn money_increment() {
+    let response = query_postgres(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                val MONEY NOT NULL
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, val) VALUES (1, 1.0)
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let mutation = indoc! {r#"
+            mutation {
+              userUpdate(by: { id: 1 }, input: { val: { increment: "68.0" } }) {
+                id
+              }
+            }
+        "#};
+
+        api.execute(mutation).await;
+
+        let query = indoc! {r#"
+            query {
+              user(by: { id: 1 }) {
+                id
+                val
+              }
+            }    
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "user": {
+              "id": 1,
+              "val": "$69.00"
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn array_set() {
+    let response = query_postgres(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                val INT2[] NOT NULL
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, val) VALUES (1, '{1, 2}')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let mutation = indoc! {r#"
+            mutation {
+              userUpdate(by: { id: 1 }, input: { val: { set: [3, 4] } }) {
+                id
+              }
+            }
+        "#};
+
+        api.execute(mutation).await;
+
+        let query = indoc! {r#"
+            query {
+              user(by: { id: 1 }) {
+                id
+                val
+              }
+            }    
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "user": {
+              "id": 1,
+              "val": [
+                3,
+                4
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn jsonb_append() {
+    let response = query_postgres(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                val JSONB NOT NULL
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, val) VALUES (1, '[1]')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let mutation = indoc! {r#"
+            mutation {
+              userUpdate(by: { id: 1 }, input: { val: { append: [2, 3] } }) {
+                id
+              }
+            }
+        "#};
+
+        api.execute(mutation).await;
+
+        let query = indoc! {r#"
+            query {
+              user(by: { id: 1 }) {
+                id
+                val
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "user": {
+              "id": 1,
+              "val": [
+                1,
+                2,
+                3
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn jsonb_prepend() {
+    let response = query_postgres(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                val JSONB NOT NULL
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, val) VALUES (1, '[1]')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let mutation = indoc! {r#"
+            mutation {
+              userUpdate(by: { id: 1 }, input: { val: { prepend: [2, 3] } }) {
+                id
+              }
+            }
+        "#};
+
+        api.execute(mutation).await;
+
+        let query = indoc! {r#"
+            query {
+              user(by: { id: 1 }) {
+                id
+                val
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "user": {
+              "id": 1,
+              "val": [
+                2,
+                3,
+                1
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn jsonb_delete_key_from_object() {
+    let response = query_postgres(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                val JSONB NOT NULL
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, val) VALUES (1, '{ "foo": 1, "bar": 2 }')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let mutation = indoc! {r#"
+            mutation {
+              userUpdate(by: { id: 1 }, input: { val: { deleteKey: "foo" } }) {
+                id
+              }
+            }
+        "#};
+
+        api.execute(mutation).await;
+
+        let query = indoc! {r#"
+            query {
+              user(by: { id: 1 }) {
+                id
+                val
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "user": {
+              "id": 1,
+              "val": {
+                "bar": 2
+              }
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn jsonb_delete_key_from_array() {
+    let response = query_postgres(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                val JSONB NOT NULL
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, val) VALUES (1, '["foo", "bar"]')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let mutation = indoc! {r#"
+            mutation {
+              userUpdate(by: { id: 1 }, input: { val: { deleteKey: "foo" } }) {
+                id
+              }
+            }
+        "#};
+
+        api.execute(mutation).await;
+
+        let query = indoc! {r#"
+            query {
+              user(by: { id: 1 }) {
+                id
+                val
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "user": {
+              "id": 1,
+              "val": [
+                "bar"
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn jsonb_delete_at_path() {
+    let response = query_postgres(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                val JSONB NOT NULL
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, val) VALUES (1, '["a", { "b": 1 }]')
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let mutation = indoc! {r#"
+            mutation {
+              userUpdate(by: { id: 1 }, input: { val: { deleteAtPath: ["1", "b"] } }) {
+                id
+              }
+            }
+        "#};
+
+        api.execute(mutation).await;
+
+        let query = indoc! {r#"
+            query {
+              user(by: { id: 1 }) {
+                id
+                val
+              }
+            }
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "user": {
+              "id": 1,
+              "val": [
+                "a",
+                {}
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}

--- a/engine/crates/parser-postgres/src/registry/context/input.rs
+++ b/engine/crates/parser-postgres/src/registry/context/input.rs
@@ -22,6 +22,15 @@ impl<'a> InputContext<'a> {
         self.directive_name
     }
 
+    pub(crate) fn update_type_name(&self, scalar: &str) -> String {
+        let base_name = format!("{scalar}_update_input");
+
+        match self.namespace {
+            Some(namespace) => format!("{namespace}_{base_name}").to_pascal_case(),
+            None => base_name.to_pascal_case(),
+        }
+    }
+
     pub(crate) fn type_name<'b>(&self, name: &'b str) -> Cow<'b, str> {
         match self.namespace {
             Some(namespace) => Cow::Owned(format!("{namespace}_{name}").to_pascal_case()),

--- a/engine/crates/parser-postgres/src/registry/queries.rs
+++ b/engine/crates/parser-postgres/src/registry/queries.rs
@@ -5,6 +5,7 @@ mod delete_one;
 mod find_many;
 mod find_one;
 mod input;
+mod update_many;
 mod update_one;
 
 use super::context::{InputContext, OutputContext};
@@ -29,5 +30,6 @@ pub(super) fn generate(input_ctx: &InputContext<'_>, output_ctx: &mut OutputCont
         create_one::register(input_ctx, table, &create_input_type, output_ctx);
         create_many::register(input_ctx, table, &create_input_type, output_ctx);
         update_one::register(input_ctx, table, &filter_oneof_type, &update_input_type, output_ctx);
+        update_many::register(input_ctx, table, &simple_filter, &update_input_type, output_ctx);
     }
 }

--- a/engine/crates/parser-postgres/src/registry/queries.rs
+++ b/engine/crates/parser-postgres/src/registry/queries.rs
@@ -5,6 +5,7 @@ mod delete_one;
 mod find_many;
 mod find_one;
 mod input;
+mod update_one;
 
 use super::context::{InputContext, OutputContext};
 
@@ -17,6 +18,8 @@ pub(super) fn generate(input_ctx: &InputContext<'_>, output_ctx: &mut OutputCont
     for table in tables {
         let filter_oneof_type = input::oneof::register(input_ctx, table, output_ctx);
         let create_input_type = input::create::register(input_ctx, table, output_ctx);
+        let update_input_type = input::update::register(input_ctx, table, output_ctx);
+
         let (simple_filter, complex_filter) = input::filter::register(input_ctx, table, output_ctx);
 
         find_one::register(input_ctx, table, &filter_oneof_type, output_ctx);
@@ -25,5 +28,6 @@ pub(super) fn generate(input_ctx: &InputContext<'_>, output_ctx: &mut OutputCont
         delete_many::register(input_ctx, table, &simple_filter, output_ctx);
         create_one::register(input_ctx, table, &create_input_type, output_ctx);
         create_many::register(input_ctx, table, &create_input_type, output_ctx);
+        update_one::register(input_ctx, table, &filter_oneof_type, &update_input_type, output_ctx);
     }
 }

--- a/engine/crates/parser-postgres/src/registry/queries/input.rs
+++ b/engine/crates/parser-postgres/src/registry/queries/input.rs
@@ -1,6 +1,7 @@
 pub(super) mod create;
 pub(super) mod filter;
 pub(super) mod oneof;
+pub(super) mod update;
 
 use engine::registry::MetaInputValue;
 use postgres_types::database_definition::TableColumnWalker;

--- a/engine/crates/parser-postgres/src/registry/queries/input/update.rs
+++ b/engine/crates/parser-postgres/src/registry/queries/input/update.rs
@@ -1,0 +1,35 @@
+use std::borrow::Cow;
+
+use crate::registry::context::{InputContext, OutputContext};
+use engine::registry::MetaInputValue;
+use postgres_types::database_definition::TableWalker;
+
+pub(crate) fn register(input_ctx: &InputContext<'_>, table: TableWalker<'_>, output_ctx: &mut OutputContext) -> String {
+    let input_type_name = input_ctx.update_type_name(table.client_name());
+
+    output_ctx.with_input_type(&input_type_name, table.id(), |builder| {
+        for column in table.columns() {
+            let mut client_type: Cow<'static, str> = column
+                .graphql_base_type()
+                .expect("non-supported types are filtered before reaching this")
+                .into();
+
+            if column.database_type().is_json() {
+                client_type = Cow::Borrowed("SimpleJSON");
+            }
+
+            let r#type = if column.is_array() {
+                input_ctx.update_type_name(&format!("{client_type}Array"))
+            } else {
+                input_ctx.update_type_name(&client_type)
+            };
+
+            let mut input = MetaInputValue::new(column.client_name(), r#type);
+            input.rename = Some(table.database_name().to_string());
+
+            builder.push_input_column(input, column.id());
+        }
+    });
+
+    input_type_name
+}

--- a/engine/crates/parser-postgres/src/registry/queries/update_many.rs
+++ b/engine/crates/parser-postgres/src/registry/queries/update_many.rs
@@ -1,0 +1,37 @@
+use common_types::auth::Operations;
+use engine::registry::{
+    resolvers::{
+        postgres::{Operation, PostgresResolver},
+        Resolver,
+    },
+    MetaField, MetaInputValue,
+};
+use inflector::Inflector;
+use postgres_types::database_definition::TableWalker;
+
+use crate::registry::context::{InputContext, OutputContext};
+
+pub(crate) fn register(
+    input_ctx: &InputContext<'_>,
+    table: TableWalker<'_>,
+    update_filter_type: &str,
+    update_input_type: &str,
+    output_ctx: &mut OutputContext,
+) {
+    let type_name = input_ctx.reduced_type_name(table.client_name());
+    let query_name = format!("{}_Update_Many", table.client_name()).to_camel_case();
+
+    let by_value = MetaInputValue::new("filter", format!("{update_filter_type}!"));
+
+    let input_value = MetaInputValue::new("input", format!("{update_input_type}!"));
+    let mut meta_field = MetaField::new(query_name, format!("[{type_name}]!"));
+
+    meta_field.description = Some(format!("Update multiple {}s", table.client_name()));
+    meta_field.required_operation = Some(Operations::UPDATE);
+    meta_field.args = [("filter".to_string(), by_value), ("input".to_string(), input_value)].into();
+
+    meta_field.resolver =
+        Resolver::PostgresResolver(PostgresResolver::new(Operation::UpdateMany, input_ctx.directive_name()));
+
+    output_ctx.push_mutation(meta_field);
+}

--- a/engine/crates/parser-postgres/src/registry/queries/update_one.rs
+++ b/engine/crates/parser-postgres/src/registry/queries/update_one.rs
@@ -1,0 +1,37 @@
+use common_types::auth::Operations;
+use engine::registry::{
+    resolvers::{
+        postgres::{Operation, PostgresResolver},
+        Resolver,
+    },
+    MetaField, MetaInputValue,
+};
+use inflector::Inflector;
+use postgres_types::database_definition::TableWalker;
+
+use crate::registry::context::{InputContext, OutputContext};
+
+pub(crate) fn register(
+    input_ctx: &InputContext<'_>,
+    table: TableWalker<'_>,
+    filter_oneof_type: &str,
+    update_input_type: &str,
+    output_ctx: &mut OutputContext,
+) {
+    let type_name = input_ctx.reduced_type_name(table.client_name());
+    let query_name = format!("{}_Update", table.client_name()).to_camel_case();
+
+    let by_value = MetaInputValue::new("by", format!("{filter_oneof_type}!"));
+
+    let input_value = MetaInputValue::new("input", format!("{update_input_type}!"));
+    let mut meta_field = MetaField::new(query_name, type_name);
+
+    meta_field.description = Some(format!("Update a unique {}", table.client_name()));
+    meta_field.required_operation = Some(Operations::UPDATE);
+    meta_field.args = [("by".to_string(), by_value), ("input".to_string(), input_value)].into();
+
+    meta_field.resolver =
+        Resolver::PostgresResolver(PostgresResolver::new(Operation::UpdateOne, input_ctx.directive_name()));
+
+    output_ctx.push_mutation(meta_field);
+}

--- a/engine/crates/parser-postgres/src/registry/types/scalar.rs
+++ b/engine/crates/parser-postgres/src/registry/types/scalar.rs
@@ -127,14 +127,14 @@ fn create_scalar_update_type(input_ctx: &InputContext<'_>, scalar: &str, output_
     if scalar == "JSON" {
         fields.push({
             let mut input = MetaInputValue::new("append", scalar);
-            input.description = Some(String::from("Append json value to the column."));
+            input.description = Some(String::from("Append JSON value to the column."));
 
             input
         });
 
         fields.push({
             let mut input = MetaInputValue::new("prepend", scalar);
-            input.description = Some(String::from("Prepend json value to the column."));
+            input.description = Some(String::from("Prepend JSON value to the column."));
 
             input
         });

--- a/engine/crates/parser-postgres/src/registry/types/scalar.rs
+++ b/engine/crates/parser-postgres/src/registry/types/scalar.rs
@@ -14,6 +14,8 @@ static SCALARS: &[&str] = &[
     "ID",
     "Int",
     "JSON",
+    // virtual type for non-JSONB operations (only set)
+    "SimpleJSON",
     "PhoneNumber",
     "String",
     "URL",
@@ -23,103 +25,243 @@ static SCALARS: &[&str] = &[
     "Time",
 ];
 
+static NUMERIC_SCALARS: &[&str] = &["BigInt", "Float", "Decimal", "Int"];
+
+static SCALAR_FILTERS: &[(&str, &str, &str)] = &[
+    ("eq", "=", "The value is exactly the one given"),
+    ("ne", "<>", "The value is not the one given"),
+    ("gt", ">", "The value is greater than the one given"),
+    ("lt", "<", "The value is less than the one given"),
+    ("gte", ">=", "The value is greater than, or equal to the one given"),
+    ("lte", "<=", "The value is less than, or equal to the one given"),
+];
+
 pub(super) fn register(input_ctx: &InputContext<'_>, output_ctx: &mut OutputContext) {
-    static SCALAR_FILTERS: &[(&str, &str, &str)] = &[
-        ("eq", "=", "The value is exactly the one given"),
-        ("ne", "<>", "The value is not the one given"),
-        ("gt", ">", "The value is greater than the one given"),
-        ("lt", "<", "The value is less than the one given"),
-        ("gte", ">=", "The value is greater than, or equal to the one given"),
-        ("lte", "<=", "The value is less than, or equal to the one given"),
-    ];
-
     for scalar in SCALARS {
-        let type_name = input_ctx.filter_type_name(scalar);
-        let mut fields = Vec::with_capacity(SCALAR_FILTERS.len() + 2);
+        create_filter_types(input_ctx, scalar, output_ctx);
+        create_scalar_update_type(input_ctx, scalar, output_ctx);
+        create_array_update_type(input_ctx, scalar, output_ctx);
+    }
+}
 
-        for (filter, mapped_name, description) in SCALAR_FILTERS {
-            let mut input = MetaInputValue::new(*filter, *scalar);
-            input.description = Some(String::from(*description));
-            input.rename = Some((*mapped_name).to_string());
+fn create_array_update_type(input_ctx: &InputContext<'_>, scalar: &str, output_ctx: &mut OutputContext) {
+    let type_name = input_ctx.update_type_name(&format!("{scalar}Array"));
+    let mut fields = Vec::new();
 
-            fields.push(input);
-        }
+    fields.push({
+        let mut input = MetaInputValue::new("set", format!("[{scalar}]"));
+        input.description = Some(String::from("Replaces the value of a field with the specified value."));
+        input
+    });
 
+    fields.push({
+        let mut input = MetaInputValue::new("append", format!("[{scalar}]"));
+        input.description = Some(String::from("Append an array value to the column."));
+
+        input
+    });
+
+    fields.push({
+        let mut input = MetaInputValue::new("prepend", format!("[{scalar}]"));
+        input.description = Some(String::from("Prepend an array value to the column."));
+
+        input
+    });
+
+    let description = format!("Update input for {scalar} array type.");
+    let input_type = InputObjectType::new(type_name, fields).with_description(Some(description));
+
+    output_ctx.create_input_type(input_type);
+}
+
+fn create_scalar_update_type(input_ctx: &InputContext<'_>, scalar: &str, output_ctx: &mut OutputContext) {
+    let type_name = input_ctx.update_type_name(scalar);
+    let mut fields = Vec::new();
+
+    fields.push({
+        let mut input = MetaInputValue::new("set", scalar);
+        input.description = Some(String::from("Replaces the value of a field with the specified value."));
+        input
+    });
+
+    if NUMERIC_SCALARS.contains(&scalar) {
         fields.push({
-            let mut input = MetaInputValue::new("in", format!("[{scalar}]"));
-            input.description = Some(String::from("The value is in the given array of values"));
+            let mut input = MetaInputValue::new("increment", scalar);
+
+            input.description = Some(String::from(
+                "Increments the value of the field by the specified amount.",
+            ));
 
             input
         });
 
         fields.push({
-            let mut input = MetaInputValue::new("nin", format!("[{scalar}]"));
-            input.description = Some(String::from("The value is not in the given array of values"));
+            let mut input = MetaInputValue::new("decrement", scalar);
+
+            input.description = Some(String::from(
+                "Decrements the value of the field by the specified amount.",
+            ));
 
             input
         });
 
-        fields.push(MetaInputValue::new("not", type_name.as_str()));
+        fields.push({
+            let mut input = MetaInputValue::new("multiply", scalar);
 
-        let description = format!("Search filter input for {scalar} type.");
-        let input_type = InputObjectType::new(type_name.clone(), fields).with_description(Some(description));
+            input.description = Some(String::from(
+                "Multiplies the value of the field by the specified amount.",
+            ));
 
-        output_ctx.create_input_type(input_type);
+            input
+        });
+
+        fields.push({
+            let mut input = MetaInputValue::new("divide", scalar);
+
+            input.description = Some(String::from("Divides the value of the field with the given value."));
+
+            input
+        });
     }
 
-    // arrays
-    for scalar in SCALARS {
-        let type_name = input_ctx.filter_type_name(&format!("{scalar}Array"));
-        let mut fields = Vec::with_capacity(SCALAR_FILTERS.len() + 2);
-
-        for (filter, mapped_name, description) in SCALAR_FILTERS {
-            let mut input = MetaInputValue::new(*filter, format!("[{scalar}]"));
-            input.description = Some(String::from(*description));
-            input.rename = Some((*mapped_name).to_string());
-
-            fields.push(input);
-        }
-
+    if scalar == "JSON" {
         fields.push({
-            let mut input = MetaInputValue::new("in", format!("[[{scalar}]]"));
-            input.description = Some(String::from("The value is in the given array of values"));
+            let mut input = MetaInputValue::new("append", scalar);
+            input.description = Some(String::from("Append json value to the column."));
 
             input
         });
 
         fields.push({
-            let mut input = MetaInputValue::new("nin", format!("[[{scalar}]]"));
-            input.description = Some(String::from("The value is not in the given array of values"));
+            let mut input = MetaInputValue::new("prepend", scalar);
+            input.description = Some(String::from("Prepend json value to the column."));
 
             input
         });
 
         fields.push({
-            let mut input = MetaInputValue::new("contains", format!("[{scalar}]"));
-            input.description = Some(String::from("The column contains all elements from the given array."));
+            let mut input = MetaInputValue::new("deleteKey", "String");
+
+            input.description = Some(String::from(
+                "Deletes a key (and its value) from a JSON object, or matching string value(s) from a JSON array.",
+            ));
 
             input
         });
 
         fields.push({
-            let mut input = MetaInputValue::new("contained", format!("[{scalar}]"));
-            input.description = Some(String::from("The given array contains all elements from the column."));
+            let mut input = MetaInputValue::new("deleteElem", "Int");
+
+            input.description = Some(String::from(
+                "Deletes the array element with specified index (negative integers count from the end). Throws an error if JSON value is not an array.",
+            ));
 
             input
         });
 
         fields.push({
-            let mut input = MetaInputValue::new("overlaps", format!("[{scalar}]"));
-            input.description = Some(String::from("Do the arrays have any elements in common."));
+            let mut input = MetaInputValue::new("deleteAtPath", "[String!]");
+
+            input.description = Some(String::from(
+                "Deletes the field or array element at the specified path, where path elements can be either field keys or array indexes.",
+            ));
 
             input
         });
-
-        fields.push(MetaInputValue::new("not", type_name.as_str()));
-
-        let description = format!("Search filter input for {scalar} type.");
-        let input_type = InputObjectType::new(type_name.clone(), fields).with_description(Some(description));
-
-        output_ctx.create_input_type(input_type);
     }
+
+    let description = format!("Update input for {scalar} type.");
+
+    let input_type = InputObjectType::new(type_name.clone(), fields)
+        .with_description(Some(description))
+        .with_oneof(true);
+
+    output_ctx.create_input_type(input_type);
+}
+
+fn create_filter_types(input_ctx: &InputContext<'_>, scalar: &&str, output_ctx: &mut OutputContext) {
+    let type_name = input_ctx.filter_type_name(scalar);
+    let mut fields = Vec::with_capacity(SCALAR_FILTERS.len() + 2);
+
+    for (filter, mapped_name, description) in SCALAR_FILTERS {
+        let mut input = MetaInputValue::new(*filter, *scalar);
+        input.description = Some(String::from(*description));
+        input.rename = Some((*mapped_name).to_string());
+
+        fields.push(input);
+    }
+
+    fields.push({
+        let mut input = MetaInputValue::new("in", format!("[{scalar}]"));
+        input.description = Some(String::from("The value is in the given array of values"));
+
+        input
+    });
+
+    fields.push({
+        let mut input = MetaInputValue::new("nin", format!("[{scalar}]"));
+        input.description = Some(String::from("The value is not in the given array of values"));
+
+        input
+    });
+
+    fields.push(MetaInputValue::new("not", type_name.as_str()));
+
+    let description = format!("Search filter input for {scalar} type.");
+    let input_type = InputObjectType::new(type_name.clone(), fields).with_description(Some(description));
+
+    output_ctx.create_input_type(input_type);
+
+    let type_name = input_ctx.filter_type_name(&format!("{scalar}Array"));
+    let mut fields = Vec::with_capacity(SCALAR_FILTERS.len() + 2);
+
+    for (filter, mapped_name, description) in SCALAR_FILTERS {
+        let mut input = MetaInputValue::new(*filter, format!("[{scalar}]"));
+        input.description = Some(String::from(*description));
+        input.rename = Some((*mapped_name).to_string());
+
+        fields.push(input);
+    }
+
+    fields.push({
+        let mut input = MetaInputValue::new("in", format!("[[{scalar}]]"));
+        input.description = Some(String::from("The value is in the given array of values"));
+
+        input
+    });
+
+    fields.push({
+        let mut input = MetaInputValue::new("nin", format!("[[{scalar}]]"));
+        input.description = Some(String::from("The value is not in the given array of values"));
+
+        input
+    });
+
+    fields.push({
+        let mut input = MetaInputValue::new("contains", format!("[{scalar}]"));
+        input.description = Some(String::from("The column contains all elements from the given array."));
+
+        input
+    });
+
+    fields.push({
+        let mut input = MetaInputValue::new("contained", format!("[{scalar}]"));
+        input.description = Some(String::from("The given array contains all elements from the column."));
+
+        input
+    });
+
+    fields.push({
+        let mut input = MetaInputValue::new("overlaps", format!("[{scalar}]"));
+        input.description = Some(String::from("Do the arrays have any elements in common."));
+
+        input
+    });
+
+    fields.push(MetaInputValue::new("not", type_name.as_str()));
+
+    let description = format!("Search filter input for {scalar} type.");
+    let input_type = InputObjectType::new(type_name.clone(), fields).with_description(Some(description));
+
+    output_ctx.create_input_type(input_type);
 }

--- a/engine/crates/postgres-types/src/database_definition/postgres_type.rs
+++ b/engine/crates/postgres-types/src/database_definition/postgres_type.rs
@@ -18,6 +18,10 @@ impl<'a> DatabaseType<'a> {
     pub fn is_json(&self) -> bool {
         matches!(self, DatabaseType::Scalar(ScalarType::Json | ScalarType::JsonArray))
     }
+
+    pub fn is_jsonb(&self) -> bool {
+        matches!(self, DatabaseType::Scalar(ScalarType::Jsonb | ScalarType::JsonbArray))
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/engine/crates/postgres-types/src/database_definition/postgres_type.rs
+++ b/engine/crates/postgres-types/src/database_definition/postgres_type.rs
@@ -14,6 +14,10 @@ impl<'a> DatabaseType<'a> {
     pub fn is_binary(&self) -> bool {
         matches!(self, DatabaseType::Scalar(ScalarType::Bytea | ScalarType::ByteaArray))
     }
+
+    pub fn is_json(&self) -> bool {
+        matches!(self, DatabaseType::Scalar(ScalarType::Json | ScalarType::JsonArray))
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
# PostgreSQL update mutations

Adds the update and updateMany mutations for PostgreSQL.

Tests: 2425 lines
Implementation: 469 lines

## Update one

Updates one row in the database.

```graphql
query {
  userUpdate(by: { id: 1 }, input: { name: "Musti" }) {
    id
    name
  }
}
```

The return value is a user:

```json
{
  "data": {
    "userUpdate": {
      "id": 1,
      "name": "Musti"
    }
  }
}
```

So far only scalar fields can be used in the updates. We'll be coming back to the nested updates in the following issue: https://linear.app/grafbase/issue/GB-5089/nested-updates

## Update many

Updates multiple rows in the database

```graphql
query {
  userUpdateMany(filter: { id: { eq: 1 } }, input: { name: "Musti" }) {
    id
    name
  }
}
```

The return value is a list of users:

```json
{
  "data": {
    "userUpdateMany": [
      {
        "id": 1,
        "name": "Musti"
      }
    ]
  }
}
```

## Update query

The query is not just a simple update, but we're preparing it for the nested updates that are coming later:

```sql
WITH "user" AS (UPDATE "User" SET "name" = 'Musti' WHERE id = 1 RETURNING id, name)
SELECT json_build_object('id', "user"."id", 'name', "user"."name")
```

Closes: GB-4680