### PR TITLE
feat(sdk): add types for resolver  `context` and `info` args

### DIFF
--- a/packages/grafbase-sdk/src/index.ts
+++ b/packages/grafbase-sdk/src/index.ts
@@ -13,6 +13,9 @@ import path from 'path'
 import { validateIdentifier } from './validation'
 import { PostgresParams, PartialPostgresAPI } from './connector/postgres'
 
+export { type ResolverContext as Context } from './resolver/context'
+export { type ResolverInfo as Info } from './resolver/info'
+
 dotenv.config({
   // must exist, defined by "~/.grafbase/parser/parse-config.ts"
   path: path.join(process.env.GRAFBASE_PROJECT_GRAFBASE_DIR!, '.env'),

--- a/packages/grafbase-sdk/src/resolver/context.ts
+++ b/packages/grafbase-sdk/src/resolver/context.ts
@@ -1,0 +1,71 @@
+import { KVListResult, KVMetadata, KVGetOptions, KVSetOptions, KVListOptions } from './context/kv'
+import { Classification } from './context/ai'
+
+/**
+ * The type of the `context` argument in a Grafbase edge resolver.
+ *
+ * Reference: https://grafbase.com/docs/edge-gateway/resolvers#context
+ *
+ * @example
+ *
+ * import { Context, Info } from '@grafbase/sdk'
+ *
+ * export default async function(_parent, _args, context: Context) {
+ *   // ...
+ * }
+ */
+export type ResolverContext = {
+  /** Context about the HTTP request being handled. */
+  request: {
+    headers: Record<string, any>,
+  }
+  /**
+   * Grafbase KV
+   *
+   * If you want to use this, please make sure to [enable KV in your Grafbase configuration](https://grafbase.com/docs/edge-gateway/resolvers#enable-kv).
+   *
+   * See the reference documentation: https://grafbase.com/docs/edge-gateway/resolvers#kv
+   */
+  kv: {
+    /** Retrieve the value and metadata for a key. See [the docs](https://grafbase.com/docs/edge-gateway/resolvers#get) for examples. */
+    get: (key: string, options?: KVGetOptions) => Promise<{ metadata: KVMetadata, value: any }>
+    /** Create a new key-value pair or update an existing one. See [the docs](https://grafbase.com/docs/edge-gateway/resolvers#set) for examples. */
+    set: (key: string, value: any, options?: KVSetOptions) => Promise<void>
+    /** Delete a key and its value. */
+    delete: (key: string) => Promise<void>
+    /** Fetch the list of all keys. See [the docs](https://grafbase.com/docs/edge-gateway/resolvers#list) for examples. */
+    list: (options?: KVListOptions) => Promise<KVListResult>
+  },
+  ai: {
+    textLlm: (args: {
+      model?: string // closed set of possibilities? see common/grafbase-sdk/src/api/ai/models.rs in grafbase/api
+      prompt?: string
+      messages?: { role: 'system' | 'user', content: string }[]
+    }) => Promise<{ response: string }>
+    textClassification: (args: {
+      model?: string
+      text: string
+    }) => Promise<{ response: [Classification, Classification] }>
+    textTranslation: (args: {
+      model?: string
+      text: string
+      /** Defaults to English. */
+      from?: string
+      to: string
+    }) => Promise<{ translated_text: string }>
+    // Reference for the return type: https://developers.cloudflare.com/workers-ai/models/embedding/
+    textEmbeddings: (args: {
+      model?: string
+      text: string | string[]
+    }) => Promise<{ shape: number[], data: number[][] }>
+    imageClassification: (args: {
+      model?: string
+      /** The string should be a base64 encoded binary string */
+      image: string | number[]
+    }) => Promise<{ label: string, score: number }[]>
+    speechToText: (args: {
+      model?: string
+      audio: string | number[]
+    }) => Promise<{ text: string }>
+  }
+}

--- a/packages/grafbase-sdk/src/resolver/context/ai.ts
+++ b/packages/grafbase-sdk/src/resolver/context/ai.ts
@@ -1,0 +1,5 @@
+// extra source of truth: https://developers.cloudflare.com/workers-ai/models/sentiment-analysis/
+export type Classification = {
+  label: string
+  score: number
+}

--- a/packages/grafbase-sdk/src/resolver/context/kv.ts
+++ b/packages/grafbase-sdk/src/resolver/context/kv.ts
@@ -1,0 +1,48 @@
+/** The metadata for a key in KV. Data of any shape can be stored. */
+export type KVMetadata = any
+
+// https://developers.cloudflare.com/kv/api/list-keys/
+/** The result of a [`list()`](https://grafbase.com/docs/edge-gateway/resolvers#list) call.  */
+export type KVListResult = {
+  keys: KVListKey[]
+  list_complete: boolean
+  /** If `list_complete` is false then you will receive a `cursor` value you can pass to `list()` to obtain the next set of results. */
+  cursor?: string
+}
+
+export type KVListKey = {
+  customKey: string
+  /** Only returned if the key has an expiration set. */
+  expiration?: number
+  metadata: KVMetadata
+}
+
+// source of truth: https://github.com/grafbase/api/blob/main/common/grafbase-sdk/src/api/kv/input.rs
+export type KVGetOptions = {
+  /**
+   * The cacheTtl parameter must be an integer that is greater than or equal to 60, which is the default.
+   * It defines the length of time in seconds that a KV result is cached in the global network location
+   * that it is accessed from.
+   */
+  ttl?: number
+  /**  Type of the value. */
+  type: "text" | "json" | "arraybuffer" | "stream"
+}
+
+export type KVSetOptions = {
+  /** Value will expire at specified time. Seconds since epoch. */
+  expires?: number
+  /** Time to live of the value in seconds. */
+  ttl?: number
+  /** Arbitrary JSON to be associated with a key/value pair. */
+  metadata: KVMetadata
+}
+
+export type KVListOptions = {
+  /** A string prefix you can use to filter all keys */
+  prefix?: string
+  /** Maximum number of keys returned. The default is 1,000, which is the maximum. It is unlikely that you will want to change this default but it is included for completeness. */
+  limit?: number
+  /** Used for paginating responses. */
+  cursor?: string
+}

--- a/packages/grafbase-sdk/src/resolver/info.ts
+++ b/packages/grafbase-sdk/src/resolver/info.ts
@@ -1,0 +1,32 @@
+/**
+ * The type of the `info` argument in a Grafbase edge resolver.
+ *
+ * Reference: https://grafbase.com/docs/edge-gateway/resolvers#info
+ *
+ * @example
+ *
+ * import { Context, Info } from '@grafbase/sdk'
+ *
+ * export default async function(_parent, _args, context: Context, info: Info) {
+ *   // ...
+ * }
+ */
+export type ResolverInfo = {
+  /** The name of the resolved field in the parent type. */
+  fieldName: string
+  /**  The fields traversed prior to the called resolver. */
+  path: ResolverInfoPath
+  /** The variables defined for the query. */
+  variableValues: { [variableName: string]: any }
+}
+
+/** A field traversed prior to calling a resolver. Also see ResolverInfo. */
+export type ResolverInfoPath = {
+  // definition: engine/crates/engine/src/registry/resolvers/custom.rs and engine/crates/engine/src/query_path.rs
+  /** The name of the field or the index of the value in a list. */
+  key: string | number
+  /** The name of the parent type of the field. */
+  typename?: string
+  /** The field traversed before this one. */
+  prev?: ResolverInfoPath
+}


### PR DESCRIPTION
# Description

This commit adds two exports to `@grafbase/sdk':

- `Context`: the type of the `context` arg in resolvers.
- `Info`: the type of the `info` arg in resolvers.

The source is, at much as possible, annotated with the source of truth
for each part of the types in the comments.

This commit implements that section of the RFC: https://www.notion.so/grafbase/Typed-Resolvers-b4a0b47f4b5b4d2b9815e0aa82c6a8a8?pvs=4#7e9386db2ac648a28d5fd8db11f9b4b1

Questions:

- In several places, I used `any`, but we may want to use `unknown`
  instead (different DX for sure). Are there opinions? Graphql.JS for
  example uses `Record<string, unknown>` for variables.
- My current plan for testing that these types match reality is to
  release `@grafbase/sdk` once this is merged, then manually check in
  a deployment. Is there a relevant test suite that would also work?
  Or would a local project with the CLI in dev mode give enough
  confidence?

Part of GB-5097

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
