### PR TITLE
feat: federation resolver for resolvable basic types

### DIFF
--- a/engine/crates/engine/src/registry/federation.rs
+++ b/engine/crates/engine/src/registry/federation.rs
@@ -17,8 +17,20 @@ pub struct FederationEntity {
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub enum FederationResolver {
+    /// Fetches a dynamo entity by some unique key
     DynamoUnique,
+    /// Makes an HTTP call to resolve
     Http(HttpResolver),
+    /// This "resolver" doesn't actually resolve data in the same way the others do.
+    ///
+    /// This should be put on entities where the primary representation lives in
+    /// another subgraph but we contribute fields to it - the result of resolution
+    /// will be the representation we are passed from the router.
+    ///
+    /// This should only ever be applied to types where all the fields on that type
+    /// are present in the representation or resolvable from the representation (e.g.
+    /// fields with custom resolvers)
+    BasicType,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -57,6 +69,13 @@ impl FederationKey {
         FederationKey {
             selections,
             resolver: None,
+        }
+    }
+
+    pub fn basic_type(selections: Vec<Selection>) -> Self {
+        FederationKey {
+            selections,
+            resolver: Some(FederationResolver::BasicType),
         }
     }
 

--- a/engine/crates/engine/src/registry/resolvers/federation.rs
+++ b/engine/crates/engine/src/registry/resolvers/federation.rs
@@ -9,7 +9,7 @@ use crate::{
 
 use super::{dynamo_querying::DynamoResolver, ResolvedValue, ResolverContext};
 
-#[derive(serde::Deserialize)]
+#[derive(serde::Deserialize, serde::Serialize)]
 struct Representation {
     #[serde(rename = "__typename")]
     ty: NamedType<'static>,
@@ -78,6 +78,7 @@ async fn resolve_representation(ctx: &ContextField<'_>, representation: Represen
             let last_resolver_value = Some(ResolvedValue::new(representation.data));
             resolver.resolve(ctx, &resolver_context, last_resolver_value).await
         }
+        Some(FederationResolver::BasicType) => Ok(ResolvedValue::new(serde_json::to_value(&representation)?)),
         None => {
             return Err(Error::new(format!(
                 "Tried to resolve an unresolvable key for {}",

--- a/engine/crates/engine/src/registry/type_names.rs
+++ b/engine/crates/engine/src/registry/type_names.rs
@@ -164,7 +164,7 @@ impl TypeReference for TypeCondition {
 }
 
 /// A named GraphQL type without any non-null or list wrappers
-#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
 pub struct NamedType<'a>(Cow<'a, str>);
 
 impl NamedType<'_> {

--- a/engine/crates/parser-sdl/src/rules/federation/directive.rs
+++ b/engine/crates/parser-sdl/src/rules/federation/directive.rs
@@ -54,7 +54,7 @@ impl<'a> Visitor<'a> for FederationDirectiveVisitor {
 mod tests {
     use std::collections::HashMap;
 
-    use crate::RuleError;
+    use crate::tests::assert_validation_error;
 
     #[test]
     fn test_federation_with_a_model() {
@@ -72,22 +72,6 @@ mod tests {
             .registry;
 
         insta::assert_display_snapshot!(registry.export_sdl(true));
-    }
-
-    macro_rules! assert_validation_error {
-        ($schema:literal, $expected_message:literal) => {
-            assert_matches!(
-                crate::parse_registry($schema)
-                    .err()
-                    .and_then(crate::Error::validation_errors)
-                    // We don't care whether there are more errors or not.
-                    // It only matters that we find the expected error.
-                    .and_then(|errors| errors.into_iter().next()),
-                Some(RuleError { message, .. }) => {
-                    assert_eq!(message, $expected_message);
-                }
-            )
-        };
     }
 
     #[test]

--- a/engine/crates/parser-sdl/src/rules/federation/key.rs
+++ b/engine/crates/parser-sdl/src/rules/federation/key.rs
@@ -83,34 +83,4 @@ mod tests {
 
         insta::assert_display_snapshot!(registry.export_sdl(true));
     }
-
-    macro_rules! assert_validation_error {
-        ($schema:literal, $expected_message:literal) => {
-            assert_matches!(
-                crate::parse_registry($schema)
-                    .err()
-                    .and_then(crate::Error::validation_errors)
-                    // We don't care whether there are more errors or not.
-                    // It only matters that we find the expected error.
-                    .and_then(|errors| errors.into_iter().next()),
-                Some(crate::RuleError { message, .. }) => {
-                    assert_eq!(message, $expected_message);
-                }
-            )
-        };
-    }
-
-    #[test]
-    fn resolvable_basic_types_not_allowed() {
-        assert_validation_error!(
-            r#"
-                extend schema @federation(version: "2.3")
-
-                type User @key(fields: "id") {
-                    id: ID!
-                }
-            "#,
-            "Found a resolvable key on a basic type, which is currently unsupported"
-        );
-    }
 }

--- a/engine/crates/parser-sdl/src/rules/graphql_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/graphql_directive.rs
@@ -133,7 +133,7 @@ mod tests {
 
     use futures::executor::block_on;
 
-    use crate::{connector_parsers::MockConnectorParsers, rules::visitor::RuleError};
+    use crate::{connector_parsers::MockConnectorParsers, tests::assert_validation_error};
 
     #[test]
     fn parsing_graphql_directive() {
@@ -261,22 +261,6 @@ mod tests {
             },
         ]
         "###);
-    }
-
-    macro_rules! assert_validation_error {
-        ($schema:literal, $expected_message:literal) => {
-            assert_matches!(
-                crate::parse_registry($schema)
-                    .err()
-                    .and_then(crate::Error::validation_errors)
-                    // We don't care whether there are more errors or not.
-                    // It only matters that we find the expected error.
-                    .and_then(|errors| errors.into_iter().next()),
-                Some(RuleError { message, .. }) => {
-                    assert_eq!(message, $expected_message);
-                }
-            );
-        };
     }
 
     #[test]

--- a/engine/crates/parser-sdl/src/rules/openapi_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/openapi_directive.rs
@@ -140,7 +140,7 @@ mod tests {
     use rstest::rstest;
 
     use super::OpenApiQueryNamingStrategy;
-    use crate::{connector_parsers::MockConnectorParsers, rules::visitor::RuleError};
+    use crate::{connector_parsers::MockConnectorParsers, tests::assert_validation_error};
 
     #[test]
     fn test_parsing_openapi_directive() {
@@ -236,22 +236,6 @@ mod tests {
                 .query_naming,
             expected
         );
-    }
-
-    macro_rules! assert_validation_error {
-        ($schema:literal, $expected_message:literal) => {
-            assert_matches!(
-                crate::parse_registry($schema)
-                    .err()
-                    .and_then(crate::Error::validation_errors)
-                    // We don't care whether there are more errors or not.
-                    // It only matters that we find the expected error.
-                    .and_then(|errors| errors.into_iter().next()),
-                Some(RuleError { message, .. }) => {
-                    assert_eq!(message, $expected_message);
-                }
-            );
-        };
     }
 
     #[test]

--- a/engine/crates/parser-sdl/src/rules/postgres_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/postgres_directive.rs
@@ -49,7 +49,7 @@ impl Directive for PostgresDirective {
           The full connection string to the database.
           """
           url: String!
-          
+
           """
           If true, namespaces queries and mutations with the
           connector name. Defaults to true.
@@ -86,23 +86,7 @@ mod tests {
 
     use futures::executor::block_on;
 
-    use crate::{connector_parsers::MockConnectorParsers, rules::visitor::RuleError};
-
-    macro_rules! assert_validation_error {
-        ($schema:literal, $expected_message:literal) => {
-            assert_matches!(
-                crate::parse_registry($schema)
-                    .err()
-                    .and_then(crate::Error::validation_errors)
-                    // We don't care whether there are more errors or not.
-                    // It only matters that we find the expected error.
-                    .and_then(|errors| errors.into_iter().next()),
-                Some(RuleError { message, .. }) => {
-                    assert_eq!(message, $expected_message);
-                }
-            );
-        };
-    }
+    use crate::{connector_parsers::MockConnectorParsers, tests::assert_validation_error};
 
     #[test]
     fn parsing_postgres_directive() {

--- a/engine/crates/parser-sdl/src/rules/unique_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/unique_directive.rs
@@ -220,23 +220,7 @@ mod tests {
     use engine::Schema;
     use pretty_assertions::assert_eq;
 
-    use crate::rules::visitor::RuleError;
-
-    macro_rules! assert_validation_error {
-        ($schema:literal, $expected_message:literal) => {
-            assert_matches!(
-                crate::parse_registry($schema)
-                    .err()
-                    .and_then(crate::Error::validation_errors)
-                    // We don't care whether there are more errors or not.
-                    // It only matters that we find the expected error.
-                    .and_then(|errors| errors.into_iter().next()),
-                Some(RuleError { message, .. }) => {
-                    assert_eq!(message, $expected_message);
-                }
-            );
-        };
-    }
+    use crate::tests::assert_validation_error;
 
     #[test]
     fn test_not_usable_on_nullable_fields() {

--- a/engine/crates/parser-sdl/src/tests.rs
+++ b/engine/crates/parser-sdl/src/tests.rs
@@ -5,21 +5,23 @@ use engine::{registry::Registry, Schema};
 use function_name::named;
 use serde_json as _;
 
-use crate::rules::visitor::RuleError;
-
 macro_rules! assert_validation_error {
     ($schema:literal, $expected_message:literal) => {
         assert_matches!(
-            super::parse_registry($schema)
+            $crate::parse_registry($schema)
                 .err()
-                .and_then(super::Error::validation_errors)
+                .and_then(crate::Error::validation_errors)
                 // We don't care whether there are more errors or not.
                 // It only matters that we find the expected error.
                 .and_then(|errors| errors.into_iter().next()),
-            Some(RuleError { message, .. }) if message == $expected_message
-        );
+            Some(crate::RuleError { message, .. }) => {
+                assert_eq!(message, $expected_message);
+            }
+        )
     };
 }
+
+pub(crate) use assert_validation_error;
 
 fn assert_snapshot(name: &str, registry: Registry) {
     let _reg_string = serde_json::to_value(&registry).unwrap();


### PR DESCRIPTION
Sometimes one subgraph will want to add fields to a type that is owned by another subgraph.  This partially enables suppport for that in Grafbase.  e.g. to add a name to a `TodoList` owned by another subgraph you could use this schema:

```graphql
extend schema @federation(version: "2.3")

type TodoList @key(fields: "id") {
    id: ID!
    name: String! @resolver(name: "todoListName")
}
```