### PR TITLE
feat(connector): Log Postgres queries

### DIFF
--- a/cli/crates/server/src/bridge/log.rs
+++ b/cli/crates/server/src/bridge/log.rs
@@ -43,6 +43,17 @@ pub async fn log_event_endpoint(
                 body,
                 content_type,
             }),
+            InputLogEventType::SqlQuery {
+                successful,
+                sql,
+                duration,
+                body,
+            } => OutputLogEventType::NestedEvent(crate::types::NestedRequestScopedMessage::SqlQuery {
+                successful,
+                sql,
+                duration,
+                body,
+            }),
         },
     };
     handler_state.message_sender.send(message).unwrap();

--- a/cli/crates/server/src/bridge/types.rs
+++ b/cli/crates/server/src/bridge/types.rs
@@ -104,6 +104,13 @@ pub enum LogEventType {
         #[serde(rename = "contentType")]
         content_type: Option<String>,
     },
+    SqlQuery {
+        successful: bool,
+        sql: String,
+        #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
+        duration: std::time::Duration,
+        body: Option<String>,
+    },
 }
 
 #[derive(Deserialize, Debug)]

--- a/cli/crates/server/src/types.rs
+++ b/cli/crates/server/src/types.rs
@@ -25,6 +25,12 @@ pub enum NestedRequestScopedMessage {
         body: Option<String>,
         content_type: Option<String>,
     },
+    SqlQuery {
+        successful: bool,
+        sql: String,
+        duration: std::time::Duration,
+        body: Option<String>,
+    },
 }
 
 #[derive(Clone, Debug)]

--- a/engine/crates/common-types/src/lib.rs
+++ b/engine/crates/common-types/src/lib.rs
@@ -88,6 +88,13 @@ pub enum LogEventType<'a> {
         #[serde(rename = "contentType")]
         content_type: Option<String>,
     },
+    SqlQuery {
+        successful: bool,
+        sql: String,
+        #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
+        duration: std::time::Duration,
+        body: Option<String>,
+    },
     UdfMessage {
         level: LogLevel,
         message: String,
@@ -101,6 +108,10 @@ impl LogEventType<'_> {
             LogEventType::OperationStarted { .. }
             | LogEventType::OperationCompleted { .. }
             | LogEventType::NestedRequest { .. } => LogLevel::Info,
+            LogEventType::SqlQuery { successful, .. } => match successful {
+                true => LogLevel::Info,
+                false => LogLevel::Error,
+            },
             LogEventType::GatewayRequest { status_code, .. } => match *status_code {
                 200..=299 => LogLevel::Info,
                 _other => LogLevel::Error,

--- a/engine/crates/engine/src/registry/resolvers/postgres/context.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/context.rs
@@ -166,4 +166,16 @@ impl<'a> PostgresContext<'a> {
     pub fn transport(&self) -> &NeonTransport {
         &self.transport
     }
+
+    pub fn runtime_ctx(&self) -> Result<&runtime::Context, crate::Error> {
+        self.context.data::<runtime::Context>()
+    }
+
+    pub fn ray_id(&self) -> Result<&str, crate::Error> {
+        Ok(self.runtime_ctx()?.ray_id())
+    }
+
+    pub fn fetch_log_endpoint_url(&self) -> Result<Option<&str>, crate::Error> {
+        Ok(self.runtime_ctx()?.log.fetch_log_endpoint_url.as_deref())
+    }
 }

--- a/engine/crates/engine/src/registry/resolvers/postgres/request.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request.rs
@@ -4,12 +4,19 @@ mod delete_many;
 mod delete_one;
 mod find_many;
 mod find_one;
+mod log;
 mod query;
 mod update_many;
 mod update_one;
 
 use super::{context::PostgresContext, Operation};
 use crate::{registry::resolvers::ResolvedValue, Error};
+use serde_json::Value;
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+struct RowData {
+    root: Value,
+}
 
 pub(super) async fn execute(ctx: PostgresContext<'_>, operation: Operation) -> Result<ResolvedValue, Error> {
     match operation {

--- a/engine/crates/engine/src/registry/resolvers/postgres/request/create_many.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request/create_many.rs
@@ -1,23 +1,14 @@
-use super::query;
+use super::{log, query, RowData};
 use crate::registry::resolvers::{postgres::context::PostgresContext, ResolvedValue};
 use grafbase_sql_ast::renderer::{self, Renderer};
 use postgres_types::transport::Transport;
 use serde_json::Value;
 
-#[derive(Debug, serde::Deserialize)]
-struct Response {
-    root: Value,
-}
-
 pub(crate) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, crate::Error> {
     let (sql, params) = renderer::Postgres::build(query::insert::build(&ctx, ctx.create_many_input()?)?);
 
-    let response = ctx
-        .transport()
-        .parameterized_query::<Response>(&sql, params)
-        .await
-        .map_err(|error| crate::Error::new(error.to_string()))?;
-
+    let operation = ctx.transport().parameterized_query::<RowData>(&sql, params);
+    let response = log::query(&ctx, &sql, operation).await?;
     let rows = response.into_rows().map(|row| row.root).collect();
 
     Ok(ResolvedValue::new(Value::Array(rows)))

--- a/engine/crates/engine/src/registry/resolvers/postgres/request/delete_many.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request/delete_many.rs
@@ -7,22 +7,14 @@ use crate::{
     Error,
 };
 
-use super::query;
-
-#[derive(Debug, serde::Deserialize)]
-struct Response {
-    root: Value,
-}
+use super::{log, query, RowData};
 
 pub(crate) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, Error> {
     let (sql, params) = renderer::Postgres::build(query::delete::build(&ctx, ctx.filter()?)?);
 
-    let response = ctx
-        .transport()
-        .parameterized_query::<Response>(&sql, params)
-        .await
-        .map_err(|error| Error::new(error.to_string()))?;
-
+    let operation = ctx.transport().parameterized_query::<RowData>(&sql, params);
+    let response = log::query(&ctx, &sql, operation).await?;
     let rows = response.into_rows().map(|row| row.root).collect();
+
     Ok(ResolvedValue::new(Value::Array(rows)))
 }

--- a/engine/crates/engine/src/registry/resolvers/postgres/request/delete_one.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request/delete_one.rs
@@ -7,21 +7,12 @@ use crate::{
     Error,
 };
 
-use super::query;
-
-#[derive(Debug, serde::Deserialize)]
-struct Response {
-    root: Value,
-}
+use super::{log, query, RowData};
 
 pub(crate) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, Error> {
     let (sql, params) = renderer::Postgres::build(query::delete::build(&ctx, ctx.by_filter()?)?);
-
-    let response = ctx
-        .transport()
-        .parameterized_query::<Response>(&sql, params)
-        .await
-        .map_err(|error| Error::new(error.to_string()))?;
+    let operation = ctx.transport().parameterized_query::<RowData>(&sql, params);
+    let response = log::query(&ctx, &sql, operation).await?;
 
     Ok(ResolvedValue::new(
         response.into_single_row().map(|row| row.root).unwrap_or(Value::Null),

--- a/engine/crates/engine/src/registry/resolvers/postgres/request/find_one.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request/find_one.rs
@@ -1,3 +1,4 @@
+use super::{log, RowData};
 use crate::{
     registry::resolvers::{
         postgres::{
@@ -12,11 +13,6 @@ use grafbase_sql_ast::renderer::{self, Renderer};
 use postgres_types::transport::Transport;
 use serde_json::Value;
 
-#[derive(Debug, serde::Deserialize)]
-struct Response {
-    root: Value,
-}
-
 pub(super) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, Error> {
     let mut builder = SelectBuilder::new(ctx.table(), ctx.selection(), "root");
 
@@ -26,13 +22,9 @@ pub(super) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, E
 
     let (sql, params) = renderer::Postgres::build(query::select::build(builder)?);
 
-    let response = ctx
-        .transport()
-        .parameterized_query::<Response>(&sql, params)
-        .await
-        .map_err(|error| Error::new(error.to_string()))?;
+    let operation = ctx.transport().parameterized_query::<RowData>(&sql, params);
+    let response = log::query(&ctx, &sql, operation).await?;
+    let row = response.into_single_row().map(|row| row.root).unwrap_or(Value::Null);
 
-    Ok(ResolvedValue::new(
-        response.into_single_row().map(|row| row.root).unwrap_or(Value::Null),
-    ))
+    Ok(ResolvedValue::new(row))
 }

--- a/engine/crates/engine/src/registry/resolvers/postgres/request/log.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request/log.rs
@@ -1,0 +1,49 @@
+use std::future::Future;
+
+use common_types::LogEventType;
+use postgres_types::transport::QueryResponse;
+use runtime::log::LogEvent;
+
+use crate::{registry::resolvers::postgres::context::PostgresContext, Error};
+
+use super::RowData;
+
+pub(super) async fn query<F>(
+    ctx: &PostgresContext<'_>,
+    sql: &str,
+    operation: F,
+) -> crate::Result<QueryResponse<RowData>>
+where
+    F: Future<Output = postgres_types::Result<QueryResponse<RowData>>> + Send,
+{
+    let Some(log_endpoint_url) = ctx.fetch_log_endpoint_url()? else {
+        return operation.await.map_err(|error| Error::new(error.to_string()));
+    };
+
+    let request_id = ctx.ray_id()?;
+    let start_time = web_time::Instant::now();
+    let response = operation.await;
+    let duration = start_time.elapsed();
+
+    let body = response
+        .as_ref()
+        .ok()
+        .and_then(|response| serde_json::to_string(&response.clone_rows()).ok());
+
+    let r#type = LogEventType::SqlQuery {
+        successful: response.is_ok(),
+        sql: sql.to_string(),
+        duration,
+        body,
+    };
+
+    let log_event = LogEvent { request_id, r#type };
+
+    reqwest::Client::new()
+        .post(format!("{log_endpoint_url}/log-event"))
+        .json(&log_event)
+        .send()
+        .await?;
+
+    response.map_err(|error| Error::new(error.to_string()))
+}

--- a/engine/crates/postgres-types/src/transport.rs
+++ b/engine/crates/postgres-types/src/transport.rs
@@ -52,6 +52,13 @@ impl<T> QueryResponse<T> {
     pub fn into_single_row(self) -> Option<T> {
         self.into_rows().next()
     }
+
+    pub fn clone_rows(&self) -> Vec<T>
+    where
+        T: Clone,
+    {
+        self.rows.clone()
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Debug logs for Postgres queries and mutations. Only available for the CLI when running logs in debug mode, not a great idea to have these on production due to the queries having data we don't want in public logs.

![2023-10-12_14-10-1697113544](https://github.com/grafbase/grafbase/assets/34967/237149d1-f450-4ea0-b9c9-9e7b3b834e39)

Example shows two mutation queries: the first one errors, and the second one is successful and returns data.

Closes: GB-5065
