### PR TITLE
sdk: export type definition for authorizer arguments and return type

### DIFF
--- a/packages/grafbase-sdk/src/authorizer/context.ts
+++ b/packages/grafbase-sdk/src/authorizer/context.ts
@@ -1,0 +1,19 @@
+/**
+ * The type of the `context` argument in a [Custom Authorizer](https://grafbase.com/docs/auth/providers#custom-authorizer). 
+ *
+ * @example
+ * 
+ * // grafbase/authorizers/myJwt.ts
+ *
+ * import { AuthorizerContext, VerifiedIdentity } from '@grafbase/sdk'
+ *
+ * export default async ({ request }: AuthorizerContext): VerifiedIdentity? {
+ *   // ...
+ * }
+ */
+export type AuthorizerContext = {
+  /** The incoming HTTP request. */
+  request: {
+    headers: Record<string, string>
+  }
+}

--- a/packages/grafbase-sdk/src/authorizer/verifiedIdentity.ts
+++ b/packages/grafbase-sdk/src/authorizer/verifiedIdentity.ts
@@ -19,5 +19,5 @@ export type VerifiedIdentity = {
     groups?: string[]
     /** Extra, custom token claims. */
     [tokenClaim: string]: any
-	} 
+  } 
 }

--- a/packages/grafbase-sdk/src/authorizer/verifiedIdentity.ts
+++ b/packages/grafbase-sdk/src/authorizer/verifiedIdentity.ts
@@ -1,0 +1,23 @@
+/**
+ * The data returned by a [Custom Authorizer](https://grafbase.com/docs/auth/providers#custom-authorizer) when it can verify the identity of the incoming request.
+ *
+ * @example
+ * 
+ * // grafbase/authorizers/myJwt.ts
+ *
+ * import { AuthorizerContext, VerifiedIdentity } from '@grafbase/sdk'
+ *
+ * export default async ({ request }: AuthorizerContext): VerifiedIdentity? {
+ *   // ...
+ * }
+ */
+export type VerifiedIdentity = {
+  identity: {
+    /** The identity subject (= owner). */
+    sub?: string 
+    /** Groups the authentified request belongs to. */
+    groups?: string[]
+    /** Extra, custom token claims. */
+    [tokenClaim: string]: any
+	} 
+}

--- a/packages/grafbase-sdk/src/index.ts
+++ b/packages/grafbase-sdk/src/index.ts
@@ -15,6 +15,8 @@ import { PostgresParams, PartialPostgresAPI } from './connector/postgres'
 
 export { type ResolverContext as Context } from './resolver/context'
 export { type ResolverInfo as Info } from './resolver/info'
+export { type VerifiedIdentity } from './authorizer/verifiedIdentity'
+export { type AuthorizerContext } from './authorizer/context'
 
 dotenv.config({
   // must exist, defined by "~/.grafbase/parser/parse-config.ts"


### PR DESCRIPTION
# Description

It looks like this:

```typescript
// grafbase/authorizers/myJwt.ts

import { AuthorizerContext, VerifiedIdentity } from '@grafbase/sdk'

export default async ({ request }: AuthorizerContext): VerifiedIdentity? {
  // ...
}
```

Implements the [relevant section of the RFC](https://www.notion.so/grafbase/Typed-Resolvers-b4a0b47f4b5b4d2b9815e0aa82c6a8a8?pvs=4#51dd1771bc334f3094f9ce915c6a83d3).

Closes GB-5113

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
