### PR TITLE
Remove Send requirement from the Postgres query logger

### DIFF
--- a/engine/crates/engine/src/registry/resolvers/postgres/request/log.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request/log.rs
@@ -14,7 +14,7 @@ pub(super) async fn query<F>(
     operation: F,
 ) -> crate::Result<QueryResponse<RowData>>
 where
-    F: Future<Output = postgres_types::Result<QueryResponse<RowData>>> + Send,
+    F: Future<Output = postgres_types::Result<QueryResponse<RowData>>>,
 {
     let Some(log_endpoint_url) = ctx.fetch_log_endpoint_url()? else {
         return operation.await.map_err(|error| Error::new(error.to_string()));


### PR DESCRIPTION
Fixes problems in here https://github.com/grafbase/api/actions/runs/6506409579/job/17671891694?pr=2858

In wasm futures are not `Send`, so we cannot require that in the logger.