### PR TITLE
[DO NOT MERGE] fix(cli): implement grafbase binary selection on bun

### DIFF
--- a/cli/npm/cli/grafbase
+++ b/cli/npm/cli/grafbase
@@ -1,1 +1,6 @@
-This file is necessary to allow linking the grafbase binary
+#!/usr/bin/env node
+
+// With node.js and npm, this script is never executed: the postinstall lifecycle script is invoked by npm after installing the `grafbase` package, and this file is replaced with the appropriate platform-specific binary. The only role of this file is as a placeholder than can be replaced by the appropriate binary or a symlink to it.
+
+// Bun however [does not execute lifecycle scripts](https://bun.sh/docs/install/lifecycle) on dependencies. The next line is here so that on first invocation, the postinstall script is invoked and this file gets replaced by the appropriate binary.
+require('./postinstall');


### PR DESCRIPTION
When you try to run the grafbase CLI from npm with bun, for example with `bunx grafbase`, you get errors that look like this (linux):

```
error: Failed to run "grafbase" due to error InvalidExe
```

or like this (MacOS):

```
grafbase dev
/Users/fredrik/.bun/bin/grafbase: line 1: This: command not found
```

The `grafbase` npm package relies on a postinstall npm lifecycle hook to link or copy the right platform-native binary to
node_modules/grafbase/grafbase. Where bun is different is that it does not run postinstall hooks, or any lifecycle scripts for that matter (source: https://bun.sh/docs/install/lifecycle).

This commit is a slightly acrobatic attempt at solving this problem by replacing the placeholder `grafbase` file in the `grafbase` npm package with a script that will overwrite itself with the correct binary on first invocation. The script simply runs the postinstall hook as a regular import, since bun will not run it for us.

Part of GB-4936

# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
