### PR TITLE
examples: add a KV + typed resolver and authorizer example

### DIFF
--- a/examples/resolvers-kv/README.md
+++ b/examples/resolvers-kv/README.md
@@ -1,0 +1,11 @@
+# Resolvers using KV with typed context
+
+This examples shows how to use [KV from the `context` argument in Edge Resolvers](https://grafbase.com/docs/edge-gateway/resolvers#kv).
+
+## Getting Started
+
+1. Run `npx degit grafbase/grafbase/examples/resolvers-kv grafbase-with-resolvers-kv` to clone this example
+2. Change directory into the new folder `cd grafbase-with-resolvers-kv`
+3. Run `npx grafbase dev` to start local dev server with your schema
+4. Open [Pathfinder](http://localhost:4000)
+

--- a/examples/resolvers-kv/grafbase/auth/allowAll.ts
+++ b/examples/resolvers-kv/grafbase/auth/allowAll.ts
@@ -1,0 +1,10 @@
+import { AuthorizerContext, VerifiedIdentity } from '@grafbase/sdk'
+
+export default async function ({ request }: AuthorizerContext): Promise<VerifiedIdentity> {
+    console.log(JSON.stringify(request))
+    return {
+        identity: {
+            groups: ["all"]
+        }
+    }
+}

--- a/examples/resolvers-kv/grafbase/grafbase.config.ts
+++ b/examples/resolvers-kv/grafbase/grafbase.config.ts
@@ -1,0 +1,40 @@
+import { g, auth, config } from '@grafbase/sdk'
+
+// Welcome to Grafbase!
+// Define your data models, integrate auth, permission rules, custom resolvers, search, and more with Grafbase.
+
+// Integrate Auth
+// https://grafbase.com/docs/auth
+const authProvider = auth.Authorizer({
+    name: 'allowAll',
+})
+
+// Define Data Models
+// https://grafbase.com/docs/database
+
+g.model('Question', {
+    author: g.relation(() => user).optional(),
+    content: g.string(),
+    getAnswer: g.string().resolver('getAnswer')
+})
+
+const user = g.model('User', {
+    name: g.string(),
+    // Extend models with resolvers
+    // https://grafbase.com/docs/edge-gateway/resolvers
+})
+
+export default config({
+    schema: g,
+    // Integrate Auth
+    // https://grafbase.com/docs/auth
+    auth: {
+        providers: [authProvider],
+        rules: (rules) => {
+            rules.private()
+        }
+    },
+    experimental: {
+        kv: true
+    }
+})

--- a/examples/resolvers-kv/grafbase/resolvers/getAnswer.ts
+++ b/examples/resolvers-kv/grafbase/resolvers/getAnswer.ts
@@ -1,0 +1,6 @@
+import { Context, Info } from '@grafbase/sdk'
+
+export default async function(parent, _, { kv }: Context, info: Info) {
+    const { value } = await kv.get(`answers/${parent.id}`)
+    return `⚙️ Result of ${info.fieldName}: ${value}`
+}

--- a/examples/resolvers-kv/package-lock.json
+++ b/examples/resolvers-kv/package-lock.json
@@ -1,0 +1,69 @@
+{
+  "name": "resolvers-kv",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "resolvers-kv",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@types/node": "^20.8.5"
+      },
+      "devDependencies": {
+        "@grafbase/sdk": "~0.6.1"
+      }
+    },
+    "node_modules/@grafbase/sdk": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.6.8.tgz",
+      "integrity": "sha512-BkSrjulHb9+SEzRGxzefKICLaGCanTqrwap9n4Ar01y5EFbsW/LSc0orTiPyCMOefpePGhLOgRqAlnCZsWoEsw==",
+      "dev": true,
+      "dependencies": {
+        "dotenv": "^16.1.4",
+        "type-fest": "^3.9.0"
+      },
+      "engines": {
+        "node": ">=16.13.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.8.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.5.tgz",
+      "integrity": "sha512-SPlobFgbidfIeOYlzXiEjSYeIJiOCthv+9tSQVpvk4PAdIIc+2SmjNVzWXk9t0Y7dl73Zdf+OgXKHX9XtkqUpw==",
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.25.3",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
+      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA=="
+    }
+  }
+}

--- a/examples/resolvers-kv/package.json
+++ b/examples/resolvers-kv/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "resolvers-kv",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@grafbase/sdk": "~0.6.9",
+    "@types/node": "^20.8.5"
+  },
+  "dependencies": {
+  }
+}

--- a/packages/grafbase-sdk/src/authorizer/context.ts
+++ b/packages/grafbase-sdk/src/authorizer/context.ts
@@ -7,7 +7,7 @@
  *
  * import { AuthorizerContext, VerifiedIdentity } from '@grafbase/sdk'
  *
- * export default async ({ request }: AuthorizerContext): VerifiedIdentity? {
+ * export default async function({ request }: AuthorizerContext): VerifiedIdentity? {
  *   // ...
  * }
  */

--- a/packages/grafbase-sdk/src/authorizer/verifiedIdentity.ts
+++ b/packages/grafbase-sdk/src/authorizer/verifiedIdentity.ts
@@ -7,7 +7,7 @@
  *
  * import { AuthorizerContext, VerifiedIdentity } from '@grafbase/sdk'
  *
- * export default async ({ request }: AuthorizerContext): VerifiedIdentity? {
+ * export default async function({ request }: AuthorizerContext): VerifiedIdentity? {
  *   // ...
  * }
  */


### PR DESCRIPTION
I haven't found existing examples (in `/examples`) using KV, so this seemed like an opportunity. The original purpose of this PR is to have a working example of typed resolvers and authorizers with the recently added types from SDK, so we can link to it in the changelog.

It is very very basic and not much of a functioning app, feedback welcome.