### PR TITLE
feat: add federation key support to sdk

### DIFF
--- a/packages/grafbase-sdk/src/federation.ts
+++ b/packages/grafbase-sdk/src/federation.ts
@@ -13,3 +13,27 @@ export class Federation {
     return `\nextend schema @federation(version: "${this.version}")\n`
   }
 }
+
+export interface FederationKeyParameters {
+  resolvable?: boolean
+}
+
+const DefaultFederationParameters: FederationKeyParameters = {
+  resolvable: true
+}
+
+export class FederationKey {
+  private fields: string
+  private parameters: FederationKeyParameters
+
+  constructor(fields: string, parameters?: FederationKeyParameters) {
+    parameters = parameters || {}
+
+    this.fields = fields
+    this.parameters = { ...DefaultFederationParameters, ...parameters }
+  }
+
+  public toString(): string {
+    return `@key(fields: "${this.fields}" resolvable: ${this.parameters.resolvable})`
+  }
+}

--- a/packages/grafbase-sdk/tests/unit/types.test.ts
+++ b/packages/grafbase-sdk/tests/unit/types.test.ts
@@ -328,4 +328,28 @@ describe('Type generator', () => {
       }"
     `)
   })
+
+  it('supports federation keys', () => {
+    g.type('User', {
+      id: g.id()
+    }).key('id')
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+"type User @key(fields: "id" resolvable: true) {
+  id: ID!
+}"
+`)
+  })
+
+  it('supports unresolvable federation keys', () => {
+    g.type('User', {
+      id: g.id()
+    }).key('id', { resolvable: false })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+"type User @key(fields: "id" resolvable: false) {
+  id: ID!
+}"
+`)
+  })
 })


### PR DESCRIPTION
I added support for the `@key` directive to SDL in #790 - this adds the equivalent functionality into the SDK:


```typescript
g.type('User', {
  id: g.id()
}).key('id')
```