### PR TITLE
feat: pull the current SDK version from its package.json

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,10 +23,11 @@ keywords = ["grafbase"]
 repository = "https://github.com/grafbase/grafbase"
 
 [workspace.dependencies]
-futures-util = "0.3"
 axum = "0.6"
-ulid = { git = "https://github.com/grafbase/ulid-rs", rev = "6d06156193d51a2db3216f058cbfadd4923df2c7" }
+futures-util = "0.3"
+serde_json = "1"
 tokio = "1"
+ulid = { git = "https://github.com/grafbase/ulid-rs", rev = "6d06156193d51a2db3216f058cbfadd4923df2c7" }
 
 [profile.release]
 strip = "symbols"

--- a/cli/crates/cli/tests/init_ts.rs
+++ b/cli/crates/cli/tests/init_ts.rs
@@ -2,7 +2,7 @@
 mod utils;
 
 use backend::project::ConfigType;
-use serde_json::json;
+use serde_json::{json, Value};
 use utils::environment::Environment;
 
 #[test]
@@ -34,9 +34,12 @@ fn init_ts_existing_package_json() {
     assert!(env.directory.join("grafbase").exists());
     assert!(env.directory.join("grafbase").join("grafbase.config.ts").exists());
 
-    let package_json = env.load_file_from_project("package.json");
+    let package_json = serde_json::from_str::<Value>(&env.load_file_from_project("package.json")).expect("valid JSON");
 
-    insta::assert_snapshot!(&package_json, @r###"
+    insta::assert_json_snapshot!(&package_json, {
+      r#".devDependencies["@grafbase/sdk"]"# => "[version]"
+    },
+    @r###"
     {
       "name": "test",
       "version": "1.0.0",
@@ -46,7 +49,7 @@ fn init_ts_existing_package_json() {
       "author": "",
       "license": "ISC",
       "devDependencies": {
-        "@grafbase/sdk": "~0.6.1"
+        "@grafbase/sdk": "[version]"
       }
     }
     "###);
@@ -72,9 +75,12 @@ fn init_ts_new_project() {
     let package_json: serde_json::Value = serde_json::from_str(&env.load_file_from_project("package.json")).unwrap();
     let package_json = package_json.as_object().unwrap().get("devDependencies").unwrap();
 
-    insta::assert_json_snapshot!(&package_json, @r###"
+    insta::assert_json_snapshot!(&package_json, {
+      r#"["@grafbase/sdk"]"# => "[version]"
+    },
+    @r###"
     {
-      "@grafbase/sdk": "~0.6.1"
+      "@grafbase/sdk": "[version]"
     }
     "###);
 }

--- a/cli/crates/common/Cargo.toml
+++ b/cli/crates/common/Cargo.toml
@@ -23,3 +23,6 @@ thiserror = "1"
 ulid = { version = "1", features = ["serde"] }
 
 common-types = { path = "../../../engine/crates/common-types" }
+
+[build-dependencies]
+serde_json.workspace = true

--- a/cli/crates/common/build.rs
+++ b/cli/crates/common/build.rs
@@ -1,0 +1,13 @@
+use serde_json::Value;
+
+fn main() {
+    let sdk_package = serde_json::from_slice::<Value>(
+        &std::fs::read("../../../packages/grafbase-sdk/package.json")
+            .expect("to be able to read the SDKs package.json"),
+    )
+    .expect("the SDK package.json to be JSON");
+
+    let sdk_version = sdk_package["version"].as_str().expect("the version to be a string");
+
+    println!("cargo:rustc-env=GRAFBASE_SDK_PACKAGE_VERSION=~{sdk_version}");
+}

--- a/cli/crates/common/src/consts.rs
+++ b/cli/crates/common/src/consts.rs
@@ -33,7 +33,7 @@ pub const GRAFBASE_HOME: &str = "GRAFBASE_HOME";
 /// the name of the Grafbase SDK npm package
 pub const GRAFBASE_SDK_PACKAGE_NAME: &str = "@grafbase/sdk";
 /// the version string of the Grafbase SDK npm package
-pub const GRAFBASE_SDK_PACKAGE_VERSION: &str = "~0.6.1";
+pub const GRAFBASE_SDK_PACKAGE_VERSION: &str = env!("GRAFBASE_SDK_PACKAGE_VERSION");
 /// the package.json file name
 pub const PACKAGE_JSON_FILE_NAME: &str = "package.json";
 /// the package.json dev dependencies key


### PR DESCRIPTION
I released 0.7.0 of the SDK earlier, but forgot to update the `GRAFBASE_SDK_PACKAGE_VERSION` constant that the CLI uses to create package.json files.

This PR automates that process - instead of having a hardcoded constant we now read the package.json and populate the constant with whatever is in there.