### PR TITLE
Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.dockerignore
+.gitignore
+.github
+.git
+cli/target
+engine/target
+Dockerfile
+node_modules
+templates
+examples

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ WORKDIR /grafbase
 
 RUN apk add --no-cache nodejs npm
 
+RUN adduser -g wheel -D grafbase -h "/data" && mkdir -p /data && chown grafbase: /data
+USER grafbase
+
 COPY --from=build /grafbase/cli/target/release/grafbase /bin/grafbase
 
 ENTRYPOINT ["/bin/grafbase"]
@@ -26,3 +29,6 @@ ENTRYPOINT ["/bin/grafbase"]
 CMD ["start"]
 
 EXPOSE 4000
+
+VOLUME ["/data"]
+WORKDIR "/data"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Build
+FROM rust:1.73 AS build
+
+WORKDIR /grafbase
+
+COPY ./cli ./cli
+COPY ./engine ./engine
+
+COPY ./cli/Cargo.lock ./cli/Cargo.lock
+COPY ./cli/Cargo.toml ./cli/Cargo.toml
+COPY ./engine/Cargo.lock ./engine/Cargo.lock
+COPY ./engine/Cargo.toml ./engine/Cargo.toml
+
+WORKDIR /grafbase/cli
+
+RUN cargo build --release
+
+# Run
+FROM debian:bullseye AS run
+
+COPY --from=build /grafbase/cli/target/release/grafbase .
+
+CMD ["./grafbase", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ WORKDIR /grafbase/cli
 RUN cargo build --release
 
 # Run
-FROM debian:bullseye AS run
+FROM debian:bookworm AS run
+
+WORKDIR /grafbase
 
 COPY --from=build /grafbase/cli/target/release/grafbase .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ FROM alpine:3.18
 
 WORKDIR /grafbase
 
+RUN apk add --no-cache nodejs npm
+
 COPY --from=build /grafbase/cli/target/release/grafbase /bin/grafbase
 
 ENTRYPOINT ["/bin/grafbase"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ FROM debian:bookworm AS run
 
 WORKDIR /grafbase
 
-COPY --from=build /grafbase/cli/target/release/grafbase .
+COPY --from=build /grafbase/cli/target/release/grafbase /bin/grafbase
 
-CMD ["./grafbase", "start"]
+ENTRYPOINT ["/bin/grafbase"]
+
+CMD ["start"]
+
+EXPOSE 4000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,19 @@
 # Build
-FROM rust:1.73 AS build
+FROM rust:1.73-alpine3.18 AS build
 
 WORKDIR /grafbase
 
 COPY ./cli ./cli
 COPY ./engine ./engine
 
-COPY ./cli/Cargo.lock ./cli/Cargo.lock
-COPY ./cli/Cargo.toml ./cli/Cargo.toml
-COPY ./engine/Cargo.lock ./engine/Cargo.lock
-COPY ./engine/Cargo.toml ./engine/Cargo.toml
-
 WORKDIR /grafbase/cli
+
+RUN apk add --no-cache git musl-dev
 
 RUN cargo build --release
 
 # Run
-FROM debian:bookworm AS run
+FROM alpine:3.18
 
 WORKDIR /grafbase
 


### PR DESCRIPTION
# Description

Adds Dockerfile to enable running Grafbase in a container.

Currently the Dockerfile lives in the root folder because the cli and engine live at the same level. The engine folder should move to the cli folder along with the Dockerfile eventually.

To run the container locally with a grafbase folder containing the schema:
```
docker run --name grafbase -v "./grafbase:/grafbase" grafbase
```


TODO: ensure resolvers work.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
