### PR TITLE
feat(cli): include Pathfinder here instead of through CDN assets

### DIFF
--- a/.github/actions/cdn_assets/action.yml
+++ b/.github/actions/cdn_assets/action.yml
@@ -21,15 +21,15 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: |
         curl https://${{ inputs.cdn }}/cli/${{ inputs.assets_version }}.tar.gz --output assets.tar.gz --fail
-        curl https://${{ inputs.cdn }}/cli/pathfinder/static.tgz --output static.tgz --fail
-        tar -zxvf static.tgz
-        rm static.tgz
-        gunzip assets.tar.gz
-        tar -rf assets.tar static
-        rm -r static
-        gzip assets.tar
         cp assets.tar.gz crates/server/assets
         mkdir ~/.grafbase
         cp assets.tar.gz ~/.grafbase
         (cd ~/.grafbase && tar -xf assets.tar.gz)
         touch ~/.grafbase/version.txt
+
+    - name: Build cli-app
+      shell: bash
+      working-directory: './packages/cli-app'
+      run: |
+        npx pnpm i
+        npx pnpm run cli-app:build

--- a/.github/actions/cli_assets/action.yml
+++ b/.github/actions/cli_assets/action.yml
@@ -1,5 +1,5 @@
-name: Download CLI assets
-description: Download CLI assets from Grafbase CDN
+name: Download and build CLI assets
+description: Download and build CLI assets from Grafbase CDN and from source
 
 inputs:
   working-directory:

--- a/.github/workflows/cli-partial-release.yml
+++ b/.github/workflows/cli-partial-release.yml
@@ -54,8 +54,8 @@ jobs:
         with:
           cmd: yq '.env.ASSETS_VERSION' './.github/workflows/cli.yml'
 
-      - name: Fetch CDN assets
-        uses: ./.github/actions/cdn_assets
+      - name: Build CLI assets
+        uses: ./.github/actions/cli_assets
         with:
           cdn: ${{ steps.lookup-prod-assets.outputs.result }}
           assets_version: ${{ steps.lookup-assets-version.outputs.result }}

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -84,7 +84,7 @@ jobs:
           restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-dev
 
       - name: Prepare CLI assets
-        uses: ./.github/actions/cdn_assets
+        uses: ./.github/actions/cli_assets
         with:
           cdn: ${{ env.PROD_ASSETS }}
           assets_version: ${{ env.ASSETS_VERSION }}
@@ -114,7 +114,7 @@ jobs:
           restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-build
 
       - name: Fetch CDN assets
-        uses: ./.github/actions/cdn_assets
+        uses: ./.github/actions/cli_assets
         with:
           cdn: ${{ env.PROD_ASSETS }}
           assets_version: ${{ env.ASSETS_VERSION }}
@@ -144,7 +144,7 @@ jobs:
           restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release
 
       - name: Prepare CLI assets
-        uses: ./.github/actions/cdn_assets
+        uses: ./.github/actions/cli_assets
         with:
           cdn: ${{ env.PROD_ASSETS }}
           assets_version: ${{ env.ASSETS_VERSION }}
@@ -224,7 +224,7 @@ jobs:
           restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release
 
       - name: Prepare CLI assets
-        uses: ./.github/actions/cdn_assets
+        uses: ./.github/actions/cli_assets
         with:
           cdn: ${{ env.PROD_ASSETS }}
           assets_version: ${{ env.ASSETS_VERSION }}
@@ -291,7 +291,7 @@ jobs:
           restore-key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}
 
       - name: Prepare CLI assets
-        uses: ./.github/actions/cdn_assets
+        uses: ./.github/actions/cli_assets
         with:
           cdn: ${{ env.PROD_ASSETS }}
           assets_version: ${{ env.ASSETS_VERSION }}

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -83,7 +83,7 @@ jobs:
           cache-key: ${{ runner.os }}-${{ runner.arch }}-cargo-dev-${{ hashFiles('cli/Cargo.lock') }}
           restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-dev
 
-      - name: Fetch CDN assets
+      - name: Prepare CLI assets
         uses: ./.github/actions/cdn_assets
         with:
           cdn: ${{ env.PROD_ASSETS }}
@@ -143,7 +143,7 @@ jobs:
           cache-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release-${{ hashFiles('cli/Cargo.lock') }}
           restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release
 
-      - name: Fetch CDN assets
+      - name: Prepare CLI assets
         uses: ./.github/actions/cdn_assets
         with:
           cdn: ${{ env.PROD_ASSETS }}
@@ -223,7 +223,7 @@ jobs:
           cache-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release-${{ hashFiles('cli/Cargo.lock') }}
           restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release
 
-      - name: Fetch CDN assets
+      - name: Prepare CLI assets
         uses: ./.github/actions/cdn_assets
         with:
           cdn: ${{ env.PROD_ASSETS }}
@@ -290,7 +290,7 @@ jobs:
           cache-key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-cargo-release-${{ hashFiles('cli/Cargo.lock') }}
           restore-key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}
 
-      - name: Fetch CDN assets
+      - name: Prepare CLI assets
         uses: ./.github/actions/cdn_assets
         with:
           cdn: ${{ env.PROD_ASSETS }}

--- a/.github/workflows/sanitize-alert-schedule.yml
+++ b/.github/workflows/sanitize-alert-schedule.yml
@@ -32,8 +32,8 @@ jobs:
           platform: linux
           cache-key: ${{ runner.os }}-${{ runner.arch }}-cargo-dev-${{ hashFiles('cli/Cargo.lock') }}
 
-      - name: Fetch CDN assets
-        uses: ./.github/actions/cdn_assets
+      - name: Build CLI assets
+        uses: ./.github/actions/cli_assets
         with:
           cdn: ${{ env.PROD_ASSETS }}
           assets_version: ${{ env.ASSETS_VERSION }}

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1988,6 +1988,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
+ "libz-sys",
  "miniz_oxide 0.7.1",
 ]
 
@@ -3311,6 +3312,17 @@ name = "libsqlite3-sys"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
 dependencies = [
  "cc",
  "pkg-config",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,6 +25,8 @@ repository = "https://github.com/grafbase/grafbase"
 [workspace.dependencies]
 axum = "0.6"
 futures-util = "0.3"
+# Temporary change till https://github.com/alexcrichton/tar-rs/pull/319 is released
+tar = { git = "https://github.com/obmarg/tar-rs.git", rev = "bffee32190d531c03d806680daebd89cb1544be1" }
 serde_json = "1"
 tokio = "1"
 ulid = { git = "https://github.com/grafbase/ulid-rs", rev = "6d06156193d51a2db3216f058cbfadd4923df2c7" }

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -46,8 +46,7 @@ sqlx = { version = "0.7", features = [
 strip-ansi-escapes = "0.1"
 strum = { version = "0.25", features = ["derive"] }
 tantivy = { version = "0.19", default-features = false, features = ["mmap"] }
-# Temporary change till https://github.com/alexcrichton/tar-rs/pull/319 is release
-tar = { git = "https://github.com/obmarg/tar-rs.git", rev = "bffee32190d531c03d806680daebd89cb1544be1" }
+tar.workspace = true
 tempfile = "3"
 thiserror = "1"
 tokio = { workspace = true, features = ["full"] }
@@ -78,6 +77,11 @@ common-types = { path = "../../../engine/crates/common-types" }
 
 [dev-dependencies]
 serde_json = "1"
+
+[build-dependencies]
+flate2 = "1"
+tar.workspace = true
+tempfile = "3"
 
 [features]
 dynamodb = ["gateway/dynamodb"]

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -79,7 +79,7 @@ common-types = { path = "../../../engine/crates/common-types" }
 serde_json = "1"
 
 [build-dependencies]
-flate2 = "1"
+flate2 = { version = "1", features = ["zlib"] }
 tar.workspace = true
 tempfile = "3"
 

--- a/cli/crates/server/README.md
+++ b/cli/crates/server/README.md
@@ -1,1 +1,26 @@
 # Server
+
+## Building assets
+
+This crate includes non-rust assets. We are in the process of migrating the
+process to assemble the final `assets.tar.gz` embedded in the CLI binary to
+this repository.
+
+If you see errors related to the assets, please use the following sections to
+make sure the assets necessary to build the CLI are present.
+
+### Pathfinder
+
+If you see an error about not finding a bundled Pathfinder build to include in
+the CLI binary, you must either provide the
+`GRAFBASE_CLI_PATHFINDER_BUNDLE_PATH` environment variable or build the cli-app
+in this repository at the default location (`/packages/cli-app`).
+
+By default, you can go to [`packages/cli-app`] in this repo and run `pnpm run
+cli-app:build` to build the Pathfinder wrapper used by the CLI. This part of
+the CLI build should now succeed.
+
+### assets.tar.gz
+
+If you see a an error about including `assets.tar.gz`, you need to download a
+built version of this file. See the CLI [`Makefile.toml`](../../Makefile.toml).

--- a/cli/crates/server/build.rs
+++ b/cli/crates/server/build.rs
@@ -1,0 +1,88 @@
+#![allow(clippy::panic)] // this is a build script, an explicit panic is more readable than Result
+
+use std::{env, fs, io, path::Path};
+
+/// Env var name
+const GRAFBASE_CLI_PATHFINDER_BUNDLE_PATH: &str = "GRAFBASE_CLI_PATHFINDER_BUNDLE_PATH";
+const ASSETS_GZIP_PATH: &str = "./assets/assets.tar.gz";
+
+/// The path to the contents of the dist/ folder of a successful build of cli-app.
+fn find_pathfinder_bundle_location() -> String {
+    eprintln!("Making sure the pathfinder app is built...");
+    if let Ok(location) = env::var(GRAFBASE_CLI_PATHFINDER_BUNDLE_PATH) {
+        assert!(
+            fs::metadata(&location).is_ok(),
+            "The location specified in {GRAFBASE_CLI_PATHFINDER_BUNDLE_PATH} ({location} does ont exist."
+        );
+        return location;
+    }
+
+    let default_path = "../../../packages/cli-app/dist";
+
+    eprintln!("Using the default location for the pathfinder app...");
+    if fs::metadata(default_path).is_ok() {
+        return default_path.to_owned();
+    }
+
+    panic!(
+        r#"
+Could not find a bundled pathfinder to include in cli binary.
+
+You must either provide the GRAFBASE_CLI_PATHFINDER_BUNDLE_PATH environment variable or
+build the Pathfinder app at the default location.
+
+Please see the instructions in cli/crates/server/README.md.
+    "#
+    );
+}
+
+fn decompress_assets() -> io::Result<tempfile::TempDir> {
+    use flate2::bufread::GzDecoder;
+    let dir = tempfile::tempdir()?;
+    eprintln!("Decompressing the assets at `{ASSETS_GZIP_PATH}` from `server` crate build script.");
+    let file_reader = io::BufReader::new(fs::File::open(ASSETS_GZIP_PATH)?);
+    let assets_reader = GzDecoder::new(file_reader);
+    tar::Archive::new(assets_reader).unpack(dir.path())?;
+    Ok(dir)
+}
+
+fn recompress_assets(assets_path: &Path) -> io::Result<()> {
+    use flate2::{write::GzEncoder, Compression};
+
+    eprintln!("Reconstructing assets.tar.gz");
+    let out_file_path = Path::new(&env::var("OUT_DIR").unwrap()).join("assets.tar.gz");
+    eprintln!("   Creating {out_file_path:?}");
+    let out_file = fs::File::create(out_file_path)?;
+    let out = GzEncoder::new(out_file, Compression::default());
+    let mut tar_builder = tar::Builder::new(out);
+    tar_builder.mode(tar::HeaderMode::Deterministic);
+    eprintln!("   Adding {assets_path:?} to archive");
+    tar_builder.append_dir_all(".", assets_path).unwrap();
+    tar_builder.finish()?;
+
+    Ok(())
+}
+
+fn main() -> io::Result<()> {
+    let tmp_assets = decompress_assets()?;
+    let bundle_location = find_pathfinder_bundle_location();
+
+    eprintln!("Copying bundled pathfinder to the assets dir...");
+    let target_path = tmp_assets.path().join("static/assets");
+    fs::create_dir_all(&target_path)?;
+    for file in fs::read_dir(Path::new(&bundle_location).join("assets"))? {
+        let file_path = file?.path();
+        let dest_path = target_path.join(file_path.file_name().unwrap());
+        eprintln!("    {file_path:?} -> {dest_path:?}");
+        fs::copy(file_path, &dest_path)?;
+    }
+
+    recompress_assets(tmp_assets.path())?;
+
+    // Tell Cargo to rerun this script only if the assets or the pathfinder bundle changed.
+    println!("cargo:rerun-if-changed={bundle_location}");
+    println!("cargo:rerun-if-env-changed={GRAFBASE_CLI_PATHFINDER_BUNDLE_PATH}");
+    println!("cargo:rerun-if-changed={ASSETS_GZIP_PATH}");
+
+    Ok(())
+}

--- a/cli/crates/server/build.rs
+++ b/cli/crates/server/build.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::panic)] // this is a build script, an explicit panic is more readable than Result
 
-use std::{env, fs, io, path::Path};
+use std::{env, fs, io, path::Path, time};
 
 /// Env var name
 const GRAFBASE_CLI_PATHFINDER_BUNDLE_PATH: &str = "GRAFBASE_CLI_PATHFINDER_BUNDLE_PATH";
@@ -64,8 +64,18 @@ fn recompress_assets(assets_path: &Path) -> io::Result<()> {
 }
 
 fn main() -> io::Result<()> {
+    let start = time::Instant::now();
+
     let tmp_assets = decompress_assets()?;
+    eprintln!(
+        "⏱️ Timing after decompress_assets(): {:?}",
+        time::Instant::now().duration_since(start)
+    );
     let bundle_location = find_pathfinder_bundle_location();
+    eprintln!(
+        "⏱️ Timing after find_pathfinder_bundle_location(): {:?}",
+        time::Instant::now().duration_since(start)
+    );
 
     eprintln!("Copying bundled pathfinder to the assets dir...");
     let target_path = tmp_assets.path().join("static/assets");
@@ -76,8 +86,10 @@ fn main() -> io::Result<()> {
         eprintln!("    {file_path:?} -> {dest_path:?}");
         fs::copy(file_path, &dest_path)?;
     }
+    eprintln!("⏱️ Timing after copy: {:?}", time::Instant::now().duration_since(start));
 
     recompress_assets(tmp_assets.path())?;
+    eprintln!("⏱️ Timing after recompress: {:?}", time::Instant::now().duration_since(start));
 
     // Tell Cargo to rerun this script only if the assets or the pathfinder bundle changed.
     println!("cargo:rerun-if-changed={bundle_location}");

--- a/cli/crates/server/build.rs
+++ b/cli/crates/server/build.rs
@@ -89,7 +89,10 @@ fn main() -> io::Result<()> {
     eprintln!("⏱️ Timing after copy: {:?}", time::Instant::now().duration_since(start));
 
     recompress_assets(tmp_assets.path())?;
-    eprintln!("⏱️ Timing after recompress: {:?}", time::Instant::now().duration_since(start));
+    eprintln!(
+        "⏱️ Timing after recompress: {:?}",
+        time::Instant::now().duration_since(start)
+    );
 
     // Tell Cargo to rerun this script only if the assets or the pathfinder bundle changed.
     println!("cargo:rerun-if-changed={bundle_location}");

--- a/cli/crates/server/src/types.rs
+++ b/cli/crates/server/src/types.rs
@@ -1,7 +1,7 @@
 use common::types::{LogLevel, UdfKind};
 use std::path::PathBuf;
 
-pub const ASSETS_GZIP: &[u8] = include_bytes!("../assets/assets.tar.gz");
+pub const ASSETS_GZIP: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/assets.tar.gz"));
 
 #[derive(Clone, Copy, Debug)]
 pub enum RequestCompletedOutcome {

--- a/cli/crates/server/templates/pathfinder.hbs
+++ b/cli/crates/server/templates/pathfinder.hbs
@@ -7,34 +7,6 @@
     <link rel="stylesheet" href="{{ASSET_URL}}/assets/index.css" />
     <script>
       window.GRAPHQL_URL = '{{GRAPHQL_URL}}';
-      self['MonacoEnvironment'] = (function (paths) {
-        return {
-          globalAPI: false,
-          getWorkerUrl: function (moduleId, label) {
-            var result = paths[label];
-            if (/^((http:)|(https:)|(file:)|(\/\/))/.test(result)) {
-              var currentUrl = String(window.location);
-              var currentOrigin = currentUrl.substr(
-                0,
-                currentUrl.length -
-                  window.location.hash.length -
-                  window.location.search.length -
-                  window.location.pathname.length,
-              );
-              if (result.substring(0, currentOrigin.length) !== currentOrigin) {
-                var js = '/*' + label + '*/importScripts("' + result + '");';
-                var blob = new Blob([js], { type: 'application/javascript' });
-                return URL.createObjectURL(blob);
-              }
-            }
-            return result;
-          },
-        };
-      })({
-        json: '{{ASSET_URL}}/monacoeditorwork/json.worker.bundle.js',
-        editorWorkerService: '{{ASSET_URL}}/monacoeditorwork/editor.worker.bundle.js',
-        graphql: '{{ASSET_URL}}/monacoeditorwork/graphql.worker.bundle.js',
-      });
     </script>
     <script type="module" crossorigin src="{{ASSET_URL}}/assets/index.js"></script>
   </head>

--- a/cli/scripts/load-assets.sh
+++ b/cli/scripts/load-assets.sh
@@ -88,13 +88,6 @@ cd "$assets_dir"
 
 printf "Loading new assets: %s...\n" "$url"
 curl --fail "$url" -o assets.tar.gz
-curl https://assets.grafbase.com/cli/pathfinder/static.tgz --output static.tgz --fail
-tar -zxvf static.tgz
-rm static.tgz
-gunzip assets.tar.gz
-tar -rf assets.tar static
-rm -r static
-gzip assets.tar
 cat >"$assets_dir/.gitignore" <<EOM
 *
 !.gitignore


### PR DESCRIPTION
# Description

The CLI includes [Pathfinder](https://github.com/grafbase/pathfinder) as part of the `grafbase dev` workflow. A bundled build of Pathfinder is included in the assets file (`assets.tar.gz`) that is built locally when we iterate in this repo, and downloaded from a canonical source for CLI releases. The assets are included in the compiled CLI binaries, then decompressed to `~/.grafbase` when we start a server.

Before this commit, a bundled build of Pathfinder is included in the assets archive that is built and downloaded separately from this repo.

What this commit changes:

- the Pathfinder wrapper app (the `cli-app` package) moves from the website repo to this repo, under `packages/`.
- the Pathfinder build included in the CLI binary is built from source in this repo. **This makes updating Pathfinder much easier: we just bump the version in packages/cli-app/packages.json**.

This commit does not change how the assets archive that is included in the CLI is handled. It only adds the local build of pathfinder to that archive when the `server` crate is built, via a cargo build script.

The build script expects to find a built version of cli-app, either in the default location or at a path specified via `GRAFBASE_CLI_PATHFINDER_BUNDLE_PATH`. It will not try to build it itself — that can be done, but that felt like too much magic. On failure, it points to a relevant section in the README that explains why the error happens and how to build cli-app to remediate.

This approach lets us progressively move the contents and construction logic for `assets.tar.gz` from other repos to this repo, without changing how the assets are consumed.

Upsides:

- Incremental migration away from existing assets bundling
- Avoids introducing new include_bytes!() with their own unpacking logic. Keeps a single entry point for these files.
- Easy to iterate on locally (just iterate on and build cli-app)
- Easy to upgrade pathfinder (upgrade through cli-app package.json and package lock).

Downsides:

- The build scripts unpacks `assets.tar.gz`, adds pathfinder, then rebuilds the archive. We don't have the final built assets in an immutable location anymore. 
- Requires a JS project build to build the CLI
  - In development, you only need to build once.
  - The build process is documented and the error carefully points you to how to build.
  - If we want to move away from downloaded, pre-bundled assets that are built elsewhere, we will need to build the assets in this repo.
- Does more work at build time, potentially making builds slower.
  - The build script will only re-run if the bundle to include changed, it won't make iteration slower.

closes GB-4984

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
