### PR TITLE
fix(connector): Make Postgres mutations use explicit returning value

### DIFF
--- a/engine/crates/engine/src/registry/resolvers/postgres/request/create_many.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request/create_many.rs
@@ -2,14 +2,27 @@ use super::{log, query, RowData};
 use crate::registry::resolvers::{postgres::context::PostgresContext, ResolvedValue};
 use grafbase_sql_ast::renderer::{self, Renderer};
 use postgres_types::transport::Transport;
-use serde_json::Value;
 
 pub(crate) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, crate::Error> {
-    let (sql, params) = renderer::Postgres::build(query::insert::build(&ctx, ctx.create_many_input()?)?);
+    let input = ctx.create_many_input()?;
+    let (sql, params) = renderer::Postgres::build(query::insert::build(&ctx, input)?);
 
-    let operation = ctx.transport().parameterized_query::<RowData>(&sql, params);
-    let response = log::query(&ctx, &sql, operation).await?;
-    let rows = response.into_iter().map(|row| row.root).collect();
+    if ctx.mutation_is_returning() {
+        let operation = ctx.transport().parameterized_query::<RowData>(&sql, params);
+        let response = log::query(&ctx, &sql, operation).await?;
+        let rows: Vec<_> = response.into_iter().map(|row| row.root).collect();
+        let row_count = rows.len();
 
-    Ok(ResolvedValue::new(Value::Array(rows)))
+        Ok(ResolvedValue::new(serde_json::json!({
+            "returning": rows,
+            "rowCount": row_count,
+        })))
+    } else {
+        let operation = ctx.transport().parameterized_execute(&sql, params);
+        let row_count = log::execute(&ctx, &sql, operation).await?;
+
+        Ok(ResolvedValue::new(serde_json::json!({
+            "rowCount": row_count,
+        })))
+    }
 }

--- a/engine/crates/engine/src/registry/resolvers/postgres/request/create_one.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request/create_one.rs
@@ -12,9 +12,22 @@ use super::{log, RowData};
 pub(crate) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, crate::Error> {
     let (sql, params) = renderer::Postgres::build(query::insert::build(&ctx, [ctx.create_input()?])?);
 
-    let operation = ctx.transport().parameterized_query::<RowData>(&sql, params);
-    let rows = log::query(&ctx, &sql, operation).await?;
-    let row = rows.into_iter().next().map(|row| row.root).unwrap_or(Value::Null);
+    if ctx.mutation_is_returning() {
+        let operation = ctx.transport().parameterized_query::<RowData>(&sql, params);
+        let rows = log::query(&ctx, &sql, operation).await?;
+        let row = rows.into_iter().next().map(|row| row.root).unwrap_or(Value::Null);
+        let row_count = if row.is_null() { 0 } else { 1 };
 
-    Ok(ResolvedValue::new(row))
+        Ok(ResolvedValue::new(serde_json::json!({
+            "returning": row,
+            "rowCount": row_count,
+        })))
+    } else {
+        let operation = ctx.transport().parameterized_execute(&sql, params);
+        let row_count = log::execute(&ctx, &sql, operation).await?;
+
+        Ok(ResolvedValue::new(serde_json::json!({
+            "rowCount": row_count
+        })))
+    }
 }

--- a/engine/crates/engine/src/registry/resolvers/postgres/request/delete_many.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request/delete_many.rs
@@ -1,6 +1,5 @@
 use grafbase_sql_ast::renderer::{self, Renderer};
 use postgres_types::transport::Transport;
-use serde_json::Value;
 
 use crate::{
     registry::resolvers::{postgres::context::PostgresContext, ResolvedValue},
@@ -12,9 +11,22 @@ use super::{log, query, RowData};
 pub(crate) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, Error> {
     let (sql, params) = renderer::Postgres::build(query::delete::build(&ctx, ctx.filter()?)?);
 
-    let operation = ctx.transport().parameterized_query::<RowData>(&sql, params);
-    let response = log::query(&ctx, &sql, operation).await?;
-    let rows = response.into_iter().map(|row| row.root).collect();
+    if ctx.mutation_is_returning() {
+        let operation = ctx.transport().parameterized_query::<RowData>(&sql, params);
+        let response = log::query(&ctx, &sql, operation).await?;
+        let rows: Vec<_> = response.into_iter().map(|row| row.root).collect();
+        let row_count = rows.len();
 
-    Ok(ResolvedValue::new(Value::Array(rows)))
+        Ok(ResolvedValue::new(serde_json::json!({
+            "returning": rows,
+            "rowCount": row_count,
+        })))
+    } else {
+        let operation = ctx.transport().parameterized_execute(&sql, params);
+        let row_count = log::execute(&ctx, &sql, operation).await?;
+
+        Ok(ResolvedValue::new(serde_json::json!({
+            "rowCount": row_count,
+        })))
+    }
 }

--- a/engine/crates/engine/src/registry/resolvers/postgres/request/delete_one.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request/delete_one.rs
@@ -11,10 +11,24 @@ use super::{log, query, RowData};
 
 pub(crate) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, Error> {
     let (sql, params) = renderer::Postgres::build(query::delete::build(&ctx, ctx.by_filter()?)?);
-    let operation = ctx.transport().parameterized_query::<RowData>(&sql, params);
-    let rows = log::query(&ctx, &sql, operation).await?;
 
-    Ok(ResolvedValue::new(
-        rows.into_iter().next().map(|row| row.root).unwrap_or(Value::Null),
-    ))
+    if ctx.mutation_is_returning() {
+        let operation = ctx.transport().parameterized_query::<RowData>(&sql, params);
+        let rows = log::query(&ctx, &sql, operation).await?;
+        let row = rows.into_iter().next().map(|row| row.root).unwrap_or(Value::Null);
+
+        let row_count = if row.is_null() { 0 } else { 1 };
+
+        Ok(ResolvedValue::new(serde_json::json!({
+            "returning": row,
+            "rowCount": row_count,
+        })))
+    } else {
+        let operation = ctx.transport().parameterized_execute(&sql, params);
+        let row_count = log::execute(&ctx, &sql, operation).await?;
+
+        Ok(ResolvedValue::new(serde_json::json!({
+            "rowCount": row_count,
+        })))
+    }
 }

--- a/engine/crates/engine/src/registry/resolvers/postgres/request/query/delete.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request/query/delete.rs
@@ -3,23 +3,26 @@ use grafbase_sql_ast::ast::{json_build_object, Aliasable, Column, ConditionTree,
 
 pub fn build<'a>(ctx: &'a PostgresContext<'a>, filter: FilterIterator<'a>) -> Result<Delete<'a>, crate::Error> {
     let sql_table = Table::from((ctx.table().schema(), ctx.table().database_name())).alias(ctx.table().database_name());
-    let mut returning = Vec::new();
-
-    for selection in ctx.selection() {
-        match selection? {
-            TableSelection::Column(column) => {
-                returning.push((column.database_name(), Column::from(column.database_name())));
-            }
-            // our output type doesn't have relations, so this is never reachable
-            TableSelection::JoinMany(..) | TableSelection::JoinUnique(..) => {
-                unreachable!("we cannot join in a delete statement")
-            }
-        }
-    }
-
     let mut query = Delete::from_table(sql_table);
     query.so_that(filter.fold(ConditionTree::NoCondition, ConditionTree::and));
-    query.returning([json_build_object(returning).alias("root")]);
+
+    if let Some(selection) = ctx.returning_selection() {
+        let mut returning = Vec::new();
+
+        for selection in selection {
+            match selection? {
+                TableSelection::Column(column) => {
+                    returning.push((column.database_name(), Column::from(column.database_name())));
+                }
+                // our output type doesn't have relations, so this is never reachable
+                TableSelection::JoinMany(..) | TableSelection::JoinUnique(..) => {
+                    unreachable!("we cannot join in a delete statement")
+                }
+            }
+        }
+
+        query.returning([json_build_object(returning).alias("root")]);
+    }
 
     Ok(query)
 }

--- a/engine/crates/engine/src/registry/resolvers/postgres/request/query/update.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request/query/update.rs
@@ -1,10 +1,10 @@
 use grafbase_sql_ast::ast::{
-    json_build_object, Aliasable, Column, CommonTableExpression, ConditionTree, Select, Update,
+    json_build_object, Aliasable, Column, CommonTableExpression, ConditionTree, Query, Select, Update,
 };
 
 use crate::registry::resolvers::postgres::context::{FilterIterator, PostgresContext, TableSelection, UpdateInputItem};
 
-pub fn build<'a>(ctx: &'a PostgresContext<'a>, filter: FilterIterator<'a>) -> Result<Select<'a>, crate::Error> {
+pub fn build<'a>(ctx: &'a PostgresContext<'a>, filter: FilterIterator<'a>) -> Result<Query<'a>, crate::Error> {
     let mut update = Update::table(ctx.table().database_name());
     update.so_that(filter.fold(ConditionTree::NoCondition, ConditionTree::and));
 
@@ -14,33 +14,37 @@ pub fn build<'a>(ctx: &'a PostgresContext<'a>, filter: FilterIterator<'a>) -> Re
         }
     }
 
-    let update_name = format!("{}_{}_update", ctx.table().schema(), ctx.table().database_name());
+    if let Some(selection) = ctx.returning_selection() {
+        let update_name = format!("{}_{}_update", ctx.table().schema(), ctx.table().database_name());
 
-    let mut returning = Vec::new();
-    let mut selected_data = Vec::new();
+        let mut returning = Vec::new();
+        let mut selected_data = Vec::new();
 
-    for selection in ctx.selection() {
-        match selection? {
-            TableSelection::Column(column) => {
-                selected_data.push((
-                    column.database_name(),
-                    Column::from((update_name.clone(), column.database_name())),
-                ));
+        for selection in selection {
+            match selection? {
+                TableSelection::Column(column) => {
+                    selected_data.push((
+                        column.database_name(),
+                        Column::from((update_name.clone(), column.database_name())),
+                    ));
 
-                returning.push(column.database_name());
-            }
-            // we will not have relations in the first phase
-            TableSelection::JoinUnique(..) | TableSelection::JoinMany(..) => {
-                todo!("we'll get back to this with nested updates")
+                    returning.push(column.database_name());
+                }
+                // we will not have relations in the first phase
+                TableSelection::JoinUnique(..) | TableSelection::JoinMany(..) => {
+                    todo!("we'll get back to this with nested updates")
+                }
             }
         }
+
+        update.returning(returning);
+
+        let mut select = Select::from_table(update_name.clone());
+        select.with(CommonTableExpression::new(update_name, update));
+        select.value(json_build_object(selected_data).alias("root"));
+
+        Ok(Query::from(select))
+    } else {
+        Ok(Query::from(update))
     }
-
-    update.returning(returning);
-
-    let mut select = Select::from_table(update_name.clone());
-    select.with(CommonTableExpression::new(update_name, update));
-    select.value(json_build_object(selected_data).alias("root"));
-
-    Ok(select)
 }

--- a/engine/crates/engine/src/registry/resolvers/postgres/request/update_many.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request/update_many.rs
@@ -1,26 +1,31 @@
+use super::{log, RowData};
 use grafbase_sql_ast::renderer::{self, Renderer};
 use postgres_types::transport::Transport;
-use serde_json::Value;
 
 use crate::registry::resolvers::{
     postgres::{context::PostgresContext, request::query},
     ResolvedValue,
 };
 
-#[derive(Debug, serde::Deserialize)]
-struct Response {
-    root: Value,
-}
-
 pub(crate) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, crate::Error> {
     let (sql, params) = renderer::Postgres::build(query::update::build(&ctx, ctx.filter()?)?);
 
-    let response = ctx
-        .transport()
-        .parameterized_query::<Response>(&sql, params)
-        .await
-        .map_err(|error| crate::Error::new(error.to_string()))?;
+    if ctx.mutation_is_returning() {
+        let operation = ctx.transport().parameterized_query::<RowData>(&sql, params);
+        let response = log::query(&ctx, &sql, operation).await?;
+        let rows: Vec<_> = response.into_iter().map(|row| row.root).collect();
+        let row_count = rows.len();
 
-    let rows = response.into_iter().map(|row| row.root).collect();
-    Ok(ResolvedValue::new(Value::Array(rows)))
+        Ok(ResolvedValue::new(serde_json::json!({
+            "returning": rows,
+            "rowCount": row_count,
+        })))
+    } else {
+        let operation = ctx.transport().parameterized_execute(&sql, params);
+        let row_count = log::execute(&ctx, &sql, operation).await?;
+
+        Ok(ResolvedValue::new(serde_json::json!({
+            "rowCount": row_count,
+        })))
+    }
 }

--- a/engine/crates/engine/src/registry/resolvers/postgres/request/update_one.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/request/update_one.rs
@@ -1,3 +1,4 @@
+use super::{log, RowData};
 use grafbase_sql_ast::renderer::{self, Renderer};
 use postgres_types::transport::Transport;
 use serde_json::Value;
@@ -7,21 +8,27 @@ use crate::registry::resolvers::{
     ResolvedValue,
 };
 
-#[derive(Debug, serde::Deserialize)]
-struct Response {
-    root: Value,
-}
-
 pub(crate) async fn execute(ctx: PostgresContext<'_>) -> Result<ResolvedValue, crate::Error> {
     let (sql, params) = renderer::Postgres::build(query::update::build(&ctx, ctx.by_filter()?)?);
 
-    let response = ctx
-        .transport()
-        .parameterized_query::<Response>(&sql, params)
-        .await
-        .map_err(|error| crate::Error::new(error.to_string()))?;
+    if ctx.mutation_is_returning() {
+        let operation = ctx.transport().parameterized_query::<RowData>(&sql, params);
 
-    Ok(ResolvedValue::new(
-        response.into_iter().next().map(|row| row.root).unwrap_or(Value::Null),
-    ))
+        let response = log::query(&ctx, &sql, operation).await?;
+        let row = response.into_iter().next().map(|row| row.root).unwrap_or(Value::Null);
+        let row_count = if row.is_null() { 0 } else { 1 };
+
+        Ok(ResolvedValue::new(serde_json::json!({
+            "returning": row,
+            "rowCount": row_count,
+        })))
+    } else {
+        let operation = ctx.transport().parameterized_execute(&sql, params);
+
+        let row_count = log::execute(&ctx, &sql, operation).await?;
+
+        Ok(ResolvedValue::new(serde_json::json!({
+            "rowCount": row_count,
+        })))
+    }
 }

--- a/engine/crates/integration-tests/tests/postgres/create_one/types.rs
+++ b/engine/crates/integration-tests/tests/postgres/create_one/types.rs
@@ -17,7 +17,7 @@ fn char() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "Musti" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -33,7 +33,9 @@ fn char() {
         {
           "data": {
             "userCreate": {
-              "val": "Musti"
+              "returning": {
+                "val": "Musti"
+              }
             }
           }
         }"#]];
@@ -56,7 +58,7 @@ fn char_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["Musti", "Naukio"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -72,10 +74,12 @@ fn char_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "Musti ",
-                "Naukio"
-              ]
+              "returning": {
+                "val": [
+                  "Musti ",
+                  "Naukio"
+                ]
+              }
             }
           }
         }"#]];
@@ -98,7 +102,7 @@ fn name() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "Musti" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -114,7 +118,9 @@ fn name() {
         {
           "data": {
             "userCreate": {
-              "val": "Musti"
+              "returning": {
+                "val": "Musti"
+              }
             }
           }
         }"#]];
@@ -137,7 +143,7 @@ fn name_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["Musti", "Naukio"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -153,10 +159,12 @@ fn name_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "Musti",
-                "Naukio"
-              ]
+              "returning": {
+                "val": [
+                  "Musti",
+                  "Naukio"
+                ]
+              }
             }
           }
         }"#]];
@@ -179,7 +187,7 @@ fn text() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "Musti" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -195,7 +203,9 @@ fn text() {
         {
           "data": {
             "userCreate": {
-              "val": "Musti"
+              "returning": {
+                "val": "Musti"
+              }
             }
           }
         }"#]];
@@ -218,7 +228,7 @@ fn text_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["Musti", "Naukio"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -234,10 +244,12 @@ fn text_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "Musti",
-                "Naukio"
-              ]
+              "returning": {
+                "val": [
+                  "Musti",
+                  "Naukio"
+                ]
+              }
             }
           }
         }"#]];
@@ -260,7 +272,7 @@ fn xml() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "<html></html>" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -276,7 +288,9 @@ fn xml() {
         {
           "data": {
             "userCreate": {
-              "val": "<html></html>"
+              "returning": {
+                "val": "<html></html>"
+              }
             }
           }
         }"#]];
@@ -299,7 +313,7 @@ fn xml_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["<html></html>", "<head></head>"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -315,10 +329,12 @@ fn xml_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "<html></html>",
-                "<head></head>"
-              ]
+              "returning": {
+                "val": [
+                  "<html></html>",
+                  "<head></head>"
+                ]
+              }
             }
           }
         }"#]];
@@ -341,7 +357,7 @@ fn cidr() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "0.0.0.0/0" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -357,7 +373,9 @@ fn cidr() {
         {
           "data": {
             "userCreate": {
-              "val": "0.0.0.0/0"
+              "returning": {
+                "val": "0.0.0.0/0"
+              }
             }
           }
         }"#]];
@@ -380,7 +398,7 @@ fn cidr_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["0.0.0.0/0", "192.168.0.0/32"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -396,10 +414,12 @@ fn cidr_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "0.0.0.0/0",
-                "192.168.0.0/32"
-              ]
+              "returning": {
+                "val": [
+                  "0.0.0.0/0",
+                  "192.168.0.0/32"
+                ]
+              }
             }
           }
         }"#]];
@@ -422,7 +442,7 @@ fn macaddr8() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "08:00:2b:01:02:03:04:05" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -438,7 +458,9 @@ fn macaddr8() {
         {
           "data": {
             "userCreate": {
-              "val": "08:00:2b:01:02:03:04:05"
+              "returning": {
+                "val": "08:00:2b:01:02:03:04:05"
+              }
             }
           }
         }"#]];
@@ -461,7 +483,7 @@ fn macaddr8_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["08:00:2b:01:02:03:04:05", "08002b:0102030405"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -477,10 +499,12 @@ fn macaddr8_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "08:00:2b:01:02:03:04:05",
-                "08:00:2b:01:02:03:04:05"
-              ]
+              "returning": {
+                "val": [
+                  "08:00:2b:01:02:03:04:05",
+                  "08:00:2b:01:02:03:04:05"
+                ]
+              }
             }
           }
         }"#]];
@@ -503,7 +527,7 @@ fn macaddr() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "08:00:2b:01:02:03" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -519,7 +543,9 @@ fn macaddr() {
         {
           "data": {
             "userCreate": {
-              "val": "08:00:2b:01:02:03"
+              "returning": {
+                "val": "08:00:2b:01:02:03"
+              }
             }
           }
         }"#]];
@@ -542,7 +568,7 @@ fn macaddr_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["08:00:2b:01:02:03", "08:00:2b:01:02:04"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -558,10 +584,12 @@ fn macaddr_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "08:00:2b:01:02:03",
-                "08:00:2b:01:02:04"
-              ]
+              "returning": {
+                "val": [
+                  "08:00:2b:01:02:03",
+                  "08:00:2b:01:02:04"
+                ]
+              }
             }
           }
         }"#]];
@@ -584,7 +612,7 @@ fn bpchar() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "Musti" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -600,7 +628,9 @@ fn bpchar() {
         {
           "data": {
             "userCreate": {
-              "val": "Musti"
+              "returning": {
+                "val": "Musti"
+              }
             }
           }
         }"#]];
@@ -623,7 +653,7 @@ fn bpchar_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["Musti", "Naukio"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -639,10 +669,12 @@ fn bpchar_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "Musti ",
-                "Naukio"
-              ]
+              "returning": {
+                "val": [
+                  "Musti ",
+                  "Naukio"
+                ]
+              }
             }
           }
         }"#]];
@@ -665,7 +697,7 @@ fn varchar() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "Musti" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -681,7 +713,9 @@ fn varchar() {
         {
           "data": {
             "userCreate": {
-              "val": "Musti"
+              "returning": {
+                "val": "Musti"
+              }
             }
           }
         }"#]];
@@ -704,7 +738,7 @@ fn varchar_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["Musti", "Naukio"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -720,10 +754,12 @@ fn varchar_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "Musti",
-                "Naukio"
-              ]
+              "returning": {
+                "val": [
+                  "Musti",
+                  "Naukio"
+                ]
+              }
             }
           }
         }"#]];
@@ -746,7 +782,7 @@ fn bit() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "010" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -762,7 +798,9 @@ fn bit() {
         {
           "data": {
             "userCreate": {
-              "val": "010"
+              "returning": {
+                "val": "010"
+              }
             }
           }
         }"#]];
@@ -785,7 +823,7 @@ fn bit_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["010", "101"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -801,10 +839,12 @@ fn bit_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "010",
-                "101"
-              ]
+              "returning": {
+                "val": [
+                  "010",
+                  "101"
+                ]
+              }
             }
           }
         }"#]];
@@ -827,7 +867,7 @@ fn varbit() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "010" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -843,7 +883,9 @@ fn varbit() {
         {
           "data": {
             "userCreate": {
-              "val": "010"
+              "returning": {
+                "val": "010"
+              }
             }
           }
         }"#]];
@@ -866,7 +908,7 @@ fn varbit_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["010", "101"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -882,10 +924,12 @@ fn varbit_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "010",
-                "101"
-              ]
+              "returning": {
+                "val": [
+                  "010",
+                  "101"
+                ]
+              }
             }
           }
         }"#]];
@@ -908,7 +952,7 @@ fn int2() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: 420 }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -924,7 +968,9 @@ fn int2() {
         {
           "data": {
             "userCreate": {
-              "val": 420
+              "returning": {
+                "val": 420
+              }
             }
           }
         }"#]];
@@ -947,7 +993,7 @@ fn int2_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: [1, 2] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -963,10 +1009,12 @@ fn int2_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                1,
-                2
-              ]
+              "returning": {
+                "val": [
+                  1,
+                  2
+                ]
+              }
             }
           }
         }"#]];
@@ -989,7 +1037,7 @@ fn int4() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: 420 }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1005,7 +1053,9 @@ fn int4() {
         {
           "data": {
             "userCreate": {
-              "val": 420
+              "returning": {
+                "val": 420
+              }
             }
           }
         }"#]];
@@ -1028,7 +1078,7 @@ fn int4_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: [1, 2] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1044,10 +1094,12 @@ fn int4_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                1,
-                2
-              ]
+              "returning": {
+                "val": [
+                  1,
+                  2
+                ]
+              }
             }
           }
         }"#]];
@@ -1070,7 +1122,7 @@ fn int8() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "420" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1086,7 +1138,9 @@ fn int8() {
         {
           "data": {
             "userCreate": {
-              "val": "420"
+              "returning": {
+                "val": "420"
+              }
             }
           }
         }"#]];
@@ -1109,7 +1163,7 @@ fn int8_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["1", "2"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1125,10 +1179,12 @@ fn int8_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "1",
-                "2"
-              ]
+              "returning": {
+                "val": [
+                  "1",
+                  "2"
+                ]
+              }
             }
           }
         }"#]];
@@ -1151,7 +1207,7 @@ fn oid() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "420" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1167,7 +1223,9 @@ fn oid() {
         {
           "data": {
             "userCreate": {
-              "val": "420"
+              "returning": {
+                "val": "420"
+              }
             }
           }
         }"#]];
@@ -1190,7 +1248,7 @@ fn oid_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["1", "2"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1206,10 +1264,12 @@ fn oid_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "1",
-                "2"
-              ]
+              "returning": {
+                "val": [
+                  "1",
+                  "2"
+                ]
+              }
             }
           }
         }"#]];
@@ -1232,7 +1292,7 @@ fn json() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: { foo: 1 } }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1248,8 +1308,10 @@ fn json() {
         {
           "data": {
             "userCreate": {
-              "val": {
-                "foo": 1
+              "returning": {
+                "val": {
+                  "foo": 1
+                }
               }
             }
           }
@@ -1273,7 +1335,7 @@ fn json_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: [{ foo: 1 }, { bar: 2 }] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1289,14 +1351,16 @@ fn json_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                {
-                  "foo": 1
-                },
-                {
-                  "bar": 2
-                }
-              ]
+              "returning": {
+                "val": [
+                  {
+                    "foo": 1
+                  },
+                  {
+                    "bar": 2
+                  }
+                ]
+              }
             }
           }
         }"#]];
@@ -1319,7 +1383,7 @@ fn jsonb() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: { foo: 1 } }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1335,8 +1399,10 @@ fn jsonb() {
         {
           "data": {
             "userCreate": {
-              "val": {
-                "foo": 1
+              "returning": {
+                "val": {
+                  "foo": 1
+                }
               }
             }
           }
@@ -1360,7 +1426,7 @@ fn jsonb_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: [{ foo: 1 }, { bar: 2 }] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1376,14 +1442,16 @@ fn jsonb_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                {
-                  "foo": 1
-                },
-                {
-                  "bar": 2
-                }
-              ]
+              "returning": {
+                "val": [
+                  {
+                    "foo": 1
+                  },
+                  {
+                    "bar": 2
+                  }
+                ]
+              }
             }
           }
         }"#]];
@@ -1406,7 +1474,7 @@ fn money() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "1.23" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1422,7 +1490,9 @@ fn money() {
         {
           "data": {
             "userCreate": {
-              "val": "$1.23"
+              "returning": {
+                "val": "$1.23"
+              }
             }
           }
         }"#]];
@@ -1445,7 +1515,7 @@ fn money_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["1.23", "3.14"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1461,10 +1531,12 @@ fn money_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "$1.23",
-                "$3.14"
-              ]
+              "returning": {
+                "val": [
+                  "$1.23",
+                  "$3.14"
+                ]
+              }
             }
           }
         }"#]];
@@ -1487,7 +1559,7 @@ fn numeric() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "1.23" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1503,7 +1575,9 @@ fn numeric() {
         {
           "data": {
             "userCreate": {
-              "val": "1.23"
+              "returning": {
+                "val": "1.23"
+              }
             }
           }
         }"#]];
@@ -1526,7 +1600,7 @@ fn numeric_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["1.23", "3.14"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1542,10 +1616,12 @@ fn numeric_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "1.23",
-                "3.14"
-              ]
+              "returning": {
+                "val": [
+                  "1.23",
+                  "3.14"
+                ]
+              }
             }
           }
         }"#]];
@@ -1568,7 +1644,7 @@ fn float4() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: 3.14 }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1584,7 +1660,9 @@ fn float4() {
         {
           "data": {
             "userCreate": {
-              "val": 3.14
+              "returning": {
+                "val": 3.14
+              }
             }
           }
         }"#]];
@@ -1607,7 +1685,7 @@ fn float4_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: [3.14, 1.23] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1623,10 +1701,12 @@ fn float4_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                3.14,
-                1.23
-              ]
+              "returning": {
+                "val": [
+                  3.14,
+                  1.23
+                ]
+              }
             }
           }
         }"#]];
@@ -1649,7 +1729,7 @@ fn float8() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: 3.14 }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1665,7 +1745,9 @@ fn float8() {
         {
           "data": {
             "userCreate": {
-              "val": 3.14
+              "returning": {
+                "val": 3.14
+              }
             }
           }
         }"#]];
@@ -1688,7 +1770,7 @@ fn float8_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: [3.14, 1.23] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1704,10 +1786,12 @@ fn float8_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                3.14,
-                1.23
-              ]
+              "returning": {
+                "val": [
+                  3.14,
+                  1.23
+                ]
+              }
             }
           }
         }"#]];
@@ -1730,7 +1814,7 @@ fn time() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "16:20:00" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1746,7 +1830,9 @@ fn time() {
         {
           "data": {
             "userCreate": {
-              "val": "16:20:00"
+              "returning": {
+                "val": "16:20:00"
+              }
             }
           }
         }"#]];
@@ -1769,7 +1855,7 @@ fn time_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["16:20:00", "04:20:00"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1785,10 +1871,12 @@ fn time_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "16:20:00",
-                "04:20:00"
-              ]
+              "returning": {
+                "val": [
+                  "16:20:00",
+                  "04:20:00"
+                ]
+              }
             }
           }
         }"#]];
@@ -1811,7 +1899,7 @@ fn timetz() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "16:20:00+00" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1827,7 +1915,9 @@ fn timetz() {
         {
           "data": {
             "userCreate": {
-              "val": "16:20:00+00"
+              "returning": {
+                "val": "16:20:00+00"
+              }
             }
           }
         }"#]];
@@ -1850,7 +1940,7 @@ fn timetz_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["16:20:00+00", "04:20:00Z"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1866,10 +1956,12 @@ fn timetz_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "16:20:00+00",
-                "04:20:00+00"
-              ]
+              "returning": {
+                "val": [
+                  "16:20:00+00",
+                  "04:20:00+00"
+                ]
+              }
             }
           }
         }"#]];
@@ -1892,7 +1984,7 @@ fn bool() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: true }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1908,7 +2000,9 @@ fn bool() {
         {
           "data": {
             "userCreate": {
-              "val": true
+              "returning": {
+                "val": true
+              }
             }
           }
         }"#]];
@@ -1931,7 +2025,7 @@ fn bool_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: [true, false] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1947,10 +2041,12 @@ fn bool_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                true,
-                false
-              ]
+              "returning": {
+                "val": [
+                  true,
+                  false
+                ]
+              }
             }
           }
         }"#]];
@@ -1973,7 +2069,7 @@ fn bytea() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "XHg0NDQ1NDE0NDQyNDU0NTQ2" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -1989,7 +2085,9 @@ fn bytea() {
         {
           "data": {
             "userCreate": {
-              "val": "XHg0NDQ1NDE0NDQyNDU0NTQ2"
+              "returning": {
+                "val": "XHg0NDQ1NDE0NDQyNDU0NTQ2"
+              }
             }
           }
         }"#]];
@@ -2012,7 +2110,7 @@ fn bytea_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["XHg0NDQ1NDE0NDQyNDU0NTQ2", "XHg0NDQ1NDE0NDQyNDU0NTQ3"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -2028,10 +2126,12 @@ fn bytea_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "XHg0NDQ1NDE0NDQyNDU0NTQ2",
-                "XHg0NDQ1NDE0NDQyNDU0NTQ3"
-              ]
+              "returning": {
+                "val": [
+                  "XHg0NDQ1NDE0NDQyNDU0NTQ2",
+                  "XHg0NDQ1NDE0NDQyNDU0NTQ3"
+                ]
+              }
             }
           }
         }"#]];
@@ -2054,7 +2154,7 @@ fn inet() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "192.168.0.1" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -2070,7 +2170,9 @@ fn inet() {
         {
           "data": {
             "userCreate": {
-              "val": "192.168.0.1"
+              "returning": {
+                "val": "192.168.0.1"
+              }
             }
           }
         }"#]];
@@ -2093,7 +2195,7 @@ fn inet_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["192.168.0.1", "10.0.0.1"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -2109,10 +2211,12 @@ fn inet_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "192.168.0.1",
-                "10.0.0.1"
-              ]
+              "returning": {
+                "val": [
+                  "192.168.0.1",
+                  "10.0.0.1"
+                ]
+              }
             }
           }
         }"#]];
@@ -2135,7 +2239,7 @@ fn date() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "1999-01-08" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -2151,7 +2255,9 @@ fn date() {
         {
           "data": {
             "userCreate": {
-              "val": "1999-01-08"
+              "returning": {
+                "val": "1999-01-08"
+              }
             }
           }
         }"#]];
@@ -2174,7 +2280,7 @@ fn date_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["1999-01-08", "1999-01-09"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -2190,10 +2296,12 @@ fn date_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "1999-01-08",
-                "1999-01-09"
-              ]
+              "returning": {
+                "val": [
+                  "1999-01-08",
+                  "1999-01-09"
+                ]
+              }
             }
           }
         }"#]];
@@ -2216,7 +2324,7 @@ fn timestamp() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "2004-10-19T10:23:54" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -2232,7 +2340,9 @@ fn timestamp() {
         {
           "data": {
             "userCreate": {
-              "val": "2004-10-19T10:23:54"
+              "returning": {
+                "val": "2004-10-19T10:23:54"
+              }
             }
           }
         }"#]];
@@ -2255,7 +2365,7 @@ fn timestamp_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["2004-10-19T10:23:54", "2004-10-19T10:23:55"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -2271,10 +2381,12 @@ fn timestamp_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "2004-10-19T10:23:54",
-                "2004-10-19T10:23:55"
-              ]
+              "returning": {
+                "val": [
+                  "2004-10-19T10:23:54",
+                  "2004-10-19T10:23:55"
+                ]
+              }
             }
           }
         }"#]];
@@ -2297,7 +2409,7 @@ fn timestamptz() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "2004-10-19T10:23:54.000Z" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -2313,7 +2425,9 @@ fn timestamptz() {
         {
           "data": {
             "userCreate": {
-              "val": "2004-10-19T10:23:54.000Z"
+              "returning": {
+                "val": "2004-10-19T10:23:54.000Z"
+              }
             }
           }
         }"#]];
@@ -2336,7 +2450,7 @@ fn timestamptz_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["2004-10-19T10:23:54.000Z", "2004-10-19T10:23:55.000Z"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -2352,10 +2466,12 @@ fn timestamptz_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "2004-10-19T10:23:54.000Z",
-                "2004-10-19T10:23:55.000Z"
-              ]
+              "returning": {
+                "val": [
+                  "2004-10-19T10:23:54.000Z",
+                  "2004-10-19T10:23:55.000Z"
+                ]
+              }
             }
           }
         }"#]];
@@ -2378,7 +2494,7 @@ fn uuid() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: "d89bd15d-ac64-4c71-895c-adba9c35a132" }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -2394,7 +2510,9 @@ fn uuid() {
         {
           "data": {
             "userCreate": {
-              "val": "d89bd15d-ac64-4c71-895c-adba9c35a132"
+              "returning": {
+                "val": "d89bd15d-ac64-4c71-895c-adba9c35a132"
+              }
             }
           }
         }"#]];
@@ -2417,7 +2535,7 @@ fn uuid_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: ["d89bd15d-ac64-4c71-895c-adba9c35a132", "d89bd15d-ac64-4c71-895c-adba9c35a133"] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -2433,10 +2551,12 @@ fn uuid_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "d89bd15d-ac64-4c71-895c-adba9c35a132",
-                "d89bd15d-ac64-4c71-895c-adba9c35a133"
-              ]
+              "returning": {
+                "val": [
+                  "d89bd15d-ac64-4c71-895c-adba9c35a132",
+                  "d89bd15d-ac64-4c71-895c-adba9c35a133"
+                ]
+              }
             }
           }
         }"#]];
@@ -2465,7 +2585,7 @@ fn r#enum() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: YELLOW }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -2481,7 +2601,9 @@ fn r#enum() {
         {
           "data": {
             "userCreate": {
-              "val": "YELLOW"
+              "returning": {
+                "val": "YELLOW"
+              }
             }
           }
         }"#]];
@@ -2510,7 +2632,7 @@ fn enum_array() {
         let mutation = indoc! {r#"
             mutation {
               userCreate(input: { val: [YELLOW, GREEN] }) {
-                val
+                returning { val }
               }
             }
         "#};
@@ -2526,10 +2648,12 @@ fn enum_array() {
         {
           "data": {
             "userCreate": {
-              "val": [
-                "YELLOW",
-                "GREEN"
-              ]
+              "returning": {
+                "val": [
+                  "YELLOW",
+                  "GREEN"
+                ]
+              }
             }
           }
         }"#]];

--- a/engine/crates/integration-tests/tests/postgres/introspection.rs
+++ b/engine/crates/integration-tests/tests/postgres/introspection.rs
@@ -71,27 +71,27 @@ fn table_with_serial_primary_key() {
           """
             Delete a unique User by a field or combination of fields
           """
-          userDelete(by: UserByInput!): UserReduced
+          userDelete(by: UserByInput!): UserMutation
           """
             Delete multiple rows of User by a filter
           """
-          userDeleteMany(filter: UserReducedCollection!): [UserReduced]!
+          userDeleteMany(filter: UserMutationCollection!): UserBatchMutation
           """
             Create a User
           """
-          userCreate(input: UserInput!): UserReduced
+          userCreate(input: UserInput!): UserMutation
           """
             Create multiple Users
           """
-          userCreateMany(input: [UserInput!]!): [UserReduced!]!
+          userCreateMany(input: [UserInput!]!): UserBatchMutation
           """
             Update a unique User
           """
-          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
+          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserMutation
           """
             Update multiple Users
           """
-          userUpdateMany(filter: UserReducedCollection!, input: UserUpdateInput!): [UserReduced]!
+          userUpdateMany(filter: UserMutationCollection!, input: UserUpdateInput!): UserBatchMutation
         }
 
         enum OrderByDirection {
@@ -119,6 +119,17 @@ fn table_with_serial_primary_key() {
 
         type User {
           id: Int!
+        }
+
+        type UserBatchMutation {
+          """
+            Returned items from the mutation.
+          """
+          returning: [UserReturning]!
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
         }
 
         input UserByInput {
@@ -152,25 +163,36 @@ fn table_with_serial_primary_key() {
           id: Int
         }
 
+        type UserMutation {
+          """
+            Returned item from the mutation.
+          """
+          returning: UserReturning
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
+        input UserMutationCollection {
+          id: IntSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [UserMutationCollection]
+          """
+            None of the filters must match
+          """ NONE: [UserMutationCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [UserMutationCollection]
+        }
+
         input UserOrderByInput {
           id: OrderByDirection
         }
 
-        type UserReduced {
+        type UserReturning {
           id: Int!
-        }
-
-        input UserReducedCollection {
-          id: IntSearchFilterInput
-          """
-            All of the filters must match
-          """ ALL: [UserReducedCollection]
-          """
-            None of the filters must match
-          """ NONE: [UserReducedCollection]
-          """
-            At least one of the filters must match
-          """ ANY: [UserReducedCollection]
         }
 
         input UserUpdateInput {
@@ -211,6 +233,17 @@ fn table_with_enum_field() {
           val: StreetLight!
         }
 
+        type ABatchMutation {
+          """
+            Returned items from the mutation.
+          """
+          returning: [AReturning]!
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
         input AByInput {
           id: Int
         }
@@ -244,28 +277,39 @@ fn table_with_enum_field() {
           val: StreetLight!
         }
 
+        type AMutation {
+          """
+            Returned item from the mutation.
+          """
+          returning: AReturning
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
+        input AMutationCollection {
+          id: IntSearchFilterInput
+          val: StreetLightSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [AMutationCollection]
+          """
+            None of the filters must match
+          """ NONE: [AMutationCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [AMutationCollection]
+        }
+
         input AOrderByInput {
           id: OrderByDirection
           val: OrderByDirection
         }
 
-        type AReduced {
+        type AReturning {
           id: Int!
           val: StreetLight!
-        }
-
-        input AReducedCollection {
-          id: IntSearchFilterInput
-          val: StreetLightSearchFilterInput
-          """
-            All of the filters must match
-          """ ALL: [AReducedCollection]
-          """
-            None of the filters must match
-          """ NONE: [AReducedCollection]
-          """
-            At least one of the filters must match
-          """ ANY: [AReducedCollection]
         }
 
         input AUpdateInput {
@@ -329,27 +373,27 @@ fn table_with_enum_field() {
           """
             Delete a unique A by a field or combination of fields
           """
-          aDelete(by: AByInput!): AReduced
+          aDelete(by: AByInput!): AMutation
           """
             Delete multiple rows of A by a filter
           """
-          aDeleteMany(filter: AReducedCollection!): [AReduced]!
+          aDeleteMany(filter: AMutationCollection!): ABatchMutation
           """
             Create a A
           """
-          aCreate(input: AInput!): AReduced
+          aCreate(input: AInput!): AMutation
           """
             Create multiple As
           """
-          aCreateMany(input: [AInput!]!): [AReduced!]!
+          aCreateMany(input: [AInput!]!): ABatchMutation
           """
             Update a unique A
           """
-          aUpdate(by: AByInput!, input: AUpdateInput!): AReduced
+          aUpdate(by: AByInput!, input: AUpdateInput!): AMutation
           """
             Update multiple As
           """
-          aUpdateMany(filter: AReducedCollection!, input: AUpdateInput!): [AReduced]!
+          aUpdateMany(filter: AMutationCollection!, input: AUpdateInput!): ABatchMutation
         }
 
         enum OrderByDirection {
@@ -459,27 +503,27 @@ fn table_with_int_primary_key() {
           """
             Delete a unique User by a field or combination of fields
           """
-          userDelete(by: UserByInput!): UserReduced
+          userDelete(by: UserByInput!): UserMutation
           """
             Delete multiple rows of User by a filter
           """
-          userDeleteMany(filter: UserReducedCollection!): [UserReduced]!
+          userDeleteMany(filter: UserMutationCollection!): UserBatchMutation
           """
             Create a User
           """
-          userCreate(input: UserInput!): UserReduced
+          userCreate(input: UserInput!): UserMutation
           """
             Create multiple Users
           """
-          userCreateMany(input: [UserInput!]!): [UserReduced!]!
+          userCreateMany(input: [UserInput!]!): UserBatchMutation
           """
             Update a unique User
           """
-          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
+          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserMutation
           """
             Update multiple Users
           """
-          userUpdateMany(filter: UserReducedCollection!, input: UserUpdateInput!): [UserReduced]!
+          userUpdateMany(filter: UserMutationCollection!, input: UserUpdateInput!): UserBatchMutation
         }
 
         enum OrderByDirection {
@@ -507,6 +551,17 @@ fn table_with_int_primary_key() {
 
         type User {
           id: Int!
+        }
+
+        type UserBatchMutation {
+          """
+            Returned items from the mutation.
+          """
+          returning: [UserReturning]!
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
         }
 
         input UserByInput {
@@ -540,25 +595,36 @@ fn table_with_int_primary_key() {
           id: Int!
         }
 
+        type UserMutation {
+          """
+            Returned item from the mutation.
+          """
+          returning: UserReturning
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
+        input UserMutationCollection {
+          id: IntSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [UserMutationCollection]
+          """
+            None of the filters must match
+          """ NONE: [UserMutationCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [UserMutationCollection]
+        }
+
         input UserOrderByInput {
           id: OrderByDirection
         }
 
-        type UserReduced {
+        type UserReturning {
           id: Int!
-        }
-
-        input UserReducedCollection {
-          id: IntSearchFilterInput
-          """
-            All of the filters must match
-          """ ALL: [UserReducedCollection]
-          """
-            None of the filters must match
-          """ NONE: [UserReducedCollection]
-          """
-            At least one of the filters must match
-          """ ANY: [UserReducedCollection]
         }
 
         input UserUpdateInput {
@@ -643,27 +709,27 @@ fn table_with_int_unique() {
           """
             Delete a unique User by a field or combination of fields
           """
-          userDelete(by: UserByInput!): UserReduced
+          userDelete(by: UserByInput!): UserMutation
           """
             Delete multiple rows of User by a filter
           """
-          userDeleteMany(filter: UserReducedCollection!): [UserReduced]!
+          userDeleteMany(filter: UserMutationCollection!): UserBatchMutation
           """
             Create a User
           """
-          userCreate(input: UserInput!): UserReduced
+          userCreate(input: UserInput!): UserMutation
           """
             Create multiple Users
           """
-          userCreateMany(input: [UserInput!]!): [UserReduced!]!
+          userCreateMany(input: [UserInput!]!): UserBatchMutation
           """
             Update a unique User
           """
-          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
+          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserMutation
           """
             Update multiple Users
           """
-          userUpdateMany(filter: UserReducedCollection!, input: UserUpdateInput!): [UserReduced]!
+          userUpdateMany(filter: UserMutationCollection!, input: UserUpdateInput!): UserBatchMutation
         }
 
         enum OrderByDirection {
@@ -691,6 +757,17 @@ fn table_with_int_unique() {
 
         type User {
           id: Int!
+        }
+
+        type UserBatchMutation {
+          """
+            Returned items from the mutation.
+          """
+          returning: [UserReturning]!
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
         }
 
         input UserByInput {
@@ -724,25 +801,36 @@ fn table_with_int_unique() {
           id: Int!
         }
 
+        type UserMutation {
+          """
+            Returned item from the mutation.
+          """
+          returning: UserReturning
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
+        input UserMutationCollection {
+          id: IntSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [UserMutationCollection]
+          """
+            None of the filters must match
+          """ NONE: [UserMutationCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [UserMutationCollection]
+        }
+
         input UserOrderByInput {
           id: OrderByDirection
         }
 
-        type UserReduced {
+        type UserReturning {
           id: Int!
-        }
-
-        input UserReducedCollection {
-          id: IntSearchFilterInput
-          """
-            All of the filters must match
-          """ ALL: [UserReducedCollection]
-          """
-            None of the filters must match
-          """ NONE: [UserReducedCollection]
-          """
-            At least one of the filters must match
-          """ ANY: [UserReducedCollection]
         }
 
         input UserUpdateInput {
@@ -828,27 +916,27 @@ fn table_with_serial_primary_key_string_unique() {
           """
             Delete a unique User by a field or combination of fields
           """
-          userDelete(by: UserByInput!): UserReduced
+          userDelete(by: UserByInput!): UserMutation
           """
             Delete multiple rows of User by a filter
           """
-          userDeleteMany(filter: UserReducedCollection!): [UserReduced]!
+          userDeleteMany(filter: UserMutationCollection!): UserBatchMutation
           """
             Create a User
           """
-          userCreate(input: UserInput!): UserReduced
+          userCreate(input: UserInput!): UserMutation
           """
             Create multiple Users
           """
-          userCreateMany(input: [UserInput!]!): [UserReduced!]!
+          userCreateMany(input: [UserInput!]!): UserBatchMutation
           """
             Update a unique User
           """
-          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
+          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserMutation
           """
             Update multiple Users
           """
-          userUpdateMany(filter: UserReducedCollection!, input: UserUpdateInput!): [UserReduced]!
+          userUpdateMany(filter: UserMutationCollection!, input: UserUpdateInput!): UserBatchMutation
         }
 
         enum OrderByDirection {
@@ -917,6 +1005,17 @@ fn table_with_serial_primary_key_string_unique() {
         type User {
           id: Int!
           email: String!
+        }
+
+        type UserBatchMutation {
+          """
+            Returned items from the mutation.
+          """
+          returning: [UserReturning]!
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
         }
 
         input UserByInput {
@@ -953,28 +1052,39 @@ fn table_with_serial_primary_key_string_unique() {
           email: String!
         }
 
+        type UserMutation {
+          """
+            Returned item from the mutation.
+          """
+          returning: UserReturning
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
+        input UserMutationCollection {
+          id: IntSearchFilterInput
+          email: StringSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [UserMutationCollection]
+          """
+            None of the filters must match
+          """ NONE: [UserMutationCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [UserMutationCollection]
+        }
+
         input UserOrderByInput {
           id: OrderByDirection
           email: OrderByDirection
         }
 
-        type UserReduced {
+        type UserReturning {
           id: Int!
           email: String!
-        }
-
-        input UserReducedCollection {
-          id: IntSearchFilterInput
-          email: StringSearchFilterInput
-          """
-            All of the filters must match
-          """ ALL: [UserReducedCollection]
-          """
-            None of the filters must match
-          """ NONE: [UserReducedCollection]
-          """
-            At least one of the filters must match
-          """ ANY: [UserReducedCollection]
         }
 
         input UserUpdateInput {
@@ -1010,27 +1120,27 @@ fn table_with_composite_primary_key() {
           """
             Delete a unique User by a field or combination of fields
           """
-          userDelete(by: UserByInput!): UserReduced
+          userDelete(by: UserByInput!): UserMutation
           """
             Delete multiple rows of User by a filter
           """
-          userDeleteMany(filter: UserReducedCollection!): [UserReduced]!
+          userDeleteMany(filter: UserMutationCollection!): UserBatchMutation
           """
             Create a User
           """
-          userCreate(input: UserInput!): UserReduced
+          userCreate(input: UserInput!): UserMutation
           """
             Create multiple Users
           """
-          userCreateMany(input: [UserInput!]!): [UserReduced!]!
+          userCreateMany(input: [UserInput!]!): UserBatchMutation
           """
             Update a unique User
           """
-          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
+          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserMutation
           """
             Update multiple Users
           """
-          userUpdateMany(filter: UserReducedCollection!, input: UserUpdateInput!): [UserReduced]!
+          userUpdateMany(filter: UserMutationCollection!, input: UserUpdateInput!): UserBatchMutation
         }
 
         enum OrderByDirection {
@@ -1101,6 +1211,17 @@ fn table_with_composite_primary_key() {
           email: String!
         }
 
+        type UserBatchMutation {
+          """
+            Returned items from the mutation.
+          """
+          returning: [UserReturning]!
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
         input UserByInput {
           nameEmail: UserNameEmailInput
         }
@@ -1134,6 +1255,31 @@ fn table_with_composite_primary_key() {
           email: String!
         }
 
+        type UserMutation {
+          """
+            Returned item from the mutation.
+          """
+          returning: UserReturning
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
+        input UserMutationCollection {
+          name: StringSearchFilterInput
+          email: StringSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [UserMutationCollection]
+          """
+            None of the filters must match
+          """ NONE: [UserMutationCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [UserMutationCollection]
+        }
+
         input UserNameEmailInput {
           name: String!
           email: String!
@@ -1144,23 +1290,9 @@ fn table_with_composite_primary_key() {
           email: OrderByDirection
         }
 
-        type UserReduced {
+        type UserReturning {
           name: String!
           email: String!
-        }
-
-        input UserReducedCollection {
-          name: StringSearchFilterInput
-          email: StringSearchFilterInput
-          """
-            All of the filters must match
-          """ ALL: [UserReducedCollection]
-          """
-            None of the filters must match
-          """ NONE: [UserReducedCollection]
-          """
-            At least one of the filters must match
-          """ ANY: [UserReducedCollection]
         }
 
         input UserUpdateInput {
@@ -1256,51 +1388,51 @@ fn two_schemas_same_table_name() {
           """
             Delete a unique PrivateUser by a field or combination of fields
           """
-          privateUserDelete(by: PrivateUserByInput!): PrivateUserReduced
+          privateUserDelete(by: PrivateUserByInput!): PrivateUserMutation
           """
             Delete multiple rows of PrivateUser by a filter
           """
-          privateUserDeleteMany(filter: PrivateUserReducedCollection!): [PrivateUserReduced]!
+          privateUserDeleteMany(filter: PrivateUserMutationCollection!): PrivateUserBatchMutation
           """
             Create a PrivateUser
           """
-          privateUserCreate(input: PrivateUserInput!): PrivateUserReduced
+          privateUserCreate(input: PrivateUserInput!): PrivateUserMutation
           """
             Create multiple PrivateUsers
           """
-          privateUserCreateMany(input: [PrivateUserInput!]!): [PrivateUserReduced!]!
+          privateUserCreateMany(input: [PrivateUserInput!]!): PrivateUserBatchMutation
           """
             Update a unique PrivateUser
           """
-          privateUserUpdate(by: PrivateUserByInput!, input: PrivateUserUpdateInput!): PrivateUserReduced
+          privateUserUpdate(by: PrivateUserByInput!, input: PrivateUserUpdateInput!): PrivateUserMutation
           """
             Update multiple PrivateUsers
           """
-          privateUserUpdateMany(filter: PrivateUserReducedCollection!, input: PrivateUserUpdateInput!): [PrivateUserReduced]!
+          privateUserUpdateMany(filter: PrivateUserMutationCollection!, input: PrivateUserUpdateInput!): PrivateUserBatchMutation
           """
             Delete a unique PublicUser by a field or combination of fields
           """
-          publicUserDelete(by: PublicUserByInput!): PublicUserReduced
+          publicUserDelete(by: PublicUserByInput!): PublicUserMutation
           """
             Delete multiple rows of PublicUser by a filter
           """
-          publicUserDeleteMany(filter: PublicUserReducedCollection!): [PublicUserReduced]!
+          publicUserDeleteMany(filter: PublicUserMutationCollection!): PublicUserBatchMutation
           """
             Create a PublicUser
           """
-          publicUserCreate(input: PublicUserInput!): PublicUserReduced
+          publicUserCreate(input: PublicUserInput!): PublicUserMutation
           """
             Create multiple PublicUsers
           """
-          publicUserCreateMany(input: [PublicUserInput!]!): [PublicUserReduced!]!
+          publicUserCreateMany(input: [PublicUserInput!]!): PublicUserBatchMutation
           """
             Update a unique PublicUser
           """
-          publicUserUpdate(by: PublicUserByInput!, input: PublicUserUpdateInput!): PublicUserReduced
+          publicUserUpdate(by: PublicUserByInput!, input: PublicUserUpdateInput!): PublicUserMutation
           """
             Update multiple PublicUsers
           """
-          publicUserUpdateMany(filter: PublicUserReducedCollection!, input: PublicUserUpdateInput!): [PublicUserReduced]!
+          publicUserUpdateMany(filter: PublicUserMutationCollection!, input: PublicUserUpdateInput!): PublicUserBatchMutation
         }
 
         enum OrderByDirection {
@@ -1317,6 +1449,17 @@ fn two_schemas_same_table_name() {
 
         type PrivateUser {
           id: Int!
+        }
+
+        type PrivateUserBatchMutation {
+          """
+            Returned items from the mutation.
+          """
+          returning: [PrivateUserReturning]!
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
         }
 
         input PrivateUserByInput {
@@ -1350,25 +1493,36 @@ fn two_schemas_same_table_name() {
           id: Int
         }
 
+        type PrivateUserMutation {
+          """
+            Returned item from the mutation.
+          """
+          returning: PrivateUserReturning
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
+        input PrivateUserMutationCollection {
+          id: IntSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [PrivateUserMutationCollection]
+          """
+            None of the filters must match
+          """ NONE: [PrivateUserMutationCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [PrivateUserMutationCollection]
+        }
+
         input PrivateUserOrderByInput {
           id: OrderByDirection
         }
 
-        type PrivateUserReduced {
+        type PrivateUserReturning {
           id: Int!
-        }
-
-        input PrivateUserReducedCollection {
-          id: IntSearchFilterInput
-          """
-            All of the filters must match
-          """ ALL: [PrivateUserReducedCollection]
-          """
-            None of the filters must match
-          """ NONE: [PrivateUserReducedCollection]
-          """
-            At least one of the filters must match
-          """ ANY: [PrivateUserReducedCollection]
         }
 
         input PrivateUserUpdateInput {
@@ -1377,6 +1531,17 @@ fn two_schemas_same_table_name() {
 
         type PublicUser {
           id: Int!
+        }
+
+        type PublicUserBatchMutation {
+          """
+            Returned items from the mutation.
+          """
+          returning: [PublicUserReturning]!
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
         }
 
         input PublicUserByInput {
@@ -1410,25 +1575,36 @@ fn two_schemas_same_table_name() {
           id: Int
         }
 
+        type PublicUserMutation {
+          """
+            Returned item from the mutation.
+          """
+          returning: PublicUserReturning
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
+        input PublicUserMutationCollection {
+          id: IntSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [PublicUserMutationCollection]
+          """
+            None of the filters must match
+          """ NONE: [PublicUserMutationCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [PublicUserMutationCollection]
+        }
+
         input PublicUserOrderByInput {
           id: OrderByDirection
         }
 
-        type PublicUserReduced {
+        type PublicUserReturning {
           id: Int!
-        }
-
-        input PublicUserReducedCollection {
-          id: IntSearchFilterInput
-          """
-            All of the filters must match
-          """ ALL: [PublicUserReducedCollection]
-          """
-            None of the filters must match
-          """ NONE: [PublicUserReducedCollection]
-          """
-            At least one of the filters must match
-          """ ANY: [PublicUserReducedCollection]
         }
 
         input PublicUserUpdateInput {
@@ -1536,27 +1712,27 @@ fn table_with_serial_primary_key_namespaced() {
           """
             Delete a unique User by a field or combination of fields
           """
-          userDelete(by: NeonUserByInput!): NeonUserReduced
+          userDelete(by: NeonUserByInput!): NeonUserMutation
           """
             Delete multiple rows of User by a filter
           """
-          userDeleteMany(filter: NeonUserReducedCollection!): [NeonUserReduced]!
+          userDeleteMany(filter: NeonUserMutationCollection!): NeonUserBatchMutation
           """
             Create a User
           """
-          userCreate(input: NeonUserInput!): NeonUserReduced
+          userCreate(input: NeonUserInput!): NeonUserMutation
           """
             Create multiple Users
           """
-          userCreateMany(input: [NeonUserInput!]!): [NeonUserReduced!]!
+          userCreateMany(input: [NeonUserInput!]!): NeonUserBatchMutation
           """
             Update a unique User
           """
-          userUpdate(by: NeonUserByInput!, input: NeonUserUpdateInput!): NeonUserReduced
+          userUpdate(by: NeonUserByInput!, input: NeonUserUpdateInput!): NeonUserMutation
           """
             Update multiple Users
           """
-          userUpdateMany(filter: NeonUserReducedCollection!, input: NeonUserUpdateInput!): [NeonUserReduced]!
+          userUpdateMany(filter: NeonUserMutationCollection!, input: NeonUserUpdateInput!): NeonUserBatchMutation
         }
 
         enum NeonOrderByDirection {
@@ -1584,6 +1760,17 @@ fn table_with_serial_primary_key_namespaced() {
 
         type NeonUser {
           id: Int!
+        }
+
+        type NeonUserBatchMutation {
+          """
+            Returned items from the mutation.
+          """
+          returning: [NeonUserReturning]!
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
         }
 
         input NeonUserByInput {
@@ -1617,25 +1804,36 @@ fn table_with_serial_primary_key_namespaced() {
           id: Int
         }
 
+        type NeonUserMutation {
+          """
+            Returned item from the mutation.
+          """
+          returning: NeonUserReturning
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
+        input NeonUserMutationCollection {
+          id: NeonIntSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [NeonUserMutationCollection]
+          """
+            None of the filters must match
+          """ NONE: [NeonUserMutationCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [NeonUserMutationCollection]
+        }
+
         input NeonUserOrderByInput {
           id: NeonOrderByDirection
         }
 
-        type NeonUserReduced {
+        type NeonUserReturning {
           id: Int!
-        }
-
-        input NeonUserReducedCollection {
-          id: NeonIntSearchFilterInput
-          """
-            All of the filters must match
-          """ ALL: [NeonUserReducedCollection]
-          """
-            None of the filters must match
-          """ NONE: [NeonUserReducedCollection]
-          """
-            At least one of the filters must match
-          """ ANY: [NeonUserReducedCollection]
         }
 
         input NeonUserUpdateInput {
@@ -1780,27 +1978,27 @@ fn table_with_an_array_column() {
           """
             Delete a unique User by a field or combination of fields
           """
-          userDelete(by: UserByInput!): UserReduced
+          userDelete(by: UserByInput!): UserMutation
           """
             Delete multiple rows of User by a filter
           """
-          userDeleteMany(filter: UserReducedCollection!): [UserReduced]!
+          userDeleteMany(filter: UserMutationCollection!): UserBatchMutation
           """
             Create a User
           """
-          userCreate(input: UserInput!): UserReduced
+          userCreate(input: UserInput!): UserMutation
           """
             Create multiple Users
           """
-          userCreateMany(input: [UserInput!]!): [UserReduced!]!
+          userCreateMany(input: [UserInput!]!): UserBatchMutation
           """
             Update a unique User
           """
-          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
+          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserMutation
           """
             Update multiple Users
           """
-          userUpdateMany(filter: UserReducedCollection!, input: UserUpdateInput!): [UserReduced]!
+          userUpdateMany(filter: UserMutationCollection!, input: UserUpdateInput!): UserBatchMutation
         }
 
         enum OrderByDirection {
@@ -1829,6 +2027,17 @@ fn table_with_an_array_column() {
         type User {
           id: Int!
           name: [Int]!
+        }
+
+        type UserBatchMutation {
+          """
+            Returned items from the mutation.
+          """
+          returning: [UserReturning]!
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
         }
 
         input UserByInput {
@@ -1864,28 +2073,39 @@ fn table_with_an_array_column() {
           name: [Int]!
         }
 
+        type UserMutation {
+          """
+            Returned item from the mutation.
+          """
+          returning: UserReturning
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
+        input UserMutationCollection {
+          id: IntSearchFilterInput
+          name: IntArraySearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [UserMutationCollection]
+          """
+            None of the filters must match
+          """ NONE: [UserMutationCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [UserMutationCollection]
+        }
+
         input UserOrderByInput {
           id: OrderByDirection
           name: OrderByDirection
         }
 
-        type UserReduced {
+        type UserReturning {
           id: Int!
           name: [Int]!
-        }
-
-        input UserReducedCollection {
-          id: IntSearchFilterInput
-          name: IntArraySearchFilterInput
-          """
-            All of the filters must match
-          """ ALL: [UserReducedCollection]
-          """
-            None of the filters must match
-          """ NONE: [UserReducedCollection]
-          """
-            At least one of the filters must match
-          """ ANY: [UserReducedCollection]
         }
 
         input UserUpdateInput {
@@ -2032,27 +2252,27 @@ fn table_with_jsonb_column() {
           """
             Delete a unique User by a field or combination of fields
           """
-          userDelete(by: UserByInput!): UserReduced
+          userDelete(by: UserByInput!): UserMutation
           """
             Delete multiple rows of User by a filter
           """
-          userDeleteMany(filter: UserReducedCollection!): [UserReduced]!
+          userDeleteMany(filter: UserMutationCollection!): UserBatchMutation
           """
             Create a User
           """
-          userCreate(input: UserInput!): UserReduced
+          userCreate(input: UserInput!): UserMutation
           """
             Create multiple Users
           """
-          userCreateMany(input: [UserInput!]!): [UserReduced!]!
+          userCreateMany(input: [UserInput!]!): UserBatchMutation
           """
             Update a unique User
           """
-          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
+          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserMutation
           """
             Update multiple Users
           """
-          userUpdateMany(filter: UserReducedCollection!, input: UserUpdateInput!): [UserReduced]!
+          userUpdateMany(filter: UserMutationCollection!, input: UserUpdateInput!): UserBatchMutation
         }
 
         enum OrderByDirection {
@@ -2081,6 +2301,17 @@ fn table_with_jsonb_column() {
         type User {
           id: Int!
           name: JSON!
+        }
+
+        type UserBatchMutation {
+          """
+            Returned items from the mutation.
+          """
+          returning: [UserReturning]!
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
         }
 
         input UserByInput {
@@ -2116,28 +2347,39 @@ fn table_with_jsonb_column() {
           name: JSON!
         }
 
+        type UserMutation {
+          """
+            Returned item from the mutation.
+          """
+          returning: UserReturning
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
+        input UserMutationCollection {
+          id: IntSearchFilterInput
+          name: JsonSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [UserMutationCollection]
+          """
+            None of the filters must match
+          """ NONE: [UserMutationCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [UserMutationCollection]
+        }
+
         input UserOrderByInput {
           id: OrderByDirection
           name: OrderByDirection
         }
 
-        type UserReduced {
+        type UserReturning {
           id: Int!
           name: JSON!
-        }
-
-        input UserReducedCollection {
-          id: IntSearchFilterInput
-          name: JsonSearchFilterInput
-          """
-            All of the filters must match
-          """ ALL: [UserReducedCollection]
-          """
-            None of the filters must match
-          """ NONE: [UserReducedCollection]
-          """
-            At least one of the filters must match
-          """ ANY: [UserReducedCollection]
         }
 
         input UserUpdateInput {
@@ -2260,27 +2502,27 @@ fn table_with_json_column() {
           """
             Delete a unique User by a field or combination of fields
           """
-          userDelete(by: UserByInput!): UserReduced
+          userDelete(by: UserByInput!): UserMutation
           """
             Delete multiple rows of User by a filter
           """
-          userDeleteMany(filter: UserReducedCollection!): [UserReduced]!
+          userDeleteMany(filter: UserMutationCollection!): UserBatchMutation
           """
             Create a User
           """
-          userCreate(input: UserInput!): UserReduced
+          userCreate(input: UserInput!): UserMutation
           """
             Create multiple Users
           """
-          userCreateMany(input: [UserInput!]!): [UserReduced!]!
+          userCreateMany(input: [UserInput!]!): UserBatchMutation
           """
             Update a unique User
           """
-          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
+          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserMutation
           """
             Update multiple Users
           """
-          userUpdateMany(filter: UserReducedCollection!, input: UserUpdateInput!): [UserReduced]!
+          userUpdateMany(filter: UserMutationCollection!, input: UserUpdateInput!): UserBatchMutation
         }
 
         enum OrderByDirection {
@@ -2320,6 +2562,17 @@ fn table_with_json_column() {
           name: JSON!
         }
 
+        type UserBatchMutation {
+          """
+            Returned items from the mutation.
+          """
+          returning: [UserReturning]!
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
         input UserByInput {
           id: Int
         }
@@ -2353,28 +2606,39 @@ fn table_with_json_column() {
           name: JSON!
         }
 
+        type UserMutation {
+          """
+            Returned item from the mutation.
+          """
+          returning: UserReturning
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
+        input UserMutationCollection {
+          id: IntSearchFilterInput
+          name: JsonSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [UserMutationCollection]
+          """
+            None of the filters must match
+          """ NONE: [UserMutationCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [UserMutationCollection]
+        }
+
         input UserOrderByInput {
           id: OrderByDirection
           name: OrderByDirection
         }
 
-        type UserReduced {
+        type UserReturning {
           id: Int!
           name: JSON!
-        }
-
-        input UserReducedCollection {
-          id: IntSearchFilterInput
-          name: JsonSearchFilterInput
-          """
-            All of the filters must match
-          """ ALL: [UserReducedCollection]
-          """
-            None of the filters must match
-          """ NONE: [UserReducedCollection]
-          """
-            At least one of the filters must match
-          """ ANY: [UserReducedCollection]
         }
 
         input UserUpdateInput {
@@ -2425,6 +2689,17 @@ fn two_tables_with_single_column_foreign_key() {
           user: User!
         }
 
+        type BlogBatchMutation {
+          """
+            Returned items from the mutation.
+          """
+          returning: [BlogReturning]!
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
         input BlogByInput {
           id: Int
         }
@@ -2467,6 +2742,33 @@ fn two_tables_with_single_column_foreign_key() {
           userId: Int!
         }
 
+        type BlogMutation {
+          """
+            Returned item from the mutation.
+          """
+          returning: BlogReturning
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
+        input BlogMutationCollection {
+          id: IntSearchFilterInput
+          title: StringSearchFilterInput
+          content: StringSearchFilterInput
+          userId: IntSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [BlogMutationCollection]
+          """
+            None of the filters must match
+          """ NONE: [BlogMutationCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [BlogMutationCollection]
+        }
+
         input BlogOrderByInput {
           id: OrderByDirection
           title: OrderByDirection
@@ -2474,27 +2776,11 @@ fn two_tables_with_single_column_foreign_key() {
           userId: OrderByDirection
         }
 
-        type BlogReduced {
+        type BlogReturning {
           id: Int!
           title: String!
           content: String
           userId: Int!
-        }
-
-        input BlogReducedCollection {
-          id: IntSearchFilterInput
-          title: StringSearchFilterInput
-          content: StringSearchFilterInput
-          userId: IntSearchFilterInput
-          """
-            All of the filters must match
-          """ ALL: [BlogReducedCollection]
-          """
-            None of the filters must match
-          """ NONE: [BlogReducedCollection]
-          """
-            At least one of the filters must match
-          """ ANY: [BlogReducedCollection]
         }
 
         input BlogUpdateInput {
@@ -2560,51 +2846,51 @@ fn two_tables_with_single_column_foreign_key() {
           """
             Delete a unique Blog by a field or combination of fields
           """
-          blogDelete(by: BlogByInput!): BlogReduced
+          blogDelete(by: BlogByInput!): BlogMutation
           """
             Delete multiple rows of Blog by a filter
           """
-          blogDeleteMany(filter: BlogReducedCollection!): [BlogReduced]!
+          blogDeleteMany(filter: BlogMutationCollection!): BlogBatchMutation
           """
             Create a Blog
           """
-          blogCreate(input: BlogInput!): BlogReduced
+          blogCreate(input: BlogInput!): BlogMutation
           """
             Create multiple Blogs
           """
-          blogCreateMany(input: [BlogInput!]!): [BlogReduced!]!
+          blogCreateMany(input: [BlogInput!]!): BlogBatchMutation
           """
             Update a unique Blog
           """
-          blogUpdate(by: BlogByInput!, input: BlogUpdateInput!): BlogReduced
+          blogUpdate(by: BlogByInput!, input: BlogUpdateInput!): BlogMutation
           """
             Update multiple Blogs
           """
-          blogUpdateMany(filter: BlogReducedCollection!, input: BlogUpdateInput!): [BlogReduced]!
+          blogUpdateMany(filter: BlogMutationCollection!, input: BlogUpdateInput!): BlogBatchMutation
           """
             Delete a unique User by a field or combination of fields
           """
-          userDelete(by: UserByInput!): UserReduced
+          userDelete(by: UserByInput!): UserMutation
           """
             Delete multiple rows of User by a filter
           """
-          userDeleteMany(filter: UserReducedCollection!): [UserReduced]!
+          userDeleteMany(filter: UserMutationCollection!): UserBatchMutation
           """
             Create a User
           """
-          userCreate(input: UserInput!): UserReduced
+          userCreate(input: UserInput!): UserMutation
           """
             Create multiple Users
           """
-          userCreateMany(input: [UserInput!]!): [UserReduced!]!
+          userCreateMany(input: [UserInput!]!): UserBatchMutation
           """
             Update a unique User
           """
-          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserReduced
+          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserMutation
           """
             Update multiple Users
           """
-          userUpdateMany(filter: UserReducedCollection!, input: UserUpdateInput!): [UserReduced]!
+          userUpdateMany(filter: UserMutationCollection!, input: UserUpdateInput!): UserBatchMutation
         }
 
         enum OrderByDirection {
@@ -2684,6 +2970,17 @@ fn two_tables_with_single_column_foreign_key() {
           blogs(first: Int, last: Int, before: String, after: String, orderBy: [BlogOrderByInput!]): BlogConnection
         }
 
+        type UserBatchMutation {
+          """
+            Returned items from the mutation.
+          """
+          returning: [UserReturning]!
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
         input UserByInput {
           id: Int
         }
@@ -2718,28 +3015,39 @@ fn two_tables_with_single_column_foreign_key() {
           name: String!
         }
 
+        type UserMutation {
+          """
+            Returned item from the mutation.
+          """
+          returning: UserReturning
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
+        input UserMutationCollection {
+          id: IntSearchFilterInput
+          name: StringSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [UserMutationCollection]
+          """
+            None of the filters must match
+          """ NONE: [UserMutationCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [UserMutationCollection]
+        }
+
         input UserOrderByInput {
           id: OrderByDirection
           name: OrderByDirection
         }
 
-        type UserReduced {
+        type UserReturning {
           id: Int!
           name: String!
-        }
-
-        input UserReducedCollection {
-          id: IntSearchFilterInput
-          name: StringSearchFilterInput
-          """
-            All of the filters must match
-          """ ALL: [UserReducedCollection]
-          """
-            None of the filters must match
-          """ NONE: [UserReducedCollection]
-          """
-            At least one of the filters must match
-          """ ANY: [UserReducedCollection]
         }
 
         input UserUpdateInput {

--- a/engine/crates/integration-tests/tests/postgres/update_many.rs
+++ b/engine/crates/integration-tests/tests/postgres/update_many.rs
@@ -3,7 +3,7 @@ use indoc::indoc;
 use integration_tests::postgres::query_postgres;
 
 #[test]
-fn smoke() {
+fn with_returning() {
     let response = query_postgres(|api| async move {
         let schema = indoc! {r#"
             CREATE TABLE "User" (
@@ -27,9 +27,12 @@ fn smoke() {
         let mutation = indoc! {r#"
             mutation {
               userUpdateMany(filter: { age: { eq: 11 } }, input: { age: { set: 10 } }) {
-                id
-                name
-                age
+                returning {
+                  id
+                  name
+                  age
+                }
+                rowCount
               }
             }
         "#};
@@ -39,18 +42,109 @@ fn smoke() {
         let expected = expect![[r#"
             {
               "data": {
-                "userUpdateMany": [
-                  {
+                "userUpdateMany": {
+                  "returning": [
+                    {
+                      "id": 1,
+                      "name": "Musti",
+                      "age": 10
+                    },
+                    {
+                      "id": 2,
+                      "name": "Naukio",
+                      "age": 10
+                    }
+                  ],
+                  "rowCount": 2
+                }
+              }
+            }"#]];
+
+        expected.assert_eq(&result);
+
+        let query = indoc! {r#"
+            query {
+              userCollection(first: 10) {
+                edges { node { id name age } }
+              }
+            }    
+        "#};
+
+        api.execute(query).await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "userCollection": {
+              "edges": [
+                {
+                  "node": {
                     "id": 1,
                     "name": "Musti",
                     "age": 10
-                  },
-                  {
+                  }
+                },
+                {
+                  "node": {
                     "id": 2,
                     "name": "Naukio",
                     "age": 10
                   }
-                ]
+                },
+                {
+                  "node": {
+                    "id": 3,
+                    "name": "Pertti",
+                    "age": 12
+                  }
+                }
+              ]
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn no_returning() {
+    let response = query_postgres(|api| async move {
+        let schema = indoc! {r#"
+            CREATE TABLE "User" (
+                id INT PRIMARY KEY,
+                name VARCHAR(255) NOT NULL,
+                age INT NOT NULL
+            )
+        "#};
+
+        api.execute_sql(schema).await;
+
+        let insert = indoc! {r#"
+            INSERT INTO "User" (id, name, age) VALUES
+                (1, 'Musti', 11),
+                (2, 'Naukio', 11),
+                (3, 'Pertti', 12)
+        "#};
+
+        api.execute_sql(insert).await;
+
+        let mutation = indoc! {r#"
+            mutation {
+              userUpdateMany(filter: { age: { eq: 11 } }, input: { age: { set: 10 } }) {
+                rowCount
+              }
+            }
+        "#};
+
+        let result = serde_json::to_string_pretty(&api.execute(mutation).await.to_graphql_response()).unwrap();
+
+        let expected = expect![[r#"
+            {
+              "data": {
+                "userUpdateMany": {
+                  "rowCount": 2
+                }
               }
             }"#]];
 

--- a/engine/crates/parser-postgres/src/registry/context/input.rs
+++ b/engine/crates/parser-postgres/src/registry/context/input.rs
@@ -39,10 +39,25 @@ impl<'a> InputContext<'a> {
     }
 
     // an output type which has limited number of fields, e.g. only scalar fields.
-    pub(crate) fn reduced_type_name(&self, name: &str) -> String {
+    pub(crate) fn mutation_return_type_name(&self, name: &str) -> String {
         match self.namespace {
-            Some(namespace) => format!("{namespace}_{name}_reduced").to_pascal_case(),
-            None => format!("{name}_reduced").to_pascal_case(),
+            Some(namespace) => format!("{namespace}_{name}_mutation").to_pascal_case(),
+            None => format!("{name}_mutation").to_pascal_case(),
+        }
+    }
+
+    // an output type which has limited number of fields, e.g. only scalar fields.
+    pub(crate) fn batch_mutation_return_type_name(&self, name: &str) -> String {
+        match self.namespace {
+            Some(namespace) => format!("{namespace}_{name}_batch_mutation").to_pascal_case(),
+            None => format!("{name}_batch_mutation").to_pascal_case(),
+        }
+    }
+
+    pub(crate) fn returning_type_name(&self, name: &str) -> String {
+        match self.namespace {
+            Some(namespace) => format!("{namespace}_{name}_returning").to_pascal_case(),
+            None => format!("{name}_returning").to_pascal_case(),
         }
     }
 

--- a/engine/crates/parser-postgres/src/registry/queries/create_many.rs
+++ b/engine/crates/parser-postgres/src/registry/queries/create_many.rs
@@ -17,11 +17,11 @@ pub(crate) fn register(
     create_input_type: &str,
     output_ctx: &mut OutputContext,
 ) {
-    let type_name = input_ctx.reduced_type_name(table.client_name());
+    let type_name = input_ctx.batch_mutation_return_type_name(table.client_name());
     let query_name = format!("{}_Create_Many", table.client_name()).to_camel_case();
     let input_value = MetaInputValue::new("input", format!("[{create_input_type}!]!"));
 
-    let mut meta_field = MetaField::new(query_name, format!("[{type_name}!]!"));
+    let mut meta_field = MetaField::new(query_name, type_name);
     meta_field.description = Some(format!("Create multiple {}s", table.client_name()));
     meta_field.args = [("input".to_string(), input_value)].into();
     meta_field.required_operation = Some(Operations::CREATE);

--- a/engine/crates/parser-postgres/src/registry/queries/create_one.rs
+++ b/engine/crates/parser-postgres/src/registry/queries/create_one.rs
@@ -17,7 +17,7 @@ pub(crate) fn register(
     create_input_type: &str,
     output_ctx: &mut OutputContext,
 ) {
-    let type_name = input_ctx.reduced_type_name(table.client_name());
+    let type_name = input_ctx.mutation_return_type_name(table.client_name());
     let query_name = format!("{}_Create", table.client_name()).to_camel_case();
     let input_value = MetaInputValue::new("input", format!("{create_input_type}!"));
     let mut meta_field = MetaField::new(query_name, type_name);

--- a/engine/crates/parser-postgres/src/registry/queries/delete_many.rs
+++ b/engine/crates/parser-postgres/src/registry/queries/delete_many.rs
@@ -17,13 +17,13 @@ pub(crate) fn register(
     simple_filter: &str,
     output_ctx: &mut OutputContext,
 ) {
-    let type_name = input_ctx.reduced_type_name(table.client_name());
+    let type_name = input_ctx.batch_mutation_return_type_name(table.client_name());
     let query_name = format!("{}_Delete_Many", table.client_name()).to_camel_case();
 
     let filter_description = format!("The filter definining which rows to delete from the {type_name} table");
     let filter_input = MetaInputValue::new("filter", format!("{simple_filter}!")).with_description(filter_description);
 
-    let mut meta_field = MetaField::new(query_name, format!("[{type_name}]!"));
+    let mut meta_field = MetaField::new(query_name, type_name);
     meta_field.description = Some(format!("Delete multiple rows of {} by a filter", table.client_name()));
     meta_field.args = [("filter".to_string(), filter_input)].into();
     meta_field.resolver =

--- a/engine/crates/parser-postgres/src/registry/queries/delete_one.rs
+++ b/engine/crates/parser-postgres/src/registry/queries/delete_one.rs
@@ -17,17 +17,19 @@ pub(crate) fn register(
     filter_oneof_type: &str,
     output_ctx: &mut OutputContext,
 ) {
-    let type_name = input_ctx.reduced_type_name(table.client_name());
+    let type_name = input_ctx.mutation_return_type_name(table.client_name());
     let query_name = format!("{}_Delete", table.client_name()).to_camel_case();
 
     let filter_description = format!("The field and value by which to delete the {type_name}");
     let filter_input = MetaInputValue::new("by", format!("{filter_oneof_type}!")).with_description(filter_description);
 
-    let mut meta_field = MetaField::new(query_name, type_name.to_string());
+    let mut meta_field = MetaField::new(query_name, type_name);
+
     meta_field.description = Some(format!(
         "Delete a unique {} by a field or combination of fields",
         table.client_name()
     ));
+
     meta_field.args = [("by".to_string(), filter_input)].into();
     meta_field.resolver =
         Resolver::PostgresResolver(PostgresResolver::new(Operation::DeleteOne, input_ctx.directive_name()));

--- a/engine/crates/parser-postgres/src/registry/queries/input/filter.rs
+++ b/engine/crates/parser-postgres/src/registry/queries/input/filter.rs
@@ -35,7 +35,7 @@ pub(crate) fn register(
         });
     });
 
-    let simple_input = format!("{}Collection", input_ctx.reduced_type_name(table.client_name()));
+    let simple_input = format!("{}Collection", input_ctx.mutation_return_type_name(table.client_name()));
 
     output_ctx.with_input_type(&simple_input, table.id(), |builder| {
         for column in table.columns() {

--- a/engine/crates/parser-postgres/src/registry/queries/update_many.rs
+++ b/engine/crates/parser-postgres/src/registry/queries/update_many.rs
@@ -18,13 +18,13 @@ pub(crate) fn register(
     update_input_type: &str,
     output_ctx: &mut OutputContext,
 ) {
-    let type_name = input_ctx.reduced_type_name(table.client_name());
+    let type_name = input_ctx.batch_mutation_return_type_name(table.client_name());
     let query_name = format!("{}_Update_Many", table.client_name()).to_camel_case();
 
     let by_value = MetaInputValue::new("filter", format!("{update_filter_type}!"));
 
     let input_value = MetaInputValue::new("input", format!("{update_input_type}!"));
-    let mut meta_field = MetaField::new(query_name, format!("[{type_name}]!"));
+    let mut meta_field = MetaField::new(query_name, type_name);
 
     meta_field.description = Some(format!("Update multiple {}s", table.client_name()));
     meta_field.required_operation = Some(Operations::UPDATE);

--- a/engine/crates/parser-postgres/src/registry/queries/update_one.rs
+++ b/engine/crates/parser-postgres/src/registry/queries/update_one.rs
@@ -18,7 +18,7 @@ pub(crate) fn register(
     update_input_type: &str,
     output_ctx: &mut OutputContext,
 ) {
-    let type_name = input_ctx.reduced_type_name(table.client_name());
+    let type_name = input_ctx.mutation_return_type_name(table.client_name());
     let query_name = format!("{}_Update", table.client_name()).to_camel_case();
 
     let by_value = MetaInputValue::new("by", format!("{filter_oneof_type}!"));

--- a/engine/crates/postgres-types/src/transport/tcp.rs
+++ b/engine/crates/postgres-types/src/transport/tcp.rs
@@ -125,6 +125,10 @@ impl Transport for TcpTransport {
         let params = json_to_string(params);
         let row_stream = self.client.query_raw_txt(query, params).await?;
 
+        pin_mut!(row_stream);
+
+        while (row_stream.next().await).is_some() {}
+
         let command_tag = row_stream.command_tag().unwrap_or_default();
         let mut command_tag_split = command_tag.split(' ');
         let command_tag_name = command_tag_split.next().unwrap_or_default();


### PR DESCRIPTION
# Postgres explicit returning

This patch changes all Postgres mutations in a way which allows setting the `returning` selection explicitly, or leave it out from the query. So a query that used to work like this:

```graphql
userDeleteMany(filter: { age: { gt: 18 } }) {
  id
  name
}
```

is now:

```graphql
userDeleteMany(filter: { age: { gt: 18 } }) {
  returning {
    id
    name
  }
  rowCount
}
```

If the user is not passing the `returning` value in the selection, we do not load any data from the database. This makes sense, if deleting large amounts of data, and the result set is too big to fit to the memory. Additional value `rowCount` is added to mark how many rows the mutation affected.

Now, one can write the delete like so:

```graphql
userDeleteMany(filter: { age: { gt: 18 } }) {
  rowCount
}
```

The operation is going to be much faster and the only value loaded and returned is a single number.

Additionally, when implementing more database connectors, such as MySQL, which doesn't have `RETURNING` statement, the api difference is much smaller: we just don't have `returning` selection, and the `rowCount` stays the same.

The PR changes all mutation selection as described in the `userDeleteMany` example: for create, update and delete, batch and no batch.

Closes: GB-5062