### PR TITLE
fix: empty connector names shouldn't be allowed

### DIFF
--- a/engine/crates/parser-sdl/src/lib.rs
+++ b/engine/crates/parser-sdl/src/lib.rs
@@ -47,6 +47,7 @@ use rules::{
 };
 
 mod type_names;
+mod validations;
 
 pub use connector_parsers::ConnectorParsers;
 pub use engine::registry::Registry;

--- a/engine/crates/parser-sdl/src/rules/postgres_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/postgres_directive.rs
@@ -209,7 +209,7 @@ mod tests {
               @postgres(
                 name: "",
                 namespace: true,
-                url: "{{ env.PG_CONNECTION_STRING }}",
+                url: "postgres://postgres:grafbase@localhost:5432/postgres",
               )
             "#,
             "Connector names cannot be empty"
@@ -221,12 +221,10 @@ mod tests {
         assert_validation_error!(
             r#"
             extend schema
-              @mongodb(
-                name: "1234"
-                apiKey: "i am a key"
-                url: "http://example.com/mongodbinnit"
-                dataSource: "woop"
-                database: "poow"
+              @postgres(
+                name: "123",
+                namespace: true,
+                url: "postgres://postgres:grafbase@localhost:5432/postgres",
               )
             "#,
             "Connector names must be alphanumeric and cannot start with a number"

--- a/engine/crates/parser-sdl/src/rules/postgres_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/postgres_directive.rs
@@ -5,7 +5,7 @@ use super::{
     directive::Directive,
     visitor::{Visitor, VisitorContext},
 };
-use crate::directive_de::parse_directive;
+use crate::{directive_de::parse_directive, validations::validate_connector_name};
 
 const POSTGRES_DIRECTIVE_NAME: &str = "postgres";
 
@@ -72,11 +72,23 @@ impl<'a> Visitor<'a> for PostgresVisitor {
             .filter(|d| d.node.name.node == POSTGRES_DIRECTIVE_NAME);
 
         for directive in directives {
-            match parse_directive::<PostgresDirective>(&directive.node, ctx.variables) {
+            let result = parse_directive::<PostgresDirective>(&directive.node, ctx.variables)
+                .map_err(|error| error.to_string())
+                .and_then(|directive| directive.validate());
+
+            match result {
                 Ok(parsed_directive) => ctx.postgres_directives.push((parsed_directive, directive.pos)),
                 Err(err) => ctx.report_error(vec![directive.pos], err.to_string()),
             }
         }
+    }
+}
+
+impl PostgresDirective {
+    fn validate(self) -> Result<Self, String> {
+        validate_connector_name(&self.name)?;
+
+        Ok(self)
     }
 }
 
@@ -186,6 +198,38 @@ mod tests {
               )
             "#,
             "Name \"Test\" is not unique. A connector must have a unique name."
+        );
+    }
+
+    #[test]
+    fn empty_name() {
+        assert_validation_error!(
+            r#"
+            extend schema
+              @postgres(
+                name: "",
+                namespace: true,
+                url: "{{ env.PG_CONNECTION_STRING }}",
+              )
+            "#,
+            "Connector names cannot be empty"
+        );
+    }
+
+    #[test]
+    fn invalid_name() {
+        assert_validation_error!(
+            r#"
+            extend schema
+              @mongodb(
+                name: "1234"
+                apiKey: "i am a key"
+                url: "http://example.com/mongodbinnit"
+                dataSource: "woop"
+                database: "poow"
+              )
+            "#,
+            "Connector names must be alphanumeric and cannot start with a number"
         );
     }
 }

--- a/engine/crates/parser-sdl/src/validations.rs
+++ b/engine/crates/parser-sdl/src/validations.rs
@@ -1,0 +1,19 @@
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+static NAME_REGEX: OnceLock<Regex> = OnceLock::new();
+
+pub fn validate_connector_name(name: &str) -> Result<(), String> {
+    let name_regex = NAME_REGEX.get_or_init(|| Regex::new("^[A-Za-z_][A-Za-z0-9_]*$").unwrap());
+
+    if name.is_empty() {
+        return Err("Connector names cannot be empty".into());
+    }
+
+    if !name_regex.is_match(name) {
+        return Err("Connector names must be alphanumeric and cannot start with a number".into());
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Until now we've done no validation of connector names, so silly things like `""` are allowed.  This adds some simple validation using the GraphQL name validation rules.

Fixes GB-5134
