### PR TITLE
fix(logs): CLI: Adjust runtime logs based on the new federation orientation

### DIFF
--- a/cli/crates/cli/src/logs.rs
+++ b/cli/crates/cli/src/logs.rs
@@ -74,6 +74,7 @@ pub enum LogEventType {
         http_method: String,
         path: String,
         http_status: u16,
+        duration: std::time::Duration,
     },
     FunctionMessage {
         log_level: LogLevel,
@@ -110,6 +111,7 @@ pub async fn log_events_for_time_range(
                 http_status,
                 url,
                 message,
+                duration,
                 ..
             }) => Some(LogEvent {
                 id: id.parse().expect("must be a valid ULID"),
@@ -119,6 +121,7 @@ pub async fn log_events_for_time_range(
                     http_method,
                     path: url::Url::from_str(&url).expect("must be a valid URL").path().to_owned(),
                     http_status: u16::try_from(http_status).expect("must be valid"),
+                    duration: std::time::Duration::from_millis(duration.try_into().expect("must be a positive number")),
                 },
             }),
             api::LogEvent::FunctionLogEvent(api::FunctionLogEvent {

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -403,17 +403,15 @@ pub fn print_log_entry(
 ) {
     let created_at: chrono::DateTime<chrono::Local> = chrono::DateTime::from(created_at);
 
-    let extra_properties = match log_event_type {
-        crate::logs::LogEventType::Request {
-            http_method,
-            path,
-            http_status,
-        } => format!("{http_method} {path} {http_status}"),
+    let rest = match log_event_type {
+        crate::logs::LogEventType::Request { duration, .. } => {
+            format!("{message} {duration}", duration = format_duration(duration))
+        }
         crate::logs::LogEventType::FunctionMessage {
             log_level,
             function_kind,
             function_name,
-        } => format!("[{log_level}] {function_kind} {function_name}"),
+        } => format!("[{log_level}] {function_kind} {function_name} | {message}"),
     };
-    println!("{} {extra_properties} | {message}", created_at.to_rfc3339());
+    println!("{} {rest}", created_at.to_rfc3339());
 }


### PR DESCRIPTION
# Description

CLI: Adjust runtime logs based on the new federation orientation.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
