### PR TITLE
feat: A bunch of improvements for grafbase start and build command

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2484,6 +2484,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "sha2",
  "slug",
  "sqlx",
  "strip-ansi-escapes",
@@ -2500,6 +2501,7 @@ dependencies = [
  "ulid",
  "unicode-normalization",
  "version-compare",
+ "walkdir",
  "which",
 ]
 

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -39,6 +39,7 @@ uuid = { version = "1", features = ["v4"] }
 url = "2"
 webbrowser = "0.8"
 lru = "0.12"
+futures-util = "0.3"
 
 server = { package = "grafbase-local-server", path = "../server", version = "0.40.2" }
 backend = { package = "grafbase-local-backend", path = "../backend", version = "0.40.2" }

--- a/cli/crates/cli/src/build.rs
+++ b/cli/crates/cli/src/build.rs
@@ -1,0 +1,12 @@
+use std::num::NonZeroUsize;
+
+use futures_util::TryFutureExt;
+
+use crate::{cli_input::LogLevelFilters, errors::CliError};
+
+pub fn build(parallelism: NonZeroUsize, tracing: bool) -> Result<(), CliError> {
+    trace!("attempting to build server");
+    crate::start::run(LogLevelFilters::default(), |message_sender| {
+        server::ProductionServer::build(message_sender, parallelism, tracing).map_ok(|_| ())
+    })
+}

--- a/cli/crates/cli/src/dev.rs
+++ b/cli/crates/cli/src/dev.rs
@@ -39,7 +39,7 @@ pub fn dev(
 
         while let Some(message) = message_receiver.recv().await {
             match message {
-                ServerMessage::Ready(port) => {
+                ServerMessage::Ready { port, .. } => {
                     READY.call_once(|| report::start_dev_server(resolvers_reported, port, external_port));
                 }
                 ServerMessage::Reload(path) => report::reload(path),
@@ -75,6 +75,7 @@ pub fn dev(
                     }
                 },
                 ServerMessage::CompilationError(error) => report::error(&CliError::CompilationError(error)),
+                ServerMessage::StartUdfBuildAll | ServerMessage::CompleteUdfBuildAll { .. } => {}
             }
 
             // Flush nested events that are really old – if a user interrupts a request, we will not see an operation completion event.

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(test, allow(unused_crate_dependencies))]
 #![forbid(unsafe_code)]
 
+mod build;
 mod cli_input;
 mod create;
 mod deploy;
@@ -23,6 +24,7 @@ mod watercolor;
 extern crate log;
 
 use crate::{
+    build::build,
     cli_input::{Args, ArgumentNames, LogsCommand, SubCommand},
     create::create,
     deploy::deploy,
@@ -120,6 +122,14 @@ fn try_main(args: Args) -> Result<(), CliError> {
             });
 
             start(cmd.listen_address(), cmd.port, cmd.log_levels(), args.trace >= 2)
+        }
+        SubCommand::Build(cmd) => {
+            let _ = ctrlc::set_handler(|| {
+                report::goodbye();
+                process::exit(exitcode::OK);
+            });
+
+            build(cmd.parallelism(), args.trace >= 2)
         }
     }
 }

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -113,11 +113,27 @@ pub fn goodbye() {
     watercolor::output!("\n👋 See you next time!", @BrightBlue);
 }
 
+pub fn start_udf_build_all() {
+    println!("{} compiling user defined functions...", watercolor!("wait", @Cyan),);
+}
+
 pub fn start_udf_build(udf_kind: UdfKind, udf_name: &str) {
     println!(
         "{} compiling {udf_kind} {udf_name}...",
         watercolor!("wait", @Cyan),
         udf_name = udf_name.to_string().bold()
+    );
+}
+
+pub fn complete_udf_build_all(duration: std::time::Duration) {
+    let formatted_duration = if duration < std::time::Duration::from_secs(1) {
+        format!("{}ms", duration.as_millis())
+    } else {
+        format!("{:.1}s", duration.as_secs_f64())
+    };
+    println!(
+        "{} user defined functions compiled successfully in {formatted_duration}",
+        watercolor!("event", @BrightMagenta),
     );
 }
 

--- a/cli/crates/cli/src/start.rs
+++ b/cli/crates/cli/src/start.rs
@@ -3,10 +3,12 @@ use crate::output::report;
 use crate::CliError;
 use backend::types::{LogEventType, ServerMessage};
 use common::utils::get_thread_panic_message;
-use server::types::NestedRequestScopedMessage;
+use futures_util::Future;
+use server::{errors::ServerError, types::NestedRequestScopedMessage};
 use std::net::IpAddr;
 use std::num::NonZeroUsize;
 use std::thread;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 struct MessageGroup {
     created_at: tokio::time::Instant,
@@ -21,79 +23,43 @@ impl MessageGroup {
         }
     }
 }
-
 pub fn start(
     listen_address: IpAddr,
     port: u16,
     log_level_filters: LogLevelFilters,
     tracing: bool,
 ) -> Result<(), CliError> {
-    const EVENT_MAX_DELAY: tokio::time::Duration = tokio::time::Duration::from_secs(60);
-
     trace!("attempting to start server");
-    let (message_sender, mut message_receiver) = tokio::sync::mpsc::unbounded_channel::<ServerMessage>();
-    let server = server::production_start(listen_address, port, tracing, message_sender);
-    let reporter = async move {
-        // Using a LRU cache, we store data for at most the last 1024 requests. We'll certainly
-        // revisit that logic, but it limits the possibility of memory problems.
-        let mut message_group_buffer = lru::LruCache::new(NonZeroUsize::new(1024).unwrap());
-        while let Some(message) = message_receiver.recv().await {
-            #[allow(clippy::single_match)] // will certainly change in the future
-            match message {
-                ServerMessage::Ready(port) => {
-                    report::start_prod_server(listen_address, port);
-                }
-                ServerMessage::RequestScopedMessage { event_type, request_id } => match event_type {
-                    LogEventType::RequestCompleted {
-                        name,
-                        duration,
-                        request_completed_type,
-                    } => {
-                        let nested_events = message_group_buffer
-                            .pop(&request_id)
-                            .map(|group: MessageGroup| group.events)
-                            .unwrap_or_default();
-                        report::operation_log(name, duration, request_completed_type, nested_events, log_level_filters);
-                    }
-                    LogEventType::NestedEvent(nested_event) => {
-                        message_group_buffer
-                            .get_or_insert_mut(request_id, MessageGroup::new)
-                            .events
-                            .push(nested_event);
-                    }
-                },
-                ServerMessage::StartUdfBuild { udf_kind, udf_name } => {
-                    report::start_udf_build(udf_kind, &udf_name);
-                }
-                ServerMessage::CompleteUdfBuild {
-                    udf_kind,
-                    udf_name,
-                    duration,
-                } => {
-                    report::complete_udf_build(udf_kind, &udf_name, duration);
-                }
-                ServerMessage::CompilationError(error) => report::error(&CliError::CompilationError(error)),
-                ServerMessage::Reload(_) => (),
-            }
-            // Just avoiding keeping message indefinitely and imitating dev command logic.
-            while message_group_buffer
-                .peek_lru()
-                .map(|(_, group)| group.created_at.elapsed() > EVENT_MAX_DELAY)
-                .unwrap_or_default()
-            {
-                message_group_buffer.pop_lru();
-            }
-        }
-    };
+    run(log_level_filters, |message_sender| async move {
+        // not sure we'll keep building in the start command, so keeping the same behavior as
+        // before building UDFs serially.
+        let parallelism = NonZeroUsize::new(1).expect("strictly positive");
+        server::ProductionServer::build(message_sender, parallelism, tracing)
+            .await?
+            .serve(listen_address, port)
+            .await
+    })
+}
+
+pub(crate) fn run<F>(
+    log_level_filters: LogLevelFilters,
+    build: impl FnOnce(UnboundedSender<ServerMessage>) -> F,
+) -> Result<(), CliError>
+where
+    F: Future<Output = Result<(), ServerError>> + Send + 'static,
+{
+    let (message_sender, message_receiver) = tokio::sync::mpsc::unbounded_channel::<ServerMessage>();
+    let action = build(message_sender);
+    let log_reporter = log_reporter(message_receiver, log_level_filters);
 
     let handle = thread::spawn(move || {
         #[allow(clippy::ignored_unit_patterns)]
         tokio::runtime::Runtime::new().unwrap().block_on(async {
             tokio::select! {
-                result = server => {
+                result = action => {
                     result?;
                 }
-                _ = reporter => {}
+                _ = log_reporter => {}
             }
             Ok(())
         })
@@ -108,4 +74,55 @@ pub fn start(
         .map_err(CliError::ServerError)?;
 
     Ok(())
+}
+
+async fn log_reporter(mut message_receiver: UnboundedReceiver<ServerMessage>, log_level_filters: LogLevelFilters) {
+    const EVENT_MAX_DELAY: tokio::time::Duration = tokio::time::Duration::from_secs(60);
+
+    // Using a LRU cache, we store data for at most the last 1024 requests. We'll certainly
+    // revisit that logic, but it limits the possibility of memory problems.
+    let mut message_group_buffer = lru::LruCache::new(NonZeroUsize::new(1024).unwrap());
+    while let Some(message) = message_receiver.recv().await {
+        #[allow(clippy::single_match)] // will certainly change in the future
+        match message {
+            ServerMessage::Ready { listen_address, port } => {
+                report::start_prod_server(listen_address, port);
+            }
+            ServerMessage::RequestScopedMessage { event_type, request_id } => match event_type {
+                LogEventType::RequestCompleted {
+                    name,
+                    duration,
+                    request_completed_type,
+                } => {
+                    let nested_events = message_group_buffer
+                        .pop(&request_id)
+                        .map(|group: MessageGroup| group.events)
+                        .unwrap_or_default();
+                    report::operation_log(name, duration, request_completed_type, nested_events, log_level_filters);
+                }
+                LogEventType::NestedEvent(nested_event) => {
+                    message_group_buffer
+                        .get_or_insert_mut(request_id, MessageGroup::new)
+                        .events
+                        .push(nested_event);
+                }
+            },
+            ServerMessage::StartUdfBuildAll => {
+                report::start_udf_build_all();
+            }
+            ServerMessage::CompleteUdfBuildAll { duration } => {
+                report::complete_udf_build_all(duration);
+            }
+            ServerMessage::CompilationError(error) => report::error(&CliError::CompilationError(error)),
+            _ => {}
+        }
+        // Just avoiding keeping message indefinitely and imitating dev command logic.
+        while message_group_buffer
+            .peek_lru()
+            .map(|(_, group)| group.created_at.elapsed() > EVENT_MAX_DELAY)
+            .unwrap_or_default()
+        {
+            message_group_buffer.pop_lru();
+        }
+    }
 }

--- a/cli/crates/common/src/environment.rs
+++ b/cli/crates/common/src/environment.rs
@@ -57,10 +57,14 @@ impl GrafbaseSchemaPath {
     }
 
     fn parent(&self) -> Option<&Path> {
-        use SchemaLocation::{Graphql, TsConfig};
+        self.path().parent()
+    }
 
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        use SchemaLocation::{Graphql, TsConfig};
         match self.location() {
-            TsConfig(path) | Graphql(path) => path.parent(),
+            TsConfig(path) | Graphql(path) => path,
         }
     }
 }

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -58,6 +58,8 @@ ulid = "1"
 version-compare = "0.1"
 which = "4"
 cfg-if = "1"
+walkdir = "2"
+sha2 = "0.10"
 
 # Same version as Tantivy
 tantivy-fst = "0.4.0"

--- a/cli/crates/server/src/lib.rs
+++ b/cli/crates/server/src/lib.rs
@@ -36,4 +36,4 @@ mod udf_builder;
 pub mod errors;
 pub mod types;
 
-pub use servers::{production_start, start};
+pub use servers::{start, ProductionServer};

--- a/cli/crates/server/src/types.rs
+++ b/cli/crates/server/src/types.rs
@@ -1,5 +1,5 @@
 use common::types::{LogLevel, UdfKind};
-use std::path::PathBuf;
+use std::{net::IpAddr, path::PathBuf};
 
 pub const ASSETS_GZIP: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/assets.tar.gz"));
 
@@ -45,8 +45,15 @@ pub enum LogEventType {
 
 #[derive(Clone, Debug)]
 pub enum ServerMessage {
-    Ready(u16),
+    Ready {
+        listen_address: IpAddr,
+        port: u16,
+    },
     Reload(PathBuf),
+    StartUdfBuildAll,
+    CompleteUdfBuildAll {
+        duration: std::time::Duration,
+    },
     StartUdfBuild {
         udf_kind: UdfKind,
         udf_name: String,


### PR DESCRIPTION
- Only a single instance of miniflare is used, shared across workers.
- UDFs are built in parallel
- Adding a very simple cache mechanism, avoiding recompiling UDFs
  if nothing changed.

I'm also adding a `build` command which does all the UDF compilation in a separate step. It's only helpful for the `start` command currently, allowing one to `grafbase build` during a docker image build.

Resolves: GB-5109,GB-5110

# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
