### PR TITLE
feat(cli): implement typescript code generation for resolvers

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -898,6 +898,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+
+[[package]]
 name = "case"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,6 +1436,18 @@ dependencies = [
  "futures-util",
  "lru 0.11.1",
  "tracing",
+]
+
+[[package]]
+name = "datatest-stable"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a384d02609f0774f4dbf0c38fc57eb2769b24c30b9185911ff657ec14837da"
+dependencies = [
+ "camino",
+ "libtest-mimic",
+ "regex",
+ "walkdir",
 ]
 
 [[package]]
@@ -3316,6 +3334,17 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libtest-mimic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d8de370f98a6cb8a4606618e53e802f93b094ddec0f96988eaec2c27e6e9ce7"
+dependencies = [
+ "clap",
+ "termcolor",
+ "threadpool",
 ]
 
 [[package]]
@@ -6108,6 +6137,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "time"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6443,6 +6481,15 @@ checksum = "39a40ba241047e1174c927dc5f61c141a166b938d61a2ff61838441368cc7d0e"
 dependencies = [
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "typed-resolvers"
+version = "0.40.2"
+dependencies = [
+ "datatest-stable",
+ "graphql-parser",
+ "similar",
 ]
 
 [[package]]

--- a/cli/crates/typed-resolvers/Cargo.toml
+++ b/cli/crates/typed-resolvers/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "typed-resolvers"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+graphql-parser = "0.4"
+
+[dev-dependencies]
+similar = "2"
+datatest-stable = "0.2.3"
+
+[[test]]
+name = "schema_types"
+harness = false

--- a/cli/crates/typed-resolvers/README.md
+++ b/cli/crates/typed-resolvers/README.md
@@ -1,0 +1,30 @@
+# typed-resolvers
+
+This crate implements code generation and resolver discovery for custom resolvers.
+
+## Design
+
+This crate does not reuse existing infrastructure because the amount of
+analysis required on the schema is very limited: we do not want to do extra
+validation because we want to tolerate fairly broken schemas and still generate
+code. Also code generation has to be fast for integration in the `gb dev` loop.
+
+Unlike graphql-code-generator, we do not generate types for the resolver
+functions. By design, the generated module has one TypeScript type per GraphQL
+type. They have the same name (except TS reserved keywords), and they are in
+the same order in the generated file as in the source file.
+
+## Tests
+
+### Overview
+
+The tests are located in the `tests/` directory.
+
+Each test is a GraphQL file. When you run `cargo test`, the typescript module
+is generated for each graphql file and compared with the matching
+`.expected.ts` snapshot. Test discovery is implemented in `build.rs` and the
+test runner in `tests/`.
+
+### Updating the snapshots
+
+Run `cargo test` with the `UPDATE_EXPECT` env var defined.

--- a/cli/crates/typed-resolvers/src/analyze.rs
+++ b/cli/crates/typed-resolvers/src/analyze.rs
@@ -1,0 +1,444 @@
+use graphql_parser::schema as ast;
+use std::{collections::HashMap, ops, str::FromStr};
+
+pub(crate) fn analyze<'doc>(graphql_document: &'doc ast::Document<'doc, &'doc str>) -> AnalyzedSchema<'doc> {
+    let mut schema = AnalyzedSchema::default();
+
+    analyze_top_level(graphql_document, &mut schema);
+    analyze_fields(graphql_document, &mut schema);
+
+    schema
+}
+
+/// First pass. Resolve what definitions exist in the schema (objects, unions, etc.).
+fn analyze_top_level<'doc>(graphql_document: &'doc ast::Document<'doc, &'doc str>, schema: &mut AnalyzedSchema<'doc>) {
+    for definition in &graphql_document.definitions {
+        match definition {
+            ast::Definition::DirectiveDefinition(_) | ast::Definition::SchemaDefinition(_) => (), // not interested
+            ast::Definition::TypeDefinition(ast::TypeDefinition::Object(output_type)) => {
+                schema.push_output_type(Object {
+                    name: output_type.name,
+                    docs: output_type.description.as_deref(),
+                    kind: ObjectKind::Object,
+                });
+            }
+            ast::Definition::TypeDefinition(ast::TypeDefinition::InputObject(object_definition)) => {
+                schema.push_output_type(Object {
+                    name: object_definition.name,
+                    docs: object_definition.description.as_deref(),
+                    kind: ObjectKind::InputObject,
+                });
+            }
+            ast::Definition::TypeDefinition(ast::TypeDefinition::Interface(object_definition)) => {
+                schema.push_output_type(Object {
+                    name: object_definition.name,
+                    docs: object_definition.description.as_deref(),
+                    kind: ObjectKind::Interface,
+                });
+            }
+            ast::Definition::TypeDefinition(ast::TypeDefinition::Scalar(scalar)) => {
+                schema.push_custom_scalar(CustomScalar {
+                    name: scalar.name,
+                    docs: scalar.description.as_deref(),
+                });
+            }
+            ast::Definition::TypeDefinition(ast::TypeDefinition::Union(union_definition)) => {
+                schema.push_union(Union {
+                    name: union_definition.name,
+                });
+            }
+            ast::Definition::TypeDefinition(ast::TypeDefinition::Enum(enum_definition)) => {
+                let id = schema.push_enum(Enum {
+                    name: enum_definition.name,
+                    docs: enum_definition.description.as_deref(),
+                });
+
+                for variant in &enum_definition.values {
+                    schema.push_enum_variant(id, variant.name);
+                }
+            }
+            ast::Definition::TypeExtension(_) => {
+                // We ignore type extensions in the first pass because we can't know if they extend
+                // types defined in the document yet.
+            }
+        }
+    }
+}
+
+/// Second pass. We know about all definitions, now we analyze fields inside object and interface
+/// types, and variants inside unions.
+fn analyze_fields<'doc>(graphql_document: &'doc ast::Document<'doc, &'doc str>, schema: &mut AnalyzedSchema<'doc>) {
+    for definition in &graphql_document.definitions {
+        match definition {
+            ast::Definition::DirectiveDefinition(_) | ast::Definition::SchemaDefinition(_) => (), // not interested
+            ast::Definition::TypeDefinition(ast::TypeDefinition::Union(union_definition)) => {
+                let Definition::Union(union_id) = schema.definition_names[union_definition.name] else {
+                    continue;
+                };
+
+                for variant_name in &union_definition.types {
+                    match schema.definition_names.get(variant_name) {
+                        Some(Definition::Object(object_id)) => schema.push_union_variant(union_id, *object_id),
+                        None | Some(_) => (), // invalid: union variant is not an object name. Ignore here.
+                    }
+                }
+            }
+            ast::Definition::TypeDefinition(ast::TypeDefinition::Object(object_definition)) => {
+                let Definition::Object(object_id) = schema.definition_names[object_definition.name] else {
+                    continue;
+                };
+
+                for field in &object_definition.fields {
+                    if let Some(field) = analyze_ast_field(field, schema) {
+                        schema.object_fields.push((object_id, field));
+                    }
+                }
+            }
+            ast::Definition::TypeDefinition(ast::TypeDefinition::InputObject(object_definition)) => {
+                let Definition::Object(object_id) = schema.definition_names[object_definition.name] else {
+                    continue;
+                };
+
+                for field in &object_definition.fields {
+                    if let Some(field) = analyze_ast_input_field(field, schema) {
+                        schema.object_fields.push((object_id, field));
+                    }
+                }
+            }
+            ast::Definition::TypeDefinition(ast::TypeDefinition::Interface(object_definition)) => {
+                let Definition::Object(object_id) = schema.definition_names[object_definition.name] else {
+                    continue;
+                };
+
+                for field in &object_definition.fields {
+                    if let Some(field) = analyze_ast_field(field, schema) {
+                        schema.object_fields.push((object_id, field));
+                    }
+                }
+            }
+            ast::Definition::TypeExtension(ast::TypeExtension::Object(obj)) => {
+                let Some(Definition::Object(extended_object_id)) = schema.definition_names.get(obj.name) else {
+                    continue;
+                };
+
+                for field in &obj.fields {
+                    if let Some(field) = analyze_ast_field(field, schema) {
+                        schema.object_fields.push((*extended_object_id, field));
+                    }
+                }
+            }
+            ast::Definition::TypeExtension(ast::TypeExtension::InputObject(obj)) => {
+                let Some(Definition::Object(extended_object_id)) = schema.definition_names.get(obj.name) else {
+                    continue;
+                };
+
+                for field in &obj.fields {
+                    if let Some(field) = analyze_ast_input_field(field, schema) {
+                        schema.object_fields.push((*extended_object_id, field));
+                    }
+                }
+            }
+            // Already completely handled in first pass.
+            ast::Definition::TypeDefinition(ast::TypeDefinition::Scalar(_) | ast::TypeDefinition::Enum(_))
+            // Not handled
+            | ast::Definition::TypeExtension(_) => {}
+        }
+    }
+
+    schema.object_fields.sort_by_key(|(object_id, _)| *object_id);
+}
+
+fn analyze_ast_input_field<'doc>(
+    field: &'doc ast::InputValue<'doc, &'doc str>,
+    schema: &AnalyzedSchema<'doc>,
+) -> Option<Field<'doc>> {
+    let (name, inner_is_nullable, list_wrappers) = type_from_nested(&field.value_type);
+    Some(Field {
+        name: field.name,
+        docs: field.description.as_deref(),
+        kind: BuiltinScalar::from_str(name)
+            .ok()
+            .map(FieldTypeKind::BuiltinScalar)
+            .or_else(|| schema.definition_names.get(name).map(|d| FieldTypeKind::Definition(*d)))?,
+        inner_is_nullable,
+        list_wrappers,
+    })
+}
+
+fn analyze_ast_field<'doc>(
+    field: &'doc ast::Field<'doc, &'doc str>,
+    schema: &AnalyzedSchema<'doc>,
+) -> Option<Field<'doc>> {
+    let (name, inner_is_nullable, list_wrappers) = type_from_nested(&field.field_type);
+    Some(Field {
+        name: field.name,
+        docs: field.description.as_deref(),
+        kind: BuiltinScalar::from_str(name)
+            .ok()
+            .map(FieldTypeKind::BuiltinScalar)
+            .or_else(|| schema.definition_names.get(name).map(|d| FieldTypeKind::Definition(*d)))?,
+        inner_is_nullable,
+        list_wrappers,
+    })
+}
+
+fn type_from_nested<'a>(ty: &ast::Type<'a, &'a str>) -> (&'a str, bool, Vec<ListWrapper>) {
+    match ty {
+        ast::Type::NonNullType(ty) => match ty.as_ref() {
+            ast::Type::ListType(inner) => {
+                let (name, inner_is_nullable, mut wrappers) = type_from_nested(inner);
+                wrappers.push(ListWrapper::NonNullList);
+                (name, inner_is_nullable, wrappers)
+            }
+            ast::Type::NamedType(name) => (name, false, Vec::new()),
+            ast::Type::NonNullType(_) => {
+                unreachable!("unreachable double required (!!)");
+            }
+        },
+        ast::Type::NamedType(name) => (name, true, Vec::new()),
+        ast::Type::ListType(inner) => {
+            let (name, inner, mut wrappers) = type_from_nested(inner);
+            wrappers.push(ListWrapper::NullableList);
+            (name, inner, wrappers)
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+pub(crate) struct AnalyzedSchema<'doc> {
+    pub(crate) definitions: Vec<Definition>,
+
+    // Index mapping names to definitions.
+    definition_names: HashMap<&'doc str, Definition>,
+
+    pub(crate) objects: Vec<Object<'doc>>,
+
+    object_fields: Vec<(ObjectId, Field<'doc>)>,
+
+    pub(crate) unions: Vec<Union<'doc>>,
+    // Invariant: This is sorted because we iterate unions in order. We rely on that for binary
+    // search.
+    pub(crate) union_variants: Vec<(UnionId, ObjectId)>,
+
+    pub(crate) enums: Vec<Enum<'doc>>,
+    // Invariant: This is sorted. We rely on that for binary search.
+    pub(crate) enum_variants: Vec<(EnumId, &'doc str)>,
+
+    pub(crate) custom_scalars: Vec<CustomScalar<'doc>>,
+}
+
+#[derive(Debug)]
+pub(crate) struct Field<'doc> {
+    pub(crate) name: &'doc str,
+    pub(crate) kind: FieldTypeKind,
+    pub(crate) docs: Option<&'doc str>,
+
+    inner_is_nullable: bool,
+    // TODO: a more compact and/or normalized representation
+    /// The list wrapper types, from innermost to outermost.
+    list_wrappers: Vec<ListWrapper>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ListWrapper {
+    NullableList,
+    NonNullList,
+}
+
+impl Field<'_> {
+    /// Returns whether the innermost type is nullable.
+    ///
+    /// For example `[Test]!` would return true, `[Test!]` would return false, `Test` would be
+    /// true, and `Test!` would be false.
+    pub(crate) fn inner_is_nullable(&self) -> bool {
+        self.inner_is_nullable
+    }
+
+    /// Iterate list wrapper types from innermost to outermost.
+    ///
+    /// Example: `[[Int!]!]` would yield `NonNull, NonNullList, List`. You can then look up the
+    /// unwrapped type in `OutputField::kind`.
+    pub(crate) fn iter_list_wrappers(&self) -> impl Iterator<Item = ListWrapper> + '_ {
+        self.list_wrappers.iter().copied()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum FieldTypeKind {
+    BuiltinScalar(BuiltinScalar),
+    Definition(Definition),
+}
+
+#[derive(Debug)]
+pub(crate) struct CustomScalar<'doc> {
+    pub(crate) name: &'doc str,
+    pub(crate) docs: Option<&'doc str>,
+}
+
+#[derive(Debug)]
+pub(crate) enum BuiltinScalar {
+    Int,
+    Float,
+    String,
+    Boolean,
+    Id,
+}
+
+impl FromStr for BuiltinScalar {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "String" => Ok(BuiltinScalar::String),
+            "Int" => Ok(BuiltinScalar::Int),
+            "Float" => Ok(BuiltinScalar::Float),
+            "Boolean" => Ok(BuiltinScalar::Boolean),
+            "ID" => Ok(BuiltinScalar::Id),
+            _ => Err(()),
+        }
+    }
+}
+
+impl<'doc> AnalyzedSchema<'doc> {
+    pub(crate) fn iter_object_fields(&self, object_id: ObjectId) -> impl Iterator<Item = &Field<'doc>> {
+        let start = self.object_fields.partition_point(|(id, _)| *id < object_id);
+        self.object_fields[start..]
+            .iter()
+            .take_while(move |(id, _)| object_id == *id)
+            .map(|(_, output_field)| output_field)
+    }
+
+    pub(crate) fn iter_enum_variants(&self, enum_id: EnumId) -> impl Iterator<Item = &'doc str> + '_ {
+        let start = self.enum_variants.partition_point(|(id, _)| *id < enum_id);
+        self.enum_variants[start..]
+            .iter()
+            .take_while(move |(id, _)| enum_id == *id)
+            .map(|(_, variant)| *variant)
+    }
+
+    pub(crate) fn iter_union_variants(&self, union_id: UnionId) -> impl Iterator<Item = &Object<'doc>> {
+        let start = self.union_variants.partition_point(|(id, _)| *id < union_id);
+        self.union_variants[start..]
+            .iter()
+            .take_while(move |(id, _)| *id == union_id)
+            .map(|(_, output_type_id)| &self[*output_type_id])
+    }
+
+    fn push_definition(&mut self, name: &'doc str, definition: Definition) {
+        self.definitions.push(definition);
+        self.definition_names.insert(name, definition);
+    }
+
+    fn push_custom_scalar(&mut self, scalar: CustomScalar<'doc>) -> CustomScalarId {
+        let id = CustomScalarId(self.custom_scalars.len());
+        self.push_definition(scalar.name, Definition::CustomScalar(id));
+        self.custom_scalars.push(scalar);
+        id
+    }
+
+    fn push_enum(&mut self, enum_definition: Enum<'doc>) -> EnumId {
+        let id = EnumId(self.enums.len());
+        self.push_definition(enum_definition.name, Definition::Enum(id));
+        self.enums.push(enum_definition);
+        id
+    }
+
+    fn push_enum_variant(&mut self, id: EnumId, variant: &'doc str) {
+        self.enum_variants.push((id, variant));
+    }
+
+    fn push_output_type(&mut self, output_type: Object<'doc>) -> ObjectId {
+        let id = ObjectId(self.objects.len());
+        self.push_definition(output_type.name, Definition::Object(id));
+        self.objects.push(output_type);
+        id
+    }
+
+    fn push_union(&mut self, union: Union<'doc>) -> UnionId {
+        let id = UnionId(self.unions.len());
+        self.push_definition(union.name, Definition::Union(id));
+        self.unions.push(union);
+        id
+    }
+
+    fn push_union_variant(&mut self, union: UnionId, variant: ObjectId) {
+        self.union_variants.push((union, variant));
+    }
+}
+
+impl<'doc> ops::Index<CustomScalarId> for AnalyzedSchema<'doc> {
+    type Output = CustomScalar<'doc>;
+
+    fn index(&self, index: CustomScalarId) -> &Self::Output {
+        &self.custom_scalars[index.0]
+    }
+}
+
+impl<'doc> ops::Index<EnumId> for AnalyzedSchema<'doc> {
+    type Output = Enum<'doc>;
+
+    fn index(&self, index: EnumId) -> &Self::Output {
+        &self.enums[index.0]
+    }
+}
+
+impl<'doc> ops::Index<ObjectId> for AnalyzedSchema<'doc> {
+    type Output = Object<'doc>;
+
+    fn index(&self, index: ObjectId) -> &Self::Output {
+        &self.objects[index.0]
+    }
+}
+
+impl<'doc> ops::Index<UnionId> for AnalyzedSchema<'doc> {
+    type Output = Union<'doc>;
+
+    fn index(&self, index: UnionId) -> &Self::Output {
+        &self.unions[index.0]
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum Definition {
+    CustomScalar(CustomScalarId),
+    Enum(EnumId),
+    Object(ObjectId),
+    Union(UnionId),
+}
+
+#[derive(Debug)]
+pub(crate) struct Object<'doc> {
+    pub(crate) name: &'doc str,
+    pub(crate) docs: Option<&'doc str>,
+    pub(crate) kind: ObjectKind,
+}
+
+#[derive(Debug)]
+pub(crate) enum ObjectKind {
+    Object,
+    InputObject,
+    Interface,
+}
+
+#[derive(Debug)]
+pub(crate) struct Union<'doc> {
+    pub(crate) name: &'doc str,
+}
+
+#[derive(Debug)]
+pub(crate) struct Enum<'doc> {
+    pub(crate) name: &'doc str,
+    pub(crate) docs: Option<&'doc str>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd)]
+pub(crate) struct EnumId(usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ObjectId(usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd)]
+pub(crate) struct UnionId(usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd)]
+pub(crate) struct CustomScalarId(usize);

--- a/cli/crates/typed-resolvers/src/codegen.rs
+++ b/cli/crates/typed-resolvers/src/codegen.rs
@@ -1,0 +1,149 @@
+use crate::analyze::{AnalyzedSchema, BuiltinScalar, Definition, Field, FieldTypeKind, ListWrapper, ObjectKind};
+use std::fmt;
+
+const INDENT: &str = "  ";
+
+pub(crate) fn generate_module<O>(schema: &AnalyzedSchema<'_>, out: &mut O) -> fmt::Result
+where
+    O: fmt::Write,
+{
+    for (idx, definition) in schema.definitions.iter().enumerate() {
+        match definition {
+            Definition::Object(id) => {
+                let object_type = &schema[*id];
+                let graphql_type_name = object_type.name;
+                let ts_type_name = safe_ts_type_name(graphql_type_name);
+                let is_input_object = matches!(object_type.kind, ObjectKind::InputObject);
+
+                maybe_docs(out, object_type.docs, "")?;
+                writeln!(out, "export type {ts_type_name} = {{")?;
+
+                if let ObjectKind::Object = object_type.kind {
+                    writeln!(out, "{INDENT}__typename?: '{graphql_type_name}';")?;
+                }
+
+                for field in schema.iter_object_fields(*id) {
+                    let field_optional = !is_input_object
+                        && matches!(
+                            field.kind,
+                            FieldTypeKind::Definition(Definition::Object(_) | Definition::Union(_))
+                        );
+
+                    let field_optional = if field_optional { "?" } else { "" };
+                    let field_name = field.name;
+                    let field_type = render_field_type(field, schema);
+
+                    maybe_docs(out, field.docs, INDENT)?;
+                    writeln!(out, "{INDENT}{field_name}{field_optional}: {field_type};")?;
+                }
+
+                out.write_str("};\n")?;
+            }
+            Definition::Union(union_id) => {
+                let union_name = schema[*union_id].name;
+                write!(out, "export type {union_name} = ")?;
+
+                let mut variants = schema.iter_union_variants(*union_id).peekable();
+                while let Some(variant) = variants.next() {
+                    write!(out, "{}", safe_ts_type_name(variant.name))?;
+
+                    if variants.peek().is_some() {
+                        out.write_str(" | ")?;
+                    }
+                }
+                out.write_str(";\n")?;
+            }
+            Definition::Enum(enum_id) => {
+                let r#enum = &schema[*enum_id];
+                let enum_name = safe_ts_type_name(r#enum.name);
+                maybe_docs(out, r#enum.docs, "")?;
+                writeln!(out, "export enum {enum_name} {{")?;
+                for variant in schema.iter_enum_variants(*enum_id) {
+                    out.write_str(INDENT)?;
+                    out.write_str(variant)?;
+                    out.write_str(",\n")?;
+                }
+                out.write_str("}\n")?;
+            }
+            Definition::CustomScalar(id) => {
+                let scalar = &schema[*id];
+                let scalar_name = safe_ts_type_name(scalar.name);
+                maybe_docs(out, scalar.docs, "")?;
+                writeln!(out, "export type {scalar_name} = any;")?;
+            }
+        }
+
+        // Newline between definitions but not at the end.
+        if idx + 1 < schema.definitions.len() {
+            writeln!(out)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn render_field_type(field: &Field<'_>, schema: &AnalyzedSchema<'_>) -> String {
+    let mut type_string = match &field.kind {
+        FieldTypeKind::BuiltinScalar(scalar) => match scalar {
+            BuiltinScalar::Int | BuiltinScalar::Float => "number",
+            BuiltinScalar::String | BuiltinScalar::Id => "string",
+            BuiltinScalar::Boolean => "boolean",
+        }
+        .to_owned(),
+        FieldTypeKind::Definition(def) => safe_ts_type_name(match *def {
+            Definition::CustomScalar(id) => schema[id].name,
+            Definition::Enum(id) => schema[id].name,
+            Definition::Object(id) => schema[id].name,
+            Definition::Union(id) => schema[id].name,
+        })
+        .to_string(),
+    };
+
+    if field.inner_is_nullable() {
+        type_string.push_str(" | null");
+    }
+
+    for wrapper in field.iter_list_wrappers() {
+        type_string = match wrapper {
+            ListWrapper::NullableList => format!("Array<{type_string}> | null"),
+            ListWrapper::NonNullList => format!("Array<{type_string}>"),
+        }
+    }
+
+    type_string
+}
+
+/// Takes a GraphQL name, and returns a typescript-safe version. This takes TypeScript reserved keywords into account.
+fn safe_ts_type_name(graphql_name: &str) -> impl fmt::Display + '_ {
+    struct SafeName<'a>(&'a str);
+
+    impl fmt::Display for SafeName<'_> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self.0 {
+                "any" | "async" | "boolean" | "interface" | "never" | "null" | "number" | "object" | "string"
+                | "symbol" | "undefined" | "unknown" | "void" => {
+                    f.write_str("_")?;
+                    f.write_str(self.0)
+                }
+                _ => f.write_str(self.0),
+            }
+        }
+    }
+
+    SafeName(graphql_name)
+}
+
+fn maybe_docs<O>(out: &mut O, docs: Option<&str>, indentation: &str) -> fmt::Result
+where
+    O: fmt::Write,
+{
+    let Some(docs) = docs else { return Ok(()) };
+
+    writeln!(out, "{indentation}/**")?;
+
+    for line in docs.lines() {
+        writeln!(out, "{indentation} * {line}")?;
+    }
+
+    writeln!(out, "{indentation} */")
+}

--- a/cli/crates/typed-resolvers/src/error.rs
+++ b/cli/crates/typed-resolvers/src/error.rs
@@ -1,0 +1,29 @@
+use graphql_parser::schema::ParseError;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum CodegenError {
+    ParseError(ParseError),
+    FmtError(fmt::Error),
+}
+
+impl fmt::Display for CodegenError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CodegenError::ParseError(err) => fmt::Display::fmt(err, f),
+            CodegenError::FmtError(err) => fmt::Display::fmt(err, f),
+        }
+    }
+}
+
+impl From<fmt::Error> for CodegenError {
+    fn from(value: fmt::Error) -> Self {
+        CodegenError::FmtError(value)
+    }
+}
+
+impl From<ParseError> for CodegenError {
+    fn from(value: ParseError) -> Self {
+        CodegenError::ParseError(value)
+    }
+}

--- a/cli/crates/typed-resolvers/src/lib.rs
+++ b/cli/crates/typed-resolvers/src/lib.rs
@@ -1,0 +1,20 @@
+#![allow(unused_crate_dependencies)]
+
+mod analyze;
+mod codegen;
+mod error;
+
+use self::error::CodegenError;
+use std::fmt;
+
+/// Generate a TypeScript module that contains input and output type definitions for resolver
+/// authoring purposes, based on the passed in SDL schema.
+pub fn generate_ts_resolver_types<O>(graphql_sdl: &str, out: &mut O) -> Result<(), CodegenError>
+where
+    O: fmt::Write,
+{
+    let parsed_schema = graphql_parser::parse_schema::<&str>(graphql_sdl)?;
+    let analyzed_schema = analyze::analyze(&parsed_schema);
+    codegen::generate_module(&analyzed_schema, out)?;
+    Ok(())
+}

--- a/cli/crates/typed-resolvers/tests/schema_types.rs
+++ b/cli/crates/typed-resolvers/tests/schema_types.rs
@@ -1,0 +1,47 @@
+#![allow(clippy::panic)] // this is tests, panicking signals failure
+
+use graphql_parser as _;
+use std::{fs, path::Path, sync::OnceLock};
+
+fn update_expect() -> bool {
+    static UPDATE_EXPECT: OnceLock<bool> = OnceLock::new();
+    *UPDATE_EXPECT.get_or_init(|| std::env::var("UPDATE_EXPECT").is_ok())
+}
+
+#[allow(clippy::unnecessary_wraps)] // we can't change the signature expected by datatest_stable
+fn run_test(path: &Path) -> datatest_stable::Result<()> {
+    let graphql = fs::read_to_string(path).unwrap();
+    let expected_file_path = path.with_extension("expected.ts");
+    let mut expected = fs::read_to_string(&expected_file_path).unwrap_or_default();
+    let generated = {
+        let mut out = String::with_capacity(graphql.len() / 2);
+        typed_resolvers::generate_ts_resolver_types(&graphql, &mut out).unwrap();
+        out
+    };
+
+    if cfg!(target_os = "windows") {
+        expected.retain(|c| c != '\r');
+    }
+
+    if generated == expected {
+        return Ok(());
+    }
+
+    if update_expect() {
+        std::fs::write(expected_file_path, &generated).unwrap();
+        return Ok(());
+    }
+
+    panic!(
+        "{}\n\n\n=== Hint: run the tests again with UPDATE_EXPECT=1 to update the snapshot. ===",
+        similar::udiff::unified_diff(
+            similar::Algorithm::default(),
+            &expected,
+            &generated,
+            5,
+            Some(("Expected", "Actual"))
+        )
+    );
+}
+
+datatest_stable::harness! { run_test, "./tests/schema_types", ".*\\.graphql$" }

--- a/cli/crates/typed-resolvers/tests/schema_types/basic.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/basic.expected.ts
@@ -1,0 +1,4 @@
+export type Test = {
+  __typename?: 'Test';
+  id: string | null;
+};

--- a/cli/crates/typed-resolvers/tests/schema_types/basic.graphql
+++ b/cli/crates/typed-resolvers/tests/schema_types/basic.graphql
@@ -1,0 +1,3 @@
+type Test {
+  id: ID
+}

--- a/cli/crates/typed-resolvers/tests/schema_types/basic_enum.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/basic_enum.expected.ts
@@ -1,0 +1,5 @@
+export enum Color {
+  RED,
+  GREEN,
+  BLUE,
+}

--- a/cli/crates/typed-resolvers/tests/schema_types/basic_enum.graphql
+++ b/cli/crates/typed-resolvers/tests/schema_types/basic_enum.graphql
@@ -1,0 +1,5 @@
+enum Color {
+  RED
+  GREEN
+  BLUE
+}

--- a/cli/crates/typed-resolvers/tests/schema_types/custom_scalars.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/custom_scalars.expected.ts
@@ -1,0 +1,9 @@
+/**
+ * An IPv4 address
+ */
+export type NetworkAddress = any;
+
+export type QueryRoot = {
+  __typename?: 'QueryRoot';
+  address: NetworkAddress | null;
+};

--- a/cli/crates/typed-resolvers/tests/schema_types/custom_scalars.graphql
+++ b/cli/crates/typed-resolvers/tests/schema_types/custom_scalars.graphql
@@ -1,0 +1,12 @@
+schema {
+  query: QueryRoot
+}
+
+"""
+An IPv4 address
+"""
+scalar NetworkAddress
+
+type QueryRoot {
+  address: NetworkAddress
+}

--- a/cli/crates/typed-resolvers/tests/schema_types/interfaces.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/interfaces.expected.ts
@@ -1,0 +1,21 @@
+export type Human = {
+  __typename?: 'Human';
+  id: string;
+  firstName: string;
+  lastName: string;
+};
+
+export type Dog = {
+  __typename?: 'Dog';
+  id: string;
+  name: string;
+};
+
+export type LivingThing = {
+  metabolicRate: number;
+  age: number;
+};
+
+export type Animal = {
+  pettable: boolean;
+};

--- a/cli/crates/typed-resolvers/tests/schema_types/interfaces.graphql
+++ b/cli/crates/typed-resolvers/tests/schema_types/interfaces.graphql
@@ -1,0 +1,19 @@
+type Human implements LivingThing {
+  id: ID!
+  firstName: String!
+  lastName: String!
+}
+
+type Dog implements LivingThing & Animal {
+  id: ID!
+  name: String!
+}
+
+interface LivingThing {
+  metabolicRate: Float!
+  age: Int!
+}
+
+interface Animal {
+  pettable: Boolean!
+}

--- a/cli/crates/typed-resolvers/tests/schema_types/keyword_names.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/keyword_names.expected.ts
@@ -1,0 +1,57 @@
+export type holycow = type | _interface | _object | union;
+
+/**
+ * GraphQL field names can be anything.
+ */
+export type Cursed = {
+  __typename?: 'Cursed';
+  self: boolean | null;
+  this: string | null;
+  let: number | null;
+  type: number | null;
+  number: number | null;
+  super: boolean | null;
+  const: boolean | null;
+  /**
+   * lol
+   */
+  async: boolean | null;
+  _: boolean | null;
+};
+
+/**
+ * Look, this enum is called undefined!
+ */
+export enum _undefined {
+  void,
+  string,
+}
+
+export type type = {
+  __typename?: 'type';
+  type?: type;
+  interface?: _interface;
+};
+
+export type _object = {
+  __typename?: 'object';
+  id: string;
+};
+
+export type union = {
+  id: string;
+};
+
+export type _interface = {
+  __typename?: 'interface';
+  type?: type;
+  interface?: _interface | null;
+};
+
+export type schema = {
+  id: string;
+};
+
+export type query = {
+  fragment?: type | null;
+};

--- a/cli/crates/typed-resolvers/tests/schema_types/keyword_names.graphql
+++ b/cli/crates/typed-resolvers/tests/schema_types/keyword_names.graphql
@@ -1,0 +1,53 @@
+union holycow = type | interface | object | union
+
+"""
+GraphQL field names can be anything.
+"""
+type Cursed {
+  self: Boolean
+  this: String
+  let: Int
+  type: Float
+  number: Int
+  super: Boolean
+  const: Boolean
+  """
+  lol
+  """
+  async: Boolean
+  _: Boolean
+}
+
+"""
+Look, this enum is called undefined!
+"""
+enum undefined {
+  void
+  string
+}
+
+type type {
+  type: type!
+  interface: interface!
+}
+
+type object {
+  id: ID!
+}
+
+interface union {
+  id: ID!
+}
+
+type interface implements query {
+  type: type!
+  interface: interface
+}
+
+interface schema {
+  id: ID!
+}
+
+interface query {
+  fragment: type
+}

--- a/cli/crates/typed-resolvers/tests/schema_types/recursive_types.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/recursive_types.expected.ts
@@ -1,0 +1,20 @@
+export type TreeNode = {
+  __typename?: 'TreeNode';
+  value: number;
+  children?: Array<TreeNode | null> | null;
+};
+
+export type TreeNodeInput = {
+  value: number;
+  children: Array<TreeNodeInput | null> | null;
+};
+
+export type Query = {
+  __typename?: 'Query';
+  getTree?: TreeNode | null;
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  createTree?: TreeNode | null;
+};

--- a/cli/crates/typed-resolvers/tests/schema_types/recursive_types.graphql
+++ b/cli/crates/typed-resolvers/tests/schema_types/recursive_types.graphql
@@ -1,0 +1,19 @@
+# Recursive Output Type
+type TreeNode {
+  value: Int!
+  children: [TreeNode]
+}
+
+# Recursive Input Type
+input TreeNodeInput {
+  value: Int!
+  children: [TreeNodeInput]
+}
+
+type Query {
+  getTree: TreeNode
+}
+
+type Mutation {
+  createTree(input: TreeNodeInput): TreeNode
+}

--- a/cli/crates/typed-resolvers/tests/schema_types/type_extensions.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/type_extensions.expected.ts
@@ -1,0 +1,37 @@
+export type Query = {
+  __typename?: 'Query';
+  episode?: Episode | null;
+  character?: Character | null;
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  createEpisode?: Episode;
+};
+
+export type Episode = {
+  __typename?: 'Episode';
+  id: string;
+  title: string;
+  season: number;
+  episodeNumber: number;
+  description: string | null;
+  characters?: Array<Character>;
+};
+
+export type Character = {
+  __typename?: 'Character';
+  id: string;
+  name: string;
+  occupation: string | null;
+  episodes?: Array<Episode>;
+  friends?: Array<Character> | null;
+};
+
+export type CreateEpisodeInput = {
+  title: string;
+  season: number;
+  episodeNumber: number;
+  description: string | null;
+  characters: Array<string> | null;
+};

--- a/cli/crates/typed-resolvers/tests/schema_types/type_extensions.graphql
+++ b/cli/crates/typed-resolvers/tests/schema_types/type_extensions.graphql
@@ -1,0 +1,51 @@
+# Initial Type Definitions
+
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+type Query {
+  episode(id: ID!): Episode
+  character(id: ID!): Character
+}
+
+type Mutation {
+  createEpisode(input: CreateEpisodeInput!): Episode!
+}
+
+type Episode {
+  id: ID!
+  title: String!
+  season: Int!
+}
+
+type Character {
+  id: ID!
+  name: String!
+}
+
+input CreateEpisodeInput {
+  title: String!
+  season: Int!
+}
+
+# Type Extensions
+
+extend type Episode {
+  episodeNumber: Int!
+  description: String
+  characters: [Character!]!
+}
+
+extend type Character {
+  occupation: String
+  episodes: [Episode!]!
+  friends: [Character!]
+}
+
+extend input CreateEpisodeInput {
+  episodeNumber: Int!
+  description: String
+  characters: [ID!]
+}

--- a/cli/crates/typed-resolvers/tests/schema_types/union.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/union.expected.ts
@@ -1,0 +1,13 @@
+export type Dog = {
+  __typename?: 'Dog';
+  id: string;
+  barkVolume: number | null;
+};
+
+export type Cat = {
+  __typename?: 'Cat';
+  id: string;
+  meowVolume: number | null;
+};
+
+export type Pet = Cat | Dog;

--- a/cli/crates/typed-resolvers/tests/schema_types/union.graphql
+++ b/cli/crates/typed-resolvers/tests/schema_types/union.graphql
@@ -1,0 +1,11 @@
+type Dog {
+  id: ID!
+  barkVolume: Float
+}
+
+type Cat {
+  id: ID!
+  meowVolume: Float
+}
+
+union Pet = Cat | Dog

--- a/cli/crates/typed-resolvers/tests/schema_types/wrapper_types.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/wrapper_types.expected.ts
@@ -1,0 +1,72 @@
+export type Query = {
+  __typename?: 'Query';
+  episode?: Episode | null;
+  episodesBySeason?: Array<Episode>;
+  character?: Character | null;
+  searchCharacters?: Array<Character>;
+  locations?: Array<Location>;
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  createEpisode?: Episode;
+  updateEpisode?: Episode | null;
+};
+
+export type CreateEpisodeInput = {
+  title: string;
+  season: number;
+  episodeNumber: number;
+  description: string | null;
+  characters: Array<string>;
+};
+
+export type UpdateEpisodeInput = {
+  title: string | null;
+  season: number | null;
+  episodeNumber: number | null;
+  description: string | null;
+  characters: Array<string> | null;
+};
+
+export type Episode = {
+  __typename?: 'Episode';
+  id: string;
+  title: string;
+  season: number;
+  episodeNumber: number;
+  description: string | null;
+  characters?: Array<Character>;
+  nestedTrivia?: Array<Array<Array<TriviaItem> | null> | null> | null;
+};
+
+export type Character = {
+  __typename?: 'Character';
+  id: string;
+  name: string;
+  occupation: string | null;
+  episodes?: Array<Episode>;
+  friends?: Array<Character> | null;
+  favoriteLocations?: Array<Location | null> | null;
+  deepRelations?: Array<Array<Array<Array<Relation | null> | null>> | null> | null;
+};
+
+export type Location = {
+  __typename?: 'Location';
+  id: string;
+  name: string;
+  type: string;
+  frequentVisitors?: Array<Character | null> | null;
+};
+
+export type TriviaItem = {
+  __typename?: 'TriviaItem';
+  fact: string;
+  episode?: Episode;
+};
+
+export type Relation = {
+  __typename?: 'Relation';
+  relationType: string;
+  character?: Character;
+};

--- a/cli/crates/typed-resolvers/tests/schema_types/wrapper_types.graphql
+++ b/cli/crates/typed-resolvers/tests/schema_types/wrapper_types.graphql
@@ -1,0 +1,70 @@
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+type Query {
+  episode(id: ID!): Episode
+  episodesBySeason(season: Int!): [Episode!]!
+  character(id: ID!): Character
+  searchCharacters(name: String!): [Character!]!
+  locations: [Location!]!
+}
+
+type Mutation {
+  createEpisode(input: CreateEpisodeInput!): Episode!
+  updateEpisode(id: ID!, input: UpdateEpisodeInput!): Episode
+}
+
+input CreateEpisodeInput {
+  title: String!
+  season: Int!
+  episodeNumber: Int!
+  description: String
+  characters: [ID!]!
+}
+
+input UpdateEpisodeInput {
+  title: String
+  season: Int
+  episodeNumber: Int
+  description: String
+  characters: [ID!]
+}
+
+type Episode {
+  id: ID!
+  title: String!
+  season: Int!
+  episodeNumber: Int!
+  description: String
+  characters: [Character!]!
+  nestedTrivia: [[[TriviaItem!]]] # List nested up to three levels
+}
+
+type Character {
+  id: ID!
+  name: String!
+  occupation: String
+  episodes: [Episode!]!
+  friends: [Character!]
+  favoriteLocations: [Location]
+  deepRelations: [[[[Relation]]!]] # List nested up to four levels
+}
+
+type Location {
+  id: ID!
+  name: String!
+  type: String!
+  frequentVisitors: [Character]
+}
+
+type TriviaItem {
+  fact: String!
+  episode: Episode!
+}
+
+type Relation {
+  relationType: String!
+  character: Character!
+}


### PR DESCRIPTION
# Description

This PR is large, but mostly because of tests.

First iteration of the implementation of the GraphQL SDL -> TypeScript
resolver types part of Typed Resolvers.

This is a new standalone crate in `cli`. It does not reuse existing
infrastructure because the amount of analysis required on the schema is
very limited: we do not want to do extra validation because we want to
tolerate fairly broken schemas and still generate code,and code
generation has to be fast for integration in the `gb dev` loop.

Unlike graphql-code-generator, we do not generate types for the resolver
functions. By design, the generated module has one TypeScript type per
GraphQL type. They have the same name (except TS reserved keywords), and
they are in the same order in the generated file as in the source file.

We do not want types for the resolver functions because we are going to
try using the resolvers as the source of truth (RFC section pending).
Resolver function types can easily be added later if that approach does
not pan out.

Not implemented yet:

- Custom scalar types. They are typed as `any`. We probably want to have
  a configurable location for the generated code to import them from.
- More subtle interface typing. The current approach is very naive, it
  only includes the interface fields.

closes GB-5146


# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
