### PR TITLE
fix: proper FieldSet parsing

### DIFF
--- a/engine/crates/engine/src/registry/export_sdl.rs
+++ b/engine/crates/engine/src/registry/export_sdl.rs
@@ -68,7 +68,7 @@ impl Registry {
                 if field.external {
                     write!(sdl, " @external").ok();
                 }
-                if let Some(requires) = field.requires.as_deref() {
+                if let Some(requires) = &field.requires {
                     write!(sdl, " @requires(fields: \"{requires}\")").ok();
                 }
                 if let Some(provides) = field.provides.as_deref() {

--- a/engine/crates/engine/src/registry/federation.rs
+++ b/engine/crates/engine/src/registry/federation.rs
@@ -65,16 +65,16 @@ impl FederationKey {
         }
     }
 
-    pub fn unresolvable(selections: Vec<Selection>) -> Self {
+    pub fn unresolvable(selections: FieldSet) -> Self {
         FederationKey {
-            selections: FieldSet::new(selections),
+            selections,
             resolver: None,
         }
     }
 
-    pub fn basic_type(selections: Vec<Selection>) -> Self {
+    pub fn basic_type(selections: FieldSet) -> Self {
         FederationKey {
-            selections: FieldSet::new(selections),
+            selections,
             resolver: Some(FederationResolver::BasicType),
         }
     }

--- a/engine/crates/engine/src/registry/field_set.rs
+++ b/engine/crates/engine/src/registry/field_set.rs
@@ -1,7 +1,7 @@
 use serde_json::{Map, Value};
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-pub struct FieldSet(Vec<Selection>);
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Hash, PartialEq)]
+pub struct FieldSet(pub Vec<Selection>);
 
 impl FieldSet {
     pub fn new(selections: impl IntoIterator<Item = Selection>) -> Self {
@@ -30,7 +30,7 @@ fn selections_are_present(object: &Map<String, Value>, selections: &[Selection])
     })
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Hash, PartialEq)]
 #[serde_with::minify_field_names(serialize = "minified", deserialize = "minified")]
 #[serde_with::skip_serializing_defaults(Option, Vec, ConstraintType)]
 pub struct Selection {
@@ -56,13 +56,10 @@ impl std::fmt::Display for Selection {
         write!(f, "{field}")?;
         if !selections.is_empty() {
             write!(f, " {{")?;
-            for (i, selection) in selections.iter().enumerate() {
-                if i != 0 {
-                    write!(f, " ")?;
-                }
-                write!(f, "{selection}")?;
+            for selection in selections {
+                write!(f, " {selection}")?;
             }
-            write!(f, "}}")?;
+            write!(f, " }}")?;
         }
         Ok(())
     }

--- a/engine/crates/engine/src/registry/field_set.rs
+++ b/engine/crates/engine/src/registry/field_set.rs
@@ -1,0 +1,69 @@
+use serde_json::{Map, Value};
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct FieldSet(Vec<Selection>);
+
+impl FieldSet {
+    pub fn new(selections: impl IntoIterator<Item = Selection>) -> Self {
+        FieldSet(selections.into_iter().collect())
+    }
+
+    /// Checks if all the fields of this FieldSet are present in the given JSON object
+    pub fn all_fields_are_present(&self, object: &Map<String, Value>) -> bool {
+        selections_are_present(object, &self.0)
+    }
+}
+
+fn selections_are_present(object: &Map<String, Value>, selections: &[Selection]) -> bool {
+    selections.iter().all(|selection| {
+        if !object.contains_key(&selection.field) {
+            return false;
+        }
+        if selection.selections.is_empty() {
+            return true;
+        }
+        // Make sure any sub-selections are also present
+        let Some(object) = object.get(&selection.field).and_then(Value::as_object) else {
+            return false;
+        };
+        selections_are_present(object, &selection.selections)
+    })
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde_with::minify_field_names(serialize = "minified", deserialize = "minified")]
+#[serde_with::skip_serializing_defaults(Option, Vec, ConstraintType)]
+pub struct Selection {
+    pub field: String,
+    pub selections: Vec<Selection>,
+}
+
+impl std::fmt::Display for FieldSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (i, selection) in self.0.iter().enumerate() {
+            if i != 0 {
+                write!(f, " ")?;
+            }
+            write!(f, "{selection}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for Selection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Selection { field, selections } = self;
+        write!(f, "{field}")?;
+        if !selections.is_empty() {
+            write!(f, " {{")?;
+            for (i, selection) in selections.iter().enumerate() {
+                if i != 0 {
+                    write!(f, " ")?;
+                }
+                write!(f, "{selection}")?;
+            }
+            write!(f, "}}")?;
+        }
+        Ok(())
+    }
+}

--- a/engine/crates/engine/src/registry/mod.rs
+++ b/engine/crates/engine/src/registry/mod.rs
@@ -4,6 +4,7 @@ mod connector_headers;
 pub mod enums;
 mod export_sdl;
 pub mod federation;
+pub mod field_set;
 pub mod relations;
 pub mod resolvers;
 pub mod scalars;
@@ -41,6 +42,7 @@ pub use self::{
         CachePartialRegistry,
     },
     connector_headers::{ConnectorHeaderValue, ConnectorHeaders},
+    field_set::FieldSet,
     type_names::{
         InputValueType, MetaFieldType, ModelName, NamedType, TypeCondition, TypeReference, WrappingType,
         WrappingTypeIter,

--- a/engine/crates/engine/src/registry/mod.rs
+++ b/engine/crates/engine/src/registry/mod.rs
@@ -304,7 +304,7 @@ pub struct MetaField {
     pub deprecation: Deprecation,
     pub cache_control: CacheControl,
     pub external: bool,
-    pub requires: Option<String>,
+    pub requires: Option<FieldSet>,
     pub provides: Option<String>,
     #[serde(skip)]
     #[derivative(Debug = "ignore")]

--- a/engine/crates/engine/src/registry/requires.rs
+++ b/engine/crates/engine/src/registry/requires.rs
@@ -1,4 +1,0 @@
-//! Fields can declare that they "require" other fields.
-//!
-//! This is usually used on a field with a custom resolver where that custom resolver
-//! needs some context from the containing type in order to do its work.

--- a/engine/crates/engine/src/registry/requires.rs
+++ b/engine/crates/engine/src/registry/requires.rs
@@ -1,0 +1,4 @@
+//! Fields can declare that they "require" other fields.
+//!
+//! This is usually used on a field with a custom resolver where that custom resolver
+//! needs some context from the containing type in order to do its work.

--- a/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__flat_output-2.snap
+++ b/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__flat_output-2.snap
@@ -2076,12 +2076,14 @@ Registry {
         "PetstoreUser": FederationEntity {
             keys: [
                 FederationKey {
-                    selections: [
-                        Selection {
-                            field: "username",
-                            selections: [],
-                        },
-                    ],
+                    selections: FieldSet(
+                        [
+                            Selection {
+                                field: "username",
+                                selections: [],
+                            },
+                        ],
+                    ),
                     resolver: Some(
                         Http(
                             HttpResolver {

--- a/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__petstore_output-2.snap
+++ b/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__petstore_output-2.snap
@@ -2166,12 +2166,14 @@ Registry {
         "PetstoreUser": FederationEntity {
             keys: [
                 FederationKey {
-                    selections: [
-                        Selection {
-                            field: "username",
-                            selections: [],
-                        },
-                    ],
+                    selections: FieldSet(
+                        [
+                            Selection {
+                                field: "username",
+                                selections: [],
+                            },
+                        ],
+                    ),
                     resolver: Some(
                         Http(
                             HttpResolver {

--- a/engine/crates/parser-sdl/src/rules/basic_type.rs
+++ b/engine/crates/parser-sdl/src/rules/basic_type.rs
@@ -127,9 +127,9 @@ impl<'a> Visitor<'a> for BasicType {
 impl KeyDirective {
     fn into_key(self) -> FederationKey {
         if self.resolvable {
-            FederationKey::basic_type(self.fields)
+            FederationKey::basic_type(self.fields.0)
         } else {
-            FederationKey::unresolvable(self.fields)
+            FederationKey::unresolvable(self.fields.0)
         }
     }
 }
@@ -149,7 +149,7 @@ fn validate_keys_against_fields(oks: &[(Pos, KeyDirective)], object: ObjectType)
 
     // First make sure all the keys are actually fields
     for (pos, key) in oks {
-        for field in &key.fields {
+        for field in &key.fields.0 .0 {
             if object.field_by_name(&field.field).is_none() {
                 errors.push(RuleError::new(
                     vec![*pos],

--- a/engine/crates/parser-sdl/src/rules/federation/field_set.rs
+++ b/engine/crates/parser-sdl/src/rules/federation/field_set.rs
@@ -1,0 +1,143 @@
+use std::str::FromStr;
+
+use engine::registry::{self, field_set::Selection};
+use nom::{
+    branch::alt,
+    bytes::complete::tag,
+    character::complete::{alpha1, alphanumeric1},
+    combinator::recognize,
+    error::{convert_error, ParseError, VerboseError},
+    multi::{many0_count, many1},
+    sequence::{delimited, pair},
+    AsChar, Finish, IResult, InputTakeAtPosition, Parser,
+};
+use serde::de::Error;
+
+/// Newtype wrapper around registry::FieldSet that Deserializes from a String
+#[derive(Debug)]
+pub struct FieldSet(pub engine::registry::FieldSet);
+
+impl<'de> serde::Deserialize<'de> for FieldSet {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?
+            .parse::<FieldSet>()
+            .map_err(D::Error::custom)
+    }
+}
+
+impl FromStr for FieldSet {
+    type Err = String;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let (remainder, output) = parse_field_set(input)
+            .finish()
+            .map_err(|error| convert_error(input, error))?;
+
+        if !remainder.is_empty() {
+            return Err(format!(
+                "Couldn't parse all of `{input}` as a FieldSet. `{remainder}` did not parse correctly"
+            ));
+        }
+
+        Ok(output)
+    }
+}
+
+fn parse_field_set(input: &str) -> IResult<&str, FieldSet, VerboseError<&str>> {
+    many1(parse_selection)
+        .map(|selections| FieldSet(registry::FieldSet::new(selections)))
+        .parse(input)
+}
+
+fn parse_selection(input: &str) -> IResult<&str, Selection, VerboseError<&str>> {
+    alt((
+        pair(ws(parse_name), ws(parse_selection_set)),
+        ws(parse_name).map(|name| (name, vec![])),
+    ))
+    .map(|(field, selections)| Selection {
+        field: field.to_string(),
+        selections,
+    })
+    .parse(input)
+}
+
+fn parse_selection_set(input: &str) -> IResult<&str, Vec<Selection>, VerboseError<&str>> {
+    delimited(tag("{"), many1(parse_selection), tag("}"))(input)
+}
+
+fn parse_name(input: &str) -> IResult<&str, &str, VerboseError<&str>> {
+    recognize(pair(
+        alt((alpha1, tag("_"))),
+        many0_count(alt((alphanumeric1, tag("_")))),
+    ))
+    .parse(input)
+}
+
+/// A combinator that takes a parser `inner` and produces a parser that also consumes both leading and
+/// trailing whitespace, returning the output of `inner`.
+fn ws<'a, F, O, E: ParseError<&'a str>>(inner: F) -> impl FnMut(&'a str) -> IResult<&'a str, O, E>
+where
+    F: Parser<&'a str, O, E>,
+{
+    delimited(ignored_chars, inner, ignored_chars)
+}
+
+/// nom parser for characters we ignore in GraphQL (commas & whitespace mostly)
+pub fn ignored_chars<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
+where
+    T: InputTakeAtPosition,
+    <T as InputTakeAtPosition>::Item: AsChar + Clone,
+{
+    input.split_at_position_complete(|item| {
+        let c = item.as_char();
+        !(c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == ',')
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(input: &str) -> String {
+        input.parse::<FieldSet>().unwrap().0.to_string()
+    }
+
+    #[test]
+    fn test_parsing_fieldset() {
+        assert_eq!(roundtrip("foo"), "foo");
+        assert_eq!(roundtrip("foo { bar }"), "foo { bar }");
+        assert_eq!(roundtrip("foo { bar baz }"), "foo { bar baz }");
+        assert_eq!(roundtrip("foo { bar baz { bun }}"), "foo { bar baz { bun } }");
+        assert_eq!(
+            roundtrip("foo { bar baz { bun }} bleep"),
+            "foo { bar baz { bun } } bleep"
+        );
+
+        // Make sure we ignore whitespace & commas
+        assert_eq!(roundtrip("   foo { bar baz { bun }}"), "foo { bar baz { bun } }");
+        assert_eq!(roundtrip("   foo {   bar baz { bun }}"), "foo { bar baz { bun } }");
+        assert_eq!(
+            roundtrip("  , foo {,,, bar ,, baz ,,{ bun }, , }, "),
+            "foo { bar baz { bun } }"
+        );
+    }
+
+    fn expect_error(input: &str) {
+        input
+            .parse::<FieldSet>()
+            .expect_err(&format!("Expected parsing `{input}` to fail"));
+    }
+
+    #[test]
+    fn test_failures() {
+        expect_error("foo {{");
+        expect_error("foo {");
+        expect_error("foo {}");
+        expect_error("{ foo }");
+        expect_error("{{");
+        expect_error("1foo {");
+    }
+}

--- a/engine/crates/parser-sdl/src/rules/federation/key.rs
+++ b/engine/crates/parser-sdl/src/rules/federation/key.rs
@@ -1,4 +1,4 @@
-use engine::registry::federation::Selection;
+use engine::registry::field_set::Selection;
 use serde::Deserializer;
 
 use crate::rules::directive::Directive;

--- a/engine/crates/parser-sdl/src/rules/federation/key.rs
+++ b/engine/crates/parser-sdl/src/rules/federation/key.rs
@@ -1,13 +1,11 @@
-use engine::registry::field_set::Selection;
-use serde::Deserializer;
-
 use crate::rules::directive::Directive;
+
+use super::field_set::FieldSet;
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct KeyDirective {
-    #[serde(deserialize_with = "deserialize_selections")]
-    pub fields: Vec<Selection>,
+    pub fields: FieldSet,
     #[serde(default = "default_to_true")]
     pub resolvable: bool,
 }
@@ -26,41 +24,6 @@ impl Directive for KeyDirective {
         "#
         .to_string()
     }
-}
-
-fn deserialize_selections<'de, D>(deserializer: D) -> Result<Vec<Selection>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    struct Visitor;
-    impl<'de> serde::de::Visitor<'de> for Visitor {
-        type Value = Vec<Selection>;
-
-        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
-        {
-            // This whole implementation is extremely naive and doesn't support a lot of stuff.
-            // Will fix in https://linear.app/grafbase/issue/GB-5086
-            if value.contains('{') {
-                return Err(E::custom("nested fields in keys aren't supported at the moment"));
-            }
-
-            Ok(value
-                .split(' ')
-                .map(|field| Selection {
-                    field: field.to_string(),
-                    selections: vec![],
-                })
-                .collect())
-        }
-
-        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(formatter, "a string in FieldSet format")
-        }
-    }
-
-    deserializer.deserialize_str(Visitor)
 }
 
 #[cfg(test)]

--- a/engine/crates/parser-sdl/src/rules/federation/mod.rs
+++ b/engine/crates/parser-sdl/src/rules/federation/mod.rs
@@ -1,4 +1,5 @@
 mod directive;
+mod field_set;
 mod key;
 
 pub use directive::*;


### PR DESCRIPTION
Federation makes quite a lot of use of `FieldSet`s - a simplified GraphQL string without arguments, fragments, spreads etc.

For the sake of speed I added a naive parser of these in a previous PR.  But I'm in the middle of implementing `@requires` which will likely run into the limitations of my previous approach.

So, this PR adds some more thorough parsing.