### PR TITLE
fix(logs): running the `logs` command should be possible without being in a project context

### DIFF
--- a/cli/crates/cli/src/cli_input.rs
+++ b/cli/crates/cli/src/cli_input.rs
@@ -394,7 +394,10 @@ impl SubCommand {
                 | Self::Deploy
                 | Self::Dev(_)
                 | Self::Link(_)
-                | Self::Logs(_)
+                | Self::Logs(LogsCommand {
+                    project_branch: None,
+                    ..
+                })
                 | Self::Reset
                 | Self::Start(_)
                 | Self::Build(_)


### PR DESCRIPTION
# Description

Ensure the project context is only required if no reference is passed to the `logs` command.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
