### PR TITLE
chore: better debug logging in parser-openapi

### DIFF
--- a/engine/crates/parser-openapi/src/graph/debug.rs
+++ b/engine/crates/parser-openapi/src/graph/debug.rs
@@ -1,0 +1,39 @@
+use std::fmt::Debug;
+
+use super::OpenApiGraph;
+
+/// std::fmt::Debug for a node in our graph
+///
+/// Our nodes are usually just wrappers around indices so
+/// the default Debug impl is pretty useless.  This trait adds an
+/// extra graph parameter so we can get at the actual data.
+pub trait DebugNode: Sized {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>, graph: &OpenApiGraph) -> std::fmt::Result;
+
+    fn debug<'a>(&'a self, graph: &'a OpenApiGraph) -> GraphDebug<'a, Self> {
+        GraphDebug(graph, self)
+    }
+}
+
+impl<Node> DebugNode for Vec<Node>
+where
+    Node: DebugNode,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>, graph: &OpenApiGraph) -> std::fmt::Result {
+        f.debug_list()
+            .entries(self.iter().map(|node| node.debug(graph)))
+            .finish()
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct GraphDebug<'a, Node>(&'a OpenApiGraph, &'a Node);
+
+impl<'a, Node> Debug for GraphDebug<'a, Node>
+where
+    Node: DebugNode,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.1.fmt(f, self.0)
+    }
+}

--- a/engine/crates/parser-openapi/src/graph/input_value.rs
+++ b/engine/crates/parser-openapi/src/graph/input_value.rs
@@ -4,7 +4,7 @@ use inflector::Inflector;
 use petgraph::{graph::NodeIndex, visit::EdgeRef};
 use serde_json::Value;
 
-use super::{Edge, Enum, InputObject, Node, OpenApiGraph, ScalarKind, WrappingType};
+use super::{DebugNode, Edge, Enum, InputObject, Node, OpenApiGraph, ScalarKind, WrappingType};
 
 #[derive(Clone, Debug)]
 pub struct InputValue {
@@ -12,6 +12,7 @@ pub struct InputValue {
     wrapping: WrappingType,
 }
 
+#[derive(Clone, Copy, Debug)]
 pub enum InputValueKind {
     Scalar,
     InputObject,
@@ -160,5 +161,14 @@ impl InputValue {
                 None
             }
         }
+    }
+}
+
+impl DebugNode for InputValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>, graph: &OpenApiGraph) -> std::fmt::Result {
+        f.debug_struct("InputValue")
+            .field("kind", &self.kind(graph))
+            .field("wrapping_type", self.wrapping_type())
+            .finish_non_exhaustive()
     }
 }

--- a/engine/crates/parser-openapi/src/graph/mod.rs
+++ b/engine/crates/parser-openapi/src/graph/mod.rs
@@ -22,9 +22,11 @@ mod transforms;
 
 mod all_of_member;
 pub mod construction;
+mod debug;
 mod resource;
 
 pub use self::{
+    debug::DebugNode,
     enums::Enum,
     input_object::{InputField, InputObject},
     input_value::{InputValue, InputValueKind},

--- a/engine/crates/parser-openapi/src/graph/operations.rs
+++ b/engine/crates/parser-openapi/src/graph/operations.rs
@@ -6,8 +6,8 @@ use petgraph::{
 };
 
 use super::{
-    output_type::OutputFieldType, Arity, Edge, HttpMethod, Node, OperationDetails, PathParameter, QueryParameter,
-    RequestBody, RequestBodyContentType,
+    output_type::OutputFieldType, Arity, DebugNode, Edge, HttpMethod, Node, OperationDetails, PathParameter,
+    QueryParameter, RequestBody, RequestBodyContentType,
 };
 use crate::{is_ok, QueryNamingStrategy};
 
@@ -225,6 +225,15 @@ impl Operation {
                 }
                 _ => None,
             })
+    }
+}
+
+impl DebugNode for Operation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>, graph: &super::OpenApiGraph) -> std::fmt::Result {
+        f.debug_struct("Operation")
+            .field("name", &self.name(graph))
+            .field("path_parameters", &self.path_parameters(graph).debug(graph))
+            .finish_non_exhaustive()
     }
 }
 

--- a/engine/crates/parser-openapi/src/graph/parameters.rs
+++ b/engine/crates/parser-openapi/src/graph/parameters.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use engine::registry::resolvers::http::{QueryParameterEncodingStyle, RequestBodyContentType};
 use petgraph::graph::EdgeIndex;
 
-use super::{input_value::InputValue, Edge, FieldName};
+use super::{input_value::InputValue, DebugNode, Edge, FieldName};
 
 #[derive(Clone, Copy)]
 pub struct PathParameter(pub(super) EdgeIndex);
@@ -35,6 +35,19 @@ impl PathParameter {
             Edge::HasPathParameter { wrapping, .. } => InputValue::from_index(dest_index, wrapping.clone(), graph),
             _ => None,
         }
+    }
+}
+
+impl DebugNode for PathParameter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>, graph: &super::OpenApiGraph) -> std::fmt::Result {
+        f.debug_struct("PathParameter")
+            .field("openapi_name", &self.openapi_name(graph))
+            .field("graphql_name", &self.graphql_name(graph).to_string())
+            .field(
+                "input_value",
+                &self.input_value(graph).as_ref().map(|value| value.debug(graph)),
+            )
+            .finish()
     }
 }
 

--- a/engine/crates/parser-openapi/src/graph/resource.rs
+++ b/engine/crates/parser-openapi/src/graph/resource.rs
@@ -1,6 +1,6 @@
 use petgraph::{graph::NodeIndex, visit::EdgeRef, Direction};
 
-use super::{Arity, Edge, Node, OpenApiGraph, Operation, OutputType};
+use super::{Arity, DebugNode, Edge, Node, OpenApiGraph, Operation, OutputType};
 
 /// A Resource is any named schema in the OpenAPI document that some endpoint
 /// directly contains in it's response.
@@ -14,11 +14,11 @@ use super::{Arity, Edge, Node, OpenApiGraph, Operation, OutputType};
 ///   ^------ForResource {arity: Many}--- GetUsers Operation
 ///
 /// See `determine_resource_relationships` for how this is calculated
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 pub struct Resource(NodeIndex);
 
 /// An operation associated with a resource
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 pub struct ResourceOperation {
     pub operation: Operation,
     pub arity: Arity,
@@ -69,6 +69,25 @@ impl Resource {
         }
 
         Some(Resource(index))
+    }
+}
+
+impl DebugNode for Resource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>, graph: &OpenApiGraph) -> std::fmt::Result {
+        let operations = self.operations(graph).collect::<Vec<_>>();
+        f.debug_struct("Resource")
+            .field("name", &self.name(graph))
+            .field("operations", &operations.debug(graph))
+            .finish_non_exhaustive()
+    }
+}
+
+impl DebugNode for ResourceOperation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>, graph: &OpenApiGraph) -> std::fmt::Result {
+        f.debug_struct("ResourceOperation")
+            .field("operation", &self.operation.debug(graph))
+            .field("arity", &self.arity)
+            .finish()
     }
 }
 

--- a/engine/crates/parser-openapi/src/tests/federation.rs
+++ b/engine/crates/parser-openapi/src/tests/federation.rs
@@ -4,6 +4,8 @@ use super::*;
 
 #[test]
 fn test_stripe_federation_schema() {
+    super::init_tracing();
+
     let metadata = ApiMetadata {
         url: None,
         ..metadata("stripe", true)

--- a/engine/crates/parser-openapi/src/tests/mod.rs
+++ b/engine/crates/parser-openapi/src/tests/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Once;
+
 use assert_matches::assert_matches;
 use engine::registry::{MetaType, UnionType};
 
@@ -113,7 +115,7 @@ fn test_orb() {
 
 #[test]
 fn test_mongo_atlas() {
-    tracing_subscriber::fmt().with_env_filter("trace").pretty().init();
+    init_tracing();
 
     // Mongo Atlas is a 3.1 spec
     insta::assert_snapshot!(build_registry(
@@ -212,4 +214,15 @@ fn metadata(name: &str, namespace: bool) -> ApiMetadata {
         headers: ConnectorHeaders::new([]),
         query_naming: QueryNamingStrategy::SchemaName,
     }
+}
+
+fn init_tracing() {
+    static INITIALIZER: Once = Once::new();
+    INITIALIZER.call_once(|| {
+        tracing_subscriber::fmt()
+            .with_env_filter("trace")
+            .without_time()
+            .with_test_writer()
+            .init();
+    });
 }


### PR DESCRIPTION
The types `parser-openapi` works with are often just wrappers around a `NodeIndex`.  When working with these it can be quite awkward to debug - if you try to log details of the types you're working with you just get `OutputType(123)` or whatever.

This PR adds a `DebugNode` trait and implements it for some of these wrapper types - basically a clone of `Debug` that takes an `OpenApiGraph` (which is where the actual data these IDs refer to lives).

Also added some better tracing setup for the `parser-openapi` tests.

I've had this sitting on my local machine for a week or two, figured i should get it pushed up before I forget