### PR TITLE
cli: Subgraph introspection

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -161,6 +161,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "apollo-encoder"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee9f27b20841d14923dd5f0714a79f86360b23492d2f98ab5d1651471a56b7a4"
+dependencies = [
+ "apollo-parser",
+ "thiserror",
+]
+
+[[package]]
+name = "apollo-parser"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c382f531987366a6954ac687305652b1428b049ca1294b4502b0a9dbbf0d37b8"
+dependencies = [
+ "memchr",
+ "rowan",
+ "thiserror",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,8 +337,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "738953986114630243230d0961968972ac326530532dca8e46f085a42c26fc31"
 dependencies = [
  "async-graphql-derive 6.0.6",
- "async-graphql-parser 6.0.6",
- "async-graphql-value 6.0.6",
+ "async-graphql-parser 6.0.9",
+ "async-graphql-value 6.0.9",
  "async-stream",
  "async-trait",
  "base64 0.13.1",
@@ -382,7 +403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6f224b1a028d601e27c6fc8456eb580064cb20a58069c21e513b16d5d751e91"
 dependencies = [
  "Inflector",
- "async-graphql-parser 6.0.6",
+ "async-graphql-parser 6.0.9",
  "darling 0.20.3",
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -406,11 +427,11 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-parser"
-version = "6.0.6"
+version = "6.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a6788bfac416c4ef118d3314d603ace7bae4159cd453ad8b9d8b071efd6ce0"
+checksum = "c47e1c1ff6cb7cae62c9cd768d76475cc68f156d8234b024fd2499ad0e91da21"
 dependencies = [
- "async-graphql-value 6.0.6",
+ "async-graphql-value 6.0.9",
  "pest",
  "serde",
  "serde_json",
@@ -430,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-value"
-version = "6.0.6"
+version = "6.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141bdc0b12f87ad76c963bf1bae5c04608e0547ad6831a86fbb8f753b2c438f"
+checksum = "2270df3a642efce860ed06fbcf61fc6db10f83c2ecb5613127fb453c82e012a4"
 dependencies = [
  "bytes",
  "indexmap 2.0.0",
@@ -1178,6 +1199,12 @@ checksum = "2d458e66999348f56fd3ffcfbb7f7951542075ca8359687c703de6500c1ddccd"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "cpufeatures"
@@ -2383,6 +2410,7 @@ dependencies = [
  "async-graphql 5.0.10",
  "async-graphql-axum",
  "async-trait",
+ "atty",
  "axum",
  "backtrace",
  "cfg-if",
@@ -2399,6 +2427,7 @@ dependencies = [
  "exitcode",
  "fslock",
  "futures-util",
+ "grafbase-graphql-introspection",
  "grafbase-local-backend",
  "grafbase-local-common",
  "grafbase-local-server",
@@ -2441,6 +2470,19 @@ dependencies = [
  "webbrowser",
  "which",
  "wiremock",
+]
+
+[[package]]
+name = "grafbase-graphql-introspection"
+version = "0.40.2"
+dependencies = [
+ "apollo-encoder",
+ "apollo-parser",
+ "cynic",
+ "cynic-introspection",
+ "indoc",
+ "reqwest",
+ "serde",
 ]
 
 [[package]]
@@ -3051,9 +3093,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2cb48b81b1dc9f39676bf99f5499babfec7cd8fe14307f7b3d747208fb5690"
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "infer"
@@ -3572,9 +3614,9 @@ checksum = "8c408dc227d302f1496c84d9dc68c00fec6f56f9228a18f3023f976f3ca7c945"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memmap2"
@@ -4185,10 +4227,11 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.6.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16833386b02953ca926d19f64af613b9bf742c48dcd5e09b32fbfc9740bf84e2"
+checksum = "c022f1e7b65d6a24c0dbbd5fb344c66881bc01f3e5ae74a1c8100f2f985d98a4"
 dependencies = [
+ "memchr",
  "thiserror",
  "ucd-trie",
 ]
@@ -4786,9 +4829,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.18"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
  "base64 0.21.2",
  "bytes",
@@ -4813,6 +4856,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "system-configuration",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -4820,9 +4864,9 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.2.3",
+ "wasm-streams",
  "web-sys",
- "webpki-roots 0.22.6",
+ "webpki-roots 0.25.2",
  "winreg",
 ]
 
@@ -4904,6 +4948,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rowan"
+version = "0.15.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "906057e449592587bf6724f00155bf82a6752c868d78a8fb3aa41f4e6357cfe8"
+dependencies = [
+ "countme",
+ "hashbrown 0.12.3",
+ "memoffset",
+ "rustc-hash",
+ "text-size",
 ]
 
 [[package]]
@@ -5399,9 +5456,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
 ]
@@ -5429,9 +5486,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6326,6 +6383,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tantivy"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6481,6 +6559,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "textwrap"
@@ -7020,9 +7104,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -7226,19 +7310,6 @@ checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "wasm-streams"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-streams"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
@@ -7289,25 +7360,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7315,6 +7367,12 @@ checksum = "b291546d5d9d1eab74f069c77749f2cb8504a12caa20f0f2de93ddbf6f411888"
 dependencies = [
  "rustls-webpki",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "which"
@@ -7520,11 +7578,12 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7571,7 +7630,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.3.0",
+ "wasm-streams",
  "web-sys",
  "worker-kv",
  "worker-macros",

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -44,7 +44,8 @@ futures-util = "0.3"
 server = { package = "grafbase-local-server", path = "../server", version = "0.40.2" }
 backend = { package = "grafbase-local-backend", path = "../backend", version = "0.40.2" }
 common = { package = "grafbase-local-common", path = "../common", version = "0.40.2" }
-
+graphql-introspection = { package = "grafbase-graphql-introspection", path = "../graphql-introspection" }
+atty = "0.2.14"
 
 [dev-dependencies]
 async-graphql = "5"

--- a/cli/crates/cli/src/errors.rs
+++ b/cli/crates/cli/src/errors.rs
@@ -50,6 +50,8 @@ pub enum CliError {
     /// returned if `logs` is run without a project branch reference, and no project has been linked
     #[error("no project is linked to the workspace and `logs` has been invoked without any argument")]
     LogsNoLinkedProject,
+    #[error("error during graph introspection: {0}")]
+    Introspection(String),
 }
 
 #[cfg(target_family = "windows")]

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -17,6 +17,7 @@ mod panic_hook;
 mod prompts;
 mod reset;
 mod start;
+mod subgraph;
 mod unlink;
 mod watercolor;
 
@@ -36,6 +37,7 @@ use crate::{
     logs::logs,
     reset::reset,
     start::start,
+    subgraph::subgraph,
     unlink::unlink,
 };
 use clap::Parser;
@@ -68,7 +70,11 @@ fn try_main(args: Args) -> Result<(), CliError> {
 
     tracing_subscriber::registry().with(fmt::layer()).with(filter).init();
     trace!("subcommand: {}", args.command);
-    report::cli_header();
+
+    // do not display header if we're in a pipe
+    if atty::is(atty::Stream::Stdout) {
+        report::cli_header();
+    }
 
     if args.command.in_project_context() {
         Environment::try_init_with_project(args.home).map_err(CliError::CommonError)?;
@@ -131,5 +137,6 @@ fn try_main(args: Args) -> Result<(), CliError> {
 
             build(cmd.parallelism(), args.trace >= 2)
         }
+        SubCommand::Subgraph(cmd) => subgraph(cmd),
     }
 }

--- a/cli/crates/cli/src/subgraph.rs
+++ b/cli/crates/cli/src/subgraph.rs
@@ -1,0 +1,22 @@
+use tokio::runtime::Runtime;
+
+use crate::{
+    cli_input::{SubgraphCommand, SubgraphCommandKind},
+    errors::CliError,
+};
+
+pub(super) fn subgraph(cmd: SubgraphCommand) -> Result<(), CliError> {
+    match cmd.kind {
+        SubgraphCommandKind::Introspect(command) => {
+            let headers = command.headers().collect::<Vec<_>>();
+            let operation = graphql_introspection::introspect(command.url(), &headers);
+
+            match Runtime::new().unwrap().block_on(operation) {
+                Ok(result) => println!("{result}"),
+                Err(e) => return Err(CliError::Introspection(e)),
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/cli/crates/cli/tests/introspection.rs
+++ b/cli/crates/cli/tests/introspection.rs
@@ -1,0 +1,257 @@
+#![allow(unused_crate_dependencies)]
+#![recursion_limit = "256"]
+
+#[path = "graphql-directive/server.rs"]
+mod server;
+
+mod utils;
+
+use serde_json::json;
+use utils::environment::Environment;
+use wiremock::{
+    matchers::{body_json, header, method, path},
+    Mock, MockServer, ResponseTemplate,
+};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn subgraph() {
+    let env = Environment::init();
+    let server = MockServer::start().await;
+
+    let request = json!({
+        "query": "query {\n  _service {\n    sdl\n  }\n}    \n",
+        "variables": {}
+    });
+
+    let response = ResponseTemplate::new(200).set_body_json(json!({
+        "data": {
+            "_service": {
+                "sdl": indoc::indoc! {r#"
+                    type Test {
+                      id: ID!
+                    }
+                "#}
+            }
+        }
+    }));
+
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .and(body_json(request))
+        .respond_with(response)
+        .mount(&server)
+        .await;
+
+    let address = server.address();
+    let url = format!("http://localhost:{}/graphql", address.port());
+
+    let output = env.grafbase_introspect(&url, &[]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    println!("{stderr}");
+    assert!(output.stderr.is_empty());
+
+    insta::assert_snapshot!(&stdout, @r###"
+    type Test {
+      id: ID!
+    }
+
+    "###);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn header_no_whitespace() {
+    let env = Environment::init();
+    let server = MockServer::start().await;
+
+    let request = json!({
+        "query": "query {\n  _service {\n    sdl\n  }\n}    \n",
+        "variables": {}
+    });
+
+    let response = ResponseTemplate::new(200).set_body_json(json!({
+        "data": {
+            "_service": {
+                "sdl": indoc::indoc! {r#"
+                    type Test {
+                      id: ID!
+                    }
+                "#}
+            }
+        }
+    }));
+
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .and(body_json(request))
+        .and(header("x-api-key", "foo"))
+        .respond_with(response)
+        .mount(&server)
+        .await;
+
+    let address = server.address();
+    let url = format!("http://localhost:{}/graphql", address.port());
+
+    let output = env.grafbase_introspect(&url, &["x-api-key:foo"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    println!("{stderr}");
+    assert!(output.stderr.is_empty());
+
+    insta::assert_snapshot!(&stdout, @r###"
+    type Test {
+      id: ID!
+    }
+
+    "###);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn header_with_whitespace() {
+    let env = Environment::init();
+    let server = MockServer::start().await;
+
+    let request = json!({
+        "query": "query {\n  _service {\n    sdl\n  }\n}    \n",
+        "variables": {}
+    });
+
+    let response = ResponseTemplate::new(200).set_body_json(json!({
+        "data": {
+            "_service": {
+                "sdl": indoc::indoc! {r#"
+                    type Test {
+                      id: ID!
+                    }
+                "#}
+            }
+        }
+    }));
+
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .and(body_json(request))
+        .and(header("x-api-key", "foo"))
+        .respond_with(response)
+        .mount(&server)
+        .await;
+
+    let address = server.address();
+    let url = format!("http://localhost:{}/graphql", address.port());
+
+    let output = env.grafbase_introspect(&url, &["x-api-key: foo"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    println!("{stderr}");
+    assert!(output.stderr.is_empty());
+
+    insta::assert_snapshot!(&stdout, @r###"
+    type Test {
+      id: ID!
+    }
+
+    "###);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn two_headers() {
+    let env = Environment::init();
+    let server = MockServer::start().await;
+
+    let request = json!({
+        "query": "query {\n  _service {\n    sdl\n  }\n}    \n",
+        "variables": {}
+    });
+
+    let response = ResponseTemplate::new(200).set_body_json(json!({
+        "data": {
+            "_service": {
+                "sdl": indoc::indoc! {r#"
+                    type Test {
+                      id: ID!
+                    }
+                "#}
+            }
+        }
+    }));
+
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .and(body_json(request))
+        .and(header("x-api-key", "foo"))
+        .and(header("x-other-key", "bar"))
+        .respond_with(response)
+        .mount(&server)
+        .await;
+
+    let address = server.address();
+    let url = format!("http://localhost:{}/graphql", address.port());
+
+    let output = env.grafbase_introspect(&url, &["x-api-key: foo", "x-other-key: bar"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    println!("{stderr}");
+    assert!(output.stderr.is_empty());
+
+    insta::assert_snapshot!(&stdout, @r###"
+    type Test {
+      id: ID!
+    }
+
+    "###);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[allow(clippy::too_many_lines)]
+async fn standard() {
+    let port = server::run().await;
+
+    let env = Environment::init();
+
+    let url = format!("http://localhost:{port}/");
+
+    let output = env.grafbase_introspect(&url, &[]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    println!("{stderr}");
+    assert!(output.stderr.is_empty());
+
+    insta::assert_snapshot!(&stdout, @r###"
+    type Bot {
+      id: ID!
+    }
+    type Header {
+      name: String!
+      value: String!
+    }
+    type Issue implements PullRequestOrIssue {
+      title: String!
+      author: UserOrBot!
+    }
+    type PullRequest implements PullRequestOrIssue {
+      title: String!
+      checks: [String!]!
+      author: UserOrBot!
+    }
+    type Query {
+      serverVersion: String!
+      pullRequestOrIssue(id: ID!): PullRequestOrIssue
+      headers: [Header!]!
+    }
+    type User {
+      name: String!
+      email: String!
+    }
+    interface PullRequestOrIssue {
+      title: String!
+      author: UserOrBot!
+    }
+    union UserOrBot = User | Bot
+
+    "###);
+}

--- a/cli/crates/cli/tests/utils/environment.rs
+++ b/cli/crates/cli/tests/utils/environment.rs
@@ -215,6 +215,24 @@ impl Environment {
     }
 
     #[track_caller]
+    pub fn grafbase_introspect(&self, url: &str, headers: &[&str]) -> Output {
+        let mut args = vec!["subgraph", "introspect", url];
+
+        for header in headers {
+            args.push("--header");
+            args.push(*header);
+        }
+
+        duct::cmd(cargo_bin("grafbase"), args)
+            .dir(&self.directory)
+            .stdout_capture()
+            .stderr_capture()
+            .unchecked()
+            .run()
+            .unwrap()
+    }
+
+    #[track_caller]
     pub fn grafbase_init(&self, config_format: ConfigType) {
         cmd!(
             cargo_bin("grafbase"),

--- a/cli/crates/graphql-introspection/Cargo.toml
+++ b/cli/crates/graphql-introspection/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "grafbase-graphql-introspection"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+repository.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+indoc = "2.0.4"
+reqwest = { version = "0.11.22", default-features = false, features = ["json", "rustls"] }
+cynic = { version = "3.2.2", features = ["http-reqwest"] }
+cynic-introspection = "3.2.2"
+serde = "1.0.189"
+apollo-parser = "0.7.1"
+apollo-encoder = "0.8.0"

--- a/cli/crates/graphql-introspection/src/lib.rs
+++ b/cli/crates/graphql-introspection/src/lib.rs
@@ -1,0 +1,19 @@
+mod standard;
+mod subgraph;
+
+pub async fn introspect(url: &str, headers: &[(&str, &str)]) -> Result<String, String> {
+    if let Ok(result) = subgraph::introspect(url, headers).await {
+        return Ok(prettify(result));
+    };
+
+    standard::introspect(url, headers).await.map(prettify)
+}
+
+fn prettify(graphql: String) -> String {
+    let parsed = apollo_parser::Parser::new(&graphql).parse().document();
+
+    match apollo_encoder::Document::try_from(parsed) {
+        Ok(encoded) => encoded.to_string(),
+        Err(_) => graphql,
+    }
+}

--- a/cli/crates/graphql-introspection/src/standard.rs
+++ b/cli/crates/graphql-introspection/src/standard.rs
@@ -1,0 +1,35 @@
+use cynic::{http::ReqwestExt, QueryBuilder};
+use cynic_introspection::IntrospectionQuery;
+use reqwest::header::USER_AGENT;
+
+pub(super) async fn introspect(url: &str, headers: &[(&str, &str)]) -> Result<String, String> {
+    let mut request_builder = reqwest::Client::new().post(url).header(USER_AGENT, "Grafbase");
+
+    for (name, value) in headers {
+        request_builder = request_builder.header(*name, *value);
+    }
+
+    let result = match request_builder.run_graphql(IntrospectionQuery::build(())).await {
+        Ok(result) => match (result.errors, result.data) {
+            (Some(errors), _) => {
+                let message = errors
+                    .into_iter()
+                    .map(|error| error.to_string())
+                    .collect::<Vec<_>>()
+                    .join(",");
+
+                return Err(message);
+            }
+            (_, Some(data)) => data,
+            _ => return Err(String::from("missing introspection data")),
+        },
+        Err(error) => return Err(error.to_string()),
+    };
+
+    let schema = match result.into_schema() {
+        Ok(schema) => schema,
+        Err(error) => return Err(error.to_string()),
+    };
+
+    Ok(schema.to_sdl())
+}

--- a/cli/crates/graphql-introspection/src/subgraph.rs
+++ b/cli/crates/graphql-introspection/src/subgraph.rs
@@ -1,0 +1,66 @@
+use reqwest::header::USER_AGENT;
+use std::collections::HashMap;
+
+#[derive(Debug, serde::Deserialize)]
+struct Service {
+    sdl: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct Data {
+    #[serde(rename = "_service")]
+    service: Service,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct Response {
+    data: Option<Data>,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct Request {
+    query: &'static str,
+    variables: HashMap<&'static str, String>,
+}
+
+pub(super) async fn introspect(url: &str, headers: &[(&str, &str)]) -> Result<String, ()> {
+    let query = indoc::indoc! {r#"
+        query {
+          _service {
+            sdl
+          }
+        }    
+    "#};
+
+    let request = Request {
+        query,
+        variables: HashMap::default(),
+    };
+
+    let mut request_builder = reqwest::Client::new()
+        .post(url)
+        .header(USER_AGENT, "Grafbase")
+        .json(&request);
+
+    for (name, value) in headers {
+        request_builder = request_builder.header(*name, *value);
+    }
+
+    let Ok(response) = request_builder.send().await else {
+        return Err(());
+    };
+
+    let Ok(response) = response.error_for_status() else {
+        return Err(());
+    };
+
+    let response: Response = match response.json().await {
+        Ok(response) => response,
+        Err(_) => return Err(()),
+    };
+
+    match response.data {
+        Some(data) => Ok(data.service.sdl),
+        _ => Err(()),
+    }
+}


### PR DESCRIPTION
Introduces a new subcommand `subgraph` and one subcommad to that called `introspect`. This command first runs a query to the given endpoint:

```graphql
query {
  _service {
    sdl
  }
}
```

If this query succeeds, that's the given output. If not, we run the standard GraphQL introspection and output _that_ schema.

Closes: GB-5141
