### PR TITLE
feat(sdk): add new ResolverFn export

### DIFF
--- a/packages/grafbase-sdk/src/index.ts
+++ b/packages/grafbase-sdk/src/index.ts
@@ -14,6 +14,7 @@ import { validateIdentifier } from './validation'
 import { PostgresParams, PartialPostgresAPI } from './connector/postgres'
 
 export { type ResolverContext as Context } from './resolver/context'
+export { type ResolverFn } from './resolver/resolverFn'
 export { type ResolverInfo as Info } from './resolver/info'
 export { type VerifiedIdentity } from './authorizer/verifiedIdentity'
 export { type AuthorizerContext } from './authorizer/context'

--- a/packages/grafbase-sdk/src/resolver/resolverFn.ts
+++ b/packages/grafbase-sdk/src/resolver/resolverFn.ts
@@ -1,0 +1,21 @@
+import { type ResolverContext } from './context'
+import { type ResolverInfo } from './info'
+
+/**
+ * The type of a [resolver function](https://grafbase.com/docs/edge-gateway/resolvers).
+ *
+ * This is a generic type because different resolvers have different `parent` and `args` arguments, as well as different return types, depending on the schema.
+ *
+ * This type is better used through the generated resolver signatures, rather than directly.
+ *
+ * @example
+ *
+ * import { ResolverFn } from '@grafbase/sdk'
+ *
+ * const myResolver: ResolverFn<{ id: string }, { shout: boolean }, string> => (parent, args, _ctx, _info) => {
+ *   return `parent id: ${parent.id}${args.shout ? '!' : ''}`
+ * }
+ *
+ */
+export type ResolverFn<Parent, Args, Return> = ((parent: Parent, args: Args, context: ResolverContext, info: ResolverInfo) => Return) |
+    ((parent: Parent, args: Args, context: ResolverContext, pageInfo: ResolverInfo) => Promise<Return>)


### PR DESCRIPTION
# Description

This is a convenience type for resolver functions. It is generic because resolvers have different parent, argument and return types. It works for both sync and async resolvers. This will be used by generated code as part of the typed resolvers work, so it is not meant primarily for direct end-user consumption.

Related to https://github.com/grafbase/grafbase/pull/843 but not blocking.

first part of GB-5163

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
