### PR TITLE
cli: future proof generated TS type names, improve DX

### DIFF
--- a/cli/crates/typed-resolvers/src/codegen.rs
+++ b/cli/crates/typed-resolvers/src/codegen.rs
@@ -2,26 +2,27 @@ use crate::analyze::{AnalyzedSchema, BuiltinScalar, Definition, GraphqlType, Lis
 use std::fmt;
 
 const INDENT: &str = "  ";
+const DOUBLE_INDENT: &str = "    ";
 
 pub(crate) fn generate_module<O>(schema: &AnalyzedSchema<'_>, out: &mut O) -> fmt::Result
 where
     O: fmt::Write,
 {
     out.write_str(HEADER)?;
+    out.write_str("export type Schema = {\n")?;
 
-    for (idx, definition) in schema.definitions.iter().enumerate() {
+    for definition in &schema.definitions {
         match definition {
             Definition::Object(id) => {
                 let object_type = &schema[*id];
-                let graphql_type_name = object_type.name;
-                let ts_type_name = safe_ts_type_name(graphql_type_name);
+                let object_type_name = object_type.name;
                 let is_input_object = matches!(object_type.kind, ObjectKind::InputObject);
 
-                maybe_docs(out, object_type.docs, "")?;
-                writeln!(out, "export type {ts_type_name} = {{")?;
+                maybe_docs(out, object_type.docs, INDENT)?;
+                writeln!(out, "{INDENT}'{object_type_name}': {{")?;
 
                 if let ObjectKind::Object = object_type.kind {
-                    writeln!(out, "{INDENT}__typename?: '{graphql_type_name}';")?;
+                    writeln!(out, "{DOUBLE_INDENT}__typename?: '{object_type_name}';")?;
                 }
 
                 for field in schema.iter_object_fields(*id) {
@@ -36,49 +37,39 @@ where
                     let field_type = render_graphql_type(&field.r#type, schema);
 
                     maybe_docs(out, field.docs, INDENT)?;
-                    writeln!(out, "{INDENT}{field_name}{field_optional}: {field_type};")?;
+                    writeln!(out, "{DOUBLE_INDENT}{field_name}{field_optional}: {field_type};")?;
                 }
 
-                out.write_str("};\n")?;
+                writeln!(out, "{INDENT}}};")?;
             }
             Definition::Union(union_id) => {
                 let union_name = schema[*union_id].name;
-                write!(out, "export type {union_name} = ")?;
-
-                let mut variants = schema.iter_union_variants(*union_id).peekable();
-                while let Some(variant) = variants.next() {
-                    write!(out, "{}", safe_ts_type_name(variant.name))?;
-
-                    if variants.peek().is_some() {
-                        out.write_str(" | ")?;
-                    }
+                write!(out, "{INDENT}'{union_name}':")?;
+                for variant in schema.iter_union_variants(*union_id) {
+                    write!(out, " | Schema['{}']", variant.name)?;
                 }
                 out.write_str(";\n")?;
             }
             Definition::Enum(enum_id) => {
                 let r#enum = &schema[*enum_id];
-                let enum_name = safe_ts_type_name(r#enum.name);
-                maybe_docs(out, r#enum.docs, "")?;
-                writeln!(out, "export enum {enum_name} {{")?;
+                let enum_name = r#enum.name;
+                maybe_docs(out, r#enum.docs, INDENT)?;
+                write!(out, "{INDENT}'{enum_name}': ")?;
                 for variant in schema.iter_enum_variants(*enum_id) {
-                    out.write_str(INDENT)?;
-                    out.write_str(variant)?;
-                    out.write_str(",\n")?;
+                    write!(out, "| '{variant}'")?;
                 }
-                out.write_str("}\n")?;
+                out.write_str(";\n")?;
             }
             Definition::CustomScalar(id) => {
                 let scalar = &schema[*id];
-                let scalar_name = safe_ts_type_name(scalar.name);
-                maybe_docs(out, scalar.docs, "")?;
-                writeln!(out, "export type {scalar_name} = any;")?;
+                let scalar_name = scalar.name;
+                maybe_docs(out, scalar.docs, INDENT)?;
+                writeln!(out, "{INDENT}'{scalar_name}': any;")?;
             }
         }
-
-        if idx + 1 < schema.definitions.len() {
-            writeln!(out)?;
-        }
     }
+
+    out.write_str("};\n")?;
 
     write_resolver_type(schema, out)
 }
@@ -91,13 +82,15 @@ fn render_graphql_type(r#type: &GraphqlType, schema: &AnalyzedSchema<'_>) -> Str
             BuiltinScalar::Boolean => "boolean",
         }
         .to_owned(),
-        TypeKind::Definition(def) => safe_ts_type_name(match *def {
-            Definition::CustomScalar(id) => schema[id].name,
-            Definition::Enum(id) => schema[id].name,
-            Definition::Object(id) => schema[id].name,
-            Definition::Union(id) => schema[id].name,
-        })
-        .to_string(),
+        TypeKind::Definition(def) => {
+            let name = match *def {
+                Definition::CustomScalar(id) => schema[id].name,
+                Definition::Enum(id) => schema[id].name,
+                Definition::Object(id) => schema[id].name,
+                Definition::Union(id) => schema[id].name,
+            };
+            format!("Schema['{name}']")
+        }
     };
 
     if r#type.inner_is_nullable() {
@@ -112,26 +105,6 @@ fn render_graphql_type(r#type: &GraphqlType, schema: &AnalyzedSchema<'_>) -> Str
     }
 
     type_string
-}
-
-/// Takes a GraphQL name, and returns a typescript-safe version. This takes TypeScript reserved keywords into account.
-fn safe_ts_type_name(graphql_name: &str) -> impl fmt::Display + '_ {
-    struct SafeName<'a>(&'a str);
-
-    impl fmt::Display for SafeName<'_> {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            match self.0 {
-                "any" | "async" | "boolean" | "interface" | "never" | "null" | "number" | "object" | "string"
-                | "symbol" | "undefined" | "unknown" | "void" => {
-                    f.write_str("_")?;
-                    f.write_str(self.0)
-                }
-                _ => f.write_str(self.0),
-            }
-        }
-    }
-
-    SafeName(graphql_name)
 }
 
 fn maybe_docs<O>(out: &mut O, docs: Option<&str>, indentation: &str) -> fmt::Result
@@ -159,13 +132,13 @@ fn write_resolver_type<O: fmt::Write>(schema: &AnalyzedSchema<'_>, out: &mut O) 
         return Ok(());
     }
 
-    writeln!(out, "\nimport * as sdk from '@grafbase/sdk'\n")?;
-    writeln!(out, "export type Resolver = {{")?;
+    out.write_str("\nimport { ResolverFn } from '@grafbase/sdk'\n\n")?;
+    out.write_str("export type Resolver = {\n")?;
 
     for (object_id, field_id, field) in fields {
         let parent_object = &schema[*object_id];
-        let resolver_id = format!("{}.{}", parent_object.name, field.name);
-        let parent_object_generated_type_name = safe_ts_type_name(parent_object.name);
+        let parent_object_type_name = parent_object.name;
+        let resolver_id = format!("{parent_object_type_name}.{}", field.name);
         let rendered_field_type = render_graphql_type(&field.r#type, schema);
 
         let mut arguments = String::from("{ ");
@@ -181,7 +154,7 @@ fn write_resolver_type<O: fmt::Write>(schema: &AnalyzedSchema<'_>, out: &mut O) 
 
         writeln!(
             out,
-            "{INDENT}'{resolver_id}': sdk.ResolverFn<{parent_object_generated_type_name}, {arguments}, {rendered_field_type}>"
+            "{INDENT}'{resolver_id}': ResolverFn<Schema['{parent_object_type_name}'], {arguments}, {rendered_field_type}>"
         )?;
     }
 

--- a/cli/crates/typed-resolvers/tests/schema_types/basic.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/basic.expected.ts
@@ -11,7 +11,9 @@
 //    }
 //  }
 
-export type Test = {
-  __typename?: 'Test';
-  id: string | null;
+export type Schema = {
+  'Test': {
+    __typename?: 'Test';
+    id: string | null;
+  };
 };

--- a/cli/crates/typed-resolvers/tests/schema_types/basic_enum.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/basic_enum.expected.ts
@@ -11,8 +11,6 @@
 //    }
 //  }
 
-export enum Color {
-  RED,
-  GREEN,
-  BLUE,
-}
+export type Schema = {
+  'Color': | 'RED'| 'GREEN'| 'BLUE';
+};

--- a/cli/crates/typed-resolvers/tests/schema_types/custom_scalars.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/custom_scalars.expected.ts
@@ -11,12 +11,13 @@
 //    }
 //  }
 
-/**
- * An IPv4 address
- */
-export type NetworkAddress = any;
-
-export type QueryRoot = {
-  __typename?: 'QueryRoot';
-  address: NetworkAddress | null;
+export type Schema = {
+  /**
+   * An IPv4 address
+   */
+  'NetworkAddress': any;
+  'QueryRoot': {
+    __typename?: 'QueryRoot';
+    address: Schema['NetworkAddress'] | null;
+  };
 };

--- a/cli/crates/typed-resolvers/tests/schema_types/interfaces.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/interfaces.expected.ts
@@ -11,24 +11,23 @@
 //    }
 //  }
 
-export type Human = {
-  __typename?: 'Human';
-  id: string;
-  firstName: string;
-  lastName: string;
-};
-
-export type Dog = {
-  __typename?: 'Dog';
-  id: string;
-  name: string;
-};
-
-export type LivingThing = {
-  metabolicRate: number;
-  age: number;
-};
-
-export type Animal = {
-  pettable: boolean;
+export type Schema = {
+  'Human': {
+    __typename?: 'Human';
+    id: string;
+    firstName: string;
+    lastName: string;
+  };
+  'Dog': {
+    __typename?: 'Dog';
+    id: string;
+    name: string;
+  };
+  'LivingThing': {
+    metabolicRate: number;
+    age: number;
+  };
+  'Animal': {
+    pettable: boolean;
+  };
 };

--- a/cli/crates/typed-resolvers/tests/schema_types/keyword_names.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/keyword_names.expected.ts
@@ -11,60 +11,51 @@
 //    }
 //  }
 
-export type holycow = type | _interface | _object | union;
-
-/**
- * GraphQL field names can be anything.
- */
-export type Cursed = {
-  __typename?: 'Cursed';
-  self: boolean | null;
-  this: string | null;
-  let: number | null;
-  type: number | null;
-  number: number | null;
-  super: boolean | null;
-  const: boolean | null;
+export type Schema = {
+  'holycow': | Schema['type'] | Schema['interface'] | Schema['object'] | Schema['union'];
+  /**
+   * GraphQL field names can be anything.
+   */
+  'Cursed': {
+    __typename?: 'Cursed';
+    self: boolean | null;
+    this: string | null;
+    let: number | null;
+    type: number | null;
+    number: number | null;
+    super: boolean | null;
+    const: boolean | null;
   /**
    * lol
    */
-  async: boolean | null;
-  _: boolean | null;
-};
-
-/**
- * Look, this enum is called undefined!
- */
-export enum _undefined {
-  void,
-  string,
-}
-
-export type type = {
-  __typename?: 'type';
-  type?: type;
-  interface?: _interface;
-};
-
-export type _object = {
-  __typename?: 'object';
-  id: string;
-};
-
-export type union = {
-  id: string;
-};
-
-export type _interface = {
-  __typename?: 'interface';
-  type?: type;
-  interface?: _interface | null;
-};
-
-export type schema = {
-  id: string;
-};
-
-export type query = {
-  fragment?: type | null;
+    async: boolean | null;
+    _: boolean | null;
+  };
+  /**
+   * Look, this enum is called undefined!
+   */
+  'undefined': | 'void'| 'string';
+  'type': {
+    __typename?: 'type';
+    type?: Schema['type'];
+    interface?: Schema['interface'];
+  };
+  'object': {
+    __typename?: 'object';
+    id: string;
+  };
+  'union': {
+    id: string;
+  };
+  'interface': {
+    __typename?: 'interface';
+    type?: Schema['type'];
+    interface?: Schema['interface'] | null;
+  };
+  'schema': {
+    id: string;
+  };
+  'query': {
+    fragment?: Schema['type'] | null;
+  };
 };

--- a/cli/crates/typed-resolvers/tests/schema_types/recursive_types.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/recursive_types.expected.ts
@@ -11,23 +11,22 @@
 //    }
 //  }
 
-export type TreeNode = {
-  __typename?: 'TreeNode';
-  value: number;
-  children?: Array<TreeNode | null> | null;
-};
-
-export type TreeNodeInput = {
-  value: number;
-  children: Array<TreeNodeInput | null> | null;
-};
-
-export type Query = {
-  __typename?: 'Query';
-  getTree?: TreeNode | null;
-};
-
-export type Mutation = {
-  __typename?: 'Mutation';
-  createTree?: TreeNode | null;
+export type Schema = {
+  'TreeNode': {
+    __typename?: 'TreeNode';
+    value: number;
+    children?: Array<Schema['TreeNode'] | null> | null;
+  };
+  'TreeNodeInput': {
+    value: number;
+    children: Array<Schema['TreeNodeInput'] | null> | null;
+  };
+  'Query': {
+    __typename?: 'Query';
+    getTree?: Schema['TreeNode'] | null;
+  };
+  'Mutation': {
+    __typename?: 'Mutation';
+    createTree?: Schema['TreeNode'] | null;
+  };
 };

--- a/cli/crates/typed-resolvers/tests/schema_types/type_extensions.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/type_extensions.expected.ts
@@ -11,40 +11,38 @@
 //    }
 //  }
 
-export type Query = {
-  __typename?: 'Query';
-  episode?: Episode | null;
-  character?: Character | null;
-};
-
-export type Mutation = {
-  __typename?: 'Mutation';
-  createEpisode?: Episode;
-};
-
-export type Episode = {
-  __typename?: 'Episode';
-  id: string;
-  title: string;
-  season: number;
-  episodeNumber: number;
-  description: string | null;
-  characters?: Array<Character>;
-};
-
-export type Character = {
-  __typename?: 'Character';
-  id: string;
-  name: string;
-  occupation: string | null;
-  episodes?: Array<Episode>;
-  friends?: Array<Character> | null;
-};
-
-export type CreateEpisodeInput = {
-  title: string;
-  season: number;
-  episodeNumber: number;
-  description: string | null;
-  characters: Array<string> | null;
+export type Schema = {
+  'Query': {
+    __typename?: 'Query';
+    episode?: Schema['Episode'] | null;
+    character?: Schema['Character'] | null;
+  };
+  'Mutation': {
+    __typename?: 'Mutation';
+    createEpisode?: Schema['Episode'];
+  };
+  'Episode': {
+    __typename?: 'Episode';
+    id: string;
+    title: string;
+    season: number;
+    episodeNumber: number;
+    description: string | null;
+    characters?: Array<Schema['Character']>;
+  };
+  'Character': {
+    __typename?: 'Character';
+    id: string;
+    name: string;
+    occupation: string | null;
+    episodes?: Array<Schema['Episode']>;
+    friends?: Array<Schema['Character']> | null;
+  };
+  'CreateEpisodeInput': {
+    title: string;
+    season: number;
+    episodeNumber: number;
+    description: string | null;
+    characters: Array<string> | null;
+  };
 };

--- a/cli/crates/typed-resolvers/tests/schema_types/union.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/union.expected.ts
@@ -11,16 +11,16 @@
 //    }
 //  }
 
-export type Dog = {
-  __typename?: 'Dog';
-  id: string;
-  barkVolume: number | null;
+export type Schema = {
+  'Dog': {
+    __typename?: 'Dog';
+    id: string;
+    barkVolume: number | null;
+  };
+  'Cat': {
+    __typename?: 'Cat';
+    id: string;
+    meowVolume: number | null;
+  };
+  'Pet': | Schema['Cat'] | Schema['Dog'];
 };
-
-export type Cat = {
-  __typename?: 'Cat';
-  id: string;
-  meowVolume: number | null;
-};
-
-export type Pet = Cat | Dog;

--- a/cli/crates/typed-resolvers/tests/schema_types/with_resolvers.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/with_resolvers.expected.ts
@@ -11,40 +11,38 @@
 //    }
 //  }
 
-export type User = {
-  __typename?: 'User';
-  id: string;
-  name: string;
-  account?: Account;
+export type Schema = {
+  'User': {
+    __typename?: 'User';
+    id: string;
+    name: string;
+    account?: Schema['Account'];
+  };
+  'Account': {
+    __typename?: 'Account';
+    id: string;
+    email: string;
+  };
+  'Other': {
+    __typename?: 'Other';
+    id: string;
+  };
+  'UserFilter': {
+    name_eq: string | null;
+  };
+  'Query': {
+    __typename?: 'Query';
+    user?: Schema['User'] | null;
+    users?: Array<Schema['User'] | null> | null;
+    other?: Schema['Other'] | null;
+  };
 };
 
-export type Account = {
-  __typename?: 'Account';
-  id: string;
-  email: string;
-};
-
-export type Other = {
-  __typename?: 'Other';
-  id: string;
-};
-
-export type UserFilter = {
-  name_eq: string | null;
-};
-
-export type Query = {
-  __typename?: 'Query';
-  user?: User | null;
-  users?: Array<User | null> | null;
-  other?: Other | null;
-};
-
-import * as sdk from '@grafbase/sdk'
+import { ResolverFn } from '@grafbase/sdk'
 
 export type Resolver = {
-  'Query.user': sdk.ResolverFn<Query, { anonymize: boolean | null,  }, User | null>
-  'Query.users': sdk.ResolverFn<Query, { filter: UserFilter | null, take: number,  }, Array<User | null> | null>
-  'Query.other': sdk.ResolverFn<Query, {  }, Other | null>
+  'Query.user': ResolverFn<Schema['Query'], { anonymize: boolean | null,  }, Schema['User'] | null>
+  'Query.users': ResolverFn<Schema['Query'], { filter: Schema['UserFilter'] | null, take: number,  }, Array<Schema['User'] | null> | null>
+  'Query.other': ResolverFn<Schema['Query'], {  }, Schema['Other'] | null>
 }
 

--- a/cli/crates/typed-resolvers/tests/schema_types/wrapper_types.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/wrapper_types.expected.ts
@@ -11,75 +11,69 @@
 //    }
 //  }
 
-export type Query = {
-  __typename?: 'Query';
-  episode?: Episode | null;
-  episodesBySeason?: Array<Episode>;
-  character?: Character | null;
-  searchCharacters?: Array<Character>;
-  locations?: Array<Location>;
-};
-
-export type Mutation = {
-  __typename?: 'Mutation';
-  createEpisode?: Episode;
-  updateEpisode?: Episode | null;
-};
-
-export type CreateEpisodeInput = {
-  title: string;
-  season: number;
-  episodeNumber: number;
-  description: string | null;
-  characters: Array<string>;
-};
-
-export type UpdateEpisodeInput = {
-  title: string | null;
-  season: number | null;
-  episodeNumber: number | null;
-  description: string | null;
-  characters: Array<string> | null;
-};
-
-export type Episode = {
-  __typename?: 'Episode';
-  id: string;
-  title: string;
-  season: number;
-  episodeNumber: number;
-  description: string | null;
-  characters?: Array<Character>;
-  nestedTrivia?: Array<Array<Array<TriviaItem> | null> | null> | null;
-};
-
-export type Character = {
-  __typename?: 'Character';
-  id: string;
-  name: string;
-  occupation: string | null;
-  episodes?: Array<Episode>;
-  friends?: Array<Character> | null;
-  favoriteLocations?: Array<Location | null> | null;
-  deepRelations?: Array<Array<Array<Array<Relation | null> | null>> | null> | null;
-};
-
-export type Location = {
-  __typename?: 'Location';
-  id: string;
-  name: string;
-  type: string;
-  frequentVisitors?: Array<Character | null> | null;
-};
-
-export type TriviaItem = {
-  __typename?: 'TriviaItem';
-  fact: string;
-  episode?: Episode;
-};
-
-export type Relation = {
-  __typename?: 'Relation';
-  relationType: string;
-  character?: Character;
+export type Schema = {
+  'Query': {
+    __typename?: 'Query';
+    episode?: Schema['Episode'] | null;
+    episodesBySeason?: Array<Schema['Episode']>;
+    character?: Schema['Character'] | null;
+    searchCharacters?: Array<Schema['Character']>;
+    locations?: Array<Schema['Location']>;
+  };
+  'Mutation': {
+    __typename?: 'Mutation';
+    createEpisode?: Schema['Episode'];
+    updateEpisode?: Schema['Episode'] | null;
+  };
+  'CreateEpisodeInput': {
+    title: string;
+    season: number;
+    episodeNumber: number;
+    description: string | null;
+    characters: Array<string>;
+  };
+  'UpdateEpisodeInput': {
+    title: string | null;
+    season: number | null;
+    episodeNumber: number | null;
+    description: string | null;
+    characters: Array<string> | null;
+  };
+  'Episode': {
+    __typename?: 'Episode';
+    id: string;
+    title: string;
+    season: number;
+    episodeNumber: number;
+    description: string | null;
+    characters?: Array<Schema['Character']>;
+    nestedTrivia?: Array<Array<Array<Schema['TriviaItem']> | null> | null> | null;
+  };
+  'Character': {
+    __typename?: 'Character';
+    id: string;
+    name: string;
+    occupation: string | null;
+    episodes?: Array<Schema['Episode']>;
+    friends?: Array<Schema['Character']> | null;
+    favoriteLocations?: Array<Schema['Location'] | null> | null;
+    deepRelations?: Array<Array<Array<Array<Schema['Relation'] | null> | null>> | null> | null;
+  };
+  'Location': {
+    __typename?: 'Location';
+    id: string;
+    name: string;
+    type: string;
+    frequentVisitors?: Array<Schema['Character'] | null> | null;
+  };
+  'TriviaItem': {
+    __typename?: 'TriviaItem';
+    fact: string;
+    episode?: Schema['Episode'];
+  };
+  'Relation': {
+    __typename?: 'Relation';
+    relationType: string;
+    character?: Schema['Character'];
+  };
 };


### PR DESCRIPTION
This commit is prompted by a fear that has been visiting me at night since 9aba0fc513e67afb2a877c187f71f782f10c299e. The name of that fear is name collisions in generated code.

Before this commit, we have `safe_ts_type_name()`, a function that takes care of making a GraphQL type name TypeScript-safe, turning `undefined` into `_undefined` for example. We then generate one `export type` or moral equivalent for each GraphQL definition in the GraphQL schema.

There are several problems with that approach:

- Name collisions with other types we generate (`Resolver`) or types from the SDK. Of course we could add extra exceptions and rename `Resolver` to `_Resolver` for example, but that doesn't seem fool proof.
- Discoverability. If we rename types, they are not as discoverable.

The solution implemented here is nesting: the generated TypeScript code exports exactly two types: `Schema` and `Resolver`. The TypeScript type definitions for each GraphQL schema definition (objects, unions, etc.) and resolver live inside these two types. That makes name collisions impossible and completely removes the need to escape/change type names.

That comes with an extra improvement in DX. If you hover on the `parent` argument when writing a resolver, before you would see a type like `User` (or `_undefined`). Now you will see the fields inside.

Closes GB-5170

Before:

![2023-10-25_09-10-16](https://github.com/grafbase/grafbase/assets/13155277/0681a367-c5ea-4cf6-974f-0149c931da28)


After:

![2023-10-25_09-10-31](https://github.com/grafbase/grafbase/assets/13155277/9a46de92-e17a-4b98-bba4-fca6d1401652)


# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [x] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
