### PR TITLE
fix: un-namespaced OpenAPI types were still being prefixed

### DIFF
--- a/engine/crates/parser-openapi/src/graph/mod.rs
+++ b/engine/crates/parser-openapi/src/graph/mod.rs
@@ -444,10 +444,9 @@ impl OpenApiGraph {
 
                 let root_name = self.graph[named_node].name().unwrap();
                 name_components.push(Cow::Borrowed(root_name.as_str()));
-                name_components.push(Cow::Owned(self.metadata.unique_namespace()));
                 name_components.reverse();
 
-                Some(name_components.join("_").to_pascal_case())
+                Some(self.metadata.prefix_type(&name_components.join("_")).to_pascal_case())
             }
             Node::Scalar(kind) => Some(kind.type_name()),
             Node::PlaceholderType => {

--- a/engine/crates/parser-openapi/src/tests/mod.rs
+++ b/engine/crates/parser-openapi/src/tests/mod.rs
@@ -42,6 +42,21 @@ fn test_petstore_output() {
 }
 
 #[test]
+fn test_petstore_without_prefix() {
+    let registry = build_registry(
+        "test_data/petstore.openapi.json",
+        Format::Json,
+        ApiMetadata {
+            type_prefix: None,
+            ..metadata("petstore", false)
+        },
+    )
+    .unwrap();
+
+    insta::assert_snapshot!(registry.export_sdl(false));
+}
+
+#[test]
 fn test_flat_output() {
     let registry = build_registry(
         "test_data/petstore.openapi.json",

--- a/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__petstore_without_prefix.snap
+++ b/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__petstore_without_prefix.snap
@@ -1,0 +1,113 @@
+---
+source: crates/parser-openapi/src/tests/mod.rs
+expression: registry.export_sdl(false)
+---
+type ApiResponse {
+	message: String
+	type: String
+	code: Int
+}
+type Category {
+	name: String
+	id: Int
+}
+input CategoryInput {
+	name: String
+	id: Int
+}
+enum FindPetsByStatusStatus {
+	AVAILABLE
+	PENDING
+	SOLD
+}
+type Mutation {
+	updatePet(input: PetInput!): Pet
+	addPet(input: PetInput!): Pet
+	uploadFile(petId: Int!, additionalMetadata: String): ApiResponse
+	placeOrder(input: OrderInput!): Order
+	createUsersWithListInput(input: [UserInput!]!): User
+}
+type Order {
+	complete: Boolean
+	status: OrderStatus
+	shipDate: String
+	quantity: Int
+	petId: Int
+	id: Int
+}
+input OrderInput {
+	complete: Boolean
+	status: OrderStatus
+	shipDate: String
+	quantity: Int
+	petId: Int
+	id: Int
+}
+enum OrderStatus {
+	PLACED
+	APPROVED
+	DELIVERED
+}
+type Pet {
+	status: PetStatus
+	tags: [Tag!]
+	photoUrls: [String!]!
+	category: Category
+	name: String!
+	id: Int
+}
+input PetInput {
+	status: PetStatus
+	tags: [TagInput!]!
+	photoUrls: [String!]!
+	category: CategoryInput!
+	name: String!
+	id: Int
+}
+enum PetStatus {
+	AVAILABLE
+	PENDING
+	SOLD
+}
+type Query {
+	findPetsByStatus(status: FindPetsByStatusStatus = AVAILABLE): [Pet!]
+	findPetsByTags(tags: [String!]): [Pet!]
+	pet(petId: Int!): Pet
+	inventory: JSON
+	order(orderId: Int!): Order
+	loginUser(password: String, username: String): String
+	user(username: String!): User
+}
+type Tag {
+	name: String
+	id: Int
+}
+input TagInput {
+	name: String
+	id: Int
+}
+type User {
+	userStatus: Int
+	phone: String
+	password: String
+	email: String
+	lastName: String
+	firstName: String
+	username: String
+	id: Int
+}
+input UserInput {
+	userStatus: Int
+	phone: String
+	password: String
+	email: String
+	lastName: String
+	firstName: String
+	username: String
+	id: Int
+}
+schema {
+	query: Query
+	mutation: Mutation
+}
+


### PR DESCRIPTION
I updated OpenAPI to not prefix types if namespacing was disabled in #828 - but apparently I did not test it well enough because they were still mostly being prefixed.  This fixes that.