### PR TITLE
fix(cli): fix generated TS code for resolvers on root types

### DIFF
--- a/cli/crates/typed-resolvers/src/analyze.rs
+++ b/cli/crates/typed-resolvers/src/analyze.rs
@@ -65,6 +65,16 @@ fn analyze_top_level<'doc>(graphql_document: &'doc ast::ServiceDocument, schema:
             ast::TypeSystemDefinition::Schema(_) | ast::TypeSystemDefinition::Directive(_) => (), // not interested
         }
     }
+
+    for name in ["Query", "Mutation", "Subscription"] {
+        if !schema.definition_names.contains_key(name) {
+            schema.push_output_type(Object {
+                name,
+                docs: None,
+                kind: ObjectKind::Object,
+            });
+        }
+    }
 }
 
 /// Second pass. We know about all definitions, now we analyze fields inside object and interface

--- a/cli/crates/typed-resolvers/src/codegen.rs
+++ b/cli/crates/typed-resolvers/src/codegen.rs
@@ -15,6 +15,12 @@ where
         match definition {
             Definition::Object(id) => {
                 let object_type = &schema[*id];
+                let mut fields = schema.iter_object_fields(*id).peekable();
+
+                if fields.peek().is_none() {
+                    continue;
+                }
+
                 let object_type_name = object_type.name;
                 let is_input_object = matches!(object_type.kind, ObjectKind::InputObject);
 
@@ -25,7 +31,7 @@ where
                     writeln!(out, "{DOUBLE_INDENT}__typename?: '{object_type_name}';")?;
                 }
 
-                for field in schema.iter_object_fields(*id) {
+                for field in fields {
                     let field_optional = !is_input_object
                         && matches!(
                             field.r#type.kind,

--- a/cli/crates/typed-resolvers/tests/schema_types/extend_root_type.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/extend_root_type.expected.ts
@@ -1,0 +1,35 @@
+// This is a generated file. It should not be edited manually.
+//
+// You can decide to commit this file or add it to your `.gitignore`.
+//
+// By convention, this module is imported as `@grafbase/generated`. To make this syntax possible,
+// add a `paths` entry to your `tsconfig.json`.
+//
+//  "compilerOptions": {
+//    "paths": {
+//      "@grafbase/generated": ["./grafbase/generated"]
+//    }
+//  }
+
+export type Schema = {
+  'Query': {
+    __typename?: 'Query';
+    ping: string;
+  };
+  'Mutation': {
+    __typename?: 'Mutation';
+    pong: string;
+  };
+  'Subscription': {
+    __typename?: 'Subscription';
+    pingPongs: Array<string>;
+  };
+};
+
+import { ResolverFn } from '@grafbase/sdk'
+
+export type Resolver = {
+  'Query.ping': ResolverFn<Schema['Query'], { name: string | null,  }, string>
+  'Mutation.pong': ResolverFn<Schema['Mutation'], {  }, string>
+}
+

--- a/cli/crates/typed-resolvers/tests/schema_types/extend_root_type.graphql
+++ b/cli/crates/typed-resolvers/tests/schema_types/extend_root_type.graphql
@@ -1,0 +1,12 @@
+
+extend type Query {
+  ping(name: String): String! @resolver(name: "ping")
+}
+
+extend type Mutation {
+  pong: String! @resolver(name: "pong")
+}
+
+extend type Subscription {
+  pingPongs: [String!]!
+}


### PR DESCRIPTION
The source of the bug is that the SDL schemas produced by the CLI extend `Query`, `Mutation` and `Subscription` but do not define them. The fix involves defining them ourselves in analysis if they are not already defined.

closes GB-5175

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
