### PR TITLE
composition: first bits

### DIFF
--- a/crates/composition/.gitignore
+++ b/crates/composition/.gitignore
@@ -1,0 +1,1 @@
+/Cargo.lock

--- a/crates/composition/Cargo.toml
+++ b/crates/composition/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "grafbase-composition"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+async-graphql-parser = "6"
+indexmap = "2"
+itertools = "0.11.0"
+
+[dev-dependencies]
+datatest-stable = "0.2.3"
+similar = "2"
+miette = { version = "5.10.0", features = ["fancy"] }
+
+[[test]]
+name = "composition_tests"
+harness = false
+

--- a/crates/composition/src/compose_supergraph.rs
+++ b/crates/composition/src/compose_supergraph.rs
@@ -1,0 +1,52 @@
+use crate::{
+    subgraphs::{DefinitionKind, DefinitionWalker},
+    Context,
+};
+
+pub(crate) fn build_supergraph(ctx: &mut Context<'_>) {
+    ctx.subgraphs
+        .iter_definition_groups(|first, rest| match first.kind() {
+            DefinitionKind::Object => merge_object_definitions(ctx, first, rest),
+            _ => todo!(),
+        });
+
+    ctx.subgraphs.iter_field_groups(|first, rest| {
+        if let Some(next) = rest.next() {
+            ctx.diagnostics.push_fatal(format!(
+                "The field `{}` on `{}` is defined in two subgraphs (`{}` and `{}`).",
+                first.name_str(),
+                first.parent_definition().name_str(),
+                first.parent_definition().subgraph().name_str(),
+                next.parent_definition().subgraph().name_str(),
+            ));
+        }
+
+        ctx.supergraph.insert_field(
+            first.parent_definition().name(),
+            first.name(),
+            first.type_name(),
+        )
+    });
+}
+
+fn merge_object_definitions<'a>(
+    ctx: &mut Context<'_>,
+    first: DefinitionWalker<'a>,
+    mut rest: impl Iterator<Item = DefinitionWalker<'a>>,
+) {
+    let kind = first.kind();
+
+    if let Some(incompatible) = rest.find(|definition| definition.kind() != kind) {
+        let first_kind = first.kind();
+        let second_kind = incompatible.kind();
+        let name = first.name_str();
+        let first_subgraph = first.subgraph().name_str();
+        let second_subgraph = incompatible.subgraph().name_str();
+        ctx.diagnostics.push_fatal(format!(
+            "Cannot merge {first_kind:?} with {second_kind:?} (`{name}` in `{first_subgraph}` and `{second_subgraph}`)",
+        ));
+    }
+
+    ctx.supergraph
+        .insert_definition(first.name(), DefinitionKind::Object);
+}

--- a/crates/composition/src/context.rs
+++ b/crates/composition/src/context.rs
@@ -1,0 +1,7 @@
+use crate::{Diagnostics, Subgraphs, Supergraph};
+
+pub(crate) struct Context<'a> {
+    pub(crate) subgraphs: &'a Subgraphs,
+    pub(crate) supergraph: Supergraph,
+    pub(crate) diagnostics: Diagnostics,
+}

--- a/crates/composition/src/diagnostics.rs
+++ b/crates/composition/src/diagnostics.rs
@@ -1,0 +1,28 @@
+/// Warnings and errors produced by composition.
+#[derive(Default)]
+pub struct Diagnostics(Vec<Diagnostic>);
+
+impl Diagnostics {
+    pub(crate) fn any_fatal(&self) -> bool {
+        self.0.iter().any(|diagnostic| diagnostic.is_fatal)
+    }
+
+    /// Iterate over all diagnostic messages.
+    pub fn iter_messages(&self) -> impl Iterator<Item = &str> {
+        self.0.iter().map(|diagnostic| diagnostic.message.as_str())
+    }
+
+    pub(crate) fn push_fatal(&mut self, message: String) {
+        self.0.push(Diagnostic {
+            message,
+            is_fatal: true,
+        });
+    }
+}
+
+/// A composition diagnostic.
+pub(crate) struct Diagnostic {
+    message: String,
+    /// Should this diagnostic be interpreted as a composition failure?
+    is_fatal: bool,
+}

--- a/crates/composition/src/ingest_subgraph.rs
+++ b/crates/composition/src/ingest_subgraph.rs
@@ -1,0 +1,56 @@
+//! This is a separate module because we want to use only the public API of [Subgraphs] and avoid
+//! mixing GraphQL parser logic and types with our internals.
+
+use crate::{subgraphs::DefinitionKind, Subgraphs};
+use async_graphql_parser::types as ast;
+
+pub(crate) fn ingest_subgraph(
+    document: &ast::ServiceDocument,
+    name: &str,
+    subgraphs: &mut Subgraphs,
+) {
+    let subgraph_id = subgraphs.push_subgraph(name);
+
+    for definition in &document.definitions {
+        match definition {
+            ast::TypeSystemDefinition::Type(type_definition) => {
+                let type_name = &type_definition.node.name.node;
+                match &type_definition.node.kind {
+                    ast::TypeKind::Object(object_type) => {
+                        let definition_id = subgraphs.push_definition(
+                            subgraph_id,
+                            type_name,
+                            DefinitionKind::Object,
+                        );
+
+                        for field in &object_type.fields {
+                            let type_name = resolve_field_type(&field.node.ty.node.base);
+                            subgraphs.push_field(
+                                definition_id,
+                                &field.node.name.node,
+                                type_name,
+                            );
+                        }
+                    }
+                    ast::TypeKind::Interface(_interface_type) => {
+                        let _definition_id = subgraphs.push_definition(
+                            subgraph_id,
+                            type_name,
+                            DefinitionKind::Interface,
+                        );
+                    }
+                    _ => (), // TODO
+                }
+            }
+            ast::TypeSystemDefinition::Schema(_) => (), // TODO
+            ast::TypeSystemDefinition::Directive(_) => (), // TODO
+        }
+    }
+}
+
+fn resolve_field_type(base_type: &ast::BaseType) -> &str {
+    match base_type {
+        ast::BaseType::Named(name) => name,
+        ast::BaseType::List(inner) => resolve_field_type(&inner.base),
+    }
+}

--- a/crates/composition/src/lib.rs
+++ b/crates/composition/src/lib.rs
@@ -1,0 +1,34 @@
+#![deny(unsafe_code, missing_docs, rust_2018_idioms)]
+
+//! GraphQL schema composition.
+
+mod compose_supergraph;
+mod context;
+mod diagnostics;
+mod ingest_subgraph;
+mod result;
+mod strings;
+mod subgraphs;
+mod supergraph;
+
+pub use self::{diagnostics::Diagnostics, result::CompositionResult, subgraphs::Subgraphs};
+
+use self::{context::Context, strings::StringId, supergraph::Supergraph};
+
+/// Compose subgraphs into a supergraph
+pub fn compose(subgraphs: &Subgraphs) -> CompositionResult {
+    let mut context = Context {
+        subgraphs,
+        supergraph: Supergraph::default(),
+        diagnostics: Diagnostics::default(),
+    };
+
+    compose_supergraph::build_supergraph(&mut context);
+
+    let supergraph_sdl = context.supergraph.render(&context.subgraphs.strings);
+
+    CompositionResult {
+        supergraph_sdl,
+        diagnostics: context.diagnostics,
+    }
+}

--- a/crates/composition/src/result.rs
+++ b/crates/composition/src/result.rs
@@ -1,0 +1,26 @@
+use crate::Diagnostics;
+
+/// The result of a [`compose()`](crate::compose()) invocation.
+pub struct CompositionResult {
+    pub(crate) supergraph_sdl: String,
+    pub(crate) diagnostics: Diagnostics,
+}
+
+impl CompositionResult {
+    /// Simplify the result data to a yes-no answer: did composition succeed?
+    ///
+    /// `Ok()` contains the supergraph SDL.
+    /// `Err()` contains all diagnostics.
+    pub fn into_result(self) -> Result<String, Diagnostics> {
+        if self.diagnostics.any_fatal() {
+            Err(self.diagnostics)
+        } else {
+            Ok(self.supergraph_sdl)
+        }
+    }
+
+    /// Composition warnings and errors.
+    pub fn diagnostics(&self) -> &Diagnostics {
+        &self.diagnostics
+    }
+}

--- a/crates/composition/src/strings.rs
+++ b/crates/composition/src/strings.rs
@@ -1,0 +1,42 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct StringId(usize);
+
+impl StringId {
+    pub(crate) const MIN: StringId = StringId(usize::MIN);
+    pub(crate) const MAX: StringId = StringId(usize::MAX);
+}
+
+/// Very simple implementation of string interning.
+#[derive(Default)]
+pub(crate) struct Strings(indexmap::IndexSet<Box<str>>);
+
+impl Strings {
+    /// Interns a string-like value, avoiding allocation if the same string has already been
+    /// interned.
+    pub(crate) fn intern<T>(&mut self, string: T) -> StringId
+    where
+        T: AsRef<str> + Into<Box<str>>,
+    {
+        if let Some(idx) = self.0.get_index_of(string.as_ref()) {
+            return StringId(idx);
+        }
+
+        StringId(self.0.insert_full(string.into()).0)
+    }
+
+    /// Resolve a [StringId] into an `&str`. The unwrap is safe because we only issue [StringId]s
+    /// here. The only plausible error cases is if you pass in a [StringId] produced by another
+    /// [Strings] instance.
+    pub(crate) fn resolve(&self, id: StringId) -> &str {
+        self.0.get_index(id.0).unwrap().as_ref()
+    }
+}
+
+// Sugar for [Strings::resolve()].
+impl std::ops::Index<StringId> for Strings {
+    type Output = str;
+
+    fn index(&self, index: StringId) -> &Self::Output {
+        self.resolve(index)
+    }
+}

--- a/crates/composition/src/subgraphs.rs
+++ b/crates/composition/src/subgraphs.rs
@@ -1,0 +1,180 @@
+mod walkers;
+
+pub(crate) use walkers::*;
+
+use crate::strings::{StringId, Strings};
+use itertools::Itertools;
+use std::collections::BTreeSet;
+
+/// A set of subgraphs to be composed.
+#[derive(Default)]
+pub struct Subgraphs {
+    pub(crate) strings: Strings,
+    subgraphs: Vec<Subgraph>,
+
+    // Invariant: `fields` is sorted by `Definition::subgraph_id`. We rely on it for binary search.
+    definitions: Vec<Definition>,
+
+    // Invariant: `fields` is sorted by `Field::object_id`. We rely on it for binary search.
+    fields: Vec<Field>,
+
+    // Secondary indexes.
+
+    // We want a set and not a map, because each name corresponds to one _or more_ definitions (in
+    // different subgrahs). And a BTreeSet because we need range queries.
+    //
+    // (definition name, definition id)
+    definition_names: BTreeSet<(StringId, DefinitionId)>,
+
+    // We want a set and not a map, because each name corresponds to one _or more_ fields (in
+    // different subgrahs). And a BTreeSet because we need range queries.
+    //
+    // `(definition name, field name, field id)`
+    field_names: BTreeSet<(StringId, StringId, FieldId)>,
+}
+
+impl Subgraphs {
+    /// Add a subgraph to compose.
+    pub fn ingest(
+        &mut self,
+        subgraph_schema: &async_graphql_parser::types::ServiceDocument,
+        name: &str,
+    ) {
+        crate::ingest_subgraph::ingest_subgraph(subgraph_schema, name, self)
+    }
+
+    /// Iterate over groups of definitions to compose. The definitions are grouped by name. The
+    /// argument is a closure that receives, for each group, the first definition of the group and
+    /// an iterator over all the other definitions in the group. The order of iteration is
+    /// deterministic but unspecified.
+    pub(crate) fn iter_definition_groups<'a>(
+        &'a self,
+        mut compose_fn: impl FnMut(DefinitionWalker<'a>, &mut dyn Iterator<Item = DefinitionWalker<'a>>),
+    ) {
+        for (_, group) in &self.definition_names.iter().group_by(|(name, _)| name) {
+            let mut group = group
+                .into_iter()
+                .map(move |(_, definition_id)| self.walk(*definition_id));
+            let Some(first_definition_id) = group.next() else {
+                continue;
+            };
+            compose_fn(first_definition_id, &mut group);
+        }
+    }
+
+    /// Iterate over groups of fields to compose. The definitions are grouped by parent type name
+    /// and field name. The argument is a closure that receives, for each group, the first field of
+    /// the group and an iterator over all the other fields in the group. The order of iteration is
+    /// deterministic but unspecified.
+    pub(crate) fn iter_field_groups(
+        &self,
+        mut compose_fn: impl FnMut(FieldWalker<'_>, &mut dyn Iterator<Item = FieldWalker<'_>>),
+    ) {
+        for (_, group) in &self
+            .field_names
+            .iter()
+            .group_by(|(parent_name, field_name, _)| (parent_name, field_name))
+        {
+            let mut group = group
+                .into_iter()
+                .map(|(_, _, field_id)| self.walk(*field_id));
+            let Some(first_field_id) = group.next() else {
+                continue;
+            };
+            compose_fn(first_field_id, &mut group);
+        }
+    }
+
+    pub(crate) fn push_subgraph(&mut self, name: &str) -> SubgraphId {
+        let subgraph = Subgraph {
+            name: self.strings.intern(name),
+        };
+        push_and_return_id(&mut self.subgraphs, subgraph, SubgraphId)
+    }
+
+    pub(crate) fn push_definition(
+        &mut self,
+        subgraph_id: SubgraphId,
+        name: &str,
+        kind: DefinitionKind,
+    ) -> DefinitionId {
+        let name = self.strings.intern(name);
+        let definition = Definition {
+            subgraph_id,
+            name,
+            kind,
+        };
+        let id = push_and_return_id(&mut self.definitions, definition, DefinitionId);
+        self.definition_names.insert((name, id));
+        id
+    }
+
+    pub(crate) fn push_field(
+        &mut self,
+        parent_id: DefinitionId,
+        field_name: &str,
+        type_name: &str,
+    ) -> FieldId {
+        let name = self.strings.intern(field_name);
+        let field = Field {
+            parent_id,
+            name,
+            type_name: self.strings.intern(type_name),
+        };
+        let id = push_and_return_id(&mut self.fields, field, FieldId);
+        let parent_object_name = self.walk(parent_id).name();
+        self.field_names.insert((parent_object_name, name, id));
+        id
+    }
+
+    pub(crate) fn walk<Id>(&self, id: Id) -> Walker<'_, Id> {
+        Walker {
+            id,
+            subgraphs: self,
+        }
+    }
+}
+
+pub(crate) struct Subgraph {
+    /// The name of the subgraph. It is not contained in the GraphQL schema of the subgraph, it only makes sense within a
+    /// project.
+    name: StringId,
+}
+
+pub(crate) struct Definition {
+    subgraph_id: SubgraphId,
+    name: StringId,
+    kind: DefinitionKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DefinitionKind {
+    Object,
+    Interface,
+    // InputObject,
+    // Union,
+    // CustomScalar,
+}
+
+/// A field in an object, interface or input object type.
+pub(crate) struct Field {
+    parent_id: DefinitionId,
+    name: StringId,
+    type_name: StringId,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SubgraphId(usize);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct DefinitionId(usize);
+
+/// The unique identifier for a field in an object, interface or input object field.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct FieldId(usize);
+
+fn push_and_return_id<T, Id>(elems: &mut Vec<T>, new_elem: T, make_id: fn(usize) -> Id) -> Id {
+    let id = make_id(elems.len());
+    elems.push(new_elem);
+    id
+}

--- a/crates/composition/src/subgraphs/walkers.rs
+++ b/crates/composition/src/subgraphs/walkers.rs
@@ -1,0 +1,96 @@
+//! The public API for traversing [Subgraphs].
+
+use super::*;
+
+#[derive(Clone, Copy)]
+pub(crate) struct Walker<'a, Id> {
+    pub(crate) id: Id,
+    pub(crate) subgraphs: &'a Subgraphs,
+}
+
+impl<'a, Id> Walker<'a, Id> {
+    pub(crate) fn walk<T>(self, other: T) -> Walker<'a, T> {
+        self.subgraphs.walk(other)
+    }
+}
+
+pub(crate) type DefinitionWalker<'a> = Walker<'a, DefinitionId>;
+pub(crate) type FieldWalker<'a> = Walker<'a, FieldId>;
+pub(crate) type SubgraphWalker<'a> = Walker<'a, SubgraphId>;
+
+impl<'a> SubgraphWalker<'a> {
+    fn subgraph(self) -> &'a Subgraph {
+        &self.subgraphs.subgraphs[self.id.0]
+    }
+
+    pub(crate) fn name_str(self) -> &'a str {
+        self.subgraphs.strings.resolve(self.subgraph().name)
+    }
+}
+
+impl<'a> DefinitionWalker<'a> {
+    fn definition(self) -> &'a Definition {
+        &self.subgraphs.definitions[self.id.0]
+    }
+
+    pub fn name_str(self) -> &'a str {
+        self.subgraphs.strings.resolve(self.name())
+    }
+
+    pub fn name(self) -> StringId {
+        self.definition().name
+    }
+
+    pub fn kind(self) -> DefinitionKind {
+        self.definition().kind
+    }
+
+    pub fn subgraph(self) -> SubgraphWalker<'a> {
+        self.walk(self.definition().subgraph_id)
+    }
+
+    // pub fn object_fields(self) -> impl Iterator<Item = ObjectFieldWalker<'a>> {
+    //     binary_search_range_for_key(&self.subgraphs.object_fields, self.id, |field| {
+    //         field.object_id
+    //     })
+    //     .map(move |idx| self.walk(ObjectFieldId(idx)))
+    // }
+}
+
+impl<'a> FieldWalker<'a> {
+    fn field(self) -> &'a Field {
+        &self.subgraphs.fields[self.id.0]
+    }
+
+    pub fn parent_definition(self) -> DefinitionWalker<'a> {
+        self.walk(self.field().parent_id)
+    }
+
+    pub fn name(self) -> StringId {
+        self.field().name
+    }
+
+    pub fn name_str(self) -> &'a str {
+        self.subgraphs.strings.resolve(self.name())
+    }
+
+    pub fn type_name(self) -> StringId {
+        self.field().type_name
+    }
+}
+
+// fn binary_search_range_for_key<'a, T, K>(
+//     store: &'a [T],
+//     key: K,
+//     extract_key: impl Fn(&T) -> K + 'a,
+// ) -> impl Iterator<Item = usize> + 'a
+// where
+//     K: Ord + Eq + 'static,
+// {
+//     let start = store.partition_point(|item| extract_key(item) < key);
+//     store[start..]
+//         .iter()
+//         .take_while(move |item| extract_key(*item) == key)
+//         .enumerate()
+//         .map(move |(idx, _)| idx + start)
+// }

--- a/crates/composition/src/supergraph.rs
+++ b/crates/composition/src/supergraph.rs
@@ -1,0 +1,44 @@
+mod render;
+
+use crate::{subgraphs::DefinitionKind, StringId};
+use std::collections::BTreeMap;
+
+/// This is a **write only** data structure. The source of truth for the contents of the supergraph
+/// is the subgraphs.
+#[derive(Default, Debug)]
+pub(crate) struct Supergraph {
+    // We use BTreeMaps here in order to have a consistent ordering when rendering the supergraph
+    // schema.
+    definitions: BTreeMap<StringId, DefinitionKind>,
+    // (definition_name, field_name) -> field_type
+    fields: BTreeMap<(StringId, StringId), StringId>,
+}
+
+impl Supergraph {
+    /// # Panics
+    ///
+    /// If called twice with the same name.
+    pub(crate) fn insert_definition(&mut self, name: StringId, kind: DefinitionKind) {
+        if self.definitions.insert(name, kind).is_some() {
+            panic!("Invariant broken: Supergraph::insert_definition() was called twice with the same name.");
+        }
+    }
+
+    /// # Panics
+    ///
+    /// If called twice with the same parent and field name.
+    pub(crate) fn insert_field(
+        &mut self,
+        parent_type_name: StringId,
+        field_name: StringId,
+        field_type: StringId,
+    ) {
+        if self
+            .fields
+            .insert((parent_type_name, field_name), field_type)
+            .is_some()
+        {
+            panic!("Invariant broken: Supergraph::insert_field() was called twice with the same parent type and field name.");
+        }
+    }
+}

--- a/crates/composition/src/supergraph/render.rs
+++ b/crates/composition/src/supergraph/render.rs
@@ -1,0 +1,32 @@
+use crate::{strings::Strings, subgraphs::DefinitionKind, StringId, Supergraph};
+use std::fmt::Write as _;
+
+/// This cannot fail, other than on a format error, and does not produce diagnostics.
+impl Supergraph {
+    pub(crate) fn render(&self, strings: &Strings) -> String {
+        let mut out = String::new();
+        for (definition_name, definition_kind) in &self.definitions {
+            match definition_kind {
+                DefinitionKind::Object => {
+                    writeln!(out, "type {} {{", &strings[*definition_name]).unwrap();
+
+                    for ((_, field_name), field_type) in self
+                        .fields
+                        .range((*definition_name, StringId::MIN)..(*definition_name, StringId::MAX))
+                    {
+                        writeln!(
+                            out,
+                            "    {}: {}",
+                            &strings[*field_name], &strings[*field_type]
+                        )
+                        .unwrap();
+                    }
+
+                    out.push_str("}\n");
+                }
+                _ => todo!(),
+            }
+        }
+        out
+    }
+}

--- a/crates/composition/tests/composition/object_fields_clash/subgraphs/critics.graphql
+++ b/crates/composition/tests/composition/object_fields_clash/subgraphs/critics.graphql
@@ -1,0 +1,4 @@
+type Band {
+  genre: String
+  name: String!
+}

--- a/crates/composition/tests/composition/object_fields_clash/subgraphs/label.graphql
+++ b/crates/composition/tests/composition/object_fields_clash/subgraphs/label.graphql
@@ -1,0 +1,4 @@
+type Band {
+    name: String!
+    revenue: Int
+}

--- a/crates/composition/tests/composition/object_fields_clash/supergraph.graphql
+++ b/crates/composition/tests/composition/object_fields_clash/supergraph.graphql
@@ -1,0 +1,1 @@
+The field `name` on `Band` is defined in two subgraphs (`label` and `critics`).

--- a/crates/composition/tests/composition/object_interface_clash/subgraphs/accounting.graphql
+++ b/crates/composition/tests/composition/object_interface_clash/subgraphs/accounting.graphql
@@ -1,0 +1,5 @@
+type Customer {
+    id: ID!
+    name: String!
+}
+

--- a/crates/composition/tests/composition/object_interface_clash/subgraphs/inventory.graphql
+++ b/crates/composition/tests/composition/object_interface_clash/subgraphs/inventory.graphql
@@ -1,0 +1,3 @@
+interface Customer {
+    deliveryAddress: String!
+}

--- a/crates/composition/tests/composition/object_interface_clash/supergraph.graphql
+++ b/crates/composition/tests/composition/object_interface_clash/supergraph.graphql
@@ -1,0 +1,1 @@
+Cannot merge Object with Interface (`Customer` in `accounting` and `inventory`)

--- a/crates/composition/tests/composition/objects_basic/subgraphs/a.graphql
+++ b/crates/composition/tests/composition/objects_basic/subgraphs/a.graphql
@@ -1,0 +1,4 @@
+type User {
+  id: ID!
+  score: Float
+}

--- a/crates/composition/tests/composition/objects_basic/subgraphs/b.graphql
+++ b/crates/composition/tests/composition/objects_basic/subgraphs/b.graphql
@@ -1,0 +1,5 @@
+type User {
+  name: String!
+  age: Int
+}
+

--- a/crates/composition/tests/composition/objects_basic/supergraph.graphql
+++ b/crates/composition/tests/composition/objects_basic/supergraph.graphql
@@ -1,0 +1,6 @@
+type User {
+    name: String
+    age: Int
+    id: ID
+    score: Float
+}

--- a/crates/composition/tests/composition_tests.rs
+++ b/crates/composition/tests/composition_tests.rs
@@ -1,0 +1,60 @@
+use std::{fs, path::Path, sync::OnceLock};
+
+fn update_expect() -> bool {
+    static UPDATE_EXPECT: OnceLock<bool> = OnceLock::new();
+    *UPDATE_EXPECT.get_or_init(|| std::env::var("UPDATE_EXPECT").is_ok())
+}
+
+#[allow(clippy::unnecessary_wraps)] // we can't change the signature expected by datatest_stable
+fn run_test(supergraph_path: &Path) -> datatest_stable::Result<()> {
+    let subgraphs_dir = supergraph_path.with_file_name("").join("subgraphs");
+
+    if !subgraphs_dir.is_dir() {
+        return Err(miette::miette!("{} is not a directory.", subgraphs_dir.display()).into());
+    }
+
+    let subgraphs_sdl = fs::read_dir(subgraphs_dir)?
+        .filter_map(Result::ok)
+        .map(|file| fs::read_to_string(file.path()).map(|contents| (contents, file.path())))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut subgraphs = grafbase_composition::Subgraphs::default();
+
+    for (sdl, path) in subgraphs_sdl {
+        let parsed = async_graphql_parser::parse_schema(&sdl)
+            .map_err(|err| miette::miette!("Error parsing {}: {err}", path.display()))?;
+        subgraphs.ingest(&parsed, path.file_stem().unwrap().to_str().unwrap());
+    }
+
+    let expected = fs::read_to_string(supergraph_path)
+        .map_err(|err| miette::miette!("Error trying to read supergraph.graphql: {}", err))?;
+    let actual = match grafbase_composition::compose(&subgraphs).into_result() {
+        Ok(sdl) => sdl,
+        Err(diagnostics) => format!(
+            "{}\n",
+            diagnostics.iter_messages().collect::<Vec<_>>().join("\n"),
+        ),
+    };
+
+    if expected == actual {
+        return Ok(());
+    }
+
+    if update_expect() {
+        return fs::write(supergraph_path, actual).map_err(From::from);
+    }
+
+    Err(miette::miette!(
+        "{}\n\n\n=== Hint: run the tests again with UPDATE_EXPECT=1 to update the snapshot. ===",
+        similar::udiff::unified_diff(
+            similar::Algorithm::default(),
+            &expected,
+            &actual,
+            5,
+            Some(("Expected", "Actual"))
+        )
+    )
+    .into())
+}
+
+datatest_stable::harness! { run_test, "./tests/composition", r"^.*supergraph.graphql$" }


### PR DESCRIPTION
# Description

This commit is a proposal for a general crate structure for supergraph
composition. Everything is a suggestion and up for discussion. It is
definitely very far from complete, and some areas (error reporting) are
just sketched.

What this commit _does_ contains: a proposed public API with a compose
function:

```rust
pub fn compose(subgraphs: &Subgraphs) -> CompositionResult
```

Where `CompositionResult` is SDL for a supergraph and diagnostics.

As well as the general flow, a test suite and the two following
composition rules as a proofs of concept:

- Declaration of different kinds cannot be merged. For example if you
  have `type User { ... }` and `interface User { ... }` in two different
  subgraphs, this is a composition error.
- Objects can be merged as long as their fields do not overlap (no name
  collision). This is the simplest rule of object merging. Handling any
  directive at all is out of scope for this PR.

Here is a non-exhaustive list of design choices that may be
controversial and that we may want to discuss:

1. Subgraphs are considered as a whole set, and the supergraph is an
  entirely separate data structure. There is a possibly viable
  alternative path: merging subgraphs pair-wise, with the resulting
  merged schema being the supergraph. I'm not sure I see all the
  tradeoffs clearly, but a few thoughts:

  - We can probably produce better diagnostics (errors) with global
    knowledge of all the subgraphs.
  - Supergraph SDL looks very different from the union of the subgraph
    schemas with additional rules. We would need to filter out, add
    attributes in non obvious ways to post-process the last remaining
    schema at the end of pair-wise merges.

2. Composition is separate from validation of individual subgraph
  schemas, but it assumes valid schemas as input.

3. Composition produces a SDL string for a supergraph, not a structured
  representation. This is because the requirements of the consumers are
  not known, and a data structure designed for rendering to SDL will
  look different from a data structure for the same supergraph but aimed
  at efficiently resolving queries. For example, `@key` directives will
  matter a great deal for composition, but as far as I can tell, they're
  not in the supergraph SDL.

  This API proposed in this commit picks the easy solution and only
  designs for rendering. The `Supergraph` type is opaque and write only
  however, so we should be able to change how it is organized internally
  relatively easily if we decide we want to use it for something other
  than rendering as GraphQL SDL in the future.

  So I see two questions to resolve:

  - Does it make sense to have a common data structure to represent a
    GraphQL schema, or do we opt for specialized data structures like
    `Subgraphs` in this commit? I think specializing is worth the
    effort, for separation of concerns and simplicity.
  - If we do want specialized data structures, should composition build
    the supergraph data structure or just SDL, and leave the supergraph
    schema data structure implementation to the router?

4. String interning from the start. The main argument against doing this
  now is that it would be premature optimization. On the other hand, we
  know that when merging many subgraphs, we will store, manipulate and
  compare many strings.

  - Storage is cheaper with interning: we have only one copy of each
    string in memory.
  - Manipulation is easier with interning: since `StringId`s are `Copy`,
    we don't need to worry about lifetimes (unlike `&str`), and we don't
    need to worry about ownership and allocation (unlike `String`)
  - Comparison is cheaper: comparing small integers is cheaper than
    comparing strings.

5. Efficient data access patterns from the start. More specifically,
  avoid doing anything `O(n²)` or worse on the number of types in the
  supergraph, or the number of fields in a type (think about `Query`).
  Composing large supergraphs out of many subgraphs in a reasonable
  amount of time is a requirement. It does mean that we have to maintain
  extra data structures as "secondary indexes".

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
