### PR TITLE
typed-resolvers: make all fields that could have resolvers attached optional

### DIFF
--- a/cli/crates/typed-resolvers/src/analyze.rs
+++ b/cli/crates/typed-resolvers/src/analyze.rs
@@ -202,6 +202,7 @@ fn analyze_ast_input_field<'doc>(
         docs: field.description.as_ref().map(|d| d.node.as_str()),
         r#type: GraphqlType::resolve(&field.ty.node, schema)?,
         resolver_name: None, // no resolvers on input fields
+        has_arguments: false,
     })
 }
 
@@ -228,6 +229,7 @@ fn analyze_ast_field<'doc>(field: &'doc ast::FieldDefinition, schema: &AnalyzedS
         docs: field.description.as_ref().map(|d| d.node.as_str()),
         r#type,
         resolver_name,
+        has_arguments: !field.arguments.is_empty(),
     })
 }
 
@@ -288,6 +290,7 @@ pub(crate) struct Field<'doc> {
     pub(crate) name: &'doc str,
     pub(crate) docs: Option<&'doc str>,
     pub(crate) r#type: GraphqlType,
+    pub(crate) has_arguments: bool,
 
     /// ```graphql,ignore
     /// @resolver(name: "user/fullName")

--- a/cli/crates/typed-resolvers/src/codegen.rs
+++ b/cli/crates/typed-resolvers/src/codegen.rs
@@ -33,10 +33,11 @@ where
 
                 for field in fields {
                     let field_optional = !is_input_object
-                        && matches!(
+                        && (matches!(
                             field.r#type.kind,
                             TypeKind::Definition(Definition::Object(_) | Definition::Union(_))
-                        );
+                        ) || field.resolver_name.is_some()
+                            || field.has_arguments);
 
                     let field_optional = if field_optional { "?" } else { "" };
                     let field_name = field.name;

--- a/cli/crates/typed-resolvers/tests/schema_types/extend_root_type.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/extend_root_type.expected.ts
@@ -14,11 +14,11 @@
 export type Schema = {
   'Query': {
     __typename?: 'Query';
-    ping: string;
+    ping?: string;
   };
   'Mutation': {
     __typename?: 'Mutation';
-    pong: string;
+    pong?: string;
   };
   'Subscription': {
     __typename?: 'Subscription';

--- a/cli/crates/typed-resolvers/tests/schema_types/with_resolvers.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/with_resolvers.expected.ts
@@ -16,6 +16,8 @@ export type Schema = {
     __typename?: 'User';
     id: string;
     name: string;
+    biography?: string;
+    linkedInProfile?: string;
     account?: Schema['Account'];
   };
   'Account': {
@@ -41,6 +43,7 @@ export type Schema = {
 import { ResolverFn } from '@grafbase/sdk'
 
 export type Resolver = {
+  'User.linkedInProfile': ResolverFn<Schema['User'], {  }, string>
   'Query.user': ResolverFn<Schema['Query'], { anonymize: boolean | null,  }, Schema['User'] | null>
   'Query.users': ResolverFn<Schema['Query'], { filter: Schema['UserFilter'] | null, take: number,  }, Array<Schema['User'] | null> | null>
   'Query.other': ResolverFn<Schema['Query'], {  }, Schema['Other'] | null>

--- a/cli/crates/typed-resolvers/tests/schema_types/with_resolvers.graphql
+++ b/cli/crates/typed-resolvers/tests/schema_types/with_resolvers.graphql
@@ -3,6 +3,8 @@ directive @resolver(name: String) on FIELD_DEFINITION
 type User {
     id: ID!
     name: String!
+    biography(short: Boolean): String!
+    linkedInProfile: String! @resolver(name: "user/linkedin-profile")
     account: Account!
 }
 


### PR DESCRIPTION
For object and interface types, in the generated TypeScript code. This is a correctness problem:

- In the `parent` argument, because that data may not be present (e.g. sibling resolver's responses)
- In the return types, because the resolver is not necessarily responsible for returning that data.

Thanks @obmarg  for noticing the problems.

closes GB-5177

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
