### PR TITLE
feat: @join directive

### DIFF
--- a/engine/crates/engine/parser/src/lib.rs
+++ b/engine/crates/engine/parser/src/lib.rs
@@ -16,7 +16,7 @@
 use std::fmt::{self, Display, Formatter};
 
 use engine_value::Name;
-pub use parse::{parse_query, parse_schema, parse_selection_set};
+pub use parse::{parse_field, parse_query, parse_schema, parse_selection_set};
 use pest::{error::LineColLocation, RuleType};
 pub use pos::{Pos, Positioned};
 use serde::{Serialize, Serializer};

--- a/engine/crates/engine/parser/src/parse/mod.rs
+++ b/engine/crates/engine/parser/src/parse/mod.rs
@@ -22,7 +22,7 @@ mod service;
 mod utils;
 
 use engine_value::{ConstValue, Name, Number, Value};
-pub use executable::{parse_query, parse_selection_set};
+pub use executable::{parse_field, parse_query, parse_selection_set};
 pub use service::parse_schema;
 
 #[derive(Parser)]

--- a/engine/crates/engine/src/context/field.rs
+++ b/engine/crates/engine/src/context/field.rs
@@ -92,6 +92,20 @@ impl<'a> ContextField<'a> {
         }
     }
 
+    pub fn to_join_context(
+        &self,
+        item: &'a Positioned<Field>,
+        field: &'a MetaField,
+        parent_type: SelectionSetTarget<'a>,
+    ) -> Self {
+        Self {
+            field,
+            item,
+            parent_type,
+            ..self.clone()
+        }
+    }
+
     /// Returns the base type for the currently resolving field
     pub fn field_base_type(&self) -> OutputType<'a> {
         self.registry()

--- a/engine/crates/engine/src/registry/resolvers/graphql/serializer.rs
+++ b/engine/crates/engine/src/registry/resolvers/graphql/serializer.rs
@@ -153,8 +153,8 @@ impl<'a: 'b, 'b: 'a, 'c: 'a> Serializer<'a, 'b> {
 
     fn serialize_field(&mut self, field: &Field, schema_field: Option<&MetaField>) -> Result<(), Error> {
         if let Some(schema_field) = schema_field {
-            if schema_field.resolver.is_custom() {
-                // Skip fields that have resolvers, as they won't exist in the downstream
+            if schema_field.resolver.is_custom() || schema_field.resolver.is_join() {
+                // Skip fields that have resolvers or are joins - they won't exist in the downstream
                 // server
                 return Ok(());
             }

--- a/engine/crates/engine/src/registry/resolvers/join.rs
+++ b/engine/crates/engine/src/registry/resolvers/join.rs
@@ -1,0 +1,125 @@
+use std::collections::BTreeMap;
+
+use engine_parser::{types::Field, Positioned};
+use engine_value::{argument_set::ArgumentSet, ConstValue, Name, Value};
+
+use crate::{Context, ContextField, Error};
+
+use super::{ResolvedValue, ResolverContext};
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
+#[serde_with::minify_field_names(serialize = "minified", deserialize = "minified")]
+pub struct JoinResolver {
+    field_name: String,
+    arguments: ArgumentSet,
+}
+
+// ArgumentSet can't be hashed so we've got a manual impl here that goes via JSON.
+// Would be nice to get rid of the Hash requirement from these types
+impl core::hash::Hash for JoinResolver {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.field_name.hash(state);
+        serde_json::to_string(&self.arguments).unwrap_or_default().hash(state);
+    }
+}
+
+impl JoinResolver {
+    pub fn new(field_name: String, arguments: Vec<(Name, Value)>) -> Self {
+        JoinResolver {
+            field_name,
+            arguments: ArgumentSet::new(arguments),
+        }
+    }
+}
+
+impl JoinResolver {
+    pub async fn resolve(
+        &self,
+        ctx: &ContextField<'_>,
+        last_resolver_value: Option<ResolvedValue>,
+    ) -> Result<ResolvedValue, Error> {
+        let root_type = ctx
+            .schema_env()
+            .registry
+            .root_type(engine_parser::types::OperationType::Query);
+
+        let last_resolver_value = last_resolver_value.unwrap_or_default();
+        let meta_field = root_type.field(&self.field_name).ok_or_else(|| {
+            Error::new(format!(
+                "Internal error: could not find joined field {}",
+                &self.field_name
+            ))
+        })?;
+
+        let fake_query_field = self.field_for_join(ctx.item, last_resolver_value)?;
+        let join_context = ctx.to_join_context(&fake_query_field, meta_field, root_type);
+        let resolver_context = ResolverContext::new(&join_context);
+
+        meta_field
+            .resolver
+            .resolve(&join_context, &resolver_context, None)
+            .await
+    }
+}
+
+impl JoinResolver {
+    fn field_for_join(
+        &self,
+        actual_field: &Positioned<Field>,
+        last_resolver_value: ResolvedValue,
+    ) -> Result<Positioned<Field>, Error> {
+        let arguments = self.resolve_arguments(last_resolver_value)?;
+
+        let Positioned { pos, node: field } = actual_field;
+
+        Ok(Positioned::new(
+            Field {
+                alias: None,
+                name: Positioned::new(Name::new(&self.field_name), *pos),
+                arguments: arguments
+                    .into_iter()
+                    .map(|(name, value)| (Positioned::new(Name::new(name), *pos), Positioned::new(value, *pos)))
+                    .collect(),
+                directives: field.directives.clone(),
+                selection_set: field.selection_set.clone(),
+            },
+            *pos,
+        ))
+    }
+
+    fn resolve_arguments(&self, last_resolver_value: ResolvedValue) -> Result<Vec<(String, Value)>, Error> {
+        let serde_json::Value::Object(parent_object) = last_resolver_value.data_resolved() else {
+            // This might be an error but I'm going to defer reporting to the child resolver for now.
+            // Saves us some work here.  Can revisit if it doesn't work very well (which is very possible)
+            return Ok(vec![]);
+        };
+
+        let mut arguments = BTreeMap::new();
+
+        for (name, value) in self.arguments.clone() {
+            // Any variables this value refers to are actually fields on the last_resolver_value
+            // so we need to resolve with into_const_with then convert back to a value.
+            arguments.insert(
+                name.to_string(),
+                value
+                    .into_const_with(|variable_name| {
+                        let value = parent_object.get(variable_name.as_str()).cloned().ok_or_else(|| {
+                            Error::new(format!(
+                                "Internal error: couldn't find {variable_name} in parent_resolver_value"
+                            ))
+                        })?;
+
+                        ConstValue::from_json(value)
+                            .map_err(|_| Error::new("Internal error converting intermediate values"))
+                    })?
+                    .into_value(),
+            );
+        }
+
+        // At some point we'll probably want to think about forwarding arguments from the current field
+        // to the joined field.  But we can handle that when the need comes up, this PR is already too
+        // big
+
+        Ok(arguments.into_iter().collect())
+    }
+}

--- a/engine/crates/engine/value/src/argument_set.rs
+++ b/engine/crates/engine/value/src/argument_set.rs
@@ -1,0 +1,328 @@
+//! Defines ArgumentSet - a special kind of Value that can be serialized to JSON while preserving
+//! enums and variables.
+//!
+//! This should not be used for user facing things, but can be used when you want to preserve a set
+//! of GraphQL arguments in the registry for example.
+
+use std::fmt::{self, Formatter};
+
+use bytes::Bytes;
+use indexmap::IndexMap;
+use serde::{
+    de::{Error as DeError, MapAccess, SeqAccess, Visitor},
+    ser::SerializeMap,
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+use serde_json::Number;
+
+use crate::Name;
+
+/// A Serializable set of arguments to a GraphQL field.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArgumentSet(Vec<(Name, SerializableArgument)>);
+
+impl ArgumentSet {
+    /// Create a new ArgumentSet
+    pub fn new(arguments: Vec<(Name, crate::Value)>) -> Self {
+        ArgumentSet(
+            arguments
+                .into_iter()
+                .map(|(name, value)| (name, value.into()))
+                .collect(),
+        )
+    }
+}
+
+impl IntoIterator for ArgumentSet {
+    type Item = (Name, crate::Value);
+
+    type IntoIter = ArgumentSetIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        ArgumentSetIter(self.0.into_iter())
+    }
+}
+
+/// Owned iterator for ArgumentSet
+pub struct ArgumentSetIter(<Vec<(Name, SerializableArgument)> as IntoIterator>::IntoIter);
+
+impl Iterator for ArgumentSetIter {
+    type Item = (Name, crate::Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (name, argument) = self.0.next()?;
+        Some((name, argument.into()))
+    }
+}
+
+/// A Serializable argument to a GraphQL field
+///
+/// This is very similar to Value, but it can serialize both variables and enums instead of erroring
+/// when it encounters them:
+///
+/// 1. Variables will be serialized as `{"$var": "X"}`
+/// 2. Enums will be serialized ass `{"$enum": "X"}`
+///
+/// Accordingly, this should only be used in contexts where we control the inputs and such an object can't exist,
+/// e.g. in the registry.
+///
+/// Note that this is private intentionally - this should only really be used for serialization via
+/// ArgumentSet above.  Convert it to Value if you want to work with it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum SerializableArgument {
+    /// A variable, without the `$`.
+    Variable(Name),
+    /// `null`.
+    Null,
+    /// A number.
+    Number(Number),
+    /// A string.
+    String(String),
+    /// A boolean.
+    Boolean(bool),
+    /// A binary.
+    Binary(Bytes),
+    /// An enum. These are typically in `SCREAMING_SNAKE_CASE`.
+    Enum(Name),
+    /// A list of values.
+    List(Vec<SerializableArgument>),
+    /// An object. This is a map of keys to values.
+    Object(IndexMap<Name, SerializableArgument>),
+}
+
+impl From<SerializableArgument> for crate::Value {
+    fn from(value: SerializableArgument) -> Self {
+        match value {
+            SerializableArgument::Variable(name) => crate::Value::Variable(name),
+            SerializableArgument::Null => crate::Value::Null,
+            SerializableArgument::Number(num) => {
+                // We force it to be a f64 in the internal representation to generate the
+                // appropriate ArrowSchema
+                crate::Value::Number(Number::from_f64(num.as_f64().expect("can't fail")).expect("can't fail"))
+            }
+            SerializableArgument::String(s) => crate::Value::String(s),
+            SerializableArgument::Boolean(b) => crate::Value::Boolean(b),
+            SerializableArgument::Binary(bytes) => crate::Value::Binary(bytes),
+            SerializableArgument::Enum(v) => crate::Value::Enum(v),
+            SerializableArgument::List(items) => crate::Value::List(items.into_iter().map(Into::into).collect()),
+            SerializableArgument::Object(map) => {
+                crate::Value::Object(map.into_iter().map(|(key, value)| (key, value.into())).collect())
+            }
+        }
+    }
+}
+
+impl From<crate::Value> for SerializableArgument {
+    fn from(value: crate::Value) -> Self {
+        match value {
+            crate::Value::Variable(name) => SerializableArgument::Variable(name),
+            crate::Value::Null => SerializableArgument::Null,
+            crate::Value::Number(num) => {
+                // We force it to be a f64 in the internal representation to generate the
+                // appropriate ArrowSchema
+                SerializableArgument::Number(Number::from_f64(num.as_f64().expect("can't fail")).expect("can't fail"))
+            }
+            crate::Value::String(s) => SerializableArgument::String(s),
+            crate::Value::Boolean(b) => SerializableArgument::Boolean(b),
+            crate::Value::Binary(bytes) => SerializableArgument::Binary(bytes),
+            crate::Value::Enum(v) => SerializableArgument::Enum(v),
+            crate::Value::List(items) => SerializableArgument::List(items.into_iter().map(Into::into).collect()),
+            crate::Value::Object(map) => {
+                SerializableArgument::Object(map.into_iter().map(|(key, value)| (key, value.into())).collect())
+            }
+        }
+    }
+}
+
+impl Serialize for SerializableArgument {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            SerializableArgument::Variable(name) => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("$var", name)?;
+                map.end()
+            }
+            SerializableArgument::Null => serializer.serialize_none(),
+            SerializableArgument::Number(v) => v.serialize(serializer),
+            SerializableArgument::String(v) => serializer.serialize_str(v),
+            SerializableArgument::Boolean(v) => serializer.serialize_bool(*v),
+            SerializableArgument::Binary(v) => serializer.serialize_bytes(v),
+            SerializableArgument::Enum(name) => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("$enum", name)?;
+                map.end()
+            }
+            SerializableArgument::List(v) => v.serialize(serializer),
+            SerializableArgument::Object(v) => v.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for SerializableArgument {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct ValueVisitor;
+
+        impl<'de> Visitor<'de> for ValueVisitor {
+            type Value = SerializableArgument;
+
+            #[inline]
+            fn expecting(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+                formatter.write_str("any valid value")
+            }
+
+            #[inline]
+            fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                Ok(SerializableArgument::Boolean(v))
+            }
+
+            #[inline]
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                Ok(SerializableArgument::Number(v.into()))
+            }
+
+            #[inline]
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                Ok(SerializableArgument::Number(v.into()))
+            }
+
+            #[inline]
+            fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                Ok(Number::from_f64(v).map_or(SerializableArgument::Null, SerializableArgument::Number))
+            }
+
+            #[inline]
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                Ok(SerializableArgument::String(v.to_string()))
+            }
+
+            #[inline]
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                Ok(SerializableArgument::String(v))
+            }
+
+            #[inline]
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                Ok(SerializableArgument::Binary(v.to_vec().into()))
+            }
+
+            #[inline]
+            fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                Ok(SerializableArgument::Binary(v.into()))
+            }
+
+            #[inline]
+            fn visit_none<E>(self) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                Ok(SerializableArgument::Null)
+            }
+
+            #[inline]
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                Deserialize::deserialize(deserializer)
+            }
+
+            #[inline]
+            fn visit_unit<E>(self) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                Ok(SerializableArgument::Null)
+            }
+
+            fn visit_seq<A>(self, mut visitor: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut vec = Vec::new();
+                while let Some(elem) = visitor.next_element()? {
+                    vec.push(elem);
+                }
+                Ok(SerializableArgument::List(vec))
+            }
+
+            fn visit_map<A>(self, mut visitor: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut map = IndexMap::new();
+                while let Some((name, value)) = visitor.next_entry()? {
+                    map.insert(name, value);
+                }
+                if map.len() == 1 {
+                    if let Some(SerializableArgument::String(value)) = map.get("$var") {
+                        return Ok(SerializableArgument::Variable(Name::new(value)));
+                    }
+                    if let Some(SerializableArgument::String(value)) = map.get("$enum") {
+                        return Ok(SerializableArgument::Enum(Name::new(value)));
+                    }
+                }
+                Ok(SerializableArgument::Object(map))
+            }
+        }
+
+        deserializer.deserialize_any(ValueVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Deserialize;
+
+    use super::*;
+
+    fn roundtrip_test(input: SerializableArgument) {
+        assert_eq!(
+            SerializableArgument::deserialize(serde_json::to_value(&input).unwrap()).unwrap(),
+            input,
+        );
+    }
+
+    #[test]
+    fn serde_tests() {
+        roundtrip_test(SerializableArgument::Enum(Name::new("foo")));
+        roundtrip_test(SerializableArgument::Variable(Name::new("bar")));
+
+        roundtrip_test(SerializableArgument::Object(IndexMap::from([
+            (Name::new("foo"), SerializableArgument::Boolean(true)),
+            (Name::new("bar"), SerializableArgument::Boolean(false)),
+        ])));
+
+        roundtrip_test(SerializableArgument::List(vec![
+            SerializableArgument::Boolean(true),
+            SerializableArgument::Boolean(false),
+        ]));
+
+        roundtrip_test(SerializableArgument::Null);
+        roundtrip_test(SerializableArgument::String("hello".into()));
+        roundtrip_test(SerializableArgument::Number(1.into()));
+    }
+}

--- a/engine/crates/engine/value/src/lib.rs
+++ b/engine/crates/engine/value/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::manual_let_else)]
 #![allow(clippy::module_name_repetitions)]
 
+pub mod argument_set;
 mod deserializer;
 mod macros;
 mod serializer;

--- a/engine/crates/integration-tests/tests/execution/joins.rs
+++ b/engine/crates/integration-tests/tests/execution/joins.rs
@@ -1,0 +1,115 @@
+//! Tests of the join directive
+
+use integration_tests::{runtime, udfs::RustUdfs, EngineBuilder, MockGraphQlServer, ResponseExt};
+use runtime::udf::{CustomResolverRequestPayload, CustomResolverResponse};
+use serde_json::{json, Value};
+
+#[test]
+fn join_on_basic_type() {
+    runtime().block_on(async {
+        let schema = r#"
+            extend type Query {
+                greetPerson(name: String): String! @resolver(name: "greetPerson")
+                user: User! @resolver(name: "user")
+            }
+
+            type User {
+                id: ID!
+                name: String!
+                greeting: String! @join(select: "greetPerson(name: $name)")
+            }
+        "#;
+
+        let engine = EngineBuilder::new(schema)
+            .with_custom_resolvers(
+                RustUdfs::new()
+                    .resolver(
+                        "user",
+                        CustomResolverResponse::Success(json!({"id": "123", "name": "Bob"})),
+                    )
+                    .resolver("greetPerson", |input: CustomResolverRequestPayload| {
+                        Ok(CustomResolverResponse::Success(
+                            format!("Hello {}", input.arguments["name"].as_str().unwrap(),).into(),
+                        ))
+                    }),
+            )
+            .build()
+            .await;
+
+        insta::assert_json_snapshot!(
+            engine
+                .execute("{ user { greeting } }")
+                .await
+                .into_data::<Value>(),
+                @r###"
+        {
+          "user": {
+            "greeting": "Hello Bob"
+          }
+        }
+        "###
+        );
+    });
+}
+
+#[test]
+fn join_on_connector_type() {
+    runtime().block_on(async {
+        let graphql_mock = MockGraphQlServer::new().await;
+        let port = graphql_mock.port();
+
+        let schema = format!(
+            r#"
+            extend schema
+                @graphql(
+                    name: "gothub",
+                    namespace: false,
+                    url: "http://127.0.0.1:{port}",
+                )
+
+            extend type Query {{
+                describeIssue(name: String): String! @resolver(name: "describeIssue")
+            }}
+
+            extend type Issue {{
+                description: String! @join(select: "describeIssue(name: $title)")
+            }}
+            "#
+        );
+
+        let engine = EngineBuilder::new(schema)
+            .with_custom_resolvers(
+                RustUdfs::new().resolver("describeIssue", |input: CustomResolverRequestPayload| {
+                    Ok(CustomResolverResponse::Success(
+                        format!("Oh no {}", input.arguments["name"].as_str().unwrap(),).into(),
+                    ))
+                }),
+            )
+            .build()
+            .await;
+
+        insta::assert_json_snapshot!(
+            engine
+                .execute(r#"
+                query {
+                    pullRequestOrIssue(id: "3") {
+                        ... on Issue {
+                            title
+                            description
+                        }
+                    }
+                }
+                "#)
+                .await
+                .into_data::<Value>(),
+                @r###"
+        {
+          "pullRequestOrIssue": {
+            "description": "Oh no Everythings fucked",
+            "title": "Everythings fucked"
+          }
+        }
+        "###
+        );
+    });
+}

--- a/engine/crates/integration-tests/tests/execution/mod.rs
+++ b/engine/crates/integration-tests/tests/execution/mod.rs
@@ -8,6 +8,7 @@
 
 use std::net::SocketAddr;
 
+mod joins;
 mod requires;
 
 use integration_tests::{runtime, udfs::RustUdfs, Engine, EngineBuilder, ResponseExt};

--- a/engine/crates/integration-tests/tests/graphql_connector/basic.rs
+++ b/engine/crates/integration-tests/tests/graphql_connector/basic.rs
@@ -184,7 +184,6 @@ fn schema(port: u16, namespace: bool) -> String {
             name: "gothub",
             namespace: {namespace},
             url: "http://127.0.0.1:{port}",
-            schema: "http://127.0.0.1:{port}/spec.json",
           )
         "#
     )

--- a/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__petstore_without_namespace.snap
+++ b/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__petstore_without_namespace.snap
@@ -1,0 +1,113 @@
+---
+source: crates/parser-openapi/src/tests/mod.rs
+expression: registry.export_sdl(false)
+---
+type Mutation {
+	updatePet(input: PetstorePetInput!): PetstorePet
+	addPet(input: PetstorePetInput!): PetstorePet
+	uploadFile(petId: Int!, additionalMetadata: String): PetstoreApiResponse
+	placeOrder(input: PetstoreOrderInput!): PetstoreOrder
+	createUsersWithListInput(input: [PetstoreUserInput!]!): PetstoreUser
+}
+type PetstoreApiResponse {
+	message: String
+	type: String
+	code: Int
+}
+type PetstoreCategory {
+	name: String
+	id: Int
+}
+input PetstoreCategoryInput {
+	name: String
+	id: Int
+}
+enum PetstoreFindPetsByStatusStatus {
+	AVAILABLE
+	PENDING
+	SOLD
+}
+type PetstoreOrder {
+	complete: Boolean
+	status: PetstoreOrderStatus
+	shipDate: String
+	quantity: Int
+	petId: Int
+	id: Int
+}
+input PetstoreOrderInput {
+	complete: Boolean
+	status: PetstoreOrderStatus
+	shipDate: String
+	quantity: Int
+	petId: Int
+	id: Int
+}
+enum PetstoreOrderStatus {
+	PLACED
+	APPROVED
+	DELIVERED
+}
+type PetstorePet {
+	status: PetstorePetStatus
+	tags: [PetstoreTag!]
+	photoUrls: [String!]!
+	category: PetstoreCategory
+	name: String!
+	id: Int
+}
+input PetstorePetInput {
+	status: PetstorePetStatus
+	tags: [PetstoreTagInput!]!
+	photoUrls: [String!]!
+	category: PetstoreCategoryInput!
+	name: String!
+	id: Int
+}
+enum PetstorePetStatus {
+	AVAILABLE
+	PENDING
+	SOLD
+}
+type PetstoreTag {
+	name: String
+	id: Int
+}
+input PetstoreTagInput {
+	name: String
+	id: Int
+}
+type PetstoreUser {
+	userStatus: Int
+	phone: String
+	password: String
+	email: String
+	lastName: String
+	firstName: String
+	username: String
+	id: Int
+}
+input PetstoreUserInput {
+	userStatus: Int
+	phone: String
+	password: String
+	email: String
+	lastName: String
+	firstName: String
+	username: String
+	id: Int
+}
+type Query {
+	findPetsByStatus(status: PetstoreFindPetsByStatusStatus = AVAILABLE): [PetstorePet!]
+	findPetsByTags(tags: [String!]): [PetstorePet!]
+	pet(petId: Int!): PetstorePet
+	inventory: JSON
+	order(orderId: Int!): PetstoreOrder
+	loginUser(password: String, username: String): String
+	user(username: String!): PetstoreUser
+}
+schema {
+	query: Query
+	mutation: Mutation
+}
+

--- a/engine/crates/parser-sdl/src/lib.rs
+++ b/engine/crates/parser-sdl/src/lib.rs
@@ -31,6 +31,7 @@ use rules::{
     federation::{FederationDirective, FederationDirectiveVisitor, KeyDirective},
     graphql_directive::GraphqlVisitor,
     input_object::InputObjectVisitor,
+    join_directive::JoinDirective,
     length_directive::LengthDirective,
     map_directive::MapDirective,
     model_directive::ModelDirective,
@@ -138,7 +139,8 @@ fn parse_schema(schema: &str) -> engine::parser::Result<ServiceDocument> {
         .with::<ExperimentalDirective>()
         .with::<FederationDirective>()
         .with::<RequiresDirective>()
-        .with::<KeyDirective>();
+        .with::<KeyDirective>()
+        .with::<JoinDirective>();
 
     let schema = format!(
         "{}\n{}\n{}\n{}",

--- a/engine/crates/parser-sdl/src/rules/join_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/join_directive.rs
@@ -1,0 +1,155 @@
+use std::collections::{BTreeSet, HashMap};
+
+use engine::registry::{field_set::Selection, resolvers::join::JoinResolver, FieldSet};
+use engine_parser::{parse_field, types::ConstDirective, Positioned};
+use engine_value::{Name, Value};
+use serde::de::Error;
+
+use crate::directive_de::parse_directive;
+
+use super::{directive::Directive, visitor::VisitorContext};
+
+#[derive(Debug)]
+pub struct JoinDirective {
+    field_name: String,
+    arguments: Vec<(Name, Value)>,
+    required_fields: Vec<String>,
+}
+
+impl Directive for JoinDirective {
+    fn definition() -> String {
+        "directive @join(select: String!) on FIELD_DEFINITION".into()
+    }
+}
+
+impl JoinDirective {
+    pub fn from_directives(
+        directives: &[Positioned<ConstDirective>],
+        ctx: &mut VisitorContext<'_>,
+    ) -> Option<JoinDirective> {
+        let directive = directives.iter().find(|directive| directive.name.node == "join")?;
+
+        match parse_directive::<Self>(directive, &HashMap::new()) {
+            Ok(directive) => Some(directive),
+            Err(error) => {
+                ctx.append_errors(vec![error]);
+                None
+            }
+        }
+    }
+
+    pub fn required_fieldset(&self) -> Option<FieldSet> {
+        if self.required_fields.is_empty() {
+            return None;
+        }
+
+        Some(FieldSet::new(self.required_fields.iter().map(|field| Selection {
+            field: field.clone(),
+            selections: vec![],
+        })))
+    }
+
+    pub fn to_join_resolver(&self) -> JoinResolver {
+        JoinResolver::new(self.field_name.clone(), self.arguments.clone())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for JoinDirective {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct RawDirective {
+            // TODO: Is this the best right name?  Not sure...
+            select: String,
+        }
+
+        let raw_directive = RawDirective::deserialize(deserializer)?;
+
+        let field = parse_field(raw_directive.select)
+            .map_err(|error| D::Error::custom(format!("Could not parse join: {error}")))?;
+
+        if !field.node.selection_set.items.is_empty() {
+            return Err(D::Error::custom(
+                "this join attempts to select children, but joins can only select a single field",
+            ));
+        }
+
+        let arguments = field
+            .node
+            .arguments
+            .into_iter()
+            .map(|(name, value)| (name.node, value.node))
+            .collect::<Vec<_>>();
+
+        let required_fields = arguments
+            .iter()
+            .flat_map(|(_, value)| value.variables_used())
+            .map(|variable| variable.to_string())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        Ok(JoinDirective {
+            field_name: field.node.name.node.to_string(),
+            arguments,
+            required_fields,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use insta::assert_debug_snapshot;
+    use serde::Deserialize;
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn join_directive_deser() {
+        let directive = JoinDirective::deserialize(json!({"select": "findUser(name: $name, filters: {eq: $filters})"}));
+
+        assert_debug_snapshot!(directive, @r###"
+        Ok(
+            JoinDirective {
+                field_name: "findUser",
+                arguments: [
+                    (
+                        Name(
+                            "name",
+                        ),
+                        Variable(
+                            Name(
+                                "name",
+                            ),
+                        ),
+                    ),
+                    (
+                        Name(
+                            "filters",
+                        ),
+                        Object(
+                            {
+                                Name(
+                                    "eq",
+                                ): Variable(
+                                    Name(
+                                        "filters",
+                                    ),
+                                ),
+                            },
+                        ),
+                    ),
+                ],
+                required_fields: [
+                    "filters",
+                    "name",
+                ],
+            },
+        )
+        "###);
+    }
+}

--- a/engine/crates/parser-sdl/src/rules/mod.rs
+++ b/engine/crates/parser-sdl/src/rules/mod.rs
@@ -18,6 +18,7 @@ pub mod extend_query_and_mutation_types;
 pub mod federation;
 pub mod graphql_directive;
 pub mod input_object;
+pub mod join_directive;
 pub mod length_directive;
 pub mod map_directive;
 pub mod model_directive;


### PR DESCRIPTION
I've been working on a test case for the OpenAPI<->Subgraph integration where I've got a Locations API & a Reviews API.  With the integration as it currently stands I've managed to add a `location` field into the `Review` entity quite easily.  What's currently quite difficult is extending the `Location` type with endpoints from the Reviews API.

My reviews API has an endpoint `location_reviews/:id` which I'd like to add to the `Location` type as `reviewsForLocation: [Review]`.  The OpenAPI connector exposes this endpoint as a field on the `Query` type: `locationReviews(locationId: String)`.  But there's no way to add that `Query` field onto the `Location` type.

I've solved that by adding the `@join` directive that we've spoke about in the past, as it does basically what we want.  So for my test case I can add the following to the reviews subgraph schema:

```graphql
type Location @key(fields: "id") {
  id: String!
  reviewsForLocation: [Review] @join(select: "locationReviews(locationId: $id)")
}
```

The syntax is a GraphQL field selection, and all the fields of the current type are implicitly available as variables.  It'll automatically infer an `@requires` directive from the used variables, so users shouldn't have to worry about making sure they query for those fields.  (`@requires` doesn't work for all our connectors at the moment, but we can fix that when/if it becomes a problem).

This is very much a first pass - you can't pass nested fields in to the sub-query, there's no way to pass arguments from the field to the sub-query and you can only query top level fields - no nesting at the moment.  We can handle those later if needed though - I have ideas for all of them so pretty sure they're all possible.

I've skipped validating the query much in this PR as it's already quite big.  Will do that & adding to the SDK in separate PRs.