### PR TITLE
composition: implement @shareable and @link basics

### DIFF
--- a/.github/workflows/composition.yml
+++ b/.github/workflows/composition.yml
@@ -1,0 +1,27 @@
+on:
+  pull_request:
+    paths:
+      - 'crates/composition/**/*'
+
+jobs:
+  composition:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Rust job init
+        uses: ./.github/actions/init_rust_job
+        with:
+          platform: linux
+          cache-key: ${{ runner.os }}-${{ runner.arch }}-cargo-dev-${{ hashFiles('crates/composition/Cargo.toml') }}
+          restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-dev
+
+      - run: cargo clippy
+        working-directory: 'crates/composition'
+
+      - run: cargo test
+        working-directory: 'crates/composition'
+      
+      - run: cargo fmt --check
+         working-directory: 'crates/composition'

--- a/crates/composition/Cargo.toml
+++ b/crates/composition/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 async-graphql-parser = "6"
+async-graphql-value = "6"
 indexmap = "2"
 itertools = "0.11.0"
 

--- a/crates/composition/src/ingest_subgraph.rs
+++ b/crates/composition/src/ingest_subgraph.rs
@@ -1,7 +1,13 @@
 //! This is a separate module because we want to use only the public API of [Subgraphs] and avoid
 //! mixing GraphQL parser logic and types with our internals.
 
-use crate::{subgraphs::DefinitionKind, Subgraphs};
+mod schema_definitions;
+
+use self::schema_definitions::*;
+use crate::{
+    subgraphs::{DefinitionKind, SubgraphId},
+    Subgraphs,
+};
 use async_graphql_parser::types as ast;
 
 pub(crate) fn ingest_subgraph(
@@ -11,6 +17,23 @@ pub(crate) fn ingest_subgraph(
 ) {
     let subgraph_id = subgraphs.push_subgraph(name);
 
+    let federation_directives_matcher = ingest_schema_definitions(document);
+
+    ingest_top_level_definitions(
+        subgraph_id,
+        document,
+        subgraphs,
+        &federation_directives_matcher,
+    );
+}
+
+
+fn ingest_top_level_definitions(
+    subgraph_id: SubgraphId,
+    document: &ast::ServiceDocument,
+    subgraphs: &mut Subgraphs,
+    federation_directives_matcher: &FederationDirectivesMatcher<'_>,
+) {
     for definition in &document.definitions {
         match definition {
             ast::TypeSystemDefinition::Type(type_definition) => {
@@ -23,12 +46,22 @@ pub(crate) fn ingest_subgraph(
                             DefinitionKind::Object,
                         );
 
+                        let object_is_shareable = type_definition.node.directives.iter().any(|d| {
+                            federation_directives_matcher.is_shareable(d.node.name.node.as_str())
+                        });
+
                         for field in &object_type.fields {
+                            let is_shareable = object_is_shareable
+                                || field.node.directives.iter().any(|directive| {
+                                    federation_directives_matcher
+                                        .is_shareable(directive.node.name.node.as_str())
+                                });
                             let type_name = resolve_field_type(&field.node.ty.node.base);
                             subgraphs.push_field(
                                 definition_id,
                                 &field.node.name.node,
                                 type_name,
+                                is_shareable,
                             );
                         }
                     }
@@ -42,8 +75,8 @@ pub(crate) fn ingest_subgraph(
                     _ => (), // TODO
                 }
             }
-            ast::TypeSystemDefinition::Schema(_) => (), // TODO
-            ast::TypeSystemDefinition::Directive(_) => (), // TODO
+            ast::TypeSystemDefinition::Schema(_) => (),
+            ast::TypeSystemDefinition::Directive(_) => (),
         }
     }
 }

--- a/crates/composition/src/ingest_subgraph/schema_definitions.rs
+++ b/crates/composition/src/ingest_subgraph/schema_definitions.rs
@@ -1,0 +1,232 @@
+use async_graphql_parser::types as ast;
+use async_graphql_value::ConstValue;
+use std::borrow::Cow;
+
+pub(super) fn ingest_schema_definitions(
+    document: &ast::ServiceDocument,
+) -> FederationDirectivesMatcher<'_> {
+    document
+        .definitions
+        .iter()
+        .filter_map(|def| {
+            if let ast::TypeSystemDefinition::Schema(schema) = def {
+                Some(schema)
+            } else {
+                None
+            }
+        })
+        .flat_map(|schema_definition| schema_definition.node.directives.iter())
+        .map(|d| &d.node)
+        .find(|d| FederationDirectivesMatcher::is_federation_directive(d))
+        .map(FederationDirectivesMatcher::new)
+        .unwrap_or_default()
+}
+
+/// This struct is the source of truth for matching federation directives by name when ingesting a
+/// subgraph's GraphQL SDL.
+///
+/// The names of federation directives are influenced by `@link` directives on schema definitions
+/// or extensions in two ways:
+///
+/// - Imports in link directives bring the directives in scope, with optional renaming.
+///   Example: `@link(url: "...", import: [{ name: "@shareable", as: "@federationShareable"}])
+///   Example: `@link(url: "...", import: ["@key"])`
+///
+/// - The `as` argument: `@link(url: "...", as: "compositionDirectives")
+///   - In the absence of an `@link` or `as` argument, all directives are in scope prefixed with
+///   `@federation__`, for example `@federation__shareable`.
+///   - With an `@link(as: "something")`, they are in scope under the `@something__` prefix.
+///
+/// Last rule: if a directive is `import`ed, it is no longer available under the prefix.
+#[derive(Debug)]
+pub(crate) struct FederationDirectivesMatcher<'a> {
+    shareable: Cow<'a, str>,
+    #[cfg(test)]
+    key: Cow<'a, str>,
+}
+
+const DEFAULT_FEDERATION_PREFIX: &str = "federation__";
+
+impl Default for FederationDirectivesMatcher<'_> {
+    fn default() -> Self {
+        FederationDirectivesMatcher {
+            shareable: Cow::Owned(format!("{DEFAULT_FEDERATION_PREFIX}shareable")),
+            #[cfg(test)]
+            key: Cow::Owned(format!("{DEFAULT_FEDERATION_PREFIX}key")),
+        }
+    }
+}
+
+impl<'a> FederationDirectivesMatcher<'a> {
+    pub(crate) fn is_federation_directive(directive: &ast::ConstDirective) -> bool {
+        if directive.name.node != "link" {
+            return false;
+        }
+
+        directive
+            .get_argument("url")
+            .map(|url| match &url.node {
+                ConstValue::String(s) => s.contains("dev/federation/v2"),
+                _ => false,
+            })
+            .unwrap_or_default()
+    }
+
+    /// Matcher for federation directives in a given subgraph. See [FederationDirectivesMatcher] for more docs.        
+    pub(crate) fn new(directive: &'a ast::ConstDirective) -> FederationDirectivesMatcher<'a> {
+        let mut r#as = None;
+        let mut imported: Vec<(&str, &str)> = Vec::new();
+
+        for (arg_name, arg_value) in &directive.arguments {
+            match (arg_name.node.as_str(), &arg_value.node) {
+                ("as", ConstValue::String(value)) => r#as = Some(value.as_str()),
+                ("import", ConstValue::List(imports)) => read_imports(imports, &mut imported),
+                _ => (),
+            }
+        }
+
+        let federation_prefix = r#as
+            .map(|prefix| Cow::Owned(format!("{prefix}__")))
+            .unwrap_or(Cow::Borrowed(DEFAULT_FEDERATION_PREFIX));
+        let final_name = |directive_name: &str| {
+            imported
+                .iter()
+                .find(|(original, _alias)| *original == directive_name)
+                .map(|(_, alias)| Cow::Borrowed(*alias))
+                .unwrap_or_else(|| Cow::Owned(format!("{federation_prefix}{directive_name}")))
+        };
+
+        FederationDirectivesMatcher {
+            shareable: final_name("shareable"),
+            #[cfg(test)]
+            key: final_name("key"),
+        }
+    }
+
+    pub(crate) fn is_shareable(&self, directive_name: &str) -> bool {
+        self.shareable == directive_name
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_key(&self, directive_name: &str) -> bool {
+        self.key == directive_name
+    }
+}
+
+fn read_imports<'a>(ast_imports: &'a [ConstValue], out: &mut Vec<(&'a str, &'a str)>) {
+    for import in ast_imports {
+        match import {
+            ConstValue::String(import) => {
+                let import = import.trim_start_matches('@');
+                out.push((import, import));
+            }
+            ConstValue::Object(obj) => {
+                if let Some(ConstValue::String(name)) = obj.get("name") {
+                    let alias = obj.get("as").and_then(|value| match value {
+                        ConstValue::String(s) => Some(s),
+                        _ => None,
+                    });
+                    out.push((
+                        name.trim_start_matches('@'),
+                        alias.unwrap_or(name).trim_start_matches('@'),
+                    ));
+                }
+            }
+            _ => (),
+        }
+    }
+}
+
+#[cfg(test)]
+mod federation_directives_matcher_tests {
+    use super::*;
+
+    fn with_matcher_for_schema(
+        graphql_sdl: &str,
+        test: impl FnOnce(FederationDirectivesMatcher<'_>),
+    ) {
+        let ast = async_graphql_parser::parse_schema(graphql_sdl).unwrap();
+        let matcher = ingest_schema_definitions(&ast);
+        test(matcher)
+    }
+
+    #[test]
+    fn no_link_declaration() {
+        with_matcher_for_schema("type Irrelevant { id: ID! }", |matcher| {
+            assert!(matcher.is_key("federation__key"));
+            assert!(matcher.is_shareable("federation__shareable"));
+            assert!(!matcher.is_key("key"));
+            assert!(!matcher.is_key("@key"));
+            assert!(!matcher.is_shareable("shareable"));
+        });
+    }
+
+    #[test]
+    fn irrelevant_link_declaration() {
+        let schema = r#"extend schema @link(url: "https://bad.horse", as: "horse")"#;
+        with_matcher_for_schema(schema, |matcher| {
+            assert!(matcher.is_key("federation__key"));
+            assert!(matcher.is_shareable("federation__shareable"));
+            assert!(!matcher.is_key("key"));
+            assert!(!matcher.is_key("@key"));
+            assert!(!matcher.is_shareable("shareable"));
+        });
+    }
+
+    #[test]
+    fn alias() {
+        let schema = r#"extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", as: "romulans")"#;
+        with_matcher_for_schema(schema, |matcher| {
+            assert!(!matcher.is_key("federation__key"));
+            assert!(matcher.is_key("romulans__key"));
+            assert!(!matcher.is_shareable("federation__shareable"));
+            assert!(!matcher.is_shareable("@federation__shareable"));
+            assert!(matcher.is_shareable("romulans__shareable"));
+            assert!(!matcher.is_key("key"));
+            assert!(!matcher.is_key("@key"));
+            assert!(!matcher.is_shareable("shareable"));
+        });
+    }
+
+    #[test]
+    fn direct_import_and_alias() {
+        let schema = r#"
+            extend schema @link(
+                url: "https://specs.apollo.dev/federation/v2.3",
+                as: "romulans"
+                import: [{ name: "@shareable", as: "partageable" }]
+            )
+        "#;
+        with_matcher_for_schema(schema, |matcher| {
+            assert!(!matcher.is_key("federation__key"));
+            assert!(!matcher.is_shareable("romulans__shareable"));
+            assert!(!matcher.is_shareable("romulans__partageable"));
+            assert!(!matcher.is_shareable("romulans__shareable"));
+            assert!(!matcher.is_shareable("@federation__shareable"));
+            assert!(!matcher.is_key("key"));
+
+            assert!(matcher.is_key("romulans__key"));
+            assert!(matcher.is_shareable("partageable"));
+        });
+    }
+
+    #[test]
+    fn regular_imports() {
+        let schema = r#"
+            extend schema @link(
+                url: "https://specs.apollo.dev/federation/v2.3",
+                as: "romulans"
+                import: [{ name: "@key" }, "@shareable"]
+            )
+        "#;
+        with_matcher_for_schema(schema, |matcher| {
+            assert!(!matcher.is_key("federation__key"));
+            assert!(!matcher.is_shareable("federation__shareable"));
+            assert!(!matcher.is_shareable("romulans__shareable"));
+            assert!(!matcher.is_shareable("@federation__shareable"));
+
+            assert!(matcher.is_key("key"));
+            assert!(matcher.is_shareable("shareable"));
+        });
+    }
+}

--- a/crates/composition/src/subgraphs/walkers.rs
+++ b/crates/composition/src/subgraphs/walkers.rs
@@ -48,18 +48,15 @@ impl<'a> DefinitionWalker<'a> {
     pub fn subgraph(self) -> SubgraphWalker<'a> {
         self.walk(self.definition().subgraph_id)
     }
-
-    // pub fn object_fields(self) -> impl Iterator<Item = ObjectFieldWalker<'a>> {
-    //     binary_search_range_for_key(&self.subgraphs.object_fields, self.id, |field| {
-    //         field.object_id
-    //     })
-    //     .map(move |idx| self.walk(ObjectFieldId(idx)))
-    // }
 }
 
 impl<'a> FieldWalker<'a> {
     fn field(self) -> &'a Field {
         &self.subgraphs.fields[self.id.0]
+    }
+
+    pub fn is_shareable(self) -> bool {
+        self.field().is_shareable
     }
 
     pub fn parent_definition(self) -> DefinitionWalker<'a> {
@@ -78,19 +75,3 @@ impl<'a> FieldWalker<'a> {
         self.field().type_name
     }
 }
-
-// fn binary_search_range_for_key<'a, T, K>(
-//     store: &'a [T],
-//     key: K,
-//     extract_key: impl Fn(&T) -> K + 'a,
-// ) -> impl Iterator<Item = usize> + 'a
-// where
-//     K: Ord + Eq + 'static,
-// {
-//     let start = store.partition_point(|item| extract_key(item) < key);
-//     store[start..]
-//         .iter()
-//         .take_while(move |item| extract_key(*item) == key)
-//         .enumerate()
-//         .map(move |(idx, _)| idx + start)
-// }

--- a/crates/composition/tests/composition/shareable_basic/subgraphs/accounts.graphql
+++ b/crates/composition/tests/composition/shareable_basic/subgraphs/accounts.graphql
@@ -1,0 +1,11 @@
+extend schema
+    @link(
+        url: "https://specs.apollo.dev/federation/v2.3",
+        import: ["@key", "@shareable"]
+     )
+
+type Customer {
+    id: ID! @shareable
+    name: String @shareable
+    other: Int
+}

--- a/crates/composition/tests/composition/shareable_basic/subgraphs/marketing.graphql
+++ b/crates/composition/tests/composition/shareable_basic/subgraphs/marketing.graphql
@@ -1,0 +1,12 @@
+extend schema
+    @link(
+        url: "https://specs.apollo.dev/federation/v2.3",
+        import: [{ name: "@shareable", as: "@partageable" }]
+     )
+
+type Customer @partageable {
+    id: ID!
+    name: String
+    
+    newsletterSubscribed: Boolean
+}

--- a/crates/composition/tests/composition/shareable_basic/subgraphs/subscriptions.graphql
+++ b/crates/composition/tests/composition/shareable_basic/subgraphs/subscriptions.graphql
@@ -1,0 +1,16 @@
+extend schema
+    @link(
+        url: "https://specs.apollo.dev/federation/v2.3",
+        import: ["@key", "@shareable"]
+     )
+
+enum Plan {
+    Hobby
+    Pro
+}
+
+type Customer {
+    id: ID! @shareable
+    name: String @shareable
+    subscriptionPlan: Plan!
+}

--- a/crates/composition/tests/composition/shareable_basic/supergraph.graphql
+++ b/crates/composition/tests/composition/shareable_basic/supergraph.graphql
@@ -1,0 +1,7 @@
+type Customer {
+    id: ID
+    name: String
+    subscriptionPlan: Plan
+    newsletterSubscribed: Boolean
+    other: Int
+}


### PR DESCRIPTION
Implemented in this PR:

- `@link` directive imports and aliasing (see docs in diff)
- Fields with `@shareable` are allowed to be defined in multiple
  subgraphs

Also sets up very basic CI for crates/composition.

Part of GB-5176

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
