### PR TITLE
cli: release 0.41.2

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.41.2] - 2023-10-27
+
+[CHANGELOG](changelog/0.41.2.md)
+
 ## [0.41.1] - 2023-10-25
 
 [CHANGELOG](changelog/0.41.1.md)

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2282,7 +2282,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "async-graphql 6.0.6",
  "async-trait",
@@ -2405,7 +2405,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "async-graphql 5.0.10",
  "async-graphql-axum",
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-graphql-introspection"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "apollo-encoder",
  "apollo-parser",
@@ -2487,7 +2487,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "async-compression",
  "async-tar",
@@ -2519,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "chrono",
  "common-types",
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -6972,7 +6972,7 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typed-resolvers"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "datatest-stable",
  "engine-parser",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,7 +15,7 @@ ulid = { git = "https://github.com/grafbase/ulid-rs", rev = "6d06156193d51a2db32
 
 
 [workspace.package]
-version = "0.41.1"
+version = "0.41.2"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://grafbase.com"

--- a/cli/changelog/0.41.2.md
+++ b/cli/changelog/0.41.2.md
@@ -1,0 +1,4 @@
+### Fixes
+
+- Fields of generated TypeScript types for sibling and downstream resolvers are now optional (#861)
+- Generated TS resolver types now work even if you extend root types (e.g. Query) without defining them (#859)

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -40,8 +40,8 @@ url = "2"
 urlencoding = "2"
 walkdir = "2"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.41.1" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.41.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.41.2" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.41.2" }
 
 [build-dependencies]
 cynic-codegen = { version = "3", features = ["rkyv"] }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -41,9 +41,9 @@ webbrowser = "0.8"
 lru = "0.12"
 futures-util = "0.3"
 
-server = { package = "grafbase-local-server", path = "../server", version = "0.41.1" }
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.41.1" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.41.1" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.41.2" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.41.2" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.41.2" }
 graphql-introspection = { package = "grafbase-graphql-introspection", path = "../graphql-introspection" }
 atty = "0.2.14"
 

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -64,7 +64,7 @@ sha2 = "0.10"
 # Same version as Tantivy
 tantivy-fst = "0.4.0"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.41.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.41.2" }
 gateway = { path = "../gateway" }
 typed-resolvers = { path = "../typed-resolvers" }
 engine = { path = "../../../engine/crates/engine" }

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.41.1",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.41.1",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.41.1",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.41.1",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.41.1"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.41.2",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.41.2",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.41.2",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.41.2",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.41.2"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
Fixes

- Fields of generated TypeScript types for sibling and downstream resolvers are now optional (#861)
- Generated TS resolver types now work even if you extend root types (e.g. Query) without defining them (#859)

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
