### PR TITLE
feat: extend openapi types with federation keys

### DIFF
--- a/engine/crates/engine/src/registry/federation.rs
+++ b/engine/crates/engine/src/registry/federation.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use super::{
     field_set::{FieldSet, Selection},
-    resolvers::http::HttpResolver,
+    resolvers::{http::HttpResolver, join::JoinResolver},
 };
 
 /// Federation details for a particular entity
@@ -34,6 +34,9 @@ pub enum FederationResolver {
     /// are present in the representation or resolvable from the representation (e.g.
     /// fields with custom resolvers)
     BasicType,
+    /// This entity resolves to a specific field in the schema using the same mechanism
+    /// as a JoinResolver
+    Join(JoinResolver),
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -76,6 +79,13 @@ impl FederationKey {
         FederationKey {
             selections,
             resolver: Some(FederationResolver::BasicType),
+        }
+    }
+
+    pub fn join(selections: FieldSet, resolver: JoinResolver) -> Self {
+        FederationKey {
+            selections,
+            resolver: Some(FederationResolver::Join(resolver)),
         }
     }
 

--- a/engine/crates/engine/src/registry/resolvers/federation.rs
+++ b/engine/crates/engine/src/registry/resolvers/federation.rs
@@ -79,6 +79,10 @@ async fn resolve_representation(ctx: &ContextField<'_>, representation: Represen
             resolver.resolve(ctx, &resolver_context, last_resolver_value).await
         }
         Some(FederationResolver::BasicType) => Ok(ResolvedValue::new(serde_json::to_value(&representation)?)),
+        Some(FederationResolver::Join(resolver)) => {
+            let last_resolver_value = Some(ResolvedValue::new(representation.data));
+            resolver.resolve(ctx, last_resolver_value).await
+        }
         None => {
             return Err(Error::new(format!(
                 "Tried to resolve an unresolvable key for {}",

--- a/engine/crates/parser-sdl/src/rules/extend_connector_types.rs
+++ b/engine/crates/parser-sdl/src/rules/extend_connector_types.rs
@@ -59,8 +59,8 @@ impl<'a> Visitor<'a> for ExtendConnectorTypes {
                             // If someone asks we could do it
                             ctx.report_error(vec![field.pos], "A field can't have a join and a requires on it");
                         }
-                        requires = join_directive.required_fieldset();
-                        Resolver::Join(join_directive.to_join_resolver())
+                        requires = join_directive.select.required_fieldset();
+                        Resolver::Join(join_directive.select.to_join_resolver())
                     }
                     (Some(_), Some(_)) => {
                         ctx.report_error(vec![field.pos], "A field can't have a join and a custom resolver on it");

--- a/engine/crates/parser-sdl/src/rules/federation/key.rs
+++ b/engine/crates/parser-sdl/src/rules/federation/key.rs
@@ -1,4 +1,6 @@
-use crate::rules::directive::Directive;
+use std::collections::BTreeSet;
+
+use crate::rules::{directive::Directive, join_directive::FieldSelection};
 
 use super::field_set::FieldSet;
 
@@ -8,6 +10,32 @@ pub struct KeyDirective {
     pub fields: FieldSet,
     #[serde(default = "default_to_true")]
     pub resolvable: bool,
+    pub select: Option<FieldSelection>,
+}
+
+impl KeyDirective {
+    pub fn validate(&self) -> Vec<String> {
+        let mut errors = vec![];
+        if !self.resolvable && self.select.is_some() {
+            errors.push("A key with a selection must be resolvable".into());
+        }
+
+        if let Some(required_fields) = self.select.as_ref().and_then(FieldSelection::required_fieldset) {
+            for missing_field in
+                fields_from_fieldset(&required_fields).difference(&fields_from_fieldset(&self.fields.0))
+            {
+                errors.push(format!(
+                    "The select for this key requires the field {missing_field} which is not present in the key"
+                ));
+            }
+        }
+
+        errors
+    }
+}
+
+fn fields_from_fieldset(fieldset: &engine::registry::FieldSet) -> BTreeSet<&str> {
+    fieldset.0.iter().map(|field| field.field.as_str()).collect()
 }
 
 fn default_to_true() -> bool {
@@ -19,8 +47,7 @@ impl Directive for KeyDirective {
         // Note: technically this is meant to be declared "repeatable"
         // but our parser doesn't seem to support it.
         r#"
-        directive @key(fields: FieldSet!, resolvable: Boolean = true) on OBJECT | INTERFACE
-
+        directive @key(fields: FieldSet!, resolvable: Boolean = true, select: FieldSelection) on OBJECT | INTERFACE
         "#
         .to_string()
     }
@@ -29,6 +56,8 @@ impl Directive for KeyDirective {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+
+    use crate::tests::assert_validation_error;
 
     #[test]
     fn unresolvable_federation_entity_on_normal_type() {
@@ -45,5 +74,146 @@ mod tests {
             .registry;
 
         insta::assert_display_snapshot!(registry.export_sdl(true));
+    }
+
+    #[test]
+    fn entity_with_selection() {
+        let schema = r#"
+            extend schema @federation(version: "2.3")
+
+            extend type Query {
+                blah(id: ID!): User! @resolver(name: "blah")
+            }
+
+            type User @key(fields: "id", select: "blah(id: $id)" ) {
+                id: ID!
+            }
+        "#;
+
+        let registry = crate::to_parse_result_with_variables(schema, &HashMap::new())
+            .unwrap()
+            .registry;
+
+        insta::assert_json_snapshot!(registry.federation_entities.get("User").unwrap().keys, @r###"
+        [
+          {
+            "selections": [
+              {
+                "field": "id",
+                "selections": []
+              }
+            ],
+            "resolver": {
+              "Join": {
+                "field_name": "blah",
+                "arguments": [
+                  [
+                    "id",
+                    {
+                      "$var": "id"
+                    }
+                  ]
+                ]
+              }
+            }
+          }
+        ]
+        "###);
+    }
+
+    #[test]
+    fn entity_with_selection_but_optional_joined_type() {
+        let schema = r#"
+            extend schema @federation(version: "2.3")
+
+            extend type Query {
+                blah(id: ID!): User @resolver(name: "blah")
+            }
+
+            type User @key(fields: "id", select: "blah(id: $id)" ) {
+                id: ID!
+            }
+        "#;
+
+        let registry = crate::to_parse_result_with_variables(schema, &HashMap::new())
+            .unwrap()
+            .registry;
+
+        insta::assert_json_snapshot!(registry.federation_entities.get("User").unwrap().keys, @r###"
+        [
+          {
+            "selections": [
+              {
+                "field": "id",
+                "selections": []
+              }
+            ],
+            "resolver": {
+              "Join": {
+                "field_name": "blah",
+                "arguments": [
+                  [
+                    "id",
+                    {
+                      "$var": "id"
+                    }
+                  ]
+                ]
+              }
+            }
+          }
+        ]
+        "###);
+    }
+
+    #[test]
+    fn user_can_only_use_fields_in_key_in_selection() {
+        assert_validation_error!(
+            r#"
+            extend schema @federation(version: "2.3")
+
+            extend type Query {
+                blah(id: ID!): User @resolver(name: "blah")
+            }
+
+            type User @key(fields: "id", select: "blah(id: $other)" ) {
+                id: ID!
+                other: String!
+            }
+            "#,
+            "The select for this key requires the field other which is not present in the key"
+        );
+    }
+
+    #[test]
+    fn unresolvable_federation_keys_with_select() {
+        assert_validation_error!(
+            r#"
+            extend schema @federation(version: "2.3")
+
+            type User @key(fields: "id", resolvable: false, select: "blah" ) {
+                id: ID!
+            }
+            "#,
+            "A key with a selection must be resolvable"
+        );
+    }
+
+    #[test]
+    fn test_key_resolver_type_mismatches() {
+        assert_validation_error!(
+            r#"
+            extend schema @federation(version: "2.3")
+
+            extend type Query {
+                blah(id: ID!): [User!]! @resolver(name: "blah")
+            }
+
+            type User @key(fields: "id", select: "blah(id: $id)" ) {
+                id: ID!
+            }
+            "#,
+            "The federation key `id` on the type User is trying to join with the field named blah, but those fields do not have compatible types"
+        );
     }
 }

--- a/engine/crates/parser-sdl/src/rules/requires_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/requires_directive.rs
@@ -88,7 +88,7 @@ mod tests {
                 nickname: String! @requires(fields: "id name")
             }
             "#,
-            "The field nickname on User declares that it requires the field name on User but that field doesn't exist"
+            "The field nickname on the type User declares that it requires the field name on User but that field doesn't exist"
         );
     }
 
@@ -108,7 +108,7 @@ mod tests {
                 id: ID!
             }
             "#,
-            "The field nickname on User declares that it requires the field name on Account but that field doesn't exist"
+            "The field nickname on the type User declares that it requires the field name on Account but that field doesn't exist"
         );
     }
 
@@ -124,7 +124,7 @@ mod tests {
                 nickname: String! @requires(fields: "id name { blah }")
             }
             "#,
-            "The field nickname on User tries to require subfields of name on User but that field is a leaf type"
+            "The field nickname on the type User tries to require subfields of name on User but that field is a leaf type"
         );
     }
 }

--- a/engine/crates/parser-sdl/src/rules/snapshots/parser_sdl__rules__join_directive__tests__acceptable_return_type_nullability_mismatch.snap
+++ b/engine/crates/parser-sdl/src/rules/snapshots/parser_sdl__rules__join_directive__tests__acceptable_return_type_nullability_mismatch.snap
@@ -1,0 +1,17 @@
+---
+source: crates/parser-sdl/src/rules/join_directive.rs
+expression: resolver
+---
+{
+  "J": {
+    "field_name": "blah",
+    "arguments": [
+      [
+        "id",
+        {
+          "$var": "id"
+        }
+      ]
+    ]
+  }
+}

--- a/engine/crates/parser-sdl/src/rules/snapshots/parser_sdl__rules__join_directive__tests__return_type_lists_success.snap
+++ b/engine/crates/parser-sdl/src/rules/snapshots/parser_sdl__rules__join_directive__tests__return_type_lists_success.snap
@@ -1,0 +1,17 @@
+---
+source: crates/parser-sdl/src/rules/join_directive.rs
+expression: resolver
+---
+{
+  "J": {
+    "field_name": "blah",
+    "arguments": [
+      [
+        "id",
+        {
+          "$var": "id"
+        }
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
The OpenAPI connector attempts to infer federation keys from the shape of the underlying API.  If an endpoint returns a named type from the schema, and has a URL parameter that clearly maps to some field on that type, then we can easily generate a resolver.  This works OK for some schemas but there are a lot of edge cases where it just doesn't.

For those cases, we want users to be able to specify how a key should be resolved when the `_entities` field is called with that key.  This PR does that by adding a `select` field to the `@key` directive - which takes the same input as the `@join` directive and is hooked up to the same resolution mechanism.

