### PR TITLE
fix: silence federation introspection queries in dev command

### DIFF
--- a/engine/crates/engine/src/response/mod.rs
+++ b/engine/crates/engine/src/response/mod.rs
@@ -70,8 +70,9 @@ fn is_operation_introspection(operation: &OperationDefinition) -> bool {
             // If field name starts with `__` it is part of introspection system, see http://spec.graphql.org/October2021/#sec-Names.Reserved-Names
             .all(|item| {
                 matches!(
-                &item.node,
-                Selection::Field(field) if field.node.name.node.starts_with("__"))
+                    &item.node,
+                    Selection::Field(field) if field.node.name.node.starts_with("__") || field.node.name.node == "_service"
+                )
             })
 }
 


### PR DESCRIPTION
If you're running rover in development it'll poll your subgraph every 2 seconds.  If that subgraph is `grafbase dev` then it's quite noisy: a constant stream of `query SubgraphIntrospectQuery 0ns` messages in your console.

This PR updates the `is_operation_introspection` query to consider the `_service` field as part of introspection, which should silence those queries like we do with normal introspection.