### PR TITLE
[experiment] ci: fix phantom jobs keeping builds yellow

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -3,6 +3,10 @@ name: cli
 on:
   workflow_dispatch:
   pull_request:
+    paths:
+      - 'cli/**/*'
+      - 'crates/**/*'
+      - 'engine/**/*'
   push:
     tags:
       - 'cli-*'


### PR DESCRIPTION
In the cli workflow, on PRs that do not affect cli, the builds never turn green because detect-change-type makes the darwin and linux build jobs wait on the lint action indefinitely.

closes GB-5114
