### PR TITLE
composition: interfaces, custom scalars & enums

### DIFF
--- a/.github/workflows/composition.yml
+++ b/.github/workflows/composition.yml
@@ -1,3 +1,5 @@
+name: grafbase-composition
+
 on:
   pull_request:
     paths:

--- a/crates/composition/src/compose_supergraph.rs
+++ b/crates/composition/src/compose_supergraph.rs
@@ -1,4 +1,6 @@
+mod enums;
 mod input_object;
+mod interface;
 mod object;
 
 use self::input_object::*;
@@ -18,7 +20,14 @@ pub(crate) fn build_supergraph(ctx: &mut Context<'_>) {
             DefinitionKind::Object => merge_object_definitions(ctx, first, definitions),
             DefinitionKind::Union => merge_union_definitions(ctx, first, definitions),
             DefinitionKind::InputObject => merge_input_object_definitions(ctx, first, definitions),
-            _ => todo!(),
+            DefinitionKind::Interface => {
+                interface::merge_interface_definitions(ctx, first, definitions)
+            }
+            DefinitionKind::Scalar => {
+                ctx.supergraph
+                    .insert_definition(first.name(), DefinitionKind::Scalar);
+            }
+            DefinitionKind::Enum => enums::merge_enum_definitions(first, definitions, ctx),
         }
     });
 

--- a/crates/composition/src/compose_supergraph/enums.rs
+++ b/crates/composition/src/compose_supergraph/enums.rs
@@ -1,0 +1,134 @@
+use super::*;
+use crate::{strings::StringId, Subgraphs};
+use std::collections::HashSet;
+
+pub(super) fn merge_enum_definitions(
+    first: &DefinitionWalker<'_>,
+    definitions: &[DefinitionWalker<'_>],
+    ctx: &mut Context<'_>,
+) {
+    let enum_name = first.name();
+
+    match (
+        enum_is_used_in_input(enum_name, ctx.subgraphs),
+        enum_is_used_in_return_position(enum_name, ctx.subgraphs),
+    ) {
+        (true, false) => merge_intersection(first, definitions, ctx),
+        (false, true) => merge_union(first, definitions, ctx),
+        (true, true) => merge_exactly_matching(first, definitions, ctx),
+        (false, false) => {
+            // The enum isn't used at all, omit it from the supergraph.
+        }
+    }
+}
+
+/// Returns whether the enum is used anywhere in a field argument or an input type field.
+fn enum_is_used_in_input(enum_name: StringId, subgraphs: &Subgraphs) -> bool {
+    let in_field_arguments = || {
+        subgraphs
+            .iter_fields()
+            .flat_map(|field| field.arguments())
+            .any(|arg| arg.argument_type().type_name() == enum_name)
+    };
+    let in_input_type_fields = || {
+        subgraphs
+            .iter_fields()
+            .filter(|field| field.parent_definition().kind() == DefinitionKind::InputObject)
+            .any(|field| field.r#type().type_name() == enum_name)
+    };
+    in_field_arguments() || in_input_type_fields()
+}
+
+/// Returns whether the enum is returned by a field anywhere.
+fn enum_is_used_in_return_position(enum_name: StringId, subgraphs: &Subgraphs) -> bool {
+    subgraphs
+        .iter_fields()
+        .filter(|field| {
+            matches!(
+                field.parent_definition().kind(),
+                DefinitionKind::Object | DefinitionKind::Interface
+            )
+        })
+        .any(|field| field.r#type().type_name() == enum_name)
+}
+
+fn merge_intersection(
+    first: &DefinitionWalker<'_>,
+    definitions: &[DefinitionWalker<'_>],
+    ctx: &mut Context<'_>,
+) {
+    let mut intersection: Vec<StringId> = first.enum_values().collect();
+    let mut scratch = HashSet::new();
+
+    for definition in definitions {
+        scratch.clear();
+        scratch.extend(definition.enum_values());
+        intersection.retain(|elem| scratch.contains(elem));
+    }
+
+    if intersection.is_empty() {
+        ctx.diagnostics.push_fatal(format!(
+            "Values for enum {} are empty (intersection)",
+            first.name_str(),
+        ));
+    }
+
+    ctx.supergraph
+        .insert_definition(first.name(), DefinitionKind::Enum);
+
+    for value in intersection {
+        ctx.supergraph.insert_enum_value(first.name(), value)
+    }
+}
+
+fn merge_union(
+    first: &DefinitionWalker<'_>,
+    definitions: &[DefinitionWalker<'_>],
+    ctx: &mut Context<'_>,
+) {
+    ctx.supergraph
+        .insert_definition(first.name(), DefinitionKind::Enum);
+
+    for value in definitions.iter().flat_map(|def| def.enum_values()) {
+        ctx.supergraph.insert_enum_value(first.name(), value)
+    }
+}
+
+fn merge_exactly_matching(
+    first: &DefinitionWalker<'_>,
+    definitions: &[DefinitionWalker<'_>],
+    ctx: &mut Context<'_>,
+) {
+    let expected: Vec<_> = first.enum_values().collect();
+
+    for definition in definitions {
+        if !is_slice_match(&expected, definition.enum_values()) {
+            ctx.diagnostics.push_fatal(format!(
+                "The enum {} should match exactly in all subgraphs, but it does not",
+                first.name_str()
+            ));
+            return;
+        }
+    }
+
+    ctx.supergraph
+        .insert_definition(first.name(), DefinitionKind::Enum);
+
+    for value in expected {
+        ctx.supergraph.insert_enum_value(first.name(), value)
+    }
+}
+
+fn is_slice_match<T: PartialEq>(slice: &[T], iterator: impl Iterator<Item = T>) -> bool {
+    let mut idx = 0;
+
+    for item in iterator {
+        if slice[idx] != item {
+            return false;
+        }
+
+        idx += 1;
+    }
+
+    idx == slice.len()
+}

--- a/crates/composition/src/compose_supergraph/input_object.rs
+++ b/crates/composition/src/compose_supergraph/input_object.rs
@@ -16,7 +16,7 @@ pub(super) fn merge_input_object_definitions(
     for input_object in definitions {
         fields_buf.clear();
         fields_buf.extend(input_object.fields().map(|f| f.name()));
-        common_fields.retain(|field_name, _| fields_buf.contains(&field_name));
+        common_fields.retain(|field_name, _| fields_buf.contains(field_name));
     }
 
     // Check that no required field was excluded.

--- a/crates/composition/src/compose_supergraph/interface.rs
+++ b/crates/composition/src/compose_supergraph/interface.rs
@@ -1,0 +1,27 @@
+use super::*;
+use crate::{strings::StringId, subgraphs::FieldId};
+
+pub(super) fn merge_interface_definitions(
+    ctx: &mut Context<'_>,
+    first: &DefinitionWalker<'_>,
+    definitions: &[DefinitionWalker<'_>],
+) {
+    let mut all_fields: indexmap::IndexMap<StringId, FieldId> = indexmap::IndexMap::new();
+
+    for field in definitions.iter().flat_map(|def| def.fields()) {
+        all_fields.entry(field.name()).or_insert(field.id);
+    }
+
+    ctx.supergraph
+        .insert_definition(first.name(), DefinitionKind::Interface);
+
+    for field in all_fields.values() {
+        let field = first.walk(*field);
+        ctx.supergraph.insert_field(
+            first.name(),
+            field.name(),
+            field.r#type().type_name(),
+            Vec::new(),
+        );
+    }
+}

--- a/crates/composition/src/compose_supergraph/object.rs
+++ b/crates/composition/src/compose_supergraph/object.rs
@@ -8,7 +8,7 @@ pub(super) fn merge_field_arguments(
     first: FieldWalker<'_>,
     fields: &[FieldWalker<'_>],
 ) -> Vec<(StringId, StringId)> {
-    let mut intersection: HashSet<_> = first.arguments().map(|arg| arg.argument_name()).collect();
+    let mut intersection: Vec<_> = first.arguments().map(|arg| arg.argument_name()).collect();
     let mut buf = HashSet::new();
 
     for field in &fields[1..] {

--- a/crates/composition/src/ingest_subgraph/enums.rs
+++ b/crates/composition/src/ingest_subgraph/enums.rs
@@ -1,0 +1,13 @@
+use super::*;
+use crate::subgraphs::*;
+
+pub(super) fn ingest_enum(
+    definition_id: DefinitionId,
+    enum_type: &ast::EnumType,
+    subgraphs: &mut Subgraphs,
+) {
+    for value in &enum_type.values {
+        let value = subgraphs.strings.intern(value.node.value.node.as_str());
+        subgraphs.push_enum_value(definition_id, value);
+    }
+}

--- a/crates/composition/src/subgraphs.rs
+++ b/crates/composition/src/subgraphs.rs
@@ -1,4 +1,5 @@
 mod definitions;
+mod enums;
 mod field_types;
 mod fields;
 mod keys;
@@ -22,13 +23,10 @@ pub struct Subgraphs {
     pub(crate) strings: Strings,
     subgraphs: Vec<Subgraph>,
     definitions: definitions::Definitions,
+    enums: enums::Enums,
     fields: fields::Fields,
     field_types: field_types::FieldTypes,
-
-    /// All the keys (`@key(...)`) in all the subgraphs in one container.
     keys: keys::Keys,
-
-    /// All the unions in all subgraphs.
     unions: unions::Unions,
 
     // Secondary indexes.

--- a/crates/composition/src/subgraphs/definitions.rs
+++ b/crates/composition/src/subgraphs/definitions.rs
@@ -20,7 +20,8 @@ pub(crate) enum DefinitionKind {
     Interface,
     Union,
     InputObject,
-    // CustomScalar,
+    Scalar,
+    Enum,
 }
 
 impl Subgraphs {

--- a/crates/composition/src/subgraphs/enums.rs
+++ b/crates/composition/src/subgraphs/enums.rs
@@ -1,0 +1,23 @@
+use super::*;
+
+#[derive(Default)]
+pub(super) struct Enums {
+    values: BTreeSet<(DefinitionId, StringId)>,
+}
+
+impl Subgraphs {
+    pub(crate) fn push_enum_value(&mut self, enum_id: DefinitionId, enum_value: StringId) {
+        self.enums.values.insert((enum_id, enum_value));
+    }
+}
+
+impl<'a> DefinitionWalker<'a> {
+    pub(crate) fn enum_values(self) -> impl Iterator<Item = StringId> + 'a {
+        let id = self.id;
+        self.subgraphs
+            .enums
+            .values
+            .range((id, StringId::MIN)..(id, StringId::MAX))
+            .map(|(_, value)| *value)
+    }
+}

--- a/crates/composition/src/subgraphs/fields.rs
+++ b/crates/composition/src/subgraphs/fields.rs
@@ -18,6 +18,12 @@ struct Field {
 }
 
 impl Subgraphs {
+    pub(crate) fn iter_fields(&self) -> impl Iterator<Item = FieldWalker<'_>> {
+        (0..self.fields.0.len())
+            .map(FieldId)
+            .map(|id| self.walk(id))
+    }
+
     pub(crate) fn push_field(
         &mut self,
         parent_definition_id: DefinitionId,

--- a/crates/composition/src/subgraphs/keys.rs
+++ b/crates/composition/src/subgraphs/keys.rs
@@ -1,6 +1,7 @@
 use super::*;
 use async_graphql_parser::types as ast;
 
+/// All the keys (`@key(...)`) in all the subgraphs in one container.
 #[derive(Default)]
 pub(crate) struct Keys(Vec<(DefinitionId, Key)>);
 

--- a/crates/composition/src/subgraphs/unions.rs
+++ b/crates/composition/src/subgraphs/unions.rs
@@ -2,6 +2,7 @@ use super::DefinitionId;
 use crate::Subgraphs;
 use std::collections::BTreeSet;
 
+/// All the unions in all subgraphs.
 #[derive(Default)]
 pub(crate) struct Unions(
     /// (union, member)

--- a/crates/composition/src/supergraph.rs
+++ b/crates/composition/src/supergraph.rs
@@ -10,10 +10,12 @@ pub(crate) struct Supergraph {
     // We use BTreeMaps here in order to have a consistent ordering when rendering the supergraph
     // schema.
     definitions: BTreeMap<StringId, DefinitionKind>,
-    // (definition_name, field_name) -> (arguments, field_type)
-    fields: BTreeMap<(StringId, StringId), (Vec<(StringId, StringId)>, StringId)>,
+    // (definition_name, field_name) -> Field
+    fields: BTreeMap<(StringId, StringId), Field>,
     // (union_name, member_name)
     union_members: BTreeSet<(StringId, StringId)>,
+    // (enum_name, value)
+    enum_values: BTreeSet<(StringId, StringId)>,
 }
 
 impl Supergraph {
@@ -36,9 +38,13 @@ impl Supergraph {
         field_type: StringId,
         arguments: Vec<(StringId, StringId)>,
     ) {
+        let field = Field {
+            arguments,
+            field_type,
+        };
         if self
             .fields
-            .insert((parent_type_name, field_name), (arguments, field_type))
+            .insert((parent_type_name, field_name), field)
             .is_some()
         {
             panic!("Invariant broken: Supergraph::insert_field() was called twice with the same parent type and field name.");
@@ -52,4 +58,14 @@ impl Supergraph {
     ) {
         self.union_members.insert((parent_union_name, member_name));
     }
+
+    pub(crate) fn insert_enum_value(&mut self, enum_name: StringId, value: StringId) {
+        self.enum_values.insert((enum_name, value));
+    }
+}
+
+#[derive(Debug)]
+struct Field {
+    arguments: Vec<(StringId, StringId)>,
+    field_type: StringId,
 }

--- a/crates/composition/tests/composition/custom_scalars_basic/subgraphs/bar.graphql
+++ b/crates/composition/tests/composition/custom_scalars_basic/subgraphs/bar.graphql
@@ -1,0 +1,3 @@
+scalar Yan
+scalar Tan
+

--- a/crates/composition/tests/composition/custom_scalars_basic/subgraphs/baz.graphql
+++ b/crates/composition/tests/composition/custom_scalars_basic/subgraphs/baz.graphql
@@ -1,0 +1,5 @@
+scalar Texture
+
+type Sheep {
+  texture: Texture!
+}

--- a/crates/composition/tests/composition/custom_scalars_basic/subgraphs/foo.graphql
+++ b/crates/composition/tests/composition/custom_scalars_basic/subgraphs/foo.graphql
@@ -1,0 +1,8 @@
+
+scalar Yan
+scalar Tan
+scalar Tethera
+
+type Sheep {
+  sheepIdx: Tethera
+}

--- a/crates/composition/tests/composition/custom_scalars_basic/supergraph.graphql
+++ b/crates/composition/tests/composition/custom_scalars_basic/supergraph.graphql
@@ -1,0 +1,8 @@
+scalar Yan
+scalar Tan
+scalar Texture
+type Sheep {
+    texture: Texture
+    sheepIdx: Tethera
+}
+scalar Tethera

--- a/crates/composition/tests/composition/enum_only_inputs/subgraphs/foodSearch.graphql
+++ b/crates/composition/tests/composition/enum_only_inputs/subgraphs/foodSearch.graphql
@@ -1,0 +1,11 @@
+type Query {
+  searchFood(filterName: FilterName, filterValue: String): [String!]
+}
+
+enum FilterName {
+  NAME
+  CREATED_AT
+  CALORIES
+  MAGNESIUM
+  DOESITTASTEGOOD
+}

--- a/crates/composition/tests/composition/enum_only_inputs/subgraphs/productSearch.graphql
+++ b/crates/composition/tests/composition/enum_only_inputs/subgraphs/productSearch.graphql
@@ -1,0 +1,11 @@
+type Query {
+  searchProduct(filterName: FilterName, filterValue: String): [String!]
+}
+
+enum FilterName {
+  ROLE
+  CREATED_AT
+  NAME
+  PROFESSION
+}
+

--- a/crates/composition/tests/composition/enum_only_inputs/subgraphs/userSearch.graphql
+++ b/crates/composition/tests/composition/enum_only_inputs/subgraphs/userSearch.graphql
@@ -1,0 +1,10 @@
+type Query {
+  searchUser(filterName: FilterName, filterValue: String): [String!]
+}
+
+enum FilterName {
+  ROLE
+  NAME
+  PROFESSION
+  CREATED_AT
+}

--- a/crates/composition/tests/composition/enum_only_inputs/supergraph.graphql
+++ b/crates/composition/tests/composition/enum_only_inputs/supergraph.graphql
@@ -1,0 +1,9 @@
+type Query {
+    searchFood(filterName: FilterName, filterValue: String): String
+    searchProduct(filterName: FilterName, filterValue: String): String
+    searchUser(filterName: FilterName, filterValue: String): String
+}
+enum FilterName {
+  NAME
+  CREATED_AT
+}

--- a/crates/composition/tests/composition/enum_only_inputs_no_common_values/subgraphs/foodSearch.graphql
+++ b/crates/composition/tests/composition/enum_only_inputs_no_common_values/subgraphs/foodSearch.graphql
@@ -1,0 +1,9 @@
+type Query {
+  searchFood(filterName: FilterName, filterValue: String): [String!]
+}
+
+enum FilterName {
+  CALORIES
+  MAGNESIUM
+  DOESITTASTEGOOD
+}

--- a/crates/composition/tests/composition/enum_only_inputs_no_common_values/subgraphs/productSearch.graphql
+++ b/crates/composition/tests/composition/enum_only_inputs_no_common_values/subgraphs/productSearch.graphql
@@ -1,0 +1,9 @@
+type Query {
+  searchProduct(filterName: FilterName, filterValue: String): [String!]
+}
+
+enum FilterName {
+  ROLE
+  PROFESSION
+}
+

--- a/crates/composition/tests/composition/enum_only_inputs_no_common_values/subgraphs/userSearch.graphql
+++ b/crates/composition/tests/composition/enum_only_inputs_no_common_values/subgraphs/userSearch.graphql
@@ -1,0 +1,10 @@
+type Query {
+  searchUser(filterName: FilterName, filterValue: String): [String!]
+}
+
+enum FilterName {
+  ROLE
+  NAME
+  PROFESSION
+  CREATED_AT
+}

--- a/crates/composition/tests/composition/enum_only_inputs_no_common_values/supergraph.graphql
+++ b/crates/composition/tests/composition/enum_only_inputs_no_common_values/supergraph.graphql
@@ -1,0 +1,1 @@
+# Values for enum FilterName are empty (intersection)

--- a/crates/composition/tests/composition/enum_only_outputs/subgraphs/activities.graphql
+++ b/crates/composition/tests/composition/enum_only_outputs/subgraphs/activities.graphql
@@ -1,0 +1,20 @@
+type Activity {
+  name: String!
+  description: String!
+  participatingTeletubby: Teletubby!
+}
+
+type Teletubby @federation__key(fields: "name") {
+  name: String!
+  activities: [Activity]
+  favoriteToy: FavoriteToy @federation__shareable
+}
+
+type Query {
+  getActivity(name: String!): Activity
+}
+
+enum FavoriteToy {
+  PLUSHTOY
+  TOBOGGAN
+}

--- a/crates/composition/tests/composition/enum_only_outputs/subgraphs/episodes.graphql
+++ b/crates/composition/tests/composition/enum_only_outputs/subgraphs/episodes.graphql
@@ -1,0 +1,22 @@
+type Episode {
+  title: String!
+  duration: Int! # Duration in seconds
+  featuredTeletubby: Teletubby!
+  featuredToys: [FavoriteToy!]
+}
+
+type Teletubby @federation__key(fields: "name") {
+  name: String!
+  episodesFeatured: [Episode]
+  favoriteToy: FavoriteToy @federation__shareable
+}
+
+type Query {
+  getEpisode(title: String!): Episode
+}
+
+enum FavoriteToy {
+  SCOOTER
+  BAG
+  HAT
+}

--- a/crates/composition/tests/composition/enum_only_outputs/subgraphs/teletubbyRepository.graphql
+++ b/crates/composition/tests/composition/enum_only_outputs/subgraphs/teletubbyRepository.graphql
@@ -1,0 +1,21 @@
+type Teletubby @federation__key(fields: "name") {
+  name: String!
+  color: String!
+  favoriteToy: FavoriteToy @federation__shareable
+  mood: Mood
+}
+
+enum Mood {
+  HAPPY
+  SAD
+}
+
+type Query {
+  getTeletubby(name: String!): Teletubby
+}
+
+enum FavoriteToy {
+  BAG
+  HAT
+  BALL
+}

--- a/crates/composition/tests/composition/enum_only_outputs/supergraph.graphql
+++ b/crates/composition/tests/composition/enum_only_outputs/supergraph.graphql
@@ -1,0 +1,36 @@
+type Activity {
+    name: String
+    description: String
+    participatingTeletubby: Teletubby
+}
+type Teletubby {
+    activities: Activity
+    name: String
+    favoriteToy: FavoriteToy
+    episodesFeatured: Episode
+    color: String
+    mood: Mood
+}
+type Query {
+    getActivity(name: String): Activity
+    getEpisode(title: String): Episode
+    getTeletubby(name: String): Teletubby
+}
+enum FavoriteToy {
+  PLUSHTOY
+  TOBOGGAN
+  SCOOTER
+  BAG
+  HAT
+  BALL
+}
+type Episode {
+    title: String
+    duration: Int
+    featuredTeletubby: Teletubby
+    featuredToys: FavoriteToy
+}
+enum Mood {
+  HAPPY
+  SAD
+}

--- a/crates/composition/tests/composition/enum_strict_matching_error/subgraphs/activities.graphql
+++ b/crates/composition/tests/composition/enum_strict_matching_error/subgraphs/activities.graphql
@@ -1,0 +1,20 @@
+type Activity {
+  name: String!
+  description: String!
+  participatingTeletubby: Teletubby!
+}
+
+type Teletubby @federation__key(fields: "name") {
+  name: String!
+  activities: [Activity]
+  favoriteToy: FavoriteToy @federation__shareable
+}
+
+type Query {
+  getActivity(name: String!): Activity
+}
+
+enum FavoriteToy {
+  PLUSHTOY
+  TOBOGGAN
+}

--- a/crates/composition/tests/composition/enum_strict_matching_error/subgraphs/episodes.graphql
+++ b/crates/composition/tests/composition/enum_strict_matching_error/subgraphs/episodes.graphql
@@ -1,0 +1,23 @@
+type Episode {
+  title: String!
+  duration: Int! # Duration in seconds
+  featuredTeletubby: Teletubby!
+  featuredToys: [FavoriteToy!]
+}
+
+type Teletubby @federation__key(fields: "name") {
+  name: String!
+  episodesFeatured: [Episode]
+  favoriteToy: FavoriteToy @federation__shareable
+}
+
+type Query {
+  getEpisode(title: String!): Episode
+  episodesFeaturingToys(toys: [FavoriteToy!]): [Episode!]
+}
+
+enum FavoriteToy {
+  SCOOTER
+  BAG
+  HAT
+}

--- a/crates/composition/tests/composition/enum_strict_matching_error/subgraphs/teletubbyRepository.graphql
+++ b/crates/composition/tests/composition/enum_strict_matching_error/subgraphs/teletubbyRepository.graphql
@@ -1,0 +1,21 @@
+type Teletubby @federation__key(fields: "name") {
+  name: String!
+  color: String!
+  favoriteToy: FavoriteToy @federation__shareable
+  mood: Mood
+}
+
+enum Mood {
+  HAPPY
+  SAD
+}
+
+type Query {
+  getTeletubby(name: String!): Teletubby
+}
+
+enum FavoriteToy {
+  BAG
+  HAT
+  BALL
+}

--- a/crates/composition/tests/composition/enum_strict_matching_error/supergraph.graphql
+++ b/crates/composition/tests/composition/enum_strict_matching_error/supergraph.graphql
@@ -1,0 +1,1 @@
+# The enum FavoriteToy should match exactly in all subgraphs, but it does not

--- a/crates/composition/tests/composition/enum_unused/subgraphs/theschema.graphql
+++ b/crates/composition/tests/composition/enum_unused/subgraphs/theschema.graphql
@@ -1,0 +1,9 @@
+type User {
+  id: ID!
+  name: String!
+}
+
+enum UserType {
+  ADMIN
+  REGULAR
+}

--- a/crates/composition/tests/composition/enum_unused/supergraph.graphql
+++ b/crates/composition/tests/composition/enum_unused/supergraph.graphql
@@ -1,0 +1,4 @@
+type User {
+    id: ID
+    name: String
+}

--- a/crates/composition/tests/composition/interfaces_basic/subgraphs/electronics.graphql
+++ b/crates/composition/tests/composition/interfaces_basic/subgraphs/electronics.graphql
@@ -1,0 +1,7 @@
+interface FurbyType {
+  id: ID!
+  batteryType: String!
+  connectivity: String # such as Bluetooth, WiFi, etc.
+  sensorTypes: [String!] # such as "motion", "sound", etc.
+}
+

--- a/crates/composition/tests/composition/interfaces_basic/subgraphs/physical.graphql
+++ b/crates/composition/tests/composition/interfaces_basic/subgraphs/physical.graphql
@@ -1,0 +1,6 @@
+interface FurbyType {
+  id: ID!
+  color: String!
+  height: Float! # in centimeters
+  weight: Float! # in grams
+}

--- a/crates/composition/tests/composition/interfaces_basic/subgraphs/social.graphql
+++ b/crates/composition/tests/composition/interfaces_basic/subgraphs/social.graphql
@@ -1,0 +1,18 @@
+interface FurbyType {
+  id: ID!
+  languages: [String!] # languages it can understand
+  canSing: Boolean!
+  canDance: Boolean!
+}
+
+type Furby implements FurbyType & SocialFurby {
+    id: ID!
+  languages: [String!]
+  canSing: Boolean!
+  canDance: Boolean!
+  friends: [Furby!]
+}
+
+interface SocialFurby {
+  friends: [Furby!]
+}

--- a/crates/composition/tests/composition/interfaces_basic/supergraph.graphql
+++ b/crates/composition/tests/composition/interfaces_basic/supergraph.graphql
@@ -1,0 +1,22 @@
+interface FurbyType {
+    id: ID
+    batteryType: String
+    connectivity: String
+    sensorTypes: String
+    color: String
+    height: Float
+    weight: Float
+    languages: String
+    canSing: Boolean
+    canDance: Boolean
+}
+type Furby {
+    id: ID
+    languages: String
+    canSing: Boolean
+    canDance: Boolean
+    friends: Furby
+}
+interface SocialFurby {
+    friends: Furby
+}

--- a/crates/composition/tests/composition/shareable_basic/supergraph.graphql
+++ b/crates/composition/tests/composition/shareable_basic/supergraph.graphql
@@ -5,3 +5,7 @@ type Customer {
     newsletterSubscribed: Boolean
     subscriptionPlan: Plan
 }
+enum Plan {
+  Hobby
+  Pro
+}


### PR DESCRIPTION
- Interfaces. Non-entity interfaces only for now. Like unions,
  interfaces are merged by composition.
- Custom scalars. No particular rule, they are all picked up and merged
  into the resulting final schema.
- Enums. The rules are more complicated. If the enum is used in output
  position only, the enums from different subgraphs are merged. If the
  enum is used in input position, only the values they have in common
  are retained. And if the enum is used in both argument and output
  position, the enums must match exactly in all schemas.

Part of GB-5176
Closes GB-5228
Closes GB-5230
Closes GB-5231
# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
