### PR TITLE
chore: pub use postgres transport

### DIFF
--- a/engine/crates/postgres-types/src/transport/tcp.rs
+++ b/engine/crates/postgres-types/src/transport/tcp.rs
@@ -2,14 +2,14 @@ mod conversion;
 mod executor;
 mod transaction;
 
-use self::conversion::json_to_string;
+pub use tokio_postgres::Transaction;
 
+use self::conversion::json_to_string;
 use super::Transport;
 use crate::error::Error;
 use async_trait::async_trait;
 use futures::stream::BoxStream;
 use serde_json::Value;
-use tokio_postgres::Transaction;
 
 pub struct TcpTransport {
     client: tokio_postgres::Client,


### PR DESCRIPTION
This makes it much easier to use the transaction in the api: the postgres-types is the crate dictating the version and the feature flags, and we can just

```rust
use postgres_types::transport::tcp::Transaction;
```

in the api.
