### PR TITLE
fix: update the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,22 @@ FROM rust:1.73-alpine3.18 AS build
 
 WORKDIR /grafbase
 
+RUN mkdir -p packages/grafbase-sdk
+
 COPY ./cli ./cli
 COPY ./engine ./engine
+COPY ./packages/grafbase-sdk/package.json ./packages/grafbase-sdk
+COPY ./packages/cli-app ./packages/cli-app
+
+RUN apk add --no-cache git musl-dev npm
+
+WORKDIR /grafbase/packages/cli-app
+
+RUN npx --yes pnpm i
+RUN npx --yes pnpm run cli-app:build
 
 WORKDIR /grafbase/cli
 
-RUN apk add --no-cache git musl-dev
 
 RUN cargo build --release
 


### PR DESCRIPTION
We've made a few changes to the build process since this was added, so needed some updates:

1. The CLI now reads the SDKs `package.json`.  Easy to fix.
2. We also need the cli-app assets.  I've opted to build these in the dockerfile.