### PR TITLE
fix(connector): Prevent type statement caching for Postgres

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -4464,7 +4464,6 @@ dependencies = [
  "futures",
  "indexmap 2.0.0-pre",
  "itertools 0.11.0",
- "percent-encoding",
  "reqwest",
  "rustls",
  "rustls-native-certs",
@@ -4481,7 +4480,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.6"
-source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#a7731024191390654f89721df2396277b9f9cca1"
+source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#69df3c14a26e604396ef46caa7ded791686f34ce"
 dependencies = [
  "base64 0.21.2",
  "byteorder",
@@ -4499,7 +4498,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.6"
-source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#a7731024191390654f89721df2396277b9f9cca1"
+source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#69df3c14a26e604396ef46caa7ded791686f34ce"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -6696,7 +6695,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.10"
-source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#a7731024191390654f89721df2396277b9f9cca1"
+source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#69df3c14a26e604396ef46caa7ded791686f34ce"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -2932,7 +2932,6 @@ dependencies = [
  "futures",
  "indexmap 2.0.0-pre",
  "itertools",
- "percent-encoding",
  "reqwest",
  "rustls",
  "rustls-native-certs",
@@ -2949,7 +2948,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.6"
-source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#a7731024191390654f89721df2396277b9f9cca1"
+source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#69df3c14a26e604396ef46caa7ded791686f34ce"
 dependencies = [
  "base64 0.21.4",
  "byteorder",
@@ -2967,7 +2966,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.6"
-source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#a7731024191390654f89721df2396277b9f9cca1"
+source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#69df3c14a26e604396ef46caa7ded791686f34ce"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -4348,7 +4347,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.10"
-source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#a7731024191390654f89721df2396277b9f9cca1"
+source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#69df3c14a26e604396ef46caa7ded791686f34ce"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/engine/crates/postgres-connector-types/Cargo.toml
+++ b/engine/crates/postgres-connector-types/Cargo.toml
@@ -25,7 +25,6 @@ thiserror.workspace = true
 url.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-percent-encoding = "2.3.0"
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 # https://github.com/sfackler/rust-postgres/pull/1067
 tokio-postgres = { git = "https://github.com/grafbase/rust-postgres/", branch = "grafbase", features = ["js"], default-features = false }


### PR DESCRIPTION
Tokio-postgres loves to cache everything internally and in secrecy. This will not play well with transactional connection pools. Let's disable that.
