### PR TITLE
composition: re-export grafbase_federated_graph::render_sdl

### DIFF
--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -3,6 +3,9 @@ name: engine
 on:
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - 'crates/**/*'
+      - 'packages/**/*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/crates/composition/src/lib.rs
+++ b/crates/composition/src/lib.rs
@@ -12,6 +12,7 @@ mod strings;
 mod subgraphs;
 
 pub use self::{diagnostics::Diagnostics, result::CompositionResult, subgraphs::Subgraphs};
+pub use grafbase_federated_graph::render_sdl;
 
 use self::{
     compose::{compose_subgraphs, ComposeContext},


### PR DESCRIPTION
This is an omission from https://github.com/grafbase/grafbase/pull/889. When we update this crate in api, we will have to call render_sdl on the federated graph to get the SDL string.
