### PR TITLE
composition: populate entity provenance

### DIFF
--- a/crates/composition/src/compose.rs
+++ b/crates/composition/src/compose.rs
@@ -46,8 +46,8 @@ fn merge_object_definitions<'a>(
         let first_kind = first.kind();
         let second_kind = incompatible.kind();
         let name = first.name().as_str();
-        let first_subgraph = first.subgraph().name_str();
-        let second_subgraph = incompatible.subgraph().name_str();
+        let first_subgraph = first.subgraph().name().as_str();
+        let second_subgraph = incompatible.subgraph().name().as_str();
         ctx.diagnostics.push_fatal(format!(
             "Cannot merge {first_kind:?} with {second_kind:?} (`{name}` in `{first_subgraph}` and `{second_subgraph}`)",
         ));
@@ -67,16 +67,24 @@ fn merge_object_definitions<'a>(
             "The `{name}` object is an entity in subgraphs {} but not in subgraphs {}.",
             entity_subgraphs
                 .into_iter()
-                .map(|d| d.subgraph().name_str())
+                .map(|d| d.subgraph().name().as_str())
                 .join(", "),
             non_entity_subgraphs
                 .into_iter()
-                .map(|d| d.subgraph().name_str())
+                .map(|d| d.subgraph().name().as_str())
                 .join(", "),
         ));
     }
 
-    ctx.insert_object(first.name());
+    let object_id = ctx.insert_object(first.name());
+
+    for key in definitions
+        .iter()
+        .flat_map(|def| def.entity_keys())
+        .filter(|key| key.is_resolvable())
+    {
+        ctx.insert_resolvable_key(object_id, key.id);
+    }
 }
 
 fn merge_field_definitions(ctx: &mut Context<'_>, fields: &[FieldWalker<'_>]) {
@@ -93,8 +101,8 @@ fn merge_field_definitions(ctx: &mut Context<'_>, fields: &[FieldWalker<'_>]) {
             "The field `{}` on `{}` is defined in two subgraphs (`{}` and `{}`).",
             first.name().as_str(),
             first.parent_definition().name().as_str(),
-            first.parent_definition().subgraph().name_str(),
-            next.parent_definition().subgraph().name_str(),
+            first.parent_definition().subgraph().name().as_str(),
+            next.parent_definition().subgraph().name().as_str(),
         ));
     }
 
@@ -113,11 +121,11 @@ fn merge_field_definitions(ctx: &mut Context<'_>, fields: &[FieldWalker<'_>]) {
             "The field `{name}` is part of `@key` in {} but not in {}",
             key_subgraphs
                 .into_iter()
-                .map(|f| f.parent_definition().subgraph().name_str())
+                .map(|f| f.parent_definition().subgraph().name().as_str())
                 .join(", "),
             non_key_subgraphs
                 .into_iter()
-                .map(|f| f.parent_definition().subgraph().name_str())
+                .map(|f| f.parent_definition().subgraph().name().as_str())
                 .join(", "),
         ));
     }

--- a/crates/composition/src/compose/context.rs
+++ b/crates/composition/src/compose/context.rs
@@ -3,7 +3,7 @@ use crate::{
     subgraphs::{self, StringWalker},
     Diagnostics,
 };
-use grafbase_federated_graph as out;
+use grafbase_federated_graph as federated;
 
 /// Context for [`compose`](crate::compose::compose).
 pub(crate) struct Context<'a> {
@@ -37,11 +37,15 @@ impl<'a> Context<'a> {
         self.ir
     }
 
-    pub(crate) fn insert_enum(&mut self, name: StringWalker<'_>) -> out::EnumId {
+    pub(crate) fn insert_enum(&mut self, name: StringWalker<'_>) -> federated::EnumId {
         self.ir.insert_enum(name)
     }
 
-    pub(crate) fn insert_enum_value(&mut self, enum_id: out::EnumId, value: StringWalker<'_>) {
+    pub(crate) fn insert_enum_value(
+        &mut self,
+        enum_id: federated::EnumId,
+        value: StringWalker<'_>,
+    ) {
         self.ir.insert_enum_value(enum_id, value)
     }
 
@@ -56,15 +60,18 @@ impl<'a> Context<'a> {
             .insert_field(parent_name, field_name, field_type, arguments)
     }
 
-    pub(crate) fn insert_input_object(&mut self, name: StringWalker<'_>) -> out::InputObjectId {
+    pub(crate) fn insert_input_object(
+        &mut self,
+        name: StringWalker<'_>,
+    ) -> federated::InputObjectId {
         self.ir.insert_input_object(name)
     }
 
-    pub(crate) fn insert_interface(&mut self, name: StringWalker<'_>) -> out::InterfaceId {
+    pub(crate) fn insert_interface(&mut self, name: StringWalker<'_>) -> federated::InterfaceId {
         self.ir.insert_interface(name)
     }
 
-    pub(crate) fn insert_object(&mut self, name: StringWalker<'_>) {
+    pub(crate) fn insert_object(&mut self, name: StringWalker<'_>) -> federated::ObjectId {
         self.ir.insert_object(name)
     }
 
@@ -72,7 +79,7 @@ impl<'a> Context<'a> {
         self.ir.insert_scalar(name)
     }
 
-    pub(crate) fn insert_union(&mut self, name: StringWalker<'_>) -> out::UnionId {
+    pub(crate) fn insert_union(&mut self, name: StringWalker<'_>) -> federated::UnionId {
         self.ir.insert_union(name)
     }
 
@@ -82,6 +89,14 @@ impl<'a> Context<'a> {
         member_name: subgraphs::StringId,
     ) {
         self.ir.insert_union_member(union_name, member_name)
+    }
+
+    pub(crate) fn insert_resolvable_key(
+        &mut self,
+        object_id: federated::ObjectId,
+        key_id: subgraphs::KeyId,
+    ) {
+        self.ir.insert_resolvable_key(object_id, key_id)
     }
 }
 

--- a/crates/composition/src/compose/input_object.rs
+++ b/crates/composition/src/compose/input_object.rs
@@ -31,7 +31,7 @@ pub(super) fn merge_input_object_definitions(
                 "The {input_type_name}.{field_name} field is not defined in all subgraphs, but it is required in {bad_subgraph}",
                 input_type_name = first.name().as_str(),
                 field_name = field.name().as_str(),
-                bad_subgraph = field.parent_definition().subgraph().name_str(),
+                bad_subgraph = field.parent_definition().subgraph().name().as_str(),
             ));
         }
     }

--- a/crates/composition/src/composition_ir.rs
+++ b/crates/composition/src/composition_ir.rs
@@ -188,14 +188,6 @@ impl StringsIr {
     }
 }
 
-impl std::ops::Index<federated::StringId> for StringsIr {
-    type Output = String;
-
-    fn index(&self, index: federated::StringId) -> &Self::Output {
-        &self.strings[index.0]
-    }
-}
-
 pub(crate) struct KeyIr {
     pub(crate) object_id: federated::ObjectId,
     pub(crate) key_id: subgraphs::KeyId,

--- a/crates/composition/src/composition_ir.rs
+++ b/crates/composition/src/composition_ir.rs
@@ -27,6 +27,7 @@ pub(crate) struct CompositionIr {
     pub(crate) strings: StringsIr,
     pub(crate) fields: Vec<FieldIr>,
     pub(crate) union_members: BTreeSet<(subgraphs::StringId, subgraphs::StringId)>,
+    pub(crate) resolvable_keys: Vec<KeyIr>,
 }
 
 impl CompositionIr {
@@ -85,7 +86,15 @@ impl CompositionIr {
         id
     }
 
-    pub(crate) fn insert_object(&mut self, object_name: StringWalker<'_>) {
+    pub(crate) fn insert_resolvable_key(
+        &mut self,
+        object_id: federated::ObjectId,
+        key_id: subgraphs::KeyId,
+    ) {
+        self.resolvable_keys.push(KeyIr { object_id, key_id });
+    }
+
+    pub(crate) fn insert_object(&mut self, object_name: StringWalker<'_>) -> federated::ObjectId {
         let name = self.insert_string(object_name);
         let object = federated::Object {
             name,
@@ -96,6 +105,7 @@ impl CompositionIr {
         let id = federated::ObjectId(self.objects.push_return_idx(object));
         self.definitions_by_name
             .insert(object_name.id, federated::Definition::Object(id));
+        id
     }
 
     pub(crate) fn insert_union(&mut self, union_name: StringWalker<'_>) -> federated::UnionId {
@@ -176,4 +186,17 @@ impl StringsIr {
             federated::StringId(self.strings.push_return_idx(string.as_str().to_owned()))
         })
     }
+}
+
+impl std::ops::Index<federated::StringId> for StringsIr {
+    type Output = String;
+
+    fn index(&self, index: federated::StringId) -> &Self::Output {
+        &self.strings[index.0]
+    }
+}
+
+pub(crate) struct KeyIr {
+    pub(crate) object_id: federated::ObjectId,
+    pub(crate) key_id: subgraphs::KeyId,
 }

--- a/crates/composition/src/emit_federated_graph.rs
+++ b/crates/composition/src/emit_federated_graph.rs
@@ -2,12 +2,19 @@ mod field_types_map;
 
 use self::field_types_map::FieldTypesMap;
 use crate::{
-    composition_ir::{CompositionIr, FieldIr, StringsIr},
+    composition_ir::{CompositionIr, FieldIr, KeyIr, StringsIr},
     subgraphs, Subgraphs, VecExt,
 };
 use grafbase_federated_graph as federated;
 use itertools::Itertools;
 use std::collections::BTreeSet;
+
+struct Context<'a> {
+    strings_ir: &'a mut StringsIr,
+    field_types_map: &'a mut FieldTypesMap,
+    out: &'a mut federated::FederatedGraph,
+    subgraphs: &'a Subgraphs,
+}
 
 /// This can't fail. All the relevant, correct information should already be in the CompositionIr.
 pub(crate) fn emit_federated_graph(
@@ -26,15 +33,18 @@ pub(crate) fn emit_federated_graph(
         ..Default::default()
     };
 
-    emit_fields(
-        &ir.fields,
+    let mut ctx = Context {
+        strings_ir: &mut strings_ir,
+        field_types_map: &mut field_types_map,
+        out: &mut out,
         subgraphs,
-        &mut strings_ir,
-        &mut field_types_map,
-        &mut out,
-    );
+    };
 
-    emit_union_members(&ir.union_members, &mut field_types_map, &mut out);
+    emit_subgraphs(&mut ctx);
+    emit_fields(&ir.fields, &mut ctx);
+
+    emit_union_members(&ir.union_members, &mut ctx);
+    emit_keys(&ir.resolvable_keys, &mut ctx);
 
     out.field_types = field_types_map.field_types;
     out.strings = strings_ir.strings;
@@ -44,10 +54,12 @@ pub(crate) fn emit_federated_graph(
 
 fn emit_fields(
     ir_fields: &[FieldIr],
-    subgraphs: &Subgraphs,
-    strings: &mut StringsIr,
-    field_types_map: &mut FieldTypesMap,
-    out: &mut federated::FederatedGraph,
+    Context {
+        strings_ir,
+        field_types_map,
+        out,
+        subgraphs,
+    }: &mut Context<'_>,
 ) {
     for FieldIr {
         parent_name,
@@ -57,11 +69,11 @@ fn emit_fields(
     } in ir_fields
     {
         let field_type_id = field_types_map.insert(subgraphs.walk(*field_type));
-        let field_name = strings.insert(subgraphs.walk(*field_name));
+        let field_name = strings_ir.insert(subgraphs.walk(*field_name));
         let arguments = arguments
             .iter()
             .map(|(arg_name, arg_type)| federated::FieldArgument {
-                name: strings.insert(subgraphs.walk(*arg_name)),
+                name: strings_ir.insert(subgraphs.walk(*arg_name)),
                 type_id: field_types_map.insert(subgraphs.walk(*arg_type)),
             })
             .collect();
@@ -111,8 +123,11 @@ fn emit_fields(
 
 fn emit_union_members(
     ir_members: &BTreeSet<(subgraphs::StringId, subgraphs::StringId)>,
-    field_types_map: &mut FieldTypesMap,
-    out: &mut federated::FederatedGraph,
+    Context {
+        field_types_map,
+        out,
+        ..
+    }: &mut Context<'_>,
 ) {
     for (union_name, members) in &ir_members.iter().group_by(|(union_name, _)| union_name) {
         let federated::Definition::Union(union_id) = field_types_map.definitions[union_name] else {
@@ -127,5 +142,72 @@ fn emit_union_members(
             };
             union.members.push(object_id);
         }
+    }
+}
+
+fn emit_keys(keys: &[KeyIr], ctx: &mut Context<'_>) {
+    for KeyIr { object_id, key_id } in keys {
+        let parent_id = federated::Definition::Object(*object_id);
+        let key = ctx.subgraphs.walk(*key_id);
+        let selection = attach_selection(key.fields(), parent_id, ctx);
+        ctx.out[*object_id].resolvable_keys.push(federated::Key {
+            subgraph_id: federated::SubgraphId(key.parent_definition().subgraph().id.idx()),
+            fields: selection,
+        });
+    }
+}
+
+/// Attach a selection set defined in strings to a FederatedGraph, transforming the strings into
+/// field ids.
+fn attach_selection(
+    selection_set: &[subgraphs::Selection],
+    parent_id: federated::Definition,
+    ctx: &mut Context<'_>,
+) -> federated::SelectionSet {
+    selection_set
+        .iter()
+        .map(|selection| {
+            let field = match parent_id {
+                federated::Definition::Object(object_id) => ctx
+                    .out
+                    .object_fields
+                    .iter()
+                    .find(|object_field| {
+                        let field_name = ctx.out[object_field.field_id].name;
+                        object_field.object_id == object_id
+                            && ctx.strings_ir[field_name]
+                                == ctx.subgraphs.walk(selection.field).as_str()
+                    })
+                    .map(|of| of.field_id)
+                    .unwrap(),
+                federated::Definition::Interface(interface_id) => ctx
+                    .out
+                    .interface_fields
+                    .iter()
+                    .find(|interface_field| {
+                        interface_field.interface_id == interface_id
+                            && ctx.strings_ir[ctx.out[interface_field.field_id].name]
+                                == ctx.subgraphs.walk(selection.field).as_str()
+                    })
+                    .map(|of| of.field_id)
+                    .unwrap(),
+                _ => unreachable!(),
+            };
+
+            let field_ty = ctx.field_types_map[ctx.out[field].field_type_id].kind;
+            federated::Selection {
+                field,
+                subselection: attach_selection(&selection.subselection, field_ty, ctx),
+            }
+        })
+        .collect()
+}
+
+fn emit_subgraphs(ctx: &mut Context<'_>) {
+    for subgraph in ctx.subgraphs.iter_subgraphs() {
+        ctx.out.subgraphs.push(federated::Subgraph {
+            name: ctx.strings_ir.insert(subgraph.name()),
+            url: ctx.strings_ir.insert(subgraph.url()),
+        });
     }
 }

--- a/crates/composition/src/emit_federated_graph/context.rs
+++ b/crates/composition/src/emit_federated_graph/context.rs
@@ -1,0 +1,24 @@
+use super::field_types_map::FieldTypesMap;
+use crate::{subgraphs, VecExt};
+use grafbase_federated_graph as federated;
+use std::collections::HashMap;
+
+pub(super) struct Context<'a> {
+    pub(super) field_types_map: &'a mut FieldTypesMap,
+    pub(super) out: &'a mut federated::FederatedGraph,
+    pub(super) subgraphs: &'a subgraphs::Subgraphs,
+    pub(super) definitions: HashMap<subgraphs::StringId, federated::Definition>,
+    pub(super) strings_map: HashMap<subgraphs::StringId, federated::StringId>,
+}
+
+impl Context<'_> {
+    /// Subgraphs string -> federated graph string.
+    pub(crate) fn insert_string(
+        &mut self,
+        string: subgraphs::StringWalker<'_>,
+    ) -> federated::StringId {
+        *self.strings_map.entry(string.id).or_insert_with(|| {
+            federated::StringId(self.out.strings.push_return_idx(string.as_str().to_owned()))
+        })
+    }
+}

--- a/crates/composition/src/emit_federated_graph/context.rs
+++ b/crates/composition/src/emit_federated_graph/context.rs
@@ -1,17 +1,35 @@
 use super::field_types_map::FieldTypesMap;
-use crate::{subgraphs, VecExt};
+use crate::{composition_ir::CompositionIr, subgraphs, VecExt};
 use grafbase_federated_graph as federated;
 use std::collections::HashMap;
 
 pub(super) struct Context<'a> {
-    pub(super) field_types_map: &'a mut FieldTypesMap,
     pub(super) out: &'a mut federated::FederatedGraph,
     pub(super) subgraphs: &'a subgraphs::Subgraphs,
     pub(super) definitions: HashMap<subgraphs::StringId, federated::Definition>,
-    pub(super) strings_map: HashMap<subgraphs::StringId, federated::StringId>,
+    pub(super) field_types_map: FieldTypesMap,
+    pub(super) selection_map:
+        HashMap<(federated::Definition, federated::StringId), federated::FieldId>,
+
+    strings_map: HashMap<subgraphs::StringId, federated::StringId>,
 }
 
-impl Context<'_> {
+impl<'a> Context<'a> {
+    pub(crate) fn new(
+        ir: &mut CompositionIr,
+        subgraphs: &'a subgraphs::Subgraphs,
+        out: &'a mut federated::FederatedGraph,
+    ) -> Self {
+        Context {
+            out,
+            subgraphs,
+            definitions: std::mem::take(&mut ir.definitions_by_name),
+            strings_map: std::mem::take(&mut ir.strings.map),
+            selection_map: HashMap::with_capacity(ir.fields.len()),
+            field_types_map: FieldTypesMap::default(),
+        }
+    }
+
     /// Subgraphs string -> federated graph string.
     pub(crate) fn insert_string(
         &mut self,
@@ -19,6 +37,38 @@ impl Context<'_> {
     ) -> federated::StringId {
         *self.strings_map.entry(string.id).or_insert_with(|| {
             federated::StringId(self.out.strings.push_return_idx(string.as_str().to_owned()))
+        })
+    }
+
+    pub(crate) fn push_object_field(
+        &mut self,
+        object_id: federated::ObjectId,
+        field_id: federated::FieldId,
+    ) {
+        let key = (
+            federated::Definition::Object(object_id),
+            self.out[field_id].name,
+        );
+        self.selection_map.insert(key, field_id);
+        self.out.object_fields.push(federated::ObjectField {
+            object_id,
+            field_id,
+        })
+    }
+
+    pub(crate) fn push_interface_field(
+        &mut self,
+        interface_id: federated::InterfaceId,
+        field_id: federated::FieldId,
+    ) {
+        let key = (
+            federated::Definition::Interface(interface_id),
+            self.out[field_id].name,
+        );
+        self.selection_map.insert(key, field_id);
+        self.out.interface_fields.push(federated::InterfaceField {
+            interface_id,
+            field_id,
         })
     }
 }

--- a/crates/composition/src/emit_federated_graph/field_types_map.rs
+++ b/crates/composition/src/emit_federated_graph/field_types_map.rs
@@ -51,3 +51,11 @@ impl FieldTypesMap {
         })
     }
 }
+
+impl std::ops::Index<federated::FieldTypeId> for FieldTypesMap {
+    type Output = federated::FieldType;
+
+    fn index(&self, index: federated::FieldTypeId) -> &Self::Output {
+        &self.field_types[index.0]
+    }
+}

--- a/crates/composition/src/emit_federated_graph/field_types_map.rs
+++ b/crates/composition/src/emit_federated_graph/field_types_map.rs
@@ -1,61 +1,50 @@
+use super::Context;
 use crate::{subgraphs, VecExt};
 use grafbase_federated_graph as federated;
 use std::collections::HashMap;
 
-/// Responsible for mapping field types between the subgraphs and the federated graph.
+/// Responsible for mapping field types between the subgraphs and the federated graph. See
+/// [Context::insert_field_type()].
+#[derive(Default)]
 pub(super) struct FieldTypesMap {
-    pub(super) field_types: Vec<federated::FieldType>,
-    pub(super) definitions: HashMap<subgraphs::StringId, federated::Definition>,
-
     map: HashMap<subgraphs::FieldTypeId, federated::FieldTypeId>,
 }
 
-impl FieldTypesMap {
-    pub(super) fn new(definitions: HashMap<subgraphs::StringId, federated::Definition>) -> Self {
-        Self {
-            definitions,
-            map: HashMap::default(),
-            field_types: Vec::new(),
-        }
-    }
-
-    pub(super) fn insert(
+impl Context<'_> {
+    /// Subgraphs field type -> federated graph field type.
+    pub(super) fn insert_field_type(
         &mut self,
         field_type: subgraphs::FieldTypeWalker<'_>,
     ) -> federated::FieldTypeId {
-        *self.map.entry(field_type.id).or_insert_with(|| {
-            let Some(kind) = self.definitions.get(&field_type.type_name().id).copied() else {
-                panic!(
-                    "Invariant violation: definition {:?} from field type not registered.",
-                    field_type.type_name().as_str()
+        *self
+            .field_types_map
+            .map
+            .entry(field_type.id)
+            .or_insert_with(|| {
+                let Some(kind) = self.definitions.get(&field_type.type_name().id).copied() else {
+                    panic!(
+                        "Invariant violation: definition {:?} from field type not registered.",
+                        field_type.type_name().as_str()
+                    )
+                };
+
+                federated::FieldTypeId(
+                    self.out.field_types.push_return_idx(federated::FieldType {
+                        kind,
+                        inner_is_required: field_type.inner_is_required(),
+                        list_wrappers: field_type
+                            .iter_wrappers()
+                            .map(|wrapper| match wrapper {
+                                subgraphs::WrapperTypeKind::List => {
+                                    federated::ListWrapper::NullableList
+                                }
+                                subgraphs::WrapperTypeKind::NonNullList => {
+                                    federated::ListWrapper::RequiredList
+                                }
+                            })
+                            .collect(),
+                    }),
                 )
-            };
-
-            federated::FieldTypeId(
-                self.field_types.push_return_idx(federated::FieldType {
-                    kind,
-                    inner_is_required: field_type.inner_is_required(),
-                    list_wrappers: field_type
-                        .iter_wrappers()
-                        .map(|wrapper| match wrapper {
-                            subgraphs::WrapperTypeKind::List => {
-                                federated::ListWrapper::NullableList
-                            }
-                            subgraphs::WrapperTypeKind::NonNullList => {
-                                federated::ListWrapper::RequiredList
-                            }
-                        })
-                        .collect(),
-                }),
-            )
-        })
-    }
-}
-
-impl std::ops::Index<federated::FieldTypeId> for FieldTypesMap {
-    type Output = federated::FieldType;
-
-    fn index(&self, index: federated::FieldTypeId) -> &Self::Output {
-        &self.field_types[index.0]
+            })
     }
 }

--- a/crates/composition/src/subgraphs.rs
+++ b/crates/composition/src/subgraphs.rs
@@ -11,6 +11,7 @@ pub(crate) use self::{
     definitions::{DefinitionId, DefinitionKind, DefinitionWalker},
     field_types::*,
     fields::*,
+    keys::*,
     strings::StringWalker,
     walkers::*,
 };
@@ -118,6 +119,10 @@ impl Subgraphs {
             .filter_map(|name| self.strings.lookup(name))
             .map(|string| self.walk(string))
     }
+
+    pub(crate) fn iter_subgraphs(&self) -> impl Iterator<Item = SubgraphWalker<'_>> {
+        (0..self.subgraphs.len()).map(|idx| self.walk(SubgraphId(idx)))
+    }
 }
 
 pub(crate) struct Subgraph {
@@ -128,3 +133,9 @@ pub(crate) struct Subgraph {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct SubgraphId(usize);
+
+impl SubgraphId {
+    pub(crate) fn idx(self) -> usize {
+        self.0
+    }
+}

--- a/crates/composition/src/subgraphs/definitions.rs
+++ b/crates/composition/src/subgraphs/definitions.rs
@@ -72,7 +72,7 @@ impl<'a> DefinitionWalker<'a> {
     }
 
     pub fn is_entity(self) -> bool {
-        self.subgraphs.iter_object_keys(self.id).next().is_some()
+        self.entity_keys().next().is_some()
     }
 
     pub fn is_shareable(self) -> bool {

--- a/crates/composition/src/subgraphs/fields.rs
+++ b/crates/composition/src/subgraphs/fields.rs
@@ -83,20 +83,19 @@ impl<'a> FieldWalker<'a> {
     /// key).
     pub fn is_key(self) -> bool {
         let field = self.field();
-        self.subgraphs
-            .iter_object_keys(field.parent_definition_id)
-            .any(|key| {
-                let mut key_fields = key.fields();
-                let Some(first_field) = key_fields.next() else {
-                    return false;
-                };
+        self.parent_definition().entity_keys().any(|key| {
+            let mut key_fields = key.fields().iter();
 
-                if key_fields.next().is_some() || !first_field.subselection.is_empty() {
-                    return false;
-                }
+            let Some(first_field) = key_fields.next() else {
+                return false;
+            };
 
-                first_field.field == field.name
-            })
+            if key_fields.next().is_some() || !first_field.subselection.is_empty() {
+                return false;
+            }
+
+            first_field.field == field.name
+        })
     }
 
     pub fn is_shareable(self) -> bool {

--- a/crates/composition/src/subgraphs/walkers.rs
+++ b/crates/composition/src/subgraphs/walkers.rs
@@ -21,7 +21,11 @@ impl<'a> SubgraphWalker<'a> {
         &self.subgraphs.subgraphs[self.id.0]
     }
 
-    pub(crate) fn name_str(self) -> &'a str {
-        self.subgraphs.strings.resolve(self.subgraph().name)
+    pub(crate) fn name(self) -> StringWalker<'a> {
+        self.walk(self.subgraph().name)
+    }
+
+    pub(crate) fn url(self) -> StringWalker<'a> {
+        self.walk(self.subgraph().name) // TODO: take the url as input
     }
 }

--- a/crates/composition/tests/composition/enum_only_outputs/federated.graphql
+++ b/crates/composition/tests/composition/enum_only_outputs/federated.graphql
@@ -4,6 +4,9 @@ type Activity {
     participatingTeletubby: Teletubby!
 }
 
+# Entity with key (name) in `activities`
+# Entity with key (name) in `episodes`
+# Entity with key (name) in `teletubbyRepository`
 type Teletubby {
     activities: [Activity]
     name: String!

--- a/crates/federated-graph/src/federated_graph.rs
+++ b/crates/federated-graph/src/federated_graph.rs
@@ -128,7 +128,7 @@ pub enum Value {
     List(Vec<Value>),
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Copy)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum Definition {
     Scalar(ScalarId),
     Object(ObjectId),

--- a/crates/federated-graph/src/federated_graph.rs
+++ b/crates/federated-graph/src/federated_graph.rs
@@ -67,7 +67,7 @@ pub struct ObjectField {
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct Key {
-    /// The subgraph that can resolve the entity with these fields.
+    /// The subgraph that can resolve the entity with the fields in [Key::fields].
     pub subgraph_id: SubgraphId,
 
     /// Corresponds to the fields in an `@key` directive.


### PR DESCRIPTION
Populate the grafbase_federated_graph::Object::resolvable_keys list for each object.

closes GB-5266

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
