### PR TITLE
fix: correct the error on UDF build errors

### DIFF
--- a/cli/crates/server/src/bridge/server.rs
+++ b/cli/crates/server/src/bridge/server.rs
@@ -110,10 +110,7 @@ impl BridgeState for Arc<HandlerState> {
     }
 
     async fn build_all_udfs(&self, udfs: Vec<DetectedUdf>, parallelism: NonZeroUsize) -> Result<(), ServerError> {
-        self.udf_runtime
-            .build_all(udfs, parallelism)
-            .await
-            .map_err(|_| ServerError::NodeInPath)
+        Ok(self.udf_runtime.build_all(udfs, parallelism).await?)
     }
 }
 

--- a/cli/crates/server/src/errors.rs
+++ b/cli/crates/server/src/errors.rs
@@ -184,6 +184,9 @@ pub enum ServerError {
 
     #[error("Could not release the lock for the wrangler installation: {0}")]
     Unlock(fslock::Error),
+
+    #[error(transparent)]
+    UdfBuildError(#[from] UdfBuildError),
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
It was wrong, leading to a very confusing "node isn't installed" error if a resolver failed to build.