### PR TITLE
composition: handle missing `Query` without panicking

### DIFF
--- a/crates/composition/src/compose.rs
+++ b/crates/composition/src/compose.rs
@@ -32,6 +32,11 @@ pub(crate) fn compose_subgraphs(ctx: &mut Context<'_>) {
 
     ctx.subgraphs
         .iter_field_groups(|fields| merge_field_definitions(ctx, fields));
+
+    if !ctx.has_query_type() {
+        ctx.diagnostics
+            .push_fatal("The root `Query` object is not defined in any subgraph.".to_owned());
+    }
 }
 
 fn merge_object_definitions<'a>(

--- a/crates/composition/src/compose/context.rs
+++ b/crates/composition/src/compose/context.rs
@@ -33,6 +33,10 @@ impl<'a> Context<'a> {
         }
     }
 
+    pub(crate) fn has_query_type(&self) -> bool {
+        self.ir.query_type.is_some()
+    }
+
     pub(crate) fn into_ir(self) -> CompositionIr {
         self.ir
     }

--- a/crates/composition/src/composition_ir.rs
+++ b/crates/composition/src/composition_ir.rs
@@ -24,6 +24,15 @@ pub(crate) struct CompositionIr {
     pub(crate) scalars: Vec<federated::Scalar>,
     pub(crate) input_objects: Vec<federated::InputObject>,
 
+    /// The root `Query` type
+    pub(crate) query_type: Option<federated::ObjectId>,
+
+    /// The root `Mutation` type
+    pub(crate) mutation_type: Option<federated::ObjectId>,
+
+    /// The root `Subscription` type
+    pub(crate) subscription_type: Option<federated::ObjectId>,
+
     pub(crate) strings: StringsIr,
     pub(crate) fields: Vec<FieldIr>,
     pub(crate) union_members: BTreeSet<(subgraphs::StringId, subgraphs::StringId)>,
@@ -105,6 +114,15 @@ impl CompositionIr {
         let id = federated::ObjectId(self.objects.push_return_idx(object));
         self.definitions_by_name
             .insert(object_name.id, federated::Definition::Object(id));
+
+        // FIXME: Those roots probably shouldn't be hardcoded.
+        match object_name.as_str() {
+            "Query" => self.query_type = Some(id),
+            "Mutation" => self.mutation_type = Some(id),
+            "Subscription" => self.subscription_type = Some(id),
+            _ => (),
+        }
+
         id
     }
 

--- a/crates/composition/src/emit_federated_graph.rs
+++ b/crates/composition/src/emit_federated_graph.rs
@@ -16,19 +16,6 @@ pub(crate) fn emit_federated_graph(
     mut ir: CompositionIr,
     subgraphs: &Subgraphs,
 ) -> federated::FederatedGraph {
-    let find_object = |name: &str| {
-        ir.objects.iter().enumerate().find_map(|(id, object)| {
-            if ir.strings.strings[object.name.0] == name {
-                Some(federated::ObjectId(id))
-            } else {
-                None
-            }
-        })
-    };
-    // FIXME: Those roots probably shouldn't be hardcoded.
-    let query_object_id = find_object("Query").expect("Query root operation type not found");
-    let mutation_object_id = find_object("Mutation");
-    let subscription_object_id = find_object("Subscription");
     let mut out = federated::FederatedGraph {
         enums: mem::take(&mut ir.enums),
         objects: mem::take(&mut ir.objects),
@@ -39,9 +26,9 @@ pub(crate) fn emit_federated_graph(
         strings: mem::take(&mut ir.strings.strings),
         subgraphs: vec![],
         root_operation_types: RootOperationTypes {
-            query: query_object_id,
-            mutation: mutation_object_id,
-            subscription: subscription_object_id,
+            query: ir.query_type.unwrap(),
+            mutation: ir.mutation_type,
+            subscription: ir.subscription_type,
         },
         object_fields: vec![],
         interface_fields: vec![],

--- a/crates/composition/tests/composition/input_objects_nonshared_required_field/subgraphs/cyclist.graphql
+++ b/crates/composition/tests/composition/input_objects_nonshared_required_field/subgraphs/cyclist.graphql
@@ -1,3 +1,7 @@
+type Query {
+  cyclistByStartNumber(number: Int): Cyclist
+}
+
 type Mutation {
   createCyclist(input: CyclistInput): Cyclist
 }

--- a/crates/composition/tests/composition/missing_query_type/federated.graphql
+++ b/crates/composition/tests/composition/missing_query_type/federated.graphql
@@ -1,0 +1,1 @@
+# The root `Query` object is not defined in any subgraph.

--- a/crates/composition/tests/composition/missing_query_type/subgraphs/one.graphql
+++ b/crates/composition/tests/composition/missing_query_type/subgraphs/one.graphql
@@ -1,0 +1,3 @@
+type un {
+  id: ID!
+}

--- a/crates/composition/tests/composition/missing_query_type/subgraphs/two.graphql
+++ b/crates/composition/tests/composition/missing_query_type/subgraphs/two.graphql
@@ -1,0 +1,3 @@
+type deux {
+  id: ID!
+}

--- a/crates/composition/tests/composition/object_fields_clash/subgraphs/label.graphql
+++ b/crates/composition/tests/composition/object_fields_clash/subgraphs/label.graphql
@@ -2,3 +2,7 @@ type Band {
     name: String!
     revenue: Int
 }
+
+type Query {
+  todaysBand: Band!
+}

--- a/crates/composition/tests/composition/object_interface_clash/subgraphs/accounting.graphql
+++ b/crates/composition/tests/composition/object_interface_clash/subgraphs/accounting.graphql
@@ -3,3 +3,6 @@ type Customer {
     name: String!
 }
 
+type Query {
+  getCustomer(name: String): Customer
+}


### PR DESCRIPTION
By moving finding the root types from emit_federated_graph to composition, where we can produce diagnostics.

