### PR TITLE
fix: don't assume templates are SDL based in init

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -4480,7 +4480,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.6"
-source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#69df3c14a26e604396ef46caa7ded791686f34ce"
+source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#9913ef3e5e61205d232773ac3caabbc95d310944"
 dependencies = [
  "base64 0.21.2",
  "byteorder",
@@ -4498,7 +4498,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.6"
-source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#69df3c14a26e604396ef46caa7ded791686f34ce"
+source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#9913ef3e5e61205d232773ac3caabbc95d310944"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -6695,7 +6695,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.10"
-source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#69df3c14a26e604396ef46caa7ded791686f34ce"
+source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#9913ef3e5e61205d232773ac3caabbc95d310944"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -4480,7 +4480,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.6"
-source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#9913ef3e5e61205d232773ac3caabbc95d310944"
+source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#69df3c14a26e604396ef46caa7ded791686f34ce"
 dependencies = [
  "base64 0.21.2",
  "byteorder",
@@ -4498,7 +4498,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.6"
-source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#9913ef3e5e61205d232773ac3caabbc95d310944"
+source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#69df3c14a26e604396ef46caa7ded791686f34ce"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -6695,7 +6695,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.10"
-source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#9913ef3e5e61205d232773ac3caabbc95d310944"
+source = "git+https://github.com/grafbase/rust-postgres/?branch=grafbase#69df3c14a26e604396ef46caa7ded791686f34ce"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/cli/crates/backend/src/project.rs
+++ b/cli/crates/backend/src/project.rs
@@ -96,7 +96,6 @@ pub enum Template<'a> {
 /// - returns [`BackendError::GetRepositoryInformation`] if the request to get the information for a repository returned a non 200-299 status
 ///
 /// - returns [`BackendError::ReadRepositoryInformation`] if the request to get the information for a repository returned a response that could not be parsed
-// #[tokio::main]
 pub fn init(name: Option<&str>, template: Template<'_>) -> Result<ConfigType, BackendError> {
     let project_path = to_project_path(name)?;
     let grafbase_path = project_path.join(GRAFBASE_DIRECTORY_NAME);

--- a/cli/crates/cli/src/init.rs
+++ b/cli/crates/cli/src/init.rs
@@ -19,8 +19,8 @@ pub fn init(name: Option<&str>, template: Option<&str>, config_format: Option<Co
         }
     };
 
-    project::init(name, template).map_err(CliError::BackendError)?;
-    report::project_created(name, template);
+    let config_type = project::init(name, template).map_err(CliError::BackendError)?;
+    report::project_created(name, config_type);
 
     Ok(())
 }

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -51,7 +51,7 @@ pub fn start_dev_server(resolvers_reported: bool, port: u16, start_port: u16) {
     );
 }
 
-pub fn project_created(name: Option<&str>, config_type: ConfigType /*template: Template<'_>*/) {
+pub fn project_created(name: Option<&str>, config_type: ConfigType) {
     let slash = std::path::MAIN_SEPARATOR.to_string();
 
     let schema_file_name = match config_type {

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -5,7 +5,7 @@ use crate::{
     watercolor::{self, watercolor},
 };
 use backend::{
-    project::{ConfigType, Template},
+    project::ConfigType,
     types::{NestedRequestScopedMessage, RequestCompletedOutcome},
 };
 use colored::Colorize;
@@ -51,12 +51,12 @@ pub fn start_dev_server(resolvers_reported: bool, port: u16, start_port: u16) {
     );
 }
 
-pub fn project_created(name: Option<&str>, template: Template<'_>) {
+pub fn project_created(name: Option<&str>, config_type: ConfigType /*template: Template<'_>*/) {
     let slash = std::path::MAIN_SEPARATOR.to_string();
 
-    let schema_file_name = match template {
-        Template::FromDefault(ConfigType::TypeScript) => GRAFBASE_TS_CONFIG_FILE_NAME,
-        _ => GRAFBASE_SCHEMA_FILE_NAME,
+    let schema_file_name = match config_type {
+        ConfigType::TypeScript => GRAFBASE_TS_CONFIG_FILE_NAME,
+        ConfigType::GraphQL => GRAFBASE_SCHEMA_FILE_NAME,
     };
 
     if let Some(name) = name {
@@ -74,12 +74,12 @@ pub fn project_created(name: Option<&str>, template: Template<'_>) {
         let schema_path = &[".", GRAFBASE_DIRECTORY_NAME, schema_file_name].join(&slash);
 
         println!(
-            "Your new schema can be found at {}",
+            "Your new configuration can be found at {}",
             watercolor!("{schema_path}", @BrightBlue)
         );
     }
 
-    if let Template::FromDefault(ConfigType::TypeScript) = template {
+    if let ConfigType::TypeScript = config_type {
         println!(
             "We've added our SDK to your {}, make sure to install dependencies before continuing.",
             watercolor!("package.json", @BrightBlue)


### PR DESCRIPTION
`grafbase init` can set up a project from a template.  The output assumed that all the templates were written using SDL though, and always pointed the user at a `schema.graphql` file.  This makes it a little smarter: it'll now do the right thing depending on the template.

Unfortunately had to get rid of a `tokio::main` attr because it didn't like  return values, but 🤷‍♂️.