### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/examples/nuxt/src/plugins/urql.ts
+++ b/examples/nuxt/src/plugins/urql.ts
@@ -5,7 +5,7 @@ import urql, {
   ssrExchange
 } from '@urql/vue'
 import { devtoolsExchange } from '@urql/devtools'
-import { defineNuxtPlugin, useRuntimeConfig } from '#app'
+import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 import { cacheExchange } from '@/graphql/urql.exchange'
 
 export default defineNuxtPlugin((nuxtApp) => {


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update

This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.