### PR TITLE
fix: `@deprecated` directive

### DIFF
--- a/engine/crates/engine/src/registry/export_sdl.rs
+++ b/engine/crates/engine/src/registry/export_sdl.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 
-use super::{EnumType, InputObjectType, InterfaceType, ObjectType, ScalarType, UnionType};
+use super::{Deprecation, EnumType, InputObjectType, InterfaceType, ObjectType, ScalarType, UnionType};
 use crate::registry::{MetaField, MetaInputValue, MetaType, Registry};
 
 impl Registry {
@@ -62,6 +62,13 @@ impl Registry {
                 write!(sdl, "): {}", field.ty).ok();
             } else {
                 write!(sdl, "\t{}: {}", field.name, field.ty).ok();
+            }
+
+            if let Deprecation::Deprecated { reason } = &field.deprecation {
+                write!(sdl, " @deprecated").ok();
+                if let Some(reason) = reason {
+                    write!(sdl, "(reason: \"{}\")", reason.escape_default()).ok();
+                }
             }
 
             if federation {
@@ -201,7 +208,15 @@ impl Registry {
                 write!(sdl, "enum {name} ").ok();
                 writeln!(sdl, "{{").ok();
                 for value in enum_values.values() {
-                    writeln!(sdl, "\t{}", value.name).ok();
+                    write!(sdl, "\t{}", value.name).ok();
+
+                    if let Deprecation::Deprecated { reason } = &value.deprecation {
+                        write!(sdl, " @deprecated").ok();
+                        if let Some(reason) = reason {
+                            write!(sdl, "(reason: \"{}\")", reason.escape_default()).ok();
+                        }
+                    }
+                    writeln!(sdl).ok();
                 }
                 writeln!(sdl, "}}").ok();
             }

--- a/engine/crates/engine/src/registry/mod.rs
+++ b/engine/crates/engine/src/registry/mod.rs
@@ -292,7 +292,7 @@ impl From<Constraint> for dynamodb::export::graph_entities::ConstraintDefinition
 }
 
 #[serde_with::minify_field_names(serialize = "minified", deserialize = "minified")]
-#[serde_with::skip_serializing_defaults(Option, Vec, bool, CacheControl)]
+#[serde_with::skip_serializing_defaults(Option, Vec, bool, CacheControl, Deprecation)]
 #[derive(Clone, Default, derivative::Derivative, serde::Deserialize, serde::Serialize)]
 #[derivative(Debug)]
 pub struct MetaField {
@@ -546,6 +546,10 @@ impl MetaEnumValue {
 
     pub fn with_description(self, description: Option<String>) -> Self {
         MetaEnumValue { description, ..self }
+    }
+
+    pub fn with_deprecation(self, deprecation: Deprecation) -> Self {
+        MetaEnumValue { deprecation, ..self }
     }
 }
 

--- a/engine/crates/engine/src/registry/tests.rs
+++ b/engine/crates/engine/src/registry/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use sha2::{Digest, Sha256};
 use std::borrow::Cow;
 
-const EXPECTED_SHA: &str = "d7e48694f72c0a6246eabb79bae2ce2aa44bf27f5e2b1e8b9e245fc7b5d08964";
+const EXPECTED_SHA: &str = "86586b4bbc667719c8b977a7f587691fc43c68937937c255c0fcd6de267f89f6";
 
 #[test]
 fn test_serde_roundtrip() {

--- a/engine/crates/parser-graphql/src/snapshots/parser_graphql__conversion__tests__array_input_value.snap
+++ b/engine/crates/parser-graphql/src/snapshots/parser_graphql__conversion__tests__array_input_value.snap
@@ -18,20 +18,17 @@ expression: registry_from_introspection(schema)
           "code": {
             "n": "code",
             "a": {},
-            "t": "ID!",
-            "D": "N"
+            "t": "ID!"
           },
           "countries": {
             "n": "countries",
             "a": {},
-            "t": "[Country!]!",
-            "D": "N"
+            "t": "[Country!]!"
           },
           "name": {
             "n": "name",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           }
         },
         "r": "Continent"
@@ -56,56 +53,47 @@ expression: registry_from_introspection(schema)
           "awsRegion": {
             "n": "awsRegion",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "capital": {
             "n": "capital",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "code": {
             "n": "code",
             "a": {},
-            "t": "ID!",
-            "D": "N"
+            "t": "ID!"
           },
           "continent": {
             "n": "continent",
             "a": {},
-            "t": "Continent!",
-            "D": "N"
+            "t": "Continent!"
           },
           "currencies": {
             "n": "currencies",
             "a": {},
-            "t": "[String!]!",
-            "D": "N"
+            "t": "[String!]!"
           },
           "currency": {
             "n": "currency",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "emoji": {
             "n": "emoji",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "emojiU": {
             "n": "emojiU",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "languages": {
             "n": "languages",
             "a": {},
-            "t": "[Language!]!",
-            "D": "N"
+            "t": "[Language!]!"
           },
           "name": {
             "n": "name",
@@ -115,38 +103,32 @@ expression: registry_from_introspection(schema)
                 "t": "String"
               }
             },
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "native": {
             "n": "native",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "phone": {
             "n": "phone",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "phones": {
             "n": "phones",
             "a": {},
-            "t": "[String!]!",
-            "D": "N"
+            "t": "[String!]!"
           },
           "states": {
             "n": "states",
             "a": {},
-            "t": "[State!]!",
-            "D": "N"
+            "t": "[State!]!"
           },
           "subdivisions": {
             "n": "subdivisions",
             "a": {},
-            "t": "[Subdivision!]!",
-            "D": "N"
+            "t": "[Subdivision!]!"
           }
         },
         "r": "Country"
@@ -200,26 +182,22 @@ expression: registry_from_introspection(schema)
           "code": {
             "n": "code",
             "a": {},
-            "t": "ID!",
-            "D": "N"
+            "t": "ID!"
           },
           "name": {
             "n": "name",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "native": {
             "n": "native",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "rtl": {
             "n": "rtl",
             "a": {},
-            "t": "Boolean!",
-            "D": "N"
+            "t": "Boolean!"
           }
         },
         "r": "Language"
@@ -249,8 +227,7 @@ expression: registry_from_introspection(schema)
                 "t": "ID!"
               }
             },
-            "t": "Continent",
-            "D": "N"
+            "t": "Continent"
           },
           "continents": {
             "n": "continents",
@@ -261,8 +238,7 @@ expression: registry_from_introspection(schema)
                 "D": "{}"
               }
             },
-            "t": "[Continent!]!",
-            "D": "N"
+            "t": "[Continent!]!"
           },
           "countries": {
             "n": "countries",
@@ -273,8 +249,7 @@ expression: registry_from_introspection(schema)
                 "D": "{}"
               }
             },
-            "t": "[Country!]!",
-            "D": "N"
+            "t": "[Country!]!"
           },
           "country": {
             "n": "country",
@@ -284,8 +259,7 @@ expression: registry_from_introspection(schema)
                 "t": "ID!"
               }
             },
-            "t": "Country",
-            "D": "N"
+            "t": "Country"
           },
           "language": {
             "n": "language",
@@ -295,8 +269,7 @@ expression: registry_from_introspection(schema)
                 "t": "ID!"
               }
             },
-            "t": "Language",
-            "D": "N"
+            "t": "Language"
           },
           "languages": {
             "n": "languages",
@@ -307,8 +280,7 @@ expression: registry_from_introspection(schema)
                 "D": "{}"
               }
             },
-            "t": "[Language!]!",
-            "D": "N"
+            "t": "[Language!]!"
           }
         },
         "r": "Query"
@@ -321,20 +293,17 @@ expression: registry_from_introspection(schema)
           "code": {
             "n": "code",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "country": {
             "n": "country",
             "a": {},
-            "t": "Country!",
-            "D": "N"
+            "t": "Country!"
           },
           "name": {
             "n": "name",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           }
         },
         "r": "State"
@@ -382,20 +351,17 @@ expression: registry_from_introspection(schema)
           "code": {
             "n": "code",
             "a": {},
-            "t": "ID!",
-            "D": "N"
+            "t": "ID!"
           },
           "emoji": {
             "n": "emoji",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "name": {
             "n": "name",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           }
         },
         "r": "Subdivision"
@@ -415,32 +381,27 @@ expression: registry_from_introspection(schema)
                 "D": "false"
               }
             },
-            "t": "[__InputValue!]!",
-            "D": "N"
+            "t": "[__InputValue!]!"
           },
           "description": {
             "n": "description",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "isRepeatable": {
             "n": "isRepeatable",
             "a": {},
-            "t": "Boolean!",
-            "D": "N"
+            "t": "Boolean!"
           },
           "locations": {
             "n": "locations",
             "a": {},
-            "t": "[__DirectiveLocation!]!",
-            "D": "N"
+            "t": "[__DirectiveLocation!]!"
           },
           "name": {
             "n": "name",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           }
         },
         "r": "__Directive"
@@ -539,26 +500,22 @@ expression: registry_from_introspection(schema)
           "deprecationReason": {
             "n": "deprecationReason",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "description": {
             "n": "description",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "isDeprecated": {
             "n": "isDeprecated",
             "a": {},
-            "t": "Boolean!",
-            "D": "N"
+            "t": "Boolean!"
           },
           "name": {
             "n": "name",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           }
         },
         "r": "__EnumValue"
@@ -578,38 +535,32 @@ expression: registry_from_introspection(schema)
                 "D": "false"
               }
             },
-            "t": "[__InputValue!]!",
-            "D": "N"
+            "t": "[__InputValue!]!"
           },
           "deprecationReason": {
             "n": "deprecationReason",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "description": {
             "n": "description",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "isDeprecated": {
             "n": "isDeprecated",
             "a": {},
-            "t": "Boolean!",
-            "D": "N"
+            "t": "Boolean!"
           },
           "name": {
             "n": "name",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "type": {
             "n": "type",
             "a": {},
-            "t": "__Type!",
-            "D": "N"
+            "t": "__Type!"
           }
         },
         "r": "__Field"
@@ -624,38 +575,32 @@ expression: registry_from_introspection(schema)
             "n": "defaultValue",
             "d": "A GraphQL-formatted string representing the default value for this input value.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "deprecationReason": {
             "n": "deprecationReason",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "description": {
             "n": "description",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "isDeprecated": {
             "n": "isDeprecated",
             "a": {},
-            "t": "Boolean!",
-            "D": "N"
+            "t": "Boolean!"
           },
           "name": {
             "n": "name",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "type": {
             "n": "type",
             "a": {},
-            "t": "__Type!",
-            "D": "N"
+            "t": "__Type!"
           }
         },
         "r": "__InputValue"
@@ -669,43 +614,37 @@ expression: registry_from_introspection(schema)
           "description": {
             "n": "description",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "directives": {
             "n": "directives",
             "d": "A list of all directives supported by this server.",
             "a": {},
-            "t": "[__Directive!]!",
-            "D": "N"
+            "t": "[__Directive!]!"
           },
           "mutationType": {
             "n": "mutationType",
             "d": "If this server supports mutation, the type that mutation operations will be rooted at.",
             "a": {},
-            "t": "__Type",
-            "D": "N"
+            "t": "__Type"
           },
           "queryType": {
             "n": "queryType",
             "d": "The type that query operations will be rooted at.",
             "a": {},
-            "t": "__Type!",
-            "D": "N"
+            "t": "__Type!"
           },
           "subscriptionType": {
             "n": "subscriptionType",
             "d": "If this server support subscription, the type that subscription operations will be rooted at.",
             "a": {},
-            "t": "__Type",
-            "D": "N"
+            "t": "__Type"
           },
           "types": {
             "n": "types",
             "d": "A list of all types supported by this server.",
             "a": {},
-            "t": "[__Type!]!",
-            "D": "N"
+            "t": "[__Type!]!"
           }
         },
         "r": "__Schema"
@@ -719,8 +658,7 @@ expression: registry_from_introspection(schema)
           "description": {
             "n": "description",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "enumValues": {
             "n": "enumValues",
@@ -731,8 +669,7 @@ expression: registry_from_introspection(schema)
                 "D": "false"
               }
             },
-            "t": "[__EnumValue!]",
-            "D": "N"
+            "t": "[__EnumValue!]"
           },
           "fields": {
             "n": "fields",
@@ -743,8 +680,7 @@ expression: registry_from_introspection(schema)
                 "D": "false"
               }
             },
-            "t": "[__Field!]",
-            "D": "N"
+            "t": "[__Field!]"
           },
           "inputFields": {
             "n": "inputFields",
@@ -755,44 +691,37 @@ expression: registry_from_introspection(schema)
                 "D": "false"
               }
             },
-            "t": "[__InputValue!]",
-            "D": "N"
+            "t": "[__InputValue!]"
           },
           "interfaces": {
             "n": "interfaces",
             "a": {},
-            "t": "[__Type!]",
-            "D": "N"
+            "t": "[__Type!]"
           },
           "kind": {
             "n": "kind",
             "a": {},
-            "t": "__TypeKind!",
-            "D": "N"
+            "t": "__TypeKind!"
           },
           "name": {
             "n": "name",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "ofType": {
             "n": "ofType",
             "a": {},
-            "t": "__Type",
-            "D": "N"
+            "t": "__Type"
           },
           "possibleTypes": {
             "n": "possibleTypes",
             "a": {},
-            "t": "[__Type!]",
-            "D": "N"
+            "t": "[__Type!]"
           },
           "specifiedByURL": {
             "n": "specifiedByURL",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           }
         },
         "r": "__Type"

--- a/engine/crates/parser-graphql/src/snapshots/parser_graphql__conversion__tests__conversion.snap
+++ b/engine/crates/parser-graphql/src/snapshots/parser_graphql__conversion__tests__conversion.snap
@@ -36,50 +36,43 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "FilmCharactersConnection",
-            "D": "N"
+            "t": "FilmCharactersConnection"
           },
           "created": {
             "n": "created",
             "d": "The ISO 8601 date format of the time that this resource was created.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "director": {
             "n": "director",
             "d": "The name of the director of this film.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "edited": {
             "n": "edited",
             "d": "The ISO 8601 date format of the time that this resource was edited.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "episodeID": {
             "n": "episodeID",
             "d": "The episode number of this film.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           },
           "id": {
             "n": "id",
             "d": "The ID of an object",
             "a": {},
-            "t": "ID!",
-            "D": "N"
+            "t": "ID!"
           },
           "openingCrawl": {
             "n": "openingCrawl",
             "d": "The opening paragraphs at the beginning of this film.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "planetConnection": {
             "n": "planetConnection",
@@ -101,22 +94,19 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "FilmPlanetsConnection",
-            "D": "N"
+            "t": "FilmPlanetsConnection"
           },
           "producers": {
             "n": "producers",
             "d": "The name(s) of the producer(s) of this film.",
             "a": {},
-            "t": "[String]",
-            "D": "N"
+            "t": "[String]"
           },
           "releaseDate": {
             "n": "releaseDate",
             "d": "The ISO 8601 date format of film release at original creator country.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "speciesConnection": {
             "n": "speciesConnection",
@@ -138,8 +128,7 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "FilmSpeciesConnection",
-            "D": "N"
+            "t": "FilmSpeciesConnection"
           },
           "starshipConnection": {
             "n": "starshipConnection",
@@ -161,15 +150,13 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "FilmStarshipsConnection",
-            "D": "N"
+            "t": "FilmStarshipsConnection"
           },
           "title": {
             "n": "title",
             "d": "The title of this film.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "vehicleConnection": {
             "n": "vehicleConnection",
@@ -191,8 +178,7 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "FilmVehiclesConnection",
-            "D": "N"
+            "t": "FilmVehiclesConnection"
           }
         },
         "r": "Film"
@@ -207,29 +193,25 @@ expression: registry_from_introspection(schema)
             "n": "characters",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Person]",
-            "D": "N"
+            "t": "[Person]"
           },
           "edges": {
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[FilmCharactersEdge]",
-            "D": "N"
+            "t": "[FilmCharactersEdge]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           }
         },
         "r": "FilmCharactersConnection"
@@ -244,15 +226,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Person",
-            "D": "N"
+            "t": "Person"
           }
         },
         "r": "FilmCharactersEdge"
@@ -267,29 +247,25 @@ expression: registry_from_introspection(schema)
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[FilmPlanetsEdge]",
-            "D": "N"
+            "t": "[FilmPlanetsEdge]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "planets": {
             "n": "planets",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Planet]",
-            "D": "N"
+            "t": "[Planet]"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           }
         },
         "r": "FilmPlanetsConnection"
@@ -304,15 +280,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Planet",
-            "D": "N"
+            "t": "Planet"
           }
         },
         "r": "FilmPlanetsEdge"
@@ -327,29 +301,25 @@ expression: registry_from_introspection(schema)
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[FilmSpeciesEdge]",
-            "D": "N"
+            "t": "[FilmSpeciesEdge]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "species": {
             "n": "species",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Species]",
-            "D": "N"
+            "t": "[Species]"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           }
         },
         "r": "FilmSpeciesConnection"
@@ -364,15 +334,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Species",
-            "D": "N"
+            "t": "Species"
           }
         },
         "r": "FilmSpeciesEdge"
@@ -387,29 +355,25 @@ expression: registry_from_introspection(schema)
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[FilmStarshipsEdge]",
-            "D": "N"
+            "t": "[FilmStarshipsEdge]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "starships": {
             "n": "starships",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Starship]",
-            "D": "N"
+            "t": "[Starship]"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           }
         },
         "r": "FilmStarshipsConnection"
@@ -424,15 +388,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Starship",
-            "D": "N"
+            "t": "Starship"
           }
         },
         "r": "FilmStarshipsEdge"
@@ -447,29 +409,25 @@ expression: registry_from_introspection(schema)
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[FilmVehiclesEdge]",
-            "D": "N"
+            "t": "[FilmVehiclesEdge]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           },
           "vehicles": {
             "n": "vehicles",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Vehicle]",
-            "D": "N"
+            "t": "[Vehicle]"
           }
         },
         "r": "FilmVehiclesConnection"
@@ -484,15 +442,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Vehicle",
-            "D": "N"
+            "t": "Vehicle"
           }
         },
         "r": "FilmVehiclesEdge"
@@ -507,29 +463,25 @@ expression: registry_from_introspection(schema)
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[FilmsEdge]",
-            "D": "N"
+            "t": "[FilmsEdge]"
           },
           "films": {
             "n": "films",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Film]",
-            "D": "N"
+            "t": "[Film]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           }
         },
         "r": "FilmsConnection"
@@ -544,15 +496,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Film",
-            "D": "N"
+            "t": "Film"
           }
         },
         "r": "FilmsEdge"
@@ -588,8 +538,7 @@ expression: registry_from_introspection(schema)
             "n": "id",
             "d": "The id of the object.",
             "a": {},
-            "t": "ID!",
-            "D": "N"
+            "t": "ID!"
           }
         },
         "p": [
@@ -612,29 +561,25 @@ expression: registry_from_introspection(schema)
             "n": "endCursor",
             "d": "When paginating forwards, the cursor to continue.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "hasNextPage": {
             "n": "hasNextPage",
             "d": "When paginating forwards, are there more items?",
             "a": {},
-            "t": "Boolean!",
-            "D": "N"
+            "t": "Boolean!"
           },
           "hasPreviousPage": {
             "n": "hasPreviousPage",
             "d": "When paginating backwards, are there more items?",
             "a": {},
-            "t": "Boolean!",
-            "D": "N"
+            "t": "Boolean!"
           },
           "startCursor": {
             "n": "startCursor",
             "d": "When paginating backwards, the cursor to continue.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           }
         },
         "r": "PageInfo"
@@ -649,29 +594,25 @@ expression: registry_from_introspection(schema)
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[PeopleEdge]",
-            "D": "N"
+            "t": "[PeopleEdge]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "people": {
             "n": "people",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Person]",
-            "D": "N"
+            "t": "[Person]"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           }
         },
         "r": "PeopleConnection"
@@ -686,15 +627,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Person",
-            "D": "N"
+            "t": "Person"
           }
         },
         "r": "PeopleEdge"
@@ -709,29 +648,25 @@ expression: registry_from_introspection(schema)
             "n": "birthYear",
             "d": "The birth year of the person, using the in-universe standard of BBY or ABY -\nBefore the Battle of Yavin or After the Battle of Yavin. The Battle of Yavin is\na battle that occurs at the end of Star Wars episode IV: A New Hope.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "created": {
             "n": "created",
             "d": "The ISO 8601 date format of the time that this resource was created.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "edited": {
             "n": "edited",
             "d": "The ISO 8601 date format of the time that this resource was edited.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "eyeColor": {
             "n": "eyeColor",
             "d": "The eye color of this person. Will be \"unknown\" if not known or \"n/a\" if the\nperson does not have an eye.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "filmConnection": {
             "n": "filmConnection",
@@ -753,71 +688,61 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "PersonFilmsConnection",
-            "D": "N"
+            "t": "PersonFilmsConnection"
           },
           "gender": {
             "n": "gender",
             "d": "The gender of this person. Either \"Male\", \"Female\" or \"unknown\",\n\"n/a\" if the person does not have a gender.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "hairColor": {
             "n": "hairColor",
             "d": "The hair color of this person. Will be \"unknown\" if not known or \"n/a\" if the\nperson does not have hair.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "height": {
             "n": "height",
             "d": "The height of the person in centimeters.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           },
           "homeworld": {
             "n": "homeworld",
             "d": "A planet that this person was born on or inhabits.",
             "a": {},
-            "t": "Planet",
-            "D": "N"
+            "t": "Planet"
           },
           "id": {
             "n": "id",
             "d": "The ID of an object",
             "a": {},
-            "t": "ID!",
-            "D": "N"
+            "t": "ID!"
           },
           "mass": {
             "n": "mass",
             "d": "The mass of the person in kilograms.",
             "a": {},
-            "t": "Float",
-            "D": "N"
+            "t": "Float"
           },
           "name": {
             "n": "name",
             "d": "The name of this person.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "skinColor": {
             "n": "skinColor",
             "d": "The skin color of this person.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "species": {
             "n": "species",
             "d": "The species that this person belongs to, or null if unknown.",
             "a": {},
-            "t": "Species",
-            "D": "N"
+            "t": "Species"
           },
           "starshipConnection": {
             "n": "starshipConnection",
@@ -839,8 +764,7 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "PersonStarshipsConnection",
-            "D": "N"
+            "t": "PersonStarshipsConnection"
           },
           "vehicleConnection": {
             "n": "vehicleConnection",
@@ -862,8 +786,7 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "PersonVehiclesConnection",
-            "D": "N"
+            "t": "PersonVehiclesConnection"
           }
         },
         "r": "Person"
@@ -878,29 +801,25 @@ expression: registry_from_introspection(schema)
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[PersonFilmsEdge]",
-            "D": "N"
+            "t": "[PersonFilmsEdge]"
           },
           "films": {
             "n": "films",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Film]",
-            "D": "N"
+            "t": "[Film]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           }
         },
         "r": "PersonFilmsConnection"
@@ -915,15 +834,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Film",
-            "D": "N"
+            "t": "Film"
           }
         },
         "r": "PersonFilmsEdge"
@@ -938,29 +855,25 @@ expression: registry_from_introspection(schema)
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[PersonStarshipsEdge]",
-            "D": "N"
+            "t": "[PersonStarshipsEdge]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "starships": {
             "n": "starships",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Starship]",
-            "D": "N"
+            "t": "[Starship]"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           }
         },
         "r": "PersonStarshipsConnection"
@@ -975,15 +888,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Starship",
-            "D": "N"
+            "t": "Starship"
           }
         },
         "r": "PersonStarshipsEdge"
@@ -998,29 +909,25 @@ expression: registry_from_introspection(schema)
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[PersonVehiclesEdge]",
-            "D": "N"
+            "t": "[PersonVehiclesEdge]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           },
           "vehicles": {
             "n": "vehicles",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Vehicle]",
-            "D": "N"
+            "t": "[Vehicle]"
           }
         },
         "r": "PersonVehiclesConnection"
@@ -1035,15 +942,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Vehicle",
-            "D": "N"
+            "t": "Vehicle"
           }
         },
         "r": "PersonVehiclesEdge"
@@ -1058,29 +963,25 @@ expression: registry_from_introspection(schema)
             "n": "climates",
             "d": "The climates of this planet.",
             "a": {},
-            "t": "[String]",
-            "D": "N"
+            "t": "[String]"
           },
           "created": {
             "n": "created",
             "d": "The ISO 8601 date format of the time that this resource was created.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "diameter": {
             "n": "diameter",
             "d": "The diameter of this planet in kilometers.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           },
           "edited": {
             "n": "edited",
             "d": "The ISO 8601 date format of the time that this resource was edited.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "filmConnection": {
             "n": "filmConnection",
@@ -1102,43 +1003,37 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "PlanetFilmsConnection",
-            "D": "N"
+            "t": "PlanetFilmsConnection"
           },
           "gravity": {
             "n": "gravity",
             "d": "A number denoting the gravity of this planet, where \"1\" is normal or 1 standard\nG. \"2\" is twice or 2 standard Gs. \"0.5\" is half or 0.5 standard Gs.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "id": {
             "n": "id",
             "d": "The ID of an object",
             "a": {},
-            "t": "ID!",
-            "D": "N"
+            "t": "ID!"
           },
           "name": {
             "n": "name",
             "d": "The name of this planet.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "orbitalPeriod": {
             "n": "orbitalPeriod",
             "d": "The number of standard days it takes for this planet to complete a single orbit\nof its local star.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           },
           "population": {
             "n": "population",
             "d": "The average population of sentient beings inhabiting this planet.",
             "a": {},
-            "t": "Float",
-            "D": "N"
+            "t": "Float"
           },
           "residentConnection": {
             "n": "residentConnection",
@@ -1160,29 +1055,25 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "PlanetResidentsConnection",
-            "D": "N"
+            "t": "PlanetResidentsConnection"
           },
           "rotationPeriod": {
             "n": "rotationPeriod",
             "d": "The number of standard hours it takes for this planet to complete a single\nrotation on its axis.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           },
           "surfaceWater": {
             "n": "surfaceWater",
             "d": "The percentage of the planet surface that is naturally occurring water or bodies\nof water.",
             "a": {},
-            "t": "Float",
-            "D": "N"
+            "t": "Float"
           },
           "terrains": {
             "n": "terrains",
             "d": "The terrains of this planet.",
             "a": {},
-            "t": "[String]",
-            "D": "N"
+            "t": "[String]"
           }
         },
         "r": "Planet"
@@ -1197,29 +1088,25 @@ expression: registry_from_introspection(schema)
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[PlanetFilmsEdge]",
-            "D": "N"
+            "t": "[PlanetFilmsEdge]"
           },
           "films": {
             "n": "films",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Film]",
-            "D": "N"
+            "t": "[Film]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           }
         },
         "r": "PlanetFilmsConnection"
@@ -1234,15 +1121,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Film",
-            "D": "N"
+            "t": "Film"
           }
         },
         "r": "PlanetFilmsEdge"
@@ -1257,29 +1142,25 @@ expression: registry_from_introspection(schema)
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[PlanetResidentsEdge]",
-            "D": "N"
+            "t": "[PlanetResidentsEdge]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "residents": {
             "n": "residents",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Person]",
-            "D": "N"
+            "t": "[Person]"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           }
         },
         "r": "PlanetResidentsConnection"
@@ -1294,15 +1175,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Person",
-            "D": "N"
+            "t": "Person"
           }
         },
         "r": "PlanetResidentsEdge"
@@ -1317,29 +1196,25 @@ expression: registry_from_introspection(schema)
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[PlanetsEdge]",
-            "D": "N"
+            "t": "[PlanetsEdge]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "planets": {
             "n": "planets",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Planet]",
-            "D": "N"
+            "t": "[Planet]"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           }
         },
         "r": "PlanetsConnection"
@@ -1354,15 +1229,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Planet",
-            "D": "N"
+            "t": "Planet"
           }
         },
         "r": "PlanetsEdge"
@@ -1392,8 +1265,7 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "FilmsConnection",
-            "D": "N"
+            "t": "FilmsConnection"
           },
           "allPeople": {
             "n": "allPeople",
@@ -1415,8 +1287,7 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "PeopleConnection",
-            "D": "N"
+            "t": "PeopleConnection"
           },
           "allPlanets": {
             "n": "allPlanets",
@@ -1438,8 +1309,7 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "PlanetsConnection",
-            "D": "N"
+            "t": "PlanetsConnection"
           },
           "allSpecies": {
             "n": "allSpecies",
@@ -1461,8 +1331,7 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "SpeciesConnection",
-            "D": "N"
+            "t": "SpeciesConnection"
           },
           "allStarships": {
             "n": "allStarships",
@@ -1484,8 +1353,7 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "StarshipsConnection",
-            "D": "N"
+            "t": "StarshipsConnection"
           },
           "allVehicles": {
             "n": "allVehicles",
@@ -1507,8 +1375,7 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "VehiclesConnection",
-            "D": "N"
+            "t": "VehiclesConnection"
           },
           "film": {
             "n": "film",
@@ -1522,8 +1389,7 @@ expression: registry_from_introspection(schema)
                 "t": "ID"
               }
             },
-            "t": "Film",
-            "D": "N"
+            "t": "Film"
           },
           "node": {
             "n": "node",
@@ -1535,8 +1401,7 @@ expression: registry_from_introspection(schema)
                 "t": "ID!"
               }
             },
-            "t": "Node",
-            "D": "N"
+            "t": "Node"
           },
           "person": {
             "n": "person",
@@ -1550,8 +1415,7 @@ expression: registry_from_introspection(schema)
                 "t": "ID"
               }
             },
-            "t": "Person",
-            "D": "N"
+            "t": "Person"
           },
           "planet": {
             "n": "planet",
@@ -1565,8 +1429,7 @@ expression: registry_from_introspection(schema)
                 "t": "ID"
               }
             },
-            "t": "Planet",
-            "D": "N"
+            "t": "Planet"
           },
           "species": {
             "n": "species",
@@ -1580,8 +1443,7 @@ expression: registry_from_introspection(schema)
                 "t": "ID"
               }
             },
-            "t": "Species",
-            "D": "N"
+            "t": "Species"
           },
           "starship": {
             "n": "starship",
@@ -1595,8 +1457,7 @@ expression: registry_from_introspection(schema)
                 "t": "ID"
               }
             },
-            "t": "Starship",
-            "D": "N"
+            "t": "Starship"
           },
           "vehicle": {
             "n": "vehicle",
@@ -1610,8 +1471,7 @@ expression: registry_from_introspection(schema)
                 "t": "ID"
               }
             },
-            "t": "Vehicle",
-            "D": "N"
+            "t": "Vehicle"
           }
         },
         "r": "Root"
@@ -1626,50 +1486,43 @@ expression: registry_from_introspection(schema)
             "n": "averageHeight",
             "d": "The average height of this species in centimeters.",
             "a": {},
-            "t": "Float",
-            "D": "N"
+            "t": "Float"
           },
           "averageLifespan": {
             "n": "averageLifespan",
             "d": "The average lifespan of this species in years, null if unknown.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           },
           "classification": {
             "n": "classification",
             "d": "The classification of this species, such as \"mammal\" or \"reptile\".",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "created": {
             "n": "created",
             "d": "The ISO 8601 date format of the time that this resource was created.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "designation": {
             "n": "designation",
             "d": "The designation of this species, such as \"sentient\".",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "edited": {
             "n": "edited",
             "d": "The ISO 8601 date format of the time that this resource was edited.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "eyeColors": {
             "n": "eyeColors",
             "d": "Common eye colors for this species, null if this species does not typically\nhave eyes.",
             "a": {},
-            "t": "[String]",
-            "D": "N"
+            "t": "[String]"
           },
           "filmConnection": {
             "n": "filmConnection",
@@ -1691,43 +1544,37 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "SpeciesFilmsConnection",
-            "D": "N"
+            "t": "SpeciesFilmsConnection"
           },
           "hairColors": {
             "n": "hairColors",
             "d": "Common hair colors for this species, null if this species does not typically\nhave hair.",
             "a": {},
-            "t": "[String]",
-            "D": "N"
+            "t": "[String]"
           },
           "homeworld": {
             "n": "homeworld",
             "d": "A planet that this species originates from.",
             "a": {},
-            "t": "Planet",
-            "D": "N"
+            "t": "Planet"
           },
           "id": {
             "n": "id",
             "d": "The ID of an object",
             "a": {},
-            "t": "ID!",
-            "D": "N"
+            "t": "ID!"
           },
           "language": {
             "n": "language",
             "d": "The language commonly spoken by this species.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "name": {
             "n": "name",
             "d": "The name of this species.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "personConnection": {
             "n": "personConnection",
@@ -1749,15 +1596,13 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "SpeciesPeopleConnection",
-            "D": "N"
+            "t": "SpeciesPeopleConnection"
           },
           "skinColors": {
             "n": "skinColors",
             "d": "Common skin colors for this species, null if this species does not typically\nhave skin.",
             "a": {},
-            "t": "[String]",
-            "D": "N"
+            "t": "[String]"
           }
         },
         "r": "Species"
@@ -1772,29 +1617,25 @@ expression: registry_from_introspection(schema)
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[SpeciesEdge]",
-            "D": "N"
+            "t": "[SpeciesEdge]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "species": {
             "n": "species",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Species]",
-            "D": "N"
+            "t": "[Species]"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           }
         },
         "r": "SpeciesConnection"
@@ -1809,15 +1650,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Species",
-            "D": "N"
+            "t": "Species"
           }
         },
         "r": "SpeciesEdge"
@@ -1832,29 +1671,25 @@ expression: registry_from_introspection(schema)
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[SpeciesFilmsEdge]",
-            "D": "N"
+            "t": "[SpeciesFilmsEdge]"
           },
           "films": {
             "n": "films",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Film]",
-            "D": "N"
+            "t": "[Film]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           }
         },
         "r": "SpeciesFilmsConnection"
@@ -1869,15 +1704,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Film",
-            "D": "N"
+            "t": "Film"
           }
         },
         "r": "SpeciesFilmsEdge"
@@ -1892,29 +1725,25 @@ expression: registry_from_introspection(schema)
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[SpeciesPeopleEdge]",
-            "D": "N"
+            "t": "[SpeciesPeopleEdge]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "people": {
             "n": "people",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Person]",
-            "D": "N"
+            "t": "[Person]"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           }
         },
         "r": "SpeciesPeopleConnection"
@@ -1929,15 +1758,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Person",
-            "D": "N"
+            "t": "Person"
           }
         },
         "r": "SpeciesPeopleEdge"
@@ -1952,50 +1779,43 @@ expression: registry_from_introspection(schema)
             "n": "MGLT",
             "d": "The Maximum number of Megalights this starship can travel in a standard hour.\nA \"Megalight\" is a standard unit of distance and has never been defined before\nwithin the Star Wars universe. This figure is only really useful for measuring\nthe difference in speed of starships. We can assume it is similar to AU, the\ndistance between our Sun (Sol) and Earth.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           },
           "cargoCapacity": {
             "n": "cargoCapacity",
             "d": "The maximum number of kilograms that this starship can transport.",
             "a": {},
-            "t": "Float",
-            "D": "N"
+            "t": "Float"
           },
           "consumables": {
             "n": "consumables",
             "d": "The maximum length of time that this starship can provide consumables for its\nentire crew without having to resupply.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "costInCredits": {
             "n": "costInCredits",
             "d": "The cost of this starship new, in galactic credits.",
             "a": {},
-            "t": "Float",
-            "D": "N"
+            "t": "Float"
           },
           "created": {
             "n": "created",
             "d": "The ISO 8601 date format of the time that this resource was created.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "crew": {
             "n": "crew",
             "d": "The number of personnel needed to run or pilot this starship.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "edited": {
             "n": "edited",
             "d": "The ISO 8601 date format of the time that this resource was edited.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "filmConnection": {
             "n": "filmConnection",
@@ -2017,64 +1837,55 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "StarshipFilmsConnection",
-            "D": "N"
+            "t": "StarshipFilmsConnection"
           },
           "hyperdriveRating": {
             "n": "hyperdriveRating",
             "d": "The class of this starships hyperdrive.",
             "a": {},
-            "t": "Float",
-            "D": "N"
+            "t": "Float"
           },
           "id": {
             "n": "id",
             "d": "The ID of an object",
             "a": {},
-            "t": "ID!",
-            "D": "N"
+            "t": "ID!"
           },
           "length": {
             "n": "length",
             "d": "The length of this starship in meters.",
             "a": {},
-            "t": "Float",
-            "D": "N"
+            "t": "Float"
           },
           "manufacturers": {
             "n": "manufacturers",
             "d": "The manufacturers of this starship.",
             "a": {},
-            "t": "[String]",
-            "D": "N"
+            "t": "[String]"
           },
           "maxAtmospheringSpeed": {
             "n": "maxAtmospheringSpeed",
             "d": "The maximum speed of this starship in atmosphere. null if this starship is\nincapable of atmosphering flight.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           },
           "model": {
             "n": "model",
             "d": "The model or official name of this starship. Such as \"T-65 X-wing\" or \"DS-1\nOrbital Battle Station\".",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "name": {
             "n": "name",
             "d": "The name of this starship. The common name, such as \"Death Star\".",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "passengers": {
             "n": "passengers",
             "d": "The number of non-essential people this starship can transport.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "pilotConnection": {
             "n": "pilotConnection",
@@ -2096,15 +1907,13 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "StarshipPilotsConnection",
-            "D": "N"
+            "t": "StarshipPilotsConnection"
           },
           "starshipClass": {
             "n": "starshipClass",
             "d": "The class of this starship, such as \"Starfighter\" or \"Deep Space Mobile\nBattlestation\"",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           }
         },
         "r": "Starship"
@@ -2119,29 +1928,25 @@ expression: registry_from_introspection(schema)
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[StarshipFilmsEdge]",
-            "D": "N"
+            "t": "[StarshipFilmsEdge]"
           },
           "films": {
             "n": "films",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Film]",
-            "D": "N"
+            "t": "[Film]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           }
         },
         "r": "StarshipFilmsConnection"
@@ -2156,15 +1961,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Film",
-            "D": "N"
+            "t": "Film"
           }
         },
         "r": "StarshipFilmsEdge"
@@ -2179,29 +1982,25 @@ expression: registry_from_introspection(schema)
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[StarshipPilotsEdge]",
-            "D": "N"
+            "t": "[StarshipPilotsEdge]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "pilots": {
             "n": "pilots",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Person]",
-            "D": "N"
+            "t": "[Person]"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           }
         },
         "r": "StarshipPilotsConnection"
@@ -2216,15 +2015,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Person",
-            "D": "N"
+            "t": "Person"
           }
         },
         "r": "StarshipPilotsEdge"
@@ -2239,29 +2036,25 @@ expression: registry_from_introspection(schema)
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[StarshipsEdge]",
-            "D": "N"
+            "t": "[StarshipsEdge]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "starships": {
             "n": "starships",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Starship]",
-            "D": "N"
+            "t": "[Starship]"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           }
         },
         "r": "StarshipsConnection"
@@ -2276,15 +2069,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Starship",
-            "D": "N"
+            "t": "Starship"
           }
         },
         "r": "StarshipsEdge"
@@ -2306,43 +2097,37 @@ expression: registry_from_introspection(schema)
             "n": "cargoCapacity",
             "d": "The maximum number of kilograms that this vehicle can transport.",
             "a": {},
-            "t": "Float",
-            "D": "N"
+            "t": "Float"
           },
           "consumables": {
             "n": "consumables",
             "d": "The maximum length of time that this vehicle can provide consumables for its\nentire crew without having to resupply.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "costInCredits": {
             "n": "costInCredits",
             "d": "The cost of this vehicle new, in Galactic Credits.",
             "a": {},
-            "t": "Float",
-            "D": "N"
+            "t": "Float"
           },
           "created": {
             "n": "created",
             "d": "The ISO 8601 date format of the time that this resource was created.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "crew": {
             "n": "crew",
             "d": "The number of personnel needed to run or pilot this vehicle.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "edited": {
             "n": "edited",
             "d": "The ISO 8601 date format of the time that this resource was edited.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "filmConnection": {
             "n": "filmConnection",
@@ -2364,57 +2149,49 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "VehicleFilmsConnection",
-            "D": "N"
+            "t": "VehicleFilmsConnection"
           },
           "id": {
             "n": "id",
             "d": "The ID of an object",
             "a": {},
-            "t": "ID!",
-            "D": "N"
+            "t": "ID!"
           },
           "length": {
             "n": "length",
             "d": "The length of this vehicle in meters.",
             "a": {},
-            "t": "Float",
-            "D": "N"
+            "t": "Float"
           },
           "manufacturers": {
             "n": "manufacturers",
             "d": "The manufacturers of this vehicle.",
             "a": {},
-            "t": "[String]",
-            "D": "N"
+            "t": "[String]"
           },
           "maxAtmospheringSpeed": {
             "n": "maxAtmospheringSpeed",
             "d": "The maximum speed of this vehicle in atmosphere.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           },
           "model": {
             "n": "model",
             "d": "The model or official name of this vehicle. Such as \"All-Terrain Attack\nTransport\".",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "name": {
             "n": "name",
             "d": "The name of this vehicle. The common name, such as \"Sand Crawler\" or \"Speeder\nbike\".",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "passengers": {
             "n": "passengers",
             "d": "The number of non-essential people this vehicle can transport.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "pilotConnection": {
             "n": "pilotConnection",
@@ -2436,15 +2213,13 @@ expression: registry_from_introspection(schema)
                 "t": "Int"
               }
             },
-            "t": "VehiclePilotsConnection",
-            "D": "N"
+            "t": "VehiclePilotsConnection"
           },
           "vehicleClass": {
             "n": "vehicleClass",
             "d": "The class of this vehicle, such as \"Wheeled\" or \"Repulsorcraft\".",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           }
         },
         "r": "Vehicle"
@@ -2459,29 +2234,25 @@ expression: registry_from_introspection(schema)
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[VehicleFilmsEdge]",
-            "D": "N"
+            "t": "[VehicleFilmsEdge]"
           },
           "films": {
             "n": "films",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Film]",
-            "D": "N"
+            "t": "[Film]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           }
         },
         "r": "VehicleFilmsConnection"
@@ -2496,15 +2267,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Film",
-            "D": "N"
+            "t": "Film"
           }
         },
         "r": "VehicleFilmsEdge"
@@ -2519,29 +2288,25 @@ expression: registry_from_introspection(schema)
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[VehiclePilotsEdge]",
-            "D": "N"
+            "t": "[VehiclePilotsEdge]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "pilots": {
             "n": "pilots",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Person]",
-            "D": "N"
+            "t": "[Person]"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           }
         },
         "r": "VehiclePilotsConnection"
@@ -2556,15 +2321,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Person",
-            "D": "N"
+            "t": "Person"
           }
         },
         "r": "VehiclePilotsEdge"
@@ -2579,29 +2342,25 @@ expression: registry_from_introspection(schema)
             "n": "edges",
             "d": "A list of edges.",
             "a": {},
-            "t": "[VehiclesEdge]",
-            "D": "N"
+            "t": "[VehiclesEdge]"
           },
           "pageInfo": {
             "n": "pageInfo",
             "d": "Information to aid in pagination.",
             "a": {},
-            "t": "PageInfo!",
-            "D": "N"
+            "t": "PageInfo!"
           },
           "totalCount": {
             "n": "totalCount",
             "d": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
             "a": {},
-            "t": "Int",
-            "D": "N"
+            "t": "Int"
           },
           "vehicles": {
             "n": "vehicles",
             "d": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
             "a": {},
-            "t": "[Vehicle]",
-            "D": "N"
+            "t": "[Vehicle]"
           }
         },
         "r": "VehiclesConnection"
@@ -2616,15 +2375,13 @@ expression: registry_from_introspection(schema)
             "n": "cursor",
             "d": "A cursor for use in pagination",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "node": {
             "n": "node",
             "d": "The item at the end of the edge",
             "a": {},
-            "t": "Vehicle",
-            "D": "N"
+            "t": "Vehicle"
           }
         },
         "r": "VehiclesEdge"
@@ -2638,26 +2395,22 @@ expression: registry_from_introspection(schema)
           "args": {
             "n": "args",
             "a": {},
-            "t": "[__InputValue!]!",
-            "D": "N"
+            "t": "[__InputValue!]!"
           },
           "description": {
             "n": "description",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "locations": {
             "n": "locations",
             "a": {},
-            "t": "[__DirectiveLocation!]!",
-            "D": "N"
+            "t": "[__DirectiveLocation!]!"
           },
           "name": {
             "n": "name",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           }
         },
         "r": "__Directive"
@@ -2756,26 +2509,22 @@ expression: registry_from_introspection(schema)
           "deprecationReason": {
             "n": "deprecationReason",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "description": {
             "n": "description",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "isDeprecated": {
             "n": "isDeprecated",
             "a": {},
-            "t": "Boolean!",
-            "D": "N"
+            "t": "Boolean!"
           },
           "name": {
             "n": "name",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           }
         },
         "r": "__EnumValue"
@@ -2789,38 +2538,32 @@ expression: registry_from_introspection(schema)
           "args": {
             "n": "args",
             "a": {},
-            "t": "[__InputValue!]!",
-            "D": "N"
+            "t": "[__InputValue!]!"
           },
           "deprecationReason": {
             "n": "deprecationReason",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "description": {
             "n": "description",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "isDeprecated": {
             "n": "isDeprecated",
             "a": {},
-            "t": "Boolean!",
-            "D": "N"
+            "t": "Boolean!"
           },
           "name": {
             "n": "name",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "type": {
             "n": "type",
             "a": {},
-            "t": "__Type!",
-            "D": "N"
+            "t": "__Type!"
           }
         },
         "r": "__Field"
@@ -2835,26 +2578,22 @@ expression: registry_from_introspection(schema)
             "n": "defaultValue",
             "d": "A GraphQL-formatted string representing the default value for this input value.",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "description": {
             "n": "description",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "name": {
             "n": "name",
             "a": {},
-            "t": "String!",
-            "D": "N"
+            "t": "String!"
           },
           "type": {
             "n": "type",
             "a": {},
-            "t": "__Type!",
-            "D": "N"
+            "t": "__Type!"
           }
         },
         "r": "__InputValue"
@@ -2869,36 +2608,31 @@ expression: registry_from_introspection(schema)
             "n": "directives",
             "d": "A list of all directives supported by this server.",
             "a": {},
-            "t": "[__Directive!]!",
-            "D": "N"
+            "t": "[__Directive!]!"
           },
           "mutationType": {
             "n": "mutationType",
             "d": "If this server supports mutation, the type that mutation operations will be rooted at.",
             "a": {},
-            "t": "__Type",
-            "D": "N"
+            "t": "__Type"
           },
           "queryType": {
             "n": "queryType",
             "d": "The type that query operations will be rooted at.",
             "a": {},
-            "t": "__Type!",
-            "D": "N"
+            "t": "__Type!"
           },
           "subscriptionType": {
             "n": "subscriptionType",
             "d": "If this server support subscription, the type that subscription operations will be rooted at.",
             "a": {},
-            "t": "__Type",
-            "D": "N"
+            "t": "__Type"
           },
           "types": {
             "n": "types",
             "d": "A list of all types supported by this server.",
             "a": {},
-            "t": "[__Type!]!",
-            "D": "N"
+            "t": "[__Type!]!"
           }
         },
         "r": "__Schema"
@@ -2912,8 +2646,7 @@ expression: registry_from_introspection(schema)
           "description": {
             "n": "description",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "enumValues": {
             "n": "enumValues",
@@ -2924,8 +2657,7 @@ expression: registry_from_introspection(schema)
                 "D": "false"
               }
             },
-            "t": "[__EnumValue!]",
-            "D": "N"
+            "t": "[__EnumValue!]"
           },
           "fields": {
             "n": "fields",
@@ -2936,44 +2668,37 @@ expression: registry_from_introspection(schema)
                 "D": "false"
               }
             },
-            "t": "[__Field!]",
-            "D": "N"
+            "t": "[__Field!]"
           },
           "inputFields": {
             "n": "inputFields",
             "a": {},
-            "t": "[__InputValue!]",
-            "D": "N"
+            "t": "[__InputValue!]"
           },
           "interfaces": {
             "n": "interfaces",
             "a": {},
-            "t": "[__Type!]",
-            "D": "N"
+            "t": "[__Type!]"
           },
           "kind": {
             "n": "kind",
             "a": {},
-            "t": "__TypeKind!",
-            "D": "N"
+            "t": "__TypeKind!"
           },
           "name": {
             "n": "name",
             "a": {},
-            "t": "String",
-            "D": "N"
+            "t": "String"
           },
           "ofType": {
             "n": "ofType",
             "a": {},
-            "t": "__Type",
-            "D": "N"
+            "t": "__Type"
           },
           "possibleTypes": {
             "n": "possibleTypes",
             "a": {},
-            "t": "[__Type!]",
-            "D": "N"
+            "t": "[__Type!]"
           }
         },
         "r": "__Type"

--- a/engine/crates/parser-graphql/src/snapshots/parser_graphql__tests__counries_output.snap
+++ b/engine/crates/parser-graphql/src/snapshots/parser_graphql__tests__counries_output.snap
@@ -1,5 +1,5 @@
 ---
-source: common/parser-graphql/src/lib.rs
+source: crates/parser-graphql/src/lib.rs
 expression: result
 ---
 enum FooBarAccelerationUnit {
@@ -282,103 +282,103 @@ type FooBarCar {
 	"""
 	ID provided by a car data source as the row ID
 	"""
-	externalId: String
+	externalId: String @deprecated(reason: "Will be removed in the future")
 	"""
 	Car manufacturer
 	"""
-	make: String
+	make: String @deprecated(reason: "In favor of naming.make")
 	"""
 	Car model
 	"""
-	carModel: String
+	carModel: String @deprecated(reason: "In favor of naming.model")
 	"""
 	Car edition
 	"""
-	edition: String
+	edition: String @deprecated(reason: "In favor of naming.version")
 	"""
 	Car model edition. Added by Chargetrip as an alternative for when a car manufacturer does not provide an edition name, or uses the same edition name across all trims or consecutive years
 	"""
-	chargetripEdition: String
+	chargetripEdition: String @deprecated(reason: "In favor of naming.chargetrip_version")
 	"""
 	Car version
 	"""
-	version: String
+	version: String @deprecated(reason: "In favor of naming.edition")
 	"""
 	Chargetrip's custom real world range provides a carefully calculated display range for all EV models. This is based on our own research and driving data
 	"""
-	chargetripRange: FooBarChargetripRange
+	chargetripRange: FooBarChargetripRange @deprecated(reason: "In favor of range.chargetrip_range")
 	"""
 	Cars that support fast charging have a minimum charging speed of 43 kWh
 	"""
-	fastChargingSupport: Boolean
+	fastChargingSupport: Boolean @deprecated(reason: "In favor of routing.fast_charging_support")
 	"""
 	Current production mode of a car
 	"""
-	mode: FooBarCarMode
+	mode: FooBarCarMode @deprecated(reason: "In favor of availability.status")
 	"""
 	Number of seats
 	"""
-	seats: Int
+	seats: Int @deprecated(reason: "In favor of body.seats")
 	"""
 	Weight in kg
 	"""
-	weight: Float
+	weight: Float @deprecated(reason: "In favor of body.weight")
 	"""
 	Height in mm
 	"""
-	height: Int
+	height: Int @deprecated(reason: "In favor of body.height")
 	"""
 	Width in mm
 	"""
-	width: Int
+	width: Int @deprecated(reason: "In favor of body.width")
 	"""
 	Usable battery capacity in kWh
 	"""
-	batteryUsableKwh: Float
+	batteryUsableKwh: Float @deprecated(reason: "In favor of battery.usable_kwh")
 	"""
 	Full battery capacity in kWh
 	"""
-	batteryFullKwh: Float
+	batteryFullKwh: Float @deprecated(reason: "In favor of battery.full_kwh")
 	"""
 	Battery efficiency in the city, highway and combined depending on weather conditions
 	"""
-	batteryEfficiency: FooBarCarBatteryEfficiency
+	batteryEfficiency: FooBarCarBatteryEfficiency @deprecated(reason: "In favor of efficiency")
 	"""
 	Acceleration time from 0 to 100 km/h
 	"""
-	acceleration: Float
+	acceleration: Float @deprecated(reason: "In favor of performance.acceleration")
 	"""
 	Maximum car speed in km/h
 	"""
-	topSpeed: Float
+	topSpeed: Float @deprecated(reason: "In favor of performance.top_speed")
 	"""
 	Power of a car in Kw
 	"""
-	power: Float
+	power: Float @deprecated(reason: "In favor of drivetrain.power")
 	"""
 	Engine torque
 	"""
-	torque: Float
+	torque: Float @deprecated(reason: "In favor of drivetrain.torque")
 	"""
 	Extra consumption model
 	"""
-	consumption: FooBarCarExtraConsumption
+	consumption: FooBarCarExtraConsumption @deprecated(reason: "In favor of routing.consumption")
 	"""
 	Amount of petrol a similar petrol car would consume per 100 km
 	"""
-	petrolConsumption: Float
+	petrolConsumption: Float @deprecated(reason: "In favor of routing.petrol_consumption")
 	"""
 	A list of offset data for different charging speeds
 	"""
-	chargingOffset: FooBarJSON
+	chargingOffset: FooBarJSON @deprecated(reason: "You will receive null values")
 	"""
 	Images of a car
 	"""
-	images: [FooBarCarImage]
+	images: [FooBarCarImage] @deprecated(reason: "In favor of media.image_list")
 	"""
 	Images of a car in structured data
 	"""
-	imagesData: FooBarCarImageData
+	imagesData: FooBarCarImageData @deprecated(reason: "In favor of media.image or media.brand")
 }
 type FooBarCarAvailability {
 	"""
@@ -650,74 +650,74 @@ type FooBarCarList {
 	"""
 	ID provided by a car data source as the row ID
 	"""
-	externalId: String
+	externalId: String @deprecated(reason: "Will be removed in the future")
 	"""
 	Car manufacturer
 	"""
-	make: String
+	make: String @deprecated(reason: "In favor of naming.make")
 	"""
 	Car model
 	"""
-	carModel: String
+	carModel: String @deprecated(reason: "In favor of naming.model")
 	"""
 	Car edition
 	"""
-	edition: String
+	edition: String @deprecated(reason: "In favor of naming.version")
 	"""
 	Car model edition. Added by Chargetrip as an alternative for when a car manufacturer does not provide an edition name, or uses the same edition name across all trims or consecutive years
 	"""
-	chargetripEdition: String
+	chargetripEdition: String @deprecated(reason: "In favor of naming.chargetrip_version")
 	"""
 	Car version
 	"""
-	version: String
+	version: String @deprecated(reason: "In favor of naming.edition")
 	"""
 	Chargetrip's custom real world range provides a carefully calculated display range for all EV models. This is based on our own research and driving data
 	"""
-	chargetripRange: FooBarChargetripRange
+	chargetripRange: FooBarChargetripRange @deprecated(reason: "In favor of range.chargetrip_range")
 	"""
 	Cars that support fast charging have a minimum charging speed of 43 kWh
 	"""
-	fastChargingSupport: Boolean
+	fastChargingSupport: Boolean @deprecated(reason: "In favor of routing.fast_charging_support")
 	"""
 	Current production mode of a car
 	"""
-	mode: FooBarCarMode
+	mode: FooBarCarMode @deprecated(reason: "In favor of availability.status")
 	"""
 	Number of seats
 	"""
-	seats: Int
+	seats: Int @deprecated(reason: "In favor of body.seats")
 	"""
 	Usable battery capacity in kWh
 	"""
-	batteryUsableKwh: Float
+	batteryUsableKwh: Float @deprecated(reason: "In favor of battery.usable_kwh")
 	"""
 	Full battery capacity in kWh
 	"""
-	batteryFullKwh: Float
+	batteryFullKwh: Float @deprecated(reason: "In favor of battery.full_kwh")
 	"""
 	Images of a car in structured data
 	"""
-	imagesData: FooBarCarImageData
-	power: Float
-	acceleration: Float
-	topSpeed: Float
-	torque: Float
-	batteryEfficiency: FooBarCarBatteryEfficiency
-	weight: Float
-	height: Int
-	width: Int
-	consumption: FooBarCarExtraConsumption
-	petrolConsumption: Float
-	chargingOffset: FooBarJSON
-	auxConsumption: Float
-	bmsConsumption: Float
-	dragCoefficient: Float
-	tirePressure: Float
-	motorEfficiency: Float
-	drivelineEfficiency: Float
-	regenEfficiency: Float
-	images: [FooBarCarImage]
+	imagesData: FooBarCarImageData @deprecated(reason: "In favor of media.image and media.brand")
+	power: Float @deprecated(reason: "You will receive null values")
+	acceleration: Float @deprecated(reason: "You will receive null values")
+	topSpeed: Float @deprecated(reason: "You will receive null values")
+	torque: Float @deprecated(reason: "You will receive null values")
+	batteryEfficiency: FooBarCarBatteryEfficiency @deprecated(reason: "You will receive null values")
+	weight: Float @deprecated(reason: "You will receive null values")
+	height: Int @deprecated(reason: "You will receive null values")
+	width: Int @deprecated(reason: "You will receive null values")
+	consumption: FooBarCarExtraConsumption @deprecated(reason: "You will receive null values")
+	petrolConsumption: Float @deprecated(reason: "You will receive null values")
+	chargingOffset: FooBarJSON @deprecated(reason: "You will receive null values")
+	auxConsumption: Float @deprecated(reason: "You will receive null values")
+	bmsConsumption: Float @deprecated(reason: "You will receive null values")
+	dragCoefficient: Float @deprecated(reason: "You will receive null values")
+	tirePressure: Float @deprecated(reason: "You will receive null values")
+	motorEfficiency: Float @deprecated(reason: "You will receive null values")
+	drivelineEfficiency: Float @deprecated(reason: "You will receive null values")
+	regenEfficiency: Float @deprecated(reason: "You will receive null values")
+	images: [FooBarCarImage] @deprecated(reason: "You will receive null values")
 }
 type FooBarCarListAvailability {
 	"""
@@ -840,9 +840,9 @@ type FooBarCarListRange {
 	(Comparable to Range_Real from EV Database.) It is essentially a normalized range to display in the front-end.
 	"""
 	chargetrip_range: FooBarChargetripRange
-	wltp: Float
-	worst: FooBarCarEstimationData
-	best: FooBarCarEstimationData
+	wltp: Float @deprecated(reason: "You will receive null values")
+	worst: FooBarCarEstimationData @deprecated(reason: "You will receive null values")
+	best: FooBarCarEstimationData @deprecated(reason: "You will receive null values")
 }
 type FooBarCarListRouting {
 	"""
@@ -878,7 +878,7 @@ type FooBarCarMedia {
 	"""
 	URL to detail page on EV database
 	"""
-	evdb_detail_url: String
+	evdb_detail_url: String @deprecated(reason: "Will be removed in the future. Please use evdb_details_url")
 }
 """
 Mode (state) of the current production
@@ -1193,7 +1193,7 @@ type FooBarCarPremiumBody {
 	"""
 	Indicates whether a car has roof rails as a standard
 	"""
-	rooftrails: Boolean
+	rooftrails: Boolean @deprecated(reason: "In favor of has_roofrails")
 }
 type FooBarCarPremiumCharge {
 	"""
@@ -1609,7 +1609,7 @@ type FooBarCarPremiumMedia {
 	"""
 	URL to detail page on EV database
 	"""
-	evdb_detail_url: String
+	evdb_detail_url: String @deprecated(reason: "Will be removed in the future. Please use evdb_details_url")
 }
 type FooBarCarPremiumNaming {
 	"""
@@ -1681,7 +1681,7 @@ type FooBarCarPremiumPriceValue {
 	"""
 	Indicates if price value is based on estimates
 	"""
-	estimated: Boolean
+	estimated: Boolean @deprecated(reason: "In favor of is_estimated")
 }
 type FooBarCarPremiumPriceValueWithGrant {
 	"""
@@ -1703,7 +1703,7 @@ type FooBarCarPremiumPriceValueWithGrant {
 	"""
 	Indicates if price value is based on estimates
 	"""
-	estimated: Boolean
+	estimated: Boolean @deprecated(reason: "In favor of is_estimated")
 }
 type FooBarCarPremiumRange {
 	"""
@@ -1872,7 +1872,7 @@ type FooBarCarRange {
 	Chargetrip's custom real world range provides a carefully calculated display range for all EV models. This is based on our own research and driving data
 	"""
 	chargetrip_range: FooBarChargetripRange
-	wltp: Float
+	wltp: Float @deprecated(reason: "You will receive null values")
 }
 type FooBarCarRangeValue {
 	"""
@@ -2259,7 +2259,7 @@ type FooBarConnector {
 	"""
 	Charging prices
 	"""
-	pricing: FooBarPricing
+	pricing: FooBarPricing @deprecated(reason: "In favor of custom_properties.pricing")
 	"""
 	Custom properties of a connector. These are vendor specific and will return null values on the fields that are not supported by your station database
 	"""
@@ -4451,7 +4451,7 @@ type FooBarRequestEv {
 	"""
 	The number of passengers on board
 	"""
-	numberOfPassengers: Int
+	numberOfPassengers: Int @deprecated(reason: "In favor of occupants")
 	"""
 	Number of occupants
 	"""
@@ -4633,7 +4633,7 @@ type FooBarRequestRoute {
 	"""
 	Requested amenities near the stations, within a 1 kilometer radius
 	"""
-	amenities: [String]
+	amenities: [String] @deprecated(reason: "Will be removed. Use the amenity preferences instead")
 	"""
 	Amenity preferences for a route
 	"""
@@ -4641,15 +4641,15 @@ type FooBarRequestRoute {
 	"""
 	Requested operators
 	"""
-	operatorIds: [String]
+	operatorIds: [String] @deprecated(reason: "Will be removed. Use the operators property instead")
 	"""
 	Preferred operators are required. In case there are no preferred operators the route cannot be calculated
 	"""
-	operatorRequired: Boolean
+	operatorRequired: Boolean @deprecated(reason: "Will be removed. Use the operators property instead")
 	"""
 	Encourage the route to use preferred operators. In case there are no preferred operators the route can still be calculated
 	"""
-	operatorPrefer: Boolean
+	operatorPrefer: Boolean @deprecated(reason: "Will be removed. Use the operators property instead")
 	"""
 	Operator prioritization for a route
 	"""
@@ -4916,15 +4916,15 @@ type FooBarReviewUser {
 	"""
 	User ID
 	"""
-	id: ID
+	id: ID @deprecated(reason: "Not sent back anymore, will be null")
 	"""
 	First name
 	"""
-	firstName: String
+	firstName: String @deprecated(reason: "Please use name instead")
 	"""
 	Last name
 	"""
-	lastName: String
+	lastName: String @deprecated(reason: "Please use name instead")
 }
 type FooBarRoute {
 	"""
@@ -4943,7 +4943,7 @@ type FooBarRoute {
 	Route telemetry data
 	"""
 	telemetry: FooBarJSON
-	user: FooBarRequestUser
+	user: FooBarRequestUser @deprecated(reason: "You will receive null values")
 	"""
 	Route request data
 	"""
@@ -5005,7 +5005,7 @@ type FooBarRouteAlternative {
 	"""
 	Amenity ranking for an alternative
 	"""
-	amenityRanking: Int
+	amenityRanking: Int @deprecated(reason: "Will be removed in the future")
 	"""
 	Range, in meters, available at the beginning of a trip
 	"""
@@ -5045,7 +5045,7 @@ type FooBarRouteAlternative {
 	"""
 	Elevation values. Each elevationPlot has a hundred points, independent of the length of a route
 	"""
-	elevationPlot: [Float]
+	elevationPlot: [Float] @deprecated(reason: "Will be removed in the future; Use the pathPlot property")
 	"""
 	Total number of meters which are going up on a route
 	"""
@@ -5812,11 +5812,11 @@ type FooBarStation {
 	"""
 	Station availability
 	"""
-	predicted_availability: [FooBarStationPredictedAvailability]
+	predicted_availability: [FooBarStationPredictedAvailability] @deprecated(reason: "predicted_availability, no value will be sent. Deprecated in favor of predicted_occupancy")
 	"""
 	Predicted station occupancy
 	"""
-	predicted_occupancy: [FooBarStationPredictedOccupancy]
+	predicted_occupancy: [FooBarStationPredictedOccupancy] @deprecated(reason: "In favor of custom_properties.predicted_occupancy")
 	"""
 	Charging speed for a station
 	"""

--- a/engine/crates/parser-graphql/src/snapshots/parser_graphql__tests__unnamed_connector.snap
+++ b/engine/crates/parser-graphql/src/snapshots/parser_graphql__tests__unnamed_connector.snap
@@ -1,5 +1,5 @@
 ---
-source: common/parser-graphql/src/lib.rs
+source: crates/parser-graphql/src/lib.rs
 expression: result
 ---
 enum AccelerationUnit {
@@ -282,103 +282,103 @@ type Car {
 	"""
 	ID provided by a car data source as the row ID
 	"""
-	externalId: String
+	externalId: String @deprecated(reason: "Will be removed in the future")
 	"""
 	Car manufacturer
 	"""
-	make: String
+	make: String @deprecated(reason: "In favor of naming.make")
 	"""
 	Car model
 	"""
-	carModel: String
+	carModel: String @deprecated(reason: "In favor of naming.model")
 	"""
 	Car edition
 	"""
-	edition: String
+	edition: String @deprecated(reason: "In favor of naming.version")
 	"""
 	Car model edition. Added by Chargetrip as an alternative for when a car manufacturer does not provide an edition name, or uses the same edition name across all trims or consecutive years
 	"""
-	chargetripEdition: String
+	chargetripEdition: String @deprecated(reason: "In favor of naming.chargetrip_version")
 	"""
 	Car version
 	"""
-	version: String
+	version: String @deprecated(reason: "In favor of naming.edition")
 	"""
 	Chargetrip's custom real world range provides a carefully calculated display range for all EV models. This is based on our own research and driving data
 	"""
-	chargetripRange: ChargetripRange
+	chargetripRange: ChargetripRange @deprecated(reason: "In favor of range.chargetrip_range")
 	"""
 	Cars that support fast charging have a minimum charging speed of 43 kWh
 	"""
-	fastChargingSupport: Boolean
+	fastChargingSupport: Boolean @deprecated(reason: "In favor of routing.fast_charging_support")
 	"""
 	Current production mode of a car
 	"""
-	mode: CarMode
+	mode: CarMode @deprecated(reason: "In favor of availability.status")
 	"""
 	Number of seats
 	"""
-	seats: Int
+	seats: Int @deprecated(reason: "In favor of body.seats")
 	"""
 	Weight in kg
 	"""
-	weight: Float
+	weight: Float @deprecated(reason: "In favor of body.weight")
 	"""
 	Height in mm
 	"""
-	height: Int
+	height: Int @deprecated(reason: "In favor of body.height")
 	"""
 	Width in mm
 	"""
-	width: Int
+	width: Int @deprecated(reason: "In favor of body.width")
 	"""
 	Usable battery capacity in kWh
 	"""
-	batteryUsableKwh: Float
+	batteryUsableKwh: Float @deprecated(reason: "In favor of battery.usable_kwh")
 	"""
 	Full battery capacity in kWh
 	"""
-	batteryFullKwh: Float
+	batteryFullKwh: Float @deprecated(reason: "In favor of battery.full_kwh")
 	"""
 	Battery efficiency in the city, highway and combined depending on weather conditions
 	"""
-	batteryEfficiency: CarBatteryEfficiency
+	batteryEfficiency: CarBatteryEfficiency @deprecated(reason: "In favor of efficiency")
 	"""
 	Acceleration time from 0 to 100 km/h
 	"""
-	acceleration: Float
+	acceleration: Float @deprecated(reason: "In favor of performance.acceleration")
 	"""
 	Maximum car speed in km/h
 	"""
-	topSpeed: Float
+	topSpeed: Float @deprecated(reason: "In favor of performance.top_speed")
 	"""
 	Power of a car in Kw
 	"""
-	power: Float
+	power: Float @deprecated(reason: "In favor of drivetrain.power")
 	"""
 	Engine torque
 	"""
-	torque: Float
+	torque: Float @deprecated(reason: "In favor of drivetrain.torque")
 	"""
 	Extra consumption model
 	"""
-	consumption: CarExtraConsumption
+	consumption: CarExtraConsumption @deprecated(reason: "In favor of routing.consumption")
 	"""
 	Amount of petrol a similar petrol car would consume per 100 km
 	"""
-	petrolConsumption: Float
+	petrolConsumption: Float @deprecated(reason: "In favor of routing.petrol_consumption")
 	"""
 	A list of offset data for different charging speeds
 	"""
-	chargingOffset: JSON
+	chargingOffset: JSON @deprecated(reason: "You will receive null values")
 	"""
 	Images of a car
 	"""
-	images: [CarImage]
+	images: [CarImage] @deprecated(reason: "In favor of media.image_list")
 	"""
 	Images of a car in structured data
 	"""
-	imagesData: CarImageData
+	imagesData: CarImageData @deprecated(reason: "In favor of media.image or media.brand")
 }
 type CarAvailability {
 	"""
@@ -650,74 +650,74 @@ type CarList {
 	"""
 	ID provided by a car data source as the row ID
 	"""
-	externalId: String
+	externalId: String @deprecated(reason: "Will be removed in the future")
 	"""
 	Car manufacturer
 	"""
-	make: String
+	make: String @deprecated(reason: "In favor of naming.make")
 	"""
 	Car model
 	"""
-	carModel: String
+	carModel: String @deprecated(reason: "In favor of naming.model")
 	"""
 	Car edition
 	"""
-	edition: String
+	edition: String @deprecated(reason: "In favor of naming.version")
 	"""
 	Car model edition. Added by Chargetrip as an alternative for when a car manufacturer does not provide an edition name, or uses the same edition name across all trims or consecutive years
 	"""
-	chargetripEdition: String
+	chargetripEdition: String @deprecated(reason: "In favor of naming.chargetrip_version")
 	"""
 	Car version
 	"""
-	version: String
+	version: String @deprecated(reason: "In favor of naming.edition")
 	"""
 	Chargetrip's custom real world range provides a carefully calculated display range for all EV models. This is based on our own research and driving data
 	"""
-	chargetripRange: ChargetripRange
+	chargetripRange: ChargetripRange @deprecated(reason: "In favor of range.chargetrip_range")
 	"""
 	Cars that support fast charging have a minimum charging speed of 43 kWh
 	"""
-	fastChargingSupport: Boolean
+	fastChargingSupport: Boolean @deprecated(reason: "In favor of routing.fast_charging_support")
 	"""
 	Current production mode of a car
 	"""
-	mode: CarMode
+	mode: CarMode @deprecated(reason: "In favor of availability.status")
 	"""
 	Number of seats
 	"""
-	seats: Int
+	seats: Int @deprecated(reason: "In favor of body.seats")
 	"""
 	Usable battery capacity in kWh
 	"""
-	batteryUsableKwh: Float
+	batteryUsableKwh: Float @deprecated(reason: "In favor of battery.usable_kwh")
 	"""
 	Full battery capacity in kWh
 	"""
-	batteryFullKwh: Float
+	batteryFullKwh: Float @deprecated(reason: "In favor of battery.full_kwh")
 	"""
 	Images of a car in structured data
 	"""
-	imagesData: CarImageData
-	power: Float
-	acceleration: Float
-	topSpeed: Float
-	torque: Float
-	batteryEfficiency: CarBatteryEfficiency
-	weight: Float
-	height: Int
-	width: Int
-	consumption: CarExtraConsumption
-	petrolConsumption: Float
-	chargingOffset: JSON
-	auxConsumption: Float
-	bmsConsumption: Float
-	dragCoefficient: Float
-	tirePressure: Float
-	motorEfficiency: Float
-	drivelineEfficiency: Float
-	regenEfficiency: Float
-	images: [CarImage]
+	imagesData: CarImageData @deprecated(reason: "In favor of media.image and media.brand")
+	power: Float @deprecated(reason: "You will receive null values")
+	acceleration: Float @deprecated(reason: "You will receive null values")
+	topSpeed: Float @deprecated(reason: "You will receive null values")
+	torque: Float @deprecated(reason: "You will receive null values")
+	batteryEfficiency: CarBatteryEfficiency @deprecated(reason: "You will receive null values")
+	weight: Float @deprecated(reason: "You will receive null values")
+	height: Int @deprecated(reason: "You will receive null values")
+	width: Int @deprecated(reason: "You will receive null values")
+	consumption: CarExtraConsumption @deprecated(reason: "You will receive null values")
+	petrolConsumption: Float @deprecated(reason: "You will receive null values")
+	chargingOffset: JSON @deprecated(reason: "You will receive null values")
+	auxConsumption: Float @deprecated(reason: "You will receive null values")
+	bmsConsumption: Float @deprecated(reason: "You will receive null values")
+	dragCoefficient: Float @deprecated(reason: "You will receive null values")
+	tirePressure: Float @deprecated(reason: "You will receive null values")
+	motorEfficiency: Float @deprecated(reason: "You will receive null values")
+	drivelineEfficiency: Float @deprecated(reason: "You will receive null values")
+	regenEfficiency: Float @deprecated(reason: "You will receive null values")
+	images: [CarImage] @deprecated(reason: "You will receive null values")
 }
 type CarListAvailability {
 	"""
@@ -840,9 +840,9 @@ type CarListRange {
 	(Comparable to Range_Real from EV Database.) It is essentially a normalized range to display in the front-end.
 	"""
 	chargetrip_range: ChargetripRange
-	wltp: Float
-	worst: CarEstimationData
-	best: CarEstimationData
+	wltp: Float @deprecated(reason: "You will receive null values")
+	worst: CarEstimationData @deprecated(reason: "You will receive null values")
+	best: CarEstimationData @deprecated(reason: "You will receive null values")
 }
 type CarListRouting {
 	"""
@@ -878,7 +878,7 @@ type CarMedia {
 	"""
 	URL to detail page on EV database
 	"""
-	evdb_detail_url: String
+	evdb_detail_url: String @deprecated(reason: "Will be removed in the future. Please use evdb_details_url")
 }
 """
 Mode (state) of the current production
@@ -1193,7 +1193,7 @@ type CarPremiumBody {
 	"""
 	Indicates whether a car has roof rails as a standard
 	"""
-	rooftrails: Boolean
+	rooftrails: Boolean @deprecated(reason: "In favor of has_roofrails")
 }
 type CarPremiumCharge {
 	"""
@@ -1609,7 +1609,7 @@ type CarPremiumMedia {
 	"""
 	URL to detail page on EV database
 	"""
-	evdb_detail_url: String
+	evdb_detail_url: String @deprecated(reason: "Will be removed in the future. Please use evdb_details_url")
 }
 type CarPremiumNaming {
 	"""
@@ -1681,7 +1681,7 @@ type CarPremiumPriceValue {
 	"""
 	Indicates if price value is based on estimates
 	"""
-	estimated: Boolean
+	estimated: Boolean @deprecated(reason: "In favor of is_estimated")
 }
 type CarPremiumPriceValueWithGrant {
 	"""
@@ -1703,7 +1703,7 @@ type CarPremiumPriceValueWithGrant {
 	"""
 	Indicates if price value is based on estimates
 	"""
-	estimated: Boolean
+	estimated: Boolean @deprecated(reason: "In favor of is_estimated")
 }
 type CarPremiumRange {
 	"""
@@ -1872,7 +1872,7 @@ type CarRange {
 	Chargetrip's custom real world range provides a carefully calculated display range for all EV models. This is based on our own research and driving data
 	"""
 	chargetrip_range: ChargetripRange
-	wltp: Float
+	wltp: Float @deprecated(reason: "You will receive null values")
 }
 type CarRangeValue {
 	"""
@@ -2259,7 +2259,7 @@ type Connector {
 	"""
 	Charging prices
 	"""
-	pricing: Pricing
+	pricing: Pricing @deprecated(reason: "In favor of custom_properties.pricing")
 	"""
 	Custom properties of a connector. These are vendor specific and will return null values on the fields that are not supported by your station database
 	"""
@@ -4451,7 +4451,7 @@ type RequestEv {
 	"""
 	The number of passengers on board
 	"""
-	numberOfPassengers: Int
+	numberOfPassengers: Int @deprecated(reason: "In favor of occupants")
 	"""
 	Number of occupants
 	"""
@@ -4633,7 +4633,7 @@ type RequestRoute {
 	"""
 	Requested amenities near the stations, within a 1 kilometer radius
 	"""
-	amenities: [String]
+	amenities: [String] @deprecated(reason: "Will be removed. Use the amenity preferences instead")
 	"""
 	Amenity preferences for a route
 	"""
@@ -4641,15 +4641,15 @@ type RequestRoute {
 	"""
 	Requested operators
 	"""
-	operatorIds: [String]
+	operatorIds: [String] @deprecated(reason: "Will be removed. Use the operators property instead")
 	"""
 	Preferred operators are required. In case there are no preferred operators the route cannot be calculated
 	"""
-	operatorRequired: Boolean
+	operatorRequired: Boolean @deprecated(reason: "Will be removed. Use the operators property instead")
 	"""
 	Encourage the route to use preferred operators. In case there are no preferred operators the route can still be calculated
 	"""
-	operatorPrefer: Boolean
+	operatorPrefer: Boolean @deprecated(reason: "Will be removed. Use the operators property instead")
 	"""
 	Operator prioritization for a route
 	"""
@@ -4916,15 +4916,15 @@ type ReviewUser {
 	"""
 	User ID
 	"""
-	id: ID
+	id: ID @deprecated(reason: "Not sent back anymore, will be null")
 	"""
 	First name
 	"""
-	firstName: String
+	firstName: String @deprecated(reason: "Please use name instead")
 	"""
 	Last name
 	"""
-	lastName: String
+	lastName: String @deprecated(reason: "Please use name instead")
 }
 type Route {
 	"""
@@ -4943,7 +4943,7 @@ type Route {
 	Route telemetry data
 	"""
 	telemetry: JSON
-	user: RequestUser
+	user: RequestUser @deprecated(reason: "You will receive null values")
 	"""
 	Route request data
 	"""
@@ -5005,7 +5005,7 @@ type RouteAlternative {
 	"""
 	Amenity ranking for an alternative
 	"""
-	amenityRanking: Int
+	amenityRanking: Int @deprecated(reason: "Will be removed in the future")
 	"""
 	Range, in meters, available at the beginning of a trip
 	"""
@@ -5045,7 +5045,7 @@ type RouteAlternative {
 	"""
 	Elevation values. Each elevationPlot has a hundred points, independent of the length of a route
 	"""
-	elevationPlot: [Float]
+	elevationPlot: [Float] @deprecated(reason: "Will be removed in the future; Use the pathPlot property")
 	"""
 	Total number of meters which are going up on a route
 	"""
@@ -5812,11 +5812,11 @@ type Station {
 	"""
 	Station availability
 	"""
-	predicted_availability: [StationPredictedAvailability]
+	predicted_availability: [StationPredictedAvailability] @deprecated(reason: "predicted_availability, no value will be sent. Deprecated in favor of predicted_occupancy")
 	"""
 	Predicted station occupancy
 	"""
-	predicted_occupancy: [StationPredictedOccupancy]
+	predicted_occupancy: [StationPredictedOccupancy] @deprecated(reason: "In favor of custom_properties.predicted_occupancy")
 	"""
 	Charging speed for a station
 	"""

--- a/engine/crates/parser-sdl/src/lib.rs
+++ b/engine/crates/parser-sdl/src/lib.rs
@@ -24,6 +24,7 @@ use rules::{
     connector_transforms::run_transforms,
     default_directive::DefaultDirective,
     default_directive_types::DefaultDirectiveTypes,
+    deprecated_directive::DeprecatedDirective,
     directive::Directives,
     enum_type::EnumType,
     extend_connector_types::ExtendConnectorTypes,
@@ -148,7 +149,8 @@ fn parse_schema(schema: &str) -> engine::parser::Result<ServiceDocument> {
         .with::<ExternalDirective>()
         .with::<ShareableDirective>()
         .with::<OverrideDirective>()
-        .with::<ProvidesDirective>();
+        .with::<ProvidesDirective>()
+        .with::<DeprecatedDirective>();
 
     let schema = format!(
         "{}\n{}\n{}\n{}",

--- a/engine/crates/parser-sdl/src/rules/basic_type.rs
+++ b/engine/crates/parser-sdl/src/rules/basic_type.rs
@@ -17,6 +17,7 @@ use engine_parser::{
 use itertools::Itertools;
 
 use super::{
+    deprecated_directive::DeprecatedDirective,
     federation::{ExternalDirective, KeyDirective, OverrideDirective, ProvidesDirective, ShareableDirective},
     join_directive::JoinDirective,
     requires_directive::RequiresDirective,
@@ -67,6 +68,7 @@ impl<'a> Visitor<'a> for BasicType {
                     OverrideDirective::from_directives(&field.directives, ctx).map(|directive| directive.from);
                 let provides =
                     ProvidesDirective::from_directives(&field.directives, ctx).map(|directive| directive.fields);
+                let deprecation = DeprecatedDirective::from_directives(&field.directives, ctx);
 
                 if let Some(join_directive) = JoinDirective::from_directives(&field.node.directives, ctx) {
                     if resolver.is_custom() {
@@ -93,6 +95,7 @@ impl<'a> Visitor<'a> for BasicType {
                     shareable,
                     provides,
                     r#override,
+                    deprecation,
                     ..Default::default()
                 }
             })

--- a/engine/crates/parser-sdl/src/rules/deprecated_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/deprecated_directive.rs
@@ -1,0 +1,92 @@
+use engine::registry::Deprecation;
+use engine_parser::{types::ConstDirective, Positioned};
+
+use crate::{
+    directive_de::parse_directive,
+    rules::{directive::Directive, visitor::VisitorContext},
+};
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DeprecatedDirective {
+    pub reason: Option<String>,
+}
+
+impl DeprecatedDirective {
+    pub fn from_directives(directives: &[Positioned<ConstDirective>], ctx: &mut VisitorContext<'_>) -> Deprecation {
+        let Some(directive) = directives.iter().find(|directive| directive.name.node == "deprecated") else {
+            return Deprecation::NoDeprecated;
+        };
+
+        match parse_directive::<Self>(directive, ctx.variables) {
+            Ok(directive) => Deprecation::Deprecated {
+                reason: directive.reason,
+            },
+            Err(error) => {
+                ctx.append_errors(vec![error]);
+                Deprecation::NoDeprecated
+            }
+        }
+    }
+}
+
+impl Directive for DeprecatedDirective {
+    fn definition() -> String {
+        r#"
+        directive @deprecated(
+            reason: String = "No longer supported"
+        ) on FIELD_DEFINITION | ENUM_VALUE
+        "#
+        .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::parse_registry;
+
+    #[test]
+    fn test_deprecated_directive() {
+        let result = parse_registry(
+            r#"
+                extend type Query {
+                    oldField: MyEnum
+                        @deprecated
+                        @resolver(name: "blah")
+                    olderField: Int
+                        @deprecated(reason: "It is older than the sun")
+                        @resolver(name: "blah")
+                    Blah: Int
+                        @deprecated(reason: "\" there's a quote just to ruin your day")
+                        @resolver(name: "blah")
+                }
+
+                enum MyEnum {
+                    HAPPY_VALUE,
+                    OLD_VALUE @derecated
+                    OLDER_VALUE @deprecated(reason: "Dinosaurs thought this was passé")
+                    QUOTED_VALUE @deprecated(reason: "\" there's a quote just to ruin your day")
+                }
+            "#,
+        )
+        .unwrap();
+
+        insta::assert_snapshot!(result.export_sdl(false), @r###"
+        enum MyEnum {
+        	HAPPY_VALUE
+        	OLD_VALUE
+        	OLDER_VALUE @deprecated(reason: "Dinosaurs thought this was pass\u{e9}")
+        	QUOTED_VALUE @deprecated(reason: "\" there\'s a quote just to ruin your day")
+        }
+        type Query {
+        	oldField: MyEnum @deprecated
+        	olderField: Int @deprecated(reason: "It is older than the sun")
+        	Blah: Int @deprecated(reason: "\" there\'s a quote just to ruin your day")
+        }
+        schema {
+        	query: Query
+        }
+        "###);
+    }
+}

--- a/engine/crates/parser-sdl/src/rules/extend_connector_types.rs
+++ b/engine/crates/parser-sdl/src/rules/extend_connector_types.rs
@@ -6,6 +6,7 @@ use engine::registry::{
 use engine_parser::types::TypeKind;
 
 use super::{
+    deprecated_directive::DeprecatedDirective,
     federation::{ExternalDirective, OverrideDirective, ProvidesDirective, ShareableDirective},
     join_directive::JoinDirective,
     requires_directive::RequiresDirective,
@@ -49,6 +50,7 @@ impl<'a> Visitor<'a> for ExtendConnectorTypes {
                     OverrideDirective::from_directives(&field.directives, ctx).map(|directive| directive.from);
                 let provides =
                     ProvidesDirective::from_directives(&field.directives, ctx).map(|directive| directive.fields);
+                let deprecation = DeprecatedDirective::from_directives(&field.directives, ctx);
 
                 let resolver = match (join_directive, resolver_name) {
                     (None, None) => {
@@ -96,6 +98,7 @@ impl<'a> Visitor<'a> for ExtendConnectorTypes {
                     shareable,
                     r#override,
                     provides,
+                    deprecation,
                     ..MetaField::default()
                 })
             })

--- a/engine/crates/parser-sdl/src/rules/mod.rs
+++ b/engine/crates/parser-sdl/src/rules/mod.rs
@@ -10,6 +10,7 @@ mod connector_headers;
 pub mod connector_transforms;
 pub mod default_directive;
 pub mod default_directive_types;
+pub mod deprecated_directive;
 pub mod directive;
 pub mod enum_type;
 pub mod experimental;

--- a/engine/crates/parser-sdl/src/snapshots/parser_sdl__tests__schema.snap
+++ b/engine/crates/parser-sdl/src/snapshots/parser_sdl__tests__schema.snap
@@ -145,7 +145,6 @@ expression: req_string_a
       "O": {
         "f": {
           "userCreate": {
-            "D": "N",
             "_r": 1,
             "a": {
               "input": {
@@ -168,7 +167,6 @@ expression: req_string_a
             "t": "UserCreatePayload"
           },
           "userCreateMany": {
-            "D": "N",
             "_r": 1,
             "a": {
               "input": {
@@ -191,7 +189,6 @@ expression: req_string_a
             "t": "UserCreateManyPayload"
           },
           "userDelete": {
-            "D": "N",
             "_r": 16,
             "a": {
               "by": {
@@ -214,7 +211,6 @@ expression: req_string_a
             "t": "UserDeletePayload"
           },
           "userDeleteMany": {
-            "D": "N",
             "_r": 16,
             "a": {
               "input": {
@@ -237,7 +233,6 @@ expression: req_string_a
             "t": "UserDeleteManyPayload"
           },
           "userUpdate": {
-            "D": "N",
             "_r": 8,
             "a": {
               "by": {
@@ -267,7 +262,6 @@ expression: req_string_a
             "t": "UserUpdatePayload"
           },
           "userUpdateMany": {
-            "D": "N",
             "_r": 8,
             "a": {
               "input": {
@@ -298,7 +292,6 @@ expression: req_string_a
       "O": {
         "f": {
           "requiredField": {
-            "D": "N",
             "a": {},
             "n": "requiredField",
             "r_": {
@@ -346,7 +339,6 @@ expression: req_string_a
       "O": {
         "f": {
           "endCursor": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "n": "endCursor",
@@ -367,7 +359,6 @@ expression: req_string_a
             "t": "String"
           },
           "hasNextPage": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "n": "hasNextPage",
@@ -388,7 +379,6 @@ expression: req_string_a
             "t": "Boolean!"
           },
           "hasPreviousPage": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "n": "hasPreviousPage",
@@ -409,7 +399,6 @@ expression: req_string_a
             "t": "Boolean!"
           },
           "startCursor": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "n": "startCursor",
@@ -438,14 +427,12 @@ expression: req_string_a
       "O": {
         "f": {
           "__schema": {
-            "D": "N",
             "a": {},
             "d": "Access the current type schema of this server.",
             "n": "__schema",
             "t": "__Schema!"
           },
           "__type": {
-            "D": "N",
             "a": {
               "name": {
                 "n": "name",
@@ -457,7 +444,6 @@ expression: req_string_a
             "t": "__Type!"
           },
           "user": {
-            "D": "N",
             "_r": 2,
             "a": {
               "by": {
@@ -481,7 +467,6 @@ expression: req_string_a
             "t": "User"
           },
           "userCollection": {
-            "D": "N",
             "R": {
               "birectional": false,
               "kind": "OneToMany",
@@ -567,7 +552,6 @@ expression: req_string_a
         "I": true,
         "f": {
           "createdAt": {
-            "D": "N",
             "a": {},
             "d": "when the model was created",
             "n": "createdAt",
@@ -592,7 +576,6 @@ expression: req_string_a
             "t": "DateTime!"
           },
           "id": {
-            "D": "N",
             "a": {},
             "d": "Unique identifier",
             "n": "id",
@@ -617,7 +600,6 @@ expression: req_string_a
             "t": "ID!"
           },
           "nested": {
-            "D": "N",
             "a": {},
             "n": "nested",
             "r_": {
@@ -641,7 +623,6 @@ expression: req_string_a
             "t": "Nested"
           },
           "updatedAt": {
-            "D": "N",
             "a": {},
             "d": "when the model was updated",
             "n": "updatedAt",
@@ -699,14 +680,12 @@ expression: req_string_a
       "O": {
         "f": {
           "edges": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "n": "edges",
             "t": "[UserEdge]"
           },
           "pageInfo": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "d": "Information to aid in pagination",
@@ -747,7 +726,6 @@ expression: req_string_a
       "O": {
         "f": {
           "userCollection": {
-            "D": "N",
             "_r": 1,
             "a": {},
             "n": "userCollection",
@@ -772,7 +750,6 @@ expression: req_string_a
       "O": {
         "f": {
           "user": {
-            "D": "N",
             "_r": 1,
             "a": {},
             "n": "user",
@@ -812,7 +789,6 @@ expression: req_string_a
       "O": {
         "f": {
           "deletedIds": {
-            "D": "N",
             "_r": 16,
             "a": {},
             "n": "deletedIds",
@@ -834,7 +810,6 @@ expression: req_string_a
       "O": {
         "f": {
           "deletedId": {
-            "D": "N",
             "_r": 16,
             "a": {},
             "n": "deletedId",
@@ -856,7 +831,6 @@ expression: req_string_a
       "O": {
         "f": {
           "cursor": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "n": "cursor",
@@ -884,7 +858,6 @@ expression: req_string_a
             "t": "String!"
           },
           "node": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "n": "node",
@@ -941,7 +914,6 @@ expression: req_string_a
       "O": {
         "f": {
           "userCollection": {
-            "D": "N",
             "_r": 8,
             "a": {},
             "n": "userCollection",
@@ -966,7 +938,6 @@ expression: req_string_a
       "O": {
         "f": {
           "user": {
-            "D": "N",
             "_r": 8,
             "a": {},
             "n": "user",
@@ -995,31 +966,26 @@ expression: req_string_a
         "d": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
         "f": {
           "args": {
-            "D": "N",
             "a": {},
             "n": "args",
             "t": "[__InputValue!]!"
           },
           "description": {
-            "D": "N",
             "a": {},
             "n": "description",
             "t": "String"
           },
           "isRepeatable": {
-            "D": "N",
             "a": {},
             "n": "isRepeatable",
             "t": "Boolean!"
           },
           "locations": {
-            "D": "N",
             "a": {},
             "n": "locations",
             "t": "[__DirectiveLocation!]!"
           },
           "name": {
-            "D": "N",
             "a": {},
             "n": "name",
             "t": "String!"
@@ -1119,25 +1085,21 @@ expression: req_string_a
         "d": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
         "f": {
           "deprecationReason": {
-            "D": "N",
             "a": {},
             "n": "deprecationReason",
             "t": "String"
           },
           "description": {
-            "D": "N",
             "a": {},
             "n": "description",
             "t": "String"
           },
           "isDeprecated": {
-            "D": "N",
             "a": {},
             "n": "isDeprecated",
             "t": "Boolean!"
           },
           "name": {
-            "D": "N",
             "a": {},
             "n": "name",
             "t": "String!"
@@ -1152,37 +1114,31 @@ expression: req_string_a
         "d": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
         "f": {
           "args": {
-            "D": "N",
             "a": {},
             "n": "args",
             "t": "[__InputValue!]!"
           },
           "deprecationReason": {
-            "D": "N",
             "a": {},
             "n": "deprecationReason",
             "t": "String"
           },
           "description": {
-            "D": "N",
             "a": {},
             "n": "description",
             "t": "String"
           },
           "isDeprecated": {
-            "D": "N",
             "a": {},
             "n": "isDeprecated",
             "t": "Boolean!"
           },
           "name": {
-            "D": "N",
             "a": {},
             "n": "name",
             "t": "String!"
           },
           "type": {
-            "D": "N",
             "a": {},
             "n": "type",
             "t": "__Type!"
@@ -1197,25 +1153,21 @@ expression: req_string_a
         "d": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
         "f": {
           "defaultValue": {
-            "D": "N",
             "a": {},
             "n": "defaultValue",
             "t": "String"
           },
           "description": {
-            "D": "N",
             "a": {},
             "n": "description",
             "t": "String"
           },
           "name": {
-            "D": "N",
             "a": {},
             "n": "name",
             "t": "String!"
           },
           "type": {
-            "D": "N",
             "a": {},
             "n": "type",
             "t": "__Type!"
@@ -1230,41 +1182,35 @@ expression: req_string_a
         "d": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
         "f": {
           "description": {
-            "D": "N",
             "a": {},
             "n": "description",
             "t": "String"
           },
           "directives": {
-            "D": "N",
             "a": {},
             "d": "A list of all directives supported by this server.",
             "n": "directives",
             "t": "[__Directive!]!"
           },
           "mutationType": {
-            "D": "N",
             "a": {},
             "d": "If this server supports mutation, the type that mutation operations will be rooted at.",
             "n": "mutationType",
             "t": "__Type"
           },
           "queryType": {
-            "D": "N",
             "a": {},
             "d": "The type that query operations will be rooted at.",
             "n": "queryType",
             "t": "__Type!"
           },
           "subscriptionType": {
-            "D": "N",
             "a": {},
             "d": "If this server support subscription, the type that subscription operations will be rooted at.",
             "n": "subscriptionType",
             "t": "__Type"
           },
           "types": {
-            "D": "N",
             "a": {},
             "d": "A list of all types supported by this server.",
             "n": "types",
@@ -1280,13 +1226,11 @@ expression: req_string_a
         "d": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
         "f": {
           "description": {
-            "D": "N",
             "a": {},
             "n": "description",
             "t": "String"
           },
           "enumValues": {
-            "D": "N",
             "a": {
               "includeDeprecated": {
                 "D": false,
@@ -1298,7 +1242,6 @@ expression: req_string_a
             "t": "[__EnumValue!]"
           },
           "fields": {
-            "D": "N",
             "a": {
               "includeDeprecated": {
                 "D": false,
@@ -1310,49 +1253,41 @@ expression: req_string_a
             "t": "[__Field!]"
           },
           "inputFields": {
-            "D": "N",
             "a": {},
             "n": "inputFields",
             "t": "[__InputValue!]"
           },
           "interfaces": {
-            "D": "N",
             "a": {},
             "n": "interfaces",
             "t": "[__Type!]"
           },
           "isOneOf": {
-            "D": "N",
             "a": {},
             "n": "isOneOf",
             "t": "Boolean"
           },
           "kind": {
-            "D": "N",
             "a": {},
             "n": "kind",
             "t": "__TypeKind!"
           },
           "name": {
-            "D": "N",
             "a": {},
             "n": "name",
             "t": "String"
           },
           "ofType": {
-            "D": "N",
             "a": {},
             "n": "ofType",
             "t": "__Type"
           },
           "possibleTypes": {
-            "D": "N",
             "a": {},
             "n": "possibleTypes",
             "t": "[__Type!]"
           },
           "specifiedByURL": {
-            "D": "N",
             "a": {},
             "n": "specifiedByURL",
             "t": "String"

--- a/engine/crates/parser-sdl/src/snapshots/parser_sdl__tests__test_model_reserved_fields-req-a.snap
+++ b/engine/crates/parser-sdl/src/snapshots/parser_sdl__tests__test_model_reserved_fields-req-a.snap
@@ -145,7 +145,6 @@ expression: req_string_a
       "O": {
         "f": {
           "productCreate": {
-            "D": "N",
             "_r": 1,
             "a": {
               "input": {
@@ -168,7 +167,6 @@ expression: req_string_a
             "t": "ProductCreatePayload"
           },
           "productCreateMany": {
-            "D": "N",
             "_r": 1,
             "a": {
               "input": {
@@ -191,7 +189,6 @@ expression: req_string_a
             "t": "ProductCreateManyPayload"
           },
           "productDelete": {
-            "D": "N",
             "_r": 16,
             "a": {
               "by": {
@@ -214,7 +211,6 @@ expression: req_string_a
             "t": "ProductDeletePayload"
           },
           "productDeleteMany": {
-            "D": "N",
             "_r": 16,
             "a": {
               "input": {
@@ -237,7 +233,6 @@ expression: req_string_a
             "t": "ProductDeleteManyPayload"
           },
           "productUpdate": {
-            "D": "N",
             "_r": 8,
             "a": {
               "by": {
@@ -267,7 +262,6 @@ expression: req_string_a
             "t": "ProductUpdatePayload"
           },
           "productUpdateMany": {
-            "D": "N",
             "_r": 8,
             "a": {
               "input": {
@@ -312,7 +306,6 @@ expression: req_string_a
       "O": {
         "f": {
           "endCursor": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "n": "endCursor",
@@ -333,7 +326,6 @@ expression: req_string_a
             "t": "String"
           },
           "hasNextPage": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "n": "hasNextPage",
@@ -354,7 +346,6 @@ expression: req_string_a
             "t": "Boolean!"
           },
           "hasPreviousPage": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "n": "hasPreviousPage",
@@ -375,7 +366,6 @@ expression: req_string_a
             "t": "Boolean!"
           },
           "startCursor": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "n": "startCursor",
@@ -405,7 +395,6 @@ expression: req_string_a
         "I": true,
         "f": {
           "createdAt": {
-            "D": "N",
             "a": {},
             "d": "when the model was created",
             "n": "createdAt",
@@ -430,7 +419,6 @@ expression: req_string_a
             "t": "DateTime!"
           },
           "id": {
-            "D": "N",
             "a": {},
             "d": "Unique identifier",
             "n": "id",
@@ -455,7 +443,6 @@ expression: req_string_a
             "t": "ID!"
           },
           "title": {
-            "D": "N",
             "a": {},
             "n": "title",
             "r_": {
@@ -479,7 +466,6 @@ expression: req_string_a
             "t": "String"
           },
           "updatedAt": {
-            "D": "N",
             "a": {},
             "d": "when the model was updated",
             "n": "updatedAt",
@@ -537,14 +523,12 @@ expression: req_string_a
       "O": {
         "f": {
           "edges": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "n": "edges",
             "t": "[ProductEdge]"
           },
           "pageInfo": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "d": "Information to aid in pagination",
@@ -585,7 +569,6 @@ expression: req_string_a
       "O": {
         "f": {
           "productCollection": {
-            "D": "N",
             "_r": 1,
             "a": {},
             "n": "productCollection",
@@ -610,7 +593,6 @@ expression: req_string_a
       "O": {
         "f": {
           "product": {
-            "D": "N",
             "_r": 1,
             "a": {},
             "n": "product",
@@ -650,7 +632,6 @@ expression: req_string_a
       "O": {
         "f": {
           "deletedIds": {
-            "D": "N",
             "_r": 16,
             "a": {},
             "n": "deletedIds",
@@ -672,7 +653,6 @@ expression: req_string_a
       "O": {
         "f": {
           "deletedId": {
-            "D": "N",
             "_r": 16,
             "a": {},
             "n": "deletedId",
@@ -694,7 +674,6 @@ expression: req_string_a
       "O": {
         "f": {
           "cursor": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "n": "cursor",
@@ -722,7 +701,6 @@ expression: req_string_a
             "t": "String!"
           },
           "node": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "n": "node",
@@ -779,7 +757,6 @@ expression: req_string_a
       "O": {
         "f": {
           "productCollection": {
-            "D": "N",
             "_r": 8,
             "a": {},
             "n": "productCollection",
@@ -804,7 +781,6 @@ expression: req_string_a
       "O": {
         "f": {
           "product": {
-            "D": "N",
             "_r": 8,
             "a": {},
             "n": "product",
@@ -832,14 +808,12 @@ expression: req_string_a
       "O": {
         "f": {
           "__schema": {
-            "D": "N",
             "a": {},
             "d": "Access the current type schema of this server.",
             "n": "__schema",
             "t": "__Schema!"
           },
           "__type": {
-            "D": "N",
             "a": {
               "name": {
                 "n": "name",
@@ -851,7 +825,6 @@ expression: req_string_a
             "t": "__Type!"
           },
           "product": {
-            "D": "N",
             "_r": 2,
             "a": {
               "by": {
@@ -875,7 +848,6 @@ expression: req_string_a
             "t": "Product"
           },
           "productCollection": {
-            "D": "N",
             "R": {
               "birectional": false,
               "kind": "OneToMany",
@@ -961,31 +933,26 @@ expression: req_string_a
         "d": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
         "f": {
           "args": {
-            "D": "N",
             "a": {},
             "n": "args",
             "t": "[__InputValue!]!"
           },
           "description": {
-            "D": "N",
             "a": {},
             "n": "description",
             "t": "String"
           },
           "isRepeatable": {
-            "D": "N",
             "a": {},
             "n": "isRepeatable",
             "t": "Boolean!"
           },
           "locations": {
-            "D": "N",
             "a": {},
             "n": "locations",
             "t": "[__DirectiveLocation!]!"
           },
           "name": {
-            "D": "N",
             "a": {},
             "n": "name",
             "t": "String!"
@@ -1085,25 +1052,21 @@ expression: req_string_a
         "d": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
         "f": {
           "deprecationReason": {
-            "D": "N",
             "a": {},
             "n": "deprecationReason",
             "t": "String"
           },
           "description": {
-            "D": "N",
             "a": {},
             "n": "description",
             "t": "String"
           },
           "isDeprecated": {
-            "D": "N",
             "a": {},
             "n": "isDeprecated",
             "t": "Boolean!"
           },
           "name": {
-            "D": "N",
             "a": {},
             "n": "name",
             "t": "String!"
@@ -1118,37 +1081,31 @@ expression: req_string_a
         "d": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
         "f": {
           "args": {
-            "D": "N",
             "a": {},
             "n": "args",
             "t": "[__InputValue!]!"
           },
           "deprecationReason": {
-            "D": "N",
             "a": {},
             "n": "deprecationReason",
             "t": "String"
           },
           "description": {
-            "D": "N",
             "a": {},
             "n": "description",
             "t": "String"
           },
           "isDeprecated": {
-            "D": "N",
             "a": {},
             "n": "isDeprecated",
             "t": "Boolean!"
           },
           "name": {
-            "D": "N",
             "a": {},
             "n": "name",
             "t": "String!"
           },
           "type": {
-            "D": "N",
             "a": {},
             "n": "type",
             "t": "__Type!"
@@ -1163,25 +1120,21 @@ expression: req_string_a
         "d": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
         "f": {
           "defaultValue": {
-            "D": "N",
             "a": {},
             "n": "defaultValue",
             "t": "String"
           },
           "description": {
-            "D": "N",
             "a": {},
             "n": "description",
             "t": "String"
           },
           "name": {
-            "D": "N",
             "a": {},
             "n": "name",
             "t": "String!"
           },
           "type": {
-            "D": "N",
             "a": {},
             "n": "type",
             "t": "__Type!"
@@ -1196,41 +1149,35 @@ expression: req_string_a
         "d": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
         "f": {
           "description": {
-            "D": "N",
             "a": {},
             "n": "description",
             "t": "String"
           },
           "directives": {
-            "D": "N",
             "a": {},
             "d": "A list of all directives supported by this server.",
             "n": "directives",
             "t": "[__Directive!]!"
           },
           "mutationType": {
-            "D": "N",
             "a": {},
             "d": "If this server supports mutation, the type that mutation operations will be rooted at.",
             "n": "mutationType",
             "t": "__Type"
           },
           "queryType": {
-            "D": "N",
             "a": {},
             "d": "The type that query operations will be rooted at.",
             "n": "queryType",
             "t": "__Type!"
           },
           "subscriptionType": {
-            "D": "N",
             "a": {},
             "d": "If this server support subscription, the type that subscription operations will be rooted at.",
             "n": "subscriptionType",
             "t": "__Type"
           },
           "types": {
-            "D": "N",
             "a": {},
             "d": "A list of all types supported by this server.",
             "n": "types",
@@ -1246,13 +1193,11 @@ expression: req_string_a
         "d": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
         "f": {
           "description": {
-            "D": "N",
             "a": {},
             "n": "description",
             "t": "String"
           },
           "enumValues": {
-            "D": "N",
             "a": {
               "includeDeprecated": {
                 "D": false,
@@ -1264,7 +1209,6 @@ expression: req_string_a
             "t": "[__EnumValue!]"
           },
           "fields": {
-            "D": "N",
             "a": {
               "includeDeprecated": {
                 "D": false,
@@ -1276,49 +1220,41 @@ expression: req_string_a
             "t": "[__Field!]"
           },
           "inputFields": {
-            "D": "N",
             "a": {},
             "n": "inputFields",
             "t": "[__InputValue!]"
           },
           "interfaces": {
-            "D": "N",
             "a": {},
             "n": "interfaces",
             "t": "[__Type!]"
           },
           "isOneOf": {
-            "D": "N",
             "a": {},
             "n": "isOneOf",
             "t": "Boolean"
           },
           "kind": {
-            "D": "N",
             "a": {},
             "n": "kind",
             "t": "__TypeKind!"
           },
           "name": {
-            "D": "N",
             "a": {},
             "n": "name",
             "t": "String"
           },
           "ofType": {
-            "D": "N",
             "a": {},
             "n": "ofType",
             "t": "__Type"
           },
           "possibleTypes": {
-            "D": "N",
             "a": {},
             "n": "possibleTypes",
             "t": "[__Type!]"
           },
           "specifiedByURL": {
-            "D": "N",
             "a": {},
             "n": "specifiedByURL",
             "t": "String"

--- a/engine/crates/parser-sdl/src/snapshots/parser_sdl__tests__test_model_reserved_fields-req-b.snap
+++ b/engine/crates/parser-sdl/src/snapshots/parser_sdl__tests__test_model_reserved_fields-req-b.snap
@@ -145,7 +145,6 @@ expression: req_string_b
       "O": {
         "f": {
           "productCreate": {
-            "D": "N",
             "_r": 1,
             "a": {
               "input": {
@@ -168,7 +167,6 @@ expression: req_string_b
             "t": "ProductCreatePayload"
           },
           "productCreateMany": {
-            "D": "N",
             "_r": 1,
             "a": {
               "input": {
@@ -191,7 +189,6 @@ expression: req_string_b
             "t": "ProductCreateManyPayload"
           },
           "productDelete": {
-            "D": "N",
             "_r": 16,
             "a": {
               "by": {
@@ -214,7 +211,6 @@ expression: req_string_b
             "t": "ProductDeletePayload"
           },
           "productDeleteMany": {
-            "D": "N",
             "_r": 16,
             "a": {
               "input": {
@@ -237,7 +233,6 @@ expression: req_string_b
             "t": "ProductDeleteManyPayload"
           },
           "productUpdate": {
-            "D": "N",
             "_r": 8,
             "a": {
               "by": {
@@ -267,7 +262,6 @@ expression: req_string_b
             "t": "ProductUpdatePayload"
           },
           "productUpdateMany": {
-            "D": "N",
             "_r": 8,
             "a": {
               "input": {
@@ -312,7 +306,6 @@ expression: req_string_b
       "O": {
         "f": {
           "endCursor": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "n": "endCursor",
@@ -333,7 +326,6 @@ expression: req_string_b
             "t": "String"
           },
           "hasNextPage": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "n": "hasNextPage",
@@ -354,7 +346,6 @@ expression: req_string_b
             "t": "Boolean!"
           },
           "hasPreviousPage": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "n": "hasPreviousPage",
@@ -375,7 +366,6 @@ expression: req_string_b
             "t": "Boolean!"
           },
           "startCursor": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "n": "startCursor",
@@ -405,7 +395,6 @@ expression: req_string_b
         "I": true,
         "f": {
           "createdAt": {
-            "D": "N",
             "a": {},
             "d": "when the model was created",
             "n": "createdAt",
@@ -430,7 +419,6 @@ expression: req_string_b
             "t": "DateTime!"
           },
           "id": {
-            "D": "N",
             "a": {},
             "d": "Unique identifier",
             "n": "id",
@@ -455,7 +443,6 @@ expression: req_string_b
             "t": "ID!"
           },
           "title": {
-            "D": "N",
             "a": {},
             "n": "title",
             "r_": {
@@ -479,7 +466,6 @@ expression: req_string_b
             "t": "String"
           },
           "updatedAt": {
-            "D": "N",
             "a": {},
             "d": "when the model was updated",
             "n": "updatedAt",
@@ -537,14 +523,12 @@ expression: req_string_b
       "O": {
         "f": {
           "edges": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "n": "edges",
             "t": "[ProductEdge]"
           },
           "pageInfo": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "d": "Information to aid in pagination",
@@ -585,7 +569,6 @@ expression: req_string_b
       "O": {
         "f": {
           "productCollection": {
-            "D": "N",
             "_r": 1,
             "a": {},
             "n": "productCollection",
@@ -610,7 +593,6 @@ expression: req_string_b
       "O": {
         "f": {
           "product": {
-            "D": "N",
             "_r": 1,
             "a": {},
             "n": "product",
@@ -650,7 +632,6 @@ expression: req_string_b
       "O": {
         "f": {
           "deletedIds": {
-            "D": "N",
             "_r": 16,
             "a": {},
             "n": "deletedIds",
@@ -672,7 +653,6 @@ expression: req_string_b
       "O": {
         "f": {
           "deletedId": {
-            "D": "N",
             "_r": 16,
             "a": {},
             "n": "deletedId",
@@ -694,7 +674,6 @@ expression: req_string_b
       "O": {
         "f": {
           "cursor": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "n": "cursor",
@@ -722,7 +701,6 @@ expression: req_string_b
             "t": "String!"
           },
           "node": {
-            "D": "N",
             "_r": 4,
             "a": {},
             "n": "node",
@@ -779,7 +757,6 @@ expression: req_string_b
       "O": {
         "f": {
           "productCollection": {
-            "D": "N",
             "_r": 8,
             "a": {},
             "n": "productCollection",
@@ -804,7 +781,6 @@ expression: req_string_b
       "O": {
         "f": {
           "product": {
-            "D": "N",
             "_r": 8,
             "a": {},
             "n": "product",
@@ -832,14 +808,12 @@ expression: req_string_b
       "O": {
         "f": {
           "__schema": {
-            "D": "N",
             "a": {},
             "d": "Access the current type schema of this server.",
             "n": "__schema",
             "t": "__Schema!"
           },
           "__type": {
-            "D": "N",
             "a": {
               "name": {
                 "n": "name",
@@ -851,7 +825,6 @@ expression: req_string_b
             "t": "__Type!"
           },
           "product": {
-            "D": "N",
             "_r": 2,
             "a": {
               "by": {
@@ -875,7 +848,6 @@ expression: req_string_b
             "t": "Product"
           },
           "productCollection": {
-            "D": "N",
             "R": {
               "birectional": false,
               "kind": "OneToMany",
@@ -961,31 +933,26 @@ expression: req_string_b
         "d": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
         "f": {
           "args": {
-            "D": "N",
             "a": {},
             "n": "args",
             "t": "[__InputValue!]!"
           },
           "description": {
-            "D": "N",
             "a": {},
             "n": "description",
             "t": "String"
           },
           "isRepeatable": {
-            "D": "N",
             "a": {},
             "n": "isRepeatable",
             "t": "Boolean!"
           },
           "locations": {
-            "D": "N",
             "a": {},
             "n": "locations",
             "t": "[__DirectiveLocation!]!"
           },
           "name": {
-            "D": "N",
             "a": {},
             "n": "name",
             "t": "String!"
@@ -1085,25 +1052,21 @@ expression: req_string_b
         "d": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
         "f": {
           "deprecationReason": {
-            "D": "N",
             "a": {},
             "n": "deprecationReason",
             "t": "String"
           },
           "description": {
-            "D": "N",
             "a": {},
             "n": "description",
             "t": "String"
           },
           "isDeprecated": {
-            "D": "N",
             "a": {},
             "n": "isDeprecated",
             "t": "Boolean!"
           },
           "name": {
-            "D": "N",
             "a": {},
             "n": "name",
             "t": "String!"
@@ -1118,37 +1081,31 @@ expression: req_string_b
         "d": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
         "f": {
           "args": {
-            "D": "N",
             "a": {},
             "n": "args",
             "t": "[__InputValue!]!"
           },
           "deprecationReason": {
-            "D": "N",
             "a": {},
             "n": "deprecationReason",
             "t": "String"
           },
           "description": {
-            "D": "N",
             "a": {},
             "n": "description",
             "t": "String"
           },
           "isDeprecated": {
-            "D": "N",
             "a": {},
             "n": "isDeprecated",
             "t": "Boolean!"
           },
           "name": {
-            "D": "N",
             "a": {},
             "n": "name",
             "t": "String!"
           },
           "type": {
-            "D": "N",
             "a": {},
             "n": "type",
             "t": "__Type!"
@@ -1163,25 +1120,21 @@ expression: req_string_b
         "d": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
         "f": {
           "defaultValue": {
-            "D": "N",
             "a": {},
             "n": "defaultValue",
             "t": "String"
           },
           "description": {
-            "D": "N",
             "a": {},
             "n": "description",
             "t": "String"
           },
           "name": {
-            "D": "N",
             "a": {},
             "n": "name",
             "t": "String!"
           },
           "type": {
-            "D": "N",
             "a": {},
             "n": "type",
             "t": "__Type!"
@@ -1196,41 +1149,35 @@ expression: req_string_b
         "d": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
         "f": {
           "description": {
-            "D": "N",
             "a": {},
             "n": "description",
             "t": "String"
           },
           "directives": {
-            "D": "N",
             "a": {},
             "d": "A list of all directives supported by this server.",
             "n": "directives",
             "t": "[__Directive!]!"
           },
           "mutationType": {
-            "D": "N",
             "a": {},
             "d": "If this server supports mutation, the type that mutation operations will be rooted at.",
             "n": "mutationType",
             "t": "__Type"
           },
           "queryType": {
-            "D": "N",
             "a": {},
             "d": "The type that query operations will be rooted at.",
             "n": "queryType",
             "t": "__Type!"
           },
           "subscriptionType": {
-            "D": "N",
             "a": {},
             "d": "If this server support subscription, the type that subscription operations will be rooted at.",
             "n": "subscriptionType",
             "t": "__Type"
           },
           "types": {
-            "D": "N",
             "a": {},
             "d": "A list of all types supported by this server.",
             "n": "types",
@@ -1246,13 +1193,11 @@ expression: req_string_b
         "d": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
         "f": {
           "description": {
-            "D": "N",
             "a": {},
             "n": "description",
             "t": "String"
           },
           "enumValues": {
-            "D": "N",
             "a": {
               "includeDeprecated": {
                 "D": false,
@@ -1264,7 +1209,6 @@ expression: req_string_b
             "t": "[__EnumValue!]"
           },
           "fields": {
-            "D": "N",
             "a": {
               "includeDeprecated": {
                 "D": false,
@@ -1276,49 +1220,41 @@ expression: req_string_b
             "t": "[__Field!]"
           },
           "inputFields": {
-            "D": "N",
             "a": {},
             "n": "inputFields",
             "t": "[__InputValue!]"
           },
           "interfaces": {
-            "D": "N",
             "a": {},
             "n": "interfaces",
             "t": "[__Type!]"
           },
           "isOneOf": {
-            "D": "N",
             "a": {},
             "n": "isOneOf",
             "t": "Boolean"
           },
           "kind": {
-            "D": "N",
             "a": {},
             "n": "kind",
             "t": "__TypeKind!"
           },
           "name": {
-            "D": "N",
             "a": {},
             "n": "name",
             "t": "String"
           },
           "ofType": {
-            "D": "N",
             "a": {},
             "n": "ofType",
             "t": "__Type"
           },
           "possibleTypes": {
-            "D": "N",
             "a": {},
             "n": "possibleTypes",
             "t": "[__Type!]"
           },
           "specifiedByURL": {
-            "D": "N",
             "a": {},
             "n": "specifiedByURL",
             "t": "String"


### PR DESCRIPTION
While testing the federation subgraph stuff, I noticed we don't support the `@deprecated` directive properly.  This is core GraphQL stuff so figured I should probably fix.

Part of GB-5001