### PR TITLE
feat: `@inaccessible` & `@tag` directives

### DIFF
--- a/engine/crates/engine/src/registry/export_sdl.rs
+++ b/engine/crates/engine/src/registry/export_sdl.rs
@@ -87,6 +87,12 @@ impl Registry {
                 if let Some(provides) = field.provides.as_deref() {
                     write!(sdl, " @provides(fields: \"{provides}\")").ok();
                 }
+                if field.inaccessible {
+                    write!(sdl, " @inaccessible").ok();
+                }
+                for tag in &field.tags {
+                    write!(sdl, " @tag(name: \"{}\")", tag.escape_default()).ok();
+                }
             }
 
             writeln!(sdl).ok();

--- a/engine/crates/engine/src/registry/mod.rs
+++ b/engine/crates/engine/src/registry/mod.rs
@@ -328,6 +328,8 @@ pub struct MetaField {
     pub required_operation: Option<Operations>,
     pub auth: Option<AuthConfig>,
     pub r#override: Option<String>,
+    pub tags: Vec<String>,
+    pub inaccessible: bool,
 }
 
 impl MetaField {

--- a/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__flat_output-2.snap
+++ b/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__flat_output-2.snap
@@ -65,6 +65,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "addPet": MetaField {
                         name: "addPet",
@@ -122,6 +124,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "uploadFile": MetaField {
                         name: "uploadFile",
@@ -197,6 +201,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "placeOrder": MetaField {
                         name: "placeOrder",
@@ -254,6 +260,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "createUsersWithListInput": MetaField {
                         name: "createUsersWithListInput",
@@ -311,6 +319,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                 },
                 cache_control: CacheControl {
@@ -364,6 +374,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "type": MetaField {
                         name: "type",
@@ -395,6 +407,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "code": MetaField {
                         name: "code",
@@ -426,6 +440,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                 },
                 cache_control: CacheControl {
@@ -479,6 +495,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "id": MetaField {
                         name: "id",
@@ -510,6 +528,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                 },
                 cache_control: CacheControl {
@@ -626,6 +646,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "status": MetaField {
                         name: "status",
@@ -664,6 +686,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "shipDate": MetaField {
                         name: "shipDate",
@@ -695,6 +719,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "quantity": MetaField {
                         name: "quantity",
@@ -726,6 +752,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "petId": MetaField {
                         name: "petId",
@@ -757,6 +785,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "id": MetaField {
                         name: "id",
@@ -788,6 +818,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                 },
                 cache_control: CacheControl {
@@ -951,6 +983,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "tags": MetaField {
                         name: "tags",
@@ -982,6 +1016,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "photoUrls": MetaField {
                         name: "photoUrls",
@@ -1013,6 +1049,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "category": MetaField {
                         name: "category",
@@ -1044,6 +1082,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "name": MetaField {
                         name: "name",
@@ -1075,6 +1115,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "id": MetaField {
                         name: "id",
@@ -1106,6 +1148,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                 },
                 cache_control: CacheControl {
@@ -1262,6 +1306,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "id": MetaField {
                         name: "id",
@@ -1293,6 +1339,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                 },
                 cache_control: CacheControl {
@@ -1376,6 +1424,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "phone": MetaField {
                         name: "phone",
@@ -1407,6 +1457,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "password": MetaField {
                         name: "password",
@@ -1438,6 +1490,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "email": MetaField {
                         name: "email",
@@ -1469,6 +1523,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "lastName": MetaField {
                         name: "lastName",
@@ -1500,6 +1556,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "firstName": MetaField {
                         name: "firstName",
@@ -1531,6 +1589,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "username": MetaField {
                         name: "username",
@@ -1562,6 +1622,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "id": MetaField {
                         name: "id",
@@ -1593,6 +1655,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                 },
                 cache_control: CacheControl {
@@ -1769,6 +1833,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "findPetsByTags": MetaField {
                         name: "findPetsByTags",
@@ -1827,6 +1893,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "pet": MetaField {
                         name: "pet",
@@ -1884,6 +1952,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "inventory": MetaField {
                         name: "inventory",
@@ -1923,6 +1993,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "order": MetaField {
                         name: "order",
@@ -1980,6 +2052,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "loginUser": MetaField {
                         name: "loginUser",
@@ -2055,6 +2129,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "user": MetaField {
                         name: "user",
@@ -2112,6 +2188,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                 },
                 cache_control: CacheControl {

--- a/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__petstore_output-2.snap
+++ b/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__petstore_output-2.snap
@@ -35,6 +35,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                 },
                 cache_control: CacheControl {
@@ -88,6 +90,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "type": MetaField {
                         name: "type",
@@ -119,6 +123,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "code": MetaField {
                         name: "code",
@@ -150,6 +156,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                 },
                 cache_control: CacheControl {
@@ -203,6 +211,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "id": MetaField {
                         name: "id",
@@ -234,6 +244,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                 },
                 cache_control: CacheControl {
@@ -376,6 +388,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "addPet": MetaField {
                         name: "addPet",
@@ -433,6 +447,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "uploadFile": MetaField {
                         name: "uploadFile",
@@ -508,6 +524,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "placeOrder": MetaField {
                         name: "placeOrder",
@@ -565,6 +583,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "createUsersWithListInput": MetaField {
                         name: "createUsersWithListInput",
@@ -622,6 +642,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                 },
                 cache_control: CacheControl {
@@ -675,6 +697,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "status": MetaField {
                         name: "status",
@@ -713,6 +737,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "shipDate": MetaField {
                         name: "shipDate",
@@ -744,6 +770,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "quantity": MetaField {
                         name: "quantity",
@@ -775,6 +803,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "petId": MetaField {
                         name: "petId",
@@ -806,6 +836,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "id": MetaField {
                         name: "id",
@@ -837,6 +869,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                 },
                 cache_control: CacheControl {
@@ -1000,6 +1034,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "tags": MetaField {
                         name: "tags",
@@ -1031,6 +1067,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "photoUrls": MetaField {
                         name: "photoUrls",
@@ -1062,6 +1100,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "category": MetaField {
                         name: "category",
@@ -1093,6 +1133,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "name": MetaField {
                         name: "name",
@@ -1124,6 +1166,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "id": MetaField {
                         name: "id",
@@ -1155,6 +1199,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                 },
                 cache_control: CacheControl {
@@ -1344,6 +1390,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "findPetsByTags": MetaField {
                         name: "findPetsByTags",
@@ -1402,6 +1450,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "pet": MetaField {
                         name: "pet",
@@ -1459,6 +1509,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "inventory": MetaField {
                         name: "inventory",
@@ -1498,6 +1550,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "order": MetaField {
                         name: "order",
@@ -1555,6 +1609,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "loginUser": MetaField {
                         name: "loginUser",
@@ -1630,6 +1686,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "user": MetaField {
                         name: "user",
@@ -1687,6 +1745,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                 },
                 cache_control: CacheControl {
@@ -1740,6 +1800,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "id": MetaField {
                         name: "id",
@@ -1771,6 +1833,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                 },
                 cache_control: CacheControl {
@@ -1854,6 +1918,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "phone": MetaField {
                         name: "phone",
@@ -1885,6 +1951,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "password": MetaField {
                         name: "password",
@@ -1916,6 +1984,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "email": MetaField {
                         name: "email",
@@ -1947,6 +2017,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "lastName": MetaField {
                         name: "lastName",
@@ -1978,6 +2050,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "firstName": MetaField {
                         name: "firstName",
@@ -2009,6 +2083,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "username": MetaField {
                         name: "username",
@@ -2040,6 +2116,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                     "id": MetaField {
                         name: "id",
@@ -2071,6 +2149,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                 },
                 cache_control: CacheControl {
@@ -2210,6 +2290,8 @@ Registry {
                         required_operation: None,
                         auth: None,
                         r#override: None,
+                        tags: [],
+                        inaccessible: false,
                     },
                 },
                 cache_control: CacheControl {

--- a/engine/crates/parser-sdl/src/lib.rs
+++ b/engine/crates/parser-sdl/src/lib.rs
@@ -30,8 +30,8 @@ use rules::{
     extend_connector_types::ExtendConnectorTypes,
     extend_query_and_mutation_types::ExtendQueryAndMutationTypes,
     federation::{
-        ExternalDirective, FederationDirective, FederationDirectiveVisitor, KeyDirective, OverrideDirective,
-        ProvidesDirective, ShareableDirective,
+        ExternalDirective, FederationDirective, FederationDirectiveVisitor, InaccessibleDirective, KeyDirective,
+        OverrideDirective, ProvidesDirective, ShareableDirective, TagDirective,
     },
     graphql_directive::GraphqlVisitor,
     input_object::InputObjectVisitor,
@@ -150,7 +150,9 @@ fn parse_schema(schema: &str) -> engine::parser::Result<ServiceDocument> {
         .with::<ShareableDirective>()
         .with::<OverrideDirective>()
         .with::<ProvidesDirective>()
-        .with::<DeprecatedDirective>();
+        .with::<DeprecatedDirective>()
+        .with::<InaccessibleDirective>()
+        .with::<TagDirective>();
 
     let schema = format!(
         "{}\n{}\n{}\n{}",

--- a/engine/crates/parser-sdl/src/registry/pagination.rs
+++ b/engine/crates/parser-sdl/src/registry/pagination.rs
@@ -237,6 +237,8 @@ pub fn add_query_paginated_collection(
         required_operation: Some(Operations::LIST),
         auth: model_auth.cloned(),
         shareable: false,
+        inaccessible: false,
+        tags: vec![],
     });
 }
 

--- a/engine/crates/parser-sdl/src/registry/search.rs
+++ b/engine/crates/parser-sdl/src/registry/search.rs
@@ -283,6 +283,8 @@ pub fn add_query_search(
         required_operation: Some(Operations::LIST),
         auth: model_auth.cloned(),
         shareable: false,
+        inaccessible: false,
+        tags: vec![],
     });
 }
 

--- a/engine/crates/parser-sdl/src/rules/basic_type.rs
+++ b/engine/crates/parser-sdl/src/rules/basic_type.rs
@@ -18,7 +18,10 @@ use itertools::Itertools;
 
 use super::{
     deprecated_directive::DeprecatedDirective,
-    federation::{ExternalDirective, KeyDirective, OverrideDirective, ProvidesDirective, ShareableDirective},
+    federation::{
+        ExternalDirective, InaccessibleDirective, KeyDirective, OverrideDirective, ProvidesDirective,
+        ShareableDirective, TagDirective,
+    },
     join_directive::JoinDirective,
     requires_directive::RequiresDirective,
     resolver_directive::ResolverDirective,
@@ -69,6 +72,8 @@ impl<'a> Visitor<'a> for BasicType {
                 let provides =
                     ProvidesDirective::from_directives(&field.directives, ctx).map(|directive| directive.fields);
                 let deprecation = DeprecatedDirective::from_directives(&field.directives, ctx);
+                let inaccessible = InaccessibleDirective::from_directives(&field.directives, ctx);
+                let tags = TagDirective::from_directives(&field.directives, ctx);
 
                 if let Some(join_directive) = JoinDirective::from_directives(&field.node.directives, ctx) {
                     if resolver.is_custom() {
@@ -96,6 +101,8 @@ impl<'a> Visitor<'a> for BasicType {
                     provides,
                     r#override,
                     deprecation,
+                    inaccessible,
+                    tags,
                     ..Default::default()
                 }
             })

--- a/engine/crates/parser-sdl/src/rules/extend_connector_types.rs
+++ b/engine/crates/parser-sdl/src/rules/extend_connector_types.rs
@@ -7,7 +7,10 @@ use engine_parser::types::TypeKind;
 
 use super::{
     deprecated_directive::DeprecatedDirective,
-    federation::{ExternalDirective, OverrideDirective, ProvidesDirective, ShareableDirective},
+    federation::{
+        ExternalDirective, InaccessibleDirective, OverrideDirective, ProvidesDirective, ShareableDirective,
+        TagDirective,
+    },
     join_directive::JoinDirective,
     requires_directive::RequiresDirective,
     visitor::{Visitor, VisitorContext},
@@ -51,6 +54,8 @@ impl<'a> Visitor<'a> for ExtendConnectorTypes {
                 let provides =
                     ProvidesDirective::from_directives(&field.directives, ctx).map(|directive| directive.fields);
                 let deprecation = DeprecatedDirective::from_directives(&field.directives, ctx);
+                let inaccessible = InaccessibleDirective::from_directives(&field.directives, ctx);
+                let tags = TagDirective::from_directives(&field.directives, ctx);
 
                 let resolver = match (join_directive, resolver_name) {
                     (None, None) => {
@@ -99,6 +104,8 @@ impl<'a> Visitor<'a> for ExtendConnectorTypes {
                     r#override,
                     provides,
                     deprecation,
+                    inaccessible,
+                    tags,
                     ..MetaField::default()
                 })
             })

--- a/engine/crates/parser-sdl/src/rules/extend_query_and_mutation_types.rs
+++ b/engine/crates/parser-sdl/src/rules/extend_query_and_mutation_types.rs
@@ -7,6 +7,7 @@ use engine_parser::types::{ObjectType, TypeKind};
 
 use super::{
     deprecated_directive::DeprecatedDirective,
+    federation::{InaccessibleDirective, TagDirective},
     visitor::{Visitor, VisitorContext, MUTATION_TYPE, QUERY_TYPE},
 };
 use crate::rules::{cache_directive::CacheDirective, resolver_directive::ResolverDirective};
@@ -52,6 +53,8 @@ impl<'a> Visitor<'a> for ExtendQueryAndMutationTypes {
                     continue;
                 };
                 let deprecation = DeprecatedDirective::from_directives(&field.directives, ctx);
+                let inaccessible = InaccessibleDirective::from_directives(&field.directives, ctx);
+                let tags = TagDirective::from_directives(&field.directives, ctx);
 
                 let (field_collection, cache_control) = match entry_point {
                     EntryPoint::Query => (&mut ctx.queries, CacheDirective::parse(&field.node.directives)),
@@ -90,6 +93,8 @@ impl<'a> Visitor<'a> for ExtendQueryAndMutationTypes {
                     required_operation,
                     auth: None,
                     shareable: false,
+                    inaccessible,
+                    tags,
                 });
             }
         }

--- a/engine/crates/parser-sdl/src/rules/federation/inaccessible.rs
+++ b/engine/crates/parser-sdl/src/rules/federation/inaccessible.rs
@@ -1,0 +1,50 @@
+use engine_parser::{types::ConstDirective, Positioned};
+
+use crate::rules::{directive::Directive, visitor::VisitorContext};
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct InaccessibleDirective;
+
+impl InaccessibleDirective {
+    pub fn from_directives(directives: &[Positioned<ConstDirective>], _ctx: &mut VisitorContext<'_>) -> bool {
+        directives.iter().any(|directive| directive.name.node == "inaccessible")
+    }
+}
+
+impl Directive for InaccessibleDirective {
+    fn definition() -> String {
+        // The real inaccessible is meant to be available in a lot more positions than this
+        // but for now we're only supporting this one
+        r#"
+        directive @inaccessible on FIELD_DEFINITION
+        "#
+        .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    #[test]
+    fn inaccessible_field_on_basic_type() {
+        let schema = r#"
+            extend schema @federation(version: "2.3")
+
+            type User @key(fields: "id", resolvable: false) {
+                id: ID! @inaccessible
+            }
+        "#;
+
+        let registry = crate::to_parse_result_with_variables(schema, &HashMap::new())
+            .unwrap()
+            .registry;
+
+        insta::assert_display_snapshot!(registry.export_sdl(true), @r###"
+        type User @key(fields: "id" resolvable: false) {
+        	id: ID! @inaccessible
+        }
+        "###);
+    }
+}

--- a/engine/crates/parser-sdl/src/rules/federation/mod.rs
+++ b/engine/crates/parser-sdl/src/rules/federation/mod.rs
@@ -1,15 +1,19 @@
 mod directive;
 mod external;
 mod field_set;
+mod inaccessible;
 mod key;
 mod r#override;
 mod provides;
 mod shareable;
+mod tag;
 
 pub use directive::*;
 pub use external::*;
 pub use field_set::*;
+pub use inaccessible::*;
 pub use key::*;
 pub use provides::*;
 pub use r#override::*;
 pub use shareable::*;
+pub use tag::*;

--- a/engine/crates/parser-sdl/src/rules/federation/tag.rs
+++ b/engine/crates/parser-sdl/src/rules/federation/tag.rs
@@ -1,0 +1,79 @@
+use engine_parser::{types::ConstDirective, Positioned};
+
+use crate::{
+    directive_de::parse_directive,
+    rules::{directive::Directive, visitor::VisitorContext},
+};
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TagDirective {
+    name: String,
+}
+
+impl TagDirective {
+    pub fn from_directives(directives: &[Positioned<ConstDirective>], ctx: &mut VisitorContext<'_>) -> Vec<String> {
+        directives
+            .iter()
+            .filter(|directive| directive.name.node == "tag")
+            .filter_map(|directive| match parse_directive::<Self>(directive, ctx.variables) {
+                Ok(directive) => Some(directive.name),
+                Err(error) => {
+                    ctx.append_errors(vec![error]);
+                    None
+                }
+            })
+            .collect()
+    }
+}
+
+impl Directive for TagDirective {
+    fn definition() -> String {
+        // The real tag is meant to be available in a lot more positions than this
+        // but for now we're only supporting FIELD_DEFINITION position.
+        //
+        // These are also marked as repeatable in the actual definition but we
+        // don't support that keyword at the moment
+        r#"
+        directive @tag(name: String!) on FIELD_DEFINITION
+        "#
+        .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    #[test]
+    fn tag_field_on_basic_type() {
+        let schema = r#"
+            extend schema @federation(version: "2.3")
+
+            type User @key(fields: "id", resolvable: false) {
+                id: ID!
+                name: Whatever! @tag(name: "woop")
+                other: Whatever! @tag(name: "woop") @tag(name: "poow")
+            }
+
+            type Whatever {
+                blah: String
+            }
+        "#;
+
+        let registry = crate::to_parse_result_with_variables(schema, &HashMap::new())
+            .unwrap()
+            .registry;
+
+        insta::assert_display_snapshot!(registry.export_sdl(true), @r###"
+        type User @key(fields: "id" resolvable: false) {
+        	id: ID!
+        	name: Whatever! @tag(name: "woop")
+        	other: Whatever! @tag(name: "woop") @tag(name: "poow")
+        }
+        type Whatever {
+        	blah: String
+        }
+        "###);
+    }
+}


### PR DESCRIPTION
I think these are the last two simple federation directives.

They can apply to a lot more than just fields but for now I'm only supporting them on fields.  Not super hard to fix that later, but would like to save the time for now.