### PR TITLE
fix: the publish step in the SDK CLI

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -70,5 +70,5 @@ jobs:
         shell: bash
         run: |
           npm set "//registry.npmjs.org/:_authToken" ${{ secrets.NPM_ACCESS_TOKEN }}
-          cd packages/grafbase-sdk
+          cd grafbase-sdk
           npm publish


### PR DESCRIPTION
#921 added a default working directory of `./packages`, but this step was trying to `cd packages`.
