### PR TITLE
fix(cli): Change the project root semantics such as `grafbase/` becomes only a fallback for the project root

### DIFF
--- a/cli/crates/backend/src/api/create.rs
+++ b/cli/crates/backend/src/api/create.rs
@@ -85,6 +85,7 @@ pub async fn create(
             account_id: Id::new(account_id),
             database_regions,
             project_slug,
+            project_root_path: ".",
         },
     });
 

--- a/cli/crates/backend/src/api/deploy.rs
+++ b/cli/crates/backend/src/api/deploy.rs
@@ -7,7 +7,6 @@ use super::graphql::mutations::{
 };
 use super::types::ProjectMetadata;
 use crate::consts::USER_AGENT;
-use common::consts::GRAFBASE_DIRECTORY_NAME;
 use common::environment::Project;
 use cynic::http::ReqwestExt;
 use cynic::{Id, MutationBuilder};
@@ -58,26 +57,20 @@ pub async fn deploy() -> Result<(), ApiError> {
             .map_err(ApiError::AppendToArchive)?;
     }
 
-    let walker = WalkDir::new(&project.grafbase_directory_path).into_iter();
+    let walker = WalkDir::new(&project.path).into_iter();
     for entry in walker.filter_entry(|entry| entry_not_in_blacklist(entry, &project.path)) {
         let entry = entry.map_err(ApiError::ReadProjectFile)?;
 
         let entry_path = entry.path().to_owned();
-        let path_in_tar = PathBuf::from(GRAFBASE_DIRECTORY_NAME).join(
-            entry_path
-                .strip_prefix(&project.path)
-                .expect("must include prefix")
-                .strip_prefix(GRAFBASE_DIRECTORY_NAME)
-                .expect("must include grafbase dir name"),
-        );
+        let path_in_tar = entry_path.strip_prefix(&project.path).expect("must include prefix");
         let entry_metadata = entry.metadata().map_err(ApiError::ReadProjectFile)?;
         if entry_metadata.is_file() {
-            tar.append_path_with_name(entry_path, path_in_tar)
+            tar.append_path_with_name(&entry_path, path_in_tar)
                 .await
                 .map_err(ApiError::AppendToArchive)?;
         } else {
             // as we don't follow links, anything else will be a directory
-            tar.append_dir(path_in_tar, entry_path)
+            tar.append_dir(path_in_tar, &entry_path)
                 .await
                 .map_err(ApiError::AppendToArchive)?;
         }

--- a/cli/crates/backend/src/api/graphql/api.graphql
+++ b/cli/crates/backend/src/api/graphql/api.graphql
@@ -93,6 +93,8 @@ type AccountResourcesStatus {
   dbWrites: ResourceStatus!
   dbSize: ResourceStatus!
   buildDuration: ResourceStatus!
+  udfRequestCount: ResourceStatus!
+  udfExecUnits: ResourceStatus!
   execUnits: ResourceStatus!
 }
 
@@ -102,8 +104,10 @@ type AccountResourcesUsage {
   dbWrites: TimeSeries!
   dbSize: TimeSeries!
   buildDuration: TimeSeries!
-  execUnits: TimeSeries!
+  udfExecUnits: TimeSeries!
+  udfRequestCount: TimeSeries!
   granularity: TimeAggregationGranularity!
+  execUnits: TimeSeries!
 }
 
 """
@@ -158,6 +162,8 @@ type Branch {
   deployments(after: String, before: String, first: Int, last: Int): DeploymentConnection!
   project: Project!
   environment: BranchEnvironment!
+  schema: String
+  subgraphs: [Subgraph!]!
 }
 
 type BranchConnection {
@@ -281,13 +287,8 @@ type DatabaseUsage {
   dbSize: Distribution!
   buildDuration: Distribution!
   execUnits: Distribution!
+  udfRequestCount: Distribution!
   granularity: DatabaseUsageGranularity!
-}
-
-input DatabaseUsageFilter {
-  environment: BranchEnvironment
-  startDate: DateTime
-  endDate: DateTime
 }
 
 enum DatabaseUsageGranularity {
@@ -357,6 +358,10 @@ type DeploymentCreateSuccess {
   query: Query!
 }
 
+type DeploymentDoesNotExistError {
+  query: Query!
+}
+
 """
 An edge in a connection.
 """
@@ -385,6 +390,16 @@ type DeploymentLogEntry {
 enum DeploymentLogLevel {
   ERROR
   INFO
+}
+
+union DeploymentRedeployPayload =
+    DeploymentRedeploySuccess
+  | DeploymentDoesNotExistError
+  | DailyDeploymentCountLimitExceededError
+
+type DeploymentRedeploySuccess {
+  deployment: Deployment!
+  query: Query!
 }
 
 enum DeploymentStatus {
@@ -661,6 +676,10 @@ type InvalidEnvironmentVariablesError {
   errors: [InvalidEnvironmentVariableError!]!
 }
 
+type InvalidProjectRootPathError {
+  query: Query!
+}
+
 type Invite {
   id: ID!
   role: MemberRole!
@@ -895,13 +914,6 @@ type MissingStripeCustomerError {
   query: Query!
 }
 
-type MonthlyLimits {
-  reads: Int
-  writes: Int
-  apiRequests: Int
-  size: Int
-}
-
 type MustLeaveAtLeastOneKeyForEnvironmentError {
   query: Query!
 }
@@ -942,6 +954,15 @@ type Mutation {
   Create a new deployment for an existing project.
   """
   deploymentCreate(input: DeploymentCreateInput!): DeploymentCreatePayload!
+  """
+  Create a new deployment for an existing project.
+  """
+  deploymentRedeploy(
+    """
+    ID of the deployment
+    """
+    id: ID!
+  ): DeploymentRedeployPayload!
   """
   Create a new environment variable.
   """
@@ -996,6 +1017,10 @@ type Mutation {
   projectCreateFromTemplate(input: ProjectCreateFromTemplateInput!): ProjectCreateFromTemplatePayload!
   projectUpdate(input: ProjectUpdateInput!): ProjectUpdatePayload!
   projectDelete(input: ProjectDeleteInput!): ProjectDeletePayload!
+  """
+  Publish a new subgraph.
+  """
+  publish(input: PublishInput!): PublishPayload!
   stripeSetupIntentCreate: StripeSetupIntentCreatePayload!
 }
 
@@ -1490,8 +1515,6 @@ type Project {
   environmentVariables(after: String, before: String, first: Int, last: Int): EnvironmentVariableConnection!
   deployments(after: String, before: String, first: Int, last: Int, filter: DeploymentFilter): DeploymentConnection!
   databaseRegions: [DatabaseRegion!]!
-  usage(filter: DatabaseUsageFilter): DatabaseUsage!
-  plan: ProjectPlan!
   status: ProjectStatus!
   databaseRegionChangeStatus: DatabaseRegionChangeStatus!
   customDomains: [String!]!
@@ -1597,6 +1620,7 @@ input ProjectCreateFromRepositoryInput {
   productionBranch: String!
   databaseRegions: [String!]! = []
   environmentVariables: [EnvironmentVariableSpecification!]! = []
+  projectRootPath: String! = "grafbase"
 }
 
 union ProjectCreateFromRepositoryPayload =
@@ -1613,6 +1637,7 @@ union ProjectCreateFromRepositoryPayload =
   | InvalidDatabaseRegionsError
   | EnvironmentVariableCountLimitExceededError
   | InvalidEnvironmentVariablesError
+  | InvalidProjectRootPathError
 
 type ProjectCreateFromRepositorySuccess {
   project: Project!
@@ -1655,6 +1680,7 @@ input ProjectCreateFromTemplateInput {
   repoPrivate: Boolean!
   databaseRegions: [String!]! = []
   environmentVariables: [EnvironmentVariableSpecification!]! = []
+  projectRootPath: String! = "grafbase"
 }
 
 union ProjectCreateFromTemplatePayload =
@@ -1672,6 +1698,7 @@ union ProjectCreateFromTemplatePayload =
   | InvalidDatabaseRegionsError
   | EnvironmentVariableCountLimitExceededError
   | InvalidEnvironmentVariablesError
+  | InvalidProjectRootPathError
   | GithubInstallationInsufficientPermissionsError
 
 type ProjectCreateFromTemplateSuccess {
@@ -1682,8 +1709,9 @@ type ProjectCreateFromTemplateSuccess {
 input ProjectCreateInput {
   accountId: ID!
   projectSlug: String!
-  databaseRegions: [String!]!
+  databaseRegions: [String!]! = []
   environmentVariables: [EnvironmentVariableSpecification!]! = []
+  projectRootPath: String! = "grafbase"
 }
 
 union ProjectCreatePayload =
@@ -1699,6 +1727,7 @@ union ProjectCreatePayload =
   | InvalidDatabaseRegionsError
   | EnvironmentVariableCountLimitExceededError
   | InvalidEnvironmentVariablesError
+  | InvalidProjectRootPathError
 
 type ProjectCreateSuccess {
   project: Project!
@@ -1737,11 +1766,6 @@ type ProjectNotDeployed {
   query: Query!
 }
 
-type ProjectPlan {
-  name: String!
-  monthlyLimits: MonthlyLimits!
-}
-
 input ProjectRequestAnalyticsFilter {
   branch: String = null
   period: ProjectRequestAnalyticsPeriod!
@@ -1764,6 +1788,7 @@ input ProjectUpdateInput {
   id: ID!
   projectSlug: String
   productionBranch: String
+  projectRootPath: String
 }
 
 union ProjectUpdatePayload =
@@ -1775,6 +1800,21 @@ union ProjectUpdatePayload =
 
 type ProjectUpdateSuccess {
   project: Project!
+  query: Query!
+}
+
+input PublishInput {
+  accountSlug: String!
+  projectSlug: String!
+  branch: String
+  subgraph: String!
+  url: String!
+  schema: String!
+}
+
+union PublishPayload = PublishSuccess | ProjectDoesNotExistError
+
+type PublishSuccess {
   query: Query!
 }
 
@@ -1888,6 +1928,27 @@ type Query {
     """
     id: ID!
   ): Project
+  """
+  Get subgraph.
+  """
+  subgraph(
+    """
+    account slug
+    """
+    accountSlug: String!
+    """
+    project slug
+    """
+    projectSlug: String!
+    """
+    name of the branch
+    """
+    branch: String
+    """
+    name of the subgraph
+    """
+    subgraphName: String!
+  ): Subgraph
   """
   Give the actual connected user.
   """
@@ -2072,6 +2133,14 @@ union StripeSetupIntentCreatePayload = StripeSetupIntentCreateSuccess
 type StripeSetupIntentCreateSuccess {
   setupIntent: StripeSetupIntent!
   query: Query!
+}
+
+type Subgraph {
+  name: String!
+  url: String!
+  schema: String!
+  createdAt: DateTime!
+  updatedAt: DateTime!
 }
 
 type TemplateDoesNotExistError {

--- a/cli/crates/backend/src/api/graphql/types/mutations.rs
+++ b/cli/crates/backend/src/api/graphql/types/mutations.rs
@@ -5,6 +5,7 @@ pub struct ProjectCreateInput<'a> {
     pub account_id: cynic::Id,
     pub project_slug: &'a str,
     pub database_regions: &'a [String],
+    pub project_root_path: &'a str,
 }
 
 #[derive(cynic::QueryVariables)]

--- a/cli/crates/backend/src/errors.rs
+++ b/cli/crates/backend/src/errors.rs
@@ -99,6 +99,10 @@ pub enum BackendError {
     #[error("could not read the repository information for {0}")]
     ReadRepositoryInformation(String),
 
+    /// returned if creating a temporary directory for the template stream fails
+    #[error("could not create a temporary directory to download the template archive: {0}")]
+    CouldNotCreateTemporaryDirectory(std::io::Error),
+
     // wraps a [`CommonError`]
     #[error(transparent)]
     CommonError(#[from] CommonError),

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -12,7 +12,7 @@ use colored::Colorize;
 use common::consts::GRAFBASE_TS_CONFIG_FILE_NAME;
 use common::types::{LogLevel, UdfKind};
 use common::{
-    consts::{GRAFBASE_DIRECTORY_NAME, GRAFBASE_SCHEMA_FILE_NAME, LOCALHOST},
+    consts::{GRAFBASE_SCHEMA_FILE_NAME, LOCALHOST},
     environment::Warning,
 };
 use std::{net::IpAddr, path::Path};
@@ -62,7 +62,7 @@ pub fn project_created(name: Option<&str>, config_type: ConfigType) {
     if let Some(name) = name {
         watercolor::output!(r#"✨ {name} was successfully initialized!"#, @BrightBlue);
 
-        let schema_path = &[".", name, GRAFBASE_DIRECTORY_NAME, schema_file_name].join(&slash);
+        let schema_path = &[".", name, schema_file_name].join(&slash);
 
         println!(
             "The configuration for your new project can be found at {}",
@@ -71,7 +71,7 @@ pub fn project_created(name: Option<&str>, config_type: ConfigType) {
     } else {
         watercolor::output!(r#"✨ Your project was successfully set up for Grafbase!"#, @BrightBlue);
 
-        let schema_path = &[".", GRAFBASE_DIRECTORY_NAME, schema_file_name].join(&slash);
+        let schema_path = &[".", schema_file_name].join(&slash);
 
         println!(
             "Your new configuration can be found at {}",

--- a/cli/crates/cli/tests/custom_resolvers.rs
+++ b/cli/crates/cli/tests/custom_resolvers.rs
@@ -277,7 +277,7 @@ fn test_field_resolver(
 ) {
     let mut env = Environment::init();
     env.grafbase_init(ConfigType::GraphQL);
-    std::fs::write(env.directory.join("grafbase/.env"), "MY_OWN_VARIABLE=test_value").unwrap();
+    std::fs::write(env.directory_path.join(".env"), "MY_OWN_VARIABLE=test_value").unwrap();
     env.write_schema(schema);
     env.write_resolver(resolver_name, resolver_contents);
     if let Some((package_manager, package_json)) = package_json {
@@ -286,10 +286,7 @@ fn test_field_resolver(
         // See https://github.com/rust-lang/rust/issues/37519.
         let program_path = which::which(package_manager.to_string()).expect("command must be found");
         let command = duct::cmd!(program_path, "install");
-        command
-            .dir(env.directory.join("grafbase"))
-            .run()
-            .expect("should have succeeded");
+        command.dir(&env.directory_path).run().expect("should have succeeded");
     }
     env.grafbase_dev();
     let client = env

--- a/cli/crates/cli/tests/dev_watch.rs
+++ b/cli/crates/cli/tests/dev_watch.rs
@@ -48,7 +48,7 @@ fn dev_watch() {
 
     {
         // Check that the TS resolver types are being generated.
-        let generated_types_path = env.directory.join("grafbase/generated/index.ts");
+        let generated_types_path = env.directory_path.join("generated/index.ts");
         assert!(generated_types_path.is_file());
     }
 }

--- a/cli/crates/cli/tests/init.rs
+++ b/cli/crates/cli/tests/init.rs
@@ -5,50 +5,64 @@ use backend::project::ConfigType;
 use utils::environment::Environment;
 
 #[test]
-fn init() {
+fn init_1() {
     let env = Environment::init();
 
     env.grafbase_init(ConfigType::GraphQL);
-    assert!(env.directory.join("grafbase").exists());
-    assert!(env.directory.join("grafbase").join("schema.graphql").exists());
+    assert!(env.directory_path.exists());
+    assert!(env.directory_path.join("schema.graphql").exists());
+}
+
+#[test]
+fn init_2() {
+    let env = Environment::init();
+
+    env.grafbase_init(ConfigType::GraphQL);
+    assert!(env.directory_path.exists());
+    assert!(env.directory_path.join("schema.graphql").exists());
 
     let output = env.grafbase_init_output(ConfigType::GraphQL);
     assert!(!output.status.success());
     assert!(!output.stderr.is_empty());
     assert!(std::str::from_utf8(&output.stderr).unwrap().contains("already exists"));
-    env.remove_grafbase_dir(None);
+}
+
+#[test]
+fn init_3() {
+    let env = Environment::init();
 
     env.grafbase_init_template(None, "graphql-github");
-    assert!(env.directory.join("grafbase").exists());
-    assert!(env.directory.join("grafbase").join("grafbase.config.ts").exists());
-    assert!(env.directory.join("package.json").exists());
+    assert!(env.directory_path.exists());
+    assert!(env.directory_path.join("grafbase/grafbase.config.ts").exists());
+    assert!(env.directory_path.join("package.json").exists());
+}
 
-    env.remove_grafbase_dir(None);
+#[test]
+fn init_4() {
+    let env = Environment::init();
 
     env.grafbase_init_template(Some("new-project"), "graphql-github");
-    let directory = env.directory.join("new-project").join("grafbase");
-    assert!(directory.exists());
-    assert!(directory.join("grafbase.config.ts").exists());
-    env.remove_grafbase_dir(Some("new-project"));
+    let directory_path = env.directory_path.join("new-project");
+    assert!(directory_path.exists());
+    assert!(directory_path.join("grafbase/grafbase.config.ts").exists());
+}
+
+#[test]
+fn init_5() {
+    let env = Environment::init();
 
     env.grafbase_init_template(
         None,
         "https://github.com/grafbase/grafbase/tree/main/templates/graphql-github",
     );
-    assert!(env.directory.join("grafbase").exists());
-    assert!(env.directory.join("grafbase").join("grafbase.config.ts").exists());
-    assert!(env.directory.join("package.json").exists());
-    env.remove_grafbase_dir(None);
+    assert!(env.directory_path.join("grafbase/grafbase.config.ts").exists());
+    assert!(env.directory_path.join("package.json").exists());
+}
 
-    env.grafbase_init_template(
-        Some("new-project"),
-        "https://github.com/grafbase/grafbase/tree/main/templates/graphql-github",
-    );
-    let directory = env.directory.join("new-project").join("grafbase");
-    assert!(directory.exists());
-    assert!(directory.join("grafbase.config.ts").exists());
+#[test]
+fn init_6() {
+    let env = Environment::init();
 
-    env.remove_grafbase_dir(Some("new-project"));
     let output = env.grafbase_init_template_output(
         None,
         "https://example.com/grafbase/grafbase/tree/main/templates/graphql-github",
@@ -57,12 +71,22 @@ fn init() {
     assert!(std::str::from_utf8(&output.stderr)
         .unwrap()
         .contains("is not a supported template URL"));
+}
+
+#[test]
+fn init_7() {
+    let env = Environment::init();
 
     let output = env.grafbase_init_template_output(None, "https://github.com/grafbase/grafbase/tree/main/templates");
     assert!(!output.stderr.is_empty());
     assert!(std::str::from_utf8(&output.stderr)
         .unwrap()
         .contains("could not find the provided template within the template repository"));
+}
+
+#[test]
+fn init_8() {
+    let env = Environment::init();
 
     // FIXME: this error message will change once we check for existing templates before downloading
     let output = env.grafbase_init_template_output(None, "not_a_template");

--- a/cli/crates/cli/tests/init_ts.rs
+++ b/cli/crates/cli/tests/init_ts.rs
@@ -31,8 +31,7 @@ fn init_ts_existing_package_json() {
     );
     assert!(output.status.success());
 
-    assert!(env.directory.join("grafbase").exists());
-    assert!(env.directory.join("grafbase").join("grafbase.config.ts").exists());
+    assert!(env.directory_path.join("grafbase.config.ts").exists());
 
     let package_json = serde_json::from_str::<Value>(&env.load_file_from_project("package.json")).expect("valid JSON");
 
@@ -68,9 +67,8 @@ fn init_ts_new_project() {
     );
     assert!(output.status.success());
 
-    assert!(env.directory.join("grafbase").exists());
-    assert!(env.directory.join("grafbase").join("grafbase.config.ts").exists());
-    assert!(env.directory.join("package.json").exists());
+    assert!(env.directory_path.join("grafbase.config.ts").exists());
+    assert!(env.directory_path.join("package.json").exists());
 
     let package_json: serde_json::Value = serde_json::from_str(&env.load_file_from_project("package.json")).unwrap();
     let package_json = package_json.as_object().unwrap().get("devDependencies").unwrap();

--- a/cli/crates/cli/tests/link.rs
+++ b/cli/crates/cli/tests/link.rs
@@ -17,16 +17,18 @@ fn link_success() {
     assert!(link_output.status.success());
 
     assert!(env
-        .directory
+        .directory_path
         .join(DOT_GRAFBASE_DIRECTORY)
         .join(PROJECT_METADATA_FILE)
         .exists());
 
-    assert!(
-        std::fs::read_to_string(env.directory.join(DOT_GRAFBASE_DIRECTORY).join(PROJECT_METADATA_FILE))
-            .unwrap()
-            .contains(correct_ulid)
-    );
+    assert!(std::fs::read_to_string(
+        env.directory_path
+            .join(DOT_GRAFBASE_DIRECTORY)
+            .join(PROJECT_METADATA_FILE)
+    )
+    .unwrap()
+    .contains(correct_ulid));
 }
 
 #[test]

--- a/cli/crates/server/src/codegen_server.rs
+++ b/cli/crates/server/src/codegen_server.rs
@@ -25,7 +25,7 @@ async fn codegen_worker_loop(
     let resolvers_path = project.udfs_source_path(common_types::UdfKind::Resolver);
     let schema_path = &project.schema_path;
     let mut last_seen_sdl = None;
-    let generated_ts_resolver_types_path = project.grafbase_directory_path.join("generated/index.ts");
+    let generated_ts_resolver_types_path = project.path.join("generated/index.ts");
 
     // Try generating types on start up.
     if let SchemaLocation::Graphql(schema_path) = schema_path.location() {

--- a/cli/crates/server/src/environment.rs
+++ b/cli/crates/server/src/environment.rs
@@ -5,7 +5,7 @@ use crate::consts::DOT_ENV_FILE_NAME;
 #[allow(deprecated)] // https://github.com/dotenv-rs/dotenv/pull/54
 pub fn variables() -> impl Iterator<Item = (String, String)> {
     let project = Project::get();
-    let dot_env_file_path = project.grafbase_directory_path.join(DOT_ENV_FILE_NAME);
+    let dot_env_file_path = project.path.join(DOT_ENV_FILE_NAME);
     // We don't use dotenv::dotenv() as we don't want to pollute the process' environment.
     // Doing otherwise would make us unable to properly refresh it whenever any of the .env files
     // changes which is something we may want to do in the future.


### PR DESCRIPTION
# Description

Introduce a fallback mechanism in searching the paths such as the current `grafbase` subdirectory remains supported. It will be phased out in the future. At the same time, the main search path for 'schema.graphql' and 'grafbase.config.ts' will now be the current directory.

# Type of change

- [ ] 💔 Breaking
- [X] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
