### PR TITLE
cli: make codegen opt-in with an experimental feature

### DIFF
--- a/cli/crates/cli/tests/dev_watch.rs
+++ b/cli/crates/cli/tests/dev_watch.rs
@@ -13,7 +13,7 @@ fn dev_watch() {
 
     env.grafbase_init(ConfigType::GraphQL);
 
-    env.write_schema(DEFAULT_SCHEMA);
+    env.write_schema(format!("extend schema @experimental(codegen: true)\n{DEFAULT_SCHEMA}"));
 
     env.grafbase_dev_watch();
 

--- a/cli/crates/typed-resolvers/src/error.rs
+++ b/cli/crates/typed-resolvers/src/error.rs
@@ -1,33 +1,12 @@
 use engine_parser::Error as ParseError;
 use std::fmt;
 
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum CodegenError {
+    #[error("The `codegen` experimental feature is not enabled")]
     ExperimentalFeatureNotEnabled,
-    ParseError(ParseError),
-    FmtError(fmt::Error),
-}
-
-impl fmt::Display for CodegenError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            CodegenError::ExperimentalFeatureNotEnabled => {
-                f.write_str("The `codegen` experimental feature is not enabled")
-            }
-            CodegenError::ParseError(err) => fmt::Display::fmt(err, f),
-            CodegenError::FmtError(err) => fmt::Display::fmt(err, f),
-        }
-    }
-}
-
-impl From<fmt::Error> for CodegenError {
-    fn from(value: fmt::Error) -> Self {
-        CodegenError::FmtError(value)
-    }
-}
-
-impl From<ParseError> for CodegenError {
-    fn from(value: ParseError) -> Self {
-        CodegenError::ParseError(value)
-    }
+    #[error(transparent)]
+    ParseError(#[from] ParseError),
+    #[error(transparent)]
+    FmtError(#[from] fmt::Error),
 }

--- a/cli/crates/typed-resolvers/src/error.rs
+++ b/cli/crates/typed-resolvers/src/error.rs
@@ -3,6 +3,7 @@ use std::fmt;
 
 #[derive(Debug)]
 pub enum CodegenError {
+    ExperimentalFeatureNotEnabled,
     ParseError(ParseError),
     FmtError(fmt::Error),
 }
@@ -10,6 +11,9 @@ pub enum CodegenError {
 impl fmt::Display for CodegenError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            CodegenError::ExperimentalFeatureNotEnabled => {
+                f.write_str("The `codegen` experimental feature is not enabled")
+            }
             CodegenError::ParseError(err) => fmt::Display::fmt(err, f),
             CodegenError::FmtError(err) => fmt::Display::fmt(err, f),
         }

--- a/cli/crates/typed-resolvers/tests/schema_types.rs
+++ b/cli/crates/typed-resolvers/tests/schema_types.rs
@@ -9,7 +9,8 @@ fn update_expect() -> bool {
 
 #[allow(clippy::unnecessary_wraps)] // we can't change the signature expected by datatest_stable
 fn run_test(path: &Path) -> datatest_stable::Result<()> {
-    let graphql = fs::read_to_string(path).unwrap();
+    // TODO: remove this once codegen is no longer experimental
+    let graphql = fs::read_to_string(path).unwrap() + "extend schema @experimental(codegen: true)";
     let expected_file_path = path.with_extension("expected.ts");
     let mut expected = fs::read_to_string(&expected_file_path).unwrap_or_default();
     let generated = {

--- a/engine/crates/parser-sdl/src/rules/experimental.rs
+++ b/engine/crates/parser-sdl/src/rules/experimental.rs
@@ -23,6 +23,7 @@ pub enum ExperimentalDirectiveError {
 pub struct ExperimentalDirective {
     pub kv: Option<bool>,
     pub ai: Option<bool>,
+    pub codegen: Option<bool>,
 }
 
 pub struct ExperimentalDirectiveVisitor;
@@ -63,6 +64,10 @@ impl Directive for ExperimentalDirective {
           Enable experimental usage of AI in resolvers.
           """
           ai: Boolean
+          """
+          Enable experimental typed resolver code generation.
+          """
+          codegen: Boolean
         ) on SCHEMA
         "#
         .to_string()
@@ -82,7 +87,7 @@ mod tests {
     #[rstest::rstest]
     #[case::error_parsing_unknown_field(r#"
         extend schema @experimental(random: true)
-    "#, &["Unable to parse @experimental - [2:37] unknown field `random`, expected `kv` or `ai`"], "", false)]
+    "#, &["Unable to parse @experimental - [2:37] unknown field `random`, expected one of `kv`, `ai`, `codegen`"], "", false)]
     #[case::successful_parsing_kv_enabled(r#"
         extend schema @experimental(kv: true)
     "#, &[], "kv", true)]


### PR DESCRIPTION
Unfortunately we can't use the same mechanism as the other experimental features, because the typed resolvers logic is outside of the engine and doesn't have access to the registry.

Confirmed that this works locally, ideally there would be automated tests, but this should go in today's release.

closes GB-5332
