### PR TITLE
 sdk: release 0.9.1

### DIFF
--- a/packages/grafbase-sdk/CHANGELOG.md
+++ b/packages/grafbase-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.9.1] - Fri Nov 10 2023
+
+[CHANGELOG](changelog/0.9.1.md)
+
 ## [0.9.0] - Thu Nov 9 2023
 
 [CHANGELOG](changelog/0.9.0.md)

--- a/packages/grafbase-sdk/changelog/0.9.1.md
+++ b/packages/grafbase-sdk/changelog/0.9.1.md
@@ -1,0 +1,3 @@
+## Breaking
+
+- The typed resolvers code generation is now an experimental feature, you have to enable it in the `experimental.codegen` field in your config.

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",

--- a/packages/grafbase-sdk/src/experimental.ts
+++ b/packages/grafbase-sdk/src/experimental.ts
@@ -4,6 +4,7 @@
 export interface ExperimentalParams {
   kv?: boolean
   ai?: boolean
+  codegen?: boolean
 }
 
 export class Experimental {


### PR DESCRIPTION
## Breaking

- The typed resolvers code generation is now an experimental feature, you have to enable it in the `experimental.codegen` field in your config.

---

Also adds a line that was missing in https://github.com/grafbase/grafbase/pull/930. Can do a separate PR if that is problematic.