### PR TITLE
fix(watcher): Ensure the watcher doesn't pick up on changes from .grafbase

### DIFF
--- a/cli/crates/cli/tests/link.rs
+++ b/cli/crates/cli/tests/link.rs
@@ -2,7 +2,7 @@
 mod utils;
 
 use backend::{api::consts::PROJECT_METADATA_FILE, project::ConfigType};
-use common::consts::DOT_GRAFBASE_DIRECTORY;
+use common::consts::DOT_GRAFBASE_DIRECTORY_NAME;
 use utils::environment::Environment;
 
 #[test]
@@ -18,13 +18,13 @@ fn link_success() {
 
     assert!(env
         .directory_path
-        .join(DOT_GRAFBASE_DIRECTORY)
+        .join(DOT_GRAFBASE_DIRECTORY_NAME)
         .join(PROJECT_METADATA_FILE)
         .exists());
 
     assert!(std::fs::read_to_string(
         env.directory_path
-            .join(DOT_GRAFBASE_DIRECTORY)
+            .join(DOT_GRAFBASE_DIRECTORY_NAME)
             .join(PROJECT_METADATA_FILE)
     )
     .unwrap()

--- a/cli/crates/common/src/consts.rs
+++ b/cli/crates/common/src/consts.rs
@@ -13,7 +13,7 @@ pub const GRAFBASE_TS_CONFIG_FILE_NAME: &str = "grafbase.config.ts";
 /// a file expected to be in the grafbase directory
 pub const GRAFBASE_ENV_FILE_NAME: &str = ".env";
 /// the name for the db / cache directory per project and the global cache directory for the user
-pub const DOT_GRAFBASE_DIRECTORY: &str = ".grafbase";
+pub const DOT_GRAFBASE_DIRECTORY_NAME: &str = ".grafbase";
 /// the registry.json file generated from schema.graphql
 pub const REGISTRY_FILE: &str = "registry.json";
 /// the /resolvers directory containing resolver implementations

--- a/cli/crates/common/src/environment.rs
+++ b/cli/crates/common/src/environment.rs
@@ -4,7 +4,7 @@ use crate::consts::{AUTHORIZERS_DIRECTORY_NAME, GRAFBASE_DIRECTORY_NAME};
 use crate::types::UdfKind;
 use crate::{
     consts::{
-        DATABASE_DIRECTORY, DOT_GRAFBASE_DIRECTORY, GRAFBASE_HOME, GRAFBASE_SCHEMA_FILE_NAME,
+        DATABASE_DIRECTORY, DOT_GRAFBASE_DIRECTORY_NAME, GRAFBASE_HOME, GRAFBASE_SCHEMA_FILE_NAME,
         GRAFBASE_TS_CONFIG_FILE_NAME, PACKAGE_JSON_DEV_DEPENDENCIES, PACKAGE_JSON_FILE_NAME, REGISTRY_FILE,
         RESOLVERS_DIRECTORY_NAME, WRANGLER_DIRECTORY_NAME,
     },
@@ -171,19 +171,19 @@ static ENVIRONMENT: OnceLock<Environment> = OnceLock::new();
 
 #[must_use]
 pub fn get_default_user_dot_grafbase_path() -> Option<PathBuf> {
-    dirs::home_dir().map(|home| home.join(DOT_GRAFBASE_DIRECTORY))
+    dirs::home_dir().map(|home| home.join(DOT_GRAFBASE_DIRECTORY_NAME))
 }
 
 pub fn get_user_dot_grafbase_path_from_env() -> Option<PathBuf> {
     env::var(GRAFBASE_HOME)
         .ok()
         .map(PathBuf::from)
-        .map(|env_override| env_override.join(DOT_GRAFBASE_DIRECTORY))
+        .map(|env_override| env_override.join(DOT_GRAFBASE_DIRECTORY_NAME))
 }
 
 pub fn get_user_dot_grafbase_path(r#override: Option<PathBuf>) -> Option<PathBuf> {
     r#override
-        .map(|r#override| r#override.join(DOT_GRAFBASE_DIRECTORY))
+        .map(|r#override| r#override.join(DOT_GRAFBASE_DIRECTORY_NAME))
         .or_else(get_user_dot_grafbase_path_from_env)
         .or_else(get_default_user_dot_grafbase_path)
 }
@@ -197,7 +197,7 @@ impl Project {
             .expect("the grafbase directory must have a parent directory by definition")
             .to_path_buf();
 
-        let dot_grafbase_directory_path = path.join(DOT_GRAFBASE_DIRECTORY);
+        let dot_grafbase_directory_path = path.join(DOT_GRAFBASE_DIRECTORY_NAME);
         let registry_path = dot_grafbase_directory_path.join(REGISTRY_FILE);
         let database_directory_path = dot_grafbase_directory_path.join(DATABASE_DIRECTORY);
         let package_json_path = [path.as_path(), path.parent().expect("must have a parent")]

--- a/cli/crates/server/src/file_watcher.rs
+++ b/cli/crates/server/src/file_watcher.rs
@@ -1,7 +1,7 @@
 use crate::consts::DOT_ENV_FILE_NAME;
 use crate::errors::ServerError;
 use crate::udf_builder::LOCK_FILE_NAMES;
-use common::consts::GRAFBASE_SCHEMA_FILE_NAME;
+use common::consts::{DOT_GRAFBASE_DIRECTORY_NAME, GRAFBASE_SCHEMA_FILE_NAME};
 use notify::RecursiveMode;
 use notify_debouncer_mini::new_debouncer;
 use std::path::{Path, PathBuf};
@@ -59,7 +59,7 @@ const ROOT_FILE_WHITELIST: [&str; 2] = [GRAFBASE_SCHEMA_FILE_NAME, DOT_ENV_FILE_
 const EXTENSION_WHITELIST: [&str; 11] = [
     "js", "ts", "jsx", "tsx", "mjs", "mts", ".wasm", "cjs", "json", "yaml", "yml",
 ];
-const DIRECTORY_BLACKLIST: &[&str] = &["node_modules", "generated"];
+const DIRECTORY_BLACKLIST: &[&str] = &[DOT_GRAFBASE_DIRECTORY_NAME, "node_modules", "generated"];
 
 fn should_handle_change(path: &Path, root: &Path) -> bool {
     is_whitelisted_root_file(path, root)


### PR DESCRIPTION
# Description

With the new projecct root scheme, .grafbase is located inside the project root
Therefore, it must be excluded from watching.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
