### PR TITLE
fix(postgres): Add enum filter and update types for nested collections

### DIFF
--- a/engine/crates/integration-tests/tests/postgres/introspection.rs
+++ b/engine/crates/integration-tests/tests/postgres/introspection.rs
@@ -425,6 +425,46 @@ fn table_with_enum_field() {
           GREEN
         }
 
+        """
+          Search filter input for StreetLight type.
+        """
+        input StreetLightSearchFilterInput {
+          """
+            The value is exactly the one given
+          """ eq: StreetLight
+          """
+            The value is not the one given
+          """ ne: StreetLight
+          """
+            The value is greater than the one given
+          """ gt: StreetLight
+          """
+            The value is less than the one given
+          """ lt: StreetLight
+          """
+            The value is greater than, or equal to the one given
+          """ gte: StreetLight
+          """
+            The value is less than, or equal to the one given
+          """ lte: StreetLight
+          """
+            The value is in the given array of values
+          """ in: [StreetLight]
+          """
+            The value is not in the given array of values
+          """ nin: [StreetLight]
+          not: StreetLightSearchFilterInput
+        }
+
+        """
+          Update input for StreetLight type.
+        """
+        input StreetLightUpdateInput {
+          """
+            Replaces the value of a field with the specified value.
+          """ set: StreetLight
+        }
+
         schema {
           query: Query
           mutation: Mutation
@@ -3053,6 +3093,478 @@ fn two_tables_with_single_column_foreign_key() {
         input UserUpdateInput {
           id: IntUpdateInput
           name: StringUpdateInput
+        }
+
+        schema {
+          query: Query
+          mutation: Mutation
+        }
+    "#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn cedalio_issue_november_2023() {
+    let response = introspect_namespaced_postgres("pg", |api| async move {
+        let create = indoc! {r#"
+            CREATE TYPE access_mode AS ENUM ('PUBLIC', 'PUBLIC_READ', 'PRIVATE');
+        "#};
+
+        api.execute_sql(create).await;
+
+        let create = indoc! {r#"
+            CREATE TYPE project_status AS ENUM ('CREATED', 'READY', 'FAILED');
+        "#};
+
+        api.execute_sql(create).await;
+
+        let create = indoc! {r#"
+            CREATE TABLE networks (
+                id SERIAL PRIMARY KEY
+            );
+        "#};
+
+        api.execute_sql(create).await;
+
+        let create = indoc! {r#"
+            CREATE TABLE projects (
+                id SERIAL PRIMARY KEY,
+                access_mode access_mode NOT NULL,
+                status project_status DEFAULT 'CREATED' NOT NULL,
+                network_id INT REFERENCES networks(id)
+            );
+        "#};
+
+        api.execute_sql(create).await;
+    });
+
+    let expected = expect![[r#"
+        type Mutation {
+          pg: PgMutation
+        }
+
+        enum PgAccessMode {
+          PUBLIC
+          PUBLIC_READ
+          PRIVATE
+        }
+
+        """
+          Search filter input for PgAccessMode type.
+        """
+        input PgAccessModeSearchFilterInput {
+          """
+            The value is exactly the one given
+          """ eq: PgAccessMode
+          """
+            The value is not the one given
+          """ ne: PgAccessMode
+          """
+            The value is greater than the one given
+          """ gt: PgAccessMode
+          """
+            The value is less than the one given
+          """ lt: PgAccessMode
+          """
+            The value is greater than, or equal to the one given
+          """ gte: PgAccessMode
+          """
+            The value is less than, or equal to the one given
+          """ lte: PgAccessMode
+          """
+            The value is in the given array of values
+          """ in: [PgAccessMode]
+          """
+            The value is not in the given array of values
+          """ nin: [PgAccessMode]
+          not: PgAccessModeSearchFilterInput
+        }
+
+        """
+          Update input for PgAccessMode type.
+        """
+        input PgAccessModeUpdateInput {
+          """
+            Replaces the value of a field with the specified value.
+          """ set: PgAccessMode
+        }
+
+        """
+          Search filter input for Int type.
+        """
+        input PgIntSearchFilterInput {
+          """
+            The value is exactly the one given
+          """ eq: Int
+          """
+            The value is not the one given
+          """ ne: Int
+          """
+            The value is greater than the one given
+          """ gt: Int
+          """
+            The value is less than the one given
+          """ lt: Int
+          """
+            The value is greater than, or equal to the one given
+          """ gte: Int
+          """
+            The value is less than, or equal to the one given
+          """ lte: Int
+          """
+            The value is in the given array of values
+          """ in: [Int]
+          """
+            The value is not in the given array of values
+          """ nin: [Int]
+          not: PgIntSearchFilterInput
+        }
+
+        """
+          Update input for Int type.
+        """
+        input PgIntUpdateInput {
+          """
+            Replaces the value of a field with the specified value.
+          """ set: Int
+          """
+            Increments the value of the field by the specified amount.
+          """ increment: Int
+          """
+            Decrements the value of the field by the specified amount.
+          """ decrement: Int
+          """
+            Multiplies the value of the field by the specified amount.
+          """ multiply: Int
+          """
+            Divides the value of the field with the given value.
+          """ divide: Int
+        }
+
+        type PgMutation {
+          """
+            Delete a unique Networks by a field or combination of fields
+          """
+          networksDelete(by: PgNetworksByInput!): PgNetworksMutation
+          """
+            Delete multiple rows of Networks by a filter
+          """
+          networksDeleteMany(filter: PgNetworksMutationCollection!): PgNetworksBatchMutation
+          """
+            Create a Networks
+          """
+          networksCreate(input: PgNetworksInput!): PgNetworksMutation
+          """
+            Create multiple Networkss
+          """
+          networksCreateMany(input: [PgNetworksInput!]!): PgNetworksBatchMutation
+          """
+            Update a unique Networks
+          """
+          networksUpdate(by: PgNetworksByInput!, input: PgNetworksUpdateInput!): PgNetworksMutation
+          """
+            Update multiple Networkss
+          """
+          networksUpdateMany(filter: PgNetworksMutationCollection!, input: PgNetworksUpdateInput!): PgNetworksBatchMutation
+          """
+            Delete a unique Projects by a field or combination of fields
+          """
+          projectsDelete(by: PgProjectsByInput!): PgProjectsMutation
+          """
+            Delete multiple rows of Projects by a filter
+          """
+          projectsDeleteMany(filter: PgProjectsMutationCollection!): PgProjectsBatchMutation
+          """
+            Create a Projects
+          """
+          projectsCreate(input: PgProjectsInput!): PgProjectsMutation
+          """
+            Create multiple Projectss
+          """
+          projectsCreateMany(input: [PgProjectsInput!]!): PgProjectsBatchMutation
+          """
+            Update a unique Projects
+          """
+          projectsUpdate(by: PgProjectsByInput!, input: PgProjectsUpdateInput!): PgProjectsMutation
+          """
+            Update multiple Projectss
+          """
+          projectsUpdateMany(filter: PgProjectsMutationCollection!, input: PgProjectsUpdateInput!): PgProjectsBatchMutation
+        }
+
+        type PgNetworks {
+          id: Int!
+          projects(first: Int, last: Int, before: String, after: String, orderBy: [PgProjectsOrderByInput!]): PgProjectsConnection
+        }
+
+        type PgNetworksBatchMutation {
+          """
+            Returned items from the mutation.
+          """
+          returning: [PgNetworksReturning]!
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
+        input PgNetworksByInput {
+          id: Int
+        }
+
+        input PgNetworksCollection {
+          id: PgIntSearchFilterInput
+          projects: PgProjectsCollectionContains
+          """
+            All of the filters must match
+          """ ALL: [PgNetworksCollection]
+          """
+            None of the filters must match
+          """ NONE: [PgNetworksCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [PgNetworksCollection]
+        }
+
+        type PgNetworksConnection {
+          edges: [PgNetworksEdge]!
+          pageInfo: PgPageInfo!
+        }
+
+        type PgNetworksEdge {
+          node: PgNetworks!
+          cursor: String!
+        }
+
+        input PgNetworksInput {
+          id: Int
+        }
+
+        type PgNetworksMutation {
+          """
+            Returned item from the mutation.
+          """
+          returning: PgNetworksReturning
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
+        input PgNetworksMutationCollection {
+          id: PgIntSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [PgNetworksMutationCollection]
+          """
+            None of the filters must match
+          """ NONE: [PgNetworksMutationCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [PgNetworksMutationCollection]
+        }
+
+        input PgNetworksOrderByInput {
+          id: PgOrderByDirection
+        }
+
+        type PgNetworksReturning {
+          id: Int!
+        }
+
+        input PgNetworksUpdateInput {
+          id: PgIntUpdateInput
+        }
+
+        enum PgOrderByDirection {
+          ASC
+          DESC
+        }
+
+        type PgPageInfo {
+          hasPreviousPage: Boolean!
+          hasNextPage: Boolean!
+          startCursor: String
+          endCursor: String
+        }
+
+        enum PgProjectStatus {
+          CREATED
+          READY
+          FAILED
+        }
+
+        """
+          Search filter input for PgProjectStatus type.
+        """
+        input PgProjectStatusSearchFilterInput {
+          """
+            The value is exactly the one given
+          """ eq: PgProjectStatus
+          """
+            The value is not the one given
+          """ ne: PgProjectStatus
+          """
+            The value is greater than the one given
+          """ gt: PgProjectStatus
+          """
+            The value is less than the one given
+          """ lt: PgProjectStatus
+          """
+            The value is greater than, or equal to the one given
+          """ gte: PgProjectStatus
+          """
+            The value is less than, or equal to the one given
+          """ lte: PgProjectStatus
+          """
+            The value is in the given array of values
+          """ in: [PgProjectStatus]
+          """
+            The value is not in the given array of values
+          """ nin: [PgProjectStatus]
+          not: PgProjectStatusSearchFilterInput
+        }
+
+        """
+          Update input for PgProjectStatus type.
+        """
+        input PgProjectStatusUpdateInput {
+          """
+            Replaces the value of a field with the specified value.
+          """ set: PgProjectStatus
+        }
+
+        type PgProjects {
+          id: Int!
+          accessMode: PgAccessMode!
+          status: PgProjectStatus!
+          networkId: Int
+          networks: PgNetworks
+        }
+
+        type PgProjectsBatchMutation {
+          """
+            Returned items from the mutation.
+          """
+          returning: [PgProjectsReturning]!
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
+        input PgProjectsByInput {
+          id: Int
+        }
+
+        input PgProjectsCollection {
+          id: PgIntSearchFilterInput
+          accessMode: PgAccessModeSearchFilterInput
+          status: PgProjectStatusSearchFilterInput
+          networkId: PgIntSearchFilterInput
+          networks: PgNetworksCollection
+          """
+            All of the filters must match
+          """ ALL: [PgProjectsCollection]
+          """
+            None of the filters must match
+          """ NONE: [PgProjectsCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [PgProjectsCollection]
+        }
+
+        input PgProjectsCollectionContains {
+          contains: PgProjectsCollection
+        }
+
+        type PgProjectsConnection {
+          edges: [PgProjectsEdge]!
+          pageInfo: PgPageInfo!
+        }
+
+        type PgProjectsEdge {
+          node: PgProjects!
+          cursor: String!
+        }
+
+        input PgProjectsInput {
+          id: Int
+          accessMode: PgAccessMode!
+          status: PgProjectStatus
+          networkId: Int
+        }
+
+        type PgProjectsMutation {
+          """
+            Returned item from the mutation.
+          """
+          returning: PgProjectsReturning
+          """
+            The number of rows mutated.
+          """
+          rowCount: Int!
+        }
+
+        input PgProjectsMutationCollection {
+          id: PgIntSearchFilterInput
+          accessMode: PgAccessModeSearchFilterInput
+          status: PgProjectStatusSearchFilterInput
+          networkId: PgIntSearchFilterInput
+          """
+            All of the filters must match
+          """ ALL: [PgProjectsMutationCollection]
+          """
+            None of the filters must match
+          """ NONE: [PgProjectsMutationCollection]
+          """
+            At least one of the filters must match
+          """ ANY: [PgProjectsMutationCollection]
+        }
+
+        input PgProjectsOrderByInput {
+          id: PgOrderByDirection
+          accessMode: PgOrderByDirection
+          status: PgOrderByDirection
+          networkId: PgOrderByDirection
+        }
+
+        type PgProjectsReturning {
+          id: Int!
+          accessMode: PgAccessMode!
+          status: PgProjectStatus!
+          networkId: Int
+        }
+
+        input PgProjectsUpdateInput {
+          id: PgIntUpdateInput
+          accessMode: PgAccessModeUpdateInput
+          status: PgProjectStatusUpdateInput
+          networkId: PgIntUpdateInput
+        }
+
+        type PgQuery {
+          """
+            Query a single PgNetworks by a field
+          """
+          networks(by: PgNetworksByInput!): PgNetworks
+          """
+            Paginated query to fetch the whole list of Networks
+          """
+          networksCollection(filter: PgNetworksCollection, first: Int, last: Int, before: String, after: String, orderBy: [PgNetworksOrderByInput]): PgNetworksConnection
+          """
+            Query a single PgProjects by a field
+          """
+          projects(by: PgProjectsByInput!): PgProjects
+          """
+            Paginated query to fetch the whole list of Projects
+          """
+          projectsCollection(filter: PgProjectsCollection, first: Int, last: Int, before: String, after: String, orderBy: [PgProjectsOrderByInput]): PgProjectsConnection
+        }
+
+        type Query {
+          pg: PgQuery
         }
 
         schema {

--- a/engine/crates/parser-postgres/src/introspection/queries/enums.sql
+++ b/engine/crates/parser-postgres/src/introspection/queries/enums.sql
@@ -6,4 +6,4 @@ FROM pg_type
 JOIN pg_enum ON pg_type.oid = pg_enum.enumtypid
 JOIN pg_namespace ON pg_namespace.oid = pg_type.typnamespace
 WHERE pg_namespace.nspname <> ALL ( $1 )
-ORDER BY pg_enum.enumsortorder;
+ORDER BY pg_namespace.nspname, pg_type.typname, pg_enum.enumsortorder;

--- a/engine/crates/parser-postgres/src/registry/context/input.rs
+++ b/engine/crates/parser-postgres/src/registry/context/input.rs
@@ -18,6 +18,10 @@ impl<'a> InputContext<'a> {
         }
     }
 
+    pub(crate) fn namespace(&self) -> Option<&str> {
+        self.namespace
+    }
+
     pub(crate) fn directive_name(&self) -> &str {
         self.directive_name
     }

--- a/engine/crates/parser-postgres/src/registry/queries/input.rs
+++ b/engine/crates/parser-postgres/src/registry/queries/input.rs
@@ -10,7 +10,7 @@ use postgres_connector_types::database_definition::TableColumnWalker;
 
 fn input_value_from_column(column: TableColumnWalker<'_>, oneof: bool) -> MetaInputValue {
     let mut client_type = column
-        .graphql_type()
+        .graphql_type(None)
         .expect("unsupported types are filtered out at this point");
 
     // Oneof types can't enforce arguments, the runtime expects one of the arguments to be

--- a/engine/crates/parser-postgres/src/registry/queries/input/create.rs
+++ b/engine/crates/parser-postgres/src/registry/queries/input/create.rs
@@ -11,7 +11,7 @@ pub(crate) fn register(input_ctx: &InputContext<'_>, table: TableWalker<'_>, out
     output_ctx.with_input_type(&input_type_name, table.id(), move |builder| {
         for column in table.columns() {
             let r#type = column
-                .graphql_type()
+                .graphql_type(input_ctx.namespace())
                 .expect("non-supported types are filtered out at this point");
 
             let r#type = if column.nullable() || column.has_default() {

--- a/engine/crates/parser-postgres/src/registry/queries/input/filter.rs
+++ b/engine/crates/parser-postgres/src/registry/queries/input/filter.rs
@@ -74,7 +74,7 @@ fn add_relation(input_ctx: &InputContext<'_>, relation: RelationWalker<'_>, buil
 
 fn add_column(input_ctx: &InputContext<'_>, column: TableColumnWalker<'_>, builder: &mut InputTypeBuilder) {
     let scalar = column
-        .graphql_base_type()
+        .graphql_base_type(None)
         .expect("unsupported types are filtered out at this point");
 
     let type_name = if column.is_array() {

--- a/engine/crates/parser-postgres/src/registry/queries/input/update.rs
+++ b/engine/crates/parser-postgres/src/registry/queries/input/update.rs
@@ -11,7 +11,7 @@ pub(crate) fn register(input_ctx: &InputContext<'_>, table: TableWalker<'_>, out
     output_ctx.with_input_type(&input_type_name, table.id(), |builder| {
         for column in table.columns() {
             let mut client_type: Cow<'static, str> = column
-                .graphql_base_type()
+                .graphql_base_type(None)
                 .expect("non-supported types are filtered before reaching this")
                 .into();
 

--- a/engine/crates/parser-postgres/src/registry/types.rs
+++ b/engine/crates/parser-postgres/src/registry/types.rs
@@ -5,6 +5,8 @@ mod table;
 
 use engine::registry::MetaEnumValue;
 
+use self::scalar::{create_array_update_type, create_filter_types, create_scalar_update_type, TypeKind};
+
 use super::context::{InputContext, OutputContext};
 
 pub(super) fn generate(input_ctx: &InputContext<'_>, output_ctx: &mut OutputContext) {
@@ -33,5 +35,9 @@ pub(super) fn generate(input_ctx: &InputContext<'_>, output_ctx: &mut OutputCont
                 builder.push_variant(meta_value);
             }
         });
+
+        create_filter_types(input_ctx, TypeKind::Enum(r#enum.client_name()), output_ctx);
+        create_scalar_update_type(input_ctx, TypeKind::Enum(r#enum.client_name()), output_ctx);
+        create_array_update_type(input_ctx, TypeKind::Enum(r#enum.client_name()), output_ctx);
     }
 }

--- a/engine/crates/parser-postgres/src/registry/types/table.rs
+++ b/engine/crates/parser-postgres/src/registry/types/table.rs
@@ -23,7 +23,7 @@ pub(super) fn generate(
     // The full type with relations
     output_ctx.with_object_type(&type_name, table.id(), |builder| {
         for column in table.columns() {
-            add_column(column, builder);
+            add_column(input_ctx, column, builder);
         }
 
         for relation in table.relations() {
@@ -45,7 +45,7 @@ pub(super) fn generate(
     // a simple type, which does not have relations in it (e.g. for deletions)
     output_ctx.with_object_type(&returning_type_name, table.id(), |builder| {
         for column in table.columns() {
-            add_column(column, builder);
+            add_column(input_ctx, column, builder);
         }
     });
 
@@ -86,9 +86,9 @@ pub(super) fn generate(
     });
 }
 
-fn add_column(column: TableColumnWalker<'_>, builder: &mut ObjectTypeBuilder) {
+fn add_column(input_ctx: &InputContext<'_>, column: TableColumnWalker<'_>, builder: &mut ObjectTypeBuilder) {
     let client_type = column
-        .graphql_type()
+        .graphql_type(input_ctx.namespace())
         .expect("forgot to filter unsupported types before generating");
 
     let client_type = if column.nullable() {


### PR DESCRIPTION
This case was missing from our tests:

- Using a namespaced connector
- A table with an enum column
- A relation to that table so that the side with an enum column being to-many

Now the update and filter types were missing, and the user gets an error `Type 'EnumTypeName' not found!`