### PR TITLE
chore: make `MockGraphQlServer` generic over any schema

### DIFF
--- a/engine/crates/integration-tests/src/lib.rs
+++ b/engine/crates/integration-tests/src/lib.rs
@@ -2,7 +2,7 @@
 
 pub mod engine;
 pub mod helpers;
-mod mocks;
+pub mod mocks;
 pub mod mongodb;
 pub mod postgres;
 pub mod types;

--- a/engine/crates/integration-tests/src/mocks/graphql/fake_github.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql/fake_github.rs
@@ -1,0 +1,169 @@
+use async_graphql::{EmptyMutation, EmptySubscription, InputObject, Interface, Object, SimpleObject, Union, ID};
+
+pub struct FakeGithubSchema;
+
+#[async_trait::async_trait]
+impl super::Schema for FakeGithubSchema {
+    async fn execute(
+        &self,
+        headers: Vec<(String, String)>,
+        request: async_graphql::Request,
+    ) -> async_graphql::Response {
+        async_graphql::Schema::build(Query { headers }, EmptyMutation, EmptySubscription)
+            .finish()
+            .execute(request)
+            .await
+    }
+}
+
+struct Query {
+    headers: Vec<(String, String)>,
+}
+
+#[Object]
+impl Query {
+    // A top level scalar field for testing
+    async fn server_version(&self) -> &str {
+        "1"
+    }
+
+    async fn pull_requests_and_issues(&self, _filter: PullRequestsAndIssuesFilters) -> Vec<PullRequestOrIssue> {
+        // This doesn't actually filter anything because I don't need that for my test.
+        vec![
+            PullRequestOrIssue::PullRequest(PullRequest {
+                title: "Creating the thing".into(),
+                checks: vec!["Success!".into()],
+                author: UserOrBot::User(User {
+                    name: "Jim".into(),
+                    email: "jim@example.com".into(),
+                }),
+            }),
+            PullRequestOrIssue::PullRequest(PullRequest {
+                title: "Some bot PR".into(),
+                checks: vec!["Success!".into()],
+                author: UserOrBot::Bot(Bot { id: "123".into() }),
+            }),
+            PullRequestOrIssue::Issue(Issue {
+                title: "Everythings fucked".into(),
+                author: UserOrBot::User(User {
+                    name: "The Pessimist".into(),
+                    email: "pessimist@example.com".into(),
+                }),
+            }),
+        ]
+    }
+
+    #[allow(unused_variables)]
+    async fn bot_pull_requests(&self, bots: Vec<Option<Vec<BotInput>>>) -> Vec<PullRequest> {
+        vec![
+            PullRequest {
+                title: "Creating the thing".into(),
+                checks: vec!["Success!".into()],
+                author: UserOrBot::User(User {
+                    name: "Jim".into(),
+                    email: "jim@example.com".into(),
+                }),
+            },
+            PullRequest {
+                title: "Some bot PR".into(),
+                checks: vec!["Success!".into()],
+                author: UserOrBot::Bot(Bot { id: "123".into() }),
+            },
+        ]
+    }
+
+    async fn pull_request_or_issue(&self, id: ID) -> Option<PullRequestOrIssue> {
+        if id == "1" {
+            return Some(PullRequestOrIssue::PullRequest(PullRequest {
+                title: "Creating the thing".into(),
+                checks: vec!["Success!".into()],
+                author: UserOrBot::User(User {
+                    name: "Jim".into(),
+                    email: "jim@example.com".into(),
+                }),
+            }));
+        } else if id == "2" {
+            return Some(PullRequestOrIssue::PullRequest(PullRequest {
+                title: "Some bot PR".into(),
+                checks: vec!["Success!".into()],
+                author: UserOrBot::Bot(Bot { id: "123".into() }),
+            }));
+        } else if id == "3" {
+            return Some(PullRequestOrIssue::Issue(Issue {
+                title: "Everythings fucked".into(),
+                author: UserOrBot::User(User {
+                    name: "The Pessimist".into(),
+                    email: "pessimist@example.com".into(),
+                }),
+            }));
+        }
+        None
+    }
+
+    async fn headers(&self) -> Vec<Header> {
+        self.headers
+            .clone()
+            .into_iter()
+            .map(|(name, value)| Header { name, value })
+            .collect()
+    }
+}
+
+#[derive(SimpleObject)]
+struct Header {
+    name: String,
+    value: String,
+}
+
+#[derive(SimpleObject)]
+struct PullRequest {
+    title: String,
+    checks: Vec<String>,
+    author: UserOrBot,
+}
+
+#[derive(SimpleObject)]
+struct Issue {
+    title: String,
+    author: UserOrBot,
+}
+
+#[derive(Interface)]
+#[graphql(field(name = "title", ty = "String"), field(name = "author", ty = "UserOrBot"))]
+enum PullRequestOrIssue {
+    PullRequest(PullRequest),
+    Issue(Issue),
+}
+
+#[derive(Union, Clone)]
+enum UserOrBot {
+    User(User),
+    Bot(Bot),
+}
+
+#[derive(SimpleObject, Clone)]
+struct User {
+    name: String,
+    email: String,
+}
+
+#[derive(SimpleObject, Clone)]
+struct Bot {
+    id: ID,
+}
+
+#[derive(InputObject)]
+struct BotInput {
+    id: ID,
+}
+
+impl From<&UserOrBot> for UserOrBot {
+    fn from(value: &UserOrBot) -> Self {
+        value.clone()
+    }
+}
+
+#[derive(Debug, InputObject)]
+struct PullRequestsAndIssuesFilters {
+    search: String,
+}

--- a/engine/crates/integration-tests/tests/execution/joins.rs
+++ b/engine/crates/integration-tests/tests/execution/joins.rs
@@ -1,6 +1,8 @@
 //! Tests of the join directive
 
-use integration_tests::{runtime, udfs::RustUdfs, EngineBuilder, MockGraphQlServer, ResponseExt};
+use integration_tests::{
+    mocks::graphql::FakeGithubSchema, runtime, udfs::RustUdfs, EngineBuilder, MockGraphQlServer, ResponseExt,
+};
 use runtime::udf::{CustomResolverRequestPayload, CustomResolverResponse};
 use serde_json::{json, Value};
 
@@ -55,7 +57,7 @@ fn join_on_basic_type() {
 #[test]
 fn join_on_connector_type() {
     runtime().block_on(async {
-        let graphql_mock = MockGraphQlServer::new().await;
+        let graphql_mock = MockGraphQlServer::new(FakeGithubSchema).await;
         let port = graphql_mock.port();
 
         let schema = format!(

--- a/engine/crates/integration-tests/tests/graphql_connector/basic.rs
+++ b/engine/crates/integration-tests/tests/graphql_connector/basic.rs
@@ -1,4 +1,4 @@
-use integration_tests::{runtime, EngineBuilder, MockGraphQlServer, ResponseExt};
+use integration_tests::{mocks::graphql::FakeGithubSchema, runtime, EngineBuilder, MockGraphQlServer, ResponseExt};
 use serde_json::json;
 
 const NAMESPACED_QUERY: &str = "
@@ -39,7 +39,7 @@ const NAMESPACED_QUERY: &str = "
 #[test]
 fn graphql_test_with_namespace() {
     runtime().block_on(async {
-        let graphql_mock = MockGraphQlServer::new().await;
+        let graphql_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
         let engine = EngineBuilder::new(schema(graphql_mock.port(), true)).build().await;
 
@@ -135,7 +135,7 @@ const UNNAMESPACED_QUERY: &str = "
 #[test]
 fn graphql_test_without_namespace() {
     runtime().block_on(async {
-        let graphql_mock = MockGraphQlServer::new().await;
+        let graphql_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
         let engine = EngineBuilder::new(schema(graphql_mock.port(), false)).build().await;
 
@@ -177,7 +177,7 @@ fn graphql_test_without_namespace() {
 #[test]
 fn test_nested_variable_forwarding() {
     runtime().block_on(async {
-        let graphql_mock = MockGraphQlServer::new().await;
+        let graphql_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
         let engine = EngineBuilder::new(schema(graphql_mock.port(), false)).build().await;
 

--- a/engine/crates/integration-tests/tests/graphql_connector/defer.rs
+++ b/engine/crates/integration-tests/tests/graphql_connector/defer.rs
@@ -1,11 +1,11 @@
-use integration_tests::{runtime, EngineBuilder, MockGraphQlServer, ResponseExt};
+use integration_tests::{mocks::graphql::FakeGithubSchema, runtime, EngineBuilder, MockGraphQlServer, ResponseExt};
 
 #[test]
 fn test_defer_on_graphql_connector() {
     // Note: this test relies on async-graphql not supporting @defer
     // When that changes we might need to re-think this
     runtime().block_on(async {
-        let graphql_mock = MockGraphQlServer::new().await;
+        let graphql_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
         let engine = EngineBuilder::new(schema(graphql_mock.port())).build().await;
 

--- a/engine/crates/integration-tests/tests/graphql_connector/headers.rs
+++ b/engine/crates/integration-tests/tests/graphql_connector/headers.rs
@@ -1,10 +1,10 @@
-use integration_tests::{runtime, EngineBuilder, MockGraphQlServer, ResponseExt};
+use integration_tests::{mocks::graphql::FakeGithubSchema, runtime, EngineBuilder, MockGraphQlServer, ResponseExt};
 use serde_json::json;
 
 #[test]
 fn test_header_forwarding() {
     runtime().block_on(async {
-        let graphql_mock = MockGraphQlServer::new().await;
+        let graphql_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
         let engine = EngineBuilder::new(schema(graphql_mock.port()))
             .with_env_var("API_KEY", "BLAH")

--- a/engine/crates/integration-tests/tests/graphql_connector/transforms.rs
+++ b/engine/crates/integration-tests/tests/graphql_connector/transforms.rs
@@ -1,11 +1,11 @@
 use cynic::QueryBuilder;
 use cynic_introspection::IntrospectionQuery;
-use integration_tests::{runtime, EngineBuilder, MockGraphQlServer, ResponseExt};
+use integration_tests::{mocks::graphql::FakeGithubSchema, runtime, EngineBuilder, MockGraphQlServer, ResponseExt};
 
 #[test]
 fn graphql_test_with_transforms() {
     runtime().block_on(async {
-        let graphql_mock = MockGraphQlServer::new().await;
+        let graphql_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
         let engine = EngineBuilder::new(schema(graphql_mock.port())).build().await;
 


### PR DESCRIPTION
For testing federation we're going to need a variety of different GraphQL servers in our integration tests.  This commit is prep work for that: it makes the MockGraphQlServer able to support any `async_graphql` schema.

A follow up PR will add some that we can use for federation testing