### PR TITLE
test: introsect subgraphs in federation integration tests

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -144,6 +144,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "apollo-encoder"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee9f27b20841d14923dd5f0714a79f86360b23492d2f98ab5d1651471a56b7a4"
+dependencies = [
+ "apollo-parser",
+ "thiserror",
+]
+
+[[package]]
+name = "apollo-parser"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb81e4793effa1744cc96f49542aec487696e595e0faeabbd9f8a83e5c83036"
+dependencies = [
+ "memchr",
+ "rowan",
+ "thiserror",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,6 +869,12 @@ checksum = "2d458e66999348f56fd3ffcfbb7f7951542075ca8359687c703de6500c1ddccd"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "cpufeatures"
@@ -1772,6 +1799,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "grafbase-graphql-introspection"
+version = "0.44.2"
+dependencies = [
+ "apollo-encoder",
+ "apollo-parser",
+ "cynic",
+ "cynic-introspection",
+ "indoc",
+ "reqwest",
+ "serde",
+]
+
+[[package]]
 name = "grafbase-sql-ast"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2243,6 +2283,7 @@ dependencies = [
  "engine-v2",
  "expect-test",
  "futures",
+ "grafbase-graphql-introspection",
  "graphql-composition",
  "graphql-parser",
  "http",
@@ -2533,6 +2574,15 @@ name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+
+[[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "miette"
@@ -3546,8 +3596,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.18"
-source = "git+https://github.com/seanmonstar/reqwest.git?rev=839623312f8359b173437fb01b1932f204449cca#839623312f8359b173437fb01b1932f204449cca"
+version = "0.11.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
  "base64 0.21.4",
  "bytes",
@@ -3573,6 +3624,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -3632,6 +3684,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rowan"
+version = "0.15.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "906057e449592587bf6724f00155bf82a6752c868d78a8fb3aa41f4e6357cfe8"
+dependencies = [
+ "countme",
+ "hashbrown 0.12.3",
+ "memoffset",
+ "rustc-hash",
+ "text-size",
 ]
 
 [[package]]
@@ -3833,6 +3898,12 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -4073,9 +4144,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.189"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 dependencies = [
  "serde_derive",
 ]
@@ -4103,9 +4174,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.189"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4500,6 +4571,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4536,6 +4628,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "textwrap"
@@ -5545,3 +5643,8 @@ dependencies = [
  "quote",
  "syn 2.0.38",
 ]
+
+[[patch.unused]]
+name = "reqwest"
+version = "0.11.18"
+source = "git+https://github.com/seanmonstar/reqwest.git?rev=839623312f8359b173437fb01b1932f204449cca#839623312f8359b173437fb01b1932f204449cca"

--- a/engine/crates/integration-tests/Cargo.toml
+++ b/engine/crates/integration-tests/Cargo.toml
@@ -18,6 +18,7 @@ engine-parser.workspace = true
 engine-v2.workspace = true
 expect-test = "1.4"
 futures = "0.3"
+grafbase-graphql-introspection = { path = "../../../cli/crates/graphql-introspection" }
 graphql-composition.workspace = true
 graphql-parser = "0.4.0"
 http = { workspace = true }

--- a/engine/crates/integration-tests/src/federation/builder.rs
+++ b/engine/crates/integration-tests/src/federation/builder.rs
@@ -1,6 +1,8 @@
 use async_graphql_parser::types::ServiceDocument;
 use engine_v2::Engine;
 
+use crate::MockGraphQlServer;
+
 use super::TestFederationEngine;
 
 #[must_use]
@@ -16,15 +18,17 @@ pub trait EngineV2Ext {
 
 impl EngineV2Ext for engine_v2::Engine {}
 
+#[async_trait::async_trait]
 pub trait SchemaSource {
-    fn sdl(&self) -> String;
+    async fn sdl(&self) -> String;
+    fn url(&self) -> String;
 }
 
 impl FederationEngineBuilder {
-    pub fn with_schema(mut self, name: &str, schema: impl SchemaSource) -> Self {
+    pub async fn with_schema(mut self, _name: &str, schema: impl SchemaSource) -> Self {
         self.schemas.push((
-            name.to_string(),
-            async_graphql_parser::parse_schema(schema.sdl()).expect("schema to be well formed"),
+            schema.url(), // Note: this is temporary while composition doesn't support urls properly.
+            async_graphql_parser::parse_schema(schema.sdl().await).expect("schema to be well formed"),
         ));
         self
     }
@@ -44,18 +48,41 @@ impl FederationEngineBuilder {
     }
 }
 
-// At some point we could provide one of these that introspects.  But for now just a dumb string impl
+#[async_trait::async_trait]
 impl SchemaSource for String {
-    fn sdl(&self) -> String {
+    async fn sdl(&self) -> String {
         self.clone()
+    }
+
+    // Probably shouldn't really use this SchemaSource since this'll never work.
+    fn url(&self) -> String {
+        "http://example.com".to_string()
     }
 }
 
-impl<T> SchemaSource for T
+#[async_trait::async_trait]
+impl<T> SchemaSource for &T
 where
-    T: crate::mocks::graphql::Schema,
+    T: SchemaSource + Send + Sync,
 {
-    fn sdl(&self) -> String {
-        crate::mocks::graphql::Schema::sdl(self)
+    async fn sdl(&self) -> String {
+        T::sdl(self).await
+    }
+
+    fn url(&self) -> String {
+        T::url(self)
+    }
+}
+
+#[async_trait::async_trait]
+impl SchemaSource for MockGraphQlServer {
+    async fn sdl(&self) -> String {
+        grafbase_graphql_introspection::introspect(&self.url(), &[])
+            .await
+            .expect("introspection to succeed")
+    }
+
+    fn url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port())
     }
 }

--- a/engine/crates/integration-tests/tests/federation/basic/fragments.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/fragments.rs
@@ -1,13 +1,15 @@
 use engine_v2::Engine;
-use integration_tests::{federation::EngineV2Ext, mocks::graphql::FakeGithubSchema, runtime};
+use integration_tests::{federation::EngineV2Ext, mocks::graphql::FakeGithubSchema, runtime, MockGraphQlServer};
 
 #[test]
 #[ignore]
 fn named_fragment_on_object() {
-    let engine = Engine::build().with_schema("schema", FakeGithubSchema).finish();
-
     let response = runtime()
         .block_on(async move {
+            let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
+
+            let engine = Engine::build().with_schema("schema", &github_mock).await.finish();
+
             engine
                 .execute(
                     r#"
@@ -37,10 +39,12 @@ fn named_fragment_on_object() {
 #[test]
 #[ignore]
 fn inline_fragment_on_object() {
-    let engine = Engine::build().with_schema("schema", FakeGithubSchema).finish();
-
     let response = runtime()
         .block_on(async move {
+            let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
+
+            let engine = Engine::build().with_schema("schema", &github_mock).await.finish();
+
             engine
                 .execute(
                     r#"
@@ -68,10 +72,12 @@ fn inline_fragment_on_object() {
 #[test]
 #[ignore]
 fn inline_fragment_on_object_with_type_condition() {
-    let engine = Engine::build().with_schema("schema", FakeGithubSchema).finish();
-
     let response = runtime()
         .block_on(async move {
+            let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
+
+            let engine = Engine::build().with_schema("schema", &github_mock).await.finish();
+
             engine
                 .execute(
                     r#"
@@ -99,10 +105,12 @@ fn inline_fragment_on_object_with_type_condition() {
 #[test]
 #[ignore]
 fn inline_fragments_on_polymorphic_types() {
-    let engine = Engine::build().with_schema("schema", FakeGithubSchema).finish();
-
     let response = runtime()
         .block_on(async move {
+            let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
+
+            let engine = Engine::build().with_schema("schema", &github_mock).await.finish();
+
             engine
                 .execute(
                     r#"
@@ -139,10 +147,12 @@ fn inline_fragments_on_polymorphic_types() {
 #[test]
 #[ignore]
 fn named_fragments_on_polymorphic_types() {
-    let engine = Engine::build().with_schema("schema", FakeGithubSchema).finish();
-
     let response = runtime()
         .block_on(async move {
+            let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
+
+            let engine = Engine::build().with_schema("schema", &github_mock).await.finish();
+
             engine
                 .execute(
                     r#"


### PR DESCRIPTION
Updates the federation tests to start their mock servers & introspect them over HTTP.

This commit also temporarily passes the downstream URL in as a the name of the subgraph.  I'll change this back when the composition library lets you pass in a URL and a name.

Part of GB-5337