### PR TITLE
fix: remove hardcoded JWTs from owner tests

### DIFF
--- a/cli/crates/cli/tests/owner.rs
+++ b/cli/crates/cli/tests/owner.rs
@@ -1,58 +1,9 @@
 #![allow(unused_crate_dependencies)]
+
+use chrono::Duration;
+use serde_json::json;
+
 mod utils;
-
-/*
-All JWTs were generated using header:
-```json
-{
-  "alg": "HS256",
-  "typ": "JWT"
-}
-```
-and signature `abc123`
-*/
-
-/*
-{
-  "iss": "https://idp.example.com",
-  "exp": 3000000000,
-  "iat": 1516239022,
-  "sub": "user1"
-}
-*/
-const USER1: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2lkcC5leGFtcGxlLmNvbSIsImV4cCI6MzAwMDAwMDAwMCwiaWF0IjoxNTE2MjM5MDIyLCJzdWIiOiJ1c2VyMSJ9.GmXb5LgkrN72MqxdTUKUIWgYlMRTO4WJdQebAghCyXk";
-/*
-{
-  "iss": "https://idp.example.com",
-  "exp": 3000000000,
-  "iat": 1516239022,
-  "sub": "user2"
-}
-*/
-const USER2: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2lkcC5leGFtcGxlLmNvbSIsImV4cCI6MzAwMDAwMDAwMCwiaWF0IjoxNTE2MjM5MDIyLCJzdWIiOiJ1c2VyMiJ9.J8j7tjrjd-WaRFcxRBUjev0-1uifRnE0IVt_W-IXdHM";
-/*
-{
-  "iss": "https://idp.example.com",
-  "groups": [
-    "admin"
-  ],
-  "exp": 1700000000,
-  "sub": "user3",
-  "iat": 1516239022
-}
-*/
-const USER3: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2lkcC5leGFtcGxlLmNvbSIsImdyb3VwcyI6WyJhZG1pbiJdLCJleHAiOjE3MDAwMDAwMDAsInN1YiI6InVzZXIzIiwiaWF0IjoxNTE2MjM5MDIyfQ.spBDmilxTWvrPVBTdPP5FKHRTY5aFvXvVeDcC82MVq4";
-/*
-{
-  "iss": "https://idp.example.com",
-  "groups": [
-    "admin"
-  ],
-  "exp": 1700000000,
-  "iat": 1516239022
-}
-*/
-const ADMIN:&str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2lkcC5leGFtcGxlLmNvbSIsImdyb3VwcyI6WyJhZG1pbiJdLCJleHAiOjE3MDAwMDAwMDAsImlhdCI6MTUxNjIzOTAyMn0.1cEYNKTmOMMOE9DXpQWB5YLQgzjpMSMXt5lzWEXhjsY";
 
 mod global {
 
@@ -62,7 +13,7 @@ mod global {
             OWNER_TODO_OWNER_CREATE_SCHEMA, OWNER_TODO_SCHEMA, OWNER_TODO_UPDATE,
         };
         use crate::utils::environment::Environment;
-        use crate::{ADMIN, USER1, USER2, USER3};
+        use crate::{admin_jwt, user_one_jwt, user_three_jwt, user_two_jwt};
         use backend::project::ConfigType;
         use json_dotpath::DotPaths;
         use serde_json::{json, Value};
@@ -79,7 +30,7 @@ mod global {
             // user1 creates a todo.
             let todo_created = client
                 .gql::<Value>(OWNER_TODO_CREATE)
-                .bearer(USER1)
+                .bearer(&user_one_jwt())
                 .variables(json!({ "title": "1", "complete": false }))
                 .send();
 
@@ -89,13 +40,16 @@ mod global {
                 .unwrap()
                 .expect("id must be present");
             // user1.list should see the todo.
-            insta::assert_json_snapshot!("user1-list", client.gql::<Value>(OWNER_TODO_LIST).bearer(USER1).send());
+            insta::assert_json_snapshot!(
+                "user1-list",
+                client.gql::<Value>(OWNER_TODO_LIST).bearer(&user_one_jwt()).send()
+            );
             // user1 should be able to get the todo by id.
             insta::assert_json_snapshot!(
                 "user1-get",
                 client
                     .gql::<Value>(OWNER_TODO_GET)
-                    .bearer(USER1)
+                    .bearer(&user_one_jwt())
                     .variables(json!({ "id": id }))
                     .send()
             );
@@ -104,57 +58,63 @@ mod global {
                 "user1-update",
                 client
                     .gql::<Value>(OWNER_TODO_UPDATE)
-                    .bearer(USER1)
+                    .bearer(&user_one_jwt())
                     .variables(json!({"id": id, "input": { "complete": true }}))
                     .send()
             );
             // user1.list should see the todo with updated complete status.
             insta::assert_json_snapshot!(
                 "user1-list-2",
-                client.gql::<Value>(OWNER_TODO_LIST).bearer(USER1).send()
+                client.gql::<Value>(OWNER_TODO_LIST).bearer(&user_one_jwt()).send()
             );
             // user2.list should be empty.
-            insta::assert_json_snapshot!("list-empty", client.gql::<Value>(OWNER_TODO_LIST).bearer(USER2).send());
+            insta::assert_json_snapshot!(
+                "list-empty",
+                client.gql::<Value>(OWNER_TODO_LIST).bearer(&user_two_jwt()).send()
+            );
             // user2 should not be able to get the todo by id.
             insta::assert_json_snapshot!(
                 "user2-get-fail",
                 client
                     .gql::<Value>(OWNER_TODO_GET)
-                    .bearer(USER2)
+                    .bearer(&user_two_jwt())
                     .variables(json!({ "id": id }))
                     .send()
             );
             // an attempt by user2 to update the todo should fail.
             client
                 .gql::<Value>(OWNER_TODO_UPDATE)
-                .bearer(USER2)
+                .bearer(&user_two_jwt())
                 .variables(json!({"id": id, "input": { "complete": false }}))
                 .send();
             insta::assert_json_snapshot!(
                 "user1-list-2",
-                client.gql::<Value>(OWNER_TODO_LIST).bearer(USER1).send()
+                client.gql::<Value>(OWNER_TODO_LIST).bearer(&user_one_jwt()).send()
             );
             // an attemt by user2 to delete the todo should fail.
             client
                 .gql::<Value>(OWNER_TODO_DELETE)
-                .bearer(USER2)
+                .bearer(&user_two_jwt())
                 .variables(json!({ "id": id }))
                 .send();
             insta::assert_json_snapshot!(
                 "user1-list-2",
-                client.gql::<Value>(OWNER_TODO_LIST).bearer(USER1).send()
+                client.gql::<Value>(OWNER_TODO_LIST).bearer(&user_one_jwt()).send()
             );
             // user1 deletes the todo.
             insta::assert_json_snapshot!(
                 "user1-delete",
                 client
                     .gql::<Value>(OWNER_TODO_DELETE)
-                    .bearer(USER1)
+                    .bearer(&user_one_jwt())
                     .variables(json!({ "id": id }))
                     .send()
             );
             // list of todos should be empty.
-            insta::assert_json_snapshot!("list-empty", client.gql::<Value>(OWNER_TODO_LIST).bearer(USER1).send());
+            insta::assert_json_snapshot!(
+                "list-empty",
+                client.gql::<Value>(OWNER_TODO_LIST).bearer(&user_one_jwt()).send()
+            );
         }
 
         #[test]
@@ -169,7 +129,7 @@ mod global {
             // user1 creates a todo.
             let todo_created = client
                 .gql::<Value>(OWNER_TODO_CREATE)
-                .bearer(USER1)
+                .bearer(&user_one_jwt())
                 .variables(json!({ "title": "1", "complete": false }))
                 .send();
             insta::assert_json_snapshot!("user1-create", todo_created, {".data.todoCreate.todo.id" => "[id]"});
@@ -179,20 +139,29 @@ mod global {
                 .expect("id must be present");
 
             // // admin.list should see the todo.
-            insta::assert_json_snapshot!("list", client.gql::<Value>(OWNER_TODO_LIST).bearer(ADMIN).send());
+            insta::assert_json_snapshot!("list", client.gql::<Value>(OWNER_TODO_LIST).bearer(&admin_jwt()).send());
             // user3.list should see the todo.
-            insta::assert_json_snapshot!("list", client.gql::<Value>(OWNER_TODO_LIST).bearer(USER3).send());
+            insta::assert_json_snapshot!(
+                "list",
+                client.gql::<Value>(OWNER_TODO_LIST).bearer(&user_three_jwt()).send()
+            );
             // user1.list should be unauthorized.
-            insta::assert_json_snapshot!("list-fail", client.gql::<Value>(OWNER_TODO_LIST).bearer(USER1).send());
+            insta::assert_json_snapshot!(
+                "list-fail",
+                client.gql::<Value>(OWNER_TODO_LIST).bearer(&user_one_jwt()).send()
+            );
             // user2.list should be unauthorized.
-            insta::assert_json_snapshot!("list-fail", client.gql::<Value>(OWNER_TODO_LIST).bearer(USER2).send());
+            insta::assert_json_snapshot!(
+                "list-fail",
+                client.gql::<Value>(OWNER_TODO_LIST).bearer(&user_two_jwt()).send()
+            );
 
             // user1 should be able to get the todo by id.
             insta::assert_json_snapshot!(
                 "get",
                 client
                     .gql::<Value>(OWNER_TODO_GET)
-                    .bearer(USER1)
+                    .bearer(&user_one_jwt())
                     .variables(json!({ "id": id }))
                     .send()
             );
@@ -201,7 +170,7 @@ mod global {
                 "get-fail",
                 client
                     .gql::<Value>(OWNER_TODO_GET)
-                    .bearer(USER2)
+                    .bearer(&user_two_jwt())
                     .variables(json!({ "id": id }))
                     .send()
             );
@@ -210,7 +179,7 @@ mod global {
                 "get",
                 client
                     .gql::<Value>(OWNER_TODO_GET)
-                    .bearer(ADMIN)
+                    .bearer(&admin_jwt())
                     .variables(json!({ "id": id }))
                     .send()
             );
@@ -219,7 +188,7 @@ mod global {
                 "get",
                 client
                     .gql::<Value>(OWNER_TODO_GET)
-                    .bearer(USER3)
+                    .bearer(&user_three_jwt())
                     .variables(json!({ "id": id }))
                     .send()
             );
@@ -237,7 +206,7 @@ mod global {
             // user1 creates a todo.
             let todo_created = client
                 .gql::<Value>(OWNER_TODO_CREATE)
-                .bearer(USER1)
+                .bearer(&user_one_jwt())
                 .variables(json!({ "title": "1", "complete": false }))
                 .send();
             insta::assert_json_snapshot!("user1-create", todo_created, {".data.todoCreate.todo.id" => "[id]"});
@@ -247,20 +216,29 @@ mod global {
                 .expect("id must be present");
 
             // admin.list should see the todo.
-            insta::assert_json_snapshot!("list", client.gql::<Value>(OWNER_TODO_LIST).bearer(ADMIN).send());
+            insta::assert_json_snapshot!("list", client.gql::<Value>(OWNER_TODO_LIST).bearer(&admin_jwt()).send());
             // user3.list should see the todo.
-            insta::assert_json_snapshot!("list", client.gql::<Value>(OWNER_TODO_LIST).bearer(USER3).send());
+            insta::assert_json_snapshot!(
+                "list",
+                client.gql::<Value>(OWNER_TODO_LIST).bearer(&user_three_jwt()).send()
+            );
             // user1.list should see the todo.
-            insta::assert_json_snapshot!("list", client.gql::<Value>(OWNER_TODO_LIST).bearer(USER1).send());
+            insta::assert_json_snapshot!(
+                "list",
+                client.gql::<Value>(OWNER_TODO_LIST).bearer(&user_one_jwt()).send()
+            );
             // user2.list should be unauthorized.
-            insta::assert_json_snapshot!("list", client.gql::<Value>(OWNER_TODO_LIST).bearer(USER1).send());
+            insta::assert_json_snapshot!(
+                "list",
+                client.gql::<Value>(OWNER_TODO_LIST).bearer(&user_one_jwt()).send()
+            );
 
             // user1 should see the todo.
             insta::assert_json_snapshot!(
                 "get",
                 client
                     .gql::<Value>(OWNER_TODO_GET)
-                    .bearer(USER1)
+                    .bearer(&user_one_jwt())
                     .variables(json!({ "id": id }))
                     .send()
             );
@@ -269,7 +247,7 @@ mod global {
                 "get-fail",
                 client
                     .gql::<Value>(OWNER_TODO_GET)
-                    .bearer(USER2)
+                    .bearer(&user_two_jwt())
                     .variables(json!({ "id": id }))
                     .send()
             );
@@ -278,7 +256,7 @@ mod global {
                 "get",
                 client
                     .gql::<Value>(OWNER_TODO_GET)
-                    .bearer(ADMIN)
+                    .bearer(&admin_jwt())
                     .variables(json!({ "id": id }))
                     .send()
             );
@@ -287,7 +265,7 @@ mod global {
                 "get",
                 client
                     .gql::<Value>(OWNER_TODO_GET)
-                    .bearer(USER3)
+                    .bearer(&user_three_jwt())
                     .variables(json!({ "id": id }))
                     .send()
             );
@@ -300,7 +278,7 @@ mod global {
             OWNER_TWITTER_USER_CREATE, OWNER_TWITTER_USER_GET_BY_EMAIL, OWNER_TWITTER_USER_GET_BY_ID,
         };
         use crate::utils::environment::Environment;
-        use crate::{USER1, USER2};
+        use crate::{user_one_jwt, user_two_jwt};
         use backend::project::ConfigType;
         use json_dotpath::DotPaths;
         use serde_json::{json, Value};
@@ -318,7 +296,7 @@ mod global {
             let email: &str = "user1@example.com";
             let user_created = client
                 .gql::<Value>(OWNER_TWITTER_USER_CREATE)
-                .bearer(USER1)
+                .bearer(&user_one_jwt())
                 .variables(
                     json!({ "username": "user1", "email": email, "avatar": "http://example.com", "url": "http://example.com" }),
                 )
@@ -334,7 +312,7 @@ mod global {
                 "user1-get",
                 client
                     .gql::<Value>(OWNER_TWITTER_USER_GET_BY_ID)
-                    .bearer(USER1)
+                    .bearer(&user_one_jwt())
                     .variables(json!({ "id": id }))
                     .send()
             );
@@ -343,7 +321,7 @@ mod global {
                 "user2-get-empty",
                 client
                     .gql::<Value>(OWNER_TWITTER_USER_GET_BY_ID)
-                    .bearer(USER2)
+                    .bearer(&user_two_jwt())
                     .variables(json!({ "id": id }))
                     .send()
             );
@@ -362,7 +340,7 @@ mod global {
             let email: &str = "user1@example.com";
             let user_created = client
                 .gql::<Value>(OWNER_TWITTER_USER_CREATE)
-                .bearer(USER1)
+                .bearer(&user_one_jwt())
                 .variables(
                     json!({ "username": "user1", "email": email, "avatar": "http://example.com", "url": "http://example.com" }),
                 )
@@ -374,7 +352,7 @@ mod global {
                 "user1-get",
                 client
                     .gql::<Value>(OWNER_TWITTER_USER_GET_BY_EMAIL)
-                    .bearer(USER1)
+                    .bearer(&user_one_jwt())
                     .variables(json!({ "email": email }))
                     .send()
             );
@@ -383,7 +361,7 @@ mod global {
                 "user2-get-empty",
                 client
                     .gql::<Value>(OWNER_TWITTER_USER_GET_BY_EMAIL)
-                    .bearer(USER2)
+                    .bearer(&user_two_jwt())
                     .variables(json!({ "email": email }))
                     .send()
             );
@@ -402,7 +380,7 @@ mod global {
             let email: &str = "user1@example.com";
             let user_created = client
                 .gql::<Value>(OWNER_TWITTER_USER_CREATE)
-                .bearer(USER1)
+                .bearer(&user_one_jwt())
                 .variables(
                     json!({ "username": "user1", "email": email, "avatar": "http://example.com", "url": "http://example.com" }),
                 )
@@ -418,7 +396,7 @@ mod global {
                 "user1-create-tweet",
                 client
                     .gql::<Value>(OWNER_TWITTER_TWEET_CREATE)
-                    .bearer(USER1)
+                    .bearer(&user_one_jwt())
                     .variables(json!({ "userId": id }))
                     .send(),
                 {".data.tweetCreate.tweet.id" => "[id]"}
@@ -428,7 +406,7 @@ mod global {
                 "user2-create-tweet-fail",
                 client
                     .gql::<Value>(OWNER_TWITTER_TWEET_CREATE)
-                    .bearer(USER2)
+                    .bearer(&user_two_jwt())
                     .variables(json!({ "userId": id }))
                     .send()
             );
@@ -437,10 +415,57 @@ mod global {
                 "user1-and-tweets-get",
                 client
                     .gql::<Value>(OWNER_TWITTER_USER_AND_TWEETS_GET_BY_ID)
-                    .bearer(USER1)
+                    .bearer(&user_one_jwt())
                     .variables(json!({ "id": id }))
                     .send()
             );
         }
     }
+}
+
+fn user_one_jwt() -> String {
+    make_jwt(&json!({
+        "iss": "https://idp.example.com",
+        "sub": "user1"
+    }))
+}
+
+fn user_two_jwt() -> String {
+    make_jwt(&json!({
+        "iss": "https://idp.example.com",
+        "sub": "user2"
+    }))
+}
+
+fn user_three_jwt() -> String {
+    make_jwt(&json!({
+        "iss": "https://idp.example.com",
+        "groups": [
+            "admin"
+        ],
+        "sub": "user3",
+    }))
+}
+
+fn admin_jwt() -> String {
+    make_jwt(&json!({
+        "iss": "https://idp.example.com",
+        "groups": [
+            "admin"
+        ],
+    }))
+}
+
+fn make_jwt(claims: &serde_json::Value) -> String {
+    use jwt_compact::{
+        alg::{Hs256, Hs256Key},
+        AlgorithmExt, Claims, Header, TimeOptions,
+    };
+
+    let claims = Claims::new(claims).set_duration_and_issuance(&TimeOptions::default(), Duration::days(7));
+
+    let key = Hs256Key::new(b"abc123");
+    let header = Header::empty().with_key_id("my-key");
+
+    Hs256.token(&header, &claims, &key).unwrap()
 }


### PR DESCRIPTION
These were hardcoded with an expiration date of 1700000000 which was yesterday, causing all the tests to suddenly fail. I've updated the tests to just generate their own JWTs, which should prevent this becoming an issue again.

Hardcoded JWTs in tests is kind of a bad idea anyway - harder to debug, harder to write, requires more documentation and you run into silly things like this.
