### PR TITLE
cli: release 0.44.3

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.44.3] - 2023-11-15
+
+[CHANGELOG](changelog/0.44.3.md)
+
 ## [0.44.2] - 2023-11-13
 
 [CHANGELOG](changelog/0.44.2.md)

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2282,7 +2282,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "async-graphql 6.0.6",
  "async-trait",
@@ -2405,7 +2405,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "async-graphql 5.0.10",
  "async-graphql-axum",
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-graphql-introspection"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "apollo-encoder",
  "apollo-parser",
@@ -2487,7 +2487,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "async-compression",
  "async-tar",
@@ -2519,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "chrono",
  "common-types",
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -6970,7 +6970,7 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typed-resolvers"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "datatest-stable",
  "engine-parser",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,7 +15,7 @@ ulid = { git = "https://github.com/grafbase/ulid-rs", rev = "6d06156193d51a2db32
 
 
 [workspace.package]
-version = "0.44.2"
+version = "0.44.3"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://grafbase.com"

--- a/cli/changelog/0.44.3.md
+++ b/cli/changelog/0.44.3.md
@@ -1,0 +1,4 @@
+### Features
+
+- `grafbase subgraphs introspect` has been renamed to `grafbase introspect`.
+- New hidden subcommands in CLI: `schema`, `publish` and `subgraphs`.

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -40,8 +40,8 @@ url = "2"
 urlencoding = "2"
 walkdir = "2"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.44.2" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.44.2" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.44.3" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.44.3" }
 
 [build-dependencies]
 cynic-codegen = { version = "3", features = ["rkyv"] }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -41,9 +41,9 @@ webbrowser = "0.8"
 lru = "0.12"
 futures-util = "0.3"
 
-server = { package = "grafbase-local-server", path = "../server", version = "0.44.2" }
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.44.2" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.44.2" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.44.3" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.44.3" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.44.3" }
 graphql-introspection = { package = "grafbase-graphql-introspection", path = "../graphql-introspection" }
 atty = "0.2.14"
 

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -64,7 +64,7 @@ sha2 = "0.10"
 # Same version as Tantivy
 tantivy-fst = "0.4.0"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.44.2" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.44.3" }
 gateway = { path = "../gateway" }
 typed-resolvers = { path = "../typed-resolvers" }
 engine = { path = "../../../engine/crates/engine" }

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.44.2",
+  "version": "0.44.3",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.44.2",
+  "version": "0.44.3",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.44.2",
+  "version": "0.44.3",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.44.2",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.44.2",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.44.2",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.44.2",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.44.2"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.44.3",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.44.3",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.44.3",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.44.3",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.44.3"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.44.2",
+  "version": "0.44.3",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.44.2",
+  "version": "0.44.3",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.44.2",
+  "version": "0.44.3",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1800,7 +1800,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-graphql-introspection"
-version = "0.44.2"
+version = "0.44.3"
 dependencies = [
  "apollo-encoder",
  "apollo-parser",
@@ -5643,8 +5643,3 @@ dependencies = [
  "quote",
  "syn 2.0.38",
 ]
-
-[[patch.unused]]
-name = "reqwest"
-version = "0.11.18"
-source = "git+https://github.com/seanmonstar/reqwest.git?rev=839623312f8359b173437fb01b1932f204449cca#839623312f8359b173437fb01b1932f204449cca"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -12,8 +12,6 @@ resolver = "2"
 again = { git = "https://github.com/grafbase/again", branch = "cloudflare-workers-compatibility" }
 # Use our fork of dynomite that uses the 0.48 version of rusoto.
 dynomite = { git = "https://github.com/grafbase/dynomite", branch = "rusoto-0_48" }
-# FIXME: Drop on next release.
-reqwest = { git = "https://github.com/seanmonstar/reqwest.git", rev = "839623312f8359b173437fb01b1932f204449cca" }
 serde_with = { git = "https://github.com/grafbase/serde_with", rev = "00b1e328bf4ce750e01ea2450dcfe83e4955f2af" }
 ulid = { git = "https://github.com/grafbase/ulid-rs", rev = "6d06156193d51a2db3216f058cbfadd4923df2c7" }
 


### PR DESCRIPTION
Features

- `grafbase subgraphs introspect` has been renamed to `grafbase introspect`.
- New hidden subcommands in CLI: `schema`, `publish` and `subgraphs`.
