### PR TITLE
feat: graphql-composiiton now accepts a url

### DIFF
--- a/engine/crates/composition/src/ingest_subgraph.rs
+++ b/engine/crates/composition/src/ingest_subgraph.rs
@@ -13,8 +13,8 @@ use crate::{
 };
 use async_graphql_parser::types as ast;
 
-pub(crate) fn ingest_subgraph(document: &ast::ServiceDocument, name: &str, subgraphs: &mut Subgraphs) {
-    let subgraph_id = subgraphs.push_subgraph(name);
+pub(crate) fn ingest_subgraph(document: &ast::ServiceDocument, name: &str, url: &str, subgraphs: &mut Subgraphs) {
+    let subgraph_id = subgraphs.push_subgraph(name, url);
 
     let federation_directives_matcher = ingest_schema_definitions(document);
 

--- a/engine/crates/composition/src/subgraphs.rs
+++ b/engine/crates/composition/src/subgraphs.rs
@@ -51,8 +51,8 @@ pub struct Subgraphs {
 
 impl Subgraphs {
     /// Add a subgraph to compose.
-    pub fn ingest(&mut self, subgraph_schema: &async_graphql_parser::types::ServiceDocument, name: &str) {
-        crate::ingest_subgraph::ingest_subgraph(subgraph_schema, name, self);
+    pub fn ingest(&mut self, subgraph_schema: &async_graphql_parser::types::ServiceDocument, name: &str, url: &str) {
+        crate::ingest_subgraph::ingest_subgraph(subgraph_schema, name, url, self);
     }
 
     /// Iterate over groups of definitions to compose. The definitions are grouped by name. The
@@ -87,9 +87,10 @@ impl Subgraphs {
         }
     }
 
-    pub(crate) fn push_subgraph(&mut self, name: &str) -> SubgraphId {
+    pub(crate) fn push_subgraph(&mut self, name: &str, url: &str) -> SubgraphId {
         let subgraph = Subgraph {
             name: self.strings.intern(name),
+            url: self.strings.intern(url),
         };
         SubgraphId(self.subgraphs.push_return_idx(subgraph))
     }
@@ -115,6 +116,7 @@ pub(crate) struct Subgraph {
     /// The name of the subgraph. It is not contained in the GraphQL schema of the subgraph, it
     /// only makes sense within a project.
     name: StringId,
+    url: StringId,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/engine/crates/composition/src/subgraphs/walkers.rs
+++ b/engine/crates/composition/src/subgraphs/walkers.rs
@@ -26,6 +26,6 @@ impl<'a> SubgraphWalker<'a> {
     }
 
     pub(crate) fn url(self) -> StringWalker<'a> {
-        self.walk(self.subgraph().name) // TODO: take the url as input
+        self.walk(self.subgraph().url)
     }
 }

--- a/engine/crates/composition/tests/composition/custom_scalars_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/custom_scalars_basic/federated.graphql
@@ -1,7 +1,7 @@
 enum join__Graph {
-    BAR @join__graph(name: "bar", url: "bar")
-    BAZ @join__graph(name: "baz", url: "baz")
-    FOO @join__graph(name: "foo", url: "foo")
+    BAR @join__graph(name: "bar", url: "http://example.com/bar")
+    BAZ @join__graph(name: "baz", url: "http://example.com/baz")
+    FOO @join__graph(name: "foo", url: "http://example.com/foo")
 }
 
 scalar Yan

--- a/engine/crates/composition/tests/composition/enum_only_inputs/federated.graphql
+++ b/engine/crates/composition/tests/composition/enum_only_inputs/federated.graphql
@@ -1,7 +1,7 @@
 enum join__Graph {
-    FOODSEARCH @join__graph(name: "foodSearch", url: "foodSearch")
-    PRODUCTSEARCH @join__graph(name: "productSearch", url: "productSearch")
-    USERSEARCH @join__graph(name: "userSearch", url: "userSearch")
+    FOODSEARCH @join__graph(name: "foodSearch", url: "http://example.com/foodSearch")
+    PRODUCTSEARCH @join__graph(name: "productSearch", url: "http://example.com/productSearch")
+    USERSEARCH @join__graph(name: "userSearch", url: "http://example.com/userSearch")
 }
 
 type Query {

--- a/engine/crates/composition/tests/composition/enum_only_outputs/federated.graphql
+++ b/engine/crates/composition/tests/composition/enum_only_outputs/federated.graphql
@@ -1,7 +1,7 @@
 enum join__Graph {
-    ACTIVITIES @join__graph(name: "activities", url: "activities")
-    EPISODES @join__graph(name: "episodes", url: "episodes")
-    TELETUBBYREPOSITORY @join__graph(name: "teletubbyRepository", url: "teletubbyRepository")
+    ACTIVITIES @join__graph(name: "activities", url: "http://example.com/activities")
+    EPISODES @join__graph(name: "episodes", url: "http://example.com/episodes")
+    TELETUBBYREPOSITORY @join__graph(name: "teletubbyRepository", url: "http://example.com/teletubbyRepository")
 }
 
 type Activity {

--- a/engine/crates/composition/tests/composition/enum_unused/federated.graphql
+++ b/engine/crates/composition/tests/composition/enum_unused/federated.graphql
@@ -1,5 +1,5 @@
 enum join__Graph {
-    THESCHEMA @join__graph(name: "theschema", url: "theschema")
+    THESCHEMA @join__graph(name: "theschema", url: "http://example.com/theschema")
 }
 
 type User {

--- a/engine/crates/composition/tests/composition/input_object_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/input_object_basic/federated.graphql
@@ -1,6 +1,6 @@
 enum join__Graph {
-    EMAILBOOK @join__graph(name: "emailbook", url: "emailbook")
-    PHONEBOOK @join__graph(name: "phonebook", url: "phonebook")
+    EMAILBOOK @join__graph(name: "emailbook", url: "http://example.com/emailbook")
+    PHONEBOOK @join__graph(name: "phonebook", url: "http://example.com/phonebook")
 }
 
 type Query {

--- a/engine/crates/composition/tests/composition/interfaces_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/interfaces_basic/federated.graphql
@@ -1,7 +1,7 @@
 enum join__Graph {
-    ELECTRONICS @join__graph(name: "electronics", url: "electronics")
-    PHYSICAL @join__graph(name: "physical", url: "physical")
-    SOCIAL @join__graph(name: "social", url: "social")
+    ELECTRONICS @join__graph(name: "electronics", url: "http://example.com/electronics")
+    PHYSICAL @join__graph(name: "physical", url: "http://example.com/physical")
+    SOCIAL @join__graph(name: "social", url: "http://example.com/social")
 }
 
 type Furby {

--- a/engine/crates/composition/tests/composition/object_field_arguments_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/object_field_arguments_basic/federated.graphql
@@ -1,7 +1,7 @@
 enum join__Graph {
-    HISTORY @join__graph(name: "history", url: "history")
-    INVENTORY @join__graph(name: "inventory", url: "inventory")
-    PERFORMANCE @join__graph(name: "performance", url: "performance")
+    HISTORY @join__graph(name: "history", url: "http://example.com/history")
+    INVENTORY @join__graph(name: "inventory", url: "http://example.com/inventory")
+    PERFORMANCE @join__graph(name: "performance", url: "http://example.com/performance")
 }
 
 type Query {

--- a/engine/crates/composition/tests/composition/objects_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/objects_basic/federated.graphql
@@ -1,6 +1,6 @@
 enum join__Graph {
-    A @join__graph(name: "a", url: "a")
-    B @join__graph(name: "b", url: "b")
+    A @join__graph(name: "a", url: "http://example.com/a")
+    B @join__graph(name: "b", url: "http://example.com/b")
 }
 
 type User {

--- a/engine/crates/composition/tests/composition/shareable_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/shareable_basic/federated.graphql
@@ -1,7 +1,7 @@
 enum join__Graph {
-    ACCOUNTS @join__graph(name: "accounts", url: "accounts")
-    MARKETING @join__graph(name: "marketing", url: "marketing")
-    SUBSCRIPTIONS @join__graph(name: "subscriptions", url: "subscriptions")
+    ACCOUNTS @join__graph(name: "accounts", url: "http://example.com/accounts")
+    MARKETING @join__graph(name: "marketing", url: "http://example.com/marketing")
+    SUBSCRIPTIONS @join__graph(name: "subscriptions", url: "http://example.com/subscriptions")
 }
 
 type Customer {

--- a/engine/crates/composition/tests/composition/unions_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/unions_basic/federated.graphql
@@ -1,6 +1,6 @@
 enum join__Graph {
-    PIZZA @join__graph(name: "pizza", url: "pizza")
-    SUSHI @join__graph(name: "sushi", url: "sushi")
+    PIZZA @join__graph(name: "pizza", url: "http://example.com/pizza")
+    SUSHI @join__graph(name: "sushi", url: "http://example.com/sushi")
 }
 
 type Pizza {

--- a/engine/crates/composition/tests/composition_tests.rs
+++ b/engine/crates/composition/tests/composition_tests.rs
@@ -29,7 +29,10 @@ fn run_test(federated_graph_path: &Path) -> datatest_stable::Result<()> {
     for (sdl, path) in subgraphs_sdl {
         let parsed = async_graphql_parser::parse_schema(&sdl)
             .map_err(|err| miette::miette!("Error parsing {}: {err}", path.display()))?;
-        subgraphs.ingest(&parsed, path.file_stem().unwrap().to_str().unwrap());
+
+        let name = path.file_stem().unwrap().to_str().unwrap();
+
+        subgraphs.ingest(&parsed, name, &format!("http://example.com/{name}"));
     }
 
     let expected = fs::read_to_string(federated_graph_path)


### PR DESCRIPTION
The output from `graphql-composition` has a `url` field in it, which was being populated from the `name`.  This adds another parameter for the `url` and populates from that instead.

Tried not to overthink this: it's just a plain &str argument rather than a `Url` or anything more strongly typed.  Though happy to change if anyone has preferences.