### PR TITLE
fix(deploy): Fix the root path handling for newly created projects.

### DIFF
--- a/cli/crates/backend/src/api/create.rs
+++ b/cli/crates/backend/src/api/create.rs
@@ -85,7 +85,15 @@ pub async fn create(
             account_id: Id::new(account_id),
             database_regions,
             project_slug,
-            project_root_path: ".",
+            project_root_path: project
+                .schema_path
+                .path()
+                .parent()
+                .expect("must have a parent")
+                .strip_prefix(&project.path)
+                .expect("must be a prefix")
+                .to_str()
+                .expect("must be a valid string"),
         },
     });
 


### PR DESCRIPTION
# Description

The traversal when constructing the archive should use a minimum depth of 1.
This also changes how the relative project root is determined (it isn't hardcoced to '.'). This coincidentally allows people to keep using UDFs outside the relative project root path, which should be a common use case.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
