### PR TITLE
composition: implement composite key support

### DIFF
--- a/engine/crates/composition/src/compose/object.rs
+++ b/engine/crates/composition/src/compose/object.rs
@@ -30,7 +30,7 @@ pub(super) fn merge_field_arguments<'a>(
 pub(super) fn compose_object_fields<'a>(first: FieldWalker<'a>, fields: &[FieldWalker<'a>], ctx: &mut Context<'a>) {
     if fields
         .iter()
-        .filter(|f| !(f.is_shareable() || f.is_external() || f.is_key()))
+        .filter(|f| !(f.is_shareable() || f.is_external() || f.is_part_of_key()))
         .count()
         > 1
     {
@@ -45,8 +45,11 @@ pub(super) fn compose_object_fields<'a>(first: FieldWalker<'a>, fields: &[FieldW
         ));
     }
 
-    let first_is_key = first.is_key();
-    if fields.iter().any(|field| field.is_key() != first_is_key) {
+    let first_is_part_of_key = first.is_part_of_key();
+    if fields
+        .iter()
+        .any(|field| field.is_part_of_key() != first_is_part_of_key)
+    {
         let name = format!(
             "{}.{}",
             first.parent_definition().name().as_str(),
@@ -54,7 +57,7 @@ pub(super) fn compose_object_fields<'a>(first: FieldWalker<'a>, fields: &[FieldW
         );
         let (key_subgraphs, non_key_subgraphs) = fields
             .iter()
-            .partition::<Vec<FieldWalker<'_>>, _>(|field| field.is_key());
+            .partition::<Vec<FieldWalker<'_>>, _>(|field| field.is_part_of_key());
 
         ctx.diagnostics.push_fatal(format!(
             "The field `{name}` is part of `@key` in {} but not in {}",

--- a/engine/crates/composition/src/ingest_subgraph.rs
+++ b/engine/crates/composition/src/ingest_subgraph.rs
@@ -3,10 +3,11 @@
 
 mod enums;
 mod field;
+mod nested_key_fields;
 mod object;
 mod schema_definitions;
 
-use self::schema_definitions::*;
+use self::{nested_key_fields::ingest_nested_key_fields, schema_definitions::*};
 use crate::{
     subgraphs::{self, DefinitionKind, SubgraphId},
     Subgraphs,
@@ -19,8 +20,8 @@ pub(crate) fn ingest_subgraph(document: &ast::ServiceDocument, name: &str, url: 
     let federation_directives_matcher = ingest_schema_definitions(document);
 
     ingest_top_level_definitions(subgraph_id, document, subgraphs, &federation_directives_matcher);
-
     ingest_definition_bodies(subgraph_id, document, subgraphs, &federation_directives_matcher);
+    ingest_nested_key_fields(subgraph_id, subgraphs);
 }
 
 fn ingest_top_level_definitions(

--- a/engine/crates/composition/src/ingest_subgraph/nested_key_fields.rs
+++ b/engine/crates/composition/src/ingest_subgraph/nested_key_fields.rs
@@ -1,0 +1,47 @@
+use crate::subgraphs::*;
+
+/// See [crate::subgraphs::Keys::nested_key_fields].
+pub(super) fn ingest_nested_key_fields(subgraph_id: SubgraphId, subgraphs: &mut Subgraphs) {
+    subgraphs.with_nested_key_fields(|subgraphs, nested_key_fields| {
+        for definition in subgraphs.walk(subgraph_id).definitions() {
+            for key in definition.entity_keys() {
+                for field in key.fields() {
+                    let Some(field_type) = definition
+                        .find_field(field.field)
+                        .and_then(|field| field.r#type().definition(subgraph_id))
+                    else {
+                        continue;
+                    };
+
+                    for subselection_field in &field.subselection {
+                        ingest_nested_key_fields_rec(field_type, subselection_field, nested_key_fields);
+                    }
+                }
+            }
+        }
+    });
+}
+
+fn ingest_nested_key_fields_rec(
+    parent_definition: DefinitionWalker<'_>,
+    selection: &Selection,
+    nested_key_fields: &mut NestedKeyFields,
+) {
+    let Some(field) = parent_definition.find_field(selection.field) else {
+        return;
+    };
+
+    nested_key_fields.insert(field);
+
+    if selection.subselection.is_empty() {
+        return;
+    }
+
+    let Some(selection_field_type) = field.r#type().definition(parent_definition.subgraph().id) else {
+        return;
+    };
+
+    for subselection in &selection.subselection {
+        ingest_nested_key_fields_rec(selection_field_type, subselection, nested_key_fields);
+    }
+}

--- a/engine/crates/composition/src/ingest_subgraph/object.rs
+++ b/engine/crates/composition/src/ingest_subgraph/object.rs
@@ -4,7 +4,6 @@ use async_graphql_value::ConstValue;
 use super::schema_definitions::FederationDirectivesMatcher;
 use crate::{subgraphs::DefinitionId, Subgraphs};
 
-/// Returns whether the object is shareable.
 pub(super) fn ingest_directives(
     definition_id: DefinitionId,
     type_definition: &ast::TypeDefinition,

--- a/engine/crates/composition/src/subgraphs/definitions.rs
+++ b/engine/crates/composition/src/subgraphs/definitions.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct DefinitionId(pub(super) usize);
 
 // Invariant: `definitions` is sorted by `Definition::subgraph_id`. We rely on it for binary search.
@@ -26,9 +26,13 @@ pub(crate) enum DefinitionKind {
 }
 
 impl Subgraphs {
+    pub(crate) fn definition_by_name_id(&self, name: StringId, subgraph_id: SubgraphId) -> Option<DefinitionId> {
+        self.definition_names.get(&(name, subgraph_id)).copied()
+    }
+
     pub(crate) fn definition_by_name(&mut self, name: &str, subgraph_id: SubgraphId) -> DefinitionId {
         let interned_name = self.strings.intern(name);
-        self.definition_names[&(interned_name, subgraph_id)]
+        self.definition_by_name_id(interned_name, subgraph_id).unwrap()
     }
 
     pub(crate) fn set_external(&mut self, definition_id: DefinitionId) {
@@ -74,10 +78,6 @@ impl<'a> DefinitionWalker<'a> {
         self.definition().kind
     }
 
-    pub fn is_entity(self) -> bool {
-        self.entity_keys().next().is_some()
-    }
-
     pub fn is_shareable(self) -> bool {
         self.definition().is_shareable
     }
@@ -88,5 +88,19 @@ impl<'a> DefinitionWalker<'a> {
 
     pub fn subgraph(self) -> SubgraphWalker<'a> {
         self.walk(self.definition().subgraph_id)
+    }
+}
+
+impl<'a> SubgraphWalker<'a> {
+    pub(crate) fn definitions(self) -> impl Iterator<Item = DefinitionWalker<'a>> {
+        let subgraph_id = self.id;
+        let definitions = &self.subgraphs.definitions.0;
+        let start = definitions.partition_point(|def| def.subgraph_id < self.id);
+        let subgraph_definitions = definitions[start..]
+            .iter()
+            .take_while(move |def| def.subgraph_id == subgraph_id);
+        subgraph_definitions
+            .enumerate()
+            .map(move |(idx, _)| self.walk(DefinitionId(idx + start)))
     }
 }

--- a/engine/crates/composition/src/subgraphs/field_types.rs
+++ b/engine/crates/composition/src/subgraphs/field_types.rs
@@ -77,6 +77,13 @@ impl<'a> FieldTypeWalker<'a> {
         self.subgraphs.field_types.inner_types.get_index(self.id.0).unwrap()
     }
 
+    /// The definition with the name returned by `type_name` in `subgraph`.
+    pub(crate) fn definition(self, subgraph: SubgraphId) -> Option<DefinitionWalker<'a>> {
+        self.subgraphs
+            .definition_by_name_id(self.type_name().id, subgraph)
+            .map(|id| self.walk(id))
+    }
+
     /// ```ignore,graphql
     /// type MyObject {
     ///   id: ID!

--- a/engine/crates/composition/src/subgraphs/keys.rs
+++ b/engine/crates/composition/src/subgraphs/keys.rs
@@ -95,6 +95,20 @@ pub(crate) struct NestedKeyFields {
     fields: HashSet<FieldId>,
 
     /// Objects that are part of keys that are not defined on the object itself.
+    ///
+    /// Example:
+    ///
+    /// ```graphql,ignore
+    /// type Entity @key(fields: "name nested { identifier }") {
+    ///   name: String!
+    /// }
+    ///
+    /// type Nested {
+    ///   identifier: ID!
+    /// }
+    /// ```
+    ///
+    /// `Nested` is an object with a nested key.
     objects_with_nested_keys: HashSet<DefinitionId>,
 }
 

--- a/engine/crates/composition/src/subgraphs/keys.rs
+++ b/engine/crates/composition/src/subgraphs/keys.rs
@@ -1,10 +1,13 @@
-use async_graphql_parser::types as ast;
-
 use super::*;
+use async_graphql_parser::types as ast;
+use std::collections::HashSet;
 
 /// All the keys (`@key(...)`) in all the subgraphs in one container.
 #[derive(Default)]
-pub(crate) struct Keys(Vec<(DefinitionId, Key)>);
+pub(crate) struct Keys {
+    keys: Vec<(DefinitionId, Key)>,
+    nested_key_fields: NestedKeyFields,
+}
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct KeyId(usize);
@@ -17,11 +20,12 @@ impl Subgraphs {
         resolvable: bool,
     ) -> Result<(), String> {
         let selection_set = self.selection_set_from_str(selection_set_str)?;
+
         let key = Key {
             selection_set,
             resolvable,
         };
-        self.keys.0.push((object_id, key));
+        self.keys.keys.push((object_id, key));
         Ok(())
     }
 
@@ -61,6 +65,44 @@ impl Subgraphs {
 
         build_selection_set(&selection_set_ast.items, self)
     }
+
+    pub(crate) fn with_nested_key_fields<F>(&mut self, handler: F)
+    where
+        F: FnOnce(&Subgraphs, &mut NestedKeyFields),
+    {
+        let mut nested_key_fields = std::mem::take(&mut self.keys.nested_key_fields);
+        handler(self, &mut nested_key_fields);
+        self.keys.nested_key_fields = nested_key_fields;
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct NestedKeyFields {
+    /// Fields that are part of a nested key key _on another type/entity_. Example:
+    ///
+    /// ```graphql,ignore
+    /// type Entity @key(fields: "name nested { identifier }") {
+    ///   name: String!
+    /// }
+    ///
+    /// type Nested {
+    ///   identifier: ID!
+    /// }
+    ///
+    /// ```
+    ///
+    /// `Nested.identifier` is a nested key field.
+    fields: HashSet<FieldId>,
+
+    /// Objects that are part of keys that are not defined on the object itself.
+    objects_with_nested_keys: HashSet<DefinitionId>,
+}
+
+impl NestedKeyFields {
+    pub(crate) fn insert(&mut self, field: FieldWalker<'_>) {
+        self.fields.insert(field.id);
+        self.objects_with_nested_keys.insert(field.parent_definition().id);
+    }
 }
 
 /// Corresponds to an `@key` annotation.
@@ -80,7 +122,7 @@ pub(crate) type KeyWalker<'a> = Walker<'a, KeyId>;
 
 impl<'a> KeyWalker<'a> {
     fn key(self) -> &'a (DefinitionId, Key) {
-        &self.subgraphs.keys.0[self.id.0]
+        &self.subgraphs.keys.keys[self.id.0]
     }
 
     pub(crate) fn fields(self) -> &'a [Selection] {
@@ -97,12 +139,39 @@ impl<'a> KeyWalker<'a> {
 }
 
 impl<'a> DefinitionWalker<'a> {
+    pub fn is_entity(self) -> bool {
+        self.entity_keys().next().is_some()
+            || self
+                .subgraphs
+                .keys
+                .nested_key_fields
+                .objects_with_nested_keys
+                .contains(&self.id)
+    }
+
     pub fn entity_keys(self) -> impl Iterator<Item = KeyWalker<'a>> {
-        let start = self.subgraphs.keys.0.partition_point(|(parent, _)| *parent < self.id);
-        self.subgraphs.keys.0[start..]
+        let start = self
+            .subgraphs
+            .keys
+            .keys
+            .partition_point(|(parent, _)| *parent < self.id);
+        self.subgraphs.keys.keys[start..]
             .iter()
             .take_while(move |(parent, _)| *parent == self.id)
             .enumerate()
             .map(move |(idx, _)| self.walk(KeyId(start + idx)))
+    }
+}
+
+impl<'a> FieldWalker<'a> {
+    /// Returns true iff there is an `@key` directive containing this field, possibly with others
+    /// as part of a composite key.
+    pub(crate) fn is_part_of_key(self) -> bool {
+        let field = self.field();
+        self.parent_definition()
+            .entity_keys()
+            .flat_map(|key| key.fields().iter())
+            .any(|key_field| key_field.field == field.name)
+            || self.subgraphs.keys.nested_key_fields.fields.contains(&self.id)
     }
 }

--- a/engine/crates/composition/tests/composition/entity_composite_key_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_composite_key_basic/federated.graphql
@@ -1,0 +1,52 @@
+enum join__Graph {
+    COURSES @join__graph(name: "courses", url: "http://example.com/courses")
+    RATINGS @join__graph(name: "ratings", url: "http://example.com/ratings")
+    STUDENTS @join__graph(name: "students", url: "http://example.com/students")
+}
+
+type Query {
+    courses: [Course] @join__field(graph: COURSES)
+    course(id: ID!): Course @join__field(graph: COURSES)
+    courseRating(courseId: ID!): [CourseRating] @join__field(graph: RATINGS)
+    students: [Student] @join__field(graph: STUDENTS)
+    student(id: ID!): Student @join__field(graph: STUDENTS)
+}
+
+type Course
+    @join__type(graph: COURSES, key: "id")
+    @join__type(graph: STUDENTS, key: "id")
+{
+    id: ID!
+    name: String @join__field(graph: COURSES)
+    description: String @join__field(graph: COURSES)
+    enrolledStudents: [Student] @join__field(graph: STUDENTS, requires: "id")
+}
+
+type Enrollment
+    @join__type(graph: COURSES, key: "studentId courseId")
+    @join__type(graph: RATINGS, key: "studentId courseId")
+    @join__type(graph: STUDENTS, key: "studentId courseId")
+{
+    studentId: ID!
+    courseId: ID!
+    course: Course @join__field(graph: STUDENTS)
+    enrollmentDetails: Enrollment @join__field(graph: COURSES, requires: "studentId courseId")
+    rating: CourseRating @join__field(graph: RATINGS)
+    enrollmentDate: String @join__field(graph: STUDENTS)
+}
+
+type CourseRating
+    @join__type(graph: RATINGS, key: "courseId")
+{
+    courseId: ID! @join__field(graph: RATINGS)
+    rating: Float @join__field(graph: RATINGS)
+    comments: String @join__field(graph: RATINGS)
+}
+
+type Student
+    @join__type(graph: STUDENTS, key: "id")
+{
+    id: ID! @join__field(graph: STUDENTS)
+    name: String @join__field(graph: STUDENTS)
+    enrollments: [Enrollment] @join__field(graph: STUDENTS)
+}

--- a/engine/crates/composition/tests/composition/entity_composite_key_basic/subgraphs/courses.graphql
+++ b/engine/crates/composition/tests/composition/entity_composite_key_basic/subgraphs/courses.graphql
@@ -1,0 +1,22 @@
+extend schema
+    @link(
+        url: "https://specs.apollo.dev/federation/v2.3",
+        import: ["@key", "@external", "@requires"]
+     )
+
+type Query {
+  course(id: ID!): Course
+  courses: [Course]
+}
+
+type Course @key(fields: "id") {
+  id: ID!
+  name: String
+  description: String
+}
+
+extend type Enrollment @key(fields: "studentId courseId") {
+  studentId: ID! @external
+  courseId: ID! @external
+  enrollmentDetails: Enrollment @requires(fields: "studentId courseId")
+}

--- a/engine/crates/composition/tests/composition/entity_composite_key_basic/subgraphs/ratings.graphql
+++ b/engine/crates/composition/tests/composition/entity_composite_key_basic/subgraphs/ratings.graphql
@@ -1,0 +1,22 @@
+extend schema
+    @link(
+        url: "https://specs.apollo.dev/federation/v2.3",
+        import: ["@key", "@external", "@requires"]
+     )
+
+type Query {
+  courseRating(courseId: ID!): [CourseRating]
+}
+
+type CourseRating @key(fields: "courseId") {
+  courseId: ID!
+  rating: Float
+  comments: String
+}
+
+type Enrollment @key(fields: "studentId courseId") {
+  studentId: ID!
+  courseId: ID!
+  rating: CourseRating
+}
+

--- a/engine/crates/composition/tests/composition/entity_composite_key_basic/subgraphs/students.graphql
+++ b/engine/crates/composition/tests/composition/entity_composite_key_basic/subgraphs/students.graphql
@@ -1,0 +1,28 @@
+extend schema
+    @link(
+        url: "https://specs.apollo.dev/federation/v2.3",
+        import: ["@key", "@external", "@requires"]
+     )
+
+type Query {
+  student(id: ID!): Student
+  students: [Student]
+}
+
+type Student @key(fields: "id") {
+  id: ID!
+  name: String
+  enrollments: [Enrollment]
+}
+
+type Enrollment @key(fields: "studentId courseId") {
+  studentId: ID!
+  courseId: ID!
+  course: Course @provides(fields: "name")
+  enrollmentDate: String
+}
+
+extend type Course @key(fields: "id") {
+  id: ID! @external
+  enrolledStudents: [Student] @requires(fields: "id")
+}

--- a/engine/crates/composition/tests/composition/entity_composite_key_nested/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_composite_key_nested/federated.graphql
@@ -1,0 +1,33 @@
+enum join__Graph {
+    PATIENT_INFO @join__graph(name: "patient_info", url: "http://example.com/patient_info")
+    PATIENT_RECORD @join__graph(name: "patient_record", url: "http://example.com/patient_record")
+}
+
+type Query {
+    patient(id: ID!): Patient @join__field(graph: PATIENT_INFO)
+    patients: [Patient] @join__field(graph: PATIENT_INFO)
+    patientRecord(patientId: ID!, recordId: ID!): PatientRecord @join__field(graph: PATIENT_RECORD)
+    patientRecords: [PatientRecord] @join__field(graph: PATIENT_RECORD)
+}
+
+type Patient
+    @join__type(graph: PATIENT_INFO, key: "id")
+    @join__type(graph: PATIENT_RECORD, key: "id")
+{
+    id: ID!
+    name: String @join__field(graph: PATIENT_INFO)
+    dateOfBirth: String @join__field(graph: PATIENT_INFO)
+    medicalRecords: [PatientRecord] @join__field(graph: PATIENT_RECORD, requires: "id")
+}
+
+type PatientRecord
+    @join__type(graph: PATIENT_INFO, key: "patient { id } recordId")
+    @join__type(graph: PATIENT_RECORD, key: "patient { id } recordId")
+{
+    patient: Patient
+    recordId: ID!
+    admissionDate: String @join__field(graph: PATIENT_INFO)
+    extendPatientRecord: PatientRecord @join__field(graph: PATIENT_INFO, requires: "patient { id } recordId")
+    diagnosis: String @join__field(graph: PATIENT_RECORD)
+    treatmentPlan: String @join__field(graph: PATIENT_RECORD)
+}

--- a/engine/crates/composition/tests/composition/entity_composite_key_nested/subgraphs/patient_info.graphql
+++ b/engine/crates/composition/tests/composition/entity_composite_key_nested/subgraphs/patient_info.graphql
@@ -1,0 +1,23 @@
+extend schema
+    @link(
+        url: "https://specs.apollo.dev/federation/v2.3",
+        import: ["@key", "@requires"]
+     )
+
+type Query {
+  patient(id: ID!): Patient
+  patients: [Patient]
+}
+
+type Patient @key(fields: "id") {
+  id: ID!
+  name: String
+  dateOfBirth: String
+}
+
+type PatientRecord @key(fields: "patient { id } recordId") {
+  patient: Patient
+  recordId: ID!
+  admissionDate: String
+  extendPatientRecord: PatientRecord @requires(fields: "patient { id } recordId")
+}

--- a/engine/crates/composition/tests/composition/entity_composite_key_nested/subgraphs/patient_record.graphql
+++ b/engine/crates/composition/tests/composition/entity_composite_key_nested/subgraphs/patient_record.graphql
@@ -1,0 +1,22 @@
+extend schema
+    @link(
+        url: "https://specs.apollo.dev/federation/v2.3",
+        import: ["@key", "@requires"]
+     )
+
+type Query {
+  patientRecord(patientId: ID!, recordId: ID!): PatientRecord
+  patientRecords: [PatientRecord]
+}
+
+type PatientRecord @key(fields: "patient { id } recordId") {
+  patient: Patient @external
+  recordId: ID!
+  diagnosis: String
+  treatmentPlan: String
+}
+
+extend type Patient @key(fields: "id") {
+  id: ID!
+  medicalRecords: [PatientRecord] @requires(fields: "id")
+}

--- a/engine/crates/composition/tests/composition/entity_staggered_composite_key/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_staggered_composite_key/federated.graphql
@@ -1,0 +1,24 @@
+enum join__Graph {
+    FIRST @join__graph(name: "first", url: "http://example.com/first")
+    SECOND @join__graph(name: "second", url: "http://example.com/second")
+}
+
+type Query {
+    as: [A] @join__field(graph: FIRST)
+    bs: [B] @join__field(graph: SECOND)
+}
+
+type A
+    @join__type(graph: FIRST, key: "b { id } c")
+{
+    b: B! @join__field(graph: FIRST)
+    c: String! @join__field(graph: FIRST)
+}
+
+type B
+    @join__type(graph: SECOND, key: "id")
+{
+    id: ID!
+    foo: String @join__field(graph: FIRST)
+    bar: String @join__field(graph: SECOND)
+}

--- a/engine/crates/composition/tests/composition/entity_staggered_composite_key/subgraphs/first.graphql
+++ b/engine/crates/composition/tests/composition/entity_staggered_composite_key/subgraphs/first.graphql
@@ -1,0 +1,19 @@
+extend schema
+    @link(
+        url: "https://specs.apollo.dev/federation/v2.3",
+        import: ["@key"]
+     )
+
+extend type Query {
+  as: [A]
+}
+
+type A @key(fields: "b { id } c") {
+  b: B!
+  c: String!
+}
+
+type B {
+  id: ID!
+  foo: String
+}

--- a/engine/crates/composition/tests/composition/entity_staggered_composite_key/subgraphs/second.graphql
+++ b/engine/crates/composition/tests/composition/entity_staggered_composite_key/subgraphs/second.graphql
@@ -1,0 +1,15 @@
+extend schema
+    @link(
+        url: "https://specs.apollo.dev/federation/v2.3",
+        import: ["@key"]
+     )
+
+extend type Query {
+  bs: [B]
+}
+
+
+type B @key(fields: "id") {
+  id: ID!
+  bar: String
+}


### PR DESCRIPTION
# Description

Concretely, entities defining keys like `@key(fields: "id name")` and
even nested selections like `@key(fields: "patient { id } recordId")`.


A lot of the complexity in this PR comes from the machinery to detect
that:

1. An object is part of an entity in a subgraph because one of its field
   is part of a nested key on another entity.
2. A field is part of a key, not on its parent object but another object
   that includes it in its key through a nested selection.

closes GB-5264

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
