### PR TITLE
fix: Only set resolvers at root fields in the v2 schema for federation

### DIFF
--- a/engine/crates/engine-v2/schema/src/conversion.rs
+++ b/engine/crates/engine-v2/schema/src/conversion.rs
@@ -5,7 +5,7 @@ use super::*;
 
 impl From<federated_graph::FederatedGraph> for Schema {
     fn from(graph: federated_graph::FederatedGraph) -> Self {
-        let mut out = Schema {
+        let mut schema = Schema {
             data_sources: (0..graph.subgraphs.len())
                 .map(|i| DataSource::Subgraph(SubgraphId::from(i)))
                 .collect(),
@@ -28,12 +28,32 @@ impl From<federated_graph::FederatedGraph> for Schema {
             strings: graph.strings,
             resolvers: vec![],
         };
-        out.object_fields.sort_unstable();
-        out.interface_fields.sort_unstable_by_key(|field| field.interface_id);
+        schema.object_fields.sort_unstable();
+        schema.interface_fields.sort_unstable_by_key(|field| field.interface_id);
+
+        let root_fields = {
+            let mut root_fields = vec![];
+            for field_id in schema.object_fields(schema.root_operation_types.query) {
+                root_fields.push(field_id);
+            }
+            if let Some(mutation) = schema.root_operation_types.mutation {
+                for field_id in schema.object_fields(mutation) {
+                    root_fields.push(field_id);
+                }
+            }
+            if let Some(subscription) = schema.root_operation_types.subscription {
+                for field_id in schema.object_fields(subscription) {
+                    root_fields.push(field_id);
+                }
+            }
+            root_fields.sort_unstable();
+            root_fields
+        };
 
         // Yeah it's ugly, conversion should be cleaned up once we got it working I guess.
         let mut resolvers = HashMap::<Resolver, ResolverId>::new();
-        for field in graph.fields {
+        for (i, field) in graph.fields.into_iter().enumerate() {
+            let field_id = FieldId::from(i);
             let mut field_resolvers = vec![];
             let mut field_requires = field
                 .requires
@@ -41,19 +61,21 @@ impl From<federated_graph::FederatedGraph> for Schema {
                 .map(|federated_graph::FieldRequires { subgraph_id, fields }| (subgraph_id, fields))
                 .collect::<HashMap<_, _>>();
             if let Some(subgraph_id) = field.resolvable_in {
-                let n = resolvers.len();
-                let resolver_id = *resolvers
-                    .entry(Resolver::Subgraph(SubgraphResolver {
-                        subgraph_id: subgraph_id.into(),
-                    }))
-                    .or_insert_with(|| ResolverId::from(n));
-                let requires = field_requires.remove(&subgraph_id).unwrap_or_default();
-                field_resolvers.push(FieldResolver {
-                    resolver_id,
-                    requires: requires.into_iter().map(Into::into).collect(),
-                });
+                if root_fields.binary_search(&field_id).is_ok() {
+                    let n = resolvers.len();
+                    let resolver_id = *resolvers
+                        .entry(Resolver::Subgraph(SubgraphResolver {
+                            subgraph_id: subgraph_id.into(),
+                        }))
+                        .or_insert_with(|| ResolverId::from(n));
+                    let requires = field_requires.remove(&subgraph_id).unwrap_or_default();
+                    field_resolvers.push(FieldResolver {
+                        resolver_id,
+                        requires: requires.into_iter().map(Into::into).collect(),
+                    });
+                }
             }
-            out.fields.push(Field {
+            schema.fields.push(Field {
                 name: field.name.into(),
                 field_type_id: field.field_type_id.into(),
                 resolvers: field_resolvers,
@@ -64,8 +86,8 @@ impl From<federated_graph::FederatedGraph> for Schema {
         }
         let mut resolvers = resolvers.into_iter().collect::<Vec<_>>();
         resolvers.sort_unstable_by_key(|(_, resolver_id)| *resolver_id);
-        out.resolvers = resolvers.into_iter().map(|(resolver, _)| resolver).collect();
-        out
+        schema.resolvers = resolvers.into_iter().map(|(resolver, _)| resolver).collect();
+        schema
     }
 }
 

--- a/engine/crates/engine-v2/schema/src/lib.rs
+++ b/engine/crates/engine-v2/schema/src/lib.rs
@@ -206,6 +206,7 @@ impl Field {
     }
 }
 
+#[derive(Debug)]
 pub struct FieldResolver {
     pub resolver_id: ResolverId,
     pub requires: FieldSet,

--- a/engine/crates/engine-v2/src/plan/planner.rs
+++ b/engine/crates/engine-v2/src/plan/planner.rs
@@ -142,6 +142,8 @@ impl<'a, 'b> Planner<'a, 'b> {
                 resolver_id,
             });
 
+            println!("PLAN:\n{:#?}", self.debug(&self.plans[plan_id]));
+
             for plan in &mut to_be_planned {
                 plan.parent = Some(plan_id);
             }
@@ -155,7 +157,7 @@ impl<'a, 'b> Planner<'a, 'b> {
             }
         }
 
-        assert!(children.is_empty(), "{children:?}");
+        assert!(children.is_empty(), "CHILDREN:\n{:#?}", self.debug(&children));
         children
     }
 

--- a/engine/crates/integration-tests/tests/federation/basic/mod.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/mod.rs
@@ -53,7 +53,6 @@ fn top_level_typename() {
 }
 
 #[test]
-#[ignore]
 fn response_with_lists() {
     let response = runtime()
         .block_on(async move {
@@ -68,7 +67,14 @@ fn response_with_lists() {
     insta::assert_json_snapshot!(response, @r###"
     {
       "data": {
-        "__typename": "Query"
+        "allBotPullRequests": [
+          {
+            "title": "Creating the thing"
+          },
+          {
+            "title": "Some bot PR"
+          }
+        ]
       }
     }
     "###);


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
