### PR TITLE
fix(udf): Fix an issue with path resolution for resolvers/authorizers with the new root scheme

### DIFF
--- a/cli/crates/cli/tests/custom_resolvers.rs
+++ b/cli/crates/cli/tests/custom_resolvers.rs
@@ -274,14 +274,19 @@ fn test_field_resolver(
     #[case] resolver_contents: &str,
     #[case] queries: &[(&str, &str)],
     #[case] package_json: Option<(JavaScriptPackageManager, &str)>,
+    #[values(("./", "./"), ("./grafbase", "../"))] variant: (&str, &str),
 ) {
-    let mut env = Environment::init();
+    let (subdirectory_path, package_json_path) = variant;
+    let mut env = Environment::init_in_subdirectory(subdirectory_path);
     env.grafbase_init(ConfigType::GraphQL);
     std::fs::write(env.directory_path.join(".env"), "MY_OWN_VARIABLE=test_value").unwrap();
     env.write_schema(schema);
     env.write_resolver(resolver_name, resolver_contents);
     if let Some((package_manager, package_json)) = package_json {
-        env.write_file("package.json", package_json);
+        env.write_file(
+            std::path::Path::new(package_json_path).join("package.json"),
+            package_json,
+        );
         // Use `which` to work-around weird path search issues on Windows.
         // See https://github.com/rust-lang/rust/issues/37519.
         let program_path = which::which(package_manager.to_string()).expect("command must be found");

--- a/cli/crates/cli/tests/utils/environment.rs
+++ b/cli/crates/cli/tests/utils/environment.rs
@@ -251,7 +251,7 @@ impl Environment {
     #[track_caller]
     pub fn grafbase_init(&self, config_format: ConfigType) {
         let current_directory_path = self.schema_path.parent().expect("must be defined");
-        std::fs::create_dir_all(&current_directory_path).unwrap();
+        std::fs::create_dir_all(current_directory_path).unwrap();
         cmd!(
             cargo_bin("grafbase"),
             "--trace",
@@ -268,7 +268,7 @@ impl Environment {
     #[track_caller]
     pub fn grafbase_init_output(&self, config_format: ConfigType) -> Output {
         let current_directory_path = self.schema_path.parent().expect("must be defined");
-        std::fs::create_dir_all(&current_directory_path).unwrap();
+        std::fs::create_dir_all(current_directory_path).unwrap();
         cmd!(
             cargo_bin("grafbase"),
             "--trace",

--- a/cli/crates/common/src/environment.rs
+++ b/cli/crates/common/src/environment.rs
@@ -104,6 +104,7 @@ impl Warning {
 pub struct Project {
     /// the path of the (assumed) user project root (`$PROJECT`), the nearest ancestor directory
     /// with a `schema.graphql` file or a `grafbase.config.ts` file
+    // FIXME: Temporarily, it can also be the parent directory of the `grafbase` directory, until we phase that out.
     pub path: PathBuf,
     /// the path of the Grafbase schema, in the nearest ancestor directory with
     /// said directory and file
@@ -128,7 +129,10 @@ impl Project {
             UdfKind::Resolver => RESOLVERS_DIRECTORY_NAME,
             UdfKind::Authorizer => AUTHORIZERS_DIRECTORY_NAME,
         };
-        self.path.join(subdirectory_name)
+        self.schema_path
+            .parent()
+            .expect("must have a parent")
+            .join(subdirectory_name)
     }
 
     /// the path of the directory containing the build artifacts corresponding to the UDF type (resolvers, authorizers).


### PR DESCRIPTION
# Description

We have failed to account for the new default project root path in how we're resolving the paths to UDFs.
Ensure the tests are parametrised by both back-compat and present scheme.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
