### PR TITLE
chore: don't return result from some actor handler functions

### DIFF
--- a/cli/crates/federated-dev/src/dev/composer.rs
+++ b/cli/crates/federated-dev/src/dev/composer.rs
@@ -25,36 +25,38 @@ impl Composer {
         }
     }
 
-    pub(crate) async fn handler(mut self) -> Result<(), crate::Error> {
+    pub(crate) async fn handler(mut self) {
         log::trace!("starting the composer handler");
 
         loop {
-            match self.bus.recv().await {
+            let result = match self.bus.recv().await {
                 Some(ComposeMessage::Introspect(message)) => {
                     log::trace!("composer handling introspection for subgraph '{}'", message.name());
-                    self.handle_introspect(message).await?;
+                    self.handle_introspect(message).await
                 }
                 Some(ComposeMessage::Compose(message)) => {
                     log::trace!("composer handling composition for subgraph '{}'", message.name());
-                    self.handle_compose(message).await?;
+                    self.handle_compose(message).await
                 }
                 Some(ComposeMessage::RemoveSubgraph(message)) => {
                     log::trace!("composer handling removing a subgraph '{}'", message.name());
-                    self.handle_remove_subgraph(message).await?;
+                    self.handle_remove_subgraph(message).await
                 }
                 Some(ComposeMessage::Recompose) => {
                     log::trace!("composer handling recomposition");
-                    self.handle_recompose().await?;
+                    self.handle_recompose().await
                 }
                 Some(ComposeMessage::InitializeRefresh) => {
                     log::trace!("composer initializing a refresh");
-                    self.handle_init_refresh().await?;
+                    self.handle_init_refresh().await
                 }
                 None => break,
+            };
+
+            if let Err(error) = result {
+                log::warn!("Error in composer: {error:?}");
             }
         }
-
-        Ok(())
     }
 
     async fn handle_introspect(&mut self, message: IntrospectSchema) -> Result<(), crate::Error> {

--- a/cli/crates/federated-dev/src/dev/router.rs
+++ b/cli/crates/federated-dev/src/dev/router.rs
@@ -23,7 +23,7 @@ impl Router {
         }
     }
 
-    pub async fn handler(mut self) -> Result<(), crate::Error> {
+    pub async fn handler(mut self) {
         log::trace!("starting the router handler");
 
         let streams: [RouterStream; 2] = [
@@ -57,8 +57,6 @@ impl Router {
                 }
             }
         }
-
-        Ok(())
     }
 }
 


### PR DESCRIPTION
Some of the handler functions in federation dev return `Result`, which makes it really easy to use `?`.  Normally this would be good, but in this case `?` is going to break the loop inside these actors, causing them to shutdown their channels, and the system to subtly stop working properly.

This updates two of the more critical actors to handle errors a bit more explicitly.  I've left Refresher & Ticket alone for now because their only instances of `?` are probably fine to early return.  Though maybe we should just be consistent, any thoughts?