### PR TITLE
fix(udf): Fix the handling of the .env file in grafbase/ for UDFs.

### DIFF
--- a/cli/crates/cli/tests/custom_resolvers.rs
+++ b/cli/crates/cli/tests/custom_resolvers.rs
@@ -279,7 +279,11 @@ fn test_field_resolver(
     let (subdirectory_path, package_json_path) = variant;
     let mut env = Environment::init_in_subdirectory(subdirectory_path);
     env.grafbase_init(ConfigType::GraphQL);
-    std::fs::write(env.directory_path.join(".env"), "MY_OWN_VARIABLE=test_value").unwrap();
+    std::fs::write(
+        env.directory_path.join(subdirectory_path).join(".env"),
+        "MY_OWN_VARIABLE=test_value",
+    )
+    .unwrap();
     env.write_schema(schema);
     env.write_resolver(resolver_name, resolver_contents);
     if let Some((package_manager, package_json)) = package_json {

--- a/cli/crates/server/src/environment.rs
+++ b/cli/crates/server/src/environment.rs
@@ -5,7 +5,12 @@ use crate::consts::DOT_ENV_FILE_NAME;
 #[allow(deprecated)] // https://github.com/dotenv-rs/dotenv/pull/54
 pub fn variables() -> impl Iterator<Item = (String, String)> {
     let project = Project::get();
-    let dot_env_file_path = project.path.join(DOT_ENV_FILE_NAME);
+    let dot_env_file_path = project
+        .schema_path
+        .path()
+        .parent()
+        .expect("must be defined")
+        .join(DOT_ENV_FILE_NAME);
     // We don't use dotenv::dotenv() as we don't want to pollute the process' environment.
     // Doing otherwise would make us unable to properly refresh it whenever any of the .env files
     // changes which is something we may want to do in the future.


### PR DESCRIPTION
# Description

Environment variables from grafbase/.env weren't being picked up after a recent regression. This PR fixes that.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
