### PR TITLE
composition: change federation directive visibility rules, test multikeys

### DIFF
--- a/engine/crates/composition/tests/composition/entity_multiple_keys_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_multiple_keys_basic/federated.graphql
@@ -1,0 +1,33 @@
+enum join__Graph {
+    MULTI_KEY @join__graph(name: "multi_key", url: "http://example.com/multi_key")
+    SINGLE_KEY @join__graph(name: "single_key", url: "http://example.com/single_key")
+}
+
+type Query {
+    getUserComments(name: String!, email: String!): User @join__field(graph: MULTI_KEY)
+    getUser(id: ID!): User @join__field(graph: SINGLE_KEY)
+}
+
+type User
+    @join__type(graph: MULTI_KEY, key: "id")
+    @join__type(graph: MULTI_KEY, key: "name email")
+    @join__type(graph: SINGLE_KEY, key: "id")
+{
+    id: ID!
+    name: String! @join__field(graph: MULTI_KEY)
+    email: String! @join__field(graph: MULTI_KEY)
+    comments: [Comment!]! @join__field(graph: MULTI_KEY)
+    posts: [Post!]! @join__field(graph: SINGLE_KEY)
+}
+
+type Comment {
+    id: ID! @join__field(graph: MULTI_KEY)
+    text: String! @join__field(graph: MULTI_KEY)
+}
+
+type Post {
+    id: ID! @join__field(graph: SINGLE_KEY)
+    title: String! @join__field(graph: SINGLE_KEY)
+    body: String! @join__field(graph: SINGLE_KEY)
+    published: Boolean! @join__field(graph: SINGLE_KEY)
+}

--- a/engine/crates/composition/tests/composition/entity_multiple_keys_basic/subgraphs/multi_key.graphql
+++ b/engine/crates/composition/tests/composition/entity_multiple_keys_basic/subgraphs/multi_key.graphql
@@ -1,0 +1,15 @@
+extend type Query {
+  getUserComments(name: String! email: String!): User
+}
+
+type User @key(fields: "id") @key(fields: "name email") {
+  id: ID!
+  name: String!
+  email: String!
+  comments: [Comment!]!
+}
+
+type Comment {
+  id: ID!
+  text: String!
+}

--- a/engine/crates/composition/tests/composition/entity_multiple_keys_basic/subgraphs/single_key.graphql
+++ b/engine/crates/composition/tests/composition/entity_multiple_keys_basic/subgraphs/single_key.graphql
@@ -1,0 +1,15 @@
+extend type Query {
+  getUser(id: ID!): User
+}
+
+type User @key(fields: "id") {
+  id: ID!
+  posts: [Post!]!
+}
+
+type Post {
+  id: ID!
+  title: String!
+  body: String!
+  published: Boolean!
+}

--- a/engine/crates/composition/tests/composition/enum_only_outputs/subgraphs/activities.graphql
+++ b/engine/crates/composition/tests/composition/enum_only_outputs/subgraphs/activities.graphql
@@ -1,3 +1,5 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.3")
+
 type Activity {
   name: String!
   description: String!

--- a/engine/crates/composition/tests/composition/enum_only_outputs/subgraphs/episodes.graphql
+++ b/engine/crates/composition/tests/composition/enum_only_outputs/subgraphs/episodes.graphql
@@ -5,10 +5,10 @@ type Episode {
   featuredToys: [FavoriteToy!]
 }
 
-type Teletubby @federation__key(fields: "name") {
+type Teletubby @key(fields: "name") {
   name: String!
   episodesFeatured: [Episode]
-  favoriteToy: FavoriteToy @federation__shareable
+  favoriteToy: FavoriteToy @shareable
 }
 
 type Query {

--- a/engine/crates/composition/tests/composition/enum_only_outputs/subgraphs/teletubbyRepository.graphql
+++ b/engine/crates/composition/tests/composition/enum_only_outputs/subgraphs/teletubbyRepository.graphql
@@ -1,3 +1,5 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.3")
+
 type Teletubby @federation__key(fields: "name") {
   name: String!
   color: String!

--- a/engine/crates/composition/tests/composition/enum_strict_matching_error/subgraphs/activities.graphql
+++ b/engine/crates/composition/tests/composition/enum_strict_matching_error/subgraphs/activities.graphql
@@ -4,10 +4,10 @@ type Activity {
   participatingTeletubby: Teletubby!
 }
 
-type Teletubby @federation__key(fields: "name") {
+type Teletubby @key(fields: "name") {
   name: String!
   activities: [Activity]
-  favoriteToy: FavoriteToy @federation__shareable
+  favoriteToy: FavoriteToy @shareable
 }
 
 type Query {

--- a/engine/crates/composition/tests/composition/enum_strict_matching_error/subgraphs/episodes.graphql
+++ b/engine/crates/composition/tests/composition/enum_strict_matching_error/subgraphs/episodes.graphql
@@ -1,3 +1,5 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.3")
+
 type Episode {
   title: String!
   duration: Int! # Duration in seconds

--- a/engine/crates/composition/tests/composition/enum_strict_matching_error/subgraphs/teletubbyRepository.graphql
+++ b/engine/crates/composition/tests/composition/enum_strict_matching_error/subgraphs/teletubbyRepository.graphql
@@ -1,7 +1,7 @@
-type Teletubby @federation__key(fields: "name") {
+type Teletubby @key(fields: "name") {
   name: String!
   color: String!
-  favoriteToy: FavoriteToy @federation__shareable
+  favoriteToy: FavoriteToy @shareable
   mood: Mood
 }
 

--- a/engine/crates/composition/tests/composition/inconsistent_entitiness/subgraphs/natural-reserve.graphql
+++ b/engine/crates/composition/tests/composition/inconsistent_entitiness/subgraphs/natural-reserve.graphql
@@ -1,4 +1,4 @@
-type Animal @federation__key(fields: "id") {
+type Animal @key(fields: "id") {
     id: ID!
     age: Int!
 }

--- a/engine/crates/composition/tests/composition/inconsistent_entitiness/subgraphs/zoo.graphql
+++ b/engine/crates/composition/tests/composition/inconsistent_entitiness/subgraphs/zoo.graphql
@@ -1,4 +1,4 @@
-type Animal @federation__key(fields: "id") {
+type Animal @key(fields: "id") {
     id: ID!
     name: String!
 }

--- a/engine/crates/composition/tests/composition/inconsistent_keys/subgraphs/academia.graphql
+++ b/engine/crates/composition/tests/composition/inconsistent_keys/subgraphs/academia.graphql
@@ -1,3 +1,5 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.3")
+
 type Author @federation__key(fields: "name") {
   id: ID! @federation__shareable
   name: String!

--- a/engine/crates/composition/tests/composition/inconsistent_keys/subgraphs/novelists.graphql
+++ b/engine/crates/composition/tests/composition/inconsistent_keys/subgraphs/novelists.graphql
@@ -1,3 +1,5 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.3")
+
 enum Genre {
   FICTION
   NONFICTION

--- a/engine/crates/composition/tests/composition/input_object_basic/subgraphs/emailbook.graphql
+++ b/engine/crates/composition/tests/composition/input_object_basic/subgraphs/emailbook.graphql
@@ -1,3 +1,5 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.3")
+
 type Query {
   getPersonInfo(input: InputPerson!): Person
 }

--- a/engine/crates/composition/tests/composition/input_object_basic/subgraphs/phonebook.graphql
+++ b/engine/crates/composition/tests/composition/input_object_basic/subgraphs/phonebook.graphql
@@ -1,3 +1,5 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.3")
+
 type Query {
   searchPerson(input: InputPerson!): [Person]
 }

--- a/engine/crates/composition/tests/composition/provides_basic/subgraphs/products.graphql
+++ b/engine/crates/composition/tests/composition/provides_basic/subgraphs/products.graphql
@@ -1,3 +1,5 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.3")
+
 type Query {
   product(id: ID!): Product
 }

--- a/engine/crates/composition/tests/composition/provides_basic/subgraphs/users.graphql
+++ b/engine/crates/composition/tests/composition/provides_basic/subgraphs/users.graphql
@@ -2,7 +2,7 @@ type Query {
   user(id: ID!): User
 }
 
-type User @federation__key(fields: "id") {
+type User @key(fields: "id") {
   id: ID!
   name: String
   email: String

--- a/engine/crates/composition/tests/composition/requires_basic/subgraphs/chilies.graphql
+++ b/engine/crates/composition/tests/composition/requires_basic/subgraphs/chilies.graphql
@@ -1,3 +1,5 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.3")
+
 extend type Farm @federation__key(fields: "id") {
   id: ID! @federation__external
   chiliId: ID! @federation__external


### PR DESCRIPTION
# Description

Change federation directive visibility rules: to align with the ecosystem, do not require an `@link` directive to be present to put the federation directives (`@key`, `@shareable`, `@provides`, etc.) in scope, unprefixed.

Test multikeys: add a test case with an entity with multiple keys to confirm that it works.

closes GB-5265
closes GB-5367

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
