### PR TITLE
cli: make branch optional in ProjectRef

### DIFF
--- a/cli/crates/backend/src/api/graphql/types/queries/fetch_subgraph_schema.rs
+++ b/cli/crates/backend/src/api/graphql/types/queries/fetch_subgraph_schema.rs
@@ -5,7 +5,7 @@ pub struct FetchSubgraphSchemaArguments<'a> {
     pub account: &'a str,
     pub project: &'a str,
     pub subgraph_name: &'a str,
-    pub branch: &'a str,
+    pub branch: Option<&'a str>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]

--- a/cli/crates/backend/src/api/publish.rs
+++ b/cli/crates/backend/src/api/publish.rs
@@ -10,7 +10,7 @@ pub async fn publish(
     // The Good Code™
     account: &str,
     project: &str,
-    branch: &str,
+    branch: Option<&str>,
     subgraph_name: &str,
     url: &str,
     schema: &str,
@@ -21,7 +21,7 @@ pub async fn publish(
         input: super::graphql::mutations::PublishInput {
             account_slug: account,
             project_slug: project,
-            branch: Some(branch),
+            branch,
             subgraph: subgraph_name,
             url,
             schema,

--- a/cli/crates/backend/src/api/schema.rs
+++ b/cli/crates/backend/src/api/schema.rs
@@ -9,17 +9,27 @@ use cynic::{http::ReqwestExt, QueryBuilder};
 pub async fn schema(
     account: &str,
     project: &str,
-    branch: &str,
+    branch: Option<&str>,
     subgraph_name: Option<&str>,
 ) -> Result<Option<String>, ApiError> {
     if let Some(subgraph_name) = subgraph_name {
         subgraph_schema(account, project, branch, subgraph_name).await.map(Some)
     } else {
+        let Some(branch) = branch else {
+            return Err(ApiError::SubgraphsError(
+                "A branch must be specified when fetching a federated graph schema".to_owned(),
+            ));
+        };
         federated_graph_schema(account, project, branch).await
     }
 }
 
-async fn subgraph_schema(account: &str, project: &str, branch: &str, subgraph_name: &str) -> Result<String, ApiError> {
+async fn subgraph_schema(
+    account: &str,
+    project: &str,
+    branch: Option<&str>,
+    subgraph_name: &str,
+) -> Result<String, ApiError> {
     let client = create_client().await?;
     let operation = FetchSubgraphSchemaQuery::build(FetchSubgraphSchemaArguments {
         account,

--- a/cli/crates/backend/src/api/subgraphs.rs
+++ b/cli/crates/backend/src/api/subgraphs.rs
@@ -7,8 +7,13 @@ use super::{
 use cynic::{http::ReqwestExt, QueryBuilder};
 
 /// The `grafbase subgraphs` command.
-pub async fn subgraphs(account: &str, project: &str, branch: &str) -> Result<Vec<Subgraph>, ApiError> {
+pub async fn subgraphs(account: &str, project: &str, branch: Option<&str>) -> Result<Vec<Subgraph>, ApiError> {
     let client = create_client().await?;
+    let Some(branch) = branch else {
+        return Err(ApiError::SubgraphsError(
+            "A branch must be specified in order to list subgraphs".to_owned(),
+        ));
+    };
 
     let operation = ListSubgraphsQuery::build(ListSubgraphsArguments {
         account,

--- a/cli/crates/cli/src/cli_input/project_ref.rs
+++ b/cli/crates/cli/src/cli_input/project_ref.rs
@@ -5,7 +5,7 @@ use std::{fmt, str};
 pub struct ProjectRef {
     account: String,
     project: String,
-    branch: String,
+    branch: Option<String>,
 }
 
 impl ProjectRef {
@@ -20,8 +20,8 @@ impl ProjectRef {
         self.project.as_ref()
     }
 
-    pub(crate) fn branch(&self) -> &str {
-        self.branch.as_ref()
+    pub(crate) fn branch(&self) -> Option<&str> {
+        self.branch.as_deref()
     }
 }
 
@@ -47,14 +47,10 @@ impl str::FromStr for ProjectRef {
             return Err("The project name is missing.");
         }
 
-        if branch.is_empty() {
-            return Err(r#"The branch name is missing after "@"."#);
-        }
-
         Ok(ProjectRef {
             account: account.to_owned(),
             project: project.to_owned(),
-            branch: branch.to_owned(),
+            branch: Some(branch).filter(|s| !s.is_empty()).map(String::from),
         })
     }
 }
@@ -64,8 +60,13 @@ impl fmt::Display for ProjectRef {
         f.write_str(&self.account)?;
         f.write_str("/")?;
         f.write_str(&self.project)?;
-        f.write_str("@")?;
-        f.write_str(&self.branch)
+
+        if let Some(branch) = &self.branch {
+            f.write_str("@")?;
+            f.write_str(branch)?;
+        }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
# Description

As you will see in the diff, this works everywhere except in `grafbase schema` and `grafbase subgraphs`, because the branch is required by the API schema in these cases.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
