### PR TITLE
fix: Introduce closing functionality to Postgres transport

### DIFF
--- a/engine/crates/postgres-connector-types/src/transport.rs
+++ b/engine/crates/postgres-connector-types/src/transport.rs
@@ -33,6 +33,8 @@ impl Column {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait Transport: Send + Sync {
+    async fn close(self) -> crate::Result<()>;
+
     async fn parameterized_execute(&self, query: &str, params: Vec<Value>) -> crate::Result<i64>;
 
     fn parameterized_query<'a>(&'a self, query: &'a str, params: Vec<Value>) -> BoxStream<'a, Result<Value, Error>>;

--- a/engine/crates/postgres-connector-types/src/transport/tcp/transaction.rs
+++ b/engine/crates/postgres-connector-types/src/transport/tcp/transaction.rs
@@ -9,6 +9,10 @@ use crate::{error::Error, transport::Transport};
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl Transport for Transaction<'_> {
+    async fn close(self) -> crate::Result<()> {
+        Ok(())
+    }
+
     fn parameterized_query<'a>(&'a self, query: &'a str, params: Vec<Value>) -> BoxStream<'a, Result<Value, Error>> {
         executor::query(self, query, params)
     }


### PR DESCRIPTION
The close function will take care the client and connection are cleanly closed. This is going to solve the issue in the API with connection leaks and all kinds of annoying race conditions.
