### PR TITLE
composition: implement @deprecated, @tag on fields

### DIFF
--- a/engine/crates/composition/src/compose/context.rs
+++ b/engine/crates/composition/src/compose/context.rs
@@ -42,8 +42,13 @@ impl<'a> Context<'a> {
         self.ir.insert_enum(name)
     }
 
-    pub(crate) fn insert_enum_value(&mut self, enum_id: federated::EnumId, value: StringWalker<'_>) {
-        self.ir.insert_enum_value(enum_id, value);
+    pub(crate) fn insert_enum_value(
+        &mut self,
+        enum_id: federated::EnumId,
+        value: StringWalker<'_>,
+        deprecation: Option<Option<StringWalker<'_>>>,
+    ) {
+        self.ir.insert_enum_value(enum_id, value, deprecation);
     }
 
     pub(crate) fn insert_field(&mut self, ir: crate::composition_ir::FieldIr) {
@@ -76,6 +81,19 @@ impl<'a> Context<'a> {
 
     pub(crate) fn insert_resolvable_key(&mut self, object_id: federated::ObjectId, key_id: subgraphs::KeyId) {
         self.ir.insert_resolvable_key(object_id, key_id);
+    }
+
+    pub(crate) fn insert_string(&mut self, string_id: subgraphs::StringId) -> federated::StringId {
+        self.ir.insert_string(self.subgraphs.walk(string_id))
+    }
+
+    // We need a separate method for strings that appear in the federated graph but were not
+    // interned in subgraphs.
+    pub(crate) fn insert_static_str(&mut self, string: &'static str) -> federated::StringId {
+        match self.subgraphs.strings.lookup(string) {
+            Some(id) => self.ir.insert_string(self.subgraphs.walk(id)),
+            None => self.ir.insert_static_str(string),
+        }
     }
 }
 

--- a/engine/crates/composition/src/compose/enums.rs
+++ b/engine/crates/composition/src/compose/enums.rs
@@ -73,7 +73,8 @@ fn merge_intersection(first: &DefinitionWalker<'_>, definitions: &[DefinitionWal
     let enum_id = ctx.insert_enum(first.name());
 
     for value in intersection {
-        ctx.insert_enum_value(enum_id, first.walk(value));
+        let deprecation = ctx.subgraphs.get_enum_value_deprecation((first.name().id, value));
+        ctx.insert_enum_value(enum_id, first.walk(value), deprecation);
     }
 }
 
@@ -81,7 +82,8 @@ fn merge_union(first: &DefinitionWalker<'_>, definitions: &[DefinitionWalker<'_>
     let enum_id = ctx.insert_enum(first.name());
 
     for value in definitions.iter().flat_map(|def| def.enum_values()) {
-        ctx.insert_enum_value(enum_id, first.walk(value));
+        let deprecation = ctx.subgraphs.get_enum_value_deprecation((first.name().id, value));
+        ctx.insert_enum_value(enum_id, first.walk(value), deprecation);
     }
 }
 
@@ -101,7 +103,8 @@ fn merge_exactly_matching(first: &DefinitionWalker<'_>, definitions: &[Definitio
     let enum_id = ctx.insert_enum(first.name());
 
     for value in expected {
-        ctx.insert_enum_value(enum_id, first.walk(value));
+        let deprecation = ctx.subgraphs.get_enum_value_deprecation((first.name().id, value));
+        ctx.insert_enum_value(enum_id, first.walk(value), deprecation);
     }
 }
 

--- a/engine/crates/composition/src/compose/input_object.rs
+++ b/engine/crates/composition/src/compose/input_object.rs
@@ -40,6 +40,7 @@ pub(super) fn merge_input_object_definitions(
             resolvable_in: None,
             provides: Vec::new(),
             requires: Vec::new(),
+            composed_directives: Vec::new(),
         });
     }
 }

--- a/engine/crates/composition/src/compose/interface.rs
+++ b/engine/crates/composition/src/compose/interface.rs
@@ -27,6 +27,7 @@ pub(super) fn merge_interface_definitions(
             resolvable_in: None,
             provides: Vec::new(),
             requires: Vec::new(),
+            composed_directives: Vec::new(),
         });
     }
 }

--- a/engine/crates/composition/src/emit_federated_graph.rs
+++ b/engine/crates/composition/src/emit_federated_graph.rs
@@ -67,6 +67,7 @@ fn emit_fields<'a>(ir_fields: Vec<FieldIr>, ctx: &mut Context<'a>) {
         resolvable_in,
         provides,
         requires,
+        composed_directives,
     } in ir_fields
     {
         let field_type_id = ctx.insert_field_type(ctx.subgraphs.walk(field_type));
@@ -88,7 +89,7 @@ fn emit_fields<'a>(ir_fields: Vec<FieldIr>, ctx: &mut Context<'a>) {
                 provides: Vec::new(),
                 requires: Vec::new(),
                 resolvable_in,
-                composed_directives: Vec::new(),
+                composed_directives,
             };
 
             let id = federated::FieldId(ctx.out.fields.push_return_idx(field));

--- a/engine/crates/composition/src/ingest_subgraph.rs
+++ b/engine/crates/composition/src/ingest_subgraph.rs
@@ -12,7 +12,10 @@ use crate::{
     subgraphs::{self, DefinitionKind, SubgraphId},
     Subgraphs,
 };
-use async_graphql_parser::types as ast;
+use async_graphql_parser::{
+    types::{self as ast, ConstDirective},
+    Positioned,
+};
 
 pub(crate) fn ingest_subgraph(document: &ast::ServiceDocument, name: &str, url: &str, subgraphs: &mut Subgraphs) {
     let subgraph_id = subgraphs.push_subgraph(name, url);
@@ -94,6 +97,8 @@ fn ingest_definition_bodies(
                 let definition_id = subgraphs.definition_by_name(&definition.node.name.node, subgraph_id);
                 for field in &input_object.fields {
                     let field_type = subgraphs.intern_field_type(&field.node.ty.node);
+                    let deprecated = find_deprecated_directive(&field.node.directives, subgraphs);
+                    let tags = find_tag_directives(&field.node.directives);
                     subgraphs
                         .push_field(subgraphs::FieldIngest {
                             parent_definition_id: definition_id,
@@ -103,6 +108,8 @@ fn ingest_definition_bodies(
                             is_external: false,
                             provides: None,
                             requires: None,
+                            deprecated,
+                            tags,
                         })
                         .unwrap();
                 }
@@ -112,6 +119,8 @@ fn ingest_definition_bodies(
 
                 for field in &interface.fields {
                     let field_type = subgraphs.intern_field_type(&field.node.ty.node);
+                    let tags = find_tag_directives(&field.node.directives);
+                    let deprecated = find_deprecated_directive(&field.node.directives, subgraphs);
                     subgraphs
                         .push_field(subgraphs::FieldIngest {
                             parent_definition_id: definition_id,
@@ -121,6 +130,8 @@ fn ingest_definition_bodies(
                             is_external: false,
                             provides: None,
                             requires: None,
+                            deprecated,
+                            tags,
                         })
                         .unwrap();
                 }
@@ -132,4 +143,36 @@ fn ingest_definition_bodies(
             _ => (),
         }
     }
+}
+
+fn find_deprecated_directive(
+    directives: &[Positioned<ConstDirective>],
+    subgraphs: &mut Subgraphs,
+) -> Option<subgraphs::Deprecation> {
+    let directive = directives
+        .iter()
+        .find(|directive| directive.node.name.node == "deprecated")?;
+
+    let reason = directive.node.get_argument("reason")?;
+
+    let reason = match &reason.node {
+        async_graphql_value::ConstValue::String(s) => Some(subgraphs.strings.intern(s.as_str())),
+        _ => None,
+    };
+
+    Some(subgraphs::Deprecation { reason })
+}
+
+fn find_tag_directives(directives: &[Positioned<ConstDirective>]) -> Vec<&str> {
+    directives
+        .iter()
+        .filter(|directive| directive.node.name.node == "tag")
+        .filter_map(|directive| {
+            let value = directive.node.get_argument("name")?;
+            match &value.node {
+                async_graphql_value::ConstValue::String(s) => Some(s.as_str()),
+                _ => None,
+            }
+        })
+        .collect()
 }

--- a/engine/crates/composition/src/ingest_subgraph/enums.rs
+++ b/engine/crates/composition/src/ingest_subgraph/enums.rs
@@ -3,7 +3,11 @@ use crate::subgraphs::*;
 
 pub(super) fn ingest_enum(definition_id: DefinitionId, enum_type: &ast::EnumType, subgraphs: &mut Subgraphs) {
     for value in &enum_type.values {
-        let value = subgraphs.strings.intern(value.node.value.node.as_str());
-        subgraphs.push_enum_value(definition_id, value);
+        let value_name = subgraphs.strings.intern(value.node.value.node.as_str());
+        subgraphs.push_enum_value(definition_id, value_name);
+
+        if let Some(deprecated) = super::find_deprecated_directive(&value.node.directives, subgraphs) {
+            subgraphs.deprecate_enum_value((subgraphs.walk(definition_id).name().id, value_name), deprecated);
+        }
     }
 }

--- a/engine/crates/composition/src/ingest_subgraph/object.rs
+++ b/engine/crates/composition/src/ingest_subgraph/object.rs
@@ -84,6 +84,8 @@ pub(super) fn ingest_fields(
                 _ => None,
             });
 
+        let deprecated = super::find_deprecated_directive(&field.directives, subgraphs);
+        let tags = super::find_tag_directives(&field.directives);
         let field_type = subgraphs.intern_field_type(&field.ty.node);
         let field_id = subgraphs
             .push_field(crate::subgraphs::FieldIngest {
@@ -94,6 +96,8 @@ pub(super) fn ingest_fields(
                 is_external,
                 provides,
                 requires,
+                deprecated,
+                tags,
             })
             .unwrap();
 

--- a/engine/crates/composition/src/lib.rs
+++ b/engine/crates/composition/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(unsafe_code, missing_docs, rust_2018_idioms)]
+#![allow(clippy::option_option)]
 
 //! GraphQL schema composition.
 

--- a/engine/crates/composition/src/subgraphs.rs
+++ b/engine/crates/composition/src/subgraphs.rs
@@ -7,10 +7,6 @@ mod strings;
 mod unions;
 mod walkers;
 
-use std::collections::{BTreeMap, BTreeSet};
-
-use itertools::Itertools;
-
 pub(crate) use self::{
     definitions::{DefinitionId, DefinitionKind, DefinitionWalker},
     field_types::*,
@@ -19,7 +15,10 @@ pub(crate) use self::{
     strings::{StringId, StringWalker},
     walkers::*,
 };
+
 use crate::VecExt;
+use itertools::Itertools;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 /// A set of subgraphs to be composed.
 #[derive(Default)]

--- a/engine/crates/composition/src/subgraphs/enums.rs
+++ b/engine/crates/composition/src/subgraphs/enums.rs
@@ -3,11 +3,24 @@ use super::*;
 #[derive(Default)]
 pub(super) struct Enums {
     values: BTreeSet<(DefinitionId, StringId)>,
+    // (enum name, enum value) -> deprecation
+    deprecated: HashMap<(StringId, StringId), Deprecation>,
 }
 
 impl Subgraphs {
+    pub(crate) fn get_enum_value_deprecation(&self, path: (StringId, StringId)) -> Option<Option<StringWalker<'_>>> {
+        self.enums
+            .deprecated
+            .get(&path)
+            .map(|deprecation| deprecation.reason.map(|reason| self.walk(reason)))
+    }
+
     pub(crate) fn push_enum_value(&mut self, enum_id: DefinitionId, enum_value: StringId) {
         self.enums.values.insert((enum_id, enum_value));
+    }
+
+    pub(crate) fn deprecate_enum_value(&mut self, path: (StringId, StringId), reason: Deprecation) {
+        self.enums.deprecated.insert(path, reason);
     }
 }
 

--- a/engine/crates/composition/tests/composition/composed_directives_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/composed_directives_basic/federated.graphql
@@ -1,0 +1,58 @@
+enum join__Graph {
+    BIRDWATCH_BASIC @join__graph(name: "birdwatch_basic", url: "http://example.com/birdwatch_basic")
+    OBSERVATIONS @join__graph(name: "observations", url: "http://example.com/observations")
+    SIGHTINGS @join__graph(name: "sightings", url: "http://example.com/sightings")
+}
+
+scalar DateTime
+
+type Bird {
+    id: ID!
+    name: String!
+    species: String!
+    observedAt: DateTime! @deprecated(reason: "Use UNIX timestamps instead as customary in bird watching")
+    location: String! @tag(name: "locationService") @tag(name: "b") @tag(name: "a")
+    notes: String @deprecated(reason: "Field is obsolete due to new data model.")
+}
+
+type Query {
+    birds: [Bird] @join__field(graph: BIRDWATCH_BASIC)
+    bird(id: ID!): Bird @join__field(graph: BIRDWATCH_BASIC)
+    birdObservations(filters: BirdObservationFilters): [BirdObservation] @join__field(graph: OBSERVATIONS)
+    birdObservation(observationID: ID!): BirdObservation @join__field(graph: OBSERVATIONS)
+    birdSightings: [BirdSighting] @join__field(graph: SIGHTINGS)
+    birdSighting(sightingID: ID!, private: Boolean): BirdSighting @join__field(graph: SIGHTINGS)
+}
+
+type BirdObservation {
+    bird: Bird! @join__field(graph: OBSERVATIONS)
+    observationID: ID! @join__field(graph: OBSERVATIONS)
+    observerDetails: ObserverDetails! @join__field(graph: OBSERVATIONS)
+    timeOfObservation: DateTime! @join__field(graph: OBSERVATIONS)
+}
+
+type ObserverDetails {
+    name: String! @join__field(graph: OBSERVATIONS)
+    membershipNumber: String @join__field(graph: OBSERVATIONS)
+    observerType: ObserverType! @join__field(graph: OBSERVATIONS)
+}
+
+type BirdSighting {
+    bird: Bird! @join__field(graph: SIGHTINGS)
+    sightingID: ID! @join__field(graph: SIGHTINGS)
+    observer: String! @join__field(graph: SIGHTINGS)
+    weatherConditions: String @join__field(graph: SIGHTINGS)
+}
+
+enum ObserverType {
+    AMATEUR
+    SEMIPROFESSIONAL @deprecated(reason: "No such thing as semiprofessionals")
+    PROFESSIONAL
+}
+
+input BirdObservationFilters {
+    observerName: String
+    observerType: ObserverType
+    observedAt: DateTime
+    first: Int
+}

--- a/engine/crates/composition/tests/composition/composed_directives_basic/subgraphs/birdwatch_basic.graphql
+++ b/engine/crates/composition/tests/composition/composed_directives_basic/subgraphs/birdwatch_basic.graphql
@@ -1,0 +1,19 @@
+scalar DateTime
+
+type Bird @shareable {
+    id: ID!
+    name: String!
+    species: String!
+    observedAt: DateTime! @deprecated(reason: "Use UNIX timestamps instead as customary in bird watching")
+    location: String! @tag(name: "locationService") @tag(name: "b")
+    notes: String
+}
+
+type Query {
+    birds: [Bird]
+    bird(id: ID!): Bird
+}
+
+schema {
+    query: Query
+}

--- a/engine/crates/composition/tests/composition/composed_directives_basic/subgraphs/observations.graphql
+++ b/engine/crates/composition/tests/composition/composed_directives_basic/subgraphs/observations.graphql
@@ -1,0 +1,43 @@
+type Bird @shareable {
+    id: ID!
+    name: String!
+    species: String!
+    observedAt: DateTime! @deprecated
+    location: String! @tag(name: "locationService") @tag(name: "a")
+    notes: String @deprecated(reason: "Field is obsolete due to new data model.")
+}
+
+type BirdObservation @id(fields: "observationID") {
+    observationID: ID!
+    bird: Bird!
+    observerDetails: ObserverDetails!
+    timeOfObservation: DateTime!
+}
+
+type ObserverDetails {
+    name: String!
+    membershipNumber: String
+    observerType: ObserverType!
+}
+
+enum ObserverType {
+    AMATEUR
+    SEMIPROFESSIONAL @deprecated(reason: "No such thing as semiprofessionals")
+    PROFESSIONAL
+}
+
+input BirdObservationFilters {
+    observerName: String
+    observerType: ObserverType
+    observedAt: DateTime @deprecated(reason: "UNIX timestamps instead, as usual in bird watching")
+    first: Int
+}
+
+type Query {
+    birdObservations(filters: BirdObservationFilters): [BirdObservation]
+    birdObservation(observationID: ID!): BirdObservation
+}
+
+schema {
+    query: Query
+}

--- a/engine/crates/composition/tests/composition/composed_directives_basic/subgraphs/sightings.graphql
+++ b/engine/crates/composition/tests/composition/composed_directives_basic/subgraphs/sightings.graphql
@@ -1,0 +1,25 @@
+type Bird @shareable {
+    id: ID!
+    name: String!
+    species: String!
+    observedAt: DateTime! @deprecated
+    location: String!
+    notes: String @deprecated(reason: "Use `birdSighting` field instead.")
+}
+
+type BirdSighting @key(field: "id") @deprecated(reason: "we haven't seen any birds in a while :(") {
+    sightingID: ID!
+    bird: Bird!
+    observer: String!
+    weatherConditions: String
+}
+
+type Query {
+    birdSightings: [BirdSighting]
+    birdSighting(sightingID: ID!, private: Boolean @deprecated): BirdSighting
+}
+
+schema {
+    query: Query
+}
+

--- a/engine/crates/federated-graph/src/from_sdl.rs
+++ b/engine/crates/federated-graph/src/from_sdl.rs
@@ -87,6 +87,19 @@ impl<'a> State<'a> {
 
         StringId(self.strings.insert_full(s.to_owned()).0)
     }
+
+    fn insert_value(&mut self, node: &async_graphql_value::ConstValue) -> Value {
+        match node {
+            async_graphql_value::ConstValue::Null => Value::String(self.insert_string("null")),
+            async_graphql_value::ConstValue::Number(number) => Value::String(self.insert_string(&number.to_string())),
+            async_graphql_value::ConstValue::String(s) => Value::String(self.insert_string(s)),
+            async_graphql_value::ConstValue::Boolean(b) => Value::Boolean(*b),
+            async_graphql_value::ConstValue::Enum(enm) => Value::EnumValue(self.insert_string(enm)),
+            async_graphql_value::ConstValue::Binary(_) => unreachable!(),
+            async_graphql_value::ConstValue::List(_) => todo!(),
+            async_graphql_value::ConstValue::Object(_) => todo!(),
+        }
+    }
 }
 
 pub fn from_sdl(sdl: &str) -> Result<FederatedGraph, DomainError> {
@@ -354,10 +367,11 @@ fn ingest_definitions<'a>(document: &'a ast::ServiceDocument, state: &mut State<
                         state.definition_names.insert(type_name, Definition::Enum(enum_id));
 
                         for value in &enm.values {
+                            let composed_directives = collect_composed_directives(&value.node.directives, state);
                             let value = state.insert_string(value.node.value.node.as_str());
                             state.enums[enum_id.0].values.push(EnumValue {
                                 value,
-                                composed_directives: Vec::new(),
+                                composed_directives,
                             });
                         }
                     }
@@ -422,6 +436,8 @@ fn ingest_field<'a>(parent_id: Definition, ast_field: &'a ast::FieldDefinition, 
             _ => None,
         });
 
+    let composed_directives = collect_composed_directives(&ast_field.directives, state);
+
     let field_id = FieldId(state.fields.push_return_idx(Field {
         name,
         field_type_id,
@@ -429,7 +445,7 @@ fn ingest_field<'a>(parent_id: Definition, ast_field: &'a ast::FieldDefinition, 
         provides: Vec::new(),
         requires: Vec::new(),
         arguments,
-        composed_directives: Vec::new(),
+        composed_directives,
     }));
 
     state.selection_map.insert((parent_id, field_name), field_id);
@@ -576,4 +592,25 @@ impl<T> VecExt<T> for Vec<T> {
         self.push(elem);
         idx
     }
+}
+
+fn collect_composed_directives(
+    directives: &[Positioned<ast::ConstDirective>],
+    state: &mut State<'_>,
+) -> Vec<Directive> {
+    directives
+        .iter()
+        .filter(|dir| dir.node.name.node != JOIN_FIELD_DIRECTIVE_NAME)
+        .map(|directive| Directive {
+            name: state.insert_string(directive.node.name.node.as_str()),
+            arguments: directive
+                .node
+                .arguments
+                .iter()
+                .map(|(name, value)| -> (StringId, Value) {
+                    (state.insert_string(name.node.as_str()), state.insert_value(&value.node))
+                })
+                .collect(),
+        })
+        .collect()
 }

--- a/engine/crates/federated-graph/src/render_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl.rs
@@ -70,8 +70,16 @@ pub fn render_sdl(graph: &FederatedGraph) -> Result<String, fmt::Error> {
         writeln!(sdl, "enum {enum_name} {{")?;
 
         for value in &r#enum.values {
-            let value = &graph[value.value];
-            writeln!(sdl, "{INDENT}{value}")?;
+            let value_name = &graph[value.value];
+            write!(sdl, "{INDENT}{value_name}")?;
+
+            for directive in &value.composed_directives {
+                let directive_name = &graph[directive.name];
+                let arguments = DirectiveArguments(&directive.arguments, graph);
+                write!(sdl, " @{directive_name}{arguments}")?;
+            }
+
+            sdl.push('\n');
         }
 
         writeln!(sdl, "}}\n")?;
@@ -146,8 +154,19 @@ fn write_field(field_id: FieldId, graph: &FederatedGraph, sdl: &mut String) -> f
 
     write_provides(field, graph, sdl)?;
     write_requires(field, graph, sdl)?;
+    write_composed_directives(field, graph, sdl)?;
 
     sdl.push('\n');
+    Ok(())
+}
+
+fn write_composed_directives(field: &Field, graph: &FederatedGraph, sdl: &mut String) -> fmt::Result {
+    for directive in &field.composed_directives {
+        let directive_name = &graph[directive.name];
+        let arguments = DirectiveArguments(&directive.arguments, graph);
+        write!(sdl, " @{directive_name}{arguments}")?;
+    }
+
     Ok(())
 }
 
@@ -297,5 +316,54 @@ impl<T: Display> Display for MaybeDisplay<T> {
         }
 
         Ok(())
+    }
+}
+
+struct DirectiveArguments<'a>(&'a [(StringId, Value)], &'a FederatedGraph);
+
+impl Display for DirectiveArguments<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let DirectiveArguments(arguments, graph) = self;
+
+        if arguments.is_empty() {
+            return Ok(());
+        }
+
+        f.write_str("(")?;
+
+        let mut arguments = arguments.iter().peekable();
+
+        while let Some((name, value)) = arguments.next() {
+            let name = &graph[*name];
+            let value = ValueDisplay(value, graph);
+            write!(f, "{name}: {value}")?;
+
+            if arguments.peek().is_some() {
+                f.write_str(", ")?;
+            }
+        }
+
+        f.write_str(")")
+    }
+}
+
+struct ValueDisplay<'a>(&'a Value, &'a FederatedGraph);
+
+impl Display for ValueDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let ValueDisplay(value, graph) = self;
+        match value {
+            Value::String(s) => {
+                f.write_str("\"")?;
+                f.write_str(&graph[*s])?;
+                f.write_str("\"")
+            }
+            Value::Int(i) => Display::fmt(i, f),
+            Value::Float(val) | Value::EnumValue(val) => f.write_str(&graph[*val]),
+            Value::Boolean(true) => f.write_str("true"),
+            Value::Boolean(false) => f.write_str("false"),
+            Value::Object(_) => todo!(),
+            Value::List(_) => todo!(),
+        }
     }
 }


### PR DESCRIPTION
This is the first PR that composes directives, so some of the work here is starting to lay down foundations for this.

What is implemented:

- `@deprecated` everywhere it is valid in the GraphQL 2021 spec (i.e. object fields and enum values)
- `@tag` on object fields. It can be in many other places, but I did not want to make this PR much larger than it already is.

Closes GB-5395
Part of GB-5396

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
