### PR TITLE
composition: compose interface implementations 

### DIFF
--- a/engine/crates/composition/src/composition_ir.rs
+++ b/engine/crates/composition/src/composition_ir.rs
@@ -57,6 +57,7 @@ impl CompositionIr {
         let name = self.insert_string(iface_name);
         let iface = federated::Interface {
             name,
+            implements_interfaces: Vec::new(),
             composed_directives: Vec::new(),
         };
         let id = federated::InterfaceId(self.interfaces.push_return_idx(iface));

--- a/engine/crates/composition/src/ingest_subgraph.rs
+++ b/engine/crates/composition/src/ingest_subgraph.rs
@@ -109,6 +109,12 @@ fn ingest_definition_bodies(
             }
             ast::TypeKind::Interface(interface) => {
                 let definition_id = subgraphs.definition_by_name(&definition.node.name.node, subgraph_id);
+                let definition_name = subgraphs.walk(definition_id).name().id;
+
+                for implemented_interface in &interface.implements {
+                    let implemented_interface = subgraphs.strings.intern(implemented_interface.node.as_str());
+                    subgraphs.push_interface_impl(definition_name, implemented_interface);
+                }
 
                 for field in &interface.fields {
                     let field_type = subgraphs.intern_field_type(&field.node.ty.node);
@@ -127,6 +133,13 @@ fn ingest_definition_bodies(
             }
             ast::TypeKind::Object(object_type) => {
                 let definition_id = subgraphs.definition_by_name(&definition.node.name.node, subgraph_id);
+                let definition_name = subgraphs.walk(definition_id).name().id;
+
+                for implemented_interface in &object_type.implements {
+                    let implemented_interface = subgraphs.strings.intern(implemented_interface.node.as_str());
+                    subgraphs.push_interface_impl(definition_name, implemented_interface);
+                }
+
                 object::ingest_fields(definition_id, object_type, federation_directives_matcher, subgraphs);
             }
             _ => (),

--- a/engine/crates/composition/tests/composition/interface_implementing_interface_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/interface_implementing_interface_basic/federated.graphql
@@ -1,0 +1,33 @@
+enum join__Graph {
+    PRODUCT @join__graph(name: "product", url: "http://example.com/product")
+    USER @join__graph(name: "user", url: "http://example.com/user")
+}
+
+type Product implements Node {
+    id: ID! @join__field(graph: PRODUCT)
+    name: String! @join__field(graph: PRODUCT)
+    price: Float! @join__field(graph: PRODUCT)
+    description: String @join__field(graph: PRODUCT)
+}
+
+type User implements Timestamped {
+    id: ID! @join__field(graph: USER)
+    createdAt: String! @join__field(graph: USER)
+    updatedAt: String! @join__field(graph: USER)
+    username: String! @join__field(graph: USER)
+    email: String! @join__field(graph: USER)
+}
+
+type Query {
+    user(id: ID!): User @join__field(graph: USER)
+}
+
+interface Node {
+    id: ID!
+}
+
+interface Timestamped implements Node {
+    id: ID!
+    createdAt: String!
+    updatedAt: String!
+}

--- a/engine/crates/composition/tests/composition/interface_implementing_interface_basic/subgraphs/product.graphql
+++ b/engine/crates/composition/tests/composition/interface_implementing_interface_basic/subgraphs/product.graphql
@@ -1,0 +1,10 @@
+interface Node {
+  id: ID!
+}
+
+type Product implements Node {
+  id: ID!
+  name: String!
+  price: Float!
+  description: String
+}

--- a/engine/crates/composition/tests/composition/interface_implementing_interface_basic/subgraphs/user.graphql
+++ b/engine/crates/composition/tests/composition/interface_implementing_interface_basic/subgraphs/user.graphql
@@ -1,0 +1,21 @@
+interface Node {
+  id: ID!
+}
+
+interface Timestamped implements Node {
+  id: ID!
+  createdAt: String!
+  updatedAt: String!
+}
+
+type User implements Timestamped {
+  id: ID!
+  createdAt: String!
+  updatedAt: String!
+  username: String!
+  email: String!
+}
+
+extend type Query {
+  user(id: ID!): User
+}

--- a/engine/crates/composition/tests/composition/interfaces_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/interfaces_basic/federated.graphql
@@ -4,7 +4,7 @@ enum join__Graph {
     SOCIAL @join__graph(name: "social", url: "http://example.com/social")
 }
 
-type Furby {
+type Furby implements FurbyType & SocialFurby {
     id: ID! @join__field(graph: SOCIAL)
     languages: [String!]! @join__field(graph: SOCIAL)
     canSing: Boolean! @join__field(graph: SOCIAL)

--- a/engine/crates/composition/tests/composition_tests.rs
+++ b/engine/crates/composition/tests/composition_tests.rs
@@ -80,7 +80,8 @@ fn test_sdl_roundtrip(federated_graph_path: &Path) -> datatest_stable::Result<()
     }
 
     let roundtripped = graphql_federated_graph::render_sdl(
-        &graphql_federated_graph::from_sdl(&sdl).map_err(|err| format!("Error ingesting SDL: {err}"))?,
+        &graphql_federated_graph::from_sdl(&sdl)
+            .map_err(|err| miette::miette!("Error ingesting SDL: {err}\n\nSDL:\n{sdl}"))?,
     )?;
 
     if roundtripped == sdl {

--- a/engine/crates/federated-graph/src/federated_graph.rs
+++ b/engine/crates/federated-graph/src/federated_graph.rs
@@ -186,6 +186,8 @@ pub struct FieldRequires {
 pub struct Interface {
     pub name: StringId,
 
+    pub implements_interfaces: Vec<InterfaceId>,
+
     /// All directives that made it through composition. Notably includes `@tag`.
     pub composed_directives: Vec<Directive>,
 }

--- a/engine/crates/federated-graph/src/render_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl.rs
@@ -27,6 +27,19 @@ pub fn render_sdl(graph: &FederatedGraph) -> Result<String, fmt::Error> {
         sdl.push_str("type ");
         sdl.push_str(object_name);
 
+        if !object.implements_interfaces.is_empty() {
+            sdl.push_str(" implements ");
+
+            for (idx, interface) in object.implements_interfaces.iter().enumerate() {
+                let interface_name = &graph[graph[*interface].name];
+                sdl.push_str(interface_name);
+
+                if idx < object.implements_interfaces.len() - 1 {
+                    sdl.push_str(" & ");
+                }
+            }
+        }
+
         if object.resolvable_keys.is_empty() {
             sdl.push_str(" {\n");
         } else {
@@ -52,7 +65,22 @@ pub fn render_sdl(graph: &FederatedGraph) -> Result<String, fmt::Error> {
 
     for (idx, interface) in graph.interfaces.iter().enumerate() {
         let interface_name = &graph[interface.name];
-        writeln!(sdl, "interface {interface_name} {{")?;
+        write!(sdl, "interface {interface_name}")?;
+
+        if !interface.implements_interfaces.is_empty() {
+            sdl.push_str(" implements ");
+
+            for (idx, implemented) in interface.implements_interfaces.iter().enumerate() {
+                let implemented_interface_name = &graph[graph[*implemented].name];
+                sdl.push_str(implemented_interface_name);
+
+                if idx < interface.implements_interfaces.len() - 1 {
+                    sdl.push_str(" & ");
+                }
+            }
+        }
+
+        sdl.push_str(" {\n");
 
         for field in graph
             .interface_fields

--- a/engine/crates/integration-tests/tests/federation/introspection.rs
+++ b/engine/crates/integration-tests/tests/federation/introspection.rs
@@ -36,12 +36,12 @@ fn can_run_2018_introspection_query() {
       value: String!
     }
 
-    type Issue {
+    type Issue implements PullRequestOrIssue {
       author: UserOrBot!
       title: String!
     }
 
-    type PullRequest {
+    type PullRequest implements PullRequestOrIssue {
       author: UserOrBot!
       checks: [String!]!
       title: String!
@@ -104,12 +104,12 @@ fn can_run_2021_introspection_query() {
       value: String!
     }
 
-    type Issue {
+    type Issue implements PullRequestOrIssue {
       author: UserOrBot!
       title: String!
     }
 
-    type PullRequest {
+    type PullRequest implements PullRequestOrIssue {
       author: UserOrBot!
       checks: [String!]!
       title: String!
@@ -235,14 +235,14 @@ fn can_introsect_when_multiple_subgraphs() {
       recursiveObjectList: [InputObj!]!
     }
 
-    type Issue {
+    type Issue implements PullRequestOrIssue {
       author: UserOrBot!
       title: String!
     }
 
     scalar JSON
 
-    type PullRequest {
+    type PullRequest implements PullRequestOrIssue {
       author: UserOrBot!
       checks: [String!]!
       title: String!
@@ -337,7 +337,9 @@ fn supports_the_type_field() {
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+            {}
+          ],
           "kind": "OBJECT",
           "name": "PullRequest",
           "ofType": null,
@@ -419,7 +421,132 @@ fn supports_recursing_through_types() {
     {
       "data": {
         "__type": {
-          "possibleTypes": []
+          "possibleTypes": [
+            {
+              "interfaces": [
+                {
+                  "name": "PullRequestOrIssue",
+                  "possibleTypes": [
+                    {
+                      "interfaces": [
+                        {
+                          "name": "PullRequestOrIssue",
+                          "possibleTypes": [
+                            {
+                              "interfaces": [
+                                {
+                                  "name": "PullRequestOrIssue"
+                                }
+                              ],
+                              "name": "Issue"
+                            },
+                            {
+                              "interfaces": [
+                                {
+                                  "name": "PullRequestOrIssue"
+                                }
+                              ],
+                              "name": "PullRequest"
+                            }
+                          ]
+                        }
+                      ],
+                      "name": "Issue"
+                    },
+                    {
+                      "interfaces": [
+                        {
+                          "name": "PullRequestOrIssue",
+                          "possibleTypes": [
+                            {
+                              "interfaces": [
+                                {
+                                  "name": "PullRequestOrIssue"
+                                }
+                              ],
+                              "name": "Issue"
+                            },
+                            {
+                              "interfaces": [
+                                {
+                                  "name": "PullRequestOrIssue"
+                                }
+                              ],
+                              "name": "PullRequest"
+                            }
+                          ]
+                        }
+                      ],
+                      "name": "PullRequest"
+                    }
+                  ]
+                }
+              ],
+              "name": "Issue"
+            },
+            {
+              "interfaces": [
+                {
+                  "name": "PullRequestOrIssue",
+                  "possibleTypes": [
+                    {
+                      "interfaces": [
+                        {
+                          "name": "PullRequestOrIssue",
+                          "possibleTypes": [
+                            {
+                              "interfaces": [
+                                {
+                                  "name": "PullRequestOrIssue"
+                                }
+                              ],
+                              "name": "Issue"
+                            },
+                            {
+                              "interfaces": [
+                                {
+                                  "name": "PullRequestOrIssue"
+                                }
+                              ],
+                              "name": "PullRequest"
+                            }
+                          ]
+                        }
+                      ],
+                      "name": "Issue"
+                    },
+                    {
+                      "interfaces": [
+                        {
+                          "name": "PullRequestOrIssue",
+                          "possibleTypes": [
+                            {
+                              "interfaces": [
+                                {
+                                  "name": "PullRequestOrIssue"
+                                }
+                              ],
+                              "name": "Issue"
+                            },
+                            {
+                              "interfaces": [
+                                {
+                                  "name": "PullRequestOrIssue"
+                                }
+                              ],
+                              "name": "PullRequest"
+                            }
+                          ]
+                        }
+                      ],
+                      "name": "PullRequest"
+                    }
+                  ]
+                }
+              ],
+              "name": "PullRequest"
+            }
+          ]
         }
       }
     }


### PR DESCRIPTION
# Description

Previously, we were not adding `implements x & y & z` to any model or interface in the federated schemas. This commit implements the composition of these implementations.

closes GB-5393

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
