### PR TITLE
chore: Add simple engine-v2 test with a query having fields from two different subgraphs

### DIFF
--- a/engine/crates/integration-tests/src/mocks/graphql.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql.rs
@@ -7,8 +7,13 @@ use axum::{extract::State, http::HeaderMap, routing::post, Router};
 
 mod echo;
 mod fake_github;
+mod federation;
 
-pub use {echo::EchoSchema, fake_github::FakeGithubSchema};
+pub use {
+    echo::EchoSchema,
+    fake_github::FakeGithubSchema,
+    federation::{FakeFederationAccountsSchema, FakeFederationProductsSchema, FakeFederationReviewsSchema},
+};
 
 pub struct MockGraphQlServer {
     shutdown: Option<tokio::sync::oneshot::Sender<()>>,

--- a/engine/crates/integration-tests/src/mocks/graphql/federation/accounts.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql/federation/accounts.rs
@@ -1,0 +1,87 @@
+// See https://github.com/async-graphql/examples
+use async_graphql::{EmptyMutation, EmptySubscription, Object, Schema, SimpleObject, ID};
+
+pub struct FakeFederationAccountsSchema;
+
+impl FakeFederationAccountsSchema {
+    fn schema() -> Schema<Query, EmptyMutation, EmptySubscription> {
+        Schema::build(Query, EmptyMutation, EmptySubscription)
+            .enable_federation()
+            .finish()
+    }
+}
+
+#[async_trait::async_trait]
+impl super::super::Schema for FakeFederationAccountsSchema {
+    async fn execute(
+        &self,
+        _headers: Vec<(String, String)>,
+        request: async_graphql::Request,
+    ) -> async_graphql::Response {
+        Self::schema().execute(request).await
+    }
+
+    fn sdl(&self) -> String {
+        Self::schema().sdl_with_options(async_graphql::SDLExportOptions::new())
+    }
+}
+
+#[derive(SimpleObject)]
+struct User {
+    id: ID,
+    username: String,
+    profile_picture: Option<Picture>,
+    /// This used to be part of this subgraph, but is now being overridden from
+    /// `reviews`
+    review_count: u32,
+    joined_timestamp: u64,
+}
+
+impl User {
+    fn me() -> User {
+        User {
+            id: "1234".into(),
+            username: "Me".to_string(),
+            profile_picture: Some(Picture {
+                url: "http://localhost:8080/me.jpg".to_string(),
+                width: 256,
+                height: 256,
+            }),
+            review_count: 0,
+            joined_timestamp: 1,
+        }
+    }
+}
+
+#[derive(SimpleObject)]
+#[graphql(shareable)]
+struct Picture {
+    url: String,
+    width: u32,
+    height: u32,
+}
+
+struct Query;
+
+#[Object]
+impl Query {
+    async fn me(&self) -> User {
+        User::me()
+    }
+
+    #[graphql(entity)]
+    async fn find_user_by_id(&self, id: ID) -> User {
+        if id == "1234" {
+            User::me()
+        } else {
+            let username = format!("User {}", id.as_str());
+            User {
+                id,
+                username,
+                profile_picture: None,
+                review_count: 0,
+                joined_timestamp: 1500,
+            }
+        }
+    }
+}

--- a/engine/crates/integration-tests/src/mocks/graphql/federation/mod.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql/federation/mod.rs
@@ -1,0 +1,9 @@
+// Mostly taken from:
+// https://github.com/async-graphql/examples
+mod accounts;
+mod products;
+mod reviews;
+
+pub use accounts::FakeFederationAccountsSchema;
+pub use products::FakeFederationProductsSchema;
+pub use reviews::FakeFederationReviewsSchema;

--- a/engine/crates/integration-tests/src/mocks/graphql/federation/products.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql/federation/products.rs
@@ -1,0 +1,68 @@
+// See https://github.com/async-graphql/examples
+use async_graphql::{Context, EmptyMutation, EmptySubscription, Object, Schema, SimpleObject};
+
+pub struct FakeFederationProductsSchema;
+
+impl FakeFederationProductsSchema {
+    fn schema() -> Schema<Query, EmptyMutation, EmptySubscription> {
+        let hats = vec![
+            Product {
+                upc: "top-1".to_string(),
+                name: "Trilby".to_string(),
+                price: 11,
+            },
+            Product {
+                upc: "top-2".to_string(),
+                name: "Fedora".to_string(),
+                price: 22,
+            },
+            Product {
+                upc: "top-3".to_string(),
+                name: "Boater".to_string(),
+                price: 33,
+            },
+        ];
+        Schema::build(Query, EmptyMutation, EmptySubscription)
+            .enable_federation()
+            .data(hats)
+            .finish()
+    }
+}
+
+#[async_trait::async_trait]
+impl super::super::Schema for FakeFederationProductsSchema {
+    async fn execute(
+        &self,
+        _headers: Vec<(String, String)>,
+        request: async_graphql::Request,
+    ) -> async_graphql::Response {
+        Self::schema().execute(request).await
+    }
+
+    fn sdl(&self) -> String {
+        Self::schema().sdl_with_options(async_graphql::SDLExportOptions::new())
+    }
+}
+
+#[derive(SimpleObject)]
+struct Product {
+    upc: String,
+    name: String,
+    #[graphql(shareable)]
+    price: i32,
+}
+
+struct Query;
+
+#[Object]
+impl Query {
+    async fn top_products<'a>(&self, ctx: &'a Context<'_>) -> &'a Vec<Product> {
+        ctx.data_unchecked::<Vec<Product>>()
+    }
+
+    #[graphql(entity)]
+    async fn find_product_by_upc<'a>(&self, ctx: &'a Context<'_>, upc: String) -> Option<&'a Product> {
+        let hats = ctx.data_unchecked::<Vec<Product>>();
+        hats.iter().find(|product| product.upc == upc)
+    }
+}

--- a/engine/crates/integration-tests/src/mocks/graphql/federation/reviews.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql/federation/reviews.rs
@@ -1,0 +1,210 @@
+// See https://github.com/async-graphql/examples
+use async_graphql::{ComplexObject, Context, EmptyMutation, EmptySubscription, Enum, Object, Schema, SimpleObject, ID};
+
+pub struct FakeFederationReviewsSchema;
+
+impl FakeFederationReviewsSchema {
+    fn schema() -> Schema<Query, EmptyMutation, EmptySubscription> {
+        let reviews = vec![
+            Review {
+                id: "review-1".into(),
+                body: "A highly effective form of birth control.".into(),
+                pictures: vec![
+                    Picture {
+                        url: "http://localhost:8080/ugly_hat.jpg".to_string(),
+                        width: 100,
+                        height: 100,
+                        alt_text: "A Trilby".to_string(),
+                    },
+                    Picture {
+                        url: "http://localhost:8080/troll_face.jpg".to_string(),
+                        width: 42,
+                        height: 42,
+                        alt_text: "The troll face meme".to_string(),
+                    },
+                ],
+            },
+            Review {
+                id: "review-2".into(),
+                body:
+                    "Fedoras are one of the most fashionable hats around and can look great with a variety of outfits."
+                        .into(),
+                pictures: vec![],
+            },
+            Review {
+                id: "review-3".into(),
+                body: "This is the last straw. Hat you will wear. 11/10".into(),
+                pictures: vec![],
+            },
+        ];
+
+        Schema::build(Query, EmptyMutation, EmptySubscription)
+            .data(reviews)
+            .enable_federation()
+            .finish()
+    }
+}
+
+#[async_trait::async_trait]
+impl super::super::Schema for FakeFederationReviewsSchema {
+    async fn execute(
+        &self,
+        _headers: Vec<(String, String)>,
+        request: async_graphql::Request,
+    ) -> async_graphql::Response {
+        Self::schema().execute(request).await
+    }
+
+    fn sdl(&self) -> String {
+        Self::schema().sdl_with_options(async_graphql::SDLExportOptions::new())
+    }
+}
+
+#[derive(SimpleObject)]
+#[graphql(complex)]
+struct User {
+    id: ID,
+    #[graphql(override_from = "accounts")]
+    review_count: u32,
+    #[graphql(external)]
+    joined_timestamp: u64,
+}
+
+#[derive(Enum, Eq, PartialEq, Copy, Clone)]
+#[allow(clippy::enum_variant_names)]
+enum Trustworthiness {
+    ReallyTrusted,
+    KindaTrusted,
+    NotTrusted,
+}
+
+#[ComplexObject]
+impl User {
+    async fn reviews<'a>(&self, ctx: &'a Context<'_>) -> Vec<&'a Review> {
+        let reviews = ctx.data_unchecked::<Vec<Review>>();
+        reviews
+            .iter()
+            .filter(|review| review.get_author().id == self.id)
+            .collect()
+    }
+
+    #[graphql(requires = "joinedTimestamp")]
+    async fn trustworthiness(&self) -> Trustworthiness {
+        if self.joined_timestamp < 1_000 && self.review_count > 1 {
+            Trustworthiness::ReallyTrusted
+        } else if self.joined_timestamp < 2_000 {
+            Trustworthiness::KindaTrusted
+        } else {
+            Trustworthiness::NotTrusted
+        }
+    }
+}
+
+#[derive(SimpleObject)]
+#[graphql(complex)]
+struct Product {
+    upc: String,
+    #[graphql(external)]
+    price: u32,
+}
+
+#[ComplexObject]
+impl Product {
+    async fn reviews<'a>(&self, ctx: &'a Context<'_>) -> Vec<&'a Review> {
+        let reviews = ctx.data_unchecked::<Vec<Review>>();
+        reviews
+            .iter()
+            .filter(|review| review.get_product().upc == self.upc)
+            .collect()
+    }
+}
+
+#[derive(SimpleObject)]
+#[graphql(complex)]
+struct Review {
+    id: ID,
+    body: String,
+    pictures: Vec<Picture>,
+}
+
+#[ComplexObject]
+impl Review {
+    #[graphql(provides = "price")]
+    async fn product<'a>(&self) -> Product {
+        self.get_product()
+    }
+
+    async fn author(&self) -> User {
+        self.get_author()
+    }
+}
+
+impl Review {
+    fn get_product(&self) -> Product {
+        match self.id.as_str() {
+            "review-1" => Product {
+                upc: "top-1".to_string(),
+                price: 10,
+            },
+            "review-2" => Product {
+                upc: "top-2".to_string(),
+                price: 20,
+            },
+            "review-3" => Product {
+                upc: "top-3".to_string(),
+                price: 30,
+            },
+            _ => panic!("Unknown review id"),
+        }
+    }
+
+    fn get_author(&self) -> User {
+        let user_id: ID = match self.id.as_str() {
+            "review-1" | "review-2" => "1234",
+            "review-3" => "7777",
+            _ => panic!("Unknown review id"),
+        }
+        .into();
+        user_by_id(user_id, None)
+    }
+}
+
+#[derive(SimpleObject)]
+#[graphql(shareable)]
+struct Picture {
+    url: String,
+    width: u32,
+    height: u32,
+    #[graphql(inaccessible)] // Field not added to Accounts yet
+    alt_text: String,
+}
+
+struct Query;
+
+#[Object]
+impl Query {
+    #[graphql(entity)]
+    async fn find_user_by_id(&self, #[graphql(key)] id: ID, joined_timestamp: Option<u64>) -> User {
+        user_by_id(id, joined_timestamp)
+    }
+
+    #[graphql(entity)]
+    async fn find_product_by_upc(&self, upc: String) -> Product {
+        Product { upc, price: 0 }
+    }
+}
+
+fn user_by_id(id: ID, joined_timestamp: Option<u64>) -> User {
+    let review_count = match id.as_str() {
+        "1234" => 2,
+        "7777" => 1,
+        _ => 0,
+    };
+    // This will be set if the user requested the fields that require it.
+    let joined_timestamp = joined_timestamp.unwrap_or(9001);
+    User {
+        id,
+        review_count,
+        joined_timestamp,
+    }
+}

--- a/engine/crates/integration-tests/tests/federation/introspection.rs
+++ b/engine/crates/integration-tests/tests/federation/introspection.rs
@@ -34,12 +34,12 @@ fn can_run_pathfinder_introspection_query() {
       value: String!
     }
 
-    type Issue {
+    type Issue implements PullRequestOrIssue {
       author: UserOrBot!
       title: String!
     }
 
-    type PullRequest {
+    type PullRequest implements PullRequestOrIssue {
       author: UserOrBot!
       checks: [String!]!
       title: String!
@@ -368,9 +368,15 @@ fn supports_the_type_field() {
                             fields(includeDeprecated: true) {
                                 name
                             }
-                            interfaces
-                            possibleTypes
-                            enumValues
+                            interfaces {
+                                name
+                            }
+                            possibleTypes {
+                                name
+                            }
+                            enumValues {
+                                name
+                            }
                             inputFields {
                                 name
                             }
@@ -404,7 +410,9 @@ fn supports_the_type_field() {
           ],
           "inputFields": null,
           "interfaces": [
-            {}
+            {
+              "name": "PullRequestOrIssue"
+            }
           ],
           "kind": "OBJECT",
           "name": "PullRequest",

--- a/engine/crates/integration-tests/tests/federation/mod.rs
+++ b/engine/crates/integration-tests/tests/federation/mod.rs
@@ -1,2 +1,3 @@
 mod basic;
 mod introspection;
+mod subgraphs;

--- a/engine/crates/integration-tests/tests/federation/subgraphs/mod.rs
+++ b/engine/crates/integration-tests/tests/federation/subgraphs/mod.rs
@@ -1,0 +1,124 @@
+use engine_v2::Engine;
+use integration_tests::{
+    federation::EngineV2Ext,
+    mocks::graphql::{FakeFederationAccountsSchema, FakeFederationProductsSchema},
+    runtime, MockGraphQlServer,
+};
+
+#[test]
+fn root_fields_from_different_subgraphs() {
+    let response = runtime().block_on(async move {
+        let accounts = MockGraphQlServer::new(FakeFederationAccountsSchema).await;
+        let products = MockGraphQlServer::new(FakeFederationProductsSchema).await;
+
+        let engine = Engine::build()
+            .with_schema("accounts", &accounts)
+            .await
+            .with_schema("products", &products)
+            .await
+            .finish();
+
+        engine
+            .execute(
+                r"
+                query {
+                    me {
+                        id
+                        username
+                    }
+                    topProducts {
+                        name
+                        price
+                    }
+                }
+                ",
+            )
+            .await
+    });
+
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": {
+        "me": {
+          "id": "1234",
+          "username": "Me"
+        },
+        "topProducts": [
+          {
+            "name": "Trilby",
+            "price": 11
+          },
+          {
+            "name": "Fedora",
+            "price": 22
+          },
+          {
+            "name": "Boater",
+            "price": 33
+          }
+        ]
+      }
+    }
+    "###);
+}
+
+#[test]
+fn root_fragment_on_different_subgraphs() {
+    let response = runtime().block_on(async move {
+        let accounts = MockGraphQlServer::new(FakeFederationAccountsSchema).await;
+        let products = MockGraphQlServer::new(FakeFederationProductsSchema).await;
+
+        let engine = Engine::build()
+            .with_schema("accounts", &accounts)
+            .await
+            .with_schema("products", &products)
+            .await
+            .finish();
+
+        engine
+            .execute(
+                r"
+                query {
+                    ...Test
+                }
+
+                fragment Test on Query {
+                    me {
+                        id
+                        username
+                    }
+                    topProducts {
+                        name
+                        price
+                    }
+                }
+                ",
+            )
+            .await
+    });
+
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": {
+        "me": {
+          "id": "1234",
+          "username": "Me"
+        },
+        "topProducts": [
+          {
+            "name": "Trilby",
+            "price": 11
+          },
+          {
+            "name": "Fedora",
+            "price": 22
+          },
+          {
+            "name": "Boater",
+            "price": 33
+          }
+        ]
+      }
+    }
+    "###);
+}


### PR DESCRIPTION
Adding fake federation subgraphs and execute two tests on those with a few bug fixes.