### PR TITLE
fix custom resolver CI issue

### DIFF
--- a/.github/actions/sanitize/action.yml
+++ b/.github/actions/sanitize/action.yml
@@ -31,8 +31,13 @@ runs:
           --all-targets \
           --tests -- -D warnings
 
+    # https://github.com/actions/setup-node/issues/899
+    - name: Enable Corepack before setting up Node
+      shell: bash
+      run: corepack enable
+
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18
 

--- a/cli/crates/cli/tests/custom_resolvers.rs
+++ b/cli/crates/cli/tests/custom_resolvers.rs
@@ -263,7 +263,7 @@ enum JavaScriptPackageManager {
             "dependencies": {
                 "is-palindrome": "^0.3.0"
             },
-            "packageManager": "^yarn@1.22.0"
+            "packageManager": "yarn@1.22.0"
         }
     "#))
 )]


### PR DESCRIPTION
Fixing:
```
--- TRY 3 STDERR:        grafbase::custom_resolvers test_field_resolver::case_10::variant_2______grafbase___________ ---
error This project's package.json defines "packageManager": "yarn@^yarn@1.22.0". However the current global version of Yarn is 1.22.21.

Presence of the "packageManager" field indicates that the project is meant to be used with Corepack, a tool included by default with all official Node.js distributions starting from 16.9 and 14.19.
Corepack must currently be enabled by running corepack enable in your terminal. For more information, check out https://yarnpkg.com/corepack.
thread 'test_field_resolver::case_10::variant_2______grafbase___________' panicked at crates\cli\tests\custom_resolvers.rs:298:48:
should have succeeded: Custom { kind: Other, error: "command [\"C:\\\\npm\\\\prefix\\\\yarn.cmd\", \"install\"] exited with code 1" }
```