### PR TITLE
fix(postgres): On a local context, we want to cache connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,6 +2518,7 @@ dependencies = [
  "gateway-core",
  "graphql-extensions",
  "http",
+ "postgres-connector-types",
  "runtime",
  "runtime-local",
  "runtime-noop",

--- a/cli/crates/gateway/Cargo.toml
+++ b/cli/crates/gateway/Cargo.toml
@@ -33,6 +33,7 @@ runtime = { path = "../../../engine/crates/runtime" }
 runtime-local = { path = "../../../engine/crates/runtime-local" }
 runtime-noop = { path = "../../../engine/crates/runtime-noop" }
 common-types = { path = "../../../engine/crates/common-types" }
+postgres-connector-types = { path = "../../../engine/crates/postgres-connector-types" }
 
 [features]
 default = ["sqlite"]

--- a/cli/crates/server/src/errors.rs
+++ b/cli/crates/server/src/errors.rs
@@ -187,6 +187,9 @@ pub enum ServerError {
 
     #[error(transparent)]
     UdfBuildError(#[from] UdfBuildError),
+
+    #[error("Error in gateway initialization: {0}")]
+    GatewayError(String),
 }
 
 #[derive(Debug, Error)]

--- a/engine/crates/engine/src/registry/resolvers/postgres.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres.rs
@@ -69,11 +69,9 @@ impl PostgresResolver {
                     &self.directive_name
                 )))?;
 
-            let transport = pg_transport_factory
-                .try_new(&self.directive_name, database_definition)
-                .await?;
-
+            let transport = pg_transport_factory.fetch_cached(&self.directive_name)?;
             let context = PostgresContext::new(ctx, resolver_ctx, database_definition, transport).await?;
+
             request::execute(context, self.operation).await
         }))
     }

--- a/engine/crates/engine/src/registry/resolvers/postgres/context.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/context.rs
@@ -26,7 +26,7 @@ pub struct PostgresContext<'a> {
     context: &'a ContextField<'a>,
     resolver_context: &'a ResolverContext<'a>,
     database_definition: &'a DatabaseDefinition,
-    transport: Box<dyn Transport>,
+    transport: &'a dyn Transport,
 }
 
 impl<'a> PostgresContext<'a> {
@@ -34,7 +34,7 @@ impl<'a> PostgresContext<'a> {
         context: &'a ContextField<'a>,
         resolver_context: &'a ResolverContext<'a>,
         database_definition: &'a DatabaseDefinition,
-        transport: Box<dyn Transport>,
+        transport: &'a dyn Transport,
     ) -> Result<PostgresContext<'a>, Error> {
         Ok(Self {
             context,
@@ -182,7 +182,7 @@ impl<'a> PostgresContext<'a> {
 
     /// The database connection.
     pub fn transport(&self) -> &dyn Transport {
-        self.transport.as_ref()
+        self.transport
     }
 
     pub fn runtime_ctx(&self) -> Result<&runtime::Context, crate::Error> {

--- a/engine/crates/integration-tests/src/engine/builder.rs
+++ b/engine/crates/integration-tests/src/engine/builder.rs
@@ -79,7 +79,14 @@ impl EngineBuilder {
             .await
             .unwrap();
 
-        let registry = serde_json::from_value(serde_json::to_value(registry).unwrap()).unwrap();
+        let registry: Registry = serde_json::from_value(serde_json::to_value(registry).unwrap()).unwrap();
+
+        let mut postgres_transports = HashMap::new();
+
+        for (name, definition) in &registry.postgres_databases {
+            let transport = TcpTransport::new(definition.connection_string()).await.unwrap();
+            postgres_transports.insert(name.to_string(), transport);
+        }
 
         let mut schema_builder = Schema::build(registry)
             .data(QueryBatcher::new())
@@ -93,7 +100,9 @@ impl EngineBuilder {
                     request_log_event_id: None,
                 },
             ))
-            .data(runtime_local::LocalPgTransportFactory::runtime_factory());
+            .data(runtime_local::LocalPgTransportFactory::runtime_factory(Arc::new(
+                postgres_transports,
+            )));
 
         if self.local_dynamo {
             schema_builder = enable_local_dynamo(schema_builder).await;

--- a/engine/crates/runtime/src/pg.rs
+++ b/engine/crates/runtime/src/pg.rs
@@ -6,6 +6,8 @@ use postgres_connector_types::{database_definition::DatabaseDefinition, transpor
 pub enum PgTransportFactoryError {
     #[error("Transport creation error: {0}")]
     TransportCreation(#[from] postgres_connector_types::error::Error),
+    #[error("Transport not found for name: {0}")]
+    TransportNotFound(String),
 }
 
 pub type PgTransportFactoryResult<T> = std::result::Result<T, PgTransportFactoryError>;
@@ -17,6 +19,8 @@ pub trait PgTransportFactoryInner {
         name: &str,
         database_definition: &DatabaseDefinition,
     ) -> PgTransportFactoryResult<Box<dyn Transport>>;
+
+    fn fetch_cached(&self, name: &str) -> PgTransportFactoryResult<&dyn Transport>;
 }
 
 type BoxedPgTransportFactoryImpl = Box<dyn PgTransportFactoryInner + Send + Sync>;


### PR DESCRIPTION
# Description

This caches connections for postgres for local dev, storing them to a dumb hashmap. No pooling yet, but for quick and dirty dev runs this cuts hundreds of milliseconds from every query.

I seriously hope the factory changes don't hurt us in the API. We might want to have an extra command for a cached connections, if that is the case.