### PR TITLE
fix(deploy): Attempt at fixing GB-5429

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,7 +633,7 @@ dependencies = [
  "libc",
  "pin-project",
  "redox_syscall 0.2.16",
- "xattr",
+ "xattr 0.2.3",
 ]
 
 [[package]]
@@ -2730,6 +2730,7 @@ dependencies = [
  "reqwest-middleware",
  "serde",
  "serde_json",
+ "tar 0.4.40",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2801,7 +2802,7 @@ dependencies = [
  "strum",
  "tantivy",
  "tantivy-fst",
- "tar",
+ "tar 0.4.38",
  "tempfile",
  "thiserror",
  "tokio",
@@ -6962,7 +6963,18 @@ source = "git+https://github.com/obmarg/tar-rs.git?rev=bffee32190d531c03d806680d
 dependencies = [
  "filetime",
  "libc",
- "xattr",
+ "xattr 0.2.3",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr 1.0.1",
 ]
 
 [[package]]
@@ -8162,6 +8174,15 @@ name = "xattr"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "xattr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
 dependencies = [
  "libc",
 ]

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -29,6 +29,7 @@ reqwest = { version = "0.11", features = [
 reqwest-middleware = "0.2"
 serde = "1"
 serde_json = "1"
+tar = "0.4"
 tempfile = "3.4"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }

--- a/cli/crates/backend/src/project.rs
+++ b/cli/crates/backend/src/project.rs
@@ -1,7 +1,6 @@
 use crate::consts::{DEFAULT_DOT_ENV, DEFAULT_SCHEMA_FEDERATED, DEFAULT_SCHEMA_SINGLE, USER_AGENT};
 use crate::errors::BackendError;
 use async_compression::tokio::bufread::GzipDecoder;
-use async_tar::Archive;
 use common::consts::{
     GRAFBASE_DIRECTORY_NAME, GRAFBASE_ENV_FILE_NAME, GRAFBASE_SCHEMA_FILE_NAME, GRAFBASE_SDK_PACKAGE_NAME,
     GRAFBASE_SDK_PACKAGE_VERSION, GRAFBASE_TS_CONFIG_FILE_NAME,
@@ -387,7 +386,8 @@ async fn stream_github_archive<'a>(
 
     let tar_gz_reader = StreamReader::new(tar_gz_stream);
     let tar = GzipDecoder::new(tar_gz_reader);
-    let archive = Archive::new(tar.compat());
+
+    let archive = async_tar::Archive::new(tar.compat());
 
     let mut entries = archive.entries().map_err(|_| BackendError::ReadArchiveEntries)?;
 


### PR DESCRIPTION
# Description

Use [tar](https://crates.io/crates/tar) rather than [async-tar](https://crates.io/crates/async-tar) to create the archive that gets pushed as part of the `grafbase deploy` flow.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
