### PR TITLE
cli: fix cargo make `bump` script

### DIFF
--- a/cli/Makefile.toml
+++ b/cli/Makefile.toml
@@ -36,7 +36,7 @@ then
   echo "Error: '$VERSION' is not a valid semantic version" 1>&2
   exit 1
 fi
-cargo release version $VERSION --execute --no-confirm
+cargo release version $VERSION --execute --no-confirm -p grafbase
 cd npm/cli
 npm version --git-tag-version false $VERSION
 cd ../aarch64-unknown-linux-musl


### PR DESCRIPTION
# Description

It broke with yesterday's PR merging the two cargo workspaces. The solution is to upgrade only `grafbase` (the crate in `cli/crates/cli`). That cascades to bumping all crates that inherit the workspace version, which is the expected behaviour.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
