### PR TITLE
ci: skip buildjet cache on macos builds

### DIFF
--- a/.github/actions/init_rust_job/action.yml
+++ b/.github/actions/init_rust_job/action.yml
@@ -22,6 +22,7 @@ runs:
   steps:
     - name: Cargo cache
       uses: buildjet/cache@v3
+      if: inputs.platform != 'macos'
       continue-on-error: false
       with:
         key: ${{ inputs.cache-key }}


### PR DESCRIPTION
We suspect it causes the jobs to hang and fail sometimes.
