### PR TITLE
ci: try reverting to actions/cache@v3

### DIFF
--- a/.github/actions/init_rust_job/action.yml
+++ b/.github/actions/init_rust_job/action.yml
@@ -21,7 +21,7 @@ runs:
   using: 'composite'
   steps:
     - name: Cargo cache
-      uses: buildjet/cache@v3
+      uses: actions/cache@v3
       continue-on-error: false
       with:
         key: ${{ inputs.cache-key }}


### PR DESCRIPTION
We suspect there might be problems with the buildjet cache and macos builders
