### PR TITLE
feat(composition): implement entity interfaces

### DIFF
--- a/engine/crates/composition/src/compose/entity_interface.rs
+++ b/engine/crates/composition/src/compose/entity_interface.rs
@@ -1,0 +1,181 @@
+use super::*;
+use crate::composition_ir as ir;
+use std::collections::{BTreeMap, BTreeSet};
+
+pub(crate) fn merge_entity_interface_definitions(
+    ctx: &mut Context<'_>,
+    first: DefinitionWalker<'_>,
+    definitions: &[DefinitionWalker<'_>],
+) {
+    let interface_name = first.name();
+
+    let interface_defs = || definitions.iter().filter(|def| def.kind() == DefinitionKind::Interface);
+    let mut interfaces = interface_defs();
+
+    let Some(interface_def) = interfaces.next() else {
+        ctx.diagnostics.push_fatal(format!(
+            "The entity interface `{}` is not defined as an interface in any subgraph.",
+            interface_name.as_str()
+        ));
+        return;
+    };
+
+    // More than one interface in subgraphs.
+    if interfaces.next().is_some() {
+        let all_implementers: BTreeSet<_> = interface_defs()
+            .flat_map(|interface| {
+                interface
+                    .subgraph()
+                    .interface_implementers(interface_name.id)
+                    .map(|def| def.name().id)
+            })
+            .collect();
+
+        // All subsequent interfaces must have the same implementers.
+        for interface in interface_defs() {
+            let implementers: BTreeSet<_> = interface
+                .subgraph()
+                .interface_implementers(interface_name.id)
+                .map(|def| def.name().id)
+                .collect();
+
+            if implementers != all_implementers {
+                let subgraph_name = interface.subgraph().name().as_str();
+                let interface_name = interface_name.as_str();
+                let implementer_names = all_implementers
+                    .difference(&implementers)
+                    .map(|id| ctx.subgraphs.walk(*id).as_str())
+                    .join(", ");
+                ctx.diagnostics.push_fatal(format!(
+                r#"[{subgraph_name}]: Interface type "{interface_name}" has a resolvable key in subgraph "{subgraph_name}" but that subgraph is missing some of the supergraph implementation types of "{interface_name}". Subgraph "{subgraph_name}" should define types {implementer_names}."#
+                ));
+            }
+
+            if interface.is_interface_object() {
+                ctx.diagnostics.push_fatal(format!(
+                    "[{}] The @interfaceObject directive is not valid on interfaces (on `{}`).",
+                    interface.subgraph().name().as_str(),
+                    interface_name.as_str(),
+                ));
+            }
+        }
+    }
+
+    let interface_id = ctx.insert_interface(interface_name);
+
+    let mut fields = BTreeMap::new();
+
+    for field in interface_def.fields() {
+        fields.entry(field.name().id).or_insert_with(|| ir::FieldIr {
+            parent_name: interface_def.name().id,
+            field_name: field.name().id,
+            field_type: field.r#type().id,
+            arguments: field
+                .arguments()
+                .map(|arg| (arg.argument_name().id, arg.argument_type().id))
+                .collect(),
+            resolvable_in: None,
+            provides: Vec::new(),
+            requires: Vec::new(),
+            composed_directives: Vec::new(),
+        });
+    }
+
+    // All objects implementing that interface in the subgraph must have the same key.
+    let Some(expected_key) = interface_def.entity_keys().next() else {
+        ctx.diagnostics.push_fatal(format!(
+            "The entity interface `{}` is missing a key in the `{}` subgraph.",
+            interface_name.as_str(),
+            interface_def.subgraph().name().as_str(),
+        ));
+        return;
+    };
+
+    ctx.insert_interface_resolvable_key(interface_id, expected_key.id, false);
+
+    // Each object has to have @interfaceObject and the same key as the entity interface.
+    for definition in definitions.iter().filter(|def| def.kind() == DefinitionKind::Object) {
+        if !definition.is_interface_object() {
+            ctx.diagnostics.push_fatal(format!(
+                "`{}` is an entity interface but the object type `{}` is missing the @interfaceObject directive in the `{}` subgraph.",
+                definition.name().as_str(),
+                definition.name().as_str(),
+                definition.subgraph().name().as_str(),
+            ));
+        }
+
+        if definition.entity_keys().next().is_none() {
+            ctx.diagnostics.push_fatal(format!(
+                "The object type `{}` is annotated with @interfaceObject but missing a key in the `{}` subgraph.",
+                interface_name.as_str(),
+                definition.subgraph().name().as_str(),
+            ));
+        }
+
+        for entity_key in definition.entity_keys().filter(|key| key.is_resolvable()) {
+            ctx.insert_interface_resolvable_key(interface_id, entity_key.id, true);
+        }
+
+        for field in definition.fields() {
+            fields.entry(field.name().id).or_insert_with(|| ir::FieldIr {
+                parent_name: definition.name().id,
+                field_name: field.name().id,
+                field_type: field.r#type().id,
+                arguments: field
+                    .arguments()
+                    .map(|arg| (arg.argument_name().id, arg.argument_type().id))
+                    .collect(),
+                resolvable_in: Some(graphql_federated_graph::SubgraphId(definition.subgraph().id.idx())),
+                provides: Vec::new(),
+                requires: Vec::new(),
+                composed_directives: Vec::new(),
+            });
+        }
+    }
+
+    // Contribute the interface fields from the interface object definitions to the implementer of
+    // that interface.
+    for object in interface_def.subgraph().interface_implementers(interface_name.id) {
+        match object.entity_keys().next() {
+            Some(key) if key.fields() == expected_key.fields() => (),
+            Some(_) => ctx.diagnostics.push_fatal(format!(
+                "[{}] The object type `{}` is annotated with @interfaceObject but has a different key than the entity interface `{}`.",
+                object.subgraph().name().as_str(),
+                object.name().as_str(),
+                interface_name.as_str(),
+            )),
+            None => ctx.diagnostics.push_fatal(format!(
+                "[{}] The object type `{}` is annotated with @interfaceObject but missing a key.",
+                object.subgraph().name().as_str(),
+                object.name().as_str(),
+            )),
+        }
+
+        for ir::FieldIr {
+            parent_name: _,
+            field_name,
+            field_type,
+            arguments,
+            resolvable_in,
+            provides,
+            requires,
+            composed_directives,
+        } in fields.values()
+        {
+            ctx.insert_field(ir::FieldIr {
+                parent_name: object.name().id,
+                field_name: *field_name,
+                field_type: *field_type,
+                arguments: arguments.clone(),
+                resolvable_in: *resolvable_in,
+                provides: provides.clone(),
+                requires: requires.clone(),
+                composed_directives: composed_directives.clone(),
+            });
+        }
+    }
+
+    for field in fields.into_values() {
+        ctx.insert_field(field);
+    }
+}

--- a/engine/crates/composition/src/composition_ir.rs
+++ b/engine/crates/composition/src/composition_ir.rs
@@ -53,16 +53,17 @@ impl CompositionIr {
         id
     }
 
-    pub(crate) fn insert_interface(&mut self, iface_name: StringWalker<'_>) -> federated::InterfaceId {
-        let name = self.insert_string(iface_name);
-        let iface = federated::Interface {
+    pub(crate) fn insert_interface(&mut self, interface_name: StringWalker<'_>) -> federated::InterfaceId {
+        let name = self.insert_string(interface_name);
+        let interface = federated::Interface {
             name,
             implements_interfaces: Vec::new(),
+            resolvable_keys: Vec::new(),
             composed_directives: Vec::new(),
         };
-        let id = federated::InterfaceId(self.interfaces.push_return_idx(iface));
+        let id = federated::InterfaceId(self.interfaces.push_return_idx(interface));
         self.definitions_by_name
-            .insert(iface_name.id, federated::Definition::Interface(id));
+            .insert(interface_name.id, federated::Definition::Interface(id));
         id
     }
 
@@ -90,8 +91,17 @@ impl CompositionIr {
         id
     }
 
-    pub(crate) fn insert_resolvable_key(&mut self, object_id: federated::ObjectId, key_id: subgraphs::KeyId) {
-        self.resolvable_keys.push(KeyIr { object_id, key_id });
+    pub(crate) fn insert_resolvable_key(
+        &mut self,
+        parent: federated::Definition,
+        key_id: subgraphs::KeyId,
+        is_interface_object: bool,
+    ) {
+        self.resolvable_keys.push(KeyIr {
+            parent,
+            key_id,
+            is_interface_object,
+        });
     }
 
     pub(crate) fn insert_object(&mut self, object_name: StringWalker<'_>) -> federated::ObjectId {
@@ -164,10 +174,6 @@ impl CompositionIr {
         });
     }
 
-    pub(crate) fn insert_field(&mut self, ir: FieldIr) {
-        self.fields.push(ir);
-    }
-
     pub(crate) fn insert_union_member(&mut self, union_name: subgraphs::StringId, member_name: subgraphs::StringId) {
         self.union_members.insert((union_name, member_name));
     }
@@ -221,6 +227,7 @@ impl StringsIr {
 }
 
 pub(crate) struct KeyIr {
-    pub(crate) object_id: federated::ObjectId,
+    pub(crate) parent: federated::Definition,
     pub(crate) key_id: subgraphs::KeyId,
+    pub(crate) is_interface_object: bool,
 }

--- a/engine/crates/composition/src/emit_federated_graph.rs
+++ b/engine/crates/composition/src/emit_federated_graph.rs
@@ -45,7 +45,7 @@ pub(crate) fn emit_federated_graph(mut ir: CompositionIr, subgraphs: &Subgraphs)
 }
 
 fn emit_interface_impls(ctx: &mut Context<'_>) {
-    for (implementer, implementee) in ctx.subgraphs.iter_interface_impls() {
+    for (implementee, implementer) in ctx.subgraphs.iter_interface_impls() {
         let federated::Definition::Interface(implementee) = ctx.definitions[&implementee] else {
             continue;
         };
@@ -194,14 +194,29 @@ fn emit_union_members(ir_members: &BTreeSet<(subgraphs::StringId, subgraphs::Str
 }
 
 fn emit_keys(keys: &[KeyIr], ctx: &mut Context<'_>) {
-    for KeyIr { object_id, key_id } in keys {
-        let parent_id = federated::Definition::Object(*object_id);
+    for KeyIr {
+        parent,
+        key_id,
+        is_interface_object,
+    } in keys
+    {
         let key = ctx.subgraphs.walk(*key_id);
-        let selection = attach_selection(key.fields(), parent_id, ctx);
-        ctx.out[*object_id].resolvable_keys.push(federated::Key {
+        let selection = attach_selection(key.fields(), *parent, ctx);
+        let key = federated::Key {
             subgraph_id: federated::SubgraphId(key.parent_definition().subgraph().id.idx()),
             fields: selection,
-        });
+            is_interface_object: *is_interface_object,
+        };
+
+        match parent {
+            federated::Definition::Object(object_id) => {
+                ctx.out[*object_id].resolvable_keys.push(key);
+            }
+            federated::Definition::Interface(interface_id) => {
+                ctx.out[*interface_id].resolvable_keys.push(key);
+            }
+            _ => unreachable!("non-object, non-interface key parent"),
+        }
     }
 }
 

--- a/engine/crates/composition/src/ingest_subgraph.rs
+++ b/engine/crates/composition/src/ingest_subgraph.rs
@@ -48,7 +48,15 @@ fn ingest_top_level_definitions(
                         );
                     }
                     ast::TypeKind::Interface(_interface_type) => {
-                        subgraphs.push_definition(subgraph_id, type_name, DefinitionKind::Interface);
+                        let definition_id =
+                            subgraphs.push_definition(subgraph_id, type_name, DefinitionKind::Interface);
+
+                        object::ingest_directives(
+                            definition_id,
+                            &type_definition.node,
+                            subgraphs,
+                            federation_directives_matcher,
+                        );
                     }
                     ast::TypeKind::Union(_) => {
                         subgraphs.push_definition(subgraph_id, type_name, DefinitionKind::Union);

--- a/engine/crates/composition/src/ingest_subgraph/object.rs
+++ b/engine/crates/composition/src/ingest_subgraph/object.rs
@@ -22,6 +22,11 @@ pub(super) fn ingest_directives(
             continue;
         }
 
+        if federation_directives_matcher.is_interface_object(directive_name) {
+            subgraphs.set_interface_object(definition_id);
+            continue;
+        }
+
         if federation_directives_matcher.is_key(directive_name) {
             let fields_arg = directive.node.get_argument("fields").map(|v| &v.node);
             let Some(ConstValue::String(fields_arg)) = fields_arg else {

--- a/engine/crates/composition/src/ingest_subgraph/schema_definitions.rs
+++ b/engine/crates/composition/src/ingest_subgraph/schema_definitions.rs
@@ -44,6 +44,7 @@ pub(crate) struct FederationDirectivesMatcher<'a> {
     external: Cow<'a, str>,
     provides: Cow<'a, str>,
     requires: Cow<'a, str>,
+    interface_object: Cow<'a, str>,
 }
 
 const DEFAULT_FEDERATION_PREFIX: &str = "federation__";
@@ -56,6 +57,7 @@ impl Default for FederationDirectivesMatcher<'_> {
             external: Cow::Borrowed("external"),
             provides: Cow::Borrowed("provides"),
             requires: Cow::Borrowed("requires"),
+            interface_object: Cow::Borrowed("interfaceObject"),
         }
     }
 }
@@ -105,11 +107,16 @@ impl<'a> FederationDirectivesMatcher<'a> {
             external: final_name("external"),
             provides: final_name("provides"),
             requires: final_name("requires"),
+            interface_object: final_name("interfaceObject"),
         }
     }
 
     pub(crate) fn is_external(&self, directive_name: &str) -> bool {
         self.external == directive_name
+    }
+
+    pub(crate) fn is_interface_object(&self, directive_name: &str) -> bool {
+        self.interface_object == directive_name
     }
 
     pub(crate) fn is_shareable(&self, directive_name: &str) -> bool {

--- a/engine/crates/composition/src/subgraphs.rs
+++ b/engine/crates/composition/src/subgraphs.rs
@@ -73,12 +73,16 @@ impl Subgraphs {
     /// Iterate over groups of fields to compose. The fields are grouped by parent type name and
     /// field name. The argument is a closure that receives each group as an argument. The order of
     /// iteration is deterministic but unspecified.
-    pub(crate) fn iter_field_groups<'a>(&'a self, mut compose_fn: impl FnMut(&[FieldWalker<'a>])) {
+    pub(crate) fn iter_field_groups<'a>(
+        &'a self,
+        parent_name: StringId,
+        mut compose_fn: impl FnMut(&[FieldWalker<'a>]),
+    ) {
         let mut buf = Vec::new();
         for (_, group) in &self
             .field_names
-            .iter()
-            .group_by(|(parent_name, field_name, _)| (parent_name, field_name))
+            .range((parent_name, StringId::MIN, FieldId::MIN)..(parent_name, StringId::MAX, FieldId::MAX))
+            .group_by(|(_, field_name, _)| field_name)
         {
             buf.clear();
             buf.extend(group.into_iter().map(|(_, _, field_id)| self.walk(*field_id)));

--- a/engine/crates/composition/src/subgraphs/fields.rs
+++ b/engine/crates/composition/src/subgraphs/fields.rs
@@ -8,6 +8,11 @@ pub(crate) struct Fields(Vec<Field>);
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct FieldId(usize);
 
+impl FieldId {
+    pub const MIN: Self = Self(usize::MIN);
+    pub const MAX: Self = Self(usize::MAX);
+}
+
 /// A field in an object, interface or input object type.
 pub(super) struct Field {
     pub(super) parent_definition_id: DefinitionId,

--- a/engine/crates/composition/tests/composition/entity_interface_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_interface_basic/federated.graphql
@@ -1,0 +1,37 @@
+enum join__Graph {
+    FOREST @join__graph(name: "forest", url: "http://example.com/forest")
+    SAVANNA @join__graph(name: "savanna", url: "http://example.com/savanna")
+    STEPPE @join__graph(name: "steppe", url: "http://example.com/steppe")
+}
+
+type Squirrel {
+    favouriteFood: String @join__field(graph: FOREST)
+}
+
+type Cheetah implements Animal
+    @join__type(graph: SAVANNA, key: "species")
+{
+    species: String!
+    favouriteFood: String @join__field(graph: FOREST)
+    weightGrams: Int @join__field(graph: STEPPE)
+    species: String! @join__field(graph: SAVANNA)
+    topSpeed: Int! @join__field(graph: SAVANNA)
+}
+
+type Query {
+    getMammoth: Mammoth @join__field(graph: STEPPE)
+}
+
+type Mammoth {
+    tuskLength: Int @join__field(graph: STEPPE)
+}
+
+interface Animal
+    @join__type(graph: SAVANNA, key: "species")
+    @join__type(graph: FOREST, key: "species", isInterfaceObject: true)
+    @join__type(graph: STEPPE, key: "species", isInterfaceObject: true)
+{
+    species: String!
+    favouriteFood: String @join__field(graph: FOREST)
+    weightGrams: Int @join__field(graph: STEPPE)
+}

--- a/engine/crates/composition/tests/composition/entity_interface_basic/subgraphs/forest.graphql
+++ b/engine/crates/composition/tests/composition/entity_interface_basic/subgraphs/forest.graphql
@@ -1,0 +1,8 @@
+type Squirrel {
+  favouriteFood: String
+}
+
+type Animal @interfaceObject @key(fields: "species") {
+  species: String
+  favouriteFood: String
+}

--- a/engine/crates/composition/tests/composition/entity_interface_basic/subgraphs/savanna.graphql
+++ b/engine/crates/composition/tests/composition/entity_interface_basic/subgraphs/savanna.graphql
@@ -1,0 +1,8 @@
+interface Animal @key(fields: "species") {
+  species: String!
+}
+
+type Cheetah implements Animal @key(fields: "species") {
+  species: String!
+  topSpeed: Int!
+}

--- a/engine/crates/composition/tests/composition/entity_interface_basic/subgraphs/steppe.graphql
+++ b/engine/crates/composition/tests/composition/entity_interface_basic/subgraphs/steppe.graphql
@@ -1,0 +1,12 @@
+type Query {
+  getMammoth: Mammoth
+}
+
+type Animal @interfaceObject @key(fields: "species") {
+  species: String
+  weightGrams: Int
+}
+
+type Mammoth {
+  tuskLength: Int
+}

--- a/engine/crates/composition/tests/composition/entity_interface_compose_with_regular_object/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_interface_compose_with_regular_object/federated.graphql
@@ -1,0 +1,3 @@
+# The object type `Animal` is annotated with @interfaceObject but missing a key in the `forest` subgraph.
+# `Animal` is an entity interface but the object type `Animal` is missing the @interfaceObject directive in the `steppe` subgraph.
+# The object type `Animal` is annotated with @interfaceObject but missing a key in the `steppe` subgraph.

--- a/engine/crates/composition/tests/composition/entity_interface_compose_with_regular_object/subgraphs/forest.graphql
+++ b/engine/crates/composition/tests/composition/entity_interface_compose_with_regular_object/subgraphs/forest.graphql
@@ -1,0 +1,7 @@
+type Squirrel {
+  favouriteFood: String
+}
+
+type Animal @interfaceObject {
+  favouriteFood: String
+}

--- a/engine/crates/composition/tests/composition/entity_interface_compose_with_regular_object/subgraphs/savana.graphql
+++ b/engine/crates/composition/tests/composition/entity_interface_compose_with_regular_object/subgraphs/savana.graphql
@@ -1,0 +1,8 @@
+interface Animal @key(fields: "species") {
+  species: String!
+}
+
+type Cheetah implements Animal @key(fields: "species") {
+  species: String!
+  topSpeed: Int!
+}

--- a/engine/crates/composition/tests/composition/entity_interface_compose_with_regular_object/subgraphs/steppe.graphql
+++ b/engine/crates/composition/tests/composition/entity_interface_compose_with_regular_object/subgraphs/steppe.graphql
@@ -1,0 +1,13 @@
+type Query {
+  getMammoth: Mammoth
+}
+
+# Wrong: this is missing @interfaceObject
+type Animal {
+  weightGrams: Int
+}
+
+type Mammoth {
+  weightGrams: Int
+  tuskLength: Int
+}

--- a/engine/crates/composition/tests/composition/entity_interface_different_key/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_interface_different_key/federated.graphql
@@ -1,0 +1,1 @@
+# [savanna] The object type `Cheetah` is annotated with @interfaceObject but has a different key than the entity interface `Animal`.

--- a/engine/crates/composition/tests/composition/entity_interface_different_key/subgraphs/forest.graphql
+++ b/engine/crates/composition/tests/composition/entity_interface_different_key/subgraphs/forest.graphql
@@ -1,0 +1,8 @@
+type Squirrel {
+  favouriteFood: String
+}
+
+type Animal @interfaceObject @key(fields: "species") {
+  species: String!
+  favouriteFood: String
+}

--- a/engine/crates/composition/tests/composition/entity_interface_different_key/subgraphs/savanna.graphql
+++ b/engine/crates/composition/tests/composition/entity_interface_different_key/subgraphs/savanna.graphql
@@ -1,0 +1,10 @@
+interface Animal @key(fields: "species") {
+  species: String!
+}
+
+# Wrong: the key must be the same as the interface's
+type Cheetah implements Animal @key(fields: "id") {
+  id: ID!
+  species: String!
+  topSpeed: Int!
+}

--- a/engine/crates/composition/tests/composition/entity_interface_different_key/subgraphs/steppe.graphql
+++ b/engine/crates/composition/tests/composition/entity_interface_different_key/subgraphs/steppe.graphql
@@ -1,0 +1,15 @@
+type Query {
+  getMammoth: Mammoth
+}
+
+# Wrong: the key must match the entity interface's key in the other subgraph.
+type Animal @interfaceObject @key(fields: "taxon") {
+  species: String
+  taxon: String!
+  weightGrams: Int
+}
+
+type Mammoth {
+  weightGrams: Int
+  tuskLength: Int
+}

--- a/engine/crates/composition/tests/composition/entity_interface_implementer_missing_key/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_interface_implementer_missing_key/federated.graphql
@@ -1,0 +1,1 @@
+# [a] The object type `Fruit` is annotated with @interfaceObject but missing a key.

--- a/engine/crates/composition/tests/composition/entity_interface_implementer_missing_key/subgraphs/a.graphql
+++ b/engine/crates/composition/tests/composition/entity_interface_implementer_missing_key/subgraphs/a.graphql
@@ -1,0 +1,17 @@
+type Query {
+    groceryList: [GroceryItem]
+}
+
+interface GroceryItem @key(fields: "id") {
+  id: ID!
+  name: String
+  price: Int
+}
+
+# Invalid: this is missing the key.
+type Fruit implements GroceryItem {
+  id: ID!
+  name: String
+  price: Int
+  glycemicIndex: Int
+}

--- a/engine/crates/composition/tests/composition/entity_interface_only_interface_objects/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_interface_only_interface_objects/federated.graphql
@@ -1,0 +1,1 @@
+# The entity interface `Animal` is not defined as an interface in any subgraph.

--- a/engine/crates/composition/tests/composition/entity_interface_only_interface_objects/subgraphs/forest.graphql
+++ b/engine/crates/composition/tests/composition/entity_interface_only_interface_objects/subgraphs/forest.graphql
@@ -1,0 +1,7 @@
+type Squirrel {
+  favouriteFood: String
+}
+
+type Animal @interfaceObject {
+  favouriteFood: String
+}

--- a/engine/crates/composition/tests/composition/entity_interface_only_interface_objects/subgraphs/savana.graphql
+++ b/engine/crates/composition/tests/composition/entity_interface_only_interface_objects/subgraphs/savana.graphql
@@ -1,0 +1,8 @@
+type Animal @key(fields: "species") @interfaceObject {
+  species: String!
+}
+
+type Cheetah @key(fields: "species") {
+  species: String!
+  topSpeed: Int!
+}

--- a/engine/crates/composition/tests/composition/entity_interface_only_interface_objects/subgraphs/steppe.graphql
+++ b/engine/crates/composition/tests/composition/entity_interface_only_interface_objects/subgraphs/steppe.graphql
@@ -1,0 +1,12 @@
+type Query {
+  getMammoth: Mammoth
+}
+
+type Animal @interfaceObject {
+  weightGrams: Int
+}
+
+type Mammoth {
+  weightGrams: Int
+  tuskLength: Int
+}

--- a/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph/federated.graphql
@@ -1,0 +1,44 @@
+enum join__Graph {
+    FOREST @join__graph(name: "forest", url: "http://example.com/forest")
+    MANGROVE @join__graph(name: "mangrove", url: "http://example.com/mangrove")
+    SAVANA @join__graph(name: "savana", url: "http://example.com/savana")
+    STEPPE @join__graph(name: "steppe", url: "http://example.com/steppe")
+}
+
+type Squirrel {
+    favouriteFood: String @join__field(graph: FOREST)
+}
+
+type Cheetah implements Animal
+    @join__type(graph: MANGROVE, key: "species")
+    @join__type(graph: SAVANA, key: "species")
+{
+    species: String!
+    favouriteFood: String @join__field(graph: FOREST)
+    swimSpeedKmh: Float
+    weightGrams: Int @join__field(graph: STEPPE)
+    species: String!
+    swimSpeedKmh: Float @join__field(graph: MANGROVE)
+    runSpeedKmh: Float @join__field(graph: MANGROVE)
+    topSpeed: Int! @join__field(graph: SAVANA)
+}
+
+type Query {
+    getMammoth: Mammoth @join__field(graph: STEPPE)
+}
+
+type Mammoth {
+    weightGrams: Int @join__field(graph: STEPPE)
+    tuskLength: Int @join__field(graph: STEPPE)
+}
+
+interface Animal
+    @join__type(graph: MANGROVE, key: "species")
+    @join__type(graph: FOREST, key: "species", isInterfaceObject: true)
+    @join__type(graph: STEPPE, key: "species", isInterfaceObject: true)
+{
+    species: String!
+    favouriteFood: String @join__field(graph: FOREST)
+    swimSpeedKmh: Float
+    weightGrams: Int @join__field(graph: STEPPE)
+}

--- a/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph/subgraphs/forest.graphql
+++ b/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph/subgraphs/forest.graphql
@@ -1,0 +1,10 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@interfaceObject", "@key"])
+
+type Squirrel {
+  favouriteFood: String
+}
+
+type Animal @interfaceObject @key(fields: "species") {
+  species: String!
+  favouriteFood: String
+}

--- a/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph/subgraphs/mangrove.graphql
+++ b/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph/subgraphs/mangrove.graphql
@@ -1,0 +1,12 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@interfaceObject", "@key"])
+
+interface Animal @key(fields: "species") {
+  species: String!
+  swimSpeedKmh: Float
+}
+
+type Cheetah implements Animal @key(fields: "species") {
+  species: String!
+  swimSpeedKmh: Float
+  runSpeedKmh: Float
+}

--- a/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph/subgraphs/savana.graphql
+++ b/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph/subgraphs/savana.graphql
@@ -1,0 +1,10 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@interfaceObject", "@key"])
+
+interface Animal @key(fields: "species") {
+  species: String!
+}
+
+type Cheetah implements Animal @key(fields: "species") {
+  species: String!
+  topSpeed: Int!
+}

--- a/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph/subgraphs/steppe.graphql
+++ b/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph/subgraphs/steppe.graphql
@@ -1,0 +1,15 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@interfaceObject", "@key"])
+
+type Query {
+  getMammoth: Mammoth
+}
+
+type Animal @interfaceObject @key(fields: "species") {
+    species: String!
+  weightGrams: Int
+}
+
+type Mammoth {
+  weightGrams: Int
+  tuskLength: Int
+}

--- a/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph_missing_implementer/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph_missing_implementer/federated.graphql
@@ -1,0 +1,1 @@
+# [mangrove]: Interface type "Animal" has a resolvable key in subgraph "mangrove" but that subgraph is missing some of the supergraph implementation types of "Animal". Subgraph "mangrove" should define types Cheetah.

--- a/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph_missing_implementer/subgraphs/forest.graphql
+++ b/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph_missing_implementer/subgraphs/forest.graphql
@@ -1,0 +1,10 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@interfaceObject", "@key"])
+
+type Squirrel {
+  favouriteFood: String
+}
+
+type Animal @interfaceObject @key(fields: "species") {
+  species: String!
+  favouriteFood: String
+}

--- a/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph_missing_implementer/subgraphs/mangrove.graphql
+++ b/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph_missing_implementer/subgraphs/mangrove.graphql
@@ -1,0 +1,6 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@interfaceObject", "@key"])
+
+interface Animal @key(fields: "species") {
+  species: String!
+  swimSpeedKmh: Float
+}

--- a/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph_missing_implementer/subgraphs/savana.graphql
+++ b/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph_missing_implementer/subgraphs/savana.graphql
@@ -1,0 +1,10 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@interfaceObject", "@key"])
+
+interface Animal @key(fields: "species") {
+  species: String!
+}
+
+type Cheetah implements Animal @key(fields: "species") {
+  species: String!
+  topSpeed: Int!
+}

--- a/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph_missing_implementer/subgraphs/steppe.graphql
+++ b/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph_missing_implementer/subgraphs/steppe.graphql
@@ -1,0 +1,15 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@interfaceObject", "@key"])
+
+type Query {
+  getMammoth: Mammoth
+}
+
+type Animal @interfaceObject @key(fields: "species") {
+    species: String!
+  weightGrams: Int
+}
+
+type Mammoth {
+  weightGrams: Int
+  tuskLength: Int
+}

--- a/engine/crates/federated-graph/src/federated_graph.rs
+++ b/engine/crates/federated-graph/src/federated_graph.rs
@@ -79,6 +79,9 @@ pub struct Key {
 
     /// Corresponds to the fields in an `@key` directive.
     pub fields: FieldSet,
+
+    /// Correspond to the `@join__type(isInterfaceObject: true)` directive argument.
+    pub is_interface_object: bool,
 }
 
 pub type FieldSet = Vec<FieldSetItem>;
@@ -117,13 +120,13 @@ pub struct FieldArgument {
     pub type_id: FieldTypeId,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
 pub struct Directive {
     pub name: StringId,
     pub arguments: Vec<(StringId, Value)>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
 pub enum Value {
     String(StringId),
     Int(i64),
@@ -187,6 +190,9 @@ pub struct Interface {
     pub name: StringId,
 
     pub implements_interfaces: Vec<InterfaceId>,
+
+    /// All _resolvable_ keys, for entity interfaces.
+    pub resolvable_keys: Vec<Key>,
 
     /// All directives that made it through composition. Notably includes `@tag`.
     pub composed_directives: Vec<Directive>,

--- a/engine/crates/federated-graph/src/render_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl.rs
@@ -80,7 +80,26 @@ pub fn render_sdl(graph: &FederatedGraph) -> Result<String, fmt::Error> {
             }
         }
 
-        sdl.push_str(" {\n");
+        if interface.resolvable_keys.is_empty() {
+            sdl.push_str(" {\n");
+        } else {
+            sdl.push('\n');
+            for resolvable_key in &interface.resolvable_keys {
+                let selection_set = FieldSetDisplay(&resolvable_key.fields, graph);
+                let subgraph_name = GraphEnumVariantName(&graph[graph[resolvable_key.subgraph_id].name]);
+                let is_interface_object = if resolvable_key.is_interface_object {
+                    ", isInterfaceObject: true"
+                } else {
+                    ""
+                };
+                writeln!(
+                    sdl,
+                    r#"{INDENT}@join__type(graph: {subgraph_name}, key: "{selection_set}"{is_interface_object})"#
+                )?;
+            }
+
+            sdl.push_str("{\n");
+        }
 
         for field in graph
             .interface_fields


### PR DESCRIPTION
# Description

The implementation is pretty long, I would suggest getting familiar with
the docs and reading tests first to review.

This commit contains a change in control flow in how we compose fields
of objects. At a high level, the change here is the following:

- Before, we were iterating every object type in all subgraphs not
  thinking about their fields, then iterating all object fields in a
  second pass.
- Now, for every object, we iterate the fields for that object when
  composing the object in the first pass.

The reason for the previous behaviour was that we were expecting the second pass to need all the results from the first pass (e.g. to resolve field types), but it turns out we do well without, we don't really accumulate data during composition and composition IR is read only, which is a good property.

The reason for this change now is that for entity interfaces, we really want to compose the fields in a context where we know that we are dealing with fields that are part of an entity interface, so in this PR, we stop throwing away that context.

closes GB-5229

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
