### PR TITLE
chore: Version the federated graph to make breaking changes easier later

### DIFF
--- a/engine/crates/composition/src/emit_federated_graph.rs
+++ b/engine/crates/composition/src/emit_federated_graph.rs
@@ -13,7 +13,7 @@ use std::{collections::BTreeSet, mem};
 
 /// This can't fail. All the relevant, correct information should already be in the CompositionIr.
 pub(crate) fn emit_federated_graph(mut ir: CompositionIr, subgraphs: &Subgraphs) -> federated::FederatedGraph {
-    let mut out = federated::FederatedGraph {
+    let mut out = federated::FederatedGraphV1 {
         enums: mem::take(&mut ir.enums),
         objects: mem::take(&mut ir.objects),
         interfaces: mem::take(&mut ir.interfaces),
@@ -41,7 +41,7 @@ pub(crate) fn emit_federated_graph(mut ir: CompositionIr, subgraphs: &Subgraphs)
     emit_union_members(&ir.union_members, &mut ctx);
     emit_keys(&ir.resolvable_keys, &mut ctx);
 
-    out
+    federated::FederatedGraph::V1(out)
 }
 
 fn emit_interface_impls(ctx: &mut Context<'_>) {

--- a/engine/crates/composition/src/emit_federated_graph/context.rs
+++ b/engine/crates/composition/src/emit_federated_graph/context.rs
@@ -4,7 +4,7 @@ use graphql_federated_graph as federated;
 use std::collections::HashMap;
 
 pub(super) struct Context<'a> {
-    pub(super) out: &'a mut federated::FederatedGraph,
+    pub(super) out: &'a mut federated::FederatedGraphV1,
     pub(super) subgraphs: &'a subgraphs::Subgraphs,
     pub(super) definitions: HashMap<subgraphs::StringId, federated::Definition>,
     pub(super) field_types_map: FieldTypesMap,
@@ -17,7 +17,7 @@ impl<'a> Context<'a> {
     pub(crate) fn new(
         ir: &mut CompositionIr,
         subgraphs: &'a subgraphs::Subgraphs,
-        out: &'a mut federated::FederatedGraph,
+        out: &'a mut federated::FederatedGraphV1,
     ) -> Self {
         Context {
             out,

--- a/engine/crates/engine-v2/schema/src/conversion.rs
+++ b/engine/crates/engine-v2/schema/src/conversion.rs
@@ -6,6 +6,7 @@ use crate::introspection::Introspection;
 
 impl From<federated_graph::FederatedGraph> for Schema {
     fn from(graph: federated_graph::FederatedGraph) -> Self {
+        let federated_graph::FederatedGraph::V1(graph) = graph;
         let mut schema = Schema {
             description: None,
             data_sources: (0..graph.subgraphs.len())

--- a/engine/crates/federated-graph/src/federated_graph.rs
+++ b/engine/crates/federated-graph/src/federated_graph.rs
@@ -10,7 +10,7 @@
 ///
 /// - The ordering of items inside each `Vec`.
 #[derive(serde::Serialize, serde::Deserialize)]
-pub struct FederatedGraph {
+pub struct FederatedGraphV1 {
     pub subgraphs: Vec<Subgraph>,
 
     pub root_operation_types: RootOperationTypes,
@@ -41,9 +41,9 @@ pub struct RootOperationTypes {
     pub subscription: Option<ObjectId>,
 }
 
-impl std::fmt::Debug for FederatedGraph {
+impl std::fmt::Debug for FederatedGraphV1 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct(std::any::type_name::<FederatedGraph>()).finish()
+        f.debug_struct(std::any::type_name::<FederatedGraphV1>()).finish()
     }
 }
 
@@ -277,7 +277,7 @@ macro_rules! id_newtypes {
             #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
             pub struct $name(pub usize);
 
-            impl std::ops::Index<$name> for FederatedGraph {
+            impl std::ops::Index<$name> for FederatedGraphV1 {
                 type Output = $out;
 
                 fn index(&self, index: $name) -> &$out {
@@ -285,7 +285,7 @@ macro_rules! id_newtypes {
                 }
             }
 
-            impl std::ops::IndexMut<$name> for FederatedGraph {
+            impl std::ops::IndexMut<$name> for FederatedGraphV1 {
                 fn index_mut(&mut self, index: $name) -> &mut $out {
                     &mut self.$storage[index.0]
                 }

--- a/engine/crates/federated-graph/src/from_sdl.rs
+++ b/engine/crates/federated-graph/src/from_sdl.rs
@@ -1,4 +1,4 @@
-use crate::federated_graph::*;
+use crate::{federated_graph::*, FederatedGraph};
 use async_graphql_parser::{types as ast, Positioned};
 use indexmap::IndexSet;
 use std::{collections::HashMap, error::Error as StdError, fmt};
@@ -111,7 +111,7 @@ pub fn from_sdl(sdl: &str) -> Result<FederatedGraph, DomainError> {
     // This needs to happen after all fields have been ingested, in order to attach selection sets.
     ingest_selection_sets(&parsed, &mut state)?;
 
-    Ok(FederatedGraph {
+    Ok(FederatedGraph::V1(FederatedGraphV1 {
         subgraphs: state.subgraphs,
         root_operation_types: RootOperationTypes {
             query: state
@@ -131,7 +131,7 @@ pub fn from_sdl(sdl: &str) -> Result<FederatedGraph, DomainError> {
         input_objects: state.input_objects,
         strings: state.strings.into_iter().collect(),
         field_types: state.field_types.into_iter().collect(),
-    })
+    }))
 }
 
 fn ingest_fields<'a>(parsed: &'a ast::ServiceDocument, state: &mut State<'a>) -> Result<(), DomainError> {

--- a/engine/crates/federated-graph/src/lib.rs
+++ b/engine/crates/federated-graph/src/lib.rs
@@ -13,3 +13,8 @@ mod from_sdl;
 
 #[cfg(feature = "from_sdl")]
 pub use from_sdl::from_sdl;
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum FederatedGraph {
+    V1(FederatedGraphV1),
+}


### PR DESCRIPTION
Changes `FederatedGraph` to be:
```rust
pub enum FederatedGraph {
    V1(FederatedGraphV1),
}
```
It's not perfect, but it's a lot better than nothing when we'll break things.