### PR TITLE
cli: improve logged output of federated dev

### DIFF
--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -49,8 +49,8 @@ pub fn start_dev_server(resolvers_reported: bool, port: u16, start_port: u16) {
 pub fn start_federated_dev_server(port: u16) {
     println!("📡 Listening on port {}\n", watercolor!("{port}", @BrightBlue));
     println!(
-        "Use {} to add subgraphs to the server\n",
-        watercolor!("gb publish --dev", @BrightBlue)
+        "Run {} to add subgraphs to the federated graph\n",
+        watercolor!("grafbase publish --dev", @BrightBlue)
     );
     println!(
         "- Pathfinder: {}",
@@ -440,6 +440,20 @@ pub(crate) fn schema_command_success(schema: Option<&str>) {
 
 pub(crate) fn publishing() {
     println!("⏳ Publishing...");
+}
+
+pub(crate) fn local_publish_command_failure(subgraph_name: &str, composition_errors: &str) {
+    println!("❌ Publish failed: could not compose subgraph {subgraph_name} with the other subgraphs. Errors:\n{composition_errors}",
+        subgraph_name = watercolor!("{subgraph_name}", @BrightBlue)
+
+             );
+}
+
+pub(crate) fn local_publish_command_success(subgraph_name: &str) {
+    println!(
+        "💾 Successfully published subgraph {} to the registry and composed",
+        watercolor!("{subgraph_name}", @BrightBlue)
+    );
 }
 
 pub(crate) fn publish_command_success(subgraph_name: &str) {

--- a/cli/crates/federated-dev/src/dev/bus/message.rs
+++ b/cli/crates/federated-dev/src/dev/bus/message.rs
@@ -8,11 +8,15 @@ use url::Url;
 
 pub(crate) type ResponseSender<T> = oneshot::Sender<Result<T, Error>>;
 
+pub(crate) enum RecomposeDescription {
+    Removed(String),
+}
+
 pub(crate) enum ComposeMessage {
     Introspect(IntrospectSchema),
     Compose(ComposeSchema),
     RemoveSubgraph(RemoveSubgraph),
-    Recompose,
+    Recompose(RecomposeDescription),
     InitializeRefresh,
 }
 

--- a/cli/crates/federated-dev/src/dev/router.rs
+++ b/cli/crates/federated-dev/src/dev/router.rs
@@ -45,7 +45,7 @@ impl Router {
                     tokio::spawn(run_request(request, response_sender, Arc::clone(engine)));
                 }
                 (RouterMessage::Request(_, response_sender), None) => {
-                    log::trace!("router got a new request with a missingengine");
+                    log::trace!("router got a new request with a missing engine");
 
                     response_sender.send(Err(RouterError::NoSubgraphs)).ok();
                 }


### PR DESCRIPTION
The output messages fall in two categories:

- In the federated dev process output
  + We now log the outcome of composition (success/failure) whenever a subgraph is added or removed from the federated graph.
- The `publish` output
  + Improved rendering of composition errors on publish
  + New message when publish succeeds

closes GB-5513
closes GB-5514
closes GB-5515
closes GB-5516

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
