### PR TITLE
composition: implement description composition

### DIFF
--- a/engine/crates/composition/src/compose.rs
+++ b/engine/crates/composition/src/compose.rs
@@ -82,7 +82,9 @@ fn merge_object_definitions<'a>(
         ));
     }
 
-    let object_id = ctx.insert_object(first.name(), is_inaccessible);
+    let description = definitions.iter().find_map(|def| def.description());
+
+    let object_id = ctx.insert_object(first.name(), is_inaccessible, description);
 
     for key in definitions
         .iter()
@@ -105,7 +107,8 @@ fn merge_union_definitions(
 ) {
     let union_name = first_union.name();
     let is_inaccessible = definitions.iter().any(|definition| definition.is_inaccessible());
-    ctx.insert_union(union_name, is_inaccessible);
+    let description = definitions.iter().find_map(|def| def.description());
+    ctx.insert_union(union_name, is_inaccessible, description);
 
     for member in definitions
         .iter()

--- a/engine/crates/composition/src/compose/entity_interface.rs
+++ b/engine/crates/composition/src/compose/entity_interface.rs
@@ -61,7 +61,8 @@ pub(crate) fn merge_entity_interface_definitions(
         }
     }
 
-    let interface_id = ctx.insert_interface(interface_name, is_inaccessible);
+    let description = interface_def.description();
+    let interface_id = ctx.insert_interface(interface_name, is_inaccessible, description);
 
     let mut fields = BTreeMap::new();
 
@@ -90,6 +91,7 @@ pub(crate) fn merge_entity_interface_definitions(
             requires: Vec::new(),
             composed_directives: Vec::new(),
             overrides: Vec::new(),
+            description: field.description().map(|description| ctx.insert_string(description.id)),
         });
     }
 
@@ -129,6 +131,7 @@ pub(crate) fn merge_entity_interface_definitions(
         }
 
         for field in definition.fields() {
+            let description = field.description().map(|description| ctx.insert_string(description.id));
             fields.entry(field.name().id).or_insert_with(|| ir::FieldIr {
                 parent_name: definition.name().id,
                 field_name: field.name().id,
@@ -153,6 +156,7 @@ pub(crate) fn merge_entity_interface_definitions(
                 requires: Vec::new(),
                 composed_directives: Vec::new(),
                 overrides: Vec::new(),
+                description,
             });
         }
     }
@@ -185,6 +189,7 @@ pub(crate) fn merge_entity_interface_definitions(
             requires,
             composed_directives,
             overrides,
+            description,
         } in fields.values()
         {
             ctx.insert_field(ir::FieldIr {
@@ -197,6 +202,7 @@ pub(crate) fn merge_entity_interface_definitions(
                 requires: requires.clone(),
                 composed_directives: composed_directives.clone(),
                 overrides: overrides.clone(),
+                description: *description,
             });
         }
     }

--- a/engine/crates/composition/src/compose/enums.rs
+++ b/engine/crates/composition/src/compose/enums.rs
@@ -60,6 +60,7 @@ fn merge_intersection(
     is_inaccessible: bool,
     ctx: &mut Context<'_>,
 ) {
+    let description = definitions.iter().find_map(|def| def.description());
     let mut intersection: Vec<StringId> = first.enum_values().collect();
     let mut scratch = HashSet::new();
 
@@ -76,11 +77,11 @@ fn merge_intersection(
         ));
     }
 
-    let enum_id = ctx.insert_enum(first.name(), is_inaccessible);
+    let enum_id = ctx.insert_enum(first.name(), is_inaccessible, description);
 
     for value in intersection {
         let deprecation = ctx.subgraphs.get_enum_value_deprecation((first.name().id, value));
-        ctx.insert_enum_value(enum_id, first.walk(value), deprecation);
+        ctx.insert_enum_value(enum_id, first.walk(value), deprecation, None);
     }
 }
 
@@ -90,11 +91,12 @@ fn merge_union(
     is_inaccessible: bool,
     ctx: &mut Context<'_>,
 ) {
-    let enum_id = ctx.insert_enum(first.name(), is_inaccessible);
+    let description = definitions.iter().find_map(|def| def.description());
+    let enum_id = ctx.insert_enum(first.name(), is_inaccessible, description);
 
     for value in definitions.iter().flat_map(|def| def.enum_values()) {
         let deprecation = ctx.subgraphs.get_enum_value_deprecation((first.name().id, value));
-        ctx.insert_enum_value(enum_id, first.walk(value), deprecation);
+        ctx.insert_enum_value(enum_id, first.walk(value), deprecation, None);
     }
 }
 
@@ -116,11 +118,12 @@ fn merge_exactly_matching(
         }
     }
 
-    let enum_id = ctx.insert_enum(first.name(), is_inaccessible);
+    let description = definitions.iter().find_map(|def| def.description());
+    let enum_id = ctx.insert_enum(first.name(), is_inaccessible, description);
 
     for value in expected {
         let deprecation = ctx.subgraphs.get_enum_value_deprecation((first.name().id, value));
-        ctx.insert_enum_value(enum_id, first.walk(value), deprecation);
+        ctx.insert_enum_value(enum_id, first.walk(value), deprecation, None);
     }
 }
 

--- a/engine/crates/composition/src/compose/interface.rs
+++ b/engine/crates/composition/src/compose/interface.rs
@@ -11,15 +11,17 @@ pub(super) fn merge_interface_definitions(
 ) {
     let mut all_fields: indexmap::IndexMap<StringId, FieldId> = indexmap::IndexMap::new();
     let is_inaccessible = definitions.iter().any(|definition| definition.is_inaccessible());
+    let interface_description = definitions.iter().find_map(|def| def.description());
 
     for field in definitions.iter().flat_map(|def| def.fields()) {
         all_fields.entry(field.name().id).or_insert(field.id);
     }
 
-    ctx.insert_interface(first.name(), is_inaccessible);
+    ctx.insert_interface(first.name(), is_inaccessible, interface_description);
 
     for field in all_fields.values() {
         let field = first.walk(*field);
+        let description = field.description().map(|description| ctx.insert_string(description.id));
         ctx.insert_field(ir::FieldIr {
             parent_name: first.name().id,
             field_name: field.name().id,
@@ -30,6 +32,7 @@ pub(super) fn merge_interface_definitions(
             requires: Vec::new(),
             composed_directives: Vec::new(),
             overrides: Vec::new(),
+            description,
         });
     }
 }

--- a/engine/crates/composition/src/compose/object.rs
+++ b/engine/crates/composition/src/compose/object.rs
@@ -179,6 +179,9 @@ pub(super) fn compose_object_fields<'a>(first: FieldWalker<'a>, fields: &[FieldW
     }
 
     let overrides = collect_overrides(fields, ctx);
+    let description = fields
+        .iter()
+        .find_map(|f| f.description().map(|d| ctx.insert_string(d.id)));
 
     ctx.insert_field(ir::FieldIr {
         parent_name: first.parent_definition().name().id,
@@ -190,6 +193,7 @@ pub(super) fn compose_object_fields<'a>(first: FieldWalker<'a>, fields: &[FieldW
         requires,
         composed_directives,
         overrides,
+        description,
     });
 }
 

--- a/engine/crates/composition/src/compose/scalar.rs
+++ b/engine/crates/composition/src/compose/scalar.rs
@@ -6,6 +6,7 @@ pub(crate) fn merge_scalar_definitions(
     ctx: &mut Context<'_>,
 ) {
     let is_inaccessible = definitions.iter().any(|definition| definition.is_inaccessible());
+    let description = definitions.iter().find_map(|def| def.description());
 
-    ctx.insert_scalar(first.name(), is_inaccessible);
+    ctx.insert_scalar(first.name(), is_inaccessible, description);
 }

--- a/engine/crates/composition/src/emit_federated_graph.rs
+++ b/engine/crates/composition/src/emit_federated_graph.rs
@@ -90,6 +90,7 @@ fn emit_fields<'a>(ir_fields: Vec<FieldIr>, ctx: &mut Context<'a>) {
         requires,
         composed_directives,
         overrides,
+        description,
     } in ir_fields
     {
         let field_type_id = ctx.insert_field_type(ctx.subgraphs.walk(field_type));
@@ -100,6 +101,7 @@ fn emit_fields<'a>(ir_fields: Vec<FieldIr>, ctx: &mut Context<'a>) {
                 name: ctx.insert_string(ctx.subgraphs.walk(argument.argument_name)),
                 type_id: ctx.insert_field_type(ctx.subgraphs.walk(argument.argument_type)),
                 composed_directives: argument.composed_directives.clone(),
+                description,
             })
             .collect();
 
@@ -115,6 +117,7 @@ fn emit_fields<'a>(ir_fields: Vec<FieldIr>, ctx: &mut Context<'a>) {
                     requires: Vec::new(),
                     resolvable_in,
                     composed_directives,
+                    description,
                 };
 
                 let id = federated::FieldId(ctx.out.fields.push_return_idx(field));
@@ -161,6 +164,7 @@ fn emit_fields<'a>(ir_fields: Vec<FieldIr>, ctx: &mut Context<'a>) {
                     name: field_name,
                     field_type_id,
                     composed_directives,
+                    description,
                 });
             }
             _ => unreachable!(),

--- a/engine/crates/composition/src/ingest_subgraph.rs
+++ b/engine/crates/composition/src/ingest_subgraph.rs
@@ -39,22 +39,32 @@ fn ingest_top_level_definitions(
         match definition {
             ast::TypeSystemDefinition::Type(type_definition) => {
                 let type_name = &type_definition.node.name.node;
+                let description = type_definition
+                    .node
+                    .description
+                    .as_ref()
+                    .map(|description| subgraphs.strings.intern(description.node.as_str()));
                 let definition_id = match &type_definition.node.kind {
                     ast::TypeKind::Object(_) => {
-                        subgraphs.push_definition(subgraph_id, type_name, DefinitionKind::Object)
+                        subgraphs.push_definition(subgraph_id, type_name, DefinitionKind::Object, description)
                     }
                     ast::TypeKind::Interface(_interface_type) => {
-                        subgraphs.push_definition(subgraph_id, type_name, DefinitionKind::Interface)
+                        subgraphs.push_definition(subgraph_id, type_name, DefinitionKind::Interface, description)
                     }
-                    ast::TypeKind::Union(_) => subgraphs.push_definition(subgraph_id, type_name, DefinitionKind::Union),
+                    ast::TypeKind::Union(_) => {
+                        subgraphs.push_definition(subgraph_id, type_name, DefinitionKind::Union, description)
+                    }
                     ast::TypeKind::InputObject(_) => {
-                        subgraphs.push_definition(subgraph_id, type_name, DefinitionKind::InputObject)
+                        subgraphs.push_definition(subgraph_id, type_name, DefinitionKind::InputObject, description)
                     }
 
-                    ast::TypeKind::Scalar => subgraphs.push_definition(subgraph_id, type_name, DefinitionKind::Scalar),
+                    ast::TypeKind::Scalar => {
+                        subgraphs.push_definition(subgraph_id, type_name, DefinitionKind::Scalar, description)
+                    }
 
                     ast::TypeKind::Enum(enum_type) => {
-                        let definition_id = subgraphs.push_definition(subgraph_id, type_name, DefinitionKind::Enum);
+                        let definition_id =
+                            subgraphs.push_definition(subgraph_id, type_name, DefinitionKind::Enum, description);
                         enums::ingest_enum(definition_id, enum_type, subgraphs);
                         definition_id
                     }
@@ -98,6 +108,11 @@ fn ingest_definition_bodies(
                     let field_type = subgraphs.intern_field_type(&field.node.ty.node);
                     let deprecated = find_deprecated_directive(&field.node.directives, subgraphs);
                     let tags = find_tag_directives(&field.node.directives);
+                    let description = field
+                        .node
+                        .description
+                        .as_ref()
+                        .map(|description| subgraphs.strings.intern(description.node.as_str()));
                     subgraphs
                         .push_field(subgraphs::FieldIngest {
                             parent_definition_id: definition_id,
@@ -114,6 +129,7 @@ fn ingest_definition_bodies(
                             overrides: None,
                             deprecated,
                             tags,
+                            description,
                         })
                         .unwrap();
                 }
@@ -131,6 +147,11 @@ fn ingest_definition_bodies(
                     let field_type = subgraphs.intern_field_type(&field.node.ty.node);
                     let tags = find_tag_directives(&field.node.directives);
                     let deprecated = find_deprecated_directive(&field.node.directives, subgraphs);
+                    let description = field
+                        .node
+                        .description
+                        .as_ref()
+                        .map(|description| subgraphs.strings.intern(description.node.as_str()));
                     subgraphs
                         .push_field(subgraphs::FieldIngest {
                             parent_definition_id: definition_id,
@@ -147,6 +168,7 @@ fn ingest_definition_bodies(
                             overrides: None,
                             deprecated,
                             tags,
+                            description,
                         })
                         .unwrap();
                 }

--- a/engine/crates/composition/src/ingest_subgraph/object.rs
+++ b/engine/crates/composition/src/ingest_subgraph/object.rs
@@ -58,6 +58,11 @@ pub(super) fn ingest_fields(
                 _ => None,
             });
 
+        let description = field
+            .description
+            .as_ref()
+            .map(|description| subgraphs.strings.intern(description.node.as_str()));
+
         let deprecated = super::find_deprecated_directive(&field.directives, subgraphs);
         let overrides = find_override_directive(&field.directives, subgraphs, federation_directives_matcher);
         let tags = super::find_tag_directives(&field.directives);
@@ -75,6 +80,7 @@ pub(super) fn ingest_fields(
                 deprecated,
                 tags,
                 overrides,
+                description,
             })
             .unwrap();
 

--- a/engine/crates/composition/src/subgraphs/definitions.rs
+++ b/engine/crates/composition/src/subgraphs/definitions.rs
@@ -16,6 +16,7 @@ pub(crate) struct Definition {
     subgraph_id: SubgraphId,
     name: StringId,
     kind: DefinitionKind,
+    description: Option<StringId>,
     is_shareable: bool,
     is_external: bool,
     is_inaccessible: bool,
@@ -67,12 +68,14 @@ impl Subgraphs {
         subgraph_id: SubgraphId,
         name: &str,
         kind: DefinitionKind,
+        description: Option<StringId>,
     ) -> DefinitionId {
         let name = self.strings.intern(name);
         let definition = Definition {
             subgraph_id,
             name,
             kind,
+            description,
             is_shareable: false,
             is_external: false,
             is_inaccessible: false,
@@ -103,6 +106,19 @@ impl<'a> DefinitionWalker<'a> {
 
     pub fn kind(self) -> DefinitionKind {
         self.definition().kind
+    }
+
+    /// ```graphql,ignore
+    /// """
+    /// The root query type.
+    /// """
+    /// ^^^^^^^^^^^^^^^^^^^^
+    /// type Query {
+    ///   # ...
+    /// }
+    /// ```
+    pub fn description(self) -> Option<StringWalker<'a>> {
+        self.definition().description.map(|id| self.walk(id))
     }
 
     pub fn is_interface_object(self) -> bool {

--- a/engine/crates/composition/src/subgraphs/fields.rs
+++ b/engine/crates/composition/src/subgraphs/fields.rs
@@ -30,6 +30,8 @@ pub(super) struct Field {
 
     // @tag
     tags: Vec<StringId>,
+
+    description: Option<StringId>,
 }
 
 /// Corresponds to an `@deprecated` directive.
@@ -57,6 +59,7 @@ impl Subgraphs {
             deprecated,
             tags,
             overrides,
+            description,
         }: FieldIngest<'_>,
     ) -> Result<FieldId, String> {
         let provides = provides
@@ -85,6 +88,7 @@ impl Subgraphs {
             deprecated,
             tags,
             overrides,
+            description,
         };
         let id = FieldId(self.fields.0.push_return_idx(field));
         let parent_object_name = self.walk(parent_definition_id).name().id;
@@ -127,6 +131,7 @@ pub(crate) struct FieldIngest<'a> {
     pub(crate) requires: Option<&'a str>,
     pub(crate) deprecated: Option<Deprecation>,
     pub(crate) tags: Vec<&'a str>,
+    pub(crate) description: Option<StringId>,
 
     /// The @override(from: ...) directive.
     pub(crate) overrides: Option<StringId>,
@@ -148,6 +153,10 @@ impl<'a> FieldWalker<'a> {
     /// ```
     pub(crate) fn arguments(self) -> impl Iterator<Item = ArgumentWalker<'a>> {
         self.field().arguments.iter().map(move |id| self.walk(*id))
+    }
+
+    pub(crate) fn description(self) -> Option<StringWalker<'a>> {
+        self.field().description.map(|id| self.walk(id))
     }
 
     /// The contents of the `@deprecated` directive. `None` in the absence of directive,

--- a/engine/crates/composition/tests/composition/descriptions_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/descriptions_basic/federated.graphql
@@ -1,0 +1,160 @@
+directive @core(feature: String!) repeatable on SCHEMA
+
+directive @join__owner(graph: join__Graph!) on OBJECT
+
+directive @join__type(
+    graph: join__Graph!
+    key: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__field(
+    graph: join__Graph
+    requires: String
+    provides: String
+) on FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+enum join__Graph {
+    SELFEXPLANATORYTOFU @join__graph(name: "selfExplanatoryTofu", url: "http://example.com/selfExplanatoryTofu")
+    TOFU @join__graph(name: "tofu", url: "http://example.com/tofu")
+}
+
+"""
+Custom scalar to represent the texture profile of tofu.
+"""
+scalar TextureProfile
+
+"""
+The Tofu type represents various properties of tofu.
+"""
+type Tofu {
+    """
+    The unique ID of the tofu.
+    """
+    id: ID!
+    """
+    The name of the tofu.
+    """
+    name: String!
+    """
+    The type of tofu (e.g., silken, firm).
+    """
+    type: TofuType
+    """
+    Nutritional information about the tofu.
+    """
+    nutrition: Nutrition
+    """
+    List of recipes that include this tofu.
+    """
+    recipes(filter: RecipeFilter): [Recipe]
+    """
+    The texture profile of the tofu, expressed through a custom scalar.
+    """
+    texture: TextureProfile
+}
+
+"""
+Nutritional information for tofu.
+"""
+type Nutrition {
+    """
+    The amount of calories per serving.
+    """
+    calories: Int
+    """
+    The amount of protein per serving.
+    """
+    protein: Float
+    """
+    Total fat content per serving.
+    """
+    fat: Float
+}
+
+"""
+A recipe that includes tofu as an ingredient.
+"""
+type Recipe {
+    """
+    The unique ID of the recipe.
+    """
+    id: ID!
+    """
+    The name of the recipe.
+    """
+    name: String!
+    """
+    Description of the recipe.
+    """
+    description: String
+    """
+    The main type of tofu used in this recipe.
+    """
+    tofuType: TofuType
+    """
+    The ingredients used in the recipe, including tofu.
+    """
+    ingredients: [FoodItem]
+}
+
+"""
+Vegetable type used in tofu recipes.
+"""
+type Vegetable {
+    """
+    Name of the vegetable.
+    """
+    name: String
+    """
+    Nutritional information of the vegetable.
+    """
+    nutrition: Nutrition
+}
+
+"""
+Spice type used in tofu recipes.
+"""
+type Spice {
+    """
+    Name of the spice.
+    """
+    name: String
+    """
+    Description of the spice's flavor.
+    """
+    flavorDescription: String
+}
+
+type Query {
+    allTheTofus: [Tofu] @join__field(graph: TOFU)
+}
+
+"""
+Defines different types of tofu.
+"""
+enum TofuType {
+    SILKEN
+    FIRM
+    EXTRA_FIRM
+}
+
+"""
+Union representing different food items that can be part of a recipe.
+"""
+union FoodItem = Tofu | Vegetable | Spice
+
+"""
+Filter criteria for tofu recipes.
+"""
+input RecipeFilter {
+    """
+    Minimum required protein content.
+    """
+    minProtein: Float
+    """
+    Maximum allowed calorie count.
+    """
+    maxCalories: Int
+}

--- a/engine/crates/composition/tests/composition/descriptions_basic/subgraphs/selfExplanatoryTofu.graphql
+++ b/engine/crates/composition/tests/composition/descriptions_basic/subgraphs/selfExplanatoryTofu.graphql
@@ -1,0 +1,47 @@
+type Tofu @shareable {
+  id: ID!
+  name: String!
+  type: TofuType
+  nutrition: Nutrition
+  recipes(filter: RecipeFilter): [Recipe]
+  texture: TextureProfile
+}
+
+type Nutrition @shareable {
+  calories: Int
+  protein: Float
+  fat: Float
+}
+
+enum TofuType {
+  SILKEN
+  FIRM
+  EXTRA_FIRM
+}
+
+input RecipeFilter {
+  minProtein: Float
+  maxCalories: Int
+}
+
+type Recipe @shareable {
+  id: ID!
+  name: String!
+  description: String
+  tofuType: TofuType
+  ingredients: [FoodItem]
+}
+
+scalar TextureProfile
+
+union FoodItem = Tofu | Vegetable | Spice
+
+type Vegetable @shareable {
+  name: String
+  nutrition: Nutrition
+}
+
+type Spice @shareable {
+  name: String
+  flavorDescription: String
+}

--- a/engine/crates/composition/tests/composition/descriptions_basic/subgraphs/tofu.graphql
+++ b/engine/crates/composition/tests/composition/descriptions_basic/subgraphs/tofu.graphql
@@ -1,0 +1,181 @@
+"""
+The Tofu type represents various properties of tofu.
+"""
+type Tofu @shareable {
+  """
+  The unique ID of the tofu.
+  """
+  id: ID!
+
+  """
+  The name of the tofu.
+  """
+  name: String!
+
+  """
+  The type of tofu (e.g., silken, firm).
+  """
+  type: TofuType
+
+  """
+  Nutritional information about the tofu.
+  """
+  nutrition: Nutrition
+
+  """
+  List of recipes that include this tofu.
+  """
+  recipes(filter: RecipeFilter): [Recipe]
+
+  """
+  The texture profile of the tofu, expressed through a custom scalar.
+  """
+  texture: TextureProfile
+}
+
+"""
+Nutritional information for tofu.
+"""
+type Nutrition {
+  """
+  The amount of calories per serving.
+  """
+  calories: Int
+
+  """
+  The amount of protein per serving.
+  """
+  protein: Float
+
+  """
+  Total fat content per serving.
+  """
+  fat: Float
+}
+
+"""
+Defines different types of tofu.
+"""
+enum TofuType {
+  """
+  Silken tofu - soft and smooth, often used in soups and sauces.
+  """
+  SILKEN
+
+  """
+  Firm tofu - holds its shape well, good for grilling and frying.
+  """
+  FIRM
+
+  """
+  Extra firm tofu - very dense and solid, ideal for stir-fries.
+  """
+  EXTRA_FIRM
+}
+
+"""
+Filter criteria for tofu recipes.
+"""
+input RecipeFilter {
+  """
+  Minimum required protein content.
+  """
+  minProtein: Float
+
+  """
+  Maximum allowed calorie count.
+  """
+  maxCalories: Int
+}
+
+"""
+A recipe that includes tofu as an ingredient.
+"""
+type Recipe @shareable {
+  """
+  The unique ID of the recipe.
+  """
+  id: ID!
+
+  """
+  The name of the recipe.
+  """
+  name: String!
+
+  """
+  Description of the recipe.
+  """
+  description: String
+
+  """
+  The main type of tofu used in this recipe.
+  """
+  tofuType: TofuType
+
+  """
+  The ingredients used in the recipe, including tofu.
+  """
+  ingredients: [FoodItem]
+}
+
+"""
+Custom scalar to represent the texture profile of tofu.
+"""
+scalar TextureProfile
+
+"""
+Union representing different food items that can be part of a recipe.
+"""
+union FoodItem = Tofu | Vegetable | Spice
+
+"""
+Vegetable type used in tofu recipes.
+"""
+type Vegetable {
+  """
+  Name of the vegetable.
+  """
+  name: String
+
+  """
+  Nutritional information of the vegetable.
+  """
+  nutrition: Nutrition
+}
+
+"""
+Spice type used in tofu recipes.
+"""
+type Spice {
+  """
+  Name of the spice.
+  """
+  name: String
+
+  """
+  Description of the spice's flavor.
+  """
+  flavorDescription: String
+}
+
+"""
+Directives provide an extendable way to modify the execution behavior in GraphQL.
+"""
+directive @include(
+  """
+  Included if the argument is true.
+  """
+  if: Boolean!
+) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @skip(
+  """
+  Skipped if the argument is true.
+  """
+  if: Boolean!
+) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+
+type Query {
+  allTheTofus: [Tofu]
+}

--- a/engine/crates/federated-graph/src/federated_graph.rs
+++ b/engine/crates/federated-graph/src/federated_graph.rs
@@ -64,6 +64,9 @@ pub struct Object {
 
     /// All directives that made it through composition. Notably includes `@tag`.
     pub composed_directives: Vec<Directive>,
+
+    #[serde(default)]
+    pub description: Option<StringId>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -115,6 +118,9 @@ pub struct Field {
 
     /// All directives that made it through composition. Notably includes `@tag`.
     pub composed_directives: Vec<Directive>,
+
+    #[serde(default)]
+    pub description: Option<StringId>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -122,6 +128,8 @@ pub struct FieldArgument {
     pub name: StringId,
     pub type_id: FieldTypeId,
     pub composed_directives: Vec<Directive>,
+    #[serde(default)]
+    pub description: Option<StringId>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone)]
@@ -215,6 +223,9 @@ pub struct Interface {
 
     /// All directives that made it through composition. Notably includes `@tag`.
     pub composed_directives: Vec<Directive>,
+
+    #[serde(default)]
+    pub description: Option<StringId>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -230,6 +241,9 @@ pub struct Enum {
 
     /// All directives that made it through composition. Notably includes `@tag`.
     pub composed_directives: Vec<Directive>,
+
+    #[serde(default)]
+    pub description: Option<StringId>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -238,6 +252,9 @@ pub struct EnumValue {
 
     /// All directives that made it through composition. Notably includes `@tag`.
     pub composed_directives: Vec<Directive>,
+
+    #[serde(default)]
+    pub description: Option<StringId>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -247,6 +264,9 @@ pub struct Union {
 
     /// All directives that made it through composition. Notably includes `@tag`.
     pub composed_directives: Vec<Directive>,
+
+    #[serde(default)]
+    pub description: Option<StringId>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -255,6 +275,9 @@ pub struct Scalar {
 
     /// All directives that made it through composition. Notably includes `@tag`.
     pub composed_directives: Vec<Directive>,
+
+    #[serde(default)]
+    pub description: Option<StringId>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -264,6 +287,9 @@ pub struct InputObject {
 
     /// All directives that made it through composition. Notably includes `@tag`.
     pub composed_directives: Vec<Directive>,
+
+    #[serde(default)]
+    pub description: Option<StringId>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -271,6 +297,8 @@ pub struct InputObjectField {
     pub name: StringId,
     pub field_type_id: FieldTypeId,
     pub composed_directives: Vec<Directive>,
+    #[serde(default)]
+    pub description: Option<StringId>,
 }
 
 macro_rules! id_newtypes {


### PR DESCRIPTION
The strategy for composing descriptions seems to be picking the first one we find. There can be an optional lint to enforce that they are the same across subgraphs.

closes GB-5394