### PR TITLE
feat: `@extendField` directive

### DIFF
--- a/engine/crates/parser-sdl/src/lib.rs
+++ b/engine/crates/parser-sdl/src/lib.rs
@@ -28,6 +28,7 @@ use rules::{
     directive::Directives,
     enum_type::EnumType,
     extend_connector_types::ExtendConnectorTypes,
+    extend_field::{ExtendFieldDirective, ExtendFieldVisitor},
     extend_query_and_mutation_types::ExtendQueryAndMutationTypes,
     federation::{
         ExternalDirective, FederationDirective, FederationDirectiveVisitor, InaccessibleDirective, KeyDirective,
@@ -156,7 +157,8 @@ fn parse_schema(schema: &str) -> engine::parser::Result<ServiceDocument> {
         .with::<ProvidesDirective>()
         .with::<DeprecatedDirective>()
         .with::<InaccessibleDirective>()
-        .with::<TagDirective>();
+        .with::<TagDirective>()
+        .with::<ExtendFieldDirective>();
 
     let schema = format!(
         "{}\n{}\n{}\n{}",
@@ -350,7 +352,8 @@ fn parse_types<'a>(schema: &'a ServiceDocument, ctx: &mut VisitorContext<'a>) {
         .with(UniqueObjectFields)
         .with(CheckAllDirectivesAreKnown::default())
         .with(ExperimentalDirectiveVisitor)
-        .with(FederationDirectiveVisitor); // This will likely need moved.  Here'll do for now though
+        .with(FederationDirectiveVisitor) // This will likely need moved.  Here'll do for now though
+        .with(ExtendFieldVisitor);
 
     visit(&mut rules, ctx, schema);
 }

--- a/engine/crates/parser-sdl/src/rules/extend_field.rs
+++ b/engine/crates/parser-sdl/src/rules/extend_field.rs
@@ -1,0 +1,285 @@
+//! Implements parsing of the `@extendField` directive on types.
+//!
+//! This can be used to add additional directives to a generated field
+//! of a generated type.
+
+use engine::registry::MetaType;
+use engine_parser::types::TypeKind;
+
+use super::{
+    directive::Directive,
+    federation::{OverrideDirective, ProvidesDirective},
+    visitor::{Visitor, VisitorContext},
+};
+use crate::directive_de::parse_directive;
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ExtendFieldDirective {
+    name: String,
+    external: Option<bool>,
+    inaccessible: Option<bool>,
+    r#override: Option<OverrideDirective>,
+    provides: Option<ProvidesDirective>,
+    shareable: Option<bool>,
+    #[serde(default)]
+    tags: Vec<String>,
+}
+
+impl Directive for ExtendFieldDirective {
+    fn definition() -> String {
+        r#"
+        directive @extendField(
+            name: String!,
+            external: Boolean,
+            inaccessible: Boolean,
+            override: ExtendFieldOverride,
+            provides: ExtendFieldProvides,
+            shareable: Boolean,
+            tags: [String!],
+        ) on OBJECT
+
+        input ExtendFieldOverride {
+            from: String!
+        }
+
+        input ExtendFieldProvides {
+            fields: FieldSet!
+        }
+        "#
+        .to_string()
+    }
+}
+
+pub struct ExtendFieldVisitor;
+
+impl<'a> Visitor<'a> for ExtendFieldVisitor {
+    fn enter_type_definition(
+        &mut self,
+        ctx: &mut VisitorContext<'a>,
+        type_definition: &'a engine::Positioned<engine_parser::types::TypeDefinition>,
+    ) {
+        if ["Query", "Mutation"].contains(&type_definition.node.name.node.as_str()) {
+            return;
+        }
+
+        let TypeKind::Object(_) = &type_definition.node.kind else {
+            return;
+        };
+
+        let name = &type_definition.node.name.node;
+
+        let metatype = ctx.registry.borrow().types.get(name.as_str()).cloned();
+        let object = match metatype {
+            Some(MetaType::Object(object)) => object,
+            Some(_) => {
+                ctx.report_error(
+                    vec![type_definition.name.pos],
+                    format!("You tried to extend the object {name} but {name} is not an object"),
+                );
+                return;
+            }
+            None => {
+                // This error is reported elsewhere
+                return;
+            }
+        };
+
+        let directives = type_definition
+            .node
+            .directives
+            .iter()
+            .filter(|directive| directive.name.node == "extendField")
+            .filter_map(
+                |directive| match parse_directive::<ExtendFieldDirective>(directive, ctx.variables) {
+                    Ok(parsed_directive) => {
+                        if object.field_by_name(&parsed_directive.name).is_none() {
+                            ctx.report_error(
+                                vec![directive.pos],
+                                format!(
+                                    "You tried to extend the field {} which does not exist on {name}",
+                                    &parsed_directive.name
+                                ),
+                            );
+                            return None;
+                        }
+                        Some(parsed_directive)
+                    }
+                    Err(error) => {
+                        ctx.append_errors(vec![error]);
+                        None
+                    }
+                },
+            )
+            .collect::<Vec<_>>();
+
+        if directives.is_empty() {
+            return;
+        }
+
+        let mut registry = ctx.registry.borrow_mut();
+        let Some(MetaType::Object(object)) = registry.types.get_mut(name.as_str()) else {
+            unreachable!("Verified this above")
+        };
+
+        for directive in directives {
+            let Some(field) = object.fields.get_mut(&directive.name) else {
+                unreachable!("Verified this above");
+            };
+
+            if let Some(external) = directive.external {
+                field.external = external;
+            }
+            if let Some(inaccessible) = directive.inaccessible {
+                field.inaccessible = inaccessible;
+            }
+            if let Some(r#override) = directive.r#override {
+                field.r#override = Some(r#override.from);
+            }
+            if let Some(provides) = directive.provides {
+                field.provides = Some(provides.fields);
+            }
+            if let Some(shareable) = directive.shareable {
+                field.shareable = shareable;
+            }
+            field.tags.extend(directive.tags);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use engine::{
+        registry::{self, MetaField},
+        Registry,
+    };
+
+    use crate::{
+        tests::assert_validation_error, ConnectorParsers, GraphqlDirective, OpenApiDirective, PostgresDirective,
+    };
+
+    #[test]
+    fn test_extending_field_on_connector_types() {
+        let schema = r#"
+            extend type Blah
+              @extendField(
+                name: "foo"
+                external: true
+                override: {from: "Blah"}
+                provides: {fields: "id"}
+              )
+              @extendField(
+                name: "bar"
+                shareable: true
+              )
+
+            extend schema
+              @openapi(name: "foo", namespace: false, schema: "http://example.com")
+              @federation(version: "2.3")
+        "#;
+
+        let output =
+            futures::executor::block_on(crate::parse(schema, &HashMap::new(), false, &FakeConnectorParser)).unwrap();
+
+        insta::assert_display_snapshot!(output.registry.export_sdl(true), @r###"
+        type Blah {
+        	foo: String! @external @override(from: "Blah") @provides(fields: "id")
+        	bar: ID! @shareable
+        	bloop: ID!
+        }
+        type Query {
+        	blah: Blah
+        }
+        "###)
+    }
+
+    #[test]
+    fn test_missing_type_error() {
+        assert_validation_error!(
+            r#"
+            extend type Blah
+              @extendField(
+                name: "foo"
+                external: true
+                override: {from: "Blah"}
+                provides: {fields: "id"}
+              )
+            "#,
+            "Type 'Blah' does not exist"
+        );
+    }
+
+    #[test]
+    fn test_missing_field_error() {
+        let schema = r#"
+            extend type Blah
+              @extendField(
+                name: "nope"
+                external: true
+                override: {from: "Blah"}
+                provides: {fields: "id"}
+              )
+
+            extend schema
+              @openapi(name: "foo", namespace: false, schema: "http://example.com")
+              @federation(version: "2.3")
+        "#;
+
+        let error = futures::executor::block_on(crate::parse(schema, &HashMap::new(), false, &FakeConnectorParser))
+            .unwrap_err();
+
+        insta::assert_display_snapshot!(error, @r###"[RuleError { locations: [Pos(3:15)], message: "You tried to extend the field nope which does not exist on Blah" }]"###)
+    }
+
+    struct FakeConnectorParser;
+
+    #[async_trait::async_trait]
+    impl ConnectorParsers for FakeConnectorParser {
+        async fn fetch_and_parse_openapi(&self, _directive: OpenApiDirective) -> Result<Registry, Vec<String>> {
+            let mut registry = Registry::new();
+            registry.types.insert(
+                "Blah".into(),
+                registry::ObjectType::new(
+                    "Blah",
+                    [
+                        MetaField {
+                            name: "foo".into(),
+                            ty: "String!".into(),
+                            ..MetaField::default()
+                        },
+                        MetaField {
+                            name: "bar".into(),
+                            ty: "ID!".into(),
+                            ..MetaField::default()
+                        },
+                        MetaField {
+                            name: "bloop".into(),
+                            ty: "ID!".into(),
+                            ..MetaField::default()
+                        },
+                    ],
+                )
+                .into(),
+            );
+            registry.query_root_mut().fields_mut().unwrap().insert(
+                "customer".into(),
+                MetaField {
+                    name: "blah".into(),
+                    ty: "Blah".into(),
+                    ..MetaField::default()
+                },
+            );
+            Ok(registry)
+        }
+
+        async fn fetch_and_parse_graphql(&self, _directive: GraphqlDirective) -> Result<Registry, Vec<String>> {
+            Err(Vec::new())
+        }
+
+        async fn fetch_and_parse_postgres(&self, _: &PostgresDirective) -> Result<Registry, Vec<String>> {
+            Err(Vec::new())
+        }
+    }
+}

--- a/engine/crates/parser-sdl/src/rules/mod.rs
+++ b/engine/crates/parser-sdl/src/rules/mod.rs
@@ -15,6 +15,7 @@ pub mod directive;
 pub mod enum_type;
 pub mod experimental;
 pub mod extend_connector_types;
+pub mod extend_field;
 pub mod extend_query_and_mutation_types;
 pub mod federation;
 pub mod graph_directive;

--- a/engine/crates/parser-sdl/src/tests.rs
+++ b/engine/crates/parser-sdl/src/tests.rs
@@ -676,7 +676,7 @@ fn test_name_clashes_dont_cause_panic() {
             id: ID!
         }
 
-        type UserInput {
+        input UserInput {
             id: ID!
         }
     ";


### PR DESCRIPTION
Users might want to add federation directives to connector generated types. Doing this with the existing extend keyword is awkward because either:

1. We'd have to force users to write out the full field definition or
2. We'd have to just ignore the arguments & return type inside extensions - which is a bit ambigous, is the user adding a clashing field or adding a field just to extend its directives?

So I've added a `extendField` directive to objects to allow users to do this:

```graphql
extend type Blah
  @extendField(
    name: "foo"
    external: true
    override: {from: "Blah"}
    provides: {fields: "id"}
  )
```

Part of GB-5518