### PR TITLE
GB-5481 - Deprecate g and schema

### DIFF
--- a/packages/grafbase-sdk/src/config.ts
+++ b/packages/grafbase-sdk/src/config.ts
@@ -9,7 +9,7 @@ import { Federation, FederationParams } from './federation'
  *
  * An interface to create the complete config definition.
  */
-export interface ExperimentalSingleGraphConfigInput {
+export interface SingleGraphConfigInput {
   graph: SingleGraph
   auth?: AuthParams
   cache?: CacheParams
@@ -17,16 +17,12 @@ export interface ExperimentalSingleGraphConfigInput {
   federation?: FederationParams
 }
 
-// /**
-//  * @deprecated use `graph` instead of `schema`
-//  * An interface to create the complete config definition.
-//  */
-/*
- *
+/**
+ * @deprecated use `graph` instead of `schema`
  * An interface to create the complete config definition.
  */
-export interface SingleGraphConfigInput {
-  // /** @deprecated use `graph` instead */
+export interface DeprecatedSingleGraphConfigInput {
+  /** @deprecated use `graph` instead */
   schema: SingleGraph
   auth?: AuthParams
   cache?: CacheParams
@@ -53,11 +49,11 @@ export class SingleGraphConfig {
   private readonly experimental?: Experimental
   private readonly federation?: Federation
 
-  constructor(input: ExperimentalSingleGraphConfigInput)
-  // /** @deprecated use `graph` instead of `schema` */
   constructor(input: SingleGraphConfigInput)
+  /** @deprecated use `graph` instead of `schema` */
+  constructor(input: DeprecatedSingleGraphConfigInput)
   constructor(
-    input: ExperimentalSingleGraphConfigInput | SingleGraphConfigInput
+    input: SingleGraphConfigInput | DeprecatedSingleGraphConfigInput
   ) {
     this.graph = 'graph' in input ? input.graph : input.schema
 

--- a/packages/grafbase-sdk/src/index.ts
+++ b/packages/grafbase-sdk/src/index.ts
@@ -1,7 +1,7 @@
 import {
   SingleGraphConfig,
-  ExperimentalSingleGraphConfigInput,
   SingleGraphConfigInput,
+  DeprecatedSingleGraphConfigInput,
   FederatedGraphConfig,
   FederatedGraphConfigInput
 } from './config'
@@ -28,7 +28,7 @@ export { type AuthorizerContext } from './authorizer/context'
 
 export { graph }
 
-// /** @deprecated use `graph.Single()` instead */
+/** @deprecated use `graph.Single()` instead */
 export const g = graph.Single()
 
 dotenv.config({
@@ -42,7 +42,7 @@ export type AtLeastOne<T> = [T, ...T[]]
 const isFederatedGraphConfigInput = (
   input:
     | SingleGraphConfigInput
-    | ExperimentalSingleGraphConfigInput
+    | DeprecatedSingleGraphConfigInput
     | FederatedGraphConfigInput
 ): input is FederatedGraphConfigInput =>
   'graph' in input && input.graph instanceof FederatedGraph
@@ -51,15 +51,15 @@ const isFederatedGraphConfigInput = (
  * A constructor for a complete Grafbase configuration.
  */
 export function config(input: SingleGraphConfigInput): SingleGraphConfig
-// /** @deprecated use `graph` instead of `schema` */
+/** @deprecated use `graph` instead of `schema` */
 export function config(
-  input: ExperimentalSingleGraphConfigInput
+  input: DeprecatedSingleGraphConfigInput
 ): SingleGraphConfig
 export function config(input: FederatedGraphConfigInput): FederatedGraphConfig
 export function config(
   input:
     | SingleGraphConfigInput
-    | ExperimentalSingleGraphConfigInput
+    | DeprecatedSingleGraphConfigInput
     | FederatedGraphConfigInput
 ): SingleGraphConfig | FederatedGraphConfig {
   if (isFederatedGraphConfigInput(input)) {


### PR DESCRIPTION
# Description

## Features

- Deprecates `g` and `config({ schema })`

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
