### PR TITLE
fix(engine-v2): Add the ability to inject a self domain configuration with a custom `worker::Fetcher` to route requests through

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2009,6 +2009,7 @@ version = "3.0.31"
 dependencies = [
  "anyhow",
  "async-runtime",
+ "bytes",
  "derive_more",
  "engine",
  "engine-parser",
@@ -2020,10 +2021,14 @@ dependencies = [
  "itertools 0.11.0",
  "lasso",
  "reqwest",
+ "send_wrapper 0.6.0",
  "serde",
  "serde-value",
+ "serde-wasm-bindgen 0.6.1",
  "serde_json",
  "thiserror",
+ "url",
+ "worker",
 ]
 
 [[package]]
@@ -5992,6 +5997,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ba92964781421b6cef36bf0d7da26d201e96d84e1b10e7ae6ed416e516906d"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_cbor"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8151,7 +8167,7 @@ dependencies = [
  "matchit 0.4.6",
  "pin-project",
  "serde",
- "serde-wasm-bindgen",
+ "serde-wasm-bindgen 0.5.0",
  "serde_json",
  "tokio",
  "url",
@@ -8172,7 +8188,7 @@ checksum = "3d4b9fe1a87b7aef252fceb4f30bf6303036a5de329c81ccad9be9c35d1fdbc7"
 dependencies = [
  "js-sys",
  "serde",
- "serde-wasm-bindgen",
+ "serde-wasm-bindgen 0.5.0",
  "serde_json",
  "thiserror",
  "wasm-bindgen",

--- a/engine/crates/engine-v2/Cargo.toml
+++ b/engine/crates/engine-v2/Cargo.toml
@@ -13,15 +13,22 @@ keywords = ["graphql", "engine", "grafbase"]
 [lints]
 workspace = true
 
+[features]
+default = []
+cf-workers = ["serde-wasm-bindgen", "worker"]
+
 [dependencies]
 async-runtime = { workspace = true }
+bytes = "1"
 derive_more = "0.99"
 im = "15"
 lasso = "0.7"
 anyhow = "1"
 itertools.workspace = true
+send_wrapper.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde-wasm-bindgen = { workspace = true, optional = true }
 serde-value = "0.7"
 thiserror.workspace = true
 futures-locks = "0.7"
@@ -30,6 +37,8 @@ reqwest = { version = "0.11", default-features = false, features = [
   "json",
   "rustls-tls",
 ] }
+url = "2"
+worker = { version = "0.0.18", optional = true }
 
 engine-value = { path = "../engine/value" }
 engine-parser = { path = "../engine/parser" }

--- a/engine/crates/engine-v2/src/engine.rs
+++ b/engine/crates/engine-v2/src/engine.rs
@@ -13,12 +13,32 @@ pub struct Engine {
     // We use an Arc for the schema to have a self-contained response which may still
     // needs access to the schema strings
     pub(crate) schema: Arc<Schema>,
+
+    // Cloudflare Workers only.
+    // Domain requests against which should be routed through a service binding.
+    #[cfg(feature = "cf-workers")]
+    pub(crate) self_domain_configuration: Option<(String, send_wrapper::SendWrapper<worker::Fetcher>)>,
 }
 
 impl Engine {
     pub fn new(schema: Schema) -> Self {
+        #[cfg(feature = "cf-workers")]
+        return Self {
+            schema: Arc::new(schema),
+            self_domain_configuration: None,
+        };
+
+        #[cfg(not(feature = "cf-workers"))]
+        return Self {
+            schema: Arc::new(schema),
+        };
+    }
+
+    #[cfg(feature = "cf-workers")]
+    pub fn new_with_self_domain_routing(schema: Schema, self_domain: String, service: worker::Fetcher) -> Self {
         Self {
             schema: Arc::new(schema),
+            self_domain_configuration: Some((self_domain, send_wrapper::SendWrapper::new(service))),
         }
     }
 

--- a/engine/crates/engine-v2/src/executor/graphql/mod.rs
+++ b/engine/crates/engine-v2/src/executor/graphql/mod.rs
@@ -14,9 +14,14 @@ mod query;
 pub struct GraphqlExecutor<'a> {
     endpoint_name: String,
     url: String,
+    payload: Payload<'a>,
+    response_object_root: ResponseObjectRoot,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct Payload<'a> {
     query: String,
     variables: HashMap<String, &'a ConstValue>,
-    response_object_root: ResponseObjectRoot,
 }
 
 impl<'a> GraphqlExecutor<'a> {
@@ -37,10 +42,22 @@ impl<'a> GraphqlExecutor<'a> {
         Ok(Executor::GraphQL(Self {
             endpoint_name: ctx.engine.schema[subgraph.name].to_string(),
             url: ctx.engine.schema[subgraph.url].clone(),
-            query,
-            variables,
+            payload: Payload { query, variables },
             response_object_root: input.root_response_objects.root(),
         }))
+    }
+
+    async fn send_request(&self) -> Result<bytes::Bytes, ExecutorError> {
+        let response = reqwest::Client::new()
+            .post(&self.url)
+            .json(&self.payload)
+            .send()
+            .await
+            .map_err(|err| format!("Request to '{}' failed with: {err}", self.endpoint_name))?;
+        response
+            .bytes()
+            .await
+            .map_err(|_err| "Failed to read response".to_string().into())
     }
 
     pub(super) async fn execute(
@@ -48,16 +65,54 @@ impl<'a> GraphqlExecutor<'a> {
         ctx: ExecutionContext<'_, '_>,
         output: &mut ResponsePartBuilder,
     ) -> Result<(), ExecutorError> {
-        let response = reqwest::Client::new()
-            .post(self.url)
-            .json(&serde_json::json!({
-                "query": self.query,
-                "variables": self.variables,
-            }))
-            .send()
-            .await
-            .map_err(|err| format!("Request to '{}' failed with: {err}", self.endpoint_name))?;
-        let bytes = response.bytes().await.map_err(|_err| "Failed to read response")?;
+        #[cfg(feature = "cf-workers")]
+        let bytes = match &ctx.engine.self_domain_configuration {
+            Some((self_domain, service))
+                if self
+                    .url
+                    .parse::<url::Url>()
+                    .map_err(|_err| "invalid URL".to_string())?
+                    .domain()
+                    .is_some_and(|parsed_domain| {
+                        parsed_domain
+                            .rsplit('.')
+                            .zip(self_domain.rsplit('.'))
+                            .all(|(lhs, rhs)| lhs == rhs)
+                    }) =>
+            {
+                let url = self.url.clone();
+                Box::pin(send_wrapper::SendWrapper::new(async move {
+                    use serde::Serialize;
+
+                    let mut init = worker::RequestInit::new();
+                    init.with_method(worker::Method::Post);
+                    init.with_body(Some(
+                        worker::js_sys::JSON::stringify(
+                            &self
+                                .payload
+                                .serialize(&serde_wasm_bindgen::Serializer::json_compatible())
+                                .expect("necessarily serializable"),
+                        )
+                        .expect("must succeed")
+                        .into(),
+                    ));
+                    service
+                        .fetch_request(worker::Request::new_with_init(&url, &init).map_err(|err| err.to_string())?)
+                        .await
+                        .map_err(|err| err.to_string())?
+                        .bytes()
+                        .await
+                        .map_err(|err| err.to_string())
+                        .map(From::from)
+                }))
+                .await?
+            }
+            _ => self.send_request().await?,
+        };
+
+        #[cfg(not(feature = "cf-workers"))]
+        let bytes = self.send_request().await?;
+
         deserialize::UniqueRootSeed {
             ctx: &ctx,
             output,


### PR DESCRIPTION
# Description

For internal use.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
