### PR TITLE
composition: finish @tag implementation

### DIFF
--- a/engine/crates/composition/src/compose/directives.rs
+++ b/engine/crates/composition/src/compose/directives.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub(super) fn collect_composed_directives<'a>(
     containers: impl Iterator<Item = subgraphs::DirectiveContainerWalker<'a>> + Clone,
-    ctx: &mut ComposeContext<'a>,
+    ctx: &mut ComposeContext<'_>,
 ) -> Vec<federated::Directive> {
     let mut tags: BTreeSet<StringId> = BTreeSet::new();
     let mut is_inaccessible = false;

--- a/engine/crates/composition/src/compose/entity_interface.rs
+++ b/engine/crates/composition/src/compose/entity_interface.rs
@@ -1,15 +1,13 @@
 use super::*;
 use crate::composition_ir as ir;
 
-pub(crate) fn merge_entity_interface_definitions(
-    ctx: &mut Context<'_>,
-    first: DefinitionWalker<'_>,
-    definitions: &[DefinitionWalker<'_>],
+pub(crate) fn merge_entity_interface_definitions<'a>(
+    ctx: &mut Context<'a>,
+    first: DefinitionWalker<'a>,
+    definitions: &[DefinitionWalker<'a>],
 ) {
     let interface_name = first.name();
-    let is_inaccessible = definitions
-        .iter()
-        .any(|definition| definition.directives().inaccessible());
+    let composed_directives = collect_composed_directives(definitions.iter().map(|def| def.directives()), ctx);
 
     let interface_defs = || definitions.iter().filter(|def| def.kind() == DefinitionKind::Interface);
     let mut interfaces = interface_defs();
@@ -64,7 +62,7 @@ pub(crate) fn merge_entity_interface_definitions(
     }
 
     let description = interface_def.description();
-    let interface_id = ctx.insert_interface(interface_name, is_inaccessible, description);
+    let interface_id = ctx.insert_interface(interface_name, description, composed_directives);
 
     let mut fields = BTreeMap::new();
 

--- a/engine/crates/composition/src/compose/interface.rs
+++ b/engine/crates/composition/src/compose/interface.rs
@@ -1,26 +1,32 @@
 use super::*;
 
-pub(super) fn merge_interface_definitions(
-    ctx: &mut Context<'_>,
-    first: &DefinitionWalker<'_>,
-    definitions: &[DefinitionWalker<'_>],
+pub(super) fn merge_interface_definitions<'a>(
+    ctx: &mut Context<'a>,
+    first: &DefinitionWalker<'a>,
+    definitions: &[DefinitionWalker<'a>],
 ) {
-    let mut all_fields: indexmap::IndexMap<StringId, _> = indexmap::IndexMap::new();
-    let is_inaccessible = definitions
-        .iter()
-        .any(|definition| definition.directives().inaccessible());
-
+    let composed_directives = collect_composed_directives(definitions.iter().map(|def| def.directives()), ctx);
     let interface_description = definitions.iter().find_map(|def| def.description());
+    ctx.insert_interface(first.name(), interface_description, composed_directives);
 
-    for field in definitions.iter().flat_map(|def| def.fields()) {
-        all_fields.entry(field.name().id).or_insert(field.id);
-    }
+    let mut all_fields: Vec<(StringId, _)> = definitions
+        .iter()
+        .flat_map(|def| def.fields().map(|field| (field.name().id, field)))
+        .collect();
 
-    ctx.insert_interface(first.name(), is_inaccessible, interface_description);
+    all_fields.sort_by_key(|(name, _)| *name);
 
-    for field in all_fields.values() {
-        let field = first.walk(*field);
+    let mut start = 0;
+
+    while start < all_fields.len() {
+        let (name, field) = all_fields[start];
+        let end = start + all_fields[start..].partition_point(|(n, _)| *n == name);
+
         let description = field.description().map(|description| ctx.insert_string(description.id));
+
+        let directive_containers = all_fields[start..end].iter().map(|(_, field)| field.directives());
+        let composed_directives = collect_composed_directives(directive_containers, ctx);
+
         ctx.insert_field(ir::FieldIr {
             parent_name: first.name().id,
             field_name: field.name().id,
@@ -29,9 +35,11 @@ pub(super) fn merge_interface_definitions(
             resolvable_in: None,
             provides: Vec::new(),
             requires: Vec::new(),
-            composed_directives: Vec::new(),
             overrides: Vec::new(),
+            composed_directives,
             description,
         });
+
+        start = end;
     }
 }

--- a/engine/crates/composition/src/compose/scalar.rs
+++ b/engine/crates/composition/src/compose/scalar.rs
@@ -1,14 +1,13 @@
 use super::*;
 
-pub(crate) fn merge_scalar_definitions(
-    first: DefinitionWalker<'_>,
-    definitions: &[DefinitionWalker<'_>],
-    ctx: &mut Context<'_>,
+pub(crate) fn merge_scalar_definitions<'a>(
+    first: DefinitionWalker<'a>,
+    definitions: &[DefinitionWalker<'a>],
+    ctx: &mut Context<'a>,
 ) {
-    let is_inaccessible = definitions
-        .iter()
-        .any(|definition| definition.directives().inaccessible());
+    let directive_containers = definitions.iter().map(|def| def.directives());
+    let directives = collect_composed_directives(directive_containers, ctx);
     let description = definitions.iter().find_map(|def| def.description());
 
-    ctx.insert_scalar(first.name(), is_inaccessible, description);
+    ctx.insert_scalar(first.name(), description, directives);
 }

--- a/engine/crates/composition/src/subgraphs/fields.rs
+++ b/engine/crates/composition/src/subgraphs/fields.rs
@@ -162,6 +162,19 @@ impl<'a> FieldWalker<'a> {
             })
     }
 
+    pub(crate) fn argument_by_name(self, name: StringId) -> Option<FieldArgumentWalker<'a>> {
+        let (FieldId(definition_id, field_name), _tuple) = self.id;
+        let argument_id = ArgumentId(definition_id, field_name, name);
+        self.subgraphs
+            .fields
+            .field_arguments
+            .get(&argument_id)
+            .map(|tuple| FieldArgumentWalker {
+                id: (argument_id, *tuple),
+                subgraphs: self.subgraphs,
+            })
+    }
+
     pub(crate) fn description(self) -> Option<StringWalker<'a>> {
         let (_, tuple) = self.id;
         tuple.description.map(|id| self.walk(id))

--- a/engine/crates/composition/tests/composition/composed_directives_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/composed_directives_basic/federated.graphql
@@ -38,7 +38,7 @@ type Query {
     birdObservations(filters: BirdObservationFilters): [BirdObservation] @join__field(graph: OBSERVATIONS)
     birdObservation(observationID: ID!): BirdObservation @join__field(graph: OBSERVATIONS)
     birdSightings: [BirdSighting] @join__field(graph: SIGHTINGS)
-    birdSighting(sightingID: ID!, private: Boolean): BirdSighting @join__field(graph: SIGHTINGS)
+    birdSighting(sightingID: ID!, private: Boolean @deprecated): BirdSighting @join__field(graph: SIGHTINGS)
 }
 
 type BirdObservation {
@@ -68,7 +68,7 @@ enum ObserverType {
 }
 
 input BirdObservationFilters {
-    observedAt: DateTime
+    observedAt: DateTime @deprecated(reason: "UNIX timestamps instead, as usual in bird watching")
     observerType: ObserverType
     observerName: String
     first: Int

--- a/engine/crates/composition/tests/composition/inaccessible_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/inaccessible_basic/federated.graphql
@@ -74,8 +74,8 @@ type Book {
 }
 
 type Mutation {
-    addBook(input: BookInput!): Book @join__field(graph: SIX_WITH_INPUT_OBJECT)
-    updateBook(id: ID!, input: BookInput!): Book @join__field(graph: SIX_WITH_INPUT_OBJECT)
+    addBook(input: BookInput! @inaccessible): Book @join__field(graph: SIX_WITH_INPUT_OBJECT)
+    updateBook(id: ID!, input: BookInput! @inaccessible): Book @join__field(graph: SIX_WITH_INPUT_OBJECT)
 }
 
 type Quadratic implements Polynomial {
@@ -97,7 +97,7 @@ interface Polynomial @inaccessible {
 
 enum UngulateType @inaccessible {
     DEER
-    HORSE
+    HORSE @inaccessible
     CAMEL
     RHINOCEROS
     GIRAFFE

--- a/engine/crates/composition/tests/composition/tag_directive_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/tag_directive_basic/federated.graphql
@@ -1,0 +1,53 @@
+directive @core(feature: String!) repeatable on SCHEMA
+
+directive @join__owner(graph: join__Graph!) on OBJECT
+
+directive @join__type(
+    graph: join__Graph!
+    key: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__field(
+    graph: join__Graph
+    requires: String
+    provides: String
+) on FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+enum join__Graph {
+    APPLE @join__graph(name: "apple", url: "http://example.com/apple")
+    ORANGE @join__graph(name: "orange", url: "http://example.com/orange")
+}
+
+scalar Texture @tag(name: "appleTexture") @tag(name: "orangeTexture")
+
+type Query @tag(name: "appleQuery") @tag(name: "orangeQuery") {
+    tags(filter: String @tag(name: "appleTagsFilter") @tag(name: "orangeTagsFilter")): [String] @tag(name: "appleField") @tag(name: "orangeField")
+}
+
+type Apple implements HasId @tag(name: "appleType") {
+    id: ID! @join__field(graph: APPLE)
+    variety: AppleVariety @join__field(graph: APPLE)
+    texture: Texture @join__field(graph: APPLE)
+}
+
+type Orange implements HasId @tag(name: "orangeType") {
+    id: ID! @join__field(graph: ORANGE)
+    variety: String @join__field(graph: ORANGE)
+    texture: Texture @join__field(graph: ORANGE)
+}
+
+interface HasId @tag(name: "appleInterface") @tag(name: "orangeInterface") {
+    id: ID! @tag(name: "appleField") @tag(name: "orangeField")
+}
+
+enum AppleVariety @tag(name: "appleEnum") {
+    FUJI
+    GRANNY_SMITH
+    HONEYCRISP @tag(name: "appleEnumValue")
+}
+
+input Filter @tag(name: "appleInput") @tag(name: "orangeInput") {
+    value: String @tag(name: "appleInputField") @tag(name: "orangeInputField")
+}

--- a/engine/crates/composition/tests/composition/tag_directive_basic/subgraphs/apple.graphql
+++ b/engine/crates/composition/tests/composition/tag_directive_basic/subgraphs/apple.graphql
@@ -1,0 +1,25 @@
+type Query @tag(name: "appleQuery") @shareable {
+  tags(filter: String @tag(name: "appleTagsFilter")): [String] @tag(name: "appleField")
+}
+
+interface HasId @tag(name: "appleInterface") {
+  id: ID! @tag(name: "appleField")
+}
+
+enum AppleVariety @tag(name: "appleEnum") {
+  FUJI
+  GRANNY_SMITH
+  HONEYCRISP @tag(name: "appleEnumValue")
+}
+
+type Apple implements HasId @tag(name: "appleType") @shareable {
+  id: ID!
+  variety: AppleVariety
+  texture: Texture
+}
+
+scalar Texture @tag(name: "appleTexture")
+
+input Filter @tag(name: "appleInput") {
+    value: String @tag(name: "appleInputField")
+}

--- a/engine/crates/composition/tests/composition/tag_directive_basic/subgraphs/orange.graphql
+++ b/engine/crates/composition/tests/composition/tag_directive_basic/subgraphs/orange.graphql
@@ -1,0 +1,20 @@
+type Query @tag(name: "orangeQuery") @shareable {
+  tags(filter: String @tag(name: "orangeTagsFilter")): [String] @tag(name: "orangeField")
+}
+
+interface HasId @tag(name: "orangeInterface") {
+  id: ID! @tag(name: "orangeField")
+}
+
+type Orange implements HasId @tag(name: "orangeType") {
+  id: ID!
+  variety: String
+  texture: Texture
+}
+
+scalar Texture @tag(name: "orangeTexture")
+
+input Filter @tag(name: "orangeInput") {
+    value: String @tag(name: "orangeInputField")
+}
+

--- a/engine/crates/federated-graph/src/federated_graph.rs
+++ b/engine/crates/federated-graph/src/federated_graph.rs
@@ -127,6 +127,7 @@ pub struct Field {
 pub struct FieldArgument {
     pub name: StringId,
     pub type_id: FieldTypeId,
+    #[serde(default)]
     pub composed_directives: Vec<Directive>,
     #[serde(default)]
     pub description: Option<StringId>,

--- a/engine/crates/federated-graph/src/render_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl.rs
@@ -421,14 +421,21 @@ fn render_field_arguments(args: &[FieldArgument], graph: &FederatedGraphV1) -> S
     } else {
         let mut inner = args
             .iter()
-            .map(|arg| (&graph[arg.name], render_field_type(&graph[arg.type_id], graph)))
+            .map(|arg| {
+                let name = &graph[arg.name];
+                let r#type = render_field_type(&graph[arg.type_id], graph);
+                let directives = &arg.composed_directives;
+                (name, r#type, directives)
+            })
             .peekable();
         let mut out = String::from('(');
 
-        while let Some((name, ty)) = inner.next() {
+        while let Some((name, ty, directives)) = inner.next() {
             out.push_str(name);
             out.push_str(": ");
             out.push_str(&ty);
+
+            write_composed_directives(directives, graph, &mut out).unwrap();
 
             if inner.peek().is_some() {
                 out.push_str(", ");


### PR DESCRIPTION


As you will see in the diff, there were places left where we weren't
properly composing and rendering all or some directives, notably
directives on field arguments. The refactorings in the past few PRs
made filling these holes doable cleanly.

The @tag directive is now implemented everywhere it is valid.

closes GB-5396

