### PR TITLE
  composition: check implementers of composed interfaces 

### DIFF
--- a/engine/crates/composition/src/compose/directives.rs
+++ b/engine/crates/composition/src/compose/directives.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 pub(super) fn collect_composed_directives<'a>(
-    containers: impl Iterator<Item = subgraphs::DirectiveContainerWalker<'a>> + Clone,
+    sites: impl Iterator<Item = subgraphs::DirectiveSiteWalker<'a>> + Clone,
     ctx: &mut ComposeContext<'_>,
 ) -> Vec<federated::Directive> {
     let mut tags: BTreeSet<StringId> = BTreeSet::new();
@@ -9,7 +9,7 @@ pub(super) fn collect_composed_directives<'a>(
     let mut extra_directives = BTreeSet::new();
     let mut composed_directives = Vec::new();
 
-    if let Some(deprecated) = containers.clone().find_map(|directives| directives.deprecated()) {
+    if let Some(deprecated) = sites.clone().find_map(|directives| directives.deprecated()) {
         composed_directives.push(federated::Directive {
             name: ctx.insert_static_str("deprecated"),
             arguments: deprecated
@@ -25,13 +25,13 @@ pub(super) fn collect_composed_directives<'a>(
         });
     }
 
-    for container in containers {
-        tags.extend(container.tags().map(|t| t.id));
+    for site in sites {
+        tags.extend(site.tags().map(|t| t.id));
 
         // The inaccessible directive is added whenever the item is inaccessible in any subgraph.
-        is_inaccessible = is_inaccessible || container.inaccessible();
+        is_inaccessible = is_inaccessible || site.inaccessible();
 
-        for (name, arguments) in container.iter_composed_directives() {
+        for (name, arguments) in site.iter_composed_directives() {
             let name = ctx.insert_string(name);
             let arguments = arguments
                 .iter()

--- a/engine/crates/composition/src/compose/enums.rs
+++ b/engine/crates/composition/src/compose/enums.rs
@@ -80,11 +80,11 @@ fn merge_intersection<'a>(
     let enum_id = ctx.insert_enum(first.name(), description, composed_directives);
 
     for value in intersection {
-        let containers = definitions
+        let sites = definitions
             .iter()
             .filter_map(|enm| enm.enum_value_by_name(value))
             .map(|value| value.directives());
-        let composed_directives = collect_composed_directives(containers, ctx);
+        let composed_directives = collect_composed_directives(sites, ctx);
         ctx.insert_enum_value(enum_id, first.walk(value), None, composed_directives);
     }
 }
@@ -106,21 +106,17 @@ fn merge_union<'a>(
 
     let mut start = 0;
 
-    loop {
+    while start < all_values.len() {
         let name = all_values[start].0;
         let end = all_values[start..].partition_point(|(n, _)| *n == name) + start;
-        let containers = all_values[start..end]
+        let sites = all_values[start..end]
             .iter()
             .map(|(_, directives)| first.walk(*directives));
-        let composed_directives = collect_composed_directives(containers, ctx);
+        let composed_directives = collect_composed_directives(sites, ctx);
 
         ctx.insert_enum_value(enum_id, first.walk(name), None, composed_directives);
 
-        if end == all_values.len() {
-            break;
-        } else {
-            start = end;
-        }
+        start = end;
     }
 }
 
@@ -146,11 +142,11 @@ fn merge_exactly_matching<'a>(
     let enum_id = ctx.insert_enum(first.name(), description, composed_directives);
 
     for value in expected {
-        let containers = definitions
+        let sites = definitions
             .iter()
             .filter_map(|enm| enm.enum_value_by_name(value))
             .map(|value| value.directives());
-        let composed_directives = collect_composed_directives(containers, ctx);
+        let composed_directives = collect_composed_directives(sites, ctx);
         ctx.insert_enum_value(enum_id, first.walk(value), None, composed_directives);
     }
 }

--- a/engine/crates/composition/src/ingest_subgraph.rs
+++ b/engine/crates/composition/src/ingest_subgraph.rs
@@ -8,7 +8,7 @@ mod nested_key_fields;
 
 use self::{directives::*, nested_key_fields::ingest_nested_key_fields};
 use crate::{
-    subgraphs::{self, DefinitionId, DefinitionKind, DirectiveContainerId, SubgraphId},
+    subgraphs::{self, DefinitionId, DefinitionKind, DirectiveSiteId, SubgraphId},
     Subgraphs,
 };
 use async_graphql_parser::{types as ast, Positioned};
@@ -46,7 +46,7 @@ fn ingest_top_level_definitions(
                     .as_ref()
                     .map(|description| subgraphs.strings.intern(description.node.as_str()));
 
-                let directives = subgraphs.new_directive_container();
+                let directives = subgraphs.new_directive_site();
 
                 let definition_id = match &type_definition.node.kind {
                     ast::TypeKind::Object(_) => subgraphs.push_definition(

--- a/engine/crates/composition/src/ingest_subgraph/directives.rs
+++ b/engine/crates/composition/src/ingest_subgraph/directives.rs
@@ -2,7 +2,7 @@ use super::*;
 use std::{borrow::Cow, collections::BTreeSet};
 
 pub(super) fn ingest_directives(
-    directives: DirectiveContainerId,
+    directives: DirectiveSiteId,
     directives_node: &[Positioned<ast::ConstDirective>],
     subgraphs: &mut Subgraphs,
     directive_matcher: &DirectiveMatcher<'_>,

--- a/engine/crates/composition/src/ingest_subgraph/enums.rs
+++ b/engine/crates/composition/src/ingest_subgraph/enums.rs
@@ -8,7 +8,7 @@ pub(super) fn ingest_enum(
 ) {
     for value in &enum_type.values {
         let value_name = subgraphs.strings.intern(value.node.value.node.as_str());
-        let value_directives = subgraphs.new_directive_container();
+        let value_directives = subgraphs.new_directive_site();
 
         subgraphs.push_enum_value(definition_id, value_name, value_directives);
 

--- a/engine/crates/composition/src/ingest_subgraph/fields.rs
+++ b/engine/crates/composition/src/ingest_subgraph/fields.rs
@@ -9,7 +9,7 @@ pub(super) fn ingest_input_fields(
 ) {
     for field in fields {
         let field_type = subgraphs.intern_field_type(&field.node.ty.node);
-        let directives = subgraphs.new_directive_container();
+        let directives = subgraphs.new_directive_site();
 
         directives::ingest_directives(directives, &field.node.directives, subgraphs, matcher);
 
@@ -39,7 +39,7 @@ fn ingest_field_arguments(
         let r#type = subgraphs.intern_field_type(&argument.node.ty.node);
         let name = subgraphs.strings.intern(argument.node.name.node.as_str());
 
-        let argument_directives = subgraphs.new_directive_container();
+        let argument_directives = subgraphs.new_directive_site();
 
         ingest_directives(argument_directives, &argument.node.directives, subgraphs, matcher);
 
@@ -68,7 +68,7 @@ pub(super) fn ingest_fields(
             .map(|description| subgraphs.strings.intern(description.node.as_str()));
 
         let field_type = subgraphs.intern_field_type(&field.ty.node);
-        let directives = subgraphs.new_directive_container();
+        let directives = subgraphs.new_directive_site();
         directives::ingest_directives(directives, &field.directives, subgraphs, directive_matcher);
 
         let field_id = subgraphs.push_field(crate::subgraphs::FieldIngest {

--- a/engine/crates/composition/src/subgraphs.rs
+++ b/engine/crates/composition/src/subgraphs.rs
@@ -114,6 +114,9 @@ pub(crate) struct Subgraph {
 pub(crate) struct SubgraphId(usize);
 
 impl SubgraphId {
+    pub(crate) const MIN: SubgraphId = SubgraphId(usize::MIN);
+    pub(crate) const MAX: SubgraphId = SubgraphId(usize::MAX);
+
     pub(crate) fn idx(self) -> usize {
         self.0
     }

--- a/engine/crates/composition/src/subgraphs/directives.rs
+++ b/engine/crates/composition/src/subgraphs/directives.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct DirectiveContainerId(usize);
+pub(crate) struct DirectiveSiteId(usize);
 
 type Arguments = Vec<(StringId, Value)>;
 
@@ -18,26 +18,26 @@ pub(crate) enum Value {
 
 #[derive(Default)]
 pub(super) struct Directives {
-    container_id_counter: usize,
+    site_id_counter: usize,
 
-    deprecated: BTreeMap<DirectiveContainerId, Deprecated>,
-    r#override: BTreeMap<DirectiveContainerId, StringId>,
-    provides: BTreeMap<DirectiveContainerId, Vec<Selection>>,
-    requires: BTreeMap<DirectiveContainerId, Vec<Selection>>,
+    deprecated: BTreeMap<DirectiveSiteId, Deprecated>,
+    r#override: BTreeMap<DirectiveSiteId, StringId>,
+    provides: BTreeMap<DirectiveSiteId, Vec<Selection>>,
+    requires: BTreeMap<DirectiveSiteId, Vec<Selection>>,
 
-    inaccessible: HashSet<DirectiveContainerId>,
-    shareable: HashSet<DirectiveContainerId>,
-    external: HashSet<DirectiveContainerId>,
-    interface_object: HashSet<DirectiveContainerId>,
+    inaccessible: HashSet<DirectiveSiteId>,
+    shareable: HashSet<DirectiveSiteId>,
+    external: HashSet<DirectiveSiteId>,
+    interface_object: HashSet<DirectiveSiteId>,
 
-    tags: BTreeSet<(DirectiveContainerId, StringId)>,
+    tags: BTreeSet<(DirectiveSiteId, StringId)>,
 
     /// From @composeDirective.
     ///
     /// (subgraph_id, directive_name)
     composed_directives: BTreeSet<(SubgraphId, StringId)>,
 
-    composed_directive_instances: Vec<(DirectiveContainerId, StringId, Arguments)>,
+    composed_directive_instances: Vec<(DirectiveSiteId, StringId, Arguments)>,
 }
 
 impl Subgraphs {
@@ -50,7 +50,7 @@ impl Subgraphs {
 
     pub(crate) fn insert_composed_directive_instance(
         &mut self,
-        id: DirectiveContainerId,
+        id: DirectiveSiteId,
         directive_name: &str,
         arguments: Arguments,
     ) {
@@ -60,58 +60,58 @@ impl Subgraphs {
             .push((id, directive_name, arguments));
     }
 
-    pub(crate) fn insert_deprecated(&mut self, id: DirectiveContainerId, reason: Option<&str>) {
+    pub(crate) fn insert_deprecated(&mut self, id: DirectiveSiteId, reason: Option<&str>) {
         let reason = reason.map(|reason| self.strings.intern(reason));
         self.directives.deprecated.insert(id, Deprecated { reason });
     }
 
-    pub(crate) fn insert_provides(&mut self, id: DirectiveContainerId, fields: &str) -> Result<(), String> {
+    pub(crate) fn insert_provides(&mut self, id: DirectiveSiteId, fields: &str) -> Result<(), String> {
         let fields = self.selection_set_from_str(fields)?;
         self.directives.provides.insert(id, fields);
         Ok(())
     }
 
-    pub(crate) fn insert_requires(&mut self, id: DirectiveContainerId, fields: &str) -> Result<(), String> {
+    pub(crate) fn insert_requires(&mut self, id: DirectiveSiteId, fields: &str) -> Result<(), String> {
         let fields = self.selection_set_from_str(fields)?;
         self.directives.requires.insert(id, fields);
         Ok(())
     }
 
-    pub(crate) fn insert_tag(&mut self, id: DirectiveContainerId, tag: &str) {
+    pub(crate) fn insert_tag(&mut self, id: DirectiveSiteId, tag: &str) {
         let tag = self.strings.intern(tag);
         self.directives.tags.insert((id, tag));
     }
 
-    pub(crate) fn new_directive_container(&mut self) -> DirectiveContainerId {
-        let id = DirectiveContainerId(self.directives.container_id_counter);
-        self.directives.container_id_counter += 1;
+    pub(crate) fn new_directive_site(&mut self) -> DirectiveSiteId {
+        let id = DirectiveSiteId(self.directives.site_id_counter);
+        self.directives.site_id_counter += 1;
         id
     }
 
-    pub(crate) fn set_external(&mut self, id: DirectiveContainerId) {
+    pub(crate) fn set_external(&mut self, id: DirectiveSiteId) {
         self.directives.external.insert(id);
     }
 
-    pub(crate) fn set_inaccessible(&mut self, id: DirectiveContainerId) {
+    pub(crate) fn set_inaccessible(&mut self, id: DirectiveSiteId) {
         self.directives.inaccessible.insert(id);
     }
 
-    pub(crate) fn set_interface_object(&mut self, id: DirectiveContainerId) {
+    pub(crate) fn set_interface_object(&mut self, id: DirectiveSiteId) {
         self.directives.interface_object.insert(id);
     }
 
-    pub(crate) fn set_override(&mut self, id: DirectiveContainerId, from: StringId) {
+    pub(crate) fn set_override(&mut self, id: DirectiveSiteId, from: StringId) {
         self.directives.r#override.insert(id, from);
     }
 
-    pub(crate) fn set_shareable(&mut self, id: DirectiveContainerId) {
+    pub(crate) fn set_shareable(&mut self, id: DirectiveSiteId) {
         self.directives.shareable.insert(id);
     }
 }
 
-pub(crate) type DirectiveContainerWalker<'a> = Walker<'a, DirectiveContainerId>;
+pub(crate) type DirectiveSiteWalker<'a> = Walker<'a, DirectiveSiteId>;
 
-impl<'a> DirectiveContainerWalker<'a> {
+impl<'a> DirectiveSiteWalker<'a> {
     pub(crate) fn deprecated(self) -> Option<DeprecatedWalker<'a>> {
         self.subgraphs
             .directives

--- a/engine/crates/composition/src/subgraphs/enums.rs
+++ b/engine/crates/composition/src/subgraphs/enums.rs
@@ -2,16 +2,11 @@ use super::*;
 
 #[derive(Default)]
 pub(super) struct Enums {
-    values: BTreeMap<(DefinitionId, StringId), DirectiveContainerId>,
+    values: BTreeMap<(DefinitionId, StringId), DirectiveSiteId>,
 }
 
 impl Subgraphs {
-    pub(crate) fn push_enum_value(
-        &mut self,
-        enum_id: DefinitionId,
-        enum_value: StringId,
-        directives: DirectiveContainerId,
-    ) {
+    pub(crate) fn push_enum_value(&mut self, enum_id: DefinitionId, enum_value: StringId, directives: DirectiveSiteId) {
         self.enums.values.insert((enum_id, enum_value), directives);
     }
 }
@@ -41,7 +36,7 @@ impl<'a> DefinitionWalker<'a> {
     }
 }
 
-pub(crate) type EnumValueWalker<'a> = Walker<'a, (DefinitionId, StringId, DirectiveContainerId)>;
+pub(crate) type EnumValueWalker<'a> = Walker<'a, (DefinitionId, StringId, DirectiveSiteId)>;
 
 impl<'a> EnumValueWalker<'a> {
     pub(crate) fn name(self) -> StringWalker<'a> {
@@ -49,7 +44,7 @@ impl<'a> EnumValueWalker<'a> {
         self.walk(value_name)
     }
 
-    pub(crate) fn directives(self) -> DirectiveContainerWalker<'a> {
+    pub(crate) fn directives(self) -> DirectiveSiteWalker<'a> {
         let (_enum_id, _value_name, directives) = self.id;
         self.walk(directives)
     }

--- a/engine/crates/composition/src/subgraphs/fields.rs
+++ b/engine/crates/composition/src/subgraphs/fields.rs
@@ -24,7 +24,7 @@ pub(crate) struct Fields {
 pub(crate) struct FieldTuple {
     r#type: FieldTypeId,
     description: Option<StringId>,
-    directives: DirectiveContainerId,
+    directives: DirectiveSiteId,
 }
 
 impl Subgraphs {
@@ -99,7 +99,7 @@ impl Subgraphs {
         FieldId(definition_id, field_name): FieldId,
         argument_name: StringId,
         r#type: FieldTypeId,
-        directives: DirectiveContainerId,
+        directives: DirectiveSiteId,
         description: Option<StringId>,
     ) {
         self.fields.field_arguments.insert(
@@ -135,7 +135,7 @@ pub(crate) struct FieldIngest<'a> {
     pub(crate) field_name: &'a str,
     pub(crate) field_type: FieldTypeId,
     pub(crate) description: Option<StringId>,
-    pub(crate) directives: DirectiveContainerId,
+    pub(crate) directives: DirectiveSiteId,
 }
 
 pub(crate) type FieldWalker<'a> = Walker<'a, (FieldId, FieldTuple)>;
@@ -180,7 +180,7 @@ impl<'a> FieldWalker<'a> {
         tuple.description.map(|id| self.walk(id))
     }
 
-    pub(crate) fn directives(self) -> DirectiveContainerWalker<'a> {
+    pub(crate) fn directives(self) -> DirectiveSiteWalker<'a> {
         let (_, tuple) = self.id;
         self.walk(tuple.directives)
     }
@@ -253,7 +253,7 @@ impl<'a> FieldArgumentWalker<'a> {
         self.walk(tuple.r#type)
     }
 
-    pub(crate) fn directives(&self) -> DirectiveContainerWalker<'a> {
+    pub(crate) fn directives(&self) -> DirectiveSiteWalker<'a> {
         let (_, tuple) = self.id;
         self.walk(tuple.directives)
     }

--- a/engine/crates/composition/tests/composition/interfaces_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/interfaces_basic/federated.graphql
@@ -23,6 +23,12 @@ enum join__Graph {
 
 type Furby implements FurbyType & SocialFurby {
     id: ID! @join__field(graph: SOCIAL)
+    batteryType: String! @join__field(graph: SOCIAL)
+    connectivity: String @join__field(graph: SOCIAL)
+    sensorTypes: [String!]! @join__field(graph: SOCIAL)
+    color: String! @join__field(graph: SOCIAL)
+    height: Float! @join__field(graph: SOCIAL)
+    weight: Float! @join__field(graph: SOCIAL)
     languages: [String!]! @join__field(graph: SOCIAL)
     canSing: Boolean! @join__field(graph: SOCIAL)
     canDance: Boolean! @join__field(graph: SOCIAL)

--- a/engine/crates/composition/tests/composition/interfaces_basic/subgraphs/social.graphql
+++ b/engine/crates/composition/tests/composition/interfaces_basic/subgraphs/social.graphql
@@ -6,11 +6,17 @@ interface FurbyType {
 }
 
 type Furby implements FurbyType & SocialFurby {
-    id: ID!
+  id: ID!
   languages: [String!]
   canSing: Boolean!
   canDance: Boolean!
   friends: [Furby!]
+  batteryType: String!
+  connectivity: String
+  sensorTypes: [String!]
+  color: String!
+  height: Float! # in centimeters
+  weight: Float! # in grams
 }
 
 interface SocialFurby {

--- a/engine/crates/composition/tests/composition/object_implementing_composed_interface/federated.graphql
+++ b/engine/crates/composition/tests/composition/object_implementing_composed_interface/federated.graphql
@@ -1,0 +1,1 @@
+# The `Edible.calories` field is not implemented by `PuddingDessert`, but it should be.

--- a/engine/crates/composition/tests/composition/object_implementing_composed_interface/subgraphs/nutrition.graphql
+++ b/engine/crates/composition/tests/composition/object_implementing_composed_interface/subgraphs/nutrition.graphql
@@ -1,0 +1,25 @@
+interface Edible {
+  id: ID!
+  calories: Int!
+}
+
+interface Perishable {
+  expirationDate: String!
+  storageTemperature: Float!
+  originCountry: String!
+  packageType: String!
+}
+
+type PuddingSnack implements Edible & Perishable {
+  id: ID!
+  name: String!
+  calories: Int!
+  isVegan: Boolean!
+  expirationDate: String!
+  storageTemperature: Float!
+  originCountry: String!
+  packageType: String!
+  servingSize: Int!
+  containsNuts: Boolean!
+}
+

--- a/engine/crates/composition/tests/composition/object_implementing_composed_interface/subgraphs/product.graphql
+++ b/engine/crates/composition/tests/composition/object_implementing_composed_interface/subgraphs/product.graphql
@@ -1,0 +1,28 @@
+type Query {
+  getDessert: PuddingDessert
+}
+
+interface Edible {
+  id: ID!
+  name: String!
+  isVegan: Boolean!
+}
+
+interface Perishable {
+  expirationDate: String!
+  storageTemperature: Float!
+  originCountry: String!
+  packageType: String!
+}
+
+type PuddingDessert implements Edible & Perishable {
+  id: ID!
+  name: String!
+  isVegan: Boolean!
+  expirationDate: String!
+  storageTemperature: Float!
+  originCountry: String!
+  packageType: String!
+  flavor: String!
+  texture: String!
+}


### PR DESCRIPTION
The rule is that a composed interface is the union of all the interfaces
in all the schemas, and objects implementing that interface in the
composed schema must implement all fields of the interfface. In this PR,
we validate that.

closes GB-5507