### PR TITLE
composition: implement strict matching rules for shareable objects

### DIFF
--- a/engine/crates/composition/src/compose.rs
+++ b/engine/crates/composition/src/compose.rs
@@ -65,6 +65,7 @@ fn merge_object_definitions<'a>(
         ctx.diagnostics.push_fatal(format!(
             "Cannot merge {first_kind:?} with {second_kind:?} (`{name}` in `{first_subgraph}` and `{second_subgraph}`)",
         ));
+        return;
     }
 
     let first_is_entity = first.is_entity();
@@ -98,6 +99,10 @@ fn merge_object_definitions<'a>(
         .filter(|key| key.is_resolvable())
     {
         ctx.insert_resolvable_key(object_id, key.id);
+    }
+
+    if is_shareable {
+        object::validate_shareable_object_fields_match(definitions, ctx);
     }
 
     ctx.subgraphs.iter_field_groups(first.name().id, |fields| {

--- a/engine/crates/composition/src/subgraphs/fields.rs
+++ b/engine/crates/composition/src/subgraphs/fields.rs
@@ -224,7 +224,16 @@ impl<'a> DefinitionWalker<'a> {
     }
 
     pub(crate) fn find_field(self, name: StringId) -> Option<FieldWalker<'a>> {
-        self.fields().find(|f| f.name().id == name)
+        let field_id = FieldId(self.id, name);
+
+        self.subgraphs
+            .fields
+            .definition_fields
+            .get(&field_id)
+            .map(|tuple| FieldWalker {
+                id: (field_id, *tuple),
+                subgraphs: self.subgraphs,
+            })
     }
 }
 

--- a/engine/crates/composition/tests/composition/inaccessible_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/inaccessible_basic/federated.graphql
@@ -56,9 +56,9 @@ type Series {
 
 type New {
     name: String! @inaccessible
+    other: String!
     message: String! @join__field(graph: ONE) @inaccessible
     old: Old! @join__field(graph: ONE) @inaccessible
-    other: String! @join__field(graph: TWO)
 }
 
 type Old @inaccessible {

--- a/engine/crates/composition/tests/composition/inaccessible_basic/subgraphs/one.graphql
+++ b/engine/crates/composition/tests/composition/inaccessible_basic/subgraphs/one.graphql
@@ -1,4 +1,5 @@
 type New @shareable {
+    other: String!
     name: String! @inaccessible
     message: String! @inaccessible
     old: Old! @inaccessible

--- a/engine/crates/composition/tests/composition/inaccessible_in_one_subgraph_is_enough/federated.graphql
+++ b/engine/crates/composition/tests/composition/inaccessible_in_one_subgraph_is_enough/federated.graphql
@@ -1,0 +1,33 @@
+directive @core(feature: String!) repeatable on SCHEMA
+
+directive @join__owner(graph: join__Graph!) on OBJECT
+
+directive @join__type(
+    graph: join__Graph!
+    key: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__field(
+    graph: join__Graph
+    requires: String
+    provides: String
+) on FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+enum join__Graph {
+    ONE @join__graph(name: "one", url: "http://example.com/one")
+    THREE @join__graph(name: "three", url: "http://example.com/three")
+    TWO @join__graph(name: "two", url: "http://example.com/two")
+}
+
+type Query {
+    colors: [Color] @join__field(graph: ONE)
+}
+
+type Color {
+    red: Int
+    green: Int
+    blue: Int
+    alpha: Int @inaccessible
+}

--- a/engine/crates/composition/tests/composition/inaccessible_in_one_subgraph_is_enough/subgraphs/one.graphql
+++ b/engine/crates/composition/tests/composition/inaccessible_in_one_subgraph_is_enough/subgraphs/one.graphql
@@ -1,0 +1,9 @@
+type Query {
+    colors: [Color]
+}
+
+type Color @shareable {
+  red: Int
+  green: Int
+  blue: Int
+}

--- a/engine/crates/composition/tests/composition/inaccessible_in_one_subgraph_is_enough/subgraphs/three.graphql
+++ b/engine/crates/composition/tests/composition/inaccessible_in_one_subgraph_is_enough/subgraphs/three.graphql
@@ -1,0 +1,6 @@
+type Color @shareable {
+  red: Int
+  green: Int
+  blue: Int
+  alpha: Int @inaccessible
+}

--- a/engine/crates/composition/tests/composition/inaccessible_in_one_subgraph_is_enough/subgraphs/two.graphql
+++ b/engine/crates/composition/tests/composition/inaccessible_in_one_subgraph_is_enough/subgraphs/two.graphql
@@ -1,0 +1,7 @@
+type Color @shareable {
+  red: Int
+  green: Int
+  blue: Int
+  alpha: Int
+}
+

--- a/engine/crates/composition/tests/composition/input_object_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/input_object_basic/federated.graphql
@@ -25,7 +25,10 @@ type Query {
     searchPerson(input: InputPerson!): [Person] @join__field(graph: PHONEBOOK)
 }
 
-type Person {
+type Person
+    @join__type(graph: EMAILBOOK, key: "id")
+    @join__type(graph: PHONEBOOK, key: "id")
+{
     id: ID!
     firstName: String!
     lastName: String!

--- a/engine/crates/composition/tests/composition/input_object_basic/subgraphs/emailbook.graphql
+++ b/engine/crates/composition/tests/composition/input_object_basic/subgraphs/emailbook.graphql
@@ -4,11 +4,11 @@ type Query {
   getPersonInfo(input: InputPerson!): Person
 }
 
-type Person @federation__shareable {
+type Person @federation__key(fields: "id") {
   id: ID!
-  firstName: String!
-  lastName: String!
-  age: Int!
+  firstName: String! @federation__shareable
+  lastName: String! @federation__shareable
+  age: Int! @federation__shareable
   email: String!
 }
 

--- a/engine/crates/composition/tests/composition/input_object_basic/subgraphs/phonebook.graphql
+++ b/engine/crates/composition/tests/composition/input_object_basic/subgraphs/phonebook.graphql
@@ -4,11 +4,11 @@ type Query {
   searchPerson(input: InputPerson!): [Person]
 }
 
-type Person @federation__shareable {
+type Person @federation__key(fields: "id") {
   id: ID!
-  firstName: String!
-  lastName: String!
-  age: Int!
+  firstName: String! @federation__shareable
+  lastName: String! @federation__shareable
+  age: Int! @federation__shareable
   phoneNumber: String
 }
 

--- a/engine/crates/composition/tests/composition/object_field_arguments_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/object_field_arguments_basic/federated.graphql
@@ -31,8 +31,8 @@ type RollerCoaster {
     height: Float!
     speed: Float!
     manufacturer: String!
-    historicalData: [HistoricalData] @join__field(graph: HISTORY)
-    numberOfInversions: Int! @join__field(graph: PERFORMANCE)
+    historicalData: [HistoricalData] @join__field(graph: HISTORY) @inaccessible
+    numberOfInversions: Int! @join__field(graph: PERFORMANCE) @inaccessible
 }
 
 type HistoricalData {

--- a/engine/crates/composition/tests/composition/object_field_arguments_basic/subgraphs/history.graphql
+++ b/engine/crates/composition/tests/composition/object_field_arguments_basic/subgraphs/history.graphql
@@ -1,7 +1,7 @@
 extend schema
     @link(
         url: "https://specs.apollo.dev/federation/v2.3",
-        import: [{ name: "@shareable" }]
+        import: [{ name: "@shareable" }, "@inaccessible"]
      )
 
 type Query {
@@ -14,7 +14,7 @@ type RollerCoaster @shareable {
   height: Float! # height in meters
   speed: Float! # speed in km/h
   manufacturer: String!
-  historicalData: [HistoricalData]
+  historicalData: [HistoricalData] @inaccessible
 }
 
 type HistoricalData @shareable {

--- a/engine/crates/composition/tests/composition/object_field_arguments_basic/subgraphs/inventory.graphql
+++ b/engine/crates/composition/tests/composition/object_field_arguments_basic/subgraphs/inventory.graphql
@@ -1,7 +1,7 @@
 extend schema
     @link(
         url: "https://specs.apollo.dev/federation/v2.3",
-        import: [{ name: "@shareable" }]
+        import: [{ name: "@shareable" }, "@inaccessible"]
      )
 
 type Query @shareable {

--- a/engine/crates/composition/tests/composition/object_field_arguments_basic/subgraphs/performance.graphql
+++ b/engine/crates/composition/tests/composition/object_field_arguments_basic/subgraphs/performance.graphql
@@ -1,7 +1,7 @@
 extend schema
     @link(
         url: "https://specs.apollo.dev/federation/v2.3",
-        import: [{ name: "@shareable" }]
+        import: [{ name: "@shareable" }, "@inaccessible"]
      )
 
 type Query {
@@ -13,6 +13,7 @@ type RollerCoaster @shareable {
   name: String!
   height: Float! # height in meters
   speed: Float! # speed in km/h
-  numberOfInversions: Int!
+  manufacturer: String!
+  numberOfInversions: Int! @inaccessible
 }
 

--- a/engine/crates/composition/tests/composition/shareable_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/shareable_basic/federated.graphql
@@ -24,9 +24,9 @@ enum join__Graph {
 type Customer {
     id: ID!
     name: String
-    other: Int @join__field(graph: ACCOUNTS)
-    newsletterSubscribed: Boolean @join__field(graph: MARKETING)
-    subscriptionPlan: Plan! @join__field(graph: SUBSCRIPTIONS)
+    other: Int @join__field(graph: ACCOUNTS) @inaccessible
+    newsletterSubscribed: Boolean @join__field(graph: MARKETING) @inaccessible
+    subscriptionPlan: Plan! @join__field(graph: SUBSCRIPTIONS) @inaccessible
 }
 
 type Query {

--- a/engine/crates/composition/tests/composition/shareable_basic/subgraphs/accounts.graphql
+++ b/engine/crates/composition/tests/composition/shareable_basic/subgraphs/accounts.graphql
@@ -1,13 +1,13 @@
 extend schema
     @link(
         url: "https://specs.apollo.dev/federation/v2.3",
-        import: ["@key", "@shareable"]
+        import: ["@key", "@shareable", "@inaccessible"]
      )
 
 type Customer {
     id: ID! @shareable
     name: String @shareable
-    other: Int
+    other: Int @inaccessible
 }
 
 type Query {

--- a/engine/crates/composition/tests/composition/shareable_basic/subgraphs/marketing.graphql
+++ b/engine/crates/composition/tests/composition/shareable_basic/subgraphs/marketing.graphql
@@ -1,12 +1,12 @@
 extend schema
     @link(
         url: "https://specs.apollo.dev/federation/v2.3",
-        import: [{ name: "@shareable", as: "@partageable" }]
+        import: [{ name: "@shareable", as: "@partageable" }, "@inaccessible"]
      )
 
 type Customer @partageable {
     id: ID!
     name: String
     
-    newsletterSubscribed: Boolean
+    newsletterSubscribed: Boolean @inaccessible
 }

--- a/engine/crates/composition/tests/composition/shareable_basic/subgraphs/subscriptions.graphql
+++ b/engine/crates/composition/tests/composition/shareable_basic/subgraphs/subscriptions.graphql
@@ -1,7 +1,7 @@
 extend schema
     @link(
         url: "https://specs.apollo.dev/federation/v2.3",
-        import: ["@key", "@shareable"]
+        import: ["@key", "@shareable", "@inaccessible"]
      )
 
 enum Plan {
@@ -12,5 +12,5 @@ enum Plan {
 type Customer {
     id: ID! @shareable
     name: String @shareable
-    subscriptionPlan: Plan!
+    subscriptionPlan: Plan! @inaccessible
 }

--- a/engine/crates/composition/tests/composition/shareable_non_matching_fields/federated.graphql
+++ b/engine/crates/composition/tests/composition/shareable_non_matching_fields/federated.graphql
@@ -1,0 +1,1 @@
+# [algae_one] The shareable object `AlgaeFarm` is missing the `productionCapacity` field defined in other subgraphs.

--- a/engine/crates/composition/tests/composition/shareable_non_matching_fields/subgraphs/algae_one.graphql
+++ b/engine/crates/composition/tests/composition/shareable_non_matching_fields/subgraphs/algae_one.graphql
@@ -1,0 +1,32 @@
+type Query {
+  getAlgaeSpecies: [AlgaeSpecies]
+}
+
+type AlgaeFarm @shareable {
+  id: ID!
+  name: String!
+  location: String
+  waterType: WaterType
+  size: Float # in hectares
+}
+
+type AlgaeSpecies {
+  id: ID! @shareable
+  name: String! @shareable
+  scientificName: String @shareable
+  preferredEnvironment: Environment @shareable
+  growthRate: Float @shareable # in grams per day
+  uses: [String] @shareable # such as biofuel, food, cosmetics
+}
+
+enum WaterType {
+  FRESHWATER
+  BRACKISH
+  MARINE
+}
+
+enum Environment {
+  OPEN_POND
+  PHOTOBIOREACTOR
+  RACEWAY_POND
+}

--- a/engine/crates/composition/tests/composition/shareable_non_matching_fields/subgraphs/algae_two.graphql
+++ b/engine/crates/composition/tests/composition/shareable_non_matching_fields/subgraphs/algae_two.graphql
@@ -1,0 +1,33 @@
+type Query {
+  getAlgaeFarms: [AlgaeFarm]
+}
+
+type AlgaeFarm @shareable {
+  id: ID!
+  name: String!
+  location: String
+  waterType: WaterType
+  size: Float # in hectares
+  productionCapacity: Float # in tons per year
+}
+
+type AlgaeSpecies {
+  id: ID! @shareable
+  name: String! @shareable
+  scientificName: String @shareable
+  preferredEnvironment: Environment @shareable
+  uses: [String] @shareable # such as biofuel, food, cosmetics
+}
+
+enum WaterType {
+  FRESHWATER
+  BRACKISH
+  MARINE
+}
+
+enum Environment {
+  OPEN_POND
+  PHOTOBIOREACTOR
+  RACEWAY_POND
+}
+


### PR DESCRIPTION
The fields must match between subgraphs, except those marked with `@inaccessible`.

closes GB-5508

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
