### PR TITLE
chore(engine-v2): Remove cf-workers feature flag and move it behind a trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2009,26 +2009,20 @@ version = "3.0.31"
 dependencies = [
  "anyhow",
  "async-runtime",
- "bytes",
  "derive_more",
  "engine",
  "engine-parser",
  "engine-v2-schema",
  "engine-value",
- "futures-locks",
  "futures-util",
  "im",
  "itertools 0.11.0",
  "lasso",
- "reqwest",
- "send_wrapper 0.6.0",
+ "runtime",
  "serde",
  "serde-value",
- "serde-wasm-bindgen 0.6.1",
  "serde_json",
  "thiserror",
- "url",
- "worker",
 ]
 
 [[package]]
@@ -2229,6 +2223,7 @@ dependencies = [
  "indoc",
  "log 0.4.20",
  "reqwest",
+ "runtime-local",
  "serde",
  "serde_json",
  "thiserror",
@@ -2469,17 +2464,6 @@ dependencies = [
  "parking",
  "pin-project-lite",
  "waker-fn",
-]
-
-[[package]]
-name = "futures-locks"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ec6fe3675af967e67c5536c0b9d44e34e6c52f86bedc4ea49c5317b8e94d06"
-dependencies = [
- "futures-channel",
- "futures-task",
- "tokio",
 ]
 
 [[package]]
@@ -5565,6 +5549,7 @@ name = "runtime"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "common-types",
  "futures-util",
  "headers",
@@ -5990,17 +5975,6 @@ name = "serde-wasm-bindgen"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ba92964781421b6cef36bf0d7da26d201e96d84e1b10e7ae6ed416e516906d"
 dependencies = [
  "js-sys",
  "serde",
@@ -8167,7 +8141,7 @@ dependencies = [
  "matchit 0.4.6",
  "pin-project",
  "serde",
- "serde-wasm-bindgen 0.5.0",
+ "serde-wasm-bindgen",
  "serde_json",
  "tokio",
  "url",
@@ -8188,7 +8162,7 @@ checksum = "3d4b9fe1a87b7aef252fceb4f30bf6303036a5de329c81ccad9be9c35d1fdbc7"
 dependencies = [
  "js-sys",
  "serde",
- "serde-wasm-bindgen 0.5.0",
+ "serde-wasm-bindgen",
  "serde_json",
  "thiserror",
  "wasm-bindgen",

--- a/cli/crates/federated-dev/Cargo.toml
+++ b/cli/crates/federated-dev/Cargo.toml
@@ -32,6 +32,7 @@ tokio-stream = "0.1"
 tower-http = { version = "0.4", features = ["cors", "fs", "trace"] }
 log = "0.4.20"
 common = { package = "grafbase-local-common", path = "../common", version = "0.47.0" }
+runtime-local.workspace = true
 
 [lints]
 workspace = true

--- a/cli/crates/federated-dev/src/dev/router.rs
+++ b/cli/crates/federated-dev/src/dev/router.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use super::bus::{GraphReceiver, RequestReceiver, ResponseSender};
-use engine_v2::Engine;
+use engine_v2::{Engine, EngineRuntime};
 use futures_concurrency::stream::Merge;
 use futures_util::{stream::BoxStream, StreamExt};
 use graphql_composition::FederatedGraph;
@@ -55,7 +55,12 @@ impl Router {
 }
 
 fn new_engine(graph: FederatedGraph) -> Arc<Engine> {
-    Arc::new(Engine::new(graph.into()))
+    Arc::new(Engine::new(
+        graph.into(),
+        EngineRuntime {
+            fetcher: runtime_local::NativeFetcher::runtime_fetcher(),
+        },
+    ))
 }
 
 async fn run_request(request: engine::Request, response_sender: ResponseSender, engine: Arc<Engine>) {

--- a/engine/crates/engine-v2/Cargo.toml
+++ b/engine/crates/engine-v2/Cargo.toml
@@ -13,32 +13,18 @@ keywords = ["graphql", "engine", "grafbase"]
 [lints]
 workspace = true
 
-[features]
-default = []
-cf-workers = ["serde-wasm-bindgen", "worker"]
-
 [dependencies]
 async-runtime = { workspace = true }
-bytes = "1"
 derive_more = "0.99"
 im = "15"
 lasso = "0.7"
 anyhow = "1"
 itertools.workspace = true
-send_wrapper.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-serde-wasm-bindgen = { workspace = true, optional = true }
 serde-value = "0.7"
 thiserror.workspace = true
-futures-locks = "0.7"
 futures-util.workspace = true
-reqwest = { version = "0.11", default-features = false, features = [
-  "json",
-  "rustls-tls",
-] }
-url = "2"
-worker = { version = "0.0.18", optional = true }
 
 engine-value = { path = "../engine/value" }
 engine-parser = { path = "../engine/parser" }
@@ -47,4 +33,5 @@ schema = { path = "./schema", package = "engine-v2-schema" }
 # might move it back to engine, the goal isn't to rewrite everything from engine per se
 # but having more explicit dependencies for now.
 engine = { path = "../engine" }
+runtime.workspace = true
 

--- a/engine/crates/engine-v2/src/engine.rs
+++ b/engine/crates/engine-v2/src/engine.rs
@@ -13,32 +13,18 @@ pub struct Engine {
     // We use an Arc for the schema to have a self-contained response which may still
     // needs access to the schema strings
     pub(crate) schema: Arc<Schema>,
+    pub(crate) runtime: EngineRuntime,
+}
 
-    // Cloudflare Workers only.
-    // Domain requests against which should be routed through a service binding.
-    #[cfg(feature = "cf-workers")]
-    pub(crate) self_domain_configuration: Option<(String, send_wrapper::SendWrapper<worker::Fetcher>)>,
+pub struct EngineRuntime {
+    pub fetcher: runtime::fetch::Fetcher,
 }
 
 impl Engine {
-    pub fn new(schema: Schema) -> Self {
-        #[cfg(feature = "cf-workers")]
-        return Self {
-            schema: Arc::new(schema),
-            self_domain_configuration: None,
-        };
-
-        #[cfg(not(feature = "cf-workers"))]
-        return Self {
-            schema: Arc::new(schema),
-        };
-    }
-
-    #[cfg(feature = "cf-workers")]
-    pub fn new_with_self_domain_routing(schema: Schema, self_domain: String, service: worker::Fetcher) -> Self {
+    pub fn new(schema: Schema, runtime: EngineRuntime) -> Self {
         Self {
             schema: Arc::new(schema),
-            self_domain_configuration: Some((self_domain, send_wrapper::SendWrapper::new(service))),
+            runtime,
         }
     }
 

--- a/engine/crates/engine-v2/src/executor/graphql/mod.rs
+++ b/engine/crates/engine-v2/src/executor/graphql/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use engine_value::ConstValue;
+use runtime::fetch::FetchRequest;
 use schema::SubgraphResolver;
 use serde::de::DeserializeSeed;
 
@@ -12,7 +13,6 @@ mod query;
 
 #[derive(Debug)]
 pub struct GraphqlExecutor<'a> {
-    endpoint_name: String,
     url: String,
     payload: Payload<'a>,
     response_object_root: ResponseObjectRoot,
@@ -38,26 +38,12 @@ impl<'a> GraphqlExecutor<'a> {
         let subgraph = &ctx.engine.schema[*subgraph_id];
         let query::Query { query, variables } =
             query::QueryBuilder::build(ctx.operation, ctx.plan_id, ctx.variables(), ctx.selection_set())
-                .map_err(|err| ExecutorError::InternalError(format!("Failed to build query: {err}")))?;
+                .map_err(|err| ExecutorError::Internal(format!("Failed to build query: {err}")))?;
         Ok(Executor::GraphQL(Self {
-            endpoint_name: ctx.engine.schema[subgraph.name].to_string(),
             url: ctx.engine.schema[subgraph.url].clone(),
             payload: Payload { query, variables },
             response_object_root: input.root_response_objects.root(),
         }))
-    }
-
-    async fn send_request(&self) -> Result<bytes::Bytes, ExecutorError> {
-        let response = reqwest::Client::new()
-            .post(&self.url)
-            .json(&self.payload)
-            .send()
-            .await
-            .map_err(|err| format!("Request to '{}' failed with: {err}", self.endpoint_name))?;
-        response
-            .bytes()
-            .await
-            .map_err(|_err| "Failed to read response".to_string().into())
     }
 
     pub(super) async fn execute(
@@ -65,53 +51,16 @@ impl<'a> GraphqlExecutor<'a> {
         ctx: ExecutionContext<'_, '_>,
         output: &mut ResponsePartBuilder,
     ) -> Result<(), ExecutorError> {
-        #[cfg(feature = "cf-workers")]
-        let bytes = match &ctx.engine.self_domain_configuration {
-            Some((self_domain, service))
-                if self
-                    .url
-                    .parse::<url::Url>()
-                    .map_err(|_err| "invalid URL".to_string())?
-                    .domain()
-                    .is_some_and(|parsed_domain| {
-                        parsed_domain
-                            .rsplit('.')
-                            .zip(self_domain.rsplit('.'))
-                            .all(|(lhs, rhs)| lhs == rhs)
-                    }) =>
-            {
-                let url = self.url.clone();
-                Box::pin(send_wrapper::SendWrapper::new(async move {
-                    use serde::Serialize;
-
-                    let mut init = worker::RequestInit::new();
-                    init.with_method(worker::Method::Post);
-                    init.with_body(Some(
-                        worker::js_sys::JSON::stringify(
-                            &self
-                                .payload
-                                .serialize(&serde_wasm_bindgen::Serializer::json_compatible())
-                                .expect("necessarily serializable"),
-                        )
-                        .expect("must succeed")
-                        .into(),
-                    ));
-                    service
-                        .fetch_request(worker::Request::new_with_init(&url, &init).map_err(|err| err.to_string())?)
-                        .await
-                        .map_err(|err| err.to_string())?
-                        .bytes()
-                        .await
-                        .map_err(|err| err.to_string())
-                        .map(From::from)
-                }))
-                .await?
-            }
-            _ => self.send_request().await?,
-        };
-
-        #[cfg(not(feature = "cf-workers"))]
-        let bytes = self.send_request().await?;
+        let bytes = ctx
+            .engine
+            .runtime
+            .fetcher
+            .post(FetchRequest {
+                url: &self.url,
+                json_body: serde_json::to_string(&self.payload).unwrap(),
+            })
+            .await?
+            .bytes;
 
         deserialize::UniqueRootSeed {
             ctx: &ctx,

--- a/engine/crates/engine-v2/src/executor/mod.rs
+++ b/engine/crates/engine-v2/src/executor/mod.rs
@@ -88,19 +88,21 @@ pub struct ExecutorInput<'a> {
 #[derive(thiserror::Error, Debug)]
 pub enum ExecutorError {
     #[error("Internal error: {0}")]
-    InternalError(String),
+    Internal(String),
     #[error(transparent)]
-    WriteError(#[from] crate::response::WriteError),
+    Write(#[from] crate::response::WriteError),
+    #[error(transparent)]
+    Fetch(#[from] runtime::fetch::FetchError),
 }
 
 impl From<&str> for ExecutorError {
     fn from(message: &str) -> Self {
-        Self::InternalError(message.to_string())
+        Self::Internal(message.to_string())
     }
 }
 
 impl From<String> for ExecutorError {
     fn from(message: String) -> Self {
-        Self::InternalError(message)
+        Self::Internal(message)
     }
 }

--- a/engine/crates/engine-v2/src/lib.rs
+++ b/engine/crates/engine-v2/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(unused_crate_dependencies)]
 mod engine;
 mod error;
 mod execution;
@@ -7,5 +6,5 @@ mod plan;
 mod request;
 mod response;
 
-pub use engine::Engine;
+pub use engine::{Engine, EngineRuntime};
 pub use response::Response;

--- a/engine/crates/integration-tests/src/federation/builder.rs
+++ b/engine/crates/integration-tests/src/federation/builder.rs
@@ -44,7 +44,12 @@ impl FederationEngineBuilder {
             .expect("schemas to compose succesfully");
 
         TestFederationEngine {
-            engine: Engine::new(graph.into()),
+            engine: Engine::new(
+                graph.into(),
+                engine_v2::EngineRuntime {
+                    fetcher: runtime_local::NativeFetcher::runtime_fetcher(),
+                },
+            ),
         }
     }
 }

--- a/engine/crates/runtime-local/src/fetch.rs
+++ b/engine/crates/runtime-local/src/fetch.rs
@@ -1,0 +1,32 @@
+use runtime::fetch::{FetchError, FetchRequest, FetchResponse, FetchResult, Fetcher, FetcherInner};
+
+pub struct NativeFetcher {
+    client: reqwest::Client,
+}
+
+impl NativeFetcher {
+    pub fn runtime_fetcher() -> Fetcher {
+        Fetcher::new(Box::new(Self {
+            client: reqwest::Client::new(),
+        }))
+    }
+}
+
+#[async_trait::async_trait]
+impl FetcherInner for NativeFetcher {
+    async fn post(&self, request: FetchRequest<'_>) -> FetchResult<FetchResponse> {
+        let response = self
+            .client
+            .post(request.url)
+            .body(request.json_body)
+            .header("Content-Type", "application/json")
+            .send()
+            .await
+            .map_err(|e| FetchError::AnyError(e.to_string()))?;
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| FetchError::AnyError(e.to_string()))?;
+        Ok(FetchResponse { bytes })
+    }
+}

--- a/engine/crates/runtime-local/src/lib.rs
+++ b/engine/crates/runtime-local/src/lib.rs
@@ -1,5 +1,6 @@
 mod bridge;
 mod cache;
+mod fetch;
 mod log;
 mod pg;
 pub mod search;
@@ -7,6 +8,7 @@ mod ufd_invoker;
 
 pub use bridge::Bridge;
 pub use cache::InMemoryCache;
+pub use fetch::NativeFetcher;
 pub use pg::LocalPgTransportFactory;
 pub use search::LocalSearchEngine;
 pub use ufd_invoker::UdfInvokerImpl;

--- a/engine/crates/runtime/Cargo.toml
+++ b/engine/crates/runtime/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = { workspace = true }
 ulid = { workspace = true }
 http = { workspace = true }
 headers = { workspace = true }
+bytes = { workspace = true }
 
 search-protocol = { path = "../search-protocol" }
 postgres-connector-types = { path = "../postgres-connector-types" }

--- a/engine/crates/runtime/src/fetch.rs
+++ b/engine/crates/runtime/src/fetch.rs
@@ -1,0 +1,48 @@
+use std::sync::Arc;
+
+use bytes::Bytes;
+
+#[derive(Debug, thiserror::Error)]
+pub enum FetchError {
+    #[error("{0}")]
+    AnyError(String),
+}
+
+pub type FetchResult<T> = Result<T, FetchError>;
+
+// very minimal for now, but will be expanded as we need it.
+pub struct FetchRequest<'a> {
+    pub url: &'a str,
+    pub json_body: String,
+}
+
+pub struct FetchResponse {
+    pub bytes: Bytes,
+}
+
+#[async_trait::async_trait]
+pub trait FetcherInner {
+    async fn post(&self, request: FetchRequest<'_>) -> FetchResult<FetchResponse>;
+}
+
+type BoxedFetcherImpl = Box<dyn FetcherInner + Send + Sync>;
+
+pub struct Fetcher {
+    inner: Arc<BoxedFetcherImpl>,
+}
+
+impl Fetcher {
+    pub fn new(fetcher: BoxedFetcherImpl) -> Fetcher {
+        Fetcher {
+            inner: Arc::new(fetcher),
+        }
+    }
+}
+
+impl std::ops::Deref for Fetcher {
+    type Target = BoxedFetcherImpl;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}

--- a/engine/crates/runtime/src/lib.rs
+++ b/engine/crates/runtime/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cache;
 pub mod context;
+pub mod fetch;
 pub mod kv;
 pub mod log;
 pub mod pg;


### PR DESCRIPTION
feature flags are a pain to deal with we've seen that with the previous
sqlite vs dynamodb for example. So environment specific logic should be
abstracted away in `runtime` crate. This also solves the problem of
sharing CF worker specific http request logic across the whole engine.

# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
