### PR TITLE
Remove do not use warnings

### DIFF
--- a/packages/grafbase-sdk/src/config.ts
+++ b/packages/grafbase-sdk/src/config.ts
@@ -5,8 +5,6 @@ import { Experimental, ExperimentalParams } from './experimental'
 import { Federation, FederationParams } from './federation'
 
 /**
- * DO NOT USE - experimental
- *
  * An interface to create the complete config definition.
  */
 export interface SingleGraphConfigInput {
@@ -31,8 +29,6 @@ export interface DeprecatedSingleGraphConfigInput {
 }
 
 /**
- * DO NOT USE - experimental
- *
  * An interface to create the federation config definition.
  */
 export interface FederatedGraphConfigInput {

--- a/packages/grafbase-sdk/src/graph.ts
+++ b/packages/grafbase-sdk/src/graph.ts
@@ -1,8 +1,6 @@
 import { FederatedGraph, SingleGraph } from './grafbase-schema'
 
 /**
- * DO NOT USE - experimental
- *
  * A builder for a Grafbase schema definition.
  */
 export const graph = {


### PR DESCRIPTION
# Description

## Fix

- Removes do not use warnings from the new graph API in the SDK

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
