### PR TITLE
cli: a fix and a tweak for the check command

### DIFF
--- a/cli/crates/cli/src/check.rs
+++ b/cli/crates/cli/src/check.rs
@@ -1,6 +1,6 @@
 use crate::{cli_input::CheckCommand, errors::CliError, report};
 use backend::api::check;
-use std::{io::Read, process::Command};
+use std::{fs, io::Read, process::Command};
 
 #[tokio::main]
 pub(crate) async fn check(command: CheckCommand) -> Result<(), CliError> {
@@ -13,7 +13,7 @@ pub(crate) async fn check(command: CheckCommand) -> Result<(), CliError> {
     let git_commit = find_git_commit();
 
     let schema = match schema {
-        Some(schema) => schema,
+        Some(schema) => fs::read_to_string(schema).map_err(CliError::SchemaReadError)?,
         None => {
             let mut schema = String::new();
 

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -423,15 +423,17 @@ pub(crate) fn check_errors<'a>(
     validation_errors: impl ExactSizeIterator<Item = &'a str>,
     composition_errors: impl ExactSizeIterator<Item = &'a str>,
 ) {
+    watercolor::output!("🔴 The schema check failed.\n", @BrightRed);
+
     if validation_errors.len() > 0 {
-        watercolor::output!("🔴 Validation errors:", @BrightRed);
+        watercolor::output!("Validation errors:", @BrightRed);
         for error in validation_errors {
             watercolor::output!("- {error}", @BrightRed);
         }
     }
 
     if composition_errors.len() > 0 {
-        watercolor::output!("🔴 Composition errors:", @BrightRed);
+        watercolor::output!("Composition errors:", @BrightRed);
         for error in composition_errors {
             watercolor::output!("- {error}", @BrightRed);
         }


### PR DESCRIPTION
The fix: we were passing on the `--schema` argument as schema to the API, but it is the filesystem path to the schema. The fix is to read the file at that path.

The tweak: schema check failures are spelled out, we don't jump straight into displaying the errors anymore.