### PR TITLE
cli: rename --subgraph to --name, document reading schema from stdin

### DIFF
--- a/cli/crates/cli/src/check.rs
+++ b/cli/crates/cli/src/check.rs
@@ -6,7 +6,7 @@ use std::{io::Read, process::Command};
 pub(crate) async fn check(command: CheckCommand) -> Result<(), CliError> {
     let CheckCommand {
         project_ref,
-        subgraph,
+        subgraph_name,
         schema,
     } = command;
 
@@ -31,7 +31,7 @@ pub(crate) async fn check(command: CheckCommand) -> Result<(), CliError> {
         project_ref.account(),
         project_ref.project(),
         project_ref.branch(),
-        subgraph.as_deref(),
+        subgraph_name.as_deref(),
         &schema,
         git_commit,
     )

--- a/cli/crates/cli/src/cli_input/check.rs
+++ b/cli/crates/cli/src/cli_input/check.rs
@@ -6,9 +6,11 @@ pub struct CheckCommand {
     pub project_ref: ProjectRef,
     /// The name of the subgraph to check. This argument is always required in a federated graph
     /// context, and it should not be used in a single graph context.
-    #[arg(long)]
-    pub subgraph: Option<String>,
-    /// The path to the GraphQL schema to check.
+    #[arg(long("name"))]
+    pub(crate) subgraph_name: Option<String>,
+
+    /// The path to the GraphQL schema to check. If this is not provided, the schema will be read
+    /// from stdin.
     #[arg(long)]
     pub schema: Option<String>,
 }


### PR DESCRIPTION
All in the check command. The renaming is in order to align with `grafbase publish`.