### PR TITLE
feat: variable coercion in engine-v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2016,12 +2016,14 @@ dependencies = [
  "engine-value",
  "futures-util",
  "im",
+ "indexmap 2.0.0-pre",
  "itertools 0.11.0",
  "lasso",
  "runtime",
  "serde",
  "serde-value",
  "serde_json",
+ "strum",
  "thiserror",
 ]
 

--- a/engine/crates/engine-v2/Cargo.toml
+++ b/engine/crates/engine-v2/Cargo.toml
@@ -17,12 +17,14 @@ workspace = true
 async-runtime = { workspace = true }
 derive_more = "0.99"
 im = "15"
+indexmap.workspace = true
 lasso = "0.7"
 anyhow = "1"
 itertools.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde-value = "0.7"
+strum.workspace = true
 thiserror.workspace = true
 futures-util.workspace = true
 

--- a/engine/crates/engine-v2/schema/src/lib.rs
+++ b/engine/crates/engine-v2/schema/src/lib.rs
@@ -294,6 +294,10 @@ impl Wrapping {
             .unwrap_or(self.inner_is_required)
     }
 
+    pub fn is_list(&self) -> bool {
+        !self.list_wrapping.is_empty()
+    }
+
     pub fn nullable() -> Self {
         Wrapping {
             inner_is_required: false,

--- a/engine/crates/engine-v2/schema/src/walkers/input_object.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/input_object.rs
@@ -29,7 +29,10 @@ impl<'a> std::fmt::Debug for InputObjectWalker<'a> {
             .field("description", &self.description())
             .field(
                 "input_fields",
-                &self.input_fields().map(|f| (f.name(), f.ty())).collect::<Vec<_>>(),
+                &self
+                    .input_fields()
+                    .map(|f| (f.name(), f.ty().name()))
+                    .collect::<Vec<_>>(),
             )
             .finish()
     }

--- a/engine/crates/engine-v2/schema/src/walkers/input_value.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/input_value.rs
@@ -12,3 +12,12 @@ impl<'a> InputValueWalker<'a> {
         self.walk(self.type_id)
     }
 }
+
+impl<'a> std::fmt::Debug for InputValueWalker<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InputValue")
+            .field("name", &self.name())
+            .field("ty", &self.ty())
+            .finish()
+    }
+}

--- a/engine/crates/engine-v2/src/engine.rs
+++ b/engine/crates/engine-v2/src/engine.rs
@@ -30,13 +30,13 @@ impl Engine {
 
     pub async fn execute(&self, request: engine::Request) -> Response {
         match self.prepare(&request).await {
-            Ok(operation) => match Variables::from_request(&operation, request.variables) {
+            Ok(operation) => match Variables::from_request(&operation, self.schema.as_ref(), request.variables) {
                 Ok(variables) => {
                     let mut executor = ExecutorCoordinator::new(self, &operation, &variables);
                     executor.execute().await;
                     executor.into_response()
                 }
-                Err(err) => Response::from_error(err),
+                Err(err) => Response::from_errors(err),
             },
             Err(err) => Response::from_error(err),
         }

--- a/engine/crates/engine-v2/src/execution/variables.rs
+++ b/engine/crates/engine-v2/src/execution/variables.rs
@@ -1,7 +1,9 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Write};
 
 use engine_parser::Pos;
-use engine_value::ConstValue;
+use engine_value::{ConstValue, Name};
+use indexmap::IndexMap;
+use schema::{DataType, InputObjectId, ListWrapping, Schema, StringId};
 
 use crate::{
     request::{Operation, VariableDefinition},
@@ -12,16 +14,78 @@ use crate::{
 pub enum VariableError {
     #[error("Missing variable '{name}'")]
     MissingVariable { name: String, location: Pos },
+    #[error("Variable ${name} got an invalid value: {error}")]
+    Coercion {
+        name: String,
+        error: CoercionError,
+        location: Pos,
+    },
 }
 
 impl From<VariableError> for ServerError {
     fn from(err: VariableError) -> Self {
         let locations = match err {
             VariableError::MissingVariable { location, .. } => vec![location],
+            VariableError::Coercion { location, .. } => vec![location],
         };
         ServerError {
             message: err.to_string(),
             locations,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CoercionError {
+    #[error("found a null where we expected a non-null type{0}")]
+    UnexpectedNull(String),
+    #[error("found a {actual} value where we expected a list{path}")]
+    MissingList { actual: ValueKind, path: String },
+    #[error("found a {actual} value where we expected a '{name}' input object{path}")]
+    MissingObject {
+        name: String,
+        actual: ValueKind,
+        path: String,
+    },
+    #[error("found a {actual} value where we expected a {expected} scalar{path}")]
+    IncorrectScalar {
+        actual: ValueKind,
+        expected: DataType,
+        path: String,
+    },
+    #[error("found a {actual} value where we expected a '{name}' enum{path}")]
+    IncorrectEnum {
+        name: String,
+        actual: ValueKind,
+        path: String,
+    },
+    #[error("found the value '{actual}' value where we expected a value of the '{name}' enum{path}")]
+    IncorrectEnumValue { name: String, actual: String, path: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display)]
+pub enum ValueKind {
+    String,
+    Integer,
+    Float,
+    Object,
+    Boolean,
+    List,
+    Null,
+}
+
+impl ValueKind {
+    fn of_value(value: &ConstValue) -> Self {
+        match value {
+            ConstValue::Null => ValueKind::Null,
+            ConstValue::Number(number) if number.is_f64() => ValueKind::Float,
+            ConstValue::Number(_) => ValueKind::Integer,
+            ConstValue::String(_) => ValueKind::String,
+            ConstValue::Boolean(_) => ValueKind::Boolean,
+            ConstValue::Binary(_) => ValueKind::String,
+            ConstValue::Enum(_) => ValueKind::String,
+            ConstValue::List(_) => ValueKind::List,
+            ConstValue::Object(_) => ValueKind::Object,
         }
     }
 }
@@ -31,34 +95,302 @@ pub struct Variables<'a> {
 }
 
 pub struct Variable<'a> {
-    pub value: ConstValue,
+    pub value: Option<ConstValue>,
     pub definition: &'a VariableDefinition,
 }
 
 impl<'a> Variables<'a> {
     pub fn from_request(
         operation: &'a Operation,
+        schema: &Schema,
         mut variables: engine_value::Variables,
-    ) -> Result<Self, VariableError> {
-        Ok(Self {
-            inner: operation
-                .variable_definitions
-                .iter()
-                .map(|definition| {
-                    variables
-                        .remove(&engine_value::Name::new(&definition.name))
-                        .or_else(|| definition.default_value.clone())
-                        .map(|value| (definition.name.clone(), Variable { value, definition }))
-                        .ok_or_else(|| VariableError::MissingVariable {
-                            name: definition.name.clone(),
-                            location: definition.name_location,
-                        })
-                })
-                .collect::<Result<HashMap<_, _>, _>>()?,
-        })
+    ) -> Result<Self, Vec<VariableError>> {
+        let mut coerced = HashMap::new();
+        let mut errors = vec![];
+
+        for definition in operation.variable_definitions.iter() {
+            match coerce_variable_value(definition, schema, &mut variables, VariablePath::new(&definition.name)) {
+                Ok(value) => {
+                    coerced.insert(definition.name.clone(), Variable { value, definition });
+                }
+                Err(error) => {
+                    errors.push(error);
+                }
+            }
+        }
+
+        if !errors.is_empty() {
+            return Err(errors);
+        }
+
+        Ok(Self { inner: coerced })
     }
 
     pub fn get(&self, name: &str) -> Option<&Variable<'_>> {
         self.inner.get(name)
+    }
+}
+
+/// Validates & coerces a variable value
+///
+/// An implementation of http://spec.graphql.org/October2021/#sec-Coercing-Variable-Values
+fn coerce_variable_value(
+    variable_definition: &VariableDefinition,
+    schema: &Schema,
+    variable_values: &mut engine_value::Variables,
+    path: VariablePath,
+) -> Result<Option<ConstValue>, VariableError> {
+    let variable_name = engine_value::Name::new(&variable_definition.name);
+    let has_value = variable_values.contains_key(&variable_name);
+    if !has_value && variable_definition.default_value.is_some() {
+        return Ok(Some(variable_definition.default_value.clone().unwrap()));
+    }
+
+    if variable_definition.r#type.wrapping.is_required() {
+        if !has_value {
+            return Err(VariableError::MissingVariable {
+                name: variable_name.to_string(),
+                location: variable_definition.name_location,
+            });
+        }
+        if variable_values.get(&variable_name) == Some(&ConstValue::Null) {
+            return Err(VariableError::Coercion {
+                name: variable_name.to_string(),
+                location: variable_definition.name_location,
+                error: CoercionError::UnexpectedNull(path.to_error_string(schema)),
+            });
+        }
+    }
+
+    if !has_value {
+        return Ok(None);
+    }
+
+    if variable_values.get(&variable_name) == Some(&ConstValue::Null) {
+        return Ok(Some(ConstValue::Null));
+    }
+
+    Ok(Some(
+        coerce_value(
+            variable_values.remove(&variable_name).unwrap(),
+            &variable_definition.r#type,
+            schema,
+            path,
+        )
+        .map_err(|error| VariableError::Coercion {
+            name: variable_name.to_string(),
+            error,
+            location: variable_definition.name_location,
+        })?,
+    ))
+}
+
+fn coerce_value(
+    mut value: ConstValue,
+    r#type: &schema::Type,
+    schema: &Schema,
+    path: VariablePath,
+) -> Result<ConstValue, CoercionError> {
+    if r#type.wrapping.is_required() && value.is_null() {
+        return Err(CoercionError::UnexpectedNull(path.to_error_string(schema)));
+    }
+
+    if r#type.wrapping.is_list() && !&value.is_array() && !value.is_null() {
+        value = coerce_named_type(value, r#type, schema, path)?;
+        for _ in &r#type.wrapping.list_wrapping {
+            value = ConstValue::List(vec![value]);
+        }
+        return Ok(value);
+    }
+
+    let lists = r#type.wrapping.list_wrapping.iter().rev().collect::<Vec<_>>();
+    coerce_list(&lists, value, r#type, schema, path)
+}
+
+fn coerce_list(
+    lists: &[&ListWrapping],
+    value: ConstValue,
+    r#type: &schema::Type,
+    schema: &Schema,
+    path: VariablePath,
+) -> Result<ConstValue, CoercionError> {
+    let Some(expected_nullability) = lists.first() else {
+        return coerce_named_type(value, r#type, schema, path);
+    };
+
+    match (value, expected_nullability) {
+        (ConstValue::Null, ListWrapping::RequiredList) => {
+            Err(CoercionError::UnexpectedNull(path.to_error_string(schema)))
+        }
+        (ConstValue::Null, ListWrapping::NullableList) => Ok(ConstValue::Null),
+        (ConstValue::List(list), _) => Ok(ConstValue::List(
+            list.into_iter()
+                .enumerate()
+                .map(|(index, item)| coerce_list(&lists[1..], item, r#type, schema, path.child(index)))
+                .collect::<Result<Vec<_>, _>>()?,
+        )),
+        (value, _) => Err(CoercionError::MissingList {
+            actual: ValueKind::of_value(&value),
+            path: path.to_error_string(schema),
+        }),
+    }
+}
+
+fn coerce_named_type(
+    value: ConstValue,
+    r#type: &schema::Type,
+    schema: &Schema,
+    path: VariablePath,
+) -> Result<ConstValue, CoercionError> {
+    if value.is_null() {
+        return if r#type.wrapping.inner_is_required {
+            Err(CoercionError::UnexpectedNull(path.to_error_string(schema)))
+        } else {
+            Ok(ConstValue::Null)
+        };
+    }
+
+    match r#type.inner {
+        schema::Definition::Scalar(scalar) => coerce_scalar(value, &schema[scalar], schema, path),
+        schema::Definition::Enum(id) => coerce_enum(value, &schema[id], schema, path),
+        schema::Definition::InputObject(object) => coerce_input_object(value, object, schema, path),
+        schema::Definition::Object(_) | schema::Definition::Interface(_) | schema::Definition::Union(_) => {
+            unreachable!("variables can't be output types.")
+        }
+    }
+}
+
+fn coerce_scalar(
+    value: ConstValue,
+    scalar: &schema::Scalar,
+    schema: &Schema,
+    path: VariablePath,
+) -> Result<ConstValue, CoercionError> {
+    match (value, scalar.data_type) {
+        (ConstValue::Number(number), DataType::Int | DataType::BigInt) if !number.is_f64() => {
+            Ok(ConstValue::Number(number))
+        }
+        (ConstValue::Number(number), DataType::Float) => Ok(ConstValue::Number(number)),
+        (ConstValue::String(value), DataType::String) => Ok(ConstValue::String(value)),
+        (ConstValue::Boolean(value), DataType::Boolean) => Ok(ConstValue::Boolean(value)),
+        (ConstValue::Binary(value), DataType::String) => Ok(ConstValue::Binary(value)),
+        (ConstValue::Enum(value), DataType::String) => Ok(ConstValue::Enum(value)),
+        (actual, expected) => Err(CoercionError::IncorrectScalar {
+            actual: ValueKind::of_value(&actual),
+            expected,
+            path: path.to_error_string(schema),
+        }),
+    }
+}
+
+fn coerce_enum(
+    value: ConstValue,
+    enum_: &schema::Enum,
+    schema: &Schema,
+    path: VariablePath,
+) -> Result<ConstValue, CoercionError> {
+    let value_str = match &value {
+        ConstValue::String(value) => value.as_str(),
+        ConstValue::Enum(value) => value.as_str(),
+        value => {
+            return Err(CoercionError::IncorrectEnum {
+                name: schema[enum_.name].to_string(),
+                actual: ValueKind::of_value(value),
+                path: path.to_error_string(schema),
+            })
+        }
+    };
+
+    if !enum_.values.iter().any(|value| schema[value.name] == value_str) {
+        return Err(CoercionError::IncorrectEnumValue {
+            name: schema[enum_.name].to_string(),
+            actual: value_str.to_string(),
+            path: path.to_error_string(schema),
+        });
+    }
+
+    Ok(value)
+}
+
+fn coerce_input_object(
+    value: ConstValue,
+    object_id: InputObjectId,
+    schema: &Schema,
+    path: VariablePath,
+) -> Result<ConstValue, CoercionError> {
+    let ConstValue::Object(mut fields) = value else {
+        return Err(CoercionError::MissingObject {
+            name: schema[schema[object_id].name].clone(),
+            actual: ValueKind::of_value(&value),
+            path: path.to_error_string(schema),
+        });
+    };
+
+    let mut coerced = IndexMap::new();
+    for field in schema.walker().walk(object_id).input_fields() {
+        match fields.remove(field.name()) {
+            None | Some(ConstValue::Null) if field.ty().wrapping.is_required() => {
+                return Err(CoercionError::UnexpectedNull(path.to_error_string(schema)));
+            }
+            None => {}
+            Some(value) => {
+                coerced.insert(
+                    Name::new(field.name()),
+                    coerce_value(value, &field.ty(), schema, path.child(field.name))?,
+                );
+            }
+        }
+    }
+
+    Ok(ConstValue::Object(coerced))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct VariablePath(String, im::Vector<VariablePathSegment>);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum VariablePathSegment {
+    Field(StringId),
+    Index(usize),
+}
+
+impl From<usize> for VariablePathSegment {
+    fn from(index: usize) -> VariablePathSegment {
+        VariablePathSegment::Index(index)
+    }
+}
+
+impl From<StringId> for VariablePathSegment {
+    fn from(id: StringId) -> VariablePathSegment {
+        VariablePathSegment::Field(id)
+    }
+}
+
+impl VariablePath {
+    fn new(variable: &str) -> Self {
+        VariablePath(variable.to_string(), Default::default())
+    }
+
+    fn child(&self, segment: impl Into<VariablePathSegment>) -> Self {
+        let mut child = self.clone();
+        child.1.push_back(segment.into());
+        child
+    }
+
+    fn to_error_string(&self, schema: &Schema) -> String {
+        let mut output = String::new();
+        write!(&mut output, " at ${}", self.0).ok();
+        for segment in self.1.iter() {
+            match segment {
+                VariablePathSegment::Field(id) => {
+                    write!(&mut output, ".{}", schema[*id]).ok();
+                }
+                VariablePathSegment::Index(idx) => {
+                    write!(&mut output, ".{idx}").ok();
+                }
+            }
+        }
+
+        output
     }
 }

--- a/engine/crates/engine-v2/src/plan/planner.rs
+++ b/engine/crates/engine-v2/src/plan/planner.rs
@@ -27,7 +27,7 @@ pub enum PlanningError {
         query_path: Vec<String>,
         missing: Vec<String>,
     },
-    #[error("Could satisfy required fields")]
+    #[error("Could not satisfy required fields")]
     CouldNotSatisfyRequires,
 }
 

--- a/engine/crates/engine-v2/src/request/walkers/field_argument.rs
+++ b/engine/crates/engine-v2/src/request/walkers/field_argument.rs
@@ -31,7 +31,8 @@ impl<'a, E> BoundFieldArgumentWalker<'a, E> {
                     .get(&name)
                     .expect("Would have failed at validation")
                     .value
-                    .clone())
+                    .clone()
+                    .unwrap_or_default())
             })
             .unwrap()
     }

--- a/engine/crates/engine-v2/src/request/walkers/variables.rs
+++ b/engine/crates/engine-v2/src/request/walkers/variables.rs
@@ -19,8 +19,8 @@ impl<'a> VariablesWalker<'a> {
 }
 
 impl<'a> VariableWalker<'a> {
-    pub fn value(&self) -> &'a ConstValue {
-        &self.inner.value
+    pub fn value(&self) -> Option<&'a ConstValue> {
+        self.inner.value.as_ref()
     }
 
     pub fn type_name(&self) -> String {

--- a/engine/crates/engine-v2/src/response/mod.rs
+++ b/engine/crates/engine-v2/src/response/mod.rs
@@ -41,6 +41,15 @@ impl Response {
             errors: vec![error.into()],
         })
     }
+
+    pub fn from_errors<E>(errors: impl IntoIterator<Item = E>) -> Self
+    where
+        E: Into<ServerError>,
+    {
+        Self::Error(ServerErrorResponse {
+            errors: errors.into_iter().map(Into::into).collect(),
+        })
+    }
 }
 
 impl std::fmt::Debug for Response {

--- a/engine/crates/engine-v2/src/sources/graphql/query.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/query.rs
@@ -173,7 +173,10 @@ impl QueryBuilder {
                     .variables()
                     .get(name)
                     .expect("we just found it in the query so validation wouldn't have passed otherwise.");
-                variables.insert(name.to_string(), variable.value());
+
+                let Some(value) = variable.value() else { return Ok(()) };
+
+                variables.insert(name.to_string(), value);
                 if let Some(default_value) = variable.default_value() {
                     f(&format_args!(
                         "${name}: {ty} = {default_value}",

--- a/engine/crates/engine/value/src/lib.rs
+++ b/engine/crates/engine/value/src/lib.rs
@@ -168,13 +168,9 @@ impl Hash for ConstValue {
 }
 
 impl ConstValue {
-    /// Check if this is neither a null or a list of null
+    /// Check if this is a null
     pub fn is_null(&self) -> bool {
-        match self {
-            ConstValue::Null => true,
-            ConstValue::List(vals) => !vals.iter().any(|x| !x.is_null()),
-            _ => false,
-        }
+        matches!(self, ConstValue::Null)
     }
 
     /// Check the [`ConstValue`] is an array

--- a/engine/crates/integration-tests/src/federation/mod.rs
+++ b/engine/crates/integration-tests/src/federation/mod.rs
@@ -80,6 +80,8 @@ impl GraphqlResponse {
     }
 
     pub fn into_data(self) -> serde_json::Value {
+        assert!(self.errors().is_empty(), "{self:#?}");
+
         match self.0 {
             serde_json::Value::Object(mut value) => value.remove("data"),
             _ => None,

--- a/engine/crates/integration-tests/src/mocks/graphql/echo.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql/echo.rs
@@ -1,4 +1,4 @@
-use async_graphql::{EmptyMutation, EmptySubscription, InputObject, Json, MaybeUndefined, Object, ID};
+use async_graphql::{EmptyMutation, EmptySubscription, Enum, InputObject, Json, MaybeUndefined, Object, ID};
 
 /// A schema that just echoes stuff back at you.
 ///
@@ -48,6 +48,17 @@ impl Query {
     async fn list_of_input_object(&self, input: InputObj) -> Json<InputObj> {
         Json(input)
     }
+
+    async fn fancy_bool(&self, input: FancyBool) -> FancyBool {
+        input
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Enum, serde::Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum FancyBool {
+    Yes,
+    No,
 }
 
 #[derive(InputObject, serde::Serialize)]
@@ -67,4 +78,6 @@ struct InputObj {
     recursive_object: MaybeUndefined<Box<InputObj>>,
     #[serde(skip_serializing_if = "MaybeUndefined::is_undefined")]
     recursive_object_list: MaybeUndefined<Vec<InputObj>>,
+    #[serde(skip_serializing_if = "MaybeUndefined::is_undefined")]
+    fancy_bool: MaybeUndefined<FancyBool>,
 }

--- a/engine/crates/integration-tests/src/mocks/graphql/echo.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql/echo.rs
@@ -1,4 +1,4 @@
-use async_graphql::{EmptyMutation, EmptySubscription, InputObject, Json, Object, ID};
+use async_graphql::{EmptyMutation, EmptySubscription, InputObject, Json, MaybeUndefined, Object, ID};
 
 /// A schema that just echoes stuff back at you.
 ///
@@ -36,23 +36,35 @@ impl Query {
 
     async fn optional_list_of_optional_strings(
         &self,
-        input: Option<Vec<Option<Vec<String>>>>,
-    ) -> Option<Vec<Option<Vec<String>>>> {
+        input: Option<Vec<Option<String>>>,
+    ) -> Option<Vec<Option<String>>> {
         input
     }
 
     async fn input_object(&self, input: InputObj) -> Json<InputObj> {
         Json(input)
     }
+
+    async fn list_of_input_object(&self, input: InputObj) -> Json<InputObj> {
+        Json(input)
+    }
 }
 
 #[derive(InputObject, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 struct InputObj {
-    string: Option<String>,
-    int: Option<u32>,
-    float: Option<f32>,
-    id: Option<ID>,
-    annoyingly_optional_strings: Option<Vec<Option<Vec<String>>>>,
-    recursive_object: Option<Box<InputObj>>,
-    recursive_object_list: Vec<InputObj>,
+    #[serde(skip_serializing_if = "MaybeUndefined::is_undefined")]
+    string: MaybeUndefined<String>,
+    #[serde(skip_serializing_if = "MaybeUndefined::is_undefined")]
+    int: MaybeUndefined<u32>,
+    #[serde(skip_serializing_if = "MaybeUndefined::is_undefined")]
+    float: MaybeUndefined<f32>,
+    #[serde(skip_serializing_if = "MaybeUndefined::is_undefined")]
+    id: MaybeUndefined<ID>,
+    #[serde(skip_serializing_if = "MaybeUndefined::is_undefined")]
+    annoyingly_optional_strings: MaybeUndefined<Vec<Option<Vec<Option<String>>>>>,
+    #[serde(skip_serializing_if = "MaybeUndefined::is_undefined")]
+    recursive_object: MaybeUndefined<Box<InputObj>>,
+    #[serde(skip_serializing_if = "MaybeUndefined::is_undefined")]
+    recursive_object_list: MaybeUndefined<Vec<InputObj>>,
 }

--- a/engine/crates/integration-tests/tests/federation/basic/variables.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/variables.rs
@@ -1,5 +1,9 @@
 use engine_v2::Engine;
-use integration_tests::{federation::EngineV2Ext, mocks::graphql::EchoSchema, runtime, MockGraphQlServer};
+use integration_tests::{
+    federation::{EngineV2Ext, GraphqlResponse},
+    mocks::graphql::EchoSchema,
+    runtime, MockGraphQlServer,
+};
 use serde::Serialize;
 use serde_json::json;
 
@@ -44,42 +48,398 @@ fn lists() {
     roundtrip_test(
         "optionalListOfOptionalStrings",
         "[String]",
-        json!([["hello", "there", "from"], ["the", "outer", "reaches"]]),
+        json!(["hello", "there", "from", null, "the", "outer", "reaches"]),
+    );
+
+    roundtrip_test("optionalListOfOptionalStrings", "[String]", json!(null));
+}
+
+#[test]
+fn input_objects() {
+    roundtrip_test(
+        "inputObject",
+        "InputObj!",
+        json!({
+            "string": "hello",
+            "int": 1,
+            "float": 1.0
+        }),
+    );
+    roundtrip_test(
+        "inputObject",
+        "InputObj!",
+        json!({
+            "string": "hello",
+            "int": 1,
+            "float": 1.0
+        }),
+    );
+    roundtrip_test(
+        "inputObject",
+        "InputObj!",
+        json!({
+            "string": null,
+        }),
+    );
+    roundtrip_test(
+        "inputObject",
+        "InputObj!",
+        json!({
+            "recursiveObject": {"string": null}
+        }),
+    );
+    roundtrip_test(
+        "inputObject",
+        "InputObj!",
+        json!({
+            "recursiveObject": {"recursiveObject": {"string": "hello"}}
+        }),
+    );
+    roundtrip_test(
+        "inputObject",
+        "InputObj!",
+        json!({
+            "recursiveObject": null
+        }),
+    );
+    roundtrip_test(
+        "inputObject",
+        "InputObj!",
+        json!({
+            "recursiveObjectList": null
+        }),
+    );
+    roundtrip_test(
+        "inputObject",
+        "InputObj!",
+        json!({
+            "recursiveObjectList": [{"string": "hello"}]
+        }),
+    );
+    roundtrip_test(
+        "inputObject",
+        "InputObj!",
+        json!({
+            "recursiveObjectList": [{"recursiveObject": {"string": "hello"}}]
+        }),
     );
 }
 
 #[test]
-#[ignore]
-fn input_objects() {
-    todo!()
+fn test_default_values() {
+    let query = r#"query($input: String = "there") { listOfListOfStrings(input: $input) }"#;
+    let input = json!({"input": "hello"});
+    assert_eq!(
+        run_query(query, &input).into_data()["listOfListOfStrings"],
+        json!([["hello"]])
+    );
+
+    let input = json!({});
+    assert_eq!(
+        run_query(query, &input).into_data()["listOfListOfStrings"],
+        json!([["there"]])
+    );
 }
 
 #[test]
 fn list_coercion() {
-    let query = "query($input: String!) { listOfListOfStrings(input: $input) }";
-    let input = json!("hello");
+    let query = "query($input: [[String!]!]!) { listOfListOfStrings(input: $input) }";
+    let input = json!({"input": "hello"});
+    assert_eq!(
+        run_query(query, &input).into_data()["listOfListOfStrings"],
+        json!([["hello"]])
+    );
 
-    let response = runtime().block_on({
-        let input = input.clone();
-        async move {
-            let echo_mock = MockGraphQlServer::new(EchoSchema::default()).await;
+    let query = "query($input: [String!]!) { listOfStrings(input: $input) }";
+    assert_eq!(run_query(query, &input).into_data()["listOfStrings"], json!(["hello"]));
 
-            let engine = Engine::build().with_schema("schema", &echo_mock).await.finish();
-
-            engine.execute(query).variables(json!({"input": input})).await
-        }
+    let query = "query($input: InputObj!) { inputObject(input: $input) }";
+    let input = json!({
+        "input": {"annoyinglyOptionalStrings": "hello", "recursiveObjectList": {"id": "1"}}
     });
-    assert!(response.errors().is_empty(), "{response:#?}");
+    assert_eq!(
+        run_query(query, &input).into_data()["inputObject"],
+        json!({
+            "annoyinglyOptionalStrings": [["hello"]],
+            "recursiveObjectList": [
+                {"id": "1"}
+            ]
+        })
+    );
 
-    assert_eq!(response.into_data(), json!({"listOfListOfStrings": [["hello"]]}));
+    let input = json!({"input": {"annoyinglyOptionalStrings": null}});
+    assert_eq!(
+        run_query(query, &input).into_data()["inputObject"],
+        json!({
+            "annoyinglyOptionalStrings": null
+        })
+    );
 }
 
 #[test]
-#[ignore]
-fn errors_on_type_mismatches() {
-    // This is kinda hard to implement without knowing how errors are returned.
-    // So just leaving it here as a TODO
-    todo!()
+fn invalid_ints() {
+    insta::assert_json_snapshot!(error_test("int", "Int!", 1.5), @r###"
+    [
+      "Variable $input got an invalid value: found a Float value where we expected a Int scalar at $input"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("int", "Int!", "blah"), @r###"
+    [
+      "Variable $input got an invalid value: found a String value where we expected a Int scalar at $input"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("int", "Int!", true), @r###"
+    [
+      "Variable $input got an invalid value: found a Boolean value where we expected a Int scalar at $input"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("int", "Int!", json!(null)), @r###"
+    [
+      "Variable $input got an invalid value: found a null where we expected a non-null type at $input"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("int", "Int!", json!({})), @r###"
+    [
+      "Variable $input got an invalid value: found a Object value where we expected a Int scalar at $input"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("int", "Int!", json!([])), @r###"
+    [
+      "Variable $input got an invalid value: found a List value where we expected a Int scalar at $input"
+    ]
+    "###);
+}
+
+#[test]
+fn invalid_strings() {
+    insta::assert_json_snapshot!(error_test("string", "String!", 1.5), @r###"
+    [
+      "Variable $input got an invalid value: found a Float value where we expected a String scalar at $input"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("string", "String!", 1), @r###"
+    [
+      "Variable $input got an invalid value: found a Integer value where we expected a String scalar at $input"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("string", "String!", true), @r###"
+    [
+      "Variable $input got an invalid value: found a Boolean value where we expected a String scalar at $input"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("string", "String!", json!(null)), @r###"
+    [
+      "Variable $input got an invalid value: found a null where we expected a non-null type at $input"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("string", "String!", json!({})), @r###"
+    [
+      "Variable $input got an invalid value: found a Object value where we expected a String scalar at $input"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("string", "String!", json!([])), @r###"
+    [
+      "Variable $input got an invalid value: found a List value where we expected a String scalar at $input"
+    ]
+    "###);
+}
+
+#[test]
+fn invalid_floats() {
+    insta::assert_json_snapshot!(error_test("float", "Float!", true), @r###"
+    [
+      "Variable $input got an invalid value: found a Boolean value where we expected a Float scalar at $input"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("float", "Float!", json!(null)), @r###"
+    [
+      "Variable $input got an invalid value: found a null where we expected a non-null type at $input"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("float", "Float!", json!({})), @r###"
+    [
+      "Variable $input got an invalid value: found a Object value where we expected a Float scalar at $input"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("float", "Float!", json!([])), @r###"
+    [
+      "Variable $input got an invalid value: found a List value where we expected a Float scalar at $input"
+    ]
+    "###);
+}
+
+#[test]
+fn invalid_id() {
+    insta::assert_json_snapshot!(error_test("id", "ID!", true), @r###"
+    [
+      "Variable $input got an invalid value: found a Boolean value where we expected a String scalar at $input"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("id", "ID!", json!(null)), @r###"
+    [
+      "Variable $input got an invalid value: found a null where we expected a non-null type at $input"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("id", "ID!", json!({})), @r###"
+    [
+      "Variable $input got an invalid value: found a Object value where we expected a String scalar at $input"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("id", "ID!", json!([])), @r###"
+    [
+      "Variable $input got an invalid value: found a List value where we expected a String scalar at $input"
+    ]
+    "###);
+}
+
+#[test]
+fn invalid_lists() {
+    insta::assert_json_snapshot!(error_test("listOfStrings", "[String!]!", true), @r###"
+    [
+      "Variable $input got an invalid value: found a Boolean value where we expected a String scalar at $input"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("listOfStrings", "[String!]!", json!(null)), @r###"
+    [
+      "Variable $input got an invalid value: found a null where we expected a non-null type at $input"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("listOfStrings", "[String!]!", json!([1])), @r###"
+    [
+      "Variable $input got an invalid value: found a Integer value where we expected a String scalar at $input.0"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("listOfStrings", "[String!]!", json!([null])), @r###"
+    [
+      "Variable $input got an invalid value: found a null where we expected a non-null type at $input.0"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("listOfStrings", "[String!]!", json!(["hello", 1, "there"])), @r###"
+    [
+      "Variable $input got an invalid value: found a Integer value where we expected a String scalar at $input.1"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("listOfStrings", "[String!]!", json!([[null]])), @r###"
+    [
+      "Variable $input got an invalid value: found a List value where we expected a String scalar at $input.0"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("listOfStrings", "[String!]!", json!([["hello"]])), @r###"
+    [
+      "Variable $input got an invalid value: found a List value where we expected a String scalar at $input.0"
+    ]
+    "###);
+}
+
+#[test]
+fn invalid_nested_lists() {
+    insta::assert_json_snapshot!(error_test("listOfListOfStrings", "[[String!]!]!", true), @r###"
+    [
+      "Variable $input got an invalid value: found a Boolean value where we expected a String scalar at $input"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("listOfListOfStrings", "[[String!]!]!", json!(null)), @r###"
+    [
+      "Variable $input got an invalid value: found a null where we expected a non-null type at $input"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("listOfListOfStrings", "[[String!]!]!", json!([1])), @r###"
+    [
+      "Variable $input got an invalid value: found a Integer value where we expected a list at $input.0"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("listOfListOfStrings", "[[String!]!]!", json!([null])), @r###"
+    [
+      "Variable $input got an invalid value: found a null where we expected a non-null type at $input.0"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("listOfListOfStrings", "[[String!]!]!", json!([[null]])), @r###"
+    [
+      "Variable $input got an invalid value: found a null where we expected a non-null type at $input.0.0"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("listOfListOfStrings", "[[String!]!]!", json!([[1]])), @r###"
+    [
+      "Variable $input got an invalid value: found a Integer value where we expected a String scalar at $input.0.0"
+    ]
+    "###);
+    insta::assert_json_snapshot!(error_test("listOfListOfStrings", "[[String!]!]!", json!([["hello", 1, "there"]])), @r###"
+    [
+      "Variable $input got an invalid value: found a Integer value where we expected a String scalar at $input.0.1"
+    ]
+    "###);
+}
+
+#[test]
+fn invalid_input_objects() {
+    insta::assert_json_snapshot!(
+        error_test("inputObject", "InputObj!", json!({"string": 1})),
+        @r###"
+    [
+      "Variable $input got an invalid value: found a Integer value where we expected a String scalar at $input.string"
+    ]
+    "###
+    );
+    insta::assert_json_snapshot!(
+        error_test("inputObject", "InputObj!", json!({"int": "hello"})),
+        @r###"
+    [
+      "Variable $input got an invalid value: found a String value where we expected a Int scalar at $input.int"
+    ]
+    "###
+    );
+    insta::assert_json_snapshot!(
+        error_test("inputObject", "InputObj!", json!({"recursiveObject": {"string": 1}})),
+        @r###"
+    [
+      "Variable $input got an invalid value: found a Integer value where we expected a String scalar at $input.recursiveObject.string"
+    ]
+    "###
+    );
+    // This one is valid because it gets list coerced
+    insta::assert_json_snapshot!(
+        error_test("inputObject", "InputObj!", json!({"recursiveObjectList": {}})),
+        @"[]"
+    );
+    insta::assert_json_snapshot!(
+        error_test("inputObject", "InputObj!", json!({"recursiveObjectList": [null]})),
+        @r###"
+    [
+      "Variable $input got an invalid value: found a null where we expected a non-null type at $input.recursiveObjectList.0"
+    ]
+    "###
+    );
+    // This one is also valid because it gets list coerced
+    insta::assert_json_snapshot!(
+        error_test("inputObject", "InputObj!", json!({"recursiveObjectList": [{"recursiveObjectList": {}}]})),
+        @"[]"
+    );
+    insta::assert_json_snapshot!(
+        error_test("inputObject", "InputObj!", json!({"recursiveObjectList": [{"recursiveObjectList": [null]}]})),
+        @r###"
+    [
+      "Variable $input got an invalid value: found a null where we expected a non-null type at $input.recursiveObjectList.0.recursiveObjectList.0"
+    ]
+    "###
+    );
+}
+
+#[test]
+fn multiple_invalid_variables() {
+    let query = "query($one: String!, $two: Int!) { string(input: $one) int(input: $two) }";
+
+    let errors = run_query(query, &json!({"one": true, "two": "hello"}))
+        .errors()
+        .iter()
+        .map(|error| error["message"].as_str().expect("message to be a string").to_string())
+        .collect::<Vec<_>>();
+
+    insta::assert_json_snapshot!(errors, @r###"
+    [
+      "Variable $one got an invalid value: found a Boolean value where we expected a String scalar at $one",
+      "Variable $two got an invalid value: found a String value where we expected a Int scalar at $two"
+    ]
+    "###);
 }
 
 fn roundtrip_test<T>(field: &str, ty: &str, input: T)
@@ -92,20 +452,36 @@ where
 }
 
 fn do_roundtrip_test(field: &str, query: &str, input: serde_json::Value) {
-    let response = runtime().block_on({
-        let input = input.clone();
+    let response = run_query(query, &json!({"input": input}));
+
+    assert_eq!(response.into_data()[field], input);
+}
+
+fn error_test<T>(field: &str, ty: &str, input: T) -> Vec<String>
+where
+    T: Serialize,
+{
+    let query = format!("query($input: {ty}) {{ {field}(input: $input) }}");
+
+    do_error_test(&query, json!({"input": input}))
+}
+
+fn do_error_test(query: &str, input: serde_json::Value) -> Vec<String> {
+    run_query(query, &input)
+        .errors()
+        .iter()
+        .map(|error| error["message"].as_str().expect("message to be a string").to_string())
+        .collect()
+}
+
+fn run_query(query: &str, input: &serde_json::Value) -> GraphqlResponse {
+    runtime().block_on({
         async move {
             let echo_mock = MockGraphQlServer::new(EchoSchema::default()).await;
 
             let engine = Engine::build().with_schema("schema", &echo_mock).await.finish();
 
-            engine.execute(query).variables(json!({"input": input})).await
+            engine.execute(query).variables(input).await
         }
-    });
-    assert!(response.errors().is_empty(), "{response:#?}");
-
-    // I'm not certain this is the right assert since execute doesn't actually return
-    // anything right now.
-    // But we can fix that later.
-    assert_eq!(response["data"][field], input);
+    })
 }

--- a/engine/crates/integration-tests/tests/federation/basic/variables.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/variables.rs
@@ -32,6 +32,11 @@ fn id() {
 }
 
 #[test]
+fn enum_roundtrip() {
+    roundtrip_test("fancyBool", "FancyBool!", "YES");
+}
+
+#[test]
 fn lists() {
     roundtrip_test(
         "listOfStrings",
@@ -121,6 +126,13 @@ fn input_objects() {
         "InputObj!",
         json!({
             "recursiveObjectList": [{"recursiveObject": {"string": "hello"}}]
+        }),
+    );
+    roundtrip_test(
+        "inputObject",
+        "InputObj!",
+        json!({
+            "recursiveObjectList": [{"recursiveObject": {"fancyBool": "YES"}}]
         }),
     );
 }
@@ -419,6 +431,26 @@ fn invalid_input_objects() {
         @r###"
     [
       "Variable $input got an invalid value: found a null where we expected a non-null type at $input.recursiveObjectList.0.recursiveObjectList.0"
+    ]
+    "###
+    );
+}
+
+#[test]
+fn invalid_enum() {
+    insta::assert_json_snapshot!(
+        error_test("fancyBool", "FancyBool!", json!("bloo")),
+        @r###"
+    [
+      "Variable $input got an invalid value: found the value 'bloo' value where we expected a value of the 'FancyBool' enum at $input"
+    ]
+    "###
+    );
+    insta::assert_json_snapshot!(
+        error_test("inputObject", "InputObj!", json!({"fancyBool": "blah"})),
+        @r###"
+    [
+      "Variable $input got an invalid value: found the value 'blah' value where we expected a value of the 'FancyBool' enum at $input.fancyBool"
     ]
     "###
     );

--- a/engine/crates/integration-tests/tests/federation/introspection.rs
+++ b/engine/crates/integration-tests/tests/federation/introspection.rs
@@ -237,6 +237,11 @@ fn echo_subgraph_introspection() {
     assert!(response.errors().is_empty(), "{response}");
 
     insta::assert_snapshot!(introspection_to_sdl(response.into_data()), @r###"
+    enum FancyBool {
+      YES
+      NO
+    }
+
     input InputObj {
       string: String
       int: Int
@@ -245,11 +250,13 @@ fn echo_subgraph_introspection() {
       annoyinglyOptionalStrings: [[String]]
       recursiveObject: InputObj
       recursiveObjectList: [InputObj!]
+      fancyBool: FancyBool
     }
 
     scalar JSON
 
     type Query {
+      fancyBool(input: FancyBool!): FancyBool!
       float(input: Float!): Float!
       id(input: ID!): ID!
       inputObject(input: InputObj!): JSON!
@@ -343,6 +350,11 @@ fn can_introsect_when_multiple_subgraphs() {
 
     scalar CustomRepoId
 
+    enum FancyBool {
+      YES
+      NO
+    }
+
     type Header {
       name: String!
       value: String!
@@ -356,6 +368,7 @@ fn can_introsect_when_multiple_subgraphs() {
       annoyinglyOptionalStrings: [[String]]
       recursiveObject: InputObj
       recursiveObjectList: [InputObj!]
+      fancyBool: FancyBool
     }
 
     type Issue implements PullRequestOrIssue {
@@ -383,6 +396,7 @@ fn can_introsect_when_multiple_subgraphs() {
     type Query {
       allBotPullRequests: [PullRequest!]!
       botPullRequests(bots: [[BotInput!]!]): [PullRequest!]!
+      fancyBool(input: FancyBool!): FancyBool!
       favoriteRepository: CustomRepoId!
       float(input: Float!): Float!
       headers: [Header!]!


### PR DESCRIPTION
This implements variable coercion in engine-v2 along with a bunch of tests.  It also includes some validation of the actual values of variables - though it doesn't implement most of the other variable validations from the spec.

Part of GB-5406