### PR TITLE
fix: cancel in progress CLI builds

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -33,6 +33,7 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   detect-change-type:


### PR DESCRIPTION
We currently don't have cancel-in-progress turned on for our CLI CI builds, which means if you push a new commit you have to wait for any existing CI runs to finish before your latest commit will get built.

Not sure if there's a good reason for this, but I can't think of one, so maybe lets try enabling `cancel-in-progress`?  Shout if you know of a reason why this will be terrible.