### PR TITLE
fix: improve error messages on coercion failure

### DIFF
--- a/engine/crates/engine-v2/schema/src/walkers/field.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/field.rs
@@ -54,13 +54,13 @@ impl<'a> std::fmt::Debug for FieldWalker<'a> {
         f.debug_struct("Field")
             .field("id", &usize::from(self.inner))
             .field("name", &self.name())
-            .field("type", &self.ty().name())
+            .field("type", &self.ty().to_string())
             .field("resolvers", &self.resolvers().map(|fr| fr.resolver).collect::<Vec<_>>())
             .field(
                 "arguments",
                 &self
                     .arguments()
-                    .map(|arg| (arg.name(), arg.ty().name()))
+                    .map(|arg| (arg.name(), arg.ty().to_string()))
                     .collect::<Vec<_>>(),
             )
             .finish()

--- a/engine/crates/engine-v2/schema/src/walkers/input_object.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/input_object.rs
@@ -31,7 +31,7 @@ impl<'a> std::fmt::Debug for InputObjectWalker<'a> {
                 "input_fields",
                 &self
                     .input_fields()
-                    .map(|f| (f.name(), f.ty().name()))
+                    .map(|f| (f.name(), f.ty().to_string()))
                     .collect::<Vec<_>>(),
             )
             .finish()

--- a/engine/crates/engine-v2/schema/src/walkers/type.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/type.rs
@@ -4,29 +4,34 @@ use crate::{DefinitionWalker, ListWrapping, TypeId};
 pub type TypeWalker<'a> = SchemaWalker<'a, TypeId>;
 
 impl<'a> TypeWalker<'a> {
-    pub fn name(&self) -> String {
-        let mut name = self.inner().name().to_string();
-        if self.wrapping.inner_is_required {
-            name.push('!');
-        }
-        for list_wrapping in &self.wrapping.list_wrapping {
-            name = match list_wrapping {
-                ListWrapping::RequiredList => format!("[{name}]!"),
-                ListWrapping::NullableList => format!("[{name}]"),
-            }
-        }
-        name
-    }
-
     pub fn inner(&self) -> DefinitionWalker<'a> {
         self.walk(self.get().inner)
+    }
+}
+
+impl std::fmt::Display for TypeWalker<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for _ in self.wrapping.list_wrapping.iter().rev() {
+            write!(f, "[")?;
+        }
+        write!(f, "{}", self.inner().name())?;
+        if self.wrapping.inner_is_required {
+            write!(f, "!")?;
+        }
+        for wrapping in &self.wrapping.list_wrapping {
+            write!(f, "]")?;
+            if *wrapping == ListWrapping::RequiredList {
+                write!(f, "!")?;
+            }
+        }
+        Ok(())
     }
 }
 
 impl<'a> std::fmt::Debug for TypeWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Type")
-            .field("name", &self.name())
+            .field("name", &self.to_string())
             .field("inner", &self.inner())
             .finish()
     }

--- a/engine/crates/engine-v2/src/request/bind.rs
+++ b/engine/crates/engine-v2/src/request/bind.rs
@@ -348,7 +348,7 @@ impl<'a> Binder<'a> {
                         }
                         _ => Err(BindError::CannotHaveSelectionSet {
                             name: name.to_string(),
-                            ty: schema_field.ty().name().to_string(),
+                            ty: schema_field.ty().to_string(),
                             location: name_location,
                         }),
                     }?)

--- a/engine/crates/integration-tests/tests/federation/basic/variables.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/variables.rs
@@ -207,7 +207,7 @@ fn invalid_ints() {
     "###);
     insta::assert_json_snapshot!(error_test("int", "Int!", json!(null)), @r###"
     [
-      "Variable $input got an invalid value: found a null where we expected a non-null type at $input"
+      "Variable $input got an invalid value: found a null where we expected a Int! at $input"
     ]
     "###);
     insta::assert_json_snapshot!(error_test("int", "Int!", json!({})), @r###"
@@ -241,7 +241,7 @@ fn invalid_strings() {
     "###);
     insta::assert_json_snapshot!(error_test("string", "String!", json!(null)), @r###"
     [
-      "Variable $input got an invalid value: found a null where we expected a non-null type at $input"
+      "Variable $input got an invalid value: found a null where we expected a String! at $input"
     ]
     "###);
     insta::assert_json_snapshot!(error_test("string", "String!", json!({})), @r###"
@@ -265,7 +265,7 @@ fn invalid_floats() {
     "###);
     insta::assert_json_snapshot!(error_test("float", "Float!", json!(null)), @r###"
     [
-      "Variable $input got an invalid value: found a null where we expected a non-null type at $input"
+      "Variable $input got an invalid value: found a null where we expected a Float! at $input"
     ]
     "###);
     insta::assert_json_snapshot!(error_test("float", "Float!", json!({})), @r###"
@@ -284,22 +284,22 @@ fn invalid_floats() {
 fn invalid_id() {
     insta::assert_json_snapshot!(error_test("id", "ID!", true), @r###"
     [
-      "Variable $input got an invalid value: found a Boolean value where we expected a String scalar at $input"
+      "Variable $input got an invalid value: found a Boolean value where we expected a ID scalar at $input"
     ]
     "###);
     insta::assert_json_snapshot!(error_test("id", "ID!", json!(null)), @r###"
     [
-      "Variable $input got an invalid value: found a null where we expected a non-null type at $input"
+      "Variable $input got an invalid value: found a null where we expected a ID! at $input"
     ]
     "###);
     insta::assert_json_snapshot!(error_test("id", "ID!", json!({})), @r###"
     [
-      "Variable $input got an invalid value: found a Object value where we expected a String scalar at $input"
+      "Variable $input got an invalid value: found a Object value where we expected a ID scalar at $input"
     ]
     "###);
     insta::assert_json_snapshot!(error_test("id", "ID!", json!([])), @r###"
     [
-      "Variable $input got an invalid value: found a List value where we expected a String scalar at $input"
+      "Variable $input got an invalid value: found a List value where we expected a ID scalar at $input"
     ]
     "###);
 }
@@ -313,7 +313,7 @@ fn invalid_lists() {
     "###);
     insta::assert_json_snapshot!(error_test("listOfStrings", "[String!]!", json!(null)), @r###"
     [
-      "Variable $input got an invalid value: found a null where we expected a non-null type at $input"
+      "Variable $input got an invalid value: found a null where we expected a [String!]! at $input"
     ]
     "###);
     insta::assert_json_snapshot!(error_test("listOfStrings", "[String!]!", json!([1])), @r###"
@@ -323,7 +323,7 @@ fn invalid_lists() {
     "###);
     insta::assert_json_snapshot!(error_test("listOfStrings", "[String!]!", json!([null])), @r###"
     [
-      "Variable $input got an invalid value: found a null where we expected a non-null type at $input.0"
+      "Variable $input got an invalid value: found a null where we expected a String! at $input.0"
     ]
     "###);
     insta::assert_json_snapshot!(error_test("listOfStrings", "[String!]!", json!(["hello", 1, "there"])), @r###"
@@ -352,22 +352,22 @@ fn invalid_nested_lists() {
     "###);
     insta::assert_json_snapshot!(error_test("listOfListOfStrings", "[[String!]!]!", json!(null)), @r###"
     [
-      "Variable $input got an invalid value: found a null where we expected a non-null type at $input"
+      "Variable $input got an invalid value: found a null where we expected a [[String!]!]! at $input"
     ]
     "###);
     insta::assert_json_snapshot!(error_test("listOfListOfStrings", "[[String!]!]!", json!([1])), @r###"
     [
-      "Variable $input got an invalid value: found a Integer value where we expected a list at $input.0"
+      "Variable $input got an invalid value: found a Integer value where we expected a [String!]! at $input.0"
     ]
     "###);
     insta::assert_json_snapshot!(error_test("listOfListOfStrings", "[[String!]!]!", json!([null])), @r###"
     [
-      "Variable $input got an invalid value: found a null where we expected a non-null type at $input.0"
+      "Variable $input got an invalid value: found a null where we expected a [String!]! at $input.0"
     ]
     "###);
     insta::assert_json_snapshot!(error_test("listOfListOfStrings", "[[String!]!]!", json!([[null]])), @r###"
     [
-      "Variable $input got an invalid value: found a null where we expected a non-null type at $input.0.0"
+      "Variable $input got an invalid value: found a null where we expected a String! at $input.0.0"
     ]
     "###);
     insta::assert_json_snapshot!(error_test("listOfListOfStrings", "[[String!]!]!", json!([[1]])), @r###"
@@ -417,7 +417,7 @@ fn invalid_input_objects() {
         error_test("inputObject", "InputObj!", json!({"recursiveObjectList": [null]})),
         @r###"
     [
-      "Variable $input got an invalid value: found a null where we expected a non-null type at $input.recursiveObjectList.0"
+      "Variable $input got an invalid value: found a null where we expected a InputObj! at $input.recursiveObjectList.0"
     ]
     "###
     );
@@ -430,7 +430,7 @@ fn invalid_input_objects() {
         error_test("inputObject", "InputObj!", json!({"recursiveObjectList": [{"recursiveObjectList": [null]}]})),
         @r###"
     [
-      "Variable $input got an invalid value: found a null where we expected a non-null type at $input.recursiveObjectList.0.recursiveObjectList.0"
+      "Variable $input got an invalid value: found a null where we expected a InputObj! at $input.recursiveObjectList.0.recursiveObjectList.0"
     ]
     "###
     );


### PR DESCRIPTION
I added variable coercion in #1084, but after PRing decided I could improve the error messages somewhat.  This does that: mostly referring to actual types instead of the hand-wavey stuff I was doing before.

Also changed a `TypeWalker::name` to a `Display` impl, because `name` seemed like a bad name, since I'd argue `[String!]!` is not really a name.

Part of GB-5406
