### PR TITLE
fix: dont wait for poll timeout if cli dies

### DIFF
--- a/cli/crates/cli/tests/utils/async_client.rs
+++ b/cli/crates/cli/tests/utils/async_client.rs
@@ -11,16 +11,19 @@ use tokio::time::sleep;
 
 use crate::utils::consts::INTROSPECTION_QUERY;
 
+use super::environment::CommandHandles;
+
 pub struct AsyncClient {
     endpoint: String,
     playground_endpoint: String,
     headers: HeaderMap,
     client: reqwest::Client,
     snapshot: Option<String>,
+    commands: CommandHandles,
 }
 
 impl AsyncClient {
-    pub fn new(endpoint: String, playground_endpoint: String) -> Self {
+    pub fn new(endpoint: String, playground_endpoint: String, commands: CommandHandles) -> Self {
         Self {
             endpoint,
             playground_endpoint,
@@ -31,6 +34,7 @@ impl AsyncClient {
                 .unwrap(),
             snapshot: None,
             headers: HeaderMap::new(),
+            commands,
         }
     }
 
@@ -102,6 +106,11 @@ impl AsyncClient {
         let start = SystemTime::now();
 
         loop {
+            assert!(
+                self.commands.still_running(),
+                "all commands terminated, polling is unlikely to succeed"
+            );
+
             let valid_response = self
                 .client
                 .head(&self.endpoint)


### PR DESCRIPTION
Last month we had a bunch of long CLI CI runs.  In one case this was because the CLI failed to start up in every single test, which is not a case we detect.  We instead wait for a 30 second timeout before ending the test.  Since we retry each test 30 times, this is a lot of waiting around.

This commit updates the `poll_endpoint` function to watch for all the current commands dying - if that happens there's no point in continuing to poll.

Have tested this with some simulated failures locally, and it does end the tests significantly faster.