### PR TITLE
cli: add introspect --dev command to dump project schema 

### DIFF
--- a/cli/crates/cli/src/cli_input/introspect.rs
+++ b/cli/crates/cli/src/cli_input/introspect.rs
@@ -1,15 +1,18 @@
 #[derive(Debug, clap::Args)]
 pub struct IntrospectCommand {
     /// GraphQL URL to introspect
-    url: String,
+    pub(crate) url: Option<String>,
     /// Add a header to the introspection request
     #[clap(short = 'H', long, value_parser, num_args = 0..)]
     header: Vec<String>,
+    /// Pass this argument to introspect the local project. --url and --dev cannot be used together
+    #[clap(long)]
+    pub(crate) dev: bool,
 }
 
 impl IntrospectCommand {
-    pub fn url(&self) -> &str {
-        &self.url
+    pub fn url(&self) -> Option<&str> {
+        self.url.as_deref()
     }
 
     pub fn headers(&self) -> impl Iterator<Item = (&str, &str)> {

--- a/cli/crates/cli/src/cli_input/sub_command.rs
+++ b/cli/crates/cli/src/cli_input/sub_command.rs
@@ -72,6 +72,11 @@ impl SubCommand {
                 | Self::Build(_)
                 | Self::Unlink
                 | Self::DumpConfig
+                | Self::Introspect(IntrospectCommand {
+                    dev: true,
+                    url: None,
+                    ..
+                })
         )
     }
 }

--- a/cli/crates/cli/src/introspect.rs
+++ b/cli/crates/cli/src/introspect.rs
@@ -1,9 +1,35 @@
-use crate::{cli_input::IntrospectCommand, errors::CliError};
+use crate::{cli_input::IntrospectCommand, errors::CliError, output::report};
 use tokio::runtime::Runtime;
 
 pub(crate) fn introspect(command: &IntrospectCommand) -> Result<(), CliError> {
-    let headers = command.headers().collect::<Vec<_>>();
-    let operation = graphql_introspection::introspect(command.url(), &headers);
+    match (command.url(), command.dev) {
+        (Some(url), _) => {
+            let headers = command.headers().collect::<Vec<_>>();
+            introspect_remote(url, &headers)
+        }
+        (None, true) => introspect_local(),
+        (None, false) => {
+            eprintln!("Error: Either the --url or the --dev argument must be provided.");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn introspect_local() -> Result<(), CliError> {
+    match server::introspect_local().map_err(CliError::ServerError)? {
+        server::IntrospectLocalOutput::Sdl(schema) => {
+            println!("{schema}");
+        }
+        server::IntrospectLocalOutput::EmptyFederated => {
+            report::federated_schema_local_introspection_not_implemented();
+        }
+    }
+
+    Ok(())
+}
+
+fn introspect_remote(url: &str, headers: &[(&str, &str)]) -> Result<(), CliError> {
+    let operation = graphql_introspection::introspect(url, headers);
 
     match Runtime::new().unwrap().block_on(operation) {
         Ok(result) => Ok(println!("{result}")),

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -546,3 +546,7 @@ pub(crate) async fn listen_to_federated_dev_events() {
         }
     });
 }
+
+pub(crate) fn federated_schema_local_introspection_not_implemented() {
+    eprintln!("⚠️ The introspected schema is empty. Introspecting federated graphs is not implemented yet.")
+}

--- a/cli/crates/server/src/introspect_local.rs
+++ b/cli/crates/server/src/introspect_local.rs
@@ -1,0 +1,28 @@
+use crate::{
+    errors::ServerError,
+    servers::{run_schema_parser, ParsingResponse},
+};
+
+pub enum IntrospectLocalOutput {
+    Sdl(String),
+    EmptyFederated,
+}
+
+#[tokio::main]
+pub async fn introspect_local() -> Result<IntrospectLocalOutput, ServerError> {
+    let env = crate::environment::variables().collect();
+
+    let ParsingResponse {
+        registry,
+        detected_udfs: _,
+        is_federated,
+    } = run_schema_parser(&env, None).await?;
+
+    let rendered_sdl = registry.export_sdl(is_federated);
+
+    if is_federated && rendered_sdl.is_empty() {
+        Ok(IntrospectLocalOutput::EmptyFederated)
+    } else {
+        Ok(IntrospectLocalOutput::Sdl(rendered_sdl))
+    }
+}

--- a/cli/crates/server/src/lib.rs
+++ b/cli/crates/server/src/lib.rs
@@ -30,6 +30,7 @@ mod environment;
 mod error_server;
 mod event;
 mod file_watcher;
+mod introspect_local;
 mod parser;
 mod proxy;
 mod servers;
@@ -39,4 +40,5 @@ pub mod errors;
 pub mod types;
 
 pub use dump_config::dump_config;
+pub use introspect_local::{introspect_local, IntrospectLocalOutput};
 pub use servers::{export_embedded_files, start, ProductionServer};


### PR DESCRIPTION
The use case is schema checks. You want the SDL schema of the current
project as it is locally, not the deployed version. The current best
solution is to start a dev server and introspect it. This commit
introduces a much easier solution: `grafbase introspect --dev`.