### PR TITLE
fix: don't remove built in scalars in composition

### DIFF
--- a/engine/crates/composition/src/subgraphs.rs
+++ b/engine/crates/composition/src/subgraphs.rs
@@ -23,7 +23,6 @@ use itertools::Itertools;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 /// A set of subgraphs to be composed.
-#[derive(Default)]
 pub struct Subgraphs {
     pub(super) strings: strings::Strings,
     subgraphs: Vec<Subgraph>,
@@ -46,6 +45,31 @@ pub struct Subgraphs {
     // (definition name, subgraph_id) -> definition id
     definition_names: BTreeMap<(StringId, SubgraphId), DefinitionId>,
 }
+
+impl Default for Subgraphs {
+    fn default() -> Self {
+        let mut strings = strings::Strings::default();
+        BUILTIN_SCALARS.into_iter().for_each(|scalar| {
+            strings.intern(scalar);
+        });
+
+        Self {
+            strings,
+            subgraphs: Default::default(),
+            definitions: Default::default(),
+            directives: Default::default(),
+            enums: Default::default(),
+            fields: Default::default(),
+            field_types: Default::default(),
+            keys: Default::default(),
+            unions: Default::default(),
+            ingestion_diagnostics: Default::default(),
+            definition_names: Default::default(),
+        }
+    }
+}
+
+const BUILTIN_SCALARS: [&str; 5] = ["ID", "String", "Boolean", "Int", "Float"];
 
 impl Subgraphs {
     /// Add a subgraph to compose.
@@ -88,9 +112,9 @@ impl Subgraphs {
 
     /// Iterates all builtin scalars _that are in use in at least one subgraph_.
     pub(crate) fn iter_builtin_scalars(&self) -> impl Iterator<Item = StringWalker<'_>> + '_ {
-        ["ID", "String", "Boolean", "Int", "Float"]
+        BUILTIN_SCALARS
             .into_iter()
-            .filter_map(|name| self.strings.lookup(name))
+            .map(|name| self.strings.lookup(name).expect("all built in scalars to be interned"))
             .map(|string| self.walk(string))
     }
 

--- a/engine/crates/integration-tests/src/mocks/graphql.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql.rs
@@ -5,11 +5,13 @@ use std::{net::TcpListener, sync::Arc, time::Duration};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::{extract::State, http::HeaderMap, routing::post, Router};
 
+mod almost_empty;
 mod echo;
 mod fake_github;
 mod federation;
 
 pub use {
+    almost_empty::AlmostEmptySchema,
     echo::EchoSchema,
     fake_github::FakeGithubSchema,
     federation::{FakeFederationAccountsSchema, FakeFederationProductsSchema, FakeFederationReviewsSchema},

--- a/engine/crates/integration-tests/src/mocks/graphql/almost_empty.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql/almost_empty.rs
@@ -1,0 +1,16 @@
+use async_graphql::{EmptyMutation, EmptySubscription, Object};
+
+/// A schema that only uses String types.
+///
+/// This is used to make sure that we're not pruning built in scalars that aren't used
+pub type AlmostEmptySchema = async_graphql::Schema<Query, EmptyMutation, EmptySubscription>;
+
+#[derive(Default)]
+pub struct Query;
+
+#[Object]
+impl Query {
+    async fn string(&self, input: String) -> String {
+        input
+    }
+}

--- a/engine/crates/integration-tests/tests/federation/basic/scalars.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/scalars.rs
@@ -1,5 +1,10 @@
 use engine_v2::Engine;
-use integration_tests::{federation::EngineV2Ext, mocks::graphql::FakeGithubSchema, runtime, MockGraphQlServer};
+use integration_tests::{
+    federation::EngineV2Ext,
+    mocks::graphql::{AlmostEmptySchema, FakeGithubSchema},
+    runtime, MockGraphQlServer,
+};
+use serde_json::json;
 
 #[test]
 fn supports_custom_scalars() {
@@ -18,6 +23,31 @@ fn supports_custom_scalars() {
           "owner": "rust-lang",
           "name": "rust"
         }
+      }
+    }
+    "###);
+}
+
+#[test]
+fn supports_unused_builtin_scalars() {
+    let response = runtime().block_on(async move {
+        let mock = MockGraphQlServer::new(AlmostEmptySchema::default()).await;
+
+        let engine = Engine::build().with_schema("schema", &mock).await.finish();
+
+        engine
+            .execute("query Blah($id: ID!) { string(input: $id) }")
+            .variables(json!({"id": "1"}))
+            .await
+    });
+
+    // Bit of a poor test this because we can never pass a valid query that makes use of a scalar that doesn't exist.
+    // But so long as any errors below don't include "Unknown type `ID` or similar I think we're good"
+
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": {
+        "string": "1"
       }
     }
     "###);


### PR DESCRIPTION
Composition was filtering out built in scalars that weren't present in any subgraph. This meant that engine-v2 wasn't aware of them, so you'd get `Unknown type: "ID"` errors if you tried to use them.  Shouldn't really matter for valid queries, but still worth fixing.

Fixes GB-5576