### PR TITLE
cli: release 0.48.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "federated-dev"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "async-graphql 6.0.10",
  "async-graphql-axum 6.0.10",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "async-graphql 6.0.10",
  "async-trait",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "async-graphql 5.0.10",
  "async-graphql-axum 5.0.10",
@@ -2716,7 +2716,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-graphql-introspection"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "apollo-encoder",
  "apollo-parser",
@@ -2729,7 +2729,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "async-compression",
  "async-tar",
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "chrono",
  "common-types",
@@ -2778,7 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -4445,7 +4445,7 @@ dependencies = [
 
 [[package]]
 name = "operation-normalizer"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -7504,7 +7504,7 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typed-resolvers"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "datatest-stable",
  "engine-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde_with = { git = "https://github.com/grafbase/serde_with", rev = "00b1e328bf
 ulid = { git = "https://github.com/grafbase/ulid-rs", rev = "6d06156193d51a2db3216f058cbfadd4923df2c7" }
 
 [workspace.package]
-version = "0.48.0"
+version = "0.48.1"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://grafbase.com"

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.48.1] - 2023-12-07
+
+[CHANGELOG](changelog/0.48.1.md)
+
 ## [0.48.0] - 2023-12-07
 
 [CHANGELOG](changelog/0.48.0.md)

--- a/cli/changelog/0.48.1.md
+++ b/cli/changelog/0.48.1.md
@@ -1,0 +1,7 @@
+### Features
+
+- The `grafbase introspect` command can now take a `--dev` flag to introspect the local project's schema. It is mutually exclusive with the `--url` flag. (#1095)
+
+### Fixes
+
+- Due to the recent added support for configuration at the repository root, the generated TS code for typed resolvers was generated at the repository root, even when the configuration lived in the ./grafbase directory. This releases fixes that behaviour: the `generated` directory will be at the same level as the configuration. (#1093)

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -41,8 +41,8 @@ url = "2"
 urlencoding = "2"
 walkdir = "2"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.48.0" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.48.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.48.1" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.48.1" }
 
 [build-dependencies]
 cynic-codegen = { version = "3", features = ["rkyv"] }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -40,9 +40,9 @@ webbrowser = "0.8"
 lru = "0.12"
 futures-util = "0.3"
 
-server = { package = "grafbase-local-server", path = "../server", version = "0.48.0" }
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.48.0" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.48.0" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.48.1" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.48.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.48.1" }
 graphql-introspection = { package = "grafbase-graphql-introspection", path = "../graphql-introspection" }
 federated-dev = { path = "../federated-dev" }
 atty = "0.2.14"

--- a/cli/crates/federated-dev/Cargo.toml
+++ b/cli/crates/federated-dev/Cargo.toml
@@ -31,7 +31,7 @@ futures-util = "0.3"
 tokio-stream = "0.1"
 tower-http = { version = "0.4", features = ["cors", "fs", "trace"] }
 log = "0.4.20"
-common = { package = "grafbase-local-common", path = "../common", version = "0.48.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.48.1" }
 runtime-local.workspace = true
 
 [lints]

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -67,7 +67,7 @@ sha2 = "0.10"
 # Same version as Tantivy
 tantivy-fst = "0.4.0"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.48.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.48.1" }
 gateway = { path = "../gateway" }
 typed-resolvers = { path = "../typed-resolvers" }
 federated-dev = { path = "../federated-dev" }

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.48.0",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.48.0",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.48.0",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.48.0",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.48.0"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.48.1",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.48.1",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.48.1",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.48.1",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.48.1"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
Features

- The `grafbase introspect` command can now take a `--dev` flag to introspect the local project's schema. It is mutually exclusive with the `--url` flag. (#1095)

Fixes

- Due to the recent added support for configuration at the repository root, the generated TS code for typed resolvers was generated at the repository root, even when the configuration lived in the ./grafbase directory. This releases fixes that behaviour: the `generated` directory will be at the same level as the configuration. (#1093)
