### PR TITLE
feat: add headers to federated-graph

### DIFF
--- a/engine/crates/composition/src/emit_federated_graph.rs
+++ b/engine/crates/composition/src/emit_federated_graph.rs
@@ -31,6 +31,7 @@ pub(crate) fn emit_federated_graph(mut ir: CompositionIr, subgraphs: &Subgraphs)
         interface_fields: vec![],
         fields: vec![],
         field_types: vec![],
+        headers: vec![],
     };
 
     let mut ctx = Context::new(&mut ir, subgraphs, &mut out);
@@ -254,6 +255,10 @@ fn emit_subgraphs(ctx: &mut Context<'_>) {
     for subgraph in ctx.subgraphs.iter_subgraphs() {
         let name = ctx.insert_string(subgraph.name());
         let url = ctx.insert_string(subgraph.url());
-        ctx.out.subgraphs.push(federated::Subgraph { name, url });
+        ctx.out.subgraphs.push(federated::Subgraph {
+            name,
+            url,
+            headers: vec![],
+        });
     }
 }

--- a/engine/crates/federated-graph/src/federated_graph.rs
+++ b/engine/crates/federated-graph/src/federated_graph.rs
@@ -32,6 +32,10 @@ pub struct FederatedGraphV1 {
 
     /// All the field types in the supergraph, deduplicated.
     pub field_types: Vec<FieldType>,
+
+    /// Any headers that we need to forward to subgraphs
+    #[serde(default)]
+    pub headers: Vec<Header>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -51,6 +55,25 @@ impl std::fmt::Debug for FederatedGraphV1 {
 pub struct Subgraph {
     pub name: StringId,
     pub url: StringId,
+
+    /// Headers that should be sent in requests to this subgraph
+    #[serde(default)]
+    pub headers: Vec<HeaderId>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct Header {
+    pub name: StringId,
+    pub value: HeaderValue,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum HeaderValue {
+    /// The given header from the current request should be forwarded
+    /// to the subgraph
+    ForwardFrom(StringId),
+    /// The given string should always be sent
+    Value(StringId),
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -336,4 +359,5 @@ id_newtypes! {
     StringId + strings + String,
     SubgraphId + subgraphs + Subgraph,
     UnionId + unions + Union,
+    HeaderId + headers + Header,
 }

--- a/engine/crates/federated-graph/src/from_sdl.rs
+++ b/engine/crates/federated-graph/src/from_sdl.rs
@@ -131,6 +131,7 @@ pub fn from_sdl(sdl: &str) -> Result<FederatedGraph, DomainError> {
         input_objects: state.input_objects,
         strings: state.strings.into_iter().collect(),
         field_types: state.field_types.into_iter().collect(),
+        headers: vec![],
     }))
 }
 
@@ -715,7 +716,11 @@ fn ingest_join_graph_enum<'a>(enm: &'a ast::EnumType, state: &mut State<'a>) -> 
 
         let name = state.insert_string(name);
         let url = state.insert_string(url);
-        let id = SubgraphId(state.subgraphs.push_return_idx(Subgraph { name, url }));
+        let id = SubgraphId(state.subgraphs.push_return_idx(Subgraph {
+            name,
+            url,
+            headers: vec![],
+        }));
         state.graph_sdl_names.insert(sdl_name, id);
     }
 


### PR DESCRIPTION
As we discovered in the demo this morning, we need a way to specify headers that should be sent to a subgraph in `engine-v2`.	

This PR adds fields for storing this information into `federated-graph`.  I'm not using them yet, wanted to get this out for review to make sure we're all agreed that this is the right place to put them.

Part of GB-5590