### PR TITLE
cli: make branch optional in `grafbase subgraphs`

### DIFF
--- a/cli/crates/backend/src/api/graphql/types/queries/list_subgraphs.rs
+++ b/cli/crates/backend/src/api/graphql/types/queries/list_subgraphs.rs
@@ -14,6 +14,24 @@ pub struct ListSubgraphsQuery {
     pub branch: Option<Branch>,
 }
 
+#[derive(cynic::QueryVariables)]
+pub struct ListSubgraphsForProductionBranchArguments<'a> {
+    pub account: &'a str,
+    pub project: &'a str,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "Query", variables = "ListSubgraphsForProductionBranchArguments")]
+pub struct ListSubgraphsForProductionBranchQuery {
+    #[arguments(accountSlug: $account, projectSlug: $project)]
+    pub project_by_account_slug: Option<Project>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct Project {
+    pub production_branch: Branch,
+}
+
 #[derive(cynic::QueryFragment, Debug)]
 pub struct Branch {
     pub name: String,

--- a/cli/crates/backend/src/api/subgraphs.rs
+++ b/cli/crates/backend/src/api/subgraphs.rs
@@ -2,18 +2,31 @@ use super::{
     client::create_client,
     consts::API_URL,
     errors::ApiError,
-    graphql::queries::list_subgraphs::{ListSubgraphsArguments, ListSubgraphsQuery, Subgraph},
+    graphql::queries::list_subgraphs::{
+        ListSubgraphsArguments, ListSubgraphsForProductionBranchArguments, ListSubgraphsForProductionBranchQuery,
+        ListSubgraphsQuery, Subgraph,
+    },
 };
 use cynic::{http::ReqwestExt, QueryBuilder};
 
-/// The `grafbase subgraphs` command.
-pub async fn subgraphs(account: &str, project: &str, branch: Option<&str>) -> Result<Vec<Subgraph>, ApiError> {
+/// The `grafbase subgraphs` command. Returns (branch name, subgraphs).
+pub async fn subgraphs(
+    account: &str,
+    project: &str,
+    branch: Option<&str>,
+) -> Result<(String, Vec<Subgraph>), ApiError> {
+    match branch {
+        Some(branch) => subgraphs_with_branch(account, project, branch).await,
+        None => subgraphs_production_branch(account, project).await,
+    }
+}
+
+async fn subgraphs_with_branch(
+    account: &str,
+    project: &str,
+    branch: &str,
+) -> Result<(String, Vec<Subgraph>), ApiError> {
     let client = create_client().await?;
-    let Some(branch) = branch else {
-        return Err(ApiError::SubgraphsError(
-            "A branch must be specified in order to list subgraphs".to_owned(),
-        ));
-    };
 
     let operation = ListSubgraphsQuery::build(ListSubgraphsArguments {
         account,
@@ -26,10 +39,33 @@ pub async fn subgraphs(account: &str, project: &str, branch: Option<&str>) -> Re
         .data
         .as_ref()
         .and_then(|branch| branch.branch.as_ref())
-        .and_then(|branch| branch.subgraphs.as_deref());
+        .and_then(|branch| Some(&branch.name).zip(branch.subgraphs.as_deref()));
 
-    if let Some(subgraphs) = subgraphs {
-        Ok(subgraphs.to_owned())
+    if let Some((branch, subgraphs)) = subgraphs {
+        Ok((branch.to_owned(), subgraphs.to_owned()))
+    } else {
+        Err(ApiError::SubgraphsError(format!(
+            "no subgraphs in response:\n{response:#?}",
+        )))
+    }
+}
+
+async fn subgraphs_production_branch(account: &str, project: &str) -> Result<(String, Vec<Subgraph>), ApiError> {
+    let client = create_client().await?;
+
+    let operation =
+        ListSubgraphsForProductionBranchQuery::build(ListSubgraphsForProductionBranchArguments { account, project });
+
+    let response = client.post(API_URL).run_graphql(operation).await?;
+    let subgraphs = response
+        .data
+        .as_ref()
+        .and_then(|query| query.project_by_account_slug.as_ref())
+        .map(|project| &project.production_branch)
+        .and_then(|branch| Some(&branch.name).zip(branch.subgraphs.as_deref()));
+
+    if let Some((branch, subgraphs)) = subgraphs {
+        Ok((branch.to_owned(), subgraphs.to_owned()))
     } else {
         Err(ApiError::SubgraphsError(format!(
             "no subgraphs in response:\n{response:#?}",

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -440,13 +440,13 @@ pub(crate) fn check_errors<'a>(
     }
 }
 
-pub(crate) fn subgraphs_command_success<'a>(subgraphs: impl ExactSizeIterator<Item = &'a str>) {
+pub(crate) fn subgraphs_command_success<'a>(branch_name: &str, subgraphs: impl ExactSizeIterator<Item = &'a str>) {
     if subgraphs.len() == 0 {
-        println!("🈳 There are no published subgraphs in this branch\n");
+        println!("🈳 There are no published subgraphs in the {branch_name} branch\n");
         return;
     }
 
-    println!("Subgraphs:\n");
+    println!("Subgraphs in branch \"{branch_name}\":\n");
 
     for name in subgraphs {
         println!("-  {name}");

--- a/cli/crates/cli/src/subgraphs.rs
+++ b/cli/crates/cli/src/subgraphs.rs
@@ -3,12 +3,12 @@ use crate::{cli_input::SubgraphsCommand, errors::CliError, output::report};
 #[tokio::main]
 pub(super) async fn subgraphs(cmd: SubgraphsCommand) -> Result<(), CliError> {
     let project_ref = cmd.project_ref;
-    let subgraphs =
+    let (branch, subgraphs) =
         backend::api::subgraphs::subgraphs(project_ref.account(), project_ref.project(), project_ref.branch())
             .await
             .map_err(CliError::BackendApiError)?;
 
-    report::subgraphs_command_success(subgraphs.iter().map(|subgraph| subgraph.name.as_str()));
+    report::subgraphs_command_success(&branch, subgraphs.iter().map(|subgraph| subgraph.name.as_str()));
 
     Ok(())
 }


### PR DESCRIPTION
The problem we faced is that the subgraphs field is on `Branch`. The fix is a different GraphQL query in the absence of a branch name. This commit uses `Project.productionBranch` instead.

closes GB-5600
