### PR TITLE
feat: add `@allSubgraphs` to parser-sdl, pass to engine-v2

### DIFF
--- a/engine/crates/engine-v2/config/src/lib.rs
+++ b/engine/crates/engine-v2/config/src/lib.rs
@@ -36,6 +36,7 @@ impl VersionedConfig {
                 graph,
                 strings: Default::default(),
                 headers: Default::default(),
+                default_headers: Default::default(),
                 subgraph_configs: Default::default(),
             },
             VersionedConfig::V2(latest) => latest,

--- a/engine/crates/engine-v2/config/src/v2.rs
+++ b/engine/crates/engine-v2/config/src/v2.rs
@@ -9,6 +9,9 @@ pub struct Config {
     pub strings: Vec<String>,
     pub headers: Vec<Header>,
 
+    /// Default headers that should be sent to every subgraph
+    pub default_headers: Vec<HeaderId>,
+
     /// Additional configuration for our subgraphs
     pub subgraph_configs: BTreeMap<SubgraphId, SubgraphConfig>,
 }

--- a/engine/crates/parser-sdl/src/lib.rs
+++ b/engine/crates/parser-sdl/src/lib.rs
@@ -14,6 +14,7 @@ use engine::{
 };
 use engine_parser::{types::ServiceDocument, Error as ParserError};
 use rules::{
+    all_subgraphs_directive::{AllSubgraphsDirective, AllSubgraphsDirectiveVisitor},
     auth_directive::AuthDirective,
     basic_type::BasicType,
     check_field_lowercase::CheckFieldCamelCase,
@@ -162,7 +163,8 @@ fn parse_schema(schema: &str) -> engine::parser::Result<ServiceDocument> {
         .with::<InaccessibleDirective>()
         .with::<TagDirective>()
         .with::<ExtendFieldDirective>()
-        .with::<SubgraphDirective>();
+        .with::<SubgraphDirective>()
+        .with::<AllSubgraphsDirective>();
 
     let schema = format!(
         "{}\n{}\n{}\n{}",
@@ -358,7 +360,8 @@ fn parse_types<'a>(schema: &'a ServiceDocument, ctx: &mut VisitorContext<'a>) {
         .with(ExperimentalDirectiveVisitor)
         .with(FederationDirectiveVisitor) // This will likely need moved.  Here'll do for now though
         .with(ExtendFieldVisitor)
-        .with(SubgraphDirectiveVisitor);
+        .with(SubgraphDirectiveVisitor)
+        .with(AllSubgraphsDirectiveVisitor);
 
     visit(&mut rules, ctx, schema);
 }

--- a/engine/crates/parser-sdl/src/rules/all_subgraphs_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/all_subgraphs_directive.rs
@@ -1,0 +1,145 @@
+use engine_parser::types::SchemaDefinition;
+
+use crate::directive_de::parse_directive;
+
+use super::{
+    connector_headers::Header,
+    directive::Directive,
+    visitor::{Visitor, VisitorContext},
+};
+
+/// Am `@allSubgraphs` directive that can be used to pass additional
+/// configuration for all subgraphs into a federated graph
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AllSubgraphsDirective {
+    /// Any additional headers we want to send to all subgraphs
+    #[serde(default)]
+    headers: Vec<Header>,
+}
+
+impl Directive for AllSubgraphsDirective {
+    fn definition() -> String {
+        r#"
+        directive @allSubgraphs(
+          "Any additional headers we want to send to all the subgraphs"
+          headers: [SubgraphHeader!]
+        ) on SCHEMA
+        "#
+        .to_string()
+    }
+}
+
+pub struct AllSubgraphsDirectiveVisitor;
+
+impl Visitor<'_> for AllSubgraphsDirectiveVisitor {
+    fn enter_schema(&mut self, ctx: &mut VisitorContext<'_>, doc: &engine::Positioned<SchemaDefinition>) {
+        let directives = doc
+            .node
+            .directives
+            .iter()
+            .filter(|directive| directive.node.name.node == "allSubgraphs")
+            .collect::<Vec<_>>();
+
+        if !ctx.registry.borrow().is_federated {
+            if !directives.is_empty() {
+                ctx.report_error(
+                    directives.into_iter().map(|directive| directive.pos).collect(),
+                    "The @allSubgraphs directive is only valid in federated graphs",
+                );
+            }
+            return;
+        }
+
+        for directive in directives {
+            let directive = match parse_directive::<AllSubgraphsDirective>(directive, ctx.variables) {
+                Ok(directive) => directive,
+                Err(error) => {
+                    ctx.append_errors(vec![error]);
+                    return;
+                }
+            };
+
+            ctx.federated_graph_config.default_headers.extend(
+                directive
+                    .headers
+                    .into_iter()
+                    .map(|header| (header.name, header.value.into())),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::{tests::assert_validation_error, to_parse_result_with_variables};
+
+    #[test]
+    fn test_happy_path() {
+        let schema = r#"
+            extend schema
+                @allSubgraphs(
+                    headers: [{name: "Auth", forward: "Authorization"}]
+                )
+                @allSubgraphs(
+                    headers: [{name: "Auth", value: "Foo"}]
+                )
+                @subgraph(
+                    name: "Products",
+                    headers: [{name: "Other", value: "Bar"}]
+                )
+                @graph(type: federated)
+        "#;
+
+        let result = to_parse_result_with_variables(schema, &HashMap::new()).unwrap();
+
+        insta::assert_debug_snapshot!(result.federated_graph_config, @r###"
+        Some(
+            FederatedGraphConfig {
+                subgraphs: {
+                    "Products": SubgraphConfig {
+                        name: "Products",
+                        headers: [
+                            (
+                                "Other",
+                                Static(
+                                    "Bar",
+                                ),
+                            ),
+                        ],
+                    },
+                },
+                default_headers: [
+                    (
+                        "Auth",
+                        Forward(
+                            "Authorization",
+                        ),
+                    ),
+                    (
+                        "Auth",
+                        Static(
+                            "Foo",
+                        ),
+                    ),
+                ],
+            },
+        )
+        "###);
+    }
+
+    #[test]
+    fn test_errors_if_not_federated_graph() {
+        assert_validation_error!(
+            r#"
+            extend schema
+              @allSubgraphs(
+                headers: [{name: "Hello", forward: true}]
+              )
+            "#,
+            "The @allSubgraphs directive is only valid in federated graphs"
+        );
+    }
+}

--- a/engine/crates/parser-sdl/src/rules/mod.rs
+++ b/engine/crates/parser-sdl/src/rules/mod.rs
@@ -1,3 +1,4 @@
+pub mod all_subgraphs_directive;
 pub mod auth_directive;
 pub mod basic_type;
 pub mod cache_directive;


### PR DESCRIPTION
PR #1105 added a `@subgraph` attribute for adding headers to a particular subgraph.  This adds `@allSubgraphs` - the equivalent directive for adding headers to all of the subgraphs.

Fixes GB-5604