### PR TITLE
fix: composition should short circuit error if composing with no graphs

### DIFF
--- a/engine/crates/composition/src/lib.rs
+++ b/engine/crates/composition/src/lib.rs
@@ -22,6 +22,17 @@ use self::{
 /// Compose subgraphs into a federated graph.
 pub fn compose(subgraphs: &Subgraphs) -> CompositionResult {
     let mut diagnostics = Diagnostics::default();
+
+    if subgraphs.iter_subgraphs().len() == 0 {
+        let error = "No graphs found for composition build. You must have at least one active graph.";
+        diagnostics.push_fatal(error.to_owned());
+
+        return CompositionResult {
+            federated_graph: None,
+            diagnostics,
+        };
+    }
+
     let mut context = ComposeContext::new(subgraphs, &mut diagnostics);
 
     compose_subgraphs(&mut context);

--- a/engine/crates/composition/src/subgraphs.rs
+++ b/engine/crates/composition/src/subgraphs.rs
@@ -118,7 +118,7 @@ impl Subgraphs {
             .map(|string| self.walk(string))
     }
 
-    pub(crate) fn iter_subgraphs(&self) -> impl Iterator<Item = SubgraphWalker<'_>> {
+    pub(crate) fn iter_subgraphs(&self) -> impl ExactSizeIterator<Item = SubgraphWalker<'_>> {
         (0..self.subgraphs.len()).map(|idx| self.walk(SubgraphId(idx)))
     }
 

--- a/engine/crates/composition/tests/composition/composition_of_zero_subgraphs/federated.graphql
+++ b/engine/crates/composition/tests/composition/composition_of_zero_subgraphs/federated.graphql
@@ -1,0 +1,1 @@
+# No graphs found for composition build. You must have at least one active graph.

--- a/engine/crates/composition/tests/composition/composition_of_zero_subgraphs/subgraphs/.gitignore
+++ b/engine/crates/composition/tests/composition/composition_of_zero_subgraphs/subgraphs/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/engine/crates/composition/tests/composition_tests.rs
+++ b/engine/crates/composition/tests/composition_tests.rs
@@ -21,6 +21,7 @@ fn run_test(federated_graph_path: &Path) -> datatest_stable::Result<()> {
 
     let mut subgraphs_sdl = fs::read_dir(subgraphs_dir)?
         .filter_map(Result::ok)
+        .filter(|file| file.file_name() != ".gitignore")
         .map(|file| fs::read_to_string(file.path()).map(|contents| (contents, file.path())))
         .collect::<Result<Vec<_>, _>>()?;
 


### PR DESCRIPTION
This gives a much better error compared to whatever it is with missing query.

Part of: GB-5588