### PR TITLE
cli: return specific composition errors when publish fails at composition

### DIFF
--- a/cli/crates/backend/src/api/graphql/types/mutations.rs
+++ b/cli/crates/backend/src/api/graphql/types/mutations.rs
@@ -186,9 +186,15 @@ pub struct PublishSuccess {
     pub __typename: String,
 }
 
+#[derive(cynic::QueryFragment, Debug)]
+pub struct FederatedGraphCompositionError {
+    pub messages: Vec<String>,
+}
+
 #[derive(cynic::InlineFragments, Debug)]
 pub enum PublishPayload {
     PublishSuccess(PublishSuccess),
+    FederatedGraphCompositionError(FederatedGraphCompositionError),
     #[cynic(fallback)]
     Unknown(String),
 }

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -550,3 +550,14 @@ pub(crate) async fn listen_to_federated_dev_events() {
 pub(crate) fn federated_schema_local_introspection_not_implemented() {
     eprintln!("⚠️ The introspected schema is empty. Introspecting federated graphs is not implemented yet.")
 }
+
+pub(crate) fn publish_command_composition_failure(messages: &[String]) {
+    watercolor::output!("🔴 Published with composition error(s).\n", @BrightRed);
+
+    if !messages.is_empty() {
+        watercolor::output!("Composition errors:", @BrightRed);
+        for error in messages {
+            watercolor::output!("- {error}", @BrightRed);
+        }
+    }
+}

--- a/cli/crates/cli/src/publish.rs
+++ b/cli/crates/cli/src/publish.rs
@@ -27,7 +27,7 @@ pub(crate) async fn publish(
 
     report::publishing();
 
-    backend::api::publish::publish(
+    let outcome = backend::api::publish::publish(
         project_ref.account(),
         project_ref.project(),
         project_ref.branch(),
@@ -38,7 +38,12 @@ pub(crate) async fn publish(
     .await
     .map_err(CliError::BackendApiError)?;
 
-    report::publish_command_success(&subgraph_name);
+    match outcome {
+        Ok(()) => report::publish_command_success(&subgraph_name),
+        Err(messages) => {
+            report::publish_command_composition_failure(&messages);
+        }
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Instead of just "FederatedGraphCompositionError".

closes GB-5585