### PR TITLE
feat: send configured headers to subgraph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3519,6 +3519,7 @@ dependencies = [
  "cynic-introspection",
  "dynamodb",
  "engine",
+ "engine-config-builder",
  "engine-parser",
  "engine-v2",
  "expect-test",

--- a/cli/crates/federated-dev/src/dev/bus.rs
+++ b/cli/crates/federated-dev/src/dev/bus.rs
@@ -5,6 +5,7 @@ mod refresh;
 
 pub(crate) use admin::AdminBus;
 pub(crate) use compose::ComposeBus;
+use engine::RequestHeaders;
 pub(crate) use message::*;
 pub(crate) use refresh::RefreshBus;
 
@@ -35,10 +36,10 @@ pub(crate) type ComposeSender = mpsc::Sender<ComposeMessage>;
 pub(crate) type ComposeReceiver = mpsc::Receiver<ComposeMessage>;
 
 /// Send half of channel for the server to send requests to the router actor
-pub(crate) type RequestSender = mpsc::Sender<(engine::Request, ResponseSender)>;
+pub(crate) type RequestSender = mpsc::Sender<(engine::Request, RequestHeaders, ResponseSender)>;
 
 /// Receive half of channel for the router actor to receive requests
-pub(crate) type RequestReceiver = mpsc::Receiver<(engine::Request, ResponseSender)>;
+pub(crate) type RequestReceiver = mpsc::Receiver<(engine::Request, RequestHeaders, ResponseSender)>;
 
 /// Send half of channel for the router actor to send responses
 pub(crate) type ResponseSender = oneshot::Sender<RouterResult<engine_v2::Response>>;

--- a/engine/crates/engine-v2/schema/src/conversion.rs
+++ b/engine/crates/engine-v2/schema/src/conversion.rs
@@ -27,6 +27,7 @@ impl From<Config> for Schema {
             unions: graph.unions.into_iter().map(Into::into).collect(),
             scalars: Vec::with_capacity(graph.scalars.len()),
             input_objects: Vec::with_capacity(graph.input_objects.len()),
+            headers: convert_headers(config.headers, graph.strings.len()),
             strings: graph.strings,
             resolvers: vec![],
             definitions: vec![],
@@ -37,7 +38,13 @@ impl From<Config> for Schema {
                 },
                 ..Default::default()
             },
+            default_headers: config.default_headers.into_iter().map(Into::into).collect(),
         };
+
+        schema.strings.extend(config.strings);
+        for (id, config) in config.subgraph_configs {
+            schema.update_subgraph_config(id, config);
+        }
 
         // -- OBJECTS --
         let mut entity_resolvers = HashMap::<ObjectId, Vec<(ResolverId, SubgraphId)>>::new();
@@ -245,6 +252,7 @@ impl From<federated_graph::Subgraph> for federation::Subgraph {
         federation::Subgraph {
             name: subgraph.name.into(),
             url: subgraph.url.into(),
+            headers: vec![],
         }
     }
 }
@@ -410,11 +418,35 @@ impl From<federated_graph::InputObjectField> for InputValue {
     }
 }
 
+fn convert_headers(headers: Vec<config::latest::Header>, base_string_index: usize) -> Vec<SubgraphHeader> {
+    headers
+        .into_iter()
+        .map(|header| SubgraphHeader {
+            name: (base_string_index + header.name.0).into(),
+            value: match header.value {
+                config::latest::HeaderValue::Forward(id) => {
+                    SubgraphHeaderValue::Forward((base_string_index + id.0).into())
+                }
+                config::latest::HeaderValue::Static(id) => {
+                    SubgraphHeaderValue::Static((base_string_index + id.0).into())
+                }
+            },
+        })
+        .collect()
+}
+
+impl Schema {
+    fn update_subgraph_config(&mut self, id: federated_graph::SubgraphId, config: config::latest::SubgraphConfig) {
+        let subgraph = &mut self.data_sources.federation[id.into()];
+        subgraph.headers = config.headers.into_iter().map(Into::into).collect()
+    }
+}
+
 macro_rules! from_id_newtypes {
-    ($($from:ident => $name:ident,)*) => {
+    ($($from:ty => $name:ident,)*) => {
         $(
-            impl From<federated_graph::$from> for $name {
-                fn from(id: federated_graph::$from) -> Self {
+            impl From<$from> for $name {
+                fn from(id: $from) -> Self {
                     $name::from(id.0)
                 }
             }
@@ -423,14 +455,15 @@ macro_rules! from_id_newtypes {
 }
 
 from_id_newtypes! {
-    EnumId => EnumId,
-    FieldId => FieldId,
-    FieldTypeId => TypeId,
-    InputObjectId => InputObjectId,
-    InterfaceId => InterfaceId,
-    ObjectId => ObjectId,
-    ScalarId => ScalarId,
-    StringId => StringId,
-    SubgraphId => SubgraphId,
-    UnionId => UnionId,
+    federated_graph::EnumId => EnumId,
+    federated_graph::FieldId => FieldId,
+    federated_graph::FieldTypeId => TypeId,
+    federated_graph::InputObjectId => InputObjectId,
+    federated_graph::InterfaceId => InterfaceId,
+    federated_graph::ObjectId => ObjectId,
+    federated_graph::ScalarId => ScalarId,
+    federated_graph::StringId => StringId,
+    federated_graph::SubgraphId => SubgraphId,
+    federated_graph::UnionId => UnionId,
+    config::latest::HeaderId => HeaderId,
 }

--- a/engine/crates/engine-v2/schema/src/conversion.rs
+++ b/engine/crates/engine-v2/schema/src/conversion.rs
@@ -418,18 +418,14 @@ impl From<federated_graph::InputObjectField> for InputValue {
     }
 }
 
-fn convert_headers(headers: Vec<config::latest::Header>, base_string_index: usize) -> Vec<SubgraphHeader> {
+fn convert_headers(headers: Vec<config::latest::Header>, base_string_index: usize) -> Vec<Header> {
     headers
         .into_iter()
-        .map(|header| SubgraphHeader {
+        .map(|header| Header {
             name: (base_string_index + header.name.0).into(),
             value: match header.value {
-                config::latest::HeaderValue::Forward(id) => {
-                    SubgraphHeaderValue::Forward((base_string_index + id.0).into())
-                }
-                config::latest::HeaderValue::Static(id) => {
-                    SubgraphHeaderValue::Static((base_string_index + id.0).into())
-                }
+                config::latest::HeaderValue::Forward(id) => HeaderValue::Forward((base_string_index + id.0).into()),
+                config::latest::HeaderValue::Static(id) => HeaderValue::Static((base_string_index + id.0).into()),
             },
         })
         .collect()

--- a/engine/crates/engine-v2/schema/src/ids.rs
+++ b/engine/crates/engine-v2/schema/src/ids.rs
@@ -2,8 +2,7 @@
 /// They can only be created by From<usize>
 use crate::{
     sources::federation::{DataSource as FederationMetadata, Subgraph},
-    Definition, Enum, Field, InputObject, InputValue, Interface, Object, Resolver, Scalar, Schema, SubgraphHeader,
-    Type, Union,
+    Definition, Enum, Field, Header, InputObject, InputValue, Interface, Object, Resolver, Scalar, Schema, Type, Union,
 };
 
 macro_rules! id_newtypes {
@@ -55,6 +54,6 @@ id_newtypes! {
     Schema.resolvers[ResolverId] => Resolver,
     Schema.definitions[DefinitionId] => Definition,
     Schema.input_values[InputValueId] => InputValue,
-    Schema.headers[HeaderId] => SubgraphHeader,
+    Schema.headers[HeaderId] => Header,
     FederationMetadata.subgraphs[SubgraphId] => Subgraph,
 }

--- a/engine/crates/engine-v2/schema/src/ids.rs
+++ b/engine/crates/engine-v2/schema/src/ids.rs
@@ -2,7 +2,8 @@
 /// They can only be created by From<usize>
 use crate::{
     sources::federation::{DataSource as FederationMetadata, Subgraph},
-    Definition, Enum, Field, InputObject, InputValue, Interface, Object, Resolver, Scalar, Schema, Type, Union,
+    Definition, Enum, Field, InputObject, InputValue, Interface, Object, Resolver, Scalar, Schema, SubgraphHeader,
+    Type, Union,
 };
 
 macro_rules! id_newtypes {
@@ -54,5 +55,6 @@ id_newtypes! {
     Schema.resolvers[ResolverId] => Resolver,
     Schema.definitions[DefinitionId] => Definition,
     Schema.input_values[InputValueId] => InputValue,
+    Schema.headers[HeaderId] => SubgraphHeader,
     FederationMetadata.subgraphs[SubgraphId] => Subgraph,
 }

--- a/engine/crates/engine-v2/schema/src/lib.rs
+++ b/engine/crates/engine-v2/schema/src/lib.rs
@@ -47,7 +47,7 @@ pub struct Schema {
     definitions: Vec<Definition>,
 
     /// Headers we might want to send to a subgraph
-    headers: Vec<SubgraphHeader>,
+    headers: Vec<Header>,
 
     default_headers: Vec<HeaderId>,
 }
@@ -458,13 +458,13 @@ impl Schema {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct SubgraphHeader {
+pub struct Header {
     pub name: StringId,
-    pub value: SubgraphHeaderValue,
+    pub value: HeaderValue,
 }
 
 #[derive(Debug, Clone, Copy)]
-pub enum SubgraphHeaderValue {
+pub enum HeaderValue {
     Forward(StringId),
     Static(StringId),
 }

--- a/engine/crates/engine-v2/schema/src/lib.rs
+++ b/engine/crates/engine-v2/schema/src/lib.rs
@@ -45,6 +45,11 @@ pub struct Schema {
     types: Vec<Type>,
     // All definitions sorted by their name (actual string)
     definitions: Vec<Definition>,
+
+    /// Headers we might want to send to a subgraph
+    headers: Vec<SubgraphHeader>,
+
+    default_headers: Vec<HeaderId>,
 }
 
 #[derive(Default)]
@@ -450,4 +455,16 @@ impl Schema {
     pub fn walker_with<'a>(&'a self, names: &'a dyn Names) -> SchemaWalker<'a, ()> {
         SchemaWalker::new((), self, names)
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SubgraphHeader {
+    pub name: StringId,
+    pub value: SubgraphHeaderValue,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum SubgraphHeaderValue {
+    Forward(StringId),
+    Static(StringId),
 }

--- a/engine/crates/engine-v2/schema/src/sources/federation.rs
+++ b/engine/crates/engine-v2/schema/src/sources/federation.rs
@@ -1,4 +1,4 @@
-use crate::{FieldSet, HeaderId, SchemaWalker, StringId, SubgraphHeader, SubgraphHeaderValue, SubgraphId};
+use crate::{FieldSet, Header, HeaderId, HeaderValue, SchemaWalker, StringId, SubgraphId};
 
 #[derive(Default)]
 pub struct DataSource {
@@ -128,7 +128,7 @@ impl<'a> std::fmt::Debug for SubgraphWalker<'a> {
     }
 }
 
-pub type SubgraphHeaderWalker<'a> = SchemaWalker<'a, &'a SubgraphHeader>;
+pub type SubgraphHeaderWalker<'a> = SchemaWalker<'a, &'a Header>;
 
 impl<'a> SubgraphHeaderWalker<'a> {
     pub fn name(&self) -> &'a str {
@@ -137,8 +137,8 @@ impl<'a> SubgraphHeaderWalker<'a> {
 
     pub fn value(&self) -> SubgraphHeaderValueRef<'a> {
         match self.inner.value {
-            SubgraphHeaderValue::Forward(id) => SubgraphHeaderValueRef::Forward(&self.schema[id]),
-            SubgraphHeaderValue::Static(id) => SubgraphHeaderValueRef::Static(&self.schema[id]),
+            HeaderValue::Forward(id) => SubgraphHeaderValueRef::Forward(&self.schema[id]),
+            HeaderValue::Static(id) => SubgraphHeaderValueRef::Static(&self.schema[id]),
         }
     }
 }

--- a/engine/crates/engine-v2/schema/src/sources/federation.rs
+++ b/engine/crates/engine-v2/schema/src/sources/federation.rs
@@ -1,4 +1,4 @@
-use crate::{FieldSet, SchemaWalker, StringId, SubgraphId};
+use crate::{FieldSet, HeaderId, SchemaWalker, StringId, SubgraphHeader, SubgraphHeaderValue, SubgraphId};
 
 #[derive(Default)]
 pub struct DataSource {
@@ -9,6 +9,7 @@ pub struct DataSource {
 pub struct Subgraph {
     pub name: StringId,
     pub url: StringId,
+    pub headers: Vec<HeaderId>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -108,6 +109,14 @@ impl<'a> SubgraphWalker<'a> {
     pub fn url(&self) -> &'a str {
         &self.schema[self.inner.url]
     }
+
+    pub fn headers(&self) -> impl Iterator<Item = SubgraphHeaderWalker<'a>> + '_ {
+        self.schema
+            .default_headers
+            .iter()
+            .chain(self.inner.headers.iter())
+            .map(|id| self.walk(&self.schema[*id]))
+    }
 }
 
 impl<'a> std::fmt::Debug for SubgraphWalker<'a> {
@@ -115,6 +124,36 @@ impl<'a> std::fmt::Debug for SubgraphWalker<'a> {
         f.debug_struct("Subgraph")
             .field("name", &self.name())
             .field("url", &self.url())
+            .finish()
+    }
+}
+
+pub type SubgraphHeaderWalker<'a> = SchemaWalker<'a, &'a SubgraphHeader>;
+
+impl<'a> SubgraphHeaderWalker<'a> {
+    pub fn name(&self) -> &'a str {
+        &self.schema[self.inner.name]
+    }
+
+    pub fn value(&self) -> SubgraphHeaderValueRef<'a> {
+        match self.inner.value {
+            SubgraphHeaderValue::Forward(id) => SubgraphHeaderValueRef::Forward(&self.schema[id]),
+            SubgraphHeaderValue::Static(id) => SubgraphHeaderValueRef::Static(&self.schema[id]),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum SubgraphHeaderValueRef<'a> {
+    Forward(&'a str),
+    Static(&'a str),
+}
+
+impl<'a> std::fmt::Debug for SubgraphHeaderWalker<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SubgraphHeaderWalker")
+            .field("name", &self.name())
+            .field("value", &self.value())
             .finish()
     }
 }

--- a/engine/crates/engine-v2/src/engine.rs
+++ b/engine/crates/engine-v2/src/engine.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use engine::RequestHeaders;
 use schema::Schema;
 
 use crate::{
@@ -27,11 +28,11 @@ impl Engine {
         }
     }
 
-    pub async fn execute(&self, request: engine::Request) -> Response {
+    pub async fn execute(&self, request: engine::Request, headers: RequestHeaders) -> Response {
         match self.prepare(&request).await {
             Ok(operation) => match Variables::from_request(&operation, self.schema.as_ref(), request.variables) {
                 Ok(variables) => {
-                    let mut executor = ExecutorCoordinator::new(self, &operation, &variables);
+                    let mut executor = ExecutorCoordinator::new(self, &operation, &variables, &headers);
                     executor.execute().await;
                     executor.into_response()
                 }

--- a/engine/crates/engine-v2/src/execution/context.rs
+++ b/engine/crates/engine-v2/src/execution/context.rs
@@ -1,3 +1,4 @@
+use engine::RequestHeaders;
 use schema::SchemaWalker;
 
 use super::Variables;
@@ -14,6 +15,7 @@ pub(crate) struct ExecutionContext<'ctx> {
     pub engine: &'ctx Engine,
     pub walker: OperationWalker<'ctx>,
     pub(super) variables: &'ctx Variables<'ctx>,
+    pub(super) request_headers: &'ctx RequestHeaders,
 }
 
 impl<'ctx> ExecutionContext<'ctx> {
@@ -55,5 +57,9 @@ impl<'ctx> ExecutionContext<'ctx> {
             boundary_item,
             &output.expectation,
         )
+    }
+
+    pub fn header(&self, name: &str) -> Option<&'ctx str> {
+        self.request_headers.find(name)
     }
 }

--- a/engine/crates/engine-v2/src/execution/coordinator.rs
+++ b/engine/crates/engine-v2/src/execution/coordinator.rs
@@ -1,4 +1,5 @@
 use async_runtime::make_send_on_wasm;
+use engine::RequestHeaders;
 use futures_util::{future::BoxFuture, stream::FuturesUnordered, StreamExt};
 
 use crate::{
@@ -16,16 +17,23 @@ pub struct ExecutorCoordinator<'ctx> {
     planner: Planner<'ctx>,
     response: ResponseBuilder,
     variables: &'ctx Variables<'ctx>,
+    request_headers: &'ctx RequestHeaders,
 }
 
 impl<'ctx> ExecutorCoordinator<'ctx> {
-    pub fn new(engine: &'ctx Engine, operation: &'ctx Operation, variables: &'ctx Variables<'ctx>) -> Self {
+    pub fn new(
+        engine: &'ctx Engine,
+        operation: &'ctx Operation,
+        variables: &'ctx Variables<'ctx>,
+        request_headers: &'ctx RequestHeaders,
+    ) -> Self {
         Self {
             engine,
             operation,
             planner: Planner::new(&engine.schema, operation),
             response: ResponseBuilder::new(operation),
             variables,
+            request_headers,
         }
     }
 
@@ -90,6 +98,7 @@ impl<'ctx> ExecutorCoordinator<'ctx> {
                                     engine: self.engine,
                                     variables: self.variables,
                                     walker: self.operation.walker_with(schema, ()),
+                                    request_headers: self.request_headers,
                                 },
                                 boundary_objects_view: self.response.read(schema, plan.input),
                                 plan_id: plan.id,

--- a/engine/crates/engine/src/headers.rs
+++ b/engine/crates/engine/src/headers.rs
@@ -38,3 +38,13 @@ impl From<&HashMap<String, String>> for RequestHeaders {
         RequestHeaders::new(value.clone())
     }
 }
+
+impl<N, V> std::iter::FromIterator<(N, V)> for RequestHeaders
+where
+    N: Into<String>,
+    V: Into<String>,
+{
+    fn from_iter<T: IntoIterator<Item = (N, V)>>(iter: T) -> Self {
+        RequestHeaders::new(iter)
+    }
+}

--- a/engine/crates/integration-tests/Cargo.toml
+++ b/engine/crates/integration-tests/Cargo.toml
@@ -19,6 +19,7 @@ cynic-introspection = "3"
 dynamodb.workspace = true
 engine-parser.workspace = true
 engine-v2.workspace = true
+engine-config-builder = { path = "../engine-config-builder" }
 expect-test = "1.4"
 futures = "0.3"
 grafbase-graphql-introspection = { path = "../../../cli/crates/graphql-introspection" }

--- a/engine/crates/integration-tests/src/federation/mod.rs
+++ b/engine/crates/integration-tests/src/federation/mod.rs
@@ -53,7 +53,9 @@ impl<'a> IntoFuture for ExecutionRequest<'a> {
     fn into_future(self) -> Self::IntoFuture {
         let request = self.graphql.into_engine_request();
 
-        Box::pin(async move { GraphqlResponse(serde_json::to_value(self.engine.execute(request).await).unwrap()) })
+        Box::pin(async move {
+            GraphqlResponse(serde_json::to_value(self.engine.execute(request, (&self.headers).into()).await).unwrap())
+        })
     }
 }
 

--- a/engine/crates/integration-tests/src/mocks/graphql/fake_github.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql/fake_github.rs
@@ -152,6 +152,7 @@ impl Query {
         self.headers
             .clone()
             .into_iter()
+            .filter(|(name, _)| name != "host" && name != "content-length")
             .map(|(name, value)| Header { name, value })
             .collect()
     }

--- a/engine/crates/integration-tests/tests/federation/basic/fragments.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/fragments.rs
@@ -6,7 +6,7 @@ fn named_fragment_on_object() {
     let response = runtime().block_on(async move {
         let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
-        let engine = Engine::build().with_schema("schema", &github_mock).await.finish();
+        let engine = Engine::build().with_schema("schema", &github_mock).await.finish().await;
 
         engine
             .execute(
@@ -64,7 +64,7 @@ fn inline_fragment_on_object() {
     let response = runtime().block_on(async move {
         let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
-        let engine = Engine::build().with_schema("schema", &github_mock).await.finish();
+        let engine = Engine::build().with_schema("schema", &github_mock).await.finish().await;
 
         engine
             .execute(
@@ -109,7 +109,7 @@ fn inline_fragment_on_object_with_type_condition() {
     let response = runtime().block_on(async move {
         let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
-        let engine = Engine::build().with_schema("schema", &github_mock).await.finish();
+        let engine = Engine::build().with_schema("schema", &github_mock).await.finish().await;
 
         engine
             .execute(
@@ -165,7 +165,7 @@ fn inline_fragments_on_polymorphic_types() {
     let response = runtime().block_on(async move {
         let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
-        let engine = Engine::build().with_schema("schema", &github_mock).await.finish();
+        let engine = Engine::build().with_schema("schema", &github_mock).await.finish().await;
 
         engine
             .execute(
@@ -236,7 +236,7 @@ fn named_fragments_on_polymorphic_types() {
     let response = runtime().block_on(async move {
         let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
-        let engine = Engine::build().with_schema("schema", &github_mock).await.finish();
+        let engine = Engine::build().with_schema("schema", &github_mock).await.finish().await;
 
         engine
             .execute(

--- a/engine/crates/integration-tests/tests/federation/basic/headers.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/headers.rs
@@ -1,0 +1,156 @@
+//! Tests of header forwarding behaviour
+
+use engine_v2::Engine;
+use integration_tests::{federation::EngineV2Ext, mocks::graphql::FakeGithubSchema, runtime, MockGraphQlServer};
+
+#[test]
+fn test_default_headers() {
+    let response = runtime().block_on(async move {
+        let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
+
+        let engine = Engine::build()
+            .with_schema("github", &github_mock)
+            .await
+            .with_supergraph_config(
+                r#"
+                    extend schema
+                        @allSubgraphs(headers: [
+                            {name: "x-foo", value: "BAR"}
+                            {name: "x-forwarded", forward: "x-source"}
+                        ])
+                "#,
+            )
+            .finish()
+            .await;
+
+        engine.execute("query { headers { name value }}").await
+    });
+
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": {
+        "headers": [
+          {
+            "name": "content-type",
+            "value": "application/json"
+          },
+          {
+            "name": "x-foo",
+            "value": "BAR"
+          },
+          {
+            "name": "accept",
+            "value": "*/*"
+          }
+        ]
+      }
+    }
+    "###);
+}
+
+#[test]
+fn test_default_headers_forwarding() {
+    let response = runtime().block_on(async move {
+        let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
+
+        let engine = Engine::build()
+            .with_schema("github", &github_mock)
+            .await
+            .with_supergraph_config(
+                r#"
+                    extend schema
+                        @allSubgraphs(headers: [
+                            {name: "x-foo", value: "BAR"}
+                            {name: "x-forwarded", forward: "x-source"}
+                        ])
+                "#,
+            )
+            .finish()
+            .await;
+
+        engine
+            .execute("query { headers { name value }}")
+            .header("x-source", "boom")
+            .await
+    });
+
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": {
+        "headers": [
+          {
+            "name": "content-type",
+            "value": "application/json"
+          },
+          {
+            "name": "x-foo",
+            "value": "BAR"
+          },
+          {
+            "name": "x-forwarded",
+            "value": "boom"
+          },
+          {
+            "name": "accept",
+            "value": "*/*"
+          }
+        ]
+      }
+    }
+    "###);
+}
+
+#[test]
+fn test_subgraph_specific_header_forwarding() {
+    let response = runtime().block_on(async move {
+        let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
+
+        let engine = Engine::build()
+            .with_schema("github", &github_mock)
+            .await
+            .with_supergraph_config(
+                r#"
+                    extend schema
+                        @subgraph(name: "other", headers: [
+                            {name: "boop", value: "bleep"}
+                        ])
+                        @subgraph(name: "github", headers: [
+                            {name: "x-foo", value: "BAR"}
+                            {name: "x-forwarded", forward: "x-source"}
+                        ])
+                "#,
+            )
+            .finish()
+            .await;
+
+        engine
+            .execute("query { headers { name value }}")
+            .header("x-source", "boom")
+            .await
+    });
+
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": {
+        "headers": [
+          {
+            "name": "content-type",
+            "value": "application/json"
+          },
+          {
+            "name": "x-foo",
+            "value": "BAR"
+          },
+          {
+            "name": "x-forwarded",
+            "value": "boom"
+          },
+          {
+            "name": "accept",
+            "value": "*/*"
+          }
+        ]
+      }
+    }
+    "###);
+}

--- a/engine/crates/integration-tests/tests/federation/basic/mod.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/mod.rs
@@ -4,6 +4,7 @@
 //! that our engine supports all the things a normal GraphQL server should.
 
 mod fragments;
+mod headers;
 mod scalars;
 mod variables;
 
@@ -15,7 +16,7 @@ fn single_field_from_single_server() {
     let response = runtime().block_on(async move {
         let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
-        let engine = Engine::build().with_schema("schema", &github_mock).await.finish();
+        let engine = Engine::build().with_schema("schema", &github_mock).await.finish().await;
 
         engine.execute("query { serverVersion }").await
     });
@@ -34,7 +35,7 @@ fn top_level_typename() {
     let response = runtime().block_on(async move {
         let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
-        let engine = Engine::build().with_schema("schema", &github_mock).await.finish();
+        let engine = Engine::build().with_schema("schema", &github_mock).await.finish().await;
 
         engine.execute("query { __typename }").await
     });
@@ -53,7 +54,7 @@ fn response_with_lists() {
     let response = runtime().block_on(async move {
         let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
-        let engine = Engine::build().with_schema("schema", &github_mock).await.finish();
+        let engine = Engine::build().with_schema("schema", &github_mock).await.finish().await;
 
         engine.execute("query { allBotPullRequests { title } }").await
     });

--- a/engine/crates/integration-tests/tests/federation/basic/scalars.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/scalars.rs
@@ -11,7 +11,7 @@ fn supports_custom_scalars() {
     let response = runtime().block_on(async move {
         let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
-        let engine = Engine::build().with_schema("schema", &github_mock).await.finish();
+        let engine = Engine::build().with_schema("schema", &github_mock).await.finish().await;
 
         engine.execute("query { favoriteRepository }").await
     });
@@ -33,7 +33,7 @@ fn supports_unused_builtin_scalars() {
     let response = runtime().block_on(async move {
         let mock = MockGraphQlServer::new(AlmostEmptySchema::default()).await;
 
-        let engine = Engine::build().with_schema("schema", &mock).await.finish();
+        let engine = Engine::build().with_schema("schema", &mock).await.finish().await;
 
         engine
             .execute("query Blah($id: ID!) { string(input: $id) }")

--- a/engine/crates/integration-tests/tests/federation/basic/variables.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/variables.rs
@@ -646,7 +646,7 @@ fn run_query(query: &str, input: &serde_json::Value) -> GraphqlResponse {
         async move {
             let echo_mock = MockGraphQlServer::new(EchoSchema::default()).await;
 
-            let engine = Engine::build().with_schema("schema", &echo_mock).await.finish();
+            let engine = Engine::build().with_schema("schema", &echo_mock).await.finish().await;
 
             engine.execute(query).variables(input).await
         }

--- a/engine/crates/integration-tests/tests/federation/introspection.rs
+++ b/engine/crates/integration-tests/tests/federation/introspection.rs
@@ -17,7 +17,7 @@ fn can_run_pathfinder_introspection_query() {
     let response = runtime().block_on(async move {
         let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
-        let engine = Engine::build().with_schema("schema", &github_mock).await.finish();
+        let engine = Engine::build().with_schema("schema", &github_mock).await.finish().await;
 
         engine.execute(PATHFINDER_INTROSPECTION_QUERY).await
     });
@@ -84,7 +84,7 @@ fn can_run_2018_introspection_query() {
     let response = runtime().block_on(async move {
         let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
-        let engine = Engine::build().with_schema("schema", &github_mock).await.finish();
+        let engine = Engine::build().with_schema("schema", &github_mock).await.finish().await;
 
         engine
             .execute(IntrospectionQuery::with_capabilities(
@@ -155,7 +155,7 @@ fn can_run_2021_introspection_query() {
     let response = runtime().block_on(async move {
         let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
-        let engine = Engine::build().with_schema("schema", &github_mock).await.finish();
+        let engine = Engine::build().with_schema("schema", &github_mock).await.finish().await;
 
         engine
             .execute(IntrospectionQuery::with_capabilities(
@@ -226,7 +226,7 @@ fn echo_subgraph_introspection() {
     let response = runtime().block_on(async move {
         let github_mock = MockGraphQlServer::new(EchoSchema::default()).await;
 
-        let engine = Engine::build().with_schema("schema", &github_mock).await.finish();
+        let engine = Engine::build().with_schema("schema", &github_mock).await.finish().await;
 
         engine
             .execute(IntrospectionQuery::with_capabilities(
@@ -276,7 +276,7 @@ fn can_run_capability_introspection_query() {
     let response = runtime().block_on(async move {
         let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
-        let engine = Engine::build().with_schema("schema", &github_mock).await.finish();
+        let engine = Engine::build().with_schema("schema", &github_mock).await.finish().await;
 
         engine.execute(CapabilitiesQuery::build(())).await
     });
@@ -298,7 +298,7 @@ fn introspection_output_matches_source() {
     let (response, _upstream_sdl) = runtime().block_on(async move {
         let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
-        let engine = Engine::build().with_schema("schema", &github_mock).await.finish();
+        let engine = Engine::build().with_schema("schema", &github_mock).await.finish().await;
 
         let response = engine.execute(IntrospectionQuery::build(())).await;
 
@@ -333,7 +333,8 @@ fn can_introsect_when_multiple_subgraphs() {
             .await
             .with_schema("echo", &echo_mock)
             .await
-            .finish();
+            .finish()
+            .await;
 
         engine.execute(IntrospectionQuery::build(())).await
     });
@@ -428,7 +429,7 @@ fn supports_the_type_field() {
     let response = runtime().block_on(async move {
         let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
-        let engine = Engine::build().with_schema("github", &github_mock).await.finish();
+        let engine = Engine::build().with_schema("github", &github_mock).await.finish().await;
 
         engine
             .execute(
@@ -502,7 +503,7 @@ fn type_field_returns_null_on_missing_type() {
     let response = runtime().block_on(async move {
         let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
-        let engine = Engine::build().with_schema("github", &github_mock).await.finish();
+        let engine = Engine::build().with_schema("github", &github_mock).await.finish().await;
 
         engine
             .execute(
@@ -532,7 +533,7 @@ fn supports_recursing_through_types() {
     let response = runtime().block_on(async move {
         let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
-        let engine = Engine::build().with_schema("github", &github_mock).await.finish();
+        let engine = Engine::build().with_schema("github", &github_mock).await.finish().await;
 
         engine
             .execute(
@@ -705,7 +706,7 @@ fn rejects_bogus_introspection_queries() {
     let response = runtime().block_on(async move {
         let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
 
-        let engine = Engine::build().with_schema("github", &github_mock).await.finish();
+        let engine = Engine::build().with_schema("github", &github_mock).await.finish().await;
 
         engine
             .execute(
@@ -754,7 +755,8 @@ fn introspection_on_multiple_federation_subgraphs() {
             .await
             .with_schema("reviews", &reviews)
             .await
-            .finish();
+            .finish()
+            .await;
 
         engine.execute(PATHFINDER_INTROSPECTION_QUERY).await
     });

--- a/engine/crates/integration-tests/tests/federation/subgraphs/mod.rs
+++ b/engine/crates/integration-tests/tests/federation/subgraphs/mod.rs
@@ -18,7 +18,8 @@ fn root_fields_from_different_subgraphs() {
             .await
             .with_schema("products", &products)
             .await
-            .finish();
+            .finish()
+            .await;
 
         engine
             .execute(
@@ -75,7 +76,8 @@ fn root_fragment_on_different_subgraphs() {
             .await
             .with_schema("products", &products)
             .await
-            .finish();
+            .finish()
+            .await;
 
         engine
             .execute(

--- a/engine/crates/integration-tests/tests/federation/subgraphs/simple_key.rs
+++ b/engine/crates/integration-tests/tests/federation/subgraphs/simple_key.rs
@@ -19,7 +19,8 @@ fn simple_key() {
             .await
             .with_schema("reviews", &reviews)
             .await
-            .finish();
+            .finish()
+            .await;
 
         engine
             .execute(

--- a/engine/crates/runtime-local/src/fetch.rs
+++ b/engine/crates/runtime-local/src/fetch.rs
@@ -1,3 +1,4 @@
+use reqwest::header::HeaderValue;
 use runtime::fetch::{FetchError, FetchRequest, FetchResponse, FetchResult, Fetcher, FetcherInner};
 
 pub struct NativeFetcher {
@@ -20,6 +21,13 @@ impl FetcherInner for NativeFetcher {
             .post(request.url)
             .body(request.json_body)
             .header("Content-Type", "application/json")
+            .headers(
+                request
+                    .headers
+                    .iter()
+                    .filter_map(|(name, value)| Some((name.parse().ok()?, HeaderValue::from_str(value).ok()?)))
+                    .collect(),
+            )
             .send()
             .await
             .map_err(|e| FetchError::AnyError(e.to_string()))?;

--- a/engine/crates/runtime/src/fetch.rs
+++ b/engine/crates/runtime/src/fetch.rs
@@ -13,6 +13,7 @@ pub type FetchResult<T> = Result<T, FetchError>;
 // very minimal for now, but will be expanded as we need it.
 pub struct FetchRequest<'a> {
     pub url: &'a str,
+    pub headers: Vec<(&'a str, &'a str)>,
     pub json_body: String,
 }
 


### PR DESCRIPTION
This updates engine-v2 to send the headers configured for each subgraph to that subgraph.

Fixes GB-5606