### PR TITLE
feat: add federation header config to SDK

### DIFF
--- a/packages/grafbase-sdk/src/config.ts
+++ b/packages/grafbase-sdk/src/config.ts
@@ -41,9 +41,7 @@ export class GraphConfig {
   private readonly cache?: GlobalCache
   private readonly experimental?: Experimental
 
-  constructor(input: GraphConfigInput)
   /** @deprecated use `graph` instead of `schema` */
-  constructor(input: DeprecatedGraphConfigInput)
   constructor(input: GraphConfigInput | DeprecatedGraphConfigInput) {
     this.graph = 'graph' in input ? input.graph : input.schema
 

--- a/packages/grafbase-sdk/src/federated/headers.ts
+++ b/packages/grafbase-sdk/src/federated/headers.ts
@@ -1,0 +1,90 @@
+import { Header } from '../connector/header'
+
+/**
+ * An accumulator class to gather headers for a federated graph
+ */
+export class FederatedGraphHeaders {
+  private defaultHeaders: Header[]
+  private subgraphs: { [name: string]: Header[] }
+
+  constructor() {
+    this.defaultHeaders = []
+    this.subgraphs = {}
+  }
+
+  /**
+   * Sets a default header to be sent to all subgraphs
+   *
+   * @param name - The name of the header
+   * @param value - The value for the header.  Either a hardcoded string or a header name to forward from.
+   */
+  public set(name: string, value: string | { forward: string }) {
+    if (typeof value === 'string') {
+      this.defaultHeaders.push(new Header(name, { type: 'static', value }))
+    } else {
+      this.defaultHeaders.push(
+        new Header(name, { type: 'forward', from: value.forward })
+      )
+    }
+  }
+
+  /**
+   * Returns a builder for setting a specific subgraphs headers
+   *
+   * @param name - The name of the subgraph
+   */
+  public subgraph(name: string): FederatedSubgraphHeaders {
+    this.subgraphs[name] ||= []
+    return new FederatedSubgraphHeaders(this.subgraphs[name])
+  }
+
+  public toString(): string {
+    const defaultHeaders =
+      this.defaultHeaders.length !== 0
+        ? `\n  @allSubgraphs(headers: [${this.defaultHeaders
+            .map(String)
+            .join(', ')}])`
+        : ''
+
+    const subgraphs =
+      Object.keys(this.subgraphs).length !== 0
+        ? Object.entries(this.subgraphs).map(
+            ([name, headers]) =>
+              `\n  @subgraph(name: "${name}", headers: [${headers
+                .map(String)
+                .join(', ')}])`
+          )
+        : ''
+
+    return `${defaultHeaders}${subgraphs}`
+  }
+}
+
+export class FederatedSubgraphHeaders {
+  private headers: Header[]
+
+  constructor(headers: Header[]) {
+    this.headers = headers
+  }
+
+  /**
+   * Sets a header to be sent to this subgraph
+   *
+   * @param name - The name of the header
+   * @param value - The value for the header.  Either a hardcoded string or a header name to forward from.
+   */
+  public set(
+    name: string,
+    value: string | { forward: string }
+  ): FederatedSubgraphHeaders {
+    if (typeof value === 'string') {
+      this.headers.push(new Header(name, { type: 'static', value }))
+    } else {
+      this.headers.push(
+        new Header(name, { type: 'forward', from: value.forward })
+      )
+    }
+
+    return this
+  }
+}

--- a/packages/grafbase-sdk/src/grafbase-schema.ts
+++ b/packages/grafbase-sdk/src/grafbase-schema.ts
@@ -24,6 +24,7 @@ import { InputDefinition } from './typedefs/input'
 import { MongoDBAPI, PartialMongoDBAPI } from './connector/mongodb'
 import { DynamoDBModel, ModelFields } from './connector/dynamodb/model'
 import { PostgresAPI, PartialPostgresAPI } from './connector/postgres'
+import { FederatedGraphHeaders } from './federated/headers'
 
 export type PartialDatasource =
   | PartialOpenAPI
@@ -507,9 +508,22 @@ export class Graph {
   }
 }
 
+export interface FederatedGraphInput {
+  headers?: (headers: FederatedGraphHeaders) => void
+}
+
 export class FederatedGraph {
+  private headers: FederatedGraphHeaders
+
+  public constructor(input?: FederatedGraphInput) {
+    this.headers = new FederatedGraphHeaders()
+    if (input?.headers) {
+      input.headers(this.headers)
+    }
+  }
+
   public toString(): string {
-    return `\nextend schema @graph(type: federated)\n`
+    return `\nextend schema\n  @graph(type: federated)${this.headers}\n`
   }
 }
 

--- a/packages/grafbase-sdk/src/graph.ts
+++ b/packages/grafbase-sdk/src/graph.ts
@@ -1,4 +1,4 @@
-import { FederatedGraph, Graph } from './grafbase-schema'
+import { FederatedGraph, FederatedGraphInput, Graph } from './grafbase-schema'
 
 export interface StandaloneInput {
   subgraph: boolean
@@ -8,6 +8,6 @@ export interface StandaloneInput {
  * A builder for a Grafbase schema definition.
  */
 export const graph = {
-  Federated: () => new FederatedGraph(),
+  Federated: (input?: FederatedGraphInput) => new FederatedGraph(input),
   Standalone: (input?: StandaloneInput) => new Graph(Boolean(input?.subgraph))
 }

--- a/packages/grafbase-sdk/tests/unit/federation-graph.test.ts
+++ b/packages/grafbase-sdk/tests/unit/federation-graph.test.ts
@@ -10,8 +10,39 @@ describe('Federation config', () => {
 
     expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "
-      extend schema @graph(type: federated)
+      extend schema
+        @graph(type: federated)
       "
-  `)
+    `)
+  })
+
+  it('supports subgraph and default headers', () => {
+    const cfg = config({
+      graph: graph.Federated({
+        headers: (headers) => {
+          headers.set('Foo', 'Bar')
+          headers.set('Forward', { forward: 'Source' })
+
+          headers
+            .subgraph('Product')
+            .set('Authorization', { forward: 'Authorization' })
+            .set('Bloop', 'Bleep')
+
+          headers.subgraph('Review').set('Bloop', 'Bleep')
+
+          headers.subgraph('Product').set('AnotherOne', 'Meep')
+        }
+      })
+    })
+
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
+      "
+      extend schema
+        @graph(type: federated)
+        @allSubgraphs(headers: [{ name: "Foo", value: "Bar" }, { name: "Forward", forward: "Source" }])
+        @subgraph(name: "Product", headers: [{ name: "Authorization", forward: "Authorization" }, { name: "Bloop", value: "Bleep" }, { name: "AnotherOne", value: "Meep" }]),
+        @subgraph(name: "Review", headers: [{ name: "Bloop", value: "Bleep" }])
+      "
+    `)
   })
 })


### PR DESCRIPTION
As outlined in the [RFC][1]

Fixes GB-5605

[1]: https://www.notion.so/Configurable-subgraph-headers-44c5e3fd62d4489db1bc4e5419119f8d
