### PR TITLE
test: allow engine-v2 tests to use engine-v1 as subgraph

### DIFF
--- a/engine/crates/integration-tests/src/engine/mod.rs
+++ b/engine/crates/integration-tests/src/engine/mod.rs
@@ -189,13 +189,6 @@ impl crate::mocks::graphql::Schema for Engine {
 
         // Not sure this will work but lets see
         async_graphql::Response::deserialize(serde_json::to_value(response).unwrap()).unwrap()
-        // async_graphql::Response {
-        //     data: async_graphql::Value::from_json(response.data.to_json_value().unwrap()).unwrap(),
-        //     extensions: response.extensions,
-        //     cache_control: response.cache_control.into(),
-        //     errors: response.errors,
-        //     http_headers: response.http_headers,
-        // }
     }
 
     fn sdl(&self) -> String {

--- a/engine/crates/integration-tests/tests/federation/introspection.rs
+++ b/engine/crates/integration-tests/tests/federation/introspection.rs
@@ -833,7 +833,7 @@ fn introspecting_with_grafbase_openapi_subgraph() {
         let petstore_mock = MockGraphQlServer::new(engine_v1).await;
 
         let engine = Engine::build()
-            .with_schema("github", &petstore_mock)
+            .with_schema("petstore", &petstore_mock)
             .await
             .finish()
             .await;

--- a/engine/crates/integration-tests/tests/federation/snapshots/integration_tests__federation__introspection__introspecting_with_grafbase_openapi_subgraph.snap
+++ b/engine/crates/integration-tests/tests/federation/snapshots/integration_tests__federation__introspection__introspecting_with_grafbase_openapi_subgraph.snap
@@ -1,0 +1,127 @@
+---
+source: engine/crates/integration-tests/tests/federation/introspection.rs
+expression: introspection_to_sdl(response.into_data())
+---
+type ApiResponse {
+  code: Int
+  message: String
+  type: String
+}
+
+type Category {
+  id: Int
+  name: String
+}
+
+input CategoryInput {
+  name: String
+  id: Int
+}
+
+enum FindPetsByStatusStatus {
+  AVAILABLE
+  PENDING
+  SOLD
+}
+
+scalar JSON
+
+type Mutation {
+  addPet(input: PetInput!): Pet
+  createUsersWithListInput(input: [UserInput!]!): User
+  placeOrder(input: OrderInput!): Order
+  updatePet(input: PetInput!): Pet
+  uploadFile(petId: Int!, additionalMetadata: String): ApiResponse
+}
+
+type Order {
+  complete: Boolean
+  id: Int
+  petId: Int
+  quantity: Int
+  shipDate: String
+  status: OrderStatus
+}
+
+input OrderInput {
+  id: Int
+  petId: Int
+  complete: Boolean
+  status: OrderStatus
+  shipDate: String
+  quantity: Int
+}
+
+enum OrderStatus {
+  PLACED
+  APPROVED
+  DELIVERED
+}
+
+type Pet {
+  category: Category
+  id: Int
+  name: String!
+  photoUrls: [String!]!
+  status: PetStatus
+  tags: [Tag!]
+}
+
+input PetInput {
+  name: String!
+  id: Int
+  status: PetStatus
+  tags: [TagInput!]!
+  photoUrls: [String!]!
+  category: CategoryInput!
+}
+
+enum PetStatus {
+  AVAILABLE
+  PENDING
+  SOLD
+}
+
+type Query {
+  findPetsByStatus(status: FindPetsByStatusStatus): [Pet!]
+  findPetsByTags(tags: [String!]): [Pet!]
+  inventory: JSON
+  loginUser(password: String, username: String): String
+  order(orderId: Int!): Order
+  pet(petId: Int!): Pet
+  user(username: String!): User
+}
+
+type Tag {
+  id: Int
+  name: String
+}
+
+input TagInput {
+  name: String
+  id: Int
+}
+
+type User {
+  email: String
+  firstName: String
+  id: Int
+  lastName: String
+  password: String
+  phone: String
+  userStatus: Int
+  username: String
+}
+
+input UserInput {
+  id: Int
+  password: String
+  username: String
+  userStatus: Int
+  phone: String
+  email: String
+  lastName: String
+  firstName: String
+}
+
+


### PR DESCRIPTION
I wanted to test some engine<->engine-v2 interactions, so figured I might as well add the code to integration-tests that allows us to do this there.

Currently only tests introspection, because that's what I needed to test - if you try making calls you _might_ need to fix some more stuff.