### PR TITLE
feat(engine-v2): Execute mutations sequentially

### DIFF
--- a/engine/crates/engine-v2/src/plan/mod.rs
+++ b/engine/crates/engine-v2/src/plan/mod.rs
@@ -13,7 +13,7 @@ mod planner;
 pub use attribution::*;
 pub use expectation::*;
 pub use ids::*;
-pub use planner::Planner;
+pub use planner::{Planner, PlanningError};
 
 #[derive(Debug)]
 pub struct Plan {
@@ -48,6 +48,7 @@ pub struct PlanOutput {
 #[derive(Debug)]
 pub struct PlanBoundary {
     pub selection_set_type: SelectionSetType,
+    pub query_path: QueryPath,
     /// A child plan isn't entirely planned yet. We only ensure that any `@requires` of children
     /// will be provided by the parent. Its actual output is only planned once we have the
     /// ResponseObjectRoots.
@@ -57,8 +58,7 @@ pub struct PlanBoundary {
 #[derive(Debug)]
 pub struct ChildPlan {
     pub id: PlanId,
-    pub path: QueryPath,
     pub resolver_id: ResolverId,
     pub input_selection_set: ReadSelectionSet,
-    pub providable: FlatSelectionSet<EntityType>,
+    pub root_selection_set: FlatSelectionSet<EntityType>,
 }

--- a/engine/crates/engine-v2/src/request/walkers/flat.rs
+++ b/engine/crates/engine-v2/src/request/walkers/flat.rs
@@ -67,7 +67,10 @@ impl<'a, Ty: Copy> FlatSelectionSetWalker<'a, Ty> {
                         origin_selection_set_ids: HashSet::new(),
                         bound_field_ids: vec![],
                     });
-                group.key = group.key.min(field.bound_response_key);
+                if field.bound_response_key < group.key {
+                    group.key = field.bound_response_key;
+                    group.definition_id = field.definition_id;
+                }
                 group.bound_field_ids.push(flat_field.bound_field_id);
                 group.origin_selection_set_ids.extend(&flat_field.selection_set_path);
 

--- a/engine/crates/engine-v2/src/response/error.rs
+++ b/engine/crates/engine-v2/src/response/error.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use super::ResponsePath;
 use crate::request::Pos;
@@ -8,5 +8,6 @@ pub(crate) struct GraphqlError {
     pub message: String,
     pub locations: Vec<Pos>,
     pub path: Option<ResponsePath>,
-    pub extensions: HashMap<String, serde_json::Value>,
+    // ensures consistent ordering for tests
+    pub extensions: BTreeMap<String, serde_json::Value>,
 }

--- a/engine/crates/engine-v2/src/response/write/deserialize/field.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/field.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::atomic::Ordering};
+use std::sync::atomic::Ordering;
 
 use schema::{DataType, ListWrapping, Wrapping};
 use serde::de::DeserializeSeed;
@@ -125,7 +125,7 @@ impl<'de, 'ctx, 'parent> DeserializeSeed<'de> for FieldSeed<'ctx, 'parent> {
                         .into_iter()
                         .collect(),
                     path: Some(self.path.clone()),
-                    extensions: HashMap::with_capacity(0),
+                    ..Default::default()
                 });
             }
             err

--- a/engine/crates/engine-v2/src/response/write/deserialize/list.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/list.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt, sync::atomic::Ordering};
+use std::{fmt, sync::atomic::Ordering};
 
 use serde::{
     de::{DeserializeSeed, IgnoredAny, SeqAccess, Visitor},
@@ -72,7 +72,7 @@ where
                                 .into_iter()
                                 .collect(),
                             path: Some(self.path.clone()),
-                            extensions: HashMap::with_capacity(0),
+                            ..Default::default()
                         });
                     }
                     // Discarding the rest of the sequence.

--- a/engine/crates/engine-v2/src/response/write/deserialize/nullable.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/nullable.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt, sync::atomic::Ordering};
+use std::{fmt, sync::atomic::Ordering};
 
 use serde::{
     de::{DeserializeSeed, Visitor},
@@ -72,7 +72,7 @@ where
                             .into_iter()
                             .collect(),
                         path: Some(self.path.clone()),
-                        extensions: HashMap::with_capacity(0),
+                        ..Default::default()
                     });
                 }
                 Ok(ResponseValue::Null)

--- a/engine/crates/engine-v2/src/response/write/manual.rs
+++ b/engine/crates/engine-v2/src/response/write/manual.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use schema::{DataType, ListWrapping, ObjectId, StringId, Wrapping};
 
@@ -258,7 +258,7 @@ impl<'a> GroupedFieldWriter<'a> {
                                 message: err.to_string(),
                                 locations: self.expected_field.name_location().into_iter().collect(),
                                 path: Some(self.path.clone()),
-                                extensions: HashMap::with_capacity(0),
+                                ..Default::default()
                             });
                         }
                         if inner_is_required {
@@ -282,7 +282,7 @@ impl<'a> GroupedFieldWriter<'a> {
             message: message.into(),
             locations: self.expected_field.name_location().into_iter().collect(),
             path: Some(self.path.clone()),
-            extensions: HashMap::with_capacity(0),
+            ..Default::default()
         });
         Err(WriteError::ErrorPropagation)
     }

--- a/engine/crates/engine-v2/src/response/write/writer.rs
+++ b/engine/crates/engine-v2/src/response/write/writer.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::HashMap, sync::atomic::AtomicBool};
+use std::{cell::RefCell, sync::atomic::AtomicBool};
 
 use serde::{de::DeserializeSeed, Deserializer};
 
@@ -75,15 +75,12 @@ impl<'a> ResponseObjectWriter<'a> {
                 if let WriteError::Any(err) = err {
                     self.data.push_error(GraphqlError {
                         message: err.to_string(),
-                        // TODO: should include locations & path of all root fields retrieved by
-                        // the plan.
-                        locations: vec![],
                         path: Some(self.boundary_item.response_path.clone()),
-                        extensions: HashMap::with_capacity(0),
+                        ..Default::default()
                     });
                 }
                 self.data
-                    .push_error_to_propagate(self.boundary_item.response_path.clone());
+                    .push_error_path_to_propagate(self.boundary_item.response_path.clone());
             }
         }
     }

--- a/engine/crates/engine-v2/src/sources/graphql/deserialize/errors.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/deserialize/errors.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use serde::{de::DeserializeSeed, Deserializer};
 
@@ -29,7 +29,7 @@ impl<'de, 'a> DeserializeSeed<'de> for UpstreamGraphqlErrorsSeed<'a> {
     {
         let errors = <Vec<UpstreamGraphqlError> as serde::Deserialize>::deserialize(deserializer)?;
         for error in errors {
-            let mut extensions = HashMap::new();
+            let mut extensions = BTreeMap::new();
             if !error.locations.is_null() {
                 extensions.insert("upstream_locations".to_string(), error.locations);
             }

--- a/engine/crates/engine-v2/src/sources/mod.rs
+++ b/engine/crates/engine-v2/src/sources/mod.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use schema::{Resolver, ResolverWalker};
 
 use crate::{
@@ -111,9 +109,7 @@ impl From<ExecutorError> for GraphqlError {
     fn from(err: ExecutorError) -> Self {
         GraphqlError {
             message: err.to_string(),
-            locations: vec![],
-            path: None,
-            extensions: HashMap::with_capacity(0),
+            ..Default::default()
         }
     }
 }

--- a/engine/crates/integration-tests/src/mocks/graphql.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql.rs
@@ -9,12 +9,14 @@ mod almost_empty;
 mod echo;
 mod fake_github;
 mod federation;
+mod state_mutation;
 
 pub use {
     almost_empty::AlmostEmptySchema,
     echo::EchoSchema,
     fake_github::FakeGithubSchema,
     federation::{FakeFederationAccountsSchema, FakeFederationProductsSchema, FakeFederationReviewsSchema},
+    state_mutation::StateMutationSchema,
 };
 
 pub struct MockGraphQlServer {

--- a/engine/crates/integration-tests/src/mocks/graphql/state_mutation.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql/state_mutation.rs
@@ -1,0 +1,72 @@
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+use async_graphql::{Context, EmptySubscription, Object, Schema};
+
+#[derive(Default)]
+pub struct StateMutationSchema {
+    state: Arc<AtomicUsize>,
+}
+
+impl StateMutationSchema {
+    fn schema(&self) -> Schema<Query, Mutation, EmptySubscription> {
+        Schema::build(Query, Mutation, EmptySubscription)
+            .enable_federation()
+            .data(Arc::clone(&self.state))
+            .finish()
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Schema for StateMutationSchema {
+    async fn execute(
+        &self,
+        _headers: Vec<(String, String)>,
+        request: async_graphql::Request,
+    ) -> async_graphql::Response {
+        self.schema().execute(request).await
+    }
+
+    fn sdl(&self) -> String {
+        self.schema()
+            .sdl_with_options(async_graphql::SDLExportOptions::new().federation())
+    }
+}
+
+struct Query;
+
+#[Object]
+impl Query {
+    async fn value(&self, ctx: &Context<'_>) -> usize {
+        ctx.data_unchecked::<Arc<AtomicUsize>>().load(Ordering::Relaxed)
+    }
+}
+
+struct Mutation;
+
+#[Object]
+impl Mutation {
+    async fn multiply(&self, ctx: &Context<'_>, by: usize) -> usize {
+        let state = ctx.data_unchecked::<Arc<AtomicUsize>>();
+        state
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |val| Some(val * by))
+            .unwrap();
+        state.load(Ordering::Relaxed)
+    }
+
+    async fn set(&self, ctx: &Context<'_>, val: usize) -> usize {
+        let state = ctx.data_unchecked::<Arc<AtomicUsize>>();
+        state.store(val, Ordering::Relaxed);
+        state.load(Ordering::Relaxed)
+    }
+
+    async fn fail(&self) -> async_graphql::FieldResult<usize> {
+        Err("This mutation always fails".into())
+    }
+
+    async fn faillible(&self) -> async_graphql::FieldResult<Option<usize>> {
+        Err("This mutation always fails".into())
+    }
+}

--- a/engine/crates/integration-tests/tests/federation/basic/mod.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/mod.rs
@@ -5,6 +5,7 @@
 
 mod fragments;
 mod headers;
+mod mutation;
 mod scalars;
 mod variables;
 

--- a/engine/crates/integration-tests/tests/federation/basic/mutation.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/mutation.rs
@@ -1,0 +1,177 @@
+use engine_v2::Engine;
+use integration_tests::{federation::EngineV2Ext, mocks::graphql::StateMutationSchema, runtime, MockGraphQlServer};
+
+#[test]
+fn mutations_should_be_executed_sequentially() {
+    runtime().block_on(async move {
+        let github_mock = MockGraphQlServer::new(StateMutationSchema::default()).await;
+        let engine = Engine::build().with_schema("schema", &github_mock).await.finish().await;
+
+        // sanity check
+        let response = engine.execute("query { value }").await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "value": 0
+          }
+        }
+        "###);
+
+        let response = engine
+            .execute(
+                r"
+                mutation {
+                    first: set(val: 1)
+                    second: multiply(by: 2)
+                    third: multiply(by: 7)
+                    fourth: set(val: 3)
+                    fifth: multiply(by: 11)
+                }
+                ",
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "first": 1,
+            "second": 2,
+            "third": 14,
+            "fourth": 3,
+            "fifth": 33
+          }
+        }
+        "###);
+
+        let response = engine.execute("query { value }").await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "value": 33
+          }
+        }
+        "###);
+    });
+}
+
+#[test]
+fn mutation_failure_should_stop_later_executions_if_required() {
+    runtime().block_on(async move {
+        let github_mock = MockGraphQlServer::new(StateMutationSchema::default()).await;
+        let engine = Engine::build().with_schema("schema", &github_mock).await.finish().await;
+
+        // sanity check
+        let response = engine.execute("query { value }").await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "value": 0
+          }
+        }
+        "###);
+
+        let response = engine
+            .execute(
+                r"
+                mutation {
+                    first: set(val: 1)
+                    second: multiply(by: 2)
+                    faillible
+                    third: multiply(by: 7)
+                }
+                ",
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "first": 1,
+            "second": 2,
+            "faillible": null,
+            "third": 14
+          },
+          "errors": [
+            {
+              "message": "Upstream error: This mutation always fails",
+              "path": [
+                "faillible"
+              ],
+              "extensions": {
+                "upstream_locations": [
+                  {
+                    "line": 2,
+                    "column": 2
+                  }
+                ],
+                "upstream_path": [
+                  "faillible"
+                ]
+              }
+            }
+          ]
+        }
+        "###);
+
+        let response = engine.execute("query { value }").await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "value": 14
+          }
+        }
+        "###);
+
+        let response = engine
+            .execute(
+                r"
+                mutation {
+                    first: set(val: 1)
+                    second: multiply(by: 2)
+                    fail
+                    third: multiply(by: 7)
+                }
+                ",
+            )
+            .await;
+
+        // the error isn't great, we could definitely do better. At least it's somewhat clear.
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "Upstream response error: Missing required field named 'fail'",
+              "path": [
+                "fail"
+              ]
+            },
+            {
+              "message": "Upstream error: This mutation always fails",
+              "path": [
+                "fail"
+              ],
+              "extensions": {
+                "upstream_locations": [
+                  {
+                    "line": 2,
+                    "column": 2
+                  }
+                ],
+                "upstream_path": [
+                  "fail"
+                ]
+              }
+            }
+          ]
+        }
+        "###);
+
+        let response = engine.execute("query { value }").await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "value": 2
+          }
+        }
+        "###);
+    });
+}


### PR DESCRIPTION
For mutations, I'm now executing executors one at a time. The executor future returns then:
```
struct ExecutorFutResult<'ctx> {
    result: ExecutorResult<ExecutorOutput>,
    next_executors: VecDeque<Executor<'ctx>>,
}
```
So the actual result to update the response and plan the children. And the next executors, which are only used for mutation root fields. Ensuring they're executed one after another. Error management is more hacky than I thought during planning, but well good enough for now.
