### PR TITLE
fix: adjust parser code to support esm modules

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -19,7 +19,7 @@ permissions:
 
 env:
   GRAFBASE_SKIP_ASSET_VERSION_CHECK: 'true'
-  ASSETS_VERSION: release/f524588-2023-10-12
+  ASSETS_VERSION: release/1696e98-2023-12-12
   PROD_ASSETS: assets.grafbase.com
   CARGO_TERM_COLOR: 'always'
   CARGO_PROFILE_DEV_DEBUG: 0

--- a/cli/crates/cli/tests/dev.rs
+++ b/cli/crates/cli/tests/dev.rs
@@ -107,3 +107,30 @@ fn dev(#[case] use_dev: bool) {
     assert_eq!(dot_get!(updated_todo_list, "status", String), "IN_PROGRESS");
     assert_eq!(dot_get_opt!(updated_todo_list, "tags", Vec<String>), None);
 }
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn dev_with_esm_project() {
+    let mut env = Environment::init();
+
+    env.write_json_file_to_project(
+        "package.json",
+        &json!({
+          "name": "test",
+          "version": "1.0.0",
+          "description": "",
+          "type": "module", // This is the important part for this test
+          "main": "index.js",
+          "keywords": [],
+          "author": "",
+          "license": "ISC"
+        }),
+    );
+    env.grafbase_init(GraphType::Single);
+    env.prepare_ts_config_dependencies();
+
+    env.grafbase_dev();
+
+    let client = env.create_client().with_api_key();
+    client.poll_endpoint(30, 300);
+}

--- a/cli/crates/server/src/consts.rs
+++ b/cli/crates/server/src/consts.rs
@@ -1,5 +1,6 @@
 pub const ASSET_VERSION_FILE: &str = "version.txt";
-pub const CONFIG_PARSER_SCRIPT: &str = "parse-config.ts";
+pub const CONFIG_PARSER_SCRIPT_CJS: &str = "parse-config.ts";
+pub const CONFIG_PARSER_SCRIPT_ESM: &str = "parse-config.mts";
 pub const DOT_ENV_FILE_NAME: &str = ".env";
 pub const GENERATED_SCHEMAS_DIR: &str = "generated/schemas";
 pub const GIT_IGNORE_CONTENTS: &str = "*\n";


### PR DESCRIPTION
A potential customer is running into issues running `grafbase dump-config` because they've got `"module": true` in their package.json.  They're getting the following error:

```
Error: could not load grafbase/grafbase.config.ts
Caused by: Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /snip/sdk/examples/connector-example/grafbase/grafbase.config.ts
require() of ES modules is not supported.
require() of /snip/connector-example/grafbase/grafbase.config.ts from /snip/.grafbase/parser/parse-config.ts is an ES module file as it is a .ts file whose nearest parent package.json contains "type": "module" which defines all .ts files in that package scope as ES modules.
Instead change the requiring code to use import(), or remove "type": "module" from /snip/sdk/examples/connector-example/package.json.
```

The only way I've managed to fix this is with a separate implementation of the `parse-config.ts` file, and by passing a bunch more arguments in on the command line.

I don't fully understand the problem here or like the solution - if anyone has better ideas please speak up.

Fixes GB-5633