### PR TITLE
cli: fix piping schema to publish

### DIFF
--- a/cli/crates/cli/src/cli_input/publish.rs
+++ b/cli/crates/cli/src/cli_input/publish.rs
@@ -10,11 +10,6 @@ use url::Url;
             .required(true)
             .args(&["dev", "project_ref"])
     ),
-    group(
-        ArgGroup::new("dev-or-schema")
-            .required(true)
-            .args(&["dev", "schema_path"])
-    )
 )]
 pub struct PublishCommand {
     #[arg(help = ProjectRef::ARG_DESCRIPTION)]


### PR DESCRIPTION
The arg groups still made --schema-path required in the absence of --dev. This change makes piping a schema to publish as in `grafbase introspect | grafbase publish account/project --url https://example.com` work.
