### PR TITLE
federated-graph: fix rendering of join__Graph variants

### DIFF
--- a/engine/crates/composition/tests/composition/kebab_case_subgraph_names/federated.graphql
+++ b/engine/crates/composition/tests/composition/kebab_case_subgraph_names/federated.graphql
@@ -1,0 +1,69 @@
+directive @core(feature: String!) repeatable on SCHEMA
+
+directive @join__owner(graph: join__Graph!) on OBJECT
+
+directive @join__type(
+    graph: join__Graph!
+    key: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__field(
+    graph: join__Graph
+    requires: String
+    provides: String
+) on FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+enum join__Graph {
+    BROCHETTE_REPOSITORY @join__graph(name: "brochette-repository", url: "http://example.com/brochette-repository")
+    KUSHI_STORE @join__graph(name: "kushi-store", url: "http://example.com/kushi-store")
+    SCHASCHLIK_SERVICE @join__graph(name: "schaschlik-service", url: "http://example.com/schaschlik-service")
+}
+
+type Kebab
+    @join__type(graph: BROCHETTE_REPOSITORY, key: "id")
+{
+    id: ID! @join__field(graph: BROCHETTE_REPOSITORY)
+    meatType: String @join__field(graph: BROCHETTE_REPOSITORY)
+    vegetables: [String] @join__field(graph: BROCHETTE_REPOSITORY)
+    breadType: String @join__field(graph: BROCHETTE_REPOSITORY)
+}
+
+type Brochette
+    @join__type(graph: BROCHETTE_REPOSITORY, key: "id")
+{
+    id: ID! @join__field(graph: BROCHETTE_REPOSITORY)
+    meatType: String @join__field(graph: BROCHETTE_REPOSITORY)
+    marinade: String @join__field(graph: BROCHETTE_REPOSITORY)
+    servedWith: String @join__field(graph: BROCHETTE_REPOSITORY)
+}
+
+type Query {
+    kebabs: [Kebab] @join__field(graph: BROCHETTE_REPOSITORY)
+    kebab(id: ID!): Kebab @join__field(graph: BROCHETTE_REPOSITORY)
+    brochettes: [Brochette] @join__field(graph: BROCHETTE_REPOSITORY)
+    brochette(id: ID!): Brochette @join__field(graph: BROCHETTE_REPOSITORY)
+    kushis: [Kushi] @join__field(graph: KUSHI_STORE)
+    kushi(id: ID!): Kushi @join__field(graph: KUSHI_STORE)
+    schaschliks: [Schaschlik] @join__field(graph: SCHASCHLIK_SERVICE)
+    schaschlik(id: ID!): Schaschlik @join__field(graph: SCHASCHLIK_SERVICE)
+}
+
+type Kushi
+    @join__type(graph: KUSHI_STORE, key: "id")
+{
+    id: ID! @join__field(graph: KUSHI_STORE)
+    meatType: String @join__field(graph: KUSHI_STORE)
+    sauce: String @join__field(graph: KUSHI_STORE)
+    stickMaterial: String @join__field(graph: KUSHI_STORE)
+}
+
+type Schaschlik
+    @join__type(graph: SCHASCHLIK_SERVICE, key: "id")
+{
+    id: ID! @join__field(graph: SCHASCHLIK_SERVICE)
+    meatType: String @join__field(graph: SCHASCHLIK_SERVICE)
+    spices: [String] @join__field(graph: SCHASCHLIK_SERVICE)
+    originCountry: String @join__field(graph: SCHASCHLIK_SERVICE)
+}

--- a/engine/crates/composition/tests/composition/kebab_case_subgraph_names/subgraphs/brochette-repository.graphql
+++ b/engine/crates/composition/tests/composition/kebab_case_subgraph_names/subgraphs/brochette-repository.graphql
@@ -1,0 +1,20 @@
+type Kebab @key(fields: "id") {
+  id: ID!
+  meatType: String
+  vegetables: [String]
+  breadType: String
+}
+
+type Brochette @key(fields: "id") {
+  id: ID!
+  meatType: String
+  marinade: String
+  servedWith: String
+}
+
+extend type Query {
+  kebabs: [Kebab]
+  kebab(id: ID!): Kebab
+  brochettes: [Brochette]
+  brochette(id: ID!): Brochette
+}

--- a/engine/crates/composition/tests/composition/kebab_case_subgraph_names/subgraphs/kushi-store.graphql
+++ b/engine/crates/composition/tests/composition/kebab_case_subgraph_names/subgraphs/kushi-store.graphql
@@ -1,0 +1,11 @@
+type Kushi @key(fields: "id") {
+  id: ID!
+  meatType: String
+  sauce: String
+  stickMaterial: String
+}
+
+extend type Query {
+  kushis: [Kushi]
+  kushi(id: ID!): Kushi
+}

--- a/engine/crates/composition/tests/composition/kebab_case_subgraph_names/subgraphs/schaschlik-service.graphql
+++ b/engine/crates/composition/tests/composition/kebab_case_subgraph_names/subgraphs/schaschlik-service.graphql
@@ -1,0 +1,11 @@
+type Schaschlik @key(fields: "id") {
+  id: ID!
+  meatType: String
+  spices: [String]
+  originCountry: String
+}
+
+extend type Query {
+  schaschliks: [Schaschlik]
+  schaschlik(id: ID!): Schaschlik
+}

--- a/engine/crates/federated-graph/src/render_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl.rs
@@ -478,8 +478,13 @@ struct GraphEnumVariantName<'a>(&'a str);
 impl Display for GraphEnumVariantName<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for char in self.0.chars() {
-            for upcased in char.to_uppercase() {
-                f.write_char(upcased)?;
+            match char {
+                '-' | '_' | ' ' => f.write_char('_')?,
+                other => {
+                    for char in other.to_uppercase() {
+                        f.write_char(char)?;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
In cases where the subgraph name contains hyphen ('-') characters, we were rendering them as-is in the join__Graph enum variant names, but this is not valid in GraphQL identifiers. We now replace them with underscores.

closes GB-5647