### PR TITLE
chore: Engine v2: add selection set walkers (without plan), needed for caching

### DIFF
--- a/engine/crates/engine-v2/src/execution/context.rs
+++ b/engine/crates/engine-v2/src/execution/context.rs
@@ -32,7 +32,7 @@ impl<'ctx> ExecutionContext<'ctx> {
         'ctx: 'p,
     {
         self.walker
-            .with_plan(PlanExt {
+            .with_ext(PlanExt {
                 attribution: &output.attribution,
                 variables: self.variables,
             })
@@ -49,7 +49,7 @@ impl<'ctx> ExecutionContext<'ctx> {
         'ctx: 'a,
     {
         ResponseObjectWriter::new(
-            self.walker.with_plan(PlanExt {
+            self.walker.with_ext(PlanExt {
                 attribution: &output.attribution,
                 variables: self.variables,
             }),

--- a/engine/crates/engine-v2/src/request/walkers/field.rs
+++ b/engine/crates/engine-v2/src/request/walkers/field.rs
@@ -1,6 +1,9 @@
 use schema::{FieldId, FieldWalker};
 
-use super::{BoundAnyFieldDefinitionWalker, BoundFieldArgumentWalker, OperationWalker, PlanExt, PlanSelectionSet};
+use super::{
+    BoundAnyFieldDefinitionWalker, BoundFieldArgumentWalker, BoundSelectionSetWalker, OperationWalker, PlanExt,
+    PlanSelectionSet,
+};
 use crate::{
     plan::ExtraFieldId,
     request::{BoundFieldDefinition, BoundFieldId},
@@ -15,6 +18,12 @@ impl<'a, E: Copy> BoundFieldWalker<'a, E> {
 
     pub fn definition(&self) -> BoundAnyFieldDefinitionWalker<'a, E> {
         self.walk_with(self.definition_id, ())
+    }
+}
+
+impl<'a> BoundFieldWalker<'a, ()> {
+    pub fn selection_set(&self) -> Option<BoundSelectionSetWalker<'a>> {
+        self.selection_set_id.map(|id| self.walk(id))
     }
 }
 

--- a/engine/crates/engine-v2/src/request/walkers/fragment.rs
+++ b/engine/crates/engine-v2/src/request/walkers/fragment.rs
@@ -1,4 +1,4 @@
-use super::{type_condition_name, OperationWalker, PlanExt, PlanSelectionSet};
+use super::{type_condition_name, BoundSelectionSetWalker, OperationWalker, PlanExt, PlanSelectionSet};
 use crate::request::{BoundFragmentDefinitionId, BoundFragmentSpread};
 
 pub type BoundFragmentSpreadWalker<'a, Extension = ()> = OperationWalker<'a, &'a BoundFragmentSpread, (), Extension>;
@@ -14,6 +14,12 @@ impl<'a, E> std::ops::Deref for BoundFragmentSpreadWalker<'a, E> {
 impl<'a, E: Copy> BoundFragmentSpreadWalker<'a, E> {
     pub fn fragment(&self) -> BoundFragmentDefinitionWalker<'a, E> {
         self.walk_with(self.wrapped.fragment_id, ())
+    }
+}
+
+impl<'a> BoundFragmentSpreadWalker<'a, ()> {
+    pub fn selection_set(&self) -> BoundSelectionSetWalker<'a> {
+        self.walk(self.wrapped.selection_set_id)
     }
 }
 

--- a/engine/crates/engine-v2/src/request/walkers/inline_fragment.rs
+++ b/engine/crates/engine-v2/src/request/walkers/inline_fragment.rs
@@ -1,4 +1,4 @@
-use super::{type_condition_name, OperationWalker, PlanExt, PlanSelectionSet};
+use super::{type_condition_name, BoundSelectionSetWalker, OperationWalker, PlanExt, PlanSelectionSet};
 use crate::request::BoundInlineFragment;
 
 pub type BoundInlineFragmentWalker<'a, Extension = ()> = OperationWalker<'a, &'a BoundInlineFragment, (), Extension>;
@@ -16,6 +16,12 @@ impl<'a, E: Copy> BoundInlineFragmentWalker<'a, E> {
         self.wrapped
             .type_condition
             .map(|cond| type_condition_name(self.schema_walker, cond))
+    }
+}
+
+impl<'a> BoundInlineFragmentWalker<'a, ()> {
+    pub fn selection_set(&self) -> BoundSelectionSetWalker<'a> {
+        self.walk(self.wrapped.selection_set_id)
     }
 }
 

--- a/engine/crates/engine-v2/src/request/walkers/mod.rs
+++ b/engine/crates/engine-v2/src/request/walkers/mod.rs
@@ -5,6 +5,7 @@ mod flat;
 mod fragment;
 mod inline_fragment;
 mod plan;
+mod plan_selection_set;
 mod selection_set;
 mod variables;
 
@@ -20,6 +21,7 @@ pub use flat::*;
 pub use fragment::*;
 pub use inline_fragment::*;
 pub use plan::*;
+pub use plan_selection_set::*;
 use schema::SchemaWalker;
 pub use selection_set::*;
 pub use variables::*;
@@ -110,7 +112,7 @@ impl<'a, W, I, E> OperationWalker<'a, W, I, E> {
         }
     }
 
-    pub fn with_plan<E2>(&self, plan: E2) -> OperationWalker<'a, W, I, E2>
+    pub fn with_ext<E2>(&self, ext: E2) -> OperationWalker<'a, W, I, E2>
     where
         W: Copy,
         I: Copy,
@@ -118,7 +120,7 @@ impl<'a, W, I, E> OperationWalker<'a, W, I, E> {
         OperationWalker {
             operation: self.operation,
             schema_walker: self.schema_walker,
-            ext: plan,
+            ext,
             wrapped: self.wrapped,
         }
     }

--- a/engine/crates/engine-v2/src/request/walkers/plan_selection_set.rs
+++ b/engine/crates/engine-v2/src/request/walkers/plan_selection_set.rs
@@ -1,0 +1,146 @@
+use std::collections::VecDeque;
+
+use schema::Definition;
+
+use super::{
+    BoundFragmentSpreadWalker, BoundInlineFragmentWalker, BoundSelectionSetWalker, OperationWalker, PlanExt, PlanField,
+    PlanOperationWalker, PlanWalker, SelectionSetTypeWalker,
+};
+use crate::{
+    plan::{ExtraFieldWalker, ExtraSelectionSetId},
+    request::{BoundFieldId, BoundSelection, SelectionSetType},
+};
+
+#[derive(Clone)]
+pub enum PlanSelectionSet<'a> {
+    RootFields(PlanOperationWalker<'a>),
+    Query(BoundSelectionSetWalker<'a, PlanExt<'a>>),
+    Extra(OperationWalker<'a, ExtraSelectionSetId, (), PlanExt<'a>>),
+}
+
+impl<'a> PlanSelectionSet<'a> {
+    pub fn ty(&self) -> SelectionSetTypeWalker<'a, ()> {
+        match self {
+            Self::RootFields(walker) => {
+                let ty: SelectionSetType = walker.wrapped.entity_type.into();
+                walker.walk_with(ty, Definition::from(ty)).with_ext(())
+            }
+            Self::Query(walker) => walker.ty(),
+            Self::Extra(walker) => {
+                let ty = walker.as_attribution_walker().ty();
+                walker.walk_with(ty, Definition::from(ty)).with_ext(())
+            }
+        }
+    }
+}
+
+pub enum PlanSelection<'a> {
+    Field(PlanField<'a>),
+    FragmentSpread(BoundFragmentSpreadWalker<'a, PlanExt<'a>>),
+    InlineFragment(BoundInlineFragmentWalker<'a, PlanExt<'a>>),
+}
+
+impl<'a> IntoIterator for PlanSelectionSet<'a> {
+    type Item = PlanSelection<'a>;
+
+    type IntoIter = PlanSelectionIterator<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            Self::RootFields(walker) => PlanSelectionIterator {
+                walker: walker.walk(()),
+                bound_field_ids: walker.wrapped.root_fields.iter().copied().collect(),
+                selections: VecDeque::with_capacity(0),
+                extra_fields: VecDeque::with_capacity(0),
+            },
+            Self::Query(walker) => PlanSelectionIterator {
+                walker: walker.walk(()),
+                bound_field_ids: VecDeque::with_capacity(0),
+                selections: walker.operation[walker.wrapped].items.iter().collect(),
+                extra_fields: walker
+                    .ext
+                    .attribution
+                    .extras_for(walker.wrapped)
+                    .map(|extras| extras.fields().collect())
+                    .unwrap_or_default(),
+            },
+            Self::Extra(walker) => PlanSelectionIterator {
+                walker: walker.walk(()),
+                bound_field_ids: VecDeque::with_capacity(0),
+                selections: VecDeque::with_capacity(0),
+                extra_fields: walker.as_attribution_walker().fields().collect(),
+            },
+        }
+    }
+}
+
+pub struct PlanSelectionIterator<'a> {
+    walker: PlanWalker<'a>,
+    bound_field_ids: VecDeque<BoundFieldId>,
+    selections: VecDeque<&'a BoundSelection>,
+    extra_fields: VecDeque<ExtraFieldWalker<'a>>,
+}
+
+impl<'a> Iterator for PlanSelectionIterator<'a> {
+    type Item = PlanSelection<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(id) = self.bound_field_ids.pop_front() {
+                let bound_field = self.walker.walk(id);
+                // Skipping over metadata fields. The plan doesn't provide them.
+                let field = bound_field.definition().as_field().map(|definition| {
+                    PlanSelection::Field(PlanField::Query(
+                        bound_field.walk_with((bound_field.id(), definition.wrapped), definition.id()),
+                    ))
+                });
+                if field.is_some() {
+                    return field;
+                }
+            } else if let Some(selection) = self.selections.pop_front() {
+                match selection {
+                    &BoundSelection::Field(id) => {
+                        if self.walker.ext.attribution.field(id) {
+                            self.bound_field_ids.push_back(id);
+                        }
+                    }
+                    BoundSelection::FragmentSpread(spread) => {
+                        if self.walker.ext.attribution.selection_set(spread.selection_set_id) {
+                            return Some(PlanSelection::FragmentSpread(self.walker.walk(spread)));
+                        }
+                    }
+                    BoundSelection::InlineFragment(fragment) => {
+                        if self.walker.ext.attribution.selection_set(fragment.selection_set_id) {
+                            return Some(PlanSelection::InlineFragment(self.walker.walk(fragment)));
+                        }
+                    }
+                }
+            } else {
+                return self.extra_fields.pop_front().map(|extra_field| {
+                    PlanSelection::Field(PlanField::Extra(
+                        self.walker.walk_with(extra_field.id(), extra_field.field_id),
+                    ))
+                });
+            }
+        }
+    }
+}
+
+impl<'a> std::fmt::Debug for PlanSelectionSet<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PlanSelectionSet")
+            .field("ty", &self.ty().name())
+            .field("items", &self.clone().into_iter().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+impl<'a> std::fmt::Debug for PlanSelection<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Field(field) => field.fmt(f),
+            Self::FragmentSpread(spread) => spread.fmt(f),
+            Self::InlineFragment(fragment) => fragment.fmt(f),
+        }
+    }
+}

--- a/engine/crates/engine-v2/src/request/walkers/selection_set.rs
+++ b/engine/crates/engine-v2/src/request/walkers/selection_set.rs
@@ -2,17 +2,17 @@ use std::collections::VecDeque;
 
 use schema::{Definition, DefinitionWalker};
 
-use super::{
-    BoundFragmentSpreadWalker, BoundInlineFragmentWalker, OperationWalker, PlanExt, PlanField, PlanOperationWalker,
-    PlanWalker,
-};
-use crate::{
-    plan::{ExtraFieldWalker, ExtraSelectionSetId},
-    request::{BoundFieldId, BoundSelection, BoundSelectionSetId, SelectionSetType},
-};
+use super::{BoundFieldWalker, BoundFragmentSpreadWalker, BoundInlineFragmentWalker, OperationWalker};
+use crate::request::{BoundSelection, BoundSelectionSetId, SelectionSetType};
 
 pub type BoundSelectionSetWalker<'a, Extension = ()> = OperationWalker<'a, BoundSelectionSetId, (), Extension>;
 pub type SelectionSetTypeWalker<'a, Extension = ()> = OperationWalker<'a, SelectionSetType, Definition, Extension>;
+
+impl<'a, E> BoundSelectionSetWalker<'a, E> {
+    pub fn ty(&self) -> SelectionSetTypeWalker<'a, ()> {
+        self.with_ext(()).walk_with(self.ty, Definition::from(self.ty))
+    }
+}
 
 impl<'a, E> std::ops::Deref for SelectionSetTypeWalker<'a, E> {
     type Target = DefinitionWalker<'a>;
@@ -22,137 +22,55 @@ impl<'a, E> std::ops::Deref for SelectionSetTypeWalker<'a, E> {
     }
 }
 
-#[derive(Clone)]
-pub enum PlanSelectionSet<'a> {
-    RootFields(PlanOperationWalker<'a>),
-    Query(BoundSelectionSetWalker<'a, PlanExt<'a>>),
-    Extra(OperationWalker<'a, ExtraSelectionSetId, (), PlanExt<'a>>),
+pub enum BoundSelectionWalker<'a, E = ()> {
+    Field(BoundFieldWalker<'a, E>),
+    FragmentSpread(BoundFragmentSpreadWalker<'a, E>),
+    InlineFragment(BoundInlineFragmentWalker<'a, E>),
 }
 
-impl<'a> PlanSelectionSet<'a> {
-    pub fn ty(&self) -> SelectionSetTypeWalker<'a, ()> {
-        match self {
-            Self::RootFields(walker) => {
-                let ty: SelectionSetType = walker.wrapped.entity_type.into();
-                walker.walk_with(ty, Definition::from(ty)).with_plan(())
-            }
-            Self::Query(walker) => walker.walk_with(walker.ty, Definition::from(walker.ty)).with_plan(()),
-            Self::Extra(walker) => {
-                let ty = walker.as_attribution_walker().ty();
-                walker.walk_with(ty, Definition::from(ty)).with_plan(())
-            }
-        }
-    }
-}
+impl<'a, E: Copy> IntoIterator for BoundSelectionSetWalker<'a, E> {
+    type Item = BoundSelectionWalker<'a, E>;
 
-pub enum PlanSelection<'a> {
-    Field(PlanField<'a>),
-    FragmentSpread(BoundFragmentSpreadWalker<'a, PlanExt<'a>>),
-    InlineFragment(BoundInlineFragmentWalker<'a, PlanExt<'a>>),
-}
-
-impl<'a> IntoIterator for PlanSelectionSet<'a> {
-    type Item = PlanSelection<'a>;
-
-    type IntoIter = PlanSelectionIterator<'a>;
+    type IntoIter = SelectionIterator<'a, E>;
 
     fn into_iter(self) -> Self::IntoIter {
-        match self {
-            Self::RootFields(walker) => PlanSelectionIterator {
-                walker: walker.walk(()),
-                bound_field_ids: walker.wrapped.root_fields.iter().copied().collect(),
-                selections: VecDeque::with_capacity(0),
-                extra_fields: VecDeque::with_capacity(0),
-            },
-            Self::Query(walker) => PlanSelectionIterator {
-                walker: walker.walk(()),
-                bound_field_ids: VecDeque::with_capacity(0),
-                selections: walker.operation[walker.wrapped].items.iter().collect(),
-                extra_fields: walker
-                    .ext
-                    .attribution
-                    .extras_for(walker.wrapped)
-                    .map(|extras| extras.fields().collect())
-                    .unwrap_or_default(),
-            },
-            Self::Extra(walker) => PlanSelectionIterator {
-                walker: walker.walk(()),
-                bound_field_ids: VecDeque::with_capacity(0),
-                selections: VecDeque::with_capacity(0),
-                extra_fields: walker.as_attribution_walker().fields().collect(),
-            },
+        SelectionIterator {
+            walker: self.walk(()),
+            selections: self.operation[self.wrapped].items.iter().collect(),
         }
     }
 }
 
-pub struct PlanSelectionIterator<'a> {
-    walker: PlanWalker<'a>,
-    bound_field_ids: VecDeque<BoundFieldId>,
+pub struct SelectionIterator<'a, E> {
+    walker: OperationWalker<'a, (), (), E>,
     selections: VecDeque<&'a BoundSelection>,
-    extra_fields: VecDeque<ExtraFieldWalker<'a>>,
 }
 
-impl<'a> Iterator for PlanSelectionIterator<'a> {
-    type Item = PlanSelection<'a>;
+impl<'a, E: Copy> Iterator for SelectionIterator<'a, E> {
+    type Item = BoundSelectionWalker<'a, E>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            if let Some(id) = self.bound_field_ids.pop_front() {
-                let bound_field = self.walker.walk(id);
-                // Skipping over metadata fields. The plan doesn't provide them.
-                let field = bound_field.definition().as_field().map(|definition| {
-                    PlanSelection::Field(PlanField::Query(
-                        bound_field.walk_with((bound_field.id(), definition.wrapped), definition.id()),
-                    ))
-                });
-                if field.is_some() {
-                    return field;
-                }
-            } else if let Some(selection) = self.selections.pop_front() {
-                match selection {
-                    &BoundSelection::Field(id) => {
-                        if self.walker.ext.attribution.field(id) {
-                            self.bound_field_ids.push_back(id);
-                        }
-                    }
-                    BoundSelection::FragmentSpread(spread) => {
-                        if self.walker.ext.attribution.selection_set(spread.selection_set_id) {
-                            return Some(PlanSelection::FragmentSpread(self.walker.walk(spread)));
-                        }
-                    }
-                    BoundSelection::InlineFragment(fragment) => {
-                        if self.walker.ext.attribution.selection_set(fragment.selection_set_id) {
-                            return Some(PlanSelection::InlineFragment(self.walker.walk(fragment)));
-                        }
-                    }
-                }
-            } else {
-                return self.extra_fields.pop_front().map(|extra_field| {
-                    PlanSelection::Field(PlanField::Extra(
-                        self.walker.walk_with(extra_field.id(), extra_field.field_id),
-                    ))
-                });
+        let selection = self.selections.pop_front()?;
+        Some(match selection {
+            &BoundSelection::Field(id) => BoundSelectionWalker::Field(self.walker.walk(id)),
+            BoundSelection::FragmentSpread(spread) => BoundSelectionWalker::FragmentSpread(self.walker.walk(spread)),
+            BoundSelection::InlineFragment(fragment) => {
+                BoundSelectionWalker::InlineFragment(self.walker.walk(fragment))
             }
-        }
+        })
     }
 }
 
-impl<'a, E> std::fmt::Debug for BoundSelectionSetWalker<'a, E> {
+impl<'a, E: Copy> std::fmt::Debug for BoundSelectionSetWalker<'a, E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("BoundSelectionSetWalker").finish_non_exhaustive()
-    }
-}
-
-impl<'a> std::fmt::Debug for PlanSelectionSet<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PlanSelectionSet")
+        f.debug_struct("BoundSelectionSet")
             .field("ty", &self.ty().name())
-            .field("fields", &self.clone().into_iter().collect::<Vec<_>>())
+            .field("items", &self.into_iter().collect::<Vec<_>>())
             .finish()
     }
 }
 
-impl<'a> std::fmt::Debug for PlanSelection<'a> {
+impl<'a, E> std::fmt::Debug for BoundSelectionWalker<'a, E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Field(field) => field.fmt(f),


### PR DESCRIPTION
This adds an `IntoIterator` implementation for the selection set walker of the operation, to iterate over fields and fragments. There is an existing for executors filtered for their plan, but caching will need that to traverse the whole operation.
