### PR TITLE
chore(engine-v2): only use upstream errors if there is any, removing serde ones.

### DIFF
--- a/engine/crates/engine-v2/src/response/write/mod.rs
+++ b/engine/crates/engine-v2/src/response/write/mod.rs
@@ -227,6 +227,15 @@ impl ExecutorOutput {
     pub fn has_errors(&self) -> bool {
         !self.errors.is_empty()
     }
+
+    /// Deserialization will generate a bunch of errors for missing fields, wrong type etc.
+    /// Those won't be relevant if upstream returned errors. So this method can be used to entirely
+    /// replace accumulated errors with upstream ones. Error paths to propagate are still kept.
+    /// Ideally they shouldn't, but currently we don't propagate errors correctly in the
+    /// coordinator.
+    pub fn replace_errors(&mut self, upstream_errors: Vec<GraphqlError>) {
+        self.errors = upstream_errors;
+    }
 }
 
 impl std::ops::Index<PlanBoundaryId> for ExecutorOutput {

--- a/engine/crates/engine-v2/src/sources/graphql/mod.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/mod.rs
@@ -86,7 +86,7 @@ impl<'ctx> GraphqlExecutor<'ctx> {
         .deserialize(&mut serde_json::Deserializer::from_slice(&bytes));
 
         if !upstream_errors.is_empty() {
-            self.output.push_errors(upstream_errors);
+            self.output.replace_errors(upstream_errors);
         } else if let Err(err) = result {
             // Only adding this if no other more precise errors were added.
             if !self.output.has_errors() {

--- a/engine/crates/integration-tests/tests/federation/basic/mutation.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/mutation.rs
@@ -139,12 +139,6 @@ fn mutation_failure_should_stop_later_executions_if_required() {
           "data": null,
           "errors": [
             {
-              "message": "Upstream response error: Missing required field named 'fail'",
-              "path": [
-                "fail"
-              ]
-            },
-            {
               "message": "Upstream error: This mutation always fails",
               "path": [
                 "fail"


### PR DESCRIPTION
Only use upstream errors if there is any, removing serde ones.
