### PR TITLE
parser-sdl: fix extending type causing duplicate type definition error

### DIFF
--- a/engine/crates/parser-sdl/src/lib.rs
+++ b/engine/crates/parser-sdl/src/lib.rs
@@ -338,7 +338,7 @@ fn parse_relations<'a>(schema: &'a ServiceDocument, ctx: &mut VisitorContext<'a>
 }
 
 fn parse_types<'a>(schema: &'a ServiceDocument, ctx: &mut VisitorContext<'a>) {
-    let mut rules = rules::visitor::VisitorNil
+    let mut first_pass_rules = rules::visitor::VisitorNil
         .with(CheckBeginsWithDoubleUnderscore)
         .with(CheckFieldCamelCase)
         .with(CheckTypeValidity)
@@ -349,7 +349,6 @@ fn parse_types<'a>(schema: &'a ServiceDocument, ctx: &mut VisitorContext<'a>) {
         .with(InputObjectVisitor)
         .with(BasicType)
         .with(ExtendQueryAndMutationTypes)
-        .with(ExtendConnectorTypes)
         .with(EnumType)
         .with(ScalarHydratation)
         .with(MongoDBTypeDirective)
@@ -363,7 +362,11 @@ fn parse_types<'a>(schema: &'a ServiceDocument, ctx: &mut VisitorContext<'a>) {
         .with(SubgraphDirectiveVisitor)
         .with(AllSubgraphsDirectiveVisitor);
 
-    visit(&mut rules, ctx, schema);
+    visit(&mut first_pass_rules, ctx, schema);
+
+    let mut second_pass_rules = rules::visitor::VisitorNil.with(ExtendConnectorTypes);
+
+    visit(&mut second_pass_rules, ctx, schema);
 }
 
 /// Visitors that require all user-defined types to be parsed already.

--- a/engine/crates/parser-sdl/src/rules/basic_type.rs
+++ b/engine/crates/parser-sdl/src/rules/basic_type.rs
@@ -42,7 +42,8 @@ impl<'a> Visitor<'a> for BasicType {
         let directives = &type_definition.node.directives;
 
         if ["Query", "Mutation"].contains(&type_definition.node.name.node.as_str())
-            | directives.iter().any(|directive| directive.is_model())
+            || directives.iter().any(|directive| directive.is_model())
+            || type_definition.node.extend
         {
             return;
         }

--- a/engine/crates/parser-sdl/src/rules/basic_type.rs
+++ b/engine/crates/parser-sdl/src/rules/basic_type.rs
@@ -131,43 +131,7 @@ impl<'a> Visitor<'a> for BasicType {
         // final schema.
         add_input_type_non_primitive(ctx, object, &type_name);
 
-        // We also need to parse any @key directives
-        let key_directives = directives
-            .iter()
-            .filter(|directive| directive.node.name.node == "key")
-            .collect::<Vec<_>>();
-
-        let (oks, errors) = key_directives
-            .into_iter()
-            .map(|directive| {
-                Ok((
-                    directive.pos,
-                    parse_directive::<KeyDirective>(directive, ctx.variables)?,
-                ))
-            })
-            .partition_result::<Vec<_>, Vec<_>, _, _>();
-
-        ctx.append_errors(errors);
-
-        ctx.append_errors(validate_keys(&oks, {
-            let registry = ctx.registry.borrow();
-            let Some(MetaType::Object(object)) = registry.types.get(&type_name) else {
-                // Apparently this can happen in the face of duplicate types.
-                // Which is annoying but ok
-                return;
-            };
-            object.clone()
-        }));
-
-        for (_, directive) in oks {
-            ctx.registry
-                .borrow_mut()
-                .federation_entities
-                .entry(type_name.clone())
-                .or_default()
-                .keys
-                .push(directive.into_key());
-        }
+        handle_key_directives(directives, &type_name, ctx)
     }
 }
 
@@ -178,6 +142,50 @@ impl KeyDirective {
             (false, _) => FederationKey::unresolvable(self.fields.0),
             (_, Some(select)) => FederationKey::join(self.fields.0, select.to_join_resolver()),
         }
+    }
+}
+
+pub(super) fn handle_key_directives(
+    directives: &[Positioned<engine_parser::types::ConstDirective>],
+    type_name: &str,
+    ctx: &mut VisitorContext<'_>,
+) {
+    // We also need to parse any @key directives
+    let key_directives = directives
+        .iter()
+        .filter(|directive| directive.node.name.node == "key")
+        .collect::<Vec<_>>();
+
+    let (oks, errors) = key_directives
+        .into_iter()
+        .map(|directive| {
+            Ok((
+                directive.pos,
+                parse_directive::<KeyDirective>(directive, ctx.variables)?,
+            ))
+        })
+        .partition_result::<Vec<_>, Vec<_>, _, _>();
+
+    ctx.append_errors(errors);
+
+    ctx.append_errors(validate_keys(&oks, {
+        let registry = ctx.registry.borrow();
+        let Some(MetaType::Object(object)) = registry.types.get(type_name) else {
+            // Apparently this can happen in the face of duplicate types.
+            // Which is annoying but ok
+            return;
+        };
+        object.clone()
+    }));
+
+    for (_, directive) in oks {
+        ctx.registry
+            .borrow_mut()
+            .federation_entities
+            .entry(type_name.to_owned())
+            .or_default()
+            .keys
+            .push(directive.into_key());
     }
 }
 

--- a/engine/crates/parser-sdl/src/rules/check_type_collision.rs
+++ b/engine/crates/parser-sdl/src/rules/check_type_collision.rs
@@ -23,6 +23,11 @@ impl<'a> Visitor<'a> for CheckTypeCollision {
     fn enter_type_definition(&mut self, ctx: &mut VisitorContext<'a>, type_definition: &'a Positioned<TypeDefinition>) {
         let ty = &type_definition.node;
         let name = ty.name.node.to_string();
+
+        if ty.extend {
+            return;
+        }
+
         if !self.type_pokedex.insert(name) {
             ctx.report_error(
                 vec![type_definition.pos],

--- a/engine/crates/parser-sdl/src/rules/extend_connector_types.rs
+++ b/engine/crates/parser-sdl/src/rules/extend_connector_types.rs
@@ -112,12 +112,27 @@ impl<'a> Visitor<'a> for ExtendConnectorTypes {
             .map(|field| (field.name.clone(), field))
             .collect::<Vec<_>>();
 
+        let is_external = ExternalDirective::from_directives(&type_definition.directives, ctx).is_some();
+        let is_shareable = ShareableDirective::from_directives(&type_definition.directives, ctx).is_some();
+
+        super::basic_type::handle_key_directives(&type_definition.directives, type_name, ctx);
+
         let mut registry = ctx.registry.borrow_mut();
-        let Some(MetaType::Object(registry::ObjectType { fields, .. })) = registry.types.get_mut(type_name) else {
+
+        let Some(MetaType::Object(registry::ObjectType {
+            fields,
+            shareable,
+            external,
+            ..
+        })) = registry.types.get_mut(type_name)
+        else {
             drop(registry);
             ctx.report_error(vec![type_definition.pos], format!("Type '{type_name}' does not exist"));
             return;
         };
+
+        *shareable |= is_shareable;
+        *external |= is_external;
 
         fields.extend(extended_fields);
     }
@@ -200,6 +215,60 @@ mod tests {
         place.field_by_name("annualPrecipitations").unwrap();
         place.field_by_name("squareMeterPrice").unwrap();
         place.field_by_name("name").unwrap();
+    }
+
+    #[test]
+    fn types_from_resolvers_of_extended_connector_types_can_be_extended_with_directives() {
+        let output = futures::executor::block_on(crate::parse(
+            r#"
+        extend schema @openapi(name: "Stripe", namespace: true, schema: "http://example.com")
+
+        extend type StripeCustomer {
+            email: String @resolver(name: "email")
+            location: Place @resolver(name: "customer/location") @shareable
+        }
+
+        extend type Place @shareable {
+            annualPrecipitations: Int @resolver(name: "place/annualPrecipitations") @external
+        }
+
+        type Place @external {
+            id: ID!
+            name: String @shareable
+        }
+
+        extend type Place {
+            squareMeterPrice: Int @resolver(name: "place/squareMeterPrice") @shareable
+        }
+        "#,
+            &HashMap::new(),
+            false,
+            &FakeConnectorParser,
+        ));
+
+        let registry = output.unwrap().registry;
+
+        let location = registry
+            .types
+            .get("StripeCustomer")
+            .unwrap()
+            .field_by_name("location")
+            .expect("StripeCustomer to have a location field after parsing");
+        assert!(location.shareable);
+
+        let place = registry.types.get("Place").unwrap();
+        let place_object = place.object().unwrap();
+        assert!(place_object.shareable);
+        assert!(place_object.external);
+
+        let annual_precipitations = place.field_by_name("annualPrecipitations").unwrap();
+        assert!(annual_precipitations.external);
+
+        let square_meter_price = place.field_by_name("squareMeterPrice").unwrap();
+        assert!(square_meter_price.shareable);
+
+        let name = place.field_by_name("name").unwrap();
+        assert!(name.shareable);
     }
 
     #[rstest::rstest]


### PR DESCRIPTION
Roughly, there are three scenarios for extend type:

- extend type Query / extend type Mutation -> these are special cases, there are tests
- extend types for types from connectors -> also tested
- extend type for types defined in the config / sdl -> that's where the issue applies

In that last point, two subcases: extending a model and extending a type that is returned by a resolver extending a connector type. The first use case is being sunset. The second use case is tested and fixed in this PR.

closes GB-5067

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
