### PR TITLE
chore: optimize build time

### DIFF
--- a/.github/actions/sanitize/action.yml
+++ b/.github/actions/sanitize/action.yml
@@ -4,11 +4,11 @@ description: Run cargo fmt, clippy, test
 inputs:
   lint:
     required: false
-    default: "true"
+    default: 'true'
     description: To run fmt/clippy or not to run
   test:
     required: false
-    default: "true"
+    default: 'true'
     description: To run test or not to run
 
 runs:

--- a/.github/actions/sanitize/action.yml
+++ b/.github/actions/sanitize/action.yml
@@ -52,4 +52,4 @@ runs:
       name: cargo nextest
       shell: bash
       run: |
-        CARGO_BUILD_JOBS=4 RUST_BACKTRACE=1 cargo nextest run --workspace --exclude integration-tests --profile ci
+        RUST_BACKTRACE=1 cargo nextest run --workspace --exclude integration-tests --profile ci

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,21 +113,21 @@ strip = "symbols"
 # These names were inherited from clang / LLVM and are not too descriptive
 # but "z" is meant to give the idea that it produces smaller binaries than "s".
 # https://docs.rust-embedded.org/book/unsorted/speed-vs-size.html#optimize-for-size
-opt-level = "z"
+#opt-level = "z"
 # by compiling as a single codegen unit (i.e. not in parallel),
 # it's possible to reduce size even further at the expense of
 # compilation time
-codegen-units = 1
+#codegen-units = 1
 # by enabling link-time optimization, we can reduce size even further
 # by telling cargo to optimize at the link stage (in addition to the
 # normal optimizations during the compilation stage)
-lto = true
+#lto = true
 
 # by overriding our dependencies' compilation settings, we can further optimize for size
 # https://docs.rust-embedded.org/book/unsorted/speed-vs-size.html#optimizing-dependencies
-[profile.release.package."*"]
-codegen-units = 1
-opt-level = "z"
+#[profile.release.package."*"]
+#codegen-units = 1
+#opt-level = "z"
 
 [workspace.lints.rust]
 nonstandard-style = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,20 +114,10 @@ strip = "symbols"
 # but "z" is meant to give the idea that it produces smaller binaries than "s".
 # https://docs.rust-embedded.org/book/unsorted/speed-vs-size.html#optimize-for-size
 opt-level = "z"
-# by compiling as a single codegen unit (i.e. not in parallel),
-# it's possible to reduce size even further at the expense of
-# compilation time
-#codegen-units = 1
 # by enabling link-time optimization, we can reduce size even further
 # by telling cargo to optimize at the link stage (in addition to the
 # normal optimizations during the compilation stage)
 lto = "thin"
-
-# by overriding our dependencies' compilation settings, we can further optimize for size
-# https://docs.rust-embedded.org/book/unsorted/speed-vs-size.html#optimizing-dependencies
-#[profile.release.package."*"]
-#codegen-units = 1
-#opt-level = "z"
 
 [workspace.lints.rust]
 nonstandard-style = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,11 +109,6 @@ debug = true
 
 [profile.release]
 strip = "symbols"
-# rustc supports two "optimize for size" levels:  opt-level = "s" and "z".
-# These names were inherited from clang / LLVM and are not too descriptive
-# but "z" is meant to give the idea that it produces smaller binaries than "s".
-# https://docs.rust-embedded.org/book/unsorted/speed-vs-size.html#optimize-for-size
-opt-level = "z"
 # by enabling link-time optimization, we can reduce size even further
 # by telling cargo to optimize at the link stage (in addition to the
 # normal optimizations during the compilation stage)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ strip = "symbols"
 # These names were inherited from clang / LLVM and are not too descriptive
 # but "z" is meant to give the idea that it produces smaller binaries than "s".
 # https://docs.rust-embedded.org/book/unsorted/speed-vs-size.html#optimize-for-size
-#opt-level = "z"
+opt-level = "z"
 # by compiling as a single codegen unit (i.e. not in parallel),
 # it's possible to reduce size even further at the expense of
 # compilation time
@@ -121,7 +121,7 @@ strip = "symbols"
 # by enabling link-time optimization, we can reduce size even further
 # by telling cargo to optimize at the link stage (in addition to the
 # normal optimizations during the compilation stage)
-#lto = true
+lto = "thin"
 
 # by overriding our dependencies' compilation settings, we can further optimize for size
 # https://docs.rust-embedded.org/book/unsorted/speed-vs-size.html#optimizing-dependencies


### PR DESCRIPTION
I've been running a lot of CLI release builds on my machine recently and it is incredibly slow to compile - about 4 minutes, even if I've only changed a couple of the CLI crates and all the dependencies are already built.  CI is also pretty slow - 30ish minutes for a full run, much of which is spent compiling for the various platforms.

This PR speeds both those things.  CI runs are down to ~18 minutes, release builds on my machine now take less than 2 minutes.

This does increase the size of the built CLI a bit - up from 38MB to 60-70MB. I kinda think that's fine, but comment if you don't?