### PR TITLE
composition: restore broken assumption about interned strings

### DIFF
--- a/engine/crates/composition/src/compose/entity_interface.rs
+++ b/engine/crates/composition/src/compose/entity_interface.rs
@@ -61,7 +61,7 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
         }
     }
 
-    let description = interface_def.description();
+    let description = interface_def.description().map(|d| d.as_str());
     let interface_name = ctx.insert_string(interface_name.id);
     let interface_id = ctx.insert_interface(interface_name, description, composed_directives);
 

--- a/engine/crates/composition/src/compose/enums.rs
+++ b/engine/crates/composition/src/compose/enums.rs
@@ -60,7 +60,7 @@ fn merge_intersection<'a>(
     composed_directives: Vec<federated::Directive>,
     ctx: &mut Context<'a>,
 ) {
-    let description = definitions.iter().find_map(|def| def.description());
+    let description = definitions.iter().find_map(|def| def.description()).map(|d| d.as_str());
     let mut intersection: Vec<StringId> = first.enum_values().map(|value| value.name().id).collect();
     let mut scratch = HashSet::new();
 
@@ -77,7 +77,7 @@ fn merge_intersection<'a>(
         ));
     }
 
-    let enum_id = ctx.insert_enum(first.name(), description, composed_directives);
+    let enum_id = ctx.insert_enum(first.name().as_str(), description, composed_directives);
 
     for value in intersection {
         let sites = definitions
@@ -85,7 +85,7 @@ fn merge_intersection<'a>(
             .filter_map(|enm| enm.enum_value_by_name(value))
             .map(|value| value.directives());
         let composed_directives = collect_composed_directives(sites, ctx);
-        ctx.insert_enum_value(enum_id, first.walk(value), None, composed_directives);
+        ctx.insert_enum_value(enum_id, first.walk(value).as_str(), None, composed_directives);
     }
 }
 
@@ -95,8 +95,8 @@ fn merge_union<'a>(
     composed_directives: Vec<federated::Directive>,
     ctx: &mut Context<'a>,
 ) {
-    let description = definitions.iter().find_map(|def| def.description());
-    let enum_id = ctx.insert_enum(first.name(), description, composed_directives);
+    let description = definitions.iter().find_map(|def| def.description()).map(|d| d.as_str());
+    let enum_id = ctx.insert_enum(first.name().as_str(), description, composed_directives);
     let mut all_values: Vec<(StringId, _)> = definitions
         .iter()
         .flat_map(|def| def.enum_values().map(|value| (value.name().id, value.directives().id)))
@@ -114,7 +114,7 @@ fn merge_union<'a>(
             .map(|(_, directives)| first.walk(*directives));
         let composed_directives = collect_composed_directives(sites, ctx);
 
-        ctx.insert_enum_value(enum_id, first.walk(name), None, composed_directives);
+        ctx.insert_enum_value(enum_id, first.walk(name).as_str(), None, composed_directives);
 
         start = end;
     }
@@ -138,8 +138,8 @@ fn merge_exactly_matching<'a>(
         }
     }
 
-    let description = definitions.iter().find_map(|def| def.description());
-    let enum_id = ctx.insert_enum(first.name(), description, composed_directives);
+    let description = definitions.iter().find_map(|def| def.description()).map(|d| d.as_str());
+    let enum_id = ctx.insert_enum(first.name().as_str(), description, composed_directives);
 
     for value in expected {
         let sites = definitions
@@ -147,7 +147,7 @@ fn merge_exactly_matching<'a>(
             .filter_map(|enm| enm.enum_value_by_name(value))
             .map(|value| value.directives());
         let composed_directives = collect_composed_directives(sites, ctx);
-        ctx.insert_enum_value(enum_id, first.walk(value), None, composed_directives);
+        ctx.insert_enum_value(enum_id, first.walk(value).as_str(), None, composed_directives);
     }
 }
 

--- a/engine/crates/composition/src/compose/input_object.rs
+++ b/engine/crates/composition/src/compose/input_object.rs
@@ -5,7 +5,7 @@ pub(super) fn merge_input_object_definitions(
     first: &DefinitionWalker<'_>,
     definitions: &[DefinitionWalker<'_>],
 ) {
-    let description = definitions.iter().find_map(|def| def.description());
+    let description = definitions.iter().find_map(|def| def.description()).map(|d| d.as_str());
 
     let composed_directives = collect_composed_directives(definitions.iter().map(|def| def.directives()), ctx);
 

--- a/engine/crates/composition/src/compose/interface.rs
+++ b/engine/crates/composition/src/compose/interface.rs
@@ -6,7 +6,7 @@ pub(super) fn merge_interface_definitions<'a>(
     definitions: &[DefinitionWalker<'a>],
 ) {
     let composed_directives = collect_composed_directives(definitions.iter().map(|def| def.directives()), ctx);
-    let interface_description = definitions.iter().find_map(|def| def.description());
+    let interface_description = definitions.iter().find_map(|def| def.description()).map(|d| d.as_str());
     let interface_name = ctx.insert_string(first.name().id);
     let interface_id = ctx.insert_interface(interface_name, interface_description, composed_directives);
 

--- a/engine/crates/composition/src/compose/scalar.rs
+++ b/engine/crates/composition/src/compose/scalar.rs
@@ -7,7 +7,7 @@ pub(crate) fn merge_scalar_definitions<'a>(
 ) {
     let directive_containers = definitions.iter().map(|def| def.directives());
     let directives = collect_composed_directives(directive_containers, ctx);
-    let description = definitions.iter().find_map(|def| def.description());
+    let description = definitions.iter().find_map(|def| def.description()).map(|d| d.as_str());
 
-    ctx.insert_scalar(first.name(), description, directives);
+    ctx.insert_scalar(first.name().as_str(), description, directives);
 }

--- a/engine/crates/composition/src/emit_federated_graph.rs
+++ b/engine/crates/composition/src/emit_federated_graph.rs
@@ -20,7 +20,7 @@ pub(crate) fn emit_federated_graph(mut ir: CompositionIr, subgraphs: &Subgraphs)
         unions: mem::take(&mut ir.unions),
         scalars: mem::take(&mut ir.scalars),
         input_objects: mem::take(&mut ir.input_objects),
-        strings: mem::take(&mut ir.strings.strings),
+        strings: Vec::new(),
         subgraphs: vec![],
         root_operation_types: RootOperationTypes {
             query: ir.query_type.unwrap(),
@@ -41,6 +41,8 @@ pub(crate) fn emit_federated_graph(mut ir: CompositionIr, subgraphs: &Subgraphs)
     emit_union_members(&ir.union_members, &mut ctx);
     emit_keys(&ir.resolvable_keys, &mut ctx);
     push_object_fields_from_interface_entities(&ir.object_fields_from_entity_interfaces, &mut ctx);
+
+    drop(ctx);
 
     federated::FederatedGraph::V1(out)
 }


### PR DESCRIPTION
A while ago, we introduced a separate string interning map for static strings that may not show up in the subgraphs but are part of the federated graph and as such, need to be in `FederatedGraph.strings`.

The problem is that the same string can end up in both the map for strings from the subgraphs, and, if the static version was inserted before, in the second map for static strings.

The important consequence of this is that you could end up with two `StringId`s that are not equal representing the same string, which defeats the point of one big reason for interning in the first place: cheap and reliable comparisons.

This commit fixes that by not trying to be smart about converting `subgraphs::StringId`s into `federated::StringId`s and rehashing the string themselves instead.
