### PR TITLE
cli: release 0.52.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "engine-config-builder"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "engine-v2-config",
  "graphql-federated-graph",
@@ -2271,7 +2271,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "federated-dev"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "async-graphql 6.0.11",
  "async-graphql-axum 6.0.11",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "async-graphql 6.0.11",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "assert_matches",
  "async-graphql 5.0.10",
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-graphql-introspection"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "apollo-encoder",
  "apollo-parser",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "async-compression",
  "async-tar",
@@ -2822,7 +2822,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "chrono",
  "common-types",
@@ -2839,7 +2839,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -4396,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "operation-normalizer"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -7395,7 +7395,7 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typed-resolvers"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "datatest-stable",
  "engine-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde_with = { git = "https://github.com/grafbase/serde_with", rev = "00b1e328bf
 ulid = { git = "https://github.com/grafbase/ulid-rs", rev = "6d06156193d51a2db3216f058cbfadd4923df2c7" }
 
 [workspace.package]
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://grafbase.com"

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.52.0] - 2023-12-20
+
+[CHANGELOG](changelog/0.52.0.md)
+
 ## [0.51.0] - 2023-12-18
 
 [CHANGELOG](changelog/0.51.0.md)

--- a/cli/changelog/0.52.0.md
+++ b/cli/changelog/0.52.0.md
@@ -1,0 +1,9 @@
+### Features
+
+- Caching support for federated graphs (#1144)
+
+### Fixes
+
+- 0.51.0 contained a regression where the TypeScript types for resolvers were not generated even when opting in to the codegen experimental feature. (#1156)
+- Handle the "branch does not exist" error in the `grafbase publish` command (#1141)
+- Fixed extending types for resolvers in many scenarios (#1143)

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -41,8 +41,8 @@ url = "2"
 urlencoding = "2"
 walkdir = "2"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.51.0" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.51.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.52.0" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.52.0" }
 
 [build-dependencies]
 cynic-codegen = { version = "3", features = ["rkyv"] }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -41,9 +41,9 @@ webbrowser = "0.8"
 lru = "0.12"
 futures-util = "0.3"
 
-server = { package = "grafbase-local-server", path = "../server", version = "0.51.0" }
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.51.0" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.51.0" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.52.0" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.52.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.52.0" }
 graphql-introspection = { package = "grafbase-graphql-introspection", path = "../graphql-introspection" }
 federated-dev = { path = "../federated-dev" }
 atty = "0.2.14"

--- a/cli/crates/federated-dev/Cargo.toml
+++ b/cli/crates/federated-dev/Cargo.toml
@@ -30,7 +30,7 @@ tokio-stream = "0.1"
 tower-http = { workspace = true, features = ["cors", "fs", "trace"] }
 url = "2.5.0"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.51.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.52.0" }
 engine = { path = "../../../engine/crates/engine" }
 engine-config-builder = { path = "../../../engine/crates/engine-config-builder" }
 engine-v2 = { path = "../../../engine/crates/engine-v2" }

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -57,7 +57,7 @@ cfg-if = "1"
 walkdir = "2"
 sha2 = "0.10"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.51.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.52.0" }
 gateway = { path = "../gateway" }
 typed-resolvers = { path = "../typed-resolvers" }
 federated-dev = { path = "../federated-dev" }

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.51.0",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.51.0",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.51.0",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.51.0",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.51.0"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.52.0",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.52.0",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.52.0",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.52.0",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.52.0"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
Features

- Caching support for federated graphs (#1144)

Fixes

- 0.51.0 contained a regression where the TypeScript types for resolvers were not generated even when opting in to the codegen experimental feature. (#1156)
- Handle the "branch does not exist" error in the `grafbase publish` command (#1141)
- Fixed extending types for resolvers in many scenarios (#1143)
