### PR TITLE
fix: print interface description _before_ `interface`

### DIFF
--- a/engine/crates/federated-graph/src/render_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl.rs
@@ -95,11 +95,12 @@ pub fn render_sdl(graph: &FederatedGraph) -> Result<String, fmt::Error> {
 
     for (idx, interface) in graph.interfaces.iter().enumerate() {
         let interface_name = &graph[interface.name];
-        write!(sdl, "interface {interface_name}")?;
 
         if let Some(description) = interface.description {
             write!(sdl, "{}", Description(&graph[description], ""))?;
         }
+
+        write!(sdl, "interface {interface_name}")?;
 
         if !interface.implements_interfaces.is_empty() {
             sdl.push_str(" implements ");


### PR DESCRIPTION
As doing: `interface Blah """` is not valid syntax.

~Seems like this SDL rendering code has made its way into the critical path for every deployment - we should probably have more tests of it, though I'm not doing that tonight.~ Actually it's probably what powers all the composition tests isn't it, never mind - just couldn't find them.