### PR TITLE
fix(create): GB-5652: Stop sending database regions to the project creation mutations

### DIFF
--- a/cli/crates/backend/src/api/create.rs
+++ b/cli/crates/backend/src/api/create.rs
@@ -79,7 +79,6 @@ pub async fn create(account_id: &str, project_slug: &str) -> Result<Vec<String>,
     let operation = ProjectCreate::build(ProjectCreateArguments {
         input: ProjectCreateInput {
             account_id: Id::new(account_id),
-            database_regions: &[],
             project_slug,
             project_root_path: project
                 .schema_path

--- a/cli/crates/backend/src/api/graphql/types/mutations.rs
+++ b/cli/crates/backend/src/api/graphql/types/mutations.rs
@@ -4,7 +4,6 @@ use super::schema;
 pub struct ProjectCreateInput<'a> {
     pub account_id: cynic::Id,
     pub project_slug: &'a str,
-    pub database_regions: &'a [String],
     pub project_root_path: &'a str,
 }
 


### PR DESCRIPTION
# Description

In preparation for the final phase out of the database feature.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
