### PR TITLE
cli: release 0.52.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "engine-config-builder"
-version = "0.52.0"
+version = "0.52.1"
 dependencies = [
  "engine-v2-config",
  "graphql-federated-graph",
@@ -1950,7 +1950,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "federated-dev"
-version = "0.52.0"
+version = "0.52.1"
 dependencies = [
  "async-graphql 6.0.11",
  "async-graphql-axum 6.0.11",
@@ -2237,7 +2237,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "0.52.0"
+version = "0.52.1"
 dependencies = [
  "async-graphql 6.0.11",
  "async-trait",
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.52.0"
+version = "0.52.1"
 dependencies = [
  "assert_matches",
  "async-graphql 5.0.10",
@@ -2420,7 +2420,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-graphql-introspection"
-version = "0.52.0"
+version = "0.52.1"
 dependencies = [
  "apollo-encoder",
  "apollo-parser",
@@ -2433,7 +2433,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.52.0"
+version = "0.52.1"
 dependencies = [
  "async-compression",
  "axum",
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.52.0"
+version = "0.52.1"
 dependencies = [
  "chrono",
  "common-types",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.52.0"
+version = "0.52.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3976,7 +3976,7 @@ dependencies = [
 
 [[package]]
 name = "operation-normalizer"
-version = "0.52.0"
+version = "0.52.1"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -6682,7 +6682,7 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typed-resolvers"
-version = "0.52.0"
+version = "0.52.1"
 dependencies = [
  "datatest-stable",
  "engine-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde_with = { git = "https://github.com/grafbase/serde_with", rev = "00b1e328bf
 ulid = { git = "https://github.com/grafbase/ulid-rs", rev = "6d06156193d51a2db3216f058cbfadd4923df2c7" }
 
 [workspace.package]
-version = "0.52.0"
+version = "0.52.1"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://grafbase.com"

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.52.1] - 2023-12-21
+
+[CHANGELOG](changelog/0.52.1.md)
+
 ## [0.52.0] - 2023-12-20
 
 [CHANGELOG](changelog/0.52.0.md)

--- a/cli/changelog/0.52.1.md
+++ b/cli/changelog/0.52.1.md
@@ -1,0 +1,4 @@
+### Fixes
+
+- Make MongoDB connector produce valid schemas when introspected (#1162)
+- Fix a bug in the rendering of GraphQL schemas where the interface description would be printed after its name (#1166)

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -37,8 +37,8 @@ url = "2"
 urlencoding = "2"
 walkdir = "2"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.52.0" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.52.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.52.1" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.52.1" }
 
 [build-dependencies]
 cynic-codegen = { version = "3", features = ["rkyv"] }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -41,9 +41,9 @@ webbrowser = "0.8"
 lru = "0.12"
 futures-util = "0.3"
 
-server = { package = "grafbase-local-server", path = "../server", version = "0.52.0" }
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.52.0" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.52.0" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.52.1" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.52.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.52.1" }
 graphql-introspection = { package = "grafbase-graphql-introspection", path = "../graphql-introspection" }
 federated-dev = { path = "../federated-dev" }
 atty = "0.2.14"

--- a/cli/crates/federated-dev/Cargo.toml
+++ b/cli/crates/federated-dev/Cargo.toml
@@ -30,7 +30,7 @@ tokio-stream = "0.1"
 tower-http = { workspace = true, features = ["cors", "fs", "trace"] }
 url = "2.5.0"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.52.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.52.1" }
 engine = { path = "../../../engine/crates/engine" }
 engine-config-builder = { path = "../../../engine/crates/engine-config-builder" }
 engine-v2 = { path = "../../../engine/crates/engine-v2" }

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -52,7 +52,7 @@ cfg-if = "1"
 walkdir = "2"
 sha2 = "0.10"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.52.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.52.1" }
 gateway = { path = "../gateway" }
 typed-resolvers = { path = "../typed-resolvers" }
 federated-dev = { path = "../federated-dev" }

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.52.0",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.52.0",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.52.0",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.52.0",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.52.0"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.52.1",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.52.1",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.52.1",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.52.1",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.52.1"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
Fixes

- Make MongoDB connector produce valid schemas when introspected (#1162)
- Fix a bug in the rendering of GraphQL schemas where the interface description would be printed after its name (#1166)
