### PR TITLE
chore(deps): GB-5699: Upgrade axum, hyper, http and friends in the CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -244,46 +244,12 @@ dependencies = [
 
 [[package]]
 name = "async-graphql"
-version = "5.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35ef8f9be23ee30fe1eb1cf175c689bc33517c6c6d0fd0669dade611e5ced7f"
-dependencies = [
- "async-graphql-derive 5.0.10",
- "async-graphql-parser 5.0.10",
- "async-graphql-value 5.0.10",
- "async-stream",
- "async-trait",
- "base64 0.13.1",
- "bytes",
- "fast_chemail",
- "fnv",
- "futures-util",
- "handlebars",
- "http",
- "indexmap 1.9.3",
- "mime",
- "multer",
- "num-traits",
- "once_cell",
- "pin-project-lite",
- "regex",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "static_assertions",
- "tempfile",
- "thiserror",
-]
-
-[[package]]
-name = "async-graphql"
 version = "6.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298a5d587d6e6fdb271bf56af2dc325a80eb291fd0fc979146584b9a05494a8c"
+source = "git+https://github.com/async-graphql/async-graphql?rev=44ae98335413a11e1acbc6c48135f452996e8a0b#44ae98335413a11e1acbc6c48135f452996e8a0b"
 dependencies = [
- "async-graphql-derive 6.0.11",
- "async-graphql-parser 6.0.11",
- "async-graphql-value 6.0.11",
+ "async-graphql-derive",
+ "async-graphql-parser",
+ "async-graphql-value",
  "async-stream",
  "async-trait",
  "base64 0.13.1",
@@ -292,10 +258,10 @@ dependencies = [
  "fnv",
  "futures-util",
  "handlebars",
- "http",
+ "http 1.0.0",
  "indexmap 2.1.0",
  "mime",
- "multer",
+ "multer 3.0.0",
  "num-traits",
  "once_cell",
  "pin-project-lite",
@@ -311,28 +277,10 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-axum"
-version = "5.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777d02b4b35c1eb15bb63391f45b4622206fe1199940fa8b4b6136904fae035c"
-dependencies = [
- "async-graphql 5.0.10",
- "async-trait",
- "axum",
- "bytes",
- "futures-util",
- "http-body",
- "serde_json",
- "tokio-util",
- "tower-service",
-]
-
-[[package]]
-name = "async-graphql-axum"
 version = "6.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a1c20a2059bffbc95130715b23435a05168c518fba9709c81fa2a38eed990c"
+source = "git+https://github.com/async-graphql/async-graphql?rev=44ae98335413a11e1acbc6c48135f452996e8a0b#44ae98335413a11e1acbc6c48135f452996e8a0b"
 dependencies = [
- "async-graphql 6.0.11",
+ "async-graphql",
  "async-trait",
  "axum",
  "bytes",
@@ -346,56 +294,26 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-derive"
-version = "5.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0f6ceed3640b4825424da70a5107e79d48d9b2bc6318dfc666b2fc4777f8c4"
-dependencies = [
- "Inflector",
- "async-graphql-parser 5.0.10",
- "darling 0.14.4",
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "thiserror",
-]
-
-[[package]]
-name = "async-graphql-derive"
 version = "6.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f329c7eb9b646a72f70c9c4b516c70867d356ec46cb00dcac8ad343fd006b0"
+source = "git+https://github.com/async-graphql/async-graphql?rev=44ae98335413a11e1acbc6c48135f452996e8a0b#44ae98335413a11e1acbc6c48135f452996e8a0b"
 dependencies = [
  "Inflector",
- "async-graphql-parser 6.0.11",
+ "async-graphql-parser",
  "darling 0.20.3",
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "strum",
- "syn 2.0.41",
+ "syn 2.0.43",
  "thiserror",
 ]
 
 [[package]]
 name = "async-graphql-parser"
-version = "5.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc308cd3bc611ee86c9cf19182d2b5ee583da40761970e41207f088be3db18f"
-dependencies = [
- "async-graphql-value 5.0.10",
- "pest",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "async-graphql-parser"
 version = "6.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6139181845757fd6a73fbb8839f3d036d7150b798db0e9bb3c6e83cdd65bd53b"
+source = "git+https://github.com/async-graphql/async-graphql?rev=44ae98335413a11e1acbc6c48135f452996e8a0b#44ae98335413a11e1acbc6c48135f452996e8a0b"
 dependencies = [
- "async-graphql-value 6.0.11",
+ "async-graphql-value",
  "pest",
  "serde",
  "serde_json",
@@ -403,21 +321,8 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-value"
-version = "5.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d461325bfb04058070712296601dfe5e5bd6cdff84780a0a8c569ffb15c87eb3"
-dependencies = [
- "bytes",
- "indexmap 1.9.3",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "async-graphql-value"
 version = "6.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323a5143f5bdd2030f45e3f2e0c821c9b1d36e79cf382129c64299c50a7f3750"
+source = "git+https://github.com/async-graphql/async-graphql?rev=44ae98335413a11e1acbc6c48135f452996e8a0b#44ae98335413a11e1acbc6c48135f452996e8a0b"
 dependencies = [
  "bytes",
  "indexmap 2.1.0",
@@ -448,7 +353,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -493,7 +398,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -504,7 +409,7 @@ checksum = "fdf6721fb0140e4f897002dd086c06f6c27775df19cfe1fccb21181a48fd2c98"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -526,20 +431,20 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.20"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+checksum = "202651474fe73c62d9e0a56c6133f7a0ff1dc1c8cf7a5b03381af2a26553ac9d"
 dependencies = [
  "async-trait",
  "axum-core",
  "base64 0.21.5",
- "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "headers",
- "http",
- "http-body",
- "hyper",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.1.0",
+ "hyper-util",
  "itoa",
  "matchit 0.7.3",
  "memchr",
@@ -562,17 +467,20 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+checksum = "77cb22c689c44d4c07b0ab44ebc25d69d8ae601a2f28fb8d672d344178fa17aa"
 dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
  "mime",
+ "pin-project-lite",
  "rustversion",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
@@ -699,7 +607,7 @@ dependencies = [
  "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
  "syn_derive",
 ]
 
@@ -958,7 +866,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -1132,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c3242926edf34aec4ac3a77108ad4854bffaa2e4ddc1824124ce59231302d5"
+checksum = "82a9b73a36529d9c47029b9fb3a6f0ea3cc916a261195352ba19e770fc1748b2"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1153,21 +1061,20 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.16"
+version = "0.9.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2fe95351b870527a5d09bf563ed3c97c0cffb87cf1c78a591bf48bb218d9aa"
+checksum = "0e3681d554572a651dda4186cd47240627c3d0114d45a95f6ad27f2f22e7548d"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.17"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d96137f14f244c37f989d9fff8f95e6c18b918e71f36638f8c49112e4c78f"
+checksum = "c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c"
 dependencies = [
  "cfg-if",
 ]
@@ -1209,12 +1116,12 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.1"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
+checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
 dependencies = [
  "nix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1247,7 +1154,7 @@ dependencies = [
  "quote",
  "rkyv",
  "strsim",
- "syn 2.0.41",
+ "syn 2.0.43",
  "thiserror",
 ]
 
@@ -1272,7 +1179,7 @@ dependencies = [
  "cynic-codegen",
  "darling 0.20.3",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -1320,7 +1227,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -1342,7 +1249,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -1368,7 +1275,7 @@ checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 name = "dataloader"
 version = "0.1.0"
 dependencies = [
- "async-graphql 6.0.11",
+ "async-graphql",
  "async-trait",
  "fnv",
  "futures-channel",
@@ -1566,9 +1473,9 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "duct"
-version = "0.13.6"
+version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ae3fc31835f74c2a7ceda3aeede378b0ae2e74c8f1c36559fcc9ae2a4e7d3e"
+checksum = "e4ab5718d1224b63252cd0c6f74f6480f9ffeb117438a2e0f5cf6d9a4798929c"
 dependencies = [
  "libc",
  "once_cell",
@@ -1704,7 +1611,7 @@ dependencies = [
  "grafbase-sql-ast",
  "graph-entities",
  "hex",
- "http",
+ "http 0.2.11",
  "im",
  "indexmap 2.1.0",
  "indoc",
@@ -1714,7 +1621,7 @@ dependencies = [
  "itertools 0.12.0",
  "log 0.1.0",
  "mime",
- "multer",
+ "multer 2.1.0",
  "nom",
  "num-traits",
  "once_cell",
@@ -1764,7 +1671,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
  "thiserror",
 ]
 
@@ -1952,9 +1859,9 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 name = "federated-dev"
 version = "0.52.1"
 dependencies = [
- "async-graphql 6.0.11",
- "async-graphql-axum 6.0.11",
- "async-graphql-parser 6.0.11",
+ "async-graphql",
+ "async-graphql-axum",
+ "async-graphql-parser",
  "axum",
  "engine",
  "engine-config-builder",
@@ -2065,7 +1972,7 @@ checksum = "3a0b11eeb173ce52f84ebd943d42e58813a2ebb78a6a3ff0a243b71c5199cd7b"
 dependencies = [
  "proc-macro2",
  "swc_macros_common",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -2110,9 +2017,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2125,9 +2032,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2148,15 +2055,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2165,9 +2072,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-lite"
@@ -2186,26 +2093,26 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-timer"
@@ -2219,9 +2126,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2239,7 +2146,7 @@ dependencies = [
 name = "gateway"
 version = "0.52.1"
 dependencies = [
- "async-graphql 6.0.11",
+ "async-graphql",
  "async-trait",
  "axum",
  "bytes",
@@ -2249,7 +2156,7 @@ dependencies = [
  "futures-util",
  "gateway-core",
  "graphql-extensions",
- "http",
+ "http 1.0.0",
  "postgres-connector-types",
  "runtime",
  "runtime-local",
@@ -2266,7 +2173,7 @@ dependencies = [
 name = "gateway-core"
 version = "3.0.31"
 dependencies = [
- "async-graphql 6.0.11",
+ "async-graphql",
  "async-runtime",
  "async-sse",
  "async-trait",
@@ -2276,7 +2183,7 @@ dependencies = [
  "engine-value",
  "futures-util",
  "headers",
- "http",
+ "http 1.0.0",
  "jwt-verifier",
  "log 0.1.0",
  "mediatype",
@@ -2353,8 +2260,8 @@ name = "grafbase"
 version = "0.52.1"
 dependencies = [
  "assert_matches",
- "async-graphql 5.0.10",
- "async-graphql-axum 5.0.10",
+ "async-graphql",
+ "async-graphql-axum",
  "async-trait",
  "atty",
  "axum",
@@ -2496,7 +2403,7 @@ dependencies = [
  "gateway",
  "grafbase-local-common",
  "handlebars",
- "hyper",
+ "hyper 0.14.28",
  "itertools 0.12.0",
  "log 0.4.20",
  "notify",
@@ -2558,8 +2465,8 @@ dependencies = [
 name = "graphql-composition"
 version = "0.2.0"
 dependencies = [
- "async-graphql-parser 6.0.11",
- "async-graphql-value 6.0.11",
+ "async-graphql-parser",
+ "async-graphql-value",
  "datatest-stable",
  "graphql-federated-graph",
  "indexmap 2.1.0",
@@ -2585,8 +2492,8 @@ dependencies = [
 name = "graphql-federated-graph"
 version = "0.2.0"
 dependencies = [
- "async-graphql-parser 6.0.11",
- "async-graphql-value 6.0.11",
+ "async-graphql-parser",
+ "async-graphql-value",
  "expect-test",
  "indexmap 2.1.0",
  "indoc",
@@ -2616,8 +2523,8 @@ dependencies = [
 name = "graphql-schema-validation"
 version = "0.1.2"
 dependencies = [
- "async-graphql-parser 6.0.11",
- "async-graphql-value 6.0.11",
+ "async-graphql-parser",
+ "async-graphql-value",
  "bitflags 2.4.1",
  "datatest-stable",
  "miette",
@@ -2635,7 +2542,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.11",
+ "indexmap 2.1.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d308f63daf4181410c242d34c11f928dcb3aa105852019e043c9d1f4e4368a"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.0.0",
  "indexmap 2.1.0",
  "slab",
  "tokio",
@@ -2693,14 +2619,14 @@ dependencies = [
 
 [[package]]
 name = "headers"
-version = "0.3.9"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
 dependencies = [
  "base64 0.21.5",
  "bytes",
  "headers-core",
- "http",
+ "http 1.0.0",
  "httpdate",
  "mime",
  "sha1",
@@ -2708,11 +2634,11 @@ dependencies = [
 
 [[package]]
 name = "headers-core"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http",
+ "http 1.0.0",
 ]
 
 [[package]]
@@ -2785,13 +2711,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.0.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -2804,7 +2764,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "cacache",
- "http",
+ "http 0.2.11",
  "http-cache-semantics",
  "httpdate",
  "serde",
@@ -2819,7 +2779,7 @@ checksum = "ee5a40915f9da8f3feef6f942f9aace74393803c47bce6870f19cd2b5123f27a"
 dependencies = [
  "anyhow",
  "async-trait",
- "http",
+ "http 0.2.11",
  "http-cache",
  "http-cache-semantics",
  "reqwest",
@@ -2835,7 +2795,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7aec9f678bca3f4a15194b980f20ed9bfe0dd38e8d298c65c559a93dfbd6380a"
 dependencies = [
- "http",
+ "http 0.2.11",
  "http-serde",
  "serde",
  "time",
@@ -2843,9 +2803,9 @@ dependencies = [
 
 [[package]]
 name = "http-range-header"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+checksum = "3ce4ef31cda248bbdb6e6820603b82dfcd9e833db65a43e997a0ccec777d11fe"
 
 [[package]]
 name = "http-serde"
@@ -2853,7 +2813,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f560b665ad9f1572cfcaf034f7fb84338a7ce945216d64a90fd81f046a3caee"
 dependencies = [
- "http",
+ "http 0.2.11",
  "serde",
 ]
 
@@ -2867,7 +2827,7 @@ dependencies = [
  "async-channel",
  "base64 0.13.1",
  "futures-lite",
- "http",
+ "http 0.2.11",
  "infer",
  "pin-project-lite",
  "rand 0.7.3",
@@ -2906,9 +2866,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.22",
+ "http 0.2.11",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -2921,14 +2881,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.0",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.28",
  "rustls 0.21.10",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -2941,10 +2920,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.28",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdea9aac0dbe5a9240d68cfd9501e2db94222c6dc06843e06640b9e07f0fdc67"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "hyper 1.1.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3124,9 +3121,9 @@ dependencies = [
 name = "integration-tests"
 version = "0.1.0"
 dependencies = [
- "async-graphql 6.0.11",
- "async-graphql-axum 6.0.11",
- "async-graphql-parser 6.0.11",
+ "async-graphql",
+ "async-graphql-axum",
+ "async-graphql-parser",
  "async-once-cell",
  "async-trait",
  "axum",
@@ -3143,7 +3140,7 @@ dependencies = [
  "grafbase-graphql-introspection",
  "graphql-composition",
  "graphql-parser 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "http",
+ "http 1.0.0",
  "indoc",
  "insta",
  "names",
@@ -3194,7 +3191,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3581,7 +3578,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3636,7 +3633,25 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 0.2.11",
+ "httparse",
+ "log 0.4.20",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
+]
+
+[[package]]
+name = "multer"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15d522be0a9c3e46fd2632e272d178f56387bdb5c9fbb3a36c649062e9b5219"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.0.0",
  "httparse",
  "log 0.4.20",
  "memchr",
@@ -3652,7 +3667,7 @@ source = "git+https://github.com/grafbase/multipart-stream-rs.git?branch=fix-mul
 dependencies = [
  "bytes",
  "futures",
- "http",
+ "http 0.2.11",
  "httparse",
  "pin-project",
 ]
@@ -3883,9 +3898,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
@@ -3923,9 +3938,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.61"
+version = "0.10.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b8419dc8cc6d866deb801274bba2e6f8f6108c1bb7fcc10ee5ab864931dbb45"
+checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -3944,7 +3959,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3955,9 +3970,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.97"
+version = "0.9.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eaad34cdd97d81de97964fc7f29e2d104f483840d906ef56daa1912338460b"
+checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
 dependencies = [
  "cc",
  "libc",
@@ -4017,9 +4032,9 @@ dependencies = [
 
 [[package]]
 name = "ouroboros"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aab3e3891cfef81d47b93c6e0aeaf4828b2dc19c0bde389f4a988fbbfe5a8f4b"
+checksum = "a50b637ffd883b2733a8483599fb6136b9dcedaa1850f7ac08b9b6f9f2061208"
 dependencies = [
  "aliasable",
  "ouroboros_macro",
@@ -4028,16 +4043,16 @@ dependencies = [
 
 [[package]]
 name = "ouroboros_macro"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd5c45035b07108752f091edb8fcc13dcaffcdb8d9f40cc017e3c9afc1a5bd"
+checksum = "3633d65683f13b9bcfaa3150880b018899fb0e5d0542f4adaea4f503fdb5eabf"
 dependencies = [
  "heck",
- "itertools 0.11.0",
- "proc-macro-error",
+ "itertools 0.12.0",
  "proc-macro2",
+ "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -4098,7 +4113,7 @@ dependencies = [
  "cynic",
  "cynic-introspection",
  "engine",
- "http",
+ "http 0.2.11",
  "insta",
  "reqwest",
  "serde_json",
@@ -4128,7 +4143,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
- "serde_yaml 0.9.27",
+ "serde_yaml 0.9.29",
  "strum",
  "thiserror",
  "tracing",
@@ -4237,7 +4252,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -4301,7 +4316,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -4330,7 +4345,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -4368,9 +4383,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
 name = "pmutil"
@@ -4380,7 +4395,7 @@ checksum = "52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -4462,7 +4477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
 dependencies = [
  "diff",
- "yansi",
+ "yansi 0.5.1",
 ]
 
 [[package]]
@@ -4510,11 +4525,24 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.43",
+ "version_check",
+ "yansi 1.0.0-rc.1",
 ]
 
 [[package]]
@@ -4710,7 +4738,7 @@ checksum = "2566c4bf6845f2c2e83b27043c3f5dfcd5ba8f2937d6c00dc009bfb51a079dc4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -4770,9 +4798,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "relative-path"
-version = "1.9.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
+checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
 
 [[package]]
 name = "rend"
@@ -4794,10 +4822,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.22",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-rustls",
  "hyper-tls",
  "ipnet",
@@ -4853,7 +4881,7 @@ checksum = "88a3e86aa6053e59030e7ce2d2a3b258dd08fc2d337d52f73f6cb480f5858690"
 dependencies = [
  "anyhow",
  "async-trait",
- "http",
+ "http 0.2.11",
  "reqwest",
  "serde",
  "task-local-extensions",
@@ -4982,7 +5010,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.41",
+ "syn 2.0.43",
  "unicode-ident",
 ]
 
@@ -4995,7 +5023,7 @@ dependencies = [
  "quote",
  "rand 0.8.5",
  "rustc_version",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -5022,7 +5050,7 @@ dependencies = [
  "common-types",
  "futures-util",
  "headers",
- "http",
+ "http 1.0.0",
  "postgres-connector-types",
  "search-protocol",
  "serde",
@@ -5125,7 +5153,7 @@ dependencies = [
  "futures",
  "hex",
  "hmac",
- "http",
+ "http 0.2.11",
  "log 0.4.20",
  "md-5",
  "percent-encoding",
@@ -5248,9 +5276,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7673e0aa20ee4937c6aacfc12bb8341cfbf054cdd21df6bec5fd0629fe9339b"
+checksum = "9e9d979b3ce68192e42760c7810125eb6cf2ea10efae545a156063e61f314e2a"
 
 [[package]]
 name = "rustls-webpki"
@@ -5306,11 +5334,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5489,7 +5517,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -5574,7 +5602,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -5591,9 +5619,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.27"
+version = "0.9.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
+checksum = "a15e0ef66bf939a7c890a0bf6d5a733c70202225f9888a89ed5c62298b019129"
 dependencies = [
  "indexmap 2.1.0",
  "itoa",
@@ -5870,7 +5898,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -5918,7 +5946,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -6039,7 +6067,7 @@ checksum = "695a1d8b461033d32429b5befbf0ad4d7a2c4d6ba9cd5ba4e0645c615839e8e4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -6050,7 +6078,7 @@ checksum = "50176cfc1cbc8bb22f41c6fe9d1ec53fbe057001219b5954961b8ad0f336fce9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -6074,7 +6102,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -6090,9 +6118,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.41"
+version = "2.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
+checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6108,7 +6136,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -6272,7 +6300,7 @@ checksum = "e7fbe9b594d6568a6a1443250a7e67d80b74e1e96f6d1715e1e21cc1888291d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -6340,9 +6368,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.0"
+version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d45b238a16291a4e1584e61820b8ae57d696cc5015c459c229ccc6990cc1c"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6365,7 +6393,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -6523,16 +6551,16 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+checksum = "09e12e6351354851911bdf8c2b8f2ab15050c567d70a8b9a37ae7b8301a4080d"
 dependencies = [
  "bitflags 2.4.1",
  "bytes",
- "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
  "http-range-header",
  "httpdate",
  "mime",
@@ -6578,7 +6606,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -6635,7 +6663,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.11",
  "httparse",
  "log 0.4.20",
  "rand 0.8.5",
@@ -6940,7 +6968,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
  "wasm-bindgen-shared",
 ]
 
@@ -6974,7 +7002,7 @@ checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7010,9 +7038,9 @@ dependencies = [
 
 [[package]]
 name = "web-time"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57099a701fb3a8043f993e8228dc24229c7b942e2b009a1b962e54489ba1d3bf"
+checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7352,7 +7380,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "http-types",
- "hyper",
+ "hyper 0.14.28",
  "log 0.4.20",
  "once_cell",
  "regex",
@@ -7372,7 +7400,7 @@ dependencies = [
  "chrono-tz",
  "futures-channel",
  "futures-util",
- "http",
+ "http 0.2.11",
  "js-sys",
  "matchit 0.4.6",
  "pin-project",
@@ -7414,7 +7442,7 @@ dependencies = [
  "async-trait",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-macro-support",
@@ -7461,9 +7489,9 @@ checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9828b178da53440fa9c766a3d2f73f7cf5d0ac1fe3980c1e5018d899fd19e07b"
+checksum = "53be06678ed9e83edb1745eb72efc0bbcd7b5c3c35711a860906aed827a13d61"
 
 [[package]]
 name = "yaml-rust"
@@ -7481,23 +7509,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
-name = "zerocopy"
-version = "0.7.31"
+name = "yansi"
+version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
+checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -7517,5 +7551,10 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.43",
 ]
+
+[[patch.unused]]
+name = "multipart-stream"
+version = "0.1.2"
+source = "git+https://github.com/grafbase/multipart-stream-rs.git?rev=96eaebfcd0f8101bc834ddc405f69f28dbf1e559#96eaebfcd0f8101bc834ddc405f69f28dbf1e559"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2403,7 +2403,8 @@ dependencies = [
  "gateway",
  "grafbase-local-common",
  "handlebars",
- "hyper 0.14.28",
+ "hyper 1.1.0",
+ "hyper-util",
  "itertools 0.12.0",
  "log 0.4.20",
  "notify",
@@ -2897,6 +2898,7 @@ dependencies = [
  "itoa",
  "pin-project-lite",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -2929,8 +2931,7 @@ dependencies = [
 [[package]]
 name = "hyper-util"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdea9aac0dbe5a9240d68cfd9501e2db94222c6dc06843e06640b9e07f0fdc67"
+source = "git+https://github.com/grafbase/hyper-util?rev=3ad8fd132812dc1e33b5a4830b96dff01b8020a3#3ad8fd132812dc1e33b5a4830b96dff01b8020a3"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2941,6 +2942,8 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
+ "tower",
+ "tower-service",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3663,11 +3663,11 @@ dependencies = [
 [[package]]
 name = "multipart-stream"
 version = "0.1.2"
-source = "git+https://github.com/grafbase/multipart-stream-rs.git?branch=fix-multipart-mixed#96eaebfcd0f8101bc834ddc405f69f28dbf1e559"
+source = "git+https://github.com/grafbase/multipart-stream-rs-fork?rev=06ff198e4041c8a8c1c93e580c260d597727c193#06ff198e4041c8a8c1c93e580c260d597727c193"
 dependencies = [
  "bytes",
  "futures",
- "http 0.2.11",
+ "http 1.0.0",
  "httparse",
  "pin-project",
 ]
@@ -7553,8 +7553,3 @@ dependencies = [
  "quote",
  "syn 2.0.43",
 ]
-
-[[patch.unused]]
-name = "multipart-stream"
-version = "0.1.2"
-source = "git+https://github.com/grafbase/multipart-stream-rs.git?rev=96eaebfcd0f8101bc834ddc405f69f28dbf1e559#96eaebfcd0f8101bc834ddc405f69f28dbf1e559"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2182,7 +2182,7 @@ dependencies = [
  "engine",
  "engine-value",
  "futures-util",
- "headers",
+ "headers 0.4.0",
  "http 1.0.0",
  "jwt-verifier",
  "log 0.1.0",
@@ -2285,7 +2285,7 @@ dependencies = [
  "grafbase-local-backend",
  "grafbase-local-common",
  "grafbase-local-server",
- "headers",
+ "headers 0.3.9",
  "indicatif",
  "indoc",
  "inquire",
@@ -2620,17 +2620,41 @@ dependencies = [
 
 [[package]]
 name = "headers"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+dependencies = [
+ "base64 0.21.5",
+ "bytes",
+ "headers-core 0.2.0",
+ "http 0.2.11",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
 dependencies = [
  "base64 0.21.5",
  "bytes",
- "headers-core",
+ "headers-core 0.3.0",
  "http 1.0.0",
  "httpdate",
  "mime",
  "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http 0.2.11",
 ]
 
 [[package]]
@@ -5052,7 +5076,7 @@ dependencies = [
  "bytes",
  "common-types",
  "futures-util",
- "headers",
+ "headers 0.4.0",
  "http 1.0.0",
  "postgres-connector-types",
  "search-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.11",
@@ -431,9 +431,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "202651474fe73c62d9e0a56c6133f7a0ff1dc1c8cf7a5b03381af2a26553ac9d"
+checksum = "d09dbe0e490df5da9d69b36dca48a76635288a82f92eca90024883a56202026d"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -463,13 +463,14 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77cb22c689c44d4c07b0ab44ebc25d69d8ae601a2f28fb8d672d344178fa17aa"
+checksum = "e87c8503f93e6d144ee5690907ba22db7ba79ab001a932ab99034f0fe836b3df"
 dependencies = [
  "async-trait",
  "bytes",
@@ -483,6 +484,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -748,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e23185c0e21df6ed832a12e2bda87c7d1def6842881fb634a8511ced741b0d76"
+checksum = "91d7b79e99bfaa0d47da0687c43aa3b7381938a62ad3a6498599039321f660b7"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -814,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.11"
+version = "4.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
+checksum = "dcfab8ba68f3668e89f6ff60f5b205cea56aa7b769451a59f34b8682f51c056d"
 dependencies = [
  "clap_builder",
  "clap_derive 4.4.7",
@@ -824,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.11"
+version = "4.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
+checksum = "fb7fb5e4e979aec3be7791562fcba452f94ad85e954da024396433e0e25a79e9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -837,11 +839,11 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.4.4"
+version = "4.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffe91f06a11b4b9420f62103854e90867812cd5d01557f853c5ee8e791b12ae"
+checksum = "a51919c5608a32e34ea1d6be321ad070065e17613e168c5b6977024290f2630b"
 dependencies = [
- "clap 4.4.11",
+ "clap 4.4.12",
 ]
 
 [[package]]
@@ -1330,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
  "serde",
@@ -2268,7 +2270,7 @@ dependencies = [
  "backtrace",
  "cfg-if",
  "chrono",
- "clap 4.4.11",
+ "clap 4.4.12",
  "clap_complete",
  "colored",
  "ctrlc",
@@ -2605,7 +2607,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.6",
+ "ahash 0.8.7",
 ]
 
 [[package]]
@@ -2614,7 +2616,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.6",
+ "ahash 0.8.7",
  "allocator-api2",
 ]
 
@@ -2973,16 +2975,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.58"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.51.1",
+ "windows-core",
 ]
 
 [[package]]
@@ -3195,7 +3197,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e976188335292f66a1533fd41d5c2ce24b32dc2c000569b8dccf4e57f489806"
 dependencies = [
- "ahash 0.8.6",
+ "ahash 0.8.7",
  "dashmap",
  "hashbrown 0.12.3",
  "once_cell",
@@ -3223,13 +3225,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
  "hermit-abi 0.3.3",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3430,7 +3432,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d8de370f98a6cb8a4606618e53e802f93b094ddec0f96988eaec2c27e6e9ce7"
 dependencies = [
- "clap 4.4.11",
+ "clap 4.4.12",
  "termcolor",
  "threadpool",
 ]
@@ -3554,9 +3556,9 @@ checksum = "bf0bc9784973713e4a90d515a4302991ca125a7c4516951cb607f2298cb757e5"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memmap2"
@@ -4034,12 +4036,12 @@ dependencies = [
 
 [[package]]
 name = "os_pipe"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae859aa07428ca9a929b936690f8b12dc5f11dd8c6992a18ca93919f28bc177"
+checksum = "57119c3b893986491ec9aa85056780d3a0f3cf4da7cc09dd3650dbd6c6738fb9"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5763,9 +5765,9 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "similar"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aeaf503862c419d66959f5d7ca015337d864e9c49485d771b732e2a20453597"
+checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
 dependencies = [
  "bstr",
  "unicode-segmentation",
@@ -6066,9 +6068,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.141.33"
+version = "0.141.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d643ce57be7c4808cd7a924201aa256188aa2ef9604248cf180c4c3e867b3fd6"
+checksum = "2a67621d078321fb09e73ebe3084da09c352a5dfc1075c6ee833dea2c0209529"
 dependencies = [
  "either",
  "new_debug_unreachable",
@@ -6247,15 +6249,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.1"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
  "redox_syscall",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6507,9 +6509,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
 dependencies = [
  "futures-util",
  "log 0.4.20",
@@ -6683,14 +6685,14 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
 dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 0.2.11",
+ "http 1.0.0",
  "httparse",
  "log 0.4.20",
  "rand 0.8.5",
@@ -7155,17 +7157,8 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
- "windows-core 0.52.0",
+ "windows-core",
  "windows-targets 0.52.0",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.51.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -7377,9 +7370,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.30"
+version = "0.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
+checksum = "97a4882e6b134d6c28953a387571f1acdd3496830d5e36c5e3a1075580ea641c"
 dependencies = [
  "memchr",
 ]
@@ -7499,9 +7492,9 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7dae5072fe1f8db8f8d29059189ac175196e410e40ba42d5d4684ae2f750995"
+checksum = "914566e6413e7fa959cc394fb30e563ba80f3541fbd40816d4c05a0fc3f2a0f1"
 dependencies = [
  "libc",
  "linux-raw-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ async-graphql-parser = { git = "https://github.com/async-graphql/async-graphql",
 async-graphql-value = { git = "https://github.com/async-graphql/async-graphql", rev = "44ae98335413a11e1acbc6c48135f452996e8a0b" }
 # Use our fork of dynomite that uses the 0.48 version of rusoto.
 dynomite = { git = "https://github.com/grafbase/dynomite", branch = "rusoto-0_48" }
+hyper-util = { git = "https://github.com/grafbase/hyper-util", rev = "3ad8fd132812dc1e33b5a4830b96dff01b8020a3" } # error-is-connect
 multipart-stream = { git = "https://github.com/grafbase/multipart-stream-rs-fork", rev = "06ff198e4041c8a8c1c93e580c260d597727c193" } # http-1.0-fix-multipart-mixed
 rusoto_core = { git = "https://github.com/grafbase/rusoto", branch = "wasm-rustls-0_48-reqwest" }
 rusoto_dynamodb = { git = "https://github.com/grafbase/rusoto", branch = "wasm-rustls-0_48-reqwest" }
@@ -52,6 +53,8 @@ futures = "0.3"
 futures-util = "0.3"
 headers = "0.4"
 http = "1"
+hyper = "1"
+hyper-util = "0.1"
 indexmap = "2"
 itertools = "0.12"
 num-traits = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ async-graphql-parser = { git = "https://github.com/async-graphql/async-graphql",
 async-graphql-value = { git = "https://github.com/async-graphql/async-graphql", rev = "44ae98335413a11e1acbc6c48135f452996e8a0b" }
 # Use our fork of dynomite that uses the 0.48 version of rusoto.
 dynomite = { git = "https://github.com/grafbase/dynomite", branch = "rusoto-0_48" }
-multipart-stream = { git = "https://github.com/grafbase/multipart-stream-rs.git", rev = "96eaebfcd0f8101bc834ddc405f69f28dbf1e559" } # fix-multipart-mixed
+multipart-stream = { git = "https://github.com/grafbase/multipart-stream-rs-fork", rev = "06ff198e4041c8a8c1c93e580c260d597727c193" } # http-1.0-fix-multipart-mixed
 rusoto_core = { git = "https://github.com/grafbase/rusoto", branch = "wasm-rustls-0_48-reqwest" }
 rusoto_dynamodb = { git = "https://github.com/grafbase/rusoto", branch = "wasm-rustls-0_48-reqwest" }
 serde_with = { git = "https://github.com/grafbase/serde_with", rev = "7c8c63e03daf81b23dcbb39b43c3c1dbb5a25b01" } # minify-field-names-strum-0.25

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,14 @@ members = [
 
 [patch.crates-io]
 again = { git = "https://github.com/grafbase/again", branch = "cloudflare-workers-compatibility" }
+# Drop these patches when https://github.com/async-graphql/async-graphql/commit/3cacd544b922683a2a87040bbbfb6f854e1a2017 is released.
+async-graphql = { git = "https://github.com/async-graphql/async-graphql", rev = "44ae98335413a11e1acbc6c48135f452996e8a0b" }
+async-graphql-axum = { git = "https://github.com/async-graphql/async-graphql", rev = "44ae98335413a11e1acbc6c48135f452996e8a0b" }
+async-graphql-parser = { git = "https://github.com/async-graphql/async-graphql", rev = "44ae98335413a11e1acbc6c48135f452996e8a0b" }
+async-graphql-value = { git = "https://github.com/async-graphql/async-graphql", rev = "44ae98335413a11e1acbc6c48135f452996e8a0b" }
 # Use our fork of dynomite that uses the 0.48 version of rusoto.
 dynomite = { git = "https://github.com/grafbase/dynomite", branch = "rusoto-0_48" }
+multipart-stream = { git = "https://github.com/grafbase/multipart-stream-rs.git", rev = "96eaebfcd0f8101bc834ddc405f69f28dbf1e559" } # fix-multipart-mixed
 rusoto_core = { git = "https://github.com/grafbase/rusoto", branch = "wasm-rustls-0_48-reqwest" }
 rusoto_dynamodb = { git = "https://github.com/grafbase/rusoto", branch = "wasm-rustls-0_48-reqwest" }
 serde_with = { git = "https://github.com/grafbase/serde_with", rev = "7c8c63e03daf81b23dcbb39b43c3c1dbb5a25b01" } # minify-field-names-strum-0.25
@@ -31,8 +37,12 @@ repository = "https://github.com/grafbase/grafbase"
 
 [workspace.dependencies]
 again = "0.1"
+async-graphql = "6"
+async-graphql-axum = "6"
+async-graphql-parser = "6"
+async-graphql-value = "6"
 async-trait = "0.1"
-axum = "0.6"
+axum = "0.7"
 base64 = "0.21"
 bitflags = "2"
 bytes = "1"
@@ -40,8 +50,8 @@ chrono = { version = "0.4", default-features = false }
 flexbuffers = "2"
 futures = "0.3"
 futures-util = "0.3"
-headers = "0.3"
-http = "0.2"
+headers = "0.4"
+http = "1"
 indexmap = "2"
 itertools = "0.12"
 num-traits = "0.2"
@@ -54,7 +64,7 @@ strum = "0.25"
 tar = "0.4"
 thiserror = "1"
 tokio = "1"
-tower-http = "0.4"
+tower-http = "0.5"
 url = "2"
 uuid = "1"
 ulid = "1"

--- a/cli/crates/backend/src/api/client.rs
+++ b/cli/crates/backend/src/api/client.rs
@@ -2,8 +2,8 @@ use super::consts::GRAFBASE_ACCESS_TOKEN_ENV_VAR;
 use super::types::Credentials;
 use super::{consts::CREDENTIALS_FILE, errors::ApiError};
 use crate::consts::USER_AGENT;
-use axum::http::{HeaderMap, HeaderValue};
 use common::environment::Environment;
+use reqwest::header::HeaderValue;
 use reqwest::{header, Client};
 use std::env;
 use tokio::fs::read_to_string;
@@ -14,7 +14,7 @@ use tokio::fs::read_to_string;
 #[allow(clippy::module_name_repetitions)]
 pub async fn create_client() -> Result<reqwest::Client, ApiError> {
     let token = get_access_token().await?;
-    let mut headers = HeaderMap::new();
+    let mut headers = header::HeaderMap::new();
     let mut bearer_token =
         HeaderValue::from_str(&format!("Bearer {token}")).map_err(|_| ApiError::CorruptAccessToken)?;
     bearer_token.set_sensitive(true);

--- a/cli/crates/backend/src/api/login.rs
+++ b/cli/crates/backend/src/api/login.rs
@@ -93,7 +93,7 @@ pub async fn login(message_sender: MspcSender<LoginMessage>) -> Result<(), ApiEr
         .send(LoginMessage::CallbackUrl(url.clone()))
         .expect("must be open");
 
-    let (shutdown_sender, mut shutdown_receiver) = tokio::sync::mpsc::channel::<Result<(), LoginApiError>>(2);
+    let (shutdown_sender, _shutdown_receiver) = tokio::sync::mpsc::channel::<Result<(), LoginApiError>>(2);
 
     let router = Router::new()
         .route("/", get(token))

--- a/cli/crates/backend/src/api/login.rs
+++ b/cli/crates/backend/src/api/login.rs
@@ -87,8 +87,6 @@ pub async fn login(message_sender: MspcSender<LoginMessage>) -> Result<(), ApiEr
 
     let port = listener.local_addr().map_err(|_| ApiError::FindAvailablePort)?.port();
 
-    let std_listener = listener.into_std().map_err(|_| ApiError::FindAvailablePort)?;
-
     let url = &format!("{AUTH_URL}?callback={}", encode(&format!("http://127.0.0.1:{port}")));
 
     message_sender
@@ -105,19 +103,16 @@ pub async fn login(message_sender: MspcSender<LoginMessage>) -> Result<(), ApiEr
             user_dot_grafbase_path: environment.user_dot_grafbase_path.clone(),
         });
 
-    let server = axum::Server::from_tcp(std_listener)
-        .map_err(|_| ApiError::StartLoginServer)?
-        .serve(router.into_make_service())
-        .with_graceful_shutdown(async {
-            let shutdown_result = shutdown_receiver.recv().await.expect("must be open");
+    let server = axum::serve(listener, router);
+    // FIXME: Uncomment when https://github.com/tokio-rs/axum/pull/2398 is merged.
+    /*.with_graceful_shutdown(async {
+        let shutdown_result = shutdown_receiver.recv().await.expect("must be open");
 
-            match shutdown_result {
-                Ok(()) => message_sender.send(LoginMessage::Done).expect("must be open"),
-                Err(error) => message_sender.send(LoginMessage::Error(error)).expect("must be open"),
-            }
-        });
+        match shutdown_result {
+            Ok(()) => message_sender.send(LoginMessage::Done).expect("must be open"),
+            Err(error) => message_sender.send(LoginMessage::Error(error)).expect("must be open"),
+        }
+    });*/
 
-    server.await.map_err(|_| ApiError::StartLoginServer)?;
-
-    Ok(())
+    server.await.map_err(|_| ApiError::StartLoginServer)
 }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -68,7 +68,7 @@ jwt-compact = { version = "0.8.0", default-features = false, features = [
   "clock",
   "rsa",
 ] }
-multipart-stream = { git = "https://github.com/grafbase/multipart-stream-rs.git", branch = "fix-multipart-mixed" }
+multipart-stream = "0.1"
 rand = "0.8"
 reqwest = { version = "0.11", features = [
   "rustls-tls",

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -49,8 +49,8 @@ federated-dev = { path = "../federated-dev" }
 atty = "0.2.14"
 
 [dev-dependencies]
-async-graphql.workspace = true
 async-graphql-axum.workspace = true
+async-graphql.workspace = true
 async-trait = "0.1"
 axum.workspace = true
 cfg-if = "1"
@@ -62,6 +62,7 @@ dirs = "5"
 duct = "0.13"
 fslock = "0.2"
 futures-util = "0.3"
+headers = "0.3"
 insta = { version = "1.34", features = ["json", "redactions", "yaml"] }
 json_dotpath = "1"
 jwt-compact = { version = "0.8.0", default-features = false, features = [
@@ -70,27 +71,26 @@ jwt-compact = { version = "0.8.0", default-features = false, features = [
 ] }
 multipart-stream = "0.1"
 rand = "0.8"
+regex = "1"
 reqwest = { version = "0.11", features = [
   "rustls-tls",
   "json",
   "blocking",
 ], default-features = false }
-rsa = "0.9"
-serde = { version = "1", features = ["derive"] }
-sysinfo = "0.29"
-tempfile = "3"
-tokio = { version = "1", features = ["full"] }
-url = "2"
-regex = "1"
 reqwest-eventsource = "0.5"
+rsa = "0.9"
 rstest = "0.18"
 rstest_reuse = "0.6"
 rusoto_core = "0.48"
 rusoto_dynamodb = "0.48"
+serde = { version = "1", features = ["derive"] }
 strum = { version = "0.25", features = ["derive"] }
+sysinfo = "0.29"
+tempfile = "3"
+tokio = { version = "1", features = ["full"] }
+url = "2"
 which = "4"
 wiremock = "0.5"
-headers.workspace = true
 
 [[bin]]
 name = "grafbase"

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -49,8 +49,8 @@ federated-dev = { path = "../federated-dev" }
 atty = "0.2.14"
 
 [dev-dependencies]
-async-graphql = "5"
-async-graphql-axum = "5"
+async-graphql.workspace = true
+async-graphql-axum.workspace = true
 async-trait = "0.1"
 axum.workspace = true
 cfg-if = "1"

--- a/cli/crates/federated-dev/Cargo.toml
+++ b/cli/crates/federated-dev/Cargo.toml
@@ -10,10 +10,10 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-graphql = { version = "6.0.11", features = ["url"] }
-async-graphql-axum = "6.0.11"
-async-graphql-parser = "6.0.11"
-axum = { workspace = true, features = ["headers"] }
+async-graphql = { workspace = true, features = ["url"] }
+async-graphql-axum.workspace = true
+async-graphql-parser.workspace = true
+axum = { workspace = true }
 futures-concurrency = "7"
 futures-util = "0.3"
 graphql-composition.workspace = true

--- a/cli/crates/federated-dev/src/dev.rs
+++ b/cli/crates/federated-dev/src/dev.rs
@@ -5,7 +5,7 @@ use axum::{
     http::{HeaderMap, StatusCode},
     response::{Html, IntoResponse},
     routing::get,
-    Json, Server,
+    Json,
 };
 use common::environment::Environment;
 use handlebars::Handlebars;
@@ -85,10 +85,10 @@ pub(super) async fn run(port: u16, expose: bool, config: ConfigReceiver) -> Resu
     } else {
         format!("127.0.0.1:{port}")
     };
-    let address = host.parse().expect("we just defined it above, it _must work_");
+    let address: std::net::SocketAddr = host.parse().expect("we just defined it above, it _must work_");
 
-    Server::bind(&address)
-        .serve(app.into_make_service())
+    let listener = tokio::net::TcpListener::bind(&address).await.unwrap();
+    axum::serve(listener, app)
         .await
         .map_err(|error| crate::Error::internal(error.to_string()))?;
 

--- a/cli/crates/gateway/Cargo.toml
+++ b/cli/crates/gateway/Cargo.toml
@@ -9,12 +9,12 @@ keywords.workspace = true
 repository.workspace = true
 
 [dependencies]
-async-graphql = "6"
+async-graphql.workspace = true
 async-trait = "0.1"
 axum = { workspace = true }
 futures-util = { workspace = true }
 thiserror = "1"
-http = "0.2"
+http.workspace = true
 tokio = { workspace = true }
 rusoto_core = "0.48"
 bytes = "1"

--- a/cli/crates/gateway/src/response.rs
+++ b/cli/crates/gateway/src/response.rs
@@ -61,11 +61,7 @@ impl gateway_core::Response for Response {
 
     fn error(code: StatusCode, message: &str) -> Self {
         println!("ERROR {code} {message}");
-        axum::response::Response::builder()
-            .status(code)
-            .body(message.to_string())
-            .expect("must be valid")
-            .into()
+        (code, message.to_string()).into_response().into()
     }
 
     fn engine(response: Arc<engine::Response>) -> Result<Self, Self::Error> {

--- a/cli/crates/gateway/src/response.rs
+++ b/cli/crates/gateway/src/response.rs
@@ -75,13 +75,7 @@ impl gateway_core::Response for Response {
     }
 
     fn with_additional_headers(mut self, headers: http::HeaderMap) -> Self {
-        use std::str::FromStr;
-        self.headers_mut().extend(headers.into_iter().map(|(name, value)| {
-            (
-                name.map(|name| axum::http::HeaderName::from_str(name.as_str()).expect("must be a valid name")),
-                axum::http::HeaderValue::from_bytes(value.as_bytes()).expect("must be a valid value"),
-            )
-        }));
+        self.headers_mut().extend(headers);
         self
     }
 }

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -21,7 +21,8 @@ flate2 = "1.0"
 fslock = "0.2"
 futures-util = { workspace = true }
 handlebars = "4"
-hyper = { version = "0.14", features = ["tcp"] }
+hyper.workspace = true
+hyper-util = { workspace = true, features = ["client", "client-legacy", "http1"] }
 itertools = "0.12"
 log = "0.4"
 notify = { version = "6", default-features = false, features = [

--- a/cli/crates/server/src/bridge/server.rs
+++ b/cli/crates/server/src/bridge/server.rs
@@ -78,10 +78,7 @@ pub async fn start(
 ) -> Result<(), ServerError> {
     let (router, ..) = build_router(message_sender, registry, tracing).await?;
 
-    let server = axum::Server::from_tcp(tcp_listener)?.serve(router.into_make_service());
-
+    let server = axum::serve(tokio::net::TcpListener::from_std(tcp_listener).unwrap(), router);
     start_signal.send(()).ok();
-    server.await?;
-
-    Ok(())
+    server.await.map_err(ServerError::StartBridgeApi)
 }

--- a/cli/crates/server/src/error_server/server.rs
+++ b/cli/crates/server/src/error_server/server.rs
@@ -29,10 +29,10 @@ pub async fn start(port: u16, error: String) -> Result<(), ServerError> {
         .with_state(error)
         .layer(TraceLayer::new_for_http());
 
-    let server =
-        axum::Server::bind(&std::net::SocketAddr::from((Ipv4Addr::LOCALHOST, port))).serve(router.into_make_service());
-
-    server.await?;
-
-    Ok(())
+    let tcp_listener = tokio::net::TcpListener::bind(&std::net::SocketAddr::from((Ipv4Addr::LOCALHOST, port)))
+        .await
+        .map_err(ServerError::StartErrorServer)?;
+    axum::serve(tcp_listener, router)
+        .await
+        .map_err(ServerError::StartErrorServer)
 }

--- a/cli/crates/server/src/errors.rs
+++ b/cli/crates/server/src/errors.rs
@@ -3,7 +3,6 @@ use axum::response::IntoResponse;
 use axum::response::Response;
 use axum::Json;
 use common::types::UdfKind;
-use hyper::Error as HyperError;
 use notify::Error as NotifyError;
 use serde_json::json;
 use std::io::Error as IoError;
@@ -49,8 +48,16 @@ pub enum ServerError {
     ReadVersion,
 
     /// returned if the sqlite bridge cannot be started
-    #[error("the bridge api encountered an error: {0}")]
-    BridgeApi(#[from] HyperError),
+    #[error("the bridge api could not be started: {0}")]
+    StartBridgeApi(std::io::Error),
+
+    /// returned if the error server cannot be started
+    #[error("the error server could not be started: {0}")]
+    StartErrorServer(std::io::Error),
+
+    /// returned if the gateway server cannot be started
+    #[error("the gateway server could not be started: {0}")]
+    StartGatewayServer(std::io::Error),
 
     /// returned if the miniflare command returns an error
     #[error("miniflare encountered an error: {0}")]
@@ -162,7 +169,7 @@ pub enum ServerError {
 
     /// returned if the proxy server could not be started
     #[error("could not start the proxy server\nCaused by:{0}")]
-    StartProxyServer(hyper::Error),
+    StartProxyServer(std::io::Error),
 
     #[error("Could not create a lock for the wrangler installation: {0}")]
     Lock(fslock::Error),

--- a/cli/crates/server/src/proxy.rs
+++ b/cli/crates/server/src/proxy.rs
@@ -126,7 +126,7 @@ async fn graphql_inner(
     mut req: Request<Body>,
     path: &str,
 ) -> Result<impl IntoResponse, impl IntoResponse> {
-    const BODY_LIMIT: usize = 1 * 1_024 * 1_024 * 512;
+    const BODY_LIMIT: usize = 1_024 * 1_024 * 512;
 
     let query = req.uri().query().map_or(String::new(), |query| format!("?{query}"));
 

--- a/cli/crates/server/src/proxy.rs
+++ b/cli/crates/server/src/proxy.rs
@@ -128,13 +128,13 @@ async fn graphql_inner(
 ) -> Result<impl IntoResponse, impl IntoResponse> {
     // Request body size limit for Cloudflare Workers enterprise.
     // See https://developers.cloudflare.com/workers/platform/limits/.
-    const BODY_LIMIT: usize = 1_024 * 1_024 * 512;
+    const REQUEST_BODY_SIZE_LIMIT: usize = 1_024 * 1_024 * 512;
 
     let query = req.uri().query().map_or(String::new(), |query| format!("?{query}"));
 
     // http::Request can't be cloned
     let (parts, body) = req.into_parts();
-    let body_bytes = axum::body::to_bytes(body, BODY_LIMIT)
+    let body_bytes = axum::body::to_bytes(body, REQUEST_BODY_SIZE_LIMIT)
         .await
         .map_err(|_| StatusCode::BAD_REQUEST)?;
     let body = String::from_utf8(body_bytes.clone().into()).map_err(|_| StatusCode::BAD_REQUEST)?;

--- a/cli/crates/server/src/proxy.rs
+++ b/cli/crates/server/src/proxy.rs
@@ -9,7 +9,7 @@ use axum::{
 };
 use common::environment::Environment;
 use handlebars::Handlebars;
-use hyper::{client::HttpConnector, Request, StatusCode};
+use hyper::{Request, StatusCode};
 use serde_json::json;
 use tokio::{
     task::{JoinError, JoinSet},
@@ -19,7 +19,7 @@ use tower_http::{cors::CorsLayer, services::ServeDir};
 
 use crate::{atomics::WORKER_PORT, errors::ServerError, servers::PortSelection};
 
-type Client = hyper::client::Client<HttpConnector, Body>;
+type Client = hyper_util::client::legacy::Client<hyper_util::client::legacy::connect::HttpConnector, Body>;
 
 #[derive(Clone)]
 struct ProxyState {
@@ -42,12 +42,16 @@ pub async fn start(port: PortSelection) -> Result<ProxyHandle, ServerError> {
 }
 
 async fn start_inner(listener: TcpListener) -> Result<(), ServerError> {
+    // FIXME: Migrate to the new abstractions.
+    use hyper_util::client::legacy::Client as HyperClient;
+    use hyper_util::rt::TokioExecutor;
+
     let port = listener.local_addr().expect("must have a local addr").port();
     trace!("starting pathfinder at port {port}");
 
-    let client: Client = hyper::Client::builder()
+    let client = HyperClient::builder(TokioExecutor::new())
         .http1_preserve_header_case(true)
-        .build(HttpConnector::new());
+        .build_http();
 
     let mut handlebars = Handlebars::new();
     let template = include_str!("../templates/pathfinder.hbs");
@@ -84,12 +88,14 @@ async fn start_inner(listener: TcpListener) -> Result<(), ServerError> {
             client,
         });
 
-    axum::Server::from_tcp(listener)
-        .map_err(ServerError::StartProxyServer)?
-        .http1_preserve_header_case(true)
-        .serve(router.into_make_service())
-        .await
-        .map_err(ServerError::StartProxyServer)?;
+    axum::serve(
+        tokio::net::TcpListener::from_std(listener).map_err(ServerError::StartProxyServer)?,
+        router,
+    )
+    // FIXME: Bring back!
+    // .preserve_header_case(true)
+    .await
+    .map_err(ServerError::StartProxyServer)?;
 
     Ok(())
 }
@@ -120,11 +126,15 @@ async fn graphql_inner(
     mut req: Request<Body>,
     path: &str,
 ) -> Result<impl IntoResponse, impl IntoResponse> {
+    const BODY_LIMIT: usize = 1 * 1_024 * 1_024 * 512;
+
     let query = req.uri().query().map_or(String::new(), |query| format!("?{query}"));
 
     // http::Request can't be cloned
     let (parts, body) = req.into_parts();
-    let body_bytes = hyper::body::to_bytes(body).await.map_err(|_| StatusCode::BAD_REQUEST)?;
+    let body_bytes = axum::body::to_bytes(body, BODY_LIMIT)
+        .await
+        .map_err(|_| StatusCode::BAD_REQUEST)?;
     let body = String::from_utf8(body_bytes.clone().into()).map_err(|_| StatusCode::BAD_REQUEST)?;
     req = Request::from_parts(parts, body_bytes.into());
 
@@ -162,7 +172,7 @@ async fn graphql_inner(
                 if error.is_connect() {
                     sleep(POLL_INTERVAL).await;
                 } else {
-                    return Err(StatusCode::BAD_REQUEST);
+                    return Err(axum::http::StatusCode::BAD_REQUEST);
                 }
             }
         };

--- a/cli/crates/server/src/proxy.rs
+++ b/cli/crates/server/src/proxy.rs
@@ -126,6 +126,8 @@ async fn graphql_inner(
     mut req: Request<Body>,
     path: &str,
 ) -> Result<impl IntoResponse, impl IntoResponse> {
+    // Request body size limit for Cloudflare Workers enterprise.
+    // See https://developers.cloudflare.com/workers/platform/limits/.
     const BODY_LIMIT: usize = 1_024 * 1_024 * 512;
 
     let query = req.uri().query().map_or(String::new(), |query| format!("?{query}"));

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -20,6 +20,7 @@ use sha2::Digest;
 use std::collections::HashMap;
 use std::env;
 use std::fs;
+use std::future::IntoFuture;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::num::NonZeroUsize;
 use std::path::Path;
@@ -106,9 +107,12 @@ impl ProductionServer {
                 .await
                 .map_err(|error| ServerError::GatewayError(error.to_string()));
         }
-        let bridge_server = axum::Server::bind(&SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0))
-            .serve(self.bridge_app.into_make_service());
-        let bridge_port = bridge_server.local_addr().port();
+
+        let tcp_listener = tokio::net::TcpListener::bind(&SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0))
+            .await
+            .map_err(ServerError::StartBridgeApi)?;
+        let bridge_port = tcp_listener.local_addr().unwrap().port();
+        let bridge_server = axum::serve(tcp_listener, self.bridge_app);
 
         let gateway_app = gateway::Gateway::new(
             self.environment_variables,
@@ -119,8 +123,12 @@ impl ProductionServer {
         .map_err(|error| ServerError::GatewayError(error.to_string()))?
         .into_router();
 
-        let gateway_server =
-            axum::Server::bind(&SocketAddr::new(listen_address, port)).serve(gateway_app.into_make_service());
+        let gateway_server = axum::serve(
+            tokio::net::TcpListener::bind(&SocketAddr::new(listen_address, port))
+                .await
+                .map_err(ServerError::StartGatewayServer)?,
+            gateway_app,
+        );
 
         let _ = self.message_sender.send(ServerMessage::Ready {
             listen_address,
@@ -128,11 +136,11 @@ impl ProductionServer {
             is_federated,
         });
         tokio::select! {
-            result = gateway_server => {
-                result?;
+            result = gateway_server.into_future() => {
+                result.map_err(ServerError::StartGatewayServer)?;
             }
-            result = bridge_server => {
-                result?;
+            result = bridge_server.into_future() => {
+                result.map_err(ServerError::StartBridgeApi)?
             }
         }
         Ok(())
@@ -371,7 +379,10 @@ async fn spawn_servers(
         port
     };
 
-    let gateway_server = axum::Server::bind(&"127.0.0.1:0".parse().unwrap()).serve(
+    let tcp_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let gateway_port = tcp_listener.local_addr().unwrap().port();
+    let gateway_server = axum::serve(
+        tcp_listener,
         gateway::Gateway::new(environment_variables, gateway::Bridge::new(bridge_port), registry)
             .await
             .map_err(|error| ServerError::GatewayError(error.to_string()))?
@@ -379,8 +390,8 @@ async fn spawn_servers(
             .into_make_service(),
     );
 
-    WORKER_PORT.store(gateway_server.local_addr().port(), Ordering::Relaxed);
-    join_set.spawn(async move { Ok(gateway_server.await?) });
+    WORKER_PORT.store(gateway_port, Ordering::Relaxed);
+    join_set.spawn(async move { gateway_server.await.map_err(ServerError::StartGatewayServer) });
 
     message_sender
         .send(ServerMessage::Ready {

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -379,7 +379,9 @@ async fn spawn_servers(
         port
     };
 
-    let tcp_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let tcp_listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .map_err(ServerError::StartGatewayServer)?;
     let gateway_port = tcp_listener.local_addr().unwrap().port();
     let gateway_server = axum::serve(
         tcp_listener,

--- a/engine/crates/dataloader/Cargo.toml
+++ b/engine/crates/dataloader/Cargo.toml
@@ -27,7 +27,7 @@ tokio = { version = "1.35", features = [
   "sync",
   "time",
 ] }
-async-graphql = "6"
+async-graphql.workspace = true
 
 [features]
 tracing = ["dep:tracing"]

--- a/engine/crates/federated-graph/Cargo.toml
+++ b/engine/crates/federated-graph/Cargo.toml
@@ -14,8 +14,8 @@ workspace = true
 serde = { version = "1", features = ["derive"] }
 indoc = "2"
 
-async-graphql-parser = { version = "6", optional = true }
-async-graphql-value = { version = "6", optional = true }
+async-graphql-parser = { workspace = true, optional = true }
+async-graphql-value = { workspace = true, optional = true }
 indexmap = { optional = true, version = "2" }
 
 [dev-dependencies]

--- a/engine/crates/gateway-core/Cargo.toml
+++ b/engine/crates/gateway-core/Cargo.toml
@@ -29,7 +29,7 @@ jwt-verifier = { workspace = true }
 log = { path = "../log" }
 mediatype = "0.19"
 mime = "0.3"
-multipart-stream = { git = "https://github.com/grafbase/multipart-stream-rs.git", branch = "fix-multipart-mixed" }
+multipart-stream = "0.1"
 runtime = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/engine/crates/gateway-core/Cargo.toml
+++ b/engine/crates/gateway-core/Cargo.toml
@@ -14,26 +14,26 @@ keywords = ["graphql", "gateway", "grafbase"]
 workspace = true
 
 [dependencies]
-thiserror = { workspace = true }
+async-graphql.workspace = true
 async-runtime = { workspace = true }
+async-sse = "5"
 async-trait = "0.1"
-async-graphql = "6"
+bytes = { workspace = true }
+common-types = { workspace = true }
 engine = { workspace = true }
 engine-value = { workspace = true }
-mediatype = "0.19"
-jwt-verifier = { workspace = true }
-tracing = { workspace = true }
-runtime = { workspace = true }
-http = "0.2"
 futures-util = { workspace = true }
-common-types = { workspace = true }
-serde_json = { workspace = true }
-log = { path = "../log" }
-bytes = { workspace = true }
-multipart-stream = { git = "https://github.com/grafbase/multipart-stream-rs.git", branch = "fix-multipart-mixed" }
-async-sse = "5"
 headers.workspace = true
+http.workspace = true
+jwt-verifier = { workspace = true }
+log = { path = "../log" }
+mediatype = "0.19"
 mime = "0.3"
+multipart-stream = { git = "https://github.com/grafbase/multipart-stream-rs.git", branch = "fix-multipart-mixed" }
+runtime = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 serde = { workspace = true }

--- a/engine/crates/integration-tests/Cargo.toml
+++ b/engine/crates/integration-tests/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-async-graphql = "6"
-async-graphql-axum = "6"
-async-graphql-parser = "6"
+async-graphql.workspace = true
+async-graphql-axum.workspace = true
+async-graphql-parser.workspace = true
 async-once-cell = "0.5.3"
 async-trait = "0.1"
 axum.workspace = true

--- a/engine/crates/integration-tests/src/mocks/graphql.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql.rs
@@ -45,14 +45,13 @@ impl MockGraphQlServer {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
 
-        let (shutdown_sender, _shutdown_receiver) = tokio::sync::oneshot::channel::<()>();
+        let (shutdown_sender, shutdown_receiver) = tokio::sync::oneshot::channel::<()>();
 
         tokio::spawn(async move {
             axum::serve(listener, app.with_state(()))
-                // FIXME: Uncomment when https://github.com/tokio-rs/axum/pull/2398 is merged.
-                /*.with_graceful_shutdown(async move {
+                .with_graceful_shutdown(async move {
                     shutdown_receiver.await.ok();
-                })*/
+                })
                 .await
                 .unwrap();
         });

--- a/engine/crates/integration-tests/src/mocks/graphql.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql.rs
@@ -45,14 +45,13 @@ impl MockGraphQlServer {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
 
-        // FIXME: `_shutdown_rx` should be used after axum adds support!
-        let (shutdown_tx, _shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        let (shutdown_sender, _shutdown_receiver) = tokio::sync::oneshot::channel::<()>();
 
         tokio::spawn(async move {
             axum::serve(listener, app.with_state(()))
                 // FIXME: Uncomment when https://github.com/tokio-rs/axum/pull/2398 is merged.
                 /*.with_graceful_shutdown(async move {
-                    shutdown_rx.await.ok();
+                    shutdown_receiver.await.ok();
                 })*/
                 .await
                 .unwrap();
@@ -63,7 +62,7 @@ impl MockGraphQlServer {
 
         MockGraphQlServer {
             schema,
-            shutdown: Some(shutdown_tx),
+            shutdown: Some(shutdown_sender),
             port,
         }
     }

--- a/engine/crates/runtime/Cargo.toml
+++ b/engine/crates/runtime/Cargo.toml
@@ -14,15 +14,15 @@ workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
+bytes = { workspace = true }
+futures-util = { workspace = true }
+headers = { workspace = true }
+http = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }
-futures-util = { workspace = true }
 thiserror = { workspace = true }
 ulid = { workspace = true }
-http = { workspace = true }
-headers = { workspace = true }
-bytes = { workspace = true }
 
 search-protocol = { path = "../search-protocol" }
 postgres-connector-types = { path = "../postgres-connector-types" }


### PR DESCRIPTION
# Description

Upgrade axum, hyper, http and other HTTP-related dependencies.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [X] 📦 Dependency
- [ ] 📖 Requires documentation update
