### PR TITLE
chore: bump to version 0.52.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "engine-config-builder"
-version = "0.52.1"
+version = "0.52.2"
 dependencies = [
  "engine-v2-config",
  "graphql-federated-graph",
@@ -1859,7 +1859,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "federated-dev"
-version = "0.52.1"
+version = "0.52.2"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "0.52.1"
+version = "0.52.2"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -2259,7 +2259,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.52.1"
+version = "0.52.2"
 dependencies = [
  "assert_matches",
  "async-graphql",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-graphql-introspection"
-version = "0.52.1"
+version = "0.52.2"
 dependencies = [
  "apollo-encoder",
  "apollo-parser",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.52.1"
+version = "0.52.2"
 dependencies = [
  "async-compression",
  "axum",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.52.1"
+version = "0.52.2"
 dependencies = [
  "chrono",
  "common-types",
@@ -2390,7 +2390,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.52.1"
+version = "0.52.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -4011,7 +4011,7 @@ dependencies = [
 
 [[package]]
 name = "operation-normalizer"
-version = "0.52.1"
+version = "0.52.2"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -6720,7 +6720,7 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typed-resolvers"
-version = "0.52.1"
+version = "0.52.2"
 dependencies = [
  "datatest-stable",
  "engine-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ tar = { git = "https://github.com/grafbase/tar-rs.git", rev = "a889df5bd9fec44fa
 ulid = { git = "https://github.com/grafbase/ulid-rs", rev = "6d06156193d51a2db3216f058cbfadd4923df2c7" } # wasm-compatibility-web-time
 
 [workspace.package]
-version = "0.52.1"
+version = "0.52.2"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://grafbase.com"

--- a/cli/changelog/0.52.2.md
+++ b/cli/changelog/0.52.2.md
@@ -1,0 +1,3 @@
+### Fixes
+
+- Allow searching with postgres bytea type

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -37,8 +37,8 @@ url = "2"
 urlencoding = "2"
 walkdir = "2"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.52.1" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.52.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.52.2" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.52.2" }
 
 [build-dependencies]
 cynic-codegen = { version = "3", features = ["rkyv"] }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -41,9 +41,9 @@ webbrowser = "0.8"
 lru = "0.12"
 futures-util = "0.3"
 
-server = { package = "grafbase-local-server", path = "../server", version = "0.52.1" }
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.52.1" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.52.1" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.52.2" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.52.2" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.52.2" }
 graphql-introspection = { package = "grafbase-graphql-introspection", path = "../graphql-introspection" }
 federated-dev = { path = "../federated-dev" }
 atty = "0.2.14"

--- a/cli/crates/federated-dev/Cargo.toml
+++ b/cli/crates/federated-dev/Cargo.toml
@@ -30,7 +30,7 @@ tokio-stream = "0.1"
 tower-http = { workspace = true, features = ["cors", "fs", "trace"] }
 url = "2.5.0"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.52.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.52.2" }
 engine = { path = "../../../engine/crates/engine" }
 engine-config-builder = { path = "../../../engine/crates/engine-config-builder" }
 engine-v2 = { path = "../../../engine/crates/engine-v2" }

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -53,7 +53,7 @@ cfg-if = "1"
 walkdir = "2"
 sha2 = "0.10"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.52.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.52.2" }
 gateway = { path = "../gateway" }
 typed-resolvers = { path = "../typed-resolvers" }
 federated-dev = { path = "../federated-dev" }

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.52.1",
+  "version": "0.52.2",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.52.1",
+  "version": "0.52.2",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.52.1",
+  "version": "0.52.2",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.52.1",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.52.1",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.52.1",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.52.1",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.52.1"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.52.2",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.52.2",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.52.2",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.52.2",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.52.2"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.52.1",
+  "version": "0.52.2",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.52.1",
+  "version": "0.52.2",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.52.1",
+  "version": "0.52.2",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
# Description

Has this fix: https://github.com/grafbase/api/pull/3071
