### PR TITLE
chore: bump upload-artifact to v4 in GH workflow

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -150,7 +150,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags') }}
         run: |
           docker tag ghcr.io/grafbase/grafbase:$SHA_TAG ghcr.io/grafbase/grafbase:latest
-          docker tag ghcr.io/grafbase/grafbase:$SHA_TAG ghcr.io/grafbase/grafbase:$(echo "$REF" | sed -e "s/^refs\/tags\/cli-//") 
+          docker tag ghcr.io/grafbase/grafbase:$SHA_TAG ghcr.io/grafbase/grafbase:$(echo "$REF" | sed -e "s/^refs\/tags\/cli-//")
         env:
           SHA_TAG: ${{ github.sha }}
           REF: ${{ github.ref }}
@@ -189,7 +189,7 @@ jobs:
           cd cli
           cargo build --release -p grafbase --target x86_64-pc-windows-msvc --timings
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: windows-release-timings.html
           path: target/cargo-timings/cargo-timing.html
@@ -216,7 +216,7 @@ jobs:
 
       - if: startsWith(github.ref, 'refs/tags/')
         name: Upload binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.VERSION_BUMP }}-windows
           path: |
@@ -269,7 +269,7 @@ jobs:
           cd cli
           cargo build --release -p grafbase --target ${{ matrix.archs.target }} --timings
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: linux-release-timings.html
           path: target/cargo-timings/cargo-timing.html
@@ -295,7 +295,7 @@ jobs:
 
       - if: startsWith(github.ref, 'refs/tags/')
         name: Upload binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.VERSION_BUMP }}-${{ matrix.archs.platform }}
           path: |
@@ -336,7 +336,7 @@ jobs:
           cd cli
           cargo build --release -p grafbase --target ${{ matrix.target }} --timings
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}-release-timings.html
           path: target/cargo-timings/cargo-timing.html
@@ -364,7 +364,7 @@ jobs:
 
       - if: startsWith(github.ref, 'refs/tags/')
         name: Upload ${{ matrix.target }} binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.VERSION_BUMP }}-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/grafbase
@@ -408,9 +408,9 @@ jobs:
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ job.status }}
-          notification_title: "({workflow}) CLI release failed"
-          message_format: "Check the link below to see what failed."
-          footer: "<{run_url}|View Run>"
+          notification_title: '({workflow}) CLI release failed'
+          message_format: 'Check the link below to see what failed.'
+          footer: '<{run_url}|View Run>'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 


### PR DESCRIPTION
# Description

Having upload in v3 and download in v4 broke our release pipeline.