### PR TITLE
fix(cli): generate TS for fields w/ grafbase scalar type

### DIFF
--- a/cli/crates/typed-resolvers/src/analyze.rs
+++ b/cli/crates/typed-resolvers/src/analyze.rs
@@ -319,11 +319,26 @@ pub(crate) struct CustomScalar<'doc> {
 
 #[derive(Debug)]
 pub(crate) enum BuiltinScalar {
+    // GraphQL builtin scalars
     Int,
     Float,
     String,
     Boolean,
     Id,
+
+    // Grafbase builtin scalars. They are not defined in user configuration, so we can't treat them
+    // as custom scalars. This will change once we base the resolver codegen on the registry.
+    Email,
+    Date,
+    DateTime,
+    IPAddress,
+    Timestamp,
+    Url,
+    Json,
+    PhoneNumber,
+    Decimal,
+    Bytes,
+    BigInt,
 }
 
 impl FromStr for BuiltinScalar {
@@ -336,6 +351,17 @@ impl FromStr for BuiltinScalar {
             "Float" => Ok(BuiltinScalar::Float),
             "Boolean" => Ok(BuiltinScalar::Boolean),
             "ID" => Ok(BuiltinScalar::Id),
+            "Email" => Ok(BuiltinScalar::Email),
+            "Date" => Ok(BuiltinScalar::Date),
+            "DateTime" => Ok(BuiltinScalar::DateTime),
+            "IPAddress" => Ok(BuiltinScalar::IPAddress),
+            "Timestamp" => Ok(BuiltinScalar::Timestamp),
+            "Url" => Ok(BuiltinScalar::Url),
+            "Json" => Ok(BuiltinScalar::Json),
+            "PhoneNumber" => Ok(BuiltinScalar::PhoneNumber),
+            "Decimal" => Ok(BuiltinScalar::Decimal),
+            "Bytes" => Ok(BuiltinScalar::Bytes),
+            "BigInt" => Ok(BuiltinScalar::BigInt),
             _ => Err(()),
         }
     }

--- a/cli/crates/typed-resolvers/src/codegen.rs
+++ b/cli/crates/typed-resolvers/src/codegen.rs
@@ -84,8 +84,18 @@ where
 fn render_graphql_type(r#type: &GraphqlType, schema: &AnalyzedSchema<'_>) -> String {
     let mut type_string = match &r#type.kind {
         TypeKind::BuiltinScalar(scalar) => match scalar {
-            BuiltinScalar::Int | BuiltinScalar::Float => "number",
-            BuiltinScalar::String | BuiltinScalar::Id => "string",
+            BuiltinScalar::Int | BuiltinScalar::Float | BuiltinScalar::BigInt | BuiltinScalar::Timestamp => "number",
+            BuiltinScalar::String
+            | BuiltinScalar::Id
+            | BuiltinScalar::Url
+            | BuiltinScalar::Email
+            | BuiltinScalar::Date
+            | BuiltinScalar::IPAddress
+            | BuiltinScalar::PhoneNumber
+            | BuiltinScalar::Bytes
+            | BuiltinScalar::Decimal
+            | BuiltinScalar::DateTime => "string",
+            BuiltinScalar::Json => "any",
             BuiltinScalar::Boolean => "boolean",
         }
         .to_owned(),

--- a/cli/crates/typed-resolvers/tests/schema_types/datetime.expected.ts
+++ b/cli/crates/typed-resolvers/tests/schema_types/datetime.expected.ts
@@ -1,0 +1,23 @@
+// This is a generated file. It should not be edited manually.
+//
+// You can decide to commit this file or add it to your `.gitignore`.
+//
+// By convention, this module is imported as `@grafbase/generated`. To make this syntax possible,
+// add a `paths` entry to your `tsconfig.json`.
+//
+//  "compilerOptions": {
+//    "paths": {
+//      "@grafbase/generated": ["./grafbase/generated"]
+//    }
+//  }
+
+export type Schema = {
+  'Task': {
+    __typename?: 'Task';
+    id: number;
+    publicId: string;
+    title: string | null;
+    dueDate: string;
+    completedAt: string | null;
+  };
+};

--- a/cli/crates/typed-resolvers/tests/schema_types/datetime.graphql
+++ b/cli/crates/typed-resolvers/tests/schema_types/datetime.graphql
@@ -1,0 +1,7 @@
+type Task {
+  id: Int!
+  publicId: String!
+  title: String
+  dueDate: DateTime!
+  completedAt: DateTime
+}


### PR DESCRIPTION
The SDL generated from user configuration does not contain custom scalar definitions for builtin types like DateTime and IPAddress, so the code generation logic could not resolve the types of these fields and left them out of the generated code.

The short term fix in this PR is to integrate those in the codegen worker's understanding of builtin scalars.

The long term fix will come with basing TS code generation on the whole registry, which we want to do anyway for a host of other reasons.

closes GB-5694
