### PR TITLE
fix: swap ts-node for tsx.

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -19,7 +19,7 @@ permissions:
 
 env:
   GRAFBASE_SKIP_ASSET_VERSION_CHECK: 'true'
-  ASSETS_VERSION: release/1696e98-2023-12-12
+  ASSETS_VERSION: release/83bd257-2024-01-03
   PROD_ASSETS: assets.grafbase.com
   CARGO_TERM_COLOR: 'always'
   CARGO_PROFILE_DEV_DEBUG: 0

--- a/cli/crates/server/src/consts.rs
+++ b/cli/crates/server/src/consts.rs
@@ -1,13 +1,12 @@
 pub const ASSET_VERSION_FILE: &str = "version.txt";
-pub const CONFIG_PARSER_SCRIPT_CJS: &str = "parse-config.ts";
-pub const CONFIG_PARSER_SCRIPT_ESM: &str = "parse-config.mts";
+pub const CONFIG_PARSER_SCRIPT: &str = "parse-config.ts";
 pub const DOT_ENV_FILE_NAME: &str = ".env";
 pub const GIT_IGNORE_CONTENTS: &str = "*\n";
 pub const GIT_IGNORE_FILE: &str = ".gitignore";
 pub const MIN_NODE_VERSION: &str = "v18.0.0";
 pub const MINIFLARE_CLI_JS_PATH: &str = "node_modules/miniflare/dist/src/cli.js";
 pub const SCHEMA_PARSER_DIR: &str = "parser";
-pub const TS_NODE_SCRIPT_PATH: &str = "node_modules/ts-node/dist/bin.js";
+pub const TSX_SCRIPT_PATH: &str = "node_modules/tsx/dist/cli.mjs";
 pub const WRAPPER_WORKER_JS_PATH: &str = "custom-resolvers/wrapper-worker.js";
 pub const GRAFBASE_WASM_SDK_NAME: &str = "grafbase-wasm-sdk_bg.wasm";
 pub const GRAFBASE_WASM_SDK_PATH: &str = "custom-resolvers/grafbase-wasm-sdk_bg.wasm";


### PR DESCRIPTION
A user found another problem with ts-nodes ability to work with CJS & ESM files, which appears to be [this
issue](https://github.com/TypeStrong/ts-node/issues/1997).  Swaping to tsx instead seems to fix this and removes the need for having two different copies of the parse-config script.

Depends on https://github.com/grafbase/api/pull/3073 being pulled in.

I've tested this with a project with CJS & ESM, on node 18 & 20.