### PR TITLE
 operation-checks: initial crate with breaking up of operations into fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4022,6 +4022,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "operation-checks"
+version = "0.52.2"
+dependencies = [
+ "async-graphql-parser",
+ "expect-test",
+]
+
+[[package]]
 name = "operation-normalizer"
 version = "0.52.2"
 dependencies = [

--- a/engine/crates/operation-checks/Cargo.toml
+++ b/engine/crates/operation-checks/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "operation-checks"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+repository.workspace = true
+
+[dependencies]
+async-graphql-parser.workspace = true
+
+[dev-dependencies]
+expect-test = "1"
+
+[lints]
+workspace = true

--- a/engine/crates/operation-checks/src/aggregate_field_usage.rs
+++ b/engine/crates/operation-checks/src/aggregate_field_usage.rs
@@ -1,0 +1,473 @@
+mod async_graphql;
+
+use std::collections::HashMap;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SelectionId(usize);
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FieldId(usize);
+
+/// Usage count of a field in a query.
+#[derive(Debug)]
+pub struct FieldUsage<'a> {
+    pub increment: u64,
+    /// field id -> usage count
+    pub count_per_field: &'a mut HashMap<FieldId, u64>,
+}
+
+impl FieldUsage<'_> {
+    pub fn with_increment(self, new_increment: u64) -> Self {
+        Self {
+            increment: new_increment,
+            count_per_field: self.count_per_field,
+        }
+    }
+
+    /// Register a field usage.
+    fn register(&mut self, field_id: FieldId) {
+        if let Some(count) = self.count_per_field.get_mut(&field_id) {
+            *count += self.increment;
+        } else {
+            self.count_per_field.insert(field_id, self.increment);
+        }
+    }
+}
+
+/// (type name, field name) -> field type
+#[derive(Debug)]
+pub struct Schema {
+    pub fields: Vec<SchemaField>,
+    pub query_type_name: String,
+    pub mutation_type_name: String,
+    pub subscription_type_name: String,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SchemaField {
+    type_name: String,
+    field_name: String,
+    /// The type fo the field without any wrapping type (! and []).
+    base_type: String,
+}
+
+impl Schema {
+    fn find_field(&self, type_name: &str, field_name: &str) -> Option<FieldId> {
+        self.fields
+            .binary_search_by_key(
+                &(type_name, field_name),
+                |SchemaField {
+                     type_name, field_name, ..
+                 }| { (type_name, field_name) },
+            )
+            .map(FieldId)
+            .ok()
+    }
+}
+
+impl std::ops::Index<FieldId> for Schema {
+    type Output = SchemaField;
+
+    fn index(&self, index: FieldId) -> &Self::Output {
+        &self.fields[index.0]
+    }
+}
+
+#[derive(Debug)]
+pub struct Query {
+    /// fragment name -> fragment
+    pub fragments: HashMap<String, Fragment>,
+
+    pub operation_type: OperationType,
+    pub root_selection: SelectionId,
+
+    /// (parent selection, selection)
+    pub selections: Vec<(SelectionId, Selection)>,
+}
+
+#[derive(Debug)]
+pub struct Fragment {
+    pub type_condition: String,
+    pub selection: SelectionId,
+}
+
+#[derive(Debug)]
+pub enum OperationType {
+    Query,
+    Mutation,
+    Subscription,
+}
+
+#[derive(Debug)]
+pub enum Selection {
+    Field {
+        field_name: String,
+        subselection: Option<SelectionId>,
+    },
+    FragmentSpread {
+        fragment_name: String,
+    },
+    InlineFragment {
+        on: Option<String>,
+        selection: SelectionId,
+    },
+}
+
+/// Given a GraphQL query and the corresponding schema, count the number of times each schema field is used.
+pub fn aggregate_field_usage(query: &Query, schema: &Schema, usage: &mut FieldUsage<'_>) {
+    let ty = match query.operation_type {
+        OperationType::Query => &schema.query_type_name,
+        OperationType::Mutation => &schema.mutation_type_name,
+        OperationType::Subscription => &schema.subscription_type_name,
+    };
+    aggregate_field_usage_inner(query.root_selection, ty, query, schema, usage);
+}
+
+fn aggregate_field_usage_inner(
+    selection_id: SelectionId,
+    parent_type_name: &str,
+    query: &Query,
+    schema: &Schema,
+    usage: &mut FieldUsage<'_>,
+) {
+    let start = query.selections.partition_point(|(id, _)| *id < selection_id);
+    let selection_set = query.selections[start..]
+        .iter()
+        .take_while(|(id, _)| *id == selection_id);
+
+    for (_, selection) in selection_set {
+        match selection {
+            Selection::Field {
+                field_name,
+                subselection,
+            } => {
+                let Some(field_id) = schema.find_field(parent_type_name, field_name) else {
+                    continue;
+                };
+
+                usage.register(field_id);
+
+                if let Some(subselection_id) = subselection {
+                    let field_type = &schema[field_id].base_type;
+                    aggregate_field_usage_inner(*subselection_id, field_type, query, schema, usage);
+                }
+            }
+            Selection::FragmentSpread { fragment_name } => {
+                let Some(Fragment {
+                    type_condition,
+                    selection,
+                }) = query.fragments.get(fragment_name)
+                else {
+                    continue;
+                };
+
+                aggregate_field_usage_inner(*selection, type_condition, query, schema, usage);
+            }
+            Selection::InlineFragment { on, selection } => {
+                let parent_type = on.as_deref().unwrap_or(parent_type_name);
+                aggregate_field_usage_inner(*selection, parent_type, query, schema, usage);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_schema(schema: &str) -> Schema {
+        async_graphql_parser::parse_schema(schema).unwrap().into()
+    }
+
+    fn parse_query(query: &str) -> Query {
+        async_graphql_parser::parse_query(query).unwrap().into()
+    }
+
+    fn run_test(query: &str, schema: &str, expected: expect_test::Expect) {
+        let query = parse_query(query);
+        let schema = parse_schema(schema);
+        let mut counts = HashMap::new();
+        let mut usage = FieldUsage {
+            increment: 1,
+            count_per_field: &mut counts,
+        };
+
+        aggregate_field_usage(&query, &schema, &mut usage);
+
+        let mut counts = counts
+            .into_iter()
+            .map(|(id, count)| format!("{}.{} => {count}", schema[id].type_name, schema[id].field_name))
+            .collect::<Vec<_>>();
+
+        counts.sort();
+
+        expected.assert_debug_eq(&counts);
+    }
+
+    #[test]
+    fn basic() {
+        let query = r#"
+            mutation {
+                createTodo {
+                    id
+                        text
+                        completed
+                        author { name }
+                }
+                deleteUser { email name }
+            }
+        "#;
+        let schema = r#"
+            type Mutation {
+                createTodo: Todo!
+                    deleteUser: User
+            }
+
+        type Todo {
+            id: ID!
+                text: String!
+                completed: Boolean!
+                charactersCount: Int!
+                author: User!
+        }
+
+        type User {
+            name: String
+                email: String
+        }
+        "#;
+        let expected = expect_test::expect![[r#"
+            [
+                "Mutation.createTodo => 1",
+                "Mutation.deleteUser => 1",
+                "Todo.author => 1",
+                "Todo.completed => 1",
+                "Todo.id => 1",
+                "Todo.text => 1",
+                "User.email => 1",
+                "User.name => 2",
+            ]
+        "#]];
+
+        run_test(query, schema, expected);
+    }
+
+    #[test]
+    fn with_fragment() {
+        let query = r#"
+            fragment TodoFields on Todo {
+                id
+                    text
+                    completed
+                    author { name }
+            }
+
+        mutation {
+            createTodo {
+                ...TodoFields
+            }
+            deleteUser { email name }
+        }
+        "#;
+
+        let schema = r#"
+            type Mutation {
+                createTodo: Todo!
+                    deleteUser: User
+            }
+
+        type Todo {
+            id: ID!
+                text: String!
+                completed: Boolean!
+                charactersCount: Int!
+                author: User!
+        }
+
+        type User {
+            name: String
+                email: String
+        }
+        "#;
+
+        let expected = expect_test::expect![[r#"
+            [
+                "Mutation.createTodo => 1",
+                "Mutation.deleteUser => 1",
+                "Todo.author => 1",
+                "Todo.completed => 1",
+                "Todo.id => 1",
+                "Todo.text => 1",
+                "User.email => 1",
+                "User.name => 2",
+            ]
+        "#]];
+
+        run_test(query, schema, expected);
+    }
+
+    #[test]
+    fn with_inline_fragment() {
+        let query = r#"
+            mutation {
+                createTodo {
+                    ... on Error {
+                        message
+                    }
+                    ... on Todo {
+                        id
+                        text
+                        completed
+                        author { name }
+                    }
+                }
+                deleteUser { email name }
+            }
+        "#;
+
+        let schema = r#"
+            type Mutation {
+                createTodo: Todo!
+                    deleteUser: User
+            }
+
+        union CreateTodoResult = Todo | Error
+
+            type Error {
+                message: String!
+            }
+
+            type Todo {
+                id: ID!
+                text: String!
+                completed: Boolean!
+                charactersCount: Int!
+                author: User
+            }
+
+            type User {
+                name: String
+                email: String
+            }
+        "#;
+
+        let expected = expect_test::expect![[r#"
+            [
+                "Error.message => 1",
+                "Mutation.createTodo => 1",
+                "Mutation.deleteUser => 1",
+                "Todo.author => 1",
+                "Todo.completed => 1",
+                "Todo.id => 1",
+                "Todo.text => 1",
+                "User.email => 1",
+                "User.name => 2",
+            ]
+        "#]];
+
+        run_test(query, schema, expected);
+    }
+
+    #[test]
+    fn selection_on_field_that_does_not_exist_in_schema() {
+        let query = r#"
+            mutation {
+                createTodo {
+                    ... on Error {
+                        message
+                        code # does not exist
+                    }
+                    ... on Todo {
+                        id
+                        text
+                        completed
+                        author { name }
+                    }
+                }
+            }
+        "#;
+
+        let schema = r#"
+            type Mutation {
+                createTodo: Todo!
+            }
+
+            union CreateTodoResult = Todo | Error
+
+            type Error {
+                message: String!
+            }
+
+            type Todo {
+                id: ID!
+                text: String!
+                completed: Boolean!
+                charactersCount: Int!
+            }
+        "#;
+
+        let expected = expect_test::expect![[r#"
+            [
+                "Error.message => 1",
+                "Mutation.createTodo => 1",
+                "Todo.completed => 1",
+                "Todo.id => 1",
+                "Todo.text => 1",
+            ]
+        "#]];
+
+        run_test(query, schema, expected);
+    }
+
+    #[test]
+    fn increment_more_than_1() {
+        let query = r#"
+            query Test {
+                ping { pong }
+                bing: ping { bong: pong message }
+            }
+        "#;
+
+        let schema = r#"
+            schema {
+                query: MyQuery
+            }
+
+            type MyQuery {
+                ping: Pong
+            }
+
+            interface Pong {
+                pong: String!
+                message: String!
+            }
+        "#;
+
+        let query = parse_query(query);
+        let schema = parse_schema(schema);
+        let mut counts = HashMap::new();
+        let mut usage = FieldUsage {
+            increment: 9000,
+            count_per_field: &mut counts,
+        };
+
+        aggregate_field_usage(&query, &schema, &mut usage);
+
+        let mut counts = counts
+            .into_iter()
+            .map(|(id, count)| format!("{}.{} => {count}", schema[id].type_name, schema[id].field_name))
+            .collect::<Vec<_>>();
+
+        counts.sort();
+
+        let expected = expect_test::expect![[r#"
+            [
+                "MyQuery.ping => 18000",
+                "Pong.message => 9000",
+                "Pong.pong => 18000",
+            ]
+        "#]];
+
+        expected.assert_debug_eq(&counts);
+    }
+}

--- a/engine/crates/operation-checks/src/aggregate_field_usage/async_graphql.rs
+++ b/engine/crates/operation-checks/src/aggregate_field_usage/async_graphql.rs
@@ -1,0 +1,185 @@
+use async_graphql_parser::types::{ExecutableDocument, ServiceDocument};
+use std::collections::HashMap;
+
+use super::{Fragment, SchemaField, SelectionId};
+
+impl From<ExecutableDocument> for super::Query {
+    fn from(value: ExecutableDocument) -> Self {
+        let mut selection_id_counter = 0usize;
+        let mut fragments = HashMap::with_capacity(value.fragments.len());
+        let mut selections = Vec::new();
+
+        for (name, fragment) in &value.fragments {
+            let selection_id = SelectionId(selection_id_counter);
+            selection_id_counter += 1;
+
+            for item in fragment.node.selection_set.node.items.iter() {
+                let item = ingest_selection(&mut selection_id_counter, &item.node, &mut selections);
+                selections.push((selection_id, item));
+            }
+            let type_condition = fragment.node.type_condition.node.on.node.to_string();
+            fragments.insert(
+                name.to_string(),
+                Fragment {
+                    type_condition,
+                    selection: selection_id,
+                },
+            );
+        }
+
+        let operation = &value.operations.iter().next().unwrap().1;
+
+        let operation_type = match operation.node.ty {
+            async_graphql_parser::types::OperationType::Query => super::OperationType::Query,
+            async_graphql_parser::types::OperationType::Mutation => super::OperationType::Mutation,
+            async_graphql_parser::types::OperationType::Subscription => super::OperationType::Subscription,
+        };
+
+        let root_selection = SelectionId(selection_id_counter);
+        selection_id_counter += 1;
+
+        for item in &operation.node.selection_set.node.items {
+            let item = ingest_selection(&mut selection_id_counter, &item.node, &mut selections);
+            selections.push((root_selection, item));
+        }
+
+        selections.sort_by_key(|(parent_id, _)| *parent_id);
+
+        super::Query {
+            fragments,
+            operation_type,
+            root_selection,
+            selections,
+        }
+    }
+}
+
+fn ingest_selection(
+    counter: &mut usize,
+    selection: &async_graphql_parser::types::Selection,
+    selections: &mut Vec<(SelectionId, super::Selection)>,
+) -> super::Selection {
+    match selection {
+        async_graphql_parser::types::Selection::Field(field) => {
+            let subselection = if field.node.selection_set.node.items.is_empty() {
+                None
+            } else {
+                let subselection_id = SelectionId(*counter);
+                *counter += 1;
+
+                for item in &field.node.selection_set.node.items {
+                    let item = ingest_selection(counter, &item.node, selections);
+                    selections.push((subselection_id, item));
+                }
+
+                Some(subselection_id)
+            };
+
+            super::Selection::Field {
+                field_name: field.node.name.node.to_string(),
+                subselection,
+            }
+        }
+        async_graphql_parser::types::Selection::FragmentSpread(fragment_name) => super::Selection::FragmentSpread {
+            fragment_name: fragment_name.node.fragment_name.node.to_string(),
+        },
+        async_graphql_parser::types::Selection::InlineFragment(inline_fragment) => {
+            let selection_id = SelectionId(*counter);
+            *counter += 1;
+
+            for item in &inline_fragment.node.selection_set.node.items {
+                let item = ingest_selection(counter, &item.node, selections);
+                selections.push((selection_id, item));
+            }
+
+            super::Selection::InlineFragment {
+                on: inline_fragment
+                    .node
+                    .type_condition
+                    .as_ref()
+                    .map(|on| on.node.on.node.to_string()),
+                selection: selection_id,
+            }
+        }
+    }
+}
+
+impl From<ServiceDocument> for super::Schema {
+    fn from(value: ServiceDocument) -> Self {
+        let mut fields: Vec<SchemaField> = Vec::new();
+        let mut query_type_name: Option<String> = None;
+        let mut mutation_type_name = None;
+        let mut subscription_type_name = None;
+
+        for definition in value.definitions {
+            match definition {
+                async_graphql_parser::types::TypeSystemDefinition::Schema(schema_def) => {
+                    if let Some(query) = schema_def.node.query {
+                        query_type_name = Some(query.node.to_string());
+                    }
+
+                    if let Some(mutation) = schema_def.node.mutation {
+                        mutation_type_name = Some(mutation.node.to_string());
+                    }
+
+                    if let Some(subscription) = schema_def.node.subscription {
+                        subscription_type_name = Some(subscription.node.to_string());
+                    }
+                }
+                async_graphql_parser::types::TypeSystemDefinition::Directive(_) => (),
+                async_graphql_parser::types::TypeSystemDefinition::Type(typedef) => {
+                    let type_name = typedef.node.name.node;
+
+                    match typedef.node.kind {
+                        async_graphql_parser::types::TypeKind::Enum(_)
+                        | async_graphql_parser::types::TypeKind::Scalar
+                        | async_graphql_parser::types::TypeKind::Union(_) => (),
+                        async_graphql_parser::types::TypeKind::Object(obj) => {
+                            for field in &obj.fields {
+                                fields.push(SchemaField {
+                                    type_name: type_name.to_string(),
+                                    field_name: field.node.name.node.to_string(),
+                                    base_type: extract_type_name(&field.node.ty.node.base),
+                                });
+                            }
+                        }
+                        async_graphql_parser::types::TypeKind::Interface(iface) => {
+                            for field in &iface.fields {
+                                fields.push(SchemaField {
+                                    type_name: type_name.to_string(),
+                                    field_name: field.node.name.node.to_string(),
+                                    base_type: extract_type_name(&field.node.ty.node.base),
+                                });
+                            }
+                        }
+                        async_graphql_parser::types::TypeKind::InputObject(input_obj) => {
+                            for field in &input_obj.fields {
+                                fields.push(SchemaField {
+                                    type_name: type_name.to_string(),
+                                    field_name: field.node.name.node.to_string(),
+                                    base_type: extract_type_name(&field.node.ty.node.base),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        fields.sort();
+
+        super::Schema {
+            fields,
+            query_type_name: query_type_name.unwrap_or_else(|| "Query".to_owned()),
+            mutation_type_name: mutation_type_name.unwrap_or_else(|| "Mutation".to_owned()),
+            subscription_type_name: subscription_type_name.unwrap_or_else(|| "Subscription".to_owned()),
+        }
+    }
+}
+
+fn extract_type_name(ty: &async_graphql_parser::types::BaseType) -> String {
+    match ty {
+        async_graphql_parser::types::BaseType::Named(name) => name.to_string(),
+        async_graphql_parser::types::BaseType::List(inner) => extract_type_name(&inner.base),
+    }
+}

--- a/engine/crates/operation-checks/src/lib.rs
+++ b/engine/crates/operation-checks/src/lib.rs
@@ -1,0 +1,3 @@
+mod aggregate_field_usage;
+
+pub use aggregate_field_usage::{aggregate_field_usage, FieldUsage, Query, Schema};


### PR DESCRIPTION
This PR adds a crate in engine/crates. The crate is called `operation-checks` and is meant to hold the business logic for operation checks.

At a high level, within a schema check, the operation check step does the following work:

1. Gathers the fields that are actively used by API consumers, with thresholds based on user settings. This can be done in two ways:

   a. Taking already aggregated field data directly from an analytics database.

   b. Taking aggregated operation-level data, and splitting it into field-level data.

2. Diff the old and the new API schema. The diffing part is already implemented in the graphql-schema-diff crate.

3. Determine if any of the breaking changes in the diff would apply to fields actively used by clients (determined in (1.)).

This PR implements bullet point 1.b.

Two tradeoffs lead to this approach:

- No splitting of field-level data for now because it turned out more challenging than expected, and we are already aggregating at the operation level, so the fine grained approach may not turn out to be necessary. The approach in this PR is also significantly less work to get a first version of the feature out.
- Not depending on engine-v2 for the splitting, but on GraphQL ASTs instead: the API is less of a moving target and I did not want to burden engine-v2 with another consumer with its own needs. For example, we want to error if a query selects a field not present in the schema in engine v2, but it is a completely expected situation in operation checks, since we work with queries that were sent to past versions of the API.

Next PR in this crate will implement part 3 as a function taking the diff and the usage counts from this PR as arguments. It will output operation check warnings and errors.

closes GB-5692
