### PR TITLE
chore: Remove Deref on walkers and clarify OperationWalker.with_ext()

### DIFF
--- a/engine/crates/engine-v2/schema/src/conversion.rs
+++ b/engine/crates/engine-v2/schema/src/conversion.rs
@@ -99,16 +99,16 @@ impl From<Config> for Schema {
             let mut root_fields = vec![];
             let walker = schema.walker();
             for field in walker.walk(schema.root_operation_types.query).fields() {
-                root_fields.push(field.wrapped);
+                root_fields.push(field.item);
             }
             if let Some(mutation) = schema.root_operation_types.mutation {
                 for field in walker.walk(mutation).fields() {
-                    root_fields.push(field.wrapped);
+                    root_fields.push(field.item);
                 }
             }
             if let Some(subscription) = schema.root_operation_types.subscription {
                 for field in walker.walk(subscription).fields() {
-                    root_fields.push(field.wrapped);
+                    root_fields.push(field.item);
                 }
             }
             root_fields.sort_unstable();

--- a/engine/crates/engine-v2/schema/src/sources/federation.rs
+++ b/engine/crates/engine-v2/schema/src/sources/federation.rs
@@ -23,7 +23,7 @@ impl<'a> std::ops::Deref for RootFieldResolverWalker<'a> {
     type Target = RootFieldResolver;
 
     fn deref(&self) -> &'a Self::Target {
-        self.wrapped
+        self.item
     }
 }
 
@@ -69,7 +69,7 @@ impl<'a> std::ops::Deref for EntityResolverWalker<'a> {
     type Target = EntityResolver;
 
     fn deref(&self) -> &'a Self::Target {
-        self.wrapped
+        self.item
     }
 }
 
@@ -103,18 +103,18 @@ pub type SubgraphWalker<'a> = SchemaWalker<'a, &'a Subgraph>;
 
 impl<'a> SubgraphWalker<'a> {
     pub fn name(&self) -> &'a str {
-        &self.schema[self.wrapped.name]
+        &self.schema[self.item.name]
     }
 
     pub fn url(&self) -> &'a str {
-        &self.schema[self.wrapped.url]
+        &self.schema[self.item.url]
     }
 
     pub fn headers(&self) -> impl Iterator<Item = SubgraphHeaderWalker<'a>> + '_ {
         self.schema
             .default_headers
             .iter()
-            .chain(self.wrapped.headers.iter())
+            .chain(self.item.headers.iter())
             .map(|id| self.walk(&self.schema[*id]))
     }
 }
@@ -132,11 +132,11 @@ pub type SubgraphHeaderWalker<'a> = SchemaWalker<'a, &'a Header>;
 
 impl<'a> SubgraphHeaderWalker<'a> {
     pub fn name(&self) -> &'a str {
-        &self.schema[self.wrapped.name]
+        &self.schema[self.item.name]
     }
 
     pub fn value(&self) -> SubgraphHeaderValueRef<'a> {
-        match self.wrapped.value {
+        match self.item.value {
             HeaderValue::Forward(id) => SubgraphHeaderValueRef::Forward(&self.schema[id]),
             HeaderValue::Static(id) => SubgraphHeaderValueRef::Static(&self.schema[id]),
         }

--- a/engine/crates/engine-v2/schema/src/walkers/definition.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/definition.rs
@@ -7,11 +7,11 @@ pub type DefinitionWalker<'a> = SchemaWalker<'a, Definition>;
 
 impl<'a> DefinitionWalker<'a> {
     pub fn id(&self) -> Definition {
-        self.wrapped
+        self.item
     }
 
     pub fn name(&self) -> &'a str {
-        match self.wrapped {
+        match self.item {
             Definition::Scalar(s) => self.names.scalar(self.schema, s),
             Definition::Object(o) => self.names.object(self.schema, o),
             Definition::Interface(i) => self.names.interface(self.schema, i),
@@ -22,7 +22,7 @@ impl<'a> DefinitionWalker<'a> {
     }
 
     pub fn schema_name_id(&self) -> StringId {
-        match self.wrapped {
+        match self.item {
             Definition::Scalar(s) => self.schema[s].name,
             Definition::Object(o) => self.schema[o].name,
             Definition::Interface(i) => self.schema[i].name,
@@ -33,7 +33,7 @@ impl<'a> DefinitionWalker<'a> {
     }
 
     pub fn schema_description_id(&self) -> Option<StringId> {
-        match self.wrapped {
+        match self.item {
             Definition::Scalar(s) => self.schema[s].description,
             Definition::Object(o) => self.schema[o].description,
             Definition::Interface(i) => self.schema[i].description,
@@ -44,7 +44,7 @@ impl<'a> DefinitionWalker<'a> {
     }
 
     pub fn fields(&self) -> Option<Box<dyn Iterator<Item = FieldWalker<'a>> + 'a>> {
-        match self.wrapped {
+        match self.item {
             Definition::Object(o) => Some(Box::new(self.walk(o).fields())),
             Definition::Interface(i) => Some(Box::new(self.walk(i).fields())),
             _ => None,
@@ -52,7 +52,7 @@ impl<'a> DefinitionWalker<'a> {
     }
 
     pub fn interfaces(&self) -> Option<Box<dyn Iterator<Item = InterfaceWalker<'a>> + 'a>> {
-        match self.wrapped {
+        match self.item {
             Definition::Object(o) => Some(Box::new(self.walk(o).interfaces())),
             Definition::Interface(i) => Some(Box::new(self.walk(i).interfaces())),
             _ => None,
@@ -60,7 +60,7 @@ impl<'a> DefinitionWalker<'a> {
     }
 
     pub fn possible_types(&self) -> Option<Box<dyn Iterator<Item = ObjectWalker<'a>> + 'a>> {
-        match self.wrapped {
+        match self.item {
             Definition::Interface(i) => Some(Box::new(self.walk(i).possible_types())),
             Definition::Union(u) => Some(Box::new(self.walk(u).possible_types())),
             _ => None,
@@ -68,35 +68,35 @@ impl<'a> DefinitionWalker<'a> {
     }
 
     pub fn as_enum(&self) -> Option<EnumWalker<'a>> {
-        match self.wrapped {
+        match self.item {
             Definition::Enum(e) => Some(self.walk(e)),
             _ => None,
         }
     }
 
     pub fn as_input_object(&self) -> Option<InputObjectWalker<'a>> {
-        match self.wrapped {
+        match self.item {
             Definition::InputObject(io) => Some(self.walk(io)),
             _ => None,
         }
     }
 
     pub fn as_scalar(&self) -> Option<ScalarWalker<'a>> {
-        match self.wrapped {
+        match self.item {
             Definition::Scalar(s) => Some(self.walk(s)),
             _ => None,
         }
     }
 
     pub fn as_object(&self) -> Option<ObjectWalker<'a>> {
-        match self.wrapped {
+        match self.item {
             Definition::Object(s) => Some(self.walk(s)),
             _ => None,
         }
     }
 
     pub fn data_type(&self) -> Option<DataType> {
-        match self.wrapped {
+        match self.item {
             Definition::Scalar(id) => Some(self.schema[id].data_type),
             Definition::Enum(_) => Some(DataType::String),
             _ => None,
@@ -104,26 +104,26 @@ impl<'a> DefinitionWalker<'a> {
     }
 
     pub fn is_object(&self) -> bool {
-        matches!(self.wrapped, Definition::Object(_))
+        matches!(self.item, Definition::Object(_))
     }
 }
 
 impl<'a> From<ObjectWalker<'a>> for DefinitionWalker<'a> {
     fn from(value: ObjectWalker<'a>) -> Self {
-        value.walk(value.wrapped.into())
+        value.walk(value.item.into())
     }
 }
 
 impl<'a> From<InterfaceWalker<'a>> for DefinitionWalker<'a> {
     fn from(value: InterfaceWalker<'a>) -> Self {
-        value.walk(value.wrapped.into())
+        value.walk(value.item.into())
     }
 }
 
 impl<'a> std::fmt::Debug for DefinitionWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug = f.debug_struct("Definition");
-        match self.wrapped {
+        match self.item {
             Definition::Scalar(s) => debug.field("inner", &self.walk(s)),
             Definition::Object(o) => debug.field("inner", &self.walk(o)),
             Definition::Interface(i) => debug.field("inner", &self.walk(i)),

--- a/engine/crates/engine-v2/schema/src/walkers/enum.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/enum.rs
@@ -5,22 +5,22 @@ pub type EnumWalker<'a> = SchemaWalker<'a, EnumId>;
 
 impl<'a> EnumWalker<'a> {
     pub fn name(&self) -> &'a str {
-        self.names.r#enum(self.schema, self.wrapped)
+        self.names.r#enum(self.schema, self.item)
     }
 
     pub fn description(&self) -> Option<&'a str> {
-        self.description.map(|id| self.schema[id].as_str())
+        self.as_ref().description.map(|id| self.schema[id].as_str())
     }
 
     pub fn values(&self) -> impl Iterator<Item = &'a EnumValue> + 'a {
-        self.schema[self.wrapped].values.iter()
+        self.schema[self.item].values.iter()
     }
 }
 
 impl<'a> std::fmt::Debug for EnumWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Enum")
-            .field("id", &usize::from(self.wrapped))
+            .field("id", &usize::from(self.item))
             .field("name", &self.name())
             .field("description", &self.description())
             .field(

--- a/engine/crates/engine-v2/schema/src/walkers/field_set.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/field_set.rs
@@ -6,17 +6,17 @@ pub type FieldSetItemWalker<'a> = SchemaWalker<'a, &'a FieldSetItem>;
 impl<'a> FieldSetWalker<'a> {
     pub fn items(&self) -> impl Iterator<Item = FieldSetItemWalker<'a>> + 'a {
         let walker = self.walk(());
-        self.wrapped.iter().map(move |item| walker.walk(item))
+        self.item.iter().map(move |item| walker.walk(item))
     }
 }
 
 impl<'a> FieldSetItemWalker<'a> {
     pub fn field(&self) -> FieldWalker<'a> {
-        self.walk(self.wrapped.field_id)
+        self.walk(self.item.field_id)
     }
 
     pub fn subselection(&self) -> FieldSetWalker<'a> {
-        self.walk(&self.wrapped.subselection)
+        self.walk(&self.item.subselection)
     }
 }
 
@@ -30,7 +30,7 @@ impl<'a> std::fmt::Debug for FieldSetWalker<'a> {
 
 impl<'a> std::fmt::Debug for FieldSetItemWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if !self.wrapped.subselection.is_empty() {
+        if !self.item.subselection.is_empty() {
             f.debug_struct("FieldSetItem")
                 .field("name", &self.field().name())
                 .field("selection_set", &self.subselection())

--- a/engine/crates/engine-v2/schema/src/walkers/input_object.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/input_object.rs
@@ -5,16 +5,16 @@ pub type InputObjectWalker<'a> = SchemaWalker<'a, InputObjectId>;
 
 impl<'a> InputObjectWalker<'a> {
     pub fn name(&self) -> &'a str {
-        self.names.input_object(self.schema, self.wrapped)
+        self.names.input_object(self.schema, self.item)
     }
 
     pub fn description(&self) -> Option<&'a str> {
-        self.description.map(|id| self.schema[id].as_str())
+        self.as_ref().description.map(|id| self.schema[id].as_str())
     }
 
     pub fn input_fields(&self) -> impl Iterator<Item = InputValueWalker<'a>> + 'a {
         let walker = *self;
-        self.schema[self.wrapped]
+        self.schema[self.item]
             .input_fields
             .iter()
             .map(move |id| walker.walk(*id))
@@ -24,7 +24,7 @@ impl<'a> InputObjectWalker<'a> {
 impl<'a> std::fmt::Debug for InputObjectWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("InputObject")
-            .field("id", &usize::from(self.wrapped))
+            .field("id", &usize::from(self.item))
             .field("name", &self.name())
             .field("description", &self.description())
             .field(

--- a/engine/crates/engine-v2/schema/src/walkers/input_value.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/input_value.rs
@@ -1,15 +1,23 @@
 use super::SchemaWalker;
-use crate::{InputValueId, TypeWalker};
+use crate::{InputValueId, StringId, TypeWalker};
 
 pub type InputValueWalker<'a> = SchemaWalker<'a, InputValueId>;
 
 impl<'a> InputValueWalker<'a> {
     pub fn name(&self) -> &'a str {
-        self.names.input_value(self.schema, self.wrapped)
+        self.names.input_value(self.schema, self.item)
+    }
+
+    pub fn name_string_id(&self) -> StringId {
+        self.as_ref().name
+    }
+
+    pub fn description_string_id(&self) -> Option<StringId> {
+        self.as_ref().description
     }
 
     pub fn ty(&self) -> TypeWalker<'a> {
-        self.walk(self.type_id)
+        self.walk(self.as_ref().type_id)
     }
 }
 

--- a/engine/crates/engine-v2/schema/src/walkers/interface.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/interface.rs
@@ -5,19 +5,19 @@ pub type InterfaceWalker<'a> = SchemaWalker<'a, InterfaceId>;
 
 impl<'a> InterfaceWalker<'a> {
     pub fn name(&self) -> &'a str {
-        self.names.interface(self.schema, self.wrapped)
+        self.names.interface(self.schema, self.item)
     }
 
     pub fn description(&self) -> Option<&'a str> {
-        self.description.map(|id| self.schema[id].as_str())
+        self.as_ref().description.map(|id| self.schema[id].as_str())
     }
 
     pub fn fields(&self) -> impl Iterator<Item = FieldWalker<'a>> + 'a {
         let start = self
             .schema
             .interface_fields
-            .partition_point(|item| item.interface_id < self.wrapped);
-        let id = self.wrapped;
+            .partition_point(|item| item.interface_id < self.item);
+        let id = self.item;
         RangeWalker {
             schema: self.schema,
             names: self.names,
@@ -35,19 +35,27 @@ impl<'a> InterfaceWalker<'a> {
 
     pub fn interfaces(&self) -> impl Iterator<Item = InterfaceWalker<'a>> + 'a {
         let walker = *self;
-        self.interfaces.clone().into_iter().map(move |id| walker.walk(id))
+        self.as_ref()
+            .interfaces
+            .clone()
+            .into_iter()
+            .map(move |id| walker.walk(id))
     }
 
     pub fn possible_types(&self) -> impl Iterator<Item = ObjectWalker<'a>> + 'a {
         let walker = *self;
-        self.possible_types.clone().into_iter().map(move |id| walker.walk(id))
+        self.as_ref()
+            .possible_types
+            .clone()
+            .into_iter()
+            .map(move |id| walker.walk(id))
     }
 }
 
 impl<'a> std::fmt::Debug for InterfaceWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Interface")
-            .field("id", &usize::from(self.wrapped))
+            .field("id", &usize::from(self.item))
             .field("name", &self.name())
             .field("description", &self.description())
             .field("fields", &self.fields().map(|f| f.name()).collect::<Vec<_>>())

--- a/engine/crates/engine-v2/schema/src/walkers/resolver.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/resolver.rs
@@ -6,7 +6,7 @@ pub type ResolverWalker<'a> = SchemaWalker<'a, ResolverId>;
 
 impl<'a> ResolverWalker<'a> {
     pub fn name(&self) -> String {
-        match self.get() {
+        match self.as_ref() {
             Resolver::Introspection(_) => "Introspection resolver".to_string(),
             Resolver::FederationRootField(resolver) => self.walk(resolver).name(),
             Resolver::FederationEntity(resolver) => self.walk(resolver).name(),
@@ -14,7 +14,7 @@ impl<'a> ResolverWalker<'a> {
     }
 
     pub fn supports_aliases(&self) -> bool {
-        match self.get() {
+        match self.as_ref() {
             Resolver::FederationRootField(_) | Resolver::Introspection(_) | Resolver::FederationEntity(_) => true,
         }
     }
@@ -28,14 +28,14 @@ impl<'a> ResolverWalker<'a> {
     }
 
     pub fn requires(&self) -> Cow<'a, FieldSet> {
-        match self.get() {
+        match self.as_ref() {
             Resolver::FederationEntity(resolver) => Cow::Borrowed(&resolver.key.fields),
             _ => Cow::Owned(FieldSet::default()),
         }
     }
 
     pub fn group(&self) -> Option<ResolverGroup> {
-        match self.get() {
+        match self.as_ref() {
             Resolver::Introspection(_) => None,
             Resolver::FederationRootField(resolver) => Some(ResolverGroup::Federation(resolver.subgraph_id)),
             Resolver::FederationEntity(resolver) => Some(ResolverGroup::Federation(resolver.subgraph_id)),
@@ -44,20 +44,20 @@ impl<'a> ResolverWalker<'a> {
 
     pub fn can_provide(&self, nested_field: FieldWalker<'_>) -> bool {
         if let Some(compatible_group) = self.group() {
-            nested_field.resolvers.is_empty()
+            nested_field.as_ref().resolvers.is_empty()
                 || nested_field
                     .resolvers()
                     .filter_map(|fr| fr.resolver.group())
                     .any(|group| group == compatible_group)
         } else {
-            nested_field.resolvers.is_empty()
+            nested_field.as_ref().resolvers.is_empty()
         }
     }
 }
 
 impl<'a> std::fmt::Debug for ResolverWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.get() {
+        match self.as_ref() {
             Resolver::Introspection(_) => f.debug_struct("Introspection").finish(),
             Resolver::FederationRootField(resolver) => self.walk(resolver).fmt(f),
             Resolver::FederationEntity(resolver) => self.walk(resolver).fmt(f),

--- a/engine/crates/engine-v2/schema/src/walkers/scalar.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/scalar.rs
@@ -1,26 +1,30 @@
 use super::SchemaWalker;
-use crate::ScalarId;
+use crate::{ScalarId, StringId};
 
 pub type ScalarWalker<'a> = SchemaWalker<'a, ScalarId>;
 
 impl<'a> ScalarWalker<'a> {
     pub fn name(&self) -> &'a str {
-        self.names.scalar(self.schema, self.wrapped)
+        self.names.scalar(self.schema, self.item)
     }
 
     pub fn specified_by_url(&self) -> Option<&'a str> {
-        self.specified_by_url.map(|id| self.schema[id].as_str())
+        self.as_ref().specified_by_url.map(|id| self.schema[id].as_str())
+    }
+
+    pub fn specified_by_url_string_id(&self) -> Option<StringId> {
+        self.as_ref().specified_by_url
     }
 
     pub fn description(&self) -> Option<&'a str> {
-        self.description.map(|id| self.schema[id].as_str())
+        self.as_ref().description.map(|id| self.schema[id].as_str())
     }
 }
 
 impl<'a> std::fmt::Debug for ScalarWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Scalar")
-            .field("id", &usize::from(self.wrapped))
+            .field("id", &usize::from(self.item))
             .field("name", &self.name())
             .field("description", &self.description())
             .field("specified_by_url", &self.specified_by_url())

--- a/engine/crates/engine-v2/schema/src/walkers/type.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/type.rs
@@ -1,24 +1,28 @@
 use super::SchemaWalker;
-use crate::{DefinitionWalker, ListWrapping, TypeId};
+use crate::{DefinitionWalker, ListWrapping, TypeId, Wrapping};
 
 pub type TypeWalker<'a> = SchemaWalker<'a, TypeId>;
 
 impl<'a> TypeWalker<'a> {
+    pub fn wrapping(&self) -> &'a Wrapping {
+        &self.as_ref().wrapping
+    }
+
     pub fn inner(&self) -> DefinitionWalker<'a> {
-        self.walk(self.get().inner)
+        self.walk(self.as_ref().inner)
     }
 }
 
 impl std::fmt::Display for TypeWalker<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for _ in self.wrapping.list_wrapping.iter().rev() {
+        for _ in self.as_ref().wrapping.list_wrapping.iter().rev() {
             write!(f, "[")?;
         }
         write!(f, "{}", self.inner().name())?;
-        if self.wrapping.inner_is_required {
+        if self.as_ref().wrapping.inner_is_required {
             write!(f, "!")?;
         }
-        for wrapping in &self.wrapping.list_wrapping {
+        for wrapping in &self.as_ref().wrapping.list_wrapping {
             write!(f, "]")?;
             if *wrapping == ListWrapping::RequiredList {
                 write!(f, "!")?;

--- a/engine/crates/engine-v2/schema/src/walkers/union.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/union.rs
@@ -5,23 +5,27 @@ pub type UnionWalker<'a> = SchemaWalker<'a, UnionId>;
 
 impl<'a> UnionWalker<'a> {
     pub fn name(&self) -> &'a str {
-        self.names.union(self.schema, self.wrapped)
+        self.names.union(self.schema, self.item)
     }
 
     pub fn description(&self) -> Option<&'a str> {
-        self.description.map(|id| self.schema[id].as_str())
+        self.as_ref().description.map(|id| self.schema[id].as_str())
     }
 
     pub fn possible_types(&self) -> impl Iterator<Item = ObjectWalker<'a>> + 'a {
         let walker = *self;
-        self.possible_types.clone().into_iter().map(move |id| walker.walk(id))
+        self.as_ref()
+            .possible_types
+            .clone()
+            .into_iter()
+            .map(move |id| walker.walk(id))
     }
 }
 
 impl<'a> std::fmt::Debug for UnionWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Union")
-            .field("id", &usize::from(self.wrapped))
+            .field("id", &usize::from(self.item))
             .field("name", &self.name())
             .field("description", &self.description())
             .field(

--- a/engine/crates/engine-v2/src/execution/context.rs
+++ b/engine/crates/engine-v2/src/execution/context.rs
@@ -4,7 +4,7 @@ use schema::SchemaWalker;
 use super::Variables;
 use crate::{
     plan::PlanOutput,
-    request::{OperationWalker, PlanExt, PlanOperationWalker, VariablesWalker},
+    request::{ExecutorWalkContext, OperationWalker, PlanOperationWalker, VariablesWalker},
     response::{ExecutorOutput, ResponseBoundaryItem, ResponseObjectWriter},
     Engine,
 };
@@ -32,7 +32,7 @@ impl<'ctx> ExecutionContext<'ctx> {
         'ctx: 'p,
     {
         self.walker
-            .with_ext(PlanExt {
+            .with_ctx(ExecutorWalkContext {
                 attribution: &output.attribution,
                 variables: self.variables,
             })
@@ -49,7 +49,7 @@ impl<'ctx> ExecutionContext<'ctx> {
         'ctx: 'a,
     {
         ResponseObjectWriter::new(
-            self.walker.with_ext(PlanExt {
+            self.walker.with_ctx(ExecutorWalkContext {
                 attribution: &output.attribution,
                 variables: self.variables,
             }),

--- a/engine/crates/engine-v2/src/execution/coordinator.rs
+++ b/engine/crates/engine-v2/src/execution/coordinator.rs
@@ -151,7 +151,7 @@ impl<'ctx> ExecutorCoordinator<'ctx> {
                                 ctx: ExecutionContext::<'ctx> {
                                     engine: self.engine,
                                     variables: self.variables,
-                                    walker: self.operation.walker_with(schema, ()),
+                                    walker: self.operation.walker_with(schema),
                                     request_headers: self.request_headers,
                                 },
                                 boundary_objects_view: self.response.read(schema, plan.input),

--- a/engine/crates/engine-v2/src/execution/variables.rs
+++ b/engine/crates/engine-v2/src/execution/variables.rs
@@ -345,7 +345,7 @@ fn coerce_input_object(
     let mut coerced = IndexMap::new();
     for field in schema.walker().walk(object_id).input_fields() {
         match fields.remove(field.name()) {
-            None | Some(ConstValue::Null) if field.ty().wrapping.is_required() => {
+            None | Some(ConstValue::Null) if field.ty().wrapping().is_required() => {
                 return Err(CoercionError::UnexpectedNull {
                     expected: field.ty().to_string(),
                     path: path.to_error_string(schema),
@@ -355,7 +355,7 @@ fn coerce_input_object(
             Some(value) => {
                 coerced.insert(
                     Name::new(field.name()),
-                    coerce_value(value, &field.ty(), schema, path.child(field.name))?,
+                    coerce_value(value, field.ty().as_ref(), schema, path.child(field.name_string_id()))?,
                 );
             }
         }

--- a/engine/crates/engine-v2/src/plan/attribution.rs
+++ b/engine/crates/engine-v2/src/plan/attribution.rs
@@ -89,7 +89,7 @@ impl<'a, Id: Copy> AttributionWalker<'a, Id>
 where
     Attribution: std::ops::Index<Id>,
 {
-    pub fn get(&self) -> &'a <Attribution as std::ops::Index<Id>>::Output {
+    pub fn as_ref(&self) -> &'a <Attribution as std::ops::Index<Id>>::Output {
         &self.attribution[self.id]
     }
 }
@@ -99,25 +99,25 @@ pub type ExtraFieldWalker<'a> = AttributionWalker<'a, ExtraFieldId>;
 
 impl<'a> ExtraSelectionSetWalker<'a> {
     pub fn ty(&self) -> SelectionSetType {
-        self.get().ty
+        self.as_ref().ty
     }
 
     pub fn fields(&self) -> impl Iterator<Item = ExtraFieldWalker<'a>> + 'a {
         let walker = self.walk(());
-        self.get().fields.iter().map(move |id| walker.walk(*id))
+        self.as_ref().fields.iter().map(move |id| walker.walk(*id))
     }
 }
 
 impl<'a> ExtraFieldWalker<'a> {
     pub fn selection_set(&self) -> Option<ExtraSelectionSetWalker<'a>> {
-        match self.get().ty {
+        match self.as_ref().ty {
             ExpectedType::Scalar(_) => None,
             ExpectedType::SelectionSet(id) => Some(self.walk(id)),
         }
     }
 
     pub fn expected_key(&self) -> &'a str {
-        &self.get().expected_key
+        &self.as_ref().expected_key
     }
 }
 
@@ -125,7 +125,7 @@ impl<'a> std::ops::Deref for ExtraFieldWalker<'a> {
     type Target = ExtraField;
 
     fn deref(&self) -> &'a Self::Target {
-        self.get()
+        self.as_ref()
     }
 }
 

--- a/engine/crates/engine-v2/src/request/mod.rs
+++ b/engine/crates/engine-v2/src/request/mod.rs
@@ -54,7 +54,7 @@ impl Operation {
                 .map(|cache_config_id| schema[cache_config_id]);
 
             let selection_set_cache_config = operation
-                .walker_with(schema.walker(), ())
+                .walker_with(schema.walker())
                 .walk(operation.root_selection_set_id)
                 .cache_config();
 
@@ -68,19 +68,18 @@ impl Operation {
         bind::bind(schema, unbound_operation)
     }
 
-    pub fn walker_with<'op, 'schema, E>(
+    pub fn walker_with<'op, 'schema>(
         &'op self,
         schema_walker: SchemaWalker<'schema, ()>,
-        ext: E,
-    ) -> OperationWalker<'op, (), (), E>
+    ) -> OperationWalker<'op, (), (), ()>
     where
         'schema: 'op,
     {
         OperationWalker {
             operation: self,
             schema_walker,
-            ext,
-            wrapped: (),
+            ctx: (),
+            item: (),
         }
     }
 }

--- a/engine/crates/engine-v2/src/request/walkers/field_argument.rs
+++ b/engine/crates/engine-v2/src/request/walkers/field_argument.rs
@@ -5,27 +5,27 @@ use schema::InputValueId;
 
 use crate::request::BoundFieldArgument;
 
-use super::{OperationWalker, PlanExt};
+use super::{ExecutorWalkContext, OperationWalker};
 
-pub type BoundFieldArgumentWalker<'a, Extension = ()> =
-    OperationWalker<'a, &'a BoundFieldArgument, InputValueId, Extension>;
+pub type BoundFieldArgumentWalker<'a, CtxOrUnit = ()> =
+    OperationWalker<'a, &'a BoundFieldArgument, InputValueId, CtxOrUnit>;
 
-impl<'a, E> BoundFieldArgumentWalker<'a, E> {
+impl<'a, C> BoundFieldArgumentWalker<'a, C> {
     // Value in the query, before variable resolution.
     pub fn query_value(&self) -> &engine_value::Value {
-        &self.wrapped.value
+        &self.item.value
     }
 }
 
-impl<'a> BoundFieldArgumentWalker<'a, PlanExt<'a>> {
+impl<'a> BoundFieldArgumentWalker<'a, ExecutorWalkContext<'a>> {
     pub fn resolved_value(&self) -> ConstValue {
         // not really efficient, but works.
-        self.wrapped
+        self.item
             .value
             .clone()
             .into_const_with::<()>(|name| {
                 Ok(self
-                    .ext
+                    .ctx
                     .variables
                     .get(&name)
                     .expect("Would have failed at validation")

--- a/engine/crates/engine-v2/src/request/walkers/fragment.rs
+++ b/engine/crates/engine-v2/src/request/walkers/fragment.rs
@@ -1,37 +1,29 @@
-use super::{type_condition_name, BoundSelectionSetWalker, OperationWalker, PlanExt, PlanSelectionSet};
+use super::{type_condition_name, BoundSelectionSetWalker, ExecutorWalkContext, OperationWalker, PlanSelectionSet};
 use crate::request::{BoundFragmentDefinitionId, BoundFragmentSpread};
 
-pub type BoundFragmentSpreadWalker<'a, Extension = ()> = OperationWalker<'a, &'a BoundFragmentSpread, (), Extension>;
+pub type BoundFragmentSpreadWalker<'a, CtxOrUnit = ()> = OperationWalker<'a, &'a BoundFragmentSpread, (), CtxOrUnit>;
 
-impl<'a, E> std::ops::Deref for BoundFragmentSpreadWalker<'a, E> {
-    type Target = BoundFragmentSpread;
-
-    fn deref(&self) -> &Self::Target {
-        self.wrapped
-    }
-}
-
-impl<'a, E: Copy> BoundFragmentSpreadWalker<'a, E> {
-    pub fn fragment(&self) -> BoundFragmentDefinitionWalker<'a, E> {
-        self.walk_with(self.wrapped.fragment_id, ())
+impl<'a, C: Copy> BoundFragmentSpreadWalker<'a, C> {
+    pub fn fragment(&self) -> BoundFragmentDefinitionWalker<'a, C> {
+        self.walk_with(self.item.fragment_id, ())
     }
 }
 
 impl<'a> BoundFragmentSpreadWalker<'a, ()> {
     pub fn selection_set(&self) -> BoundSelectionSetWalker<'a> {
-        self.walk(self.wrapped.selection_set_id)
+        self.walk(self.item.selection_set_id)
     }
 }
 
-impl<'a> BoundFragmentSpreadWalker<'a, PlanExt<'a>> {
+impl<'a> BoundFragmentSpreadWalker<'a, ExecutorWalkContext<'a>> {
     pub fn selection_set(&self) -> PlanSelectionSet<'a> {
-        PlanSelectionSet::Query(self.walk(self.wrapped.selection_set_id))
+        PlanSelectionSet::Query(self.walk(self.item.selection_set_id))
     }
 }
 
-impl<'a> std::fmt::Debug for BoundFragmentSpreadWalker<'a, PlanExt<'a>> {
+impl<'a> std::fmt::Debug for BoundFragmentSpreadWalker<'a, ()> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let fragment = &self.operation[self.wrapped.fragment_id];
+        let fragment = &self.operation[self.item.fragment_id];
         f.debug_struct("BoundFragmentSpreadWalker")
             .field("name", &fragment.name)
             .field("selection_set", &self.selection_set())
@@ -39,11 +31,25 @@ impl<'a> std::fmt::Debug for BoundFragmentSpreadWalker<'a, PlanExt<'a>> {
     }
 }
 
-pub type BoundFragmentDefinitionWalker<'a, Extension = ()> =
-    OperationWalker<'a, BoundFragmentDefinitionId, (), Extension>;
+impl<'a> std::fmt::Debug for BoundFragmentSpreadWalker<'a, ExecutorWalkContext<'a>> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let fragment = &self.operation[self.item.fragment_id];
+        f.debug_struct("BoundFragmentSpreadWalker")
+            .field("name", &fragment.name)
+            .field("selection_set", &self.selection_set())
+            .finish()
+    }
+}
 
-impl<'a, E> BoundFragmentDefinitionWalker<'a, E> {
+pub type BoundFragmentDefinitionWalker<'a, CtxOrUnit = ()> =
+    OperationWalker<'a, BoundFragmentDefinitionId, (), CtxOrUnit>;
+
+impl<'a, C> BoundFragmentDefinitionWalker<'a, C> {
+    pub fn name(&self) -> &'a str {
+        &self.as_ref().name
+    }
+
     pub fn type_condition_name(&self) -> &str {
-        type_condition_name(self.schema_walker, self.type_condition)
+        type_condition_name(self.schema_walker, self.as_ref().type_condition)
     }
 }

--- a/engine/crates/engine-v2/src/request/walkers/inline_fragment.rs
+++ b/engine/crates/engine-v2/src/request/walkers/inline_fragment.rs
@@ -1,19 +1,11 @@
-use super::{type_condition_name, BoundSelectionSetWalker, OperationWalker, PlanExt, PlanSelectionSet};
+use super::{type_condition_name, BoundSelectionSetWalker, ExecutorWalkContext, OperationWalker, PlanSelectionSet};
 use crate::request::BoundInlineFragment;
 
-pub type BoundInlineFragmentWalker<'a, Extension = ()> = OperationWalker<'a, &'a BoundInlineFragment, (), Extension>;
+pub type BoundInlineFragmentWalker<'a, CtxOrUnit = ()> = OperationWalker<'a, &'a BoundInlineFragment, (), CtxOrUnit>;
 
-impl<'a, E> std::ops::Deref for BoundInlineFragmentWalker<'a, E> {
-    type Target = BoundInlineFragment;
-
-    fn deref(&self) -> &Self::Target {
-        self.wrapped
-    }
-}
-
-impl<'a, E: Copy> BoundInlineFragmentWalker<'a, E> {
+impl<'a, C: Copy> BoundInlineFragmentWalker<'a, C> {
     pub fn type_condition_name(&self) -> Option<&str> {
-        self.wrapped
+        self.item
             .type_condition
             .map(|cond| type_condition_name(self.schema_walker, cond))
     }
@@ -21,17 +13,25 @@ impl<'a, E: Copy> BoundInlineFragmentWalker<'a, E> {
 
 impl<'a> BoundInlineFragmentWalker<'a, ()> {
     pub fn selection_set(&self) -> BoundSelectionSetWalker<'a> {
-        self.walk(self.wrapped.selection_set_id)
+        self.walk(self.item.selection_set_id)
     }
 }
 
-impl<'a> BoundInlineFragmentWalker<'a, PlanExt<'a>> {
+impl<'a> BoundInlineFragmentWalker<'a, ExecutorWalkContext<'a>> {
     pub fn selection_set(&self) -> PlanSelectionSet<'a> {
-        PlanSelectionSet::Query(self.walk(self.wrapped.selection_set_id))
+        PlanSelectionSet::Query(self.walk(self.item.selection_set_id))
     }
 }
 
-impl<'a> std::fmt::Debug for BoundInlineFragmentWalker<'a, PlanExt<'a>> {
+impl<'a> std::fmt::Debug for BoundInlineFragmentWalker<'a, ExecutorWalkContext<'a>> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BoundInlineFragmentWalker")
+            .field("selection_set", &self.selection_set())
+            .finish()
+    }
+}
+
+impl<'a> std::fmt::Debug for BoundInlineFragmentWalker<'a, ()> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BoundInlineFragmentWalker")
             .field("selection_set", &self.selection_set())

--- a/engine/crates/engine-v2/src/request/walkers/plan.rs
+++ b/engine/crates/engine-v2/src/request/walkers/plan.rs
@@ -8,21 +8,23 @@ use crate::{
     plan::{Attribution, AttributionWalker, PlanOutput},
 };
 
-pub type PlanWalker<'a> = OperationWalker<'a, (), (), PlanExt<'a>>;
-pub type PlanOperationWalker<'a> = OperationWalker<'a, &'a PlanOutput, (), PlanExt<'a>>;
-pub type PlanFragmentSpread<'a> = BoundFragmentSpreadWalker<'a, PlanExt<'a>>;
-pub type PlanInlineFragment<'a> = BoundInlineFragmentWalker<'a, PlanExt<'a>>;
-pub type PlanFieldArgument<'a> = BoundFieldArgumentWalker<'a, PlanExt<'a>>;
+// Not sure if best name, but those allow to walk over the "plan" for an executor. Attributed
+// fields and their associated variables.
+pub type PlanWalker<'a> = OperationWalker<'a, (), (), ExecutorWalkContext<'a>>;
+pub type PlanOperationWalker<'a> = OperationWalker<'a, &'a PlanOutput, (), ExecutorWalkContext<'a>>;
+pub type PlanFragmentSpread<'a> = BoundFragmentSpreadWalker<'a, ExecutorWalkContext<'a>>;
+pub type PlanInlineFragment<'a> = BoundInlineFragmentWalker<'a, ExecutorWalkContext<'a>>;
+pub type PlanFieldArgument<'a> = BoundFieldArgumentWalker<'a, ExecutorWalkContext<'a>>;
 
 #[derive(Clone, Copy)]
-pub struct PlanExt<'a> {
+pub struct ExecutorWalkContext<'a> {
     pub attribution: &'a Attribution,
     pub variables: &'a Variables<'a>,
 }
 
-impl<'a, W: Copy, S> OperationWalker<'a, W, S, PlanExt<'a>> {
-    pub(super) fn as_attribution_walker(&self) -> AttributionWalker<'a, W> {
-        self.ext.attribution.walk(self.wrapped)
+impl<'a, I: Copy, SI> OperationWalker<'a, I, SI, ExecutorWalkContext<'a>> {
+    pub(super) fn as_attribution_walker(&self) -> AttributionWalker<'a, I> {
+        self.ctx.attribution.walk(self.item)
     }
 }
 

--- a/engine/crates/engine-v2/src/request/walkers/variables.rs
+++ b/engine/crates/engine-v2/src/request/walkers/variables.rs
@@ -10,17 +10,17 @@ pub type VariableWalker<'a> = OperationWalker<'a, &'a Variable<'a>>;
 
 impl<'a> VariablesWalker<'a> {
     pub fn get(&self, name: &str) -> Option<VariableWalker<'a>> {
-        self.wrapped.get(name).map(|variable| self.walk(variable))
+        self.item.get(name).map(|variable| self.walk(variable))
     }
 }
 
 impl<'a> VariableWalker<'a> {
     pub fn value(&self) -> Option<&'a ConstValue> {
-        self.wrapped.value.as_ref()
+        self.item.value.as_ref()
     }
 
     pub fn type_name(&self) -> String {
-        let ty = &self.wrapped.definition.r#type;
+        let ty = &self.item.definition.r#type;
         let mut name = self.schema_walker.walk(ty.inner).name().to_string();
         if ty.wrapping.inner_is_required {
             name.push('!');
@@ -35,6 +35,6 @@ impl<'a> VariableWalker<'a> {
     }
 
     pub fn default_value(&self) -> &Option<ConstValue> {
-        &self.wrapped.definition.default_value
+        &self.item.definition.default_value
     }
 }

--- a/engine/crates/engine-v2/src/response/write/deserialize/selection_set/mod.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/selection_set/mod.rs
@@ -96,7 +96,7 @@ enum ObjectIdentifier<'ctx, 'parent> {
 
 impl<'ctx, 'parent> ObjectIdentifier<'ctx, 'parent> {
     fn new(ctx: &'parent SeedContext<'ctx>, root: SelectionSetType) -> Self {
-        let schema = ctx.walker.schema().get();
+        let schema = ctx.walker.schema().as_ref();
         match root {
             SelectionSetType::Interface(interface_id) => Self::Unknown {
                 discriminant_key: ctx.walker.names().interface_discriminant_key(schema, interface_id),

--- a/engine/crates/engine-v2/src/response/write/deserialize/selection_set/undetermined.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/selection_set/undetermined.rs
@@ -191,7 +191,7 @@ impl<'ctx, 'parent> UndeterminedFieldsSeed<'ctx, 'parent> {
                                             selection_set_ids: vec![id],
                                         },
                                     },
-                                    wrapping: schema_field.ty().wrapping.clone(),
+                                    wrapping: schema_field.ty().wrapping().clone(),
                                 });
                         }
                     }
@@ -222,7 +222,7 @@ impl<'ctx, 'parent> UndeterminedFieldsSeed<'ctx, 'parent> {
                                             selection_set_ids: vec![id],
                                         },
                                     },
-                                    wrapping: schema_field.ty().wrapping.clone(),
+                                    wrapping: schema_field.ty().wrapping().clone(),
                                 });
                         }
                     }
@@ -325,7 +325,7 @@ impl<'ctx, 'parent> UndeterminedFieldsSeed<'ctx, 'parent> {
                                 selection_set_ids: vec![id],
                             },
                         },
-                        wrapping: schema_field.ty().wrapping.clone(),
+                        wrapping: schema_field.ty().wrapping().clone(),
                     });
                 acc
             });

--- a/engine/crates/engine-v2/src/sources/graphql/federation.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/federation.rs
@@ -83,9 +83,12 @@ impl<'ctx> FederationEntityExecutor<'ctx> {
             .await?
             .bytes;
         let err_path = Some(
-            self.response_boundary[0]
-                .response_path
-                .child(self.ctx.walker.walk(self.plan_output.root_fields[0]).bound_response_key),
+            self.response_boundary[0].response_path.child(
+                self.ctx
+                    .walker
+                    .walk(self.plan_output.root_fields[0])
+                    .bound_response_key(),
+            ),
         );
         let mut upstream_errors = vec![];
         let result = deserialize::GraphqlResponseSeed::new(

--- a/engine/crates/engine-v2/src/sources/graphql/mod.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/mod.rs
@@ -72,9 +72,12 @@ impl<'ctx> GraphqlExecutor<'ctx> {
             .await?
             .bytes;
         let err_path = Some(
-            self.boundary_item
-                .response_path
-                .child(self.ctx.walker.walk(self.plan_output.root_fields[0]).bound_response_key),
+            self.boundary_item.response_path.child(
+                self.ctx
+                    .walker
+                    .walk(self.plan_output.root_fields[0])
+                    .bound_response_key(),
+            ),
         );
         let mut upstream_errors = vec![];
         let result = deserialize::GraphqlResponseSeed::new(

--- a/engine/crates/engine-v2/src/sources/graphql/query.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/query.rs
@@ -244,10 +244,10 @@ impl QueryBuilder {
         let name = self.fragment_content_to_name.entry(fragment_buffer).or_insert_with(|| {
             let id = self
                 .fragment_name_to_last_id
-                .entry(fragment.name.to_string())
+                .entry(fragment.name().to_string())
                 .and_modify(|id| *id += 1)
                 .or_default();
-            format!("{}_{}", fragment.name, id)
+            format!("{}_{}", fragment.name(), id)
         });
         buffer.indent_write(&format!("...{name}\n"))?;
         Ok(())

--- a/engine/crates/engine-v2/src/sources/mod.rs
+++ b/engine/crates/engine-v2/src/sources/mod.rs
@@ -75,7 +75,7 @@ impl<'exc> Executor<'exc> {
     where
         'ctx: 'exc,
     {
-        match walker.get() {
+        match walker.as_ref() {
             Resolver::Introspection(resolver) => IntrospectionExecutionPlan::build(walker.walk(resolver), input),
             Resolver::FederationRootField(resolver) => GraphqlExecutor::build(walker.walk(resolver), input),
             Resolver::FederationEntity(resolver) => {


### PR DESCRIPTION
Initially I thought walkers would just provide utility methods, but now I realize
they should just be the default way to access anything. So Deref on those was confusing
as you would have access to both `.name` (StringId) and `.name()` (str).

I also clarified the `ext` in the OperationWalker, renaming it to `ctx: ExecutorWalkContextOrUnit`
and adding an explanation.

I also renamed `wrapped` to `item`, which provides a bit more consistent naming overall

# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
