### PR TITLE
feat: update ExecutorCoordinator with subscription flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1699,6 +1699,7 @@ dependencies = [
  "engine-v2-config",
  "engine-v2-schema",
  "engine-value",
+ "futures",
  "futures-util",
  "hex",
  "im",

--- a/engine/crates/engine-v2/Cargo.toml
+++ b/engine/crates/engine-v2/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 async-runtime.workspace = true
 derive_more = "0.99"
+futures.workspace = true
 im = "15"
 indexmap.workspace = true
 lasso = "0.7"

--- a/engine/crates/engine-v2/src/engine.rs
+++ b/engine/crates/engine-v2/src/engine.rs
@@ -29,7 +29,7 @@ impl Engine {
     }
 
     pub async fn execute(&self, request: engine::Request, headers: RequestHeaders) -> Response {
-        let operation = match self.prepare(&request).await {
+        let operation = match self.prepare(&request) {
             Ok(operation) => operation,
             Err(error) => return Response::from_error(error, ExecutionMetadata::default()),
         };

--- a/engine/crates/engine-v2/src/engine.rs
+++ b/engine/crates/engine-v2/src/engine.rs
@@ -38,12 +38,11 @@ impl Engine {
             Err(errors) => return Response::from_errors(errors, ExecutionMetadata::build(&operation)),
         };
 
-        let mut executor = ExecutorCoordinator::new(self, &operation, &variables, &headers);
-        executor.execute().await;
-        executor.into_response()
+        let executor = ExecutorCoordinator::new(self, operation, variables, headers);
+        executor.execute().await
     }
 
-    async fn prepare(&self, request: &engine::Request) -> Result<Operation, GraphqlError> {
+    fn prepare(&self, request: &engine::Request) -> Result<Operation, GraphqlError> {
         let unbound_operation = parse_operation(request)?;
         let operation = Operation::build(&self.schema, unbound_operation)?;
         Ok(operation)

--- a/engine/crates/engine-v2/src/execution/context.rs
+++ b/engine/crates/engine-v2/src/execution/context.rs
@@ -14,7 +14,7 @@ use crate::{
 pub(crate) struct ExecutionContext<'ctx> {
     pub engine: &'ctx Engine,
     pub walker: OperationWalker<'ctx>,
-    pub(super) variables: &'ctx Variables<'ctx>,
+    pub(super) variables: &'ctx Variables,
     pub(super) request_headers: &'ctx RequestHeaders,
 }
 

--- a/engine/crates/engine-v2/src/execution/coordinator.rs
+++ b/engine/crates/engine-v2/src/execution/coordinator.rs
@@ -1,18 +1,21 @@
-use std::collections::{BTreeMap, VecDeque};
+use std::{
+    collections::{BTreeMap, VecDeque},
+    sync::Arc,
+};
 
 use async_runtime::make_send_on_wasm;
 use engine::RequestHeaders;
 use engine_parser::types::OperationType;
-use futures_util::{future::BoxFuture, stream::FuturesUnordered, FutureExt, StreamExt};
+use futures_util::{future::BoxFuture, stream::FuturesUnordered, Future, FutureExt, Stream, StreamExt};
 
 use crate::{
     execution::{ExecutionContext, Variables},
-    plan::{PlanBoundary, Planner, PlanningError},
+    plan::{Plan, PlanBoundary, Planner, PlanningError},
     request::{Operation, QueryPath},
     response::{
         ExecutionMetadata, ExecutorOutput, GraphqlError, Response, ResponseBoundaryItem, ResponseBuilder, ResponsePath,
     },
-    sources::{Executor, ExecutorResult, ResolverInput},
+    sources::{Executor, ExecutorResult, ResolverInput, SubscriptionExecutor},
     Engine,
 };
 
@@ -43,52 +46,42 @@ impl<'ctx> ExecutorCoordinator<'ctx> {
     }
 
     pub async fn execute(&mut self) {
-        let mut futures = FuturesUnordered::<BoxFuture<'_, ExecutorFutResult>>::new();
         // Mutation root fields need to be executed sequentially. So we're tracking for each
         // executor whether it was for one and if so execute the next executor in the queue.
         // Keeping the queue outside of the FuturesUnordered also ensures the future is static
         // which wasm target somehow required. (not entirely sure why though)
         let mut mutation_root_fields_executors = VecDeque::<Executor<'ctx>>::new();
-        let response_boundary = vec![ResponseBoundaryItem {
-            response_object_id: self
-                .response
-                .root_response_object_id()
-                .expect("No errors could have propagated to root yet."),
-            response_path: ResponsePath::default(),
-            object_id: self.operation.root_object_id,
-        }];
+        let response_boundary = vec![self.root_response_boundary()];
+
+        let plan_boundary = match self.planner.generate_root_plan_boundary() {
+            Ok(boundary) => boundary,
+            Err(err) => {
+                self.push_planning_error(QueryPath::default(), err);
+                return;
+            }
+        };
+
+        let mut futures = ExecutorFutureSet::new();
+
         match self.operation.ty {
-            OperationType::Query => match self.planner.generate_root_plan_boundary() {
-                Ok(plan_boundary) => {
-                    for executor in self.generate_executors(vec![(plan_boundary, response_boundary)]) {
-                        futures.push(Box::pin(make_send_on_wasm(
-                            executor.execute().map(ExecutorFutResult::from),
-                        )));
-                    }
+            OperationType::Query => {
+                for executor in self.generate_executors(vec![(plan_boundary, response_boundary)]) {
+                    futures.execute(executor);
                 }
-                Err(err) => {
-                    self.push_planning_error(QueryPath::default(), err);
+            }
+            OperationType::Mutation => {
+                mutation_root_fields_executors =
+                    VecDeque::from(self.generate_executors(vec![(plan_boundary, response_boundary)]));
+
+                if let Some(executor) = mutation_root_fields_executors.pop_front() {
+                    futures.execute_mutation_root(executor);
                 }
-            },
-            OperationType::Mutation => match self.planner.generate_root_plan_boundary() {
-                Ok(plan_boundary) => {
-                    mutation_root_fields_executors =
-                        VecDeque::from(self.generate_executors(vec![(plan_boundary, response_boundary)]));
-                    if let Some(executor) = mutation_root_fields_executors.pop_front() {
-                        futures.push(Box::pin(make_send_on_wasm(async move {
-                            ExecutorFutResult {
-                                result: executor.execute().await,
-                                is_mutation_root_field: true,
-                            }
-                        })));
-                    }
-                }
-                Err(err) => {
-                    self.push_planning_error(QueryPath::default(), err);
-                }
-            },
-            OperationType::Subscription => unimplemented!(),
+            }
+            OperationType::Subscription => {
+                unreachable!("execute shouldnt be called for subscriptions")
+            }
         }
+
         while let Some(ExecutorFutResult {
             result,
             is_mutation_root_field,
@@ -104,19 +97,12 @@ impl<'ctx> ExecutorCoordinator<'ctx> {
                     if self.response.root_response_object_id().is_some() {
                         if is_mutation_root_field {
                             if let Some(executor) = mutation_root_fields_executors.pop_front() {
-                                futures.push(Box::pin(make_send_on_wasm(async move {
-                                    ExecutorFutResult {
-                                        result: executor.execute().await,
-                                        is_mutation_root_field: true,
-                                    }
-                                })));
+                                futures.execute_mutation_root(executor);
                             }
                         }
                         let executors = self.generate_executors(boundaries);
                         for executor in executors {
-                            futures.push(Box::pin(make_send_on_wasm(
-                                executor.execute().map(ExecutorFutResult::from),
-                            )));
+                            futures.execute(executor);
                         }
                     }
                 }
@@ -127,53 +113,180 @@ impl<'ctx> ExecutorCoordinator<'ctx> {
         }
     }
 
+    pub fn execute_subscription(mut self) -> impl Stream<Item = Response> + 'ctx {
+        // TODO: Decide if this is even the best place to put this or if we need some
+        // new kind of cordinator?  Who knows
+        assert!(matches!(self.operation.ty, OperationType::Subscription));
+
+        let response_boundary = vec![self.root_response_boundary()];
+
+        // TODO: wonder if there's scope to combine generate_root_plan_boundary & plans_from_boundary
+        // Think we always call them together?
+        let plan = match self.planner.generate_root_plan_boundary() {
+            Ok(boundary) => {
+                let mut plans = self.plans_from_boundary((boundary, response_boundary));
+                // TODO: This probably shouldn't be an assert but yolo for now
+                assert!(plans.len() == 1);
+                plans.pop().expect("TODO: make this less hacky")
+            }
+            Err(err) => {
+                self.push_planning_error(QueryPath::default(), err);
+                todo!("return an error somehow")
+            }
+        };
+
+        let Some(executor) = self.subscription_executor_from_plan(plan) else {
+            todo!("return an error somehow")
+        };
+
+        let coordinator = Arc::new(self);
+        executor.execute().then({
+            move |(mut response, output)| {
+                let coordinator = Arc::clone(&coordinator);
+                async move {
+                    let boundaries = response.ingest(output);
+                    let mut futures = ExecutorFutureSet::new();
+                    for executor in coordinator.generate_executors(boundaries) {
+                        futures.execute(executor);
+                    }
+
+                    while let Some(ExecutorFutResult { result, .. }) = futures.next().await {
+                        let output = match result {
+                            Ok(output) => output,
+                            Err(error) => {
+                                response.push_error(error);
+                                continue;
+                            }
+                        };
+
+                        let boundaries = response.ingest(output);
+                        if response.root_response_object_id().is_some() {
+                            // TODO: THis needs to somehow use the actual response not self.response
+                            let executors = coordinator.generate_executors(boundaries);
+                            for executor in executors {
+                                futures.execute(executor);
+                            }
+                        }
+                    }
+
+                    response.build(
+                        coordinator.engine.schema.clone(),
+                        coordinator.operation.response_keys.clone(),
+                        ExecutionMetadata::build(coordinator.operation),
+                    )
+                }
+            }
+        })
+    }
+
     fn generate_executors(
         &mut self,
         boundaries: Vec<(PlanBoundary, Vec<ResponseBoundaryItem>)>,
     ) -> Vec<Executor<'ctx>> {
-        // Ordering of the executors MUST match the plan boundary order for mutation root fields.
+        // Ordering of the executors MUST match the plan boundary order for mutation root
         let mut executors = vec![];
-        for (plan_boundary, response_boundary) in boundaries {
-            let query_path = plan_boundary.query_path.clone();
-            match self.planner.generate_plans(plan_boundary, &response_boundary) {
-                Ok(plans) => {
-                    for plan in plans {
-                        let resolver = self.engine.schema.walker().walk(plan.resolver_id);
-                        let schema = self.engine.schema.walker_with(resolver.names());
-                        let output = self.response.new_output(plan.boundaries);
-                        // Ensuring that all walkers the executors has access to have a consistent
-                        // `Names`.
-                        let resolver = schema.walk(plan.resolver_id);
-                        let result = Executor::build(
-                            resolver,
-                            plan.output.entity_type,
-                            ResolverInput {
-                                ctx: ExecutionContext::<'ctx> {
-                                    engine: self.engine,
-                                    variables: self.variables,
-                                    walker: self.operation.walker_with(schema),
-                                    request_headers: self.request_headers,
-                                },
-                                boundary_objects_view: self.response.read(schema, plan.input),
-                                plan_id: plan.id,
-                                plan_output: plan.output,
-                                output,
-                            },
-                        );
-                        match result {
-                            Ok(executor) => executors.push(executor),
-                            Err(err) => {
-                                self.response.push_error(err);
-                            }
-                        }
-                    }
-                }
-                Err(err) => {
-                    self.push_planning_error(query_path, err);
-                }
+
+        for boundary in boundaries {
+            for plan in self.plans_from_boundary(boundary) {
+                executors.extend(self.executor_from_plan(plan))
             }
         }
+
         executors
+    }
+
+    fn plans_from_boundary(
+        &mut self,
+        (plan_boundary, response_boundary): (PlanBoundary, Vec<ResponseBoundaryItem>),
+    ) -> Vec<Plan> {
+        let query_path = plan_boundary.query_path.clone();
+        match self.planner.generate_plans(plan_boundary, &response_boundary) {
+            Ok(plans) => plans,
+
+            Err(err) => {
+                self.push_planning_error(query_path, err);
+                vec![]
+            }
+        }
+    }
+
+    // This function requires:
+    // - schema from self.engine
+    // - the current response
+    // - An execution context, mostly generatable from self
+    fn executor_from_plan(&mut self, plan: Plan) -> Option<Executor<'ctx>> {
+        let resolver = self.engine.schema.walker().walk(plan.resolver_id);
+        let schema = self.engine.schema.walker_with(resolver.names());
+        let output = self.response.new_output(plan.boundaries);
+        // Ensuring that all walkers the executors has access to have a consistent
+        // `Names`.
+        let resolver = schema.walk(plan.resolver_id);
+        let result = Executor::build(
+            resolver,
+            plan.output.entity_type,
+            ResolverInput {
+                ctx: ExecutionContext::<'ctx> {
+                    engine: self.engine,
+                    variables: self.variables,
+                    walker: self.operation.walker_with(schema, ()),
+                    request_headers: self.request_headers,
+                },
+                boundary_objects_view: self.response.read(schema, plan.input),
+                plan_id: plan.id,
+                plan_output: plan.output,
+                output,
+            },
+        );
+        match result {
+            Ok(executor) => Some(executor),
+            Err(err) => {
+                self.response.push_error(err);
+                None
+            }
+        }
+    }
+
+    fn subscription_executor_from_plan(&mut self, plan: Plan) -> Option<SubscriptionExecutor<'ctx>> {
+        let resolver = self.engine.schema.walker().walk(plan.resolver_id);
+        let schema = self.engine.schema.walker_with(resolver.names());
+        let output = self.response.new_output(plan.boundaries);
+        // Ensuring that all walkers the executors has access to have a consistent
+        // `Names`.
+        let resolver = schema.walk(plan.resolver_id);
+        let result = SubscriptionExecutor::build(
+            resolver,
+            plan.output.entity_type,
+            todo!(), // ResolverInput {
+                     //     ctx: ExecutionContext::<'ctx> {
+                     //         engine: self.engine,
+                     //         variables: self.variables,
+                     //         walker: self.operation.walker_with(schema, ()),
+                     //         request_headers: self.request_headers,
+                     //     },
+                     //     boundary_objects_view: self.response.read(schema, plan.input),
+                     //     plan_id: plan.id,
+                     //     plan_output: plan.output,
+                     //     output,
+                     // },
+        );
+        match result {
+            Ok(executor) => Some(executor),
+            Err(err) => {
+                self.response.push_error(err);
+                None
+            }
+        }
+    }
+
+    fn root_response_boundary(&self) -> ResponseBoundaryItem {
+        ResponseBoundaryItem {
+            response_object_id: self
+                .response
+                .root_response_object_id()
+                .expect("No errors could have propagated to root yet."),
+            response_path: ResponsePath::default(),
+            object_id: self.operation.root_object_id,
+        }
     }
 
     fn push_planning_error(&mut self, query_path: QueryPath, err: PlanningError) {
@@ -200,6 +313,35 @@ impl<'ctx> ExecutorCoordinator<'ctx> {
             self.operation.response_keys.clone(),
             ExecutionMetadata::build(self.operation),
         )
+    }
+}
+
+pub struct ExecutorFutureSet<'a>(FuturesUnordered<BoxFuture<'a, ExecutorFutResult>>);
+
+impl<'a> ExecutorFutureSet<'a> {
+    fn new() -> Self {
+        ExecutorFutureSet(FuturesUnordered::new())
+    }
+
+    fn execute(&mut self, executor: Executor<'a>) {
+        self.push(make_send_on_wasm(executor.execute().map(ExecutorFutResult::from)))
+    }
+
+    fn execute_mutation_root(&mut self, executor: Executor<'a>) {
+        self.push(make_send_on_wasm(async move {
+            ExecutorFutResult {
+                result: executor.execute().await,
+                is_mutation_root_field: true,
+            }
+        }))
+    }
+
+    fn push(&mut self, fut: impl Future<Output = ExecutorFutResult> + Send + 'a) {
+        self.0.push(Box::pin(fut));
+    }
+
+    pub async fn next(&mut self) -> Option<ExecutorFutResult> {
+        self.0.next().await
     }
 }
 

--- a/engine/crates/engine-v2/src/execution/coordinator.rs
+++ b/engine/crates/engine-v2/src/execution/coordinator.rs
@@ -6,7 +6,7 @@ use std::{
 use async_runtime::make_send_on_wasm;
 use engine::RequestHeaders;
 use engine_parser::types::OperationType;
-use futures_util::{future::BoxFuture, stream::FuturesUnordered, Future, FutureExt, Stream, StreamExt};
+use futures_util::{future::BoxFuture, stream::FuturesUnordered, Future, FutureExt, SinkExt, Stream, StreamExt};
 
 use crate::{
     execution::{ExecutionContext, Variables},
@@ -15,57 +15,73 @@ use crate::{
     response::{
         ExecutionMetadata, ExecutorOutput, GraphqlError, Response, ResponseBoundaryItem, ResponseBuilder, ResponsePath,
     },
-    sources::{Executor, ExecutorResult, ResolverInput, SubscriptionExecutor},
+    sources::{Executor, ExecutorResult, ResolverInput, SubscriptionExecutor, SubscriptionResolverInput},
     Engine,
 };
 
+pub type ResponseReceiver = futures::channel::mpsc::Receiver<Response>;
+pub type ResponseSender = futures::channel::mpsc::Sender<Response>;
+
 pub struct ExecutorCoordinator<'ctx> {
     engine: &'ctx Engine,
-    operation: &'ctx Operation,
-    planner: Planner<'ctx>,
-    variables: &'ctx Variables<'ctx>,
-    request_headers: &'ctx RequestHeaders,
+    operation: Operation,
+    variables: Variables,
+    request_headers: RequestHeaders,
+}
+
+// TODO: This could arguably be ResponseContext
+// or something since it's the context of a single response.
+// TODO: OFC its worth seeing if we even need it as a struct.
+struct TheMutableBits<'a> {
+    planner: Planner<'a>,
+    response: ResponseBuilder,
 }
 
 impl<'ctx> ExecutorCoordinator<'ctx> {
     pub fn new(
         engine: &'ctx Engine,
-        operation: &'ctx Operation,
-        variables: &'ctx Variables<'ctx>,
-        request_headers: &'ctx RequestHeaders,
+
+        // TODO: Should the next three be encapsulated in some kind of Request struct
+        operation: Operation,
+        variables: Variables,
+        request_headers: RequestHeaders,
     ) -> Self {
         Self {
             engine,
             operation,
-            planner: Planner::new(&engine.schema, operation),
             variables,
             request_headers,
         }
     }
 
-    pub async fn execute(mut self) -> Response {
-        let mut response = ResponseBuilder::new(&self.operation);
+    pub async fn execute(self) -> Response {
+        // TODO: planner maybe doesn't need to live on self either
+        let planner = Planner::new(&self.engine.schema, &self.operation);
+        let response = ResponseBuilder::new(&self.operation);
+
+        let mut mutable_bits = TheMutableBits { planner, response };
 
         // Mutation root fields need to be executed sequentially. So we're tracking for each
         // executor whether it was for one and if so execute the next executor in the queue.
         // Keeping the queue outside of the FuturesUnordered also ensures the future is static
         // which wasm target somehow required. (not entirely sure why though)
         let mut mutation_root_fields_executors = VecDeque::<Executor<'ctx>>::new();
-        let response_boundary = vec![response
+        let response_boundary = vec![mutable_bits
+            .response
             .root_response_boundary()
             .expect("a fresh response should always have a root")];
 
-        let plan_boundary = match self.planner.generate_root_plan_boundary() {
+        let plan_boundary = match mutable_bits.planner.generate_root_plan_boundary() {
             Ok(boundary) => boundary,
             Err(err) => {
-                self.push_planning_error(QueryPath::default(), err, &mut response);
+                self.push_planning_error(QueryPath::default(), err, &mut mutable_bits.response);
                 todo!("return somehow");
             }
         };
 
         let mut futures = ExecutorFutureSet::new();
 
-        let initial_exectors = self.generate_executors(vec![(plan_boundary, response_boundary)], &mut response);
+        let initial_exectors = self.generate_executors(vec![(plan_boundary, response_boundary)], &mut mutable_bits);
 
         match self.operation.ty {
             OperationType::Query => {
@@ -94,114 +110,119 @@ impl<'ctx> ExecutorCoordinator<'ctx> {
             match result {
                 Ok(output) => {
                     // Ingesting data first to propagate errors.
-                    let boundaries = response.ingest(output);
+                    let boundaries = mutable_bits.response.ingest(output);
 
                     // Hack to ensure we don't execute any subsequent mutation root fields if a
                     // previous one failed and the error propagated up to the root `data` field.
-                    if response.root_response_object_id().is_some() {
+                    if mutable_bits.response.root_response_object_id().is_some() {
                         if is_mutation_root_field {
                             if let Some(executor) = mutation_root_fields_executors.pop_front() {
                                 futures.execute_mutation_root(executor);
                             }
                         }
-                        let executors = self.generate_executors(boundaries, &mut response);
+                        let executors = self.generate_executors(boundaries, &mut mutable_bits);
                         for executor in executors {
                             futures.execute(executor);
                         }
                     }
                 }
                 Err(err) => {
-                    response.push_error(err);
+                    mutable_bits.response.push_error(err);
                 }
             }
         }
 
-        response.build(
+        mutable_bits.response.build(
             self.engine.schema.clone(),
             self.operation.response_keys.clone(),
-            ExecutionMetadata::build(self.operation),
+            ExecutionMetadata::build(&self.operation),
         )
     }
 
-    pub fn execute_subscription(&mut self) -> impl Stream<Item = Response> + 'ctx {
+    pub async fn execute_subscription(self, mut responses: ResponseSender) {
         // TODO: Decide if this is even the best place to put this or if we need some
         // new kind of cordinator?  Who knows
         assert!(matches!(self.operation.ty, OperationType::Subscription));
 
-        let response_boundary = vec![response
-            .root_response_boundary()
-            .expect("a fresh response should always have a root")];
+        let mut planner = Planner::new(&self.engine.schema, &self.operation);
 
         // TODO: wonder if there's scope to combine generate_root_plan_boundary & plans_from_boundary
         // Think we always call them together?
-        let plan = match self.planner.generate_root_plan_boundary() {
-            Ok(boundary) => {
-                let mut plans = self.plans_from_boundary((boundary, response_boundary));
-                // TODO: This probably shouldn't be an assert but yolo for now
-                assert!(plans.len() == 1);
-                plans.pop().expect("TODO: make this less hacky")
-            }
+        let planning_result = planner
+            .generate_root_plan_boundary()
+            .and_then(|boundary| planner.generate_subscription_plan(boundary));
+
+        let plan = match planning_result {
+            Ok(plan) => plan,
             Err(err) => {
                 // self.push_planning_error(QueryPath::default(), err);
                 todo!("return an error somehow")
             }
         };
 
-        let Some(executor) = self.subscription_executor_from_plan(plan, todo!()) else {
+        let Some(executor) = self.subscription_executor_from_plan(plan) else {
             todo!("return an error somehow")
         };
 
-        let coordinator = Arc::new(self);
-        executor.execute().then({
-            move |(mut response, output)| {
-                let coordinator = Arc::clone(&coordinator);
-                async move {
-                    let boundaries = response.ingest(output);
-                    let mut futures = ExecutorFutureSet::new();
-                    for executor in coordinator.generate_executors(boundaries, &mut response) {
+        let mut mutable_bits = TheMutableBits {
+            planner,
+            response: ResponseBuilder::new(&self.operation),
+        };
+
+        let mut stream = executor.execute();
+        while let Some((mut response, output)) = stream.next().await {
+            let boundaries = mutable_bits.response.ingest(output);
+            let mut futures = ExecutorFutureSet::new();
+            for executor in self.generate_executors(boundaries, &mut mutable_bits) {
+                futures.execute(executor);
+            }
+
+            while let Some(ExecutorFutResult { result, .. }) = futures.next().await {
+                let output = match result {
+                    Ok(output) => output,
+                    Err(error) => {
+                        response.push_error(error);
+                        continue;
+                    }
+                };
+
+                let boundaries = response.ingest(output);
+                if response.root_response_object_id().is_some() {
+                    let executors = self.generate_executors(boundaries, &mut mutable_bits);
+                    for executor in executors {
                         futures.execute(executor);
                     }
-
-                    while let Some(ExecutorFutResult { result, .. }) = futures.next().await {
-                        let output = match result {
-                            Ok(output) => output,
-                            Err(error) => {
-                                response.push_error(error);
-                                continue;
-                            }
-                        };
-
-                        let boundaries = response.ingest(output);
-                        if response.root_response_object_id().is_some() {
-                            // TODO: THis needs to somehow use the actual response not self.response
-                            let executors = coordinator.generate_executors(boundaries, &mut response);
-                            for executor in executors {
-                                futures.execute(executor);
-                            }
-                        }
-                    }
-
-                    response.build(
-                        coordinator.engine.schema.clone(),
-                        coordinator.operation.response_keys.clone(),
-                        ExecutionMetadata::build(coordinator.operation),
-                    )
                 }
             }
-        })
+
+            let result = responses
+                .send(response.build(
+                    self.engine.schema.clone(),
+                    self.operation.response_keys.clone(),
+                    ExecutionMetadata::build(&self.operation),
+                ))
+                .await;
+
+            mutable_bits.response = ResponseBuilder::new(&self.operation);
+
+            #[allow(clippy::all)]
+            if let Err(_) = result {
+                todo!("do something")
+            }
+        }
     }
 
     fn generate_executors(
-        &mut self,
+        &self,
         boundaries: Vec<(PlanBoundary, Vec<ResponseBoundaryItem>)>,
-        response: &mut ResponseBuilder,
-    ) -> Vec<Executor<'ctx>> {
+        mutable_bits: &mut TheMutableBits<'ctx>,
+    ) -> Vec<Executor<'_>> {
         // Ordering of the executors MUST match the plan boundary order for mutation root
         let mut executors = vec![];
 
         for boundary in boundaries {
-            for plan in self.plans_from_boundary(boundary) {
-                executors.extend(self.executor_from_plan(plan, response))
+            for plan in self.plans_from_boundary(boundary, &mut mutable_bits.planner) {
+                executors.extend(self.executor_from_plan(plan, &mut mutable_bits.response))
             }
         }
 
@@ -209,11 +230,12 @@ impl<'ctx> ExecutorCoordinator<'ctx> {
     }
 
     fn plans_from_boundary(
-        &mut self,
+        &self,
         (plan_boundary, response_boundary): (PlanBoundary, Vec<ResponseBoundaryItem>),
+        planner: &mut Planner<'_>,
     ) -> Vec<Plan> {
         let query_path = plan_boundary.query_path.clone();
-        match self.planner.generate_plans(plan_boundary, &response_boundary) {
+        match planner.generate_plans(plan_boundary, &response_boundary) {
             Ok(plans) => plans,
 
             Err(err) => {
@@ -227,7 +249,7 @@ impl<'ctx> ExecutorCoordinator<'ctx> {
     // - schema from self.engine
     // - the current response
     // - An execution context, mostly generatable from self
-    fn executor_from_plan(&mut self, plan: Plan, response: &mut ResponseBuilder) -> Option<Executor<'ctx>> {
+    fn executor_from_plan<'a>(&'a self, plan: Plan, response: &mut ResponseBuilder) -> Option<Executor<'a>> {
         let resolver = self.engine.schema.walker().walk(plan.resolver_id);
         let schema = self.engine.schema.walker_with(resolver.names());
         let output = response.new_output(plan.boundaries);
@@ -238,13 +260,14 @@ impl<'ctx> ExecutorCoordinator<'ctx> {
             resolver,
             plan.output.entity_type,
             ResolverInput {
-                ctx: ExecutionContext::<'ctx> {
+                ctx: ExecutionContext {
                     engine: self.engine,
-                    variables: self.variables,
-                    walker: self.operation.walker_with(schema, ()),
-                    request_headers: self.request_headers,
+                    variables: &self.variables,
+                    walker: self.operation.walker_with(schema),
+                    request_headers: &self.request_headers,
                 },
-                boundary_objects_view: response.read(schema, plan.input),
+                boundary_objects_view: response
+                    .read(schema, plan.input.expect("all but the subscription plan to have input")),
                 plan_id: plan.id,
                 plan_output: plan.output,
                 output,
@@ -259,43 +282,37 @@ impl<'ctx> ExecutorCoordinator<'ctx> {
         }
     }
 
-    fn subscription_executor_from_plan(
-        &mut self,
-        plan: Plan,
-        response: &mut ResponseBuilder,
-    ) -> Option<SubscriptionExecutor<'ctx>> {
+    fn subscription_executor_from_plan(&self, plan: Plan) -> Option<SubscriptionExecutor<'_>> {
         let resolver = self.engine.schema.walker().walk(plan.resolver_id);
         let schema = self.engine.schema.walker_with(resolver.names());
-        let output = response.new_output(plan.boundaries);
         // Ensuring that all walkers the executors has access to have a consistent
         // `Names`.
         let resolver = schema.walk(plan.resolver_id);
         let result = SubscriptionExecutor::build(
             resolver,
             plan.output.entity_type,
-            todo!(), // ResolverInput {
-                     //     ctx: ExecutionContext::<'ctx> {
-                     //         engine: self.engine,
-                     //         variables: self.variables,
-                     //         walker: self.operation.walker_with(schema, ()),
-                     //         request_headers: self.request_headers,
-                     //     },
-                     //     boundary_objects_view: self.response.read(schema, plan.input),
-                     //     plan_id: plan.id,
-                     //     plan_output: plan.output,
-                     //     output,
-                     // },
+            SubscriptionResolverInput {
+                ctx: ExecutionContext {
+                    engine: self.engine,
+                    variables: &self.variables,
+                    walker: self.operation.walker_with(schema),
+                    request_headers: &self.request_headers,
+                },
+                plan_id: plan.id,
+                plan_output: plan.output,
+            },
         );
+
         match result {
             Ok(executor) => Some(executor),
             Err(err) => {
-                response.push_error(err);
+                todo!("error somehow");
                 None
             }
         }
     }
 
-    fn push_planning_error(&mut self, query_path: QueryPath, err: PlanningError, response: &mut ResponseBuilder) {
+    fn push_planning_error(&self, query_path: QueryPath, err: PlanningError, response: &mut ResponseBuilder) {
         response.push_error(GraphqlError {
             message: err.to_string(),
             locations: vec![],

--- a/engine/crates/engine-v2/src/execution/coordinator.rs
+++ b/engine/crates/engine-v2/src/execution/coordinator.rs
@@ -1,25 +1,19 @@
-use std::{
-    collections::{BTreeMap, VecDeque},
-    sync::Arc,
-};
+use std::collections::BTreeMap;
 
 use async_runtime::make_send_on_wasm;
 use engine::RequestHeaders;
 use engine_parser::types::OperationType;
-use futures_util::{future::BoxFuture, stream::FuturesUnordered, Future, FutureExt, SinkExt, Stream, StreamExt};
+use futures_util::{future::BoxFuture, stream::FuturesUnordered, Future, FutureExt, SinkExt, StreamExt};
 
 use crate::{
     execution::{ExecutionContext, Variables},
     plan::{Plan, PlanBoundary, Planner, PlanningError},
-    request::{Operation, QueryPath},
-    response::{
-        ExecutionMetadata, ExecutorOutput, GraphqlError, Response, ResponseBoundaryItem, ResponseBuilder, ResponsePath,
-    },
+    request::Operation,
+    response::{ExecutionMetadata, ExecutorOutput, GraphqlError, Response, ResponseBoundaryItem, ResponseBuilder},
     sources::{Executor, ExecutorResult, ResolverInput, SubscriptionExecutor, SubscriptionResolverInput},
     Engine,
 };
 
-pub type ResponseReceiver = futures::channel::mpsc::Receiver<Response>;
 pub type ResponseSender = futures::channel::mpsc::Sender<Response>;
 
 pub struct ExecutorCoordinator<'ctx> {
@@ -29,19 +23,9 @@ pub struct ExecutorCoordinator<'ctx> {
     request_headers: RequestHeaders,
 }
 
-// TODO: This could arguably be ResponseContext
-// or something since it's the context of a single response.
-// TODO: OFC its worth seeing if we even need it as a struct.
-struct TheMutableBits<'a> {
-    planner: Planner<'a>,
-    response: ResponseBuilder,
-}
-
 impl<'ctx> ExecutorCoordinator<'ctx> {
     pub fn new(
         engine: &'ctx Engine,
-
-        // TODO: Should the next three be encapsulated in some kind of Request struct
         operation: Operation,
         variables: Variables,
         request_headers: RequestHeaders,
@@ -55,45 +39,42 @@ impl<'ctx> ExecutorCoordinator<'ctx> {
     }
 
     pub async fn execute(self) -> Response {
-        // TODO: planner maybe doesn't need to live on self either
         let planner = Planner::new(&self.engine.schema, &self.operation);
-        let response = ResponseBuilder::new(&self.operation);
-
-        let mut mutable_bits = TheMutableBits { planner, response };
+        let mut planner = planner;
+        let mut response = ResponseBuilder::new(&self.operation);
 
         // Mutation root fields need to be executed sequentially. So we're tracking for each
         // executor whether it was for one and if so execute the next executor in the queue.
         // Keeping the queue outside of the FuturesUnordered also ensures the future is static
         // which wasm target somehow required. (not entirely sure why though)
-        let mut mutation_root_fields_executors = VecDeque::<Executor<'ctx>>::new();
-        let response_boundary = vec![mutable_bits
-            .response
+        let mut mutation_root_fields_executors = vec![];
+        let response_boundary = vec![response
             .root_response_boundary()
             .expect("a fresh response should always have a root")];
 
-        let plan_boundary = match mutable_bits.planner.generate_root_plan_boundary() {
-            Ok(boundary) => boundary,
-            Err(err) => {
-                self.push_planning_error(QueryPath::default(), err, &mut mutable_bits.response);
-                todo!("return somehow");
+        let initial_executors = match planner.generate_root_plan_boundary() {
+            Ok(boundary) => self.generate_executors(vec![(boundary, response_boundary)], &mut planner, &mut response),
+            Err(error) => {
+                response.push_error(error.into_graphql_error());
+
+                vec![]
             }
         };
 
         let mut futures = ExecutorFutureSet::new();
 
-        let initial_exectors = self.generate_executors(vec![(plan_boundary, response_boundary)], &mut mutable_bits);
-
         match self.operation.ty {
             OperationType::Query => {
-                for executor in initial_exectors {
+                for executor in initial_executors {
                     futures.execute(executor);
                 }
             }
             OperationType::Mutation => {
-                // TODO: Maybe just do a reversed vec for these?
-                mutation_root_fields_executors = VecDeque::from(initial_exectors);
+                // Reverse the initial_executors so we can pop them in the order they should run
+                mutation_root_fields_executors = initial_executors;
+                mutation_root_fields_executors.reverse();
 
-                if let Some(executor) = mutation_root_fields_executors.pop_front() {
+                if let Some(executor) = mutation_root_fields_executors.pop() {
                     futures.execute_mutation_root(executor);
                 }
             }
@@ -102,6 +83,57 @@ impl<'ctx> ExecutorCoordinator<'ctx> {
             }
         }
 
+        self.execute_once(futures, response, mutation_root_fields_executors, &mut planner)
+            .await
+    }
+
+    #[allow(dead_code)]
+    pub async fn execute_subscription(self, mut responses: ResponseSender) {
+        assert!(matches!(self.operation.ty, OperationType::Subscription));
+
+        let mut planner = Planner::new(&self.engine.schema, &self.operation);
+
+        let executor = planner
+            .generate_root_plan_boundary()
+            .and_then(|boundary| planner.generate_subscription_plan(boundary))
+            .map_err(PlanningError::into_graphql_error)
+            .and_then(|plan| self.subscription_executor_from_plan(plan).map_err(GraphqlError::from));
+
+        let mut stream = match executor {
+            Ok(executor) => executor.execute(),
+            Err(error) => {
+                responses
+                    .send(ResponseBuilder::new(&self.operation).with_error(error).build(
+                        self.engine.schema.clone(),
+                        self.operation.response_keys.clone(),
+                        ExecutionMetadata::build(&self.operation),
+                    ))
+                    .await
+                    .ok();
+                return;
+            }
+        };
+
+        while let Some((response, output)) = stream.next().await {
+            let mut futures = ExecutorFutureSet::new();
+            futures.push(async move { ExecutorFutResult::from(Ok(output)) });
+
+            let response = self.execute_once(futures, response, vec![], &mut planner).await;
+
+            if responses.send(response).await.is_err() {
+                return;
+            }
+        }
+    }
+
+    /// Runs a single execution to completion, returning its response
+    async fn execute_once(
+        &'ctx self,
+        mut futures: ExecutorFutureSet<'ctx>,
+        mut response: ResponseBuilder,
+        mut mutation_root_fields_executors: Vec<Executor<'ctx>>,
+        planner: &mut Planner<'ctx>,
+    ) -> Response {
         while let Some(ExecutorFutResult {
             result,
             is_mutation_root_field,
@@ -110,145 +142,61 @@ impl<'ctx> ExecutorCoordinator<'ctx> {
             match result {
                 Ok(output) => {
                     // Ingesting data first to propagate errors.
-                    let boundaries = mutable_bits.response.ingest(output);
+                    let boundaries = response.ingest(output);
 
                     // Hack to ensure we don't execute any subsequent mutation root fields if a
                     // previous one failed and the error propagated up to the root `data` field.
-                    if mutable_bits.response.root_response_object_id().is_some() {
+                    if response.root_response_object_id().is_some() {
                         if is_mutation_root_field {
-                            if let Some(executor) = mutation_root_fields_executors.pop_front() {
+                            if let Some(executor) = mutation_root_fields_executors.pop() {
                                 futures.execute_mutation_root(executor);
                             }
                         }
-                        let executors = self.generate_executors(boundaries, &mut mutable_bits);
+                        let executors = self.generate_executors(boundaries, planner, &mut response);
                         for executor in executors {
                             futures.execute(executor);
                         }
                     }
                 }
                 Err(err) => {
-                    mutable_bits.response.push_error(err);
+                    response.push_error(err);
                 }
             }
         }
 
-        mutable_bits.response.build(
+        response.build(
             self.engine.schema.clone(),
             self.operation.response_keys.clone(),
             ExecutionMetadata::build(&self.operation),
         )
     }
 
-    pub async fn execute_subscription(self, mut responses: ResponseSender) {
-        // TODO: Decide if this is even the best place to put this or if we need some
-        // new kind of cordinator?  Who knows
-        assert!(matches!(self.operation.ty, OperationType::Subscription));
-
-        let mut planner = Planner::new(&self.engine.schema, &self.operation);
-
-        // TODO: wonder if there's scope to combine generate_root_plan_boundary & plans_from_boundary
-        // Think we always call them together?
-        let planning_result = planner
-            .generate_root_plan_boundary()
-            .and_then(|boundary| planner.generate_subscription_plan(boundary));
-
-        let plan = match planning_result {
-            Ok(plan) => plan,
-            Err(err) => {
-                // self.push_planning_error(QueryPath::default(), err);
-                todo!("return an error somehow")
-            }
-        };
-
-        let Some(executor) = self.subscription_executor_from_plan(plan) else {
-            todo!("return an error somehow")
-        };
-
-        let mut mutable_bits = TheMutableBits {
-            planner,
-            response: ResponseBuilder::new(&self.operation),
-        };
-
-        let mut stream = executor.execute();
-        while let Some((mut response, output)) = stream.next().await {
-            let boundaries = mutable_bits.response.ingest(output);
-            let mut futures = ExecutorFutureSet::new();
-            for executor in self.generate_executors(boundaries, &mut mutable_bits) {
-                futures.execute(executor);
-            }
-
-            while let Some(ExecutorFutResult { result, .. }) = futures.next().await {
-                let output = match result {
-                    Ok(output) => output,
-                    Err(error) => {
-                        response.push_error(error);
-                        continue;
-                    }
-                };
-
-                let boundaries = response.ingest(output);
-                if response.root_response_object_id().is_some() {
-                    let executors = self.generate_executors(boundaries, &mut mutable_bits);
-                    for executor in executors {
-                        futures.execute(executor);
-                    }
-                }
-            }
-
-            let result = responses
-                .send(response.build(
-                    self.engine.schema.clone(),
-                    self.operation.response_keys.clone(),
-                    ExecutionMetadata::build(&self.operation),
-                ))
-                .await;
-
-            mutable_bits.response = ResponseBuilder::new(&self.operation);
-
-            #[allow(clippy::all)]
-            if let Err(_) = result {
-                todo!("do something")
-            }
-        }
-    }
-
     fn generate_executors(
         &self,
         boundaries: Vec<(PlanBoundary, Vec<ResponseBoundaryItem>)>,
-        mutable_bits: &mut TheMutableBits<'ctx>,
+        planner: &mut Planner<'ctx>,
+        response: &mut ResponseBuilder, // mutable_bits: &mut TheMutableBits<'ctx>,
     ) -> Vec<Executor<'_>> {
         // Ordering of the executors MUST match the plan boundary order for mutation root
         let mut executors = vec![];
 
-        for boundary in boundaries {
-            for plan in self.plans_from_boundary(boundary, &mut mutable_bits.planner) {
-                executors.extend(self.executor_from_plan(plan, &mut mutable_bits.response))
+        for (plan_boundary, response_boundaries) in boundaries {
+            let plans = match planner.generate_plans(plan_boundary, &response_boundaries) {
+                Ok(plans) => plans,
+                Err(error) => {
+                    response.push_error(error.into_graphql_error());
+                    continue;
+                }
+            };
+
+            for plan in plans {
+                executors.extend(self.executor_from_plan(plan, response))
             }
         }
 
         executors
     }
 
-    fn plans_from_boundary(
-        &self,
-        (plan_boundary, response_boundary): (PlanBoundary, Vec<ResponseBoundaryItem>),
-        planner: &mut Planner<'_>,
-    ) -> Vec<Plan> {
-        let query_path = plan_boundary.query_path.clone();
-        match planner.generate_plans(plan_boundary, &response_boundary) {
-            Ok(plans) => plans,
-
-            Err(err) => {
-                todo!("self.push_planning_error(query_path, err)");
-                vec![]
-            }
-        }
-    }
-
-    // This function requires:
-    // - schema from self.engine
-    // - the current response
-    // - An execution context, mostly generatable from self
     fn executor_from_plan<'a>(&'a self, plan: Plan, response: &mut ResponseBuilder) -> Option<Executor<'a>> {
         let resolver = self.engine.schema.walker().walk(plan.resolver_id);
         let schema = self.engine.schema.walker_with(resolver.names());
@@ -282,13 +230,15 @@ impl<'ctx> ExecutorCoordinator<'ctx> {
         }
     }
 
-    fn subscription_executor_from_plan(&self, plan: Plan) -> Option<SubscriptionExecutor<'_>> {
+    fn subscription_executor_from_plan(&self, plan: Plan) -> ExecutorResult<SubscriptionExecutor<'_>> {
         let resolver = self.engine.schema.walker().walk(plan.resolver_id);
         let schema = self.engine.schema.walker_with(resolver.names());
+
         // Ensuring that all walkers the executors has access to have a consistent
         // `Names`.
         let resolver = schema.walk(plan.resolver_id);
-        let result = SubscriptionExecutor::build(
+
+        SubscriptionExecutor::build(
             resolver,
             plan.output.entity_type,
             SubscriptionResolverInput {
@@ -301,32 +251,18 @@ impl<'ctx> ExecutorCoordinator<'ctx> {
                 plan_id: plan.id,
                 plan_output: plan.output,
             },
-        );
-
-        match result {
-            Ok(executor) => Some(executor),
-            Err(err) => {
-                todo!("error somehow");
-                None
-            }
-        }
+        )
     }
+}
 
-    fn push_planning_error(&self, query_path: QueryPath, err: PlanningError, response: &mut ResponseBuilder) {
-        response.push_error(GraphqlError {
-            message: err.to_string(),
+impl PlanningError {
+    fn into_graphql_error(self) -> GraphqlError {
+        GraphqlError {
+            message: self.to_string(),
             locations: vec![],
             path: None,
-            extensions: BTreeMap::from([(
-                "queryPath".into(),
-                serde_json::Value::Array(
-                    query_path
-                        .into_iter()
-                        .map(|key| self.operation.response_keys[*key].into())
-                        .collect(),
-                ),
-            )]),
-        })
+            extensions: BTreeMap::from([("queryPath".into(), serde_json::Value::Array(vec![]))]),
+        }
     }
 }
 
@@ -354,7 +290,7 @@ impl<'a> ExecutorFutureSet<'a> {
         self.0.push(Box::pin(fut));
     }
 
-    pub async fn next(&mut self) -> Option<ExecutorFutResult> {
+    async fn next(&mut self) -> Option<ExecutorFutResult> {
         self.0.next().await
     }
 }

--- a/engine/crates/engine-v2/src/execution/mod.rs
+++ b/engine/crates/engine-v2/src/execution/mod.rs
@@ -3,5 +3,5 @@ mod coordinator;
 mod variables;
 
 pub(crate) use context::*;
-pub use coordinator::{ExecutorCoordinator, ResponseReceiver};
+pub use coordinator::ExecutorCoordinator;
 pub use variables::*;

--- a/engine/crates/engine-v2/src/execution/mod.rs
+++ b/engine/crates/engine-v2/src/execution/mod.rs
@@ -3,5 +3,5 @@ mod coordinator;
 mod variables;
 
 pub(crate) use context::*;
-pub use coordinator::ExecutorCoordinator;
+pub use coordinator::{ExecutorCoordinator, ResponseReceiver};
 pub use variables::*;

--- a/engine/crates/engine-v2/src/execution/variables.rs
+++ b/engine/crates/engine-v2/src/execution/variables.rs
@@ -4,7 +4,6 @@ use engine_parser::Pos;
 use engine_value::{ConstValue, Name};
 use indexmap::IndexMap;
 use schema::{DataType, InputObjectId, ListWrapping, Schema, StringId};
-use serde::de;
 
 use crate::{
     request::{Operation, VariableDefinition, VariableDefinitionId},

--- a/engine/crates/engine-v2/src/execution/variables.rs
+++ b/engine/crates/engine-v2/src/execution/variables.rs
@@ -4,9 +4,10 @@ use engine_parser::Pos;
 use engine_value::{ConstValue, Name};
 use indexmap::IndexMap;
 use schema::{DataType, InputObjectId, ListWrapping, Schema, StringId};
+use serde::de;
 
 use crate::{
-    request::{Operation, VariableDefinition},
+    request::{Operation, VariableDefinition, VariableDefinitionId},
     response::GraphqlError,
 };
 
@@ -95,28 +96,34 @@ impl ValueKind {
     }
 }
 
-pub struct Variables<'a> {
-    inner: HashMap<String, Variable<'a>>,
+pub struct Variables {
+    inner: HashMap<String, Variable>,
 }
 
-pub struct Variable<'a> {
+pub struct Variable {
     pub value: Option<ConstValue>,
-    pub definition: &'a VariableDefinition,
+    pub definition_id: VariableDefinitionId,
 }
 
-impl<'a> Variables<'a> {
+impl Variables {
     pub fn from_request(
-        operation: &'a Operation,
+        operation: &Operation,
         schema: &Schema,
         mut variables: engine_value::Variables,
     ) -> Result<Self, Vec<VariableError>> {
         let mut coerced = HashMap::new();
         let mut errors = vec![];
 
-        for definition in operation.variable_definitions.iter() {
+        for (id, definition) in operation.variable_definitions.iter().enumerate() {
             match coerce_variable_value(definition, schema, &mut variables, VariablePath::new(&definition.name)) {
                 Ok(value) => {
-                    coerced.insert(definition.name.clone(), Variable { value, definition });
+                    coerced.insert(
+                        definition.name.clone(),
+                        Variable {
+                            value,
+                            definition_id: id.into(),
+                        },
+                    );
                 }
                 Err(error) => {
                     errors.push(error);
@@ -131,7 +138,7 @@ impl<'a> Variables<'a> {
         Ok(Self { inner: coerced })
     }
 
-    pub fn get(&self, name: &str) -> Option<&Variable<'_>> {
+    pub fn get(&self, name: &str) -> Option<&Variable> {
         self.inner.get(name)
     }
 }

--- a/engine/crates/engine-v2/src/plan/mod.rs
+++ b/engine/crates/engine-v2/src/plan/mod.rs
@@ -19,7 +19,7 @@ pub use planner::{Planner, PlanningError};
 pub struct Plan {
     pub id: PlanId,
     pub resolver_id: ResolverId,
-    pub input: PlanInput,
+    pub input: Option<PlanInput>,
     pub output: PlanOutput,
     /// Boundaries between this plan and its children. ResponseObjectRoots will be collected at
     /// those during execution.

--- a/engine/crates/engine-v2/src/plan/planner.rs
+++ b/engine/crates/engine-v2/src/plan/planner.rs
@@ -88,30 +88,21 @@ impl<'op> Planner<'op> {
         Ok(boundary)
     }
 
-    // TODO: could I have a generate root plan that skips the response boundary stuff?
-    pub fn generate_root_plan(&mut self, boundary: PlanBoundary) -> PlanningResult<Vec<Plan>> {
-        boundary
-            .children
-            .into_iter()
-            .filter_map(|mut child| {
-                let id = child.id;
-                let resolver_id = child.resolver_id;
-                let input = PlanInput {
-                    response_boundary,
-                    selection_set: std::mem::take(&mut child.input_selection_set),
-                };
-                Some(
-                    self.create_plan_output(&boundary.query_path, child)
-                        .map(|(output, boundaries)| Plan {
-                            id,
-                            resolver_id,
-                            input,
-                            output,
-                            boundaries,
-                        }),
-                )
+    pub fn generate_subscription_plan(&mut self, mut boundary: PlanBoundary) -> PlanningResult<Plan> {
+        assert!(boundary.children.len() == 1);
+        let child = boundary.children.pop().unwrap();
+
+        let id = child.id;
+        let resolver_id = child.resolver_id;
+
+        self.create_plan_output(&boundary.query_path, child)
+            .map(|(output, boundaries)| Plan {
+                id,
+                resolver_id,
+                input: None,
+                output,
+                boundaries,
             })
-            .collect()
     }
 
     pub fn generate_plans(
@@ -151,10 +142,10 @@ impl<'op> Planner<'op> {
                 } else {
                     let id = child.id;
                     let resolver_id = child.resolver_id;
-                    let input = PlanInput {
+                    let input = Some(PlanInput {
                         response_boundary,
                         selection_set: std::mem::take(&mut child.input_selection_set),
-                    };
+                    });
                     Some(
                         self.create_plan_output(&boundary.query_path, child)
                             .map(|(output, boundaries)| Plan {

--- a/engine/crates/engine-v2/src/request/ids.rs
+++ b/engine/crates/engine-v2/src/request/ids.rs
@@ -1,8 +1,11 @@
-use super::{BoundAnyFieldDefinition, BoundField, BoundFragmentDefinition, BoundSelectionSet, Operation};
+use super::{
+    BoundAnyFieldDefinition, BoundField, BoundFragmentDefinition, BoundSelectionSet, Operation, VariableDefinition,
+};
 
 crate::utils::id_newtypes! {
     Operation.fields[BoundFieldId] => BoundField unless "Too many fields",
     Operation.selection_sets[BoundSelectionSetId] => BoundSelectionSet unless "Too many selection sets",
     Operation.field_definitions[BoundAnyFieldDefinitionId] => BoundAnyFieldDefinition unless "Too many fields",
     Operation.fragment_definitions[BoundFragmentDefinitionId] => BoundFragmentDefinition unless "Too many fragments",
+    Operation.variable_definitions[VariableDefinitionId] => VariableDefinition unless "Too many variables",
 }

--- a/engine/crates/engine-v2/src/request/mod.rs
+++ b/engine/crates/engine-v2/src/request/mod.rs
@@ -22,9 +22,6 @@ mod selection_set;
 mod variable;
 mod walkers;
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub struct VariableId(usize);
-
 pub struct Operation {
     pub ty: OperationType,
     pub root_object_id: ObjectId,

--- a/engine/crates/engine-v2/src/request/walkers/plan.rs
+++ b/engine/crates/engine-v2/src/request/walkers/plan.rs
@@ -19,7 +19,7 @@ pub type PlanFieldArgument<'a> = BoundFieldArgumentWalker<'a, ExecutorWalkContex
 #[derive(Clone, Copy)]
 pub struct ExecutorWalkContext<'a> {
     pub attribution: &'a Attribution,
-    pub variables: &'a Variables<'a>,
+    pub variables: &'a Variables,
 }
 
 impl<'a, I: Copy, SI> OperationWalker<'a, I, SI, ExecutorWalkContext<'a>> {

--- a/engine/crates/engine-v2/src/request/walkers/variables.rs
+++ b/engine/crates/engine-v2/src/request/walkers/variables.rs
@@ -5,8 +5,8 @@ use crate::execution::{Variable, Variables};
 
 use super::OperationWalker;
 
-pub type VariablesWalker<'a> = OperationWalker<'a, &'a Variables<'a>>;
-pub type VariableWalker<'a> = OperationWalker<'a, &'a Variable<'a>>;
+pub type VariablesWalker<'a> = OperationWalker<'a, &'a Variables>;
+pub type VariableWalker<'a> = OperationWalker<'a, &'a Variable>;
 
 impl<'a> VariablesWalker<'a> {
     pub fn get(&self, name: &str) -> Option<VariableWalker<'a>> {
@@ -20,7 +20,7 @@ impl<'a> VariableWalker<'a> {
     }
 
     pub fn type_name(&self) -> String {
-        let ty = &self.item.definition.r#type;
+        let ty = &self.walk(self.item.definition_id).as_ref().r#type;
         let mut name = self.schema_walker.walk(ty.inner).name().to_string();
         if ty.wrapping.inner_is_required {
             name.push('!');
@@ -34,7 +34,7 @@ impl<'a> VariableWalker<'a> {
         name
     }
 
-    pub fn default_value(&self) -> &Option<ConstValue> {
-        &self.item.definition.default_value
+    pub fn default_value(&self) -> Option<&ConstValue> {
+        self.walk(self.item.definition_id).as_ref().default_value.as_ref()
     }
 }

--- a/engine/crates/engine-v2/src/response/write/ids.rs
+++ b/engine/crates/engine-v2/src/response/write/ids.rs
@@ -80,6 +80,7 @@ impl std::ops::Index<ResponseObjectId> for ResponseData {
         &self.parts[usize::from(index.part_id)].objects[index.index as usize]
     }
 }
+
 impl std::ops::Index<ResponseListId> for ResponseData {
     type Output = [ResponseValue];
 

--- a/engine/crates/engine-v2/src/response/write/mod.rs
+++ b/engine/crates/engine-v2/src/response/write/mod.rs
@@ -46,7 +46,6 @@ pub(crate) struct ResponseBuilder {
 // least wait until we face actual problems. We're focused on OLTP workloads, so might never
 // happen.
 impl ResponseBuilder {
-    // TODO: This could probably just take the root_object_id?
     pub fn new(operation: &Operation) -> Self {
         let mut builder = ExecutorOutput::new(ResponseDataPartId::from(0), vec![]);
         let root_id = builder.push_object(ResponseObject {
@@ -101,6 +100,11 @@ impl ResponseBuilder {
     // Coordinator during the planning phase.
     pub fn push_error(&mut self, error: impl Into<GraphqlError>) {
         self.errors.push(error.into());
+    }
+
+    pub fn with_error(mut self, error: impl Into<GraphqlError>) -> Self {
+        self.push_error(error);
+        self
     }
 
     pub fn build(self, schema: Arc<Schema>, keys: Arc<ResponseKeys>, metadata: ExecutionMetadata) -> Response {

--- a/engine/crates/engine-v2/src/response/write/mod.rs
+++ b/engine/crates/engine-v2/src/response/write/mod.rs
@@ -72,6 +72,14 @@ impl ResponseBuilder {
         ExecutorOutput::new(id, boundaries)
     }
 
+    pub fn root_response_boundary(&self) -> Option<ResponseBoundaryItem> {
+        Some(ResponseBoundaryItem {
+            response_object_id: self.root?,
+            response_path: ResponsePath::default(),
+            object_id: self[self.root?].object_id,
+        })
+    }
+
     pub fn ingest(&mut self, output: ExecutorOutput) -> Vec<(PlanBoundary, Vec<ResponseBoundaryItem>)> {
         let reservation = &mut self.parts[usize::from(output.id)];
         assert!(reservation.is_empty(), "Part already has data");

--- a/engine/crates/engine-v2/src/response/write/mod.rs
+++ b/engine/crates/engine-v2/src/response/write/mod.rs
@@ -46,6 +46,7 @@ pub(crate) struct ResponseBuilder {
 // least wait until we face actual problems. We're focused on OLTP workloads, so might never
 // happen.
 impl ResponseBuilder {
+    // TODO: This could probably just take the root_object_id?
     pub fn new(operation: &Operation) -> Self {
         let mut builder = ExecutorOutput::new(ResponseDataPartId::from(0), vec![]);
         let root_id = builder.push_object(ResponseObject {

--- a/engine/crates/engine-v2/src/sources/graphql/mod.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/mod.rs
@@ -11,6 +11,9 @@ use crate::{
 mod deserialize;
 pub mod federation;
 mod query;
+mod subscription;
+
+pub use subscription::*;
 
 pub(crate) struct GraphqlExecutor<'ctx> {
     ctx: ExecutionContext<'ctx>,

--- a/engine/crates/engine-v2/src/sources/graphql/subscription.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/subscription.rs
@@ -1,11 +1,12 @@
 use schema::sources::federation::SubgraphWalker;
 
-use super::{ExecutionContext, Executor, ExecutorError, ExecutorResult, ResolverInput};
+use super::ExecutionContext;
 use crate::{
     plan::PlanOutput,
-    response::{ExecutorOutput, GraphqlError, ResponseBoundaryItem},
+    response::{ExecutorOutput, ResponseBoundaryItem},
 };
 
+#[allow(dead_code)]
 pub struct GraphqlSubscriptionExecutor<'ctx> {
     ctx: ExecutionContext<'ctx>,
     subgraph: SubgraphWalker<'ctx>,

--- a/engine/crates/engine-v2/src/sources/graphql/subscription.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/subscription.rs
@@ -1,0 +1,16 @@
+use schema::sources::federation::SubgraphWalker;
+
+use super::{ExecutionContext, Executor, ExecutorError, ExecutorResult, ResolverInput};
+use crate::{
+    plan::PlanOutput,
+    response::{ExecutorOutput, GraphqlError, ResponseBoundaryItem},
+};
+
+pub struct GraphqlSubscriptionExecutor<'ctx> {
+    ctx: ExecutionContext<'ctx>,
+    subgraph: SubgraphWalker<'ctx>,
+    json_body: String,
+    boundary_item: ResponseBoundaryItem,
+    plan_output: PlanOutput,
+    output: ExecutorOutput,
+}

--- a/engine/crates/engine-v2/src/sources/mod.rs
+++ b/engine/crates/engine-v2/src/sources/mod.rs
@@ -1,10 +1,11 @@
+use futures_util::stream::BoxStream;
 use schema::{Resolver, ResolverWalker};
 
 use crate::{
     execution::ExecutionContext,
     plan::{PlanId, PlanOutput},
     request::EntityType,
-    response::{ExecutorOutput, GraphqlError, ResponseBoundaryObjectsView},
+    response::{ExecutorOutput, GraphqlError, ResponseBoundaryObjectsView, ResponseBuilder},
 };
 
 mod graphql;
@@ -13,6 +14,8 @@ mod introspection;
 use graphql::federation::FederationEntityExecutor;
 use graphql::GraphqlExecutor;
 use introspection::IntrospectionExecutionPlan;
+
+use self::graphql::GraphqlSubscriptionExecutor;
 
 /// Executors are responsible to retrieve a selection_set from a certain point in the query.
 ///
@@ -90,6 +93,35 @@ impl<'exc> Executor<'exc> {
             Executor::Introspection(executor) => executor.execute().await,
             Executor::FederationEntity(executor) => executor.execute().await,
         }
+    }
+}
+
+pub(crate) struct SubscriptionResolverInput<'ctx> {
+    pub ctx: ExecutionContext<'ctx>,
+    pub plan_id: PlanId,
+    pub plan_output: PlanOutput,
+}
+
+pub(crate) enum SubscriptionExecutor<'a> {
+    Graphql(GraphqlSubscriptionExecutor<'a>),
+}
+
+impl<'exc> SubscriptionExecutor<'exc> {
+    pub fn build<'ctx>(
+        walker: ResolverWalker<'ctx>,
+        entity_type: EntityType,
+        input: SubscriptionResolverInput<'ctx>,
+    ) -> ExecutorResult<Self>
+    where
+        'ctx: 'exc,
+    {
+        todo!()
+    }
+
+    pub fn execute(self) -> BoxStream<'exc, (ResponseBuilder, ExecutorOutput)> {
+        // TODO: This somehow needs
+        todo!();
+        return Box::pin(futures_util::stream::pending());
     }
 }
 

--- a/engine/crates/engine-v2/src/sources/mod.rs
+++ b/engine/crates/engine-v2/src/sources/mod.rs
@@ -96,21 +96,24 @@ impl<'exc> Executor<'exc> {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) struct SubscriptionResolverInput<'ctx> {
     pub ctx: ExecutionContext<'ctx>,
     pub plan_id: PlanId,
     pub plan_output: PlanOutput,
 }
 
+#[allow(dead_code)]
 pub(crate) enum SubscriptionExecutor<'a> {
     Graphql(GraphqlSubscriptionExecutor<'a>),
 }
 
+#[allow(dead_code)]
 impl<'exc> SubscriptionExecutor<'exc> {
     pub fn build<'ctx>(
-        walker: ResolverWalker<'ctx>,
-        entity_type: EntityType,
-        input: SubscriptionResolverInput<'ctx>,
+        _walker: ResolverWalker<'ctx>,
+        _entity_type: EntityType,
+        _input: SubscriptionResolverInput<'ctx>,
     ) -> ExecutorResult<Self>
     where
         'ctx: 'exc,
@@ -119,9 +122,7 @@ impl<'exc> SubscriptionExecutor<'exc> {
     }
 
     pub fn execute(self) -> BoxStream<'exc, (ResponseBuilder, ExecutorOutput)> {
-        // TODO: This somehow needs
         todo!();
-        return Box::pin(futures_util::stream::pending());
     }
 }
 


### PR DESCRIPTION
I'm working on adding subscriptions to our federation offering.  The flow of subscriptions is fairly similar to a normal federation execution but with a few of important differences:

1. There can only be a single subscription field at the root.
2. That subscription field will translate into a subscription call to a subgraph.
3. We build up a fresh GraphQL response from each response we get back from that initial subscription.

This PR updates the ExecutorCoordinator to support the subscription flow as well as the normal flow.  I want to return a stream for subscriptions, ideally without spawning an async task, which needed a lot of refactoring.  Mostly removing references where I could, as they 

I needed to do a surprising amount of refactoring to get this working.  Mostly turning references into owned things where it made sense, and removing the mutable parts of ExecutorCoordinator into local variables instead.

Most of the changes in this PR are still dead code - my next PR will hook them up.

Part of GB-5708