### PR TITLE
feat: expose `execute_stream` from engine-v2

### DIFF
--- a/engine/crates/engine-v2/Cargo.toml
+++ b/engine/crates/engine-v2/Cargo.toml
@@ -27,7 +27,6 @@ serde_json.workspace = true
 serde-value = "0.7"
 strum.workspace = true
 thiserror.workspace = true
-futures.workspace = true
 futures-util.workspace = true
 hex = "0.4.3"
 

--- a/engine/crates/engine-v2/Cargo.toml
+++ b/engine/crates/engine-v2/Cargo.toml
@@ -27,6 +27,7 @@ serde_json.workspace = true
 serde-value = "0.7"
 strum.workspace = true
 thiserror.workspace = true
+futures.workspace = true
 futures-util.workspace = true
 hex = "0.4.3"
 

--- a/engine/crates/engine-v2/src/engine.rs
+++ b/engine/crates/engine-v2/src/engine.rs
@@ -1,10 +1,13 @@
 use std::sync::Arc;
 
 use engine::RequestHeaders;
+use engine_parser::types::OperationType;
+use futures::channel::mpsc;
+use futures_util::{future::BoxFuture, Stream};
 use schema::Schema;
 
 use crate::{
-    execution::{ExecutorCoordinator, Variables},
+    execution::{ExecutorCoordinator, ResponseReceiver, Variables},
     request::{parse_operation, Operation},
     response::{ExecutionMetadata, GraphqlError, Response},
 };
@@ -42,9 +45,76 @@ impl Engine {
         executor.execute().await
     }
 
+    pub fn execute_stream(
+        &self,
+        request: engine::Request,
+        headers: RequestHeaders,
+    ) -> impl Stream<Item = Response> + '_ {
+        let initial_state = StreamState::Starting(request, headers);
+        futures_util::stream::unfold(initial_state, move |state| async move {})
+    }
+
     fn prepare(&self, request: &engine::Request) -> Result<Operation, GraphqlError> {
         let unbound_operation = parse_operation(request)?;
+        // TODO: Can possibly move Variables::from_request here to make things nicer.
+        // Or package up Operation w/ Variables at least?  Not sure.
         let operation = Operation::build(&self.schema, unbound_operation)?;
         Ok(operation)
+    }
+}
+
+enum StreamState<'a> {
+    Starting(&'a engine::Request, &'a RequestHeaders, &'a Engine),
+    Started(ResponseReceiver, BoxFuture<'a, ()>),
+    Finished,
+}
+
+impl StreamState<'_> {
+    pub async fn handle(self) -> Option<(Response, Self)> {
+        match self {
+            StreamState::Starting(request, headers, engine) => {
+                let operation = match engine.prepare(&request) {
+                    Ok(operation) => operation,
+                    Err(error) => {
+                        return Some((
+                            Response::from_error(error, ExecutionMetadata::default()),
+                            StreamState::Finished,
+                        ))
+                    }
+                };
+
+                let variables = match Variables::from_request(&operation, engine.schema.as_ref(), request.variables) {
+                    Ok(variables) => variables,
+                    Err(errors) => {
+                        return Some((
+                            Response::from_errors(errors, ExecutionMetadata::build(&operation)),
+                            StreamState::Finished,
+                        ))
+                    }
+                };
+
+                    if matches!(operation.ty, OperationType::Query | OperationType::Mutation) {
+                        let response = ExecutorCoordinator::new(engine, operation, variables, headers)
+                            .execute()
+                            .await;
+                        return Some((response, StreamState::Finished));
+                    }
+
+                // TODO: Could probably write some tests of running queries & mutations via execute_stream
+                // now...
+
+                let executor = ExecutorCoordinator::new(engine, &operation, &variables, &headers);
+                let (sender, receiver) = mpsc::channel(2);
+
+                // Pass off to the Started handler
+                StreamState::Started(receiver, Box::pin(executor.execute_subscription(sender)))
+                    .handle()
+                    .await
+            }
+            StreamState::Started(receiver, subscription_future) => {
+                todo!()
+            }
+            StreamState::Finished => None,
+        }
     }
 }

--- a/engine/crates/engine-v2/src/execution/coordinator.rs
+++ b/engine/crates/engine-v2/src/execution/coordinator.rs
@@ -14,6 +14,7 @@ use crate::{
     Engine,
 };
 
+pub type ResponseReceiver = futures::channel::mpsc::Receiver<Response>;
 pub type ResponseSender = futures::channel::mpsc::Sender<Response>;
 
 pub struct ExecutorCoordinator<'ctx> {
@@ -36,6 +37,10 @@ impl<'ctx> ExecutorCoordinator<'ctx> {
             variables,
             request_headers,
         }
+    }
+
+    pub fn operation_type(&self) -> OperationType {
+        self.operation.ty
     }
 
     pub async fn execute(self) -> Response {
@@ -86,7 +91,6 @@ impl<'ctx> ExecutorCoordinator<'ctx> {
             .await
     }
 
-    #[allow(dead_code)]
     pub async fn execute_subscription(self, mut responses: ResponseSender) {
         assert!(matches!(self.operation.ty, OperationType::Subscription));
 

--- a/engine/crates/engine-v2/src/execution/mod.rs
+++ b/engine/crates/engine-v2/src/execution/mod.rs
@@ -3,5 +3,5 @@ mod coordinator;
 mod variables;
 
 pub(crate) use context::*;
-pub use coordinator::ExecutorCoordinator;
+pub use coordinator::{ExecutorCoordinator, ResponseReceiver};
 pub use variables::*;

--- a/engine/crates/engine-v2/src/request/selection_set.rs
+++ b/engine/crates/engine-v2/src/request/selection_set.rs
@@ -107,7 +107,6 @@ pub enum BoundAnyFieldDefinition {
     Field(BoundFieldDefinition),
 }
 
-#[allow(dead_code)]
 impl BoundAnyFieldDefinition {
     pub fn as_field(&self) -> Option<&BoundFieldDefinition> {
         match self {

--- a/engine/crates/engine-v2/src/response/error.rs
+++ b/engine/crates/engine-v2/src/response/error.rs
@@ -11,3 +11,12 @@ pub(crate) struct GraphqlError {
     // ensures consistent ordering for tests
     pub extensions: BTreeMap<String, serde_json::Value>,
 }
+
+impl GraphqlError {
+    pub fn new(message: impl Into<String>) -> Self {
+        GraphqlError {
+            message: message.into(),
+            ..Default::default()
+        }
+    }
+}

--- a/engine/crates/engine-v2/src/response/mod.rs
+++ b/engine/crates/engine-v2/src/response/mod.rs
@@ -90,6 +90,13 @@ impl Response {
             Self::RequestError(request_error) => &request_error.metadata,
         }
     }
+
+    pub fn take_metadata(self) -> ExecutionMetadata {
+        match self {
+            Self::Initial(initial) => initial.metadata,
+            Self::RequestError(request_error) => request_error.metadata,
+        }
+    }
 }
 
 impl std::fmt::Debug for Response {

--- a/engine/crates/engine-v2/src/sources/mod.rs
+++ b/engine/crates/engine-v2/src/sources/mod.rs
@@ -108,7 +108,6 @@ pub(crate) enum SubscriptionExecutor<'a> {
     Graphql(GraphqlSubscriptionExecutor<'a>),
 }
 
-#[allow(dead_code)]
 impl<'exc> SubscriptionExecutor<'exc> {
     pub fn build<'ctx>(
         _walker: ResolverWalker<'ctx>,

--- a/engine/crates/integration-tests/tests/federation/basic/mod.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/mod.rs
@@ -8,6 +8,7 @@ mod fragments;
 mod headers;
 mod mutation;
 mod scalars;
+mod streaming;
 mod variables;
 
 use engine_v2::Engine;

--- a/engine/crates/integration-tests/tests/federation/basic/streaming.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/streaming.rs
@@ -1,0 +1,69 @@
+//! Tests of the execute_stream functionality in engine-v2
+//!
+//! Subscrition specific tests will probably live elsewhere
+
+use engine_v2::Engine;
+use futures::StreamExt;
+use integration_tests::{federation::EngineV2Ext, mocks::graphql::StateMutationSchema, runtime, MockGraphQlServer};
+
+#[test]
+fn can_run_a_query_via_execute_stream() {
+    runtime().block_on(async move {
+        let github_mock = MockGraphQlServer::new(StateMutationSchema::default()).await;
+        let engine = Engine::build().with_schema("schema", &github_mock).await.finish().await;
+
+        let response = engine
+            .execute("query { value }")
+            .into_stream()
+            .collect::<Vec<_>>()
+            .await;
+
+        insta::assert_json_snapshot!(response, @r###"
+        [
+          {
+            "data": {
+              "value": 0
+            }
+          }
+        ]
+        "###);
+    })
+}
+
+#[test]
+fn can_run_a_mutation_via_execute_stream() {
+    runtime().block_on(async move {
+        let github_mock = MockGraphQlServer::new(StateMutationSchema::default()).await;
+        let engine = Engine::build().with_schema("schema", &github_mock).await.finish().await;
+
+        let response = engine
+            .execute(
+                r"
+                mutation {
+                    first: set(val: 1)
+                    second: multiply(by: 2)
+                    third: multiply(by: 7)
+                    fourth: set(val: 3)
+                    fifth: multiply(by: 11)
+                }
+                ",
+            )
+            .into_stream()
+            .collect::<Vec<_>>()
+            .await;
+
+        insta::assert_json_snapshot!(response, @r###"
+        [
+          {
+            "data": {
+              "first": 1,
+              "second": 2,
+              "third": 14,
+              "fourth": 3,
+              "fifth": 33
+            }
+          }
+        ]
+        "###);
+    })
+}


### PR DESCRIPTION
A follow up to #1198 - exposing the changes I made there to consumers of `engine-v2`.  I've not hooked this up in the CLI yet because I want to get subscriptions working first.   This does allow the code to be called in tests though.

I've added a passing test of queries & mutations via this function just to confirm.

Part of GB-5708