### PR TITLE
nix: derivation for the cli

### DIFF
--- a/cli/crates/server/build.rs
+++ b/cli/crates/server/build.rs
@@ -39,8 +39,9 @@ Please see the instructions in cli/crates/server/README.md.
 fn decompress_assets() -> io::Result<tempfile::TempDir> {
     use flate2::bufread::GzDecoder;
     let dir = tempfile::tempdir()?;
-    eprintln!("Decompressing the assets at `{ASSETS_GZIP_PATH}` from `server` crate build script.");
-    let file_reader = io::BufReader::new(fs::File::open(ASSETS_GZIP_PATH)?);
+    let assets_gzip_path = env::var("GRAFBASE_ASSETS_GZIP_PATH").unwrap_or_else(|_| ASSETS_GZIP_PATH.to_owned());
+    eprintln!("Decompressing the assets at `{assets_gzip_path}` from `server` crate build script.");
+    let file_reader = io::BufReader::new(fs::File::open(assets_gzip_path)?);
     let assets_reader = GzDecoder::new(file_reader);
     tar::Archive::new(assets_reader).unpack(dir.path())?;
     Ok(dir)

--- a/cli/nix/cli.nix
+++ b/cli/nix/cli.nix
@@ -1,0 +1,77 @@
+{ pkgs, crane, lib, config, ... }:
+
+let
+  assetsTarGz = pkgs.fetchurl {
+    url = "https://assets.grafbase.com/cli/release/83bd257-2024-01-03.tar.gz";
+    sha256 = "sha256-iOir3bAtlUL71ffn02d9PCRCjjbBic1R5/3UR2xKlsU=";
+  };
+  rustToolchain = pkgs.rust-bin.stable.latest.default;
+  craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+  workspaceRoot = builtins.path { name = "grafbase-repo-src"; path = ../../.; };
+
+  # Agressively prune the source tree for better caching.
+  extraIgnores = ''
+    *.nix
+    *.md
+    *.sh
+
+    package.json
+    assets.tar.gz
+
+    # We can't ignore /packages wholesale because we need to include
+    # grafbase-sdk/package.json later.
+    /packages/**/*.json
+    /packages/**/*.js
+    /packages/**/*.ts
+    /packages/**/*.html
+
+    /flake.lock
+    /renovate.json
+    /scripts
+    /packages/**/src
+
+    node_modules/
+    yarn.lock
+
+    !/engine/crates/validation/README.md
+    !/packages/grafbase-sdk/package.json
+  '';
+
+  src = pkgs.nix-gitignore.gitignoreSource [ extraIgnores ] (lib.cleanSourceWith {
+    filter = lib.cleanSourceFilter;
+    src = workspaceRoot;
+  });
+
+  version = pkgs.runCommand "getVersion" { } ''
+    ${pkgs.dasel}/bin/dasel \
+      --file ${../../Cargo.toml} \
+      --selector workspace.package.version\
+      --write - | tr -d "\n" > $out
+  '';
+in
+{
+  packages.cli = craneLib.buildPackage {
+    inherit src;
+    pname = "grafbase";
+    version = builtins.readFile version;
+    stdenv = pkgs.clangStdenv;
+
+    cargoBuildFlags = "-p grafbase";
+
+    RUSTFLAGS = builtins.concatStringsSep " " [
+      "-Arust-2018-idioms -Aunused-crate-dependencies"
+      "-C linker=clang -C link-arg=-fuse-ld=lld"
+    ];
+
+    GRAFBASE_ASSETS_GZIP_PATH = assetsTarGz;
+    GRAFBASE_CLI_PATHFINDER_BUNDLE_PATH = config.packages.cli-app;
+
+    doCheck = false;
+
+    nativeBuildInputs = [
+      pkgs.pkg-config
+      pkgs.openssl.dev
+      pkgs.llvmPackages.bintools # lld
+    ];
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,43 @@
 {
   "nodes": {
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1704300976,
+        "narHash": "sha256-QLMpTrHxsND2T8+khAhLCqzOY/h2SzWS0s4Z7N2ds/E=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "0efe36f9232e0961512572883ba9c995aa1f54b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1698882062,
+        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -34,6 +72,24 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1698611440,
+        "narHash": "sha256-jPjHjrerhYDy3q9+s5EAsuhyhuknNfowY6yt6pjn9pc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0cbe9f69c234a7700596e943bfae7ef27a31b735",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "pnpm2nix": {
       "inputs": {
         "flake-utils": [
@@ -59,9 +115,35 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
+        "flake-parts": "flake-parts",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "pnpm2nix": "pnpm2nix"
+        "pnpm2nix": "pnpm2nix",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1704680242,
+        "narHash": "sha256-5bD6iSPDgVTLly2gy2oJVwzuyuFZOz2p4qt8c8UoYIE=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "2037779e018ebc2d381001a891e2a793fce7a74f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/packages/nix/cli-app.nix
+++ b/packages/nix/cli-app.nix
@@ -1,8 +1,8 @@
-{
-  pkgs,
-  mkPnpmPackage,
-  ...
-}: let
+{ pkgs, pnpm2nix, system, ... }:
+
+let
+  mkPnpmPackage = pnpm2nix.packages."${system}".mkPnpmPackage;
+
   extraIgnores = ''
     /crates
     /engine
@@ -10,12 +10,14 @@
     /packages/nix
     *.nix
   '';
-  src = pkgs.nix-gitignore.gitignoreSourcePure [extraIgnores ".gitignore"] ../../packages;
+  src = pkgs.nix-gitignore.gitignoreSourcePure [ extraIgnores ".gitignore" ] ../../packages;
 in
-  mkPnpmPackage {
+{
+  packages.cli-app = mkPnpmPackage {
     inherit src;
     name = "cli-app";
     installInPlace = true;
     distDir = "../packages/cli-app/dist";
     script = "build-cli-app";
-  }
+  };
+}


### PR DESCRIPTION
This lets anybody with nix installed build the CLI from source with `nix build github:grafbase/grafbase#cli`, or run it with `nix run github:grafbase/grafbase#cli`, or build it locally with `nix build .#cli`, etc. This is also useful documentation on all the inputs required to build the Grafbase CLI.

This commit also introduces flake-parts to the repo. It is just a convenient way to organize the derivations that reuses the same module system any nixos or home-manager user will be familiar with.

One caveat though: the version and URL of the assets.tar.gz file are hardcoded. Ideally, we would also build these from source, but that can be done in a separate PR.
