### PR TITLE
test: update graphql mocks to expose subscriptions

### DIFF
--- a/engine/crates/integration-tests/src/engine/mod.rs
+++ b/engine/crates/integration-tests/src/engine/mod.rs
@@ -191,6 +191,13 @@ impl crate::mocks::graphql::Schema for Engine {
         async_graphql::Response::deserialize(serde_json::to_value(response).unwrap()).unwrap()
     }
 
+    fn execute_stream(
+        &self,
+        _request: async_graphql::Request,
+    ) -> futures::stream::BoxStream<'static, async_graphql::Response> {
+        todo!("if you need this you should implement it")
+    }
+
     fn sdl(&self) -> String {
         self.inner.schema.federation_sdl()
     }

--- a/engine/crates/integration-tests/src/mocks/graphql/fake_github.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql/fake_github.rs
@@ -17,6 +17,23 @@ impl super::Schema for FakeGithubSchema {
             .await
     }
 
+    fn execute_stream(
+        &self,
+        request: async_graphql::Request,
+    ) -> futures::stream::BoxStream<'static, async_graphql::Response> {
+        Box::pin(
+            async_graphql::Schema::build(
+                Query {
+                    headers: Default::default(),
+                },
+                EmptyMutation,
+                EmptySubscription,
+            )
+            .finish()
+            .execute_stream(request),
+        )
+    }
+
     fn sdl(&self) -> String {
         let schema = async_graphql::Schema::build(
             Query {

--- a/engine/crates/integration-tests/src/mocks/graphql/federation/accounts.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql/federation/accounts.rs
@@ -21,6 +21,13 @@ impl super::super::Schema for FakeFederationAccountsSchema {
         Self::schema().execute(request).await
     }
 
+    fn execute_stream(
+        &self,
+        request: async_graphql::Request,
+    ) -> futures::stream::BoxStream<'static, async_graphql::Response> {
+        Box::pin(Self::schema().execute_stream(request))
+    }
+
     fn sdl(&self) -> String {
         Self::schema().sdl_with_options(async_graphql::SDLExportOptions::new().federation())
     }

--- a/engine/crates/integration-tests/src/mocks/graphql/federation/reviews.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql/federation/reviews.rs
@@ -78,6 +78,13 @@ impl super::super::Schema for FakeFederationReviewsSchema {
         Self::schema().execute(request).await
     }
 
+    fn execute_stream(
+        &self,
+        request: async_graphql::Request,
+    ) -> futures::stream::BoxStream<'static, async_graphql::Response> {
+        Box::pin(Self::schema().execute_stream(request))
+    }
+
     fn sdl(&self) -> String {
         Self::schema().sdl_with_options(async_graphql::SDLExportOptions::new().federation())
     }

--- a/engine/crates/integration-tests/src/mocks/graphql/state_mutation.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql/state_mutation.rs
@@ -29,6 +29,13 @@ impl super::Schema for StateMutationSchema {
         self.schema().execute(request).await
     }
 
+    fn execute_stream(
+        &self,
+        request: async_graphql::Request,
+    ) -> futures::stream::BoxStream<'static, async_graphql::Response> {
+        Box::pin(self.schema().execute_stream(request))
+    }
+
     fn sdl(&self) -> String {
         self.schema()
             .sdl_with_options(async_graphql::SDLExportOptions::new().federation())


### PR DESCRIPTION
I'm about to start writing integration tests of my subscriptions work - and it'll be a lot easier to write those if I have subgraphs that support subscriptions.

This updates the GraphQL mock infrastructure in integration-tests to support subscriptions, and adds a subscription field to the `products` subgraph mock.