### PR TITLE
test: re-instate the start test

### DIFF
--- a/cli/crates/cli/tests/assets/sdk-package-module.json
+++ b/cli/crates/cli/tests/assets/sdk-package-module.json
@@ -1,0 +1,14 @@
+{
+  "name": "grafbase-test-package",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "@grafbase/sdk": "*"
+  },
+  "type": "module",
+  "devDependencies": {
+    "@types/node": "*",
+    "ts-node": "*",
+    "typescript": "*"
+  }
+}

--- a/cli/crates/cli/tests/utils/environment.rs
+++ b/cli/crates/cli/tests/utils/environment.rs
@@ -148,6 +148,18 @@ impl Environment {
     }
 
     #[cfg(not(target_os = "windows"))]
+    /// Exactly the same as prepare_ts_config_dependencies but it
+    /// creates a ESM package.json instead
+    pub fn prepare_ts_config_dependencies_module(&mut self) {
+        if self.ts_config_dependencies_prepared {
+            return;
+        }
+        fs::write("package.json", include_str!("../assets/sdk-package-module.json")).unwrap();
+        cmd!("npm", "install").run().unwrap();
+        self.ts_config_dependencies_prepared = true;
+    }
+
+    #[cfg(not(target_os = "windows"))]
     pub fn prepare_ts_config_dependencies(&mut self) {
         if self.ts_config_dependencies_prepared {
             return;


### PR DESCRIPTION
These tests got ignored ages ago.  I tried to resurrect them back in January but they were failing on certain platforms due to some `ts-node` issue.

Now that we're using bun they pass on all platforms, so yay to that.

Fixes GB-5912