### PR TITLE
feat: implements `Cacheable` for `v2::Response`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,6 +1698,7 @@ version = "3.0.31"
 dependencies = [
  "anyhow",
  "async-runtime",
+ "bytes",
  "derive_more",
  "engine",
  "engine-parser",

--- a/cli/crates/gateway/src/lib.rs
+++ b/cli/crates/gateway/src/lib.rs
@@ -1,6 +1,6 @@
 use engine::registry::CachePartialRegistry;
 use gateway_core::CacheConfig;
-use runtime::cache::CacheControl;
+use runtime::cache::RequestCacheControl;
 use runtime_local::InMemoryCache;
 use std::{collections::HashMap, ops::Deref, sync::Arc};
 
@@ -35,7 +35,7 @@ impl Gateway {
             global_enabled: true,
             subdomain: "localhost".to_string(),
             host_name: "localhost".to_string(),
-            cache_control: CacheControl::default(),
+            request_cache_control: RequestCacheControl::default(),
             partial_registry: CachePartialRegistry::from(registry.as_ref()),
             common_cache_tags: vec![],
         };

--- a/engine/crates/engine-v2/Cargo.toml
+++ b/engine/crates/engine-v2/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 
 [dependencies]
 async-runtime.workspace = true
+bytes.workspace = true
 derive_more = "0.99"
 futures.workspace = true
 im = "15"

--- a/engine/crates/engine-v2/src/lib.rs
+++ b/engine/crates/engine-v2/src/lib.rs
@@ -7,7 +7,7 @@ mod sources;
 mod utils;
 
 pub use engine::{Engine, EngineRuntime};
-pub use response::{Error, ExecutionMetadata, Response};
+pub use response::{cacheable::CacheableResponse, Error, ExecutionMetadata, Response};
 pub use schema::{CacheConfig, Schema};
 
 pub use ::config::{latest as config, VersionedConfig};

--- a/engine/crates/engine-v2/src/response/cacheable.rs
+++ b/engine/crates/engine-v2/src/response/cacheable.rs
@@ -53,7 +53,7 @@ impl Cacheable for CacheableResponse {
                 .metadata
                 .operation_type
                 .map(|operation_type| {
-                    operation_type != OperationType::Mutation && operation_type != OperationType::Subscription
+                    operation_type == OperationType::Query
                 })
                 .unwrap_or_default()
     }

--- a/engine/crates/engine-v2/src/response/cacheable.rs
+++ b/engine/crates/engine-v2/src/response/cacheable.rs
@@ -1,0 +1,60 @@
+use crate::ExecutionMetadata;
+use engine_parser::types::OperationType;
+use runtime::cache::Cacheable;
+use std::time::Duration;
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct CacheableResponse {
+    pub json_bytes: bytes::Bytes,
+    // Empty if coming from the cache, nothing was executed.
+    #[serde(skip, default)]
+    pub metadata: ExecutionMetadata,
+    pub has_errors: bool,
+}
+
+impl crate::Response {
+    pub fn into_cacheable(self) -> Result<CacheableResponse, serde_json::Error> {
+        let bytes = serde_json::to_vec(&self)?;
+        let has_errors = !self.errors().is_empty();
+        Ok(CacheableResponse {
+            has_errors,
+            json_bytes: bytes::Bytes::from(bytes),
+            metadata: self.take_metadata(),
+        })
+    }
+}
+
+impl Cacheable for CacheableResponse {
+    fn max_age(&self) -> Duration {
+        self.metadata
+            .cache_config
+            .map(|config| config.max_age)
+            .unwrap_or_default()
+    }
+
+    fn stale_while_revalidate(&self) -> Duration {
+        self.metadata
+            .cache_config
+            .map(|config| config.stale_while_revalidate)
+            .unwrap_or_default()
+    }
+
+    fn cache_tags(&self) -> Vec<String> {
+        vec![] // to be added when mutation invalidation is supported in v2
+    }
+
+    fn should_purge_related(&self) -> bool {
+        false // to be added when mutation invalidation is supported in v2
+    }
+
+    fn should_cache(&self) -> bool {
+        !self.has_errors
+            && self
+                .metadata
+                .operation_type
+                .map(|operation_type| {
+                    operation_type != OperationType::Mutation && operation_type != OperationType::Subscription
+                })
+                .unwrap_or_default()
+    }
+}

--- a/engine/crates/engine-v2/src/response/cacheable.rs
+++ b/engine/crates/engine-v2/src/response/cacheable.rs
@@ -52,9 +52,7 @@ impl Cacheable for CacheableResponse {
             && self
                 .metadata
                 .operation_type
-                .map(|operation_type| {
-                    operation_type == OperationType::Query
-                })
+                .map(|operation_type| operation_type == OperationType::Query)
                 .unwrap_or_default()
     }
 }

--- a/engine/crates/engine-v2/src/response/mod.rs
+++ b/engine/crates/engine-v2/src/response/mod.rs
@@ -1,5 +1,3 @@
-use engine_parser::Pos;
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 pub(crate) use error::GraphqlError;
@@ -10,6 +8,7 @@ use schema::Schema;
 pub use value::{ResponseObject, ResponseValue};
 pub use write::*;
 
+pub(crate) mod cacheable;
 mod error;
 mod metadata;
 mod path;
@@ -25,20 +24,6 @@ pub enum Response {
 // Our internal error struct shouldn't be accessible. It'll also need some context like
 // ResponseKeys to even just present paths correctly.
 pub struct Error<'a>(&'a GraphqlError);
-impl<'a> Error<'a> {
-    pub fn message(&self) -> &str {
-        &self.0.message
-    }
-    pub fn locations(&self) -> &Vec<Pos> {
-        &self.0.locations
-    }
-    pub fn path(&self) -> Option<&ResponsePath> {
-        self.0.path.as_ref()
-    }
-    pub fn extensions(&self) -> &BTreeMap<String, serde_json::Value> {
-        &self.0.extensions
-    }
-}
 
 pub struct InitialResponse {
     // will be None if an error propagated up to the root.

--- a/engine/crates/gateway-core/src/cache/build_key.rs
+++ b/engine/crates/gateway-core/src/cache/build_key.rs
@@ -331,7 +331,7 @@ mod tests {
         registry.enable_caching = true;
         CacheConfig {
             global_enabled: false,
-            cache_control: Default::default(),
+            request_cache_control: Default::default(),
             common_cache_tags: vec![],
             subdomain: String::new(),
             partial_registry: registry.into(),

--- a/engine/crates/gateway-core/src/cache/mod.rs
+++ b/engine/crates/gateway-core/src/cache/mod.rs
@@ -4,7 +4,7 @@ use http::status::StatusCode;
 
 pub use build_key::build_cache_key;
 use engine::registry::CachePartialRegistry;
-use runtime::cache::{Cache, CacheControl, CacheReadStatus, Cacheable, CachedExecutionResponse};
+use runtime::cache::{Cache, CacheReadStatus, Cacheable, CachedExecutionResponse, RequestCacheControl};
 
 use super::RequestContext;
 
@@ -16,7 +16,7 @@ pub struct CacheConfig {
     pub global_enabled: bool,
     pub subdomain: String,
     pub host_name: String,
-    pub cache_control: CacheControl,
+    pub request_cache_control: RequestCacheControl,
     pub partial_registry: CachePartialRegistry,
     pub common_cache_tags: Vec<String>,
 }
@@ -70,9 +70,9 @@ where
         },
         &runtime::cache::RequestCacheConfig {
             enabled: config.partial_registry.enable_caching,
-            cache_control: CacheControl {
-                no_cache: config.cache_control.no_cache,
-                no_store: config.cache_control.no_store,
+            cache_control: RequestCacheControl {
+                no_cache: config.request_cache_control.no_cache,
+                no_store: config.request_cache_control.no_store,
             },
         },
         cache_key,

--- a/engine/crates/gateway-core/src/lib.rs
+++ b/engine/crates/gateway-core/src/lib.rs
@@ -14,7 +14,7 @@ mod response;
 pub mod serving;
 mod streaming;
 
-use crate::cache::build_cache_key;
+pub use crate::cache::build_cache_key;
 pub use auth::{authorize_request, AdminAuthError, AuthError, Authorizer};
 pub use cache::CacheConfig;
 pub use executor::Executor;

--- a/engine/crates/runtime/src/cache/mod.rs
+++ b/engine/crates/runtime/src/cache/mod.rs
@@ -102,7 +102,7 @@ pub enum CachedExecutionResponse<T> {
 }
 
 #[derive(Clone, Default)]
-pub struct CacheControl {
+pub struct RequestCacheControl {
     /// The no-cache request directive asks caches to validate the response with the origin server before reuse.
     /// no-cache allows clients to request the most up-to-date response even if the cache has a fresh response.
     pub no_cache: bool,
@@ -123,7 +123,7 @@ pub struct GlobalCacheConfig {
 #[derive(Clone, Default)]
 pub struct RequestCacheConfig {
     pub enabled: bool,
-    pub cache_control: CacheControl,
+    pub cache_control: RequestCacheControl,
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
# Description

This PR implements `Cacheable` for `v2::Response`. With this we can re-use `runtime::cache` for v2.

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
