### PR TITLE
feat: allow SDK users to add fields to connector types

### DIFF
--- a/packages/grafbase-sdk/src/query.ts
+++ b/packages/grafbase-sdk/src/query.ts
@@ -117,6 +117,6 @@ export class Query {
     const args = this.arguments.map(String).join(', ')
     const argsStr = args ? `(${args})` : ''
 
-    return `  ${this.name}${argsStr}: ${this.returns} @resolver(name: "${this.resolver}")`
+    return `${this.name}${argsStr}: ${this.returns} @resolver(name: "${this.resolver}")`
   }
 }

--- a/packages/grafbase-sdk/src/type.ts
+++ b/packages/grafbase-sdk/src/type.ts
@@ -150,6 +150,7 @@ export class TypeExtension {
   private queries: Query[]
   private keys: FederationKey[]
   private fieldExtensions: FieldExtension[]
+  private fieldAdditions: Field[]
 
   constructor(type: string | Type) {
     if (type instanceof Type) {
@@ -162,6 +163,7 @@ export class TypeExtension {
     this.queries = []
     this.keys = []
     this.fieldExtensions = []
+    this.fieldAdditions = []
   }
 
   /**
@@ -191,6 +193,26 @@ export class TypeExtension {
    *
    * @param field The name of the field to extend
    */
+  public addField(name: string, definition: TypeFieldShape) {
+    this.fieldAdditions.push(new Field(name, definition))
+  }
+
+  /**
+   * Extends a field of this type with additional federation directives
+   *
+   * @param field The name of the field to extend
+   */
+  public addFields(fields: TypeFields) {
+    for (const [key, value] of Object.entries(fields)) {
+      this.addField(key, value)
+    }
+  }
+
+  /**
+   * Extends a field of this type with additional federation directives
+   *
+   * @param field The name of the field to extend
+   */
   public extendField(field: string): FieldExtension {
     const fieldExtension = new FieldExtension(field)
     this.fieldExtensions.push(fieldExtension)
@@ -198,20 +220,22 @@ export class TypeExtension {
   }
 
   public toString(): string {
-    const queries =
-      this.queries.length > 0
-        ? `{\n${this.queries.map(String).join('\n')}\n}`
-        : ''
+    const fields = this.queries
+      .map(String)
+      .concat(this.fieldAdditions.map(String))
+      .map((field) => `  ${field}`)
+
+    const fieldsString = fields.length > 0 ? ` {\n${fields.join('\n')}\n}` : ''
 
     const keys =
-      this.keys.length > 0 ? this.keys.map((key) => ` \n  ${key}`) : ''
+      this.keys.length > 0 ? this.keys.map((key) => `\n  ${key}`) : ''
 
     const fieldExtends =
       this.fieldExtensions.length > 0
         ? this.fieldExtensions.map((field) => `\n  ${field}`)
         : ''
 
-    return `extend type ${this.name} ${keys}${fieldExtends}${queries}`
+    return `extend type ${this.name}${keys}${fieldExtends}${fieldsString}`
   }
 }
 

--- a/packages/grafbase-sdk/tests/unit/types.test.ts
+++ b/packages/grafbase-sdk/tests/unit/types.test.ts
@@ -449,7 +449,7 @@ describe('Type generator', () => {
     })
 
     expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
-"extend type StripeCustomer  
+"extend type StripeCustomer
   @key(fields: "id" resolvable: false)"
 `)
   })
@@ -461,9 +461,27 @@ describe('Type generator', () => {
     })
 
     expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
-"extend type StripeCustomer 
-    @extendField(name: "id", shareable: true, inaccesible: true),
-    @extendField(name: "other", provides: {fields: "id blah"}, override: {from: "Product"})"
-`)
+      "extend type StripeCustomer
+          @extendField(name: "id", shareable: true, inaccesible: true),
+          @extendField(name: "other", provides: {fields: "id blah"}, override: {from: "Product"})"
+    `)
+  })
+
+  it('can add fields to extended types', () => {
+    g.extend('StripeCustomer', (extend) => {
+      extend.addField('id', g.id().join('aField'))
+      extend.addFields({
+        foo: g.boolean()
+      })
+      extend.extendField('other').provides('id blah').override('Product')
+    })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "extend type StripeCustomer
+          @extendField(name: "other", provides: {fields: "id blah"}, override: {from: "Product"}) {
+        id: ID! @join(select: "aField")
+        foo: Boolean!
+      }"
+    `)
   })
 })


### PR DESCRIPTION
I added the ability to extend connector generated types with federation directives to the SDK in 81fd711.  One thing that still wasn't added then was the ability to add fields onto connector generated types - oops.

This does that.