### PR TITLE
feat: hook runtime-local up to graphql-ws-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3609af4bbf701ddaf1f6bb4e6257dff4ff8932327d0e685d3f653724c258b1ac"
+dependencies = [
+ "futures-io",
+ "futures-util",
+ "log 0.4.20",
+ "pin-project-lite",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2628,6 +2642,22 @@ dependencies = [
  "datatest-stable",
  "miette",
  "similar",
+]
+
+[[package]]
+name = "graphql-ws-client"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "400c558067af87ebd3007b19c5b896ed6a4ff5312ea5a2db502814d309522e92"
+dependencies = [
+ "async-tungstenite",
+ "futures",
+ "log 0.4.20",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "uuid",
 ]
 
 [[package]]
@@ -5371,9 +5401,11 @@ version = "0.1.0"
 dependencies = [
  "async-runtime",
  "async-trait",
+ "async-tungstenite",
  "bytes",
  "futures-util",
  "graph-entities",
+ "graphql-ws-client",
  "log 0.1.0",
  "postgres-connector-types",
  "reqwest",

--- a/engine/crates/integration-tests/src/mocks/graphql/federation/products.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql/federation/products.rs
@@ -35,6 +35,7 @@ impl FakeFederationProductsSchema {
         ];
         Schema::build(Query, EmptyMutation, Subscription)
             .enable_federation()
+            .enable_subscription_in_federation()
             .data(hats)
             .finish()
     }

--- a/engine/crates/integration-tests/tests/federation/introspection.rs
+++ b/engine/crates/integration-tests/tests/federation/introspection.rs
@@ -830,6 +830,10 @@ fn introspection_on_multiple_federation_subgraphs() {
       product: Product!
     }
 
+    type Subscription {
+      newProducts: Product!
+    }
+
     enum Trustworthiness {
       REALLY_TRUSTED
       KINDA_TRUSTED

--- a/engine/crates/integration-tests/tests/federation/mod.rs
+++ b/engine/crates/integration-tests/tests/federation/mod.rs
@@ -2,3 +2,4 @@ mod auth;
 mod basic;
 mod introspection;
 mod subgraphs;
+mod subscriptions;

--- a/engine/crates/integration-tests/tests/federation/subscriptions.rs
+++ b/engine/crates/integration-tests/tests/federation/subscriptions.rs
@@ -1,7 +1,8 @@
-use engine_v2::Engine;
-use futures::StreamExt;
+use futures::stream::StreamExt;
+
+use gateway_v2::Gateway;
 use integration_tests::{
-    federation::EngineV2Ext,
+    federation::GatewayV2Ext,
     mocks::graphql::{FakeFederationAccountsSchema, FakeFederationProductsSchema, FakeFederationReviewsSchema},
     runtime, MockGraphQlServer,
 };
@@ -11,7 +12,11 @@ fn single_subgraph_subscription() {
     let response = runtime().block_on(async move {
         let products = MockGraphQlServer::new(FakeFederationProductsSchema).await;
 
-        let engine = Engine::build().with_schema("products", &products).await.finish().await;
+        let engine = Gateway::builder()
+            .with_schema("products", &products)
+            .await
+            .finish()
+            .await;
 
         engine
             .execute(
@@ -61,7 +66,7 @@ fn actual_federated_subscription() {
         let products = MockGraphQlServer::new(FakeFederationProductsSchema).await;
         let reviews = MockGraphQlServer::new(FakeFederationReviewsSchema).await;
 
-        let engine = Engine::build()
+        let engine = Gateway::builder()
             .with_schema("accounts", &accounts)
             .await
             .with_schema("products", &products)

--- a/engine/crates/integration-tests/tests/federation/subscriptions.rs
+++ b/engine/crates/integration-tests/tests/federation/subscriptions.rs
@@ -1,0 +1,123 @@
+use engine_v2::Engine;
+use futures::StreamExt;
+use integration_tests::{
+    federation::EngineV2Ext,
+    mocks::graphql::{FakeFederationAccountsSchema, FakeFederationProductsSchema, FakeFederationReviewsSchema},
+    runtime, MockGraphQlServer,
+};
+
+#[test]
+fn single_subgraph_subscription() {
+    let response = runtime().block_on(async move {
+        let products = MockGraphQlServer::new(FakeFederationProductsSchema).await;
+
+        let engine = Engine::build().with_schema("products", &products).await.finish().await;
+
+        engine
+            .execute(
+                r"
+                subscription {
+                    newProducts {
+                        upc
+                        name
+                        price
+                    }
+                }
+                ",
+            )
+            .into_stream()
+            .collect::<Vec<_>>()
+            .await
+    });
+
+    insta::assert_json_snapshot!(response, @r###"
+    [
+      {
+        "data": {
+          "newProducts": {
+            "upc": "top-4",
+            "name": "Jeans",
+            "price": 44
+          }
+        }
+      },
+      {
+        "data": {
+          "newProducts": {
+            "upc": "top-5",
+            "name": "Pink Jeans",
+            "price": 55
+          }
+        }
+      }
+    ]
+    "###);
+}
+
+#[test]
+fn actual_federated_subscription() {
+    let response = runtime().block_on(async move {
+        let accounts = MockGraphQlServer::new(FakeFederationAccountsSchema).await;
+        let products = MockGraphQlServer::new(FakeFederationProductsSchema).await;
+        let reviews = MockGraphQlServer::new(FakeFederationReviewsSchema).await;
+
+        let engine = Engine::build()
+            .with_schema("accounts", &accounts)
+            .await
+            .with_schema("products", &products)
+            .await
+            .with_schema("reviews", &reviews)
+            .await
+            .finish()
+            .await;
+
+        engine
+            .execute(
+                r"
+                subscription {
+                    newProducts {
+                        upc
+                        name
+                        reviews {
+                            author {
+                                username
+                            }
+                            body
+                        }
+                    }
+                }
+                ",
+            )
+            .into_stream()
+            .collect::<Vec<_>>()
+            .await
+    });
+
+    insta::assert_json_snapshot!(response, @r###"
+    [
+      {
+        "data": {
+          "newProducts": {
+            "upc": "top-4",
+            "name": "Jeans",
+            "reviews": []
+          }
+        }
+      },
+      {
+        "data": {
+          "newProducts": {
+            "upc": "top-5",
+            "name": "Pink Jeans",
+            "reviews": [
+              {
+                "author": null,
+                "body": "Beautiful Pink, my parrot loves it. Definitely recommend!"
+              }
+            ]
+          }
+        }
+      }
+    ]
+    "###);
+}

--- a/engine/crates/runtime-local/Cargo.toml
+++ b/engine/crates/runtime-local/Cargo.toml
@@ -13,11 +13,14 @@ keywords = ["local", "runtime", "grafbase"]
 workspace = true
 
 [dependencies]
-async-trait = "0.1"
 async-runtime.workspace = true
-ulid.workspace = true
-futures-util.workspace = true
+async-trait = "0.1"
+async-tungstenite = { version = "0.24.0", features = ["tokio-runtime"] }
 bytes.workspace = true
+futures-util.workspace = true
+graphql-ws-client = "0.7"
+tokio.workspace = true
+ulid.workspace = true
 
 serde.workspace = true
 serde_json.workspace  = true
@@ -28,14 +31,10 @@ log = { workspace = true, features = ["with-worker"] }
 search-protocol.workspace = true
 postgres-connector-types = { path = "../postgres-connector-types" }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-reqwest = { version = "0.11", default-features = false, features = ["json"] }
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 reqwest = { version = "0.11", default-features = false, features = [
   "json",
   "rustls-tls",
 ] }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros"] }
+tokio = { workspace = true, features = ["macros"] }

--- a/engine/crates/runtime-local/src/fetch.rs
+++ b/engine/crates/runtime-local/src/fetch.rs
@@ -1,6 +1,10 @@
+mod websockets;
+
 use futures_util::stream::BoxStream;
 use reqwest::header::HeaderValue;
 use runtime::fetch::{FetchError, FetchRequest, FetchResponse, FetchResult, Fetcher, FetcherInner, GraphqlRequest};
+
+use self::websockets::{EngineGraphqlClient, StreamingRequest, TokioSpawner};
 
 pub struct NativeFetcher {
     client: reqwest::Client,
@@ -41,8 +45,40 @@ impl FetcherInner for NativeFetcher {
 
     async fn stream(
         &self,
-        _request: GraphqlRequest<'_>,
+        request: GraphqlRequest<'_>,
     ) -> FetchResult<BoxStream<'static, Result<serde_json::Value, FetchError>>> {
-        todo!()
+        use async_tungstenite::tungstenite::{client::IntoClientRequest, http::HeaderValue};
+        use futures_util::StreamExt;
+
+        let mut client = {
+            let mut request = request.url.into_client_request().unwrap();
+            request.headers_mut().insert(
+                "Sec-WebSocket-Protocol",
+                HeaderValue::from_str("graphql-transport-ws").unwrap(),
+            );
+
+            let (connection, _) = async_tungstenite::tokio::connect_async(request).await.unwrap();
+
+            let (sink, stream) = connection.split();
+
+            graphql_ws_client::AsyncWebsocketClientBuilder::<EngineGraphqlClient>::new()
+                .build(stream, sink, TokioSpawner::current())
+                .await
+                .map_err(FetchError::any)?
+        };
+
+        Ok(Box::pin(
+            client
+                .streaming_operation(StreamingRequest::from(request))
+                .await
+                .map_err(FetchError::any)?
+                .map(move |item| {
+                    // Ignore this next line, I'm just tricking rust into
+                    // moving the client into this closure.
+                    let _client = &client;
+
+                    item.map_err(FetchError::any)
+                }),
+        ))
     }
 }

--- a/engine/crates/runtime-local/src/fetch/websockets.rs
+++ b/engine/crates/runtime-local/src/fetch/websockets.rs
@@ -1,0 +1,62 @@
+//! graphql-ws-client <> engine glue code
+
+use runtime::fetch::{FetchError, GraphqlRequest};
+use serde_json::json;
+
+pub struct EngineGraphqlClient;
+
+impl graphql_ws_client::graphql::GraphqlClient for EngineGraphqlClient {
+    type Response = serde_json::Value;
+
+    type DecodeError = FetchError;
+
+    fn error_response(errors: Vec<serde_json::Value>) -> Result<Self::Response, Self::DecodeError> {
+        Ok(json!({"errors": errors}))
+    }
+}
+
+#[derive(serde::Serialize)]
+pub struct StreamingRequest {
+    query: String,
+    variables: serde_json::Value,
+}
+
+impl From<GraphqlRequest<'_>> for StreamingRequest {
+    fn from(value: GraphqlRequest<'_>) -> Self {
+        StreamingRequest {
+            query: value.query,
+            variables: value.variables,
+        }
+    }
+}
+
+impl graphql_ws_client::graphql::GraphqlOperation for StreamingRequest {
+    type GenericResponse = serde_json::Value;
+
+    type Response = serde_json::Value;
+
+    type Error = FetchError;
+
+    fn decode(&self, data: Self::GenericResponse) -> Result<Self::Response, Self::Error> {
+        Ok(data)
+    }
+}
+
+pub struct TokioSpawner(tokio::runtime::Handle);
+
+impl TokioSpawner {
+    pub fn new(handle: tokio::runtime::Handle) -> Self {
+        TokioSpawner(handle)
+    }
+
+    pub fn current() -> Self {
+        TokioSpawner::new(tokio::runtime::Handle::current())
+    }
+}
+
+impl futures_util::task::Spawn for TokioSpawner {
+    fn spawn_obj(&self, obj: futures_util::task::FutureObj<'static, ()>) -> Result<(), futures_util::task::SpawnError> {
+        self.0.spawn(obj);
+        Ok(())
+    }
+}


### PR DESCRIPTION
PR #1222 finished the rest of the engine-v2 subscription implementation, but the actual subgraph subscription calls are delegated to the `Fetcher` trait.

This implements the websocket transport for subscription calls in `runtime-local` (as used in the CLI).  I used graphql-ws-client for the heavy lifting here (glad I _finally_ get to use this, ~3 years after I wrote the thing).

Also added some tests.

Fixes GB-5706