### PR TITLE
fix: concurrent joins in the graphql connector

### DIFF
--- a/engine/crates/engine/src/registry/resolvers/graphql.rs
+++ b/engine/crates/engine/src/registry/resolvers/graphql.rs
@@ -369,7 +369,8 @@ impl Resolver {
 
         let wrapping_field = match &target {
             Target::SelectionSet(_) => None,
-            Target::Field(field, _) => Some(field.name.node.to_string()),
+            Target::Field(field, _) if field.alias.is_none() => Some(field.name.node.to_string()),
+            Target::Field(field, _) => Some(field.alias.as_ref().unwrap().node.to_string()),
         };
 
         Box::pin(make_send_on_wasm(async move {

--- a/engine/crates/engine/src/registry/resolvers/join.rs
+++ b/engine/crates/engine/src/registry/resolvers/join.rs
@@ -1,4 +1,7 @@
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    sync::atomic::{AtomicU64, Ordering},
+};
 
 use engine_parser::{types::Field, Positioned};
 use engine_value::{argument_set::ArgumentSet, ConstValue, Name, Value};
@@ -61,6 +64,8 @@ impl JoinResolver {
     }
 }
 
+static FIELD_COUNTER: AtomicU64 = AtomicU64::new(0);
+
 impl JoinResolver {
     fn field_for_join(
         &self,
@@ -73,7 +78,10 @@ impl JoinResolver {
 
         Ok(Positioned::new(
             Field {
-                alias: None,
+                alias: Some(Positioned::new(
+                    Name::new(format!("field_{}", FIELD_COUNTER.fetch_add(1, Ordering::Relaxed))),
+                    *pos,
+                )),
                 name: Positioned::new(Name::new(&self.field_name), *pos),
                 arguments: arguments
                     .into_iter()

--- a/engine/crates/integration-tests/src/mocks/graphql/fake_github.rs
+++ b/engine/crates/integration-tests/src/mocks/graphql/fake_github.rs
@@ -78,6 +78,7 @@ impl Query {
         // This doesn't actually filter anything because I don't need that for my test.
         vec![
             PullRequestOrIssue::PullRequest(PullRequest {
+                id: "1".into(),
                 title: "Creating the thing".into(),
                 checks: vec!["Success!".into()],
                 author: UserOrBot::User(User {
@@ -86,6 +87,7 @@ impl Query {
                 }),
             }),
             PullRequestOrIssue::PullRequest(PullRequest {
+                id: "2".into(),
                 title: "Some bot PR".into(),
                 checks: vec!["Success!".into()],
                 author: UserOrBot::Bot(Bot { id: "123".into() }),
@@ -104,6 +106,7 @@ impl Query {
     async fn bot_pull_requests(&self, bots: Vec<Option<Vec<BotInput>>>) -> Vec<PullRequest> {
         vec![
             PullRequest {
+                id: "1".into(),
                 title: "Creating the thing".into(),
                 checks: vec!["Success!".into()],
                 author: UserOrBot::User(User {
@@ -112,6 +115,7 @@ impl Query {
                 }),
             },
             PullRequest {
+                id: "2".into(),
                 title: "Some bot PR".into(),
                 checks: vec!["Success!".into()],
                 author: UserOrBot::Bot(Bot { id: "123".into() }),
@@ -122,6 +126,7 @@ impl Query {
     async fn all_bot_pull_requests(&self) -> Vec<PullRequest> {
         vec![
             PullRequest {
+                id: "1".into(),
                 title: "Creating the thing".into(),
                 checks: vec!["Success!".into()],
                 author: UserOrBot::User(User {
@@ -130,6 +135,7 @@ impl Query {
                 }),
             },
             PullRequest {
+                id: "2".into(),
                 title: "Some bot PR".into(),
                 checks: vec!["Success!".into()],
                 author: UserOrBot::Bot(Bot { id: "123".into() }),
@@ -137,9 +143,32 @@ impl Query {
         ]
     }
 
+    async fn pull_request(&self, id: ID) -> Option<PullRequest> {
+        if id == "1" {
+            return Some(PullRequest {
+                id: "1".into(),
+                title: "Creating the thing".into(),
+                checks: vec!["Success!".into()],
+                author: UserOrBot::User(User {
+                    name: "Jim".into(),
+                    email: "jim@example.com".into(),
+                }),
+            });
+        } else if id == "2" {
+            return Some(PullRequest {
+                id: "2".into(),
+                title: "Some bot PR".into(),
+                checks: vec!["Success!".into()],
+                author: UserOrBot::Bot(Bot { id: "123".into() }),
+            });
+        }
+        None
+    }
+
     async fn pull_request_or_issue(&self, id: ID) -> Option<PullRequestOrIssue> {
         if id == "1" {
             return Some(PullRequestOrIssue::PullRequest(PullRequest {
+                id: "1".into(),
                 title: "Creating the thing".into(),
                 checks: vec!["Success!".into()],
                 author: UserOrBot::User(User {
@@ -149,6 +178,7 @@ impl Query {
             }));
         } else if id == "2" {
             return Some(PullRequestOrIssue::PullRequest(PullRequest {
+                id: "2".into(),
                 title: "Some bot PR".into(),
                 checks: vec!["Success!".into()],
                 author: UserOrBot::Bot(Bot { id: "123".into() }),
@@ -183,6 +213,7 @@ struct Header {
 
 #[derive(SimpleObject)]
 struct PullRequest {
+    id: async_graphql::ID,
     title: String,
     checks: Vec<String>,
     author: UserOrBot,

--- a/engine/crates/integration-tests/tests/federation/introspection.rs
+++ b/engine/crates/integration-tests/tests/federation/introspection.rs
@@ -51,6 +51,7 @@ fn can_run_pathfinder_introspection_query() {
     type PullRequest implements PullRequestOrIssue {
       author: UserOrBot!
       checks: [String!]!
+      id: ID!
       title: String!
     }
 
@@ -68,6 +69,7 @@ fn can_run_pathfinder_introspection_query() {
       botPullRequests(bots: [[BotInput!]!]): [PullRequest!]!
       favoriteRepository: CustomRepoId!
       headers: [Header!]!
+      pullRequest(id: ID!): PullRequest
       pullRequestOrIssue(id: ID!): PullRequestOrIssue
       pullRequestsAndIssues(filter: PullRequestsAndIssuesFilters!): [PullRequestOrIssue!]!
       serverVersion: String!
@@ -126,6 +128,7 @@ fn can_run_2018_introspection_query() {
     type PullRequest implements PullRequestOrIssue {
       author: UserOrBot!
       checks: [String!]!
+      id: ID!
       title: String!
     }
 
@@ -143,6 +146,7 @@ fn can_run_2018_introspection_query() {
       botPullRequests(bots: [[BotInput!]!]): [PullRequest!]!
       favoriteRepository: CustomRepoId!
       headers: [Header!]!
+      pullRequest(id: ID!): PullRequest
       pullRequestOrIssue(id: ID!): PullRequestOrIssue
       pullRequestsAndIssues(filter: PullRequestsAndIssuesFilters!): [PullRequestOrIssue!]!
       serverVersion: String!
@@ -201,6 +205,7 @@ fn can_run_2021_introspection_query() {
     type PullRequest implements PullRequestOrIssue {
       author: UserOrBot!
       checks: [String!]!
+      id: ID!
       title: String!
     }
 
@@ -218,6 +223,7 @@ fn can_run_2021_introspection_query() {
       botPullRequests(bots: [[BotInput!]!]): [PullRequest!]!
       favoriteRepository: CustomRepoId!
       headers: [Header!]!
+      pullRequest(id: ID!): PullRequest
       pullRequestOrIssue(id: ID!): PullRequestOrIssue
       pullRequestsAndIssues(filter: PullRequestsAndIssuesFilters!): [PullRequestOrIssue!]!
       serverVersion: String!
@@ -406,6 +412,7 @@ fn can_introsect_when_multiple_subgraphs() {
     type PullRequest implements PullRequestOrIssue {
       author: UserOrBot!
       checks: [String!]!
+      id: ID!
       title: String!
     }
 
@@ -432,6 +439,7 @@ fn can_introsect_when_multiple_subgraphs() {
       listOfListOfStrings(input: [[String!]!]!): [[String!]!]!
       listOfStrings(input: [String!]!): [String!]!
       optionalListOfOptionalStrings(input: [String]): [String]
+      pullRequest(id: ID!): PullRequest
       pullRequestOrIssue(id: ID!): PullRequestOrIssue
       pullRequestsAndIssues(filter: PullRequestsAndIssuesFilters!): [PullRequestOrIssue!]!
       serverVersion: String!
@@ -506,6 +514,9 @@ fn supports_the_type_field() {
             },
             {
               "name": "checks"
+            },
+            {
+              "name": "id"
             },
             {
               "name": "title"

--- a/engine/crates/integration-tests/tests/graphql_connector/basic.rs
+++ b/engine/crates/integration-tests/tests/graphql_connector/basic.rs
@@ -178,6 +178,43 @@ fn graphql_test_without_namespace() {
 }
 
 #[test]
+fn aliases_on_unnamespaced_queries() {
+    runtime().block_on(async {
+        let graphql_mock = MockGraphQlServer::new(FakeGithubSchema).await;
+
+        let engine = EngineBuilder::new(schema(graphql_mock.port(), false)).build().await;
+
+        let value = engine
+            .execute(
+                r#"
+                query {
+                    one: serverVersion
+                    two: pullRequestOrIssue(id: "1") {
+                        title
+                    }
+                }
+            "#,
+            )
+            .variables(json!({"id": "1"}))
+            .await
+            .into_value();
+
+        insta::with_settings!({sort_maps => true}, {
+            insta::assert_json_snapshot!(value, @r###"
+            {
+              "data": {
+                "one": "1",
+                "two": {
+                  "title": "Creating the thing"
+                }
+              }
+            }
+            "###);
+        });
+    });
+}
+
+#[test]
 fn test_nested_variable_forwarding() {
     runtime().block_on(async {
         let graphql_mock = MockGraphQlServer::new(FakeGithubSchema).await;

--- a/engine/crates/integration-tests/tests/graphql_connector/transforms.rs
+++ b/engine/crates/integration-tests/tests/graphql_connector/transforms.rs
@@ -32,6 +32,7 @@ fn graphql_test_with_transforms() {
         }
 
         type PullRequest implements PullRequestOrIssue {
+          id: ID!
           title: String!
           checks: [String!]!
         }
@@ -50,6 +51,7 @@ fn graphql_test_with_transforms() {
           pullRequestsAndIssues(filter: PullRequestsAndIssuesFilters!): [PullRequestOrIssue!]!
           botPullRequests(bots: [[BotInput!]]!): [PullRequest!]!
           allBotPullRequests: [PullRequest!]!
+          pullRequest(id: ID!): PullRequest
           pullRequestOrIssue(id: ID!): PullRequestOrIssue
           headers: [Header!]!
         }


### PR DESCRIPTION
A user on discord is trying to join two GraphQL connectors together.  The type containing the join appears inside a list.  When that list has > 1 item, we need to fetch > 1 field from the downstream API.  These fetches get deduplicated into a single query (cool - glad that works) but the fields in the query don't get aliased correctly.

So you end up with something like:

```
query {
  foo(id: "1") { .. }
  foo(id: "2") { .. }
} 
```

Which is not valid.  I fixed this by always aliasing fields in joins which should solve this problem.

But this uncovered another issue: the graphql connectors deserialisation wasn't taking aliases into account at all.  So even leaving aside joins any fetches of unnamespaced fields that use aliases would return null.  So I fixed that as well and added a test case.