### PR TITLE
Switch back to ts-node

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -19,7 +19,7 @@ permissions:
 
 env:
   GRAFBASE_SKIP_ASSET_VERSION_CHECK: 'true'
-  ASSETS_VERSION: release/e3f46b1-2024-01-10
+  ASSETS_VERSION: release/1696e98-2023-12-12
   PROD_ASSETS: assets.grafbase.com
   CARGO_TERM_COLOR: 'always'
   CARGO_PROFILE_DEV_DEBUG: 0

--- a/cli/crates/server/src/config/mod.rs
+++ b/cli/crates/server/src/config/mod.rs
@@ -18,7 +18,7 @@ use tokio::process::Command;
 
 use crate::{
     atomics::REGISTRY_PARSED_EPOCH_OFFSET_MILLIS,
-    consts::{CONFIG_PARSER_SCRIPT, SCHEMA_PARSER_DIR, TSX_SCRIPT_PATH},
+    consts::{CONFIG_PARSER_SCRIPT_CJS, CONFIG_PARSER_SCRIPT_ESM, SCHEMA_PARSER_DIR, TS_NODE_SCRIPT_PATH},
     node::validate_node,
 };
 
@@ -131,21 +131,43 @@ async fn parse_and_generate_config_from_ts(ts_config_path: &Path) -> Result<Stri
         std::fs::create_dir_all(generated_schemas_dir)?;
     }
 
+    let module_type = project
+        .package_json_path
+        .as_deref()
+        .and_then(ModuleType::from_package_json)
+        .unwrap_or_default();
+
     let config_parser_path = environment
         .user_dot_grafbase_path
         .join(SCHEMA_PARSER_DIR)
-        .join(CONFIG_PARSER_SCRIPT);
+        .join(match module_type {
+            ModuleType::CommonJS => CONFIG_PARSER_SCRIPT_CJS,
+            ModuleType::Esm => CONFIG_PARSER_SCRIPT_ESM,
+        });
 
-    let tsx_path = environment.user_dot_grafbase_path.join(TSX_SCRIPT_PATH);
+    let ts_node_path = environment.user_dot_grafbase_path.join(TS_NODE_SCRIPT_PATH);
 
-    validate_node().await?;
-    let node_command = Command::new("node")
-        .args([
-            tsx_path.to_string_lossy().to_string(),
+    let args = match module_type {
+        ModuleType::CommonJS => vec![
+            ts_node_path.to_string_lossy().to_string(),
             config_parser_path.to_string_lossy().to_string(),
             ts_config_path.to_string_lossy().to_string(),
             generated_config_path.to_string_lossy().to_string(),
-        ])
+        ],
+        ModuleType::Esm => vec![
+            ts_node_path.to_string_lossy().to_string(),
+            "--compilerOptions".to_string(),
+            r#"{"module": "esnext", "moduleResolution": "node", "esModuleInterop": true}"#.to_string(),
+            "--esm".to_string(),
+            config_parser_path.to_string_lossy().to_string(),
+            ts_config_path.to_string_lossy().to_string(),
+            generated_config_path.to_string_lossy().to_string(),
+        ],
+    };
+
+    validate_node().await?;
+    let node_command = Command::new("node")
+        .args(args)
         .stderr(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()?;
@@ -162,4 +184,22 @@ async fn parse_and_generate_config_from_ts(ts_config_path: &Path) -> Result<Stri
     trace!("Generated configuration in {}.", generated_config_path);
 
     Ok(generated_config_path.to_string())
+}
+
+#[derive(Default)]
+enum ModuleType {
+    #[default]
+    CommonJS,
+    Esm,
+}
+
+impl ModuleType {
+    pub fn from_package_json(package_json: &Path) -> Option<ModuleType> {
+        let value = serde_json::from_slice::<serde_json::Value>(&std::fs::read(package_json).ok()?).ok()?;
+        if value["type"].as_str()? == "module" {
+            Some(ModuleType::Esm)
+        } else {
+            Some(ModuleType::CommonJS)
+        }
+    }
 }

--- a/cli/crates/server/src/consts.rs
+++ b/cli/crates/server/src/consts.rs
@@ -1,12 +1,13 @@
 pub const ASSET_VERSION_FILE: &str = "version.txt";
-pub const CONFIG_PARSER_SCRIPT: &str = "parse-config.mts";
+pub const CONFIG_PARSER_SCRIPT_CJS: &str = "parse-config.ts";
+pub const CONFIG_PARSER_SCRIPT_ESM: &str = "parse-config.mts";
 pub const DOT_ENV_FILE_NAME: &str = ".env";
 pub const GIT_IGNORE_CONTENTS: &str = "*\n";
 pub const GIT_IGNORE_FILE: &str = ".gitignore";
 pub const MIN_NODE_VERSION: &str = "v18.0.0";
 pub const MINIFLARE_CLI_JS_PATH: &str = "node_modules/miniflare/dist/src/cli.js";
 pub const SCHEMA_PARSER_DIR: &str = "parser";
-pub const TSX_SCRIPT_PATH: &str = "node_modules/tsx/dist/cli.mjs";
+pub const TS_NODE_SCRIPT_PATH: &str = "node_modules/ts-node/dist/bin.js";
 pub const WRAPPER_WORKER_JS_PATH: &str = "custom-resolvers/wrapper-worker.js";
 pub const GRAFBASE_WASM_SDK_NAME: &str = "grafbase-wasm-sdk_bg.wasm";
 pub const GRAFBASE_WASM_SDK_PATH: &str = "custom-resolvers/grafbase-wasm-sdk_bg.wasm";


### PR DESCRIPTION
We've been trying to use tsx lately to fix some issues around ESM modules and ts-node.  tsx claimed to just work, but in practice it is _so fragile_ - seems to work whenever we test it locally and then horribly breaks the minute it reaches someone else's machine.