### PR TITLE
operation-checks: make sure we handle wrapper types correctly

### DIFF
--- a/engine/crates/operation-checks/src/check.rs
+++ b/engine/crates/operation-checks/src/check.rs
@@ -5,15 +5,21 @@ use std::collections::HashSet;
 use crate::{FieldUsage, Schema};
 use graphql_schema_diff::{Change, ChangeKind};
 
+/// A diagnostic produced by [check()].
 #[derive(Debug)]
 pub struct CheckDiagnostic {
+    /// The message of the diagnostic.
     pub message: String,
+    /// See [Severity].
     pub severity: Severity,
 }
 
+/// The severity of a [CheckDiagnostic].
 #[derive(Debug)]
 pub enum Severity {
+    /// Could be breaking.
     Warning,
+    /// Is breaking.
     Error,
 }
 

--- a/engine/crates/operation-checks/src/lib.rs
+++ b/engine/crates/operation-checks/src/lib.rs
@@ -15,6 +15,6 @@ mod operation;
 mod schema;
 
 pub use aggregate_field_usage::{aggregate_field_usage, FieldUsage};
-pub use check::{check, CheckParams};
+pub use check::{check, CheckDiagnostic, CheckParams, Severity};
 pub use operation::Operation;
 pub use schema::Schema;

--- a/engine/crates/operation-checks/src/schema.rs
+++ b/engine/crates/operation-checks/src/schema.rs
@@ -76,7 +76,9 @@ pub struct SchemaField {
 
 impl SchemaField {
     pub(crate) fn render_type(&self) -> String {
-        let mut result = self.base_type.clone();
+        let base_type = &self.base_type;
+        let bang = if self.wrappers.inner_is_required() { "!" } else { "" };
+        let mut result = format!("{base_type}{bang}");
 
         for list in self.wrappers.iter_list_types() {
             result = match list {
@@ -85,11 +87,7 @@ impl SchemaField {
             }
         }
 
-        if self.wrappers.inner_is_required() {
-            format!("{result}!")
-        } else {
-            result
-        }
+        result
     }
 
     pub(crate) fn is_required(&self) -> bool {

--- a/engine/crates/operation-checks/src/schema.rs
+++ b/engine/crates/operation-checks/src/schema.rs
@@ -75,23 +75,12 @@ pub struct SchemaField {
 }
 
 impl SchemaField {
-    pub(crate) fn render_type(&self) -> String {
-        let base_type = &self.base_type;
-        let bang = if self.wrappers.inner_is_required() { "!" } else { "" };
-        let mut result = format!("{base_type}{bang}");
-
-        for list in self.wrappers.iter_list_types() {
-            result = match list {
-                ListType::List => format!("[{result}]"),
-                ListType::NonNullList => format!("[{result}]!"),
-            }
-        }
-
-        result
+    pub(crate) fn render_type(&self) -> impl std::fmt::Display + '_ {
+        self.wrappers.render(&self.base_type)
     }
 
     pub(crate) fn is_required(&self) -> bool {
-        self.wrappers.is_required()
+        self.wrappers.is_nonnull()
     }
 }
 
@@ -126,7 +115,7 @@ impl FieldArgument {
     }
 
     pub fn is_required(&self) -> bool {
-        self.wrappers.is_required()
+        self.wrappers.is_nonnull()
     }
 
     pub(crate) fn is_required_without_default_value(&self) -> bool {

--- a/engine/crates/operation-checks/src/schema/async_graphql.rs
+++ b/engine/crates/operation-checks/src/schema/async_graphql.rs
@@ -110,7 +110,7 @@ fn extract_type(top_level_ty: &async_graphql_parser::types::Type) -> (String, Wr
     loop {
         match &ty.base {
             async_graphql_parser::types::BaseType::Named(name) => {
-                wrapper_types.set_required(!ty.nullable);
+                wrapper_types.set_inner_nonnull(!ty.nullable);
                 return (name.to_string(), wrapper_types);
             }
             async_graphql_parser::types::BaseType::List(inner) => {

--- a/engine/crates/operation-checks/src/schema/async_graphql.rs
+++ b/engine/crates/operation-checks/src/schema/async_graphql.rs
@@ -1,4 +1,4 @@
-use super::WrapperTypes;
+use super::WrappingTypes;
 use crate::schema;
 use async_graphql_parser::types::ServiceDocument;
 use std::collections::HashSet;
@@ -103,9 +103,9 @@ impl From<ServiceDocument> for schema::Schema {
     }
 }
 
-fn extract_type(top_level_ty: &async_graphql_parser::types::Type) -> (String, WrapperTypes) {
+fn extract_type(top_level_ty: &async_graphql_parser::types::Type) -> (String, WrappingTypes) {
     let mut ty = top_level_ty;
-    let mut wrapper_types = WrapperTypes::default();
+    let mut wrapper_types = WrappingTypes::default();
 
     loop {
         match &ty.base {

--- a/engine/crates/operation-checks/src/schema/wrapper_types.rs
+++ b/engine/crates/operation-checks/src/schema/wrapper_types.rs
@@ -1,0 +1,107 @@
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u8)]
+pub enum WrapperType {
+    List = 0b10,
+    Required = 0b01,
+    RequiredList = 0b11,
+}
+
+impl WrapperType {
+    const LIST: u8 = WrapperType::List as u8;
+    const REQUIRED: u8 = WrapperType::Required as u8;
+    const REQUIRED_LIST: u8 = WrapperType::RequiredList as u8;
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum WrapperTypes {
+    /// A compact representation for up to four levels of wrapper types. Each pair of bits
+    /// corresponds to an Option<WrapperType> (0b00 = None, 0b01 = Some(Required), 0b10 =>
+    /// Some(List), 0b11 => Some(RequiredList)). The least significant pair of bits corresponds to
+    /// the outermost wrappers.
+    Small(u8),
+    /// This variant is for extreme cases of list fields with more than three levels of nested
+    /// lists. From outermost to innermost.
+    Large(Box<[WrapperType]>),
+}
+
+impl WrapperTypes {
+    /// Iterate wrapper types from outermost to innermost.
+    pub(crate) fn iter_wrappers(&self) -> impl Iterator<Item = WrapperType> + '_ {
+        let (first_four, rest): ([Option<WrapperType>; 4], &[WrapperType]) = match self {
+            WrapperTypes::Small(small) => (
+                [0, 1, 2, 3].map(move |i| {
+                    let shift = i * 2; // we deal with groups of two bits
+
+                    // Shift the bits we are interested in to the lower end of the byte and mask
+                    // the rest away.
+                    let bits = (small >> shift) & 0b11;
+
+                    match bits {
+                        0b00 => None,
+                        WrapperType::REQUIRED => Some(WrapperType::Required),
+                        WrapperType::LIST => Some(WrapperType::List),
+                        WrapperType::REQUIRED_LIST => Some(WrapperType::RequiredList),
+                        _ => unreachable!(),
+                    }
+                }),
+                &[],
+            ),
+            WrapperTypes::Large(large) => ([None; 4], large.as_ref()),
+        };
+
+        first_four.into_iter().flatten().chain(rest.iter().copied())
+    }
+
+    pub(crate) fn is_required(&self) -> bool {
+        matches!(
+            self.iter_wrappers().next(),
+            Some(WrapperType::Required | WrapperType::RequiredList)
+        )
+    }
+
+    pub(crate) fn compare(&self, target: &WrapperTypes) -> WrapperTypesComparison {
+        use WrapperType::*;
+        use WrapperTypesComparison::*;
+
+        let mut src_wrappers = self.iter_wrappers();
+        let mut target_wrappers = target.iter_wrappers();
+        let mut end_state = NoChange;
+
+        loop {
+            match (src_wrappers.next(), target_wrappers.next()) {
+                (Some(List), Some(List))
+                | (Some(RequiredList), Some(RequiredList))
+                | (Some(Required), Some(Required)) => (),
+
+                (Some(Required), None) | (Some(RequiredList), Some(List)) => {
+                    end_state = match end_state {
+                        NoChange | RemovedNonNull => RemovedNonNull,
+                        AddedNonNull | NotCompatible => NotCompatible,
+                    }
+                }
+                (None, Some(Required)) | (Some(List), Some(RequiredList)) => {
+                    end_state = match end_state {
+                        NoChange | AddedNonNull => AddedNonNull,
+                        RemovedNonNull | NotCompatible => NotCompatible,
+                    }
+                }
+                (Some(_), _) | (_, Some(_)) => break NotCompatible,
+
+                (None, None) => break end_state,
+            }
+        }
+    }
+}
+
+/// The relevant changes that can happen in wrapper types for the purposes of diffing.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum WrapperTypesComparison {
+    NoChange,
+    /// The type is not required anymore _at any level_
+    RemovedNonNull,
+    //// The type became required _at any level_
+    AddedNonNull,
+    /// List nesting level changed such that there exist values of src that will not fit in target
+    /// and vice versa.
+    NotCompatible,
+}

--- a/engine/crates/operation-checks/tests/cases/change_field_argument_type.snapshot
+++ b/engine/crates/operation-checks/tests/cases/change_field_argument_type.snapshot
@@ -1,11 +1,11 @@
 Forward:
 [
     CheckDiagnostic {
-        message: "The argument `Query.findAlbumsByArtist.yearRangeEnd` changed type but it is still used by clients.",
+        message: "The argument `Query.findAlbumsByArtist.yearRangeEnd` changed type but it is used by clients.",
         severity: Error,
     },
     CheckDiagnostic {
-        message: "The argument `Query.findAlbumsByArtist.yearRangeStart` changed type but it is still used by clients.",
+        message: "The argument `Query.findAlbumsByArtist.yearRangeStart` changed type but it is used by clients.",
         severity: Error,
     },
 ]
@@ -13,11 +13,11 @@ Forward:
 Backward:
 [
     CheckDiagnostic {
-        message: "The argument `Query.findAlbumsByArtist.yearRangeEnd` changed type but it is still used by clients.",
+        message: "The argument `Query.findAlbumsByArtist.yearRangeEnd` changed type but it is used by clients.",
         severity: Error,
     },
     CheckDiagnostic {
-        message: "The argument `Query.findAlbumsByArtist.yearRangeStart` changed type but it is still used by clients.",
+        message: "The argument `Query.findAlbumsByArtist.yearRangeStart` changed type but it is used by clients.",
         severity: Error,
     },
 ]

--- a/engine/crates/operation-checks/tests/cases/change_field_type_basic.snapshot
+++ b/engine/crates/operation-checks/tests/cases/change_field_type_basic.snapshot
@@ -1,11 +1,11 @@
 Forward:
 [
     CheckDiagnostic {
-        message: "The type of the field `Mammal.weight` changed from `Float` to `Int`.",
+        message: "The type of the field `Mammal.weight` changed from `Float!` to `Int!`.",
         severity: Error,
     },
     CheckDiagnostic {
-        message: "The type of the field `MammalInput.mweight` changed from `Float` to `Int`.",
+        message: "The type of the field `MammalInput.mweight` changed from `Float!` to `Int!`.",
         severity: Error,
     },
 ]
@@ -13,11 +13,11 @@ Forward:
 Backward:
 [
     CheckDiagnostic {
-        message: "The type of the field `Mammal.weight` changed from `Int` to `Float`.",
+        message: "The type of the field `Mammal.weight` changed from `Int!` to `Float!`.",
         severity: Error,
     },
     CheckDiagnostic {
-        message: "The type of the field `MammalInput.mweight` changed from `Int` to `Float`.",
+        message: "The type of the field `MammalInput.mweight` changed from `Int!` to `Float!`.",
         severity: Error,
     },
 ]

--- a/engine/crates/operation-checks/tests/cases/change_list_type_nesting.graphql
+++ b/engine/crates/operation-checks/tests/cases/change_list_type_nesting.graphql
@@ -1,0 +1,37 @@
+type Query {
+  koalaFeed(koalaInput: [[KoalaInput]]): [HappyKoala]
+}
+
+type HappyKoala {
+  name: String
+  family: [String]
+}
+
+input KoalaInput {
+  name: String
+  family: [String]
+}
+
+# --- #
+
+type Query {
+  koalaFeed(koalaInput: [KoalaInput]): [HappyKoala]
+}
+
+type HappyKoala {
+  name: String
+  family: [[String]]
+}
+
+input KoalaInput {
+  name: String
+  family: [[String]]
+}
+
+# --- #
+
+{ koalaFeed(koalaInput: { name: "George" }) { name } }
+
+# --- #
+
+{ koalaFeed(koalaInput: { name: "George", family: [] }) { name family } }

--- a/engine/crates/operation-checks/tests/cases/change_list_type_nesting.graphql
+++ b/engine/crates/operation-checks/tests/cases/change_list_type_nesting.graphql
@@ -5,6 +5,7 @@ type Query {
 type HappyKoala {
   name: String
   family: [String]
+  familyRequired: [String!]
 }
 
 input KoalaInput {
@@ -21,6 +22,7 @@ type Query {
 type HappyKoala {
   name: String
   family: [[String]]
+  familyRequired: [[String!]]
 }
 
 input KoalaInput {
@@ -34,4 +36,4 @@ input KoalaInput {
 
 # --- #
 
-{ koalaFeed(koalaInput: { name: "George", family: [] }) { name family } }
+{ koalaFeed(koalaInput: { name: "George", family: [] }) { name family familyRequired } }

--- a/engine/crates/operation-checks/tests/cases/change_list_type_nesting.snapshot
+++ b/engine/crates/operation-checks/tests/cases/change_list_type_nesting.snapshot
@@ -5,6 +5,10 @@ Forward:
         severity: Error,
     },
     CheckDiagnostic {
+        message: "The type of the field `HappyKoala.familyRequired` changed from `[String!]` to `[[String!]]`.",
+        severity: Error,
+    },
+    CheckDiagnostic {
         message: "The type of the field `KoalaInput.family` changed from `[String]` to `[[String]]`.",
         severity: Error,
     },
@@ -18,6 +22,10 @@ Backward:
 [
     CheckDiagnostic {
         message: "The type of the field `HappyKoala.family` changed from `[[String]]` to `[String]`.",
+        severity: Error,
+    },
+    CheckDiagnostic {
+        message: "The type of the field `HappyKoala.familyRequired` changed from `[[String!]]` to `[String!]`.",
         severity: Error,
     },
     CheckDiagnostic {

--- a/engine/crates/operation-checks/tests/cases/change_list_type_nesting.snapshot
+++ b/engine/crates/operation-checks/tests/cases/change_list_type_nesting.snapshot
@@ -1,0 +1,31 @@
+Forward:
+[
+    CheckDiagnostic {
+        message: "The type of the field `HappyKoala.family` changed from `[String]` to `[[String]]`.",
+        severity: Error,
+    },
+    CheckDiagnostic {
+        message: "The type of the field `KoalaInput.family` changed from `[String]` to `[[String]]`.",
+        severity: Error,
+    },
+    CheckDiagnostic {
+        message: "The argument `Query.koalaFeed.koalaInput` changed type but it is used by clients.",
+        severity: Error,
+    },
+]
+
+Backward:
+[
+    CheckDiagnostic {
+        message: "The type of the field `HappyKoala.family` changed from `[[String]]` to `[String]`.",
+        severity: Error,
+    },
+    CheckDiagnostic {
+        message: "The type of the field `KoalaInput.family` changed from `[[String]]` to `[String]`.",
+        severity: Error,
+    },
+    CheckDiagnostic {
+        message: "The argument `Query.koalaFeed.koalaInput` changed type but it is used by clients.",
+        severity: Error,
+    },
+]

--- a/engine/crates/operation-checks/tests/cases/change_requiredness_of_nested_list_type.graphql
+++ b/engine/crates/operation-checks/tests/cases/change_requiredness_of_nested_list_type.graphql
@@ -1,0 +1,49 @@
+type Mutation {
+  createMammals(input: [[MammalInput!]]): Mammal!
+  createMammals2(input: [MammalInput]): Mammal!
+}
+
+type Mammal {
+  id: ID!
+  vernacularNames: [String!]
+}
+
+input MammalInput {
+  mname: String!
+}
+
+# --- #
+
+type Mutation {
+  createMammals(input: [[MammalInput!]!]): Mammal!
+  createMammals2(input: [MammalInput!]): Mammal!
+}
+
+type Mammal {
+  id: ID!
+  vernacularNames: [String]
+}
+
+input MammalInput {
+  mname: String!
+}
+
+# --- #
+
+mutation {
+  createMammals(input: [[{
+    mname: "Tiger"
+  }, { mname: "Panther" }]]) {
+    id
+    vernacularNames
+  }
+
+  createMammals2(input: [
+      { mname: "Tiger" },
+      { mname: "Panther" }
+  ]) {
+    id
+    vernacularNames
+  }
+}
+

--- a/engine/crates/operation-checks/tests/cases/change_requiredness_of_nested_list_type.snapshot
+++ b/engine/crates/operation-checks/tests/cases/change_requiredness_of_nested_list_type.snapshot
@@ -1,0 +1,18 @@
+Forward:
+[
+    CheckDiagnostic {
+        message: "The field `Mammal.vernacularNames` became optional, but clients do not expect null.",
+        severity: Error,
+    },
+    CheckDiagnostic {
+        message: "The argument `Mutation.createMammals.input` became required, but clients are not providing it.",
+        severity: Error,
+    },
+    CheckDiagnostic {
+        message: "The argument `Mutation.createMammals2.input` became required, but clients are not providing it.",
+        severity: Error,
+    },
+]
+
+Backward:
+[]


### PR DESCRIPTION
We were only looking at the outermost wrapper type previously and not really handling lists, not to speak of nested lists. This commit takes the wrapper types (! and []) into account on field type changes in operation checks.

In addition, expose CheckDiagnostic and Severity in public API. It was
an omission.

closes GB-5749