### PR TITLE
chore(engine): Disable validating the operation limits for the internal _grafbase/graphql introspection

### DIFF
--- a/engine/crates/engine/src/request.rs
+++ b/engine/crates/engine/src/request.rs
@@ -44,6 +44,10 @@ pub struct Request {
     /// Disable introspection queries for this request.
     #[serde(skip)]
     pub disable_introspection: bool,
+
+    /// Disable validating operation limits.
+    #[serde(skip)]
+    pub disable_operation_limits: bool,
 }
 
 impl Request {
@@ -57,6 +61,7 @@ impl Request {
             data: Data::default(),
             extensions: Default::default(),
             disable_introspection: false,
+            disable_operation_limits: false,
         }
     }
 

--- a/engine/crates/engine/src/schema.rs
+++ b/engine/crates/engine/src/schema.rs
@@ -420,34 +420,36 @@ impl Schema {
             extensions.validation(&mut validation_fut).await?
         };
 
-        // Check limits.
-        if let Some(limit_complexity) = self.operation_limits.complexity {
-            if validation_result.complexity > limit_complexity as usize {
-                return Err(vec![ServerError::new("Query is too complex.", None)]);
+        if !request.disable_operation_limits {
+            // Check limits.
+            if let Some(limit_complexity) = self.operation_limits.complexity {
+                if validation_result.complexity > limit_complexity as usize {
+                    return Err(vec![ServerError::new("Query is too complex.", None)]);
+                }
             }
-        }
 
-        if let Some(limit_depth) = self.operation_limits.depth {
-            if validation_result.depth > limit_depth as usize {
-                return Err(vec![ServerError::new("Query is nested too deep.", None)]);
+            if let Some(limit_depth) = self.operation_limits.depth {
+                if validation_result.depth > limit_depth as usize {
+                    return Err(vec![ServerError::new("Query is nested too deep.", None)]);
+                }
             }
-        }
 
-        if let Some(height) = self.operation_limits.height {
-            if validation_result.height > height as usize {
-                return Err(vec![ServerError::new("Query is too high.", None)]);
+            if let Some(height) = self.operation_limits.height {
+                if validation_result.height > height as usize {
+                    return Err(vec![ServerError::new("Query is too high.", None)]);
+                }
             }
-        }
 
-        if let Some(root_field_count) = self.operation_limits.root_fields {
-            if validation_result.root_field_count > root_field_count as usize {
-                return Err(vec![ServerError::new("Query has too many root fields.", None)]);
+            if let Some(root_field_count) = self.operation_limits.root_fields {
+                if validation_result.root_field_count > root_field_count as usize {
+                    return Err(vec![ServerError::new("Query has too many root fields.", None)]);
+                }
             }
-        }
 
-        if let Some(alias_count) = self.operation_limits.aliases {
-            if validation_result.alias_count > alias_count as usize {
-                return Err(vec![ServerError::new("Query has too many aliases.", None)]);
+            if let Some(alias_count) = self.operation_limits.aliases {
+                if validation_result.alias_count > alias_count as usize {
+                    return Err(vec![ServerError::new("Query has too many aliases.", None)]);
+                }
             }
         }
 


### PR DESCRIPTION
# Description

Disable validating the operation limits for the internal _grafbase/graphql introspection.

# Type of change

- [ ] 💔 Breaking
- [X] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
