### PR TITLE
feat: add websocket support to cli proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2491,6 +2491,7 @@ name = "grafbase-local-server"
 version = "0.52.4"
 dependencies = [
  "async-trait",
+ "async-tungstenite",
  "axum",
  "cfg-if",
  "common-types",

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 
 [dependencies]
 async-trait = "0.1"
+async-tungstenite = { version = "0.24", features = ["tokio"] }
 axum.workspace = true
 dotenv = "0.15"
 flate2 = "1.0"


### PR DESCRIPTION
I spent a good chunk of this morning saying "why the fuck am I getting 404s" when I was trying to test subscriptions.  I had forgotten that we've got a proxy sitting between the user and the actual federated dev server 🤦.

This updates that to support proxying websocket connections through to the underlying dev server (which will come in my next PR - just cleaing it up now).

Part of GB-5715