### PR TITLE
operation-checks: implement breaking root type removal detection

### DIFF
--- a/engine/crates/operation-checks/src/check.rs
+++ b/engine/crates/operation-checks/src/check.rs
@@ -1,9 +1,8 @@
 mod rules;
 
-use std::collections::HashSet;
-
 use crate::{FieldUsage, Schema};
 use graphql_schema_diff::{Change, ChangeKind};
+use std::collections::HashSet;
 
 /// A diagnostic produced by [check()].
 #[derive(Debug)]
@@ -121,13 +120,13 @@ fn check_change(args: CheckArgs<'_, '_>) -> Option<CheckDiagnostic> {
 
         // Removing a type means it isn't used anymore. That may translate to field type changes,
         // which are the actual breaking changes.
-        | ChangeKind::RemoveObjectType
         | ChangeKind::RemoveEnum
         | ChangeKind::RemoveScalar
         | ChangeKind::RemoveInterface
         | ChangeKind::RemoveInputObject
         | ChangeKind::RemoveUnion => None,
 
+        ChangeKind::RemoveObjectType => rules::remove_object_type(args),
 
         ChangeKind::RemoveField => rules::remove_field(args),
 

--- a/engine/crates/operation-checks/tests/cases/remove_mutation_root.graphql
+++ b/engine/crates/operation-checks/tests/cases/remove_mutation_root.graphql
@@ -1,0 +1,26 @@
+schema {
+    query: Qu
+    mutation: Mu
+}
+
+type Qu {
+    everything: [String]
+}
+
+type Mu {
+    deleteEverything: Qu
+}
+
+# --- #
+
+schema {
+    query: Qu
+}
+
+type Qu {
+    everything: [String]
+}
+
+# --- #
+
+mutation { deleteEverything { everything } }

--- a/engine/crates/operation-checks/tests/cases/remove_mutation_root.snapshot
+++ b/engine/crates/operation-checks/tests/cases/remove_mutation_root.snapshot
@@ -1,0 +1,10 @@
+Forward:
+[
+    CheckDiagnostic {
+        message: "The root type `Mu` was removed but it is still used by clients.",
+        severity: Error,
+    },
+]
+
+Backward:
+[]


### PR DESCRIPTION
If you remove a regular object type, it registers as a field type change for the fields that return it. But that isn't the case for the root query, mutation and subscription types, so we need to check for that case separately.

closes GB-5769
