### PR TITLE
operation-checks: implement rule about enum value removal

### DIFF
--- a/engine/crates/operation-checks/src/check.rs
+++ b/engine/crates/operation-checks/src/check.rs
@@ -57,6 +57,10 @@ impl CheckParams<'_> {
 
         self.field_usage.count_per_field_argument.contains_key(&argument_id)
     }
+
+    fn enum_value_is_used(&self, path: &str) -> bool {
+        self.field_usage.count_per_enum_value.contains_key(path)
+    }
 }
 
 /// Perform operation checks.
@@ -144,9 +148,7 @@ fn check_change(args: CheckArgs<'_, '_>) -> Option<CheckDiagnostic> {
 
         ChangeKind::RemoveUnionMember => rules::remove_union_member(args),
 
-        // Removing an enum value is safe iff it is not used explicitly as argument in any query.
-        // TODO: implement this => GB-5747
-        ChangeKind::RemoveEnumValue => None,
+        ChangeKind::RemoveEnumValue => rules::remove_enum_value(args),
 
         // Only breaking if the argument is required and at least one query leaves it out.
         // TODO: implement this => GB-5748

--- a/engine/crates/operation-checks/src/check/rules.rs
+++ b/engine/crates/operation-checks/src/check/rules.rs
@@ -353,3 +353,18 @@ pub(crate) fn remove_object_type(args: CheckArgs<'_, '_>) -> Option<CheckDiagnos
         severity: Severity::Error,
     })
 }
+
+// Removing an enum value is safe iff it is not used explicitly as argument in any query.
+pub(crate) fn remove_enum_value(args: CheckArgs<'_, '_>) -> Option<CheckDiagnostic> {
+    if !args.check_params.enum_value_is_used(&args.change.path) {
+        return None;
+    }
+
+    Some(CheckDiagnostic {
+        message: format!(
+            "The enum value `{}` was removed but it is still used by clients.",
+            args.change.path
+        ),
+        severity: Severity::Error,
+    })
+}

--- a/engine/crates/operation-checks/src/operation.rs
+++ b/engine/crates/operation-checks/src/operation.rs
@@ -16,6 +16,8 @@ pub struct Operation {
 
     /// (parent selection, selection)
     pub(crate) selections: Vec<(SelectionId, Selection)>,
+
+    pub(crate) enum_values_in_variable_defaults: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -32,10 +34,17 @@ pub enum OperationType {
 }
 
 #[derive(Debug)]
-pub enum Selection {
+pub(crate) struct Argument {
+    pub(crate) name: String,
+    /// Some(_) if the argument value is an enum literal.
+    pub(crate) enum_literal_value: Option<String>,
+}
+
+#[derive(Debug)]
+pub(crate) enum Selection {
     Field {
         field_name: String,
-        arguments: Vec<String>,
+        arguments: Vec<Argument>,
         subselection: Option<SelectionId>,
     },
     FragmentSpread {

--- a/engine/crates/operation-checks/src/schema.rs
+++ b/engine/crates/operation-checks/src/schema.rs
@@ -1,7 +1,7 @@
 mod async_graphql;
 mod wrapping_types;
 
-pub(crate) use wrapping_types::*;
+pub(crate) use self::{async_graphql::extract_type, wrapping_types::*};
 
 use std::collections::HashSet;
 

--- a/engine/crates/operation-checks/src/schema/async_graphql.rs
+++ b/engine/crates/operation-checks/src/schema/async_graphql.rs
@@ -103,7 +103,7 @@ impl From<ServiceDocument> for schema::Schema {
     }
 }
 
-fn extract_type(top_level_ty: &async_graphql_parser::types::Type) -> (String, WrappingTypes) {
+pub(crate) fn extract_type(top_level_ty: &async_graphql_parser::types::Type) -> (String, WrappingTypes) {
     let mut ty = top_level_ty;
     let mut wrapper_types = WrappingTypes::default();
 

--- a/engine/crates/operation-checks/tests/cases/remove_enum_value_used_in_argument.graphql
+++ b/engine/crates/operation-checks/tests/cases/remove_enum_value_used_in_argument.graphql
@@ -1,0 +1,30 @@
+scalar Url
+
+type Query {
+  findImage(dominantColor: Color): Url
+}
+
+enum Color {
+  RED
+  GREEN
+  BLUE
+}
+
+# --- #
+
+scalar Url
+
+type Query {
+  findImage(dominantColor: Color): Url
+}
+
+enum Color {
+  RED
+  GREEN
+}
+
+# --- #
+
+query findBlueImage {
+    findImage(dominantColor: BLUE)
+}

--- a/engine/crates/operation-checks/tests/cases/remove_enum_value_used_in_argument.snapshot
+++ b/engine/crates/operation-checks/tests/cases/remove_enum_value_used_in_argument.snapshot
@@ -1,0 +1,10 @@
+Forward:
+[
+    CheckDiagnostic {
+        message: "The enum value `Color.BLUE` was removed but it is still used by clients.",
+        severity: Error,
+    },
+]
+
+Backward:
+[]

--- a/engine/crates/operation-checks/tests/cases/remove_used_enum_value_in_variable_default.graphql
+++ b/engine/crates/operation-checks/tests/cases/remove_used_enum_value_in_variable_default.graphql
@@ -1,0 +1,31 @@
+scalar Url
+
+type Query {
+  findImage(dominantColor: Color): Url
+}
+
+enum Color {
+  RED
+  GREEN
+  BLUE
+}
+
+# --- #
+
+scalar Url
+
+type Query {
+  findImage(dominantColor: Color): Url
+}
+
+enum Color {
+  RED
+  GREEN
+}
+
+# --- #
+
+query findBlueImage($color: Color = BLUE) {
+    findImage(dominantColor: $color)
+}
+

--- a/engine/crates/operation-checks/tests/cases/remove_used_enum_value_in_variable_default.snapshot
+++ b/engine/crates/operation-checks/tests/cases/remove_used_enum_value_in_variable_default.snapshot
@@ -1,0 +1,10 @@
+Forward:
+[
+    CheckDiagnostic {
+        message: "The enum value `Color.BLUE` was removed but it is still used by clients.",
+        severity: Error,
+    },
+]
+
+Backward:
+[]


### PR DESCRIPTION
We can only check the usage of the values in literals in queries (=> not their usage in variables), but we do catch when these would break.

closes GB-5747
