### PR TITLE
chore: add federated-graph-schema arg for federated start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2554,6 +2554,7 @@ dependencies = [
  "futures-util",
  "gateway",
  "grafbase-local-common",
+ "graphql-federated-graph",
  "handlebars 5.1.1",
  "hyper",
  "hyper-util",

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ FROM alpine:3.19
 
 WORKDIR /grafbase
 
-RUN apk add --no-cache nodejs npm
+# used curl to run a health check query against the server in a docker-compose file
+RUN apk add --no-cache nodejs npm curl
 
 RUN adduser -g wheel -D grafbase -h "/data" && mkdir -p /data && chown grafbase: /data
 USER grafbase

--- a/cli/crates/cli/src/build.rs
+++ b/cli/crates/cli/src/build.rs
@@ -7,6 +7,6 @@ use crate::{cli_input::LogLevelFilters, errors::CliError};
 pub fn build(parallelism: NonZeroUsize, tracing: bool) -> Result<(), CliError> {
     trace!("attempting to build server");
     crate::start::run(LogLevelFilters::default(), |message_sender| {
-        server::ProductionServer::build(message_sender, parallelism, tracing).map_ok(|_| ())
+        server::ProductionServer::build(message_sender, parallelism, tracing, None).map_ok(|_| ())
     })
 }

--- a/cli/crates/cli/src/cli_input/start.rs
+++ b/cli/crates/cli/src/cli_input/start.rs
@@ -1,4 +1,7 @@
-use std::net::{IpAddr, Ipv4Addr};
+use std::{
+    net::{IpAddr, Ipv4Addr},
+    path::PathBuf,
+};
 
 use super::{LogLevelFilter, LogLevelFilters, DEFAULT_SUBGRAPH_PORT};
 
@@ -22,6 +25,9 @@ pub struct StartCommand {
     /// IP address on which the server will listen for incomming connections. Defaults to 127.0.0.1.
     #[arg(long)]
     pub listen_address: Option<IpAddr>,
+    /// Path to federated graph SDL. If provided, the graph will be static and cannot be updated.
+    #[arg(long)]
+    pub federated_graph_schema: Option<PathBuf>,
 }
 
 impl StartCommand {
@@ -44,5 +50,13 @@ impl StartCommand {
 
     pub fn listen_address(&self) -> IpAddr {
         self.listen_address.unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
+    }
+
+    pub fn federated_graph_schema_path(&self) -> Option<PathBuf> {
+        self.federated_graph_schema
+            .as_ref()
+            .zip(std::env::current_dir().ok())
+            .map(|(path, cwd)| cwd.join(path))
+            .or(self.federated_graph_schema.clone())
     }
 }

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -128,7 +128,13 @@ fn try_main(args: Args) -> Result<(), CliError> {
                 process::exit(exitcode::OK);
             });
 
-            start(cmd.listen_address(), cmd.port, cmd.log_levels(), args.trace >= 2)
+            start(
+                cmd.listen_address(),
+                cmd.port,
+                cmd.log_levels(),
+                cmd.federated_graph_schema_path(),
+                args.trace >= 2,
+            )
         }
         SubCommand::Build(cmd) => {
             let _ = ctrlc::set_handler(|| {

--- a/cli/crates/cli/src/start.rs
+++ b/cli/crates/cli/src/start.rs
@@ -7,6 +7,7 @@ use futures_util::Future;
 use server::{errors::ServerError, types::NestedRequestScopedMessage};
 use std::net::IpAddr;
 use std::num::NonZeroUsize;
+use std::path::PathBuf;
 use std::thread;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
@@ -23,10 +24,12 @@ impl MessageGroup {
         }
     }
 }
+
 pub fn start(
     listen_address: IpAddr,
     port: u16,
     log_level_filters: LogLevelFilters,
+    federated_graph_schema_path: Option<PathBuf>,
     tracing: bool,
 ) -> Result<(), CliError> {
     trace!("attempting to start server");
@@ -34,7 +37,7 @@ pub fn start(
         // not sure we'll keep building in the start command, so keeping the same behavior as
         // before building UDFs serially.
         let parallelism = NonZeroUsize::new(1).expect("strictly positive");
-        server::ProductionServer::build(message_sender, parallelism, tracing)
+        server::ProductionServer::build(message_sender, parallelism, tracing, federated_graph_schema_path)
             .await?
             .serve(listen_address, port)
             .await

--- a/cli/crates/common/src/consts.rs
+++ b/cli/crates/common/src/consts.rs
@@ -23,7 +23,7 @@ pub const AUTHORIZERS_DIRECTORY_NAME: &str = "auth";
 /// the wrangler installation directory within ~/.grafbase
 pub const WRANGLER_DIRECTORY_NAME: &str = "wrangler";
 /// the tracing filter to be used when tracing is on
-pub const TRACE_LOG_FILTER: &str = "grafbase=trace,grafbase_local_common=trace,grafbase_local_server=trace,grafbase_local_backend=trace,tower_http=debug,federated_dev=trace,postgres-connector-types=trace";
+pub const TRACE_LOG_FILTER: &str = "grafbase=trace,grafbase_local_common=trace,grafbase_local_server=trace,grafbase_local_backend=trace,tower_http=debug,federated_dev=trace,postgres-connector-types=trace,engine_v2=debug";
 /// the tracing filter to be used when tracing is off
 pub const DEFAULT_LOG_FILTER: &str = "off";
 /// the subdirectory within '$PROJECT/.grafbase' containing the database

--- a/cli/crates/federated-dev/Cargo.toml
+++ b/cli/crates/federated-dev/Cargo.toml
@@ -29,7 +29,7 @@ serde = "1.0.195"
 serde_json.workspace = true
 thiserror = "1.0.56"
 tokio = { workspace = true, features = ["sync", "rt", "io-std", "time"] }
-tokio-stream = "0.1"
+tokio-stream = { version = "0.1", features = ["sync"] }
 tower-http = { workspace = true, features = ["cors", "fs", "trace"] }
 tower-service.workspace = true
 ulid.workspace = true

--- a/cli/crates/federated-dev/src/dev.rs
+++ b/cli/crates/federated-dev/src/dev.rs
@@ -8,11 +8,14 @@ use axum::{
     Json,
 };
 use common::environment::Environment;
+
 use futures_util::{
     future::{join_all, BoxFuture},
     stream,
 };
 use gateway_v2::streaming::{encode_stream_response, StreamingFormat};
+
+use graphql_composition::FederatedGraph;
 use handlebars::Handlebars;
 use runtime::context::RequestContext as _;
 use serde_json::json;
@@ -28,7 +31,7 @@ use crate::{
         gateway_nanny::GatewayNanny,
         websockets::{WebsocketAccepter, WebsocketService},
     },
-    ConfigReceiver,
+    ConfigWatcher,
 };
 
 use self::{
@@ -54,43 +57,54 @@ struct ProxyState {
     gateway: GatewayWatcher,
 }
 
-pub(super) async fn run(port: u16, expose: bool, config: ConfigReceiver) -> Result<(), crate::Error> {
+pub(super) async fn run(
+    port: u16,
+    expose: bool,
+    config: ConfigWatcher,
+    graph: Option<FederatedGraph>,
+) -> Result<(), crate::Error> {
     log::trace!("starting the federated dev server");
 
-    let (graph_sender, graph_receiver) = watch::channel(None);
-    let (refresh_sender, refresh_receiver) = mpsc::channel(16);
-    let (compose_sender, compose_receiver) = mpsc::channel(16);
-    let (gateway_sender, gateway) = watch::channel(None);
+    let (gateway_sender, gateway) = watch::channel(gateway_nanny::new_gateway(graph, &config.borrow()));
     let (websocket_sender, websocket_receiver) = mpsc::channel(16);
-
-    let compose_bus = ComposeBus::new(graph_sender, refresh_sender, compose_sender.clone(), compose_receiver);
-    let refresh_bus = RefreshBus::new(refresh_receiver, compose_sender.clone());
-    let admin_bus = AdminBus::new(compose_sender.clone());
-
-    let composer = Composer::new(compose_bus);
-    tokio::spawn(composer.handler());
-
-    let refresher = Refresher::new(refresh_bus);
-    tokio::spawn(refresher.handler());
-
-    let nanny = GatewayNanny::new(graph_receiver, config, gateway_sender);
-    tokio::spawn(nanny.handler());
-
-    let ticker = Ticker::new(REFRESH_INTERVAL, compose_sender);
-    tokio::spawn(ticker.handler());
 
     let websocket_accepter = WebsocketAccepter::new(websocket_receiver, gateway.clone());
     tokio::spawn(websocket_accepter.handler());
 
-    let schema = Schema::build(admin::QueryRoot, admin::MutationRoot, EmptySubscription)
-        .data(admin_bus)
-        .finish();
+    let admin_schema = if gateway.borrow().is_some() {
+        Schema::build(admin::QueryRoot, admin::MutationRoot, EmptySubscription)
+            .data(AdminBus::new_static())
+            .finish()
+    } else {
+        let (graph_sender, graph_receiver) = watch::channel(None);
+        let (compose_sender, compose_receiver) = mpsc::channel(16);
+        let (refresh_sender, refresh_receiver) = mpsc::channel(16);
+        let refresh_bus = RefreshBus::new(refresh_receiver, compose_sender.clone());
+        let compose_bus = ComposeBus::new(graph_sender, refresh_sender, compose_sender.clone(), compose_receiver);
+        let composer = Composer::new(compose_bus);
+        tokio::spawn(composer.handler());
+
+        let ticker = Ticker::new(REFRESH_INTERVAL, compose_sender.clone());
+        tokio::spawn(ticker.handler());
+
+        let refresher = Refresher::new(refresh_bus);
+        tokio::spawn(refresher.handler());
+
+        let nanny = GatewayNanny::new(graph_receiver, config, gateway_sender);
+        tokio::spawn(nanny.handler());
+
+        let admin_bus = AdminBus::new_dynamic(compose_sender);
+
+        Schema::build(admin::QueryRoot, admin::MutationRoot, EmptySubscription)
+            .data(admin_bus)
+            .finish()
+    };
 
     let environment = Environment::get();
     let static_asset_path = environment.user_dot_grafbase_path.join("static");
 
     let app = axum::Router::new()
-        .route("/admin", get(admin).post_service(GraphQL::new(schema)))
+        .route("/admin", get(admin).post_service(GraphQL::new(admin_schema)))
         .route("/graphql", get(engine_get).post(engine_post))
         .route_service("/ws", WebsocketService::new(websocket_sender))
         .nest_service("/static", tower_http::services::ServeDir::new(static_asset_path))

--- a/cli/crates/federated-dev/src/dev/bus.rs
+++ b/cli/crates/federated-dev/src/dev/bus.rs
@@ -23,7 +23,7 @@ use super::{admin::Header, refresher::RefreshMessage};
 pub(crate) type GraphSender = watch::Sender<Option<FederatedGraph>>;
 
 /// A channel to receive a composed federated graph, typically for a router.
-pub(crate) type GraphReceiver = watch::Receiver<Option<FederatedGraph>>;
+pub(crate) type GraphWatcher = watch::Receiver<Option<FederatedGraph>>;
 
 /// A channel to send a refresh message with a collection of graphs.
 pub(crate) type RefreshSender = mpsc::Sender<Vec<RefreshMessage>>;

--- a/cli/crates/federated-dev/src/dev/bus/admin.rs
+++ b/cli/crates/federated-dev/src/dev/bus/admin.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 pub(crate) enum AdminBus {
     DynamicGraph { compose_sender: ComposeSender },
-    StatisGraph,
+    StaticGraph,
 }
 
 impl AdminBus {
@@ -14,7 +14,7 @@ impl AdminBus {
     }
 
     pub fn new_static() -> Self {
-        Self::StatisGraph
+        Self::StaticGraph
     }
 
     pub async fn compose_graph(
@@ -28,7 +28,7 @@ impl AdminBus {
             AdminBus::DynamicGraph { compose_sender } => {
                 super::compose_graph(compose_sender, name, url, headers, schema).await
             }
-            AdminBus::StatisGraph => Err(Error::internal("Cannot compose a new subgraph with a schema file.")),
+            AdminBus::StaticGraph => Err(Error::internal("Cannot compose a new subgraph with a schema file.")),
         }
     }
 
@@ -42,7 +42,7 @@ impl AdminBus {
             AdminBus::DynamicGraph { compose_sender } => {
                 super::introspect_schema(compose_sender, name, url, headers).await
             }
-            AdminBus::StatisGraph => Err(Error::internal("Nothing to introspect")),
+            AdminBus::StaticGraph => Err(Error::internal("Nothing to introspect")),
         }
     }
 }

--- a/cli/crates/federated-dev/src/dev/bus/admin.rs
+++ b/cli/crates/federated-dev/src/dev/bus/admin.rs
@@ -3,13 +3,18 @@ use crate::{dev::admin::Header, error::Error};
 use async_graphql_parser::types::ServiceDocument;
 use url::Url;
 
-pub(crate) struct AdminBus {
-    compose_sender: ComposeSender,
+pub(crate) enum AdminBus {
+    DynamicGraph { compose_sender: ComposeSender },
+    StatisGraph,
 }
 
 impl AdminBus {
-    pub fn new(compose_sender: ComposeSender) -> Self {
-        Self { compose_sender }
+    pub fn new_dynamic(compose_sender: ComposeSender) -> Self {
+        Self::DynamicGraph { compose_sender }
+    }
+
+    pub fn new_static() -> Self {
+        Self::StatisGraph
     }
 
     pub async fn compose_graph(
@@ -19,7 +24,12 @@ impl AdminBus {
         headers: Vec<Header>,
         schema: ServiceDocument,
     ) -> Result<(), Error> {
-        super::compose_graph(&self.compose_sender, name, url, headers, schema).await
+        match self {
+            AdminBus::DynamicGraph { compose_sender } => {
+                super::compose_graph(compose_sender, name, url, headers, schema).await
+            }
+            AdminBus::StatisGraph => Err(Error::internal("Cannot compose a new subgraph with a schema file.")),
+        }
     }
 
     pub async fn introspect_schema(
@@ -28,6 +38,11 @@ impl AdminBus {
         url: Url,
         headers: Vec<Header>,
     ) -> Result<ServiceDocument, Error> {
-        super::introspect_schema(&self.compose_sender, name, url, headers).await
+        match self {
+            AdminBus::DynamicGraph { compose_sender } => {
+                super::introspect_schema(compose_sender, name, url, headers).await
+            }
+            AdminBus::StatisGraph => Err(Error::internal("Nothing to introspect")),
+        }
     }
 }

--- a/cli/crates/federated-dev/src/lib.rs
+++ b/cli/crates/federated-dev/src/lib.rs
@@ -57,12 +57,13 @@ pub use self::{
     events::{subscribe, FederatedDevEvent},
 };
 
+use graphql_composition::FederatedGraph;
 use parser_sdl::federation::FederatedGraphConfig;
 use tokio::runtime::Builder;
 use url::Url;
 
 /// FederatedGraphConfig should be provided to federated-dev via this watch::Receiver type
-pub type ConfigReceiver = tokio::sync::watch::Receiver<FederatedGraphConfig>;
+pub type ConfigWatcher = tokio::sync::watch::Receiver<FederatedGraphConfig>;
 
 /// Adds a subgraph to the running dev system.
 pub fn add_subgraph(name: &str, url: &Url, dev_api_port: u16, headers: Vec<(&str, &str)>) -> Result<(), Error> {
@@ -75,6 +76,6 @@ pub fn add_subgraph(name: &str, url: &Url, dev_api_port: u16, headers: Vec<(&str
 }
 
 /// Runs the federated dev system.
-pub async fn run(port: u16, expose: bool, config: ConfigReceiver) -> Result<(), Error> {
-    dev::run(port, expose, config).await
+pub async fn run(port: u16, expose: bool, config: ConfigWatcher, graph: Option<FederatedGraph>) -> Result<(), Error> {
+    dev::run(port, expose, config, graph).await
 }

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -62,6 +62,7 @@ engine = { path = "../../../engine/crates/engine" }
 parser-sdl = { path = "../../../engine/crates/parser-sdl", features = [
   "local",
 ] }
+graphql-federated-graph = { path = "../../../engine/crates/federated-graph", features = ["from_sdl"] }
 parser-openapi = { path = "../../../engine/crates/parser-openapi" }
 parser-graphql = { path = "../../../engine/crates/parser-graphql" }
 parser-postgres = { path = "../../../engine/crates/parser-postgres" }

--- a/cli/crates/server/src/config/actor.rs
+++ b/cli/crates/server/src/config/actor.rs
@@ -64,7 +64,7 @@ impl ConfigActor {
         Box::pin(WatchStream::new(self.receiver.clone()).filter_map(|result| result.ok()))
     }
 
-    pub fn into_federated_config_receiver(mut self) -> federated_dev::ConfigReceiver {
+    pub fn into_federated_config_receiver(mut self) -> federated_dev::ConfigWatcher {
         let initial_value = match self.receiver.borrow().as_ref() {
             Ok(config) => config.federated_graph_config.clone().unwrap_or_default(),
             Err(_) => Default::default(),

--- a/cli/crates/server/src/errors.rs
+++ b/cli/crates/server/src/errors.rs
@@ -182,6 +182,9 @@ pub enum ServerError {
 
     #[error("Error in gateway initialization: {0}")]
     GatewayError(String),
+
+    #[error("Failed loading the federated graph from the SDL: {0}")]
+    InvalidFederatedGraphSdl(String),
 }
 
 #[derive(Debug, Error)]

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -16,6 +16,7 @@ use common::environment::{Environment, Project};
 use engine::registry::Registry;
 use flate2::read::GzDecoder;
 use futures_util::StreamExt;
+use graphql_federated_graph::FederatedGraph;
 use sha2::Digest;
 use std::collections::HashMap;
 use std::env;
@@ -23,18 +24,24 @@ use std::fs;
 use std::future::IntoFuture;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::num::NonZeroUsize;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::task::JoinSet;
 
-pub struct ProductionServer {
-    registry: Arc<Registry>,
-    bridge_app: axum::Router,
-    environment_variables: HashMap<String, String>,
-    message_sender: MessageSender,
-    federated_graph_config: Option<parser_sdl::federation::FederatedGraphConfig>,
+pub enum ProductionServer {
+    V1 {
+        message_sender: MessageSender,
+        registry: Arc<Registry>,
+        bridge_app: axum::Router,
+        environment_variables: HashMap<String, String>,
+    },
+    Federated {
+        message_sender: MessageSender,
+        config: parser_sdl::federation::FederatedGraphConfig,
+        graph: Option<FederatedGraph>,
+    },
 }
 
 impl ProductionServer {
@@ -42,6 +49,7 @@ impl ProductionServer {
         message_sender: MessageSender,
         parallelism: NonZeroUsize,
         tracing: bool,
+        federated_graph_schema_path: Option<PathBuf>,
     ) -> Result<Self, ServerError> {
         export_embedded_files()?;
         create_project_dot_grafbase_directory()?;
@@ -53,97 +61,122 @@ impl ProductionServer {
             federated_graph_config,
             ..
         } = build_config(&environment_variables, None).await?;
-        let registry = Arc::new(registry);
+        if let Some(config) = federated_graph_config {
+            let graph = match federated_graph_schema_path {
+                Some(path) => {
+                    let sdl = tokio::fs::read_to_string(&path)
+                        .await
+                        .map_err(|err| ServerError::InvalidFederatedGraphSdl(err.to_string()))?;
+                    Some(graphql_federated_graph::from_sdl(&sdl).map_err(|err| {
+                        ServerError::InvalidFederatedGraphSdl(format!("Invalid federated graph SDL: {}", err))
+                    })?)
+                }
+                None => None,
+            };
+            Ok(Self::Federated {
+                config,
+                message_sender,
+                graph,
+            })
+        } else {
+            let registry = Arc::new(registry);
 
-        let (bridge_app, bridge_state) =
-            bridge::build_router(message_sender.clone(), Arc::clone(&registry), tracing).await?;
-        if !detected_udfs.is_empty() {
-            validate_node().await?;
-            let project = Project::get();
+            let (bridge_app, bridge_state) =
+                bridge::build_router(message_sender.clone(), Arc::clone(&registry), tracing).await?;
+            if !detected_udfs.is_empty() {
+                validate_node().await?;
+                let project = Project::get();
 
-            let mut hasher = sha2::Sha256::new();
+                let mut hasher = sha2::Sha256::new();
 
-            for entry in walkdir::WalkDir::new(&project.path)
-                .sort_by_file_name()
-                .follow_links(true)
-                .into_iter()
-                .filter_map(Result::ok)
-                // Only path we can somewhat safely ignore is the schema one
-                .filter(|entry| !entry.file_type().is_dir() && entry.path() != project.schema_path.path())
-            {
-                let content =
-                    std::fs::read(entry.path()).map_err(|err| ServerError::ReadFile(entry.path().into(), err))?;
-                hasher.update(entry.path().to_string_lossy().as_bytes());
-                hasher.update(content);
+                for entry in walkdir::WalkDir::new(&project.path)
+                    .sort_by_file_name()
+                    .follow_links(true)
+                    .into_iter()
+                    .filter_map(Result::ok)
+                    // Only path we can somewhat safely ignore is the schema one
+                    .filter(|entry| !entry.file_type().is_dir() && entry.path() != project.schema_path.path())
+                {
+                    let content =
+                        std::fs::read(entry.path()).map_err(|err| ServerError::ReadFile(entry.path().into(), err))?;
+                    hasher.update(entry.path().to_string_lossy().as_bytes());
+                    hasher.update(content);
+                }
+                let hash = hasher.finalize().to_vec();
+                let hash_path = project.dot_grafbase_directory_path.join("grafbase_hash");
+                if hash != std::fs::read(&hash_path).unwrap_or_default() {
+                    install_wrangler(Environment::get(), tracing).await?;
+                    bridge_state.build_all_udfs(detected_udfs, parallelism).await?;
+                }
+                // If we fail to write the hash, we're just going to recompile the UDFs.
+                let _ = std::fs::write(hash_path, hash);
             }
-            let hash = hasher.finalize().to_vec();
-            let hash_path = project.dot_grafbase_directory_path.join("grafbase_hash");
-            if hash != std::fs::read(&hash_path).unwrap_or_default() {
-                install_wrangler(Environment::get(), tracing).await?;
-                bridge_state.build_all_udfs(detected_udfs, parallelism).await?;
-            }
-            // If we fail to write the hash, we're just going to recompile the UDFs.
-            let _ = std::fs::write(hash_path, hash);
+            Ok(Self::V1 {
+                registry,
+                bridge_app,
+                environment_variables,
+                message_sender,
+            })
         }
-        Ok(Self {
-            registry,
-            bridge_app,
-            environment_variables,
-            message_sender,
-            federated_graph_config,
-        })
     }
 
     pub async fn serve(self, listen_address: IpAddr, port: u16) -> Result<(), ServerError> {
-        let is_federated = self.federated_graph_config.is_some();
-
-        if let Some(config) = self.federated_graph_config {
-            let _ = self.message_sender.send(ServerMessage::Ready {
-                listen_address,
-                port,
-                is_federated,
-            });
-            return federated_dev::run(port, true, constant_watch_receiver(config))
-                .await
-                .map_err(|error| ServerError::GatewayError(error.to_string()));
-        }
-
-        let tcp_listener = tokio::net::TcpListener::bind(&SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0))
-            .await
-            .map_err(ServerError::StartBridgeApi)?;
-        let bridge_port = tcp_listener.local_addr().unwrap().port();
-        let bridge_server = axum::serve(tcp_listener, self.bridge_app);
-
-        let gateway_app = gateway::Gateway::new(
-            self.environment_variables,
-            gateway::Bridge::new(bridge_port),
-            self.registry,
-        )
-        .await
-        .map_err(|error| ServerError::GatewayError(error.to_string()))?
-        .into_router();
-
-        let gateway_server = axum::serve(
-            tokio::net::TcpListener::bind(&SocketAddr::new(listen_address, port))
-                .await
-                .map_err(ServerError::StartGatewayServer)?,
-            gateway_app,
-        );
-
-        let _ = self.message_sender.send(ServerMessage::Ready {
-            listen_address,
-            port,
-            is_federated,
-        });
-        tokio::select! {
-            result = gateway_server.into_future() => {
-                result.map_err(ServerError::StartGatewayServer)?;
+        match self {
+            ProductionServer::Federated {
+                config,
+                message_sender,
+                graph,
+            } => {
+                let _ = message_sender.send(ServerMessage::Ready {
+                    listen_address,
+                    port,
+                    is_federated: true,
+                });
+                federated_dev::run(port, true, constant_watch_receiver(config), graph)
+                    .await
+                    .map_err(|error| ServerError::GatewayError(error.to_string()))
             }
-            result = bridge_server.into_future() => {
-                result.map_err(ServerError::StartBridgeApi)?
+            ProductionServer::V1 {
+                registry,
+                bridge_app,
+                environment_variables,
+                message_sender,
+            } => {
+                let tcp_listener = tokio::net::TcpListener::bind(&SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0))
+                    .await
+                    .map_err(ServerError::StartBridgeApi)?;
+                let bridge_port = tcp_listener.local_addr().unwrap().port();
+                let bridge_server = axum::serve(tcp_listener, bridge_app);
+
+                let gateway_app =
+                    gateway::Gateway::new(environment_variables, gateway::Bridge::new(bridge_port), registry)
+                        .await
+                        .map_err(|error| ServerError::GatewayError(error.to_string()))?
+                        .into_router();
+
+                let gateway_server = axum::serve(
+                    tokio::net::TcpListener::bind(&SocketAddr::new(listen_address, port))
+                        .await
+                        .map_err(ServerError::StartGatewayServer)?,
+                    gateway_app,
+                );
+
+                let _ = message_sender.send(ServerMessage::Ready {
+                    listen_address,
+                    port,
+                    is_federated: false,
+                });
+                tokio::select! {
+                    result = gateway_server.into_future() => {
+                        result.map_err(ServerError::StartGatewayServer)?;
+                    }
+                    result = bridge_server.into_future() => {
+                        result.map_err(ServerError::StartBridgeApi)?
+                    }
+                }
+                Ok(())
             }
         }
-        Ok(())
     }
 }
 
@@ -218,7 +251,7 @@ async fn federated_dev(
         })
         .ok();
 
-    let server = federated_dev::run(worker_port, false, config.into_federated_config_receiver());
+    let server = federated_dev::run(worker_port, false, config.into_federated_config_receiver(), None);
 
     tokio::select! {
         result = proxy.join() => {


### PR DESCRIPTION
Adding an option to read an Apollo `supergraphql.graphql` (`FederatedGraph`) and use that as the graph statically. I'm not support any subgraph changes when doing so.