### PR TITLE
chore: reworked streaming transport code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2263,6 +2263,7 @@ dependencies = [
  "mime",
  "multipart-stream",
  "runtime",
+ "serde",
  "serde_json",
  "thiserror",
  "tokio",

--- a/cli/crates/federated-dev/src/dev/websockets.rs
+++ b/cli/crates/federated-dev/src/dev/websockets.rs
@@ -150,7 +150,7 @@ async fn subscription_loop(
         headers: Default::default(),
         wait_until_sender,
     };
-    let stream = gateway.execute_stream(&ctx, request);
+    let stream = gateway.execute_stream(ctx, request);
     tokio::spawn(crate::dev::wait(wait_until_receiver));
 
     pin_mut!(stream);

--- a/cli/crates/gateway/src/executor.rs
+++ b/cli/crates/gateway/src/executor.rs
@@ -106,7 +106,8 @@ impl gateway_core::Executor for Executor {
         let schema = self.build_schema(&ctx, auth).await?;
         let payload_stream = Box::pin(schema.execute_stream(request));
         let (headers, bytes_stream) =
-            gateway_core::encode_stream_response(ctx.as_ref(), payload_stream, streaming_format).await;
+            gateway_core::encode_stream_response(ctx.ray_id().to_string(), payload_stream, streaming_format).await;
+
         Ok((headers, axum::body::Body::from_stream(bytes_stream))
             .into_response()
             .into())

--- a/engine/crates/gateway-core/Cargo.toml
+++ b/engine/crates/gateway-core/Cargo.toml
@@ -31,6 +31,7 @@ mediatype = "0.19"
 mime = "0.3"
 multipart-stream = "0.1"
 runtime = { workspace = true, features = ["test-utils"] }
+serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/engine/crates/gateway-core/src/streaming/mod.rs
+++ b/engine/crates/gateway-core/src/streaming/mod.rs
@@ -1,19 +1,27 @@
 pub(super) mod format;
 
+use async_sse::Sender;
 use bytes::Bytes;
-use engine::StreamingPayload;
 use format::StreamingFormat;
-use futures_util::{stream::BoxStream, AsyncBufReadExt, Stream, StreamExt};
+use futures_util::{
+    future::{self, BoxFuture},
+    pin_mut,
+    stream::{self, BoxStream},
+    AsyncBufReadExt, FutureExt, Stream, StreamExt,
+};
 use headers::HeaderMapExt;
 
 const MULTIPART_BOUNDARY: &str = "-";
 
-pub async fn encode_stream_response(
-    ctx: &impl crate::RequestContext,
-    payload_stream: impl Stream<Item = StreamingPayload> + Send + 'static,
+pub async fn encode_stream_response<'a, T>(
+    ray_id: String,
+    payload_stream: impl Stream<Item = T> + Send + 'a,
     streaming_format: StreamingFormat,
-) -> (http::HeaderMap, BoxStream<'static, Result<Bytes, String>>) {
-    let bytes_stream: BoxStream<'static, Result<Bytes, String>> = match streaming_format {
+) -> (http::HeaderMap, BoxStream<'a, Result<Bytes, String>>)
+where
+    T: serde::Serialize + Send,
+{
+    let bytes_stream: BoxStream<'a, Result<Bytes, String>> = match streaming_format {
         StreamingFormat::IncrementalDelivery => {
             Box::pin(multipart_stream::serialize(
                 payload_stream.map(|payload| {
@@ -24,49 +32,21 @@ pub async fn encode_stream_response(
                         body: Bytes::from(serde_json::to_vec(&payload).map_err(|e| e.to_string())?),
                     })
                 }),
-                // The boundary we put in the header in execute_streaming_request
+                // The boundary we put in the header in execute_sreaming_request
                 MULTIPART_BOUNDARY,
             ))
         }
         StreamingFormat::GraphQLOverSSE => {
-            let mut payload_stream = Box::pin(payload_stream);
-
             let (sse_sender, sse_encoder) = async_sse::encode();
-            let response_stream = sse_encoder.lines().map(|line| {
+            let response_stream: BoxStream<'a, Result<Bytes, String>> = Box::pin(sse_encoder.lines().map(|line| {
                 line.map(|mut line| {
                     line.push_str("\r\n");
                     line.into()
                 })
                 .map_err(|e| e.to_string())
-            });
+            }));
 
-            let ray_id = ctx.ray_id().to_string();
-            ctx.wait_until(Box::pin(async move {
-                while let Some(payload) = payload_stream.next().await {
-                    let payload_json = match serde_json::to_string(&payload) {
-                        Ok(json) => json,
-                        Err(error) => {
-                            log::error!(ray_id, "Could not encode StreamingPayload as JSON: {error:?}");
-                            return;
-                        }
-                    };
-
-                    if let Err(error) = sse_sender.send("next", &payload_json, None).await {
-                        log::error!(ray_id, "Could not send next payload via sse_sender: {error}");
-                        return;
-                    }
-                }
-
-                // The GraphQLOverSSE spec suggests we just need the event name on the complete
-                // event but the SSE spec says that you should drop events with an empty data
-                // buffer.  So I'm just putting null in the data buffer for now.
-                if let Err(error) = sse_sender.send("complete", "null", None).await {
-                    log::error!(ray_id, "Could not send complete payload via sse_sender: {error}");
-                }
-            }))
-            .await;
-
-            Box::pin(response_stream)
+            sse_stream(ray_id, payload_stream, sse_sender, response_stream)
         }
     };
 
@@ -80,4 +60,74 @@ pub async fn encode_stream_response(
     }));
 
     (headers, bytes_stream)
+}
+
+fn sse_stream<'a, T>(
+    ray_id: String,
+    payload_stream: impl Stream<Item = T> + Send + 'a,
+    sse_sender: Sender,
+    sse_output: BoxStream<'a, Result<Bytes, String>>,
+) -> BoxStream<'a, Result<Bytes, String>>
+where
+    T: serde::Serialize + Send,
+{
+    // Start a future that pumps data from payload_stream into the sse_sender
+    let pump_future: BoxFuture<'a, ()> = Box::pin(async move {
+        pin_mut!(payload_stream);
+
+        while let Some(payload) = payload_stream.next().await {
+            let payload_json = match serde_json::to_string(&payload) {
+                Ok(json) => json,
+                Err(error) => {
+                    log::error!(ray_id, "Could not encode StreamingPayload as JSON: {error:?}");
+                    return;
+                }
+            };
+
+            if let Err(error) = sse_sender.send("next", &payload_json, None).await {
+                log::error!(ray_id, "Could not send next payload via sse_sender: {error}");
+                return;
+            }
+        }
+
+        // The GraphQLOverSSE spec suggests we just need the event name on the complete
+        // event but the SSE spec says that you should drop events with an empty data
+        // buffer.  So I'm just putting null in the data buffer for now.
+        if let Err(error) = sse_sender.send("complete", "null", None).await {
+            log::error!(ray_id, "Could not send complete payload via sse_sender: {error}");
+        }
+    });
+
+    // Return a Stream that'll run `pump_future` while taking items from sse_output
+    Box::pin(futures_util::stream::unfold(
+        SSEStreamState::Running(sse_output.fuse(), pump_future.fuse()),
+        |mut state| async {
+            loop {
+                match state {
+                    SSEStreamState::Running(mut sse_output, mut pump) => {
+                        futures_util::select! {
+                            output = sse_output.next() => {
+                                return Some((output?, SSEStreamState::Running(sse_output, pump)));
+                            }
+                            _ = pump => {
+                                state = SSEStreamState::Draining(sse_output);
+                                continue;
+                            }
+                        }
+                    }
+                    SSEStreamState::Draining(mut sse_output) => {
+                        return Some((sse_output.next().await?, SSEStreamState::Draining(sse_output)))
+                    }
+                }
+            }
+        },
+    ))
+}
+
+enum SSEStreamState<'a> {
+    Running(
+        stream::Fuse<BoxStream<'a, Result<Bytes, String>>>,
+        future::Fuse<BoxFuture<'a, ()>>,
+    ),
+    Draining(stream::Fuse<BoxStream<'a, Result<Bytes, String>>>),
 }

--- a/engine/crates/gateway-v2/src/lib.rs
+++ b/engine/crates/gateway-v2/src/lib.rs
@@ -135,10 +135,10 @@ impl Gateway {
 
     pub fn execute_stream(
         &self,
-        ctx: &impl RequestContext,
+        ctx: impl RequestContext,
         request: engine::Request,
     ) -> impl Stream<Item = engine_v2::Response> + '_ {
-        self.engine.execute_stream(request, headers(ctx))
+        self.engine.execute_stream(request, headers(&ctx))
     }
 
     fn build_cache_key(

--- a/engine/crates/integration-tests/src/federation/mod.rs
+++ b/engine/crates/integration-tests/src/federation/mod.rs
@@ -74,7 +74,7 @@ impl<'a> ExecutionRequest<'a> {
         let (ctx, futures) = RequestContext::new(self.headers);
         tokio::spawn(RequestContext::wait_for_all(futures));
         self.gateway
-            .execute_stream(&ctx, request)
+            .execute_stream(ctx, request)
             .map(|response| GraphqlResponse {
                 gql_response: serde_json::to_value(&response).unwrap(),
                 metadata: response.take_metadata(),


### PR DESCRIPTION
The existing streaming transport code made use of `wait_until` to pump messages from one place to the other.  This was causing me lifetime problems when integrating into engine-v2, so I've reworked everything to happen inside the returned `Stream`.

I'm hoping this will work on production as well - we had to be careful about where the work was done previously so it was definitely inside the request context.  But I think doing the work inside the returned stream _should_ count as inside the context.  I'll test once this is merged though.