### PR TITLE
operation-checks: implement unused argument awareness

### DIFF
--- a/engine/crates/operation-checks/src/schema.rs
+++ b/engine/crates/operation-checks/src/schema.rs
@@ -63,6 +63,25 @@ impl Schema {
                   }| type_name == other_type_name,
         )
     }
+
+    pub(crate) fn iter_field_arguments(&self, field_id: FieldId) -> impl Iterator<Item = (ArgumentId, &FieldArgument)> {
+        let field = &self[field_id];
+        let start = self.field_arguments.partition_point(
+            |FieldArgument {
+                 type_name, field_name, ..
+             }| { type_name < &field.type_name && field_name < &field.field_name },
+        );
+
+        self.field_arguments[start..]
+            .iter()
+            .take_while(
+                |FieldArgument {
+                     type_name, field_name, ..
+                 }| { type_name == &field.type_name && field_name == &field.field_name },
+            )
+            .enumerate()
+            .map(move |(idx, arg)| (ArgumentId(idx + start), arg))
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/engine/crates/operation-checks/tests/cases/make_argument_with_default_nonnull_without_default.graphql
+++ b/engine/crates/operation-checks/tests/cases/make_argument_with_default_nonnull_without_default.graphql
@@ -1,0 +1,34 @@
+type Query {
+  turtles: [Turtle!]
+}
+
+type Turtle {
+  id: ID!
+  name: String!
+  feed(food: String = "Salad"): String!
+}
+
+# --- #
+
+type Query {
+  turtles: [Turtle!]
+}
+
+type Turtle {
+  id: ID!
+  name: String!
+  # We removed the default. This is not ok because the argument is required.
+  feed(food: String!): String!
+}
+
+# --- #
+
+query {
+  turtles {
+    id
+    name
+    feed
+  }
+}
+
+

--- a/engine/crates/operation-checks/tests/cases/make_argument_with_default_nonnull_without_default.snapshot
+++ b/engine/crates/operation-checks/tests/cases/make_argument_with_default_nonnull_without_default.snapshot
@@ -1,0 +1,10 @@
+Forward:
+[
+    CheckDiagnostic {
+        message: "The argument `Turtle.feed.food` became required, but clients are not providing it.",
+        severity: Error,
+    },
+]
+
+Backward:
+[]

--- a/engine/crates/operation-checks/tests/cases/remove_nonnull_argument_default.graphql
+++ b/engine/crates/operation-checks/tests/cases/remove_nonnull_argument_default.graphql
@@ -1,0 +1,33 @@
+type Query {
+  turtles: [Turtle!]
+}
+
+type Turtle {
+  id: ID!
+  name: String!
+  feed(food: String! = "Salad"): String!
+}
+
+# --- #
+
+type Query {
+  turtles: [Turtle!]
+}
+
+type Turtle {
+  id: ID!
+  name: String!
+  # We removed the default. This is not ok because the field is required.
+  feed(food: String!): String!
+}
+
+# --- #
+
+query {
+  turtles {
+    id
+    name
+    feed
+  }
+}
+

--- a/engine/crates/operation-checks/tests/cases/remove_nonnull_argument_default.snapshot
+++ b/engine/crates/operation-checks/tests/cases/remove_nonnull_argument_default.snapshot
@@ -1,0 +1,10 @@
+Forward:
+[
+    CheckDiagnostic {
+        message: "The default value for required argument `Turtle.feed.food` was removed but some queries leave it out.",
+        severity: Error,
+    },
+]
+
+Backward:
+[]

--- a/engine/crates/operation-checks/tests/cases/remove_nullable_argument_default.graphql
+++ b/engine/crates/operation-checks/tests/cases/remove_nullable_argument_default.graphql
@@ -1,0 +1,32 @@
+type Query {
+  turtles: [Turtle!]
+}
+
+type Turtle {
+  id: ID!
+  name: String!
+  feed(food: String = "Salad"): String!
+}
+
+# --- #
+
+type Query {
+  turtles: [Turtle!]
+}
+
+type Turtle {
+  id: ID!
+  name: String!
+  # We removed the default. This is fine because the field is nullable.
+  feed(food: String): String!
+}
+
+# --- #
+
+query {
+  turtles {
+    id
+    name
+    feed
+  }
+}

--- a/engine/crates/operation-checks/tests/cases/remove_nullable_argument_default.snapshot
+++ b/engine/crates/operation-checks/tests/cases/remove_nullable_argument_default.snapshot
@@ -1,0 +1,5 @@
+Forward:
+[]
+
+Backward:
+[]


### PR DESCRIPTION
In operation checks, we not only care about the arguments queries are using, but also the arguments they are not using, because they could become mandatory, either because they go from nullable to nonnull, or because their default is removed.

This commit makes operation-checks aware of when arguments are left out so we can detect when a diff on argument default or type could cause issues. The test cases in the commit should cover all relevant scenarios.

closes GB-5748