### PR TITLE
feat: add sse & multipart transports to federated dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,7 @@ dependencies = [
 name = "async-runtime"
 version = "0.1.0"
 dependencies = [
+ "futures-util",
  "send_wrapper 0.6.0",
  "tokio",
  "wasm-bindgen-futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,6 +2427,7 @@ dependencies = [
  "grafbase-local-backend",
  "grafbase-local-common",
  "grafbase-local-server",
+ "graphql-mocks",
  "headers 0.3.9",
  "http 0.2.11",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ gateway-v2 = { path = "engine/crates/gateway-v2" }
 graph-entities = { path = "engine/crates/graph-entities" }
 graphql-composition = { path = "engine/crates/composition" }
 graphql-extensions = { path = "engine/crates/graphql-extensions" }
+graphql-mocks = { path = "engine/crates/graphql-mocks" }
 jwt-verifier = { path = "engine/crates/jwt-verifier" }
 log = { path = "engine/crates/log" }
 parser-graphql = { path = "engine/crates/parser-graphql" }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -62,6 +62,7 @@ dirs = "5"
 duct = "0.13"
 fslock = "0.2"
 futures-util = "0.3"
+graphql-mocks.workspace = true
 http = "0.2"
 headers = "0.3"
 insta = { version = "1.34", features = ["json", "redactions", "yaml"] }

--- a/cli/crates/cli/tests/federation.rs
+++ b/cli/crates/cli/tests/federation.rs
@@ -49,6 +49,7 @@ fn federation_start() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[cfg(not(target_os = "windows"))] // tsconfig setup doesn't work on windows :(
 async fn test_sse_transport() {
     let mut env = Environment::init_async().await;
     let subscription_server = MockGraphQlServer::new(graphql_mocks::FakeFederationProductsSchema).await;
@@ -114,6 +115,7 @@ async fn test_sse_transport() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[cfg(not(target_os = "windows"))] // tsconfig setup doesn't work on windows :(
 async fn test_multipart_transport() {
     let mut env = Environment::init_async().await;
     let subscription_server = MockGraphQlServer::new(graphql_mocks::FakeFederationProductsSchema).await;

--- a/cli/crates/cli/tests/utils/environment.rs
+++ b/cli/crates/cli/tests/utils/environment.rs
@@ -379,6 +379,25 @@ impl Environment {
         self.commands.0.lock().unwrap().push(command);
     }
 
+    pub fn grafbase_publish_dev(&mut self, name: impl AsRef<str>, url: impl AsRef<str>) {
+        let command = cmd!(
+            cargo_bin("grafbase"),
+            "--trace",
+            "2",
+            "publish",
+            "--dev",
+            "--dev-api-port",
+            self.port.to_string(),
+            "--name",
+            name.as_ref(),
+            "--url",
+            url.as_ref()
+        )
+        .dir(&self.directory_path);
+
+        command.run().unwrap();
+    }
+
     pub fn append_to_schema(&self, contents: &'static str) {
         let mut file = fs::OpenOptions::new().append(true).open(&self.schema_path).unwrap();
 

--- a/cli/crates/federated-dev/src/dev.rs
+++ b/cli/crates/federated-dev/src/dev.rs
@@ -187,7 +187,6 @@ async fn handle_engine_request(
 
         let (headers, stream) = encode_stream_response(ray_id, stream, streaming_format).await;
 
-        // TODO: is this the right place to spawn?
         tokio::spawn(wait(receiver));
 
         return (headers, axum::body::Body::from_stream(stream)).into_response();

--- a/engine/crates/async-runtime/Cargo.toml
+++ b/engine/crates/async-runtime/Cargo.toml
@@ -12,6 +12,9 @@ keywords = ["async", "runtime", "grafbase"]
 [lints]
 workspace = true
 
+[dependencies]
+futures-util.workspace = true
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = { version = "0.4" }
 send_wrapper = { version = "0.6", features = ["futures"] }

--- a/engine/crates/async-runtime/src/lib.rs
+++ b/engine/crates/async-runtime/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod stream;
+
 use core::future::Future;
 
 #[cfg(target_arch = "wasm32")]

--- a/engine/crates/async-runtime/src/stream.rs
+++ b/engine/crates/async-runtime/src/stream.rs
@@ -1,0 +1,49 @@
+use futures_util::{
+    future::{self, BoxFuture},
+    stream::{self, BoxStream},
+    Future, FutureExt, Stream, StreamExt,
+};
+
+/// Combines a stream and a "producer" future into a single stream
+///
+/// This can be used when you have the receivng side of a channel and a future that sends
+/// on that channel - combining the two into a single stream that'll run till the channel
+/// is exhausted.  If you drop the stream you also cancel the underlying process.
+pub fn producer_stream<'a, S, P, Item>(stream: S, producer: P) -> impl Stream<Item = Item> + 'a
+where
+    S: Stream<Item = Item> + Send + 'a,
+    P: Future<Output = ()> + Send + 'a,
+    Item: 'static,
+{
+    let stream: BoxStream<'a, Item> = Box::pin(stream);
+    let producer: BoxFuture<'a, ()> = Box::pin(producer);
+
+    futures_util::stream::unfold(
+        ProducerState::Running(stream.fuse(), producer.fuse()),
+        |mut state| async {
+            loop {
+                match state {
+                    ProducerState::Running(mut stream, mut producer) => {
+                        futures_util::select! {
+                            output = stream.next() => {
+                                return Some((output?, ProducerState::Running(stream, producer)));
+                            }
+                            _ = producer => {
+                                state = ProducerState::Draining(stream);
+                                continue;
+                            }
+                        }
+                    }
+                    ProducerState::Draining(mut stream) => {
+                        return Some((stream.next().await?, ProducerState::Draining(stream)))
+                    }
+                }
+            }
+        },
+    )
+}
+
+enum ProducerState<'a, Item> {
+    Running(stream::Fuse<BoxStream<'a, Item>>, future::Fuse<BoxFuture<'a, ()>>),
+    Draining(stream::Fuse<BoxStream<'a, Item>>),
+}

--- a/engine/crates/async-runtime/src/stream.rs
+++ b/engine/crates/async-runtime/src/stream.rs
@@ -1,46 +1,64 @@
 use futures_util::{
     future::{self, BoxFuture},
     stream::{self, BoxStream},
-    Future, FutureExt, Stream, StreamExt,
+    Future, FutureExt, Stream, StreamExt as _,
 };
 
-/// Combines a stream and a "producer" future into a single stream
-///
-/// This can be used when you have the receivng side of a channel and a future that sends
-/// on that channel - combining the two into a single stream that'll run till the channel
-/// is exhausted.  If you drop the stream you also cancel the underlying process.
-pub fn producer_stream<'a, S, P, Item>(stream: S, producer: P) -> impl Stream<Item = Item> + 'a
+pub trait StreamExt<'a> {
+    type Item;
+
+    /// Joins a future onto the execution of a stream returning a stream that also polls
+    /// the given future.
+    ///
+    /// If the future ends the stream will still continue till completion but if the stream
+    /// ends the future will be cancelled.
+    ///
+    /// This can be used when you have the receivng side of a channel and a future that sends
+    /// on that channel - combining the two into a single stream that'll run till the channel
+    /// is exhausted.  If you drop the stream you also cancel the underlying process.
+    fn join<F>(self, future: F) -> impl Stream<Item = Self::Item> + 'a
+    where
+        F: Future<Output = ()> + Send + 'a;
+}
+
+impl<'a, T, Item> StreamExt<'a> for T
 where
-    S: Stream<Item = Item> + Send + 'a,
-    P: Future<Output = ()> + Send + 'a,
+    T: Stream<Item = Item> + Send + 'a,
     Item: 'static,
 {
-    let stream: BoxStream<'a, Item> = Box::pin(stream);
-    let producer: BoxFuture<'a, ()> = Box::pin(producer);
+    type Item = Item;
 
-    futures_util::stream::unfold(
-        ProducerState::Running(stream.fuse(), producer.fuse()),
-        |mut state| async {
-            loop {
-                match state {
-                    ProducerState::Running(mut stream, mut producer) => {
-                        futures_util::select! {
-                            output = stream.next() => {
-                                return Some((output?, ProducerState::Running(stream, producer)));
-                            }
-                            _ = producer => {
-                                state = ProducerState::Draining(stream);
-                                continue;
+    fn join<F>(self, future: F) -> impl Stream<Item = Self::Item> + 'a
+    where
+        F: Future<Output = ()> + Send + 'a,
+    {
+        let stream: BoxStream<'a, Item> = Box::pin(self);
+        let future: BoxFuture<'a, ()> = Box::pin(future);
+
+        futures_util::stream::unfold(
+            ProducerState::Running(stream.fuse(), future.fuse()),
+            |mut state| async {
+                loop {
+                    match state {
+                        ProducerState::Running(mut stream, mut producer) => {
+                            futures_util::select! {
+                                output = stream.next() => {
+                                    return Some((output?, ProducerState::Running(stream, producer)));
+                                }
+                                _ = producer => {
+                                    state = ProducerState::Draining(stream);
+                                    continue;
+                                }
                             }
                         }
-                    }
-                    ProducerState::Draining(mut stream) => {
-                        return Some((stream.next().await?, ProducerState::Draining(stream)))
+                        ProducerState::Draining(mut stream) => {
+                            return Some((stream.next().await?, ProducerState::Draining(stream)))
+                        }
                     }
                 }
-            }
-        },
-    )
+            },
+        )
+    }
 }
 
 enum ProducerState<'a, Item> {

--- a/engine/crates/engine-v2/src/engine.rs
+++ b/engine/crates/engine-v2/src/engine.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use async_runtime::stream::producer_stream;
+use async_runtime::stream::StreamExt as _;
 use engine::RequestHeaders;
 use engine_parser::types::OperationType;
 use futures::channel::mpsc;
@@ -73,7 +73,7 @@ impl Engine {
         let (mut sender, receiver) = mpsc::channel(2);
         let engine = Arc::clone(self);
 
-        producer_stream(receiver, async move {
+        receiver.join(async move {
             let coordinator = match engine.prepare_coordinator(request, headers) {
                 Ok(coordinator) => coordinator,
                 Err(response) => {

--- a/engine/crates/engine-v2/src/engine.rs
+++ b/engine/crates/engine-v2/src/engine.rs
@@ -1,16 +1,14 @@
 use std::sync::Arc;
 
+use async_runtime::stream::producer_stream;
 use engine::RequestHeaders;
 use engine_parser::types::OperationType;
 use futures::channel::mpsc;
-use futures_util::{
-    future::{BoxFuture, Fuse},
-    FutureExt, Stream, StreamExt,
-};
+use futures_util::{SinkExt, Stream};
 use schema::Schema;
 
 use crate::{
-    execution::{ExecutorCoordinator, PreparedExecution, PreparedRequest, ResponseReceiver, Variables},
+    execution::{ExecutorCoordinator, PreparedExecution, PreparedRequest, Variables},
     request::{parse_operation, Operation},
     response::{ExecutionMetadata, GraphqlError, Response},
 };
@@ -68,12 +66,32 @@ impl Engine {
     }
 
     pub fn execute_stream(
-        &self,
+        self: &Arc<Self>,
         request: engine::Request,
         headers: RequestHeaders,
-    ) -> impl Stream<Item = Response> + '_ {
-        let initial_state = StreamState::Starting(request, headers, self);
-        futures_util::stream::unfold(initial_state, stream_handler)
+    ) -> impl Stream<Item = Response> {
+        let (mut sender, receiver) = mpsc::channel(2);
+        let engine = Arc::clone(self);
+
+        producer_stream(receiver, async move {
+            let coordinator = match engine.prepare_coordinator(request, headers) {
+                Ok(coordinator) => coordinator,
+                Err(response) => {
+                    sender.send(response).await.ok();
+                    return;
+                }
+            };
+
+            if matches!(
+                coordinator.operation_type(),
+                OperationType::Query | OperationType::Mutation
+            ) {
+                sender.send(coordinator.execute().await).await.ok();
+                return;
+            }
+
+            coordinator.execute_subscription(sender).await
+        })
     }
 
     fn prepare_coordinator(
@@ -97,56 +115,5 @@ impl Engine {
         let unbound_operation = parse_operation(request)?;
         let operation = Operation::build(&self.schema, unbound_operation)?;
         Ok(operation)
-    }
-}
-
-enum StreamState<'a> {
-    Starting(engine::Request, RequestHeaders, &'a Engine),
-    Running(ResponseReceiver, Fuse<BoxFuture<'a, ()>>),
-    Draining(ResponseReceiver),
-    Finished,
-}
-
-async fn stream_handler(mut state: StreamState<'_>) -> Option<(Response, StreamState<'_>)> {
-    loop {
-        match state {
-            StreamState::Starting(request, headers, engine) => {
-                let coordinator = match engine.prepare_coordinator(request, headers) {
-                    Ok(coordinator) => coordinator,
-                    Err(response) => return Some((response, StreamState::Finished)),
-                };
-
-                if matches!(
-                    coordinator.operation_type(),
-                    OperationType::Query | OperationType::Mutation
-                ) {
-                    let response = coordinator.execute().await;
-                    return Some((response, StreamState::Finished));
-                }
-
-                let (sender, receiver) = mpsc::channel(2);
-
-                let subscription_future: BoxFuture<'_, ()> = Box::pin(coordinator.execute_subscription(sender));
-
-                // Pass off to the Running handler
-                state = StreamState::Running(receiver, subscription_future.fuse());
-            }
-            StreamState::Running(mut receiver, mut subscription_future) => {
-                futures::select! {
-                    _ = subscription_future => {
-                        // Pass off to the Draining handler to make sure we deliver any pending
-                        // messages before we finish
-                        state = StreamState::Draining(receiver)
-                    },
-                    next = receiver.next() => {
-                        return Some((next?, StreamState::Running(receiver, subscription_future)));
-                    }
-                }
-            }
-            StreamState::Draining(mut receiver) => {
-                return Some((receiver.next().await?, StreamState::Draining(receiver)));
-            }
-            StreamState::Finished => return None,
-        }
     }
 }

--- a/engine/crates/engine-v2/src/execution/coordinator.rs
+++ b/engine/crates/engine-v2/src/execution/coordinator.rs
@@ -18,7 +18,6 @@ use crate::{
     Engine,
 };
 
-pub type ResponseReceiver = futures::channel::mpsc::Receiver<Response>;
 pub type ResponseSender = futures::channel::mpsc::Sender<Response>;
 
 pub struct ExecutorCoordinator<'ctx> {

--- a/engine/crates/engine-v2/src/execution/mod.rs
+++ b/engine/crates/engine-v2/src/execution/mod.rs
@@ -4,6 +4,6 @@ mod prepared;
 mod variables;
 
 pub(crate) use context::*;
-pub use coordinator::{ExecutorCoordinator, ResponseReceiver};
+pub use coordinator::ExecutorCoordinator;
 pub use prepared::*;
 pub use variables::*;

--- a/engine/crates/gateway-core/src/streaming/mod.rs
+++ b/engine/crates/gateway-core/src/streaming/mod.rs
@@ -1,6 +1,6 @@
 pub(super) mod format;
 
-use async_runtime::stream::producer_stream;
+use async_runtime::stream::StreamExt as _;
 use async_sse::Sender;
 use bytes::Bytes;
 use format::StreamingFormat;
@@ -67,8 +67,9 @@ fn sse_stream<'a, T>(
 where
     T: serde::Serialize + Send,
 {
-    // Start a future that pumps data from payload_stream into the sse_sender
-    producer_stream(sse_output, async move {
+    // Pumps data from payload_stream into the sse_sender, and run that
+    // alongside sse_output
+    sse_output.join(async move {
         pin_mut!(payload_stream);
 
         while let Some(payload) = payload_stream.next().await {

--- a/engine/crates/gateway-v2/src/lib.rs
+++ b/engine/crates/gateway-v2/src/lib.rs
@@ -12,6 +12,8 @@ use gateway_core::RequestContext;
 use headers::HeaderMapExt;
 use runtime::cache::{CacheReadStatus, CachedExecutionResponse};
 
+pub mod streaming;
+
 pub struct Gateway {
     engine: Arc<Engine>,
     env: GatewayEnv,
@@ -137,7 +139,7 @@ impl Gateway {
         &self,
         ctx: impl RequestContext,
         request: engine::Request,
-    ) -> impl Stream<Item = engine_v2::Response> + '_ {
+    ) -> impl Stream<Item = engine_v2::Response> {
         self.engine.execute_stream(request, headers(&ctx))
     }
 

--- a/engine/crates/gateway-v2/src/streaming.rs
+++ b/engine/crates/gateway-v2/src/streaming.rs
@@ -1,0 +1,8 @@
+//! Streaming utilities for gateway-v2
+//!
+//! Currently this is just re-exports of stuff from gateway_core.
+//!
+//! At some point we might want to move stuff into this crate and/or a completely
+//! separate crate.  But for now this is a good place.
+
+pub use gateway_core::{encode_stream_response, StreamingFormat};

--- a/engine/crates/graphql-mocks/src/lib.rs
+++ b/engine/crates/graphql-mocks/src/lib.rs
@@ -72,6 +72,10 @@ impl MockGraphQlServer {
     pub fn port(&self) -> u16 {
         self.port
     }
+
+    pub fn url(&self) -> String {
+        format!("http://localhost:{}", self.port)
+    }
 }
 
 async fn graphql_handler(State(state): State<AppState>, headers: HeaderMap, req: GraphQLRequest) -> GraphQLResponse {

--- a/engine/crates/integration-tests/Cargo.toml
+++ b/engine/crates/integration-tests/Cargo.toml
@@ -16,7 +16,7 @@ cynic-introspection.workspace = true
 engine-parser.workspace = true
 engine-v2.workspace = true
 gateway-v2.workspace = true
-graphql-mocks.path = "../graphql-mocks"
+graphql-mocks.workspace = true
 engine-config-builder = { path = "../engine-config-builder" }
 expect-test = "1.4"
 futures = "0.3"


### PR DESCRIPTION
Adds [Incremental Delivery][1] & [GraphQL Over SSE][2] support to federated dev.

We already had code for these in the CLI, so I'm mostly just hooking things up.

Fixes GB-5797

[1]: https://github.com/graphql/graphql-over-http/blob/main/rfcs/IncrementalDelivery.md
[2]: https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverSSE.md