### PR TITLE
chore: streaming transport utilities in cli tests

### DIFF
--- a/cli/crates/cli/tests/defer/main.rs
+++ b/cli/crates/cli/tests/defer/main.rs
@@ -30,7 +30,7 @@ async fn defer_multipart_test() {
     let mut env = Environment::init_async().await;
     let client = start_grafbase(&mut env, SCHEMA).await;
 
-    let response = client
+    let parts = client
         .gql::<Value>(
             r"
                     query {
@@ -49,21 +49,8 @@ async fn defer_multipart_test() {
                     }
                 ",
         )
-        .into_reqwest_builder()
-        .header("accept", "multipart/mixed")
-        .send()
+        .into_multipart_stream()
         .await
-        .unwrap();
-
-    assert!(response.status().is_success());
-
-    assert_eq!(
-        response.headers().get("content-type").unwrap(),
-        "multipart/mixed; boundary=\"-\""
-    );
-
-    let parts = multipart_stream::parse(response.bytes_stream(), "-")
-        .map(|result| serde_json::from_slice::<Value>(&result.unwrap().body).unwrap())
         .collect::<Vec<_>>()
         .await;
 
@@ -129,42 +116,42 @@ async fn defer_sse_test() {
                     }
                 ",
         )
-        .into_reqwest_builder()
-        .eventsource()
-        .unwrap()
-        .take_while(|event| {
-            let mut complete = false;
-            let event = event.as_ref().unwrap();
-            if let reqwest_eventsource::Event::Message(message) = event {
-                complete = message.event == "complete";
-            };
-            async move { !complete }
-        })
+        .into_sse_stream()
         .collect::<Vec<_>>()
-        .await
-        .into_iter()
-        .map(Result::unwrap)
-        .collect::<Vec<_>>();
+        .await;
 
     insta::assert_debug_snapshot!(events, @r###"
     [
-        Open,
-        Message(
-            Event {
-                event: "next",
-                data: "{\"data\":{\"todoCollection\":[{\"__typename\":\"Todo\",\"title\":\"Defer Things\",\"id\":\"1\"}]},\"hasNext\":true}",
-                id: "",
-                retry: None,
+        Object {
+            "data": Object {
+                "todoCollection": Array [
+                    Object {
+                        "__typename": String("Todo"),
+                        "id": String("1"),
+                        "title": String("Defer Things"),
+                    },
+                ],
             },
-        ),
-        Message(
-            Event {
-                event: "next",
-                data: "{\"data\":{\"deferred\":[{\"__typename\":\"Todo\",\"title\":\"Defer Things\",\"id\":\"1\"},{\"__typename\":\"Todo\",\"title\":\"Defer Things\",\"id\":\"2\"}]},\"path\":[],\"hasNext\":false}",
-                id: "",
-                retry: None,
+            "hasNext": Bool(true),
+        },
+        Object {
+            "data": Object {
+                "deferred": Array [
+                    Object {
+                        "__typename": String("Todo"),
+                        "id": String("1"),
+                        "title": String("Defer Things"),
+                    },
+                    Object {
+                        "__typename": String("Todo"),
+                        "id": String("2"),
+                        "title": String("Defer Things"),
+                    },
+                ],
             },
-        ),
+            "hasNext": Bool(false),
+            "path": Array [],
+        },
     ]
     "###);
 }

--- a/cli/crates/cli/tests/defer/main.rs
+++ b/cli/crates/cli/tests/defer/main.rs
@@ -120,38 +120,38 @@ async fn defer_sse_test() {
         .collect::<Vec<_>>()
         .await;
 
-    insta::assert_debug_snapshot!(events, @r###"
+    insta::assert_json_snapshot!(events, @r###"
     [
-        Object {
-            "data": Object {
-                "todoCollection": Array [
-                    Object {
-                        "__typename": String("Todo"),
-                        "id": String("1"),
-                        "title": String("Defer Things"),
-                    },
-                ],
-            },
-            "hasNext": Bool(true),
+      {
+        "data": {
+          "todoCollection": [
+            {
+              "__typename": "Todo",
+              "id": "1",
+              "title": "Defer Things"
+            }
+          ]
         },
-        Object {
-            "data": Object {
-                "deferred": Array [
-                    Object {
-                        "__typename": String("Todo"),
-                        "id": String("1"),
-                        "title": String("Defer Things"),
-                    },
-                    Object {
-                        "__typename": String("Todo"),
-                        "id": String("2"),
-                        "title": String("Defer Things"),
-                    },
-                ],
+        "hasNext": true
+      },
+      {
+        "data": {
+          "deferred": [
+            {
+              "__typename": "Todo",
+              "id": "1",
+              "title": "Defer Things"
             },
-            "hasNext": Bool(false),
-            "path": Array [],
+            {
+              "__typename": "Todo",
+              "id": "2",
+              "title": "Defer Things"
+            }
+          ]
         },
+        "hasNext": false,
+        "path": []
+      }
     ]
     "###);
 }

--- a/cli/crates/cli/tests/federation.rs
+++ b/cli/crates/cli/tests/federation.rs
@@ -78,26 +78,26 @@ async fn test_sse_transport() {
         .collect::<Vec<_>>()
         .await;
 
-    insta::assert_debug_snapshot!(events, @r###"
+    insta::assert_json_snapshot!(events, @r###"
     [
-        Object {
-            "data": Object {
-                "newProducts": Object {
-                    "name": String("Jeans"),
-                    "price": Number(44),
-                    "upc": String("top-4"),
-                },
-            },
-        },
-        Object {
-            "data": Object {
-                "newProducts": Object {
-                    "name": String("Pink Jeans"),
-                    "price": Number(55),
-                    "upc": String("top-5"),
-                },
-            },
-        },
+      {
+        "data": {
+          "newProducts": {
+            "name": "Jeans",
+            "price": 44,
+            "upc": "top-4"
+          }
+        }
+      },
+      {
+        "data": {
+          "newProducts": {
+            "name": "Pink Jeans",
+            "price": 55,
+            "upc": "top-5"
+          }
+        }
+      }
     ]
     "###);
 }


### PR DESCRIPTION
Currently using SSE or multipart in the cli tests is quite laborious.  I'm about to add a few more of these tests, so I've extracted out some utilities to make doing this less laborious.