### PR TITLE
chore: make `Gateway::authorize` easier to work with

### DIFF
--- a/cli/crates/federated-dev/src/dev/websockets.rs
+++ b/cli/crates/federated-dev/src/dev/websockets.rs
@@ -165,7 +165,7 @@ async fn accept_websocket(mut websocket: WebSocket, gateway: &GatewayWatcher) ->
                     return None;
                 };
 
-                let Ok(session) = gateway.authorize(payload.headers.into()).await else {
+                let Some(session) = gateway.authorize(payload.headers.into()).await else {
                     websocket
                         .send(Message::close(4403, "Forbidden").try_into().unwrap())
                         .await


### PR DESCRIPTION
I added `Gateway::authorize` recently, and made it return an `engine_v2::Response` on error, as it was the easiest thing to integrate with all the transports.

However, in the `api` repo the code _really_ wants to take a `gateway_v2::Response` - which I'd avoided using in `grafbase` because it doesn't work well with the streaming transports.

This updates the code to just return an `Option`, along with adding some easy functions for constructing the various error responses.