### PR TITLE
composition: emit multiple `@field`s for shareable fields of entities

### DIFF
--- a/engine/crates/composition/src/compose/entity_interface.rs
+++ b/engine/crates/composition/src/compose/entity_interface.rs
@@ -87,7 +87,7 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
                     },
                 })
                 .collect(),
-            resolvable_in: None,
+            resolvable_in: Vec::new(),
             provides: Vec::new(),
             requires: Vec::new(),
             composed_directives: Vec::new(),
@@ -152,7 +152,7 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
                         },
                     })
                     .collect(),
-                resolvable_in: Some(graphql_federated_graph::SubgraphId(definition.subgraph_id().idx())),
+                resolvable_in: vec![graphql_federated_graph::SubgraphId(definition.subgraph_id().idx())],
                 provides: Vec::new(),
                 requires: Vec::new(),
                 composed_directives: Vec::new(),

--- a/engine/crates/composition/src/compose/input_object.rs
+++ b/engine/crates/composition/src/compose/input_object.rs
@@ -66,7 +66,7 @@ pub(super) fn merge_input_object_definitions(
             field_name,
             field_type,
             arguments: Vec::new(),
-            resolvable_in: None,
+            resolvable_in: Vec::new(),
             provides: Vec::new(),
             requires: Vec::new(),
             overrides: Vec::new(),

--- a/engine/crates/composition/src/compose/interface.rs
+++ b/engine/crates/composition/src/compose/interface.rs
@@ -40,7 +40,7 @@ pub(super) fn merge_interface_definitions<'a>(
             field_name: field.name().id,
             field_type,
             arguments: Vec::new(),
-            resolvable_in: None,
+            resolvable_in: Vec::new(),
             provides: Vec::new(),
             requires: Vec::new(),
             overrides: Vec::new(),

--- a/engine/crates/composition/src/composition_ir.rs
+++ b/engine/crates/composition/src/composition_ir.rs
@@ -46,7 +46,7 @@ pub(crate) struct FieldIr {
     pub(crate) field_type: subgraphs::FieldTypeId,
     pub(crate) arguments: Vec<ArgumentIr>,
 
-    pub(crate) resolvable_in: Option<federated::SubgraphId>,
+    pub(crate) resolvable_in: Vec<federated::SubgraphId>,
 
     /// Subgraph fields corresponding to this federated graph field that have an `@provides`.
     pub(crate) provides: Vec<subgraphs::FieldId>,

--- a/engine/crates/composition/tests/composition/entity_composite_key_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_composite_key_basic/federated.graphql
@@ -48,7 +48,7 @@ type Enrollment
 type CourseRating
     @join__type(graph: RATINGS, key: "courseId")
 {
-    courseId: ID! @join__field(graph: RATINGS)
+    courseId: ID!
     rating: Float @join__field(graph: RATINGS)
     comments: String @join__field(graph: RATINGS)
 }
@@ -56,7 +56,7 @@ type CourseRating
 type Student
     @join__type(graph: STUDENTS, key: "id")
 {
-    id: ID! @join__field(graph: STUDENTS)
+    id: ID!
     name: String @join__field(graph: STUDENTS)
     enrollments: [Enrollment] @join__field(graph: STUDENTS)
 }

--- a/engine/crates/composition/tests/composition/entity_interface_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_interface_basic/federated.graphql
@@ -29,7 +29,7 @@ type Squirrel {
 type Cheetah implements Animal
     @join__type(graph: SAVANNA, key: "species")
 {
-    species: String! @join__field(graph: SAVANNA)
+    species: String!
     topSpeed: Int! @join__field(graph: SAVANNA)
     species: String!
     favouriteFood: String @join__field(graph: FOREST)

--- a/engine/crates/composition/tests/composition/entity_multiple_keys_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_multiple_keys_basic/federated.graphql
@@ -27,8 +27,8 @@ type User
     @join__type(graph: SINGLE_KEY, key: "id")
 {
     id: ID!
-    name: String! @join__field(graph: MULTI_KEY)
-    email: String! @join__field(graph: MULTI_KEY)
+    name: String!
+    email: String!
     comments: [Comment!]! @join__field(graph: MULTI_KEY)
     posts: [Post!]! @join__field(graph: SINGLE_KEY)
 }

--- a/engine/crates/composition/tests/composition/entity_staggered_composite_key/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_staggered_composite_key/federated.graphql
@@ -24,8 +24,8 @@ enum join__Graph {
 type A
     @join__type(graph: FIRST, key: "b { id } c")
 {
-    b: B! @join__field(graph: FIRST)
-    c: String! @join__field(graph: FIRST)
+    b: B!
+    c: String!
 }
 
 type B

--- a/engine/crates/composition/tests/composition/enum_only_outputs/federated.graphql
+++ b/engine/crates/composition/tests/composition/enum_only_outputs/federated.graphql
@@ -35,7 +35,7 @@ type Teletubby
 {
     activities: [Activity] @join__field(graph: ACTIVITIES)
     name: String!
-    favoriteToy: FavoriteToy
+    favoriteToy: FavoriteToy @join__field(graph: ACTIVITIES) @join__field(graph: EPISODES) @join__field(graph: TELETUBBYREPOSITORY)
     episodesFeatured: [Episode] @join__field(graph: EPISODES)
     color: String! @join__field(graph: TELETUBBYREPOSITORY)
     mood: Mood @join__field(graph: TELETUBBYREPOSITORY)

--- a/engine/crates/composition/tests/composition/field_type_composition/federated.graphql
+++ b/engine/crates/composition/tests/composition/field_type_composition/federated.graphql
@@ -34,7 +34,7 @@ type Manufacturer {
 }
 
 type Query {
-    fidgetSpinners(filter: SpinnerFilter!): [FidgetSpinner]
+    fidgetSpinners(filter: SpinnerFilter!): [FidgetSpinner] @join__field(graph: SPINNERS_A) @join__field(graph: SPINNERS_B)
 }
 
 interface Spinner {

--- a/engine/crates/composition/tests/composition/inaccessible_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/inaccessible_basic/federated.graphql
@@ -49,8 +49,8 @@ type Series {
 type New {
     name: String! @inaccessible
     other: String!
-    message: String! @join__field(graph: ONE) @inaccessible
-    old: Old! @join__field(graph: ONE) @inaccessible
+    message: String! @inaccessible
+    old: Old! @inaccessible
 }
 
 type Old @inaccessible {

--- a/engine/crates/composition/tests/composition/input_object_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/input_object_basic/federated.graphql
@@ -26,9 +26,9 @@ type Person
     @join__type(graph: PHONEBOOK, key: "id")
 {
     id: ID!
-    firstName: String!
-    lastName: String!
-    age: Int!
+    firstName: String! @join__field(graph: EMAILBOOK) @join__field(graph: PHONEBOOK)
+    lastName: String! @join__field(graph: EMAILBOOK) @join__field(graph: PHONEBOOK)
+    age: Int! @join__field(graph: EMAILBOOK) @join__field(graph: PHONEBOOK)
     email: String! @join__field(graph: EMAILBOOK)
     phoneNumber: String @join__field(graph: PHONEBOOK)
 }

--- a/engine/crates/composition/tests/composition/kebab_case_subgraph_names/federated.graphql
+++ b/engine/crates/composition/tests/composition/kebab_case_subgraph_names/federated.graphql
@@ -25,7 +25,7 @@ enum join__Graph {
 type Kebab
     @join__type(graph: BROCHETTE_REPOSITORY, key: "id")
 {
-    id: ID! @join__field(graph: BROCHETTE_REPOSITORY)
+    id: ID!
     meatType: String @join__field(graph: BROCHETTE_REPOSITORY)
     vegetables: [String] @join__field(graph: BROCHETTE_REPOSITORY)
     breadType: String @join__field(graph: BROCHETTE_REPOSITORY)
@@ -34,7 +34,7 @@ type Kebab
 type Brochette
     @join__type(graph: BROCHETTE_REPOSITORY, key: "id")
 {
-    id: ID! @join__field(graph: BROCHETTE_REPOSITORY)
+    id: ID!
     meatType: String @join__field(graph: BROCHETTE_REPOSITORY)
     marinade: String @join__field(graph: BROCHETTE_REPOSITORY)
     servedWith: String @join__field(graph: BROCHETTE_REPOSITORY)
@@ -43,7 +43,7 @@ type Brochette
 type Kushi
     @join__type(graph: KUSHI_STORE, key: "id")
 {
-    id: ID! @join__field(graph: KUSHI_STORE)
+    id: ID!
     meatType: String @join__field(graph: KUSHI_STORE)
     sauce: String @join__field(graph: KUSHI_STORE)
     stickMaterial: String @join__field(graph: KUSHI_STORE)
@@ -52,7 +52,7 @@ type Kushi
 type Schaschlik
     @join__type(graph: SCHASCHLIK_SERVICE, key: "id")
 {
-    id: ID! @join__field(graph: SCHASCHLIK_SERVICE)
+    id: ID!
     meatType: String @join__field(graph: SCHASCHLIK_SERVICE)
     spices: [String] @join__field(graph: SCHASCHLIK_SERVICE)
     originCountry: String @join__field(graph: SCHASCHLIK_SERVICE)

--- a/engine/crates/composition/tests/composition/object_field_arguments_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/object_field_arguments_basic/federated.graphql
@@ -28,16 +28,16 @@ type RollerCoaster {
     height: Float!
     speed: Float!
     manufacturer: String!
-    historicalData: [HistoricalData] @join__field(graph: HISTORY) @inaccessible
-    numberOfInversions: Int! @join__field(graph: PERFORMANCE) @inaccessible
+    historicalData: [HistoricalData] @inaccessible
+    numberOfInversions: Int! @inaccessible
 }
 
 type HistoricalData {
-    year: Int! @join__field(graph: HISTORY)
-    visitors: Int! @join__field(graph: HISTORY)
-    incidents: Int! @join__field(graph: HISTORY)
+    year: Int!
+    visitors: Int!
+    incidents: Int!
 }
 
 type Query {
-    getRollerCoaster(id: ID!): RollerCoaster
+    getRollerCoaster(id: ID!): RollerCoaster @join__field(graph: HISTORY) @join__field(graph: INVENTORY) @join__field(graph: PERFORMANCE)
 }

--- a/engine/crates/composition/tests/composition/provides_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/provides_basic/federated.graphql
@@ -24,7 +24,7 @@ enum join__Graph {
 type Product
     @join__type(graph: PRODUCTS, key: "id")
 {
-    id: ID! @join__field(graph: PRODUCTS)
+    id: ID!
     name: String @join__field(graph: PRODUCTS)
     reviews: [Review] @join__field(graph: PRODUCTS)
 }
@@ -32,7 +32,7 @@ type Product
 type Review
     @join__type(graph: PRODUCTS, key: "id")
 {
-    id: ID! @join__field(graph: PRODUCTS)
+    id: ID!
     content: String @join__field(graph: PRODUCTS)
     author: User @join__field(graph: PRODUCTS, provides: "name")
 }
@@ -42,7 +42,7 @@ type User
     @join__type(graph: USERS, key: "id")
 {
     id: ID!
-    name: String
+    name: String @join__field(graph: USERS)
     email: String @join__field(graph: USERS)
 }
 

--- a/engine/crates/composition/tests/composition/requires_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/requires_basic/federated.graphql
@@ -26,7 +26,7 @@ type Farm
     @join__type(graph: FARMS, key: "id")
 {
     id: ID!
-    chiliId: ID!
+    chiliId: ID! @join__field(graph: FARMS)
     chiliDetails: ChiliVariety @join__field(graph: CHILIES, requires: "chiliId")
     name: String! @join__field(graph: FARMS)
     location: String! @join__field(graph: FARMS)

--- a/engine/crates/composition/tests/composition/shareable_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/shareable_basic/federated.graphql
@@ -25,9 +25,9 @@ enum join__Graph {
 type Customer {
     id: ID!
     name: String
-    other: Int @join__field(graph: ACCOUNTS) @inaccessible
-    newsletterSubscribed: Boolean @join__field(graph: MARKETING) @inaccessible
-    subscriptionPlan: Plan! @join__field(graph: SUBSCRIPTIONS) @inaccessible
+    other: Int @inaccessible
+    newsletterSubscribed: Boolean @inaccessible
+    subscriptionPlan: Plan! @inaccessible
 }
 
 type Query {

--- a/engine/crates/composition/tests/composition/tag_directive_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/tag_directive_basic/federated.graphql
@@ -24,9 +24,9 @@ enum join__Graph {
 scalar Texture @tag(name: "appleTexture") @tag(name: "orangeTexture")
 
 type Apple implements HasId @tag(name: "appleType") {
-    id: ID! @join__field(graph: APPLE)
-    variety: AppleVariety @join__field(graph: APPLE)
-    texture: Texture @join__field(graph: APPLE)
+    id: ID!
+    variety: AppleVariety
+    texture: Texture
 }
 
 type Orange implements HasId @tag(name: "orangeType") {
@@ -36,7 +36,7 @@ type Orange implements HasId @tag(name: "orangeType") {
 }
 
 type Query @tag(name: "appleQuery") @tag(name: "orangeQuery") {
-    tags(filter: String @tag(name: "appleTagsFilter") @tag(name: "orangeTagsFilter")): [String] @tag(name: "appleField") @tag(name: "orangeField")
+    tags(filter: String @tag(name: "appleTagsFilter") @tag(name: "orangeTagsFilter")): [String] @join__field(graph: APPLE) @join__field(graph: ORANGE) @tag(name: "appleField") @tag(name: "orangeField")
 }
 
 interface HasId @tag(name: "appleInterface") @tag(name: "orangeInterface") {

--- a/engine/crates/engine-v2/schema/src/conversion.rs
+++ b/engine/crates/engine-v2/schema/src/conversion.rs
@@ -139,8 +139,9 @@ impl From<Config> for Schema {
                     )
                 })
                 .collect::<HashMap<_, _>>();
-            if let Some(subgraph_id) = field.resolvable_in {
-                let subgraph_id = subgraph_id.into();
+
+            for subgraph_id in &field.resolvable_in {
+                let subgraph_id = (*subgraph_id).into();
                 if root_fields.binary_search(&field_id).is_ok() {
                     let resolver_id = *root_field_resolvers.entry(subgraph_id).or_insert_with(|| {
                         let resolver_id = ResolverId::from(schema.resolvers.len());
@@ -175,7 +176,7 @@ impl From<Config> for Schema {
                 provides: field
                     .provides
                     .into_iter()
-                    .find(|provides| Some(provides.subgraph_id) == field.resolvable_in)
+                    .find(|provides| field.resolvable_in.contains(&provides.subgraph_id))
                     .map(|provides| provides.fields.into_iter().map(Into::into).collect())
                     .unwrap_or_default(),
                 arguments: {

--- a/engine/crates/federated-graph/src/federated_graph.rs
+++ b/engine/crates/federated-graph/src/federated_graph.rs
@@ -107,10 +107,14 @@ pub struct Field {
     pub name: StringId,
     pub field_type_id: FieldTypeId,
 
-    /// Includes the subgraph the field can be resolved in (= the subgraph that defines it), except
-    /// where the field is shareable or part of the key, in which case `resolvable_in` will be
-    /// `None`.
-    pub resolvable_in: Option<SubgraphId>,
+    /// This is populated only of fields of entities. The Vec includes all subgraphs the field can
+    /// be resolved in. For a regular field of an entity, it will be one subgraph, the subgraph
+    /// where the entity field is defined. For a shareable field in an entity, this contains the
+    /// subgraphs where the shareable field is defined on the entity. It may not be all the
+    /// subgraphs.
+    ///
+    /// On value types and input types, this is empty.
+    pub resolvable_in: Vec<SubgraphId>,
 
     /// See [FieldProvides].
     pub provides: Vec<FieldProvides>,

--- a/engine/crates/federated-graph/src/render_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl.rs
@@ -315,7 +315,7 @@ fn write_field(field_id: FieldId, graph: &FederatedGraphV1, sdl: &mut String) ->
 
     write!(sdl, "{INDENT}{field_name}{args}: {field_type}")?;
 
-    if let Some(subgraph) = &field.resolvable_in {
+    for subgraph in &field.resolvable_in {
         write_resolvable_in(*subgraph, field, graph, sdl)?;
     }
 
@@ -379,7 +379,7 @@ fn write_provides(field: &Field, graph: &FederatedGraphV1, sdl: &mut String) -> 
     for provides in field
         .provides
         .iter()
-        .filter(|provide| Some(provide.subgraph_id) != field.resolvable_in)
+        .filter(|provide| !field.resolvable_in.contains(&provide.subgraph_id))
     {
         let subgraph_name = GraphEnumVariantName(&graph[graph[provides.subgraph_id].name]);
         let fields = FieldSetDisplay(&provides.fields, graph);
@@ -393,7 +393,7 @@ fn write_requires(field: &Field, graph: &FederatedGraphV1, sdl: &mut String) -> 
     for requires in field
         .requires
         .iter()
-        .filter(|require| Some(require.subgraph_id) != field.resolvable_in)
+        .filter(|requires| !field.resolvable_in.contains(&requires.subgraph_id))
     {
         let subgraph_name = GraphEnumVariantName(&graph[graph[requires.subgraph_id].name]);
         let fields = FieldSetDisplay(&requires.fields, graph);


### PR DESCRIPTION
This is necessary for the router to know which subgraphs can resolve the shared fields. Unlike fields of value types, shareable fields of entities do not have to be defined on every subgraph that exposes the entity.

Also omitted @field on:

- inaccessible fields
- entity key fields (the information is already on `@type`)