### PR TITLE
Fix cargo warning on main

### DIFF
--- a/engine/crates/graphql-mocks/Cargo.toml
+++ b/engine/crates/graphql-mocks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graphql-mocks"
-private = true
+publish = false
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
```
prisma-desktop.tom.src/gh/grafbase/grafbase λ cargo check
warning: /home/tom/src/gh/grafbase/grafbase/engine/crates/graphql-mocks/Cargo.toml: unused manifest key: package.private
```

The option that was meant is likely "publish"
(https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field). This commit replaces private = true with publish = false.
