### PR TITLE
feat(sdk): GB-5680: Add support for operation limits to the TypeScript config translation

### DIFF
--- a/packages/grafbase-sdk/src/config.ts
+++ b/packages/grafbase-sdk/src/config.ts
@@ -6,6 +6,7 @@ import {
 } from './auth'
 import { CacheParams, GlobalCache } from './cache'
 import { FederatedGraph, Graph } from './grafbase-schema'
+import { OperationLimits, OperationLimitsParams } from './operation-limits'
 import { Experimental, ExperimentalParams } from './experimental'
 
 /**
@@ -15,6 +16,7 @@ export interface GraphConfigInput {
   graph: Graph
   auth?: AuthParams
   cache?: CacheParams
+  operationLimits?: OperationLimitsParams
   experimental?: ExperimentalParams
 }
 
@@ -26,6 +28,7 @@ export interface DeprecatedGraphConfigInput {
   /** @deprecated use `graph` instead */
   schema: Graph
   auth?: AuthParams
+  operationLimits?: OperationLimitsParams
   cache?: CacheParams
   experimental?: ExperimentalParams
 }
@@ -36,6 +39,7 @@ export interface DeprecatedGraphConfigInput {
 export interface FederatedGraphConfigInput {
   graph: FederatedGraph
   auth?: AuthParamsV2
+  operationLimits?: OperationLimitsParams
 }
 
 /**
@@ -45,6 +49,7 @@ export class GraphConfig {
   private graph: Graph
   private readonly auth?: Authentication
   private readonly cache?: GlobalCache
+  private readonly operationLimits?: OperationLimits
   private readonly experimental?: Experimental
 
   /** @deprecated use `graph` instead of `schema` */
@@ -53,6 +58,10 @@ export class GraphConfig {
 
     if (input.auth) {
       this.auth = new Authentication(input.auth)
+    }
+
+    if (input.operationLimits) {
+      this.operationLimits = new OperationLimits(input.operationLimits)
     }
 
     if (input.cache) {
@@ -67,15 +76,17 @@ export class GraphConfig {
   public toString(): string {
     const graph = this.graph.toString()
     const auth = this.auth ? this.auth.toString() : ''
+    const operationLimits = this.operationLimits ? this.operationLimits.toString() : ''
     const cache = this.cache ? this.cache.toString() : ''
     const experimental = this.experimental ? this.experimental.toString() : ''
 
-    return `${experimental}${auth}${cache}${graph}`
+    return `${experimental}${auth}${operationLimits}${cache}${graph}`
   }
 }
 
 export class FederatedGraphConfig {
   private graph: FederatedGraph
+  private readonly operationLimits?: OperationLimits
   private readonly auth?: AuthenticationV2
 
   constructor(input: FederatedGraphConfigInput) {
@@ -83,12 +94,16 @@ export class FederatedGraphConfig {
     if (input.auth) {
       this.auth = new AuthenticationV2(input.auth)
     }
+    if (input.operationLimits) {
+      this.operationLimits = new OperationLimits(input.operationLimits)
+    }
   }
 
   public toString(): string {
     const graph = this.graph.toString()
     const auth = this.auth ? this.auth.toString() : ''
+    const operationLimits = this.operationLimits ? this.operationLimits.toString() : ''
 
-    return `${auth}${graph}`
+    return `${auth}${graph}${operationLimits}`
   }
 }

--- a/packages/grafbase-sdk/src/operation-limits.ts
+++ b/packages/grafbase-sdk/src/operation-limits.ts
@@ -1,0 +1,33 @@
+/**
+ * Defines operation limits.
+ */
+export interface OperationLimitsParams {
+  aliases?: number
+  complexity?: number
+  depth?: number
+  height?: number
+  rootFields?: number
+}
+
+// FIXME: Find a way to "reflect" the keys of the interface above.
+const OPERATION_LIMITS_PARAMS_KEYS: (keyof OperationLimitsParams)[] = ['aliases', 'complexity', 'depth', 'height', 'rootFields'] as (keyof OperationLimitsParams)[]
+
+export class OperationLimits {
+  private params: OperationLimitsParams
+
+  constructor(params: OperationLimitsParams) {
+    this.params = params
+  }
+
+  public toString(): string {
+    const parameters = OPERATION_LIMITS_PARAMS_KEYS
+      .map((key) => this.params[key] ? `${key}: ${this.params[key]}` : null)
+      .filter((value) => value != null)
+      .join(', ')
+    if (parameters.length === 0) {
+      return ''
+    } else {
+      return `extend schema\n  @operationLimits(${parameters})\n\n`
+    }
+  }
+}

--- a/packages/grafbase-sdk/tests/unit/operation-limits.test.ts
+++ b/packages/grafbase-sdk/tests/unit/operation-limits.test.ts
@@ -1,0 +1,59 @@
+import { config, graph } from '../../src/index'
+import { describe, expect, it, beforeEach } from '@jest/globals'
+import { renderGraphQL } from '../utils'
+
+const g = graph.Standalone()
+
+describe('Operation limits', () => {
+  beforeEach(() => g.clear())
+
+  it('renders the defined operation limit values', async () => {
+    const cfg = config({
+      graph: g,
+      operationLimits: {
+        complexity: 100
+      }
+    })
+
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
+      "extend schema
+        @operationLimits(complexity: 100)
+
+      "
+    `)
+  })
+
+
+  it('renders the defined multiple operation limit values', async () => {
+    const cfg = config({
+      graph: g,
+      operationLimits: {
+        complexity: 100,
+        depth: 5
+      }
+    })
+
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
+      "extend schema
+        @operationLimits(complexity: 100, depth: 5)
+
+      "
+    `)
+  })
+
+  it('does not render anything if no operation limits provided', async () => {
+    const _ = g.type('User', {
+      name: g.string()
+    })
+    const cfg = config({
+      graph: g,
+      operationLimits: {}
+    })
+
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
+      "type User {
+        name: String!
+      }"
+    `)
+  })
+})


### PR DESCRIPTION
# Description

Adds support for operation limits to the TypeScript config translation.

# Type of change

- [ ] 💔 Breaking
- [X] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
