### PR TITLE
feat: Handle sibling plan dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1763,7 +1763,6 @@ version = "3.0.31"
 dependencies = [
  "anyhow",
  "async-runtime",
- "derive_more",
  "engine",
  "engine-parser",
  "engine-v2-config",
@@ -1783,6 +1782,7 @@ dependencies = [
  "serde_with",
  "strum",
  "thiserror",
+ "tracing",
  "url",
 ]
 

--- a/engine/crates/engine-v2/Cargo.toml
+++ b/engine/crates/engine-v2/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 
 [dependencies]
 async-runtime.workspace = true
-derive_more = "0.99"
 futures.workspace = true
 im = "15"
 indexmap.workspace = true
@@ -31,6 +30,7 @@ thiserror.workspace = true
 futures-util.workspace = true
 hex = "0.4.3"
 url.workspace = true
+tracing.workspace = true
 
 config = { package = "engine-v2-config", path = "./config" }
 engine-value = { path = "../engine/value" }

--- a/engine/crates/engine-v2/src/execution/coordinator.rs
+++ b/engine/crates/engine-v2/src/execution/coordinator.rs
@@ -47,9 +47,10 @@ impl<'ctx> ExecutorCoordinator<'ctx> {
     }
 
     pub async fn execute(self) -> Response {
-        if matches!(self.operation.ty, OperationType::Subscription) {
-            unreachable!("execute shouldnt be called for subscriptions")
-        }
+        assert!(
+            !matches!(self.operation.ty, OperationType::Subscription),
+            "execute shouldn't be called for subscriptions"
+        );
 
         let mut planner = Planner::new(&self.engine.schema, &self.operation);
         let mut response = ResponseBuilder::new(self.operation.root_object_id);
@@ -68,7 +69,7 @@ impl<'ctx> ExecutorCoordinator<'ctx> {
             ),
             Err(error) => {
                 response.push_error(error);
-                vec![]
+                Vec::with_capacity(0)
             }
         };
 

--- a/engine/crates/engine-v2/src/plan/attribution.rs
+++ b/engine/crates/engine-v2/src/plan/attribution.rs
@@ -1,11 +1,14 @@
 use std::collections::{HashMap, HashSet};
 
-use schema::{FieldId, ResolverWalker};
+use schema::FieldId;
 
-use super::ExpectedType;
+use super::{
+    planner::{ExtraBoundaryField, ExtraBoundarySelectionSet},
+    ExpectedType,
+};
 use crate::{
     request::{BoundFieldId, BoundSelectionSetId, FlatTypeCondition, SelectionSetType},
-    response::{ResponseEdge, ResponseKeys},
+    response::ResponseEdge,
 };
 
 mod ids {
@@ -49,16 +52,16 @@ impl Attribution {
     }
 }
 
-#[derive(Debug)]
-pub struct ExtraField {
+#[derive(Debug, Clone)]
+pub struct ExtraField<SelectionSet = ExtraSelectionSetId> {
     pub edge: ResponseEdge,
     pub type_condition: Option<FlatTypeCondition>,
     pub field_id: FieldId,
     pub expected_key: String,
-    pub ty: ExpectedType<ExtraSelectionSetId>,
+    pub ty: ExpectedType<SelectionSet>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ExtraSelectionSet {
     pub ty: SelectionSetType,
     pub fields: Vec<ExtraFieldId>,
@@ -129,19 +132,16 @@ impl<'a> std::ops::Deref for ExtraFieldWalker<'a> {
     }
 }
 
-#[derive(Debug)]
-pub(super) struct AttributionBuilder<'a> {
-    response_keys: &'a ResponseKeys,
-    resolver: ResolverWalker<'a>,
+#[derive(Debug, Default)]
+pub(super) struct AttributionBuilder {
     extra_fields: Vec<ExtraField>,
-    extra_selection_sets: Vec<ExtraSelectionSetBuilder>,
-    extra_field_names: HashMap<FieldId, String>,
+    extra_selection_sets: Vec<ExtraSelectionSet>,
     pub attributed_selection_sets: HashSet<BoundSelectionSetId>,
     pub attributed_fields: Vec<BoundFieldId>,
     pub extras: HashMap<BoundSelectionSetId, ExtraSelectionSetId>,
 }
 
-impl<'a> std::ops::Index<ExtraFieldId> for AttributionBuilder<'a> {
+impl std::ops::Index<ExtraFieldId> for AttributionBuilder {
     type Output = ExtraField;
 
     fn index(&self, index: ExtraFieldId) -> &Self::Output {
@@ -149,39 +149,26 @@ impl<'a> std::ops::Index<ExtraFieldId> for AttributionBuilder<'a> {
     }
 }
 
-impl<'a> std::ops::Index<ExtraSelectionSetId> for AttributionBuilder<'a> {
-    type Output = ExtraSelectionSetBuilder;
+impl std::ops::Index<ExtraSelectionSetId> for AttributionBuilder {
+    type Output = ExtraSelectionSet;
 
     fn index(&self, index: ExtraSelectionSetId) -> &Self::Output {
         &self.extra_selection_sets[usize::from(index)]
     }
 }
 
-impl<'a> std::ops::IndexMut<ExtraSelectionSetId> for AttributionBuilder<'a> {
+impl std::ops::IndexMut<ExtraSelectionSetId> for AttributionBuilder {
     fn index_mut(&mut self, index: ExtraSelectionSetId) -> &mut Self::Output {
         &mut self.extra_selection_sets[usize::from(index)]
     }
 }
 
-impl<'a> AttributionBuilder<'a> {
-    pub fn new(response_keys: &'a ResponseKeys, resolver: ResolverWalker<'a>) -> Self {
-        Self {
-            response_keys,
-            resolver,
-            attributed_selection_sets: HashSet::new(),
-            attributed_fields: Vec::new(),
-            extra_fields: Vec::new(),
-            extra_selection_sets: Vec::new(),
-            extras: HashMap::new(),
-            extra_field_names: HashMap::new(),
-        }
-    }
-
+impl AttributionBuilder {
     pub fn extra_fields(&self, id: BoundSelectionSetId) -> Option<impl Iterator<Item = &ExtraField> + '_> {
         self.extras.get(&id).map(|id| {
             self.extra_selection_sets[usize::from(*id)]
                 .fields
-                .values()
+                .iter()
                 .map(|id| &self.extra_fields[usize::from(*id)])
         })
     }
@@ -189,90 +176,65 @@ impl<'a> AttributionBuilder<'a> {
     pub fn extra_field_ids(&self, id: BoundSelectionSetId) -> Option<impl Iterator<Item = ExtraFieldId> + '_> {
         self.extras
             .get(&id)
-            .map(|id| self.extra_selection_sets[usize::from(*id)].fields.values().copied())
+            .map(|id| self.extra_selection_sets[usize::from(*id)].fields.iter().copied())
     }
 
-    pub fn extra_selection_set_for(&mut self, id: BoundSelectionSetId, ty: SelectionSetType) -> ExtraSelectionSetId {
-        *self.extras.entry(id).or_insert_with(|| {
-            let id = ExtraSelectionSetId::from(self.extra_selection_sets.len());
-            self.extra_selection_sets.push(ExtraSelectionSetBuilder {
-                ty,
-                fields: HashMap::new(),
-            });
-            id
-        })
+    pub fn add_extra_selection_sets(&mut self, extras: HashMap<BoundSelectionSetId, ExtraBoundarySelectionSet>) {
+        for (id, extra) in extras {
+            let extra_selection_set_id = self.insert_extra_selection_set(extra);
+            self.attributed_selection_sets.insert(id);
+            self.extras.insert(id, extra_selection_set_id);
+        }
     }
 
-    pub fn get_or_insert_extra_field_with(
-        &mut self,
-        extra_selection_set_id: ExtraSelectionSetId,
-        type_condition: Option<&FlatTypeCondition>,
-        field_id: FieldId,
-    ) -> &ExtraField {
-        // Clippy doesn't see the ownership problem, we need insert a extra selection_set during the
-        // creation of the extra field. So we can't borrow the extra_selection_sets during the
-        // extra field creation.
-        #[allow(clippy::map_entry)]
-        let extra_field_id = if !self[extra_selection_set_id].fields.contains_key(&field_id) {
-            let extra_field_id = ExtraFieldId::from(self.extra_fields.len());
-            let field = self.resolver.walk(field_id);
-            self.extra_fields.push(ExtraField {
-                edge: field_id.into(),
-                field_id,
-                type_condition: type_condition.cloned(),
-                expected_key: {
-                    if self.resolver.supports_aliases() {
-                        // When the resolver supports aliases, we must ensure that extra fields
-                        // don't collide with existing response keys. And to avoid duplicates
-                        // during field collection, we have a single unique name per field id.
-                        self.extra_field_names
-                            .entry(field_id)
-                            .or_insert_with(|| {
-                                let short_id = hex::encode(u32::from(field_id).to_be_bytes())
-                                    .trim_start_matches('0')
-                                    .to_uppercase();
-                                let name = format!("_extra{}_{}", short_id, field.name());
-                                // name is unique, but may collide with existing keys so
-                                // iterating over candidates until we find a valid one.
-                                // This is only a safeguard, it most likely won't ever run.
-                                if self.response_keys.contains(&name) {
-                                    let mut index = 0;
-                                    loop {
-                                        let candidate = format!("{name}_{index}");
-                                        if !self.response_keys.contains(&candidate) {
-                                            break candidate;
-                                        }
-                                        index += 1;
-                                    }
-                                } else {
-                                    name
+    fn insert_extra_selection_set(&mut self, extra: ExtraBoundarySelectionSet) -> ExtraSelectionSetId {
+        let selection_set = ExtraSelectionSet {
+            ty: extra.ty,
+            fields: extra
+                .fields
+                .into_values()
+                .filter_map(
+                    |ExtraBoundaryField {
+                         extra_field,
+                         read: used,
+                     }| {
+                        if used {
+                            Some(extra_field)
+                        } else {
+                            None
+                        }
+                    },
+                )
+                .map(
+                    |ExtraField {
+                         edge,
+                         type_condition,
+                         field_id,
+                         expected_key,
+                         ty,
+                     }| {
+                        let field = ExtraField {
+                            edge,
+                            type_condition,
+                            field_id,
+                            expected_key,
+                            ty: match ty {
+                                ExpectedType::Scalar(scalar) => ExpectedType::Scalar(scalar),
+                                ExpectedType::SelectionSet(extra) => {
+                                    ExpectedType::SelectionSet(self.insert_extra_selection_set(extra))
                                 }
-                            })
-                            .to_string()
-                    } else {
-                        field.name().to_string()
-                    }
-                },
-                ty: field
-                    .ty()
-                    .inner()
-                    .data_type()
-                    .map(ExpectedType::Scalar)
-                    .unwrap_or_else(|| {
-                        let id = ExtraSelectionSetId::from(self.extra_selection_sets.len());
-                        self.extra_selection_sets.push(ExtraSelectionSetBuilder {
-                            ty: SelectionSetType::maybe_from(field.ty().inner().id()).unwrap(),
-                            fields: HashMap::new(),
-                        });
-                        ExpectedType::SelectionSet(id)
-                    }),
-            });
-            self[extra_selection_set_id].fields.insert(field_id, extra_field_id);
-            extra_field_id
-        } else {
-            self[extra_selection_set_id].fields[&field_id]
+                            },
+                        };
+                        let id = ExtraFieldId::from(self.extra_fields.len());
+                        self.extra_fields.push(field);
+                        id
+                    },
+                )
+                .collect(),
         };
-        &self[extra_field_id]
+        let id = ExtraSelectionSetId::from(self.extra_selection_sets.len());
+        self.extra_selection_sets.push(selection_set);
+        id
     }
 
     pub fn build(self) -> Attribution {
@@ -280,30 +242,11 @@ impl<'a> AttributionBuilder<'a> {
             attributed_selection_sets: self.attributed_selection_sets.into_iter().collect(),
             attributed_fields: self.attributed_fields,
             extra_fields: self.extra_fields,
-            extra_selection_sets: self
-                .extra_selection_sets
-                .into_iter()
-                .map(ExtraSelectionSetBuilder::build)
-                .collect(),
+            extra_selection_sets: self.extra_selection_sets,
             extras: self.extras,
         };
         attribution.attributed_fields.sort_unstable();
         attribution.attributed_selection_sets.sort_unstable();
         attribution
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct ExtraSelectionSetBuilder {
-    pub ty: SelectionSetType,
-    pub fields: HashMap<FieldId, ExtraFieldId>,
-}
-
-impl ExtraSelectionSetBuilder {
-    pub fn build(self) -> ExtraSelectionSet {
-        ExtraSelectionSet {
-            ty: self.ty,
-            fields: self.fields.into_values().collect(),
-        }
     }
 }

--- a/engine/crates/engine-v2/src/plan/expectation.rs
+++ b/engine/crates/engine-v2/src/plan/expectation.rs
@@ -111,7 +111,7 @@ pub struct ExpectedField {
     pub ty: ExpectedType<UndeterminedSelectionSetId>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ExpectedType<Id> {
     Scalar(DataType),
     SelectionSet(Id),

--- a/engine/crates/engine-v2/src/plan/ids.rs
+++ b/engine/crates/engine-v2/src/plan/ids.rs
@@ -1,7 +1,17 @@
 use std::num::NonZeroU16;
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, derive_more::Display)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub struct PlanId(NonZeroU16);
+
+impl std::fmt::Display for PlanId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        usize::from(*self).fmt(f)
+    }
+}
+
+impl PlanId {
+    pub const MAX: PlanId = PlanId(NonZeroU16::MAX);
+}
 
 impl From<usize> for PlanId {
     fn from(value: usize) -> Self {
@@ -15,8 +25,14 @@ impl From<PlanId> for usize {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, derive_more::Display)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub struct PlanBoundaryId(NonZeroU16);
+
+impl std::fmt::Display for PlanBoundaryId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        usize::from(*self).fmt(f)
+    }
+}
 
 impl From<usize> for PlanBoundaryId {
     fn from(value: usize) -> Self {

--- a/engine/crates/engine-v2/src/plan/mod.rs
+++ b/engine/crates/engine-v2/src/plan/mod.rs
@@ -69,6 +69,7 @@ pub struct ChildPlan {
     pub root_selection_set: FlatSelectionSet<EntityType>,
     pub sibling_dependencies: HashSet<PlanId>,
     // Only includes extra fields necessary for other child plans within the same
-    // plan boundary.
+    // plan boundary. They're indexed by BoundSelectionSetId as that's what allows us find the
+    // extra fields during the traversal of the operation for the a plan.
     extra_selection_sets: HashMap<BoundSelectionSetId, planner::ExtraBoundarySelectionSet>,
 }

--- a/engine/crates/engine-v2/src/plan/planner.rs
+++ b/engine/crates/engine-v2/src/plan/planner.rs
@@ -20,12 +20,13 @@ use crate::{
     response::{GraphqlError, ReadSelectionSet, ResponseBoundaryItem, ResponseEdge},
 };
 
-pub(super) use boundary_planner::{ExtraBoundaryField, ExtraBoundarySelectionSet};
 use boundary_planner::{PlanBoundaryChildrenPlanner, PlanBoundaryParent};
+pub(super) use boundary_selection_set::ExtraBoundarySelectionSet;
 
 use super::{ExpectationsBuilder, ExpectedField, ExpectedType, UndeterminedSelectionSetId};
 
 mod boundary_planner;
+mod boundary_selection_set;
 
 #[derive(Debug, thiserror::Error)]
 pub enum PlanningError {
@@ -536,7 +537,7 @@ impl<'op, 'plan> PlanOutputBuilderContext<'op, 'plan> {
                     path: &self.path,
                     logic: self.logic.clone(),
                     attribution: self.attribution,
-                    flat_selection_set: providable.clone(),
+                    provided_selection_set: providable.clone(),
                 }),
                 missing,
             )?;

--- a/engine/crates/engine-v2/src/plan/planner/boundary_planner.rs
+++ b/engine/crates/engine-v2/src/plan/planner/boundary_planner.rs
@@ -1,0 +1,592 @@
+use std::{
+    borrow::Cow,
+    collections::{hash_map::Entry, HashMap, HashSet},
+};
+
+use schema::{FieldId, FieldResolverWalker, FieldSet, FieldSetItem, ResolverId, ResolverWalker};
+
+use crate::{
+    plan::{
+        attribution::{AttributionBuilder, ExtraField},
+        ChildPlan, EntityType, FlatTypeCondition, PlanId,
+    },
+    request::{
+        BoundFieldId, BoundSelectionSetId, FlatField, FlatSelectionSet, FlatSelectionSetId, FlatSelectionSetWalker,
+        GroupForFieldId, OperationWalker, QueryPath, SelectionSetType,
+    },
+    response::{ReadField, ReadSelectionSet},
+};
+
+use super::{AttributionLogic, ExpectedType, Planner, PlanningError, PlanningResult};
+
+pub(super) struct PlanBoundaryChildrenPlanner<'op, 'a> {
+    planner: &'a mut Planner<'op>,
+    walker: OperationWalker<'op>,
+    maybe_parent: Option<PlanBoundaryParent<'op, 'a, 'a>>,
+    children: Vec<ChildPlan>,
+}
+
+pub(super) struct PlanBoundaryParent<'op, 'plan, 'ctx> {
+    pub plan_id: PlanId,
+    pub path: &'ctx QueryPath,
+    pub logic: AttributionLogic<'op>,
+    pub attribution: &'plan mut AttributionBuilder,
+    pub flat_selection_set: FlatSelectionSetWalker<'op>,
+}
+
+#[derive(Debug)]
+enum BoundaryField<'op> {
+    Planned {
+        field: GroupForFieldId<'op>,
+        subselection: Option<BoundarySelectionSet<'op>>,
+    },
+    Extra {
+        plan_id: PlanId,
+        resolver_id: ResolverId,
+        field: ExtraBoundaryField,
+    },
+}
+
+#[derive(Debug)]
+struct BoundarySelectionSet<'op> {
+    id: FlatSelectionSetId,
+    fields: HashMap<FieldId, BoundaryField<'op>>,
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::plan) struct ExtraBoundaryField {
+    pub extra_field: ExtraField<ExtraBoundarySelectionSet>,
+    pub read: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::plan) struct ExtraBoundarySelectionSet {
+    pub ty: SelectionSetType,
+    pub fields: HashMap<FieldId, ExtraBoundaryField>,
+}
+
+impl<'op, 'a> PlanBoundaryChildrenPlanner<'op, 'a> {
+    pub fn new(planner: &'a mut Planner<'op>, maybe_parent: Option<PlanBoundaryParent<'op, 'a, 'a>>) -> Self {
+        let walker = planner.default_operation_walker();
+        PlanBoundaryChildrenPlanner {
+            planner,
+            walker,
+            maybe_parent,
+            children: vec![],
+        }
+    }
+
+    pub fn plan_children(
+        mut self,
+        missing_selection_set: FlatSelectionSetWalker<'op>,
+    ) -> PlanningResult<Vec<ChildPlan>> {
+        let selection_set_type = missing_selection_set.ty();
+
+        // All planned fields at the boundary from the parent & children plans and any extra fields
+        // added to satisfy the @requires.
+        let mut boundary_selection_set = BoundarySelectionSet {
+            id: missing_selection_set.id(),
+            fields: self
+                .maybe_parent
+                .as_ref()
+                .map(|parent| {
+                    parent
+                        .flat_selection_set
+                        .group_by_field_id()
+                        .into_iter()
+                        .map(|(field_id, group)| {
+                            (
+                                field_id,
+                                BoundaryField::Planned {
+                                    field: group,
+                                    subselection: None,
+                                },
+                            )
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
+        };
+
+        // Fields that couldn't be provided by the parent and that have yet to be planned by one
+        // child plan.
+        struct MissingField<'op> {
+            entity_type: EntityType,
+            flat_field: FlatField,
+            type_condition: Option<FlatTypeCondition>,
+            field_resolvers: Vec<FieldResolverWalker<'op>>,
+        }
+        let mut id_to_missing_fields: HashMap<BoundFieldId, MissingField<'op>> = missing_selection_set
+            .into_fields()
+            .map(|flat_field_walker| {
+                let entity_type = flat_field_walker.entity_type();
+                let field_resolvers = flat_field_walker
+                    .bound_field()
+                    .definition()
+                    .as_field()
+                    .expect("Meta fields are always providable, it can't be missing.")
+                    .resolvers()
+                    .collect::<Vec<_>>();
+
+                let flat_field = flat_field_walker.into_item();
+                (
+                    flat_field.bound_field_id,
+                    MissingField {
+                        entity_type,
+                        flat_field,
+                        // Parent selection might be a union/interface and current resolver
+                        // apply on a object.
+                        type_condition: FlatTypeCondition::flatten(
+                            self.walker.schema().as_ref(),
+                            selection_set_type,
+                            vec![entity_type.into()],
+                        ),
+                        field_resolvers,
+                    },
+                )
+            })
+            .collect();
+
+        // Possible candidates for the next child plan.
+        struct ChildPlanCandidate<'op> {
+            entity_type: EntityType,
+            resolver_id: ResolverId,
+            fields: Vec<(BoundFieldId, &'op FieldSet)>,
+        }
+        let mut candidates: HashMap<ResolverId, ChildPlanCandidate<'_>> = HashMap::new();
+
+        // Actual planning, at each iteration we:
+        // 1. generate all possibles candidates
+        // 2. select the best one and plan it
+        while !id_to_missing_fields.is_empty() {
+            candidates.clear();
+            for field in id_to_missing_fields.values() {
+                for FieldResolverWalker {
+                    resolver,
+                    field_requires,
+                } in &field.field_resolvers
+                {
+                    match candidates.entry(resolver.id()) {
+                        Entry::Occupied(mut entry) => {
+                            let candidate = entry.get_mut();
+                            if self.could_plan_requirements(
+                                &mut boundary_selection_set,
+                                field_requires,
+                                &field.type_condition,
+                            ) {
+                                candidate.fields.push((field.flat_field.bound_field_id, field_requires));
+                            }
+                        }
+                        Entry::Vacant(entry) => {
+                            if self.could_plan_requirements(
+                                &mut boundary_selection_set,
+                                &resolver.requires(),
+                                &field.type_condition,
+                            ) && self.could_plan_requirements(
+                                &mut boundary_selection_set,
+                                field_requires,
+                                &field.type_condition,
+                            ) {
+                                entry.insert(ChildPlanCandidate {
+                                    entity_type: field.entity_type,
+                                    resolver_id: resolver.id(),
+                                    fields: vec![(field.flat_field.bound_field_id, field_requires)],
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+
+            // We could be smarter, but we need to be sure there is no intersection between
+            // candidates (which impacts ordering among other things) and some fields may now be
+            // available (requires can now be provided) after planning this candidate. So the easy
+            // solution is to regenerate candidates after each plan.
+            let Some(candidate) = candidates
+                .values_mut()
+                .filter(|candidate| !candidate.fields.is_empty())
+                .max_by_key(|candidate| candidate.fields.len())
+            else {
+                return Err(PlanningError::CouldNotPlanAnyField {
+                    missing: id_to_missing_fields
+                        .into_keys()
+                        .map(|id| self.walker.walk(id).response_key_str().to_string())
+                        .collect(),
+                    query_path: self
+                        .maybe_parent
+                        .map(|parent| {
+                            parent
+                                .path
+                                .iter_strings(&self.planner.operation.response_keys)
+                                .collect()
+                        })
+                        .unwrap_or_default(),
+                });
+            };
+
+            let resolver = self.walker.schema().walk(candidate.resolver_id).with_own_names();
+            let (requires, providable) = {
+                let mut providable = vec![];
+                let mut requires = resolver.requires();
+                for (id, field_requires) in std::mem::take(&mut candidate.fields) {
+                    let flat_field = id_to_missing_fields.remove(&id).unwrap().flat_field;
+                    if !field_requires.is_empty() {
+                        requires = Cow::Owned(FieldSet::merge(&requires, field_requires));
+                    }
+                    providable.push(flat_field);
+                }
+                (requires, providable)
+            };
+            let mut sibling_dependencies = HashSet::new();
+            let input_selection_set = self.create_read_selection_set(
+                &mut sibling_dependencies,
+                &resolver,
+                &requires,
+                &mut boundary_selection_set.fields,
+            )?;
+
+            // Currently, we don't track the global execution state nor do we keep track of the
+            // parent during the execution. But we know children will only be executed once the
+            // parent finishes. So only keeping sibling dependencies.
+            if let Some(parent) = self.maybe_parent.as_ref() {
+                sibling_dependencies.remove(&parent.plan_id);
+            }
+            self.children.push(ChildPlan {
+                id: self.planner.next_plan_id(),
+                resolver_id: resolver.id(),
+                input_selection_set,
+                root_selection_set: FlatSelectionSet {
+                    ty: candidate.entity_type,
+                    id: boundary_selection_set.id,
+                    fields: providable,
+                },
+                sibling_dependencies,
+                // replaced later if necessary.
+                extra_selection_sets: HashMap::with_capacity(0),
+            });
+        }
+
+        self.attribute_extra_fields(boundary_selection_set);
+
+        Ok(self.children)
+    }
+
+    fn attribute_extra_fields(&mut self, boundary_selection_set: BoundarySelectionSet<'op>) {
+        let mut plan_id_to_extra_selection_sets: HashMap<
+            PlanId,
+            HashMap<BoundSelectionSetId, ExtraBoundarySelectionSet>,
+        > = HashMap::new();
+
+        let mut selection_sets = vec![boundary_selection_set];
+        while let Some(selection_set) = selection_sets.pop() {
+            let id = BoundSelectionSetId::from(selection_set.id);
+            for boundary_field in selection_set.fields.into_values() {
+                match boundary_field {
+                    BoundaryField::Planned { subselection, .. } => {
+                        if let Some(subselection) = subselection {
+                            selection_sets.push(subselection);
+                        }
+                    }
+                    BoundaryField::Extra { plan_id, field, .. } => {
+                        if field.read {
+                            plan_id_to_extra_selection_sets
+                                .entry(plan_id)
+                                .or_default()
+                                .entry(id)
+                                .or_insert_with(|| ExtraBoundarySelectionSet {
+                                    ty: self.walker.walk(id).as_ref().ty,
+                                    fields: HashMap::new(),
+                                })
+                                .fields
+                                .insert(field.extra_field.field_id, field);
+                        }
+                    }
+                }
+            }
+        }
+
+        for child in &mut self.children {
+            if let Some(extra_selection_sets) = plan_id_to_extra_selection_sets.remove(&child.id) {
+                child.extra_selection_sets = extra_selection_sets;
+            }
+        }
+
+        if let Some(extra_selection_sets) = plan_id_to_extra_selection_sets.into_values().next() {
+            self.maybe_parent
+                .as_mut()
+                .expect("PlanId which doesn't match any children, so should be the parent")
+                .attribution
+                .add_extra_selection_sets(extra_selection_sets);
+        }
+    }
+
+    /// Allows us to know whether a field requirements can be provided at all to order the next child
+    /// candidates.
+    fn could_plan_requirements(
+        &mut self,
+        boundary_selection_set: &mut BoundarySelectionSet<'op>,
+        requires: &FieldSet,
+        type_condition: &Option<FlatTypeCondition>,
+    ) -> bool {
+        if requires.is_empty() {
+            return true;
+        }
+        self.could_plan_requirements_on_previous_plans(PlanId::MAX, boundary_selection_set, requires, type_condition)
+    }
+
+    fn could_plan_requirements_on_previous_plans(
+        &mut self,
+        current_child_plan_id: PlanId,
+        boundary_selection_set: &mut BoundarySelectionSet<'op>,
+        requires: &FieldSet,
+        type_condition: &Option<FlatTypeCondition>,
+    ) -> bool {
+        if requires.is_empty() {
+            return true;
+        }
+        let schema = self.walker.schema();
+        'requires: for item in requires {
+            if let Some(field) = boundary_selection_set.fields.get_mut(&item.field_id) {
+                if item.subselection.is_empty() {
+                    continue;
+                }
+                match field {
+                    BoundaryField::Planned { field, subselection } => {
+                        let subselection = subselection.get_or_insert_with(|| {
+                            let flat_selection_set = self.walker.merged_selection_sets(&field.bound_field_ids);
+                            let id = flat_selection_set.id();
+                            let fields = flat_selection_set
+                                .group_by_field_id()
+                                .into_iter()
+                                .map(|(field_id, field)| {
+                                    (
+                                        field_id,
+                                        BoundaryField::Planned {
+                                            field,
+                                            subselection: None,
+                                        },
+                                    )
+                                })
+                                .collect();
+                            BoundarySelectionSet { id, fields }
+                        });
+                        if self.could_plan_requirements(subselection, requires, &None) {
+                            continue;
+                        } else {
+                            return false;
+                        }
+                    }
+                    BoundaryField::Extra { resolver_id, field, .. } => {
+                        self.update_extra_field_subselection(&schema.walk(*resolver_id), field, requires);
+                        continue;
+                    }
+                }
+            } else {
+                let field = schema.walk(item.field_id);
+                if let Some((plan_id, resolver)) = self.maybe_parent.as_ref().and_then(|parent| {
+                    // no need to check for requires here, they're only relevant when it's a
+                    // plan root field and this is a nested field. So we expect the data source
+                    // to be able to provide anything it needed for a nested object it provides.
+                    parent
+                        .logic
+                        .is_providable(field)
+                        .then(|| (parent.plan_id, *parent.logic.resolver()))
+                }) {
+                    boundary_selection_set.fields.insert(
+                        item.field_id,
+                        BoundaryField::Extra {
+                            plan_id,
+                            resolver_id: resolver.id(),
+                            field: self.create_extra_field(&resolver, type_condition, item),
+                        },
+                    );
+                    continue;
+                }
+
+                for i in 0..self.children.len() {
+                    let plan_id = self.children[i].id;
+                    if plan_id >= current_child_plan_id {
+                        break;
+                    }
+                    let resolver = schema.walk(self.children[i].resolver_id);
+                    let logic = AttributionLogic::CompatibleResolver {
+                        resolver,
+                        providable: FieldSet::default(),
+                    };
+                    if logic.is_providable(field)
+                        && self.could_plan_requirements_on_previous_plans(
+                            plan_id,
+                            boundary_selection_set,
+                            &resolver.requires(),
+                            type_condition,
+                        )
+                    {
+                        boundary_selection_set.fields.insert(
+                            item.field_id,
+                            BoundaryField::Extra {
+                                plan_id,
+                                resolver_id: resolver.id(),
+                                field: self.create_extra_field(&resolver, type_condition, item),
+                            },
+                        );
+                        continue 'requires;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        true
+    }
+
+    fn create_read_selection_set(
+        &mut self,
+        dependencies: &mut HashSet<PlanId>,
+        resolver: &ResolverWalker<'_>,
+        requires: &FieldSet,
+        boundary_fields: &mut HashMap<FieldId, BoundaryField<'op>>,
+    ) -> PlanningResult<ReadSelectionSet> {
+        if requires.is_empty() {
+            return Ok(ReadSelectionSet::default());
+        }
+        requires
+            .iter()
+            .map(|item| {
+                match boundary_fields
+                    .get_mut(&item.field_id)
+                    .expect("field should be present, we could plan it")
+                {
+                    BoundaryField::Planned { field, subselection } => {
+                        dependencies.insert(self.maybe_parent.as_ref().unwrap().plan_id);
+                        Ok(ReadField {
+                            edge: field.key.into(),
+                            name: resolver.walk(item.field_id).name().to_string(),
+                            subselection: if item.subselection.is_empty() {
+                                ReadSelectionSet::default()
+                            } else {
+                                self.create_read_selection_set(
+                                    dependencies,
+                                    resolver,
+                                    &item.subselection,
+                                    &mut subselection
+                                        .as_mut()
+                                        .expect("subselection should be present, we could plan the subselection")
+                                        .fields,
+                                )?
+                            },
+                        })
+                    }
+                    BoundaryField::Extra { plan_id, field, .. } => {
+                        dependencies.insert(*plan_id);
+                        field.read = true;
+                        Ok(ReadField {
+                            edge: field.extra_field.edge,
+                            name: resolver.walk(item.field_id).name().to_string(),
+                            subselection: create_read_selection_set_from_extras(
+                                resolver,
+                                &item.subselection,
+                                &mut field.extra_field.ty,
+                            )?,
+                        })
+                    }
+                }
+            })
+            .collect::<PlanningResult<ReadSelectionSet>>()
+    }
+
+    fn update_extra_field_subselection(
+        &mut self,
+        resolver: &ResolverWalker<'_>,
+        extra_boundary_field: &mut ExtraBoundaryField,
+        field_set: &FieldSet,
+    ) {
+        let ExpectedType::SelectionSet(ref mut selection_set) = extra_boundary_field.extra_field.ty else {
+            return;
+        };
+        for item in field_set {
+            match selection_set.fields.entry(item.field_id) {
+                Entry::Occupied(mut entry) => {
+                    self.update_extra_field_subselection(resolver, entry.get_mut(), &item.subselection);
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(self.create_extra_field(resolver, &None, item));
+                }
+            }
+        }
+    }
+
+    fn create_extra_field(
+        &mut self,
+        resolver: &ResolverWalker<'_>,
+        type_condition: &Option<FlatTypeCondition>,
+        item: &FieldSetItem,
+    ) -> ExtraBoundaryField {
+        let field = resolver.walk(item.field_id);
+        ExtraBoundaryField {
+            read: false,
+            extra_field: ExtraField {
+                edge: item.field_id.into(),
+                type_condition: type_condition.clone(),
+                field_id: item.field_id,
+                expected_key: {
+                    if resolver.supports_aliases() {
+                        // When the resolver supports aliases, we must ensure that extra fields
+                        // don't collide with existing response keys. And to avoid duplicates
+                        // during field collection, we have a single unique name per field id.
+                        self.planner.get_extra_field_name(item.field_id)
+                    } else {
+                        field.name().to_string()
+                    }
+                },
+                ty: {
+                    let definition = field.ty().inner();
+                    definition.data_type().map(ExpectedType::Scalar).unwrap_or_else(|| {
+                        ExpectedType::SelectionSet(ExtraBoundarySelectionSet {
+                            ty: SelectionSetType::maybe_from(definition.id()).expect("not a scalar"),
+                            fields: item
+                                .subselection
+                                .iter()
+                                .map(|item| {
+                                    let field = self.create_extra_field(resolver, &None, item);
+                                    (item.field_id, field)
+                                })
+                                .collect(),
+                        })
+                    })
+                },
+            },
+        }
+    }
+}
+
+fn create_read_selection_set_from_extras(
+    resolver: &ResolverWalker<'_>,
+    requires: &FieldSet,
+    parent_ty: &mut ExpectedType<ExtraBoundarySelectionSet>,
+) -> PlanningResult<ReadSelectionSet> {
+    let ExpectedType::SelectionSet(ref mut selection_set) = parent_ty else {
+        return Ok(ReadSelectionSet::default());
+    };
+    if requires.is_empty() {
+        return Ok(ReadSelectionSet::default());
+    }
+
+    requires
+        .iter()
+        .map(|item| {
+            let field = selection_set
+                .fields
+                .get_mut(&item.field_id)
+                .expect("field should be present");
+            field.read = true;
+            let subselection =
+                create_read_selection_set_from_extras(resolver, &item.subselection, &mut field.extra_field.ty)?;
+            Ok(ReadField {
+                edge: field.extra_field.edge,
+                name: resolver.walk(item.field_id).name().to_string(),
+                subselection,
+            })
+        })
+        .collect()
+}

--- a/engine/crates/engine-v2/src/plan/planner/boundary_selection_set.rs
+++ b/engine/crates/engine-v2/src/plan/planner/boundary_selection_set.rs
@@ -1,0 +1,104 @@
+use std::collections::HashMap;
+
+use schema::{FieldId, ResolverId};
+
+use crate::{
+    plan::{attribution::ExtraField, PlanId},
+    request::{FlatSelectionSetId, GroupForFieldId, SelectionSetType},
+};
+
+/// Currently Operation is immutable during the planning phase. That's something I need to fix,
+/// but in the meantime it is what is.
+///
+/// When planning children we need to keep track of which fields are present and which ones have
+/// been added to ensures that we don't add more extra fields than necessary (on different plans or
+/// duplciated).
+///
+/// So this struct represents the selection set at the boundary including the extra fields. It
+/// won't contain everything though. It's initialised with the providable fields of the parent plan
+/// if any and then extended during the planning with any fields that were required by children.
+/// Ensuring any extra field added or providable field by one child is visible to the others
+#[derive(Debug)]
+pub(super) struct BoundarySelectionSet<'op> {
+    pub id: FlatSelectionSetId,
+    pub fields: HashMap<FieldId, BoundaryField<'op>>,
+}
+
+#[derive(Debug)]
+pub(super) enum BoundaryField<'op> {
+    // Field planned by either the parent plan or a child.
+    Planned(PlannedBoundaryField<'op>),
+    // Extra field required by a child.
+    Extra {
+        plan_id: PlanId,
+        resolver_id: ResolverId,
+        field: ExtraBoundaryField,
+    },
+}
+
+#[derive(Debug)]
+pub(super) struct PlannedBoundaryField<'op> {
+    pub(super) plan_id: PlanId,
+    pub(super) field: GroupForFieldId<'op>,
+    lazy_subselection: Option<BoundarySelectionSet<'op>>,
+}
+
+impl<'op> PlannedBoundaryField<'op> {
+    pub(super) fn new(plan_id: PlanId, field: GroupForFieldId<'op>) -> Self {
+        Self {
+            plan_id,
+            field,
+            lazy_subselection: None,
+        }
+    }
+
+    pub(super) fn subselection_mut(&mut self) -> Option<&mut BoundarySelectionSet<'op>> {
+        if self.field.bound_field_ids.is_empty() {
+            return None;
+        }
+        Some(self.lazy_subselection.get_or_insert_with(|| {
+            let flat_selection_set = self
+                .field
+                .definition
+                .walk_with((), ())
+                .merged_selection_sets(&self.field.bound_field_ids);
+            let id = flat_selection_set.id();
+            let fields = flat_selection_set
+                .group_by_field_id()
+                .into_iter()
+                .map(|(field_id, field)| {
+                    (
+                        field_id,
+                        BoundaryField::Planned(Self {
+                            plan_id: self.plan_id,
+                            field,
+                            lazy_subselection: None,
+                        }),
+                    )
+                })
+                .collect();
+            BoundarySelectionSet { id, fields }
+        }))
+    }
+
+    pub(super) fn take_subselection_if_read(self) -> Option<BoundarySelectionSet<'op>> {
+        self.lazy_subselection
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::plan) struct ExtraBoundaryField {
+    pub extra_field: ExtraField<ExtraBoundarySelectionSet>,
+    // Keeping track of whether an extra field is actually read by a child. We plan extra fields
+    // eagerly to determine whether the full `requires` field set is completely providable or not.
+    // It's only once a child plan candidate is selected and we create its input that we flag the
+    // extras as 'read'. This ensures only extra fields we actually use are retrieved from
+    // upstream.
+    pub read: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::plan) struct ExtraBoundarySelectionSet {
+    pub ty: SelectionSetType,
+    pub fields: HashMap<FieldId, ExtraBoundaryField>,
+}

--- a/engine/crates/engine-v2/src/request/flat.rs
+++ b/engine/crates/engine-v2/src/request/flat.rs
@@ -4,10 +4,25 @@ use schema::{Definition, InterfaceId, ObjectId, Schema};
 
 use crate::request::{BoundFieldId, BoundSelectionSetId, SelectionSetType, TypeCondition};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FlatSelectionSetId(BoundSelectionSetId);
+
+impl From<BoundSelectionSetId> for FlatSelectionSetId {
+    fn from(value: BoundSelectionSetId) -> Self {
+        Self(value)
+    }
+}
+
+impl From<FlatSelectionSetId> for BoundSelectionSetId {
+    fn from(value: FlatSelectionSetId) -> Self {
+        value.0
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct FlatSelectionSet<Ty = SelectionSetType> {
     pub ty: Ty,
-    pub any_selection_set_id: BoundSelectionSetId,
+    pub id: FlatSelectionSetId,
     pub fields: Vec<FlatField>,
 }
 

--- a/engine/crates/engine-v2/src/request/path.rs
+++ b/engine/crates/engine-v2/src/request/path.rs
@@ -1,7 +1,17 @@
-use crate::response::ResponseKey;
+use crate::response::{ResponseKey, ResponseKeys};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct QueryPath(im::Vector<ResponseKey>);
+
+impl IntoIterator for QueryPath {
+    type Item = ResponseKey;
+
+    type IntoIter = <im::Vector<ResponseKey> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
 
 impl<'a> IntoIterator for &'a QueryPath {
     type Item = &'a ResponseKey;
@@ -22,5 +32,9 @@ impl QueryPath {
         let mut child = self.clone();
         child.0.push_back(id);
         child
+    }
+
+    pub fn iter_strings<'a>(&'a self, keys: &'a ResponseKeys) -> impl Iterator<Item = String> + 'a {
+        self.into_iter().map(move |key| keys[*key].to_string())
     }
 }

--- a/engine/crates/engine-v2/src/request/walkers/flat.rs
+++ b/engine/crates/engine-v2/src/request/walkers/flat.rs
@@ -7,8 +7,8 @@ use schema::{Definition, FieldId};
 
 use crate::{
     request::{
-        BoundAnyFieldDefinitionId, BoundFieldId, BoundSelectionSetId, FlatField, FlatSelectionSet, FlatTypeCondition,
-        SelectionSetType,
+        BoundAnyFieldDefinitionId, BoundFieldId, BoundSelectionSetId, FlatField, FlatSelectionSet, FlatSelectionSetId,
+        FlatTypeCondition, SelectionSetType,
     },
     response::{BoundResponseKey, ResponseKey},
 };
@@ -19,8 +19,8 @@ pub type FlatSelectionSetWalker<'a, Ty = SelectionSetType> = OperationWalker<'a,
 pub type FlatFieldWalker<'a> = OperationWalker<'a, Cow<'a, FlatField>>;
 
 impl<'a, Ty: Copy> FlatSelectionSetWalker<'a, Ty> {
-    pub fn any_selection_set_id(&self) -> BoundSelectionSetId {
-        self.item.any_selection_set_id
+    pub fn id(&self) -> FlatSelectionSetId {
+        self.item.id
     }
 
     pub fn ty(&self) -> Ty {
@@ -105,7 +105,7 @@ impl<'a, Ty: Copy> FlatSelectionSetWalker<'a, Ty> {
     fn with_fields(&self, fields: Vec<FlatField>) -> Self {
         self.walk(Cow::Owned(FlatSelectionSet {
             ty: self.item.ty,
-            any_selection_set_id: self.item.any_selection_set_id,
+            id: self.item.id,
             fields,
         }))
     }
@@ -156,7 +156,7 @@ impl<'a, Ty: Copy + std::fmt::Debug + Into<SelectionSetType>> std::fmt::Debug fo
         let ty_name = self.walk_with(ty, Definition::from(ty)).name();
 
         f.debug_struct("FlatSelectionSet")
-            .field("any_selection_set_id", &self.any_selection_set_id())
+            .field("id", &self.id())
             .field("ty", &ty_name)
             .field("fields", &self.fields().collect::<Vec<_>>())
             .finish()

--- a/engine/crates/engine-v2/src/request/walkers/mod.rs
+++ b/engine/crates/engine-v2/src/request/walkers/mod.rs
@@ -30,8 +30,8 @@ pub use variables::*;
 use crate::request::SelectionSetType;
 
 use super::{
-    BoundFieldId, BoundSelection, BoundSelectionSetId, FlatField, FlatSelectionSet, FlatTypeCondition, Operation,
-    TypeCondition,
+    BoundFieldId, BoundSelection, BoundSelectionSetId, FlatField, FlatSelectionSet, FlatSelectionSetId,
+    FlatTypeCondition, Operation, TypeCondition,
 };
 
 #[derive(Clone, Copy)]
@@ -152,7 +152,7 @@ impl<'a> OperationWalker<'a> {
         &self,
         merged_selection_set_ids: Vec<BoundSelectionSetId>,
     ) -> FlatSelectionSetWalker<'a> {
-        let any_selection_set_id = merged_selection_set_ids[0];
+        let id = FlatSelectionSetId::from(merged_selection_set_ids[0]);
         let selection_set_type = {
             let ty = merged_selection_set_ids
                 .iter()
@@ -208,7 +208,7 @@ impl<'a> OperationWalker<'a> {
         }
 
         self.walk(Cow::Owned(FlatSelectionSet {
-            any_selection_set_id,
+            id,
             ty: selection_set_type,
             fields,
         }))

--- a/engine/crates/engine-v2/src/request/walkers/mod.rs
+++ b/engine/crates/engine-v2/src/request/walkers/mod.rs
@@ -139,7 +139,7 @@ impl<'a> OperationWalker<'a> {
         self.operation.root_object_id
     }
 
-    pub fn merged_selection_sets(&self, bound_field_ids: &[BoundFieldId]) -> FlatSelectionSetWalker<'a> {
+    pub fn merged_selection_sets(&self, bound_field_ids: &[BoundFieldId]) -> FlatSelectionSetWalker<'a, 'static> {
         self.flatten_selection_sets(
             bound_field_ids
                 .iter()
@@ -151,7 +151,7 @@ impl<'a> OperationWalker<'a> {
     pub fn flatten_selection_sets(
         &self,
         merged_selection_set_ids: Vec<BoundSelectionSetId>,
-    ) -> FlatSelectionSetWalker<'a> {
+    ) -> FlatSelectionSetWalker<'a, 'static> {
         let id = FlatSelectionSetId::from(merged_selection_set_ids[0]);
         let selection_set_type = {
             let ty = merged_selection_set_ids

--- a/engine/crates/engine-v2/src/request/walkers/plan_selection_set.rs
+++ b/engine/crates/engine-v2/src/request/walkers/plan_selection_set.rs
@@ -51,7 +51,12 @@ impl<'a> IntoIterator for PlanSelectionSet<'a> {
                 walker: walker.walk(()),
                 bound_field_ids: walker.item.root_fields.iter().copied().collect(),
                 selections: VecDeque::with_capacity(0),
-                extra_fields: VecDeque::with_capacity(0),
+                extra_fields: walker
+                    .ctx
+                    .attribution
+                    .extras_for(walker.item.root_selection_set_id)
+                    .map(|extras| extras.fields().collect())
+                    .unwrap_or_default(),
             },
             Self::Query(walker) => PlanSelectionIterator {
                 walker: walker.walk(()),

--- a/engine/crates/engine-v2/src/request/walkers/selection_set.rs
+++ b/engine/crates/engine-v2/src/request/walkers/selection_set.rs
@@ -92,6 +92,7 @@ impl<'a, C: Copy> Iterator for SelectionIterator<'a, C> {
 impl<'a> std::fmt::Debug for BoundSelectionSetWalker<'a, ()> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BoundSelectionSet")
+            .field("id", &self.id())
             .field("ty", &self.ty().name())
             .field("items", &self.into_iter().collect::<Vec<_>>())
             .finish()
@@ -101,6 +102,7 @@ impl<'a> std::fmt::Debug for BoundSelectionSetWalker<'a, ()> {
 impl<'a> std::fmt::Debug for BoundSelectionSetWalker<'a, ExecutorWalkContext<'a>> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BoundSelectionSet")
+            .field("id", &self.id())
             .field("ty", &self.ty().name())
             .field("items", &self.into_iter().collect::<Vec<_>>())
             .finish()

--- a/engine/crates/engine-v2/src/request/walkers/selection_set.rs
+++ b/engine/crates/engine-v2/src/request/walkers/selection_set.rs
@@ -20,9 +20,8 @@ impl<'a, C> BoundSelectionSetWalker<'a, C> {
 impl<'a> BoundSelectionSetWalker<'a, ()> {
     // this merely traverses the selection set recursively and merge all cache_config present in the
     // selected fields
-    pub fn cache_config(&self) -> Option<CacheConfig> {
-        (*self)
-            .into_iter()
+    pub fn cache_config(self) -> Option<CacheConfig> {
+        self.into_iter()
             .filter_map(|selection| match selection {
                 BoundSelectionWalker::Field(field) => {
                     let cache_config = field.definition().as_field().and_then(|definition| {

--- a/engine/crates/engine-v2/src/sources/graphql/query.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/query.rs
@@ -195,7 +195,7 @@ impl QueryBuilder {
 
     fn write_fragments(&self, out: &mut String) {
         out.push_str(&format!(
-            "{}",
+            "\n{}",
             self.fragment_content_to_name
                 .iter()
                 .format_with("\n", |(fragment, name), f| {

--- a/engine/crates/engine-v2/src/sources/introspection/mod.rs
+++ b/engine/crates/engine-v2/src/sources/introspection/mod.rs
@@ -3,7 +3,7 @@ use schema::sources::introspection::{Metadata, ResolverWalker};
 use super::{Executor, ExecutorError, ResolverInput};
 use crate::{
     execution::ExecutionContext,
-    plan::PlanOutput,
+    plan::{PlanId, PlanOutput},
     response::{ExecutorOutput, ResponseBoundaryItem},
 };
 
@@ -15,6 +15,7 @@ pub(crate) struct IntrospectionExecutionPlan<'ctx> {
     metadata: &'ctx Metadata,
     plan_output: PlanOutput,
     output: ExecutorOutput,
+    pub(super) plan_id: PlanId,
 }
 
 impl<'ctx> IntrospectionExecutionPlan<'ctx> {
@@ -24,7 +25,7 @@ impl<'ctx> IntrospectionExecutionPlan<'ctx> {
         ResolverInput {
             ctx,
             boundary_objects_view: root_response_objects,
-            plan_id: _,
+            plan_id,
             plan_output,
             output,
         }: ResolverInput<'ctx, 'input>,
@@ -35,6 +36,7 @@ impl<'ctx> IntrospectionExecutionPlan<'ctx> {
             metadata: resolver.metadata(),
             plan_output,
             output,
+            plan_id,
         }))
     }
 

--- a/engine/crates/engine-v2/src/sources/mod.rs
+++ b/engine/crates/engine-v2/src/sources/mod.rs
@@ -94,6 +94,14 @@ impl<'exc> Executor<'exc> {
             Executor::FederationEntity(executor) => executor.execute().await,
         }
     }
+
+    pub fn plan_id(&self) -> PlanId {
+        match self {
+            Executor::GraphQL(executor) => executor.plan_id,
+            Executor::Introspection(executor) => executor.plan_id,
+            Executor::FederationEntity(executor) => executor.plan_id,
+        }
+    }
 }
 
 #[allow(dead_code)]

--- a/engine/crates/engine-v2/src/utils.rs
+++ b/engine/crates/engine-v2/src/utils.rs
@@ -1,7 +1,7 @@
 macro_rules! id_newtypes {
     ($($ty:ident.$field:ident[$name:ident] => $out:ident unless $msg:literal,)*) => {
         $(
-            #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, derive_more::Display)]
+            #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
             pub struct $name(std::num::NonZeroU16);
 
             impl std::ops::Index<$name> for $ty {
@@ -18,6 +18,11 @@ macro_rules! id_newtypes {
                 }
             }
 
+            impl std::fmt::Display for $name {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    usize::from(*self).fmt(f)
+                }
+            }
 
             impl From<usize> for $name {
                 fn from(value: usize) -> Self {

--- a/engine/crates/graphql-mocks/src/federation/accounts.rs
+++ b/engine/crates/graphql-mocks/src/federation/accounts.rs
@@ -1,5 +1,5 @@
 // See https://github.com/async-graphql/examples
-use async_graphql::{EmptyMutation, EmptySubscription, Object, Schema, SimpleObject, ID};
+use async_graphql::{ComplexObject, EmptyMutation, EmptySubscription, Object, Schema, SimpleObject, ID};
 
 pub struct FakeFederationAccountsSchema;
 
@@ -34,6 +34,7 @@ impl super::super::Schema for FakeFederationAccountsSchema {
 }
 
 #[derive(SimpleObject)]
+#[graphql(complex)]
 struct User {
     id: ID,
     username: String,
@@ -58,6 +59,36 @@ impl User {
             joined_timestamp: 1,
         }
     }
+}
+
+#[ComplexObject]
+impl User {
+    async fn cart(&self) -> Cart {
+        Cart
+    }
+}
+
+struct Cart;
+
+#[Object]
+impl Cart {
+    async fn products(&self) -> Vec<Product> {
+        vec![
+            Product {
+                name: "Fedora".to_string(),
+            },
+            Product {
+                name: "Pink Jeans".to_string(),
+            },
+        ]
+    }
+}
+
+#[derive(SimpleObject)]
+#[graphql(unresolvable)]
+struct Product {
+    #[graphql(external)]
+    name: String,
 }
 
 #[derive(SimpleObject)]

--- a/engine/crates/graphql-mocks/src/federation/products.rs
+++ b/engine/crates/graphql-mocks/src/federation/products.rs
@@ -84,6 +84,12 @@ impl Query {
         let hats = ctx.data_unchecked::<Vec<Product>>();
         hats.iter().find(|product| product.upc == upc)
     }
+
+    #[graphql(entity)]
+    async fn find_product_by_name<'a>(&self, ctx: &'a Context<'_>, name: String) -> Option<&'a Product> {
+        let hats = ctx.data_unchecked::<Vec<Product>>();
+        hats.iter().find(|product| product.name == name)
+    }
 }
 
 struct Subscription;

--- a/engine/crates/integration-tests/Cargo.toml
+++ b/engine/crates/integration-tests/Cargo.toml
@@ -81,3 +81,4 @@ base64.workspace = true
 rstest.workspace = true
 const_format = "0.2"
 headers.workspace = true
+

--- a/engine/crates/integration-tests/src/federation/builder.rs
+++ b/engine/crates/integration-tests/src/federation/builder.rs
@@ -53,7 +53,7 @@ impl FederationGatewayBuilder {
         let graph = graphql_composition::compose(&subgraphs)
             .into_result()
             .expect("schemas to compose succesfully");
-
+        println!("{}", graph.to_sdl().unwrap());
         let federated_graph_config = match self.config_sdl {
             Some(sdl) => {
                 parser_sdl::parse(&sdl, &HashMap::new(), false, &MockConnectorParsers::default())

--- a/engine/crates/integration-tests/src/federation/builder.rs
+++ b/engine/crates/integration-tests/src/federation/builder.rs
@@ -53,7 +53,6 @@ impl FederationGatewayBuilder {
         let graph = graphql_composition::compose(&subgraphs)
             .into_result()
             .expect("schemas to compose succesfully");
-        println!("{}", graph.to_sdl().unwrap());
         let federated_graph_config = match self.config_sdl {
             Some(sdl) => {
                 parser_sdl::parse(&sdl, &HashMap::new(), false, &MockConnectorParsers::default())

--- a/engine/crates/integration-tests/tests/federation/introspection.rs
+++ b/engine/crates/integration-tests/tests/federation/introspection.rs
@@ -814,6 +814,10 @@ fn introspection_on_multiple_federation_subgraphs() {
     assert!(response.errors().is_empty(), "{response}");
 
     insta::assert_snapshot!(introspection_to_sdl(response.into_data()), @r###"
+    type Cart {
+      products: [Product!]!
+    }
+
     type Picture {
       altText: String!
       height: Int!
@@ -852,6 +856,7 @@ fn introspection_on_multiple_federation_subgraphs() {
     }
 
     type User {
+      cart: Cart!
       id: ID!
       joinedTimestamp: Int!
       profilePicture: Picture

--- a/engine/crates/integration-tests/tests/federation/subgraphs/sibling_dependencies.rs
+++ b/engine/crates/integration-tests/tests/federation/subgraphs/sibling_dependencies.rs
@@ -1,0 +1,63 @@
+use integration_tests::runtime;
+
+#[test]
+fn sibling_dependencies() {
+    let response = runtime().block_on(super::execute(
+        r"
+        query ExampleQuery {
+            me {
+                id
+                username
+                cart {
+                    products {
+                        price
+                        reviews {
+                            author {
+                                id
+                                username
+                            }
+                            body
+                        }
+                    }
+                }
+            }
+        }
+        ",
+    ));
+
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": {
+        "me": {
+          "id": "1234",
+          "username": "Me",
+          "cart": {
+            "products": [
+              {
+                "price": 22,
+                "reviews": [
+                  {
+                    "author": {
+                      "id": "1234",
+                      "username": "Me"
+                    },
+                    "body": "Fedoras are one of the most fashionable hats around and can look great with a variety of outfits."
+                  }
+                ]
+              },
+              {
+                "price": 55,
+                "reviews": [
+                  {
+                    "author": null,
+                    "body": "Beautiful Pink, my parrot loves it. Definitely recommend!"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    }
+    "###);
+}

--- a/engine/crates/integration-tests/tests/federation/subgraphs/simple_key.rs
+++ b/engine/crates/integration-tests/tests/federation/subgraphs/simple_key.rs
@@ -1,32 +1,8 @@
-use gateway_v2::Gateway;
-use graphql_mocks::{
-    FakeFederationAccountsSchema, FakeFederationProductsSchema, FakeFederationReviewsSchema, MockGraphQlServer,
-};
-use integration_tests::{
-    federation::{GatewayV2Ext, GraphqlResponse},
-    runtime,
-};
-
-async fn execute(request: &str) -> GraphqlResponse {
-    let accounts = MockGraphQlServer::new(FakeFederationAccountsSchema).await;
-    let products = MockGraphQlServer::new(FakeFederationProductsSchema).await;
-    let reviews = MockGraphQlServer::new(FakeFederationReviewsSchema).await;
-
-    let engine = Gateway::builder()
-        .with_schema("accounts", &accounts)
-        .await
-        .with_schema("products", &products)
-        .await
-        .with_schema("reviews", &reviews)
-        .await
-        .finish()
-        .await;
-    engine.execute(request).await
-}
+use integration_tests::runtime;
 
 #[test]
 fn simple_key() {
-    let response = runtime().block_on(execute(
+    let response = runtime().block_on(super::execute(
         r"
         query ExampleQuery {
             me {
@@ -93,7 +69,7 @@ fn simple_key() {
 
 #[test]
 fn simple_key_with_missing_required_fields() {
-    let response = runtime().block_on(execute(
+    let response = runtime().block_on(super::execute(
         r"
         query ExampleQuery {
             me {
@@ -161,7 +137,7 @@ fn simple_key_with_missing_required_fields() {
 
 #[test]
 fn simple_key_with_simple_fragments() {
-    let response = runtime().block_on(execute(
+    let response = runtime().block_on(super::execute(
         r"
         query ExampleQuery {
             me {
@@ -239,7 +215,7 @@ fn simple_key_with_simple_fragments() {
 
 #[test]
 fn simple_key_with_inexistent_entities() {
-    let response = runtime().block_on(execute(
+    let response = runtime().block_on(super::execute(
         r"
         query ExampleQuery {
             topProducts {


### PR DESCRIPTION
This PR adapts the planner to take into account sibling plan dependencies. Supposing a subgraph A returns a `Product`, we might retrieve fields from a subgraph B which depends on fields coming from a different subgraph C. This typically happens when the `key` used between `A` and `B` aren't the same.

I've hanged mutations root field logic to also rely on this, making the plan for a root field a dependency of the next one.

All of this code is more complex than needed and I understood why doing this. The tricky parts of GraphQL planning are type conditions and the `skip`/`include` as this generates a lot of conditions for the shape of the queried data. However this only really impacts us when generating the expectations (how to read/validate the upstream response) but not that much the attribution (which plan/resolver is responsible for which fields and add any extra field). Currently, I'm doing both at the same time, but attribution is complex because it happens after the generation of `Operation` which we can't touch anymore during the planning phase.

So that's something I'll try to improve upon when working on the `@skip` & `@include` moving the attribution to the operation build phase. Also allowing us to cache it more easily. It should make the planning _a lot_ easier to understand afterwards.

In the meantime, the planning works roughly like this now:

Given a set of missing fields for a selection set (flattened, no fragments anymore)
- generate all possible candidate resolvers and the fields they could resolve
- if the resolver/field has requirements, we try to plan them immediately, adding extra fields if necessary to the parent plan or any previous child plan. It doesn't matter whether this candidate will be used or not at this stage, planning them immediately makes it overall a lot simpler to manage nested requirements etc.
- Currently, we suppose that If a root field of the current selection set is planned by a Plan A, all of its subselection can also be retrieved by A. So if a resolver requires `author { organizations { ... } }` and A can provide `author`, we also expect it to provide `organizations`. That's limiting, but tricky to do more for now.
- Once we have generated all possible candidates, we select the one with the most fields and generate its input (what will be read from the response). For any extra field we read, we mark them. That ensures we won't retrieve more data than necessary even though we may plan more fields than necessary.
- If there are still any missing fields, we loop again.