### PR TITLE
cli: handle types from connectors in resolver codegen

### DIFF
--- a/cli/crates/server/src/codegen_server.rs
+++ b/cli/crates/server/src/codegen_server.rs
@@ -1,72 +1,95 @@
 use std::{
-    ffi, fs,
+    ffi, fs, iter,
     path::{Path, PathBuf},
     sync::OnceLock,
 };
 
-use common::environment::{Project, SchemaLocation};
+use common::environment::Project;
+use engine::registry::resolvers::Resolver;
 use tokio::task::JoinHandle;
 use tokio_stream::{wrappers::errors::BroadcastStreamRecvError, StreamExt};
 
 use crate::{
-    config::ConfigStream,
+    config::{Config, ConfigActor, ConfigStream},
     file_watcher::ChangeStream,
     types::{MessageSender, ServerMessage},
 };
 
-static CODEGEN_WORKER_HANDLE: OnceLock<JoinHandle<()>> = OnceLock::new();
-
 /// Spawns the background worker responsible for generating TS type definitions for resolvers.
 pub(crate) fn start_codegen_worker(
     file_changes: ChangeStream,
-    config_changes: ConfigStream,
+    config_actor: &ConfigActor,
     message_sender: MessageSender,
-) -> Result<(), ()> {
-    let handle = tokio::spawn(async move { codegen_worker_task(file_changes, config_changes, message_sender).await });
-    CODEGEN_WORKER_HANDLE.set(handle).map_err(|_| ())
+) {
+    static CODEGEN_WORKER_HANDLE: OnceLock<JoinHandle<()>> = OnceLock::new();
+
+    let initial_config = config_actor
+        .current_result()
+        .as_ref()
+        .map(transform_config)
+        .ok()
+        .flatten();
+    let config_changes = config_actor.config_stream();
+
+    CODEGEN_WORKER_HANDLE.get_or_init(|| {
+        tokio::spawn(
+            async move { codegen_worker_task(file_changes, initial_config, config_changes, message_sender).await },
+        )
+    });
 }
 
 enum CodegenIncomingEvent {
-    ConfigChange,
+    ConfigChange(Config),
     FileChange(Result<PathBuf, BroadcastStreamRecvError>),
 }
 
-async fn codegen_worker_task(file_changes: ChangeStream, config_changes: ConfigStream, message_sender: MessageSender) {
+async fn codegen_worker_task(
+    file_changes: ChangeStream,
+    mut last_seen_config: Option<(String, Vec<typed_resolvers::CustomResolver>)>,
+    config_changes: ConfigStream,
+    message_sender: MessageSender,
+) {
     let project = Project::get();
-    let schema_path = &project.schema_path;
     let generated_ts_resolver_types_path = project.generated_directory_path().join("index.ts");
-    let sdl_location = project.sdl_location();
     let resolvers_path = project.udfs_source_path(common_types::UdfKind::Resolver);
 
-    let mut last_seen_sdl = None;
-
     // Try generating types on start up.
-    if let SchemaLocation::Graphql(schema_path) = schema_path.location() {
-        if let Some(sdl) = read_sdl(schema_path, &mut last_seen_sdl) {
-            generate_ts_resolver_types(sdl, &generated_ts_resolver_types_path);
-        }
+    if let Some((sdl, resolvers)) = last_seen_config.as_ref() {
+        generate_ts_resolver_types(sdl, resolvers, &generated_ts_resolver_types_path);
     }
 
     let mut stream = config_changes
-        .map(|_| CodegenIncomingEvent::ConfigChange)
+        .map(CodegenIncomingEvent::ConfigChange)
         .merge(file_changes.into_stream().map(CodegenIncomingEvent::FileChange));
 
     while let Some(next) = stream.next().await {
         match next {
-            CodegenIncomingEvent::ConfigChange => {
-                if let Some(sdl) = read_sdl(&sdl_location, &mut last_seen_sdl) {
-                    generate_ts_resolver_types(sdl, &generated_ts_resolver_types_path);
-                };
+            CodegenIncomingEvent::ConfigChange(config) => {
+                last_seen_config = transform_config(&config);
+                if let Some((sdl, resolvers)) = &last_seen_config {
+                    generate_ts_resolver_types(sdl, resolvers, &generated_ts_resolver_types_path);
+                }
             }
             CodegenIncomingEvent::FileChange(Ok(path)) => {
                 if path.extension() == Some(ffi::OsStr::new("ts"))
                     && path.ancestors().any(|ancestor| ancestor == resolvers_path)
                 {
                     // A resolver changed, check it.
-                    let Some(sdl) = last_seen_sdl.as_ref() else {
+                    let Some((sdl, resolvers)) = last_seen_config.as_ref() else {
                         continue;
                     };
-                    if let Err(err) = typed_resolvers::check_resolver(sdl, &path) {
+
+                    let Ok(parsed_sdl) = typed_resolvers::parse_schema::<&str>(sdl) else {
+                        continue;
+                    };
+
+                    let mut analyzed = typed_resolvers::analyze_schema(&parsed_sdl);
+
+                    for resolver in resolvers {
+                        analyzed.push_custom_resolver(resolver);
+                    }
+
+                    if let Err(err) = typed_resolvers::check_resolver(&path, &analyzed) {
                         message_sender
                             .send(ServerMessage::CompilationError(format!("{err:?}")))
                             .ok();
@@ -78,18 +101,49 @@ async fn codegen_worker_task(file_changes: ChangeStream, config_changes: ConfigS
     }
 }
 
-fn read_sdl<'a>(path: &Path, last_seen_sdl: &'a mut Option<String>) -> Option<&'a str> {
-    let sdl = fs::read_to_string(path).ok()?;
-    last_seen_sdl.replace(sdl);
-    last_seen_sdl.as_deref()
+fn transform_config(config: &Config) -> Option<(String, Vec<typed_resolvers::CustomResolver>)> {
+    config.registry.enable_codegen.then(|| {
+        let federation = false; // not relevant for codegen
+        let sdl = config.registry.export_sdl(federation);
+        (sdl, find_resolvers(config))
+    })
 }
 
-fn generate_ts_resolver_types(graphql_sdl: &str, target_file_path: &Path) {
+fn generate_ts_resolver_types(sdl: &str, resolvers: &[typed_resolvers::CustomResolver], target_file_path: &Path) {
+    let Ok(parsed) = typed_resolvers::parse_schema(sdl) else {
+        return;
+    };
+
+    let mut analyzed_schema = typed_resolvers::analyze_schema(&parsed);
+
+    for resolver in resolvers {
+        analyzed_schema.push_custom_resolver(resolver);
+    }
+
     // Here we write to a string first, because in case code generation fails, we don't want to
     // replace the existing types with an empty file.
     let mut out = String::new();
-    if typed_resolvers::generate_ts_resolver_types(graphql_sdl, &mut out).is_ok() {
+
+    if typed_resolvers::generate_ts_resolver_types(&analyzed_schema, &mut out).is_ok() {
         fs::create_dir_all(target_file_path.parent().unwrap()).ok();
         fs::write(target_file_path, &out).ok();
     }
+}
+
+fn find_resolvers(config: &Config) -> Vec<typed_resolvers::CustomResolver> {
+    config
+        .registry
+        .types
+        .values()
+        .filter_map(|ty| Some(ty.name()).zip(ty.fields()))
+        .flat_map(|(name, fields)| iter::repeat(name).zip(fields.values()))
+        .filter_map(|(parent_type_name, field)| match &field.resolver {
+            Resolver::CustomResolver(resolver) => Some(typed_resolvers::CustomResolver {
+                resolver_name: resolver.resolver_name.clone(),
+                field_name: field.name.clone(),
+                parent_type_name: parent_type_name.to_owned(),
+            }),
+            _ => None,
+        })
+        .collect()
 }

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -189,8 +189,7 @@ pub async fn start(
         federated_dev(proxy, message_sender, config).await?;
     } else {
         if let Some(file_changes) = file_changes {
-            crate::codegen_server::start_codegen_worker(file_changes, config.config_stream(), message_sender.clone())
-                .expect("Invariant violation: codegen worker started twice.");
+            crate::codegen_server::start_codegen_worker(file_changes, &config, message_sender.clone())
         }
 
         standalone_dev(proxy, message_sender, config, tracing).await?;

--- a/cli/crates/typed-resolvers/src/check_resolver.rs
+++ b/cli/crates/typed-resolvers/src/check_resolver.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 /// Sanity checks on resolvers to ensure that the right types are being used and the shape of
 /// exports makes sense.
-pub(crate) fn check_resolver(path: &Path, graphql_schema: &AnalyzedSchema<'_>) -> miette::Result<()> {
+pub fn check_resolver(path: &Path, graphql_schema: &AnalyzedSchema<'_>) -> miette::Result<()> {
     let (src, module) = parse_file(path)?;
     let found_resolver_signature = find_resolver_signature(&module).map_err(|err| {
         err.with_source_code(miette::NamedSource::new(

--- a/cli/crates/typed-resolvers/src/error.rs
+++ b/cli/crates/typed-resolvers/src/error.rs
@@ -1,12 +1,7 @@
-use engine_parser::Error as ParseError;
 use std::fmt;
 
 #[derive(thiserror::Error, Debug)]
 pub enum CodegenError {
-    #[error("The `codegen` experimental feature is not enabled")]
-    ExperimentalFeatureNotEnabled,
-    #[error(transparent)]
-    ParseError(#[from] ParseError),
     #[error(transparent)]
     FmtError(#[from] fmt::Error),
 }

--- a/cli/crates/typed-resolvers/src/lib.rs
+++ b/cli/crates/typed-resolvers/src/lib.rs
@@ -5,44 +5,33 @@ mod check_resolver;
 mod codegen;
 mod error;
 
-pub use self::analyze::{analyze as analyze_schema, AnalyzedSchema};
+pub use self::{
+    analyze::{analyze as analyze_schema, AnalyzedSchema},
+    check_resolver::check_resolver,
+};
 pub use engine_parser::parse_schema;
 
 use self::error::CodegenError;
 use std::{ffi, fmt, path::Path};
 
+pub struct CustomResolver {
+    pub parent_type_name: String,
+    pub field_name: String,
+    pub resolver_name: String,
+}
+
 /// Generate a TypeScript module that contains input and output type definitions for resolver
 /// authoring purposes, based on the passed in SDL schema.
-pub fn generate_ts_resolver_types<O>(graphql_sdl: &str, out: &mut O) -> Result<(), CodegenError>
+pub fn generate_ts_resolver_types<O>(schema: &analyze::AnalyzedSchema<'_>, out: &mut O) -> Result<(), CodegenError>
 where
     O: fmt::Write,
 {
-    let parsed_schema = parse_schema::<&str>(graphql_sdl)?;
-
-    if experimental_codegen_is_enabled(&parsed_schema) {
-        let analyzed_schema = analyze::analyze(&parsed_schema);
-        codegen::generate_module(&analyzed_schema, out)?;
-        Ok(())
-    } else {
-        Err(CodegenError::ExperimentalFeatureNotEnabled)
-    }
+    Ok(codegen::generate_module(schema, out)?)
 }
 
 #[must_use]
 pub struct AnalyzedResolvers {
     pub errs: Vec<miette::Error>,
-}
-
-pub fn check_resolver(sdl: &str, resolver_path: &Path) -> miette::Result<()> {
-    if resolver_path.extension() != Some(ffi::OsStr::new("ts")) {
-        return Ok(());
-    }
-    let Ok(parsed_schema) = parse_schema::<&str>(sdl) else {
-        return Ok(());
-    };
-    let schema = analyze::analyze(&parsed_schema);
-
-    check_resolver::check_resolver(resolver_path, &schema)
 }
 
 /// Returns either a GraphQL SDL string that defines the resolvers as type extensions, or errors.
@@ -60,24 +49,4 @@ pub fn check_resolvers(resolvers_root: &Path, schema: &analyze::AnalyzedSchema<'
     }
 
     AnalyzedResolvers { errs }
-}
-
-fn experimental_codegen_is_enabled(parsed_schema: &engine_parser::types::ServiceDocument) -> bool {
-    const EXPERIMENTAL_DIRECTIVE: &str = "experimental";
-    const CODEGEN_ARGUMENT: &str = "codegen";
-
-    parsed_schema
-        .definitions
-        .iter()
-        .filter_map(|def| match def {
-            engine_parser::types::TypeSystemDefinition::Schema(schema_definition) => Some(schema_definition),
-            _ => None,
-        })
-        .flat_map(|def| def.node.directives.iter())
-        .any(|directive| {
-            directive.node.name.as_str() == EXPERIMENTAL_DIRECTIVE
-                && directive.node.arguments.iter().any(|(name, value)| {
-                    name.node == CODEGEN_ARGUMENT && matches!(value.node, engine_value::ConstValue::Boolean(true))
-                })
-        })
 }

--- a/cli/crates/typed-resolvers/tests/schema_types.rs
+++ b/cli/crates/typed-resolvers/tests/schema_types.rs
@@ -15,7 +15,9 @@ fn run_test(path: &Path) -> datatest_stable::Result<()> {
     let mut expected = fs::read_to_string(&expected_file_path).unwrap_or_default();
     let generated = {
         let mut out = String::with_capacity(graphql.len() / 2);
-        typed_resolvers::generate_ts_resolver_types(&graphql, &mut out).unwrap();
+        let parsed = typed_resolvers::parse_schema(graphql).unwrap();
+        let analyzed = typed_resolvers::analyze_schema(&parsed);
+        typed_resolvers::generate_ts_resolver_types(&analyzed, &mut out).unwrap();
         out
     };
 

--- a/engine/crates/engine/src/registry/mod.rs
+++ b/engine/crates/engine/src/registry/mod.rs
@@ -1426,6 +1426,8 @@ pub struct Registry {
     pub federation_entities: BTreeMap<String, FederationEntity>,
     #[serde(default)]
     pub enable_ai: bool,
+    #[serde(default)]
+    pub enable_codegen: bool,
     // FIXME: Make an enum.
     pub is_federated: bool,
     #[serde(default)]
@@ -1453,6 +1455,7 @@ impl Default for Registry {
             enable_kv: false,
             federation_entities: Default::default(),
             enable_ai: false,
+            enable_codegen: false,
             is_federated: false,
             operation_limits: Default::default(),
         }

--- a/engine/crates/engine/src/registry/tests.rs
+++ b/engine/crates/engine/src/registry/tests.rs
@@ -4,7 +4,7 @@ use sha2::{Digest, Sha256};
 
 use super::*;
 
-const EXPECTED_SHA: &str = "51fbec45094e199d04bfab69b407202787f44a14cb692b5d4d88f6c01e402d26";
+const EXPECTED_SHA: &str = "3bbbaa266bf669b9eaa1bd7115895be5f9dd656c8bc34be6af3a06299793db75";
 
 #[test]
 fn test_serde_roundtrip() {

--- a/engine/crates/parser-graphql/src/snapshots/parser_graphql__conversion__tests__array_input_value.snap
+++ b/engine/crates/parser-graphql/src/snapshots/parser_graphql__conversion__tests__array_input_value.snap
@@ -868,6 +868,7 @@ expression: registry_from_introspection(schema)
   "enable_caching": false,
   "enable_kv": false,
   "enable_ai": false,
+  "enable_codegen": false,
   "is_federated": false,
   "operation_limits": {
     "depth": null,

--- a/engine/crates/parser-graphql/src/snapshots/parser_graphql__conversion__tests__conversion.snap
+++ b/engine/crates/parser-graphql/src/snapshots/parser_graphql__conversion__tests__conversion.snap
@@ -2841,6 +2841,7 @@ expression: registry_from_introspection(schema)
   "enable_caching": false,
   "enable_kv": false,
   "enable_ai": false,
+  "enable_codegen": false,
   "is_federated": false,
   "operation_limits": {
     "depth": null,

--- a/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__flat_output-2.snap
+++ b/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__flat_output-2.snap
@@ -2288,6 +2288,7 @@ Registry {
         },
     },
     enable_ai: false,
+    enable_codegen: false,
     is_federated: false,
     operation_limits: OperationLimits {
         depth: None,

--- a/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__petstore_output-2.snap
+++ b/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__petstore_output-2.snap
@@ -2390,6 +2390,7 @@ Registry {
         },
     },
     enable_ai: false,
+    enable_codegen: false,
     is_federated: false,
     operation_limits: OperationLimits {
         depth: None,

--- a/engine/crates/parser-sdl/src/rules/experimental.rs
+++ b/engine/crates/parser-sdl/src/rules/experimental.rs
@@ -41,6 +41,7 @@ impl<'a> Visitor<'a> for ExperimentalDirectiveVisitor {
             Ok(experimental_directive) => {
                 ctx.registry.get_mut().enable_kv = experimental_directive.kv.unwrap_or_default();
                 ctx.registry.get_mut().enable_ai = experimental_directive.ai.unwrap_or_default();
+                ctx.registry.get_mut().enable_codegen = experimental_directive.codegen.unwrap_or_default();
             }
             Err(err) => {
                 ctx.report_error(
@@ -100,6 +101,12 @@ mod tests {
     #[case::successful_parsing_ai_disabled(r"
         extend schema @experimental(ai: false)
     ", &[], "ai", false)]
+    #[case::successful_parsing_codegen_disabled(r"
+        extend schema @experimental(codegen: false)
+    ", &[], "codegen", false)]
+    #[case::successful_parsing_codegen_enabled(r"
+        extend schema @experimental(codegen: true)
+    ", &[], "codegen", true)]
     fn test_parsing(
         #[case] schema: &str,
         #[case] expected_messages: &[&str],
@@ -116,6 +123,7 @@ mod tests {
         match target {
             "ai" => assert_eq!(ctx.registry.borrow().enable_ai, expected),
             "kv" => assert_eq!(ctx.registry.borrow().enable_kv, expected),
+            "codegen" => assert_eq!(ctx.registry.borrow().enable_codegen, expected),
             _ => {}
         }
     }


### PR DESCRIPTION
The decisive change to get the GraphQL schema from the registry instead of the config. (Internal) RFC:
https://www.notion.so/grafbase/Grafbase-GraphQL-clients-integration-68b7a475f5d94222aba4c9e6a405b2d7

closes GB-5256