### PR TITLE
chore(tests): Enable the 'preserve_order' feature flag for serde_json globally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3903,6 +3903,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "more-asserts"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
+
+[[package]]
 name = "multer"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4498,6 +4504,7 @@ dependencies = [
  "indexmap 1.9.3",
  "insta",
  "itertools 0.12.0",
+ "more-asserts",
  "once_cell",
  "openapi",
  "openapiv3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ worker = "0.0.18"
 # Serde
 serde = { version = "1", features = ["derive"] }
 serde_dynamo = "4"
-serde_json = { version = "1" }
+serde_json = { version = "1", features = ["preserve_order"] }
 serde-wasm-bindgen = "0.6"
 serde_with = "3"
 

--- a/cli/crates/cli/tests/defer/main.rs
+++ b/cli/crates/cli/tests/defer/main.rs
@@ -127,8 +127,8 @@ async fn defer_sse_test() {
           "todoCollection": [
             {
               "__typename": "Todo",
-              "id": "1",
-              "title": "Defer Things"
+              "title": "Defer Things",
+              "id": "1"
             }
           ]
         },
@@ -139,18 +139,18 @@ async fn defer_sse_test() {
           "deferred": [
             {
               "__typename": "Todo",
-              "id": "1",
-              "title": "Defer Things"
+              "title": "Defer Things",
+              "id": "1"
             },
             {
               "__typename": "Todo",
-              "id": "2",
-              "title": "Defer Things"
+              "title": "Defer Things",
+              "id": "2"
             }
           ]
         },
-        "hasNext": false,
-        "path": []
+        "path": [],
+        "hasNext": false
       }
     ]
     "###);

--- a/cli/crates/cli/tests/federation.rs
+++ b/cli/crates/cli/tests/federation.rs
@@ -83,18 +83,18 @@ async fn test_sse_transport() {
       {
         "data": {
           "newProducts": {
+            "upc": "top-4",
             "name": "Jeans",
-            "price": 44,
-            "upc": "top-4"
+            "price": 44
           }
         }
       },
       {
         "data": {
           "newProducts": {
+            "upc": "top-5",
             "name": "Pink Jeans",
-            "price": 55,
-            "upc": "top-5"
+            "price": 55
           }
         }
       }
@@ -150,18 +150,18 @@ async fn test_sse_transport_with_auth() {
       {
         "data": {
           "newProducts": {
+            "upc": "top-4",
             "name": "Jeans",
-            "price": 44,
-            "upc": "top-4"
+            "price": 44
           }
         }
       },
       {
         "data": {
           "newProducts": {
+            "upc": "top-5",
             "name": "Pink Jeans",
-            "price": 55,
-            "upc": "top-5"
+            "price": 55
           }
         }
       }
@@ -264,18 +264,18 @@ async fn test_multipart_transport() {
       {
         "data": {
           "newProducts": {
+            "upc": "top-4",
             "name": "Jeans",
-            "price": 44,
-            "upc": "top-4"
+            "price": 44
           }
         }
       },
       {
         "data": {
           "newProducts": {
+            "upc": "top-5",
             "name": "Pink Jeans",
-            "price": 55,
-            "upc": "top-5"
+            "price": 55
           }
         }
       }
@@ -332,18 +332,18 @@ async fn test_multipart_transport_with_auth() {
       {
         "data": {
           "newProducts": {
+            "upc": "top-4",
             "name": "Jeans",
-            "price": 44,
-            "upc": "top-4"
+            "price": 44
           }
         }
       },
       {
         "data": {
           "newProducts": {
+            "upc": "top-5",
             "name": "Pink Jeans",
-            "price": 55,
-            "upc": "top-5"
+            "price": 55
           }
         }
       }
@@ -448,18 +448,18 @@ async fn test_websocket_transport() {
       {
         "data": {
           "newProducts": {
+            "upc": "top-4",
             "name": "Jeans",
-            "price": 44,
-            "upc": "top-4"
+            "price": 44
           }
         }
       },
       {
         "data": {
           "newProducts": {
+            "upc": "top-5",
             "name": "Pink Jeans",
-            "price": 55,
-            "upc": "top-5"
+            "price": 55
           }
         }
       }
@@ -517,18 +517,18 @@ async fn test_websocket_transport_with_auth() {
       {
         "data": {
           "newProducts": {
+            "upc": "top-4",
             "name": "Jeans",
-            "price": 44,
-            "upc": "top-4"
+            "price": 44
           }
         }
       },
       {
         "data": {
           "newProducts": {
+            "upc": "top-5",
             "name": "Pink Jeans",
-            "price": 55,
-            "upc": "top-5"
+            "price": 55
           }
         }
       }

--- a/cli/crates/cli/tests/openapi/main.rs
+++ b/cli/crates/cli/tests/openapi/main.rs
@@ -105,12 +105,12 @@ async fn openapi_test() {
 
     insta::assert_yaml_snapshot!(mock_guard.received_json_bodies().await, @r###"
     ---
-    - category: {}
-      id: 123
-      name: Doggie
-      photoUrls: []
-      status: available
+    - status: available
       tags: []
+      photoUrls: []
+      category: {}
+      name: Doggie
+      id: 123
     "###);
 }
 

--- a/engine/crates/graphql-schema-diff/tests/diff/add_fields.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/add_fields.snapshot.json
@@ -1,30 +1,30 @@
 {
   "src → target": [
     {
-      "kind": "AddField",
-      "path": "CatInHat.whimsicalQuote"
+      "path": "CatInHat.whimsicalQuote",
+      "kind": "AddField"
     },
     {
-      "kind": "AddField",
-      "path": "CreateSeussCharacterInput.favoriteRhyme"
+      "path": "CreateSeussCharacterInput.favoriteRhyme",
+      "kind": "AddField"
     },
     {
-      "kind": "AddField",
-      "path": "SeussCharacter.whimsicalQuote"
+      "path": "SeussCharacter.whimsicalQuote",
+      "kind": "AddField"
     }
   ],
   "target → src": [
     {
-      "kind": "RemoveField",
-      "path": "CatInHat.whimsicalQuote"
+      "path": "CatInHat.whimsicalQuote",
+      "kind": "RemoveField"
     },
     {
-      "kind": "RemoveField",
-      "path": "CreateSeussCharacterInput.favoriteRhyme"
+      "path": "CreateSeussCharacterInput.favoriteRhyme",
+      "kind": "RemoveField"
     },
     {
-      "kind": "RemoveField",
-      "path": "SeussCharacter.whimsicalQuote"
+      "path": "SeussCharacter.whimsicalQuote",
+      "kind": "RemoveField"
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/add_one_object.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/add_one_object.snapshot.json
@@ -1,18 +1,18 @@
 {
   "src → target": [
     {
-      "kind": "AddObjectType",
-      "path": "Locust"
+      "path": "Locust",
+      "kind": "AddObjectType"
     },
     {
-      "kind": "AddField",
-      "path": "Locust.id"
+      "path": "Locust.id",
+      "kind": "AddField"
     }
   ],
   "target → src": [
     {
-      "kind": "RemoveObjectType",
-      "path": "Locust"
+      "path": "Locust",
+      "kind": "RemoveObjectType"
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/directive_basic.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/directive_basic.snapshot.json
@@ -1,14 +1,14 @@
 {
   "src → target": [
     {
-      "kind": "RemoveDirectiveDefinition",
-      "path": "auth"
+      "path": "auth",
+      "kind": "RemoveDirectiveDefinition"
     }
   ],
   "target → src": [
     {
-      "kind": "AddDirectiveDefinition",
-      "path": "auth"
+      "path": "auth",
+      "kind": "AddDirectiveDefinition"
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/enum_basic.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/enum_basic.snapshot.json
@@ -1,30 +1,30 @@
 {
   "src → target": [
     {
-      "kind": "AddEnumValue",
-      "path": "Color.ALPHA"
+      "path": "Color.ALPHA",
+      "kind": "AddEnumValue"
     },
     {
-      "kind": "RemoveEnum",
-      "path": "People"
+      "path": "People",
+      "kind": "RemoveEnum"
     }
   ],
   "target → src": [
     {
-      "kind": "RemoveEnumValue",
-      "path": "Color.ALPHA"
+      "path": "Color.ALPHA",
+      "kind": "RemoveEnumValue"
     },
     {
-      "kind": "AddEnum",
-      "path": "People"
+      "path": "People",
+      "kind": "AddEnum"
     },
     {
-      "kind": "AddEnumValue",
-      "path": "People.CAT"
+      "path": "People.CAT",
+      "kind": "AddEnumValue"
     },
     {
-      "kind": "AddEnumValue",
-      "path": "People.DOG"
+      "path": "People.DOG",
+      "kind": "AddEnumValue"
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/field_argument_default.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/field_argument_default.snapshot.json
@@ -1,14 +1,14 @@
 {
   "src → target": [
     {
-      "kind": "AddFieldArgumentDefault",
-      "path": "Query.doMop.useMop"
+      "path": "Query.doMop.useMop",
+      "kind": "AddFieldArgumentDefault"
     }
   ],
   "target → src": [
     {
-      "kind": "RemoveFieldArgumentDefault",
-      "path": "Query.doMop.useMop"
+      "path": "Query.doMop.useMop",
+      "kind": "RemoveFieldArgumentDefault"
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/field_argument_default_value.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/field_argument_default_value.snapshot.json
@@ -1,14 +1,14 @@
 {
   "src → target": [
     {
-      "kind": "ChangeFieldArgumentDefault",
-      "path": "Query.doMop.useMop"
+      "path": "Query.doMop.useMop",
+      "kind": "ChangeFieldArgumentDefault"
     }
   ],
   "target → src": [
     {
-      "kind": "ChangeFieldArgumentDefault",
-      "path": "Query.doMop.useMop"
+      "path": "Query.doMop.useMop",
+      "kind": "ChangeFieldArgumentDefault"
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/field_arguments_basic.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/field_arguments_basic.snapshot.json
@@ -1,22 +1,22 @@
 {
   "src → target": [
     {
-      "kind": "RemoveFieldArgument",
-      "path": "MapleSyrup.pricePerLiter.currency"
+      "path": "MapleSyrup.pricePerLiter.currency",
+      "kind": "RemoveFieldArgument"
     },
     {
-      "kind": "AddField",
-      "path": "PriceArgs.currency"
+      "path": "PriceArgs.currency",
+      "kind": "AddField"
     }
   ],
   "target → src": [
     {
-      "kind": "AddFieldArgument",
-      "path": "MapleSyrup.pricePerLiter.currency"
+      "path": "MapleSyrup.pricePerLiter.currency",
+      "kind": "AddFieldArgument"
     },
     {
-      "kind": "RemoveField",
-      "path": "PriceArgs.currency"
+      "path": "PriceArgs.currency",
+      "kind": "RemoveField"
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/field_type_change.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/field_type_change.snapshot.json
@@ -1,22 +1,22 @@
 {
   "src → target": [
     {
-      "kind": "ChangeFieldType",
-      "path": "Mutation.drop"
+      "path": "Mutation.drop",
+      "kind": "ChangeFieldType"
     },
     {
-      "kind": "ChangeFieldArgumentType",
-      "path": "Mutation.drop.coin"
+      "path": "Mutation.drop.coin",
+      "kind": "ChangeFieldArgumentType"
     }
   ],
   "target → src": [
     {
-      "kind": "ChangeFieldType",
-      "path": "Mutation.drop"
+      "path": "Mutation.drop",
+      "kind": "ChangeFieldType"
     },
     {
-      "kind": "ChangeFieldArgumentType",
-      "path": "Mutation.drop.coin"
+      "path": "Mutation.drop.coin",
+      "kind": "ChangeFieldArgumentType"
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/interface_implements_interface.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/interface_implements_interface.snapshot.json
@@ -1,14 +1,14 @@
 {
   "src → target": [
     {
-      "kind": "AddInterfaceImplementation",
-      "path": "Candy.Cookie"
+      "path": "Candy.Cookie",
+      "kind": "AddInterfaceImplementation"
     }
   ],
   "target → src": [
     {
-      "kind": "RemoveInterfaceImplementation",
-      "path": "Candy.Cookie"
+      "path": "Candy.Cookie",
+      "kind": "RemoveInterfaceImplementation"
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/mutation_type_changed.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/mutation_type_changed.snapshot.json
@@ -1,14 +1,14 @@
 {
   "src → target": [
     {
-      "kind": "ChangeMutationType",
-      "path": ""
+      "path": "",
+      "kind": "ChangeMutationType"
     }
   ],
   "target → src": [
     {
-      "kind": "ChangeMutationType",
-      "path": ""
+      "path": "",
+      "kind": "ChangeMutationType"
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/object_becomes_enum.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/object_becomes_enum.snapshot.json
@@ -1,22 +1,22 @@
 {
   "src → target": [
     {
-      "kind": "RemoveObjectType",
-      "path": "Color"
+      "path": "Color",
+      "kind": "RemoveObjectType"
     },
     {
-      "kind": "AddEnum",
-      "path": "Color"
+      "path": "Color",
+      "kind": "AddEnum"
     }
   ],
   "target → src": [
     {
-      "kind": "AddObjectType",
-      "path": "Color"
+      "path": "Color",
+      "kind": "AddObjectType"
     },
     {
-      "kind": "RemoveEnum",
-      "path": "Color"
+      "path": "Color",
+      "kind": "RemoveEnum"
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/object_interface.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/object_interface.snapshot.json
@@ -1,14 +1,14 @@
 {
   "src → target": [
     {
-      "kind": "AddInterfaceImplementation",
-      "path": "Candy.Cookie"
+      "path": "Candy.Cookie",
+      "kind": "AddInterfaceImplementation"
     }
   ],
   "target → src": [
     {
-      "kind": "RemoveInterfaceImplementation",
-      "path": "Candy.Cookie"
+      "path": "Candy.Cookie",
+      "kind": "RemoveInterfaceImplementation"
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/query_type_changed.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/query_type_changed.snapshot.json
@@ -1,14 +1,14 @@
 {
   "src → target": [
     {
-      "kind": "ChangeQueryType",
-      "path": ""
+      "path": "",
+      "kind": "ChangeQueryType"
     }
   ],
   "target → src": [
     {
-      "kind": "ChangeQueryType",
-      "path": ""
+      "path": "",
+      "kind": "ChangeQueryType"
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/schema_definition_basic.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/schema_definition_basic.snapshot.json
@@ -1,14 +1,14 @@
 {
   "src → target": [
     {
-      "kind": "RemoveSchemaDefinition",
-      "path": ""
+      "path": "",
+      "kind": "RemoveSchemaDefinition"
     }
   ],
   "target → src": [
     {
-      "kind": "AddSchemaDefinition",
-      "path": ""
+      "path": "",
+      "kind": "AddSchemaDefinition"
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/subscription_type_changed.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/subscription_type_changed.snapshot.json
@@ -1,22 +1,22 @@
 {
   "src → target": [
     {
-      "kind": "ChangeMutationType",
-      "path": ""
+      "path": "",
+      "kind": "ChangeMutationType"
     },
     {
-      "kind": "ChangeSubscriptionType",
-      "path": ""
+      "path": "",
+      "kind": "ChangeSubscriptionType"
     }
   ],
   "target → src": [
     {
-      "kind": "ChangeMutationType",
-      "path": ""
+      "path": "",
+      "kind": "ChangeMutationType"
     },
     {
-      "kind": "ChangeSubscriptionType",
-      "path": ""
+      "path": "",
+      "kind": "ChangeSubscriptionType"
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/union_basic.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/union_basic.snapshot.json
@@ -1,26 +1,26 @@
 {
   "src → target": [
     {
-      "kind": "RemoveUnion",
-      "path": "Color"
+      "path": "Color",
+      "kind": "RemoveUnion"
     }
   ],
   "target → src": [
     {
-      "kind": "AddUnion",
-      "path": "Color"
+      "path": "Color",
+      "kind": "AddUnion"
     },
     {
-      "kind": "AddUnionMember",
-      "path": "Color.Blue"
+      "path": "Color.Blue",
+      "kind": "AddUnionMember"
     },
     {
-      "kind": "AddUnionMember",
-      "path": "Color.Green"
+      "path": "Color.Green",
+      "kind": "AddUnionMember"
     },
     {
-      "kind": "AddUnionMember",
-      "path": "Color.Red"
+      "path": "Color.Red",
+      "kind": "AddUnionMember"
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/union_members.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/union_members.snapshot.json
@@ -1,14 +1,14 @@
 {
   "src → target": [
     {
-      "kind": "RemoveUnionMember",
-      "path": "FloralProduct.FloralArrangement"
+      "path": "FloralProduct.FloralArrangement",
+      "kind": "RemoveUnionMember"
     }
   ],
   "target → src": [
     {
-      "kind": "AddUnionMember",
-      "path": "FloralProduct.FloralArrangement"
+      "path": "FloralProduct.FloralArrangement",
+      "kind": "AddUnionMember"
     }
   ]
 }

--- a/engine/crates/integration-tests/Cargo.toml
+++ b/engine/crates/integration-tests/Cargo.toml
@@ -31,7 +31,7 @@ names = "0.14"
 openidconnect.workspace = true
 reqwest = "0.11"
 serde.workspace = true
-serde_json = { workspace = true, features = ["preserve_order"] }
+serde_json.workspace = true
 ulid.workspace = true
 url.workspace = true
 wiremock = "0.5"

--- a/engine/crates/parser-openapi/Cargo.toml
+++ b/engine/crates/parser-openapi/Cargo.toml
@@ -41,5 +41,6 @@ parser-sdl = { path = "../parser-sdl" }
 [dev-dependencies]
 assert_matches = "1.5"
 insta = { version = "1", features = ["json"] }
+more-asserts = "0.3"
 rstest = "0.18"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/engine/crates/parser-openapi/src/graph/construction.rs
+++ b/engine/crates/parser-openapi/src/graph/construction.rs
@@ -125,7 +125,7 @@ impl<'a> TypeNode<'a> {
 
     pub fn add_default(self, default: Option<&Value>) -> Self {
         if let Some(default_value) = default {
-            let default_index = self.1.add_node(Node::Default(default_value.clone()));
+            let default_index = self.1.add_node(Node::Default(Box::new(default_value.clone())));
             self.1.add_edge(self.0, default_index, Edge::HasDefault);
         }
         self
@@ -136,9 +136,9 @@ impl<'a> TypeNode<'a> {
         T: serde::Serialize,
     {
         for value in values {
-            let value_index = self.1.add_node(Node::PossibleValue(
+            let value_index = self.1.add_node(Node::PossibleValue(Box::new(
                 serde_json::to_value(value).expect("default valueto be serializable"),
-            ));
+            )));
             self.1.add_edge(self.0, value_index, Edge::HasPossibleValue);
         }
         self

--- a/engine/crates/parser-openapi/src/graph/input_value.rs
+++ b/engine/crates/parser-openapi/src/graph/input_value.rs
@@ -108,7 +108,7 @@ impl InputValue {
                 Node::Default(value) => Some(value.clone()),
                 _ => None,
             })
-            .and_then(|value| self.transform_default(value, graph))
+            .and_then(|value| self.transform_default(*value, graph))
     }
 
     /// We get a serde_json::Value default value from OpenAPI, which is nice because it's almost

--- a/engine/crates/parser-openapi/src/graph/mod.rs
+++ b/engine/crates/parser-openapi/src/graph/mod.rs
@@ -9,7 +9,6 @@ use petgraph::{
     Graph,
 };
 use regex::Regex;
-use serde_json::Value;
 
 mod enums;
 mod input_object;
@@ -140,10 +139,10 @@ pub enum Node {
     Enum,
 
     // The default value for a type node, linked via a HasDefault edge
-    Default(Value),
+    Default(Box<serde_json::Value>),
 
     // A possible value for a given scalar/enum
-    PossibleValue(Value),
+    PossibleValue(Box<serde_json::Value>),
 
     /// An OpenAPI allOf schema.
     ///

--- a/engine/crates/parser-openapi/src/graph/mod.rs
+++ b/engine/crates/parser-openapi/src/graph/mod.rs
@@ -594,7 +594,7 @@ mod tests {
     fn test_graph_size() {
         // Our graph can end up with a ton of nodes & edges so it's important
         // that they don't get too big.
-        assert!(std::mem::size_of::<Node>() <= 48);
-        assert!(std::mem::size_of::<Edge>() <= 48);
+        more_asserts::assert_le!(std::mem::size_of::<Node>(), 48);
+        more_asserts::assert_le!(std::mem::size_of::<Edge>(), 48);
     }
 }

--- a/engine/crates/parser-openapi/src/graph/output_type.rs
+++ b/engine/crates/parser-openapi/src/graph/output_type.rs
@@ -216,7 +216,7 @@ impl OutputFieldType {
             .graph
             .neighbors(self.target_index)
             .filter_map(|index| match &graph.graph[index] {
-                Node::PossibleValue(value) => Some(value),
+                Node::PossibleValue(value) => Some(&**value),
                 _ => None,
             })
             .collect()


### PR DESCRIPTION
# Description

This will help avoid map ordering issues relative to what directory the tests are ran from.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [X] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
