### PR TITLE
fix: graphql-ws connection_ack payload shouldn't be null

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,6 +2314,7 @@ dependencies = [
  "http 1.0.0",
  "log 0.1.0",
  "runtime",
+ "serde",
  "serde_json",
 ]
 

--- a/cli/crates/federated-dev/src/dev/websockets/axum.rs
+++ b/cli/crates/federated-dev/src/dev/websockets/axum.rs
@@ -110,15 +110,19 @@ where
     }
 }
 
-impl TryFrom<super::messages::Message> for ws::Message {
-    type Error = serde_json::Error;
+pub trait MessageConvert {
+    fn to_axum_message(self) -> Result<ws::Message, serde_json::Error>;
+}
 
-    fn try_from(message: super::messages::Message) -> Result<Self, Self::Error> {
-        match message {
-            super::messages::Message::Close { code, reason } => Ok(ws::Message::Close(Some(ws::CloseFrame {
-                code,
-                reason: reason.into(),
-            }))),
+impl MessageConvert for gateway_v2::websockets::messages::Message {
+    fn to_axum_message(self) -> Result<ws::Message, serde_json::Error> {
+        match self {
+            gateway_v2::websockets::messages::Message::Close { code, reason } => {
+                Ok(ws::Message::Close(Some(ws::CloseFrame {
+                    code,
+                    reason: reason.into(),
+                })))
+            }
             message => Ok(ws::Message::Text(serde_json::to_string(&message)?)),
         }
     }

--- a/engine/crates/gateway-v2/Cargo.toml
+++ b/engine/crates/gateway-v2/Cargo.toml
@@ -20,6 +20,7 @@ gateway-core.workspace = true
 http.workspace = true
 log.workspace = true
 runtime.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 headers.workspace = true
 

--- a/engine/crates/gateway-v2/src/lib.rs
+++ b/engine/crates/gateway-v2/src/lib.rs
@@ -13,6 +13,7 @@ use headers::HeaderMapExt;
 use runtime::cache::{CacheReadStatus, CachedExecutionResponse};
 
 pub mod streaming;
+pub mod websockets;
 
 pub struct Gateway {
     engine: Arc<Engine>,

--- a/engine/crates/gateway-v2/src/websockets/messages.rs
+++ b/engine/crates/gateway-v2/src/websockets/messages.rs
@@ -47,6 +47,7 @@ pub enum Message {
         id: String,
     },
     ConnectionAck {
+        #[serde(skip_serializing_if = "Option::is_none")]
         payload: Option<serde_json::Value>,
     },
     Ping {

--- a/engine/crates/gateway-v2/src/websockets/mod.rs
+++ b/engine/crates/gateway-v2/src/websockets/mod.rs
@@ -1,0 +1,1 @@
+pub mod messages;


### PR DESCRIPTION
Apollo explorer whinges about this if you give it a null, so updated to omit if null.

Also moved the definition into `gateway-v2` so I can share this with the `api` repo.