### PR TITLE
nix: fix cli build

### DIFF
--- a/cli/nix/cli.nix
+++ b/cli/nix/cli.nix
@@ -34,6 +34,7 @@ let
     yarn.lock
 
     !/engine/crates/validation/README.md
+    !/engine/crates/graphql-schema-diff/README.md
     !/packages/grafbase-sdk/package.json
   '';
 


### PR DESCRIPTION
We can't ignore some md files because they are required to build the corresponding crate.
