### PR TITLE
fix: send headers in subscription init payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,8 +420,11 @@ dependencies = [
  "futures-util",
  "log 0.4.20",
  "pin-project-lite",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls 0.25.0",
  "tungstenite",
+ "webpki-roots 0.26.0",
 ]
 
 [[package]]
@@ -5243,7 +5246,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.3",
  "winreg",
 ]
 
@@ -7035,6 +7038,8 @@ dependencies = [
  "httparse",
  "log 0.4.20",
  "rand 0.8.5",
+ "rustls 0.22.2",
+ "rustls-pki-types",
  "sha1",
  "thiserror",
  "url",
@@ -7436,6 +7441,15 @@ name = "webpki-roots"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2cfda980f21be5a7ed2eadb3e6fe074d56022bea2cdeb1a62eb220fc04188"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "which"

--- a/cli/crates/federated-dev/Cargo.toml
+++ b/cli/crates/federated-dev/Cargo.toml
@@ -31,8 +31,8 @@ thiserror = "1.0.56"
 tokio = { workspace = true, features = ["sync", "rt", "io-std", "time"] }
 tokio-stream = "0.1"
 tower-http = { workspace = true, features = ["cors", "fs", "trace"] }
-ulid.workspace = true
 tower-service.workspace = true
+ulid.workspace = true
 url = "2.5.0"
 
 common = { package = "grafbase-local-common", path = "../common", version = "0.53.0" }

--- a/cli/crates/federated-dev/src/dev.rs
+++ b/cli/crates/federated-dev/src/dev.rs
@@ -166,6 +166,7 @@ async fn handle_engine_request(
     gateway: GatewayWatcher,
     headers: HeaderMap,
 ) -> impl IntoResponse {
+    log::debug!("engine request received");
     let Some(gateway) = gateway.borrow().clone() else {
         return Json(json!({
             "errors": [{"message": "there are no subgraphs registered currently"}]

--- a/engine/crates/runtime-local/Cargo.toml
+++ b/engine/crates/runtime-local/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 [dependencies]
 async-runtime.workspace = true
 async-trait = "0.1"
-async-tungstenite = { version = "0.24.0", features = ["tokio-runtime"] }
+async-tungstenite = { version = "0.24.0", features = ["tokio-runtime", "tokio-rustls-webpki-roots"] }
 futures-util.workspace = true
 graphql-ws-client = "0.7"
 tokio.workspace = true

--- a/engine/crates/runtime-local/src/fetch.rs
+++ b/engine/crates/runtime-local/src/fetch.rs
@@ -1,8 +1,11 @@
 mod websockets;
 
+use std::collections::HashMap;
+
 use futures_util::stream::BoxStream;
 use reqwest::header::HeaderValue;
 use runtime::fetch::{FetchError, FetchRequest, FetchResponse, FetchResult, Fetcher, FetcherInner, GraphqlRequest};
+use serde_json::json;
 
 use self::websockets::{EngineGraphqlClient, StreamingRequest, TokioSpawner};
 
@@ -51,6 +54,7 @@ impl FetcherInner for NativeFetcher {
         use futures_util::StreamExt;
 
         let mut client = {
+            let init_headers = request.headers.iter().copied().collect::<HashMap<_, _>>();
             let mut request = request.url.into_client_request().unwrap();
             request.headers_mut().insert(
                 "Sec-WebSocket-Protocol",
@@ -62,6 +66,7 @@ impl FetcherInner for NativeFetcher {
             let (sink, stream) = connection.split();
 
             graphql_ws_client::AsyncWebsocketClientBuilder::<EngineGraphqlClient>::new()
+                .payload(json!({"headers": init_headers}))
                 .build(stream, sink, TokioSpawner::current())
                 .await
                 .map_err(FetchError::any)?


### PR DESCRIPTION
I've been tesitng things with hasura, which requires auth - but was getting a
lot of "forbidden" errors.  After far too much digging, turns out this is
because I forgot to pass headers in the `connection_init` payload.

Also enabled TLS in `async_tungstenite` since it turns out to not be 
enabled by default.

Fixes GB-5879