### PR TITLE
cli: add GraphQL syntax highlighting in introspect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2515,6 +2515,7 @@ dependencies = [
  "serde_json",
  "slugify",
  "strum 0.26.1",
+ "syntect",
  "sysinfo",
  "tempfile",
  "thiserror",
@@ -3661,6 +3662,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-wrap"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
+dependencies = [
+ "safemem",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4140,6 +4150,28 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "onig"
+version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "oorandom"
@@ -4684,6 +4716,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 
 [[package]]
+name = "plist"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5699cc8a63d1aa2b1ee8e12b9ad70ac790d65788cd36101fa37f87ea46c4cef"
+dependencies = [
+ "base64 0.21.7",
+ "indexmap 2.2.1",
+ "line-wrap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "plotters"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4909,6 +4955,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5117,6 +5172,12 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -5541,6 +5602,12 @@ name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+
+[[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
@@ -6431,6 +6498,27 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "unicode-xid",
+]
+
+[[package]]
+name = "syntect"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02b4b303bf8d08bfeb0445cba5068a3d306b6baece1d5582171a9bf49188f91"
+dependencies = [
+ "bincode",
+ "bitflags 1.3.2",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "onig",
+ "plist",
+ "regex-syntax 0.7.5",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "walkdir",
+ "yaml-rust",
 ]
 
 [[package]]

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -31,6 +31,7 @@ serde_derive = "1"
 serde_json.workspace = true
 slugify = "0.1.0"
 strum = { version = "0.26", features = ["derive"] }
+syntect = "5"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/cli/crates/cli/src/cli_input/introspect.rs
+++ b/cli/crates/cli/src/cli_input/introspect.rs
@@ -8,6 +8,9 @@ pub struct IntrospectCommand {
     /// Pass this argument to introspect the local project. --url and --dev cannot be used together
     #[clap(long)]
     pub(crate) dev: bool,
+    /// Disable syntax highlighting of the introspected GraphQL
+    #[clap(long)]
+    pub(crate) no_color: bool,
 }
 
 impl IntrospectCommand {

--- a/cli/crates/cli/src/introspect.rs
+++ b/cli/crates/cli/src/introspect.rs
@@ -5,9 +5,9 @@ pub(crate) fn introspect(command: &IntrospectCommand) -> Result<(), CliError> {
     match (command.url(), command.dev) {
         (Some(url), _) => {
             let headers = command.headers().collect::<Vec<_>>();
-            introspect_remote(url, &headers)
+            introspect_remote(url, &headers, command.no_color)
         }
-        (None, true) => introspect_local(),
+        (None, true) => introspect_local(command.no_color),
         (None, false) => {
             eprintln!("Error: Either the --url or the --dev argument must be provided.");
             std::process::exit(1);
@@ -15,10 +15,10 @@ pub(crate) fn introspect(command: &IntrospectCommand) -> Result<(), CliError> {
     }
 }
 
-fn introspect_local() -> Result<(), CliError> {
+fn introspect_local(no_color: bool) -> Result<(), CliError> {
     match server::introspect_local().map_err(CliError::ServerError)? {
         server::IntrospectLocalOutput::Sdl(schema) => {
-            println!("{schema}");
+            print_introspected_schema(&schema, no_color);
         }
         server::IntrospectLocalOutput::EmptyFederated => {
             report::federated_schema_local_introspection_not_implemented();
@@ -28,11 +28,55 @@ fn introspect_local() -> Result<(), CliError> {
     Ok(())
 }
 
-fn introspect_remote(url: &str, headers: &[(&str, &str)]) -> Result<(), CliError> {
+fn introspect_remote(url: &str, headers: &[(&str, &str)], no_color: bool) -> Result<(), CliError> {
     let operation = graphql_introspection::introspect(url, headers);
 
     match Runtime::new().unwrap().block_on(operation) {
-        Ok(result) => Ok(println!("{result}")),
+        Ok(result) => {
+            print_introspected_schema(&result, no_color);
+            Ok(())
+        }
         Err(e) => Err(CliError::Introspection(e)),
     }
+}
+
+fn print_introspected_schema(sdl: &str, no_color: bool) {
+    use syntect::util::{as_24_bit_terminal_escaped, LinesWithEndings};
+
+    // No highlighting when stdout is not a tty (likely a pipe) or when explicitly requested.
+    if no_color || !atty::is(atty::Stream::Stdout) || no_color_env_var() {
+        println!("{sdl}");
+        return;
+    }
+
+    const GRAMMAR: &str = include_str!("introspect/graphql_grammar.yml");
+
+    let mut builder = syntect::parsing::SyntaxSetBuilder::new();
+    builder.add(
+        syntect::parsing::SyntaxDefinition::load_from_str(GRAMMAR, false, Some("graphql"))
+            .expect("Loading the bundled grammar"),
+    );
+    let syntax_set = builder.build();
+
+    let graphql = syntax_set
+        .find_syntax_by_extension("graphql")
+        .expect("graphql syntax to be bundled");
+    let theme_set = syntect::highlighting::ThemeSet::load_defaults();
+    let theme = &theme_set.themes["Solarized (dark)"];
+
+    let mut highlighter = syntect::easy::HighlightLines::new(graphql, theme);
+
+    for line in LinesWithEndings::from(sdl) {
+        let ranges = highlighter
+            .highlight_line(line, &syntax_set)
+            .expect("line to be highlightable");
+
+        let escaped = as_24_bit_terminal_escaped(&ranges[..], false);
+        print!("{}", escaped);
+    }
+}
+
+/// https://no-color.org/
+fn no_color_env_var() -> bool {
+    std::env::var("NO_COLOR").is_ok_and(|value| !value.is_empty())
 }

--- a/cli/crates/cli/src/introspect/graphql_grammar.yml
+++ b/cli/crates/cli/src/introspect/graphql_grammar.yml
@@ -1,0 +1,597 @@
+%YAML 1.2
+---
+# Taken from https://github.com/dncrews/GraphQL-SublimeText3/tree/9b6f6d0a86d7e7ef1d44490b107472af7fb4ffaf
+
+# See http://www.sublimetext.com/docs/3/syntax.html
+name: GraphQL
+file_extensions:
+  - graphql
+  - graphqls
+  - gql
+scope: source.graphql
+variables:
+  name_begin: (?:[_A-Za-z])
+  name_continue: (?:[_0-9A-Za-z])
+  name_break: (?!{{name_continue}})
+  name: (?:{{name_begin}}{{name_continue}}*{{name_break}})
+
+  integer_part: (?:-?(?:0|[1-9]\d*))
+  fractional_part: (?:\.\d*)
+  exponent_part: (?:[Ee][-+]?\d*)
+contexts:
+  else-pop:
+    - match: (?=\S)
+      pop: true
+
+  immediately-pop:
+    - match: ''
+      pop: true
+
+  prototype:
+    - match: '#'
+      scope: punctuation.definition.comment.graphql
+      push:
+        - meta_scope: comment.line.graphql
+        - match: $
+          pop: true
+    - match: ','
+      scope: punctuation.separator.sequence.graphql
+
+  main:
+    - match: (?=")
+      push: description
+
+    - include: executable-declaration
+    - include: type-declarations
+
+    - match: directive{{name_break}}
+      scope: keyword.declaration.directive.graphql
+      push:
+        - - match: on{{name_break}}
+            scope: keyword.declaration.directive.graphql
+            set:
+              - - match: '\|'
+                  scope: keyword.operator.graphql
+                  push: directive-location
+                - include: else-pop
+              - directive-location
+          - include: else-pop
+        - arguments-definition
+        - directive-definition-name
+
+  executable-declaration:
+    - match: query{{name_break}}
+      scope: keyword.declaration.query.graphql
+      push:
+        - selection-set
+        - directives
+        - variable-definitions
+        - query-name
+
+    - match: (?=\{)
+      push: selection-set
+
+    - match: mutation{{name_break}}
+      scope: keyword.declaration.mutation.graphql
+      push:
+        - selection-set
+        - directives
+        - variable-definitions
+        - mutation-name
+
+    - match: subscription{{name_break}}
+      scope: keyword.declaration.subscription.graphql
+      push:
+        - selection-set
+        - directives
+        - variable-definitions
+        - subscription-name
+
+    - match: fragment{{name_break}}
+      scope: keyword.declaration.fragment.graphql
+      push:
+        - selection-set
+        - directives
+        - type-condition
+        - fragment-name
+
+  type-declarations:
+    - match: schema{{name_break}}
+      scope: keyword.declaration.schema.graphql
+      push:
+        - schema-definition
+        - directives
+
+    - match: scalar{{name_break}}
+      scope: keyword.declaration.scalar.graphql
+      push:
+        - directives
+        - scalar-name
+
+    - match: type{{name_break}}
+      scope: keyword.declaration.type.graphql
+      push:
+        - type-definition
+        - directives
+        - implements
+        - type-name
+
+    - match: interface{{name_break}}
+      scope: keyword.declaration.type.interface.graphql
+      push:
+        - type-definition
+        - directives
+        - implements
+        - interface-name
+
+    - match: union{{name_break}}
+      scope: keyword.declaration.type.interface.graphql
+      push:
+        - - match: '='
+            scope: punctuation.separator.key-value.graphql
+            set:
+              - - match: '\|'
+                  scope: keyword.operator.graphql
+                  push: type-named
+                - include: else-pop
+              - - include: type-named
+                - include: else-pop
+          - include: else-pop
+        - directives
+        - union-name
+
+    - match: enum{{name_break}}
+      scope: keyword.declaration.type.enum.graphql
+      push:
+        - enum-definition
+        - directives
+        - enum-name
+
+    - match: input{{name_break}}
+      scope: keyword.declaration.type.input.graphql
+      push:
+        - input-definition
+        - directives
+        - input-name
+
+  description:
+    - match: '"""'
+      scope: string.quoted.multiline.begin.graphql
+      set:
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.multiline.graphql
+        - match: '\\"""'
+          scope: constant.character.escape.graphql
+        - match: '"""'
+          scope: string.quoted.multiline.end.graphql
+          pop: true
+
+    - match: '"'
+      scope: string.quoted.double.begin.graphql
+      set:
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.double.graphql
+        - match: '"'
+          scope: string.quoted.double.end.graphql
+          pop: true
+
+        - match: '\\u\h{4}'
+          scope: constant.character.escape.hex.graphql
+        - match: '\\u\h{,3}'
+          scope: invalid.illegal.escape.hex.graphql
+
+        - match: '\\["\\/bfnrt]'
+          scope: constant.character.escape.graphql
+        - match: '\\.'
+          scope: invalid.illegal.escape.graphql
+
+  query-name:
+    - match: '{{name}}'
+      scope: entity.name.query.graphql
+      pop: true
+    - include: else-pop
+
+  mutation-name:
+    - match: '{{name}}'
+      scope: entity.name.mutation.graphql
+      pop: true
+    - include: else-pop
+
+  subscription-name:
+    - match: '{{name}}'
+      scope: entity.name.subscription.graphql
+      pop: true
+    - include: else-pop
+
+  fragment-name:
+    - match: (?=on{{name_break}})
+      pop: true
+    - match: '{{name}}'
+      scope: entity.name.fragment.graphql
+      pop: true
+    - include: else-pop
+
+  scalar-name:
+    - match: '{{name}}'
+      scope: entity.name.type.scalar.graphql
+      pop: true
+    - include: else-pop
+
+  type-name:
+    - match: '{{name}}'
+      scope: entity.name.type.object.graphql
+      pop: true
+    - include: else-pop
+
+  interface-name:
+    - match: '{{name}}'
+      scope: entity.name.type.interface.graphql
+      pop: true
+    - include: else-pop
+
+  union-name:
+    - match: '{{name}}'
+      scope: entity.name.type.union.graphql
+      pop: true
+    - include: else-pop
+
+  enum-name:
+    - match: '{{name}}'
+      scope: entity.name.type.enum.graphql
+      pop: true
+    - include: else-pop
+
+  input-name:
+    - match: '{{name}}'
+      scope: entity.name.type.input.graphql
+      pop: true
+    - include: else-pop
+
+  directive-definition-name:
+    - match: '(@)({{name}})'
+      captures:
+        1: punctuation.definition.annotation.graphql
+        2: entity.name.definition.graphql
+      pop: true
+    - include: else-pop
+
+  type-condition:
+    - match: on{{name_break}}
+      scope: keyword.other.graphql
+      set: type-named
+    - include: else-pop
+
+  default-value:
+    - match: '='
+      scope: punctuation.separator.key-value.graphql
+      set: value
+    - include: else-pop
+
+  variable-definitions:
+    - match: \(
+      scope: punctuation.section.group.begin.graphql
+      set:
+      - match: \)
+        scope: punctuation.section.group.end.graphql
+        pop: true
+      - match: '(\$)({{name}})'
+        captures:
+          1: punctuation.definition.variable.graphql
+          2: variable.parameter.graphql
+        push:
+          - - include: default-value
+          - - match: ':'
+              scope: punctuation.separator.type.graphql
+              set: type
+            - include: else-pop
+    - include: else-pop
+
+  directives:
+    - match: '@'
+      scope: punctuation.definition.annotation.graphql
+      push:
+        - arguments
+        - directive-name
+
+    - include: else-pop
+
+  directive-name:
+    - match: (?:skip|include|deprecated){{name_break}}
+      scope: variable.function.annotation.graphql support.function.graphql
+      pop: true
+    - match: '{{name}}'
+      scope: variable.function.annotation.graphql
+      pop: true
+    - include: else-pop
+
+  selection-set:
+    - match: \{
+      scope: punctuation.section.block.begin.graphql
+      set:
+        - meta_scope: meta.block.graphql
+        - match: \}
+          scope: punctuation.section.block.end.graphql
+          pop: true
+        - match: '{{name}}'
+          scope: entity.name.field.graphql
+          push:
+            - selection-set
+            - directives
+            - field-arguments
+            - aliased-field-name
+    - include: else-pop
+
+  aliased-field-name:
+    - match: ':'
+      scope: punctuation.separator.key-value.graphql
+      set:
+      - match: '{{name}}'
+        scope: variable.parameter.graphql
+        pop: true
+      - include: else-pop
+    - include: else-pop
+
+  field-arguments:
+    - match: \(
+      scope: punctuation.section.group.begin.graphql
+      set:
+      - match: \)
+        scope: punctuation.section.group.end.graphql
+        pop: true
+      - match: '{{name}}'
+        scope: variable.parameter.graphql
+        push:
+          - - match: ':'
+              scope: punctuation.separator.type.graphql
+              set: value
+            - include: else-pop
+    - include: else-pop
+
+  schema-definition:
+    - match: \{
+      scope: punctuation.section.block.begin.graphql
+      set:
+        - meta_scope: meta.block.graphql
+        - match: \}
+          scope: punctuation.section.block.end.graphql
+          pop: true
+        - match: '(?:query|mutation|subscription)'
+          scope: keyword.other.graphql
+          push:
+            - match: ':'
+              scope: punctuation.separator.key-value.graphql
+              set: type-named
+            - include: else-pop
+    - include: else-pop
+
+  implements:
+    - match: implements{{name_break}}
+      scope: keyword.declaration.implements.graphql
+      set:
+        - - match: '&'
+            scope: keyword.operator.graphql
+            push: type-named
+          - include: else-pop
+        - - include: type-named
+          - include: else-pop
+    - include: else-pop
+
+  type-definition:
+    - match: \{
+      scope: punctuation.section.block.begin.graphql
+      set:
+        - meta_scope: meta.block.graphql
+        - match: \}
+          scope: punctuation.section.block.end.graphql
+          pop: true
+        - match: (?=")
+          push: description
+        - match: '{{name}}'
+          scope: entity.name.field.graphql
+          push:
+            - - match: ':'
+                scope: punctuation.separator.key-value.graphql
+                set:
+                  - directives
+                  - type
+              - include: else-pop
+            - arguments-definition
+    - include: else-pop
+
+  enum-definition:
+    - match: \{
+      scope: punctuation.section.block.begin.graphql
+      set:
+        - meta_scope: meta.block.graphql
+        - match: \}
+          scope: punctuation.section.block.end.graphql
+          pop: true
+        - match: (?=")
+          push: description
+        - match: '{{name}}'
+          scope: entity.name.constant.graphql
+          push: directives
+    - include: else-pop
+
+  input-definition:
+    - match: \{
+      scope: punctuation.section.block.begin.graphql
+      set:
+        - meta_scope: meta.block.graphql
+        - match: \}
+          scope: punctuation.section.block.end.graphql
+          pop: true
+        - include: input-value-definition
+    - include: else-pop
+
+  arguments-definition:
+    - match: \(
+      scope: punctuation.section.group.begin.graphql
+      set:
+        - match: \)
+          scope: punctuation.section.group.end.graphql
+          pop: true
+        - include: input-value-definition
+    - include: else-pop
+
+  input-value-definition:
+    - match: (?=")
+      push: description
+    - match: '{{name}}'
+      scope: variable.parameter.graphql
+      push:
+        - match: ':'
+          scope: punctuation.separator.key-value
+          set:
+            - directives
+            - default-value
+            - type
+        - include: else-pop
+
+  type:
+    - meta_include_prototype: false
+    - match: ''
+      set:
+        - type-non-null
+        - type-value
+
+  type-value:
+    - include: type-named
+    - match: \[
+      scope: storage.modifier.list.graphql
+      set:
+        - - match: \]
+            scope: storage.modifier.list.graphql
+            pop: true
+          - include: else-pop
+        - type
+    - include: else-pop
+
+  type-named:
+    - match: (?:Int|Float|String|Boolean|ID){{name_break}}
+      scope: variable.type.graphql support.type.graphql
+      pop: true
+    - match: '{{name}}'
+      scope: variable.type.graphql
+      pop: true
+
+  type-non-null:
+    - match: '!'
+      scope: storage.modifier.required.graphql
+      pop: true
+    - include: else-pop
+
+  directive-location:
+    - match: |
+        (?x)(?:
+          QUERY|MUTATION|SUBSCRIPTION|FIELD|FRAGMENT_DEFINITION|FRAGMENT_SPREAD|INLINE_FRAGMENT
+          |SCHEMA|SCALAR|OBJECT|FIELD_DEFINITION|ARGUMENT_DEFINITION|INTERFACE|UNION|ENUM|ENUM_VALUE|INPUT_OBJECT|INPUT_FIELD_DEFINITION
+        ){{name_break}}
+      scope: constant.language.graphql
+      pop: true
+    - include: else-pop
+
+  arguments:
+    - match: \(
+      scope: punctuation.section.group.begin.graphql
+      set:
+      - match: \)
+        scope: punctuation.section.group.end.graphql
+        pop: true
+      - match: '{{name}}'
+        scope: variable.parameter.graphql
+        push:
+          - match: ':'
+            scope: punctuation.separator.key-value.graphql
+            set: value
+          - include: else-pop
+      - include: else-pop
+    - include: else-pop
+
+  value:
+    - match: \$
+      scope: punctuation.definition.variable.graphql
+      set:
+        - match: '{{name}}'
+          scope: variable.other.graphql
+          pop: true
+        - include: ''
+          pop: true
+
+    - match: '{{integer_part}}(?:{{fractional_part}}{{exponent_part}}?|{{exponent_part}}){{name_break}}'
+      scope: constant.numeric.float.graphql
+      pop: true
+    - match: '{{integer_part}}{{name_break}}'
+      scope: constant.numeric.integer.graphql
+      pop: true
+
+    - match: null{{name_break}}
+      scope: constant.language.null.graphql
+      pop: true
+    - match: true{{name_break}}
+      scope: constant.language.boolean.true.graphql
+      pop: true
+    - match: false{{name_break}}
+      scope: constant.language.boolean.false.graphql
+      pop: true
+
+    - match: '{{name}}'
+      scope: constant.other.graphql
+      pop: true
+
+    - match: '"""'
+      scope: punctuation.definition.string.begin.graphql
+      set:
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.triple.graphql
+        - match: '\\"""'
+          scope: constant.character.escape.graphql
+        - match: '"""'
+          scope: punctuation.definition.string.end.graphql
+          pop: true
+
+    - match: '"'
+      scope: punctuation.definition.string.begin.graphql
+      set:
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.double.graphql
+        - match: '"'
+          scope: punctuation.definition.string.end.graphql
+          pop: true
+
+        - match: '\\u\h{4}'
+          scope: constant.character.escape.hex.graphql
+        - match: '\\u\h{,3}'
+          scope: invalid.illegal.escape.hex.graphql
+
+        - match: '\\["\\/bfnrt]'
+          scope: constant.character.escape.graphql
+        - match: '\\.'
+          scope: invalid.illegal.escape.graphql
+
+    - match: \[
+      scope: punctuation.section.sequence.begin.graphql
+      set:
+        - meta_scope: meta.sequence.graphql
+        - match: \]
+          scope: punctuation.section.sequence.end.graphql
+          pop: true
+        - match: (?=\S)
+          push: value
+
+    - match: \{
+      scope: punctuation.section.mapping.begin.graphql
+      set:
+        - meta_scope: meta.mapping.graphql
+        - match: \}
+          scope: punctuation.section.mapping.end.graphql
+          pop: true
+        - match: '{{name}}'
+          scope: meta.mapping.key.graphql
+          push:
+            - match: ':'
+              scope: punctuation.separator.key-value.graphql
+              set: value
+            - include: else-pop
+
+    - include: else-pop


### PR DESCRIPTION
- Implemented using [syntect](https://crates.io/crates/syntect).
- Only for `grafbase introspect` at first.
- Comes with a `--no-color` flag to disable.
- Takes into account the [`NO_COLOR` standard](https://no-color.org/)
- Does not add ansi colors when used in pipes
- Adds nearly exactly 1MB to the release binaries
- Uses the solarized dark theme because that's the only builtin dark theme that works well on my light background terminal. We could look into [bat's themes](https://github.com/sharkdp/bat/tree/master/assets/themes) or make our own for alternative options

closes GB-5888