### PR TITLE
cli: release 0.55.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "engine-config-builder"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "engine-v2-config",
  "graphql-federated-graph",
@@ -2030,7 +2030,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "federated-dev"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "assert_matches",
  "async-graphql",
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-graphql-introspection"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "apollo-encoder",
  "apollo-parser",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "async-compression",
  "axum",
@@ -2575,7 +2575,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "chrono",
  "common-types",
@@ -2592,7 +2592,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -4243,7 +4243,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "operation-checks"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "async-graphql-parser",
  "async-graphql-value",
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "operation-normalizer"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -7056,7 +7056,7 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typed-resolvers"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "datatest-stable",
  "engine-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tar = { git = "https://github.com/grafbase/tar-rs.git", rev = "a889df5bd9fec44fa
 ulid = { git = "https://github.com/grafbase/ulid-rs", rev = "05499bd1609f9ac4dd5f39e0bbf70da529179aed" } # web-time-wasm32-unknown-unknown
 
 [workspace.package]
-version = "0.54.1"
+version = "0.55.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://grafbase.com"

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.55.0] - 2024-02-01
+
+[CHANGELOG](changelog/0.55.0.md)
+
 ## [0.54.1] - 2024-01-29
 
 [CHANGELOG](changelog/0.54.1.md)

--- a/cli/changelog/0.55.0.md
+++ b/cli/changelog/0.55.0.md
@@ -1,0 +1,3 @@
+## Features
+
+- The `grafbase introspect` command now highlights the introspected GraphQL when used in an interactive terminal. This can be disabled through the NO_COLOR env var or the new `--no-color` parameter. (#1303)

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -37,8 +37,8 @@ url = "2"
 urlencoding = "2"
 walkdir = "2"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.54.1" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.54.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.55.0" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.55.0" }
 
 [build-dependencies]
 cynic-codegen = { version = "3", features = ["rkyv"] }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -43,11 +43,11 @@ lru = "0.12"
 futures-util = "0.3"
 
 atty = "0.2"
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.54.1" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.54.1" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.55.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.55.0" }
 federated-dev = { path = "../federated-dev" }
 graphql-introspection = { package = "grafbase-graphql-introspection", path = "../graphql-introspection" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.54.1" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.55.0" }
 
 [dev-dependencies]
 async-graphql-axum.workspace = true

--- a/cli/crates/cli/src/introspect/graphql_grammar.yml
+++ b/cli/crates/cli/src/introspect/graphql_grammar.yml
@@ -271,19 +271,19 @@ contexts:
     - match: \(
       scope: punctuation.section.group.begin.graphql
       set:
-      - match: \)
-        scope: punctuation.section.group.end.graphql
-        pop: true
-      - match: '(\$)({{name}})'
-        captures:
-          1: punctuation.definition.variable.graphql
-          2: variable.parameter.graphql
-        push:
-          - - include: default-value
-          - - match: ':'
-              scope: punctuation.separator.type.graphql
-              set: type
-            - include: else-pop
+        - match: \)
+          scope: punctuation.section.group.end.graphql
+          pop: true
+        - match: '(\$)({{name}})'
+          captures:
+            1: punctuation.definition.variable.graphql
+            2: variable.parameter.graphql
+          push:
+            - - include: default-value
+            - - match: ':'
+                scope: punctuation.separator.type.graphql
+                set: type
+              - include: else-pop
     - include: else-pop
 
   directives:
@@ -325,26 +325,26 @@ contexts:
     - match: ':'
       scope: punctuation.separator.key-value.graphql
       set:
-      - match: '{{name}}'
-        scope: variable.parameter.graphql
-        pop: true
-      - include: else-pop
+        - match: '{{name}}'
+          scope: variable.parameter.graphql
+          pop: true
+        - include: else-pop
     - include: else-pop
 
   field-arguments:
     - match: \(
       scope: punctuation.section.group.begin.graphql
       set:
-      - match: \)
-        scope: punctuation.section.group.end.graphql
-        pop: true
-      - match: '{{name}}'
-        scope: variable.parameter.graphql
-        push:
-          - - match: ':'
-              scope: punctuation.separator.type.graphql
-              set: value
-            - include: else-pop
+        - match: \)
+          scope: punctuation.section.group.end.graphql
+          pop: true
+        - match: '{{name}}'
+          scope: variable.parameter.graphql
+          push:
+            - - match: ':'
+                scope: punctuation.separator.type.graphql
+                set: value
+              - include: else-pop
     - include: else-pop
 
   schema-definition:
@@ -495,17 +495,17 @@ contexts:
     - match: \(
       scope: punctuation.section.group.begin.graphql
       set:
-      - match: \)
-        scope: punctuation.section.group.end.graphql
-        pop: true
-      - match: '{{name}}'
-        scope: variable.parameter.graphql
-        push:
-          - match: ':'
-            scope: punctuation.separator.key-value.graphql
-            set: value
-          - include: else-pop
-      - include: else-pop
+        - match: \)
+          scope: punctuation.section.group.end.graphql
+          pop: true
+        - match: '{{name}}'
+          scope: variable.parameter.graphql
+          push:
+            - match: ':'
+              scope: punctuation.separator.key-value.graphql
+              set: value
+            - include: else-pop
+        - include: else-pop
     - include: else-pop
 
   value:

--- a/cli/crates/federated-dev/Cargo.toml
+++ b/cli/crates/federated-dev/Cargo.toml
@@ -35,7 +35,7 @@ tower-service.workspace = true
 ulid.workspace = true
 url = "2.5.0"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.54.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.55.0" }
 engine = { path = "../../../engine/crates/engine" }
 engine-config-builder = { path = "../../../engine/crates/engine-config-builder" }
 engine-v2.workspace = true

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -51,7 +51,7 @@ tracing = "0.1"
 version-compare = "0.1"
 which.workspace = true
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.54.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.55.0" }
 gateway = { path = "../gateway" }
 typed-resolvers = { path = "../typed-resolvers" }
 federated-dev = { path = "../federated-dev" }

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.54.1",
+  "version": "0.55.0",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.54.1",
+  "version": "0.55.0",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.54.1",
+  "version": "0.55.0",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.54.1",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.54.1",
+    "@grafbase/cli-aarch64-apple-darwin": "^0.55.0",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.55.0",
     "@grafbase/cli-x86_64-pc-windows-msvc": "0.53.0",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.54.1",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.54.1"
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.55.0",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.55.0"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.54.1",
+  "version": "0.55.0",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.54.1",
+  "version": "0.55.0",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.54.1",
+  "version": "0.55.0",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
Features

- The `grafbase introspect` command now highlights the introspected GraphQL when used in an interactive terminal. This can be disabled through the NO_COLOR env var or the new `--no-color` parameter. (#1303)
