### PR TITLE
fix: handle websocket error conditions better in cli

### DIFF
--- a/engine/crates/gateway-v2/src/websockets/messages.rs
+++ b/engine/crates/gateway-v2/src/websockets/messages.rs
@@ -41,7 +41,7 @@ pub enum Message {
     },
     Error {
         id: String,
-        payload: Vec<serde_json::Value>,
+        payload: engine_v2::Response,
     },
     Complete {
         id: String,


### PR DESCRIPTION
A few things I knowingly skipped from my initial implementation:

- Timeouts if the user doesn't init the connection
- Returning the `Error` message on fatal errors.
- Erroring out if the user tries to subscribe before init

Fixes GB-5792