### PR TITLE
graphql-schema-validation: expand README, fix typo in error

### DIFF
--- a/engine/crates/validation/README.md
+++ b/engine/crates/validation/README.md
@@ -2,7 +2,6 @@
 
 [![docs.rs](https://img.shields.io/docsrs/graphql-schema-validation)](https://docs.rs/graphql-schema-validation)
 
-
 This crate implements GraphQL SDL schema validation according to the [2021
 version of the GraphQL spec](http://spec.graphql.org/October2021/).
 
@@ -12,3 +11,25 @@ Scope:
 - Query documents are out of scope, we only validate schemas.
 - The error messages should be as close as possible to the style of other
   GraphQL schema validation libraries.
+
+## Example
+
+```rust
+use graphql_schema_validation::validate;
+
+fn main() {
+  let graphql = "schema { query: MyQueryDoesNotExist }";
+
+  let diagnostics = validate(graphql);
+
+  assert!(diagnostics.has_errors());
+
+  let formatted_diagnostics = diagnostics.iter().map(|err| format!("{}", err)).collect::<Vec<String>>();
+  assert_eq!(formatted_diagnostics, ["Cannot set schema query root to unknown type `MyQueryDoesNotExist`"]);
+}
+```
+
+## Status
+
+The crate is being actively developed and maintained. It covers the spec
+completely and faithfully, as far as we are aware.

--- a/engine/crates/validation/src/validate/schema_definition.rs
+++ b/engine/crates/validation/src/validate/schema_definition.rs
@@ -72,7 +72,7 @@ pub(crate) fn validate_schema_definition_references(ctx: &mut Context<'_>) {
                 )];
                 ctx.push_error(miette::miette!(
                     labels = labels,
-                    "Cannot set schema {} root to unknown type type `{actual}`",
+                    "Cannot set schema {} root to unknown type `{actual}`",
                     default.to_lowercase()
                 ));
             }

--- a/engine/crates/validation/tests/validation_errors/unknown_type_in_schema_def.errors.txt
+++ b/engine/crates/validation/tests/validation_errors/unknown_type_in_schema_def.errors.txt
@@ -1,4 +1,4 @@
-  × Cannot set schema query root to unknown type type `Dunno`
+  × Cannot set schema query root to unknown type `Dunno`
    ╭─[1:1]
  1 │ schema {
    · ──────
@@ -6,7 +6,7 @@
    ╰────
 
 
-  × Cannot set schema mutation root to unknown type type `WhatdoIknow`
+  × Cannot set schema mutation root to unknown type `WhatdoIknow`
    ╭─[1:1]
  1 │ schema {
    · ──────
@@ -14,7 +14,7 @@
    ╰────
 
 
-  × Cannot set schema subscription root to unknown type type `ToWhat`
+  × Cannot set schema subscription root to unknown type `ToWhat`
    ╭─[1:1]
  1 │ schema {
    · ──────


### PR DESCRIPTION
There was a typo in one validation error message, this commit fixes it.

The README is made more complete by adding an `Example` section and a `Status` section.