### PR TITLE
fix: fields of basic types can have arguments.

### DIFF
--- a/engine/crates/parser-sdl/src/rules/basic_type.rs
+++ b/engine/crates/parser-sdl/src/rules/basic_type.rs
@@ -8,7 +8,7 @@ use engine::registry::{
     self,
     federation::FederationKey,
     resolvers::{custom::CustomResolver, transformer::Transformer, Resolver},
-    MetaField, MetaType, ObjectType,
+    MetaField, MetaInputValue, MetaType, ObjectType,
 };
 use engine_parser::{
     types::{FieldDefinition, TypeKind},
@@ -95,6 +95,14 @@ impl<'a> Visitor<'a> for BasicType {
                     description: field.node.description.clone().map(|x| x.node),
                     ty: field.node.ty.clone().node.to_string().into(),
                     cache_control: CacheDirective::parse(&field.node.directives),
+                    args: field
+                        .arguments
+                        .iter()
+                        .map(|argument| {
+                            MetaInputValue::new(argument.node.name.to_string(), argument.node.ty.to_string())
+                        })
+                        .map(|arg| (arg.name.clone(), arg))
+                        .collect(),
                     resolver,
                     requires,
                     external,


### PR DESCRIPTION
I added a bit of validation around arguments in #1333 which caused my tests to fail.  Turns out this is because we've been dropping arguments of the fields basic types rather than putting them into the Registry.

I'm surprised this didn't cause issues elsewhere tbh, expect we're not being very strict/have other bugs.

Easy to fix though, which this does.

