### PR TITLE
chore: pull in graphql-ws-client 0.8.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "async-tungstenite"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3609af4bbf701ddaf1f6bb4e6257dff4ff8932327d0e685d3f653724c258b1ac"
+checksum = "ef0f8d64ef9351752fbe5462f242c625d9c4910d2bc3f7ec44c43857ca123f5d"
 dependencies = [
  "futures-io",
  "futures-util",
@@ -2810,10 +2810,11 @@ dependencies = [
 
 [[package]]
 name = "graphql-ws-client"
-version = "0.7.0"
+version = "0.8.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "400c558067af87ebd3007b19c5b896ed6a4ff5312ea5a2db502814d309522e92"
+checksum = "a9eb6e2af81f2021b0d7bea5a0d98a17313ab78a019113a6c25c2a8ec0b89a2b"
 dependencies = [
+ "async-trait",
  "async-tungstenite",
  "futures",
  "log 0.4.20",
@@ -2821,7 +2822,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "uuid",
 ]
 
 [[package]]

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -54,7 +54,7 @@ server = { package = "grafbase-local-server", path = "../server", version = "0.5
 async-graphql-axum.workspace = true
 async-graphql.workspace = true
 async-trait = "0.1"
-async-tungstenite = "0.24"
+async-tungstenite = "0.25"
 axum.workspace = true
 cfg-if = "1"
 chrono = "0.4"
@@ -66,7 +66,7 @@ duct = "0.13"
 fslock = "0.2"
 futures-util = "0.3"
 graphql-mocks.workspace = true
-graphql-ws-client = "0.7"
+graphql-ws-client = { version = "0.8.0-rc.1", features = ["async-tungstenite"] }
 http.workspace = true
 hex.workspace = true
 headers.workspace = true

--- a/cli/crates/cli/tests/federation.rs
+++ b/cli/crates/cli/tests/federation.rs
@@ -692,8 +692,9 @@ async fn test_websocket_transport_with_bad_auth() {
     };
 
     insta::assert_debug_snapshot!(error, @r###"
-    Decode(
-        "got close frame, reason: Forbidden",
+    Close(
+        4403,
+        "Forbidden",
     )
     "###);
 }

--- a/cli/crates/cli/tests/utils/async_client/websockets.rs
+++ b/cli/crates/cli/tests/utils/async_client/websockets.rs
@@ -16,62 +16,39 @@ where
         use async_tungstenite::tungstenite::{client::IntoClientRequest, http::HeaderValue};
         use futures_util::StreamExt;
 
-        let mut client = {
-            let (mut request, payload_headers) = {
-                let (client, request) = self.reqwest_builder.build_split();
-                let request = request.unwrap();
+        let (mut request, payload_headers) = {
+            let (client, request) = self.reqwest_builder.build_split();
+            let request = request.unwrap();
 
-                // make sure we can still use self below
-                self.reqwest_builder = client.request(Method::GET, "http://example.com");
+            // make sure we can still use self below
+            self.reqwest_builder = client.request(Method::GET, "http://example.com");
 
-                let payload_headers = request
-                    .headers()
-                    .iter()
-                    .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or_default().to_string()))
-                    .collect::<BTreeMap<_, _>>();
+            let payload_headers = request
+                .headers()
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or_default().to_string()))
+                .collect::<BTreeMap<_, _>>();
 
-                let mut url = request.url().clone();
-                url.set_path("/ws");
-                url.set_scheme("ws").unwrap();
-                let request = url.into_client_request().unwrap();
+            let mut url = request.url().clone();
+            url.set_path("/ws");
+            url.set_scheme("ws").unwrap();
+            let request = url.into_client_request().unwrap();
 
-                (request, payload_headers)
-            };
-
-            request.headers_mut().insert(
-                "Sec-WebSocket-Protocol",
-                HeaderValue::from_str("graphql-transport-ws").unwrap(),
-            );
-
-            let (connection, _) = async_tungstenite::tokio::connect_async(request).await.unwrap();
-
-            let (sink, stream) = connection.split();
-
-            graphql_ws_client::AsyncWebsocketClientBuilder::<CliGraphqlClient>::new()
-                .payload(json!({ "headers": payload_headers }))
-                .build(stream, sink, TokioSpawner::current())
-                .await?
+            (request, payload_headers)
         };
 
-        Ok(client.streaming_operation(self).await?.map(move |item| {
-            // Ignore this next line, I'm just tricking rust into
-            // moving the client into this closure.
-            let _client = &client;
+        request.headers_mut().insert(
+            "Sec-WebSocket-Protocol",
+            HeaderValue::from_str("graphql-transport-ws").unwrap(),
+        );
 
-            item.unwrap()
-        }))
-    }
-}
+        let (connection, _) = async_tungstenite::tokio::connect_async(request).await.unwrap();
 
-pub struct CliGraphqlClient;
-
-impl graphql_ws_client::graphql::GraphqlClient for CliGraphqlClient {
-    type Response = serde_json::Value;
-
-    type DecodeError = serde_json::Error;
-
-    fn error_response(errors: Vec<serde_json::Value>) -> Result<Self::Response, Self::DecodeError> {
-        Ok(json!({"errors": errors}))
+        Ok(graphql_ws_client::Client::build(connection)
+            .payload(json!({ "headers": payload_headers }))?
+            .subscribe(self)
+            .await?
+            .map(|item| item.unwrap()))
     }
 }
 
@@ -79,32 +56,11 @@ impl<T> graphql_ws_client::graphql::GraphqlOperation for GqlRequestBuilder<T>
 where
     T: serde::de::DeserializeOwned,
 {
-    type GenericResponse = serde_json::Value;
-
     type Response = T;
 
     type Error = serde_json::Error;
 
-    fn decode(&self, data: Self::GenericResponse) -> Result<Self::Response, Self::Error> {
+    fn decode(&self, data: serde_json::Value) -> Result<Self::Response, Self::Error> {
         serde_json::from_value(data)
-    }
-}
-
-pub struct TokioSpawner(tokio::runtime::Handle);
-
-impl TokioSpawner {
-    pub fn new(handle: tokio::runtime::Handle) -> Self {
-        TokioSpawner(handle)
-    }
-
-    pub fn current() -> Self {
-        TokioSpawner::new(tokio::runtime::Handle::current())
-    }
-}
-
-impl futures_util::task::Spawn for TokioSpawner {
-    fn spawn_obj(&self, obj: futures_util::task::FutureObj<'static, ()>) -> Result<(), futures_util::task::SpawnError> {
-        self.0.spawn(obj);
-        Ok(())
     }
 }

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 async-trait = "0.1"
-async-tungstenite = { version = "0.24", features = ["tokio"] }
+async-tungstenite = { version = "0.25", features = ["tokio-runtime"] }
 axum.workspace = true
 dotenv = "0.15"
 flate2 = "1.0"

--- a/engine/crates/runtime-local/Cargo.toml
+++ b/engine/crates/runtime-local/Cargo.toml
@@ -15,10 +15,9 @@ workspace = true
 [dependencies]
 async-runtime.workspace = true
 async-trait = "0.1"
-async-tungstenite = { version = "0.24.0", features = ["tokio-runtime", "tokio-rustls-webpki-roots"] }
+async-tungstenite = { version = "0.25.0", features = ["tokio-runtime", "tokio-rustls-webpki-roots"] }
 futures-util.workspace = true
-graphql-ws-client = "0.7"
-tokio.workspace = true
+graphql-ws-client = { version = "0.8.0-rc.1", features = ["async-tungstenite"] }
 ulid.workspace = true
 
 serde.workspace = true

--- a/engine/crates/runtime-local/src/fetch/websockets.rs
+++ b/engine/crates/runtime-local/src/fetch/websockets.rs
@@ -1,19 +1,6 @@
 //! graphql-ws-client <> engine glue code
 
 use runtime::fetch::{FetchError, GraphqlRequest};
-use serde_json::json;
-
-pub struct EngineGraphqlClient;
-
-impl graphql_ws_client::graphql::GraphqlClient for EngineGraphqlClient {
-    type Response = serde_json::Value;
-
-    type DecodeError = FetchError;
-
-    fn error_response(errors: Vec<serde_json::Value>) -> Result<Self::Response, Self::DecodeError> {
-        Ok(json!({"errors": errors}))
-    }
-}
 
 #[derive(serde::Serialize)]
 pub struct StreamingRequest {
@@ -31,32 +18,11 @@ impl From<GraphqlRequest<'_>> for StreamingRequest {
 }
 
 impl graphql_ws_client::graphql::GraphqlOperation for StreamingRequest {
-    type GenericResponse = serde_json::Value;
-
     type Response = serde_json::Value;
 
     type Error = FetchError;
 
-    fn decode(&self, data: Self::GenericResponse) -> Result<Self::Response, Self::Error> {
+    fn decode(&self, data: serde_json::Value) -> Result<Self::Response, Self::Error> {
         Ok(data)
-    }
-}
-
-pub struct TokioSpawner(tokio::runtime::Handle);
-
-impl TokioSpawner {
-    pub fn new(handle: tokio::runtime::Handle) -> Self {
-        TokioSpawner(handle)
-    }
-
-    pub fn current() -> Self {
-        TokioSpawner::new(tokio::runtime::Handle::current())
-    }
-}
-
-impl futures_util::task::Spawn for TokioSpawner {
-    fn spawn_obj(&self, obj: futures_util::task::FutureObj<'static, ()>) -> Result<(), futures_util::task::SpawnError> {
-        self.0.spawn(obj);
-        Ok(())
     }
 }


### PR DESCRIPTION
I wasn't especially happy with the API for graphql-ws-client when I was building subscriptions last month, so I've spent a couple of weekends improving things.

This PR pulls in the release candidate I just put out, so I can be sure it works for our use case.