### PR TITLE
chore: Add EnumValueWalker in engine-v2

### DIFF
--- a/engine/crates/engine-v2/schema/src/names.rs
+++ b/engine/crates/engine-v2/schema/src/names.rs
@@ -1,5 +1,6 @@
 use crate::{
-    Definition, EnumId, FieldId, InputObjectId, InputValueId, InterfaceId, ObjectId, ScalarId, Schema, UnionId,
+    Definition, EnumId, EnumValueId, FieldId, InputObjectId, InputValueId, InterfaceId, ObjectId, ScalarId, Schema,
+    UnionId,
 };
 
 /// Small abstraction over the actual names to make easier to deal with
@@ -36,6 +37,10 @@ pub trait Names: Send + Sync {
 
     fn r#enum<'s>(&self, schema: &'s Schema, enum_id: EnumId) -> &'s str {
         &schema[schema[enum_id].name]
+    }
+
+    fn enum_value<'s>(&self, schema: &'s Schema, enum_value_id: EnumValueId) -> &'s str {
+        &schema[schema[enum_value_id].name]
     }
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/engine/crates/engine-v2/schema/src/walkers/enum.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/enum.rs
@@ -1,16 +1,23 @@
 use super::SchemaWalker;
-use crate::{EnumId, EnumValue};
+use crate::{EnumId, EnumValueId};
 
 pub type EnumWalker<'a> = SchemaWalker<'a, EnumId>;
+pub type EnumValueWalker<'a> = SchemaWalker<'a, EnumValueId>;
 
 impl<'a> EnumWalker<'a> {
     pub fn name(&self) -> &'a str {
         self.names.r#enum(self.schema, self.item)
     }
 
-    pub fn values(&self) -> impl ExactSizeIterator<Item = &'a EnumValue> + 'a {
-        let values = self.schema[self.item].values;
-        self.schema[values].iter()
+    pub fn values(&self) -> impl ExactSizeIterator<Item = EnumValueWalker<'a>> + 'a {
+        let walker: SchemaWalker<'a> = self.walk(());
+        self.schema[self.item].values.iter().map(move |id| walker.walk(id))
+    }
+}
+
+impl<'a> EnumValueWalker<'a> {
+    pub fn name(&self) -> &'a str {
+        self.names.enum_value(self.schema, self.item)
     }
 }
 
@@ -19,10 +26,7 @@ impl<'a> std::fmt::Debug for EnumWalker<'a> {
         f.debug_struct("Enum")
             .field("id", &usize::from(self.item))
             .field("name", &self.name())
-            .field(
-                "values",
-                &self.values().map(|value| &self.schema[value.name]).collect::<Vec<_>>(),
-            )
+            .field("values", &self.values().map(|value| value.name()).collect::<Vec<_>>())
             .finish()
     }
 }

--- a/engine/crates/engine-v2/schema/src/walkers/mod.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/mod.rs
@@ -20,7 +20,7 @@ pub use input_object::InputObjectWalker;
 pub use input_value::InputValueWalker;
 pub use interface::InterfaceWalker;
 pub use object::ObjectWalker;
-pub use r#enum::EnumWalker;
+pub use r#enum::{EnumValueWalker, EnumWalker};
 pub use r#type::TypeWalker;
 pub use resolver::ResolverWalker;
 pub use scalar::ScalarWalker;

--- a/engine/crates/engine-v2/src/execution/variables.rs
+++ b/engine/crates/engine-v2/src/execution/variables.rs
@@ -332,7 +332,7 @@ fn coerce_enum(
         }
     };
 
-    if !r#enum.values().any(|value| schema[value.name] == value_str) {
+    if !r#enum.values().any(|value| value.name() == value_str) {
         return Err(CoercionError::IncorrectEnumValue {
             name: r#enum.name().to_owned(),
             actual: value_str.to_string(),

--- a/engine/crates/engine-v2/src/sources/introspection/writer.rs
+++ b/engine/crates/engine-v2/src/sources/introspection/writer.rs
@@ -5,8 +5,8 @@ use schema::{
     sources::introspection::{
         IntrospectionField, IntrospectionObject, Metadata, __EnumValue, __Field, __InputValue, __Schema, __Type,
     },
-    Definition, DefinitionWalker, EnumValue, FieldWalker, InputValueWalker, ListWrapping, SchemaWalker, TypeWalker,
-    Wrapping,
+    Definition, DefinitionWalker, EnumValueWalker, FieldWalker, InputValueWalker, ListWrapping, SchemaWalker,
+    TypeWalker, Wrapping,
 };
 
 use crate::{
@@ -301,15 +301,15 @@ impl<'a> IntrospectionWriter<'a> {
         )
     }
 
-    fn __enum_value(&self, target: &'a EnumValue, selection_set: PlanCollectedSelectionSet<'_>) -> ResponseValue {
+    fn __enum_value(&self, target: EnumValueWalker<'a>, selection_set: PlanCollectedSelectionSet<'_>) -> ResponseValue {
         self.object(
             &self.metadata.__enum_value,
             selection_set,
             |_, __enum_value| match __enum_value {
-                __EnumValue::Name => target.name.into(),
-                __EnumValue::Description => target.description.into(),
-                __EnumValue::IsDeprecated => target.is_deprecated.into(),
-                __EnumValue::DeprecationReason => target.deprecation_reason.into(),
+                __EnumValue::Name => target.as_ref().name.into(),
+                __EnumValue::Description => target.as_ref().description.into(),
+                __EnumValue::IsDeprecated => target.as_ref().is_deprecated.into(),
+                __EnumValue::DeprecationReason => target.as_ref().deprecation_reason.into(),
             },
         )
     }


### PR DESCRIPTION
Simple EnumValue walker which supports renaming