### PR TITLE
chore: Add default values in introspection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,8 +1873,12 @@ dependencies = [
  "fnv",
  "graphql-federated-graph",
  "indexmap 2.2.2",
+ "insta",
+ "serde",
+ "serde_json",
  "strum 0.26.1",
  "strum_macros 0.26.1",
+ "thiserror",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ http = "1"
 hyper = "1"
 hyper-util = "0.1"
 indexmap = "2"
+insta = { version = "1", features = ["json"] }
 itertools = "0.12"
 jsonwebtoken = "9"
 num-traits = "0.2"

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -70,7 +70,7 @@ graphql-ws-client = { version = "0.8.0-rc.1", features = ["async-tungstenite"] }
 http.workspace = true
 hex.workspace = true
 headers.workspace = true
-insta = { version = "1.34", features = ["json", "redactions", "yaml"] }
+insta = { workspace = true, features = ["json", "redactions", "yaml"] }
 json_dotpath = "1"
 jwt-compact = { version = "0.8.0", default-features = false, features = [
   "clock",

--- a/engine/crates/engine-v2/config/Cargo.toml
+++ b/engine/crates/engine-v2/config/Cargo.toml
@@ -21,4 +21,4 @@ federated-graph = { package = "graphql-federated-graph", path = "../../federated
 
 [dev-dependencies]
 serde_json = "1.0"
-insta = { version = "1.34", features = ["json"]}
+insta.workspace = true

--- a/engine/crates/engine-v2/schema/Cargo.toml
+++ b/engine/crates/engine-v2/schema/Cargo.toml
@@ -16,6 +16,12 @@ strum_macros.workspace = true
 url.workspace = true
 fnv = "1"
 indexmap.workspace = true
+serde.workspace = true
+thiserror.workspace = true
 
 config = { package = "engine-v2-config", path = "../config" }
 federated-graph = { package = "graphql-federated-graph", path = "../../federated-graph" }
+
+[dev-dependencies]
+serde_json.workspace = true
+insta.workspace = true

--- a/engine/crates/engine-v2/schema/src/input_value/de.rs
+++ b/engine/crates/engine-v2/schema/src/input_value/de.rs
@@ -1,0 +1,99 @@
+use serde::{
+    de::{
+        value::{MapDeserializer, SeqDeserializer},
+        IntoDeserializer, Visitor,
+    },
+    forward_to_deserialize_any,
+};
+
+use crate::{InputValue, InputValueSerdeError, InputValuesContext};
+
+pub(super) struct InputValueDeserializer<'de, Str, Ctx> {
+    pub ctx: Ctx,
+    pub value: &'de InputValue<Str>,
+}
+
+impl<'de, Str, Ctx> serde::Deserializer<'de> for InputValueDeserializer<'de, Str, Ctx>
+where
+    Ctx: InputValuesContext<'de, Str>,
+    Str: 'de,
+{
+    type Error = InputValueSerdeError;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            InputValue::Null => visitor.visit_unit(),
+            InputValue::String(s) | InputValue::UnknownEnumValue(s) => visitor.visit_borrowed_str(self.ctx.get_str(s)),
+            InputValue::EnumValue(id) => visitor.visit_borrowed_str(self.ctx.schema_walker().walk(*id).name()),
+            InputValue::Int(n) => visitor.visit_i32(*n),
+            InputValue::BigInt(n) => visitor.visit_i64(*n),
+            InputValue::U64(n) => visitor.visit_u64(*n),
+            InputValue::Float(n) => visitor.visit_f64(*n),
+            InputValue::Boolean(b) => visitor.visit_bool(*b),
+            &InputValue::List(ids) => {
+                let ctx = self.ctx;
+                let mut deserializer = SeqDeserializer::new(ids.iter().map(move |id| InputValueDeserializer {
+                    value: &ctx.input_values()[id],
+                    ctx,
+                }));
+                let seq = visitor.visit_seq(&mut deserializer)?;
+                deserializer.end()?;
+                Ok(seq)
+            }
+            InputValue::InputObject(ids) => {
+                let ctx = self.ctx;
+                let mut deserializer = MapDeserializer::new(ids.iter().map(move |id| {
+                    let (id, value) = &ctx.input_values()[id];
+                    (
+                        ctx.schema_walker().walk(*id).name(),
+                        InputValueDeserializer { value, ctx },
+                    )
+                }));
+                let map = visitor.visit_map(&mut deserializer)?;
+                deserializer.end()?;
+                Ok(map)
+            }
+            InputValue::Map(ids) => {
+                let ctx = self.ctx;
+                let mut deserializer = MapDeserializer::new(ids.iter().map(move |id| {
+                    let (key, value) = &ctx.input_values()[id];
+                    (self.ctx.get_str(key), InputValueDeserializer { value, ctx })
+                }));
+                let map = visitor.visit_map(&mut deserializer)?;
+                deserializer.end()?;
+                Ok(map)
+            }
+        }
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if matches!(self.value, InputValue::Null) {
+            visitor.visit_none()
+        } else {
+            visitor.visit_some(self)
+        }
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+impl<'de, Str, Ctx> IntoDeserializer<'de, InputValueSerdeError> for InputValueDeserializer<'de, Str, Ctx>
+where
+    Ctx: InputValuesContext<'de, Str>,
+    Str: 'de,
+{
+    type Deserializer = Self;
+    fn into_deserializer(self) -> Self::Deserializer {
+        self
+    }
+}

--- a/engine/crates/engine-v2/schema/src/input_value/display.rs
+++ b/engine/crates/engine-v2/schema/src/input_value/display.rs
@@ -1,0 +1,104 @@
+use std::fmt::{Display, Formatter, Result, Write};
+
+use crate::{InputValue, InputValuesContext};
+
+/// Displays the input value with GraphQL syntax.
+pub struct GraphqlDisplayableInpuValue<'ctx, Str, Ctx> {
+    pub(super) ctx: Ctx,
+    pub(super) value: &'ctx InputValue<Str>,
+}
+
+impl<'ctx, Str, Ctx> Display for GraphqlDisplayableInpuValue<'ctx, Str, Ctx>
+where
+    Ctx: InputValuesContext<'ctx, Str>,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self.value {
+            InputValue::Null => f.write_str("null"),
+            InputValue::String(s) => write_quoted(self.ctx.get_str(s), f),
+            InputValue::Int(n) => write!(f, "{}", n),
+            InputValue::BigInt(n) => write!(f, "{}", n),
+            InputValue::Float(n) => write!(f, "{}", n),
+            InputValue::U64(n) => write!(f, "{}", n),
+            InputValue::Boolean(b) => {
+                if *b {
+                    f.write_str("true")
+                } else {
+                    f.write_str("false")
+                }
+            }
+            &InputValue::InputObject(fields) => write_object(
+                self.ctx.input_values()[fields]
+                    .iter()
+                    .map(|(input_value_definition_id, value)| {
+                        (
+                            self.ctx.schema_walker().walk(*input_value_definition_id).name(),
+                            GraphqlDisplayableInpuValue { ctx: self.ctx, value },
+                        )
+                    }),
+                f,
+            ),
+            &InputValue::Map(fields) => write_object(
+                self.ctx.input_values()[fields].iter().map(|(key, value)| {
+                    (
+                        self.ctx.get_str(key),
+                        GraphqlDisplayableInpuValue { ctx: self.ctx, value },
+                    )
+                }),
+                f,
+            ),
+            &InputValue::List(list) => write_list(
+                self.ctx.input_values()[list]
+                    .iter()
+                    .map(|v| GraphqlDisplayableInpuValue {
+                        ctx: self.ctx,
+                        value: v,
+                    }),
+                f,
+            ),
+            InputValue::EnumValue(id) => write!(f, "{}", self.ctx.schema_walker().walk(*id).name()),
+            InputValue::UnknownEnumValue(s) => write!(f, "{}", self.ctx.get_str(s)),
+        }
+    }
+}
+
+fn write_quoted(s: &str, f: &mut Formatter<'_>) -> Result {
+    f.write_char('"')?;
+    for c in s.chars() {
+        match c {
+            '\r' => f.write_str("\\r"),
+            '\n' => f.write_str("\\n"),
+            '\t' => f.write_str("\\t"),
+            '"' => f.write_str("\\\""),
+            '\\' => f.write_str("\\\\"),
+            c if c.is_control() => write!(f, "\\u{:04}", c as u32),
+            c => f.write_char(c),
+        }?;
+    }
+    f.write_char('"')
+}
+
+fn write_list<T: Display>(mut iter: impl Iterator<Item = T>, f: &mut Formatter<'_>) -> Result {
+    f.write_char('[')?;
+    if let Some(item) = iter.next() {
+        item.fmt(f)?;
+    }
+    for item in iter {
+        f.write_char(',')?;
+        item.fmt(f)?;
+    }
+    f.write_char(']')
+}
+
+fn write_object<K: Display, V: Display>(object: impl IntoIterator<Item = (K, V)>, f: &mut Formatter<'_>) -> Result {
+    f.write_char('{')?;
+    let mut iter = object.into_iter();
+    if let Some((name, value)) = iter.next() {
+        write!(f, "{name}:{value}")?;
+    }
+    for (name, value) in iter {
+        f.write_char(',')?;
+        write!(f, "{name}:{value}")?;
+    }
+    f.write_char('}')
+}

--- a/engine/crates/engine-v2/schema/src/input_value/error.rs
+++ b/engine/crates/engine-v2/schema/src/input_value/error.rs
@@ -1,0 +1,11 @@
+#[derive(thiserror::Error, Debug)]
+pub enum InputValueSerdeError {
+    #[error("{0}")]
+    Message(String),
+}
+
+impl serde::de::Error for InputValueSerdeError {
+    fn custom<T: std::fmt::Display>(msg: T) -> Self {
+        InputValueSerdeError::Message(msg.to_string())
+    }
+}

--- a/engine/crates/engine-v2/schema/src/input_value/ids.rs
+++ b/engine/crates/engine-v2/schema/src/input_value/ids.rs
@@ -1,0 +1,83 @@
+use crate::{InputValue, InputValueDefinitionId, InputValues, MAX_ID};
+
+macro_rules! input_ids {
+    ($($field:ident[$name:ident] => $out:ty | unless $msg:literal,)*) => {
+        $(
+            #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
+            pub struct $name<Str> {
+                index: std::num::NonZeroU32,
+                _phantom: std::marker::PhantomData<Str>,
+            }
+
+            impl<Str> Clone for $name<Str> {
+                fn clone(&self) -> Self {
+                    *self
+                }
+            }
+
+            impl<Str> Copy for $name<Str> {}
+
+            impl<Str> std::ops::Index<$name<Str>> for InputValues<Str> {
+                type Output = $out;
+
+                fn index(&self, id: $name<Str>) -> &$out {
+                    &self.$field[(id.index.get() - 1) as usize]
+                }
+            }
+
+            impl<Str> std::ops::IndexMut<$name<Str>> for InputValues<Str> {
+                fn index_mut(&mut self, id: $name<Str>) -> &mut $out {
+                    &mut self.$field[(id.index.get() - 1) as usize]
+                }
+            }
+
+            impl<Str> std::ops::Index<crate::ids::IdRange<$name<Str>>> for InputValues<Str> {
+                type Output = [$out];
+
+                fn index(&self, range: crate::ids::IdRange<$name<Str>>) -> &Self::Output {
+                    let crate::ids::IdRange { start, end } = range;
+                    let start = usize::from(start);
+                    let end = usize::from(end);
+                    &self.$field[start..end]
+                }
+            }
+
+            impl<Str> std::ops::IndexMut<crate::ids::IdRange<$name<Str>>> for InputValues<Str> {
+                fn index_mut(&mut self, range: crate::ids::IdRange<$name<Str>>) -> &mut Self::Output {
+                    let crate::ids::IdRange { start, end } = range;
+                    let start = usize::from(start);
+                    let end = usize::from(end);
+                    &mut self.$field[start..end]
+                }
+            }
+
+            impl<Str> From<usize> for $name<Str> {
+                fn from(index: usize) -> Self {
+                    assert!(index <= MAX_ID, "{}", $msg);
+                    Self {
+                        index: std::num::NonZeroU32::new((index + 1) as u32).unwrap(),
+                        _phantom: std::marker::PhantomData,
+                    }
+                }
+            }
+
+            impl<Str> From<$name<Str>> for usize {
+                fn from(id: $name<Str>) -> Self {
+                    (id.index.get() - 1) as usize
+                }
+            }
+
+            impl<Str> From<$name<Str>> for u32 {
+                fn from(id: $name<Str>) -> Self {
+                    id.index.get() - 1
+                }
+            }
+        )*
+    };
+}
+
+input_ids!(
+    values[InputValueId] => InputValue<Str> | unless "Too many input values",
+    input_fields[InputObjectFieldValueId] => (InputValueDefinitionId, InputValue<Str>) | unless "Too many input object fields",
+    key_values[InputKeyValueId] => (Str, InputValue<Str>) | unless "Too many input fields",
+);

--- a/engine/crates/engine-v2/schema/src/input_value/mod.rs
+++ b/engine/crates/engine-v2/schema/src/input_value/mod.rs
@@ -1,0 +1,382 @@
+use crate::{EnumValueId, IdRange, InputValueDefinitionId, SchemaWalker, StringId};
+
+mod de;
+mod display;
+mod error;
+mod ids;
+mod ser;
+
+pub use error::*;
+pub use ids::*;
+
+pub type SchemaInputValues = InputValues<StringId>;
+pub type SchemaInputValue = InputValue<StringId>;
+pub type SchemaInputValueId = InputValueId<StringId>;
+pub type SchemaInputObjectFieldValueId = InputObjectFieldValueId<StringId>;
+pub type SchemaInputKeyValueId = InputKeyValueId<StringId>;
+pub type SchemaInputMap = IdRange<InputKeyValueId<StringId>>;
+
+/// Holds input values for the Schema and for an Operation during execution.
+/// It's generic over 'Str', the string representation:
+/// - StringId for the Schema (default input values and directive arguments)
+/// - Box<str> for the Operation
+///
+/// This allow us to share the code for:
+/// - Display: used to print default values in introspection and add input values in subgraph query strings.
+/// - Serialize: used to serialize variables/arguments.
+/// - Deserializer: used by resolvers to deserialize arguments into a specific struct.
+///
+/// Data is stored in flat arrays for hopefully faster serialization and as as bonus smaller InputValue
+/// footprint on x64 architectures: u64 + usize (padding) rather than 3 * usize (Box<[]> + padding).
+pub struct InputValues<Str> {
+    /// Inidividual input values and list values
+    pub values: Vec<InputValue<Str>>,
+    /// InputObject's fields
+    pub input_fields: Vec<(InputValueDefinitionId, InputValue<Str>)>,
+    /// Object's fields (for JSON)
+    pub key_values: Vec<(Str, InputValue<Str>)>,
+}
+
+impl<Str> Default for InputValues<Str> {
+    fn default() -> Self {
+        Self {
+            input_fields: Default::default(),
+            values: Default::default(),
+            key_values: Default::default(),
+        }
+    }
+}
+
+/// Represents any possible input value for field arguments, operation variables and directive
+/// arguments.
+#[derive(Debug, Clone)]
+pub enum InputValue<Str> {
+    Null,
+    String(Str),
+    EnumValue(EnumValueId),
+    Int(i32),
+    BigInt(i64),
+    Float(f64),
+    Boolean(bool),
+    InputObject(IdRange<InputObjectFieldValueId<Str>>),
+    List(IdRange<InputValueId<Str>>),
+
+    // for JSON
+    Map(IdRange<InputKeyValueId<Str>>),
+    U64(u64),
+
+    // Directive arguments have unknown enum values. Likely doesn't make sense, but not sure.
+    UnknownEnumValue(Str),
+}
+
+impl<Str> InputValues<Str> {
+    pub fn push_value(&mut self, value: InputValue<Str>) -> InputValueId<Str> {
+        let id = InputValueId::from(self.values.len());
+        self.values.push(value);
+        id
+    }
+
+    pub fn push_list(&mut self, values: Vec<InputValue<Str>>) -> IdRange<InputValueId<Str>> {
+        let start = self.values.len();
+        self.values.extend(values);
+        (start..self.values.len()).into()
+    }
+
+    pub fn push_map(&mut self, fields: Vec<(Str, InputValue<Str>)>) -> IdRange<InputKeyValueId<Str>> {
+        let start = self.key_values.len();
+        self.key_values.extend(fields);
+        (start..self.key_values.len()).into()
+    }
+
+    pub fn push_input_object(
+        &mut self,
+        fields: Vec<(InputValueDefinitionId, InputValue<Str>)>,
+    ) -> IdRange<InputObjectFieldValueId<Str>> {
+        let start = self.input_fields.len();
+        self.input_fields.extend(fields);
+        (start..self.input_fields.len()).into()
+    }
+}
+
+pub trait InputValuesContext<'ctx, Str>: Clone + Copy + 'ctx {
+    fn schema_walker(&self) -> &SchemaWalker<'ctx, ()>;
+    fn get_str(&self, s: &Str) -> &'ctx str;
+    fn input_values(&self) -> &'ctx InputValues<Str>;
+
+    fn input_value_as_serializable(&self, id: InputValueId<Str>) -> impl serde::Serialize + 'ctx
+    where
+        Str: 'ctx,
+    {
+        ser::SerializableInputValue {
+            ctx: *self,
+            value: &self.input_values()[id],
+        }
+    }
+
+    fn input_value_as_deserializer(&self, id: InputValueId<Str>) -> impl serde::Deserializer<'ctx> + 'ctx
+    where
+        Str: 'ctx,
+    {
+        de::InputValueDeserializer {
+            ctx: *self,
+            value: &self.input_values()[id],
+        }
+    }
+
+    /// Display the input value with GraphQL syntax.
+    fn input_value_as_graphql_display(&self, id: InputValueId<Str>) -> impl std::fmt::Display + 'ctx
+    where
+        Str: 'ctx,
+    {
+        display::GraphqlDisplayableInpuValue {
+            ctx: *self,
+            value: &self.input_values()[id],
+        }
+    }
+}
+
+impl<'ctx> InputValuesContext<'ctx, StringId> for SchemaWalker<'ctx, ()> {
+    fn schema_walker(&self) -> &SchemaWalker<'ctx, ()> {
+        self
+    }
+
+    fn get_str(&self, s: &StringId) -> &'ctx str {
+        &self.schema[*s]
+    }
+
+    fn input_values(&self) -> &'ctx InputValues<StringId> {
+        &self.schema.input_values
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use serde::Deserialize;
+
+    use crate::{EnumValue, InputValueDefinition, Schema, TypeId};
+
+    use super::*;
+
+    fn create_schema() -> Schema {
+        let mut schema = Schema::empty();
+        schema.input_value_definitions.extend([
+            InputValueDefinition {
+                name: StringId::from(4),
+                description: None,
+                type_id: TypeId::from(0), // not used
+                default_value: None,
+            },
+            InputValueDefinition {
+                name: StringId::from(5),
+                description: None,
+                type_id: TypeId::from(0), // not used
+                default_value: None,
+            },
+        ]);
+        schema.enum_values.extend([
+            EnumValue {
+                name: StringId::from(2),
+                description: None,
+                composed_directives: Default::default(),
+            },
+            EnumValue {
+                name: StringId::from(3),
+                description: None,
+                composed_directives: Default::default(),
+            },
+        ]);
+        schema.strings.extend([
+            "some string value".to_string(), // 1
+            "ACTIVE".to_string(),            // 2
+            "INACTIVE".to_string(),          // 3
+            "fieldA".to_string(),            // 4
+            "fieldB".to_string(),            // 5
+            // ---
+            "null".to_string(),        // 6
+            "string".to_string(),      // 7
+            "enumValue".to_string(),   // 8
+            "int".to_string(),         // 9
+            "bigInt".to_string(),      // 10
+            "u64".to_string(),         // 11
+            "float".to_string(),       // 12
+            "boolean".to_string(),     // 13
+            "inputObject".to_string(), // 14
+            "list".to_string(),        // 15
+            "object".to_string(),      // 16
+        ]);
+        let list = schema.input_values.push_list(vec![
+            InputValue::Null,
+            InputValue::EnumValue(EnumValueId::from(0)),
+            InputValue::Int(73),
+        ]);
+        let input_fields = schema.input_values.push_input_object(vec![
+            (
+                InputValueDefinitionId::from(0),
+                InputValue::EnumValue(EnumValueId::from(1)),
+            ),
+            (InputValueDefinitionId::from(1), InputValue::String(StringId::from(1))),
+        ]);
+        let nested_fields = schema.input_values.push_map(vec![
+            (StringId::from(6), InputValue::Null),
+            (StringId::from(7), InputValue::String(StringId::from(1))),
+            (StringId::from(8), InputValue::EnumValue(EnumValueId::from(0))),
+            (StringId::from(9), InputValue::Int(7)),
+            (StringId::from(10), InputValue::BigInt(8)),
+            (StringId::from(11), InputValue::U64(9)),
+            (StringId::from(12), InputValue::Float(10.0)),
+            (StringId::from(13), InputValue::Boolean(true)),
+        ]);
+        let fields = schema.input_values.push_map(vec![
+            (StringId::from(14), InputValue::InputObject(input_fields)),
+            (StringId::from(15), InputValue::List(list)),
+            (StringId::from(16), InputValue::Map(nested_fields)),
+        ]);
+        schema.input_values.push_value(InputValue::Map(fields));
+        schema
+    }
+
+    #[test]
+    fn test_display() {
+        let schema = create_schema();
+        let walker = schema.walker();
+        let id = SchemaInputValueId::from(schema.input_values.values.len() - 1);
+
+        insta::assert_display_snapshot!(walker.input_value_as_graphql_display(id), @r###"{inputObject:{fieldA:INACTIVE,fieldB:"some string value"},list:[null,ACTIVE,73],object:{null:null,string:"some string value",enumValue:ACTIVE,int:7,bigInt:8,u64:9,float:10,boolean:true}}"###);
+    }
+
+    #[test]
+    fn test_serialize() {
+        let schema = create_schema();
+        let walker = schema.walker();
+        let id = SchemaInputValueId::from(schema.input_values.values.len() - 1);
+
+        insta::assert_json_snapshot!(walker.input_value_as_serializable(id), @r###"
+        {
+          "inputObject": {
+            "fieldA": "INACTIVE",
+            "fieldB": "some string value"
+          },
+          "list": [
+            null,
+            "ACTIVE",
+            73
+          ],
+          "object": {
+            "null": null,
+            "string": "some string value",
+            "enumValue": "ACTIVE",
+            "int": 7,
+            "bigInt": 8,
+            "u64": 9,
+            "float": 10.0,
+            "boolean": true
+          }
+        }
+        "###);
+    }
+
+    #[test]
+    fn test_deserializer() {
+        let schema = create_schema();
+        let walker = schema.walker();
+        let id = SchemaInputValueId::from(schema.input_values.values.len() - 1);
+
+        let value = serde_json::Value::deserialize(walker.input_value_as_deserializer(id)).unwrap();
+
+        insta::assert_json_snapshot!(value, @r###"
+        {
+          "inputObject": {
+            "fieldA": "INACTIVE",
+            "fieldB": "some string value"
+          },
+          "list": [
+            null,
+            "ACTIVE",
+            73
+          ],
+          "object": {
+            "null": null,
+            "string": "some string value",
+            "enumValue": "ACTIVE",
+            "int": 7,
+            "bigInt": 8,
+            "u64": 9,
+            "float": 10.0,
+            "boolean": true
+          }
+        }
+        "###);
+    }
+
+    #[test]
+    fn test_struct_deserializer() {
+        let schema = create_schema();
+        let walker = schema.walker();
+        let id = SchemaInputValueId::from(schema.input_values.values.len() - 1);
+
+        #[allow(unused)]
+        #[derive(Debug, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct InputObject<'a> {
+            #[serde(borrow)]
+            field_a: Cow<'a, str>,
+            field_b: &'a str,
+        }
+
+        #[allow(unused)]
+        #[derive(Debug, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Object {
+            null: Option<String>,
+            string: String,
+            enum_value: Option<String>,
+            int: i32,
+            big_int: i64,
+            u64: u64,
+            float: f64,
+            boolean: bool,
+        }
+
+        #[allow(unused)]
+        #[derive(Debug, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Input<'a> {
+            #[serde(borrow)]
+            input_object: InputObject<'a>,
+            list: Vec<serde_json::Value>,
+            object: Object,
+        }
+
+        let input = Input::deserialize(walker.input_value_as_deserializer(id)).unwrap();
+
+        insta::assert_debug_snapshot!(input, @r###"
+        Input {
+            input_object: InputObject {
+                field_a: "INACTIVE",
+                field_b: "some string value",
+            },
+            list: [
+                Null,
+                String("ACTIVE"),
+                Number(73),
+            ],
+            object: Object {
+                null: None,
+                string: "some string value",
+                enum_value: Some(
+                    "ACTIVE",
+                ),
+                int: 7,
+                big_int: 8,
+                u64: 9,
+                float: 10.0,
+                boolean: true,
+            },
+        }
+        "###);
+
+        serde::de::IgnoredAny::deserialize(walker.input_value_as_deserializer(id)).unwrap();
+    }
+}

--- a/engine/crates/engine-v2/schema/src/input_value/ser.rs
+++ b/engine/crates/engine-v2/schema/src/input_value/ser.rs
@@ -1,0 +1,108 @@
+use serde::ser::{SerializeMap, SerializeSeq};
+
+use crate::{IdRange, InputKeyValueId, InputObjectFieldValueId, InputValue, InputValueId};
+
+use super::InputValuesContext;
+
+pub(super) struct SerializableInputValue<'ctx, Str, Ctx> {
+    pub ctx: Ctx,
+    pub value: &'ctx InputValue<Str>,
+}
+
+impl<'ctx, Str, Ctx> serde::Serialize for SerializableInputValue<'ctx, Str, Ctx>
+where
+    Ctx: InputValuesContext<'ctx, Str>,
+    Str: 'ctx,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.value {
+            InputValue::Null => serializer.serialize_unit(),
+            InputValue::String(s) | InputValue::UnknownEnumValue(s) => self.ctx.get_str(s).serialize(serializer),
+            InputValue::EnumValue(id) => self.ctx.schema_walker().walk(*id).name().serialize(serializer),
+            InputValue::Int(n) => n.serialize(serializer),
+            InputValue::BigInt(n) => n.serialize(serializer),
+            InputValue::Float(f) => f.serialize(serializer),
+            InputValue::U64(n) => n.serialize(serializer),
+            InputValue::Boolean(b) => b.serialize(serializer),
+            &InputValue::InputObject(input_fields) => SerializableInputObject {
+                ctx: self.ctx,
+                input_fields,
+            }
+            .serialize(serializer),
+            &InputValue::List(list) => SerializableList { ctx: self.ctx, list }.serialize(serializer),
+            &InputValue::Map(fields) => SerializableMap { ctx: self.ctx, fields }.serialize(serializer),
+        }
+    }
+}
+
+struct SerializableMap<Str, Ctx> {
+    ctx: Ctx,
+    fields: IdRange<InputKeyValueId<Str>>,
+}
+
+impl<'ctx, Str, Ctx> serde::Serialize for SerializableMap<Str, Ctx>
+where
+    Ctx: InputValuesContext<'ctx, Str>,
+    Str: 'ctx,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(self.fields.len()))?;
+        for (key, value) in &self.ctx.input_values()[self.fields] {
+            map.serialize_key(self.ctx.get_str(key))?;
+            map.serialize_value(&SerializableInputValue { ctx: self.ctx, value })?;
+        }
+
+        map.end()
+    }
+}
+struct SerializableInputObject<Str, Ctx> {
+    ctx: Ctx,
+    input_fields: IdRange<InputObjectFieldValueId<Str>>,
+}
+
+impl<'ctx, Str, Ctx> serde::Serialize for SerializableInputObject<Str, Ctx>
+where
+    Ctx: InputValuesContext<'ctx, Str>,
+    Str: 'ctx,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(self.input_fields.len()))?;
+        for (input_value_definition_id, value) in &self.ctx.input_values()[self.input_fields] {
+            map.serialize_key(self.ctx.schema_walker().walk(*input_value_definition_id).name())?;
+            map.serialize_value(&SerializableInputValue { ctx: self.ctx, value })?;
+        }
+
+        map.end()
+    }
+}
+
+struct SerializableList<Str, Ctx> {
+    ctx: Ctx,
+    list: IdRange<InputValueId<Str>>,
+}
+
+impl<'ctx, Str, Ctx> serde::Serialize for SerializableList<Str, Ctx>
+where
+    Ctx: InputValuesContext<'ctx, Str>,
+    Str: 'ctx,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.list.len()))?;
+        for value in &self.ctx.input_values()[self.list] {
+            seq.serialize_element(&SerializableInputValue { ctx: self.ctx, value })?;
+        }
+        seq.end()
+    }
+}

--- a/engine/crates/engine-v2/schema/src/names.rs
+++ b/engine/crates/engine-v2/schema/src/names.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Definition, EnumId, EnumValueId, FieldId, InputObjectId, InputValueId, InterfaceId, ObjectId, ScalarId, Schema,
-    UnionId,
+    Definition, EnumId, EnumValueId, FieldId, InputObjectId, InputValueDefinitionId, InterfaceId, ObjectId, ScalarId,
+    Schema, UnionId,
 };
 
 /// Small abstraction over the actual names to make easier to deal with
@@ -23,7 +23,7 @@ pub trait Names: Send + Sync {
         &schema[schema[interface_id].name]
     }
 
-    fn input_value<'s>(&self, schema: &'s Schema, input_value_id: InputValueId) -> &'s str {
+    fn input_value<'s>(&self, schema: &'s Schema, input_value_id: InputValueDefinitionId) -> &'s str {
         &schema[schema[input_value_id].name]
     }
 

--- a/engine/crates/engine-v2/schema/src/walkers/enum.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/enum.rs
@@ -1,5 +1,5 @@
 use super::SchemaWalker;
-use crate::{EnumId, EnumValueId};
+use crate::{Directive, EnumId, EnumValueId};
 
 pub type EnumWalker<'a> = SchemaWalker<'a, EnumId>;
 pub type EnumValueWalker<'a> = SchemaWalker<'a, EnumValueId>;
@@ -18,6 +18,15 @@ impl<'a> EnumWalker<'a> {
 impl<'a> EnumValueWalker<'a> {
     pub fn name(&self) -> &'a str {
         self.names.enum_value(self.schema, self.item)
+    }
+
+    pub fn directives(&self) -> impl ExactSizeIterator<Item = &'a Directive> + 'a {
+        self.schema[self.as_ref().composed_directives].iter()
+    }
+
+    pub fn is_deprecated(&self) -> bool {
+        self.directives()
+            .any(|directive| matches!(directive, Directive::Deprecated { .. }))
     }
 }
 

--- a/engine/crates/engine-v2/schema/src/walkers/field.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/field.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use super::{resolver::ResolverWalker, SchemaWalker};
-use crate::{CacheConfig, FieldId, FieldProvides, FieldResolver, FieldSet, InputValueWalker, TypeWalker};
+use crate::{CacheConfig, Directive, FieldId, FieldProvides, FieldResolver, FieldSet, InputValueWalker, TypeWalker};
 
 pub type FieldWalker<'a> = SchemaWalker<'a, FieldId>;
 
@@ -54,6 +54,15 @@ impl<'a> FieldWalker<'a> {
         self.as_ref()
             .cache_config
             .map(|cache_config_id| self.schema[cache_config_id])
+    }
+
+    pub fn directives(&self) -> impl ExactSizeIterator<Item = &'a Directive> + 'a {
+        self.schema[self.as_ref().composed_directives].iter()
+    }
+
+    pub fn is_deprecated(&self) -> bool {
+        self.directives()
+            .any(|directive| matches!(directive, Directive::Deprecated { .. }))
     }
 }
 

--- a/engine/crates/engine-v2/schema/src/walkers/input_value.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/input_value.rs
@@ -1,7 +1,7 @@
 use super::SchemaWalker;
-use crate::{InputValueId, TypeWalker};
+use crate::{InputValueDefinitionId, TypeWalker};
 
-pub type InputValueWalker<'a> = SchemaWalker<'a, InputValueId>;
+pub type InputValueWalker<'a> = SchemaWalker<'a, InputValueDefinitionId>;
 
 impl<'a> InputValueWalker<'a> {
     pub fn name(&self) -> &'a str {

--- a/engine/crates/engine-v2/schema/src/wrapping.rs
+++ b/engine/crates/engine-v2/schema/src/wrapping.rs
@@ -1,32 +1,32 @@
-/// Wrapping is compacted into a u32 to be Copy. It's copied at various places to keep track of
-/// current wrapping. It's functionally equivalent to:
-///
-/// ```rust
-/// struct Wrapping {
-///   inner_is_required: bool,
-///   list_wrappings: VecDeque<ListWrapping>
-/// }
-/// ```
-///
-/// Since `ListWrapping` has only two cases and we won't encounter absurd levels of wrapping, we
-/// can bitpack it. The current structure supports up to 21 list_wrappings.
-///
-/// It's structured as follows:
-///
-///       start (5 bits)
-///       ↓               ↓ list_wrapping (1 == Required / 0 == Nullable)
-///   ┌────┐      ┌────────────────────────┐
-///  0000_0000_0000_0000_0000_0000_0000_0000
-///         └────┘
-///            ↑ end (5 bits)
-///  ↑
-///  inner_is_required flag (1 == required)
-///
-/// The list_wrapping is stored from innermost to outermost and use the start and end
-/// as the positions within the list_wrapping bits. Acting like a simplified fixed capacity VecDeque.
-/// For simplicity of bit shifts the list wrapping is stored from right to left.
-///
-///
+//! Wrapping is compacted into a u32 to be Copy. It's copied at various places to keep track of
+//! current wrapping. It's functionally equivalent to:
+//!
+//! ```ignore
+//! struct Wrapping {
+//!   inner_is_required: bool,
+//!   list_wrappings: VecDeque<ListWrapping>
+//! }
+//! ```
+//!
+//! Since ListWrapping has only two cases and we won't encounter absurd levels of wrapping, we
+//! can bitpack it. The current structure supports up to 21 list_wrappings.
+//!
+//! It's structured as follows:
+//!
+//!```text
+//!       start (5 bits)
+//!       ↓               ↓ list_wrapping (1 == Required / 0 == Nullable)
+//!   ┌────┐      ┌────────────────────────┐
+//!  0000_0000_0000_0000_0000_0000_0000_0000
+//!         └────┘
+//!            ↑ end (5 bits)
+//!  ↑
+//!  inner_is_required flag (1 == required)
+//!```
+//!
+//! The list_wrapping is stored from innermost to outermost and use the start and end
+//! as the positions within the list_wrapping bits. Acting like a simplified fixed capacity VecDeque.
+//! For simplicity of bit shifts the list wrapping is stored from right to left.
 const START_MASK: u32 = 0b0111_1100_0000_0000_0000_0000_0000_0000;
 const START_SHIFT: u32 = START_MASK.trailing_zeros();
 const END_MASK: u32 = 0b0000_0011_1110_0000_0000_0000_0000_0000;

--- a/engine/crates/engine-v2/src/plan/walkers/argument.rs
+++ b/engine/crates/engine-v2/src/plan/walkers/argument.rs
@@ -1,11 +1,11 @@
 use engine_value::ConstValue;
-use schema::{InputValueId, InputValueWalker};
+use schema::{InputValueDefinitionId, InputValueWalker};
 
 use crate::request::BoundFieldArgument;
 
 use super::PlanWalker;
 
-pub type PlanInputValue<'a> = PlanWalker<'a, &'a BoundFieldArgument, InputValueId>;
+pub type PlanInputValue<'a> = PlanWalker<'a, &'a BoundFieldArgument, InputValueDefinitionId>;
 
 impl<'a> PlanInputValue<'a> {
     // Value in the query, before variable resolution.

--- a/engine/crates/engine-v2/src/request/selection_set.rs
+++ b/engine/crates/engine-v2/src/request/selection_set.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use schema::{Definition, FieldId, InputValueId, InterfaceId, ObjectId, Schema, UnionId};
+use schema::{Definition, FieldId, InputValueDefinitionId, InterfaceId, ObjectId, Schema, UnionId};
 
 use crate::response::{BoundResponseKey, ResponseEdge, ResponseKey};
 
@@ -196,7 +196,7 @@ impl From<TypeCondition> for Definition {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BoundFieldArgument {
     pub name_location: Location,
-    pub input_value_id: InputValueId,
+    pub input_value_id: InputValueDefinitionId,
     pub value_location: Location,
     // TODO: Should be validated, coerced and bound.
     pub value: engine_value::Value,

--- a/engine/crates/engine-v2/src/request/walkers/field_argument.rs
+++ b/engine/crates/engine-v2/src/request/walkers/field_argument.rs
@@ -1,12 +1,12 @@
 use std::ops::Deref;
 
-use schema::InputValueId;
+use schema::InputValueDefinitionId;
 
 use crate::request::BoundFieldArgument;
 
 use super::OperationWalker;
 
-pub type BoundFieldArgumentWalker<'a> = OperationWalker<'a, &'a BoundFieldArgument, InputValueId>;
+pub type BoundFieldArgumentWalker<'a> = OperationWalker<'a, &'a BoundFieldArgument, InputValueDefinitionId>;
 
 impl<'a> BoundFieldArgumentWalker<'a> {
     // Value in the query, before variable resolution.

--- a/engine/crates/engine-v2/src/response/read/ser.rs
+++ b/engine/crates/engine-v2/src/response/read/ser.rs
@@ -170,7 +170,7 @@ impl<'a> serde::Serialize for SerializableResponseObject<'a> {
             };
             map.serialize_key(&keys[key])?;
             match value {
-                ResponseValue::Null => map.serialize_value(&serde_json::Value::Null)?,
+                ResponseValue::Null => map.serialize_value(&())?,
                 ResponseValue::Boolean { value, .. } => map.serialize_value(value)?,
                 ResponseValue::Int { value, .. } => map.serialize_value(value)?,
                 ResponseValue::Float { value, .. } => map.serialize_value(value)?,
@@ -205,7 +205,7 @@ impl<'a> serde::Serialize for SerializableResponseList<'a> {
         let mut seq = serializer.serialize_seq(Some(self.value.len()))?;
         for node in self.value {
             match node {
-                ResponseValue::Null => seq.serialize_element(&serde_json::Value::Null)?,
+                ResponseValue::Null => seq.serialize_element(&())?,
                 ResponseValue::Boolean { value, .. } => seq.serialize_element(value)?,
                 ResponseValue::Int { value, .. } => seq.serialize_element(value)?,
                 ResponseValue::Float { value, .. } => seq.serialize_element(value)?,

--- a/engine/crates/engine/Cargo.toml
+++ b/engine/crates/engine/Cargo.toml
@@ -92,7 +92,7 @@ reqwest = { workspace = true, features = [
 [dev-dependencies]
 indoc = "2"
 sha2.workspace = true
-insta = { version = "1", features = ["json"] }
+insta.workspace = true
 rstest.workspace = true
 sanitize-filename = "0.5"
 tokio = { workspace = true, features = ["macros"] }

--- a/engine/crates/parser-graphql/Cargo.toml
+++ b/engine/crates/parser-graphql/Cargo.toml
@@ -37,6 +37,6 @@ reqwest = { workspace = true, features = [
 
 
 [dev-dependencies]
-insta = { version = "1", features = ["json"] }
+insta.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 wiremock.workspace = true

--- a/engine/crates/parser-openapi/Cargo.toml
+++ b/engine/crates/parser-openapi/Cargo.toml
@@ -40,7 +40,7 @@ parser-sdl = { path = "../parser-sdl" }
 
 [dev-dependencies]
 assert_matches = "1.5"
-insta = { version = "1", features = ["json"] }
+insta.workspace = true
 more-asserts = "0.3"
 rstest = "0.18"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/engine/crates/parser-sdl/Cargo.toml
+++ b/engine/crates/parser-sdl/Cargo.toml
@@ -37,7 +37,7 @@ url = { version = "2" }
 
 [dev-dependencies]
 assert_matches = "1"
-insta = { version = "1", features = ["json"] }
+insta.workspace = true
 maplit = "1"
 pretty_assertions = "1"
 rstest.workspace = true


### PR DESCRIPTION
Adding `InputValues` to store default input values & directive arguments in
the schema and later re-use the same type for input values for an operation.

As those are stored with the `InputValueDefinitionId` and `EnumValueId`
rather than strings this will allow an engine-v2 Resolver to be entirely
unaware of schema names, meaning we could rename any part of the schema.

And also adds the default values in the introspection now :D 