### PR TITLE
chore: attempt to make gateway_core a bit clearer.

### DIFF
--- a/cli/crates/gateway/src/executor.rs
+++ b/cli/crates/gateway/src/executor.rs
@@ -83,7 +83,7 @@ impl Executor {
 impl gateway_core::Executor for Executor {
     type Context = crate::Context;
     type Error = crate::Error;
-    type Response = crate::Response;
+    type StreamingResponse = crate::Response;
 
     async fn execute(
         self: Arc<Self>,
@@ -101,7 +101,7 @@ impl gateway_core::Executor for Executor {
         auth: ExecutionAuth,
         request: engine::Request,
         streaming_format: StreamingFormat,
-    ) -> Result<Self::Response, crate::Error> {
+    ) -> Result<Self::StreamingResponse, crate::Error> {
         use axum::response::IntoResponse;
         let schema = self.build_schema(&ctx, auth).await?;
         let payload_stream = Box::pin(schema.execute_stream(request));

--- a/cli/crates/gateway/src/response.rs
+++ b/cli/crates/gateway/src/response.rs
@@ -1,41 +1,16 @@
 use axum::response::IntoResponse;
-use http::{header, status::StatusCode};
-use std::{
-    ops::{Deref, DerefMut},
-    sync::Arc,
-};
+use gateway_core::ConstructableResponse;
+use http::{header, status::StatusCode, HeaderValue};
+use std::sync::Arc;
 
 pub struct Response {
     inner: axum::response::Response,
 }
 
-impl Deref for Response {
-    type Target = axum::response::Response;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl DerefMut for Response {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
-    }
-}
-
-impl From<Result<Response, crate::Error>> for Response {
-    fn from(result: Result<Response, crate::Error>) -> Self {
-        match result {
-            Ok(resp) => resp,
-            Err(err) => err.into(),
-        }
-    }
-}
-
 impl From<crate::Error> for Response {
     fn from(err: crate::Error) -> Self {
         use crate::Error::{BadRequest, Cache, Internal, Serialization};
-        use gateway_core::Response;
+
         match err {
             BadRequest(msg) => Response::error(StatusCode::BAD_REQUEST, &msg),
             Cache(err) => Response::error(StatusCode::INTERNAL_SERVER_ERROR, &err.to_string()),
@@ -56,7 +31,7 @@ impl IntoResponse for Response {
     }
 }
 
-impl gateway_core::Response for Response {
+impl ConstructableResponse for Response {
     type Error = crate::Error;
 
     fn error(code: StatusCode, message: &str) -> Self {
@@ -64,18 +39,16 @@ impl gateway_core::Response for Response {
         (code, message.to_string()).into_response().into()
     }
 
-    fn engine(response: Arc<engine::Response>) -> Result<Self, Self::Error> {
-        let headers = [(header::CONTENT_TYPE, "application/json;charset=UTF-8")];
+    fn engine(response: Arc<engine::Response>, mut headers: http::HeaderMap) -> Result<Self, Self::Error> {
+        headers.append(
+            header::CONTENT_TYPE,
+            HeaderValue::try_from("application/json;charset=UTF-8").unwrap(),
+        );
         let body = axum::Json(response.as_ref().to_graphql_response());
         Ok((headers, body).into_response().into())
     }
 
     fn admin(response: async_graphql::Response) -> Result<Self, Self::Error> {
         Ok(axum::Json(response).into_response().into())
-    }
-
-    fn with_additional_headers(mut self, headers: http::HeaderMap) -> Self {
-        self.headers_mut().extend(headers);
-        self
     }
 }

--- a/engine/crates/gateway-core/src/cache/mod.rs
+++ b/engine/crates/gateway-core/src/cache/mod.rs
@@ -25,7 +25,7 @@ pub fn process_execution_response<Error, Response>(
 ) -> Result<Response, Error>
 where
     Error: std::fmt::Display,
-    Response: super::Response<Error = Error>,
+    Response: super::ConstructableResponse<Error = Error>,
 {
     let (response, headers) = match response {
         Ok(execution_response) => execution_response.into_response_and_headers(),
@@ -34,7 +34,7 @@ where
             return Ok(Response::error(StatusCode::INTERNAL_SERVER_ERROR, "Execution error"));
         }
     };
-    Response::engine(response).map(|resp| resp.with_additional_headers(headers))
+    Response::engine(response, headers)
 }
 
 pub async fn cached_execution<Value, Error, ValueFut>(

--- a/engine/crates/gateway-core/src/executor.rs
+++ b/engine/crates/gateway-core/src/executor.rs
@@ -6,7 +6,12 @@ use common_types::auth::ExecutionAuth;
 pub trait Executor: Send + Sync {
     type Error;
     type Context;
-    type Response;
+
+    // The response used for streaming.
+    //
+    // This is generally some http Response type (e.g. http::Response, axum::Response)
+    // that reads from a Stream
+    type StreamingResponse;
 
     // Caching can defer the actual execution of the request when the data is stale for example.
     // To simplify our code, instead of having a 'ctx lifetime, we expect those "background"
@@ -24,5 +29,5 @@ pub trait Executor: Send + Sync {
         auth: ExecutionAuth,
         request: engine::Request,
         streaming_format: crate::StreamingFormat,
-    ) -> Result<Self::Response, Self::Error>;
+    ) -> Result<Self::StreamingResponse, Self::Error>;
 }

--- a/engine/crates/gateway-core/src/response.rs
+++ b/engine/crates/gateway-core/src/response.rs
@@ -2,13 +2,12 @@ use std::sync::Arc;
 
 use http::status::StatusCode;
 
-pub trait Response: Sized + Send {
+/// Consumers of gateway_core should implement this trait for their Response types
+/// to allow gateway_core to create responses
+pub trait ConstructableResponse: Sized + Send {
     type Error;
 
-    #[must_use]
-    fn with_additional_headers(self, headers: http::HeaderMap) -> Self;
-
     fn error(code: StatusCode, message: &str) -> Self;
-    fn engine(response: Arc<engine::Response>) -> Result<Self, Self::Error>;
+    fn engine(response: Arc<engine::Response>, headers: http::HeaderMap) -> Result<Self, Self::Error>;
     fn admin(response: async_graphql::Response) -> Result<Self, Self::Error>;
 }


### PR DESCRIPTION
I'm trying to implement batching in the various gateway crates, but finding it very hard to follow some of the code.  Mostly because we have too many things named `Response` that are closely related but not quite the same (and in places we're working with 2-3 of them in a single line of code)

This attempts to clean that up a bit:

- Renamed `Executor::Response` to `Executor::StreamingResponse` since it's actually only used for `execute_stream`.
- Made the error handling for `gateway::Response` a bit clearer - we were doing a `.into()` that acted like some combination of `.unwrap()` and `map_err().unwrap_err()`.  I found this quite hard to follow (particularly since go to def doesn't work well for `From` impls) so switched it about a bit.
- Got rid of `with_additional_headers` from `gateway_core::Response` so that it was entirely functions for creating a response.
- Renamed `gateway_core::Response` to `ConstructableResponse` since it is now entirely concerned with the construction of responses.
- Got rid of some `Deref`/`DerefMut` impls that barely served any purpose.

I think this makes things a little easier to follow - though open to discussion if anyone disagrees (or has alternative suggestions).