### PR TITLE
fix: Deserialize properly GET requests for the engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2328,6 +2328,7 @@ dependencies = [
  "postgres-connector-types",
  "runtime",
  "runtime-local",
+ "serde",
  "serde_json",
  "thiserror",
  "tokio",

--- a/cli/crates/cli/tests/utils/async_client/websockets.rs
+++ b/cli/crates/cli/tests/utils/async_client/websockets.rs
@@ -6,7 +6,7 @@ use futures_util::Stream;
 use http::Method;
 use serde_json::json;
 
-use super::GqlRequestBuilder;
+use super::{GqlRequest, GqlRequestBuilder};
 
 impl<Response> GqlRequestBuilder<Response>
 where
@@ -46,13 +46,13 @@ where
 
         Ok(graphql_ws_client::Client::build(connection)
             .payload(json!({ "headers": payload_headers }))?
-            .subscribe(self)
+            .subscribe(self.request)
             .await?
             .map(|item| item.unwrap()))
     }
 }
 
-impl<T> graphql_ws_client::graphql::GraphqlOperation for GqlRequestBuilder<T>
+impl<T> graphql_ws_client::graphql::GraphqlOperation for GqlRequest<T>
 where
     T: serde::de::DeserializeOwned,
 {

--- a/cli/crates/federated-dev/src/dev.rs
+++ b/cli/crates/federated-dev/src/dev.rs
@@ -161,11 +161,11 @@ async fn admin(
 }
 
 async fn engine_get(
-    Query(request): Query<engine::Request>,
+    Query(request): Query<engine::QueryParamRequest>,
     headers: HeaderMap,
     State(ProxyState { gateway, .. }): State<ProxyState>,
 ) -> impl IntoResponse {
-    handle_engine_request(request, gateway, headers).await
+    handle_engine_request(request.into(), gateway, headers).await
 }
 
 async fn engine_post(

--- a/cli/crates/gateway/Cargo.toml
+++ b/cli/crates/gateway/Cargo.toml
@@ -18,6 +18,7 @@ http.workspace = true
 serde_json = "1"
 thiserror = "1"
 tokio.workspace = true
+serde.workspace = true
 tower-http = { workspace = true, features = ["cors"] }
 ulid = "1"
 # hyper = "0.14"

--- a/cli/crates/gateway/src/context.rs
+++ b/cli/crates/gateway/src/context.rs
@@ -11,7 +11,7 @@ pub struct Context {
     pub(crate) authorization_header: Option<String>,
     pub(crate) headers: HeaderMap,
     // TODO: or use a queue?
-    wait_until_sender: UnboundedSender<BoxFuture<'static, ()>>,
+    pub(crate) wait_until_sender: UnboundedSender<BoxFuture<'static, ()>>,
 }
 
 impl Context {

--- a/engine/crates/engine/src/lib.rs
+++ b/engine/crates/engine/src/lib.rs
@@ -78,7 +78,9 @@ pub use look_ahead::Lookahead;
 pub use parser::{Pos, Positioned};
 pub use query_path::{QueryPath, QueryPathSegment};
 pub use registry::{CacheControl, CacheInvalidation, Registry};
-pub use request::{BatchRequest, OperationPlanCacheKey, PersistedQueryRequestExtension, Request, RequestExtensions};
+pub use request::{
+    BatchRequest, OperationPlanCacheKey, PersistedQueryRequestExtension, QueryParamRequest, Request, RequestExtensions,
+};
 #[doc(no_inline)]
 pub use resolver_utils::{ContainerType, LegacyEnumType, LegacyScalarType};
 pub use response::{

--- a/engine/crates/engine/src/request.rs
+++ b/engine/crates/engine/src/request.rs
@@ -8,6 +8,9 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{Data, ParseRequestError, UploadValue, Value, Variables};
 
+mod query;
+pub use query::QueryParamRequest;
+
 /// GraphQL request.
 ///
 /// This can be deserialized from a structure of the query string, the operation name and the

--- a/engine/crates/engine/src/request/query.rs
+++ b/engine/crates/engine/src/request/query.rs
@@ -1,0 +1,77 @@
+use serde::Deserializer;
+
+use crate::Request;
+
+/// GET request have a specific format, values are encoded in JSON, but the root fields are url
+/// encoded. To ensure that the HTTP framework doesn't mess with it, we're first trying to
+/// deserialize all values as strings.
+///
+/// ```sh
+/// curl --get http://localhost:4000/graphql \
+///   --header 'content-type: application/json' \
+///   --data-urlencode 'query={__typename}' \
+///   --data-urlencode 'extensions={"persistedQuery":{"version":1,"sha256Hash":"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"}}'
+/// ```
+pub struct QueryParamRequest {
+    request: Request,
+}
+
+impl From<QueryParamRequest> for Request {
+    fn from(QueryParamRequest { request }: QueryParamRequest) -> Request {
+        request
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for QueryParamRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let query_params = QueryParams::deserialize(deserializer)?;
+        // Avoid unecessary serde round trips by creating a JSON string manually.
+        // This also ensures we stay as close as possible from the original Request deserialization
+        // behavior.
+        let mut request: Request = serde_json::from_str(&query_params.variables_and_extensions_as_json_string())
+            .map_err(|err| serde::de::Error::custom(err.to_string()))?;
+        request.operation_plan_cache_key.query = query_params.query;
+        request.operation_plan_cache_key.operation_name = query_params.operation_name;
+        Ok(QueryParamRequest { request })
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct QueryParams {
+    #[serde(default)]
+    query: String,
+    #[serde(default)]
+    variables: Option<String>,
+    #[serde(default)]
+    operation_name: Option<String>,
+    #[serde(default)]
+    extensions: Option<String>,
+}
+
+impl QueryParams {
+    fn variables_and_extensions_as_json_string(&self) -> String {
+        let mut json = String::with_capacity(
+            // {}
+            2
+            // at most 1 comma
+            + 1
+            + self.variables.as_ref().map(|v| v.len() + 12).unwrap_or_default()
+            + self.extensions.as_ref().map(|e| e.len() + 13).unwrap_or_default(),
+        );
+        json.push('{');
+        if let Some(variables) = &self.variables {
+            json.push_str(&format!(r#""variables":{}"#, variables));
+        }
+        if let Some(extensions) = &self.extensions {
+            if json.len() > 1 {
+                json.push(',');
+            }
+            json.push_str(&format!(r#""extensions":{}"#, extensions));
+        }
+        json.push('}');
+        json
+    }
+}

--- a/engine/crates/gateway-core/src/serving.rs
+++ b/engine/crates/gateway-core/src/serving.rs
@@ -1,8 +1,3 @@
-// with a GET request, we try to build the query from those parameters.
-pub const QUERY_REQUEST_PARAMETER: &str = "query";
-pub const OPERATION_NAME_REQUEST_PARAMETER: &str = "operationName";
-pub const VARIABLES_REQUEST_PARAMETER: &str = "variables";
-
 // Both auth headers were retrieved in both headers & query params.
 pub const X_API_KEY_HEADER: &str = "x-api-key";
 pub const AUTHORIZATION_HEADER: &str = "authorization";


### PR DESCRIPTION
 GET request have a specific format, values are encoded in JSON, but the root fields are url
 encoded. To ensure that the HTTP framework doesn't mess with it, we're first trying to
 deserialize all values as strings.

 ```sh
 curl --get http://localhost:4000/graphql \
   --header 'content-type: application/json' \
   --data-urlencode 'query={__typename}' \
   --data-urlencode 'extensions={"persistedQuery":{"version":1,"sha256Hash":"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"}}'
 ```

