### PR TITLE
feat: graphql batching in cli standalone graphs

### DIFF
--- a/cli/crates/cli/tests/batching.rs
+++ b/cli/crates/cli/tests/batching.rs
@@ -1,0 +1,82 @@
+//! Tests of batched requests
+
+#![allow(unused_crate_dependencies)]
+mod utils;
+
+use backend::project::GraphType;
+use utils::{async_client::AsyncClient, environment::Environment};
+
+const SCHEMA: &str = r#"
+type Todo {
+    id: ID!
+    title: String
+}
+
+extend type Query {
+    todoCollection(first: Int!): [Todo!]! @resolver(name: "todos")
+}
+"#;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn batching() {
+    let mut env = Environment::init_async().await;
+    let client = start_grafbase(&mut env, SCHEMA).await;
+
+    let response = client
+        .batch_gql([
+            r#"query { todoCollection(first: 1) { title } }"#,
+            r#"query { todoCollection(first: 2) { title } }"#,
+        ])
+        .await;
+
+    insta::assert_json_snapshot!(response, @r###"
+    [
+      {
+        "data": {
+          "todoCollection": [
+            {
+              "title": "One"
+            }
+          ]
+        }
+      },
+      {
+        "data": {
+          "todoCollection": [
+            {
+              "title": "One"
+            },
+            {
+              "title": "Two"
+            }
+          ]
+        }
+      }
+    ]
+    "###);
+}
+
+async fn start_grafbase(env: &mut Environment, schema: impl AsRef<str>) -> AsyncClient {
+    env.grafbase_init(GraphType::Single);
+    env.write_schema(schema);
+    env.set_variables([("API_KEY", "BLAH")]);
+    env.grafbase_dev_watch();
+    env.write_file(
+        "resolvers/todos.js",
+        r#"
+            export default function Resolver(_, {first}) {
+                const data = [
+                    {"id": "1", "title": "One"},
+                    {"id": "2", "title": "Two"},
+                ];
+                return data.slice(0, first);
+            }
+    "#,
+    );
+
+    let client = env.create_async_client().with_api_key();
+
+    client.poll_endpoint(30, 300).await;
+
+    client
+}

--- a/cli/crates/cli/tests/utils/async_client.rs
+++ b/cli/crates/cli/tests/utils/async_client.rs
@@ -56,7 +56,6 @@ impl AsyncClient {
         self
     }
 
-    // TODO: update this one as well...
     pub fn gql<Response>(&self, query: impl Into<String>) -> GqlRequestBuilder<Response>
     where
         Response: serde::de::DeserializeOwned + 'static,
@@ -187,6 +186,31 @@ impl AsyncClient {
             .await
             .unwrap()
             .text()
+            .await
+            .unwrap()
+    }
+
+    /// Makes a batch GraphQL request.
+    ///
+    /// At the moment this is way less functional than the non-batch request builder
+    /// but is enough to test.
+    pub async fn batch_gql<T>(&self, queries: impl IntoIterator<Item = T>) -> serde_json::Value
+    where
+        T: AsRef<str>,
+    {
+        self.client
+            .post(&self.endpoint)
+            .headers(self.headers.clone())
+            .json(
+                &queries
+                    .into_iter()
+                    .map(|query| json!({"query": query.as_ref()}))
+                    .collect::<Vec<_>>(),
+            )
+            .send()
+            .await
+            .unwrap()
+            .json()
             .await
             .unwrap()
     }

--- a/cli/crates/cli/tests/utils/async_client/websockets.rs
+++ b/cli/crates/cli/tests/utils/async_client/websockets.rs
@@ -8,11 +8,10 @@ use serde_json::json;
 
 use super::{GqlRequest, GqlRequestBuilder};
 
-impl<Response> GqlRequestBuilder<Response>
-where
-    Response: serde::de::DeserializeOwned + 'static,
-{
-    pub async fn into_websocket_stream(mut self) -> Result<impl Stream<Item = Response>, graphql_ws_client::Error> {
+impl GqlRequestBuilder<serde_json::Value> {
+    pub async fn into_websocket_stream(
+        mut self,
+    ) -> Result<impl Stream<Item = serde_json::Value>, graphql_ws_client::Error> {
         use async_tungstenite::tungstenite::{client::IntoClientRequest, http::HeaderValue};
         use futures_util::StreamExt;
 
@@ -52,11 +51,8 @@ where
     }
 }
 
-impl<T> graphql_ws_client::graphql::GraphqlOperation for GqlRequest<T>
-where
-    T: serde::de::DeserializeOwned,
-{
-    type Response = T;
+impl graphql_ws_client::graphql::GraphqlOperation for GqlRequest {
+    type Response = serde_json::Value;
 
     type Error = serde_json::Error;
 

--- a/cli/crates/cli/tests/utils/environment.rs
+++ b/cli/crates/cli/tests/utils/environment.rs
@@ -6,7 +6,6 @@ use super::{cargo_bin::cargo_bin, client::Client};
 use backend::project::GraphType;
 use common::consts::GRAFBASE_SCHEMA_FILE_NAME;
 use duct::{cmd, Handle};
-use std::fmt::Display;
 use std::io;
 use std::path::Path;
 use std::process::Output;
@@ -136,8 +135,8 @@ impl Environment {
 
     // TODO: change this to set_schema
     //
-    pub fn write_schema(&self, schema: impl AsRef<str> + Display) {
-        let schema = format!("extend schema @introspection(enable: true)\n{schema}");
+    pub fn write_schema(&self, schema: impl AsRef<str>) {
+        let schema = format!("extend schema @introspection(enable: true)\n{}", schema.as_ref());
         // TODO: this is temporary until we update all tests to use SDK
         let _ = fs::remove_file("grafbase.config.ts");
         let _ = fs::remove_file("grafbase/grafbase.config.ts");

--- a/cli/crates/gateway/src/response.rs
+++ b/cli/crates/gateway/src/response.rs
@@ -7,6 +7,19 @@ pub struct Response {
     inner: axum::response::Response,
 }
 
+impl Response {
+    pub fn batch_response(responses: Vec<Arc<engine::Response>>) -> Self {
+        let body = axum::Json(
+            responses
+                .iter()
+                .map(|response| response.to_graphql_response())
+                .collect::<Vec<_>>(),
+        );
+
+        body.into_response().into()
+    }
+}
+
 impl From<crate::Error> for Response {
     fn from(err: crate::Error) -> Self {
         use crate::Error::{BadRequest, Cache, Internal, Serialization};

--- a/cli/crates/gateway/src/serving.rs
+++ b/cli/crates/gateway/src/serving.rs
@@ -39,21 +39,51 @@ async fn post_graphql(
         .and_then(StreamingFormat::from_accept_header);
     let (sender, receiver) = mpsc::unbounded_channel();
     let ctx = crate::Context::new(headers, &params, sender);
+
     // FIXME: Pathfinder doesn't send the proper content-type, so axum complains about it.
-    let request: engine::Request = match serde_json::from_slice(&body[..]) {
+    let request: engine::BatchRequest = match serde_json::from_slice(&body[..]) {
         Ok(req) => req,
         Err(err) => {
             return Response::error(StatusCode::BAD_REQUEST, &format!("Could not parse JSON request: {err}"));
         }
     };
 
-    let response = match gateway.execute(&ctx, request, streaming_format).await {
-        Ok(response) => response,
-        Err(error) => crate::Response::from(error),
-    };
+    match request {
+        engine::BatchRequest::Single(request) => {
+            let result = match streaming_format {
+                Some(format) => gateway.execute_stream(&ctx, request, format).await,
+                None => gateway
+                    .execute(&ctx, request)
+                    .await
+                    .and_then(|(response, headers)| Response::engine(response, headers)),
+            };
 
-    tokio::spawn(wait(receiver));
-    response
+            let response = match result {
+                Ok(response) => response,
+                Err(error) => crate::Response::from(error),
+            };
+
+            tokio::spawn(wait(receiver));
+            response
+        }
+        engine::BatchRequest::Batch(requests) => {
+            if streaming_format.is_some() {
+                return crate::Response::error(
+                    StatusCode::BAD_REQUEST,
+                    "batch requests can't use multipart or event-stream responses",
+                );
+            }
+            let mut responses = Vec::with_capacity(requests.len());
+            for request in requests {
+                responses.push(match gateway.execute(&ctx, request).await {
+                    Ok((response, _)) => response,
+                    Err(error) => return crate::Response::from(error),
+                });
+            }
+
+            crate::Response::batch_response(responses)
+        }
+    }
 }
 
 #[derive(serde::Deserialize)]
@@ -85,6 +115,8 @@ async fn get_graphql(
     headers: HeaderMap,
     Query(params): Query<GetRequestParams>,
 ) -> crate::Response {
+    use gateway_core::ConstructableResponse as _;
+
     let streaming_format = headers
         .get(http::header::ACCEPT)
         .and_then(|value| value.to_str().ok())
@@ -94,7 +126,16 @@ async fn get_graphql(
 
     let mut request: engine::Request = params.request.into();
     request.ray_id = ctx.ray_id.clone();
-    let response = match gateway.execute(&ctx, request, streaming_format).await {
+
+    let result = match streaming_format {
+        None => gateway
+            .execute(&ctx, request)
+            .await
+            .and_then(|(response, headers)| Response::engine(response, headers)),
+        Some(streaming_format) => gateway.execute_stream(&ctx, request, streaming_format).await,
+    };
+
+    let response = match result {
         Ok(response) => response,
         Err(error) => Response::from(error),
     };

--- a/engine/crates/gateway-core/src/response.rs
+++ b/engine/crates/gateway-core/src/response.rs
@@ -4,6 +4,8 @@ use http::status::StatusCode;
 
 /// Consumers of gateway_core should implement this trait for their Response types
 /// to allow gateway_core to create responses
+///
+/// TODO: This is almost more like HttpResponse or something?  Not sure....
 pub trait ConstructableResponse: Sized + Send {
     type Error;
 


### PR DESCRIPTION
Implements [this RFC](https://github.com/graphql/graphql-over-http/blob/main/rfcs/Batching.md) for standalone graphs in the CLI.

The RFC is pretty silent on whether requests should be run in parallel or in series.  Even the implementations linked to from the RFC can't agree: half of them do things in parallel, half in series.  I've settled on doing things serially for now as it's easy and definitely won't break anything.  Can revisit later if we need to.

Part of GB-5931