### PR TITLE
cli: avoid crashing when stdout becomes unavailable in introspect

### DIFF
--- a/cli/nix/udf-wrapper.nix
+++ b/cli/nix/udf-wrapper.nix
@@ -4,7 +4,7 @@
   packages.udf-wrapper = pkgs.buildNpmPackage {
     src = ../udf-wrapper;
     name = "udf-wrapper";
-    npmDepsHash = "sha256-xUNkgpuwy75kP1P7pVTguVDCQUa9nvArml2PyOMuBYM=";
+    npmDepsHash = "sha256-+74Y5QTvYVpX7Yv8SLp9+lQT5qk3ZNTXE0RksdEF3HI=";
 
     nativeBuildInputs = [ pkgs.bun ];
 


### PR DESCRIPTION
This is the well known issue of `print!()` & co from the standard library panicking if stdout/stderr becomes unavailable. This commit fixes the issue in `grafbase introspect`.

Issue illustrated:

![2024-02-15_17-02-00](https://github.com/grafbase/grafbase/assets/13155277/79c4f632-5e4e-40bb-b695-ae2e51397ca5)

The panic message isn't shown anymore after this commit because introspect handles the error gracefully.

Also, update the npm deps hash in udf-wrapper.nix so `nix build .#cli` works again. 

closes GB-5788