### PR TITLE
Disable 'did you mean' suggestions if introspection is disabled

### DIFF
--- a/cli/crates/cli/tests/introspection_configuration.rs
+++ b/cli/crates/cli/tests/introspection_configuration.rs
@@ -31,7 +31,26 @@ async fn introspection_configuration() {
     let response = client.gql::<Value>(INTROSPECTION_QUERY).send().await;
 
     let errors: Option<Vec<Value>> = dot_get_opt!(response, "errors");
-    assert!(!errors.is_some_and(|errors| !errors.is_empty()));
+    assert_eq!(errors, None);
+
+    let response = client.gql::<Value>("query { hllo }").send().await;
+
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": null,
+      "errors": [
+        {
+          "message": "Unknown field \"hllo\" on type \"Query\". Did you mean \"hello\"?",
+          "locations": [
+            {
+              "line": 1,
+              "column": 9
+            }
+          ]
+        }
+      ]
+    }
+    "###);
 
     client.snapshot().await;
 
@@ -47,6 +66,42 @@ async fn introspection_configuration() {
     client.poll_endpoint_for_changes(30, 300).await;
 
     let response = client.gql::<Value>(INTROSPECTION_QUERY).send().await;
+
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": null,
+      "errors": [
+        {
+          "message": "Unauthorized for introspection.",
+          "locations": [
+            {
+              "line": 4,
+              "column": 3
+            }
+          ]
+        }
+      ]
+    }
+    "###);
+
+    let response = client.gql::<Value>("query { hllo }").send().await;
+
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": null,
+      "errors": [
+        {
+          "message": "Unknown field \"hllo\" on type \"Query\".",
+          "locations": [
+            {
+              "line": 1,
+              "column": 9
+            }
+          ]
+        }
+      ]
+    }
+    "###);
 
     let errors: Option<Vec<Value>> = dot_get_opt!(response, "errors");
     assert!(errors.is_some_and(|errors| !errors.is_empty()));
@@ -68,5 +123,24 @@ async fn introspection_configuration() {
     let response = client.gql::<Value>(INTROSPECTION_QUERY).send().await;
 
     let errors: Option<Vec<Value>> = dot_get_opt!(response, "errors");
-    assert!(!errors.is_some_and(|errors| !errors.is_empty()));
+    assert_eq!(errors, None);
+
+    let response = client.gql::<Value>("query { hllo }").send().await;
+
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": null,
+      "errors": [
+        {
+          "message": "Unknown field \"hllo\" on type \"Query\". Did you mean \"hello\"?",
+          "locations": [
+            {
+              "line": 1,
+              "column": 9
+            }
+          ]
+        }
+      ]
+    }
+    "###);
 }

--- a/engine/crates/engine/src/validation/rules/fields_on_correct_type.rs
+++ b/engine/crates/engine/src/validation/rules/fields_on_correct_type.rs
@@ -36,16 +36,20 @@ impl<'a> Visitor<'a> for FieldsOnCorrectType {
                         "Unknown field \"{}\" on type \"{}\".{}",
                         field.node.name,
                         parent_type.name(),
-                        make_suggestion(
-                            " Did you mean",
-                            parent_type
-                                .fields()
-                                .iter()
-                                .flat_map(|fields| fields.keys())
-                                .map(String::as_str),
-                            &field.node.name.node,
-                        )
-                        .unwrap_or_default()
+                        if ctx.registry.disable_introspection {
+                            String::new()
+                        } else {
+                            make_suggestion(
+                                " Did you mean",
+                                parent_type
+                                    .fields()
+                                    .iter()
+                                    .flat_map(|fields| fields.keys())
+                                    .map(String::as_str),
+                                &field.node.name.node,
+                            )
+                            .unwrap_or_default()
+                        }
                     ),
                 );
             }

--- a/engine/crates/engine/src/validation/rules/known_argument_names.rs
+++ b/engine/crates/engine/src/validation/rules/known_argument_names.rs
@@ -64,7 +64,11 @@ impl<'a> Visitor<'a> for KnownArgumentNames<'a> {
                                 name,
                                 field_name,
                                 type_name,
-                                self.get_suggestion(name.node.as_str())
+                                if ctx.registry.disable_introspection {
+                                    String::new()
+                                } else {
+                                    self.get_suggestion(name.node.as_str())
+                                }
                             ),
                         );
                     }
@@ -75,7 +79,11 @@ impl<'a> Visitor<'a> for KnownArgumentNames<'a> {
                                 "Unknown argument \"{}\" on directive \"{}\".{}",
                                 name,
                                 directive_name,
-                                self.get_suggestion(name.node.as_str())
+                                if ctx.registry.disable_introspection {
+                                    String::new()
+                                } else {
+                                    self.get_suggestion(name.node.as_str())
+                                }
                             ),
                         );
                     }


### PR DESCRIPTION
# Description

## Feature

- Disable 'did you mean' suggestions if introspection is disabled

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
