### PR TITLE
engine-v2-schema: remove inaccessible items

### DIFF
--- a/cli/nix/udf-wrapper.nix
+++ b/cli/nix/udf-wrapper.nix
@@ -4,7 +4,7 @@
   packages.udf-wrapper = pkgs.buildNpmPackage {
     src = ../udf-wrapper;
     name = "udf-wrapper";
-    npmDepsHash = "sha256-+74Y5QTvYVpX7Yv8SLp9+lQT5qk3ZNTXE0RksdEF3HI=";
+    npmDepsHash = "sha256-DParovYHR4sH0wFGZIrW5u3TAqIkqoFxAGtxvBCzAGo=";
 
     nativeBuildInputs = [ pkgs.bun ];
 

--- a/engine/crates/engine-v2/schema/src/builder/ids.rs
+++ b/engine/crates/engine-v2/schema/src/builder/ids.rs
@@ -6,14 +6,6 @@
 
 use crate::ids::*;
 
-pub(super) trait MappableId: Copy {
-    type Counterpart: Copy + From<usize>;
-
-    fn get_idx(self) -> usize;
-    fn get_map(mapper: &IdMapper) -> &[usize];
-    fn get_map_mut(mapper: &mut IdMapper) -> &mut Vec<usize>;
-}
-
 macro_rules! mapped_ids {
     ($($name:ident : $from:ty => $to:ty)*) => {
 
@@ -26,20 +18,24 @@ macro_rules! mapped_ids {
         }
 
         $(
-            impl MappableId for $from {
-                type Counterpart = $to;
+            #[allow(unused)]
+            pub(super) mod $name {
+                use super::*;
 
-                fn get_idx(self) -> usize {
-                    self.0
+                /// Mark an id as skipped in the target schema. The element has to be actually filtered out, separately.
+                pub(crate) fn skip(mapper: &mut IdMapper, id: $from) {
+                    super::skip_impl(&mut mapper.$name, id.0)
                 }
 
-                fn get_map(mapper: &IdMapper) -> &[usize] {
-                    &mapper.$name
+                /// Map a federated_graph id to an engine_schema id taking the skipped IDs into account.
+                pub(crate) fn map(mapper: &IdMapper, id: $from) -> Option<$to> {
+                    super::map_impl(&mapper.$name, id.0)
                 }
 
-                fn get_map_mut(mapper: &mut IdMapper) -> &mut Vec<usize> {
-                    &mut mapper.$name
+                pub(crate) fn map_range(mapper: &IdMapper, range: ($from, usize)) -> IdRange<$to> {
+                    super::map_range_impl(&mapper.$name, (range.0.0, range.1))
                 }
+
             }
         )*
     };
@@ -51,56 +47,41 @@ mapped_ids!(
     enum_values: federated_graph::EnumValueId => EnumValueId
 );
 
-impl IdMapper {
-    /// Mark an id as skipped in the target schema. The element has to be actually filtered out, separately.
-    pub(super) fn skip<Id: MappableId>(&mut self, id: Id) {
-        let idx = id.get_idx();
-        let entries = Id::get_map_mut(self);
-
-        if let Some(last_entry) = entries.last().copied() {
-            assert!(last_entry < idx);
-        }
-
-        entries.push(idx);
+fn skip_impl(skipped_ids: &mut Vec<usize>, idx: usize) {
+    if let Some(last_entry) = skipped_ids.last().copied() {
+        assert!(last_entry < idx, "Broken invariant: ids must be skipped in order");
     }
 
-    /// Map a federated_graph id to an engine_schema id taking the skipped IDs into account.
-    pub(super) fn map<Id: MappableId>(&self, id: Id) -> Option<Id::Counterpart> {
-        let idx = id.get_idx();
-        let map = Id::get_map(self);
-        let skipped = map.partition_point(|skipped| *skipped <= idx);
+    skipped_ids.push(idx);
+}
 
-        if let Some(last) = map[..skipped].last().copied() {
-            if last == idx {
-                return None;
-            }
+fn map_impl<T: From<usize>>(skipped_ids: &[usize], idx: usize) -> Option<T> {
+    let skipped = skipped_ids.partition_point(|skipped| *skipped <= idx);
+
+    if let Some(last) = skipped_ids[..skipped].last().copied() {
+        if last == idx {
+            return None;
         }
-
-        Some(Id::Counterpart::from(idx - skipped))
     }
 
-    pub(super) fn map_range<Id: MappableId>(&self, (start_id, len): (Id, usize)) -> crate::IdRange<Id::Counterpart>
-    where
-        usize: From<Id::Counterpart>,
-    {
-        let start_idx = start_id.get_idx();
-        let skipped = Id::get_map(self);
+    Some(T::from(idx - skipped))
+}
 
-        // How many ids were skipped before the range.
-        let skipped_before = skipped.partition_point(|skipped| *skipped < start_idx);
+fn map_range_impl<T: From<usize> + Copy>(skipped_ids: &[usize], (start_idx, len): (usize, usize)) -> crate::IdRange<T> {
+    // How many ids were skipped before the range.
+    let skipped_ids_count_before_start = skipped_ids.partition_point(|skipped| *skipped < start_idx);
 
-        // How many ids were skipped inside the range.
-        let skipped_inside = skipped[skipped_before..]
-            .iter()
-            .take_while(|skipped| **skipped < (start_idx + len))
-            .count();
+    // How many ids were skipped inside the range.
+    let skipped_ids_count_between_start_and_end = skipped_ids[skipped_ids_count_before_start..]
+        .iter()
+        .take_while(|skipped| **skipped < (start_idx + len))
+        .count();
 
-        let start = start_idx - skipped_before;
+    let start = start_idx - skipped_ids_count_before_start;
 
-        IdRange {
-            start: From::from(start),
-            end: From::from(start + (len - skipped_inside)),
-        }
+    IdRange {
+        start: From::from(start),
+        end: From::from(start + (len - skipped_ids_count_between_start_and_end)),
     }
 }
 
@@ -112,17 +93,17 @@ mod tests {
     fn skip_basic() {
         let id = federated_graph::InputValueDefinitionId(2);
         let mut mapper = IdMapper::default();
-        assert_eq!(InputValueDefinitionId::from(2), mapper.map(id).unwrap());
-        mapper.skip(federated_graph::InputValueDefinitionId(1));
-        assert_eq!(InputValueDefinitionId::from(1), mapper.map(id).unwrap());
+        assert_eq!(InputValueDefinitionId::from(2), input_values::map(&mapper, id).unwrap());
+        input_values::skip(&mut mapper, federated_graph::InputValueDefinitionId(1));
+        assert_eq!(InputValueDefinitionId::from(1), input_values::map(&mapper, id).unwrap());
     }
 
     #[test]
     fn map_skipped() {
         let id = federated_graph::InputValueDefinitionId(5);
         let mut mapper = IdMapper::default();
-        mapper.skip(id);
-        assert!(mapper.map(id).is_none());
+        input_values::skip(&mut mapper, id);
+        assert!(input_values::map(&mapper, id).is_none());
     }
 
     #[test]
@@ -134,63 +115,65 @@ mod tests {
                 start: InputValueDefinitionId::from(6),
                 end: InputValueDefinitionId::from(16)
             },
-            mapper.map_range(range)
+            input_values::map_range(&mapper, range)
         );
 
-        mapper.skip(federated_graph::InputValueDefinitionId(2));
+        input_values::skip(&mut mapper, federated_graph::InputValueDefinitionId(2));
 
         assert_eq!(
             IdRange {
                 start: InputValueDefinitionId::from(5),
                 end: InputValueDefinitionId::from(15)
             },
-            mapper.map_range(range)
+            input_values::map_range(&mapper, range)
         );
 
-        mapper.skip(federated_graph::InputValueDefinitionId(6));
+        input_values::skip(&mut mapper, federated_graph::InputValueDefinitionId(6));
 
         assert_eq!(
             IdRange {
                 start: InputValueDefinitionId::from(5),
                 end: InputValueDefinitionId::from(14)
             },
-            mapper.map_range(range)
+            input_values::map_range(&mapper, range)
         );
 
-        mapper.skip(federated_graph::InputValueDefinitionId(9));
+        input_values::skip(&mut mapper, federated_graph::InputValueDefinitionId(9));
 
         assert_eq!(
             IdRange {
                 start: InputValueDefinitionId::from(5),
                 end: InputValueDefinitionId::from(13)
             },
-            mapper.map_range(range)
+            input_values::map_range(&mapper, range)
         );
 
-        mapper.skip(federated_graph::InputValueDefinitionId(20));
+        input_values::skip(&mut mapper, federated_graph::InputValueDefinitionId(20));
 
         assert_eq!(
             IdRange {
                 start: InputValueDefinitionId::from(5),
                 end: InputValueDefinitionId::from(13)
             },
-            mapper.map_range(range)
+            input_values::map_range(&mapper, range)
         );
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed: last_entry < idx")]
+    #[should_panic(expected = "Broken invariant: ids must be skipped in order")]
     fn skip_out_of_order() {
         let mut mapper = IdMapper::default();
-        mapper.skip(federated_graph::InputValueDefinitionId(5));
-        mapper.skip(federated_graph::InputValueDefinitionId(3)); // boom
+        input_values::skip(&mut mapper, federated_graph::InputValueDefinitionId(5));
+        input_values::skip(&mut mapper, federated_graph::InputValueDefinitionId(3));
+        // boom
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed: last_entry < idx")]
+    #[should_panic(expected = "Broken invariant: ids must be skipped in order")]
     fn skip_twice() {
         let mut mapper = IdMapper::default();
-        mapper.skip(federated_graph::InputValueDefinitionId(5));
-        mapper.skip(federated_graph::InputValueDefinitionId(5)); // boom
+        input_values::skip(&mut mapper, federated_graph::InputValueDefinitionId(5));
+        input_values::skip(&mut mapper, federated_graph::InputValueDefinitionId(5));
+        // boom
     }
 }

--- a/engine/crates/engine-v2/schema/src/builder/ids.rs
+++ b/engine/crates/engine-v2/schema/src/builder/ids.rs
@@ -4,84 +4,76 @@
 //! As of 3b56f12c95d334ce6cb46f4f8654ce531a69f975, this only happens when @inaccessible items
 //! are removed.
 
+use std::marker::PhantomData;
+
 use crate::ids::*;
 
-macro_rules! mapped_ids {
-    ($($name:ident : $from:ty => $to:ty)*) => {
+pub(super) struct IdMapper<FgId: Into<usize>, Id: From<usize> + Copy> {
+    skipped_ids: Vec<usize>,
+    _fgid: PhantomData<FgId>,
+    _id: PhantomData<Id>,
+}
 
-        #[derive(Default, Debug)]
-        pub(super) struct IdMapper {
-            $(
-                /// The indexes of the skipped ids.
-                $name: Vec<usize>,
-            )*
+impl<FgId, Id> Default for IdMapper<FgId, Id>
+where
+    FgId: Into<usize>,
+    Id: From<usize> + Copy,
+{
+    fn default() -> Self {
+        IdMapper {
+            skipped_ids: Vec::new(),
+            _fgid: PhantomData,
+            _id: PhantomData,
+        }
+    }
+}
+
+impl<FgId, Id> IdMapper<FgId, Id>
+where
+    FgId: Into<usize>,
+    Id: From<usize> + Copy,
+{
+    /// Mark an id as skipped in the target schema. The element has to be actually filtered out, separately.
+    pub(super) fn skip(&mut self, id: FgId) {
+        let idx = id.into();
+        if let Some(last_entry) = self.skipped_ids.last().copied() {
+            assert!(last_entry < idx, "Broken invariant: ids must be skipped in order");
         }
 
-        $(
-            #[allow(unused)]
-            pub(super) mod $name {
-                use super::*;
+        self.skipped_ids.push(idx);
+    }
 
-                /// Mark an id as skipped in the target schema. The element has to be actually filtered out, separately.
-                pub(crate) fn skip(mapper: &mut IdMapper, id: $from) {
-                    super::skip_impl(&mut mapper.$name, id.0)
-                }
+    /// Map a federated_graph id to an engine_schema id taking the skipped IDs into account.
+    pub(super) fn map(&self, id: FgId) -> Option<Id> {
+        let idx = id.into();
+        let skipped = self.skipped_ids.partition_point(|skipped| *skipped <= idx);
 
-                /// Map a federated_graph id to an engine_schema id taking the skipped IDs into account.
-                pub(crate) fn map(mapper: &IdMapper, id: $from) -> Option<$to> {
-                    super::map_impl(&mapper.$name, id.0)
-                }
-
-                pub(crate) fn map_range(mapper: &IdMapper, range: ($from, usize)) -> IdRange<$to> {
-                    super::map_range_impl(&mapper.$name, (range.0.0, range.1))
-                }
-
+        if let Some(last) = self.skipped_ids[..skipped].last().copied() {
+            if last == idx {
+                return None;
             }
-        )*
-    };
-}
-
-mapped_ids!(
-    fields: federated_graph::FieldId => FieldId
-    input_values: federated_graph::InputValueDefinitionId => InputValueDefinitionId
-    enum_values: federated_graph::EnumValueId => EnumValueId
-);
-
-fn skip_impl(skipped_ids: &mut Vec<usize>, idx: usize) {
-    if let Some(last_entry) = skipped_ids.last().copied() {
-        assert!(last_entry < idx, "Broken invariant: ids must be skipped in order");
-    }
-
-    skipped_ids.push(idx);
-}
-
-fn map_impl<T: From<usize>>(skipped_ids: &[usize], idx: usize) -> Option<T> {
-    let skipped = skipped_ids.partition_point(|skipped| *skipped <= idx);
-
-    if let Some(last) = skipped_ids[..skipped].last().copied() {
-        if last == idx {
-            return None;
         }
+
+        Some(Id::from(idx - skipped))
     }
 
-    Some(T::from(idx - skipped))
-}
+    pub(super) fn map_range(&self, (start_id, len): (FgId, usize)) -> crate::IdRange<Id> {
+        let start_idx = start_id.into();
+        // How many ids were skipped before the range.
+        let skipped_ids_count_before_start = self.skipped_ids.partition_point(|skipped| *skipped < start_idx);
 
-fn map_range_impl<T: From<usize> + Copy>(skipped_ids: &[usize], (start_idx, len): (usize, usize)) -> crate::IdRange<T> {
-    // How many ids were skipped before the range.
-    let skipped_ids_count_before_start = skipped_ids.partition_point(|skipped| *skipped < start_idx);
+        // How many ids were skipped inside the range.
+        let skipped_ids_count_between_start_and_end = self.skipped_ids[skipped_ids_count_before_start..]
+            .iter()
+            .take_while(|skipped| **skipped < (start_idx + len))
+            .count();
 
-    // How many ids were skipped inside the range.
-    let skipped_ids_count_between_start_and_end = skipped_ids[skipped_ids_count_before_start..]
-        .iter()
-        .take_while(|skipped| **skipped < (start_idx + len))
-        .count();
+        let start = start_idx - skipped_ids_count_before_start;
 
-    let start = start_idx - skipped_ids_count_before_start;
-
-    IdRange {
-        start: From::from(start),
-        end: From::from(start + (len - skipped_ids_count_between_start_and_end)),
+        IdRange {
+            start: From::from(start),
+            end: From::from(start + (len - skipped_ids_count_between_start_and_end)),
+        }
     }
 }
 
@@ -89,21 +81,23 @@ fn map_range_impl<T: From<usize> + Copy>(skipped_ids: &[usize], (start_idx, len)
 mod tests {
     use super::*;
 
+    type IdMapper = super::IdMapper<federated_graph::InputValueDefinitionId, InputValueDefinitionId>;
+
     #[test]
     fn skip_basic() {
         let id = federated_graph::InputValueDefinitionId(2);
         let mut mapper = IdMapper::default();
-        assert_eq!(InputValueDefinitionId::from(2), input_values::map(&mapper, id).unwrap());
-        input_values::skip(&mut mapper, federated_graph::InputValueDefinitionId(1));
-        assert_eq!(InputValueDefinitionId::from(1), input_values::map(&mapper, id).unwrap());
+        assert_eq!(InputValueDefinitionId::from(2), mapper.map(id).unwrap());
+        mapper.skip(federated_graph::InputValueDefinitionId(1));
+        assert_eq!(InputValueDefinitionId::from(1), mapper.map(id).unwrap());
     }
 
     #[test]
     fn map_skipped() {
         let id = federated_graph::InputValueDefinitionId(5);
         let mut mapper = IdMapper::default();
-        input_values::skip(&mut mapper, id);
-        assert!(input_values::map(&mapper, id).is_none());
+        mapper.skip(id);
+        assert!(mapper.map(id).is_none());
     }
 
     #[test]
@@ -115,47 +109,47 @@ mod tests {
                 start: InputValueDefinitionId::from(6),
                 end: InputValueDefinitionId::from(16)
             },
-            input_values::map_range(&mapper, range)
+            mapper.map_range(range)
         );
 
-        input_values::skip(&mut mapper, federated_graph::InputValueDefinitionId(2));
+        mapper.skip(federated_graph::InputValueDefinitionId(2));
 
         assert_eq!(
             IdRange {
                 start: InputValueDefinitionId::from(5),
                 end: InputValueDefinitionId::from(15)
             },
-            input_values::map_range(&mapper, range)
+            mapper.map_range(range)
         );
 
-        input_values::skip(&mut mapper, federated_graph::InputValueDefinitionId(6));
+        mapper.skip(federated_graph::InputValueDefinitionId(6));
 
         assert_eq!(
             IdRange {
                 start: InputValueDefinitionId::from(5),
                 end: InputValueDefinitionId::from(14)
             },
-            input_values::map_range(&mapper, range)
+            mapper.map_range(range)
         );
 
-        input_values::skip(&mut mapper, federated_graph::InputValueDefinitionId(9));
+        mapper.skip(federated_graph::InputValueDefinitionId(9));
 
         assert_eq!(
             IdRange {
                 start: InputValueDefinitionId::from(5),
                 end: InputValueDefinitionId::from(13)
             },
-            input_values::map_range(&mapper, range)
+            mapper.map_range(range)
         );
 
-        input_values::skip(&mut mapper, federated_graph::InputValueDefinitionId(20));
+        mapper.skip(federated_graph::InputValueDefinitionId(20));
 
         assert_eq!(
             IdRange {
                 start: InputValueDefinitionId::from(5),
                 end: InputValueDefinitionId::from(13)
             },
-            input_values::map_range(&mapper, range)
+            mapper.map_range(range)
         );
     }
 
@@ -163,8 +157,8 @@ mod tests {
     #[should_panic(expected = "Broken invariant: ids must be skipped in order")]
     fn skip_out_of_order() {
         let mut mapper = IdMapper::default();
-        input_values::skip(&mut mapper, federated_graph::InputValueDefinitionId(5));
-        input_values::skip(&mut mapper, federated_graph::InputValueDefinitionId(3));
+        mapper.skip(federated_graph::InputValueDefinitionId(5));
+        mapper.skip(federated_graph::InputValueDefinitionId(3));
         // boom
     }
 
@@ -172,8 +166,8 @@ mod tests {
     #[should_panic(expected = "Broken invariant: ids must be skipped in order")]
     fn skip_twice() {
         let mut mapper = IdMapper::default();
-        input_values::skip(&mut mapper, federated_graph::InputValueDefinitionId(5));
-        input_values::skip(&mut mapper, federated_graph::InputValueDefinitionId(5));
+        mapper.skip(federated_graph::InputValueDefinitionId(5));
+        mapper.skip(federated_graph::InputValueDefinitionId(5));
         // boom
     }
 }

--- a/engine/crates/engine-v2/schema/src/builder/ids.rs
+++ b/engine/crates/engine-v2/schema/src/builder/ids.rs
@@ -1,0 +1,186 @@
+//! This module is responsible for mapping identifiers between federated schema and the engine v2
+//! schema when the mapping is not 1:1.
+//!
+//! As of 3b56f12c95d334ce6cb46f4f8654ce531a69f975, this only happens when @inaccessible items
+//! are removed.
+
+use crate::ids::*;
+
+pub(super) trait MappableId: Copy {
+    type Counterpart: Copy + From<usize>;
+
+    fn get_idx(self) -> usize;
+    fn get_map(mapper: &IdMapper) -> &[usize];
+    fn get_map_mut(mapper: &mut IdMapper) -> &mut Vec<usize>;
+}
+
+macro_rules! mapped_ids {
+    ($($name:ident : $from:ty => $to:ty)*) => {
+
+        #[derive(Default, Debug)]
+        pub(super) struct IdMapper {
+            $(
+                /// The index of skipped ids.
+                $name: Vec<usize>,
+            )*
+        }
+
+        $(
+            impl MappableId for $from {
+                type Counterpart = $to;
+
+                fn get_idx(self) -> usize {
+                    self.0
+                }
+
+                fn get_map(mapper: &IdMapper) -> &[usize] {
+                    &mapper.$name
+                }
+
+                fn get_map_mut(mapper: &mut IdMapper) -> &mut Vec<usize> {
+                    &mut mapper.$name
+                }
+            }
+        )*
+    };
+}
+
+mapped_ids!(
+    fields: federated_graph::FieldId => FieldId
+    input_values: federated_graph::InputValueDefinitionId => InputValueDefinitionId
+    enum_values: federated_graph::EnumValueId => EnumValueId
+);
+
+impl IdMapper {
+    pub(super) fn skip<Id: MappableId>(&mut self, id: Id) {
+        let idx = id.get_idx();
+        let entries = Id::get_map_mut(self);
+
+        if let Some(last_entry) = entries.last().copied() {
+            assert!(last_entry < idx);
+        }
+
+        entries.push(idx);
+    }
+
+    pub(super) fn map<Id: MappableId>(&self, id: Id) -> Option<Id::Counterpart> {
+        let idx = id.get_idx();
+        let map = Id::get_map(self);
+        let skipped = map.partition_point(|skipped| *skipped <= idx);
+
+        if let Some(last) = map[..skipped].last().copied() {
+            if last == idx {
+                return None;
+            }
+        }
+
+        Some(Id::Counterpart::from(idx - skipped))
+    }
+
+    pub(super) fn map_range<Id: MappableId>(&self, (start_id, len): (Id, usize)) -> crate::IdRange<Id::Counterpart>
+    where
+        usize: From<Id::Counterpart>,
+    {
+        let start_idx = start_id.get_idx();
+        let skipped = Id::get_map(self);
+
+        // How many ids were skipped before the range.
+        let skipped_before = skipped.partition_point(|skipped| *skipped < start_idx);
+
+        // How many ids were skipped inside the range.
+        let skipped_inside = skipped[skipped_before..]
+            .iter()
+            .take_while(|skipped| **skipped < (start_idx + len))
+            .count();
+
+        let start = start_idx - skipped_before;
+
+        IdRange {
+            start: From::from(start),
+            end: From::from(start + (len - skipped_inside)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skip_basic() {
+        let id = federated_graph::InputValueDefinitionId(2);
+        let mut mapper = IdMapper::default();
+        assert_eq!(InputValueDefinitionId::from(2), mapper.map(id).unwrap());
+        mapper.skip(federated_graph::InputValueDefinitionId(1));
+        assert_eq!(InputValueDefinitionId::from(1), mapper.map(id).unwrap());
+    }
+
+    #[test]
+    fn map_skipped() {
+        let id = federated_graph::InputValueDefinitionId(5);
+        let mut mapper = IdMapper::default();
+        mapper.skip(id);
+        assert!(mapper.map(id).is_none());
+    }
+
+    #[test]
+    fn map_range_basic() {
+        let range = (federated_graph::InputValueDefinitionId(6), 10);
+        let mut mapper = IdMapper::default();
+        assert_eq!(
+            IdRange {
+                start: InputValueDefinitionId::from(6),
+                end: InputValueDefinitionId::from(16)
+            },
+            mapper.map_range(range)
+        );
+
+        mapper.skip(federated_graph::InputValueDefinitionId(2));
+
+        assert_eq!(
+            IdRange {
+                start: InputValueDefinitionId::from(5),
+                end: InputValueDefinitionId::from(15)
+            },
+            mapper.map_range(range)
+        );
+
+        mapper.skip(federated_graph::InputValueDefinitionId(6));
+
+        assert_eq!(
+            IdRange {
+                start: InputValueDefinitionId::from(5),
+                end: InputValueDefinitionId::from(14)
+            },
+            mapper.map_range(range)
+        );
+
+        mapper.skip(federated_graph::InputValueDefinitionId(9));
+
+        assert_eq!(
+            IdRange {
+                start: InputValueDefinitionId::from(5),
+                end: InputValueDefinitionId::from(13)
+            },
+            mapper.map_range(range)
+        );
+
+        mapper.skip(federated_graph::InputValueDefinitionId(20));
+
+        assert_eq!(
+            IdRange {
+                start: InputValueDefinitionId::from(5),
+                end: InputValueDefinitionId::from(13)
+            },
+            mapper.map_range(range)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion failed: last_entry < idx")]
+    fn skip_out_of_order() {
+        let mut mapper = IdMapper::default();
+        mapper.skip(federated_graph::InputValueDefinitionId(5));
+        mapper.skip(federated_graph::InputValueDefinitionId(5)); // boom
+    }
+}

--- a/engine/crates/engine-v2/schema/src/builder/mod.rs
+++ b/engine/crates/engine-v2/schema/src/builder/mod.rs
@@ -136,7 +136,7 @@ impl SchemaBuilder {
 
     fn insert_directives(&mut self, config: &mut Config) {
         let mut directives = Vec::with_capacity(config.graph.directives.len());
-        for directive in &config.graph.directives {
+        for directive in take(&mut config.graph.directives) {
             let directive = match directive {
                 federated_graph::Directive::Inaccessible => Directive::Inaccessible,
                 federated_graph::Directive::Deprecated { reason } => Directive::Deprecated {

--- a/engine/crates/engine-v2/schema/src/builder/mod.rs
+++ b/engine/crates/engine-v2/schema/src/builder/mod.rs
@@ -1,3 +1,4 @@
+mod ids;
 mod interner;
 
 use std::collections::{HashMap, HashSet};
@@ -23,6 +24,7 @@ pub(crate) struct SchemaBuilder {
     pub schema: Schema,
     pub strings: Interner<String, StringId>,
     pub urls: Interner<Url, UrlId>,
+    id_mapper: ids::IdMapper,
 }
 
 impl SchemaBuilder {
@@ -37,7 +39,8 @@ impl SchemaBuilder {
     }
 
     fn initialize(config: &mut Config) -> Self {
-        Self {
+        let mut builder = Self {
+            id_mapper: ids::IdMapper::default(),
             strings: Interner::from_vec(take(&mut config.graph.strings)),
             urls: Interner::default(),
             schema: Schema {
@@ -55,26 +58,14 @@ impl SchemaBuilder {
                     .map(Into::into)
                     .collect(),
                 interfaces: take(&mut config.graph.interfaces).into_iter().map(Into::into).collect(),
-                interface_fields: take(&mut config.graph.interface_fields)
-                    .into_iter()
-                    .map(Into::into)
-                    .collect(),
-                enums: take(&mut config.graph.enums).into_iter().map(Into::into).collect(),
-                unions: take(&mut config.graph.unions).into_iter().map(Into::into).collect(),
+                interface_fields: Vec::new(),
+                enums: Vec::new(),
+                unions: Vec::with_capacity(0),
                 scalars: Vec::with_capacity(config.graph.scalars.len()),
-                input_objects: take(&mut config.graph.input_objects)
-                    .into_iter()
-                    .map(Into::into)
-                    .collect(),
+                input_objects: Vec::new(),
                 directives: Vec::new(),
-                input_value_definitions: take(&mut config.graph.input_value_definitions)
-                    .into_iter()
-                    .map(Into::into)
-                    .collect(),
-                enum_values: take(&mut config.graph.enum_values)
-                    .into_iter()
-                    .map(Into::into)
-                    .collect(),
+                input_value_definitions: Vec::new(),
+                enum_values: Vec::new(),
                 headers: Vec::with_capacity(0),
                 strings: Vec::with_capacity(0),
                 resolvers: vec![],
@@ -88,23 +79,79 @@ impl SchemaBuilder {
                 urls: Vec::new(),
                 input_values: SchemaInputValues::default(),
             },
+        };
+
+        for (idx, input_value_definition) in take(&mut config.graph.input_value_definitions).into_iter().enumerate() {
+            if is_inaccessible(&config.graph, input_value_definition.directives) {
+                builder.id_mapper.skip(federated_graph::InputValueDefinitionId(idx))
+            } else {
+                builder
+                    .schema
+                    .input_value_definitions
+                    .push(input_value_definition.into());
+            }
         }
+
+        for (idx, enum_value) in take(&mut config.graph.enum_values).into_iter().enumerate() {
+            if is_inaccessible(&config.graph, enum_value.composed_directives) {
+                builder.id_mapper.skip(federated_graph::EnumValueId(idx))
+            } else {
+                builder.schema.enum_values.push(enum_value.into());
+            }
+        }
+
+        builder.schema.interface_fields = take(&mut config.graph.interface_fields)
+            .into_iter()
+            .filter_map(|federated_graph::InterfaceField { interface_id, field_id }| {
+                Some(InterfaceField {
+                    interface_id: interface_id.into(),
+                    field_id: builder.id_mapper.map(field_id)?,
+                })
+            })
+            .collect();
+
+        builder.schema.input_objects = take(&mut config.graph.input_objects)
+            .into_iter()
+            .map(|input_object| builder.convert_input_object(input_object))
+            .collect();
+
+        builder.schema.enums = take(&mut config.graph.enums)
+            .into_iter()
+            .map(|enm| builder.convert_enum(enm))
+            .collect();
+
+        builder.schema.unions = take(&mut config.graph.unions)
+            .into_iter()
+            .map(|union| Union {
+                name: union.name.into(),
+                description: None,
+                possible_types: union
+                    .members
+                    .into_iter()
+                    .filter(|object_id| !is_inaccessible(&config.graph, config.graph[*object_id].composed_directives))
+                    .map(Into::into)
+                    .collect(),
+                composed_directives: union.composed_directives.into(),
+            })
+            .collect();
+
+        builder
     }
 
     fn insert_directives(&mut self, config: &mut Config) {
         let mut directives = Vec::with_capacity(config.graph.directives.len());
-        for directive in take(&mut config.graph.directives) {
+        for directive in &config.graph.directives {
             let directive = match directive {
                 federated_graph::Directive::Inaccessible => Directive::Inaccessible,
                 federated_graph::Directive::Deprecated { reason } => Directive::Deprecated {
                     reason: reason.map(Into::into),
                 },
                 federated_graph::Directive::Other { name, arguments } => Directive::Other {
-                    name: name.into(),
+                    name: (*name).into(),
                     arguments: {
                         let map = arguments
-                            .into_iter()
-                            .map(|(id, value)| (id.into(), self.insert_value(value)))
+                            .iter()
+                            .map(|(id, value)| ((*id).into(), self.insert_value(value)))
                             .collect();
                         self.schema.input_values.push_map(map)
                     },
@@ -115,23 +162,22 @@ impl SchemaBuilder {
         self.schema.directives = directives;
     }
 
-    fn insert_value(&mut self, value: federated_graph::Value) -> SchemaInputValue {
+    fn insert_value(&mut self, value: &federated_graph::Value) -> SchemaInputValue {
         match value {
-            federated_graph::Value::String(s) => SchemaInputValue::String(s.into()),
-            federated_graph::Value::Int(i) => SchemaInputValue::BigInt(i),
-            federated_graph::Value::Float(f) => SchemaInputValue::Float(f),
-            federated_graph::Value::Boolean(b) => SchemaInputValue::Boolean(b),
-            federated_graph::Value::EnumValue(id) => SchemaInputValue::UnknownEnumValue(id.into()),
+            federated_graph::Value::String(s) => SchemaInputValue::String((*s).into()),
+            federated_graph::Value::Int(i) => SchemaInputValue::BigInt(*i),
+            federated_graph::Value::Float(f) => SchemaInputValue::Float(*f),
+            federated_graph::Value::Boolean(b) => SchemaInputValue::Boolean(*b),
+            federated_graph::Value::EnumValue(id) => SchemaInputValue::UnknownEnumValue((*id).into()),
             federated_graph::Value::Object(fields) => {
                 let map = fields
-                    .into_vec()
-                    .into_iter()
-                    .map(|(id, value)| (id.into(), self.insert_value(value)))
+                    .iter()
+                    .map(|(id, value)| ((*id).into(), self.insert_value(value)))
                     .collect();
                 SchemaInputValue::Map(self.schema.input_values.push_map(map))
             }
             federated_graph::Value::List(l) => {
-                let list = l.into_vec().into_iter().map(|value| self.insert_value(value)).collect();
+                let list = l.iter().map(|value| self.insert_value(value)).collect();
                 SchemaInputValue::List(self.schema.input_values.push_list(list))
             }
         }
@@ -188,6 +234,7 @@ impl SchemaBuilder {
         let cache = take(&mut config.cache);
         let graph = &mut config.graph;
         let schema = &mut self.schema;
+        let id_mapper = &mut self.id_mapper;
         let mut cache_configs = Interner::<config::latest::CacheConfig, CacheConfigId>::default();
 
         // -- OBJECTS --
@@ -214,14 +261,20 @@ impl SchemaBuilder {
                     continue;
                 }
                 if key.resolvable {
+                    let key = federation::Key {
+                        fields: key
+                            .fields
+                            .into_iter()
+                            .filter_map(|item| id_mapper.convert_field_set_item(item))
+                            .collect(),
+                    };
+
                     let resolver_id = ResolverId::from(schema.resolvers.len());
                     schema
                         .resolvers
                         .push(Resolver::FederationEntity(federation::EntityResolver {
                             subgraph_id,
-                            key: federation::Key {
-                                fields: key.fields.into_iter().map(Into::into).collect(),
-                            },
+                            key,
                         }));
                     entity_resolvers
                         .entry(object_id)
@@ -232,7 +285,11 @@ impl SchemaBuilder {
                     // those fields to `provides` in the relevant fields. It's the resolvable keys
                     // that will determine which fields to retrieve during planning. And composition
                     // ensures that keys between subgraphs are coherent.
-                    let field_set: FieldSet = key.fields.into_iter().map(Into::into).collect();
+                    let field_set: FieldSet = key
+                        .fields
+                        .into_iter()
+                        .filter_map(|item| id_mapper.convert_field_set_item(item))
+                        .collect();
                     unresolvable_keys
                         .entry(object_id)
                         .or_default()
@@ -246,9 +303,21 @@ impl SchemaBuilder {
         }
 
         // -- OBJECT FIELDS --
+        for (i, field) in graph.fields.iter().enumerate() {
+            if is_inaccessible(graph, field.composed_directives) {
+                id_mapper.skip(federated_graph::FieldId(i));
+            }
+        }
+
         let mut field_id_to_maybe_object_id: Vec<Option<ObjectId>> = vec![None; graph.fields.len()];
         for object_field in take(&mut graph.object_fields) {
-            let object_field: ObjectField = object_field.into();
+            let Some(field_id) = id_mapper.map(object_field.field_id) else {
+                continue;
+            };
+            let object_field = ObjectField {
+                object_id: object_field.object_id.into(),
+                field_id,
+            };
             field_id_to_maybe_object_id[usize::from(object_field.field_id)] = Some(object_field.object_id);
             schema.object_fields.push(object_field);
         }
@@ -282,7 +351,9 @@ impl SchemaBuilder {
         //    them and having an id allows data sources to rename those more easily.
         let mut root_field_resolvers = HashMap::<SubgraphId, ResolverId>::new();
         for (i, field) in take(&mut graph.fields).into_iter().enumerate() {
-            let field_id = FieldId::from(i);
+            let Some(field_id) = id_mapper.map(federated_graph::FieldId(i)) else {
+                continue;
+            };
             let mut resolvers = vec![];
             let subgraph_requires = field
                 .requires
@@ -290,7 +361,11 @@ impl SchemaBuilder {
                 .map(|federated_graph::FieldRequires { subgraph_id, fields }| {
                     (
                         SubgraphId::from(subgraph_id),
-                        FieldSet::from_iter(fields.into_iter().map(Into::into)),
+                        FieldSet::from_iter(
+                            fields
+                                .into_iter()
+                                .filter_map(|item| id_mapper.convert_field_set_item(item)),
+                        ),
                     )
                 })
                 .collect::<HashMap<_, _>>();
@@ -317,7 +392,10 @@ impl SchemaBuilder {
             let mut provides: HashMap<SubgraphId, FieldSet> = field.provides.into_iter().fold(
                 HashMap::new(),
                 |mut provides, federated_graph::FieldProvides { subgraph_id, fields }| {
-                    let field_set: FieldSet = fields.into_iter().map(Into::into).collect();
+                    let field_set: FieldSet = fields
+                        .into_iter()
+                        .filter_map(|item| id_mapper.convert_field_set_item(item))
+                        .collect();
                     provides
                         .entry(subgraph_id.into())
                         .and_modify(|current| {
@@ -381,7 +459,7 @@ impl SchemaBuilder {
                         field_set,
                     })
                     .collect(),
-                arguments: field.arguments.into(),
+                arguments: id_mapper.map_range(field.arguments),
                 composed_directives: field.composed_directives.into(),
                 cache_config: cache
                     .rule(CacheConfigTarget::Field(federated_graph::FieldId(field_id.into())))
@@ -397,7 +475,7 @@ impl SchemaBuilder {
             let input_object = InputObject {
                 name: input_object.name.into(),
                 description: None,
-                input_fields: input_object.fields.into(),
+                input_fields: self.id_mapper.map_range(input_object.fields),
                 composed_directives: input_object.composed_directives.into(),
             };
             schema.input_objects.push(input_object);
@@ -489,6 +567,43 @@ impl SchemaBuilder {
         assert!(matches!(schema.resolvers.last(), Some(Resolver::Introspection(_))));
         schema
     }
+
+    fn convert_input_object(&self, value: federated_graph::InputObject) -> InputObject {
+        InputObject {
+            name: value.name.into(),
+            description: value.description.map(Into::into),
+            input_fields: self.id_mapper.map_range(value.fields),
+            composed_directives: value.composed_directives.into(),
+        }
+    }
+
+    fn convert_enum(&self, value: federated_graph::Enum) -> Enum {
+        Enum {
+            name: value.name.into(),
+            description: None,
+            values: self.id_mapper.map_range(value.values),
+            composed_directives: value.composed_directives.into(),
+        }
+    }
+}
+
+impl ids::IdMapper {
+    fn convert_field_set_item(&self, selection: federated_graph::FieldSetItem) -> Option<FieldSetItem> {
+        Some(FieldSetItem {
+            field_id: self.map(selection.field)?,
+            subselection: selection
+                .subselection
+                .into_iter()
+                .filter_map(|item| self.convert_field_set_item(item))
+                .collect(),
+        })
+    }
+}
+
+fn is_inaccessible(graph: &federated_graph::FederatedGraphV2, directives: federated_graph::Directives) -> bool {
+    graph[directives]
+        .iter()
+        .any(|directive| matches!(directive, federated_graph::Directive::Inaccessible))
 }
 
 impl From<federated_graph::Object> for Object {
@@ -499,15 +614,6 @@ impl From<federated_graph::Object> for Object {
             interfaces: object.implements_interfaces.into_iter().map(Into::into).collect(),
             composed_directives: object.composed_directives.into(),
             cache_config: Default::default(),
-        }
-    }
-}
-
-impl From<federated_graph::ObjectField> for ObjectField {
-    fn from(object_field: federated_graph::ObjectField) -> Self {
-        ObjectField {
-            object_id: object_field.object_id.into(),
-            field_id: object_field.field_id.into(),
         }
     }
 }
@@ -555,26 +661,6 @@ impl From<federated_graph::Interface> for Interface {
     }
 }
 
-impl From<federated_graph::InterfaceField> for InterfaceField {
-    fn from(interface_field: federated_graph::InterfaceField) -> Self {
-        InterfaceField {
-            interface_id: interface_field.interface_id.into(),
-            field_id: interface_field.field_id.into(),
-        }
-    }
-}
-
-impl From<federated_graph::InputObject> for InputObject {
-    fn from(value: federated_graph::InputObject) -> Self {
-        InputObject {
-            name: value.name.into(),
-            description: value.description.map(Into::into),
-            input_fields: value.fields.into(),
-            composed_directives: value.composed_directives.into(),
-        }
-    }
-}
-
 impl From<federated_graph::InputValueDefinition> for InputValueDefinition {
     fn from(value: federated_graph::InputValueDefinition) -> Self {
         InputValueDefinition {
@@ -582,37 +668,6 @@ impl From<federated_graph::InputValueDefinition> for InputValueDefinition {
             description: value.description.map(Into::into),
             type_id: value.type_id.into(),
             default_value: None,
-        }
-    }
-}
-
-impl From<federated_graph::Enum> for Enum {
-    fn from(value: federated_graph::Enum) -> Self {
-        Enum {
-            name: value.name.into(),
-            description: None,
-            values: value.values.into(),
-            composed_directives: value.composed_directives.into(),
-        }
-    }
-}
-
-impl From<federated_graph::Union> for Union {
-    fn from(union: federated_graph::Union) -> Self {
-        Union {
-            name: union.name.into(),
-            description: None,
-            possible_types: union.members.into_iter().map(Into::into).collect(),
-            composed_directives: union.composed_directives.into(),
-        }
-    }
-}
-
-impl From<federated_graph::FieldSetItem> for FieldSetItem {
-    fn from(selection: federated_graph::FieldSetItem) -> Self {
-        FieldSetItem {
-            field_id: selection.field.into(),
-            subselection: selection.subselection.into_iter().map(Into::into).collect(),
         }
     }
 }
@@ -642,10 +697,7 @@ macro_rules! from_id_newtypes {
 from_id_newtypes! {
     federated_graph::DirectiveId => DirectiveId,
     federated_graph::EnumId => EnumId,
-    federated_graph::EnumValueId => EnumValueId,
-    federated_graph::FieldId => FieldId,
     federated_graph::InputObjectId => InputObjectId,
-    federated_graph::InputValueDefinitionId => InputValueDefinitionId,
     federated_graph::InterfaceId => InterfaceId,
     federated_graph::ObjectId => ObjectId,
     federated_graph::ScalarId => ScalarId,

--- a/engine/crates/engine-v2/schema/tests/conversion.rs
+++ b/engine/crates/engine-v2/schema/tests/conversion.rs
@@ -273,6 +273,7 @@ fn should_remove_all_inaccessible_items() {
         let query = schema.walk(query);
 
         assert!(!query.fields().any(|f| f.name() == "currentTime"));
+        assert!(query.fields().any(|f| f.name() == "getNew"));
     }
 
     // Enum values

--- a/engine/crates/engine-v2/schema/tests/conversion.rs
+++ b/engine/crates/engine-v2/schema/tests/conversion.rs
@@ -1,4 +1,4 @@
-use engine_v2_schema::Schema;
+use engine_v2_schema::{Definition, Schema};
 use federated_graph::FederatedGraph;
 
 const SCHEMA: &str = r#"
@@ -98,4 +98,206 @@ fn should_not_fail() {
     let graph = FederatedGraph::from_sdl(SCHEMA).unwrap().into_latest();
     let config = config::VersionedConfig::V3(config::latest::Config::from_graph(graph)).into_latest();
     let _schema = Schema::from(config);
+}
+
+const SCHEMA_WITH_INACCESSIBLES: &str = r#"
+directive @core(feature: String!) repeatable on SCHEMA
+
+directive @join__owner(graph: join__Graph!) on OBJECT
+
+directive @join__type(
+    graph: join__Graph!
+    key: String!
+    resolvable: Boolean = true
+) repeatable on OBJECT | INTERFACE
+
+directive @join__field(
+    graph: join__Graph
+    requires: String
+    provides: String
+) on FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+enum join__Graph {
+    FIVE_WITH_ENUM @join__graph(name: "five_with_enum", url: "http://example.com/five_with_enum")
+    FOUR_WITH_UNION @join__graph(name: "four_with_union", url: "http://example.com/four_with_union")
+    ONE @join__graph(name: "one", url: "http://example.com/one")
+    SIX_WITH_INPUT_OBJECT @join__graph(name: "six_with_input_object", url: "http://example.com/six_with_input_object")
+    THREE_WITH_INTERFACE @join__graph(name: "three_with_interface", url: "http://example.com/three_with_interface")
+    TWO @join__graph(name: "two", url: "http://example.com/two")
+}
+
+scalar Time @inaccessible
+
+type Ungulate {
+    id: ID! @join__field(graph: FIVE_WITH_ENUM)
+    name: String! @join__field(graph: FIVE_WITH_ENUM)
+    type: UngulateType! @join__field(graph: FIVE_WITH_ENUM) @inaccessible
+}
+
+type Movie {
+    id: ID! @join__field(graph: FOUR_WITH_UNION)
+    title: String! @join__field(graph: FOUR_WITH_UNION)
+    director: String! @join__field(graph: FOUR_WITH_UNION)
+    releaseYear: Int @join__field(graph: FOUR_WITH_UNION)
+}
+
+type Series {
+    id: ID! @join__field(graph: FOUR_WITH_UNION)
+    title: String! @join__field(graph: FOUR_WITH_UNION)
+    seasons: Int @join__field(graph: FOUR_WITH_UNION)
+}
+
+type New {
+    name: String! @inaccessible
+    other: String!
+    message: String! @inaccessible
+    old: Old! @inaccessible
+}
+
+type Old @inaccessible {
+    name: String! @inaccessible
+}
+
+type Book {
+    id: ID! @join__field(graph: SIX_WITH_INPUT_OBJECT)
+    title: String! @join__field(graph: SIX_WITH_INPUT_OBJECT)
+    author: String! @join__field(graph: SIX_WITH_INPUT_OBJECT)
+    publishedYear: Int @join__field(graph: SIX_WITH_INPUT_OBJECT)
+    genre: String @join__field(graph: SIX_WITH_INPUT_OBJECT)
+}
+
+type Quadratic implements Polynomial {
+    degree: Int @join__field(graph: THREE_WITH_INTERFACE)
+    coefficients: [Float] @join__field(graph: THREE_WITH_INTERFACE)
+    discriminant: Float @join__field(graph: THREE_WITH_INTERFACE)
+}
+
+type Cubic implements Polynomial {
+    degree: Int @join__field(graph: THREE_WITH_INTERFACE)
+    coefficients: [Float] @join__field(graph: THREE_WITH_INTERFACE)
+    inflectionPoint: Float @join__field(graph: THREE_WITH_INTERFACE)
+}
+
+type Query {
+    getUngulate(id: ID!): Ungulate @join__field(graph: FIVE_WITH_ENUM)
+    getTVContent(id: ID!): TVContent @join__field(graph: FOUR_WITH_UNION) @inaccessible
+    getNew(name: String!): New @join__field(graph: ONE)
+    getBook(id: ID!): Book @join__field(graph: SIX_WITH_INPUT_OBJECT)
+    getPolynomial(id: ID!): Polynomial @join__field(graph: THREE_WITH_INTERFACE) @inaccessible
+    currentTime: Time! @join__field(graph: TWO) @inaccessible
+}
+
+type Mutation {
+    addBook(input: BookInput! @inaccessible): Book @join__field(graph: SIX_WITH_INPUT_OBJECT)
+    updateBook(id: ID!, input: BookInput2! @inaccessible): Book @join__field(graph: SIX_WITH_INPUT_OBJECT)
+}
+
+interface Polynomial @inaccessible {
+    degree: Int
+    coefficients: [Float]
+}
+
+enum UngulateType @inaccessible {
+    DEER
+    HORSE @inaccessible
+    CAMEL
+    RHINOCEROS
+    GIRAFFE
+}
+
+union TVContent @inaccessible = Movie | Series
+
+union Continent = New | Old
+
+input BookInput @inaccessible {
+    title: String!
+    author: String! @inaccessible
+    publishedYear: Int
+    genre: String
+}
+
+input BookInput2 {
+    title: String!
+    author: String! @inaccessible
+    publishedYear: Int
+    genre: String
+}
+"#;
+
+#[test]
+fn should_remove_all_inaccessible_items() {
+    let graph = FederatedGraph::from_sdl(SCHEMA_WITH_INACCESSIBLES)
+        .unwrap()
+        .into_latest();
+    let config = config::VersionedConfig::V3(config::latest::Config::from_graph(graph)).into_latest();
+    let schema = Schema::from(config);
+
+    // Inaccessible types are still in the schema, they're just not reachable through input and output fields.
+    assert!(schema.walker().definition_by_name("BookInput").is_some());
+    assert!(schema.walker().definition_by_name("TVContent").is_some());
+    assert!(schema.walker().definition_by_name("UngulateType").is_some());
+    assert!(schema.walker().definition_by_name("Old").is_some());
+
+    // Input object fields
+    {
+        let Some(Definition::InputObject(book_input_2)) = schema.walker().definition_by_name("BookInput2") else {
+            panic!("missing BookInput2");
+        };
+
+        let book_input_2 = schema.walk(book_input_2);
+
+        assert!(!book_input_2.input_fields().any(|field| field.name() == "author"));
+    }
+
+    // Field arguments
+    {
+        let Some(Definition::Object(mutation)) = schema.walker().definition_by_name("Mutation") else {
+            panic!("missing Mutation");
+        };
+
+        let mutation = schema.walk(mutation);
+
+        let field = mutation.fields().find(|field| field.name() == "addBook").unwrap();
+
+        assert!(field.argument_by_name("input").is_none())
+    }
+
+    // Object fields
+    {
+        let Some(Definition::Object(query)) = schema.walker().definition_by_name("Query") else {
+            panic!("missing Query");
+        };
+
+        let query = schema.walk(query);
+
+        assert!(!query.fields().any(|f| f.name() == "currentTime"));
+    }
+
+    // Enum values
+    {
+        let Some(Definition::Enum(ungulate_type)) = schema.definition_by_name("UngulateType") else {
+            panic!("Expected UngulateType to be defined");
+        };
+
+        let r#enum = schema.walk(ungulate_type);
+        assert!(r#enum.values().any(|value| value.name() == "GIRAFFE"));
+        assert!(!r#enum.values().any(|value| value.name() == "HORSE"));
+    }
+
+    // Union members
+    {
+        let Some(Definition::Union(continent)) = schema.definition_by_name("Continent") else {
+            panic!("Expected Continent to be defined");
+        };
+
+        let members = schema
+            .walk(continent)
+            .possible_types()
+            .map(|t| t.name())
+            .collect::<Vec<_>>();
+
+        assert_eq!(members, &["New"])
+    }
 }

--- a/engine/crates/federated-graph/src/federated_graph/v1.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v1.rs
@@ -358,6 +358,12 @@ macro_rules! id_newtypes {
             #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
             pub struct $name(pub usize);
 
+            impl From<$name> for usize {
+              fn from(value: $name) -> usize {
+                value.0
+              }
+            }
+
             impl std::ops::Index<$name> for FederatedGraphV1 {
                 type Output = $out;
 

--- a/engine/crates/federated-graph/src/federated_graph/v2.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v2.rs
@@ -218,7 +218,7 @@ impl From<DirectiveId> for usize {
 }
 pub const NO_DIRECTIVES: Directives = (DirectiveId(0), 0);
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct InputValueDefinitionId(pub usize);
 
 /// A (start, len) range in FederatedSchema.

--- a/engine/crates/integration-tests/tests/federation/introspection.rs
+++ b/engine/crates/integration-tests/tests/federation/introspection.rs
@@ -840,7 +840,6 @@ fn introspection_on_multiple_federation_subgraphs() {
     }
 
     type Picture {
-      altText: String!
       height: Int!
       url: String!
       width: Int!


### PR DESCRIPTION
Since they are not part of the API of the engine, they should be excluded as early as possible. They can fall through the cracks if they are included in the schema, so we remove them at conversion time.

The approach taken is to remove inaccessible output fields, input value definitions, union members and enum values. Since inaccessible types cause the fields returning them to also be inaccessible (composition rule), that automatically deals with inaccessible types.

closes GB-5949