### PR TITLE
feat: Validate all inputs part 1

### DIFF
--- a/engine/crates/engine-v2/schema/src/ids/range.rs
+++ b/engine/crates/engine-v2/schema/src/ids/range.rs
@@ -1,0 +1,109 @@
+use std::ops::Range;
+
+// Not necessary anymore when Rust stabilize std::iter::Step
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct IdRange<Id: Copy> {
+    pub start: Id,
+    pub end: Id,
+}
+
+impl<Id: Copy + From<usize>> Default for IdRange<Id> {
+    fn default() -> Self {
+        Self {
+            start: Id::from(0),
+            end: Id::from(0),
+        }
+    }
+}
+
+impl<Id> IdRange<Id>
+where
+    Id: From<usize> + Copy,
+    usize: From<Id>,
+{
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn len(&self) -> usize {
+        usize::from(self.end) - usize::from(self.start)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn get(&self, i: usize) -> Option<Id> {
+        let i = usize::from(self.start) + i;
+        if i < usize::from(self.end) {
+            Some(Id::from(i))
+        } else {
+            None
+        }
+    }
+
+    // An From/Into would be nicer, but it's dangerously also works for (usize, usize)
+    // which could also be interpreted as a range (start, end).
+    pub fn from_start_and_length<Src>((start, len): (Src, usize)) -> Self
+    where
+        Id: From<Src>,
+    {
+        let start = Id::from(start);
+        Self {
+            start,
+            end: Id::from(usize::from(start) + len),
+        }
+    }
+
+    pub fn from_single(id: Id) -> Self {
+        Self {
+            start: id,
+            end: Id::from(usize::from(id) + 1),
+        }
+    }
+}
+
+impl<Id, T> From<Range<T>> for IdRange<Id>
+where
+    Id: From<T> + Copy,
+{
+    fn from(Range { start, end }: Range<T>) -> Self {
+        Self {
+            start: Id::from(start),
+            end: Id::from(end),
+        }
+    }
+}
+
+impl<Id> Iterator for IdRange<Id>
+where
+    Id: Copy + From<usize>,
+    usize: From<Id>,
+{
+    type Item = Id;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if !IdRange::<Id>::is_empty(self) {
+            let id = self.start;
+            self.start = Id::from(usize::from(id) + 1);
+            Some(id)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let n = self.len();
+        (n, Some(n))
+    }
+}
+
+impl<Id> ExactSizeIterator for IdRange<Id>
+where
+    Id: Copy + From<usize>,
+    usize: From<Id>,
+{
+    fn len(&self) -> usize {
+        IdRange::len(self)
+    }
+}

--- a/engine/crates/engine-v2/schema/src/input_value/de.rs
+++ b/engine/crates/engine-v2/schema/src/input_value/de.rs
@@ -6,17 +6,11 @@ use serde::{
     forward_to_deserialize_any,
 };
 
-use crate::{InputValue, InputValueSerdeError, InputValuesContext};
+use crate::{InputValueSerdeError, RawInputValue, RawInputValueWalker, RawInputValuesContext};
 
-pub(super) struct InputValueDeserializer<'de, Str, Ctx> {
-    pub ctx: Ctx,
-    pub value: &'de InputValue<Str>,
-}
-
-impl<'de, Str, Ctx> serde::Deserializer<'de> for InputValueDeserializer<'de, Str, Ctx>
+impl<'de, Ctx> serde::Deserializer<'de> for RawInputValueWalker<'de, Ctx>
 where
-    Ctx: InputValuesContext<'de, Str>,
-    Str: 'de,
+    Ctx: RawInputValuesContext<'de>,
 {
     type Error = InputValueSerdeError;
 
@@ -25,47 +19,52 @@ where
         V: Visitor<'de>,
     {
         match self.value {
-            InputValue::Null => visitor.visit_unit(),
-            InputValue::String(s) | InputValue::UnknownEnumValue(s) => visitor.visit_borrowed_str(self.ctx.get_str(s)),
-            InputValue::EnumValue(id) => visitor.visit_borrowed_str(self.ctx.schema_walker().walk(*id).name()),
-            InputValue::Int(n) => visitor.visit_i32(*n),
-            InputValue::BigInt(n) => visitor.visit_i64(*n),
-            InputValue::U64(n) => visitor.visit_u64(*n),
-            InputValue::Float(n) => visitor.visit_f64(*n),
-            InputValue::Boolean(b) => visitor.visit_bool(*b),
-            &InputValue::List(ids) => {
-                let ctx = self.ctx;
-                let mut deserializer = SeqDeserializer::new(ids.iter().map(move |id| InputValueDeserializer {
-                    value: &ctx.input_values()[id],
-                    ctx,
-                }));
+            RawInputValue::Null | RawInputValue::Undefined => visitor.visit_none(),
+            RawInputValue::String(s) | RawInputValue::UnknownEnumValue(s) => {
+                visitor.visit_borrowed_str(self.ctx.get_str(s))
+            }
+            RawInputValue::EnumValue(id) => visitor.visit_borrowed_str(self.ctx.schema_walker().walk(*id).name()),
+            RawInputValue::Int(n) => visitor.visit_i32(*n),
+            RawInputValue::BigInt(n) => visitor.visit_i64(*n),
+            RawInputValue::U64(n) => visitor.visit_u64(*n),
+            RawInputValue::Float(n) => visitor.visit_f64(*n),
+            RawInputValue::Boolean(b) => visitor.visit_bool(*b),
+            RawInputValue::List(ids) => {
+                let mut deserializer = SeqDeserializer::new(ids.map(move |id| self.ctx.walk(id)));
                 let seq = visitor.visit_seq(&mut deserializer)?;
                 deserializer.end()?;
                 Ok(seq)
             }
-            InputValue::InputObject(ids) => {
-                let ctx = self.ctx;
-                let mut deserializer = MapDeserializer::new(ids.iter().map(move |id| {
-                    let (id, value) = &ctx.input_values()[id];
-                    (
-                        ctx.schema_walker().walk(*id).name(),
-                        InputValueDeserializer { value, ctx },
-                    )
+            RawInputValue::InputObject(ids) => {
+                let mut deserializer = MapDeserializer::new(ids.filter_map(move |id| {
+                    let (input_value_definition_id, value) = &self.ctx.input_values()[id];
+                    let value = self.walk(value);
+                    if value.is_undefined() {
+                        None
+                    } else {
+                        Some((self.ctx.schema_walker().walk(*input_value_definition_id).name(), value))
+                    }
                 }));
                 let map = visitor.visit_map(&mut deserializer)?;
                 deserializer.end()?;
                 Ok(map)
             }
-            InputValue::Map(ids) => {
-                let ctx = self.ctx;
-                let mut deserializer = MapDeserializer::new(ids.iter().map(move |id| {
-                    let (key, value) = &ctx.input_values()[id];
-                    (self.ctx.get_str(key), InputValueDeserializer { value, ctx })
+            RawInputValue::Map(ids) => {
+                let mut deserializer = MapDeserializer::new(ids.filter_map(move |id| {
+                    let (key, value) = &self.ctx.input_values()[id];
+                    let value = self.walk(value);
+                    if value.is_undefined() {
+                        None
+                    } else {
+                        Some((self.ctx.get_str(key), value))
+                    }
                 }));
                 let map = visitor.visit_map(&mut deserializer)?;
                 deserializer.end()?;
                 Ok(map)
             }
+            RawInputValue::Ref(id) => self.ctx.walk(*id).deserialize_any(visitor),
+            RawInputValue::SchemaRef(id) => self.ctx.schema_walk(*id).deserialize_any(visitor),
         }
     }
 
@@ -73,24 +72,30 @@ where
     where
         V: Visitor<'de>,
     {
-        if matches!(self.value, InputValue::Null) {
+        if matches!(self.value, RawInputValue::Null | RawInputValue::Undefined) {
             visitor.visit_none()
         } else {
             visitor.visit_some(self)
         }
     }
 
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf unit unit_struct newtype_struct seq tuple
-        tuple_struct map struct enum identifier ignored_any
+        tuple_struct map struct enum identifier
     }
 }
 
-impl<'de, Str, Ctx> IntoDeserializer<'de, InputValueSerdeError> for InputValueDeserializer<'de, Str, Ctx>
+impl<'de, Ctx> IntoDeserializer<'de, InputValueSerdeError> for RawInputValueWalker<'de, Ctx>
 where
-    Ctx: InputValuesContext<'de, Str>,
-    Str: 'de,
+    Ctx: RawInputValuesContext<'de>,
 {
     type Deserializer = Self;
     fn into_deserializer(self) -> Self::Deserializer {

--- a/engine/crates/engine-v2/schema/src/input_value/ids.rs
+++ b/engine/crates/engine-v2/schema/src/input_value/ids.rs
@@ -1,4 +1,4 @@
-use crate::{InputValue, InputValueDefinitionId, InputValues, MAX_ID};
+use crate::{InputValueDefinitionId, RawInputValue, RawInputValues, MAX_ID};
 
 macro_rules! input_ids {
     ($($field:ident[$name:ident] => $out:ty | unless $msg:literal,)*) => {
@@ -17,7 +17,7 @@ macro_rules! input_ids {
 
             impl<Str> Copy for $name<Str> {}
 
-            impl<Str> std::ops::Index<$name<Str>> for InputValues<Str> {
+            impl<Str> std::ops::Index<$name<Str>> for RawInputValues<Str> {
                 type Output = $out;
 
                 fn index(&self, id: $name<Str>) -> &$out {
@@ -25,13 +25,13 @@ macro_rules! input_ids {
                 }
             }
 
-            impl<Str> std::ops::IndexMut<$name<Str>> for InputValues<Str> {
+            impl<Str> std::ops::IndexMut<$name<Str>> for RawInputValues<Str> {
                 fn index_mut(&mut self, id: $name<Str>) -> &mut $out {
                     &mut self.$field[(id.index.get() - 1) as usize]
                 }
             }
 
-            impl<Str> std::ops::Index<crate::ids::IdRange<$name<Str>>> for InputValues<Str> {
+            impl<Str> std::ops::Index<crate::ids::IdRange<$name<Str>>> for RawInputValues<Str> {
                 type Output = [$out];
 
                 fn index(&self, range: crate::ids::IdRange<$name<Str>>) -> &Self::Output {
@@ -42,7 +42,7 @@ macro_rules! input_ids {
                 }
             }
 
-            impl<Str> std::ops::IndexMut<crate::ids::IdRange<$name<Str>>> for InputValues<Str> {
+            impl<Str> std::ops::IndexMut<crate::ids::IdRange<$name<Str>>> for RawInputValues<Str> {
                 fn index_mut(&mut self, range: crate::ids::IdRange<$name<Str>>) -> &mut Self::Output {
                     let crate::ids::IdRange { start, end } = range;
                     let start = usize::from(start);
@@ -77,7 +77,7 @@ macro_rules! input_ids {
 }
 
 input_ids!(
-    values[InputValueId] => InputValue<Str> | unless "Too many input values",
-    input_fields[InputObjectFieldValueId] => (InputValueDefinitionId, InputValue<Str>) | unless "Too many input object fields",
-    key_values[InputKeyValueId] => (Str, InputValue<Str>) | unless "Too many input fields",
+    values[RawInputValueId] => RawInputValue<Str> | unless "Too many input values",
+    input_fields[RawInputObjectFieldValueId] => (InputValueDefinitionId, RawInputValue<Str>) | unless "Too many input object fields",
+    key_values[RawInputKeyValueId] => (Str, RawInputValue<Str>) | unless "Too many input fields",
 );

--- a/engine/crates/engine-v2/schema/src/input_value/mod.rs
+++ b/engine/crates/engine-v2/schema/src/input_value/mod.rs
@@ -4,379 +4,84 @@ mod de;
 mod display;
 mod error;
 mod ids;
+mod raw;
 mod ser;
+mod walker;
 
 pub use error::*;
 pub use ids::*;
+pub use raw::*;
+pub use walker::*;
 
-pub type SchemaInputValues = InputValues<StringId>;
-pub type SchemaInputValue = InputValue<StringId>;
-pub type SchemaInputValueId = InputValueId<StringId>;
-pub type SchemaInputObjectFieldValueId = InputObjectFieldValueId<StringId>;
-pub type SchemaInputKeyValueId = InputKeyValueId<StringId>;
-pub type SchemaInputMap = IdRange<InputKeyValueId<StringId>>;
+pub type SchemaInputValues = RawInputValues<StringId>;
+pub type SchemaInputValue = RawInputValue<StringId>;
+pub type SchemaInputValueId = RawInputValueId<StringId>;
+pub type SchemaInputObjectFieldValueId = RawInputObjectFieldValueId<StringId>;
+pub type SchemaInputKeyValueId = RawInputKeyValueId<StringId>;
+pub type SchemaInputMap = IdRange<RawInputKeyValueId<StringId>>;
 
-/// Holds input values for the Schema and for an Operation during execution.
-/// It's generic over 'Str', the string representation:
-/// - StringId for the Schema (default input values and directive arguments)
-/// - Box<str> for the Operation
-///
-/// This allow us to share the code for:
-/// - Display: used to print default values in introspection and add input values in subgraph query strings.
-/// - Serialize: used to serialize variables/arguments.
-/// - Deserializer: used by resolvers to deserialize arguments into a specific struct.
-///
-/// Data is stored in flat arrays for hopefully faster serialization and as as bonus smaller InputValue
-/// footprint on x64 architectures: u64 + usize (padding) rather than 3 * usize (Box<[]> + padding).
-pub struct InputValues<Str> {
-    /// Inidividual input values and list values
-    pub values: Vec<InputValue<Str>>,
-    /// InputObject's fields
-    pub input_fields: Vec<(InputValueDefinitionId, InputValue<Str>)>,
-    /// Object's fields (for JSON)
-    pub key_values: Vec<(Str, InputValue<Str>)>,
-}
-
-impl<Str> Default for InputValues<Str> {
-    fn default() -> Self {
-        Self {
-            input_fields: Default::default(),
-            values: Default::default(),
-            key_values: Default::default(),
-        }
-    }
-}
-
-/// Represents any possible input value for field arguments, operation variables and directive
-/// arguments.
-#[derive(Debug, Clone)]
-pub enum InputValue<Str> {
+/// InputValue to be used during execution if more control is needed that what serde/display can
+/// provide for a RawInputValue. With a PlanInputValue `value`, you just need to use
+/// `InputValue::from(value)`.
+#[derive(Default, Debug, Clone)]
+pub enum InputValue<'a> {
+    #[default]
     Null,
-    String(Str),
+    String(&'a str),
     EnumValue(EnumValueId),
     Int(i32),
     BigInt(i64),
     Float(f64),
     Boolean(bool),
-    InputObject(IdRange<InputObjectFieldValueId<Str>>),
-    List(IdRange<InputValueId<Str>>),
+    // There is no guarantee on the ordering.
+    InputObject(Box<[(InputValueDefinitionId, InputValue<'a>)]>),
+    List(Box<[InputValue<'a>]>),
 
-    // for JSON
-    Map(IdRange<InputKeyValueId<Str>>),
+    /// for JSON
+    Map(Box<[(&'a str, InputValue<'a>)]>), // no guarantee on the ordering
     U64(u64),
-
-    // Directive arguments have unknown enum values. Likely doesn't make sense, but not sure.
-    UnknownEnumValue(Str),
 }
 
-impl<Str> InputValues<Str> {
-    pub fn push_value(&mut self, value: InputValue<Str>) -> InputValueId<Str> {
-        let id = InputValueId::from(self.values.len());
-        self.values.push(value);
-        id
-    }
-
-    pub fn push_list(&mut self, values: Vec<InputValue<Str>>) -> IdRange<InputValueId<Str>> {
-        let start = self.values.len();
-        self.values.extend(values);
-        (start..self.values.len()).into()
-    }
-
-    pub fn push_map(&mut self, fields: Vec<(Str, InputValue<Str>)>) -> IdRange<InputKeyValueId<Str>> {
-        let start = self.key_values.len();
-        self.key_values.extend(fields);
-        (start..self.key_values.len()).into()
-    }
-
-    pub fn push_input_object(
-        &mut self,
-        fields: Vec<(InputValueDefinitionId, InputValue<Str>)>,
-    ) -> IdRange<InputObjectFieldValueId<Str>> {
-        let start = self.input_fields.len();
-        self.input_fields.extend(fields);
-        (start..self.input_fields.len()).into()
-    }
-}
-
-pub trait InputValuesContext<'ctx, Str>: Clone + Copy + 'ctx {
-    fn schema_walker(&self) -> &SchemaWalker<'ctx, ()>;
-    fn get_str(&self, s: &Str) -> &'ctx str;
-    fn input_values(&self) -> &'ctx InputValues<Str>;
-
-    fn input_value_as_serializable(&self, id: InputValueId<Str>) -> impl serde::Serialize + 'ctx
+/// If you need to serialize a whole argument, just serialize the PlanInputValue directly without
+/// passing through InputValue. This is only useful if you want to partially serialize an argument.
+impl serde::Serialize for SchemaWalker<'_, &InputValue<'_>> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        Str: 'ctx,
+        S: serde::Serializer,
     {
-        ser::SerializableInputValue {
-            ctx: *self,
-            value: &self.input_values()[id],
+        match &self.item {
+            InputValue::Null => serializer.serialize_none(),
+            InputValue::String(s) => s.serialize(serializer),
+            InputValue::EnumValue(id) => self.walk(*id).name().serialize(serializer),
+            InputValue::Int(n) => n.serialize(serializer),
+            InputValue::BigInt(n) => n.serialize(serializer),
+            InputValue::Float(f) => f.serialize(serializer),
+            InputValue::U64(n) => n.serialize(serializer),
+            InputValue::Boolean(b) => b.serialize(serializer),
+            InputValue::InputObject(fields) => {
+                use serde::ser::SerializeMap;
+                let mut map = serializer.serialize_map(Some(fields.len()))?;
+                for (key, value) in fields.iter() {
+                    map.serialize_entry(&self.walk(*key).name(), &self.walk(value))?;
+                }
+                map.end()
+            }
+            InputValue::List(list) => {
+                use serde::ser::SerializeSeq;
+                let mut seq = serializer.serialize_seq(Some(list.len()))?;
+                for value in list.iter() {
+                    seq.serialize_element(&self.walk(value))?;
+                }
+                seq.end()
+            }
+            InputValue::Map(key_values) => {
+                use serde::ser::SerializeMap;
+                let mut map = serializer.serialize_map(Some(key_values.len()))?;
+                for (key, value) in key_values.iter() {
+                    map.serialize_entry(key, &self.walk(value))?;
+                }
+                map.end()
+            }
         }
-    }
-
-    fn input_value_as_deserializer(&self, id: InputValueId<Str>) -> impl serde::Deserializer<'ctx> + 'ctx
-    where
-        Str: 'ctx,
-    {
-        de::InputValueDeserializer {
-            ctx: *self,
-            value: &self.input_values()[id],
-        }
-    }
-
-    /// Display the input value with GraphQL syntax.
-    fn input_value_as_graphql_display(&self, id: InputValueId<Str>) -> impl std::fmt::Display + 'ctx
-    where
-        Str: 'ctx,
-    {
-        display::GraphqlDisplayableInpuValue {
-            ctx: *self,
-            value: &self.input_values()[id],
-        }
-    }
-}
-
-impl<'ctx> InputValuesContext<'ctx, StringId> for SchemaWalker<'ctx, ()> {
-    fn schema_walker(&self) -> &SchemaWalker<'ctx, ()> {
-        self
-    }
-
-    fn get_str(&self, s: &StringId) -> &'ctx str {
-        &self.schema[*s]
-    }
-
-    fn input_values(&self) -> &'ctx InputValues<StringId> {
-        &self.schema.input_values
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::borrow::Cow;
-
-    use serde::Deserialize;
-
-    use crate::{EnumValue, InputValueDefinition, Schema, TypeId};
-
-    use super::*;
-
-    fn create_schema() -> Schema {
-        let mut schema = Schema::empty();
-        schema.input_value_definitions.extend([
-            InputValueDefinition {
-                name: StringId::from(4),
-                description: None,
-                type_id: TypeId::from(0), // not used
-                default_value: None,
-            },
-            InputValueDefinition {
-                name: StringId::from(5),
-                description: None,
-                type_id: TypeId::from(0), // not used
-                default_value: None,
-            },
-        ]);
-        schema.enum_values.extend([
-            EnumValue {
-                name: StringId::from(2),
-                description: None,
-                composed_directives: Default::default(),
-            },
-            EnumValue {
-                name: StringId::from(3),
-                description: None,
-                composed_directives: Default::default(),
-            },
-        ]);
-        schema.strings.extend([
-            "some string value".to_string(), // 1
-            "ACTIVE".to_string(),            // 2
-            "INACTIVE".to_string(),          // 3
-            "fieldA".to_string(),            // 4
-            "fieldB".to_string(),            // 5
-            // ---
-            "null".to_string(),        // 6
-            "string".to_string(),      // 7
-            "enumValue".to_string(),   // 8
-            "int".to_string(),         // 9
-            "bigInt".to_string(),      // 10
-            "u64".to_string(),         // 11
-            "float".to_string(),       // 12
-            "boolean".to_string(),     // 13
-            "inputObject".to_string(), // 14
-            "list".to_string(),        // 15
-            "object".to_string(),      // 16
-        ]);
-        let list = schema.input_values.push_list(vec![
-            InputValue::Null,
-            InputValue::EnumValue(EnumValueId::from(0)),
-            InputValue::Int(73),
-        ]);
-        let input_fields = schema.input_values.push_input_object(vec![
-            (
-                InputValueDefinitionId::from(0),
-                InputValue::EnumValue(EnumValueId::from(1)),
-            ),
-            (InputValueDefinitionId::from(1), InputValue::String(StringId::from(1))),
-        ]);
-        let nested_fields = schema.input_values.push_map(vec![
-            (StringId::from(6), InputValue::Null),
-            (StringId::from(7), InputValue::String(StringId::from(1))),
-            (StringId::from(8), InputValue::EnumValue(EnumValueId::from(0))),
-            (StringId::from(9), InputValue::Int(7)),
-            (StringId::from(10), InputValue::BigInt(8)),
-            (StringId::from(11), InputValue::U64(9)),
-            (StringId::from(12), InputValue::Float(10.0)),
-            (StringId::from(13), InputValue::Boolean(true)),
-        ]);
-        let fields = schema.input_values.push_map(vec![
-            (StringId::from(14), InputValue::InputObject(input_fields)),
-            (StringId::from(15), InputValue::List(list)),
-            (StringId::from(16), InputValue::Map(nested_fields)),
-        ]);
-        schema.input_values.push_value(InputValue::Map(fields));
-        schema
-    }
-
-    #[test]
-    fn test_display() {
-        let schema = create_schema();
-        let walker = schema.walker();
-        let id = SchemaInputValueId::from(schema.input_values.values.len() - 1);
-
-        insta::assert_display_snapshot!(walker.input_value_as_graphql_display(id), @r###"{inputObject:{fieldA:INACTIVE,fieldB:"some string value"},list:[null,ACTIVE,73],object:{null:null,string:"some string value",enumValue:ACTIVE,int:7,bigInt:8,u64:9,float:10,boolean:true}}"###);
-    }
-
-    #[test]
-    fn test_serialize() {
-        let schema = create_schema();
-        let walker = schema.walker();
-        let id = SchemaInputValueId::from(schema.input_values.values.len() - 1);
-
-        insta::assert_json_snapshot!(walker.input_value_as_serializable(id), @r###"
-        {
-          "inputObject": {
-            "fieldA": "INACTIVE",
-            "fieldB": "some string value"
-          },
-          "list": [
-            null,
-            "ACTIVE",
-            73
-          ],
-          "object": {
-            "null": null,
-            "string": "some string value",
-            "enumValue": "ACTIVE",
-            "int": 7,
-            "bigInt": 8,
-            "u64": 9,
-            "float": 10.0,
-            "boolean": true
-          }
-        }
-        "###);
-    }
-
-    #[test]
-    fn test_deserializer() {
-        let schema = create_schema();
-        let walker = schema.walker();
-        let id = SchemaInputValueId::from(schema.input_values.values.len() - 1);
-
-        let value = serde_json::Value::deserialize(walker.input_value_as_deserializer(id)).unwrap();
-
-        insta::assert_json_snapshot!(value, @r###"
-        {
-          "inputObject": {
-            "fieldA": "INACTIVE",
-            "fieldB": "some string value"
-          },
-          "list": [
-            null,
-            "ACTIVE",
-            73
-          ],
-          "object": {
-            "null": null,
-            "string": "some string value",
-            "enumValue": "ACTIVE",
-            "int": 7,
-            "bigInt": 8,
-            "u64": 9,
-            "float": 10.0,
-            "boolean": true
-          }
-        }
-        "###);
-    }
-
-    #[test]
-    fn test_struct_deserializer() {
-        let schema = create_schema();
-        let walker = schema.walker();
-        let id = SchemaInputValueId::from(schema.input_values.values.len() - 1);
-
-        #[allow(unused)]
-        #[derive(Debug, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct InputObject<'a> {
-            #[serde(borrow)]
-            field_a: Cow<'a, str>,
-            field_b: &'a str,
-        }
-
-        #[allow(unused)]
-        #[derive(Debug, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct Object {
-            null: Option<String>,
-            string: String,
-            enum_value: Option<String>,
-            int: i32,
-            big_int: i64,
-            u64: u64,
-            float: f64,
-            boolean: bool,
-        }
-
-        #[allow(unused)]
-        #[derive(Debug, serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct Input<'a> {
-            #[serde(borrow)]
-            input_object: InputObject<'a>,
-            list: Vec<serde_json::Value>,
-            object: Object,
-        }
-
-        let input = Input::deserialize(walker.input_value_as_deserializer(id)).unwrap();
-
-        insta::assert_debug_snapshot!(input, @r###"
-        Input {
-            input_object: InputObject {
-                field_a: "INACTIVE",
-                field_b: "some string value",
-            },
-            list: [
-                Null,
-                String("ACTIVE"),
-                Number(73),
-            ],
-            object: Object {
-                null: None,
-                string: "some string value",
-                enum_value: Some(
-                    "ACTIVE",
-                ),
-                int: 7,
-                big_int: 8,
-                u64: 9,
-                float: 10.0,
-                boolean: true,
-            },
-        }
-        "###);
-
-        serde::de::IgnoredAny::deserialize(walker.input_value_as_deserializer(id)).unwrap();
     }
 }

--- a/engine/crates/engine-v2/schema/src/input_value/raw.rs
+++ b/engine/crates/engine-v2/schema/src/input_value/raw.rs
@@ -1,0 +1,522 @@
+use crate::{
+    EnumValueId, IdRange, InputValueDefinitionId, RawInputKeyValueId, RawInputObjectFieldValueId, RawInputValueId,
+    SchemaInputValueId,
+};
+
+/// Holds input values for the Schema and for an Operation during execution.
+/// It's generic over 'Str', the string representation:
+/// - StringId for the Schema (default input values and directive arguments)
+/// - Box<str> for the Operation
+///
+/// This allow us to share the code for:
+/// - Display: used to print default values in introspection and add input values in subgraph query strings.
+/// - Serialize: used to serialize variables/arguments.
+/// - Deserializer: used by resolvers to deserialize arguments into a specific struct.
+///
+/// Data is stored in flat arrays for hopefully faster serialization and as as bonus smaller InputValue
+/// footprint on x64 architectures: u64 + usize (padding) rather than 3 * usize (Box<[]> + padding).
+#[derive(Clone)]
+pub struct RawInputValues<Str> {
+    /// Inidividual input values and list values
+    pub(super) values: Vec<RawInputValue<Str>>,
+    /// InputObject's fields
+    pub(super) input_fields: Vec<(InputValueDefinitionId, RawInputValue<Str>)>,
+    /// Object's fields (for JSON)
+    pub(super) key_values: Vec<(Str, RawInputValue<Str>)>,
+}
+
+impl<Str> Default for RawInputValues<Str> {
+    fn default() -> Self {
+        Self {
+            // Reserve the first slot for undefined values.
+            // This allows us in the engine to create from scratch a PlanInputValue that is
+            // undefined. Used when requesting a field argument that wasn't provided.
+            values: vec![RawInputValue::Undefined],
+            input_fields: Default::default(),
+            key_values: Default::default(),
+        }
+    }
+}
+
+/// Represents any possible input value for field arguments, operation variables and directive
+/// arguments.
+/// Used for storage and as input format for operation input values to support default values,
+/// variables, etc.
+#[derive(Debug, Clone)]
+pub enum RawInputValue<Str> {
+    Null,
+    String(Str),
+    EnumValue(EnumValueId),
+    Int(i32),
+    BigInt(i64),
+    Float(f64),
+    Boolean(bool),
+    InputObject(IdRange<RawInputObjectFieldValueId<Str>>),
+    List(IdRange<RawInputValueId<Str>>),
+
+    /// for JSON
+    Map(IdRange<RawInputKeyValueId<Str>>),
+    U64(u64),
+
+    /// Directive arguments have unknown enum values. Likely doesn't make sense, but not sure.
+    UnknownEnumValue(Str),
+
+    /// Primary purpose is for operation to reference the value of a variable which is initialized
+    /// to the default or an arbitrary value first. It might also be used later to share the same
+    /// InputValue at different places.
+    Ref(RawInputValueId<Str>),
+
+    /// Used to reference default values for operation input values. It's tricky without as default
+    /// values also need to be taken into account for nested input object fields.
+    SchemaRef(SchemaInputValueId),
+
+    /// https://spec.graphql.org/October2021/#sec-Input-Objects.Input-Coercion
+    /// An input { a: $var, b: 123 } without any variable should be interpreted as { b: 123 } if a
+    /// is nullable.
+    /// However for an operation variable we reserve an InputValue slot for its future value.
+    /// Every place referencing it uses a Ref to it. So to ensure we do handle the undefiner case properly, we
+    /// need a case for it.
+    Undefined,
+}
+
+impl<Str> RawInputValues<Str> {
+    pub fn undefined_value_id(&self) -> RawInputValueId<Str> {
+        RawInputValueId::from(0)
+    }
+
+    pub fn push_value(&mut self, value: RawInputValue<Str>) -> RawInputValueId<Str> {
+        let id = RawInputValueId::from(self.values.len());
+        self.values.push(value);
+        id
+    }
+
+    #[cfg(test)]
+    pub fn push_list(&mut self, values: Vec<RawInputValue<Str>>) -> IdRange<RawInputValueId<Str>> {
+        let start = self.values.len();
+        self.values.extend(values);
+        (start..self.values.len()).into()
+    }
+
+    /// Reserve InputValue slots for a list, avoiding the need for an intermediate
+    /// Vec to hold values as we need them to be contiguous.
+    pub fn reserve_list(&mut self, n: usize) -> IdRange<RawInputValueId<Str>> {
+        let start = self.values.len();
+        self.values.reserve(n);
+        for _ in 0..n {
+            self.values.push(RawInputValue::Null);
+        }
+        (start..self.values.len()).into()
+    }
+
+    #[cfg(test)]
+    pub fn push_map(&mut self, fields: Vec<(Str, RawInputValue<Str>)>) -> IdRange<RawInputKeyValueId<Str>> {
+        let start = self.key_values.len();
+        self.key_values.extend(fields);
+        (start..self.key_values.len()).into()
+    }
+
+    /// Reserve InputKeyValue slots for a map, avoiding the need for an intermediate
+    /// Vec to hold values as we need them to be contiguous.
+    pub fn reserve_map(&mut self, s: Str, n: usize) -> IdRange<RawInputKeyValueId<Str>>
+    where
+        Str: Clone,
+    {
+        let start = self.key_values.len();
+        self.key_values.reserve(n);
+        for _ in 0..n {
+            self.key_values.push((s.clone(), RawInputValue::Null));
+        }
+        (start..self.key_values.len()).into()
+    }
+
+    pub fn push_input_object(
+        &mut self,
+        fields: impl IntoIterator<Item = (InputValueDefinitionId, RawInputValue<Str>)>,
+    ) -> IdRange<RawInputObjectFieldValueId<Str>> {
+        let start = self.input_fields.len();
+        self.input_fields.extend(fields);
+        (start..self.input_fields.len()).into()
+    }
+
+    /// Reserve InputObjectFieldValue slots for an InputObject, avoiding the need for an intermediate
+    /// Vec to hold values as we need them to be contiguous.
+    pub fn reserve_input_object(&mut self, n: usize) -> IdRange<RawInputObjectFieldValueId<Str>> {
+        let start = self.input_fields.len();
+        self.input_fields.reserve(n);
+        for _ in 0..n {
+            self.input_fields
+                .push((InputValueDefinitionId::from(0), RawInputValue::Null));
+        }
+        (start..self.input_fields.len()).into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use serde::Deserialize;
+
+    use crate::{EnumValue, InputValue, InputValueDefinition, RawInputValuesContext, Schema, StringId, TypeId};
+
+    use super::*;
+
+    fn create_schema() -> Schema {
+        let mut schema = Schema::empty();
+        schema.input_value_definitions.extend([
+            InputValueDefinition {
+                name: StringId::from(4),
+                description: None,
+                type_id: TypeId::from(0), // not used
+                default_value: None,
+            },
+            InputValueDefinition {
+                name: StringId::from(5),
+                description: None,
+                type_id: TypeId::from(0), // not used
+                default_value: None,
+            },
+        ]);
+        schema.enum_values.extend([
+            EnumValue {
+                name: StringId::from(2),
+                description: None,
+                composed_directives: Default::default(),
+            },
+            EnumValue {
+                name: StringId::from(3),
+                description: None,
+                composed_directives: Default::default(),
+            },
+        ]);
+        schema.strings.extend([
+            "some string value".to_string(), // 1
+            "ACTIVE".to_string(),            // 2
+            "INACTIVE".to_string(),          // 3
+            "fieldA".to_string(),            // 4
+            "fieldB".to_string(),            // 5
+            // ---
+            "null".to_string(),        // 6
+            "string".to_string(),      // 7
+            "enumValue".to_string(),   // 8
+            "int".to_string(),         // 9
+            "bigInt".to_string(),      // 10
+            "u64".to_string(),         // 11
+            "float".to_string(),       // 12
+            "boolean".to_string(),     // 13
+            "inputObject".to_string(), // 14
+            "list".to_string(),        // 15
+            "object".to_string(),      // 16
+        ]);
+        let list = schema.input_values.push_list(vec![
+            RawInputValue::Null,
+            RawInputValue::EnumValue(EnumValueId::from(0)),
+            RawInputValue::Int(73),
+        ]);
+        let input_fields = schema.input_values.push_input_object(vec![
+            (
+                InputValueDefinitionId::from(0),
+                RawInputValue::EnumValue(EnumValueId::from(1)),
+            ),
+            (
+                InputValueDefinitionId::from(1),
+                RawInputValue::String(StringId::from(1)),
+            ),
+        ]);
+        let nested_fields = schema.input_values.push_map(vec![
+            (StringId::from(6), RawInputValue::Null),
+            (StringId::from(7), RawInputValue::String(StringId::from(1))),
+            (StringId::from(8), RawInputValue::EnumValue(EnumValueId::from(0))),
+            (StringId::from(9), RawInputValue::Int(7)),
+            (StringId::from(10), RawInputValue::BigInt(8)),
+            (StringId::from(11), RawInputValue::U64(9)),
+            (StringId::from(12), RawInputValue::Float(10.0)),
+            (StringId::from(13), RawInputValue::Boolean(true)),
+        ]);
+        let fields = schema.input_values.push_map(vec![
+            (StringId::from(14), RawInputValue::InputObject(input_fields)),
+            (StringId::from(15), RawInputValue::List(list)),
+            (StringId::from(16), RawInputValue::Map(nested_fields)),
+        ]);
+        schema.input_values.push_value(RawInputValue::Map(fields));
+        schema
+    }
+
+    #[test]
+    fn test_display() {
+        let schema = create_schema();
+        let id = SchemaInputValueId::from(schema.input_values.values.len() - 1);
+        let walker = RawInputValuesContext::walk(&schema.walker(), id);
+
+        insta::assert_display_snapshot!(walker, @r###"{inputObject:{fieldA:INACTIVE,fieldB:"some string value"},list:[null,ACTIVE,73],object:{null:null,string:"some string value",enumValue:ACTIVE,int:7,bigInt:8,u64:9,float:10,boolean:true}}"###);
+    }
+
+    #[test]
+    fn test_serialize() {
+        let schema = create_schema();
+        let id = SchemaInputValueId::from(schema.input_values.values.len() - 1);
+        let walker = RawInputValuesContext::walk(&schema.walker(), id);
+
+        insta::assert_json_snapshot!(walker, @r###"
+        {
+          "inputObject": {
+            "fieldA": "INACTIVE",
+            "fieldB": "some string value"
+          },
+          "list": [
+            null,
+            "ACTIVE",
+            73
+          ],
+          "object": {
+            "null": null,
+            "string": "some string value",
+            "enumValue": "ACTIVE",
+            "int": 7,
+            "bigInt": 8,
+            "u64": 9,
+            "float": 10.0,
+            "boolean": true
+          }
+        }
+        "###);
+    }
+
+    #[test]
+    fn test_deserializer() {
+        let schema = create_schema();
+        let id = SchemaInputValueId::from(schema.input_values.values.len() - 1);
+        let walker = RawInputValuesContext::walk(&schema.walker(), id);
+
+        let value = serde_json::Value::deserialize(walker).unwrap();
+
+        insta::assert_json_snapshot!(value, @r###"
+        {
+          "inputObject": {
+            "fieldA": "INACTIVE",
+            "fieldB": "some string value"
+          },
+          "list": [
+            null,
+            "ACTIVE",
+            73
+          ],
+          "object": {
+            "null": null,
+            "string": "some string value",
+            "enumValue": "ACTIVE",
+            "int": 7,
+            "bigInt": 8,
+            "u64": 9,
+            "float": 10.0,
+            "boolean": true
+          }
+        }
+        "###);
+    }
+
+    #[test]
+    fn test_input_value() {
+        let schema = create_schema();
+        let id = SchemaInputValueId::from(schema.input_values.values.len() - 1);
+        let walker = RawInputValuesContext::walk(&schema.walker(), id);
+        let input_value = InputValue::from(walker);
+
+        insta::assert_debug_snapshot!(input_value, @r###"
+        Map(
+            [
+                (
+                    "inputObject",
+                    InputObject(
+                        [
+                            (
+                                InputValueDefinitionId(
+                                    1,
+                                ),
+                                EnumValue(
+                                    EnumValueId(
+                                        2,
+                                    ),
+                                ),
+                            ),
+                            (
+                                InputValueDefinitionId(
+                                    2,
+                                ),
+                                String(
+                                    "some string value",
+                                ),
+                            ),
+                        ],
+                    ),
+                ),
+                (
+                    "list",
+                    List(
+                        [
+                            Null,
+                            EnumValue(
+                                EnumValueId(
+                                    1,
+                                ),
+                            ),
+                            Int(
+                                73,
+                            ),
+                        ],
+                    ),
+                ),
+                (
+                    "object",
+                    Map(
+                        [
+                            (
+                                "null",
+                                Null,
+                            ),
+                            (
+                                "string",
+                                String(
+                                    "some string value",
+                                ),
+                            ),
+                            (
+                                "enumValue",
+                                EnumValue(
+                                    EnumValueId(
+                                        1,
+                                    ),
+                                ),
+                            ),
+                            (
+                                "int",
+                                Int(
+                                    7,
+                                ),
+                            ),
+                            (
+                                "bigInt",
+                                BigInt(
+                                    8,
+                                ),
+                            ),
+                            (
+                                "u64",
+                                U64(
+                                    9,
+                                ),
+                            ),
+                            (
+                                "float",
+                                Float(
+                                    10.0,
+                                ),
+                            ),
+                            (
+                                "boolean",
+                                Boolean(
+                                    true,
+                                ),
+                            ),
+                        ],
+                    ),
+                ),
+            ],
+        )
+        "###);
+
+        insta::assert_json_snapshot!(schema.walk(&input_value), @r###"
+        {
+          "inputObject": {
+            "fieldA": "INACTIVE",
+            "fieldB": "some string value"
+          },
+          "list": [
+            null,
+            "ACTIVE",
+            73
+          ],
+          "object": {
+            "null": null,
+            "string": "some string value",
+            "enumValue": "ACTIVE",
+            "int": 7,
+            "bigInt": 8,
+            "u64": 9,
+            "float": 10.0,
+            "boolean": true
+          }
+        }
+        "###);
+    }
+
+    #[test]
+    fn test_struct_deserializer() {
+        let schema = create_schema();
+        let id = SchemaInputValueId::from(schema.input_values.values.len() - 1);
+        let walker = RawInputValuesContext::walk(&schema.walker(), id);
+
+        #[allow(unused)]
+        #[derive(Debug, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct InputObject<'a> {
+            #[serde(borrow)]
+            field_a: Cow<'a, str>,
+            field_b: &'a str,
+        }
+
+        #[allow(unused)]
+        #[derive(Debug, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Object {
+            null: Option<String>,
+            string: String,
+            enum_value: Option<String>,
+            int: i32,
+            big_int: i64,
+            u64: u64,
+            float: f64,
+            boolean: bool,
+        }
+
+        #[allow(unused)]
+        #[derive(Debug, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Input<'a> {
+            #[serde(borrow)]
+            input_object: InputObject<'a>,
+            list: Vec<serde_json::Value>,
+            object: Object,
+        }
+
+        let input = Input::deserialize(walker).unwrap();
+
+        insta::assert_debug_snapshot!(input, @r###"
+        Input {
+            input_object: InputObject {
+                field_a: "INACTIVE",
+                field_b: "some string value",
+            },
+            list: [
+                Null,
+                String("ACTIVE"),
+                Number(73),
+            ],
+            object: Object {
+                null: None,
+                string: "some string value",
+                enum_value: Some(
+                    "ACTIVE",
+                ),
+                int: 7,
+                big_int: 8,
+                u64: 9,
+                float: 10.0,
+                boolean: true,
+            },
+        }
+        "###);
+
+        serde::de::IgnoredAny::deserialize(walker).unwrap();
+    }
+}

--- a/engine/crates/engine-v2/schema/src/input_value/ser.rs
+++ b/engine/crates/engine-v2/schema/src/input_value/ser.rs
@@ -1,108 +1,58 @@
 use serde::ser::{SerializeMap, SerializeSeq};
 
-use crate::{IdRange, InputKeyValueId, InputObjectFieldValueId, InputValue, InputValueId};
+use crate::{RawInputValue, RawInputValueWalker};
 
-use super::InputValuesContext;
+use super::RawInputValuesContext;
 
-pub(super) struct SerializableInputValue<'ctx, Str, Ctx> {
-    pub ctx: Ctx,
-    pub value: &'ctx InputValue<Str>,
-}
-
-impl<'ctx, Str, Ctx> serde::Serialize for SerializableInputValue<'ctx, Str, Ctx>
+impl<'ctx, Ctx> serde::Serialize for RawInputValueWalker<'ctx, Ctx>
 where
-    Ctx: InputValuesContext<'ctx, Str>,
-    Str: 'ctx,
+    Ctx: RawInputValuesContext<'ctx>,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
         match self.value {
-            InputValue::Null => serializer.serialize_unit(),
-            InputValue::String(s) | InputValue::UnknownEnumValue(s) => self.ctx.get_str(s).serialize(serializer),
-            InputValue::EnumValue(id) => self.ctx.schema_walker().walk(*id).name().serialize(serializer),
-            InputValue::Int(n) => n.serialize(serializer),
-            InputValue::BigInt(n) => n.serialize(serializer),
-            InputValue::Float(f) => f.serialize(serializer),
-            InputValue::U64(n) => n.serialize(serializer),
-            InputValue::Boolean(b) => b.serialize(serializer),
-            &InputValue::InputObject(input_fields) => SerializableInputObject {
-                ctx: self.ctx,
-                input_fields,
+            RawInputValue::Undefined => serializer.serialize_unit(),
+            RawInputValue::Null => serializer.serialize_none(),
+            RawInputValue::String(s) | RawInputValue::UnknownEnumValue(s) => self.ctx.get_str(s).serialize(serializer),
+            RawInputValue::EnumValue(id) => self.ctx.schema_walker().walk(*id).name().serialize(serializer),
+            RawInputValue::Int(n) => n.serialize(serializer),
+            RawInputValue::BigInt(n) => n.serialize(serializer),
+            RawInputValue::Float(f) => f.serialize(serializer),
+            RawInputValue::U64(n) => n.serialize(serializer),
+            RawInputValue::Boolean(b) => b.serialize(serializer),
+            &RawInputValue::InputObject(ids) => {
+                let mut map = serializer.serialize_map(Some(ids.len()))?;
+                for (input_value_definition_id, value) in &self.ctx.input_values()[ids] {
+                    let value = self.walk(value);
+                    if !value.is_undefined() {
+                        map.serialize_key(self.ctx.schema_walker().walk(*input_value_definition_id).name())?;
+                        map.serialize_value(&value)?;
+                    }
+                }
+                map.end()
             }
-            .serialize(serializer),
-            &InputValue::List(list) => SerializableList { ctx: self.ctx, list }.serialize(serializer),
-            &InputValue::Map(fields) => SerializableMap { ctx: self.ctx, fields }.serialize(serializer),
+            &RawInputValue::List(ids) => {
+                let mut seq = serializer.serialize_seq(Some(ids.len()))?;
+                for value in &self.ctx.input_values()[ids] {
+                    seq.serialize_element(&self.walk(value))?;
+                }
+                seq.end()
+            }
+            &RawInputValue::Map(ids) => {
+                let mut map = serializer.serialize_map(Some(ids.len()))?;
+                for (key, value) in &self.ctx.input_values()[ids] {
+                    let value = self.walk(value);
+                    if !value.is_undefined() {
+                        map.serialize_key(self.ctx.get_str(key))?;
+                        map.serialize_value(&value)?;
+                    }
+                }
+                map.end()
+            }
+            RawInputValue::Ref(id) => self.ctx.walk(*id).serialize(serializer),
+            RawInputValue::SchemaRef(id) => self.ctx.schema_walk(*id).serialize(serializer),
         }
-    }
-}
-
-struct SerializableMap<Str, Ctx> {
-    ctx: Ctx,
-    fields: IdRange<InputKeyValueId<Str>>,
-}
-
-impl<'ctx, Str, Ctx> serde::Serialize for SerializableMap<Str, Ctx>
-where
-    Ctx: InputValuesContext<'ctx, Str>,
-    Str: 'ctx,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut map = serializer.serialize_map(Some(self.fields.len()))?;
-        for (key, value) in &self.ctx.input_values()[self.fields] {
-            map.serialize_key(self.ctx.get_str(key))?;
-            map.serialize_value(&SerializableInputValue { ctx: self.ctx, value })?;
-        }
-
-        map.end()
-    }
-}
-struct SerializableInputObject<Str, Ctx> {
-    ctx: Ctx,
-    input_fields: IdRange<InputObjectFieldValueId<Str>>,
-}
-
-impl<'ctx, Str, Ctx> serde::Serialize for SerializableInputObject<Str, Ctx>
-where
-    Ctx: InputValuesContext<'ctx, Str>,
-    Str: 'ctx,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut map = serializer.serialize_map(Some(self.input_fields.len()))?;
-        for (input_value_definition_id, value) in &self.ctx.input_values()[self.input_fields] {
-            map.serialize_key(self.ctx.schema_walker().walk(*input_value_definition_id).name())?;
-            map.serialize_value(&SerializableInputValue { ctx: self.ctx, value })?;
-        }
-
-        map.end()
-    }
-}
-
-struct SerializableList<Str, Ctx> {
-    ctx: Ctx,
-    list: IdRange<InputValueId<Str>>,
-}
-
-impl<'ctx, Str, Ctx> serde::Serialize for SerializableList<Str, Ctx>
-where
-    Ctx: InputValuesContext<'ctx, Str>,
-    Str: 'ctx,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut seq = serializer.serialize_seq(Some(self.list.len()))?;
-        for value in &self.ctx.input_values()[self.list] {
-            seq.serialize_element(&SerializableInputValue { ctx: self.ctx, value })?;
-        }
-        seq.end()
     }
 }

--- a/engine/crates/engine-v2/schema/src/input_value/walker.rs
+++ b/engine/crates/engine-v2/schema/src/input_value/walker.rs
@@ -1,0 +1,123 @@
+use crate::{InputValue, RawInputValue, RawInputValueId, RawInputValues, SchemaInputValueId, SchemaWalker, StringId};
+
+/// Walker over a RawInputValue providing Serialize, Deserialize, Display and Into<InputValue<'_>>.
+#[derive(Clone, Copy)]
+pub struct RawInputValueWalker<'ctx, Ctx: RawInputValuesContext<'ctx>> {
+    pub(super) ctx: Ctx,
+    pub(super) value: &'ctx RawInputValue<Ctx::Str>,
+}
+
+impl<'ctx, Ctx> RawInputValueWalker<'ctx, Ctx>
+where
+    Ctx: RawInputValuesContext<'ctx>,
+{
+    pub(super) fn walk(&self, value: &'ctx RawInputValue<Ctx::Str>) -> Self {
+        Self { ctx: self.ctx, value }
+    }
+
+    /// Undefined values within InputObjects are silently removed according to the GraphQL spec.
+    /// But we can't remove an undefined argument
+    pub fn is_undefined(&self) -> bool {
+        match self.value {
+            RawInputValue::Undefined => true,
+            RawInputValue::Ref(id) => self.ctx.walk(*id).is_undefined(),
+            // I don't think this should ever happen, so should maybe be an unreachable!()
+            RawInputValue::SchemaRef(id) => self.ctx.schema_walk(*id).is_undefined(),
+            _ => false,
+        }
+    }
+}
+
+/// Context providing all the necessary information for the RawInputValueWalker. There are two
+/// cases:
+/// - schema input values, for which the context is simply a SchemaWalker. Strings are all interned
+///   and identified by a Stringid.
+/// - operation input values. Strings are all just Box<str>.
+pub trait RawInputValuesContext<'ctx>: Clone + Copy + 'ctx {
+    type Str: 'static;
+
+    fn schema_walker(&self) -> &SchemaWalker<'ctx, ()>;
+    fn get_str(&self, s: &'ctx Self::Str) -> &'ctx str;
+    fn input_values(&self) -> &'ctx RawInputValues<Self::Str>;
+    /// Defines how to display a InputValue::Ref(id). Used to show variable names
+    /// for operation input values when variables aren't bound yet.
+    fn input_value_ref_display(&self, id: RawInputValueId<Self::Str>) -> impl std::fmt::Display + 'ctx;
+
+    fn walk(&self, id: RawInputValueId<Self::Str>) -> RawInputValueWalker<'ctx, Self> {
+        RawInputValueWalker {
+            ctx: *self,
+            value: &self.input_values()[id],
+        }
+    }
+
+    fn schema_walk(&self, id: SchemaInputValueId) -> RawInputValueWalker<'ctx, SchemaWalker<'ctx, ()>> {
+        let ctx = *self.schema_walker();
+        let value = &ctx.input_values()[id];
+        RawInputValueWalker { ctx, value }
+    }
+}
+
+impl<'ctx> RawInputValuesContext<'ctx> for SchemaWalker<'ctx, ()> {
+    type Str = StringId;
+
+    fn schema_walker(&self) -> &SchemaWalker<'ctx, ()> {
+        self
+    }
+
+    fn get_str(&self, s: &StringId) -> &'ctx str {
+        &self.schema[*s]
+    }
+
+    fn input_values(&self) -> &'ctx RawInputValues<StringId> {
+        &self.schema.input_values
+    }
+
+    fn input_value_ref_display(&self, id: RawInputValueId<StringId>) -> impl std::fmt::Display + 'ctx {
+        RawInputValuesContext::walk(self, id)
+    }
+}
+
+/// A RawInputValue isn't very friendly to manipulate directly and it becomes even more tricky when
+/// one needs to handle default values coming from the schema and request input values.
+/// So when one needs to do more complex processing than Serialize, it's best to just manipulate an
+/// InputValue.
+impl<'ctx, Ctx> From<RawInputValueWalker<'ctx, Ctx>> for InputValue<'ctx>
+where
+    Ctx: RawInputValuesContext<'ctx>,
+{
+    fn from(walker: RawInputValueWalker<'ctx, Ctx>) -> Self {
+        match walker.value {
+            RawInputValue::Null | RawInputValue::Undefined => InputValue::Null,
+            RawInputValue::String(s) | RawInputValue::UnknownEnumValue(s) => InputValue::String(walker.ctx.get_str(s)),
+            RawInputValue::EnumValue(id) => InputValue::EnumValue(*id),
+            RawInputValue::Int(n) => InputValue::Int(*n),
+            RawInputValue::BigInt(n) => InputValue::BigInt(*n),
+            RawInputValue::Float(f) => InputValue::Float(*f),
+            RawInputValue::Boolean(b) => InputValue::Boolean(*b),
+            RawInputValue::InputObject(ids) => {
+                let mut fields = Vec::with_capacity(ids.len());
+                for (input_value_definition_id, value) in &walker.ctx.input_values()[*ids] {
+                    fields.push((*input_value_definition_id, walker.walk(value).into()));
+                }
+                InputValue::InputObject(fields.into_boxed_slice())
+            }
+            RawInputValue::List(ids) => {
+                let mut values = Vec::with_capacity(ids.len());
+                for id in *ids {
+                    values.push(walker.ctx.walk(id).into());
+                }
+                InputValue::List(values.into_boxed_slice())
+            }
+            RawInputValue::Map(ids) => {
+                let mut key_values = Vec::with_capacity(ids.len());
+                for (key, value) in &walker.ctx.input_values()[*ids] {
+                    key_values.push((walker.ctx.get_str(key), walker.walk(value).into()));
+                }
+                InputValue::Map(key_values.into_boxed_slice())
+            }
+            RawInputValue::U64(n) => InputValue::U64(*n),
+            RawInputValue::Ref(id) => walker.ctx.walk(*id).into(),
+            RawInputValue::SchemaRef(id) => walker.ctx.schema_walk(*id).into(),
+        }
+    }
+}

--- a/engine/crates/engine-v2/schema/src/sources/introspection.rs
+++ b/engine/crates/engine-v2/schema/src/sources/introspection.rs
@@ -552,7 +552,7 @@ impl<'a> IntrospectionSchemaBuilder<'a> {
         self.enums.push(crate::Enum {
             name,
             description: None,
-            values,
+            value_ids: values,
             composed_directives: IdRange::empty(),
         });
         let enum_id = EnumId::from(self.enums.len() - 1);
@@ -580,7 +580,7 @@ impl<'a> IntrospectionSchemaBuilder<'a> {
             composed_directives: IdRange::empty(),
             resolvers: vec![],
             provides: vec![],
-            arguments: IdRange::empty(),
+            argument_ids: IdRange::empty(),
             description: None,
             cache_config: None,
         });
@@ -617,7 +617,7 @@ impl<'a> IntrospectionSchemaBuilder<'a> {
 
         let end = self.input_value_definitions.len();
 
-        self[field_id].arguments = IdRange {
+        self[field_id].argument_ids = IdRange {
             start: start.into(),
             end: end.into(),
         };

--- a/engine/crates/engine-v2/schema/src/walkers/enum.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/enum.rs
@@ -9,9 +9,16 @@ impl<'a> EnumWalker<'a> {
         self.names.r#enum(self.schema, self.item)
     }
 
-    pub fn values(&self) -> impl ExactSizeIterator<Item = EnumValueWalker<'a>> + 'a {
-        let walker: SchemaWalker<'a> = self.walk(());
-        self.schema[self.item].values.iter().map(move |id| walker.walk(id))
+    pub fn values(self) -> impl ExactSizeIterator<Item = EnumValueWalker<'a>> + 'a {
+        self.as_ref().value_ids.map(move |id| self.walk(id))
+    }
+
+    pub fn find_value_by_name(&self, name: &str) -> Option<EnumValueId> {
+        let ids = self.as_ref().value_ids;
+        self.schema[ids]
+            .binary_search_by(|enum_value| self.schema[enum_value.name].as_str().cmp(name))
+            .ok()
+            .map(EnumValueId::from)
     }
 }
 

--- a/engine/crates/engine-v2/schema/src/walkers/field_set.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/field_set.rs
@@ -8,9 +8,8 @@ impl<'a> FieldSetWalker<'a> {
         self.item.is_empty()
     }
 
-    pub fn items(&self) -> impl Iterator<Item = FieldSetItemWalker<'a>> + 'a {
-        let walker = self.walk(());
-        self.item.iter().map(move |item| walker.walk(item))
+    pub fn items(self) -> impl Iterator<Item = FieldSetItemWalker<'a>> + 'a {
+        self.item.iter().map(move |item| self.walk(item))
     }
 }
 

--- a/engine/crates/engine-v2/schema/src/walkers/input_object.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/input_object.rs
@@ -1,5 +1,5 @@
 use super::SchemaWalker;
-use crate::{InputObjectId, InputValueWalker};
+use crate::{InputObjectId, InputValueDefinitionWalker};
 
 pub type InputObjectWalker<'a> = SchemaWalker<'a, InputObjectId>;
 
@@ -8,12 +8,8 @@ impl<'a> InputObjectWalker<'a> {
         self.names.input_object(self.schema, self.item)
     }
 
-    pub fn input_fields(&self) -> impl ExactSizeIterator<Item = InputValueWalker<'a>> + 'a {
-        let walker = *self;
-        self.schema[self.item]
-            .input_fields
-            .iter()
-            .map(move |id| walker.walk(id))
+    pub fn input_fields(self) -> impl ExactSizeIterator<Item = InputValueDefinitionWalker<'a>> + 'a {
+        self.schema[self.item].input_field_ids.map(move |id| self.walk(id))
     }
 }
 

--- a/engine/crates/engine-v2/schema/src/walkers/input_value.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/input_value.rs
@@ -1,9 +1,9 @@
 use super::SchemaWalker;
 use crate::{InputValueDefinitionId, TypeWalker};
 
-pub type InputValueWalker<'a> = SchemaWalker<'a, InputValueDefinitionId>;
+pub type InputValueDefinitionWalker<'a> = SchemaWalker<'a, InputValueDefinitionId>;
 
-impl<'a> InputValueWalker<'a> {
+impl<'a> InputValueDefinitionWalker<'a> {
     pub fn name(&self) -> &'a str {
         self.names.input_value(self.schema, self.item)
     }
@@ -13,7 +13,7 @@ impl<'a> InputValueWalker<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for InputValueWalker<'a> {
+impl<'a> std::fmt::Debug for InputValueDefinitionWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("InputValue")
             .field("name", &self.name())

--- a/engine/crates/engine-v2/schema/src/walkers/interface.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/interface.rs
@@ -29,22 +29,20 @@ impl<'a> InterfaceWalker<'a> {
         }
     }
 
-    pub fn interfaces(&self) -> impl ExactSizeIterator<Item = InterfaceWalker<'a>> + 'a {
-        let walker = *self;
+    pub fn interfaces(self) -> impl ExactSizeIterator<Item = InterfaceWalker<'a>> + 'a {
         self.as_ref()
             .interfaces
             .clone()
             .into_iter()
-            .map(move |id| walker.walk(id))
+            .map(move |id| self.walk(id))
     }
 
-    pub fn possible_types(&self) -> impl ExactSizeIterator<Item = ObjectWalker<'a>> + 'a {
-        let walker = *self;
+    pub fn possible_types(self) -> impl ExactSizeIterator<Item = ObjectWalker<'a>> + 'a {
         self.as_ref()
             .possible_types
             .clone()
             .into_iter()
-            .map(move |id| walker.walk(id))
+            .map(move |id| self.walk(id))
     }
 }
 

--- a/engine/crates/engine-v2/schema/src/walkers/mod.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/mod.rs
@@ -13,18 +13,18 @@ mod scalar;
 mod r#type;
 mod union;
 
-pub use definition::DefinitionWalker;
-pub use field::{FieldResolverWalker, FieldWalker};
-pub use field_set::{FieldSetItemWalker, FieldSetWalker};
-pub use input_object::InputObjectWalker;
-pub use input_value::InputValueWalker;
-pub use interface::InterfaceWalker;
-pub use object::ObjectWalker;
-pub use r#enum::{EnumValueWalker, EnumWalker};
-pub use r#type::TypeWalker;
-pub use resolver::ResolverWalker;
-pub use scalar::ScalarWalker;
-pub use union::UnionWalker;
+pub use definition::*;
+pub use field::*;
+pub use field_set::*;
+pub use input_object::*;
+pub use input_value::*;
+pub use interface::*;
+pub use object::*;
+pub use r#enum::*;
+pub use r#type::*;
+pub use resolver::*;
+pub use scalar::*;
+pub use union::*;
 
 #[derive(Clone, Copy)]
 pub struct SchemaWalker<'a, I = ()> {

--- a/engine/crates/engine-v2/schema/src/walkers/object.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/object.rs
@@ -29,13 +29,12 @@ impl<'a> ObjectWalker<'a> {
         }
     }
 
-    pub fn interfaces(&self) -> impl ExactSizeIterator<Item = InterfaceWalker<'a>> + 'a {
-        let walker = *self;
+    pub fn interfaces(self) -> impl ExactSizeIterator<Item = InterfaceWalker<'a>> + 'a {
         self.as_ref()
             .interfaces
             .clone()
             .into_iter()
-            .map(move |id| walker.walk(id))
+            .map(move |id| self.walk(id))
     }
 
     pub fn cache_config(&self) -> Option<CacheConfig> {

--- a/engine/crates/engine-v2/schema/src/walkers/union.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/union.rs
@@ -8,13 +8,12 @@ impl<'a> UnionWalker<'a> {
         self.names.union(self.schema, self.item)
     }
 
-    pub fn possible_types(&self) -> impl ExactSizeIterator<Item = ObjectWalker<'a>> + 'a {
-        let walker = *self;
+    pub fn possible_types(self) -> impl ExactSizeIterator<Item = ObjectWalker<'a>> + 'a {
         self.as_ref()
             .possible_types
             .clone()
             .into_iter()
-            .map(move |id| walker.walk(id))
+            .map(move |id| self.walk(id))
     }
 }
 

--- a/engine/crates/engine-v2/src/plan/walkers/argument.rs
+++ b/engine/crates/engine-v2/src/plan/walkers/argument.rs
@@ -1,5 +1,5 @@
 use engine_value::ConstValue;
-use schema::{InputValueDefinitionId, InputValueWalker};
+use schema::{InputValueDefinitionId, InputValueDefinitionWalker};
 
 use crate::request::BoundFieldArgument;
 
@@ -33,7 +33,7 @@ impl<'a> PlanInputValue<'a> {
 }
 
 impl<'a> std::ops::Deref for PlanInputValue<'a> {
-    type Target = InputValueWalker<'a>;
+    type Target = InputValueDefinitionWalker<'a>;
 
     fn deref(&self) -> &Self::Target {
         &self.schema_walker

--- a/engine/crates/engine-v2/src/plan/walkers/collected.rs
+++ b/engine/crates/engine-v2/src/plan/walkers/collected.rs
@@ -36,7 +36,7 @@ impl<'a> PlanCollectedSelectionSet<'a> {
     }
 
     pub fn fields(self) -> impl ExactSizeIterator<Item = PlanCollectedField<'a>> + 'a {
-        self.as_ref().fields.iter().map(move |id| self.walk(id))
+        self.as_ref().fields.map(move |id| self.walk(id))
     }
 }
 
@@ -77,7 +77,7 @@ impl<'a> PlanConditionalSelectionSet<'a> {
     }
 
     pub fn fields(self) -> impl Iterator<Item = PlanConditionalField<'a>> + 'a {
-        self.as_ref().fields.iter().map(move |id| self.walk(id))
+        self.as_ref().fields.map(move |id| self.walk(id))
     }
 }
 

--- a/engine/crates/engine-v2/src/request/walkers/field_argument.rs
+++ b/engine/crates/engine-v2/src/request/walkers/field_argument.rs
@@ -16,7 +16,7 @@ impl<'a> BoundFieldArgumentWalker<'a> {
 }
 
 impl<'a> Deref for BoundFieldArgumentWalker<'a> {
-    type Target = schema::InputValueWalker<'a>;
+    type Target = schema::InputValueDefinitionWalker<'a>;
 
     fn deref(&self) -> &Self::Target {
         &self.schema_walker

--- a/engine/crates/engine-v2/src/response/write/mod.rs
+++ b/engine/crates/engine-v2/src/response/write/mod.rs
@@ -227,7 +227,7 @@ impl ResponsePart {
             updates: Vec::new(),
             error_paths_to_propagate: Vec::new(),
             plan_boundary_ids_start: usize::from(plan_boundary_ids.start),
-            plan_boundaries: plan_boundary_ids.iter().map(|id| (id, Vec::new())).collect(),
+            plan_boundaries: plan_boundary_ids.map(|id| (id, Vec::new())).collect(),
         }
     }
 

--- a/engine/crates/engine-v2/src/sources/introspection/writer.rs
+++ b/engine/crates/engine-v2/src/sources/introspection/writer.rs
@@ -5,8 +5,8 @@ use schema::{
     sources::introspection::{
         IntrospectionField, IntrospectionObject, Metadata, __EnumValue, __Field, __InputValue, __Schema, __Type,
     },
-    Definition, DefinitionWalker, Directive, EnumValueWalker, FieldWalker, InputValueWalker, InputValuesContext,
-    ListWrapping, SchemaWalker, TypeWalker, Wrapping,
+    Definition, DefinitionWalker, Directive, EnumValueWalker, FieldWalker, InputValueDefinitionWalker, ListWrapping,
+    RawInputValuesContext, SchemaWalker, TypeWalker, Wrapping,
 };
 
 use crate::{
@@ -293,7 +293,7 @@ impl<'a> IntrospectionWriter<'a> {
 
     fn __input_value(
         &self,
-        target: InputValueWalker<'a>,
+        target: InputValueDefinitionWalker<'a>,
         selection_set: PlanCollectedSelectionSet<'_>,
     ) -> ResponseValue {
         self.object(
@@ -306,7 +306,7 @@ impl<'a> IntrospectionWriter<'a> {
                 __InputValue::DefaultValue => target
                     .as_ref()
                     .default_value
-                    .map(|id| self.schema.input_value_as_graphql_display(id).to_string())
+                    .map(|id| RawInputValuesContext::walk(&self.schema, id).to_string())
                     .into(),
             },
         )

--- a/engine/crates/integration-tests/tests/federation/introspection.rs
+++ b/engine/crates/integration-tests/tests/federation/introspection.rs
@@ -260,8 +260,8 @@ fn echo_subgraph_introspection() {
 
     insta::assert_snapshot!(introspection_to_sdl(response.into_data()), @r###"
     enum FancyBool {
-      YES
       NO
+      YES
     }
 
     input InputObj {
@@ -403,8 +403,8 @@ fn can_introsect_when_multiple_subgraphs() {
     scalar CustomRepoId
 
     enum FancyBool {
-      YES
       NO
+      YES
     }
 
     type Header {
@@ -870,9 +870,9 @@ fn introspection_on_multiple_federation_subgraphs() {
     }
 
     enum Trustworthiness {
-      REALLY_TRUSTED
       KINDA_TRUSTED
       NOT_TRUSTED
+      REALLY_TRUSTED
     }
 
     type User {

--- a/engine/crates/integration-tests/tests/federation/snapshots/integration_tests__federation__introspection__introspecting_with_grafbase_openapi_subgraph.snap
+++ b/engine/crates/integration-tests/tests/federation/snapshots/integration_tests__federation__introspection__introspecting_with_grafbase_openapi_subgraph.snap
@@ -53,9 +53,9 @@ input OrderInput {
 }
 
 enum OrderStatus {
-  PLACED
   APPROVED
   DELIVERED
+  PLACED
 }
 
 type Pet {

--- a/engine/crates/integration-tests/tests/federation/snapshots/integration_tests__federation__introspection__raw_introspetion_output.snap
+++ b/engine/crates/integration-tests/tests/federation/snapshots/integration_tests__federation__introspection__raw_introspetion_output.snap
@@ -92,13 +92,13 @@ expression: response
           "interfaces": null,
           "enumValues": [
             {
-              "name": "YES",
+              "name": "NO",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "NO",
+              "name": "YES",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null


### PR DESCRIPTION
This PR only includes the engine-v2-schema changes which were
necessary to re-use `RawInputValues` for operation input values and
make them pleasant to work with.

With the next PR it allows us to fully isolate:
- all the GraphQL-specific input processing: default values, undefined variables, coercion
- schema names from connector/data sources names. Virtually we can
  trivially rename anything now as we keep track of input value
  definition ids and enum value ids. And executors have everything
  automatically renamed by the provided SchemaWalker.

Input values, which will be accessed through a `PlanInputValue`, can be
used through:
- Serialize to serialize the data immediately
- Deserializer to map arguments to a custom type
- Display to format the value with GraphQL syntax
- InputValue<'_> which provides a friendlier format than RawInputValue
  which also abstracts away the differences between schema default
  values and operation input values.

In all cases, the values have always already been coerced and validated.
