### PR TITLE
cli: release 0.58.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "engine-config-builder"
-version = "0.58.0"
+version = "0.58.1"
 dependencies = [
  "engine-v2-config",
  "graphql-federated-graph",
@@ -2003,7 +2003,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "federated-dev"
-version = "0.58.0"
+version = "0.58.1"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2282,7 +2282,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "0.58.0"
+version = "0.58.1"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -2434,7 +2434,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.58.0"
+version = "0.58.1"
 dependencies = [
  "assert_matches",
  "async-graphql",
@@ -2510,7 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-graphql-introspection"
-version = "0.58.0"
+version = "0.58.1"
 dependencies = [
  "apollo-encoder",
  "apollo-parser",
@@ -2523,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.58.0"
+version = "0.58.1"
 dependencies = [
  "async-compression",
  "axum",
@@ -2554,7 +2554,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.58.0"
+version = "0.58.1"
 dependencies = [
  "chrono",
  "common-types",
@@ -2571,7 +2571,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.58.0"
+version = "0.58.1"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -4263,7 +4263,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "operation-checks"
-version = "0.58.0"
+version = "0.58.1"
 dependencies = [
  "async-graphql-parser",
  "async-graphql-value",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "operation-normalizer"
-version = "0.58.0"
+version = "0.58.1"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -7069,7 +7069,7 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typed-resolvers"
-version = "0.58.0"
+version = "0.58.1"
 dependencies = [
  "datatest-stable",
  "engine-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde_with = { git = "https://github.com/grafbase/serde_with", rev = "2fadab3a17
 tar = { git = "https://github.com/grafbase/tar-rs.git", rev = "a889df5bd9fec44faf081f7fade5ec81935c2418" } # overwrite-hard-links
 
 [workspace.package]
-version = "0.58.0"
+version = "0.58.1"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://grafbase.com"

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.58.1] - 2024-02-20
+
+[CHANGELOG](changelog/0.58.1.md)
+
 ## [0.58.0] - 2024-02-16
 
 [CHANGELOG](changelog/0.58.0.md)

--- a/cli/changelog/0.58.1.md
+++ b/cli/changelog/0.58.1.md
@@ -1,0 +1,5 @@
+### Fixes
+
+- Fix bad GraphQL query in `grafbase publish` (#1577)
+- Fix nested fragments in graphql connector, they did not work (#1371)
+- Fix formatting for SDK extend directives (#1370)

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -37,8 +37,8 @@ url = "2"
 urlencoding = "2"
 walkdir = "2"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.58.0" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.58.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.58.1" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.58.1" }
 
 [build-dependencies]
 cynic-codegen = { version = "3", features = ["rkyv"] }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -44,11 +44,11 @@ futures-util = "0.3"
 mimalloc = "0.1"
 
 atty = "0.2"
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.58.0" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.58.0" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.58.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.58.1" }
 federated-dev = { path = "../federated-dev" }
 graphql-introspection = { package = "grafbase-graphql-introspection", path = "../graphql-introspection" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.58.0" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.58.1" }
 
 [dev-dependencies]
 async-graphql-axum.workspace = true

--- a/cli/crates/federated-dev/Cargo.toml
+++ b/cli/crates/federated-dev/Cargo.toml
@@ -35,7 +35,7 @@ tower-service.workspace = true
 ulid.workspace = true
 url = "2.5.0"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.58.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.58.1" }
 engine = { path = "../../../engine/crates/engine" }
 engine-config-builder = { path = "../../../engine/crates/engine-config-builder" }
 engine-v2 = { workspace = true, features = ["plan_cache"] }

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -50,7 +50,7 @@ tracing = "0.1"
 version-compare = "0.1"
 which.workspace = true
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.58.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.58.1" }
 gateway = { path = "../gateway" }
 typed-resolvers = { path = "../typed-resolvers" }
 federated-dev = { path = "../federated-dev" }

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.58.0",
+  "version": "0.58.1",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.58.0",
+  "version": "0.58.1",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.58.0",
+  "version": "0.58.1",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.58.0",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.58.0",
+    "@grafbase/cli-aarch64-apple-darwin": "^0.58.1",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.58.1",
     "@grafbase/cli-x86_64-pc-windows-msvc": "0.53.0",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.58.0",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.58.0"
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.58.1",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.58.1"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.58.0",
+  "version": "0.58.1",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.58.0",
+  "version": "0.58.1",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.58.0",
+  "version": "0.58.1",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
Fixes

- Fix bad GraphQL query in `grafbase publish` (#1577)
- Fix nested fragments in graphql connector, they did not work (#1371)
- Fix formatting for SDK extend directives (#1370)