### PR TITLE
cli: new command for trusted document submission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2578,6 +2578,7 @@ dependencies = [
  "common-types",
  "derivative",
  "dirs",
+ "expect-test",
  "rudderanalytics",
  "serde",
  "serde_json",

--- a/cli/crates/backend/src/api/graphql/api.graphql
+++ b/cli/crates/backend/src/api/graphql/api.graphql
@@ -1161,6 +1161,13 @@ type Mutation {
   ): BranchOperationCheckConfigurationUpdatePayload!
   slackIntegrationCreate(input: SlackIntegrationCreateInput!): SlackNotificationCreatePayload!
   slackNotificationDelete(id: String!): SlackNotificationDeletePayload!
+  trustedDocumentsSubmit(
+    accountSlug: String!
+    projectSlug: String!
+    branchSlug: String!
+    clientName: String!
+    documents: [TrustedDocumentInput!]!
+  ): TrustedDocumentsSubmitPayload!
 }
 
 type NameAlreadyExistsError {
@@ -2337,6 +2344,31 @@ type ResourceStatus {
   percentage: Float
 }
 
+"""
+An occurrence of a trusted document that was submitted again (same id), but with a different document text. This is an error.
+"""
+type ReusedId {
+  """
+  The document id
+  """
+  documentId: String!
+  """
+  The existing document body
+  """
+  existingDocumentText: String!
+  """
+  The different, newly submitted document body
+  """
+  newDocumentText: String!
+}
+
+"""
+Trusted documents that were uploaded again (same id), but with a different document body. This is an error.
+"""
+type ReusedIds {
+  reused: [ReusedId!]!
+}
+
 enum SchemaChangeType {
   SCHEMA_DEFINITION_ADDED
   SCHEMA_DEFINITION_REMOVED
@@ -2768,6 +2800,23 @@ type TokenDoesNotExistError {
 
 type TokenLimitExceededError {
   query: Query!
+}
+
+type TrustedDocument {
+  documentId: String!
+  documentText: String!
+}
+
+input TrustedDocumentInput {
+  documentId: String!
+  documentText: String!
+}
+
+union TrustedDocumentsSubmitPayload = TrustedDocumentsSubmitSuccess | ReusedIds | ProjectDoesNotExistError
+
+type TrustedDocumentsSubmitSuccess {
+  count: Int!
+  documents: [TrustedDocument!]!
 }
 
 enum UnitType {

--- a/cli/crates/backend/src/api/graphql/types/mutations.rs
+++ b/cli/crates/backend/src/api/graphql/types/mutations.rs
@@ -1,3 +1,5 @@
+pub(crate) mod submit_trusted_documents;
+
 use super::schema;
 
 #[derive(cynic::InputObject, Clone, Debug)]

--- a/cli/crates/backend/src/api/graphql/types/mutations/submit_trusted_documents.rs
+++ b/cli/crates/backend/src/api/graphql/types/mutations/submit_trusted_documents.rs
@@ -1,0 +1,48 @@
+use super::schema;
+
+#[derive(Debug, cynic::InputObject)]
+pub struct TrustedDocumentInput {
+    pub document_id: String,
+    pub document_text: String,
+}
+
+#[derive(Debug, cynic::QueryFragment)]
+pub struct TrustedDocumentsSubmitSuccess {
+    pub count: i32,
+}
+
+#[derive(Debug, cynic::QueryFragment)]
+pub struct ReusedId {
+    pub document_id: String,
+    pub existing_document_text: String,
+    pub new_document_text: String,
+}
+
+#[derive(Debug, cynic::QueryFragment)]
+pub struct ReusedIds {
+    pub reused: Vec<ReusedId>,
+}
+
+#[derive(Debug, cynic::InlineFragments)]
+pub enum TrustedDocumentsSubmitPayload {
+    TrustedDocumentsSubmitSuccess(TrustedDocumentsSubmitSuccess),
+    ReusedIds(ReusedIds),
+    #[cynic(fallback)]
+    Unknown,
+}
+
+#[derive(Debug, cynic::QueryVariables)]
+pub struct TrustedDocumentsSubmitVariables<'a> {
+    pub account: &'a str,
+    pub project: &'a str,
+    pub branch: &'a str,
+    pub client_name: &'a str,
+    pub documents: Vec<TrustedDocumentInput>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "Mutation", variables = "TrustedDocumentsSubmitVariables")]
+pub(crate) struct TrustedDocumentsSubmit {
+    #[arguments(clientName : $client_name, projectSlug: $project, accountSlug : $account, branchSlug: $branch, documents: $documents)]
+    pub(crate) trusted_documents_submit: TrustedDocumentsSubmitPayload,
+}

--- a/cli/crates/backend/src/api/mod.rs
+++ b/cli/crates/backend/src/api/mod.rs
@@ -14,5 +14,6 @@ pub mod logs;
 pub mod publish;
 pub mod schema;
 pub mod subgraphs;
+pub mod submit_trusted_documents;
 pub mod types;
 pub mod unlink;

--- a/cli/crates/backend/src/api/submit_trusted_documents.rs
+++ b/cli/crates/backend/src/api/submit_trusted_documents.rs
@@ -1,0 +1,23 @@
+pub use crate::api::graphql::mutations::submit_trusted_documents::{
+    ReusedId, ReusedIds, TrustedDocumentInput, TrustedDocumentsSubmitPayload, TrustedDocumentsSubmitVariables,
+};
+
+use super::graphql::mutations::submit_trusted_documents::TrustedDocumentsSubmit;
+use crate::api::{client::create_client, consts::API_URL, errors::ApiError};
+use cynic::{http::ReqwestExt, MutationBuilder};
+
+#[tokio::main]
+pub async fn submit_trusted_documents(
+    variables: TrustedDocumentsSubmitVariables<'_>,
+) -> Result<TrustedDocumentsSubmitPayload, ApiError> {
+    let client = create_client().await?;
+    let operation = TrustedDocumentsSubmit::build(variables);
+
+    let cynic::GraphQlResponse { data, errors } = client.post(API_URL).run_graphql(operation).await?;
+
+    if let Some(data) = data {
+        Ok(data.trusted_documents_submit)
+    } else {
+        Err(ApiError::RequestError(format!("{errors:#?}")))
+    }
+}

--- a/cli/crates/cli/src/cli_input.rs
+++ b/cli/crates/cli/src/cli_input.rs
@@ -16,8 +16,9 @@ mod schema;
 mod start;
 mod sub_command;
 mod subgraphs;
+mod trust;
 
-pub(crate) use self::check::CheckCommand;
+pub(crate) use self::{check::CheckCommand, trust::TrustCommand};
 pub(crate) use argument_names::{filter_existing_arguments, ArgumentNames};
 pub(crate) use build::BuildCommand;
 pub(crate) use completions::CompletionsCommand;

--- a/cli/crates/cli/src/cli_input/sub_command.rs
+++ b/cli/crates/cli/src/cli_input/sub_command.rs
@@ -1,8 +1,9 @@
 use clap::Parser;
 
 use super::{
-    ArgumentNames, BuildCommand, CheckCommand, CompletionsCommand, CreateCommand, DevCommand, InitCommand,
-    IntrospectCommand, LinkCommand, LogsCommand, PublishCommand, SchemaCommand, StartCommand, SubgraphsCommand,
+    trust::TrustCommand, ArgumentNames, BuildCommand, CheckCommand, CompletionsCommand, CreateCommand, DevCommand,
+    InitCommand, IntrospectCommand, LinkCommand, LogsCommand, PublishCommand, SchemaCommand, StartCommand,
+    SubgraphsCommand,
 };
 
 #[derive(Debug, Parser, strum::AsRefStr, strum::Display)]
@@ -47,6 +48,9 @@ pub enum SubCommand {
     DumpConfig,
     /// Check a graph for validation, composition and breaking change errors
     Check(CheckCommand),
+    /// Submit a trusted documents manifest
+    #[clap(hide = true)]
+    Trust(TrustCommand),
 }
 
 impl SubCommand {
@@ -94,6 +98,7 @@ impl ArgumentNames for SubCommand {
             | SubCommand::Build(_)
             | SubCommand::Completions(_)
             | SubCommand::DumpConfig
+            | SubCommand::Trust(_)
             | SubCommand::Logs(_) => None,
         }
     }

--- a/cli/crates/cli/src/cli_input/trust.rs
+++ b/cli/crates/cli/src/cli_input/trust.rs
@@ -1,0 +1,14 @@
+use super::ProjectRef;
+use std::path::PathBuf;
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct TrustCommand {
+    #[arg(help = ProjectRef::ARG_DESCRIPTION)]
+    pub(crate) project_ref: ProjectRef,
+    /// The path to the manifest file
+    #[clap(long, short = 'm')]
+    pub(crate) manifest: PathBuf,
+    /// The name of the client
+    #[clap(long, short = 'c')]
+    pub(crate) client_name: String,
+}

--- a/cli/crates/cli/src/errors.rs
+++ b/cli/crates/cli/src/errors.rs
@@ -55,6 +55,8 @@ pub enum CliError {
     LogsNoLinkedProject,
     #[error("error during graph introspection: {0}")]
     Introspection(String),
+    #[error("could not read the trusted documents manifest")]
+    TrustedDocumentsManifestReadError(#[source] io::Error),
     #[error("could not read the GraphQL schema")]
     SchemaReadError(#[source] io::Error),
     #[error("error in publish: {0}")]

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -22,6 +22,7 @@ mod publish;
 mod schema;
 mod start;
 mod subgraphs;
+mod trust;
 mod unlink;
 mod watercolor;
 
@@ -181,5 +182,6 @@ fn try_main(args: Args) -> Result<(), CliError> {
         SubCommand::Introspect(cmd) => introspect::introspect(&cmd),
         SubCommand::DumpConfig => dump_config::dump_config(),
         SubCommand::Check(cmd) => check::check(cmd),
+        SubCommand::Trust(cmd) => trust::trust(cmd),
     }
 }

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -6,8 +6,8 @@ use crate::{
 };
 use backend::types::{NestedRequestScopedMessage, RequestCompletedOutcome};
 use colored::Colorize;
-use common::consts::GRAFBASE_TS_CONFIG_FILE_NAME;
 use common::types::{LogLevel, UdfKind};
+use common::{consts::GRAFBASE_TS_CONFIG_FILE_NAME, trusted_documents::TrustedDocumentsManifest};
 use common::{consts::LOCALHOST, environment::Warning};
 use std::{net::IpAddr, path::Path};
 
@@ -544,4 +544,29 @@ pub(crate) fn publish_command_composition_failure(messages: &[String]) {
 
 pub fn command_separator() {
     println!();
+}
+
+pub(crate) fn trust_start(manifest: &TrustedDocumentsManifest) {
+    let format = match manifest {
+        TrustedDocumentsManifest::Apollo(_) => "apollo",
+        TrustedDocumentsManifest::Relay(_) => "relay",
+    };
+    watercolor::output!("📡 Submitting trusted documents manifest (format: {format})...", @BrightBlue);
+}
+
+pub(crate) fn trust_success(count: i32) {
+    watercolor::output!("✨ Successfully submitted {count} documents", @BrightGreen)
+}
+
+pub(crate) fn trust_failed() {
+    watercolor::output!("❌ Trusted document submission failed", @BrightRed)
+}
+
+pub(crate) fn trust_reused_ids(reused: &backend::api::submit_trusted_documents::ReusedIds) {
+    watercolor::output!("Error: there already exist trusted documents with the same ids, but a different body:", @BrightRed);
+
+    for reused_id in &reused.reused {
+        let id = &reused_id.document_id;
+        watercolor::output!("- {id}", @BrightRed);
+    }
 }

--- a/cli/crates/cli/src/trust.rs
+++ b/cli/crates/cli/src/trust.rs
@@ -1,0 +1,58 @@
+use common::trusted_documents::TrustedDocumentsManifest;
+
+use crate::{cli_input::TrustCommand, errors::CliError, output::report};
+
+pub(crate) fn trust(
+    TrustCommand {
+        project_ref,
+        client_name,
+        manifest,
+    }: TrustCommand,
+) -> Result<(), CliError> {
+    let Some(branch) = project_ref.branch() else {
+        return Err(CliError::MissingArgument("branch"));
+    };
+
+    let file = std::fs::File::open(manifest).map_err(CliError::TrustedDocumentsManifestReadError)?;
+    let manifest: TrustedDocumentsManifest = serde_json::from_reader(file).map_err(|err| {
+        CliError::TrustedDocumentsManifestReadError(std::io::Error::new(std::io::ErrorKind::InvalidData, err))
+    })?;
+
+    report::trust_start(&manifest);
+
+    match backend::api::submit_trusted_documents::submit_trusted_documents(
+        backend::api::submit_trusted_documents::TrustedDocumentsSubmitVariables {
+            account: project_ref.account(),
+            project: project_ref.project(),
+            branch,
+            client_name: &client_name,
+            documents: manifest
+                .into_documents()
+                .map(
+                    |common::trusted_documents::TrustedDocument {
+                         document_id,
+                         document_text,
+                     }| backend::api::submit_trusted_documents::TrustedDocumentInput {
+                        document_id,
+                        document_text,
+                    },
+                )
+                .collect(),
+        },
+    ) {
+        Ok(payload) => match payload {
+            backend::api::submit_trusted_documents::TrustedDocumentsSubmitPayload::TrustedDocumentsSubmitSuccess(
+                success,
+            ) => {
+                report::trust_success(success.count);
+            }
+            backend::api::submit_trusted_documents::TrustedDocumentsSubmitPayload::ReusedIds(reused_ids) => {
+                report::trust_reused_ids(&reused_ids)
+            }
+            backend::api::submit_trusted_documents::TrustedDocumentsSubmitPayload::Unknown => report::trust_failed(),
+        },
+        Err(err) => return Err(CliError::BackendApiError(err)),
+    }
+
+    Ok(())
+}

--- a/cli/crates/common/Cargo.toml
+++ b/cli/crates/common/Cargo.toml
@@ -24,6 +24,7 @@ tokio.workspace = true
 ulid = { version = "1", features = ["serde"] }
 
 common-types = { path = "../../../engine/crates/common-types" }
+expect-test = "1.4.1"
 
 [build-dependencies]
 serde_json.workspace = true

--- a/cli/crates/common/src/lib.rs
+++ b/cli/crates/common/src/lib.rs
@@ -4,11 +4,15 @@ The common crate provides shared functionality for Grafbase developer tools
 
 #![forbid(unsafe_code)]
 
+#[cfg(not(test))]
+use expect_test as _;
+
 pub mod analytics;
 pub mod channels;
 pub mod consts;
 pub mod debug_macros;
 pub mod environment;
 pub mod errors;
+pub mod trusted_documents;
 pub mod types;
 pub mod utils;

--- a/cli/crates/common/src/trusted_documents.rs
+++ b/cli/crates/common/src/trusted_documents.rs
@@ -1,0 +1,121 @@
+use std::collections::BTreeMap;
+
+mod apollo;
+
+pub struct TrustedDocument {
+    pub document_id: String,
+    pub document_text: String,
+}
+
+#[derive(serde::Deserialize, Debug)]
+#[serde(untagged)]
+pub enum TrustedDocumentsManifest {
+    Apollo(apollo::ApolloOperationManifest),
+    Relay(RelayTrustedDocumentsManifest),
+}
+
+impl TrustedDocumentsManifest {
+    pub fn into_documents(self) -> Box<dyn Iterator<Item = TrustedDocument>> {
+        match self {
+            TrustedDocumentsManifest::Apollo(manifest) => Box::new(manifest.operations.into_iter().map(
+                |apollo::ApolloOperation {
+                     id,
+                     body,
+                     name: _,
+                     r#type: _,
+                 }| TrustedDocument {
+                    document_id: id,
+                    document_text: body,
+                },
+            )),
+            TrustedDocumentsManifest::Relay(map) => Box::new(map.into_iter().map(|(key, value)| TrustedDocument {
+                document_id: key,
+                document_text: value,
+            })),
+        }
+    }
+}
+
+pub type RelayTrustedDocumentsManifest = BTreeMap<String, String>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apollo_basic() {
+        // document from the docs
+        let manifest = r#"
+{
+  "format": "apollo-persisted-query-manifest",
+  "version": 1,
+  "operations": [
+    {
+      "id": "dc67510fb4289672bea757e862d6b00e83db5d3cbbcfb15260601b6f29bb2b8f",
+      "body": "query UniversalQuery { __typename }",
+      "name": "UniversalQuery",
+      "type": "query"
+    }
+  ]
+}            
+        "#;
+
+        let deserialized: TrustedDocumentsManifest = serde_json::from_str(manifest).unwrap();
+
+        let expected = expect_test::expect![[r#"
+            Apollo(
+                ApolloOperationManifest {
+                    format: "apollo-persisted-query-manifest",
+                    version: 1,
+                    operations: [
+                        ApolloOperation {
+                            id: "dc67510fb4289672bea757e862d6b00e83db5d3cbbcfb15260601b6f29bb2b8f",
+                            body: "query UniversalQuery { __typename }",
+                            name: "UniversalQuery",
+                            type: "query",
+                        },
+                    ],
+                },
+            )
+        "#]];
+
+        expected.assert_debug_eq(&deserialized)
+    }
+
+    #[test]
+    fn relay_basic() {
+        let manifest = r#"
+            {
+                "this-is-the-hash": "this-is-the-query",
+                "id-number-2": "query-number-2"
+            }
+        "#;
+
+        let deserialized: TrustedDocumentsManifest = serde_json::from_str(manifest).unwrap();
+
+        let expected = expect_test::expect![[r#"
+            Relay(
+                {
+                    "id-number-2": "query-number-2",
+                    "this-is-the-hash": "this-is-the-query",
+                },
+            )
+        "#]];
+
+        expected.assert_debug_eq(&deserialized);
+    }
+
+    #[test]
+    fn relay_empty() {
+        let empty_manifest = r#"{}"#;
+        let deserialized: TrustedDocumentsManifest = serde_json::from_str(empty_manifest).unwrap();
+
+        let expected = expect_test::expect![[r#"
+            Relay(
+                {},
+            )
+        "#]];
+
+        expected.assert_debug_eq(&deserialized);
+    }
+}

--- a/cli/crates/common/src/trusted_documents/apollo.rs
+++ b/cli/crates/common/src/trusted_documents/apollo.rs
@@ -1,0 +1,17 @@
+#![allow(unused)]
+
+/// See [the Apollo docs](https://www.apollographql.com/docs/graphos/operations/persisted-queries/#manifest-format).
+#[derive(Debug, serde::Deserialize)]
+pub struct ApolloOperationManifest {
+    pub(super) format: String,
+    pub(super) version: u32,
+    pub(super) operations: Vec<ApolloOperation>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(super) struct ApolloOperation {
+    pub(super) id: String,
+    pub(super) body: String,
+    pub(super) name: String,
+    pub(super) r#type: String,
+}


### PR DESCRIPTION
The command is called `trust` and lives at the top level, but we can
iterate if that turns out not to be self-explanatory enough.

The command is hidden for now, since the feature isn't complete in the
engine and infrastructure yet, and not documented.

It takes a branch reference, a client name and a manifest file that can
be either in Relay or Apollo Client format. We can easily add more
manifest formats as the appetite arises. We can even imagine using the
Grafbase CLI to generate manifests directly.

closes GB-6015