### PR TITLE
fix: respect `.gitignore` in `grafbase deploy`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,6 +662,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,6 +2449,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "globset"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+dependencies = [
+ "aho-corasick",
+ "bstr 1.9.1",
+ "log 0.4.20",
+ "regex-automata 0.4.5",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2553,6 +2576,7 @@ dependencies = [
  "grafbase-local-common",
  "grafbase-local-server",
  "http-cache-reqwest",
+ "ignore",
  "reqwest",
  "reqwest-middleware",
  "serde",
@@ -2567,7 +2591,6 @@ dependencies = [
  "ulid",
  "url",
  "urlencoding",
- "walkdir",
 ]
 
 [[package]]
@@ -3206,6 +3229,22 @@ name = "if_chain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
+
+[[package]]
+name = "ignore"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log 0.4.20",
+ "memchr",
+ "regex-automata 0.4.5",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "im"
@@ -6054,7 +6093,7 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
 dependencies = [
- "bstr",
+ "bstr 0.2.17",
  "unicode-segmentation",
 ]
 

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -17,6 +17,7 @@ const_format = { version = "0.2", features = ["rust_1_64"] }
 cynic = { workspace = true, features = ["http-reqwest"] }
 dirs = "5"
 http-cache-reqwest = "0.13"
+ignore = "0.4"
 reqwest = { workspace = true, features = [
     "rustls-tls",
     "stream",
@@ -35,7 +36,6 @@ tower-http = { workspace = true, features = ["trace"] }
 ulid = "1"
 url = "2"
 urlencoding = "2"
-walkdir = "2"
 
 common = { package = "grafbase-local-common", path = "../common", version = "0.59.0" }
 server = { package = "grafbase-local-server", path = "../server", version = "0.59.0" }

--- a/cli/crates/backend/src/api/errors.rs
+++ b/cli/crates/backend/src/api/errors.rs
@@ -114,7 +114,7 @@ pub enum ApiError {
 
     /// returned if a project file could not be read
     #[error("could not read a project file\nCaused by: {0}")]
-    ReadProjectFile(walkdir::Error),
+    ReadProjectFile(ignore::Error),
 
     /// returned if a project file could not be opened
     #[error("could not open a project file\nCaused by: {0}")]


### PR DESCRIPTION
A user was running into issues with `grafbase deploy` yesterday, where deployments failed with a bizzare error very similar to [this one][1].

We eventually tracked this down to files in the users `.direnv` or `.devenv` folders - based on the tar-rs issue _probably_ hard links of some description. While it would be good to not choke on hardlinks, I'd argue we shouldn't have been archiving these files in the first place: they're clearly meant to stay local to the users machine.

So this PR switches `walkdir` for `ignore`, which will respect `.gitignore` files etc, providing users with a sensible (and in most cases zero effort) way to exclude files from the archive we build on `grafbase deploy`.  I think this is a sensible default.

This _could_ have ramifications for anyone doing a `grafbase deploy` after some kind of local build step, though I don't know how likely that is really.  I suggest we try it and see - if anyone complains we can revisit, maybe adding a CLI flag to change the behaviour.

Fixes GB-6107

[1]: https://github.com/alexcrichton/tar-rs/issues/313