### PR TITLE
Change auth flow to use new dashboard [GB-6060]

### DIFF
--- a/cli/crates/backend/src/api/consts.rs
+++ b/cli/crates/backend/src/api/consts.rs
@@ -1,5 +1,5 @@
 pub const CREDENTIALS_FILE: &str = "credentials.json";
-pub const AUTH_URL: &str = "https://grafbase.com/auth/cli";
+pub const AUTH_URL: &str = "https://app.grafbase.com/auth/cli";
 pub const API_URL: &str = "https://api.grafbase.com/graphql";
 pub const PACKAGE_JSON: &str = "package.json";
 pub const TAR_CONTENT_TYPE: &str = "application/x-tar";


### PR DESCRIPTION
The CLI auth flow for the new dashboard is ready, so we can switch the CLI to start authenticating through that. The old URL already redirects to the new flow, so this won't change much from an end user perspective, and old version of the CLI won't break.