### PR TITLE
fix: Add missing upstream error for federation subgraph response.

### DIFF
--- a/engine/crates/engine-v2/src/response/write/deserialize/mod.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/mod.rs
@@ -69,12 +69,12 @@ impl<'ctx> SeedContextInner<'ctx> {
 
         if bound_field.response_key() == field.expected_key.into() {
             format!(
-                "Upstream response error: Missing required field named '{}'",
+                "Error decoding response from upstream: Missing required field named '{}'",
                 &self.plan.response_keys()[field.expected_key]
             )
         } else {
             format!(
-                "Upstream response error: Missing required field named '{}' (expected: '{}')",
+                "Error decoding response from upstream: Missing required field named '{}' (expected: '{}')",
                 bound_field.response_key_str(),
                 &self.plan.response_keys()[field.expected_key]
             )

--- a/engine/crates/engine-v2/src/response/write/mod.rs
+++ b/engine/crates/engine-v2/src/response/write/mod.rs
@@ -239,6 +239,10 @@ impl ResponsePart {
         self.errors.push(error.into());
     }
 
+    pub fn push_errors(&mut self, errors: Vec<GraphqlError>) {
+        self.errors.extend(errors);
+    }
+
     pub fn push_error_path_to_propagate(&mut self, path: ResponsePath) {
         self.error_paths_to_propagate.push(path);
     }


### PR DESCRIPTION
We wouldn't return upstream errors if data wasn't `null`, a stupid mistake.

We can do better with a custom Deserialize for federation
entities rather than re-using the generic GraphQL response one, but it
does require more work. So doing the MVP for now.
