### PR TITLE
graphql-schema-diff: stop emitting addField for fields of new objects

### DIFF
--- a/engine/crates/graphql-schema-diff/README.md
+++ b/engine/crates/graphql-schema-diff/README.md
@@ -57,14 +57,6 @@ fn main() {
               kind: ChangeKind::AddObjectType
           },
           Change {
-              path: String::from("PizzaName.english"),
-              kind: ChangeKind::AddField
-          },
-          Change {
-              path: String::from("PizzaName.italian"),
-              kind: ChangeKind::AddField
-          },
-          Change {
               path: String::from("Topping.PINEAPPLE"),
               kind: ChangeKind::RemoveEnumValue
           },

--- a/engine/crates/graphql-schema-diff/src/state.rs
+++ b/engine/crates/graphql-schema-diff/src/state.rs
@@ -126,13 +126,12 @@ fn push_field_changes(
         let parent = &types_map[type_name];
         let parent_is_gone = || matches!(parent, (Some(_), None));
 
-        if matches!(parent, (Some(a), Some(b)) if a != b) {
-            continue; // so we don't falsely interpret same name as field type change
-        }
-
         let definition = match parent {
             (None, None) => unreachable!(),
-            (Some(kind), None) | (None, Some(kind)) => *kind,
+            (Some(a), Some(b)) if a != b => {
+                continue; // so we don't falsely interpret same name as field type change
+            }
+            (Some(_), None) | (None, Some(_)) => continue,
             (Some(kind), Some(_)) => *kind,
         };
 

--- a/engine/crates/graphql-schema-diff/tests/diff/add_one_object.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/add_one_object.snapshot.json
@@ -3,10 +3,6 @@
     {
       "path": "Locust",
       "kind": "AddObjectType"
-    },
-    {
-      "path": "Locust.id",
-      "kind": "AddField"
     }
   ],
   "target → src": [

--- a/engine/crates/graphql-schema-diff/tests/diff/enum_basic.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/enum_basic.snapshot.json
@@ -17,14 +17,6 @@
     {
       "path": "People",
       "kind": "AddEnum"
-    },
-    {
-      "path": "People.CAT",
-      "kind": "AddEnumValue"
-    },
-    {
-      "path": "People.DOG",
-      "kind": "AddEnumValue"
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/union_basic.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/union_basic.snapshot.json
@@ -9,18 +9,6 @@
     {
       "path": "Color",
       "kind": "AddUnion"
-    },
-    {
-      "path": "Color.Blue",
-      "kind": "AddUnionMember"
-    },
-    {
-      "path": "Color.Green",
-      "kind": "AddUnionMember"
-    },
-    {
-      "path": "Color.Red",
-      "kind": "AddUnionMember"
     }
   ]
 }


### PR DESCRIPTION
Same goes for variants of unions, values of enums, etc.

closes GB-6104