### PR TITLE
fix: custom field entity mutation invalidation cache tag

### DIFF
--- a/engine/crates/engine/src/validation/visitors/cache_control.rs
+++ b/engine/crates/engine/src/validation/visitors/cache_control.rs
@@ -32,15 +32,16 @@ impl<'ctx, 'a> Visitor<'ctx> for CacheControlCalculate<'a> {
     }
 
     fn enter_field(&mut self, ctx: &mut VisitorContext<'_>, field: &Positioned<Field>) {
-        if let Some(registry_field) = ctx
-            .parent_type()
-            .and_then(|parent| parent.field_by_name(&field.node.name.node))
-        {
+        if let Some((registry_field, parent_type)) = ctx.parent_type().and_then(|parent| {
+            parent
+                .field_by_name(&field.node.name.node)
+                .map(|field| (field, parent.name()))
+        }) {
             self.cache_control.merge(registry_field.cache_control.clone());
 
             if let Some(policy) = &registry_field.cache_control.invalidation_policy {
                 self.invalidation_policies.insert(CacheInvalidation {
-                    ty: registry_field.ty.to_string(),
+                    ty: parent_type.to_string(),
                     policy: policy.clone(),
                 });
             }

--- a/engine/crates/integration-tests/src/engine/builder.rs
+++ b/engine/crates/integration-tests/src/engine/builder.rs
@@ -96,9 +96,15 @@ impl EngineBuilder {
     }
 
     pub async fn build(self) -> Engine {
-        let ParseResult { registry, .. } = parser_sdl::parse(&self.schema, &self.environment_variables, true, &self)
+        let ParseResult {
+            mut registry,
+            global_cache_rules,
+            ..
+        } = parser_sdl::parse(&self.schema, &self.environment_variables, true, &self)
             .await
             .unwrap();
+
+        global_cache_rules.apply(&mut registry).unwrap();
 
         let registry: Registry = serde_json::from_value(serde_json::to_value(registry).unwrap()).unwrap();
 

--- a/engine/crates/integration-tests/tests/caching/mod.rs
+++ b/engine/crates/integration-tests/tests/caching/mod.rs
@@ -1,0 +1,373 @@
+use integration_tests::udfs::RustUdfs;
+use integration_tests::{runtime, EngineBuilder};
+use runtime::cache::Cacheable;
+use runtime::udf::UdfResponse;
+use serde_json::json;
+use std::time::Duration;
+
+#[test]
+fn should_cache_with_entity_mutation_invalidation_custom_field() {
+    let schema = r#"
+        extend type Query {
+            test: Post! @resolver(name: "test")
+        }
+
+        extend schema @cache(rules: [
+                { maxAge: 60, staleWhileRevalidate: 10, types: [{name: "Post", fields: ["seconds"]}],  mutationInvalidation: { field: "seconds" } },
+            ]
+        )
+
+        type Post {
+            seconds: String
+            hello: String
+        }
+    "#;
+
+    runtime().block_on(async {
+        let engine = EngineBuilder::new(schema)
+            .with_custom_resolvers(RustUdfs::new().resolver(
+                "test",
+                UdfResponse::Success(json!({
+                    "seconds": "test"
+                })),
+            ))
+            .build()
+            .await;
+
+        // act
+        let response = engine.execute("{ test { seconds } }").await;
+
+        // assert
+        let metadata = response.metadata();
+
+        assert!(!metadata.should_purge_related);
+        assert_eq!(metadata.tags, vec!["Post#seconds:test"]);
+        assert_eq!(metadata.max_age, Duration::from_secs(60));
+        assert_eq!(metadata.stale_while_revalidate, Duration::from_secs(10));
+    });
+}
+
+#[test]
+fn should_cache_with_entity_mutation_invalidation() {
+    let schema = r#"
+        extend type Query {
+            test: Post! @resolver(name: "test")
+        }
+
+        extend schema @cache(rules: [
+                { maxAge: 60, staleWhileRevalidate: 10, types: "Post",  mutationInvalidation: entity },
+            ]
+        )
+
+        type Post {
+            seconds: String
+            hello: String
+            id: ID!
+        }
+    "#;
+
+    runtime().block_on(async {
+        let engine = EngineBuilder::new(schema)
+            .with_custom_resolvers(RustUdfs::new().resolver(
+                "test",
+                UdfResponse::Success(json!({
+                    "seconds": "test",
+                    "id": "hello",
+                })),
+            ))
+            .build()
+            .await;
+
+        // act
+        let response = engine.execute("{ test { id seconds } }").await;
+
+        // assert
+        let metadata = response.metadata();
+
+        assert!(!metadata.should_purge_related);
+        assert_eq!(metadata.tags, vec!["Post#id:hello"]);
+        assert_eq!(metadata.max_age, Duration::from_secs(60));
+        assert_eq!(metadata.stale_while_revalidate, Duration::from_secs(10));
+    });
+}
+
+#[test]
+fn should_cache_with_type_mutation_invalidation() {
+    let schema = r#"
+        extend type Query {
+            test: Post! @resolver(name: "test")
+        }
+
+        extend schema @cache(rules: [
+                { maxAge: 60, staleWhileRevalidate: 10, types: [{name: "Post", fields: ["seconds"]}],  mutationInvalidation: type },
+            ]
+        )
+
+        type Post {
+            seconds: String
+            hello: String
+        }
+    "#;
+
+    runtime().block_on(async {
+        let engine = EngineBuilder::new(schema)
+            .with_custom_resolvers(RustUdfs::new().resolver(
+                "test",
+                UdfResponse::Success(json!({
+                    "seconds": "test"
+                })),
+            ))
+            .build()
+            .await;
+
+        // act
+        let response = engine.execute("{ test { seconds } }").await;
+
+        // assert
+        let metadata = response.metadata();
+
+        assert!(!metadata.should_purge_related);
+        assert_eq!(metadata.tags, vec!["Post"]);
+        assert_eq!(metadata.max_age, Duration::from_secs(60));
+        assert_eq!(metadata.stale_while_revalidate, Duration::from_secs(10));
+    });
+}
+
+#[test]
+fn should_cache_with_list_mutation_invalidation() {
+    let schema = r#"
+        extend type Query {
+            test: Post! @resolver(name: "test")
+        }
+
+        extend schema @cache(rules: [
+                { maxAge: 60, staleWhileRevalidate: 10, types: [{name: "Post", fields: ["seconds"]}],  mutationInvalidation: list },
+            ]
+        )
+
+        type Post {
+            seconds: String
+            hello: String
+        }
+    "#;
+
+    runtime().block_on(async {
+        let engine = EngineBuilder::new(schema)
+            .with_custom_resolvers(RustUdfs::new().resolver(
+                "test",
+                UdfResponse::Success(json!({
+                    "seconds": "test"
+                })),
+            ))
+            .build()
+            .await;
+
+        // act
+        let response = engine.execute("{ test { seconds } }").await;
+
+        // assert
+        let metadata = response.metadata();
+
+        assert!(!metadata.should_purge_related);
+        assert_eq!(metadata.tags, vec!["Post#List"]);
+        assert_eq!(metadata.max_age, Duration::from_secs(60));
+        assert_eq!(metadata.stale_while_revalidate, Duration::from_secs(10));
+    });
+}
+
+#[test]
+fn should_not_cache_missing_field_from_response() {
+    let schema = r#"
+        extend type Query {
+            test: Post! @resolver(name: "test")
+        }
+
+        extend schema @cache(rules: [
+                { maxAge: 60, staleWhileRevalidate: 10, types: [{name: "Post", fields: ["seconds"]}] },
+            ]
+        )
+
+        type Post {
+            seconds: String
+            hello: String
+        }
+    "#;
+
+    runtime().block_on(async {
+        let engine = EngineBuilder::new(schema)
+            .with_custom_resolvers(RustUdfs::new().resolver(
+                "test",
+                UdfResponse::Success(json!({
+                    "hello": "test"
+                })),
+            ))
+            .build()
+            .await;
+
+        // act
+        let response = engine.execute("{ test { hello } }").await;
+
+        // assert
+        let metadata = response.metadata();
+
+        assert!(!metadata.should_purge_related);
+        assert!(metadata.tags.is_empty());
+        assert_eq!(metadata.max_age, Duration::from_secs(0));
+        assert_eq!(metadata.stale_while_revalidate, Duration::from_secs(0));
+    });
+}
+
+#[test]
+fn should_purge_related_mutation_invalidation_entity() {
+    let schema = r#"
+        extend type Mutation {
+            postCreate(name: String!): Post! @resolver(name: "test")
+        }
+
+        type Post @cache(maxAge: 10, staleWhileRevalidate: 10, mutationInvalidation: { field: "name" }) {
+            id: ID!
+            name: String!
+        }
+    "#;
+
+    runtime().block_on(async {
+        let engine = EngineBuilder::new(schema)
+            .with_custom_resolvers(RustUdfs::new().resolver(
+                "test",
+                UdfResponse::Success(json!({
+                    "id": "1",
+                    "name": "hmm",
+                })),
+            ))
+            .build()
+            .await;
+
+        // act
+        let response = engine
+            .execute("mutation { postCreate(name: \"hmm\") { id name } }")
+            .await;
+
+        // assert
+        let metadata = response.metadata();
+
+        assert!(metadata.should_purge_related);
+        assert!(!metadata.should_cache);
+        assert_eq!(metadata.tags, vec!["Post#name:hmm"]);
+    });
+}
+
+#[test]
+fn should_purge_related_mutation_invalidation_type() {
+    let schema = r#"
+        extend type Mutation {
+            postCreate(name: String!): Post! @resolver(name: "test")
+        }
+
+        type Post @cache(maxAge: 10, staleWhileRevalidate: 10, mutationInvalidation: type) {
+            id: ID!
+            name: String!
+        }
+    "#;
+
+    runtime().block_on(async {
+        let engine = EngineBuilder::new(schema)
+            .with_custom_resolvers(RustUdfs::new().resolver(
+                "test",
+                UdfResponse::Success(json!({
+                    "id": "1",
+                    "name": "hmm",
+                })),
+            ))
+            .build()
+            .await;
+
+        // act
+        let response = engine
+            .execute("mutation { postCreate(name: \"hmm\") { id name } }")
+            .await;
+
+        // assert
+        let metadata = response.metadata();
+
+        assert!(metadata.should_purge_related);
+        assert!(!metadata.should_cache);
+        assert_eq!(metadata.tags, vec!["Post"]);
+    });
+}
+
+#[test]
+fn should_purge_related_mutation_invalidation_list() {
+    let schema = r#"
+        extend type Mutation {
+            postCreate(name: String!): Post! @resolver(name: "test")
+        }
+
+        type Post @cache(maxAge: 10, staleWhileRevalidate: 10, mutationInvalidation: list) {
+            id: ID!
+            name: String!
+        }
+    "#;
+
+    runtime().block_on(async {
+        let engine = EngineBuilder::new(schema)
+            .with_custom_resolvers(RustUdfs::new().resolver(
+                "test",
+                UdfResponse::Success(json!({
+                    "id": "1",
+                    "name": "hmm",
+                })),
+            ))
+            .build()
+            .await;
+
+        // act
+        let response = engine
+            .execute("mutation { postCreate(name: \"hmm\") { id name } }")
+            .await;
+
+        // assert
+        let metadata = response.metadata();
+
+        assert!(metadata.should_purge_related);
+        assert!(!metadata.should_cache);
+        assert_eq!(metadata.tags, vec!["Post#List"]);
+    });
+}
+
+#[test]
+fn should_not_purge_related_mutation_invalidation_entity_missing_response_field() {
+    let schema = r#"
+        extend type Mutation {
+            postCreate(name: String!): Post! @resolver(name: "test")
+        }
+
+        type Post @cache(maxAge: 10, staleWhileRevalidate: 10, mutationInvalidation: { field: "name" }) {
+            id: ID!
+            name: String
+        }
+    "#;
+
+    runtime().block_on(async {
+        let engine = EngineBuilder::new(schema)
+            .with_custom_resolvers(RustUdfs::new().resolver(
+                "test",
+                UdfResponse::Success(json!({
+                    "id": "1",
+                })),
+            ))
+            .build()
+            .await;
+
+        // act
+        let response = engine
+            .execute("mutation { postCreate(name: \"hmm\") { id name } }")
+            .await;
+
+        // assert
+        let metadata = response.metadata();
+
+        assert!(!metadata.should_purge_related);
+        assert!(!metadata.should_cache);
+        assert!(metadata.tags.is_empty());
+    });
+}

--- a/engine/crates/integration-tests/tests/integration_tests.rs
+++ b/engine/crates/integration-tests/tests/integration_tests.rs
@@ -11,4 +11,5 @@ mod openapi;
 mod postgres;
 mod subgraph;
 
+mod caching;
 mod tracing;

--- a/engine/crates/tracing/src/filter.rs
+++ b/engine/crates/tracing/src/filter.rs
@@ -1,2 +1,0 @@
-/// Filter to sample spans based on a ratio
-pub mod ratio_sampling;


### PR DESCRIPTION
# Description

Fixes a bug that happened when computing response cache tags that were not present when using mutation invalidation of type `entity` with a custom field.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
