### PR TITLE
fix: connection timeout failure modes, tick burst prevention and a typo

### DIFF
--- a/cli/crates/production-server/src/server.rs
+++ b/cli/crates/production-server/src/server.rs
@@ -67,7 +67,7 @@ async fn bind(addr: SocketAddr, path: &str, router: Router, tls: Option<TlsConfi
 
     match tls {
         Some(ref tls) => {
-            tracing::info!("starting the Grafbase gateway in https://{addr}{path}");
+            tracing::info!("starting the Grafbase gateway at https://{addr}{path}");
 
             let rustls_config = RustlsConfig::from_pem_file(&tls.certificate, &tls.key)
                 .await

--- a/cli/crates/production-server/src/server/graph_updater.rs
+++ b/cli/crates/production-server/src/server/graph_updater.rs
@@ -4,6 +4,7 @@ use super::gateway::GatewaySender;
 use crate::config::{AuthenticationConfig, OperationLimitsConfig};
 use ascii::AsciiString;
 use http::{HeaderValue, StatusCode};
+use tokio::time::MissedTickBehavior;
 use tracing::Level;
 use ulid::Ulid;
 use url::Url;
@@ -116,6 +117,10 @@ impl GraphUpdater {
     /// are served before dropping.
     pub async fn poll(&mut self) {
         let mut interval = tokio::time::interval(TICK_INTERVAL);
+
+        // if we have a slow connection, this prevents bursts of connections to the GDN
+        // for all the missed ticks.
+        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         loop {
             interval.tick().await;

--- a/cli/crates/production-server/src/server/graph_updater.rs
+++ b/cli/crates/production-server/src/server/graph_updater.rs
@@ -12,10 +12,10 @@ use url::Url;
 const TICK_INTERVAL: Duration = Duration::from_secs(10);
 
 /// How long we wait for a response from the schema registry.
-const UPLINK_TIMEOUT: Duration = Duration::from_secs(30);
+const UPLINK_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// How long we keep the HTTP connection alive in the pool.
-const KEEPALIVE_DURATION: Duration = Duration::from_secs(60);
+/// How long we wait until a connection is successfully opened.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// The HTTP user-agent header we sent to the schema registry.
 const USER_AGENT: &str = "grafbase-cli";
@@ -57,8 +57,7 @@ impl GraphUpdater {
         let uplink_client = reqwest::ClientBuilder::new()
             .gzip(true)
             .timeout(UPLINK_TIMEOUT)
-            .connect_timeout(Duration::from_secs(5))
-            .tcp_keepalive(KEEPALIVE_DURATION)
+            .connect_timeout(CONNECT_TIMEOUT)
             .user_agent(USER_AGENT)
             .build()
             .map_err(|e| crate::Error::InternalError(e.to_string()))?;

--- a/cli/crates/production-server/src/server/graph_updater.rs
+++ b/cli/crates/production-server/src/server/graph_updater.rs
@@ -18,6 +18,15 @@ const UPLINK_TIMEOUT: Duration = Duration::from_secs(10);
 /// How long we wait until a connection is successfully opened.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Sets an interval for HTTP2 Ping frames should be sent to keep a connection alive.
+const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Sets a timeout for receiving an acknowledgement of the keep-alive ping.
+const KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Sets whether HTTP2 keep-alive should apply while the connection is idle.
+const KEEPALIVE_WHILE_IDLE: bool = true;
+
 /// The HTTP user-agent header we sent to the schema registry.
 const USER_AGENT: &str = "grafbase-cli";
 
@@ -59,6 +68,9 @@ impl GraphUpdater {
             .gzip(true)
             .timeout(UPLINK_TIMEOUT)
             .connect_timeout(CONNECT_TIMEOUT)
+            .http2_keep_alive_interval(Some(KEEPALIVE_INTERVAL))
+            .http2_keep_alive_timeout(KEEPALIVE_TIMEOUT)
+            .http2_keep_alive_while_idle(KEEPALIVE_WHILE_IDLE)
             .user_agent(USER_AGENT)
             .build()
             .map_err(|e| crate::Error::InternalError(e.to_string()))?;


### PR DESCRIPTION
# Description

This fixes a few things:

- When a connection fails to GDN, our subsequent connections were all failing. We prevent this by disabling the TCP keepalive.
- When a connection times out, the timeout can take a long time and when the connections are fast again we sent a burst of queries to the GDN for all the missed ticks. We should instead just skip all missed ticks and query again when the next time is due.
- Fixes a small typo in the server start log message.
- To keep http2 connection up and running nicely, we enable HTTP2 Ping, keepalive and idle pings.

Closes: GB-6214

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
