### PR TITLE
feat: allow setting uplink, api and auth urls with env vars

### DIFF
--- a/cli/crates/backend/src/api/check.rs
+++ b/cli/crates/backend/src/api/check.rs
@@ -2,7 +2,7 @@ pub use super::graphql::mutations::{SchemaCheck, SchemaCheckErrorSeverity, Schem
 
 use super::{
     client::create_client,
-    consts::API_URL,
+    consts::api_url,
     errors::ApiError,
     graphql::mutations::{SchemaCheckCreate, SchemaCheckCreateArguments, SchemaCheckCreateInput, SchemaCheckPayload},
 };
@@ -30,7 +30,7 @@ pub async fn check(
         },
     });
 
-    let result = client.post(API_URL).run_graphql(operation).await?;
+    let result = client.post(api_url()).run_graphql(operation).await?;
 
     match result {
         cynic::GraphQlResponse {

--- a/cli/crates/backend/src/api/consts.rs
+++ b/cli/crates/backend/src/api/consts.rs
@@ -1,6 +1,18 @@
+use std::sync::OnceLock;
+
 pub const CREDENTIALS_FILE: &str = "credentials.json";
-pub const AUTH_URL: &str = "https://app.grafbase.com/auth/cli";
-pub const API_URL: &str = "https://api.grafbase.com/graphql";
 pub const PACKAGE_JSON: &str = "package.json";
 pub const TAR_CONTENT_TYPE: &str = "application/x-tar";
 pub const GRAFBASE_ACCESS_TOKEN_ENV_VAR: &str = "GRAFBASE_ACCESS_TOKEN";
+pub const AUTH_URL: &str = "https://app.grafbase.com/auth/cli";
+
+const API_URL: &str = "https://api.grafbase.com/graphql";
+
+pub fn api_url() -> &'static str {
+    static API_URL: OnceLock<String> = OnceLock::new();
+
+    API_URL.get_or_init(|| match std::env::var("GRAFBASE_API_URL").ok() {
+        Some(url) => url,
+        None => self::API_URL.to_string(),
+    })
+}

--- a/cli/crates/backend/src/api/create.rs
+++ b/cli/crates/backend/src/api/create.rs
@@ -1,5 +1,5 @@
 use super::client::create_client;
-use super::consts::API_URL;
+use super::consts::api_url;
 use super::deploy;
 use super::errors::{ApiError, CreateError};
 use super::graphql::mutations::{
@@ -27,13 +27,9 @@ pub async fn get_viewer_data_for_creation() -> Result<Vec<Account>, ApiError> {
     }
 
     let client = create_client().await?;
-
     let query = Viewer::build(());
-
-    let response = client.post(API_URL).run_graphql(query).await?;
-
+    let response = client.post(api_url()).run_graphql(query).await?;
     let response = response.data.expect("must exist");
-
     let viewer_response = response.viewer.ok_or(ApiError::UnauthorizedOrDeletedUser)?;
 
     let PersonalAccount { id, name, slug } = viewer_response
@@ -93,7 +89,7 @@ pub async fn create(account_id: &str, project_slug: &str) -> Result<Vec<String>,
         },
     });
 
-    let response = client.post(API_URL).run_graphql(operation).await?;
+    let response = client.post(api_url()).run_graphql(operation).await?;
 
     let payload = response.data.ok_or(ApiError::UnauthorizedOrDeletedUser)?.project_create;
 

--- a/cli/crates/backend/src/api/deploy.rs
+++ b/cli/crates/backend/src/api/deploy.rs
@@ -1,5 +1,5 @@
 use super::client::create_client;
-use super::consts::{API_URL, PACKAGE_JSON, TAR_CONTENT_TYPE};
+use super::consts::{api_url, PACKAGE_JSON, TAR_CONTENT_TYPE};
 use super::errors::{ApiError, DeployError};
 use super::graphql::mutations::{
     ArchiveFileSizeLimitExceededError, DailyDeploymentCountLimitExceededError, DeploymentCreate,
@@ -103,7 +103,7 @@ pub async fn deploy() -> Result<(), ApiError> {
         },
     });
 
-    let response = client.post(API_URL).run_graphql(operation).await?;
+    let response = client.post(api_url()).run_graphql(operation).await?;
 
     let payload = response
         .data

--- a/cli/crates/backend/src/api/link.rs
+++ b/cli/crates/backend/src/api/link.rs
@@ -1,6 +1,6 @@
 use super::{
     client::create_client,
-    consts::API_URL,
+    consts::api_url,
     errors::ApiError,
     graphql::queries::viewer_for_link::{PersonalAccount, Viewer},
     types::{self, AccountWithProjects, ProjectMetadata},
@@ -28,13 +28,9 @@ pub async fn project_link_validations() -> Result<(), ApiError> {
 #[allow(clippy::module_name_repetitions)]
 pub async fn get_viewer_data_for_link() -> Result<Vec<AccountWithProjects>, ApiError> {
     let client = create_client().await?;
-
     let query = Viewer::build(());
-
-    let response = client.post(API_URL).run_graphql(query).await?;
-
+    let response = client.post(api_url()).run_graphql(query).await?;
     let response = response.data.expect("must exist");
-
     let viewer_response = response.viewer.ok_or(ApiError::UnauthorizedOrDeletedUser)?;
 
     let PersonalAccount {

--- a/cli/crates/backend/src/api/login.rs
+++ b/cli/crates/backend/src/api/login.rs
@@ -29,9 +29,7 @@ async fn token<'a>(
     query: Query<TokenQueryParams>,
 ) -> Result<Redirect, Redirect> {
     let access_token = &query.token;
-
     let credentials_path = user_dot_grafbase_path.join(CREDENTIALS_FILE);
-
     let write_result = tokio::fs::write(&credentials_path, Credentials { access_token }.to_string()).await;
 
     if write_result.is_ok() {

--- a/cli/crates/backend/src/api/logs.rs
+++ b/cli/crates/backend/src/api/logs.rs
@@ -6,7 +6,7 @@ pub use super::graphql::queries::log_entries::{FunctionLogEvent, GatewayRequestL
 pub use super::utils::project_linked;
 use super::{
     client::create_client,
-    consts::API_URL,
+    consts::api_url,
     errors::ApiError,
     graphql::queries::{
         branch_by_domain::{Branch, BranchByDomain, BranchByDomainArguments, Project},
@@ -24,7 +24,7 @@ pub async fn personal_account_slug() -> Result<String, ApiError> {
 
     let query = Viewer::build(());
 
-    let response = client.post(API_URL).run_graphql(query).await?;
+    let response = client.post(api_url()).run_graphql(query).await?;
 
     let response = response.data.expect("must exist");
 
@@ -45,7 +45,7 @@ pub async fn branch_by_domain(domain: &str) -> Result<Option<(String, String, St
 
     let query = BranchByDomain::build(BranchByDomainArguments { domain });
 
-    let response = client.post(API_URL).run_graphql(query).await?;
+    let response = client.post(api_url()).run_graphql(query).await?;
 
     let response = response.data.expect("must exist");
 
@@ -111,7 +111,7 @@ pub async fn logs_events_by_time_range(
     let mut log_events = vec![];
     while has_more_pages {
         let query = LogEventsQuery::build(arguments.clone());
-        let response = client.post(API_URL).run_graphql(query).await?;
+        let response = client.post(api_url()).run_graphql(query).await?;
         let response = response.data.expect("must exist");
 
         let mut project = response.project_by_account_slug.ok_or(ApiError::ProjectDoesNotExist)?;
@@ -151,7 +151,7 @@ pub async fn project_slug_by_id(id: &str) -> Result<Option<(String, String)>, Ap
 
     let query = ProjectSlugById::build(ProjectSlugByIdArguments { id });
 
-    let response = client.post(API_URL).run_graphql(query).await?;
+    let response = client.post(api_url()).run_graphql(query).await?;
 
     let response = response.data.expect("must exist");
 

--- a/cli/crates/backend/src/api/publish.rs
+++ b/cli/crates/backend/src/api/publish.rs
@@ -1,6 +1,6 @@
 use super::{
     client::create_client,
-    consts::API_URL,
+    consts::api_url,
     errors::{ApiError, PublishError},
     graphql::mutations::{
         FederatedGraphCompositionError, PublishPayload, SchemaRegistryBranchDoesNotExistError, SubgraphCreateArguments,
@@ -35,7 +35,7 @@ pub async fn publish(
         },
     });
 
-    let cynic::GraphQlResponse { data, errors } = client.post(API_URL).run_graphql(operation).await?;
+    let cynic::GraphQlResponse { data, errors } = client.post(api_url()).run_graphql(operation).await?;
 
     if let Some(data) = data {
         match data.publish {

--- a/cli/crates/backend/src/api/schema.rs
+++ b/cli/crates/backend/src/api/schema.rs
@@ -3,7 +3,7 @@ use crate::api::graphql::queries::{
     fetch_subgraph_schema::{FetchSubgraphSchemaArguments, FetchSubgraphSchemaQuery},
 };
 
-use super::{client::create_client, consts::API_URL, errors::ApiError};
+use super::{client::create_client, consts::api_url, errors::ApiError};
 use cynic::{http::ReqwestExt, QueryBuilder};
 
 pub async fn schema(
@@ -37,7 +37,7 @@ async fn subgraph_schema(
         subgraph_name,
         branch,
     });
-    let response = client.post(API_URL).run_graphql(operation).await?;
+    let response = client.post(api_url()).run_graphql(operation).await?;
 
     response
         .data
@@ -54,7 +54,7 @@ async fn federated_graph_schema(account: &str, project: &str, branch: &str) -> R
         project,
         branch,
     });
-    let response = client.post(API_URL).run_graphql(operation).await?;
+    let response = client.post(api_url()).run_graphql(operation).await?;
 
     response
         .data

--- a/cli/crates/backend/src/api/subgraphs.rs
+++ b/cli/crates/backend/src/api/subgraphs.rs
@@ -1,6 +1,6 @@
 use super::{
     client::create_client,
-    consts::API_URL,
+    consts::api_url,
     errors::ApiError,
     graphql::queries::list_subgraphs::{
         ListSubgraphsArguments, ListSubgraphsForProductionBranchArguments, ListSubgraphsForProductionBranchQuery,
@@ -34,7 +34,7 @@ async fn subgraphs_with_branch(
         branch,
     });
 
-    let response = client.post(API_URL).run_graphql(operation).await?;
+    let response = client.post(api_url()).run_graphql(operation).await?;
     let subgraphs = response
         .data
         .as_ref()
@@ -56,7 +56,7 @@ async fn subgraphs_production_branch(account: &str, project: &str) -> Result<(St
     let operation =
         ListSubgraphsForProductionBranchQuery::build(ListSubgraphsForProductionBranchArguments { account, project });
 
-    let response = client.post(API_URL).run_graphql(operation).await?;
+    let response = client.post(api_url()).run_graphql(operation).await?;
     let subgraphs = response
         .data
         .as_ref()

--- a/cli/crates/backend/src/api/submit_trusted_documents.rs
+++ b/cli/crates/backend/src/api/submit_trusted_documents.rs
@@ -3,7 +3,7 @@ pub use crate::api::graphql::mutations::submit_trusted_documents::{
 };
 
 use super::graphql::mutations::submit_trusted_documents::TrustedDocumentsSubmit;
-use crate::api::{client::create_client, consts::API_URL, errors::ApiError};
+use crate::api::{client::create_client, consts::api_url, errors::ApiError};
 use cynic::{http::ReqwestExt, MutationBuilder};
 
 #[tokio::main]
@@ -13,7 +13,7 @@ pub async fn submit_trusted_documents(
     let client = create_client().await?;
     let operation = TrustedDocumentsSubmit::build(variables);
 
-    let cynic::GraphQlResponse { data, errors } = client.post(API_URL).run_graphql(operation).await?;
+    let cynic::GraphQlResponse { data, errors } = client.post(api_url()).run_graphql(operation).await?;
 
     if let Some(data) = data {
         Ok(data.trusted_documents_submit)

--- a/cli/crates/cli/tests/production_server.rs
+++ b/cli/crates/cli/tests/production_server.rs
@@ -148,7 +148,7 @@ where
             "--graph-ref",
             graph_ref,
         )
-        .env("GRAFBASE_UPLINK_HOST", format!("http://{}", server.address()))
+        .env("GRAFBASE_GDN_URL", format!("http://{}", server.address()))
         .env("GRAFBASE_ACCESS_TOKEN", ACCESS_TOKEN);
 
         let mut commands = CommandHandles::new();

--- a/cli/crates/production-server/src/server/graph_updater.rs
+++ b/cli/crates/production-server/src/server/graph_updater.rs
@@ -73,7 +73,7 @@ impl GraphUpdater {
             .build()
             .map_err(|e| crate::Error::InternalError(e.to_string()))?;
 
-        let uplink_host = match std::env::var("GRAFBASE_UPLINK_HOST") {
+        let uplink_host = match std::env::var("GRAFBASE_GDN_URL") {
             Ok(host) => Cow::Owned(host),
             Err(_) => Cow::Borrowed(UPLINK_HOST),
         };


### PR DESCRIPTION
# Description

We need three different env vars:

- `GRAFBASE_API_URL` which is the API endpoint. Defaults to https://api.grafbase.com/graphql
- `GRAFBASE_GDN_URL` for starting the federated router, and getting the latest federated graph. Defaults to https://gdn.grafbase.com

Closes: GB-6209

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
