### PR TITLE
fix: allow access token only from env vars, add short args for start

### DIFF
--- a/cli/crates/cli/src/cli_input/federated/start.rs
+++ b/cli/crates/cli/src/cli_input/federated/start.rs
@@ -21,20 +21,20 @@ use crate::{cli_input::GraphRef, errors::CliError};
 )]
 pub struct FederatedStartCommand {
     /// IP address on which the server will listen for incomming connections. Defaults to 127.0.0.1:4000.
-    #[arg(long)]
+    #[arg(short, long)]
     pub listen_address: Option<SocketAddr>,
-    #[arg(long, help = GraphRef::ARG_DESCRIPTION, env = "GRAFBASE_GRAPH_REF")]
+    #[arg(short, long, help = GraphRef::ARG_DESCRIPTION, env = "GRAFBASE_GRAPH_REF")]
     pub graph_ref: Option<GraphRef>,
     /// An access token to the Grafbase API. The scope must allow operations on the given account,
     /// and graph defined in the graph-ref argument.
-    #[arg(long, env = "GRAFBASE_ACCESS_TOKEN")]
+    #[arg(env = "GRAFBASE_ACCESS_TOKEN")]
     pub access_token: Option<AsciiString>,
     /// Path to the TOML configuration file
-    #[arg(long)]
+    #[arg(long, short)]
     pub config: PathBuf,
     /// Path to federated graph SDL. If provided, the graph will be static and no connection is made
     /// to the Grafbase API.
-    #[arg(long)]
+    #[arg(long, short)]
     pub federated_schema: Option<PathBuf>,
 }
 

--- a/cli/crates/cli/tests/production_server.rs
+++ b/cli/crates/cli/tests/production_server.rs
@@ -137,8 +137,6 @@ where
             .mount(&server)
             .await;
 
-        std::env::set_var("GRAFBASE_UPLINK_HOST", format!("http://{}", server.address()));
-
         let command = cmd!(
             cargo_bin("grafbase"),
             "federated",
@@ -149,9 +147,9 @@ where
             &config_path.to_str().unwrap(),
             "--graph-ref",
             graph_ref,
-            "--access-token",
-            ACCESS_TOKEN,
-        );
+        )
+        .env("GRAFBASE_UPLINK_HOST", format!("http://{}", server.address()))
+        .env("GRAFBASE_ACCESS_TOKEN", ACCESS_TOKEN);
 
         let mut commands = CommandHandles::new();
         commands.push(command.start().unwrap());


### PR DESCRIPTION
# Description

Closes: GB-6208

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
