### PR TITLE
feat: separate docker setup for standalone/federated modes

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -51,6 +51,7 @@ jobs:
           filters: |
             build:
               - Dockerfile
+              - Dockerfile.*
               - 'cli/**/*'
               - 'engine/**/*'
               - '.github/workflows/cli.yml'
@@ -140,24 +141,33 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build docker image
+      - name: Build standalone docker image
         run: |
-          docker build -t ghcr.io/grafbase/grafbase:$SHA_TAG .
+          docker build -f Dockerfile.standalone -t ghcr.io/grafbase/standalone:$SHA_TAG .
         env:
           SHA_TAG: ${{ github.sha }}
 
-      - name: Tag released version
+      - name: Build federated docker image
+        run: |
+          docker build -f Dockerfile.federated -t ghcr.io/grafbase/federated:$SHA_TAG .
+        env:
+          SHA_TAG: ${{ github.sha }}
+
+      - name: Tag released versions
         if: ${{ startsWith(github.ref, 'refs/tags') }}
         run: |
-          docker tag ghcr.io/grafbase/grafbase:$SHA_TAG ghcr.io/grafbase/grafbase:latest
-          docker tag ghcr.io/grafbase/grafbase:$SHA_TAG ghcr.io/grafbase/grafbase:$(echo "$REF" | sed -e "s/^refs\/tags\/cli-//")
+          docker tag ghcr.io/grafbase/standalone:$SHA_TAG ghcr.io/grafbase/standalone:latest
+          docker tag ghcr.io/grafbase/standalone:$SHA_TAG ghcr.io/grafbase/standalone:$(echo "$REF" | sed -e "s/^refs\/tags\/cli-//")
+          docker tag ghcr.io/grafbase/federated:$SHA_TAG ghcr.io/grafbase/federated:latest
+          docker tag ghcr.io/grafbase/federated:$SHA_TAG ghcr.io/grafbase/federated:$(echo "$REF" | sed -e "s/^refs\/tags\/cli-//")
         env:
           SHA_TAG: ${{ github.sha }}
           REF: ${{ github.ref }}
 
       - name: Push docker image
         run: |
-          docker push --all-tags ghcr.io/grafbase/grafbase
+          docker push --all-tags ghcr.io/grafbase/standalone
+          docker push --all-tags ghcr.io/grafbase/federated
 
   # windows:
   #   needs: [lint]
@@ -229,8 +239,16 @@ jobs:
       matrix:
         archs:
           [
-            { runner: buildjet-8vcpu-ubuntu-2204, target: x86_64-unknown-linux-musl, platform: linux },
-            { runner: buildjet-8vcpu-ubuntu-2204-arm, target: aarch64-unknown-linux-musl, platform: linux-arm },
+            {
+              runner: buildjet-8vcpu-ubuntu-2204,
+              target: x86_64-unknown-linux-musl,
+              platform: linux
+            },
+            {
+              runner: buildjet-8vcpu-ubuntu-2204-arm,
+              target: aarch64-unknown-linux-musl,
+              platform: linux-arm
+            }
           ]
     runs-on: ${{ matrix.archs.runner }}
     steps:

--- a/Dockerfile.federated
+++ b/Dockerfile.federated
@@ -1,0 +1,67 @@
+# Build
+FROM rust:1.76-alpine3.18 AS build
+
+WORKDIR /grafbase
+
+RUN mkdir -p packages/grafbase-sdk
+
+COPY Cargo.lock Cargo.lock
+COPY Cargo.toml Cargo.toml
+COPY ./cli ./cli
+COPY ./engine ./engine
+COPY ./packages/grafbase-sdk/package.json ./packages/grafbase-sdk
+COPY ./packages/cli-app ./packages/cli-app
+
+RUN apk add --no-cache git musl-dev npm ca-certificates wget
+
+# Bun needs glibc to be installed
+RUN mkdir -p /etc/apk/keys/
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
+RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-2.28-r0.apk
+RUN apk add --no-cache --force-overwrite glibc-2.28-r0.apk
+
+WORKDIR /grafbase/packages/cli-app
+
+RUN npx --yes pnpm i
+RUN npx --yes pnpm run cli-app:build
+
+WORKDIR /grafbase/cli/udf-wrapper
+
+RUN npx --yes pnpm i
+RUN npx --yes pnpm run build
+
+WORKDIR /grafbase
+
+RUN cargo build -p grafbase --release
+
+# Remove bun dependencies
+RUN rm -rf /etc/apk/keys/sgerrand.rsa.pub
+RUN apk del glibc
+RUN rm -rf glibc-2.28-r0.apk
+
+# Run
+FROM alpine:3.19
+
+WORKDIR /grafbase
+
+# used curl to run a health check query against the server in a docker-compose file
+RUN apk add --no-cache curl
+
+RUN adduser -g wheel -D grafbase -h "/data" && mkdir -p /data && chown grafbase: /data
+USER grafbase
+
+COPY --from=build /grafbase/target/release/grafbase /bin/grafbase
+COPY --from=build /grafbase/cli/crates/production-server/config/grafbase.toml /etc/grafbase.toml
+
+ENTRYPOINT ["/bin/grafbase"]
+
+# these args should be set so the binary can start. they have to be changed for successfully running the gateway
+ARG GRAFBASE_GRAPH_REF=""
+ARG GRAFBASE_ACCESS_TOKEN=""
+
+CMD ["federated", "start", "--config", "/etc/grafbase.toml", "--listen-address", "0.0.0.0:4000"]
+
+EXPOSE 4000
+
+VOLUME ["/data"]
+WORKDIR "/data"

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -12,16 +12,32 @@ COPY ./engine ./engine
 COPY ./packages/grafbase-sdk/package.json ./packages/grafbase-sdk
 COPY ./packages/cli-app ./packages/cli-app
 
-RUN apk add --no-cache git musl-dev npm
+RUN apk add --no-cache git musl-dev npm ca-certificates wget
+
+# Bun needs glibc to be installed
+RUN mkdir -p /etc/apk/keys/
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
+RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-2.28-r0.apk
+RUN apk add --no-cache --force-overwrite glibc-2.28-r0.apk
 
 WORKDIR /grafbase/packages/cli-app
 
 RUN npx --yes pnpm i
 RUN npx --yes pnpm run cli-app:build
 
+WORKDIR /grafbase/cli/udf-wrapper
+
+RUN npx --yes pnpm i
+RUN npx --yes pnpm run build
+
 WORKDIR /grafbase
 
 RUN cargo build -p grafbase --release
+
+# Remove bun dependencies
+RUN rm -rf /etc/apk/keys/sgerrand.rsa.pub
+RUN apk del glibc
+RUN rm -rf glibc-2.28-r0.apk
 
 # Run
 FROM alpine:3.19
@@ -38,7 +54,7 @@ COPY --from=build /grafbase/target/release/grafbase /bin/grafbase
 
 ENTRYPOINT ["/bin/grafbase"]
 
-CMD ["start"]
+CMD ["start", "--listen-address", "0.0.0.0:4000"]
 
 EXPOSE 4000
 

--- a/cli/crates/production-server/config/grafbase.toml
+++ b/cli/crates/production-server/config/grafbase.toml
@@ -1,0 +1,89 @@
+[network]
+# The listen address for the Grafbase gateway
+# Set it to 0.0.0.0:4000 or [::1]:4000 to listen on a public address
+listen_address = "127.0.0.1:4000"
+
+[graph]
+# The path endpoint for the GraphQL gateway
+path = "/graphql"    
+# Set to true to enable GraphQL introspection
+introspection = false
+
+[csrf]
+# Enable if the gateway is accessed from a browser. If enabled,
+# every request must hage the header x-grafbase-csrf-protection set
+enabled = false
+
+# Cross-origin resource sharing settings are for installations that are accessed directly
+# from a browser. If this resource is accessed only from backend, these settings have no effect.
+# [cors]
+## The Access-Control-Allow-Credentials response header tells browsers
+## whether the server allows cross-origin HTTP requests to include credentials.
+## Credentials are cookies, TLS client certificates, or authentication headers
+## containing a username and password. By default, these credentials are not
+## sent in cross-origin requests, and doing so can make a site vulnerable to CSRF attacks.
+# allow_credentials = false
+## Indicates how long the results of a preflight request can be cached.
+# max_age = "60s"
+## Indicates whether the response can be shared with requesting code from the given origin.
+## Can be "any" which allows any origin, or an array of URLs.
+# allow_origins = "any"
+## Specifies methods allowed when accessing the endpoint. Can be "any" or an array of HTTP
+## methods as strings.
+# allow_methods = "any"
+## Indicates which HTTP headers can be used during the request. Can be "any" or an array of
+## header names as strings.
+# allow_headers = "any"
+## Indicates which response headers should be made available in response to a cross-origin request.
+## Can be "any" or an array of header names as strings.
+# expose_headers = "any"
+## Enables access from private networks.
+# allow_private_network = false
+
+## https://grafbase.com/docs/security/operation-limits
+# [operation_limits]
+# depth = 3
+# height = 10
+# aliases = 100
+# root_fields = 10
+# complexity = 1000
+
+## https://grafbase.com/docs/auth/federated
+# [[authentication.providers]]
+#
+# [authentication.providers.jwt]
+# name = "foo"
+#
+# [authentication.providers.jwt.jwks]
+# url = "https://example.com/.well-known/jwks.json"
+# issuer = "https://example.com/"
+# audience = "my-project"
+# poll_interval = "60s"
+
+## Global header configuration. These headers will sent down to every subgraph for every request.
+## Headers can either be static values:
+# [headers.Authentication]
+# value = "Bearer asdf"
+## Or they can be forwarded from the client, so the value here is the name of the header to be forwarded:
+## All header names are case-insensitive.
+# [headers.Content-Type]
+# forward = "content-type"
+## Sometimes a header can hold sensitive data not wanted in the configuration. In these cases environment
+## variables can be used. The environment variable must be set when starting the gateway.
+# [headers.Authentication]
+# value = "Bearer {{ env.ACCESS_TOKEN }}"
+
+## Subgraph level configuration
+# [subgraphs.products]
+## Custom websocket URL to be used for subscription requests. If not set, the default is the subgraph URL.
+# websocket_url = "wss://example.com"
+## Headers can be set per subgraph. The value can either be forwarded from the client:
+# [subgraphs.products.headers.Content-Type]
+# forward = "Content-Type"
+## or be a static value:
+# [subgraphs.products.headers.Authentication]
+# value = "Bearer ufufuf"
+## Environment variables can be used similarly as with global headers. The variables must be set
+## when starting the gateway.
+# [subgraphs.products.headers.Authentication]
+# value = "Bearer {{ env.SUBGRAPH_ACCESS_TOKEN }}"


### PR DESCRIPTION
# Description

Changes how our docker images are built, now we create two separate images:

- `grafbase/federated` for federated gateway
- `grafbase/standalone` is the current docker image we build

The builds for standalone was broken since forever (if built without a cache), because we need bun and bun needs glibc. This fixes it for both builds.

Both setups take a listen address instead of a port, and the docker images should default to `0.0.0.0:4000`.

An example docker-compose.yml for the federated build:

```yaml
version: '3'
services:
  grafbase:
    image: grafbase/federated:latest
    restart: always
    volumes:
      - ./grafbase.toml:/etc/grafbase.toml
    environment:
      GRAFBASE_GRAPH_REF: "graph-ref@branch"
      GRAFBASE_ACCESS_TOKEN: "ACCESS_TOKEN_HERE"
    ports:
      - '4000:4000'
```

The configuration in `cli/crates/production-server/config/grafbase.toml` is used as the default configuration. Copying it to the current directory will make it as the config for the federated gateway.

Closes: GB-6218