### PR TITLE
cli: include subgraph federation directives in grafbase introspect --dev

### DIFF
--- a/cli/crates/cli/tests/utils/environment.rs
+++ b/cli/crates/cli/tests/utils/environment.rs
@@ -234,6 +234,18 @@ impl Environment {
             .unwrap()
     }
 
+    pub fn grafbase_introspect_dev(&self) -> Output {
+        let args = ["introspect", "--dev"];
+
+        duct::cmd(cargo_bin("grafbase"), args)
+            .dir(&self.directory_path)
+            .stdout_capture()
+            .stderr_capture()
+            .unchecked()
+            .run()
+            .unwrap()
+    }
+
     #[track_caller]
     pub fn grafbase_init(&self, graph_type: GraphType) {
         let current_directory_path = self.schema_path.parent().expect("must be defined");

--- a/cli/crates/server/src/introspect_local.rs
+++ b/cli/crates/server/src/introspect_local.rs
@@ -19,11 +19,9 @@ pub async fn introspect_local() -> Result<IntrospectLocalOutput, ServerError> {
         ..
     } = build_config(&env, None, EnvironmentName::None).await?;
 
-    let is_federated = federated_graph_config.is_some();
+    let rendered_sdl = registry.export_sdl(registry.enable_federation);
 
-    let rendered_sdl = registry.export_sdl(is_federated);
-
-    if is_federated && rendered_sdl.is_empty() {
+    if federated_graph_config.is_some() && rendered_sdl.is_empty() {
         Ok(IntrospectLocalOutput::EmptyFederated)
     } else {
         Ok(IntrospectLocalOutput::Sdl(rendered_sdl))


### PR DESCRIPTION
This is a bug that breaks the `grafbase introspect --dev | grafbase publish` workflow.

closes GB-6246

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
