### PR TITLE
feat: drop the tracing feature in the engines 

### DIFF
--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -50,7 +50,7 @@ common = { package = "grafbase-local-common", path = "../common", version = "0.6
 federated-dev = { path = "../federated-dev" }
 graphql-introspection = { package = "grafbase-graphql-introspection", path = "../graphql-introspection" }
 server = { package = "grafbase-local-server", path = "../server", version = "0.61.0" }
-grafbase-tracing.workspace = true
+grafbase-tracing = { workspace = true, features = ["otlp"] }
 
 production-server = { path = "../production-server" }
 ascii = { version = "1.1.0", features = ["serde"] }

--- a/cli/crates/federated-dev/Cargo.toml
+++ b/cli/crates/federated-dev/Cargo.toml
@@ -36,9 +36,9 @@ ulid.workspace = true
 url = "2.5.0"
 
 common = { package = "grafbase-local-common", path = "../common", version = "0.61.0" }
-engine = { path = "../../../engine/crates/engine", features = ["tracing"] }
+engine = { path = "../../../engine/crates/engine" }
 engine-config-builder = { path = "../../../engine/crates/engine-config-builder" }
-engine-v2 = { workspace = true, features = ["plan_cache", "tracing"] }
+engine-v2 = { workspace = true, features = ["plan_cache"] }
 gateway-v2 = { workspace = true, features = ["axum"] }
 grafbase-graphql-introspection = { path = "../graphql-introspection" }
 grafbase-tracing = { workspace = true , features = ["tower"] }

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -57,7 +57,7 @@ common = { package = "grafbase-local-common", path = "../common", version = "0.6
 gateway = { path = "../gateway" }
 typed-resolvers = { path = "../typed-resolvers" }
 federated-dev = { path = "../federated-dev" }
-engine = { path = "../../../engine/crates/engine", features = ["tracing"] }
+engine = { path = "../../../engine/crates/engine" }
 parser-sdl = { path = "../../../engine/crates/parser-sdl", features = [
   "local",
 ] }

--- a/engine/crates/engine-v2/Cargo.toml
+++ b/engine/crates/engine-v2/Cargo.toml
@@ -16,7 +16,6 @@ workspace = true
 [features]
 default = []
 plan_cache = ["dep:mini-moka"]
-tracing = ["dep:grafbase-tracing"]
 
 [dependencies]
 async-runtime.workspace = true
@@ -40,7 +39,7 @@ mini-moka = { version = "0.10", optional = true, features = ["sync"] }
 config = { package = "engine-v2-config", path = "./config" }
 engine-value = { path = "../engine/value" }
 engine-parser = { path = "../engine/parser" }
-grafbase-tracing = { workspace = true, optional = true }
+grafbase-tracing.workspace = true
 schema = { path = "./schema", package = "engine-v2-schema" }
 # needed for errors, not entirely sure if we should be separate or not right now.
 # might move it back to engine, the goal isn't to rewrite everything from engine per Se

--- a/engine/crates/engine-v2/src/execution/coordinator.rs
+++ b/engine/crates/engine-v2/src/execution/coordinator.rs
@@ -8,9 +8,7 @@ use futures_util::{
     stream::{BoxStream, FuturesUnordered},
     Future, SinkExt, StreamExt,
 };
-#[cfg(feature = "tracing")]
 use grafbase_tracing::span::{GqlRecorderSpanExt, GqlRequestAttributes, GqlResponseAttributes};
-#[cfg(feature = "tracing")]
 use tracing::Span;
 
 use crate::{
@@ -53,9 +51,7 @@ impl ExecutionCoordinator {
     }
 
     pub async fn execute(self) -> Response {
-        #[cfg(feature = "tracing")]
         let gql_span = Span::current();
-        #[cfg(feature = "tracing")]
         gql_span.record_gql_request(GqlRequestAttributes {
             operation_type: self.operation().ty.as_ref(),
             operation_name: self.operation().name.as_deref(),
@@ -75,7 +71,6 @@ impl ExecutionCoordinator {
         .execute()
         .await;
 
-        #[cfg(feature = "tracing")]
         gql_span.record_gql_response(GqlResponseAttributes {
             has_errors: response.has_errors(),
         });
@@ -86,14 +81,11 @@ impl ExecutionCoordinator {
     pub async fn execute_subscription(self, mut responses: ResponseSender) {
         assert!(matches!(self.operation_plan.ty, OperationType::Subscription));
 
-        #[cfg(feature = "tracing")]
-        {
-            let current_span = Span::current();
-            current_span.record_gql_request(GqlRequestAttributes {
-                operation_type: self.operation().ty.as_ref(),
-                operation_name: self.operation().name.as_deref(),
-            });
-        }
+        let current_span = Span::current();
+        current_span.record_gql_request(GqlRequestAttributes {
+            operation_type: self.operation().ty.as_ref(),
+            operation_name: self.operation().name.as_deref(),
+        });
 
         let mut state = self.operation_plan.new_execution_state();
         let subscription_plan_id = state.pop_subscription_plan_id();

--- a/engine/crates/engine-v2/src/execution/prepared.rs
+++ b/engine/crates/engine-v2/src/execution/prepared.rs
@@ -1,10 +1,8 @@
 use std::future::IntoFuture;
 
 use futures_util::future::BoxFuture;
-use tracing::{Instrument, Span};
-
-#[cfg(feature = "tracing")]
 use grafbase_tracing::span::{GqlRecorderSpanExt, GqlResponseAttributes};
+use tracing::{Instrument, Span};
 
 use crate::{request::OperationCacheControl, Response};
 
@@ -48,7 +46,6 @@ impl IntoFuture for PreparedExecution {
     fn into_future(self) -> Self::IntoFuture {
         match self {
             PreparedExecution::BadRequest(BadRequest { response }) => {
-                #[cfg(feature = "tracing")]
                 Span::current().record_gql_response(GqlResponseAttributes {
                     has_errors: response.has_errors(),
                 });

--- a/engine/crates/engine-v2/src/sources/graphql/mod.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/mod.rs
@@ -20,7 +20,6 @@ mod subscription;
 mod variables;
 
 pub(crate) use federation::*;
-#[cfg(feature = "tracing")]
 use grafbase_tracing::span::{subgraph::SubgraphRequestSpan, GqlRecorderSpanExt, GqlResponseAttributes};
 pub(crate) use subscription::*;
 
@@ -86,7 +85,6 @@ pub(crate) struct GraphqlExecutor<'ctx> {
 impl<'ctx> GraphqlExecutor<'ctx> {
     #[tracing::instrument(skip_all, fields(plan_id = %self.plan.id(), federated_subgraph = %self.subgraph.name()))]
     pub async fn execute(mut self) -> ExecutionResult<ResponsePart> {
-        #[cfg(feature = "tracing")]
         let subgraph_request_span = SubgraphRequestSpan::new(self.subgraph.name())
             // TODO: atm this contains variables and we shouldn't be considering those. A follow up effort will take of this
             // .with_document(self.json_body.as_str())
@@ -126,7 +124,6 @@ impl<'ctx> GraphqlExecutor<'ctx> {
             &mut serde_json::Deserializer::from_slice(&bytes),
         );
 
-        #[cfg(feature = "tracing")]
         subgraph_request_span.record_gql_response(GqlResponseAttributes {
             has_errors: self.response_part.has_errors(),
         });

--- a/engine/crates/engine/Cargo.toml
+++ b/engine/crates/engine/Cargo.toml
@@ -68,7 +68,7 @@ graph-entities.workspace = true
 graphql-cursor.workspace = true
 log = { path = "../log" }
 runtime.workspace = true
-grafbase-tracing = { workspace = true, optional = true }
+grafbase-tracing.workspace = true
 
 # Feature optional dependencies
 rust_decimal = { version = "1" }
@@ -80,9 +80,6 @@ base64.workspace = true
 time = { version = "0.3.34", features = ["parsing"] }
 uuid.workspace = true
 hex = "0.4.3"
-
-[features]
-tracing = ["dep:grafbase-tracing"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 reqwest = { workspace = true, features = ["json"] }

--- a/engine/crates/integration-tests/Cargo.toml
+++ b/engine/crates/integration-tests/Cargo.toml
@@ -16,7 +16,7 @@ async-trait.workspace = true
 cynic.workspace = true
 cynic-introspection.workspace = true
 engine-parser.workspace = true
-engine-v2 = { workspace = true, features = ["tracing"] }
+engine-v2.workspace = true
 gateway-v2.workspace = true
 graphql-mocks.workspace = true
 engine-config-builder = { path = "../engine-config-builder" }
@@ -61,7 +61,6 @@ features = ["json"]
 [dependencies.engine]
 path = "../engine"
 default-features = false
-features = ["tracing"]
 
 [dependencies.parser-graphql]
 path = "../parser-graphql"

--- a/engine/crates/tracing/Cargo.toml
+++ b/engine/crates/tracing/Cargo.toml
@@ -17,7 +17,7 @@ http.workspace = true
 http-body = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
-tonic = "0.11.0"
+tonic = { version = "0.11.0", optional = true }
 tower-http = { version = "0.5", optional = true, features = ["trace"] }
 url = { version = "2.5", features = ["serde"] }
 
@@ -28,12 +28,13 @@ tracing-opentelemetry = "0.23"
 opentelemetry = "0.22"
 opentelemetry_sdk = { version = "0.22", features = ["rt-tokio"] }
 opentelemetry-stdout = { version = "0.3", features = ["trace"] }
-opentelemetry-otlp = { version = "0.15" , features = ["grpc-tonic", "tls", "tonic", "http-proto"] }
+opentelemetry-otlp = { version = "0.15" , features = ["grpc-tonic", "tls", "tonic", "http-proto"], optional = true }
 
 
 [features]
 default = []
 tower = ["tower-http"]
+otlp = ["dep:opentelemetry-otlp", "dep:tonic"]
 
 [dev-dependencies]
 indoc = "2.0.4"

--- a/engine/crates/tracing/src/otel/layer.rs
+++ b/engine/crates/tracing/src/otel/layer.rs
@@ -1,23 +1,19 @@
-use std::str::FromStr;
 use std::time::Duration;
 
 use opentelemetry::trace::noop::NoopTracer;
 use opentelemetry::trace::TracerProvider;
 use opentelemetry::{global, KeyValue};
-use opentelemetry_otlp::{SpanExporterBuilder, WithExportConfig};
 use opentelemetry_sdk::export::trace::SpanExporter;
 use opentelemetry_sdk::runtime::RuntimeChannel;
 use opentelemetry_sdk::trace::{BatchConfigBuilder, BatchSpanProcessor, Builder, RandomIdGenerator, Sampler};
 use opentelemetry_sdk::Resource;
-use tonic::metadata::MetadataKey;
-use tonic::transport::ClientTlsConfig;
 use tracing::Subscriber;
 use tracing_subscriber::filter::{FilterExt, Filtered};
 use tracing_subscriber::layer::Filter;
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::{reload, EnvFilter, Layer};
 
-use crate::config::{TracingBatchExportConfig, TracingConfig, TracingOtlpExporterProtocol};
+use crate::config::{TracingBatchExportConfig, TracingConfig};
 use crate::error::TracingError;
 
 /// A type erased layer
@@ -97,7 +93,15 @@ where
     }
 
     // otlp
+    #[cfg(feature = "otlp")]
     if let Some(otlp_exporter_config) = config.exporters.otlp {
+        use opentelemetry_otlp::{SpanExporterBuilder, WithExportConfig};
+        use std::str::FromStr;
+        use tonic::metadata::MetadataKey;
+        use tonic::transport::ClientTlsConfig;
+
+        use crate::config::TracingOtlpExporterProtocol;
+
         let span_exporter = {
             let exporter_timeout = Duration::from_secs(otlp_exporter_config.timeout.num_seconds() as u64);
 


### PR DESCRIPTION
I'm dropping the `tracing` flags across the board and instead I'm adding a new feature in `grafbase_tracing`, "otlp" to gate any otlp capabilities. 
When creating `grafbase_tracing::otel::layers`, if one wants the otlp exporter to be configured in the `SpanProcessor` attached to the layer, one needs to explicitly set the `otlp` feature.

This is useful in two different ways:

- Avoid pulling in a bunch on dependencies when we just want the basic stuff (like typed spans)
- The above mitigates `http` crate version conflicts
- Keeps the crate `default` lean

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [x] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
