### PR TITLE
feat: tracing worker integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2883,6 +2883,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
+ "worker",
 ]
 
 [[package]]

--- a/engine/crates/tracing/Cargo.toml
+++ b/engine/crates/tracing/Cargo.toml
@@ -20,6 +20,7 @@ thiserror = "1.0"
 tonic = { version = "0.11.0", optional = true }
 tower-http = { version = "0.5", optional = true, features = ["trace"] }
 url = { version = "2.5", features = ["serde"] }
+worker = { version = "0.0.20", optional = true }
 
 # tracing
 tracing.workspace = true
@@ -35,6 +36,7 @@ opentelemetry-otlp = { version = "0.15" , features = ["grpc-tonic", "tls", "toni
 default = []
 tower = ["tower-http"]
 otlp = ["dep:opentelemetry-otlp", "dep:tonic"]
+worker = ["dep:worker"]
 
 [dev-dependencies]
 indoc = "2.0.4"

--- a/engine/crates/tracing/src/config.rs
+++ b/engine/crates/tracing/src/config.rs
@@ -14,7 +14,8 @@ use url::Url;
 use crate::error::TracingError;
 
 pub(crate) const DEFAULT_COLLECT_VALUE: usize = 128;
-pub(crate) const DEFAULT_FILTER: &str = "grafbase=info,off";
+/// Default tracing filter to be applied on spans that are client facing
+pub const DEFAULT_FILTER: &str = "grafbase=info,off";
 pub(crate) const DEFAULT_SAMPLING: f64 = 0.15;
 // FIXME: Use this constant when `unwrap()` becomes const-stable.
 // const DEFAULT_EXPORT_TIMEOUT: chrono::Duration = chrono::Duration::try_seconds(60).unwrap();

--- a/engine/crates/tracing/src/span.rs
+++ b/engine/crates/tracing/src/span.rs
@@ -16,6 +16,8 @@ pub trait HttpRecorderSpanExt {
     fn record_response<B: Body>(&self, response: &Response<B>);
     /// Record response failure in the span
     fn record_failure(&self, error: &str);
+    /// Record response failure in the span
+    fn record_status_code(&self, status_code: http::StatusCode);
 }
 
 /// Extension trait to record gql request attributes

--- a/engine/crates/tracing/src/span/request.rs
+++ b/engine/crates/tracing/src/span/request.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::net::IpAddr;
 
 use crate::span::HttpRecorderSpanExt;
@@ -15,43 +16,126 @@ pub struct HttpRequestSpan<'a> {
     /// The size of the request payload body in bytes
     request_body_size: Option<usize>,
     /// HTTP request method
-    request_method: &'a http::Method,
+    request_method: Cow<'a, http::Method>,
     /// The size of the response payload body in bytes
     response_body_size: Option<usize>,
     /// HTTP response status code
-    response_status_code: Option<&'a http::StatusCode>,
+    response_status_code: Option<Cow<'a, http::StatusCode>>,
     /// HTTP response error
-    response_error: Option<&'a str>,
+    response_error: Option<Cow<'a, str>>,
     /// Value of the HTTP User-Agent header sent by the client
-    header_user_agent: Option<&'a http::HeaderValue>,
+    header_user_agent: Option<Cow<'a, http::HeaderValue>>,
     /// If the request has an X-ForwardedFor header, this will have the first value that is a valid address and not private/internal
-    header_x_forwarded_for: Option<&'a http::HeaderValue>,
+    header_x_forwarded_for: Option<Cow<'a, http::HeaderValue>>,
+    /// Value of the ray-id header sent by the server
+    header_ray_id: Option<Cow<'a, http::HeaderValue>>,
     /// Address of the local HTTP server that received the request
-    server_address: Option<&'a IpAddr>,
+    server_address: Option<Cow<'a, IpAddr>>,
     /// Port of the local HTTP server that received the request
     server_port: Option<u16>,
     /// The URI of the request
-    url: &'a http::Uri,
+    url: Cow<'a, http::Uri>,
+    /// The git branch this deployment belongs to
+    git_branch: Option<Cow<'a, http::HeaderValue>>,
+    /// The git hash this deployment corresponds to
+    git_hash: Option<Cow<'a, http::HeaderValue>>,
+    /// The environment this deployment belongs to
+    environment: Option<Cow<'a, http::HeaderValue>>,
 }
 
 impl<'a> HttpRequestSpan<'a> {
-    /// Create a new instance
-    pub fn new<B>(request: &'a http::Request<B>) -> Self
+    /// Sets the span ray_id
+    pub fn with_ray_id(mut self, ray_id: impl Into<Option<Cow<'a, http::HeaderValue>>>) -> Self {
+        self.header_ray_id = ray_id.into();
+
+        self
+    }
+
+    /// Sets the span git_branch
+    pub fn with_git_branch(mut self, git_branch: impl Into<Option<Cow<'a, http::HeaderValue>>>) -> Self {
+        self.git_branch = git_branch.into();
+
+        self
+    }
+
+    /// Sets the span git_hash
+    pub fn with_git_hash(mut self, git_hash: impl Into<Option<Cow<'a, http::HeaderValue>>>) -> Self {
+        self.git_hash = git_hash.into();
+
+        self
+    }
+
+    /// Sets the span environment
+    pub fn with_environment(mut self, environment: impl Into<Option<Cow<'a, http::HeaderValue>>>) -> Self {
+        self.environment = environment.into();
+
+        self
+    }
+}
+
+impl<'a> HttpRequestSpan<'a> {
+    /// Create a new instance from a reference of [http::Request]
+    pub fn from_http<B>(request: &'a http::Request<B>) -> Self
     where
         B: Body,
     {
         HttpRequestSpan {
             request_body_size: request.body().size_hint().upper().map(|v| v as usize),
-            request_method: request.method(),
-            header_user_agent: request.headers().get(USER_AGENT),
-            header_x_forwarded_for: request.headers().get(X_FORWARDED_FOR_HEADER),
-            url: request.uri(),
+            request_method: Cow::Borrowed(request.method()),
+            header_user_agent: request.headers().get(USER_AGENT).map(Cow::Borrowed),
+            header_x_forwarded_for: request.headers().get(X_FORWARDED_FOR_HEADER).map(Cow::Borrowed),
+            header_ray_id: None,
+            url: Cow::Borrowed(request.uri()),
             response_body_size: None,
             response_status_code: None,
             response_error: None,
             server_address: None,
             server_port: None,
+            environment: None,
+            git_branch: None,
+            git_hash: None,
         }
+    }
+
+    #[cfg(feature = "worker")]
+    /// Create a new instance from a reference of [worker::Request]
+    pub fn try_from_worker(request: &'a worker::Request) -> worker::Result<Self> {
+        use core::str::FromStr;
+        use http::HeaderValue;
+
+        let method =
+            http::Method::from_str(request.method().as_ref()).map_err(|e| worker::Error::RustError(e.to_string()))?;
+
+        let user_agent = request
+            .headers()
+            .get(USER_AGENT.as_str())?
+            .and_then(|value| HeaderValue::from_str(&value).ok())
+            .map(Cow::Owned);
+
+        let x_forwarded_for = request
+            .headers()
+            .get(X_FORWARDED_FOR_HEADER)?
+            .and_then(|value| HeaderValue::from_str(&value).ok())
+            .map(Cow::Owned);
+
+        let uri = http::Uri::try_from(request.url()?.as_str()).map_err(|e| worker::Error::RustError(e.to_string()))?;
+
+        Ok(HttpRequestSpan {
+            request_body_size: None,
+            request_method: Cow::Owned(method),
+            header_user_agent: user_agent,
+            header_x_forwarded_for: x_forwarded_for,
+            header_ray_id: None,
+            url: Cow::Owned(uri),
+            response_body_size: None,
+            response_status_code: None,
+            response_error: None,
+            server_address: None,
+            server_port: None,
+            environment: None,
+            git_branch: None,
+            git_hash: None,
+        })
     }
 
     /// Consume self and turn into a [Span]
@@ -63,14 +147,19 @@ impl<'a> HttpRequestSpan<'a> {
             "http.request.method" = self.request_method.as_str(),
             "http.response.body.size" = self.response_body_size,
             "http.response.status_code" = self.response_status_code.map(|v| v.as_u16()),
-            "http.response.error" = self.response_error,
-            "http.header.user_agent" = self.header_user_agent.and_then(|v| v.to_str().ok()),
-            "http.header.x_forwarded_for" = self.header_x_forwarded_for.and_then(|v| v.to_str().ok()),
+            "http.response.error" = self.response_error.as_ref().map(|v| v.as_ref()),
+            "http.header.user_agent" = self.header_user_agent.as_ref().and_then(|v| v.to_str().ok()),
+            "http.header.x_forwarded_for" = self.header_x_forwarded_for.as_ref().and_then(|v| v.to_str().ok()),
+            "http.header.ray_id" = self.header_ray_id.as_ref().as_ref().and_then(|v| v.to_str().ok()),
             "server.address" = self.server_address.map(|v| v.to_string()),
             "server.port" = self.server_port,
             "url.path" = self.url.path(),
             "url.query" = self.url.query(),
             "url.scheme" = self.url.scheme().map(|v| v.as_str()),
+            "url.host" = self.url.host(),
+            "git.branch" = self.git_branch.as_ref().as_ref().and_then(|v| v.to_str().ok()),
+            "git.hash" = self.git_hash.as_ref().as_ref().and_then(|v| v.to_str().ok()),
+            "environment" = self.environment.as_ref().as_ref().and_then(|v| v.to_str().ok()),
         )
     }
 }
@@ -82,7 +171,7 @@ pub struct MakeHttpRequestSpan;
 #[cfg(feature = "tower")]
 impl<B: Body> tower_http::trace::MakeSpan<B> for MakeHttpRequestSpan {
     fn make_span(&mut self, request: &http::Request<B>) -> Span {
-        HttpRequestSpan::new(request).into_span()
+        HttpRequestSpan::from_http(request).into_span()
     }
 }
 

--- a/engine/crates/tracing/src/span/request.rs
+++ b/engine/crates/tracing/src/span/request.rs
@@ -3,7 +3,7 @@ use std::net::IpAddr;
 
 use crate::span::HttpRecorderSpanExt;
 use http::header::USER_AGENT;
-use http::Response;
+use http::{Response, StatusCode};
 use http_body::Body;
 use tracing::{info_span, Span};
 
@@ -186,5 +186,9 @@ impl HttpRecorderSpanExt for Span {
 
     fn record_failure(&self, error: &str) {
         self.record("http.response.error", error);
+    }
+
+    fn record_status_code(&self, status_code: StatusCode) {
+        self.record("http.response.status_code", status_code.as_str());
     }
 }


### PR DESCRIPTION
# Description

Adds a new feature `worker` to `grafbase-tracing` so we can record http requests spans deriving from `worker::Request`. Hopefully in the future this can go away as they are moving towards using the crate `http`.

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
