### PR TITLE
fix: alias grouped fields in namespaced graphql connector

### DIFF
--- a/engine/crates/engine/src/registry/resolvers/graphql.rs
+++ b/engine/crates/engine/src/registry/resolvers/graphql.rs
@@ -707,10 +707,6 @@ mod tests {
 
         // 2. We have two query fields, but expect a single API call due to batching.
         Mock::given(method("POST"))
-            .and(request_fn(|req| {
-                let body = req.body_json::<Value>().unwrap().to_string();
-                body.contains("foo\\n\\tbar") || body.contains("bar\\n\\tfoo")
-            }))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": {} })))
             .expect(1)
             .mount(&server)
@@ -754,10 +750,6 @@ mod tests {
 
         // 2. We have two query fields, but expect a single API call due to batching.
         Mock::given(method("POST"))
-            .and(request_fn(|req| {
-                let body = req.body_json::<Value>().unwrap().to_string();
-                body.contains("foo\\n\\tbar") || body.contains("bar\\n\\tfoo")
-            }))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": {} })))
             .expect(1)
             .mount(&server)
@@ -861,12 +853,7 @@ mod tests {
             .and(request_fn(|req| {
                 let body = req.body_json::<Value>().unwrap().to_string();
 
-                let vars = body.contains("query($foo: ID, $bar: ID)") || body.contains("query($bar: ID, $foo: ID)");
-
-                let fields = body.contains("foo(id: $foo)\\n\\tbar(id: $bar)")
-                    || body.contains("bar(id: $bar)\\n\\tfoo(id: $foo)");
-
-                vars && fields
+                body.contains("query($foo: ID, $bar: ID)") || body.contains("query($bar: ID, $foo: ID)")
             }))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": {} })))
             .expect(1)


### PR DESCRIPTION
When the GraphQL connector needs to handle multiple concurrent requests to the same downstream, it tries to combine the operations from each request into a single operation.  When working with joins inside lists, this can lead to a situation where we need to get the same root field multiple times.

The naive approach to this leads to queries like this:

```graphql
query {
    foo(id: 1) {
        bar
    }
    foo(id: 2) {
        bar
    }
}
```

Which is not a valid query.  

I'd previously tried to fix this by putting aliases on the fields generated by joins, which worked alright when joins didn't support namespaced GraphQL connectors.  But now that we support namespaced queries this isn't good enough, the alias ends up put onto the root namespace field, like this:

```graphql
query {
    field_1: myApi {
        foo(id: 1) {
            bar
        }
    }
    field_2: myApi {
        foo(id: 1) {
           bar
        }
    }
}
```

But these top level fields are dropped before being sent to the downstream API, so we end up with the same problem.

I've fixed this instead aliasing all the root fields of the operation at the point of combining the queries, and tracking those aliases so we can mutate the response before returning.