### PR TITLE
fix: coerce enums when handling join variables (for real this time)

### DIFF
--- a/engine/crates/engine/src/context/field.rs
+++ b/engine/crates/engine/src/context/field.rs
@@ -155,7 +155,14 @@ impl<'a> ContextField<'a> {
                 .map(|value| self.resolve_input_value(value))
                 .transpose()?;
 
-            resolve_input(self, name, meta_input_value, maybe_value, mode)
+            resolve_input(
+                self.registry(),
+                self.item.pos,
+                name,
+                meta_input_value,
+                maybe_value,
+                mode,
+            )
         } else {
             Err(ServerError::new(
                 format!("Internal Error: Unknown argument '{name}'"),

--- a/engine/crates/engine/src/registry/resolvers/graphql/serializer.rs
+++ b/engine/crates/engine/src/registry/resolvers/graphql/serializer.rs
@@ -389,7 +389,7 @@ impl<'a: 'b, 'b: 'a, 'c: 'a> Serializer<'a, 'b> {
             let mut iter = self.variable_references().peekable();
 
             while let Some(variable_name) = iter.next() {
-                let Some(variable_definition) = self.variable_definitions.get(variable_name) else {
+                let Some(variable_definition) = &self.variable_definitions.get(variable_name) else {
                     return Err(Error::UndeclaredVariable(variable_name.to_string()));
                 };
 

--- a/engine/crates/engine/src/registry/variables/mod.rs
+++ b/engine/crates/engine/src/registry/variables/mod.rs
@@ -16,7 +16,7 @@ use self::oneof::OneOf;
 use super::InputValueType;
 use crate::{
     resolver_utils::{apply_input_transforms, InputResolveMode},
-    ContextField, Error, ServerError, ServerResult, Value,
+    Context, ContextField, Error, ServerError, ServerResult, Value,
 };
 
 pub mod id;
@@ -102,7 +102,7 @@ impl VariableResolveDefinition {
                 let result = Value::from_json(result)
                     .map_err(|error| ServerError::new(error.to_string(), Some(ctx.item.pos)))?;
 
-                apply_input_transforms(ctx, field.as_ref(), result, ty).map(Some)
+                apply_input_transforms(ctx.registry(), ctx.item.pos, field.as_ref(), result, ty).map(Some)
             }
         }
     }

--- a/engine/crates/graphql-mocks/src/fake_github.rs
+++ b/engine/crates/graphql-mocks/src/fake_github.rs
@@ -85,12 +85,14 @@ impl Query {
                     name: "Jim".into(),
                     email: "jim@example.com".into(),
                 }),
+                status: Status::Open,
             }),
             PullRequestOrIssue::PullRequest(PullRequest {
                 id: "2".into(),
                 title: "Some bot PR".into(),
                 checks: vec!["Success!".into()],
                 author: UserOrBot::Bot(Bot { id: "123".into() }),
+                status: Status::Closed,
             }),
             PullRequestOrIssue::Issue(Issue {
                 title: "Everythings fine".into(),
@@ -113,12 +115,14 @@ impl Query {
                     name: "Jim".into(),
                     email: "jim@example.com".into(),
                 }),
+                status: Status::Open,
             },
             PullRequest {
                 id: "2".into(),
                 title: "Some bot PR".into(),
                 checks: vec!["Success!".into()],
                 author: UserOrBot::Bot(Bot { id: "123".into() }),
+                status: Status::Closed,
             },
         ]
     }
@@ -133,12 +137,14 @@ impl Query {
                     name: "Jim".into(),
                     email: "jim@example.com".into(),
                 }),
+                status: Status::Open,
             },
             PullRequest {
                 id: "2".into(),
                 title: "Some bot PR".into(),
                 checks: vec!["Success!".into()],
                 author: UserOrBot::Bot(Bot { id: "123".into() }),
+                status: Status::Closed,
             },
         ]
     }
@@ -153,6 +159,7 @@ impl Query {
                     name: "Jim".into(),
                     email: "jim@example.com".into(),
                 }),
+                status: Status::Open,
             });
         } else if id == "2" {
             return Some(PullRequest {
@@ -160,6 +167,7 @@ impl Query {
                 title: "Some bot PR".into(),
                 checks: vec!["Success!".into()],
                 author: UserOrBot::Bot(Bot { id: "123".into() }),
+                status: Status::Closed,
             });
         }
         None
@@ -175,6 +183,7 @@ impl Query {
                     name: "Jim".into(),
                     email: "jim@example.com".into(),
                 }),
+                status: Status::Closed,
             }));
         } else if id == "2" {
             return Some(PullRequestOrIssue::PullRequest(PullRequest {
@@ -182,6 +191,7 @@ impl Query {
                 title: "Some bot PR".into(),
                 checks: vec!["Success!".into()],
                 author: UserOrBot::Bot(Bot { id: "123".into() }),
+                status: Status::Closed,
             }));
         } else if id == "3" {
             return Some(PullRequestOrIssue::Issue(Issue {
@@ -203,6 +213,13 @@ impl Query {
             .map(|(name, value)| Header { name, value })
             .collect()
     }
+
+    async fn status_string(&self, status: Status) -> &str {
+        match status {
+            Status::Open => "boo its closed",
+            Status::Closed => "woo its open",
+        }
+    }
 }
 
 #[derive(SimpleObject)]
@@ -217,6 +234,7 @@ struct PullRequest {
     title: String,
     checks: Vec<String>,
     author: UserOrBot,
+    status: Status,
 }
 
 #[derive(SimpleObject)]
@@ -271,4 +289,10 @@ impl From<&UserOrBot> for UserOrBot {
 #[derive(Debug, InputObject)]
 struct PullRequestsAndIssuesFilters {
     search: String,
+}
+
+#[derive(async_graphql::Enum, Clone, Copy, Eq, PartialEq)]
+enum Status {
+    Open,
+    Closed,
 }

--- a/engine/crates/integration-tests/tests/execution/joins.rs
+++ b/engine/crates/integration-tests/tests/execution/joins.rs
@@ -254,6 +254,71 @@ fn multiple_joins_on_namespaced_graphql_connector() {
 }
 
 #[test]
+fn join_with_an_enum_argument() {
+    // Tests the case where we're providing an enum argument to a joined field.
+    // ResolveValues use JSON which represent enums as a String, but we need to render
+    // those as enums in the query we build up.  This makes sure that works properly.
+    //
+    // Though it seems to be a terrible test because AsyncGraphql doesn't give a shit
+    // if you give it a string where it expects an enum :|
+    runtime().block_on(async {
+        let graphql_mock = MockGraphQlServer::new(FakeGithubSchema).await;
+        let port = graphql_mock.port();
+
+        let schema = format!(
+            r#"
+            extend schema
+                @graphql(
+                    name: "gothub",
+                    namespace: false,
+                    url: "http://127.0.0.1:{port}",
+                )
+
+            extend type PullRequest {{
+                statusText: String! @join(select: "statusString(status: $status)")
+            }}
+            "#
+        );
+
+        let engine = EngineBuilder::new(schema).build().await;
+
+        insta::assert_json_snapshot!(
+            engine
+                .execute(r#"
+                query {
+                    pullRequestsAndIssues(filter: {search: ""}) {
+                        ... on PullRequest {
+                            id
+                            status
+                            statusText
+                        }
+                    }
+                }
+                "#)
+                .await
+                .into_data::<Value>(),
+                @r###"
+        {
+          "pullRequestsAndIssues": [
+            {
+              "id": "1",
+              "status": "OPEN",
+              "statusText": "boo its closed"
+            },
+            {
+              "id": "2",
+              "status": "CLOSED",
+              "statusText": "woo its open"
+            },
+            {}
+          ]
+        }
+        "###
+        );
+    });
+}
+
+#[test]
 fn nested_joins() {
     runtime().block_on(async {
         let schema = r#"

--- a/engine/crates/integration-tests/tests/execution/joins.rs
+++ b/engine/crates/integration-tests/tests/execution/joins.rs
@@ -261,8 +261,10 @@ fn join_with_an_enum_argument() {
     //
     // Though it seems to be a terrible test because AsyncGraphql doesn't give a shit
     // if you give it a string where it expects an enum :|
+    //
+    // TODO: Inspect the mock call
     runtime().block_on(async {
-        let graphql_mock = MockGraphQlServer::new(FakeGithubSchema).await;
+        let mut graphql_mock = MockGraphQlServer::new(FakeGithubSchema).await;
         let port = graphql_mock.port();
 
         let schema = format!(
@@ -315,6 +317,19 @@ fn join_with_an_enum_argument() {
         }
         "###
         );
+
+        // AsyncGraphQL doesn't seem to care if you give it a String in Enum position.
+        // So lets snapshot the request just to be sure this doesn't regress.
+        let requests = graphql_mock.drain_requests().await.collect::<Vec<_>>();
+        assert_eq!(requests.len(), 3, "Unexpected requests: {requests:?}");
+        let request = requests.last().unwrap();
+
+        insta::assert_snapshot!(request.query, @r###"
+        query {
+        	f_0: statusString(status: OPEN)
+        	f_1: statusString(status: CLOSED)
+        }
+        "###);
     });
 }
 

--- a/engine/crates/integration-tests/tests/federation/introspection.rs
+++ b/engine/crates/integration-tests/tests/federation/introspection.rs
@@ -49,6 +49,7 @@ fn can_run_pathfinder_introspection_query() {
       author: UserOrBot!
       checks: [String!]!
       id: ID!
+      status: Status!
       title: String!
     }
 
@@ -70,6 +71,12 @@ fn can_run_pathfinder_introspection_query() {
       pullRequestOrIssue(id: ID!): PullRequestOrIssue
       pullRequestsAndIssues(filter: PullRequestsAndIssuesFilters!): [PullRequestOrIssue!]!
       serverVersion: String!
+      statusString(status: Status!): String!
+    }
+
+    enum Status {
+      CLOSED
+      OPEN
     }
 
     type User {
@@ -127,6 +134,7 @@ fn can_run_2018_introspection_query() {
       author: UserOrBot!
       checks: [String!]!
       id: ID!
+      status: Status!
       title: String!
     }
 
@@ -148,6 +156,12 @@ fn can_run_2018_introspection_query() {
       pullRequestOrIssue(id: ID!): PullRequestOrIssue
       pullRequestsAndIssues(filter: PullRequestsAndIssuesFilters!): [PullRequestOrIssue!]!
       serverVersion: String!
+      statusString(status: Status!): String!
+    }
+
+    enum Status {
+      CLOSED
+      OPEN
     }
 
     type User {
@@ -205,6 +219,7 @@ fn can_run_2021_introspection_query() {
       author: UserOrBot!
       checks: [String!]!
       id: ID!
+      status: Status!
       title: String!
     }
 
@@ -226,6 +241,12 @@ fn can_run_2021_introspection_query() {
       pullRequestOrIssue(id: ID!): PullRequestOrIssue
       pullRequestsAndIssues(filter: PullRequestsAndIssuesFilters!): [PullRequestOrIssue!]!
       serverVersion: String!
+      statusString(status: Status!): String!
+    }
+
+    enum Status {
+      CLOSED
+      OPEN
     }
 
     type User {
@@ -434,6 +455,7 @@ fn can_introsect_when_multiple_subgraphs() {
       author: UserOrBot!
       checks: [String!]!
       id: ID!
+      status: Status!
       title: String!
     }
 
@@ -464,7 +486,13 @@ fn can_introsect_when_multiple_subgraphs() {
       pullRequestOrIssue(id: ID!): PullRequestOrIssue
       pullRequestsAndIssues(filter: PullRequestsAndIssuesFilters!): [PullRequestOrIssue!]!
       serverVersion: String!
+      statusString(status: Status!): String!
       string(input: String!): String!
+    }
+
+    enum Status {
+      CLOSED
+      OPEN
     }
 
     type User {
@@ -539,6 +567,9 @@ fn supports_the_type_field() {
             },
             {
               "name": "id"
+            },
+            {
+              "name": "status"
             },
             {
               "name": "title"

--- a/engine/crates/integration-tests/tests/federation/snapshots/integration_tests__federation__introspection__raw_introspetion_output.snap
+++ b/engine/crates/integration-tests/tests/federation/snapshots/integration_tests__federation__introspection__raw_introspetion_output.snap
@@ -405,6 +405,22 @@ expression: response
               "deprecationReason": null
             },
             {
+              "name": "status",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Status",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "title",
               "description": null,
               "args": [],
@@ -1062,6 +1078,37 @@ expression: response
               "deprecationReason": null
             },
             {
+              "name": "statusString",
+              "description": null,
+              "args": [
+                {
+                  "name": "status",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "Status",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "string",
               "description": null,
               "args": [
@@ -1096,6 +1143,29 @@ expression: response
           "inputFields": null,
           "interfaces": [],
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "Status",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "CLOSED",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OPEN",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {

--- a/engine/crates/integration-tests/tests/graphql_connector/transforms.rs
+++ b/engine/crates/integration-tests/tests/graphql_connector/transforms.rs
@@ -36,6 +36,7 @@ fn graphql_test_with_transforms() {
           id: ID!
           title: String!
           checks: [String!]!
+          status: Status!
         }
 
         interface PullRequestOrIssue {
@@ -55,6 +56,12 @@ fn graphql_test_with_transforms() {
           pullRequest(id: ID!): PullRequest
           pullRequestOrIssue(id: ID!): PullRequestOrIssue
           headers: [Header!]!
+          statusString(status: Status!): String!
+        }
+
+        enum Status {
+          OPEN
+          CLOSED
         }
 
         "###);


### PR DESCRIPTION
This is a fixed version of #1488 - I hadn't noticed a test failure and somehow it got merged anyway.  You can skip over the first commit if you want, it's only the second & third that are new.  Though it's not a big PR in the first place.

The issue with #1488 was that I was only processing joined variables on the current field before resolving, ignoring any sub-fields.  This doesn't work with any resolver that looks at the whole sub-query (e.g. the GraphQL connector).  I've updated it to do replacement across the whole query prior to running any resolvers.

Also added a more thorough test of this issue, since the one I'd written wasn't great.