### PR TITLE
fix: a non-deterministic test

### DIFF
--- a/engine/crates/integration-tests/tests/execution/joins.rs
+++ b/engine/crates/integration-tests/tests/execution/joins.rs
@@ -288,12 +288,10 @@ fn join_with_an_enum_argument() {
             engine
                 .execute(r#"
                 query {
-                    pullRequestsAndIssues(filter: {search: ""}) {
-                        ... on PullRequest {
-                            id
-                            status
-                            statusText
-                        }
+                    pullRequest(id: "1") {
+                        id
+                        status
+                        statusText
                     }
                 }
                 "#)
@@ -301,19 +299,11 @@ fn join_with_an_enum_argument() {
                 .into_data::<Value>(),
                 @r###"
         {
-          "pullRequestsAndIssues": [
-            {
-              "id": "1",
-              "status": "OPEN",
-              "statusText": "boo its closed"
-            },
-            {
-              "id": "2",
-              "status": "CLOSED",
-              "statusText": "woo its open"
-            },
-            {}
-          ]
+          "pullRequest": {
+            "id": "1",
+            "status": "OPEN",
+            "statusText": "boo its closed"
+          }
         }
         "###
         );
@@ -326,8 +316,7 @@ fn join_with_an_enum_argument() {
 
         insta::assert_snapshot!(request.query, @r###"
         query {
-        	f_0: statusString(status: OPEN)
-        	f_1: statusString(status: CLOSED)
+        	field_0: statusString(status: OPEN)
         }
         "###);
     });


### PR DESCRIPTION
I'd fooled myself into thinking the order that joins were executed was determinstic - it is not.  This meant that the query snapshot could appear in one of two orders, making the test flaky.

Switched it so there's only a single fetch needed for the join, which solves the problem for now.
