### PR TITLE
feat: build lambda version of the gateway

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -290,7 +290,7 @@ jobs:
         run: |
           RUSTFLAGS="-C opt-level=s" cargo build --release -p grafbase-gateway --target ${{ matrix.archs.target }} --features lambda
 
-      - if: ${{ github.event_name == 'pull_request' && matrix.archs.runner != 'buildjet-8vcpu-ubuntu-2204-arm' }}
+      - if: ${{ github.event_name == 'pull_request' && matrix.archs.runner != 'ubicloud-standard-8-arm' }}
         name: Upload lambda gateway binary to R2
         run: |
           aws s3api put-object \

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -281,6 +281,7 @@ jobs:
       - name: Build gateway lambda release
         run: |
           cargo build --release -p grafbase-gateway --target ${{ matrix.archs.target }} --features lambda
+        env: RUSTFLAGS="-C opt-level=s"
 
       - if: ${{ github.event_name == 'pull_request' && matrix.archs.runner != 'buildjet-8vcpu-ubuntu-2204-arm' }}
         name: Upload lambda gateway binary to R2

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -145,6 +145,13 @@ jobs:
           # See: https://github.com/rust-lang/cargo/issues/4463
           cargo check --all-features --package ${{ matrix.package }}
 
+      - name: Individual package without lambda
+        if: ${{ matrix.package == 'grafbase-gateway' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo check --package ${{ matrix.package }}
+
   docker:
     needs: [test]
     if: ${{ needs.detect-change-type.outputs.build == 'true' || startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -279,9 +279,9 @@ jobs:
             target/${{ matrix.archs.target }}/release/grafbase-gateway
 
       - name: Build gateway lambda release
+        shell: bash
         run: |
-          cargo build --release -p grafbase-gateway --target ${{ matrix.archs.target }} --features lambda
-        env: RUSTFLAGS="-C opt-level=s"
+          RUSTFLAGS="-C opt-level=s" cargo build --release -p grafbase-gateway --target ${{ matrix.archs.target }} --features lambda
 
       - if: ${{ github.event_name == 'pull_request' && matrix.archs.runner != 'buildjet-8vcpu-ubuntu-2204-arm' }}
         name: Upload lambda gateway binary to R2

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -278,6 +278,30 @@ jobs:
           path: |
             target/${{ matrix.archs.target }}/release/grafbase-gateway
 
+      - name: Build gateway lambda release
+        run: |
+          cargo build --release -p grafbase-gateway --target ${{ matrix.archs.target }} --features lambda
+
+      - if: ${{ github.event_name == 'pull_request' && matrix.archs.runner != 'buildjet-8vcpu-ubuntu-2204-arm' }}
+        name: Upload lambda gateway binary to R2
+        run: |
+          aws s3api put-object \
+            --endpoint-url $CLI_RELEASE_CLOUDFLARE_R2_ENDPOINT_URL \
+            --bucket $CLI_RELEASE_CLOUDFLARE_R2_BUCKET_NAME \
+            --key ${GITHUB_SHA}/${{ matrix.archs.target }}/grafbase-gateway-lambda \
+            --body target/${{ matrix.archs.target }}/release/grafbase-gateway
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_RELEASES_BUCKET_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_RELEASES_BUCKET_SECRET_ACCESS_KEY }}
+
+      - if: startsWith(github.ref, 'refs/tags/') && startsWith(github.ref_name, 'gateway-')
+        name: Upload gateway lambda binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: gateway-lambda-${{ env.VERSION_BUMP }}-${{ matrix.archs.platform }}
+          path: |
+            target/${{ matrix.archs.target }}/release/grafbase-gateway
+
   darwin:
     needs: [test]
     runs-on: macos-latest-xlarge

--- a/.github/workflows/gateway-partial-release.yml
+++ b/.github/workflows/gateway-partial-release.yml
@@ -55,6 +55,8 @@ jobs:
           mkdir -p gateway/release/x86_64-apple-darwin
           mkdir -p gateway/release/aarch64-unknown-linux-musl
           mkdir -p gateway/release/x86_64-unknown-linux-musl
+          mkdir -p gateway/release/aarch64-unknown-linux-musl-lambda
+          mkdir -p gateway/release/x86_64-unknown-linux-musl-lambda
 
       - name: Download darwin-x86_64 artifact
         uses: actions/download-artifact@v4
@@ -80,6 +82,18 @@ jobs:
           name: gateway-${{ env.VERSION_BUMP }}-linux-arm
           path: gateway/release/aarch64-unknown-linux-musl
 
+      - name: Download Lambda AMD artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: gateway-lambda-${{ env.VERSION_BUMP }}-linux
+          path: gateway/release/x86_64-unknown-linux-musl-lambda
+
+      - name: Download Lambda ARM artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: gateway-lambda-${{ env.VERSION_BUMP }}-linux-arm
+          path: gateway/release/aarch64-unknown-linux-musl-lambda
+
       - name: Process artifacts
         shell: bash
         run: |
@@ -90,11 +104,15 @@ jobs:
           mv x86_64-apple-darwin/grafbase-gateway github/grafbase-gateway-x86_64-apple-darwin
           mv aarch64-unknown-linux-musl/grafbase-gateway github/grafbase-gateway-aarch64-unknown-linux-musl
           mv x86_64-unknown-linux-musl/grafbase-gateway github/grafbase-gateway-x86_64-unknown-linux-musl
+          mv aarch64-unknown-linux-musl-lambda/grafbase-gateway github/grafbase-gateway-lambda-aarch64-unknown-linux-musl
+          mv x86_64-unknown-linux-musl-lambda/grafbase-gateway github/grafbase-gateway-lambda-x86_64-unknown-linux-musl
 
           chmod +x github/grafbase-gateway-aarch64-apple-darwin
           chmod +x github/grafbase-gateway-x86_64-apple-darwin
           chmod +x github/grafbase-gateway-aarch64-unknown-linux-musl
           chmod +x github/grafbase-gateway-x86_64-unknown-linux-musl
+          chmod +x github/grafbase-gateway-lambda-aarch64-unknown-linux-musl
+          chmod +x github/grafbase-gateway-lambda-x86_64-unknown-linux-musl
 
       - name: Install cargo-binstall and cargo-about
         shell: bash
@@ -122,3 +140,5 @@ jobs:
             gateway/release/github/grafbase-gateway-x86_64-apple-darwin
             gateway/release/github/grafbase-gateway-aarch64-unknown-linux-musl
             gateway/release/github/grafbase-gateway-x86_64-unknown-linux-musl
+            gateway/release/github/grafbase-gateway-lambda-aarch64-unknown-linux-musl
+            gateway/release/github/grafbase-gateway-lambda-x86_64-unknown-linux-musl

--- a/.github/workflows/gateway-partial-release.yml
+++ b/.github/workflows/gateway-partial-release.yml
@@ -36,7 +36,7 @@ jobs:
           notification_title: '({workflow}) grafbase-gateway release for ${{ env.VERSION_BUMP }} started'
           footer: '<{run_url}|View Run>'
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GATEWAY_WEBHOOK_URL }}
 
       - name: Get sources
         uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2840,13 +2840,13 @@ dependencies = [
  "indoc",
  "insta",
  "mimalloc",
+ "opentelemetry-aws",
  "reqwest",
  "rustls",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
- "tracing-core",
  "tracing-subscriber",
  "wiremock",
 ]
@@ -4840,6 +4840,17 @@ dependencies = [
  "pin-project-lite",
  "thiserror",
  "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry-aws"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42c915961c059be65af3be9aeaedb3f8930e1e9590e26e5f23b1919e90d1ed7d"
+dependencies = [
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.1.0-rc.21"
+version = "0.1.0-rc.22"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.1.0-rc.21"
+version = "0.1.0-rc.22"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.1.0-rc.13"
+version = "0.1.0-rc.14"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.1.0-rc.13"
+version = "0.1.0-rc.14"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",
@@ -2841,6 +2841,7 @@ dependencies = [
  "insta",
  "mimalloc",
  "opentelemetry-aws",
+ "opentelemetry-stdout",
  "reqwest",
  "rustls",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.1.0-rc.19"
+version = "0.1.0-rc.20"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.1.0-rc.19"
+version = "0.1.0-rc.20"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2848,6 +2848,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "toml",
  "tracing-subscriber",
  "wiremock",
 ]
@@ -7584,14 +7585,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af06656561d28735e9c1cd63dfd57132c8155426aa6af24f36a00a351f88c48e"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.7",
+ "toml_edit 0.22.8",
 ]
 
 [[package]]
@@ -7627,9 +7628,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.7"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992"
+checksum = "c12219811e0c1ba077867254e5ad62ee2c9c190b0d957110750ac0cda1ae96cd"
 dependencies = [
  "indexmap 2.2.5",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2839,6 +2839,7 @@ dependencies = [
  "http 1.1.0",
  "indoc",
  "insta",
+ "mimalloc",
  "reqwest",
  "rustls",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.1.0-rc.20"
+version = "0.1.0-rc.21"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.1.0-rc.20"
+version = "0.1.0-rc.21"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.1.0-rc.24"
+version = "0.1.0"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.1.0-rc.24"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.1.0-rc.23"
+version = "0.1.0-rc.24"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.1.0-rc.23"
+version = "0.1.0-rc.24"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.1.0-rc.18"
+version = "0.1.0-rc.19"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.1.0-rc.18"
+version = "0.1.0-rc.19"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,6 +2259,7 @@ dependencies = [
  "insta",
  "itertools 0.12.1",
  "lambda_http",
+ "opentelemetry-aws",
  "parser-sdl",
  "regex",
  "reqwest",
@@ -4803,6 +4804,17 @@ dependencies = [
  "pin-project-lite",
  "thiserror",
  "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry-aws"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42c915961c059be65af3be9aeaedb3f8930e1e9590e26e5f23b1919e90d1ed7d"
+dependencies = [
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.1.0-rc.22"
+version = "0.1.0-rc.23"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.1.0-rc.22"
+version = "0.1.0-rc.23"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.1.0-rc.17"
+version = "0.1.0-rc.18"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.1.0-rc.17"
+version = "0.1.0-rc.18"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,7 +2259,6 @@ dependencies = [
  "insta",
  "itertools 0.12.1",
  "lambda_http",
- "oneshot",
  "parser-sdl",
  "regex",
  "reqwest",
@@ -2276,7 +2275,6 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
- "tracing-subscriber",
  "ulid",
  "url",
 ]
@@ -2652,19 +2650,6 @@ dependencies = [
  "serde",
  "serde_with",
  "url",
-]
-
-[[package]]
-name = "generator"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
-dependencies = [
- "cc",
- "libc",
- "log 0.4.21",
- "rustversion",
- "windows 0.48.0",
 ]
 
 [[package]]
@@ -4258,20 +4243,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
-name = "loom"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
-dependencies = [
- "cfg-if",
- "generator",
- "pin-utils",
- "scoped-tls",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "lru"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4729,15 +4700,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "oneshot"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f6640c6bda7731b1fdbab747981a0f896dd1fedaf9f4a53fa237a04a84431f4"
-dependencies = [
- "loom",
-]
 
 [[package]]
 name = "onig"
@@ -8294,15 +8256,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-targets 0.48.5",
-]
 
 [[package]]
 name = "windows"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2828,7 +2828,6 @@ dependencies = [
  "anyhow",
  "ascii 1.1.0",
  "clap",
- "ctor",
  "duct",
  "federated-server",
  "fslock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.1.0-rc.9"
+version = "0.1.0-rc.10"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.1.0-rc.9"
+version = "0.1.0-rc.10"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2846,6 +2846,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tracing-core",
  "tracing-subscriber",
  "wiremock",
 ]
@@ -7790,6 +7791,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7799,12 +7810,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2826,7 +2826,6 @@ dependencies = [
  "insta",
  "mimalloc",
  "opentelemetry-aws",
- "opentelemetry-stdout",
  "reqwest",
  "rustls",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.1.0-rc.15"
+version = "0.1.0-rc.16"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.1.0-rc.15"
+version = "0.1.0-rc.16"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2275,6 +2275,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-futures",
  "ulid",
  "url",
 ]
@@ -2825,7 +2826,6 @@ dependencies = [
  "indoc",
  "insta",
  "mimalloc",
- "opentelemetry-aws",
  "reqwest",
  "rustls",
  "serde",
@@ -4803,17 +4803,6 @@ dependencies = [
  "pin-project-lite",
  "thiserror",
  "urlencoding",
-]
-
-[[package]]
-name = "opentelemetry-aws"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42c915961c059be65af3be9aeaedb3f8930e1e9590e26e5f23b1919e90d1ed7d"
-dependencies = [
- "once_cell",
- "opentelemetry",
- "opentelemetry_sdk",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aws_lambda_events"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e84ed7ec0561e54444ad328c76b633f2946b77c234c99baf18c9e84250ceea1"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-serde",
+ "query_map",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +555,23 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-aws-lambda"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "587169c689d2c09a844e6f74f95e33c53d96f539adf79f807aa68c784b17ee70"
+dependencies = [
+ "axum 0.7.4",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "lambda_http",
+ "tower",
+ "tower-service",
 ]
 
 [[package]]
@@ -2210,6 +2243,7 @@ dependencies = [
  "ascii 1.1.0",
  "async-trait",
  "axum 0.7.4",
+ "axum-aws-lambda",
  "axum-server",
  "duration-str",
  "engine",
@@ -2224,6 +2258,7 @@ dependencies = [
  "indoc",
  "insta",
  "itertools 0.12.1",
+ "lambda_http",
  "oneshot",
  "parser-sdl",
  "regex",
@@ -2238,6 +2273,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -4019,6 +4055,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "lambda_http"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5107d9a9513f340fc9f80ec01ce88c81ab11de0a0826c9c3896504b602ae788b"
+dependencies = [
+ "aws_lambda_events",
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "lambda_runtime",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio-stream",
+ "url",
+]
+
+[[package]]
+name = "lambda_runtime"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97113292dd7dc3a4f2ca23f6f5e32cbc02b8d54d9966f9e98111a5b3f153d582"
+dependencies = [
+ "async-stream",
+ "base64 0.21.7",
+ "bytes",
+ "futures",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "http-serde",
+ "hyper 1.2.0",
+ "hyper-util",
+ "lambda_runtime_api_client",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "lambda_runtime_api_client"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "286b9131ad5312ecac04a655be8f2438988954d19e26f44986aefca6cca15333"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
+ "tokio",
+ "tower",
+ "tower-service",
+]
+
+[[package]]
 name = "lasso"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5580,6 +5688,17 @@ dependencies = [
  "bitflags 2.4.2",
  "memchr",
  "unicase",
+]
+
+[[package]]
+name = "query_map"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eab6b8b1074ef3359a863758dae650c7c0c6027927a085b7af911c8e0bf3a15"
+dependencies = [
+ "form_urlencoded",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.1.0-rc.14"
+version = "0.1.0-rc.15"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.1.0-rc.14"
+version = "0.1.0-rc.15"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.1.0-rc.8"
+version = "0.1.0-rc.9"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -2823,11 +2823,12 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.1.0-rc.8"
+version = "0.1.0-rc.9"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",
  "clap",
+ "ctor",
  "duct",
  "federated-server",
  "fslock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.1.0-rc.10"
+version = "0.1.0-rc.11"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.1.0-rc.10"
+version = "0.1.0-rc.11"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.1.0-rc.12"
+version = "0.1.0-rc.13"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.1.0-rc.12"
+version = "0.1.0-rc.13"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.1.0-rc.11"
+version = "0.1.0-rc.12"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.1.0-rc.11"
+version = "0.1.0-rc.12"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,6 +178,7 @@ strip = "symbols"
 # by telling cargo to optimize at the link stage (in addition to the
 # normal optimizations during the compilation stage)
 lto = "thin"
+codegen-units = 1
 
 [workspace.lints.rust]
 nonstandard-style = "deny"

--- a/engine/crates/tracing/Cargo.toml
+++ b/engine/crates/tracing/Cargo.toml
@@ -31,7 +31,6 @@ opentelemetry_sdk = { version = "0.22", features = ["rt-tokio"] }
 opentelemetry-stdout = { version = "0.3", features = ["trace"] }
 opentelemetry-otlp = { version = "0.15" , features = ["grpc-tonic", "tls", "tonic", "http-proto"], optional = true }
 
-
 [features]
 default = []
 tower = ["tower-http"]

--- a/engine/crates/tracing/Cargo.toml
+++ b/engine/crates/tracing/Cargo.toml
@@ -36,6 +36,7 @@ default = []
 tower = ["tower-http"]
 otlp = ["dep:opentelemetry-otlp", "dep:tonic"]
 worker = ["dep:worker"]
+lambda = []
 
 [dev-dependencies]
 indoc = "2.0.4"

--- a/engine/crates/tracing/src/config.rs
+++ b/engine/crates/tracing/src/config.rs
@@ -352,6 +352,11 @@ impl Headers {
         self.0
     }
 
+    /// Gets the headers as a referenced slice
+    pub fn inner(&self) -> &[(HeaderName, HeaderValue)] {
+        &self.0
+    }
+
     /// Consume self and return a map of header/header_value as ascii strings
     pub fn try_into_map(self) -> Result<HashMap<String, String>, TracingError> {
         self.into_inner()

--- a/engine/crates/tracing/src/otel.rs
+++ b/engine/crates/tracing/src/otel.rs
@@ -5,3 +5,4 @@ pub mod layer;
 pub use opentelemetry;
 pub use opentelemetry_sdk;
 pub use tracing_opentelemetry;
+pub use tracing_subscriber;

--- a/engine/crates/tracing/src/otel.rs
+++ b/engine/crates/tracing/src/otel.rs
@@ -1,5 +1,7 @@
 /// Contains opentelemetry tracing integrations, namely [tracing_subscriber::Layer]'s and
 pub mod layer;
+/// For creation of a tracing provider.
+pub mod provider;
 
 // re-exporting otel libs
 pub use opentelemetry;

--- a/engine/crates/tracing/src/otel/layer.rs
+++ b/engine/crates/tracing/src/otel/layer.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::time::Duration;
 
 use opentelemetry::trace::noop::NoopTracer;
@@ -110,6 +109,7 @@ where
     #[cfg(feature = "otlp")]
     if let Some(ref otlp_exporter_config) = config.exporters.otlp {
         use opentelemetry_otlp::{SpanExporterBuilder, WithExportConfig};
+        use std::borrow::Cow;
         use std::str::FromStr;
         use tonic::metadata::MetadataKey;
         use tonic::transport::ClientTlsConfig;

--- a/engine/crates/tracing/src/otel/layer.rs
+++ b/engine/crates/tracing/src/otel/layer.rs
@@ -1,11 +1,14 @@
+use std::borrow::Cow;
 use std::time::Duration;
 
 use opentelemetry::trace::noop::NoopTracer;
-use opentelemetry::trace::TracerProvider;
+use opentelemetry::trace::TracerProvider as _;
 use opentelemetry::{global, KeyValue};
 use opentelemetry_sdk::export::trace::SpanExporter;
 use opentelemetry_sdk::runtime::RuntimeChannel;
-use opentelemetry_sdk::trace::{BatchConfigBuilder, BatchSpanProcessor, Builder, RandomIdGenerator, Sampler};
+use opentelemetry_sdk::trace::{
+    BatchConfigBuilder, BatchSpanProcessor, Builder, RandomIdGenerator, Sampler, TracerProvider,
+};
 use opentelemetry_sdk::Resource;
 use tracing::Subscriber;
 use tracing_subscriber::filter::{FilterExt, Filtered};
@@ -52,6 +55,23 @@ where
     S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync,
     R: RuntimeChannel,
 {
+    let provider = new_provider(service_name, &config, runtime)?;
+    let tracer = provider.tracer("batched-otel");
+
+    let _ = global::set_tracer_provider(provider);
+
+    Ok(tracing_opentelemetry::layer().with_tracer(tracer).boxed())
+}
+
+/// Creates a new OTEL tracing provider.
+pub fn new_provider<R>(
+    service_name: impl Into<String>,
+    config: &TracingConfig,
+    runtime: R,
+) -> Result<TracerProvider, TracingError>
+where
+    R: RuntimeChannel,
+{
     let service_name = service_name.into();
 
     let builder = opentelemetry_sdk::trace::TracerProvider::builder().with_config(
@@ -64,18 +84,12 @@ where
             .with_resource(Resource::new(vec![KeyValue::new("service.name", service_name)])),
     );
 
-    let provider = setup_exporters(builder, config, runtime)?.build();
-
-    let tracer = provider.tracer("batched-otel");
-
-    let _ = global::set_tracer_provider(provider);
-
-    Ok(tracing_opentelemetry::layer().with_tracer(tracer).boxed())
+    Ok(setup_exporters(builder, config, runtime)?.build())
 }
 
 fn setup_exporters<R>(
     mut tracer_provider_builder: Builder,
-    config: TracingConfig,
+    config: &TracingConfig,
     runtime: R,
 ) -> Result<Builder, TracingError>
 where
@@ -94,7 +108,7 @@ where
 
     // otlp
     #[cfg(feature = "otlp")]
-    if let Some(otlp_exporter_config) = config.exporters.otlp {
+    if let Some(ref otlp_exporter_config) = config.exporters.otlp {
         use opentelemetry_otlp::{SpanExporterBuilder, WithExportConfig};
         use std::str::FromStr;
         use tonic::metadata::MetadataKey;
@@ -107,21 +121,35 @@ where
 
             match otlp_exporter_config.protocol {
                 TracingOtlpExporterProtocol::Grpc => {
-                    let grpc_config = otlp_exporter_config.grpc.unwrap_or_default();
+                    let grpc_config = otlp_exporter_config
+                        .grpc
+                        .as_ref()
+                        .map(Cow::Borrowed)
+                        .unwrap_or_default();
+
                     let metadata = {
                         // note: I'm not using MetadataMap::from_headers due to `http` crate version issues.
                         // we're using 1 but otel currently pins tonic to an older version that requires 0.2.
                         // once versions get aligned we can replace the following
-                        let headers = grpc_config.headers.try_into_map()?;
+                        // let headers = grpc_config.headers.try_into_map()?;
 
-                        let metadata = tonic::metadata::MetadataMap::with_capacity(headers.len());
-                        headers
-                            .into_iter()
-                            .fold(metadata, |mut acc, (header_name, header_value)| {
-                                let key = MetadataKey::from_str(&header_name).unwrap();
-                                acc.insert(key, header_value.parse().unwrap());
-                                acc
-                            })
+                        let mut metadata =
+                            tonic::metadata::MetadataMap::with_capacity(grpc_config.headers.inner().len());
+
+                        for (header_key, header_value) in grpc_config.headers.inner() {
+                            let key = MetadataKey::from_str(header_key.as_str())
+                                .map_err(|e| TracingError::SpanExporterSetup(e.to_string()))?;
+
+                            let value = header_value
+                                .to_str()
+                                .map_err(|e| TracingError::SpanExporterSetup(e.to_string()))?
+                                .parse()
+                                .unwrap();
+
+                            metadata.insert(key, value);
+                        }
+
+                        metadata
                     };
 
                     let mut grpc_exporter = opentelemetry_otlp::new_exporter()
@@ -130,8 +158,8 @@ where
                         .with_timeout(exporter_timeout)
                         .with_metadata(metadata);
 
-                    if let Some(tls_config) = grpc_config.tls {
-                        grpc_exporter = grpc_exporter.with_tls_config(ClientTlsConfig::try_from(tls_config)?);
+                    if let Some(ref tls_config) = grpc_config.tls {
+                        grpc_exporter = grpc_exporter.with_tls_config(ClientTlsConfig::try_from(tls_config.clone())?);
                     }
 
                     SpanExporterBuilder::from(grpc_exporter)
@@ -139,12 +167,17 @@ where
                         .map_err(|err| TracingError::SpanExporterSetup(err.to_string()))?
                 }
                 TracingOtlpExporterProtocol::Http => {
-                    let http_config = otlp_exporter_config.http.unwrap_or_default();
+                    let http_config = otlp_exporter_config
+                        .http
+                        .as_ref()
+                        .map(Cow::Borrowed)
+                        .unwrap_or_default();
+
                     let http_exporter = opentelemetry_otlp::new_exporter()
                         .http()
                         .with_endpoint(otlp_exporter_config.endpoint.to_string())
                         .with_timeout(exporter_timeout)
-                        .with_headers(http_config.headers.try_into_map()?);
+                        .with_headers(http_config.headers.clone().try_into_map()?);
 
                     SpanExporterBuilder::from(http_exporter)
                         .build_span_exporter()

--- a/engine/crates/tracing/src/otel/layer.rs
+++ b/engine/crates/tracing/src/otel/layer.rs
@@ -1,22 +1,18 @@
-use std::time::Duration;
-
+use opentelemetry::global;
 use opentelemetry::trace::noop::NoopTracer;
-use opentelemetry::trace::TracerProvider as _;
-use opentelemetry::{global, KeyValue};
-use opentelemetry_sdk::export::trace::SpanExporter;
+use opentelemetry::trace::TracerProvider;
 use opentelemetry_sdk::runtime::RuntimeChannel;
-use opentelemetry_sdk::trace::{
-    BatchConfigBuilder, BatchSpanProcessor, Builder, IdGenerator, RandomIdGenerator, Sampler, TracerProvider,
-};
-use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::trace::RandomIdGenerator;
 use tracing::Subscriber;
 use tracing_subscriber::filter::{FilterExt, Filtered};
 use tracing_subscriber::layer::Filter;
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::{reload, EnvFilter, Layer};
 
-use crate::config::{TracingBatchExportConfig, TracingConfig};
+use crate::config::TracingConfig;
 use crate::error::TracingError;
+
+use super::provider;
 
 /// A type erased layer
 pub type BoxedLayer<S> = Box<dyn Layer<S> + Send + Sync + 'static>;
@@ -54,154 +50,10 @@ where
     S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync,
     R: RuntimeChannel,
 {
-    let provider = new_provider(service_name, config, RandomIdGenerator::default(), runtime)?;
+    let provider = provider::create(service_name, config, RandomIdGenerator::default(), runtime)?;
     let tracer = provider.tracer("batched-otel");
 
     let _ = global::set_tracer_provider(provider);
 
     Ok(tracing_opentelemetry::layer().with_tracer(tracer).boxed())
-}
-
-/// Creates a new OTEL tracing provider.
-pub fn new_provider<R, I>(
-    service_name: impl Into<String>,
-    config: TracingConfig,
-    id_generator: I,
-    runtime: R,
-) -> Result<TracerProvider, TracingError>
-where
-    R: RuntimeChannel,
-    I: IdGenerator + 'static,
-{
-    let service_name = service_name.into();
-
-    let builder = opentelemetry_sdk::trace::TracerProvider::builder().with_config(
-        opentelemetry_sdk::trace::config()
-            .with_id_generator(id_generator)
-            .with_sampler(Sampler::TraceIdRatioBased(config.sampling))
-            .with_id_generator(RandomIdGenerator::default())
-            .with_max_events_per_span(config.collect.max_events_per_span as u32)
-            .with_max_attributes_per_span(config.collect.max_attributes_per_span as u32)
-            .with_max_events_per_span(config.collect.max_events_per_span as u32)
-            .with_resource(Resource::new(vec![KeyValue::new("service.name", service_name)])),
-    );
-
-    Ok(setup_exporters(builder, config, runtime)?.build())
-}
-
-fn setup_exporters<R>(
-    mut tracer_provider_builder: Builder,
-    config: TracingConfig,
-    runtime: R,
-) -> Result<Builder, TracingError>
-where
-    R: RuntimeChannel,
-{
-    // stdout
-    if let Some(stdout_exporter) = &config.exporters.stdout {
-        let span_processor = build_batched_span_processor(
-            stdout_exporter.timeout,
-            &stdout_exporter.batch_export,
-            opentelemetry_stdout::SpanExporter::default(),
-            runtime.clone(),
-        );
-        tracer_provider_builder = tracer_provider_builder.with_span_processor(span_processor);
-    }
-
-    // otlp
-    #[cfg(feature = "otlp")]
-    if let Some(otlp_exporter_config) = config.exporters.otlp {
-        use opentelemetry_otlp::{SpanExporterBuilder, WithExportConfig};
-        use std::str::FromStr;
-        use tonic::metadata::MetadataKey;
-        use tonic::transport::ClientTlsConfig;
-
-        use crate::config::TracingOtlpExporterProtocol;
-
-        let span_exporter = {
-            let exporter_timeout = Duration::from_secs(otlp_exporter_config.timeout.num_seconds() as u64);
-
-            match otlp_exporter_config.protocol {
-                TracingOtlpExporterProtocol::Grpc => {
-                    let grpc_config = otlp_exporter_config.grpc.unwrap_or_default();
-
-                    let metadata = {
-                        // note: I'm not using MetadataMap::from_headers due to `http` crate version issues.
-                        // we're using 1 but otel currently pins tonic to an older version that requires 0.2.
-                        // once versions get aligned we can replace the following
-                        let headers = grpc_config.headers.try_into_map()?;
-
-                        let metadata = tonic::metadata::MetadataMap::with_capacity(headers.len());
-
-                        headers
-                            .into_iter()
-                            .fold(metadata, |mut acc, (header_name, header_value)| {
-                                let key = MetadataKey::from_str(&header_name).unwrap();
-                                acc.insert(key, header_value.parse().unwrap());
-                                acc
-                            })
-                    };
-
-                    let mut grpc_exporter = opentelemetry_otlp::new_exporter()
-                        .tonic()
-                        .with_endpoint(otlp_exporter_config.endpoint.to_string())
-                        .with_timeout(exporter_timeout)
-                        .with_metadata(metadata);
-
-                    if let Some(tls_config) = grpc_config.tls {
-                        grpc_exporter = grpc_exporter.with_tls_config(ClientTlsConfig::try_from(tls_config)?);
-                    }
-
-                    SpanExporterBuilder::from(grpc_exporter)
-                        .build_span_exporter()
-                        .map_err(|err| TracingError::SpanExporterSetup(err.to_string()))?
-                }
-                TracingOtlpExporterProtocol::Http => {
-                    let http_config = otlp_exporter_config.http.unwrap_or_default();
-
-                    let http_exporter = opentelemetry_otlp::new_exporter()
-                        .http()
-                        .with_endpoint(otlp_exporter_config.endpoint.to_string())
-                        .with_timeout(exporter_timeout)
-                        .with_headers(http_config.headers.try_into_map()?);
-
-                    SpanExporterBuilder::from(http_exporter)
-                        .build_span_exporter()
-                        .map_err(|err| TracingError::SpanExporterSetup(err.to_string()))?
-                }
-            }
-        };
-
-        let span_processor = build_batched_span_processor(
-            otlp_exporter_config.timeout,
-            &otlp_exporter_config.batch_export,
-            span_exporter,
-            runtime,
-        );
-        tracer_provider_builder = tracer_provider_builder.with_span_processor(span_processor);
-    }
-
-    Ok(tracer_provider_builder)
-}
-
-fn build_batched_span_processor<R>(
-    timeout: chrono::Duration,
-    config: &TracingBatchExportConfig,
-    exporter: impl SpanExporter + 'static,
-    runtime: R,
-) -> BatchSpanProcessor<R>
-where
-    R: RuntimeChannel,
-{
-    BatchSpanProcessor::builder(exporter, runtime)
-        .with_batch_config(
-            BatchConfigBuilder::default()
-                .with_max_concurrent_exports(config.max_concurrent_exports)
-                .with_max_export_batch_size(config.max_export_batch_size)
-                .with_max_export_timeout(Duration::from_secs(timeout.num_seconds() as u64))
-                .with_max_queue_size(config.max_queue_size)
-                .with_scheduled_delay(Duration::from_secs(config.scheduled_delay.num_seconds() as u64))
-                .build(),
-        )
-        .build()
 }

--- a/engine/crates/tracing/src/otel/provider.rs
+++ b/engine/crates/tracing/src/otel/provider.rs
@@ -1,0 +1,157 @@
+use std::time::Duration;
+
+use opentelemetry::KeyValue;
+use opentelemetry_sdk::{
+    export::trace::SpanExporter,
+    runtime::RuntimeChannel,
+    trace::{BatchConfigBuilder, BatchSpanProcessor, Builder, IdGenerator, Sampler, TracerProvider},
+    Resource,
+};
+
+use crate::{
+    config::{TracingBatchExportConfig, TracingConfig},
+    error::TracingError,
+};
+
+/// Creates a new OTEL tracing provider.
+pub fn create<R, I>(
+    service_name: impl Into<String>,
+    config: TracingConfig,
+    id_generator: I,
+    runtime: R,
+) -> Result<TracerProvider, TracingError>
+where
+    R: RuntimeChannel,
+    I: IdGenerator + 'static,
+{
+    let service_name = service_name.into();
+
+    let builder = opentelemetry_sdk::trace::TracerProvider::builder().with_config(
+        opentelemetry_sdk::trace::config()
+            .with_id_generator(id_generator)
+            .with_sampler(Sampler::TraceIdRatioBased(config.sampling))
+            .with_max_events_per_span(config.collect.max_events_per_span as u32)
+            .with_max_attributes_per_span(config.collect.max_attributes_per_span as u32)
+            .with_max_events_per_span(config.collect.max_events_per_span as u32)
+            .with_resource(Resource::new(vec![KeyValue::new("service.name", service_name)])),
+    );
+
+    Ok(setup_exporters(builder, config, runtime)?.build())
+}
+
+fn setup_exporters<R>(
+    mut tracer_provider_builder: Builder,
+    config: TracingConfig,
+    runtime: R,
+) -> Result<Builder, TracingError>
+where
+    R: RuntimeChannel,
+{
+    // stdout
+    if let Some(stdout_exporter) = &config.exporters.stdout {
+        let span_processor = build_batched_span_processor(
+            stdout_exporter.timeout,
+            &stdout_exporter.batch_export,
+            opentelemetry_stdout::SpanExporter::default(),
+            runtime.clone(),
+        );
+        tracer_provider_builder = tracer_provider_builder.with_span_processor(span_processor);
+    }
+
+    // otlp
+    #[cfg(feature = "otlp")]
+    if let Some(otlp_exporter_config) = config.exporters.otlp {
+        use opentelemetry_otlp::{SpanExporterBuilder, WithExportConfig};
+        use std::str::FromStr;
+        use tonic::metadata::MetadataKey;
+        use tonic::transport::ClientTlsConfig;
+
+        use crate::config::TracingOtlpExporterProtocol;
+
+        let span_exporter = {
+            let exporter_timeout = Duration::from_secs(otlp_exporter_config.timeout.num_seconds() as u64);
+
+            match otlp_exporter_config.protocol {
+                TracingOtlpExporterProtocol::Grpc => {
+                    let grpc_config = otlp_exporter_config.grpc.unwrap_or_default();
+
+                    let metadata = {
+                        // note: I'm not using MetadataMap::from_headers due to `http` crate version issues.
+                        // we're using 1 but otel currently pins tonic to an older version that requires 0.2.
+                        // once versions get aligned we can replace the following
+                        let headers = grpc_config.headers.try_into_map()?;
+
+                        let metadata = tonic::metadata::MetadataMap::with_capacity(headers.len());
+
+                        headers
+                            .into_iter()
+                            .fold(metadata, |mut acc, (header_name, header_value)| {
+                                let key = MetadataKey::from_str(&header_name).unwrap();
+                                acc.insert(key, header_value.parse().unwrap());
+                                acc
+                            })
+                    };
+
+                    let mut grpc_exporter = opentelemetry_otlp::new_exporter()
+                        .tonic()
+                        .with_endpoint(otlp_exporter_config.endpoint.to_string())
+                        .with_timeout(exporter_timeout)
+                        .with_metadata(metadata);
+
+                    if let Some(tls_config) = grpc_config.tls {
+                        grpc_exporter = grpc_exporter.with_tls_config(ClientTlsConfig::try_from(tls_config)?);
+                    }
+
+                    SpanExporterBuilder::from(grpc_exporter)
+                        .build_span_exporter()
+                        .map_err(|err| TracingError::SpanExporterSetup(err.to_string()))?
+                }
+                TracingOtlpExporterProtocol::Http => {
+                    let http_config = otlp_exporter_config.http.unwrap_or_default();
+
+                    let http_exporter = opentelemetry_otlp::new_exporter()
+                        .http()
+                        .with_endpoint(otlp_exporter_config.endpoint.to_string())
+                        .with_timeout(exporter_timeout)
+                        .with_headers(http_config.headers.try_into_map()?);
+
+                    SpanExporterBuilder::from(http_exporter)
+                        .build_span_exporter()
+                        .map_err(|err| TracingError::SpanExporterSetup(err.to_string()))?
+                }
+            }
+        };
+
+        let span_processor = build_batched_span_processor(
+            otlp_exporter_config.timeout,
+            &otlp_exporter_config.batch_export,
+            span_exporter,
+            runtime,
+        );
+        tracer_provider_builder = tracer_provider_builder.with_span_processor(span_processor);
+    }
+
+    Ok(tracer_provider_builder)
+}
+
+fn build_batched_span_processor<R>(
+    timeout: chrono::Duration,
+    config: &TracingBatchExportConfig,
+    exporter: impl SpanExporter + 'static,
+    runtime: R,
+) -> BatchSpanProcessor<R>
+where
+    R: RuntimeChannel,
+{
+    BatchSpanProcessor::builder(exporter, runtime)
+        .with_batch_config(
+            BatchConfigBuilder::default()
+                .with_max_concurrent_exports(config.max_concurrent_exports)
+                .with_max_export_batch_size(config.max_export_batch_size)
+                .with_max_export_timeout(Duration::from_secs(timeout.num_seconds() as u64))
+                .with_max_queue_size(config.max_queue_size)
+                .with_scheduled_delay(Duration::from_secs(config.scheduled_delay.num_seconds() as u64))
+                .build(),
+        )
+        .build()
+}

--- a/engine/crates/tracing/src/span/request.rs
+++ b/engine/crates/tracing/src/span/request.rs
@@ -6,7 +6,6 @@ use http::header::USER_AGENT;
 use http::{Response, StatusCode};
 use http_body::Body;
 use tracing::{info_span, Span};
-use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 /// The name of the span that represents the root of an incoming request
 pub const GATEWAY_SPAN_NAME: &str = "gateway";
@@ -180,6 +179,7 @@ impl<B: Body> tower_http::trace::MakeSpan<B> for MakeHttpRequestSpan {
     fn make_span(&mut self, request: &http::Request<B>) -> Span {
         use opentelemetry::Context;
         use std::collections::HashMap;
+        use tracing_opentelemetry::OpenTelemetrySpanExt;
 
         let parent_ctx = opentelemetry::global::get_text_map_propagator(|propagator| {
             let headers = request

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,9 @@
             # Benchmark tool to send multiple requests
             hey
 
+            # binary bloat inspector
+            cargo-bloat
+
             # Versioning, automation and releasing
             cargo-make
             cargo-release

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [0.1.0] - 2024-03-22
+
+[CHANGELOG](changelog/0.1.0.md)

--- a/gateway/changelog/0.1.0-rc.10.md
+++ b/gateway/changelog/0.1.0-rc.10.md
@@ -1,0 +1,3 @@
+### Features
+
+- allow setting config and schema paths as env vars

--- a/gateway/changelog/0.1.0-rc.11.md
+++ b/gateway/changelog/0.1.0-rc.11.md
@@ -1,0 +1,3 @@
+### Features
+
+Replace global allocator with mimalloc

--- a/gateway/changelog/0.1.0-rc.13.md
+++ b/gateway/changelog/0.1.0-rc.13.md
@@ -1,0 +1,3 @@
+### Features
+
+Propagate x-ray tracing parent ids for lambda

--- a/gateway/changelog/0.1.0-rc.14.md
+++ b/gateway/changelog/0.1.0-rc.14.md
@@ -1,0 +1,3 @@
+### Features
+
+Try with separate trace provider for x-ray

--- a/gateway/changelog/0.1.0-rc.15.md
+++ b/gateway/changelog/0.1.0-rc.15.md
@@ -1,0 +1,3 @@
+### Fixes
+
+Map the telemetry config for xray

--- a/gateway/changelog/0.1.0-rc.16.md
+++ b/gateway/changelog/0.1.0-rc.16.md
@@ -1,0 +1,3 @@
+### Fixes
+
+Simplify otel for the main gateway binary

--- a/gateway/changelog/0.1.0-rc.17.md
+++ b/gateway/changelog/0.1.0-rc.17.md
@@ -1,0 +1,3 @@
+### Fixes
+
+Try xray otel with json output

--- a/gateway/changelog/0.1.0-rc.18.md
+++ b/gateway/changelog/0.1.0-rc.18.md
@@ -1,0 +1,3 @@
+### Fixes
+
+Back to normal otel collector

--- a/gateway/changelog/0.1.0-rc.19.md
+++ b/gateway/changelog/0.1.0-rc.19.md
@@ -1,0 +1,3 @@
+### Fixes
+
+Start the runtime earlier for otel to be able to initialize

--- a/gateway/changelog/0.1.0-rc.20.md
+++ b/gateway/changelog/0.1.0-rc.20.md
@@ -1,0 +1,3 @@
+### Fixes
+
+Handle tracing in sync for lambda

--- a/gateway/changelog/0.1.0-rc.21.md
+++ b/gateway/changelog/0.1.0-rc.21.md
@@ -1,0 +1,3 @@
+### Fixes
+
+- enables plan cache for self-hosted gateway

--- a/gateway/changelog/0.1.0-rc.22.md
+++ b/gateway/changelog/0.1.0-rc.22.md
@@ -1,0 +1,3 @@
+### Fixes
+
+Only use OTEL if configured, set the filter correctly

--- a/gateway/changelog/0.1.0-rc.23.md
+++ b/gateway/changelog/0.1.0-rc.23.md
@@ -1,0 +1,3 @@
+### Fixes
+
+Lambda telemetry should only be initialized once per start

--- a/gateway/changelog/0.1.0-rc.24.md
+++ b/gateway/changelog/0.1.0-rc.24.md
@@ -1,0 +1,3 @@
+### Features
+
+- propagating x-ray trace ids for lambda

--- a/gateway/changelog/0.1.0-rc.9.md
+++ b/gateway/changelog/0.1.0-rc.9.md
@@ -1,0 +1,3 @@
+## Features
+
+Lambda version test build #1

--- a/gateway/changelog/0.1.0.md
+++ b/gateway/changelog/0.1.0.md
@@ -1,0 +1,6 @@
+### Features
+
+Separating the federated gateway to its own binary. The `grafbase-gateway` has two versions:
+
+- One for server installations, optimized for multi-threaded workflows and compiled to optimize runtime speed over binary size.
+- The other for AWS Lambda installations, which maps seamlessly to AWS services such as X-Ray and Lambda. Optimized for binary size over runtime speed.

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.1.0-rc.17"
+version = "0.1.0-rc.18"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -36,7 +36,7 @@ runtime-noop.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "signal", "time", "net"] }
+tokio = { workspace = true, features = ["signal", "time", "net"] }
 tower-http = { version = "0.5.2", features = ["cors"] }
 tracing.workspace = true
 ulid = { workspace = true, features = ["serde"] }

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.1.0-rc.19"
+version = "0.1.0-rc.20"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -10,11 +10,14 @@ repository.workspace = true
 [lints]
 workspace = true
 
+[features]
+default = []
+lambda = ["dep:axum-aws-lambda", "dep:tower", "dep:lambda_http"]
+
 [dependencies]
 ascii = { version = "1.1.0", features = ["serde"] }
 async-trait = "0.1.78"
 axum = { workspace = true, features = ["macros", "ws", "query", "json"] }
-axum-server = { version = "0.6.0", features = ["tls-rustls"] }
 duration-str = "0.7.1"
 engine.workspace = true
 engine-config-builder.workspace = true
@@ -44,6 +47,14 @@ url = { workspace = true, features = ["serde"] }
 serde_with.workspace = true
 regex.workspace = true
 itertools.workspace = true
+
+# Lambda dependencies
+axum-aws-lambda = { version = "0.6.0", optional = true }
+tower = { version = "0.4.13", optional = true }
+lambda_http = { version = "0.9.0", optional = true }
+
+# Native dependencies
+axum-server = { version = "0.6.0", features = ["tls-rustls"] }
 
 [dev-dependencies]
 indoc = "2.0.4"

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -22,7 +22,7 @@ axum-server = { version = "0.6.0", features = ["tls-rustls"] }
 duration-str = "0.7.1"
 engine.workspace = true
 engine-config-builder.workspace = true
-engine-v2.workspace = true
+engine-v2 = { workspace = true, features = ["plan_cache"] }
 futures-util.workspace = true
 grafbase-tracing = { workspace = true, features = ["tower"] }
 gateway-core.workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.1.0-rc.12"
+version = "0.1.0-rc.13"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [features]
 default = []
-lambda = ["dep:axum-aws-lambda", "dep:tower", "dep:lambda_http", "dep:tracing-futures"]
+lambda = ["dep:axum-aws-lambda", "dep:tower", "dep:lambda_http", "dep:tracing-futures", "dep:opentelemetry-aws"]
 
 [dependencies]
 ascii = { version = "1.1.0", features = ["serde"] }
@@ -24,7 +24,7 @@ engine.workspace = true
 engine-config-builder.workspace = true
 engine-v2 = { workspace = true, features = ["plan_cache"] }
 futures-util.workspace = true
-grafbase-tracing = { workspace = true, features = ["tower"] }
+grafbase-tracing = { workspace = true, features = ["tower", "lambda"] }
 gateway-core.workspace = true
 gateway-v2 = { workspace = true, features = ["axum"] }
 graphql-composition.workspace = true
@@ -51,6 +51,7 @@ axum-aws-lambda = { version = "0.6.0", optional = true }
 tower = { version = "0.4.13", optional = true }
 lambda_http = { version = "0.9.0", optional = true }
 tracing-futures = { workspace = true, optional = true }
+opentelemetry-aws = { version = "0.10.0", optional = true }
 
 [dev-dependencies]
 indoc = "2.0.4"

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.1.0-rc.8"
+version = "0.1.0-rc.9"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -12,12 +12,13 @@ workspace = true
 
 [features]
 default = []
-lambda = ["dep:axum-aws-lambda", "dep:tower", "dep:lambda_http"]
+lambda = ["dep:axum-aws-lambda", "dep:tower", "dep:lambda_http", "dep:tracing-futures"]
 
 [dependencies]
 ascii = { version = "1.1.0", features = ["serde"] }
 async-trait = "0.1.77"
 axum = { workspace = true, features = ["macros", "ws", "query", "json"] }
+axum-server = { version = "0.6.0", features = ["tls-rustls"] }
 duration-str = "0.7.1"
 engine.workspace = true
 engine-config-builder.workspace = true
@@ -49,9 +50,7 @@ itertools.workspace = true
 axum-aws-lambda = { version = "0.6.0", optional = true }
 tower = { version = "0.4.13", optional = true }
 lambda_http = { version = "0.9.0", optional = true }
-
-# Native dependencies
-axum-server = { version = "0.6.0", features = ["tls-rustls"] }
+tracing-futures = { workspace = true, optional = true }
 
 [dev-dependencies]
 indoc = "2.0.4"

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.1.0-rc.23"
+version = "0.1.0-rc.24"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.1.0-rc.9"
+version = "0.1.0-rc.10"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.1.0-rc.20"
+version = "0.1.0-rc.21"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.1.0-rc.24"
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.1.0-rc.18"
+version = "0.1.0-rc.19"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -16,7 +16,7 @@ lambda = ["dep:axum-aws-lambda", "dep:tower", "dep:lambda_http"]
 
 [dependencies]
 ascii = { version = "1.1.0", features = ["serde"] }
-async-trait = "0.1.78"
+async-trait = "0.1.77"
 axum = { workspace = true, features = ["macros", "ws", "query", "json"] }
 duration-str = "0.7.1"
 engine.workspace = true
@@ -38,7 +38,6 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "signal", "time", "net"] }
-toml = "0.8.11"
 tower-http = { version = "0.5.2", features = ["cors"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
@@ -60,3 +59,4 @@ axum-server = { version = "0.6.0", features = ["tls-rustls"] }
 indoc = "2.0.4"
 insta.workspace = true
 temp-env = "0.3.6"
+toml = "0.8.10"

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.1.0-rc.11"
+version = "0.1.0-rc.12"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.1.0-rc.10"
+version = "0.1.0-rc.11"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.1.0-rc.21"
+version = "0.1.0-rc.22"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.1.0-rc.14"
+version = "0.1.0-rc.15"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.1.0-rc.22"
+version = "0.1.0-rc.23"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.1.0-rc.15"
+version = "0.1.0-rc.16"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.1.0-rc.13"
+version = "0.1.0-rc.14"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -28,7 +28,6 @@ gateway-core.workspace = true
 gateway-v2 = { workspace = true, features = ["axum"] }
 graphql-composition.workspace = true
 http.workspace = true
-oneshot = "0.1"
 parser-sdl = { version = "0.1.0", path = "../../../engine/crates/parser-sdl" }
 reqwest = { workspace = true, features = ["http2", "json", "rustls-tls"] }
 runtime.workspace = true
@@ -40,7 +39,6 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "signal", "time", "net"] }
 tower-http = { version = "0.5.2", features = ["cors"] }
 tracing.workspace = true
-tracing-subscriber.workspace = true
 ulid = { workspace = true, features = ["serde"] }
 url = { workspace = true, features = ["serde"] }
 serde_with.workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -12,7 +12,14 @@ workspace = true
 
 [features]
 default = []
-lambda = ["dep:axum-aws-lambda", "dep:tower", "dep:lambda_http", "dep:tracing-futures", "dep:opentelemetry-aws"]
+lambda = [
+  "dep:axum-aws-lambda",
+  "dep:tower",
+  "dep:lambda_http",
+  "dep:tracing-futures",
+  "dep:opentelemetry-aws",
+  "grafbase-tracing/lambda"
+]
 
 [dependencies]
 ascii = { version = "1.1.0", features = ["serde"] }
@@ -24,7 +31,7 @@ engine.workspace = true
 engine-config-builder.workspace = true
 engine-v2 = { workspace = true, features = ["plan_cache"] }
 futures-util.workspace = true
-grafbase-tracing = { workspace = true, features = ["tower", "lambda"] }
+grafbase-tracing = { workspace = true, features = ["tower"] }
 gateway-core.workspace = true
 gateway-v2 = { workspace = true, features = ["axum"] }
 graphql-composition.workspace = true

--- a/gateway/crates/federated-server/src/error.rs
+++ b/gateway/crates/federated-server/src/error.rs
@@ -3,12 +3,6 @@ use tokio::sync::watch::error::SendError;
 /// The Grafbase gateway error type
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// Cannot find the toml config file
-    #[error("cannot load configuration: {0}")]
-    ConfigNotFound(#[source] std::io::Error),
-    #[error("{0}")]
-    /// Toml config validation
-    TomlValidation(#[source] toml::de::Error),
     #[error("{0}")]
     /// The GraphQL schema validation
     SchemaValidationError(String),

--- a/gateway/crates/federated-server/src/lib.rs
+++ b/gateway/crates/federated-server/src/lib.rs
@@ -34,7 +34,7 @@ pub fn start<S>(
     listen_addr: Option<SocketAddr>,
     config_path: &Path,
     graph: GraphFetchMethod,
-    reload_handle: reload::Handle<FilteredLayer<S>, S>,
+    reload_handle: Option<reload::Handle<FilteredLayer<S>, S>>,
 ) -> Result<()>
 where
     S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync,
@@ -44,7 +44,7 @@ where
 
     let (otel_reload_tx, otel_reload_rx) = oneshot::channel::<Handle>();
 
-    if let Some(telemetry_config) = config.telemetry.as_ref() {
+    if let Some((telemetry_config, reload_handle)) = config.telemetry.as_ref().zip(reload_handle) {
         otel_reload(reload_handle, otel_reload_rx, telemetry_config);
     }
 

--- a/gateway/crates/federated-server/src/lib.rs
+++ b/gateway/crates/federated-server/src/lib.rs
@@ -9,13 +9,10 @@ pub use error::Error;
 pub use server::GraphFetchMethod;
 
 use std::net::SocketAddr;
-use tokio::runtime;
 
 mod config;
 mod error;
 mod server;
-
-const THREAD_NAME: &str = "grafbase-gateway";
 
 /// The crate result type.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -23,14 +20,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// Starts the self-hosted Grafbase gateway. If started with a schema path, will
 /// not connect our API for changes in the schema and if started without, we poll
 /// the schema registry every ten second for changes.
-pub fn start(listen_addr: Option<SocketAddr>, config: Config, graph: GraphFetchMethod) -> Result<()> {
-    let runtime = runtime::Builder::new_multi_thread()
-        .enable_all()
-        .thread_name(THREAD_NAME)
-        .build()
-        .map_err(|e| Error::InternalError(e.to_string()))?;
-
-    runtime.block_on(server::serve(listen_addr, config, graph))?;
+pub async fn start(listen_addr: Option<SocketAddr>, config: Config, graph: GraphFetchMethod) -> Result<()> {
+    server::serve(listen_addr, config, graph).await?;
 
     Ok(())
 }

--- a/gateway/crates/federated-server/src/lib.rs
+++ b/gateway/crates/federated-server/src/lib.rs
@@ -4,19 +4,12 @@
 
 #![deny(missing_docs)]
 
-use grafbase_tracing::otel::layer::FilteredLayer;
-use grafbase_tracing::otel::opentelemetry_sdk::runtime::Tokio;
-use std::{net::SocketAddr, thread};
-use tokio::runtime;
-use tokio::runtime::Handle;
-use tracing::log::{debug, error, warn};
-use tracing::Subscriber;
-use tracing_subscriber::registry::LookupSpan;
-use tracing_subscriber::{reload, EnvFilter};
-
 pub use crate::config::Config;
 pub use error::Error;
 pub use server::GraphFetchMethod;
+
+use std::net::SocketAddr;
+use tokio::runtime;
 
 mod config;
 mod error;
@@ -30,76 +23,14 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// Starts the self-hosted Grafbase gateway. If started with a schema path, will
 /// not connect our API for changes in the schema and if started without, we poll
 /// the schema registry every ten second for changes.
-pub fn start<S>(
-    listen_addr: Option<SocketAddr>,
-    config: Config,
-    graph: GraphFetchMethod,
-    reload_handle: Option<reload::Handle<FilteredLayer<S>, S>>,
-) -> Result<()>
-where
-    S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync,
-{
-    let (otel_reload_tx, otel_reload_rx) = oneshot::channel::<Handle>();
-
-    if let Some((telemetry_config, reload_handle)) = config.telemetry.as_ref().zip(reload_handle) {
-        otel_reload(reload_handle, otel_reload_rx, telemetry_config);
-    }
-
+pub fn start(listen_addr: Option<SocketAddr>, config: Config, graph: GraphFetchMethod) -> Result<()> {
     let runtime = runtime::Builder::new_multi_thread()
         .enable_all()
         .thread_name(THREAD_NAME)
         .build()
         .map_err(|e| Error::InternalError(e.to_string()))?;
 
-    runtime.block_on(async {
-        let _ = otel_reload_tx
-            .send(Handle::current())
-            .inspect_err(|e| error!("error sending otel reload signal: {e}"));
-
-        server::serve(listen_addr, config, graph).await
-    })?;
+    runtime.block_on(server::serve(listen_addr, config, graph))?;
 
     Ok(())
-}
-
-fn otel_reload<S>(
-    reload_handle: reload::Handle<FilteredLayer<S>, S>,
-    reload_rx: oneshot::Receiver<Handle>,
-    telemetry_config: &config::TelemetryConfig,
-) where
-    S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync,
-{
-    use tracing_subscriber::filter::FilterExt;
-
-    let otel_service_name = telemetry_config.service_name.clone();
-    let tracing_config = telemetry_config.tracing.clone();
-
-    thread::spawn(move || match reload_rx.recv() {
-        Ok(rt_handle) => {
-            debug!("reloading otel layer");
-            // new_batched will use the tokio runtime for its internals
-            rt_handle.spawn(async move {
-                // unfortunately I have to set the filters here due to: https://github.com/tokio-rs/tracing/issues/1629
-                let env_filter = EnvFilter::new(&tracing_config.filter);
-
-                // create the batched layer
-                let otel_layer =
-                    grafbase_tracing::otel::layer::new_batched::<S, Tokio>(otel_service_name, tracing_config, Tokio)
-                        .expect("should successfully build a batched otel layer for tracing");
-
-                // replace the existing layer with the new one and update its filters
-                // the explicit filters update shouldn't be required but the bug mentioned above makes it so
-                reload_handle
-                    .modify(|layer| {
-                        *layer.inner_mut() = otel_layer;
-                        // order matters, sampling goes first
-                        *layer.filter_mut() = FilterExt::boxed(env_filter);
-                    })
-                    .expect("should successfully reload otel layer");
-            });
-        }
-        Err(e) => {
-            warn!("received an error while waiting for otel reload: {e}");
-        }
-    });
 }

--- a/gateway/crates/federated-server/src/server.rs
+++ b/gateway/crates/federated-server/src/server.rs
@@ -1,3 +1,4 @@
+mod bind;
 mod cors;
 mod csrf;
 mod engine;
@@ -10,7 +11,7 @@ mod trusted_documents_client;
 
 pub use graph_fetch_method::GraphFetchMethod;
 
-use crate::config::{Config, TlsConfig};
+use crate::config::Config;
 use axum::{routing::get, Router};
 use axum_server as _;
 use gateway_v2::local_server::{WebsocketAccepter, WebsocketService};
@@ -48,64 +49,27 @@ pub(super) async fn serve(
 
     tokio::spawn(websocket_accepter.handler());
 
-    let state = ServerState::new(gateway, config.telemetry);
-
     let cors = match config.cors {
         Some(cors_config) => cors::generate(cors_config),
         None => CorsLayer::permissive(),
     };
 
-    let mut router = Router::new()
+    let router = Router::new()
         .route(path, get(engine::get).post(engine::post))
         .route_service("/ws", WebsocketService::new(websocket_sender))
         .layer(cors)
-        .layer(grafbase_tracing::tower::layer())
-        .with_state(state);
+        .layer(grafbase_tracing::tower::layer());
 
-    if config.csrf.enabled {
-        router = csrf::inject_layer(router);
-    }
-
-    bind(addr, path, router, config.tls).await?;
-
-    Ok(())
-}
-
-#[cfg(not(feature = "lambda"))]
-async fn bind(addr: SocketAddr, path: &str, router: Router, tls: Option<TlsConfig>) -> Result<(), crate::Error> {
-    let app = router.into_make_service();
-
-    match tls {
-        Some(ref tls) => {
-            tracing::info!("starting the Grafbase gateway at https://{addr}{path}");
-
-            let rustls_config = axum_server::tls_rustls::RustlsConfig::from_pem_file(&tls.certificate, &tls.key)
-                .await
-                .map_err(crate::Error::CertificateError)?;
-
-            axum_server::bind_rustls(addr, rustls_config)
-                .serve(app)
-                .await
-                .map_err(crate::Error::Server)?
-        }
-        None => {
-            tracing::info!("starting the Grafbase gateway in http://{addr}{path}");
-            axum_server::bind(addr).serve(app).await.map_err(crate::Error::Server)?
-        }
-    }
-
-    Ok(())
-}
-
-#[cfg(feature = "lambda")]
-async fn bind(_: SocketAddr, path: &str, router: Router, _: Option<TlsConfig>) -> Result<(), crate::Error> {
-    let app = tower::ServiceBuilder::new()
-        .layer(axum_aws_lambda::LambdaLayer::default())
-        .service(router);
-
-    tracing::info!("starting the Grafbase Lambda gateway in {path}");
-
-    lambda_http::run(app).await.expect("unable to start lambda http server");
+    bind::bind(bind::BindConfig {
+        addr,
+        path,
+        router,
+        gateway,
+        tls: config.tls,
+        telemetry: config.telemetry,
+        csrf: config.csrf.enabled,
+    })
+    .await?;
 
     Ok(())
 }

--- a/gateway/crates/federated-server/src/server.rs
+++ b/gateway/crates/federated-server/src/server.rs
@@ -48,7 +48,7 @@ pub(super) async fn serve(
 
     tokio::spawn(websocket_accepter.handler());
 
-    let state = ServerState { gateway };
+    let state = ServerState::new(gateway, config.telemetry);
 
     let cors = match config.cors {
         Some(cors_config) => cors::generate(cors_config),

--- a/gateway/crates/federated-server/src/server.rs
+++ b/gateway/crates/federated-server/src/server.rs
@@ -3,6 +3,7 @@ mod csrf;
 mod engine;
 mod gateway;
 mod graph_fetch_method;
+#[cfg(not(feature = "lambda"))]
 mod graph_updater;
 mod state;
 mod trusted_documents_client;

--- a/gateway/crates/federated-server/src/server/bind.rs
+++ b/gateway/crates/federated-server/src/server/bind.rs
@@ -90,7 +90,7 @@ pub(super) async fn bind(
             let filter = EnvFilter::new(&config.tracing.filter);
 
             let provider =
-                otel::layer::new_provider(&config.service_name, config.tracing, XrayIdGenerator::default(), Tokio)
+                otel::provider::create(&config.service_name, config.tracing, XrayIdGenerator::default(), Tokio)
                     .expect("error creating otel provider");
 
             let tracer = provider.tracer("lambda-otel");

--- a/gateway/crates/federated-server/src/server/bind.rs
+++ b/gateway/crates/federated-server/src/server/bind.rs
@@ -1,0 +1,122 @@
+use std::net::SocketAddr;
+
+use axum::Router;
+
+use crate::config::{TelemetryConfig, TlsConfig};
+
+use super::{gateway::GatewayWatcher, state::ServerState};
+
+pub(super) struct BindConfig<'a> {
+    #[allow(dead_code)] // for non-lambda
+    pub(super) addr: SocketAddr,
+    pub(super) path: &'a str,
+    pub(super) router: Router<ServerState>,
+    pub(super) gateway: GatewayWatcher,
+    #[allow(dead_code)] // for non-lambda
+    pub(super) tls: Option<TlsConfig>,
+    #[allow(dead_code)] // for lambda
+    pub(super) telemetry: Option<TelemetryConfig>,
+    pub(super) csrf: bool,
+}
+
+#[cfg(not(feature = "lambda"))]
+pub(super) async fn bind(
+    BindConfig {
+        addr,
+        path,
+        router,
+        gateway,
+        tls,
+        telemetry: _,
+        csrf,
+    }: BindConfig<'_>,
+) -> Result<(), crate::Error> {
+    let state = ServerState::new(gateway, None);
+    let mut router = router.with_state(state);
+
+    if csrf {
+        router = super::csrf::inject_layer(router);
+    }
+
+    let app = router.into_make_service();
+
+    match tls {
+        Some(ref tls) => {
+            tracing::info!("starting the Grafbase gateway at https://{addr}{path}");
+
+            let rustls_config = axum_server::tls_rustls::RustlsConfig::from_pem_file(&tls.certificate, &tls.key)
+                .await
+                .map_err(crate::Error::CertificateError)?;
+
+            axum_server::bind_rustls(addr, rustls_config)
+                .serve(app)
+                .await
+                .map_err(crate::Error::Server)?
+        }
+        None => {
+            tracing::info!("starting the Grafbase gateway in http://{addr}{path}");
+            axum_server::bind(addr).serve(app).await.map_err(crate::Error::Server)?
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "lambda")]
+pub(super) async fn bind(
+    BindConfig {
+        addr: _,
+        path,
+        router,
+        gateway,
+        tls: _,
+        telemetry,
+        csrf,
+    }: BindConfig<'_>,
+) -> Result<(), crate::Error> {
+    use grafbase_tracing::otel::opentelemetry::trace::TracerProvider;
+    use grafbase_tracing::otel::tracing_subscriber::layer::SubscriberExt;
+    use grafbase_tracing::otel::tracing_subscriber::EnvFilter;
+    use grafbase_tracing::otel::{self, opentelemetry_sdk::runtime::Tokio};
+    use grafbase_tracing::otel::{tracing_opentelemetry, tracing_subscriber};
+    use tracing_futures::WithSubscriber;
+
+    let (provider, subscriber) = match telemetry {
+        Some(config) => {
+            let provider = otel::layer::new_provider(&config.service_name, &config.tracing, Tokio).unwrap();
+
+            let tracer = provider.tracer("lambda-otel");
+
+            let subscriber = tracing_subscriber::registry()
+                .with(tracing_opentelemetry::layer().with_tracer(tracer))
+                .with(tracing_subscriber::fmt::layer().with_ansi(false))
+                .with(EnvFilter::new(&config.tracing.filter));
+
+            (Some(provider), Some(subscriber))
+        }
+        None => (None, None),
+    };
+
+    let state = ServerState::new(gateway, provider);
+    let mut router = router.with_state(state);
+
+    if csrf {
+        router = super::csrf::inject_layer(router);
+    }
+
+    let app = tower::ServiceBuilder::new()
+        .layer(axum_aws_lambda::LambdaLayer::default())
+        .service(router);
+
+    tracing::info!("starting the Grafbase Lambda gateway in {path}");
+
+    match subscriber {
+        Some(subscriber) => lambda_http::run(app)
+            .with_subscriber(subscriber)
+            .await
+            .expect("unable to start lambda http server"),
+        None => lambda_http::run(app).await.expect("unable to start lambda http server"),
+    }
+
+    Ok(())
+}

--- a/gateway/crates/federated-server/src/server/engine.rs
+++ b/gateway/crates/federated-server/src/server/engine.rs
@@ -62,7 +62,7 @@ async fn traced(
 
     let subscriber = tracing_subscriber::registry()
         .with(tracing_opentelemetry::layer().with_tracer(tracer))
-        .with(tracing_subscriber::fmt::layer().json());
+        .with(tracing_subscriber::fmt::layer().with_ansi(false));
 
     let response = handle(headers, request, gateway).with_subscriber(subscriber).await;
 

--- a/gateway/crates/federated-server/src/server/engine.rs
+++ b/gateway/crates/federated-server/src/server/engine.rs
@@ -1,5 +1,3 @@
-use crate::config::TelemetryConfig;
-
 use super::{gateway::GatewayWatcher, ServerState};
 use axum::{
     body::Body,
@@ -14,6 +12,7 @@ use futures_util::{
 };
 use gateway_core::{encode_stream_response, RequestContext};
 use gateway_v2::streaming::StreamingFormat;
+use grafbase_tracing::otel::opentelemetry_sdk::trace::TracerProvider;
 use http::{header, HeaderMap};
 use response::BatchResponse;
 use serde_json::json;
@@ -29,7 +28,7 @@ pub(super) async fn get(
     State(state): State<ServerState>,
 ) -> impl IntoResponse {
     let request = engine::BatchRequest::Single(request.into());
-    traced(headers, request, state.gateway().clone(), state.telemetry_config()).await
+    traced(headers, request, state.gateway().clone(), state.tracer_provider()).await
 }
 
 pub(super) async fn post(
@@ -37,60 +36,26 @@ pub(super) async fn post(
     headers: HeaderMap,
     Json(request): Json<engine::BatchRequest>,
 ) -> impl IntoResponse {
-    traced(headers, request, state.gateway().clone(), state.telemetry_config()).await
+    traced(headers, request, state.gateway().clone(), state.tracer_provider()).await
 }
 
-#[cfg(feature = "lambda")]
 async fn traced(
     headers: HeaderMap,
     request: BatchRequest,
     gateway: GatewayWatcher,
-    telemetry_config: Option<&TelemetryConfig>,
+    provider: Option<&TracerProvider>,
 ) -> http::Response<Body> {
-    // lambda has no global tracing, so we initialize it here and force flush before responding
+    let response = handle(headers, request, gateway).await;
 
-    use grafbase_tracing::otel::opentelemetry::trace::TracerProvider;
-    use grafbase_tracing::otel::tracing_subscriber::layer::SubscriberExt;
-    use grafbase_tracing::otel::tracing_subscriber::EnvFilter;
-    use grafbase_tracing::otel::{self, opentelemetry_sdk::runtime::Tokio};
-    use grafbase_tracing::otel::{tracing_opentelemetry, tracing_subscriber};
-    use tracing_futures::WithSubscriber;
-
-    match telemetry_config {
-        Some(config) => {
-            let provider = otel::layer::new_provider(&config.service_name, &config.tracing, Tokio).unwrap();
-
-            let tracer = provider.tracer("lambda-otel");
-
-            let subscriber = tracing_subscriber::registry()
-                .with(tracing_opentelemetry::layer().with_tracer(tracer))
-                .with(tracing_subscriber::fmt::layer().with_ansi(false))
-                .with(EnvFilter::new(&config.tracing.filter));
-
-            let response = handle(headers, request, gateway).with_subscriber(subscriber).await;
-
-            for result in provider.force_flush() {
-                if let Err(e) = result {
-                    println!("failed to flush traces: {e}");
-                }
+    if let Some(provider) = provider {
+        for result in provider.force_flush() {
+            if let Err(e) = result {
+                println!("error flushing events: {e}");
             }
-
-            response
         }
-        None => handle(headers, request, gateway).await,
     }
-}
 
-#[cfg(not(feature = "lambda"))]
-async fn traced(
-    headers: HeaderMap,
-    request: BatchRequest,
-    gateway: GatewayWatcher,
-    _: Option<&TelemetryConfig>,
-) -> http::Response<Body> {
-    // we do global tracing on non-lambda context.
-
-    handle(headers, request, gateway).await
+    response
 }
 
 async fn handle(headers: HeaderMap, request: BatchRequest, gateway: GatewayWatcher) -> http::Response<Body> {

--- a/gateway/crates/federated-server/src/server/gateway.rs
+++ b/gateway/crates/federated-server/src/server/gateway.rs
@@ -13,6 +13,7 @@ use tokio::sync::watch;
 use crate::config::{AuthenticationConfig, HeaderValue, OperationLimitsConfig, SubgraphConfig, TrustedDocumentsConfig};
 
 /// Send half of the gateway watch channel
+#[cfg(not(feature = "lambda"))]
 pub(crate) type GatewaySender = watch::Sender<Option<Arc<Gateway>>>;
 
 /// Receive half of the gateway watch channel.

--- a/gateway/crates/federated-server/src/server/state.rs
+++ b/gateway/crates/federated-server/src/server/state.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
-use crate::config::TelemetryConfig;
+use grafbase_tracing::otel::opentelemetry_sdk::trace::TracerProvider;
 
 use super::gateway::GatewayWatcher;
 
 struct ServerStateInner {
     gateway: GatewayWatcher,
-    telemetry_config: Option<TelemetryConfig>,
+    tracer_provider: Option<TracerProvider>,
 }
 
 #[derive(Clone)]
@@ -15,11 +15,11 @@ pub(super) struct ServerState {
 }
 
 impl ServerState {
-    pub(super) fn new(gateway: GatewayWatcher, telemetry_config: Option<TelemetryConfig>) -> Self {
+    pub(super) fn new(gateway: GatewayWatcher, tracer_provider: Option<TracerProvider>) -> Self {
         Self {
             inner: Arc::new(ServerStateInner {
                 gateway,
-                telemetry_config,
+                tracer_provider,
             }),
         }
     }
@@ -28,7 +28,7 @@ impl ServerState {
         &self.inner.gateway
     }
 
-    pub(crate) fn telemetry_config(&self) -> Option<&TelemetryConfig> {
-        self.inner.telemetry_config.as_ref()
+    pub(crate) fn tracer_provider(&self) -> Option<&TracerProvider> {
+        self.inner.tracer_provider.as_ref()
     }
 }

--- a/gateway/crates/federated-server/src/server/state.rs
+++ b/gateway/crates/federated-server/src/server/state.rs
@@ -1,6 +1,34 @@
+use std::sync::Arc;
+
+use crate::config::TelemetryConfig;
+
 use super::gateway::GatewayWatcher;
+
+struct ServerStateInner {
+    gateway: GatewayWatcher,
+    telemetry_config: Option<TelemetryConfig>,
+}
 
 #[derive(Clone)]
 pub(super) struct ServerState {
-    pub gateway: GatewayWatcher,
+    inner: Arc<ServerStateInner>,
+}
+
+impl ServerState {
+    pub(super) fn new(gateway: GatewayWatcher, telemetry_config: Option<TelemetryConfig>) -> Self {
+        Self {
+            inner: Arc::new(ServerStateInner {
+                gateway,
+                telemetry_config,
+            }),
+        }
+    }
+
+    pub(crate) fn gateway(&self) -> &GatewayWatcher {
+        &self.inner.gateway
+    }
+
+    pub(crate) fn telemetry_config(&self) -> Option<&TelemetryConfig> {
+        self.inner.telemetry_config.as_ref()
+    }
 }

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace = true
 repository.workspace = true
 
 [features]
-lambda = ["federated-server/lambda", "tracing-subscriber/json"]
+lambda = ["federated-server/lambda", "tracing-subscriber/json", "opentelemetry-aws"]
 
 [dependencies]
 anyhow = { version = "1.0.81", default-features = false }
@@ -18,8 +18,8 @@ federated-server.workspace = true
 grafbase-tracing = { workspace = true, features = ["otlp"] }
 graph-ref.workspace = true
 mimalloc = "0.1.39"
+opentelemetry-aws = { version = "0.10.0", optional = true }
 rustls = { workspace = true, features = ["ring"] }
-tracing-core = "0.1.32"
 tracing-subscriber.workspace = true
 
 [lints]

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.1.0-rc.12"
+version = "0.1.0-rc.13"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace = true
 repository.workspace = true
 
 [features]
-lambda = ["federated-server/lambda", "tracing-subscriber/json", "opentelemetry-aws", "opentelemetry-stdout"]
+lambda = ["federated-server/lambda", "tracing-subscriber/json", "opentelemetry-aws"]
 
 [dependencies]
 anyhow = { version = "1.0.81", default-features = false }
@@ -19,7 +19,6 @@ grafbase-tracing = { workspace = true, features = ["otlp"] }
 graph-ref.workspace = true
 mimalloc = "0.1.39"
 opentelemetry-aws = { version = "0.10.0", optional = true }
-opentelemetry-stdout = { version = "0.3.0", features = ["trace"], optional = true }
 rustls = { workspace = true, features = ["ring"] }
 toml = "0.8.12"
 tracing-subscriber.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.1.0-rc.18"
+version = "0.1.0-rc.19"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.1.0-rc.14"
+version = "0.1.0-rc.15"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.1.0-rc.24"
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.1.0-rc.19"
+version = "0.1.0-rc.20"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.1.0-rc.10"
+version = "0.1.0-rc.11"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.1.0-rc.11"
+version = "0.1.0-rc.12"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.1.0-rc.13"
+version = "0.1.0-rc.14"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true
@@ -8,7 +8,7 @@ keywords.workspace = true
 repository.workspace = true
 
 [features]
-lambda = ["federated-server/lambda", "tracing-subscriber/json", "opentelemetry-aws"]
+lambda = ["federated-server/lambda", "tracing-subscriber/json", "opentelemetry-aws", "opentelemetry-stdout"]
 
 [dependencies]
 anyhow = { version = "1.0.81", default-features = false }
@@ -19,6 +19,7 @@ grafbase-tracing = { workspace = true, features = ["otlp"] }
 graph-ref.workspace = true
 mimalloc = "0.1.39"
 opentelemetry-aws = { version = "0.10.0", optional = true }
+opentelemetry-stdout = { version = "0.3.0", features = ["trace"], optional = true }
 rustls = { workspace = true, features = ["ring"] }
 tracing-subscriber.workspace = true
 

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.1.0-rc.23"
+version = "0.1.0-rc.24"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -20,6 +20,7 @@ graph-ref.workspace = true
 mimalloc = "0.1.39"
 opentelemetry-aws = { version = "0.10.0", optional = true }
 rustls = { workspace = true, features = ["ring"] }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 toml = "0.8.12"
 tracing-subscriber.workspace = true
 
@@ -32,7 +33,6 @@ futures-util.workspace = true
 indoc = "2.0.4"
 serde_json.workspace = true
 tempfile = "3.10.1"
-tokio.workspace = true
 wiremock.workspace = true
 insta = { workspace = true, features = ["json", "redactions", "yaml"] }
 fslock = "0.2.1"

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -17,6 +17,7 @@ clap = { version = "4", default-features = false, features = ["std", "cargo", "w
 federated-server.workspace = true
 grafbase-tracing = { workspace = true, features = ["otlp"] }
 graph-ref.workspace = true
+mimalloc = "0.1.39"
 rustls = { workspace = true, features = ["ring"] }
 tracing-subscriber.workspace = true
 

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.1.0-rc.9"
+version = "0.1.0-rc.10"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.1.0-rc.16"
+version = "0.1.0-rc.17"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { version = "1.0.81", default-features = false }
 ascii = { version = "1.1.0", default-features = false }
 clap = { version = "4", default-features = false, features = ["std", "cargo", "wrap_help", "derive", "env"] }
 federated-server.workspace = true
-grafbase-tracing = { workspace = true, features = ["otlp"] }
+grafbase-tracing = { workspace = true, features = ["otlp", "lambda"] }
 graph-ref.workspace = true
 mimalloc = "0.1.39"
 rustls = { workspace = true, features = ["ring"] }

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -21,6 +21,7 @@ mimalloc = "0.1.39"
 opentelemetry-aws = { version = "0.10.0", optional = true }
 opentelemetry-stdout = { version = "0.3.0", features = ["trace"], optional = true }
 rustls = { workspace = true, features = ["ring"] }
+toml = "0.8.12"
 tracing-subscriber.workspace = true
 
 [lints]

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace = true
 repository.workspace = true
 
 [features]
-lambda = ["federated-server/lambda"]
+lambda = ["federated-server/lambda", "tracing-subscriber/json"]
 
 [dependencies]
 anyhow = { version = "1.0.81", default-features = false }
@@ -19,6 +19,7 @@ grafbase-tracing = { workspace = true, features = ["otlp"] }
 graph-ref.workspace = true
 mimalloc = "0.1.39"
 rustls = { workspace = true, features = ["ring"] }
+tracing-core = "0.1.32"
 tracing-subscriber.workspace = true
 
 [lints]

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -8,14 +8,14 @@ keywords.workspace = true
 repository.workspace = true
 
 [features]
-lambda = ["federated-server/lambda", "tracing-subscriber/json"]
+lambda = ["federated-server/lambda", "tracing-subscriber/json", "grafbase-tracing/lambda"]
 
 [dependencies]
 anyhow = { version = "1.0.81", default-features = false }
 ascii = { version = "1.1.0", default-features = false }
 clap = { version = "4", default-features = false, features = ["std", "cargo", "wrap_help", "derive", "env"] }
 federated-server.workspace = true
-grafbase-tracing = { workspace = true, features = ["otlp", "lambda"] }
+grafbase-tracing = { workspace = true, features = ["otlp"] }
 graph-ref.workspace = true
 mimalloc = "0.1.39"
 rustls = { workspace = true, features = ["ring"] }
@@ -27,16 +27,16 @@ tracing-subscriber.workspace = true
 workspace = true
 
 [dev-dependencies]
+ctor.workspace = true
 duct = "0.13.7"
+fslock = "0.2.1"
 futures-util.workspace = true
+grafbase-graphql-introspection.workspace = true
+http.workspace = true
 indoc = "2.0.4"
+insta = { workspace = true, features = ["json", "redactions", "yaml"] }
+reqwest.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 tempfile = "3.10.1"
 wiremock.workspace = true
-insta = { workspace = true, features = ["json", "redactions", "yaml"] }
-fslock = "0.2.1"
-reqwest.workspace = true
-http.workspace = true
-serde.workspace = true
-grafbase-graphql-introspection.workspace = true
-ctor.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace = true
 repository.workspace = true
 
 [features]
-lambda = ["federated-server/lambda", "tracing-subscriber/json", "opentelemetry-aws"]
+lambda = ["federated-server/lambda", "tracing-subscriber/json"]
 
 [dependencies]
 anyhow = { version = "1.0.81", default-features = false }
@@ -18,7 +18,6 @@ federated-server.workspace = true
 grafbase-tracing = { workspace = true, features = ["otlp"] }
 graph-ref.workspace = true
 mimalloc = "0.1.39"
-opentelemetry-aws = { version = "0.10.0", optional = true }
 rustls = { workspace = true, features = ["ring"] }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 toml = "0.8.12"

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -7,7 +7,8 @@ homepage.workspace = true
 keywords.workspace = true
 repository.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+lambda = ["federated-server/lambda"]
 
 [dependencies]
 anyhow = "1.0.81"

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.1.0-rc.20"
+version = "0.1.0-rc.21"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -11,9 +11,9 @@ repository.workspace = true
 lambda = ["federated-server/lambda"]
 
 [dependencies]
-anyhow = "1.0.81"
-ascii = "1.1.0"
-clap = { version = "4", features = ["cargo", "wrap_help", "derive", "env"] }
+anyhow = { version = "1.0.81", default-features = false }
+ascii = { version = "1.1.0", default-features = false }
+clap = { version = "4", default-features = false, features = ["std", "cargo", "wrap_help", "derive", "env"] }
 federated-server.workspace = true
 grafbase-tracing = { workspace = true, features = ["otlp"] }
 graph-ref.workspace = true
@@ -24,17 +24,16 @@ tracing-subscriber.workspace = true
 workspace = true
 
 [dev-dependencies]
-ctor.workspace = true
 duct = "0.13.7"
-fslock = "0.2.1"
 futures-util.workspace = true
-grafbase-graphql-introspection.workspace = true
-http.workspace = true
 indoc = "2.0.4"
-insta = { workspace = true, features = ["json", "redactions", "yaml"] }
-reqwest.workspace = true
 serde_json.workspace = true
-serde.workspace = true
 tempfile = "3.10.1"
 tokio.workspace = true
 wiremock.workspace = true
+insta = { workspace = true, features = ["json", "redactions", "yaml"] }
+fslock = "0.2.1"
+reqwest.workspace = true
+http.workspace = true
+serde.workspace = true
+grafbase-graphql-introspection.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.1.0-rc.22"
+version = "0.1.0-rc.23"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.1.0-rc.21"
+version = "0.1.0-rc.22"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.1.0-rc.8"
+version = "0.1.0-rc.9"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true
@@ -37,3 +37,4 @@ reqwest.workspace = true
 http.workspace = true
 serde.workspace = true
 grafbase-graphql-introspection.workspace = true
+ctor.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.1.0-rc.17"
+version = "0.1.0-rc.18"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.1.0-rc.15"
+version = "0.1.0-rc.16"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/src/args.rs
+++ b/gateway/crates/gateway-binary/src/args.rs
@@ -59,6 +59,7 @@ impl Args {
                     federated_schema: federated_graph,
                 })
             }
+            #[cfg(not(feature = "lambda"))]
             (Some(graph_ref), None) => Ok(GraphFetchMethod::FromApi {
                 access_token: self
                     .grafbase_access_token
@@ -67,6 +68,12 @@ impl Args {
                 graph_name: graph_ref.graph().to_string(),
                 branch: graph_ref.branch().map(ToString::to_string),
             }),
+            #[cfg(feature = "lambda")]
+            (Some(_), None) => {
+                let error = anyhow!("Hybrid mode is not available for lambda deployments, please provide the full GraphQL schema as a file.");
+
+                Err(error)
+            }
             _ => unreachable!(),
         }
     }

--- a/gateway/crates/gateway-binary/src/args.rs
+++ b/gateway/crates/gateway-binary/src/args.rs
@@ -37,11 +37,11 @@ pub struct Args {
     #[arg(env = "GRAFBASE_ACCESS_TOKEN")]
     pub grafbase_access_token: Option<AsciiString>,
     /// Path to the TOML configuration file
-    #[arg(long, short)]
+    #[arg(long, short, env = "GRAFBASE_CONFIG_PATH")]
     pub config: PathBuf,
     /// Path to graph SDL. If provided, the graph will be static and no connection is made
     /// to the Grafbase API.
-    #[arg(long, short)]
+    #[arg(long, short, env = "GRAFBASE_SCHEMA_PATH")]
     pub schema: Option<PathBuf>,
     /// Set the tracing level
     #[arg(short, long, default_value_t = 0)]

--- a/gateway/crates/gateway-binary/src/main.rs
+++ b/gateway/crates/gateway-binary/src/main.rs
@@ -2,7 +2,11 @@
 
 use args::Args;
 use clap::Parser;
+use mimalloc::MiMalloc;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 mod args;
 

--- a/gateway/crates/gateway-binary/src/main.rs
+++ b/gateway/crates/gateway-binary/src/main.rs
@@ -2,12 +2,8 @@
 
 use args::Args;
 use clap::Parser;
-use grafbase_tracing::otel::layer::BoxedLayer;
 use mimalloc::MiMalloc;
-use tracing_core::Subscriber;
-use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::Layer;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter};
 
 #[global_allocator]
@@ -23,11 +19,19 @@ fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     let filter = EnvFilter::builder().parse_lossy(args.log_filter());
+
+    start_server(filter, args)?;
+
+    Ok(())
+}
+
+#[cfg(not(feature = "lambda"))]
+fn start_server(filter: EnvFilter, args: Args) -> Result<(), anyhow::Error> {
     let (otel_layer, reload_handle) = grafbase_tracing::otel::layer::new_noop();
 
     tracing_subscriber::registry()
         .with(Some(otel_layer))
-        .with(log_format_layer())
+        .with(tracing_subscriber::fmt::layer())
         .with(filter)
         .init();
 
@@ -36,18 +40,22 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg(not(feature = "lambda"))]
-fn log_format_layer<S>() -> BoxedLayer<S>
-where
-    S: Subscriber + for<'a> LookupSpan<'a>,
-{
-    tracing_subscriber::fmt::layer().boxed()
-}
-
 #[cfg(feature = "lambda")]
-fn log_format_layer<S>() -> BoxedLayer<S>
-where
-    S: Subscriber + for<'a> LookupSpan<'a>,
-{
-    tracing_subscriber::fmt::layer().json().boxed()
+fn start_server(filter: EnvFilter, args: Args) -> Result<(), anyhow::Error> {
+    use grafbase_tracing::otel::opentelemetry::global;
+    use opentelemetry_aws::trace::XrayPropagator;
+
+    global::set_text_map_propagator(XrayPropagator::default());
+
+    let (otel_layer, reload_handle) = grafbase_tracing::otel::layer::new_noop();
+
+    tracing_subscriber::registry()
+        .with(Some(otel_layer))
+        .with(tracing_subscriber::fmt::layer().json())
+        .with(filter)
+        .init();
+
+    federated_server::start(args.listen_address, &args.config, args.fetch_method()?, reload_handle)?;
+
+    Ok(())
 }

--- a/gateway/crates/gateway-binary/src/main.rs
+++ b/gateway/crates/gateway-binary/src/main.rs
@@ -31,28 +31,38 @@ fn main() -> anyhow::Result<()> {
 }
 
 #[cfg(not(feature = "lambda"))]
-fn start_server(filter: EnvFilter, args: Args, config: Config) -> Result<(), anyhow::Error> {
-    let (otel_layer, reload_handle) = grafbase_tracing::otel::layer::new_noop();
+fn start_server(filter: EnvFilter, args: Args, mut config: Config) -> Result<(), anyhow::Error> {
+    // let (otel_layer, reload_handle) = grafbase_tracing::otel::layer::new_noop();
+
+    use grafbase_tracing::otel::{layer, opentelemetry_sdk::runtime::Tokio};
+
+    let (otel_layer, filter) = match config.telemetry.take() {
+        Some(config) => {
+            let env_filter = EnvFilter::new(&config.tracing.filter);
+            let otel_layer = layer::new_batched(&config.service_name, config.tracing, Tokio)?;
+
+            (Some(otel_layer), env_filter)
+        }
+        None => (None, filter),
+    };
 
     tracing_subscriber::registry()
-        .with(Some(otel_layer))
+        .with(otel_layer)
         .with(tracing_subscriber::fmt::layer())
         .with(filter)
         .init();
 
-    federated_server::start(args.listen_address, config, args.fetch_method()?, Some(reload_handle))?;
+    federated_server::start(args.listen_address, config, args.fetch_method()?)?;
 
     Ok(())
 }
 
 #[cfg(feature = "lambda")]
 fn start_server(filter: EnvFilter, args: Args, config: Config) -> Result<(), anyhow::Error> {
-    use grafbase_tracing::otel::layer::FilteredLayer;
     use grafbase_tracing::otel::opentelemetry::global;
     use grafbase_tracing::otel::opentelemetry::trace::TracerProvider as _;
     use grafbase_tracing::otel::opentelemetry_sdk::trace::TracerProvider;
     use opentelemetry_aws::trace::XrayPropagator;
-    use tracing_subscriber::{reload, Registry};
 
     let filter = config
         .telemetry
@@ -88,12 +98,7 @@ fn start_server(filter: EnvFilter, args: Args, config: Config) -> Result<(), any
 
     tracing_subscriber::registry().with(otel_layer).with(filter).init();
 
-    federated_server::start(
-        args.listen_address,
-        config,
-        args.fetch_method()?,
-        None::<reload::Handle<FilteredLayer<Registry>, Registry>>,
-    )?;
+    federated_server::start(args.listen_address, config, args.fetch_method()?)?;
 
     Ok(())
 }

--- a/gateway/crates/gateway-binary/src/main.rs
+++ b/gateway/crates/gateway-binary/src/main.rs
@@ -51,7 +51,7 @@ fn start_server(filter: EnvFilter, args: Args) -> Result<(), anyhow::Error> {
 
     tracing_subscriber::registry()
         .with(Some(otel_layer))
-        .with(tracing_subscriber::fmt::layer().json())
+        .with(tracing_subscriber::fmt::layer().with_ansi(false))
         .with(filter)
         .init();
 

--- a/gateway/crates/gateway-binary/src/main.rs
+++ b/gateway/crates/gateway-binary/src/main.rs
@@ -32,8 +32,6 @@ fn main() -> anyhow::Result<()> {
 
 #[cfg(not(feature = "lambda"))]
 fn start_server(filter: EnvFilter, args: Args, mut config: Config) -> Result<(), anyhow::Error> {
-    // let (otel_layer, reload_handle) = grafbase_tracing::otel::layer::new_noop();
-
     use grafbase_tracing::otel::{layer, opentelemetry_sdk::runtime::Tokio};
 
     let (otel_layer, filter) = match config.telemetry.take() {
@@ -58,42 +56,22 @@ fn start_server(filter: EnvFilter, args: Args, mut config: Config) -> Result<(),
 }
 
 #[cfg(feature = "lambda")]
-fn start_server(filter: EnvFilter, args: Args, config: Config) -> Result<(), anyhow::Error> {
+fn start_server(filter: EnvFilter, args: Args, mut config: Config) -> Result<(), anyhow::Error> {
+    use grafbase_tracing::otel::layer;
     use grafbase_tracing::otel::opentelemetry::global;
-    use grafbase_tracing::otel::opentelemetry::trace::TracerProvider as _;
-    use grafbase_tracing::otel::opentelemetry_sdk::trace::TracerProvider;
+    use grafbase_tracing::otel::opentelemetry_sdk::runtime::Tokio;
     use opentelemetry_aws::trace::XrayPropagator;
 
     global::set_text_map_propagator(XrayPropagator::default());
 
-    let filter = config
-        .telemetry
-        .as_ref()
-        .map(|config| EnvFilter::new(&config.tracing.filter))
-        .unwrap_or(filter);
+    let (otel_layer, filter) = match config.telemetry.take() {
+        Some(config) => {
+            let env_filter = EnvFilter::new(&config.tracing.filter);
+            let otel_layer = layer::new_batched(&config.service_name, config.tracing, Tokio)?;
 
-    let otel_layer = match config
-        .telemetry
-        .as_ref()
-        .and_then(|config| config.tracing.exporters.stdout.as_ref())
-    {
-        Some(stdout_config) if stdout_config.enabled => {
-            let otel_service_name = config
-                .telemetry
-                .as_ref()
-                .map(|config| config.service_name.as_str())
-                .unwrap_or("grafbase-gateway");
-
-            let provider = TracerProvider::builder()
-                .with_simple_exporter(opentelemetry_stdout::SpanExporter::default())
-                .build();
-
-            let tracer = provider.tracer(otel_service_name.to_string());
-            let otel_layer = grafbase_tracing::otel::tracing_opentelemetry::layer().with_tracer(tracer);
-
-            Some(otel_layer)
+            (Some(otel_layer), env_filter)
         }
-        _ => None,
+        None => (None, filter),
     };
 
     tracing_subscriber::registry()

--- a/gateway/crates/gateway-binary/src/main.rs
+++ b/gateway/crates/gateway-binary/src/main.rs
@@ -35,27 +35,46 @@ fn start_server(filter: EnvFilter, args: Args) -> Result<(), anyhow::Error> {
         .with(filter)
         .init();
 
-    federated_server::start(args.listen_address, &args.config, args.fetch_method()?, reload_handle)?;
+    federated_server::start(
+        args.listen_address,
+        &args.config,
+        args.fetch_method()?,
+        Some(reload_handle),
+    )?;
 
     Ok(())
 }
 
 #[cfg(feature = "lambda")]
 fn start_server(filter: EnvFilter, args: Args) -> Result<(), anyhow::Error> {
+    use grafbase_tracing::otel::layer::FilteredLayer;
     use grafbase_tracing::otel::opentelemetry::global;
+    use grafbase_tracing::otel::opentelemetry::trace::TracerProvider as _;
+    use grafbase_tracing::otel::opentelemetry_sdk::trace::TracerProvider;
     use opentelemetry_aws::trace::XrayPropagator;
+    use tracing_subscriber::{reload, Registry};
 
     global::set_text_map_propagator(XrayPropagator::default());
 
-    let (otel_layer, reload_handle) = grafbase_tracing::otel::layer::new_noop();
+    let provider = TracerProvider::builder()
+        .with_simple_exporter(opentelemetry_stdout::SpanExporter::default())
+        .build();
+
+    let tracer = provider.tracer("grafbase-gateway");
+
+    let otel_layer = grafbase_tracing::otel::tracing_opentelemetry::layer().with_tracer(tracer);
 
     tracing_subscriber::registry()
         .with(Some(otel_layer))
-        .with(tracing_subscriber::fmt::layer().with_ansi(false))
         .with(filter)
         .init();
 
-    federated_server::start(args.listen_address, &args.config, args.fetch_method()?, reload_handle)?;
+    federated_server::start(
+        args.listen_address,
+        &args.config,
+        args.fetch_method()?,
+        None::<reload::Handle<FilteredLayer<Registry>, Registry>>,
+    )?;
 
     Ok(())
 }

--- a/gateway/crates/gateway-binary/tests/integration_tests.rs
+++ b/gateway/crates/gateway-binary/tests/integration_tests.rs
@@ -429,6 +429,32 @@ fn static_schema() {
 }
 
 #[test]
+fn with_otel() {
+    let config = indoc! {r#"
+        [telemetry]
+        service_name = "meow"
+
+        [telemetry.tracing.exporters.stdout]
+        enabled = true
+    "#};
+
+    let schema = load_schema("big");
+
+    let query = indoc! {r#"
+        query Me {
+          me {
+            id
+          }
+        }
+    "#};
+
+    with_static_server(config, &schema, None, None, |client| async move {
+        let result: serde_json::Value = client.gql(query).send().await;
+        serde_json::to_string_pretty(&result).unwrap();
+    })
+}
+
+#[test]
 fn introspect_enabled() {
     let config = indoc! {r#"
         [graph]


### PR DESCRIPTION
Here's the lambda version of the self-hosted gateway. Some differences compared to the non-lambda version:

- traces get propagated to xray standard
- traces get flushed before responding (we can't do anything about it for now)
- lambda doesn't let you to define cli arguments, so the schema file and config file locations need to be env vars
- cutting down the binary size with certain tricks: feature flags, lto and optimizing for size instead of runtime speed

Closes: GB-6194