### PR TITLE
feat: add argument support to the SDK

### DIFF
--- a/packages/grafbase-sdk/src/field.ts
+++ b/packages/grafbase-sdk/src/field.ts
@@ -1,4 +1,6 @@
 import { FieldShape as MongoFieldShape } from './connector/mongodb/model'
+import { QueryArgument } from './query'
+import { AuthDefinition } from './typedefs/auth'
 import { DeprecatedDefinition } from './typedefs/deprecated'
 import { InaccessibleDefinition } from './typedefs/inaccessible'
 import { JoinDefinition } from './typedefs/join'
@@ -17,6 +19,7 @@ type FieldShape =
   | OverrideDefinition
   | ProvidesDefinition
   | DeprecatedDefinition
+  | AuthDefinition
 
 export class Field {
   private _name: string
@@ -34,6 +37,11 @@ export class Field {
   }
 
   public toString(): string {
-    return `${this.name}: ${this.shape}`
+    const args = Object.entries(this.shape.allArguments)
+      .map(([name, ty]) => new QueryArgument(name, ty).toString())
+      .join(', ')
+
+    const argsStr = args ? `(${args})` : ''
+    return `${this.name}${argsStr}: ${this.shape}`
   }
 }

--- a/packages/grafbase-sdk/src/field.ts
+++ b/packages/grafbase-sdk/src/field.ts
@@ -1,5 +1,5 @@
 import { FieldShape as MongoFieldShape } from './connector/mongodb/model'
-import { QueryArgument } from './query'
+import { FieldArgument } from './query'
 import { AuthDefinition } from './typedefs/auth'
 import { DeprecatedDefinition } from './typedefs/deprecated'
 import { InaccessibleDefinition } from './typedefs/inaccessible'
@@ -38,7 +38,7 @@ export class Field {
 
   public toString(): string {
     const args = Object.entries(this.shape.allArguments)
-      .map(([name, ty]) => new QueryArgument(name, ty).toString())
+      .map(([name, ty]) => new FieldArgument(name, ty).toString())
       .join(', ')
 
     const argsStr = args ? `(${args})` : ''

--- a/packages/grafbase-sdk/src/query.ts
+++ b/packages/grafbase-sdk/src/query.ts
@@ -18,6 +18,7 @@ export type InputType =
   | InputDefinition
   | InputDefaultDefinition
   | EnumDefinition<any, any>
+  | ReferenceDefinition
 
 /** The possible types of an output parameters of a query. */
 export type OutputType = ScalarDefinition | ListDefinition | ReferenceDefinition

--- a/packages/grafbase-sdk/src/query.ts
+++ b/packages/grafbase-sdk/src/query.ts
@@ -52,7 +52,7 @@ export interface QueryInput {
 /**
  * An input argument shape of a query.
  */
-export class QueryArgument {
+export class FieldArgument {
   private name: string
   private type: InputType
 
@@ -79,7 +79,7 @@ export class QueryArgument {
 export class Query {
   private name: string
   private _kind: 'mutation' | 'query'
-  private arguments: QueryArgument[]
+  private arguments: FieldArgument[]
   private returns: OutputType
   private resolver: string
 
@@ -109,7 +109,7 @@ export class Query {
    * @param type - The type of the input parameter.
    */
   public argument(name: string, type: InputType): Query {
-    this.arguments.push(new QueryArgument(name, type))
+    this.arguments.push(new FieldArgument(name, type))
 
     return this
   }

--- a/packages/grafbase-sdk/src/type.ts
+++ b/packages/grafbase-sdk/src/type.ts
@@ -21,6 +21,7 @@ import { ShareableDefinition } from './typedefs/shareable'
 import { OverrideDefinition } from './typedefs/override'
 import { ProvidesDefinition } from './typedefs/provides'
 import { DeprecatedDefinition } from './typedefs/deprecated'
+import { AuthDefinition } from './typedefs/auth'
 
 /**
  * A collection of fields in a model.
@@ -45,6 +46,7 @@ export type TypeFieldShape =
   | OverrideDefinition
   | ProvidesDefinition
   | DeprecatedDefinition
+  | AuthDefinition
 
 /**
  * A composite type definition (e.g. not a model).

--- a/packages/grafbase-sdk/src/typedefs/auth.ts
+++ b/packages/grafbase-sdk/src/typedefs/auth.ts
@@ -15,6 +15,7 @@ import { ShareableDefinition } from './shareable'
 import { OverrideDefinition } from './override'
 import { ProvidesDefinition } from './provides'
 import { DeprecatedDefinition } from './deprecated'
+import { InputType } from '../query'
 
 export type Authenticable =
   | ScalarDefinition
@@ -68,6 +69,10 @@ export class AuthDefinition {
    */
   public mapped(name: string): MapDefinition {
     return new MapDefinition(this, name)
+  }
+
+  public get allArguments(): Record<string, InputType> {
+    return this.field.allArguments
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/cache.ts
+++ b/packages/grafbase-sdk/src/typedefs/cache.ts
@@ -5,6 +5,7 @@ import {
   renderMutationInvalidation,
   renderAccessScope
 } from '../cache'
+import { InputType } from '../query'
 import { AuthDefinition } from './auth'
 import { DefaultDefinition } from './default'
 import { DeprecatedDefinition } from './deprecated'
@@ -129,6 +130,10 @@ export class CacheDefinition {
    */
   public mapped(name: string): MapDefinition {
     return new MapDefinition(this, name)
+  }
+
+  public get allArguments(): Record<string, InputType> {
+    return this.field.allArguments
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/default.ts
+++ b/packages/grafbase-sdk/src/typedefs/default.ts
@@ -12,6 +12,7 @@ import { InaccessibleDefinition } from './inaccessible'
 import { ShareableDefinition } from './shareable'
 import { OverrideDefinition } from './override'
 import { ProvidesDefinition } from './provides'
+import { InputType } from '../query'
 
 export type DefaultValueType = string | number | Date | object | boolean
 
@@ -101,6 +102,10 @@ export class DefaultDefinition {
    */
   public provides(fields: string): ProvidesDefinition {
     return new ProvidesDefinition(this, fields)
+  }
+
+  public get allArguments(): Record<string, InputType> {
+    return this._scalar.allArguments
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/deprecated.ts
+++ b/packages/grafbase-sdk/src/typedefs/deprecated.ts
@@ -8,6 +8,7 @@ import { EnumDefinition } from './enum'
 import { escapeString } from '../utils'
 import { ResolverDefinition } from './resolver'
 import { JoinDefinition } from './join'
+import { InputType } from '../query'
 
 /**
  * A list of field types that can hold a `@deprecated` attribute.
@@ -61,6 +62,10 @@ export class DeprecatedDefinition {
    */
   public cache(params: FieldCacheParams): CacheDefinition {
     return new CacheDefinition(this, new FieldLevelCache(params))
+  }
+
+  public get allArguments(): Record<string, InputType> {
+    return { ...this.field.allArguments }
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/enum.ts
+++ b/packages/grafbase-sdk/src/typedefs/enum.ts
@@ -1,5 +1,6 @@
 import { AuthRuleF } from '../auth'
 import { Enum, EnumShape } from '../enum'
+import { InputType } from '../query'
 import { AuthDefinition } from './auth'
 import { CacheDefinition, FieldCacheParams, FieldLevelCache } from './cache'
 import { DefaultDefinition } from './default'
@@ -139,6 +140,10 @@ export class EnumDefinition<T extends string, U extends EnumShape<T>> {
    */
   public provides(fields: string): ProvidesDefinition {
     return new ProvidesDefinition(this, fields)
+  }
+
+  public get allArguments(): Record<string, InputType> {
+    return {}
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/inaccessible.ts
+++ b/packages/grafbase-sdk/src/typedefs/inaccessible.ts
@@ -8,6 +8,7 @@ import { EnumDefinition } from './enum'
 import { ResolverDefinition } from './resolver'
 import { JoinDefinition } from './join'
 import { TagDefinition } from './tag'
+import { InputType } from '../query'
 
 /**
  * A list of field types that can hold an `@inaccessible` attribute.
@@ -69,6 +70,10 @@ export class InaccessibleDefinition {
    */
   public cache(params: FieldCacheParams): CacheDefinition {
     return new CacheDefinition(this, new FieldLevelCache(params))
+  }
+
+  public get allArguments(): Record<string, InputType> {
+    return { ...this.field.allArguments }
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/input.ts
+++ b/packages/grafbase-sdk/src/typedefs/input.ts
@@ -1,4 +1,5 @@
 import { Input } from '../input_type'
+import { InputType } from '../query'
 import { ListDefinition } from './list'
 
 /**
@@ -27,6 +28,12 @@ export class InputDefinition {
    */
   public list(): ListDefinition {
     return new ListDefinition(this)
+  }
+
+  public get allArguments(): Record<string, InputType> {
+    // Inputs never have arguments, but this type is valid inside ListScalarType
+    // which needs to participate in the allArguments chain
+    return {}
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/join.ts
+++ b/packages/grafbase-sdk/src/typedefs/join.ts
@@ -11,6 +11,7 @@ import { ShareableDefinition } from './shareable'
 import { OverrideDefinition } from './override'
 import { ProvidesDefinition } from './provides'
 import { DeprecatedDefinition } from './deprecated'
+import { InputType } from '../query'
 
 /**
  * A list of field types that can hold a `@join` attribute.
@@ -31,10 +32,12 @@ export type Joinable =
 export class JoinDefinition {
   private field: Joinable
   private select: string
+  private _arguments: Record<string, InputType>
 
   constructor(field: Joinable, select: string) {
     this.field = field
     this.select = select
+    this._arguments = {}
   }
 
   /**
@@ -53,6 +56,20 @@ export class JoinDefinition {
    */
   public cache(params: FieldCacheParams): CacheDefinition {
     return new CacheDefinition(this, new FieldLevelCache(params))
+  }
+
+  /**
+   * Add arguments to this field that will be available in the join string
+   *
+   * @param args - The arguments for this field
+   */
+  public arguments(args: Record<string, InputType>): JoinDefinition {
+    this._arguments = args
+    return this
+  }
+
+  public get allArguments(): Record<string, InputType> {
+    return { ...this._arguments, ...this.field.allArguments }
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/length-limited-string.ts
+++ b/packages/grafbase-sdk/src/typedefs/length-limited-string.ts
@@ -9,6 +9,7 @@ import { AuthDefinition } from './auth'
 import { CacheDefinition, FieldCacheParams, FieldLevelCache } from './cache'
 import { StringListDefinition } from './list'
 import { MapDefinition } from './map'
+import { InputType } from '../query'
 
 export interface FieldLength {
   min?: number
@@ -95,5 +96,9 @@ export class LengthLimitedStringDefinition {
 
   fieldTypeVal(): FieldType | Enum<any, any> {
     return this.scalar.fieldType
+  }
+
+  public get allArguments(): Record<string, InputType> {
+    return this.scalar.allArguments
   }
 }

--- a/packages/grafbase-sdk/src/typedefs/list.ts
+++ b/packages/grafbase-sdk/src/typedefs/list.ts
@@ -19,6 +19,7 @@ import { FieldLength } from './length-limited-string'
 import { LengthLimitedStringDefinition } from './length-limited-string'
 import { MapDefinition } from './map'
 import { escapeString } from '../utils'
+import { InputType } from '../query'
 
 export type ListScalarType =
   | ScalarDefinition
@@ -34,11 +35,13 @@ export class ListDefinition {
   private resolverName?: string
   private joinSelect?: string
   private otherDirectives: string[]
+  private _arguments: Record<string, InputType>
 
   constructor(fieldDefinition: ListScalarType) {
     this.fieldDefinition = fieldDefinition
     this.isOptional = false
     this.otherDirectives = []
+    this._arguments = {}
   }
 
   /**
@@ -135,6 +138,20 @@ export class ListDefinition {
   public provides(fields: string): ListDefinition {
     this.otherDirectives.push(`@provides(fields: ${fields})`)
     return this
+  }
+
+  /**
+   * Add arguments to this field
+   *
+   * @param args - The arguments for this field
+   */
+  public arguments(args: Record<string, InputType>): ListDefinition {
+    this._arguments = args
+    return this
+  }
+
+  public get allArguments(): Record<string, InputType> {
+    return { ...this._arguments, ...this.fieldDefinition.allArguments }
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/map.ts
+++ b/packages/grafbase-sdk/src/typedefs/map.ts
@@ -1,3 +1,4 @@
+import { InputType } from '../query'
 import { AuthDefinition } from './auth'
 import { CacheDefinition } from './cache'
 import { DefaultDefinition } from './default'
@@ -26,6 +27,10 @@ export class MapDefinition {
   constructor(field: Mappable, mappedName: string) {
     this.field = field
     this.mappedName = mappedName
+  }
+
+  public get allArguments(): Record<string, InputType> {
+    return { ...this.field.allArguments }
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/override.ts
+++ b/packages/grafbase-sdk/src/typedefs/override.ts
@@ -9,6 +9,7 @@ import { escapeString } from '../utils'
 import { ResolverDefinition } from './resolver'
 import { JoinDefinition } from './join'
 import { TagDefinition } from './tag'
+import { InputType } from '../query'
 
 /**
  * A list of field types that can hold an `@override` attribute.
@@ -72,6 +73,10 @@ export class OverrideDefinition {
    */
   public cache(params: FieldCacheParams): CacheDefinition {
     return new CacheDefinition(this, new FieldLevelCache(params))
+  }
+
+  public get allArguments(): Record<string, InputType> {
+    return { ...this.field.allArguments }
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/provides.ts
+++ b/packages/grafbase-sdk/src/typedefs/provides.ts
@@ -9,6 +9,7 @@ import { escapeString } from '../utils'
 import { ResolverDefinition } from './resolver'
 import { JoinDefinition } from './join'
 import { TagDefinition } from './tag'
+import { InputType } from '../query'
 
 /**
  * A list of field types that can hold a `@provides` attribute.
@@ -72,6 +73,10 @@ export class ProvidesDefinition {
    */
   public cache(params: FieldCacheParams): CacheDefinition {
     return new CacheDefinition(this, new FieldLevelCache(params))
+  }
+
+  public get allArguments(): Record<string, InputType> {
+    return { ...this.field.allArguments }
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/reference.ts
+++ b/packages/grafbase-sdk/src/typedefs/reference.ts
@@ -10,6 +10,7 @@ import { InaccessibleDefinition } from './inaccessible'
 import { ShareableDefinition } from './shareable'
 import { OverrideDefinition } from './override'
 import { ProvidesDefinition } from './provides'
+import { InputType } from '../query'
 
 export class ReferenceDefinition {
   private referencedType: string
@@ -106,6 +107,10 @@ export class ReferenceDefinition {
    */
   public provides(fields: string): ProvidesDefinition {
     return new ProvidesDefinition(this, fields)
+  }
+
+  public get allArguments(): Record<string, InputType> {
+    return {}
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/resolver.ts
+++ b/packages/grafbase-sdk/src/typedefs/resolver.ts
@@ -11,6 +11,7 @@ import { ShareableDefinition } from './shareable'
 import { OverrideDefinition } from './override'
 import { ProvidesDefinition } from './provides'
 import { DeprecatedDefinition } from './deprecated'
+import { InputType } from '../query'
 
 /**
  * A list of field types that can hold a `@resolver` attribute.
@@ -32,11 +33,13 @@ export class ResolverDefinition {
   private field: Resolvable
   private resolver: string
   private requiresFields: string | null
+  private _arguments: Record<string, InputType>
 
   constructor(field: Resolvable, resolver: string) {
     this.field = field
     this.resolver = resolver
     this.requiresFields = null
+    this._arguments = {}
   }
 
   /**
@@ -65,6 +68,20 @@ export class ResolverDefinition {
   public requires(fields: string): ResolverDefinition {
     this.requiresFields = fields
     return this
+  }
+
+  /**
+   * Adds arguments to this field that will be available in the resolver
+   *
+   * @param args - The arguments for this field
+   */
+  public arguments(args: Record<string, InputType>): ResolverDefinition {
+    this._arguments = args
+    return this
+  }
+
+  public get allArguments(): Record<string, InputType> {
+    return { ...this._arguments, ...this.field.allArguments }
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/scalar.ts
+++ b/packages/grafbase-sdk/src/typedefs/scalar.ts
@@ -29,6 +29,7 @@ import { ShareableDefinition } from './shareable'
 import { OverrideDefinition } from './override'
 import { ProvidesDefinition } from './provides'
 import { TagDefinition } from './tag'
+import { InputType } from '../query'
 
 export class ScalarDefinition {
   private _fieldType: FieldType | Enum<any, any>
@@ -38,6 +39,11 @@ export class ScalarDefinition {
   constructor(fieldType: FieldType | Enum<any, any>) {
     this._fieldType = fieldType
     this.isOptional = false
+  }
+
+  public get allArguments(): Record<string, InputType> {
+    // This is one of the base cases so just return null for now.
+    return {}
   }
 
   /**

--- a/packages/grafbase-sdk/src/typedefs/shareable.ts
+++ b/packages/grafbase-sdk/src/typedefs/shareable.ts
@@ -8,6 +8,7 @@ import { EnumDefinition } from './enum'
 import { ResolverDefinition } from './resolver'
 import { JoinDefinition } from './join'
 import { TagDefinition } from './tag'
+import { InputType } from '../query'
 
 /**
  * A list of field types that can hold a `@shareable` attribute.
@@ -69,6 +70,10 @@ export class ShareableDefinition {
    */
   public cache(params: FieldCacheParams): CacheDefinition {
     return new CacheDefinition(this, new FieldLevelCache(params))
+  }
+
+  public get allArguments(): Record<string, InputType> {
+    return { ...this.field.allArguments }
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/tag.ts
+++ b/packages/grafbase-sdk/src/typedefs/tag.ts
@@ -13,6 +13,7 @@ import { ShareableDefinition } from './shareable'
 import { OverrideDefinition } from './override'
 import { ProvidesDefinition } from './provides'
 import { DeprecatedDefinition } from './deprecated'
+import { InputType } from '../query'
 
 /**
  * A list of field types that can hold a `@tag` attribute.
@@ -109,6 +110,10 @@ export class TagDefinition {
    */
   public provides(fields: string): ProvidesDefinition {
     return new ProvidesDefinition(this, fields)
+  }
+
+  public get allArguments(): Record<string, InputType> {
+    return { ...this.field.allArguments }
   }
 
   public toString(): string {

--- a/packages/grafbase-sdk/src/typedefs/unique.ts
+++ b/packages/grafbase-sdk/src/typedefs/unique.ts
@@ -1,4 +1,5 @@
 import { AuthRuleF } from '../auth'
+import { InputType } from '../query'
 import { AuthDefinition } from './auth'
 import { CacheDefinition, FieldCacheParams, FieldLevelCache } from './cache'
 import { DefaultDefinition } from './default'
@@ -49,6 +50,10 @@ export class UniqueDefinition {
    */
   public mapped(name: string): MapDefinition {
     return new MapDefinition(this, name)
+  }
+
+  public get allArguments(): Record<string, InputType> {
+    return this.scalar.allArguments
   }
 
   public toString(): string {


### PR DESCRIPTION
I'm adding argument support to joins at the moment, and while planning how to do this I noticed the SDK has no way to add arguments to arbitrary fields.  It lets you add arguments to fields of the root query type but not anywhere else.

This PR fixes that by adding `arguments` functions to the `JoinDefinition` & `ResolverDefintion` types.  These are I _think_ the only places that arguments make sense at the moment, though I'm open to discussing if anyone thinks a different approach would be better.

I've also added an `allArguments` property to most of the types involved in specifying field types, even those that might not have their own arguments.  I needed to do this because e.g. `JoinDefinition` can be wrapped by `AuthDefinition` - so we need to make sure we ask every object in the fields chain of wrappers to make sure we don't miss any arguments.