### PR TITLE
feat: arguments on join fields

### DIFF
--- a/engine/crates/engine/src/registry/federation.rs
+++ b/engine/crates/engine/src/registry/federation.rs
@@ -94,6 +94,10 @@ impl FederationKey {
     pub fn is_resolvable(&self) -> bool {
         self.resolver.is_some()
     }
+
+    pub fn includes_field(&self, field: &str) -> bool {
+        self.selections.0.iter().any(|selection| selection.field == field)
+    }
 }
 
 impl FederationEntity {

--- a/engine/crates/engine/src/validation/rules/provided_non_null_arguments.rs
+++ b/engine/crates/engine/src/validation/rules/provided_non_null_arguments.rs
@@ -38,10 +38,10 @@ impl<'a> Visitor<'a> for ProvidedNonNullArguments {
                         ctx.report_error(
                             vec![field.pos],
                             format!(
-                                r#"Field "{}" argument "{}" of type "{}" is required but not provided"#,
-                                field.node.name,
+                                r#"The "{}" argument of "{}.{}" is required but not provided"#,
                                 arg.name,
-                                parent_type.name()
+                                parent_type.name(),
+                                field.node.name,
                             ),
                         );
                     }

--- a/engine/crates/parser-sdl/src/lib.rs
+++ b/engine/crates/parser-sdl/src/lib.rs
@@ -57,6 +57,7 @@ use rules::{
 };
 
 pub mod federation;
+mod schema_coord;
 mod type_names;
 mod validations;
 

--- a/engine/crates/parser-sdl/src/rules/basic_type.rs
+++ b/engine/crates/parser-sdl/src/rules/basic_type.rs
@@ -29,6 +29,7 @@ use super::{
 };
 use crate::{
     directive_de::parse_directive, registry::add_input_type_non_primitive, rules::cache_directive::CacheDirective,
+    schema_coord::SchemaCoord,
 };
 
 pub struct BasicType;
@@ -85,7 +86,13 @@ impl<'a> Visitor<'a> for BasicType {
                         // If someone asks we could do it
                         ctx.report_error(vec![field.pos], "A field can't have a join and a requires on it");
                     }
-                    requires = join_directive.select.required_fieldset();
+                    requires = join_directive.select.required_fieldset(&field.arguments);
+
+                    ctx.warnings.extend(
+                        join_directive
+                            .validate_arguments(&field.arguments, SchemaCoord::Field(type_name.as_str(), field.name())),
+                    );
+
                     resolver = Resolver::Join(join_directive.select.to_join_resolver());
                 }
 

--- a/engine/crates/parser-sdl/src/rules/extend_connector_types.rs
+++ b/engine/crates/parser-sdl/src/rules/extend_connector_types.rs
@@ -15,7 +15,7 @@ use super::{
     requires_directive::RequiresDirective,
     visitor::{Visitor, VisitorContext},
 };
-use crate::rules::resolver_directive::ResolverDirective;
+use crate::{rules::resolver_directive::ResolverDirective, schema_coord::SchemaCoord};
 
 pub struct ExtendConnectorTypes;
 
@@ -74,7 +74,13 @@ impl<'a> Visitor<'a> for ExtendConnectorTypes {
                             // If someone asks we could do it
                             ctx.report_error(vec![field.pos], "A field can't have a join and a requires on it");
                         }
-                        requires = join_directive.select.required_fieldset();
+                        requires = join_directive.select.required_fieldset(&field.arguments);
+
+                        ctx.warnings.extend(
+                            join_directive
+                                .validate_arguments(&field.arguments, SchemaCoord::Field(type_name, field.name())),
+                        );
+
                         Resolver::Join(join_directive.select.to_join_resolver())
                     }
                     (Some(_), Some(_)) => {

--- a/engine/crates/parser-sdl/src/rules/federation/key.rs
+++ b/engine/crates/parser-sdl/src/rules/federation/key.rs
@@ -19,7 +19,7 @@ impl KeyDirective {
             errors.push("A key with a selection must be resolvable".into());
         }
 
-        if let Some(required_fields) = self.select.as_ref().and_then(FieldSelection::required_fieldset) {
+        if let Some(required_fields) = self.select.as_ref().and_then(|select| select.required_fieldset(&[])) {
             for missing_field in
                 fields_from_fieldset(&required_fields).difference(&fields_from_fieldset(&self.fields.0))
             {

--- a/engine/crates/parser-sdl/src/rules/join_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/join_directive.rs
@@ -84,7 +84,6 @@ impl JoinDirective {
 
 impl FieldSelection {
     pub fn required_fieldset(&self, arguments: &[Positioned<InputValueDefinition>]) -> Option<FieldSet> {
-        // TODO: Ok, so this needs to _not_ any variables that are actually arguments.
         if self.variables_used.is_empty() {
             return None;
         }

--- a/engine/crates/parser-sdl/src/rules/join_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/join_directive.rs
@@ -1,16 +1,19 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use engine::registry::{field_set, resolvers::join::JoinResolver, FieldSet};
 use engine_parser::{
     parse_field,
-    types::{ConstDirective, Field},
+    types::{ConstDirective, Field, InputValueDefinition},
     Positioned,
 };
 use engine_value::{Name, Value};
 use serde::de::Error;
 
-use super::{directive::Directive, visitor::VisitorContext};
-use crate::directive_de::parse_directive;
+use super::{
+    directive::Directive,
+    visitor::{VisitorContext, Warning},
+};
+use crate::{directive_de::parse_directive, schema_coord::SchemaCoord};
 
 #[derive(serde::Deserialize, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -21,7 +24,7 @@ pub struct JoinDirective {
 #[derive(Debug)]
 pub struct FieldSelection {
     selections: Vec<Selection>,
-    required_fields: Vec<String>,
+    variables_used: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -54,20 +57,52 @@ impl JoinDirective {
             }
         }
     }
+
+    pub fn validate_arguments(
+        &self,
+        arguments: &[Positioned<InputValueDefinition>],
+        coord: SchemaCoord<'_>,
+    ) -> Vec<Warning> {
+        let argument_names = arguments
+            .iter()
+            .map(|argument| argument.node.name.node.as_str())
+            .collect::<BTreeSet<_>>();
+
+        let variable_names = self
+            .select
+            .variables_used
+            .iter()
+            .map(|name| name.as_str())
+            .collect::<BTreeSet<_>>();
+
+        argument_names
+            .difference(&variable_names)
+            .map(|unused_argument| Warning::ArgumentNotUsedByJoin(unused_argument.to_string(), coord.into_owned()))
+            .collect()
+    }
 }
 
 impl FieldSelection {
-    pub fn required_fieldset(&self) -> Option<FieldSet> {
-        if self.required_fields.is_empty() {
+    pub fn required_fieldset(&self, arguments: &[Positioned<InputValueDefinition>]) -> Option<FieldSet> {
+        // TODO: Ok, so this needs to _not_ any variables that are actually arguments.
+        if self.variables_used.is_empty() {
             return None;
         }
 
-        Some(FieldSet::new(self.required_fields.iter().map(|field| {
-            field_set::Selection {
-                field: field.clone(),
-                selections: vec![],
-            }
-        })))
+        let arguments = arguments
+            .iter()
+            .map(|argument| argument.node.name.node.as_str())
+            .collect::<HashSet<_>>();
+
+        Some(FieldSet::new(
+            self.variables_used
+                .iter()
+                .filter(|field| !arguments.contains(field.as_str()))
+                .map(|field| field_set::Selection {
+                    field: field.clone(),
+                    selections: vec![],
+                }),
+        ))
     }
 
     pub fn to_join_resolver(&self) -> JoinResolver {
@@ -105,7 +140,7 @@ impl<'de> serde::Deserialize<'de> for FieldSelection {
                 field: Some(field.node),
             }
             .collect(),
-            required_fields,
+            variables_used: required_fields,
         })
     }
 }
@@ -586,7 +621,7 @@ mod tests {
                             ],
                         },
                     ],
-                    required_fields: [
+                    variables_used: [
                         "filters",
                         "name",
                     ],

--- a/engine/crates/parser-sdl/src/rules/visitor.rs
+++ b/engine/crates/parser-sdl/src/rules/visitor.rs
@@ -11,7 +11,7 @@ use engine_parser::types::{
 };
 
 pub(crate) use self::{
-    cons::VisitorCons, context::VisitorContext, error::RuleError, nil::VisitorNil, r#trait::Visitor,
+    cons::VisitorCons, context::VisitorContext, error::RuleError, nil::VisitorNil, r#trait::Visitor, warnings::Warning,
 };
 
 type TypeStackType<'a> = Vec<(Option<&'a Positioned<Type>>, Option<&'a Positioned<TypeDefinition>>)>;

--- a/engine/crates/parser-sdl/src/schema_coord.rs
+++ b/engine/crates/parser-sdl/src/schema_coord.rs
@@ -1,0 +1,47 @@
+/// Helper enum for specifying the location of errors
+#[derive(Clone, Copy, Debug)]
+pub enum SchemaCoord<'a> {
+    Field(&'a str, &'a str),
+    Entity(&'a str, &'a str),
+}
+
+impl std::fmt::Display for SchemaCoord<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SchemaCoord::Field(ty, field) => {
+                write!(f, "{ty}.{field}")
+            }
+            SchemaCoord::Entity(ty, key) => {
+                write!(f, "federation key `{key}` on the type {ty}")
+            }
+        }
+    }
+}
+
+impl SchemaCoord<'_> {
+    pub fn into_owned(self) -> OwnedSchemaCoord {
+        match self {
+            SchemaCoord::Field(ty, field) => OwnedSchemaCoord::Field(ty.into(), field.into()),
+            SchemaCoord::Entity(ty, key) => OwnedSchemaCoord::Entity(ty.into(), key.into()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
+pub enum OwnedSchemaCoord {
+    Field(String, String),
+    Entity(String, String),
+}
+
+impl std::fmt::Display for OwnedSchemaCoord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OwnedSchemaCoord::Field(ty, field) => {
+                write!(f, "{ty}.{field}")
+            }
+            OwnedSchemaCoord::Entity(ty, key) => {
+                write!(f, "federation key `{key}` on the type {ty}")
+            }
+        }
+    }
+}

--- a/engine/crates/parser-sdl/src/validations.rs
+++ b/engine/crates/parser-sdl/src/validations.rs
@@ -14,7 +14,7 @@ use engine_parser::types::{BaseType, Type};
 use indexmap::IndexMap;
 use regex::Regex;
 
-use crate::rules::visitor::RuleError;
+use crate::{rules::visitor::RuleError, schema_coord::SchemaCoord};
 
 static NAME_REGEX: OnceLock<Regex> = OnceLock::new();
 
@@ -320,24 +320,4 @@ fn validate_federation_joins(registry: &Registry) -> Vec<RuleError> {
     }
 
     errors
-}
-
-/// Helper enum for specifying the location of errors
-#[derive(Clone, Copy)]
-enum SchemaCoord<'a> {
-    Field(&'a str, &'a str),
-    Entity(&'a str, &'a str),
-}
-
-impl std::fmt::Display for SchemaCoord<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SchemaCoord::Field(ty, field) => {
-                write!(f, "{ty}.{field}")
-            }
-            SchemaCoord::Entity(ty, key) => {
-                write!(f, "federation key `{key}` on the type {ty}")
-            }
-        }
-    }
 }


### PR DESCRIPTION
A customer wants to forward an argument on a join field into the query that we use to perform the join.  This adds support for that, using the same variable syntax we already use.  

Any arguments on the join field are automatically available under `$argumentName`.  Currently arguments will always shadow fields of the parent object.  So if there's a `foo` argument then `$foo` will _always_ refer to that argument, and any field on the parent type named `foo` will be inaccessible.  The alternative to this would have been to use some special syntax to differentiate fields & arguments, but that seemed like a lot more work, and I'm not sure how likely it is for users to need that functionality.  We can always revisit later.

I'm not doing much validation on these arguments at parsing time currently.  I'll do that in a follow up PR, just wanted to unblock the customer as quick as possible.

Fixes GB-6304