### PR TITLE
chore(engine-v2): remove bound prefix

### DIFF
--- a/engine/crates/engine-v2/schema/src/builder/mod.rs
+++ b/engine/crates/engine-v2/schema/src/builder/mod.rs
@@ -24,7 +24,7 @@ pub(crate) struct SchemaBuilder {
     pub schema: Schema,
     pub strings: Interner<String, StringId>,
     pub urls: Interner<Url, UrlId>,
-    field_id_mapper: ids::IdMapper<federated_graph::FieldId, FieldId>,
+    field_id_mapper: ids::IdMapper<federated_graph::FieldId, FieldDefinitionId>,
     input_value_id_mapper: ids::IdMapper<federated_graph::InputValueDefinitionId, InputValueDefinitionId>,
     enum_value_id_mapper: ids::IdMapper<federated_graph::EnumValueId, EnumValueId>,
 }
@@ -57,8 +57,8 @@ impl SchemaBuilder {
                     subscription: config.graph.root_operation_types.subscription.map(Into::into),
                 },
                 objects: Vec::with_capacity(config.graph.objects.len()),
-                fields: Vec::with_capacity(config.graph.fields.len()),
-                interfaces: Vec::with_capacity(config.graph.objects.len()),
+                field_definitions: Vec::with_capacity(config.graph.fields.len()),
+                interfaces: Vec::with_capacity(config.graph.interfaces.len()),
                 enums: Vec::new(),
                 unions: Vec::with_capacity(0),
                 scalars: Vec::with_capacity(config.graph.scalars.len()),
@@ -463,7 +463,7 @@ impl SchemaBuilder {
                 }
             }
 
-            let field = Field {
+            let field = FieldDefinition {
                 name: field.name.into(),
                 description: None,
                 r#type: field.r#type.into(),
@@ -481,7 +481,7 @@ impl SchemaBuilder {
                     .rule(CacheConfigTarget::Field(federated_graph::FieldId(field_id.into())))
                     .map(|config| cache_configs.get_or_insert(config)),
             };
-            schema.fields.push(field);
+            schema.field_definitions.push(field);
         }
 
         // -- INPUT OBJECTS --
@@ -597,7 +597,7 @@ impl SchemaBuilder {
     }
 }
 
-impl ids::IdMapper<federated_graph::FieldId, FieldId> {
+impl ids::IdMapper<federated_graph::FieldId, FieldDefinitionId> {
     fn convert_field_set_item(&self, selection: federated_graph::FieldSetItem) -> Option<FieldSetItem> {
         Some(FieldSetItem {
             field_id: self.map(selection.field)?,

--- a/engine/crates/engine-v2/schema/src/field_set.rs
+++ b/engine/crates/engine-v2/schema/src/field_set.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use crate::FieldId;
+use crate::FieldDefinitionId;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FieldSet {
@@ -55,7 +55,7 @@ impl FieldSet {
         self.items.iter()
     }
 
-    pub fn get(&self, field: FieldId) -> Option<&FieldSetItem> {
+    pub fn get(&self, field: FieldDefinitionId) -> Option<&FieldSetItem> {
         let index = self
             .items
             .binary_search_by_key(&field, |selection| selection.field_id)
@@ -63,7 +63,7 @@ impl FieldSet {
         Some(&self.items[index])
     }
 
-    pub fn contains(&self, field: FieldId) -> bool {
+    pub fn contains(&self, field: FieldDefinitionId) -> bool {
         self.items
             .binary_search_by_key(&field, |selection| selection.field_id)
             .is_ok()
@@ -120,6 +120,6 @@ impl FieldSet {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FieldSetItem {
-    pub field_id: FieldId,
+    pub field_id: FieldDefinitionId,
     pub subselection: FieldSet,
 }

--- a/engine/crates/engine-v2/schema/src/ids.rs
+++ b/engine/crates/engine-v2/schema/src/ids.rs
@@ -2,8 +2,8 @@
 /// They can only be created by From<usize>
 use crate::{
     sources::federation::{DataSource as FederationDataSource, Subgraph},
-    CacheConfig, Definition, Directive, Enum, EnumValue, Field, Header, InputObject, InputValueDefinition, Interface,
-    Object, Resolver, Scalar, Schema, Union,
+    CacheConfig, Definition, Directive, Enum, EnumValue, FieldDefinition, Header, InputObject, InputValueDefinition,
+    Interface, Object, Resolver, Scalar, Schema, Union,
 };
 use url::Url;
 
@@ -17,7 +17,7 @@ id_newtypes::U32! {
     Schema.directives[DirectiveId] => Directive | unless "Too many directives" max MAX_ID,
     Schema.enum_values[EnumValueId] => EnumValue | unless "Too many enum values" max MAX_ID,
     Schema.enums[EnumId] => Enum | unless "Too many enums" max MAX_ID,
-    Schema.fields[FieldId] => Field | unless "Too many fields" max MAX_ID,
+    Schema.field_definitions[FieldDefinitionId] => FieldDefinition | unless "Too many fields" max MAX_ID,
     Schema.headers[HeaderId] => Header | unless "Too many headers" max MAX_ID,
     Schema.input_objects[InputObjectId] => InputObject | unless "Too many input objects" max MAX_ID,
     Schema.input_value_definitions[InputValueDefinitionId] => InputValueDefinition | unless "Too many input value definitions" max MAX_ID,

--- a/engine/crates/engine-v2/schema/src/lib.rs
+++ b/engine/crates/engine-v2/schema/src/lib.rs
@@ -30,7 +30,7 @@ pub struct Schema {
     pub root_operation_types: RootOperationTypes,
     objects: Vec<Object>,
     interfaces: Vec<Interface>,
-    fields: Vec<Field>,
+    field_definitions: Vec<FieldDefinition>,
     enums: Vec<Enum>,
     unions: Vec<Union>,
     scalars: Vec<Scalar>,
@@ -72,20 +72,20 @@ impl Schema {
             .ok()
     }
 
-    pub fn object_field_by_name(&self, object_id: ObjectId, name: &str) -> Option<FieldId> {
+    pub fn object_field_by_name(&self, object_id: ObjectId, name: &str) -> Option<FieldDefinitionId> {
         let fields = self[object_id].fields;
         self[fields]
             .iter()
             .position(|field| self[field.name] == name)
-            .map(|pos| FieldId::from(usize::from(fields.start) + pos))
+            .map(|pos| FieldDefinitionId::from(usize::from(fields.start) + pos))
     }
 
-    pub fn interface_field_by_name(&self, interface_id: InterfaceId, name: &str) -> Option<FieldId> {
+    pub fn interface_field_by_name(&self, interface_id: InterfaceId, name: &str) -> Option<FieldDefinitionId> {
         let fields = self[interface_id].fields;
         self[fields]
             .iter()
             .position(|field| self[field.name] == name)
-            .map(|pos| FieldId::from(usize::from(fields.start) + pos))
+            .map(|pos| FieldDefinitionId::from(usize::from(fields.start) + pos))
     }
 
     // Used as the default resolver
@@ -124,7 +124,7 @@ impl Schema {
                 fields: IdRange::empty(),
             }],
             interfaces: Vec::new(),
-            fields: Vec::new(),
+            field_definitions: Vec::new(),
             enums: Vec::new(),
             unions: Vec::new(),
             scalars: Vec::new(),
@@ -172,10 +172,10 @@ pub struct Object {
 }
 
 pub type Directives = IdRange<DirectiveId>;
-pub type Fields = IdRange<FieldId>;
+pub type Fields = IdRange<FieldDefinitionId>;
 
 #[derive(Debug)]
-pub struct Field {
+pub struct FieldDefinition {
     pub name: StringId,
     pub description: Option<StringId>,
     pub r#type: Type,

--- a/engine/crates/engine-v2/schema/src/names.rs
+++ b/engine/crates/engine-v2/schema/src/names.rs
@@ -1,13 +1,13 @@
 use crate::{
-    Definition, EnumId, EnumValueId, FieldId, InputObjectId, InputValueDefinitionId, InterfaceId, ObjectId, ScalarId,
-    Schema, UnionId,
+    Definition, EnumId, EnumValueId, FieldDefinitionId, InputObjectId, InputValueDefinitionId, InterfaceId, ObjectId,
+    ScalarId, Schema, UnionId,
 };
 
 /// Small abstraction over the actual names to make easier to deal with
 /// renames later.
 /// It's only missing enum value names.
 pub trait Names: Send + Sync {
-    fn field<'s>(&self, schema: &'s Schema, field_id: FieldId) -> &'s str {
+    fn field<'s>(&self, schema: &'s Schema, field_id: FieldDefinitionId) -> &'s str {
         &schema[schema[field_id].name]
     }
 

--- a/engine/crates/engine-v2/schema/src/walkers/definition.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/definition.rs
@@ -1,4 +1,4 @@
-use super::{field::FieldWalker, SchemaWalker};
+use super::{field::FieldDefinitionWalker, SchemaWalker};
 use crate::{
     Definition, EnumWalker, InputObjectWalker, InterfaceWalker, ObjectWalker, ScalarType, ScalarWalker, StringId,
 };
@@ -43,7 +43,7 @@ impl<'a> DefinitionWalker<'a> {
         }
     }
 
-    pub fn fields(&self) -> Option<Box<dyn Iterator<Item = FieldWalker<'a>> + 'a>> {
+    pub fn fields(&self) -> Option<Box<dyn Iterator<Item = FieldDefinitionWalker<'a>> + 'a>> {
         match self.item {
             Definition::Object(o) => Some(Box::new(self.walk(o).fields())),
             Definition::Interface(i) => Some(Box::new(self.walk(i).fields())),

--- a/engine/crates/engine-v2/schema/src/walkers/field.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/field.rs
@@ -2,12 +2,13 @@ use std::borrow::Cow;
 
 use super::{resolver::ResolverWalker, SchemaWalker};
 use crate::{
-    CacheConfig, Directive, FieldId, FieldProvides, FieldResolver, FieldSet, InputValueDefinitionWalker, TypeWalker,
+    CacheConfig, Directive, FieldDefinitionId, FieldProvides, FieldResolver, FieldSet, InputValueDefinitionWalker,
+    TypeWalker,
 };
 
-pub type FieldWalker<'a> = SchemaWalker<'a, FieldId>;
+pub type FieldDefinitionWalker<'a> = SchemaWalker<'a, FieldDefinitionId>;
 
-impl<'a> FieldWalker<'a> {
+impl<'a> FieldDefinitionWalker<'a> {
     pub fn name(&self) -> &'a str {
         self.names.field(self.schema, self.item)
     }
@@ -71,7 +72,7 @@ pub struct FieldResolverWalker<'a> {
     pub field_requires: &'a FieldSet,
 }
 
-impl<'a> std::fmt::Debug for FieldWalker<'a> {
+impl<'a> std::fmt::Debug for FieldDefinitionWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Field")
             .field("id", &usize::from(self.item))

--- a/engine/crates/engine-v2/schema/src/walkers/field_set.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/field_set.rs
@@ -1,4 +1,4 @@
-use crate::{FieldId, FieldSet, FieldSetItem, FieldWalker, SchemaWalker};
+use crate::{FieldDefinitionId, FieldDefinitionWalker, FieldSet, FieldSetItem, SchemaWalker};
 
 pub type FieldSetWalker<'a> = SchemaWalker<'a, &'a FieldSet>;
 pub type FieldSetItemWalker<'a> = SchemaWalker<'a, &'a FieldSetItem>;
@@ -14,11 +14,11 @@ impl<'a> FieldSetWalker<'a> {
 }
 
 impl<'a> FieldSetItemWalker<'a> {
-    pub fn field_id(&self) -> FieldId {
+    pub fn field_id(&self) -> FieldDefinitionId {
         self.item.field_id
     }
 
-    pub fn field(&self) -> FieldWalker<'a> {
+    pub fn field(&self) -> FieldDefinitionWalker<'a> {
         self.walk(self.item.field_id)
     }
 

--- a/engine/crates/engine-v2/schema/src/walkers/interface.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/interface.rs
@@ -1,4 +1,4 @@
-use super::{FieldWalker, SchemaWalker};
+use super::{FieldDefinitionWalker, SchemaWalker};
 use crate::{InterfaceId, ObjectWalker};
 
 pub type InterfaceWalker<'a> = SchemaWalker<'a, InterfaceId>;
@@ -8,7 +8,7 @@ impl<'a> InterfaceWalker<'a> {
         self.names.interface(self.schema, self.item)
     }
 
-    pub fn fields(self) -> impl Iterator<Item = FieldWalker<'a>> + 'a {
+    pub fn fields(self) -> impl Iterator<Item = FieldDefinitionWalker<'a>> + 'a {
         let fields = self.schema[self.item].fields;
         fields.map(move |field_id| self.walk(field_id))
     }

--- a/engine/crates/engine-v2/schema/src/walkers/object.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/object.rs
@@ -1,4 +1,4 @@
-use super::{FieldWalker, SchemaWalker};
+use super::{FieldDefinitionWalker, SchemaWalker};
 use crate::{CacheConfig, InterfaceWalker, ObjectId};
 
 pub type ObjectWalker<'a> = SchemaWalker<'a, ObjectId>;
@@ -8,7 +8,7 @@ impl<'a> ObjectWalker<'a> {
         self.names.object(self.schema, self.item)
     }
 
-    pub fn fields(self) -> impl Iterator<Item = FieldWalker<'a>> + 'a {
+    pub fn fields(self) -> impl Iterator<Item = FieldDefinitionWalker<'a>> + 'a {
         let fields = self.schema[self.item].fields;
         fields.map(move |field_id| self.walk(field_id))
     }

--- a/engine/crates/engine-v2/schema/src/walkers/resolver.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/resolver.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use crate::{FieldId, FieldSet, Names, Resolver, ResolverGroup, ResolverId, SchemaWalker};
+use crate::{FieldDefinitionId, FieldSet, Names, Resolver, ResolverGroup, ResolverId, SchemaWalker};
 
 pub type ResolverWalker<'a> = SchemaWalker<'a, ResolverId>;
 
@@ -42,7 +42,7 @@ impl<'a> ResolverWalker<'a> {
         }
     }
 
-    pub fn can_provide(&self, nested_field_id: FieldId) -> bool {
+    pub fn can_provide(&self, nested_field_id: FieldDefinitionId) -> bool {
         let nested_field = self.walk(nested_field_id);
         if nested_field.as_ref().resolvers.is_empty() {
             return true;

--- a/engine/crates/engine-v2/src/operation/build.rs
+++ b/engine/crates/engine-v2/src/operation/build.rs
@@ -2,7 +2,7 @@ use schema::{CacheConfig, Merge, Schema};
 
 use crate::response::GraphqlError;
 
-use super::{BoundSelectionSetWalker, Operation, OperationCacheControl, OperationWalker, Variables};
+use super::{Operation, OperationCacheControl, OperationWalker, SelectionSetWalker, Variables};
 
 #[derive(Debug, thiserror::Error)]
 pub enum OperationError {
@@ -64,13 +64,13 @@ fn compute_cache_control(operation: OperationWalker<'_>, request: &engine::Reque
     }
 }
 
-impl BoundSelectionSetWalker<'_> {
+impl SelectionSetWalker<'_> {
     // this merely traverses the selection set recursively and merge all cache_config present in the
     // selected fields
     fn cache_config(&self) -> Option<CacheConfig> {
         self.fields()
             .filter_map(|field| {
-                let cache_config = field.schema_field().and_then(|definition| {
+                let cache_config = field.definition().and_then(|definition| {
                     definition
                         .cache_config()
                         .merge(definition.ty().inner().as_object().and_then(|obj| obj.cache_config()))

--- a/engine/crates/engine-v2/src/operation/ids.rs
+++ b/engine/crates/engine-v2/src/operation/ids.rs
@@ -2,19 +2,18 @@ use id_newtypes::IdRange;
 use schema::InputValueDefinitionId;
 
 use super::{
-    BoundField, BoundFieldArgument, BoundFragment, BoundFragmentSpread, BoundInlineFragment, BoundSelectionSet,
-    Operation, QueryInputKeyValueId, QueryInputObjectFieldValueId, QueryInputValue, QueryInputValueId,
-    VariableDefinition,
+    Field, FieldArgument, Fragment, FragmentSpread, InlineFragment, Operation, QueryInputKeyValueId,
+    QueryInputObjectFieldValueId, QueryInputValue, QueryInputValueId, SelectionSet, VariableDefinition,
 };
 
 id_newtypes::U16! {
-    Operation.fields[BoundFieldId] => BoundField | unless "Too many fields",
-    Operation.selection_sets[BoundSelectionSetId] => BoundSelectionSet | unless "Too many selection sets",
-    Operation.fragments[BoundFragmentId] => BoundFragment | unless "Too many fragments",
-    Operation.fragment_spreads[BoundFragmentSpreadId] => BoundFragmentSpread | unless "Too many fragment spreads",
-    Operation.inline_fragments[BoundInlineFragmentId] => BoundInlineFragment | unless "Too many inline fragments",
+    Operation.fields[FieldId] => Field | unless "Too many fields",
+    Operation.selection_sets[SelectionSetId] => SelectionSet | unless "Too many selection sets",
+    Operation.fragments[FragmentId] => Fragment | unless "Too many fragments",
+    Operation.fragment_spreads[FragmentSpreadId] => FragmentSpread | unless "Too many fragment spreads",
+    Operation.inline_fragments[InlineFragmentId] => InlineFragment | unless "Too many inline fragments",
     Operation.variable_definitions[VariableDefinitionId] => VariableDefinition | unless "Too many variables",
-    Operation.field_arguments[BoundFieldArgumentId] => BoundFieldArgument | unless "Too many arguments",
+    Operation.field_arguments[FieldArgumentId] => FieldArgument | unless "Too many arguments",
 }
 
 impl std::ops::Index<QueryInputValueId> for Operation {

--- a/engine/crates/engine-v2/src/operation/mod.rs
+++ b/engine/crates/engine-v2/src/operation/mod.rs
@@ -28,21 +28,21 @@ pub(crate) struct Operation {
     pub root_object_id: ObjectId,
     pub name: Option<String>,
     pub response_keys: ResponseKeys,
-    pub root_selection_set_id: BoundSelectionSetId,
-    pub selection_sets: Vec<BoundSelectionSet>,
-    pub fields: Vec<BoundField>,
-    pub field_to_parent: Vec<BoundSelectionSetId>,
-    pub fragments: Vec<BoundFragment>,
-    pub fragment_spreads: Vec<BoundFragmentSpread>,
-    pub inline_fragments: Vec<BoundInlineFragment>,
+    pub root_selection_set_id: SelectionSetId,
+    pub selection_sets: Vec<SelectionSet>,
+    pub fields: Vec<Field>,
+    pub field_to_parent: Vec<SelectionSetId>,
+    pub fragments: Vec<Fragment>,
+    pub fragment_spreads: Vec<FragmentSpread>,
+    pub inline_fragments: Vec<InlineFragment>,
     pub variable_definitions: Vec<VariableDefinition>,
     pub cache_control: Option<OperationCacheControl>,
-    pub field_arguments: Vec<BoundFieldArgument>,
+    pub field_arguments: Vec<FieldArgument>,
     pub query_input_values: QueryInputValues,
 }
 
 impl Operation {
-    pub fn parent_selection_set_id(&self, id: BoundFieldId) -> BoundSelectionSetId {
+    pub fn parent_selection_set_id(&self, id: FieldId) -> SelectionSetId {
         self.field_to_parent[usize::from(id)]
     }
 

--- a/engine/crates/engine-v2/src/operation/validation/operation_limits.rs
+++ b/engine/crates/engine-v2/src/operation/validation/operation_limits.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use schema::Schema;
 
-use crate::operation::{BoundSelectionSetWalker, OperationWalker};
+use crate::operation::{OperationWalker, SelectionSetWalker};
 
 #[allow(clippy::enum_variant_names)]
 #[derive(thiserror::Error, Debug)]
@@ -68,7 +68,7 @@ pub(super) fn enforce_operation_limits(
     Ok(())
 }
 
-impl BoundSelectionSetWalker<'_> {
+impl SelectionSetWalker<'_> {
     fn max_depth(&self) -> u16 {
         self.fields()
             .map(|field| {
@@ -111,10 +111,10 @@ impl BoundSelectionSetWalker<'_> {
     }
 
     // `None` stored in the set means `__typename`.
-    fn height(&self, fields_seen: &mut HashSet<Option<schema::FieldId>>) -> u16 {
+    fn height(&self, fields_seen: &mut HashSet<Option<schema::FieldDefinitionId>>) -> u16 {
         self.fields()
             .map(|field| {
-                (if fields_seen.insert(field.as_ref().schema_field_id()) {
+                (if fields_seen.insert(field.as_ref().definition_id()) {
                     1
                 } else {
                     0

--- a/engine/crates/engine-v2/src/operation/variables.rs
+++ b/engine/crates/engine-v2/src/operation/variables.rs
@@ -2,8 +2,7 @@ use schema::Schema;
 
 use super::{
     bind::{bind_variables, VariableError},
-    BoundFieldId, Location, Operation, QueryInputValueId, VariableDefinitionId, VariableInputValueId,
-    VariableInputValues,
+    FieldId, Location, Operation, QueryInputValueId, VariableDefinitionId, VariableInputValueId, VariableInputValues,
 };
 
 pub struct VariableDefinition {
@@ -13,7 +12,7 @@ pub struct VariableDefinition {
     /// Keeping track of every field that used this variable.
     /// Used to know whether the variable is used, not much more as of today.
     /// Sorted.
-    pub used_by: Vec<BoundFieldId>,
+    pub used_by: Vec<FieldId>,
     pub ty: schema::Type,
 }
 

--- a/engine/crates/engine-v2/src/operation/walkers/argument.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/argument.rs
@@ -1,10 +1,10 @@
 use schema::{InputValueDefinitionId, InputValueDefinitionWalker};
 
-use crate::operation::{BoundFieldArgumentId, QueryInputValueWalker};
+use crate::operation::{FieldArgumentId, QueryInputValueWalker};
 
 use super::OperationWalker;
 
-pub type FieldArgumentWalker<'a> = OperationWalker<'a, BoundFieldArgumentId, InputValueDefinitionId>;
+pub type FieldArgumentWalker<'a> = OperationWalker<'a, FieldArgumentId, InputValueDefinitionId>;
 
 impl<'a> FieldArgumentWalker<'a> {
     pub fn value(&self) -> Option<QueryInputValueWalker<'a>> {

--- a/engine/crates/engine-v2/src/operation/walkers/fragment.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/fragment.rs
@@ -1,22 +1,31 @@
-use super::{BoundSelectionSetWalker, OperationWalker};
-use crate::operation::{BoundFragmentId, BoundFragmentSpreadId};
+use super::{OperationWalker, SelectionSetWalker};
+use crate::operation::{FragmentId, FragmentSpreadId};
 
-pub type BoundFragmentSpreadWalker<'a> = OperationWalker<'a, BoundFragmentSpreadId>;
+pub type FragmentSpreadWalker<'a> = OperationWalker<'a, FragmentSpreadId>;
 
-impl<'a> BoundFragmentSpreadWalker<'a> {
-    pub fn selection_set(&self) -> BoundSelectionSetWalker<'a> {
+impl<'a> FragmentSpreadWalker<'a> {
+    pub fn selection_set(&self) -> SelectionSetWalker<'a> {
         self.walk(self.as_ref().selection_set_id)
+    }
+
+    pub fn fragment(&self) -> FragmentDefinitionWalker<'a> {
+        self.walk(self.as_ref().fragment_id)
     }
 }
 
-impl<'a> std::fmt::Debug for BoundFragmentSpreadWalker<'a> {
+impl<'a> std::fmt::Debug for FragmentSpreadWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let fragment = &self.operation[self.as_ref().fragment_id];
-        f.debug_struct("BoundFragmentSpreadWalker")
-            .field("name", &fragment.name)
+        f.debug_struct("FragmentSpreadWalker")
+            .field("name", &self.fragment().name())
             .field("selection_set", &self.selection_set())
             .finish()
     }
 }
 
-pub type BoundFragmentDefinitionWalker<'a> = OperationWalker<'a, BoundFragmentId>;
+pub type FragmentDefinitionWalker<'a> = OperationWalker<'a, FragmentId>;
+
+impl<'a> FragmentDefinitionWalker<'a> {
+    pub fn name(&self) -> &'a str {
+        &self.as_ref().name
+    }
+}

--- a/engine/crates/engine-v2/src/operation/walkers/inline_fragment.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/inline_fragment.rs
@@ -1,17 +1,17 @@
-use super::{BoundSelectionSetWalker, OperationWalker};
-use crate::operation::BoundInlineFragmentId;
+use super::{OperationWalker, SelectionSetWalker};
+use crate::operation::InlineFragmentId;
 
-pub type BoundInlineFragmentWalker<'a> = OperationWalker<'a, BoundInlineFragmentId>;
+pub type InlineFragmentWalker<'a> = OperationWalker<'a, InlineFragmentId>;
 
-impl<'a> BoundInlineFragmentWalker<'a> {
-    pub fn selection_set(&self) -> BoundSelectionSetWalker<'a> {
+impl<'a> InlineFragmentWalker<'a> {
+    pub fn selection_set(&self) -> SelectionSetWalker<'a> {
         self.walk(self.as_ref().selection_set_id)
     }
 }
 
-impl<'a> std::fmt::Debug for BoundInlineFragmentWalker<'a> {
+impl<'a> std::fmt::Debug for InlineFragmentWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("BoundInlineFragmentWalker")
+        f.debug_struct("InlineFragmentWalker")
             .field("selection_set", &self.selection_set())
             .finish()
     }

--- a/engine/crates/engine-v2/src/operation/walkers/mod.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/mod.rs
@@ -54,7 +54,7 @@ impl<'a> OperationWalker<'a, (), ()> {
         matches!(self.as_ref().ty, OperationType::Query)
     }
 
-    pub(crate) fn selection_set(&self) -> BoundSelectionSetWalker<'a> {
+    pub(crate) fn selection_set(&self) -> SelectionSetWalker<'a> {
         self.walk(self.operation.root_selection_set_id)
     }
 

--- a/engine/crates/engine-v2/src/plan/collected.rs
+++ b/engine/crates/engine-v2/src/plan/collected.rs
@@ -1,8 +1,8 @@
 use id_newtypes::IdRange;
-use schema::{FieldId, ObjectId, ScalarType, Wrapping};
+use schema::{FieldDefinitionId, ObjectId, ScalarType, Wrapping};
 
 use crate::{
-    operation::{BoundFieldId, SelectionSetType},
+    operation::{FieldId, SelectionSetType},
     response::{ResponseEdge, SafeResponseKey},
 };
 
@@ -58,8 +58,8 @@ pub struct ConditionalField {
     pub type_condition: Option<FlatTypeCondition>,
     /// Expected key from the upstream response when deserializing
     pub expected_key: SafeResponseKey,
-    pub bound_field_id: BoundFieldId,
-    pub schema_field_id: FieldId,
+    pub id: FieldId,
+    pub definition_id: FieldDefinitionId,
     /// a conditional field cannot have anything than a conditional selection set if any
     /// as it may be merged with other subselection at runtime.
     pub ty: FieldType<ConditionalSelectionSetId>,
@@ -94,8 +94,8 @@ pub struct CollectedField {
     pub edge: ResponseEdge,
     /// Expected key from the upstream response when deserializing
     pub expected_key: SafeResponseKey,
-    pub bound_field_id: BoundFieldId,
-    pub schema_field_id: FieldId,
+    pub id: FieldId,
+    pub definition_id: FieldDefinitionId,
     pub ty: FieldType,
     pub wrapping: Wrapping,
 }

--- a/engine/crates/engine-v2/src/plan/mod.rs
+++ b/engine/crates/engine-v2/src/plan/mod.rs
@@ -28,11 +28,11 @@ pub(crate) struct OperationPlan {
     // for a plan filtering out other plans fields and to build the collected selection set.
     //
     // BoundFieldId -> PlanId
-    bound_field_to_plan_id: Vec<PlanId>,
+    field_to_plan_id: Vec<PlanId>,
     // BoundSelectionSetId -> PlanId
-    bound_selection_to_plan_id: Vec<PlanId>,
+    selection_to_plan_id: Vec<PlanId>,
     /// BoundSelectionSetId -> Option<CollectedSelectionSetId>
-    bound_to_collected_selection_set: Vec<Option<AnyCollectedSelectionSetId>>,
+    selection_set_to_collected: Vec<Option<AnyCollectedSelectionSetId>>,
 
     // -- Plans --
     // Actual plans for the operation. A plan defines what do for a given selection set at a

--- a/engine/crates/engine-v2/src/plan/planning/logic.rs
+++ b/engine/crates/engine-v2/src/plan/planning/logic.rs
@@ -1,4 +1,4 @@
-use schema::{FieldId, FieldSet, ResolverWalker};
+use schema::{FieldDefinitionId, FieldSet, ResolverWalker};
 
 use crate::plan::PlanId;
 
@@ -23,7 +23,7 @@ pub(super) enum PlanningLogic<'schema> {
 }
 
 impl<'schema> PlanningLogic<'schema> {
-    pub(super) fn is_providable(&self, field_id: FieldId) -> bool {
+    pub(super) fn is_providable(&self, field_id: FieldDefinitionId) -> bool {
         match self {
             PlanningLogic::CompatibleResolver {
                 resolver, providable, ..
@@ -34,7 +34,7 @@ impl<'schema> PlanningLogic<'schema> {
 
     // extra fields don't have a key, I'm not entirely whether that makes sense, maybe we should
     // just use ResponsePath. Not sure.
-    pub(super) fn child(&self, field_id: FieldId) -> Self {
+    pub(super) fn child(&self, field_id: FieldDefinitionId) -> Self {
         match self {
             PlanningLogic::CompatibleResolver {
                 resolver,

--- a/engine/crates/engine-v2/src/plan/planning/walker_ext.rs
+++ b/engine/crates/engine-v2/src/plan/planning/walker_ext.rs
@@ -1,9 +1,9 @@
-use schema::FieldId;
+use schema::FieldDefinitionId;
 
 use std::collections::HashMap;
 
 use crate::{
-    operation::{BoundFieldId, OperationWalker},
+    operation::{FieldId, OperationWalker},
     response::ResponseKey,
 };
 
@@ -11,10 +11,10 @@ impl<'a> OperationWalker<'a> {
     /// Sorting is used to ensure we always pick the BoundFieldId with the lowest query position.
     pub(super) fn group_by_response_key_sorted_by_query_position(
         &self,
-        values: impl IntoIterator<Item = BoundFieldId>,
-    ) -> HashMap<ResponseKey, Vec<BoundFieldId>> {
+        values: impl IntoIterator<Item = FieldId>,
+    ) -> HashMap<ResponseKey, Vec<FieldId>> {
         let operation = self.as_ref();
-        let mut grouped: HashMap<ResponseKey, Vec<BoundFieldId>> =
+        let mut grouped: HashMap<ResponseKey, Vec<FieldId>> =
             values.into_iter().fold(Default::default(), |mut groups, id| {
                 let field = &operation[id];
                 groups.entry(field.response_key()).or_default().push(id);
@@ -29,16 +29,16 @@ impl<'a> OperationWalker<'a> {
 
 impl<'a> OperationWalker<'a> {
     /// Sorting is used to ensure we always pick the BoundFieldId with the lowest query position.
-    pub(super) fn group_by_schema_field_id_sorted_by_query_position(
+    pub(super) fn group_by_definition_id_sorted_by_query_position(
         &self,
-        values: impl IntoIterator<Item = BoundFieldId>,
-    ) -> HashMap<FieldId, Vec<BoundFieldId>> {
+        values: impl IntoIterator<Item = FieldId>,
+    ) -> HashMap<FieldDefinitionId, Vec<FieldId>> {
         let operation = self.as_ref();
-        let mut grouped: HashMap<FieldId, Vec<BoundFieldId>> =
+        let mut grouped: HashMap<FieldDefinitionId, Vec<FieldId>> =
             values.into_iter().fold(Default::default(), |mut groups, id| {
-                let bound_field = &operation[id];
-                if let Some(field_id) = bound_field.schema_field_id() {
-                    groups.entry(field_id).or_default().push(id);
+                let field = &operation[id];
+                if let Some(definition_id) = field.definition_id() {
+                    groups.entry(definition_id).or_default().push(id);
                 }
                 groups
             });

--- a/engine/crates/engine-v2/src/plan/walkers/collected.rs
+++ b/engine/crates/engine-v2/src/plan/walkers/collected.rs
@@ -45,9 +45,9 @@ impl<'a> PlanCollectedField<'a> {
         &self.operation_plan[self.item]
     }
 
-    pub fn as_bound_field(&self) -> PlanField<'a> {
+    pub fn as_operation_field(&self) -> PlanField<'a> {
         let field = self.as_ref();
-        self.walk_with(field.bound_field_id, field.schema_field_id)
+        self.walk_with(field.id, field.definition_id)
     }
 
     pub fn concrete_selection_set(&self) -> Option<PlanCollectedSelectionSet<'a>> {
@@ -86,9 +86,9 @@ impl<'a> PlanConditionalField<'a> {
         &self.operation_plan[self.item]
     }
 
-    pub fn as_bound_field(&self) -> PlanField<'a> {
+    pub fn as_operation_field(&self) -> PlanField<'a> {
         let field = self.as_ref();
-        self.walk_with(field.bound_field_id, field.schema_field_id)
+        self.walk_with(field.id, field.definition_id)
     }
 
     pub fn selection_set(&self) -> Option<PlanConditionalSelectionSet<'a>> {
@@ -136,8 +136,8 @@ impl<'a> std::fmt::Debug for PlanCollectedSelectionSet<'a> {
 impl<'a> std::fmt::Debug for PlanCollectedField<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut fmt = f.debug_struct("CollectedField");
-        fmt.field("key", &self.as_bound_field().response_key_str());
-        if self.as_bound_field().response_key() != self.as_ref().expected_key.into() {
+        fmt.field("key", &self.as_operation_field().response_key_str());
+        if self.as_operation_field().response_key() != self.as_ref().expected_key.into() {
             fmt.field(
                 "expected_key",
                 &&self.operation_plan.response_keys[self.as_ref().expected_key],
@@ -170,8 +170,8 @@ impl<'a> std::fmt::Debug for PlanConditionalSelectionSet<'a> {
 impl<'a> std::fmt::Debug for PlanConditionalField<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut fmt = f.debug_struct("ProvisionalField");
-        fmt.field("key", &self.as_bound_field().response_key_str());
-        if self.as_bound_field().response_key() != self.as_ref().expected_key.into() {
+        fmt.field("key", &self.as_operation_field().response_key_str());
+        if self.as_operation_field().response_key() != self.as_ref().expected_key.into() {
             fmt.field(
                 "expected_key",
                 &&self.operation_plan.response_keys[self.as_ref().expected_key],

--- a/engine/crates/engine-v2/src/plan/walkers/field.rs
+++ b/engine/crates/engine-v2/src/plan/walkers/field.rs
@@ -1,13 +1,13 @@
-use schema::{FieldId, FieldWalker};
+use schema::{FieldDefinitionId, FieldDefinitionWalker};
 
 use crate::{
-    operation::{BoundFieldId, FieldArgumentWalker, QueryInputValueWalker},
+    operation::{FieldArgumentWalker, FieldId, QueryInputValueWalker},
     response::{ResponseEdge, ResponseKey},
 };
 
 use super::{PlanSelectionSet, PlanWalker};
 
-pub type PlanField<'a> = PlanWalker<'a, BoundFieldId, FieldId>;
+pub type PlanField<'a> = PlanWalker<'a, FieldId, FieldDefinitionId>;
 
 impl<'a> PlanField<'a> {
     pub fn selection_set(&self) -> Option<PlanSelectionSet<'a>> {
@@ -58,7 +58,7 @@ impl<'a> PlanField<'a> {
 }
 
 impl<'a> std::ops::Deref for PlanField<'a> {
-    type Target = FieldWalker<'a>;
+    type Target = FieldDefinitionWalker<'a>;
 
     fn deref(&self) -> &Self::Target {
         &self.schema_walker

--- a/engine/crates/engine-v2/src/plan/walkers/fragment_spread.rs
+++ b/engine/crates/engine-v2/src/plan/walkers/fragment_spread.rs
@@ -1,25 +1,23 @@
-use crate::operation::{BoundFragmentDefinitionWalker, BoundFragmentSpreadId};
+use crate::operation::{FragmentDefinitionWalker, FragmentSpreadId};
 
 use super::{PlanSelectionSet, PlanWalker};
 
-pub type PlanFragmentSpread<'a> = PlanWalker<'a, BoundFragmentSpreadId, ()>;
+pub type PlanFragmentSpread<'a> = PlanWalker<'a, FragmentSpreadId, ()>;
 
 impl<'a> PlanFragmentSpread<'a> {
     pub fn selection_set(&self) -> PlanSelectionSet<'a> {
         PlanSelectionSet::SelectionSet(self.walk(self.as_ref().selection_set_id))
     }
 
-    #[allow(dead_code)]
-    pub fn fragment(&self) -> BoundFragmentDefinitionWalker<'a> {
+    pub fn fragment(&self) -> FragmentDefinitionWalker<'a> {
         self.bound_walk_with(self.as_ref().fragment_id, ())
     }
 }
 
 impl<'a> std::fmt::Debug for PlanFragmentSpread<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let fragment = &self.operation_plan[self.as_ref().fragment_id];
         f.debug_struct("PlanFragmentSpread")
-            .field("name", &fragment.name)
+            .field("name", &self.fragment().name())
             .field("selection_set", &self.selection_set())
             .finish()
     }

--- a/engine/crates/engine-v2/src/plan/walkers/inline_fragment.rs
+++ b/engine/crates/engine-v2/src/plan/walkers/inline_fragment.rs
@@ -1,7 +1,7 @@
 use super::{PlanSelectionSet, PlanWalker};
-use crate::operation::BoundInlineFragmentId;
+use crate::operation::InlineFragmentId;
 
-pub type PlanInlineFragment<'a> = PlanWalker<'a, BoundInlineFragmentId, ()>;
+pub type PlanInlineFragment<'a> = PlanWalker<'a, InlineFragmentId, ()>;
 
 impl<'a> PlanInlineFragment<'a> {
     pub fn selection_set(&self) -> PlanSelectionSet<'a> {

--- a/engine/crates/engine-v2/src/plan/walkers/selection_set.rs
+++ b/engine/crates/engine-v2/src/plan/walkers/selection_set.rs
@@ -1,7 +1,7 @@
 use schema::Definition;
 
 use crate::{
-    operation::{BoundSelection, BoundSelectionSetId, SelectionSetTypeWalker},
+    operation::{Selection, SelectionSetId, SelectionSetTypeWalker},
     plan::AnyCollectedSelectionSetId,
 };
 
@@ -10,7 +10,7 @@ use super::{PlanField, PlanFragmentSpread, PlanInlineFragment, PlanWalker};
 #[derive(Clone, Copy)]
 pub enum PlanSelectionSet<'a> {
     RootFields(PlanWalker<'a, (), ()>),
-    SelectionSet(PlanWalker<'a, BoundSelectionSetId, ()>),
+    SelectionSet(PlanWalker<'a, SelectionSetId, ()>),
 }
 
 impl<'a> PlanSelectionSet<'a> {
@@ -35,7 +35,7 @@ impl<'a> PlanSelectionSet<'a> {
             PlanSelectionSet::SelectionSet(walker) => {
                 let selection_set_id = walker.item;
                 let n = usize::from(selection_set_id);
-                let Some(id) = walker.operation_plan.bound_to_collected_selection_set[n] else {
+                let Some(id) = walker.operation_plan.selection_set_to_collected[n] else {
                     // Means we're not a root selection set, meaning we're flattened inside another
                     // one. We're a inline fragment / fragment spread.
                     return false;
@@ -85,9 +85,7 @@ impl<'a> Iterator for PlanSelectionSetIterator<'a> {
                 let id = plan.collected_selection_set().as_ref().field_ids.get(self.next_index)?;
                 self.next_index += 1;
                 let field = &plan.operation_plan[id];
-                return Some(PlanSelection::Field(
-                    plan.walk_with(field.bound_field_id, field.schema_field_id),
-                ));
+                return Some(PlanSelection::Field(plan.walk_with(field.id, field.definition_id)));
             }
             PlanSelectionSet::SelectionSet(selection_set) => loop {
                 let selection = selection_set.as_ref().items.get(self.next_index)?;
@@ -95,25 +93,25 @@ impl<'a> Iterator for PlanSelectionSetIterator<'a> {
                 let plan_id = selection_set.plan_id;
                 let operation = selection_set.operation_plan;
                 return Some(match selection {
-                    BoundSelection::Field(id) => {
-                        let Some(field_id) = operation[*id].schema_field_id() else {
+                    Selection::Field(id) => {
+                        let Some(field_id) = operation[*id].definition_id() else {
                             continue;
                         };
-                        if operation.bound_field_to_plan_id[usize::from(*id)] != plan_id {
+                        if operation.field_to_plan_id[usize::from(*id)] != plan_id {
                             continue;
                         }
                         PlanSelection::Field(selection_set.walk_with(*id, field_id))
                     }
-                    BoundSelection::FragmentSpread(id) => {
+                    Selection::FragmentSpread(id) => {
                         let spread = &operation[*id];
-                        if operation.bound_selection_to_plan_id[usize::from(spread.selection_set_id)] != plan_id {
+                        if operation.selection_to_plan_id[usize::from(spread.selection_set_id)] != plan_id {
                             continue;
                         }
                         PlanSelection::FragmentSpread(selection_set.walk(*id))
                     }
-                    BoundSelection::InlineFragment(id) => {
+                    Selection::InlineFragment(id) => {
                         let fragment = &operation[*id];
-                        if operation.bound_selection_to_plan_id[usize::from(fragment.selection_set_id)] != plan_id {
+                        if operation.selection_to_plan_id[usize::from(fragment.selection_set_id)] != plan_id {
                             continue;
                         }
                         PlanSelection::InlineFragment(selection_set.walk(*id))

--- a/engine/crates/engine-v2/src/response/write/deserialize/field.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/field.rs
@@ -24,14 +24,14 @@ impl<'de, 'ctx, 'parent> DeserializeSeed<'de> for FieldSeed<'ctx, 'parent> {
     {
         let result = if let Some(list_wrapping) = self.wrapping.pop_list_wrapping() {
             let list_seed = ListSeed {
-                bound_field_id: self.field.bound_field_id,
+                field_id: self.field.id,
                 ctx: self.ctx,
                 seed: &self,
             };
             match list_wrapping {
                 ListWrapping::RequiredList => list_seed.deserialize(deserializer),
                 ListWrapping::NullableList => NullableSeed {
-                    bound_field_id: self.field.bound_field_id,
+                    field_id: self.field.id,
                     ctx: self.ctx,
                     seed: list_seed,
                 }
@@ -49,13 +49,13 @@ impl<'de, 'ctx, 'parent> DeserializeSeed<'de> for FieldSeed<'ctx, 'parent> {
         } else {
             match &self.field.ty {
                 FieldType::Scalar(scalar_type) => NullableSeed {
-                    bound_field_id: self.field.bound_field_id,
+                    field_id: self.field.id,
                     ctx: self.ctx,
                     seed: ScalarTypeSeed(*scalar_type),
                 }
                 .deserialize(deserializer),
                 FieldType::SelectionSet(collected) => NullableSeed {
-                    bound_field_id: self.field.bound_field_id,
+                    field_id: self.field.id,
                     ctx: self.ctx,
                     seed: SelectionSetSeed {
                         ctx: self.ctx,
@@ -70,10 +70,7 @@ impl<'de, 'ctx, 'parent> DeserializeSeed<'de> for FieldSeed<'ctx, 'parent> {
             if !self.ctx.propagating_error.fetch_or(true, Ordering::Relaxed) {
                 self.ctx.response_part.borrow_mut().push_error(GraphqlError {
                     message: err.to_string(),
-                    locations: self.ctx.plan[self.field.bound_field_id]
-                        .name_location()
-                        .into_iter()
-                        .collect(),
+                    locations: self.ctx.plan[self.field.id].name_location().into_iter().collect(),
                     path: Some(self.ctx.response_path()),
                     ..Default::default()
                 });

--- a/engine/crates/engine-v2/src/response/write/deserialize/list.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/list.rs
@@ -7,12 +7,12 @@ use serde::{
 
 use super::SeedContextInner;
 use crate::{
-    operation::BoundFieldId,
+    operation::FieldId,
     response::{GraphqlError, ResponseValue},
 };
 
 pub(super) struct ListSeed<'ctx, 'parent, Seed> {
-    pub bound_field_id: BoundFieldId,
+    pub field_id: FieldId,
     pub ctx: &'parent SeedContextInner<'ctx>,
     pub seed: &'parent Seed,
 }
@@ -70,7 +70,7 @@ where
                         path.push(index.into());
                         self.ctx.response_part.borrow_mut().push_error(GraphqlError {
                             message: err.to_string(),
-                            locations: self.ctx.plan[self.bound_field_id].name_location().into_iter().collect(),
+                            locations: self.ctx.plan[self.field_id].name_location().into_iter().collect(),
                             path: Some(path),
                             ..Default::default()
                         });

--- a/engine/crates/engine-v2/src/response/write/deserialize/mod.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/mod.rs
@@ -64,19 +64,19 @@ impl<'ctx> SeedContext<'ctx> {
 }
 
 impl<'ctx> SeedContextInner<'ctx> {
-    fn missing_field_error_message(&self, field: &CollectedField) -> String {
-        let bound_field = &self.plan[field.bound_field_id];
+    fn missing_field_error_message(&self, collected_field: &CollectedField) -> String {
+        let field = &self.plan[collected_field.id];
         let response_keys = self.plan.response_keys();
-        if bound_field.response_key() == field.expected_key.into() {
+        if field.response_key() == collected_field.expected_key.into() {
             format!(
                 "Error decoding response from upstream: Missing required field named '{}'",
-                &response_keys[field.expected_key]
+                &response_keys[collected_field.expected_key]
             )
         } else {
             format!(
                 "Error decoding response from upstream: Missing required field named '{}' (expected: '{}')",
-                &response_keys[bound_field.response_key()],
-                &response_keys[field.expected_key]
+                &response_keys[field.response_key()],
+                &response_keys[collected_field.expected_key]
             )
         }
     }

--- a/engine/crates/engine-v2/src/response/write/deserialize/nullable.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/nullable.rs
@@ -7,12 +7,12 @@ use serde::{
 
 use super::SeedContextInner;
 use crate::{
-    operation::BoundFieldId,
+    operation::FieldId,
     response::{GraphqlError, ResponseValue},
 };
 
 pub(super) struct NullableSeed<'ctx, 'parent, Seed> {
-    pub bound_field_id: BoundFieldId,
+    pub field_id: FieldId,
     pub ctx: &'parent SeedContextInner<'ctx>,
     pub seed: Seed,
 }
@@ -65,7 +65,7 @@ where
                 if !self.ctx.propagating_error.fetch_and(false, Ordering::Relaxed) {
                     self.ctx.response_part.borrow_mut().push_error(GraphqlError {
                         message: err.to_string(),
-                        locations: self.ctx.plan[self.bound_field_id].name_location().into_iter().collect(),
+                        locations: self.ctx.plan[self.field_id].name_location().into_iter().collect(),
                         path: Some(self.ctx.response_path()),
                         ..Default::default()
                     });


### PR DESCRIPTION
Renaming `Field` to `FieldDefinition` in the schema and removing the
`Bound`/`bound_` prefix from almost everything. It serves no purposes
and is confusing. So now we have:

- `scham_field_id` -> `field_definition_id`
- `bound_selection_set` -> `selection_set`
- `bound_field` -> `field`
...

This PR almost exlusively renaming stuff. I only slightly improved the
`FieldWalker`.

# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
