### PR TITLE
composition: implement progressive override

### DIFF
--- a/engine/crates/composition/src/compose/object.rs
+++ b/engine/crates/composition/src/compose/object.rs
@@ -258,13 +258,13 @@ fn resolvable_in(fields: &[FieldWalker<'_>], object_is_shareable: bool) -> Vec<f
 fn collect_overrides(fields: &[FieldWalker<'_>], ctx: &mut Context<'_>) -> Vec<federated::Override> {
     let mut overrides = Vec::new();
 
-    for (field, from) in fields.iter().filter_map(|f| Some(f).zip(f.directives().r#override())) {
+    for (field, override_directive) in fields.iter().filter_map(|f| Some(f).zip(f.directives().r#override())) {
         let field_subgraph = field.parent_definition().subgraph();
 
-        if from.id == field_subgraph.name().id {
+        if override_directive.from == field_subgraph.name().id {
             ctx.diagnostics.push_fatal(format!(
                 r#"Source and destination subgraphs "{}" are the same for overridden field "{}.{}""#,
-                from.as_str(),
+                ctx.subgraphs.walk(override_directive.from).as_str(),
                 field.parent_definition().name().as_str(),
                 field.name().as_str()
             ));
@@ -273,7 +273,7 @@ fn collect_overrides(fields: &[FieldWalker<'_>], ctx: &mut Context<'_>) -> Vec<f
 
         if let Some(override_source) = fields
             .iter()
-            .find(|f| f.parent_definition().subgraph().name().id == from.id)
+            .find(|f| f.parent_definition().subgraph().name().id == override_directive.from)
         {
             if override_source.directives().r#override().is_some() {
                 ctx.diagnostics
@@ -287,13 +287,17 @@ fn collect_overrides(fields: &[FieldWalker<'_>], ctx: &mut Context<'_>) -> Vec<f
 
         overrides.push(federated::Override {
             graph: federated::SubgraphId(field_subgraph.subgraph_id().idx()),
+            label: override_directive
+                .label
+                .and_then(|label| ctx.subgraphs.walk(label).as_str().parse().ok())
+                .unwrap_or_default(),
             from: ctx
                 .subgraphs
                 .iter_subgraphs()
-                .position(|subgraph| subgraph.name().id == from.id)
+                .position(|subgraph| subgraph.name().id == override_directive.from)
                 .map(federated::SubgraphId)
                 .map(federated::OverrideSource::Subgraph)
-                .unwrap_or_else(|| federated::OverrideSource::Missing(ctx.insert_string(from.id))),
+                .unwrap_or_else(|| federated::OverrideSource::Missing(ctx.insert_string(override_directive.from))),
         });
     }
 

--- a/engine/crates/composition/src/ingest_subgraph/directives.rs
+++ b/engine/crates/composition/src/ingest_subgraph/directives.rs
@@ -42,9 +42,18 @@ pub(super) fn ingest_directives(
                 })
                 .map(|s| subgraphs.strings.intern(s));
 
+            let label = directive
+                .node
+                .get_argument("label")
+                .and_then(|v| match &v.node {
+                    ConstValue::String(s) => Some(s.as_str()),
+                    _ => None,
+                })
+                .map(|s| subgraphs.strings.intern(s));
+
             let Some(from) = from else { continue };
 
-            subgraphs.set_override(directive_site_id, from);
+            subgraphs.set_override(directive_site_id, subgraphs::OverrideDirective { from, label });
             continue;
         }
 

--- a/engine/crates/composition/tests/composition/override_label/federated.graphql
+++ b/engine/crates/composition/tests/composition/override_label/federated.graphql
@@ -17,15 +17,16 @@ directive @join__field(
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
 enum join__Graph {
-    MANGROVE @join__graph(name: "mangrove", url: "http://example.com/mangrove")
-    STEPPE @join__graph(name: "steppe", url: "http://example.com/steppe")
+    FST @join__graph(name: "fst", url: "http://example.com/fst")
 }
 
-type Mammoth {
-    tuskLength: Int
-    weightGrams: Int @join__field(graph: mangrove, override: "steppe")
+type User
+    @join__type(graph: FST, key: "id")
+{
+    id: ID!
+    name: String @join__field(graph: fst, override: "somewhereElse", overrideLabel: "percent(10)")
 }
 
 type Query {
-    getMammoth: Mammoth @join__field(graph: mangrove, override: "steppe")
+    me: User @join__field(graph: FST)
 }

--- a/engine/crates/composition/tests/composition/override_label/subgraphs/fst.graphql
+++ b/engine/crates/composition/tests/composition/override_label/subgraphs/fst.graphql
@@ -1,0 +1,18 @@
+extend schema
+  @link(
+  url: "https://specs.apollo.dev/federation/v2.7",
+  import: ["@key", "@shareable", "@override"]
+)
+
+schema {
+  query: Query
+}
+
+type Query {
+  me: User
+}
+
+type User @key(fields: "id") {
+  id: ID!
+  name: String @override(from: "somewhereElse", label: "percent(10)")
+}

--- a/engine/crates/composition/tests/composition/override_label_invalid/federated.graphql
+++ b/engine/crates/composition/tests/composition/override_label_invalid/federated.graphql
@@ -1,0 +1,2 @@
+# Invalid @override label argument on User.name: Expected a field of the format "percent(<number>)" 
+# Invalid @override label argument on User.email: Expected a field of the format "percent(<number>)" 

--- a/engine/crates/composition/tests/composition/override_label_invalid/subgraphs/fst.graphql
+++ b/engine/crates/composition/tests/composition/override_label_invalid/subgraphs/fst.graphql
@@ -1,0 +1,19 @@
+extend schema
+  @link(
+  url: "https://specs.apollo.dev/federation/v2.7",
+  import: ["@key", "@shareable", "@override"]
+)
+
+schema {
+  query: Query
+}
+
+type Query {
+  me: User
+}
+
+type User @key(fields: "id") {
+  id: ID!
+  name: String @override(from: "somewhereElse", label: "percents(10)")
+  email: String @override(from: "somewhereElse", label: "")
+}

--- a/engine/crates/federated-graph/src/federated_graph/v2.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v2.rs
@@ -1,7 +1,7 @@
 pub use super::v1::{
     Definition, EnumId, FieldId, FieldProvides, FieldRequires, FieldSet, FieldSetItem, FieldType, InputObjectId,
-    InterfaceField, InterfaceId, Key, ListWrapper, ObjectField, ObjectId, Override, OverrideSource, RootOperationTypes,
-    ScalarId, StringId, Subgraph, SubgraphId, TypeId, UnionId,
+    InterfaceField, InterfaceId, Key, ListWrapper, ObjectField, ObjectId, Override, OverrideLabel, OverrideSource,
+    RootOperationTypes, ScalarId, StringId, Subgraph, SubgraphId, TypeId, UnionId,
 };
 
 /// A composed federated graph.

--- a/engine/crates/federated-graph/src/federated_graph/v3.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v3.rs
@@ -3,8 +3,8 @@ use std::ops::Range;
 pub use super::v2::{
     Definition, DirectiveId, Directives, Enum, EnumId, EnumValue, EnumValueId, EnumValues, FieldId, FieldProvides,
     FieldRequires, FieldSet, FieldSetItem, InputObject, InputObjectId, InputValueDefinitionId, InputValueDefinitions,
-    InterfaceId, Key, ObjectId, Override, OverrideSource, RootOperationTypes, Scalar, ScalarId, StringId, Subgraph,
-    SubgraphId, Union, UnionId, Value, NO_DIRECTIVES, NO_ENUM_VALUE, NO_INPUT_VALUE_DEFINITION,
+    InterfaceId, Key, ObjectId, Override, OverrideLabel, OverrideSource, RootOperationTypes, Scalar, ScalarId,
+    StringId, Subgraph, SubgraphId, Union, UnionId, Value, NO_DIRECTIVES, NO_ENUM_VALUE, NO_INPUT_VALUE_DEFINITION,
 };
 pub use wrapping::Wrapping;
 

--- a/engine/crates/federated-graph/src/render_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl.rs
@@ -390,6 +390,7 @@ fn write_resolvable_in(subgraph: SubgraphId, field: &Field, graph: &FederatedGra
 fn write_overrides(field: &Field, graph: &FederatedGraphV3, sdl: &mut String) -> fmt::Result {
     for Override {
         graph: overriding_graph,
+        label,
         from,
     } in &field.overrides
     {
@@ -397,8 +398,18 @@ fn write_overrides(field: &Field, graph: &FederatedGraphV3, sdl: &mut String) ->
             OverrideSource::Subgraph(subgraph_id) => &graph[graph.subgraphs[subgraph_id.0].name],
             OverrideSource::Missing(string) => &graph[*string],
         };
+
+        let optional_label = if label.percent.is_some() {
+            format!(", overrideLabel: \"{}\"", label)
+        } else {
+            String::new()
+        };
+
         let graph = &graph[graph[*overriding_graph].name];
-        write!(sdl, " @join__field(graph: {graph}, overrides: \"{overrides}\")")?;
+        write!(
+            sdl,
+            " @join__field(graph: {graph}, override: \"{overrides}\"{optional_label})"
+        )?;
     }
     Ok(())
 }

--- a/engine/crates/federated-graph/src/render_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl.rs
@@ -399,7 +399,7 @@ fn write_overrides(field: &Field, graph: &FederatedGraphV3, sdl: &mut String) ->
             OverrideSource::Missing(string) => &graph[*string],
         };
 
-        let optional_label = if label.percent.is_some() {
+        let optional_label = if let OverrideLabel::Percent(_) = label {
             format!(", overrideLabel: \"{}\"", label)
         } else {
             String::new()


### PR DESCRIPTION
This consists of a new `label` argument where you can specify a percentage
of traffic to direct to the overriding subgraph.

closes GB-6126