### PR TITLE
fix: more thorough validation of join arguments

### DIFF
--- a/engine/crates/engine/src/query_path.rs
+++ b/engine/crates/engine/src/query_path.rs
@@ -36,6 +36,10 @@ impl QueryPath {
     pub fn iter(&self) -> impl DoubleEndedIterator<Item = &QueryPathSegment> {
         self.0.iter()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 impl IntoIterator for QueryPath {

--- a/engine/crates/engine/src/registry/federation.rs
+++ b/engine/crates/engine/src/registry/federation.rs
@@ -96,10 +96,7 @@ impl FederationKey {
     }
 
     pub fn includes_field(&self, field: &str) -> bool {
-        self.selections
-            .0
-            .iter()
-            .any(|selection| selection.field == field)
+        self.selections.0.iter().any(|selection| selection.field == field)
     }
 }
 

--- a/engine/crates/engine/src/registry/federation.rs
+++ b/engine/crates/engine/src/registry/federation.rs
@@ -96,7 +96,10 @@ impl FederationKey {
     }
 
     pub fn includes_field(&self, field: &str) -> bool {
-        self.selections.0.iter().any(|selection| selection.field == field)
+        self.selections
+            .0
+            .iter()
+            .any(|selection| selection.field == field)
     }
 }
 

--- a/engine/crates/engine/src/registry/type_names.rs
+++ b/engine/crates/engine/src/registry/type_names.rs
@@ -21,6 +21,14 @@ pub trait TypeReference {
     fn named_type(&self) -> NamedType<'_>;
 }
 
+impl TypeReference for Name {
+    type ExpectedType<'a> = &'a MetaType;
+
+    fn named_type(&self) -> NamedType<'_> {
+        NamedType(Cow::Borrowed(self.as_str()))
+    }
+}
+
 /// Defines basic string conversion functionality for a string wrapper.
 ///
 /// We've a lot of them in this file, so this is handy.

--- a/engine/crates/engine/value/src/argument_set.rs
+++ b/engine/crates/engine/value/src/argument_set.rs
@@ -46,6 +46,11 @@ impl ArgumentSet {
     pub fn iter_names(&self) -> impl Iterator<Item = &str> {
         self.0.iter().map(|(name, _)| name.as_str())
     }
+
+    /// Borrowing iterator
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &SerializableArgument)> {
+        self.0.iter().map(|(name, arg)| (name.as_str(), arg))
+    }
 }
 
 impl IntoIterator for ArgumentSet {
@@ -84,7 +89,7 @@ impl Iterator for ArgumentSetIter {
 /// Note that this is private intentionally - this should only really be used for serialization via
 /// ArgumentSet above.  Convert it to Value if you want to work with it.
 #[derive(Clone, Debug, PartialEq, Eq)]
-enum SerializableArgument {
+pub enum SerializableArgument {
     /// A variable, without the `$`.
     Variable(Name),
     /// `null`.

--- a/engine/crates/integration-tests/tests/subgraph/keys.rs
+++ b/engine/crates/integration-tests/tests/subgraph/keys.rs
@@ -8,11 +8,11 @@ fn test_multi_field_keys() {
         extend schema @federation(version: "2.3")
 
         extend type Query {
-            todo(list: ID!, id: ID!): Todo @resolver(name: "todo")
+            todo(listId: ID!, id: ID!): Todo @resolver(name: "todo")
         }
 
-        type Todo @key(fields: "list id", select: "todo(list: $list, id: $id)") {
-            list: ID!
+        type Todo @key(fields: "listId id", select: "todo(listId: $listId, id: $id)") {
+            listId: ID!
             id: ID!
             name: String!
         }
@@ -22,10 +22,10 @@ fn test_multi_field_keys() {
         let engine = EngineBuilder::new(schema)
             .with_custom_resolvers(RustUdfs::new().resolver("todo", |input: CustomResolverRequestPayload| {
                 let id = input.arguments["id"].as_str().unwrap();
-                let list = input.arguments["list"].as_str().unwrap();
+                let list = input.arguments["listId"].as_str().unwrap();
                 Ok(UdfResponse::Success(json!({
                     "id": id,
-                    "list": list,
+                    "listId": list,
                     "name": format!("Todo {id} in list {list}")
                 })))
             }))
@@ -49,7 +49,7 @@ fn test_multi_field_keys() {
                 .variables(json!({"repr": {
                     "__typename": "Todo",
                     "id": "123",
-                    "list": "456"
+                    "listId": "456"
                 }}))
                 .await
                 .into_data::<Value>(),
@@ -85,8 +85,12 @@ fn test_composite_keys() {
             id: ID!
         }
 
+        type List {
+            id: ID!
+        }
+
         type Todo @key(fields: "id list { id }", select: "todo(input: {id: $id, list: $list})") {
-            list: ID!
+            list: List!
             id: ID!
             name: String!
         }

--- a/engine/crates/parser-sdl/src/rules/join_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/join_directive.rs
@@ -865,4 +865,27 @@ mod tests {
             "The join on User.nickname has an invalid value for argument ids. Found null where we expected [String]!"
         );
     }
+
+    #[test]
+    fn join_with_unknown_field_inside_object_literal() {
+        assert_validation_error!(
+            r#"
+            extend schema @federation(version: "2.3")
+
+            extend type Query {
+                blah(foo: Foo): String @resolver(name: "blah")
+                user: User! @resolver(name: "user")
+            }
+
+            type User {
+                nickname: ID @join(select: "blah(foo: {foo: null})")
+            }
+
+            input Foo {
+                bar: String!
+            }
+            "#,
+            "The join on User.nickname has an invalid value for argument foo. Could not find a field named foo"
+        );
+    }
 }

--- a/engine/crates/parser-sdl/src/validations.rs
+++ b/engine/crates/parser-sdl/src/validations.rs
@@ -8,17 +8,14 @@ use engine::{
         type_kinds::SelectionSetTarget,
         MetaField, MetaFieldType, MetaInputValue, MetaType,
     },
-    QueryPath, Registry, Schema,
+    QueryPath, Registry,
 };
 use engine_parser::types::{BaseType, Type};
 use engine_value::argument_set::SerializableArgument;
 use indexmap::IndexMap;
 use regex::Regex;
 
-use crate::{
-    rules::visitor::RuleError,
-    schema_coord::{self, SchemaCoord},
-};
+use crate::{rules::visitor::RuleError, schema_coord::SchemaCoord};
 
 static NAME_REGEX: OnceLock<Regex> = OnceLock::new();
 


### PR DESCRIPTION
Prior to this change the arguments we pass in to a join were not validated very much.  The assumption was that any errors would be caught when someone tried to run the join.  But, now that joins are getting more complicated and variables present in them can come from more places, it makes sense to put the effort into improving this a bit.

And, that's what this commit does.  We now check that variables exist, check that they have compatible types and also similarly check that any literals in the string approximately make sense.  I don't expect that we'll catch every single error with this, but it should catch the dumbest of them.  In particular I've been quite lax on validating scalars - I don't want to stop block things that are technically wrong but in reality fine (e.g. passing a String to an ID field or vice versa).  It could probably be made a little stricter, but lets get this out there and see how it does.

One thing to note is that i haven't done list coercion here.  Mostly because it's complex enough as it is and I don't want to add that extra complexity.  If someone really wants it we can revisit.

Fixes GB-6305