### PR TITLE
feat(engine-v2): add argument support for @requires part3

### DIFF
--- a/engine/crates/engine-v2/src/operation/bind/mod.rs
+++ b/engine/crates/engine-v2/src/operation/bind/mod.rs
@@ -496,6 +496,7 @@ impl<'a> Binder<'a> {
             }
         }
         let end = self.field_arguments.len();
+        self.field_arguments[start..end].sort_unstable_by_key(|arg| arg.input_value_definition_id);
         Ok((start..end).into())
     }
 

--- a/engine/crates/engine-v2/src/operation/selection_set.rs
+++ b/engine/crates/engine-v2/src/operation/selection_set.rs
@@ -95,6 +95,7 @@ pub enum Field {
         bound_response_key: BoundResponseKey,
         location: Location,
         field_definition_id: FieldDefinitionId,
+        // sorted by InputValueDefinitionId
         argument_ids: IdRange<FieldArgumentId>,
         selection_set_id: Option<SelectionSetId>,
     },
@@ -103,6 +104,9 @@ pub enum Field {
         edge: ResponseEdge,
         field_definition_id: FieldDefinitionId,
         selection_set_id: Option<SelectionSetId>,
+        // sorted by InputValueDefinitionId
+        argument_ids: IdRange<FieldArgumentId>,
+        petitioner_location: Location,
         /// During the planning we may add more extra fields than necessary. To prevent retrieving
         /// unnecessary data, only those marked as read are part of the operation.
         is_read: bool,
@@ -132,11 +136,13 @@ impl Field {
         }
     }
 
-    pub fn name_location(&self) -> Option<Location> {
+    pub fn location(&self) -> Location {
         match self {
-            Field::TypeName { location, .. } => Some(*location),
-            Field::Query { location, .. } => Some(*location),
-            Field::Extra { .. } => None,
+            Field::TypeName { location, .. } => *location,
+            Field::Query { location, .. } => *location,
+            Field::Extra {
+                petitioner_location, ..
+            } => *petitioner_location,
         }
     }
 
@@ -180,7 +186,7 @@ impl Field {
         match self {
             Field::TypeName { .. } => IdRange::empty(),
             Field::Query { argument_ids, .. } => *argument_ids,
-            Field::Extra { .. } => IdRange::empty(),
+            Field::Extra { argument_ids, .. } => *argument_ids,
         }
     }
 }

--- a/engine/crates/engine-v2/src/operation/validation/introspection.rs
+++ b/engine/crates/engine-v2/src/operation/validation/introspection.rs
@@ -29,7 +29,7 @@ fn detect_introspection(selection_set: SelectionSetWalker<'_>) -> Result<(), Val
     for field in selection_set.fields() {
         if matches!(field.name(), "__schema" | "__type") {
             return Err(ValidationError::IntrospectionWhenDisabled {
-                location: field.name_location().unwrap(),
+                location: field.location(),
             });
         }
     }

--- a/engine/crates/engine-v2/src/operation/walkers/field.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/field.rs
@@ -1,6 +1,6 @@
 use schema::FieldDefinitionWalker;
 
-use super::{OperationWalker, SelectionSetWalker};
+use super::{FieldArgumentsWalker, OperationWalker, SelectionSetWalker};
 use crate::{
     operation::{Field, FieldId, Location},
     response::ResponseKey,
@@ -28,8 +28,12 @@ impl<'a> FieldWalker<'a> {
         self.operation.response_keys.try_resolve(self.response_key()).unwrap()
     }
 
-    pub fn name_location(&self) -> Option<Location> {
-        self.as_ref().name_location()
+    pub fn arguments(self) -> FieldArgumentsWalker<'a> {
+        self.walk_with(self.as_ref().argument_ids(), ())
+    }
+
+    pub fn location(&self) -> Location {
+        self.as_ref().location()
     }
 
     pub fn alias(&self) -> Option<&'a str> {

--- a/engine/crates/engine-v2/src/plan/flat.rs
+++ b/engine/crates/engine-v2/src/plan/flat.rs
@@ -94,6 +94,14 @@ pub(crate) struct FlatSelectionSet {
 }
 
 impl FlatSelectionSet {
+    pub fn empty(ty: SelectionSetType) -> Self {
+        Self {
+            ty,
+            root_selection_set_ids: Vec::new(),
+            fields: Vec::new(),
+        }
+    }
+
     pub fn partition_fields(self, predicate: impl Fn(&FlatField) -> bool) -> (Self, Self) {
         let (left, right) = self.fields.into_iter().partition(predicate);
         (

--- a/engine/crates/engine-v2/src/plan/planning/boundary.rs
+++ b/engine/crates/engine-v2/src/plan/planning/boundary.rs
@@ -1,90 +1,120 @@
 use std::{
     borrow::Cow,
-    collections::{hash_map::Entry, HashMap},
+    collections::{hash_map::Entry, BTreeMap, HashMap},
 };
 
+use id_newtypes::IdRange;
 use itertools::Itertools;
-use schema::{FieldDefinitionId, RequiredField, RequiredFieldSet, ResolverId, ResolverWalker};
+use schema::{
+    FieldDefinitionId, RequiredField, RequiredFieldId, RequiredFieldSet, RequiredFieldSetArgumentsId, ResolverId,
+    ResolverWalker,
+};
+use tracing::{instrument, Level};
 
 use super::{logic::PlanningLogic, planner::Planner, PlanningError, PlanningResult};
 use crate::{
-    operation::{Field, FieldId, QueryPath, Selection, SelectionSet, SelectionSetId, SelectionSetType},
+    operation::{
+        Field, FieldArgument, FieldArgumentId, FieldId, QueryInputValue, QueryPath, Selection, SelectionSet,
+        SelectionSetId, SelectionSetType,
+    },
     plan::{flatten_selection_sets, EntityType, FlatField, FlatSelectionSet, ParentToChildEdge, PlanId},
-    response::{ReadField, ReadSelectionSet, UnpackedResponseEdge},
+    response::{ReadField, ReadSelectionSet, ResponseKey, SafeResponseKey, UnpackedResponseEdge},
 };
 
 /// The Planner traverses the selection sets to plan all the fields, but it doesn't define the
 /// plans directly. That's the job of the BoundaryPlanner which will attribute a plan for each
 /// field for a given selection set and satisfy any requirements.
-pub(super) struct BoundaryPlanner<'schema, 'a> {
+pub(super) struct BoundarySelectionSetPlanner<'schema, 'a> {
     planner: &'a mut Planner<'schema>,
     query_path: &'a QueryPath,
     maybe_parent: Option<&'a PlanningLogic<'schema>>,
-    children: Vec<PlanId>,
+    children: Vec<(PlanId, ResolverId)>,
+    extra_response_key_suffix: usize,
+    required_field_id_to_field_id: HashMap<RequiredFieldId, FieldId>,
 }
 
-impl<'schema, 'a> BoundaryPlanner<'schema, 'a> {
+impl<'schema, 'a> BoundarySelectionSetPlanner<'schema, 'a> {
+    #[instrument(
+        level = Level::DEBUG,
+        skip_all,
+        fields(parent = %maybe_parent.as_ref().map(|p| p.to_string()).unwrap_or_default(),
+               path = %planner.walker().walk(query_path))
+    )]
     pub(super) fn plan(
         planner: &'a mut Planner<'schema>,
         query_path: &'a QueryPath,
-        maybe_parent: Option<BoundaryParent<'schema, 'a>>,
+        maybe_parent: Option<&'a PlanningLogic<'schema>>,
+        providable: FlatSelectionSet,
         unplanned: FlatSelectionSet,
     ) -> PlanningResult<Vec<PlanId>> {
-        if let Some(BoundaryParent { logic, providable }) = maybe_parent {
-            let boundary_planner = Self {
-                planner,
-                query_path,
-                maybe_parent: Some(logic),
-                children: Vec::new(),
-            };
-            let mut boundary_fields = boundary_planner.create_boundary_fields(providable)?;
-            boundary_planner.plan_selection_set(&mut boundary_fields, unplanned)
-        } else {
-            Self {
-                planner,
-                query_path,
-                maybe_parent: None,
-                children: Vec::new(),
+        let boundary_planner = Self {
+            planner,
+            query_path,
+            maybe_parent,
+            children: Vec::new(),
+            extra_response_key_suffix: 0,
+            required_field_id_to_field_id: HashMap::default(),
+        };
+        let mut boundary_fields = boundary_planner.group_fields(providable);
+        boundary_planner.plan_selection_set(&mut boundary_fields, unplanned)
+    }
+
+    fn group_subselection_fields(&self, field_ids: &[FieldId]) -> GroupedProvidableFields {
+        let subselection_set_ids = field_ids
+            .iter()
+            .filter_map(|id| self.operation[*id].selection_set_id())
+            .collect();
+        let flat_selection_set = flatten_selection_sets(self.schema, &self.operation, subselection_set_ids);
+        self.group_fields(flat_selection_set)
+    }
+
+    fn group_fields(&self, providable: FlatSelectionSet) -> GroupedProvidableFields {
+        self.group_by_definition_id_then_response_key_sorted_by_query_position(
+            providable.into_iter().map(|field| field.id),
+        )
+    }
+
+    fn group_by_definition_id_then_response_key_sorted_by_query_position(
+        &self,
+        values: impl IntoIterator<Item = FieldId>,
+    ) -> GroupedProvidableFields {
+        let mut grouped: GroupedProvidableFields = values.into_iter().fold(Default::default(), |mut groups, id| {
+            let field = &self.operation[id];
+            if let Some(definition_id) = field.definition_id() {
+                groups
+                    .entry(definition_id)
+                    .or_default()
+                    .entry(field.response_key())
+                    .and_modify(|group| group.field_ids.push(id))
+                    .or_insert_with(|| {
+                        // At this stage we're generating boundary fields for an existing selection set which
+                        // was already planned. By construction, as soon as we create a new plan with
+                        // push_plan() it plans all of the nested selection sets.
+                        // And for extra fields we add during planning, those are attributed immediately.
+                        let plan_id = self.get_field_plan(id).expect("field should be planned");
+
+                        GroupedByDefinitionThenResponseKey::new(plan_id, vec![id])
+                    });
             }
-            .plan_selection_set(&mut BoundaryFields::default(), unplanned)
+            groups
+        });
+        for group in grouped.values_mut().flat_map(|groups| groups.values_mut()) {
+            group
+                .field_ids
+                .sort_unstable_by_key(|id| self.operation[*id].query_position())
         }
-    }
-
-    fn create_boundary_fields(&self, providable: FlatSelectionSet) -> PlanningResult<BoundaryFields> {
-        let grouped = self
-            .walker()
-            .group_by_definition_id_sorted_by_query_position(providable.into_iter().map(|field| field.id));
-
-        let mut fields = BoundaryFields::default();
-        for (definition_id, field_ids) in grouped {
-            // It doesn't matter which one we take, all fields with the same field id
-            // will necessarily be resolved by the same plan.
-            let field_id = field_ids[0];
-
-            // At this stage we're generating boundary fields for an existing selection set which
-            // was already planned. By construction, as soon as we create a new plan with
-            // push_plan() it plans all of the nested selection sets.
-            // And for extra fields we add during planning, those are attributed immediately.
-            let plan_id = self.get_field_plan(field_id).expect("field should be planned");
-            fields.insert(definition_id, BoundaryField::new(plan_id, field_ids));
-        }
-        Ok(fields)
+        grouped
     }
 }
 
-pub(super) struct BoundaryParent<'schema, 'a> {
-    pub logic: &'a PlanningLogic<'schema>,
-    pub providable: FlatSelectionSet,
-}
-
-impl<'schema, 'a> std::ops::Deref for BoundaryPlanner<'schema, 'a> {
+impl<'schema, 'a> std::ops::Deref for BoundarySelectionSetPlanner<'schema, 'a> {
     type Target = Planner<'schema>;
     fn deref(&self) -> &Self::Target {
         self.planner
     }
 }
 
-impl<'schema, 'a> std::ops::DerefMut for BoundaryPlanner<'schema, 'a> {
+impl<'schema, 'a> std::ops::DerefMut for BoundarySelectionSetPlanner<'schema, 'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.planner
     }
@@ -93,17 +123,17 @@ impl<'schema, 'a> std::ops::DerefMut for BoundaryPlanner<'schema, 'a> {
 /// During the planning of the boundary we need to keep track of fields by their FieldId
 /// to satisfy requirements. The goal is not only to know what's present but also to have the
 /// correct ResponseEdge for those when reading data from the response later.
-type BoundaryFields = HashMap<FieldDefinitionId, BoundaryField>;
+type GroupedProvidableFields = HashMap<FieldDefinitionId, BTreeMap<ResponseKey, GroupedByDefinitionThenResponseKey>>;
 
 #[derive(Debug)]
-struct BoundaryField {
+struct GroupedByDefinitionThenResponseKey {
     plan_id: PlanId,
     field_ids: Vec<FieldId>,
-    lazy_subselection: Option<BoundaryFields>,
+    lazy_subselection: Option<GroupedProvidableFields>,
 }
 
-impl BoundaryField {
-    pub(super) fn new(plan_id: PlanId, field_ids: Vec<FieldId>) -> Self {
+impl GroupedByDefinitionThenResponseKey {
+    fn new(plan_id: PlanId, field_ids: Vec<FieldId>) -> Self {
         Self {
             plan_id,
             field_ids,
@@ -121,7 +151,7 @@ struct ChildPlanCandidate<'schema> {
     providable_fields: Vec<(FieldId, &'schema RequiredFieldSet)>,
 }
 
-/// Field that the parent plan could not providabe.
+/// Field that the parent plan could not providable.
 struct UnplannedField {
     entity_type: EntityType,
     flat_field: FlatField,
@@ -141,7 +171,7 @@ impl From<UnplannedField> for FlatField {
     }
 }
 
-impl<'schema, 'a> BoundaryPlanner<'schema, 'a> {
+impl<'schema, 'a> BoundarySelectionSetPlanner<'schema, 'a> {
     /// Iteratively plan fields.
     /// 1. Generate all potential plan candidates satisfying their requirements if possible.
     /// 2. Select the best candidate, generate its input and remove its output fields from the
@@ -149,7 +179,7 @@ impl<'schema, 'a> BoundaryPlanner<'schema, 'a> {
     /// 3. Continue until there are no more unplanned fields.
     fn plan_selection_set(
         mut self,
-        boundary_fields: &mut BoundaryFields,
+        grouped_fields: &mut GroupedProvidableFields,
         mut unplanned_selection_set: FlatSelectionSet,
     ) -> PlanningResult<Vec<PlanId>> {
         // Fields that couldn't be provided by the parent and that have yet to be planned by one
@@ -161,14 +191,14 @@ impl<'schema, 'a> BoundaryPlanner<'schema, 'a> {
         let mut candidates: HashMap<ResolverId, ChildPlanCandidate<'schema>> = HashMap::default();
         while !id_to_unplanned_fields.is_empty() {
             candidates.clear();
-            self.generate_all_candidates(id_to_unplanned_fields.values(), boundary_fields, &mut candidates)?;
+            self.generate_all_candidates(id_to_unplanned_fields.values(), grouped_fields, &mut candidates)?;
 
             let Some(candidate) = select_best_child_plan(&mut candidates) else {
                 let walker = self.walker();
-                tracing::debug!(
+                tracing::trace!(
                     "Could not plan fields:\n=== PARENT ===\n{:#?}\n=== CURRENT ===\n{}\n=== MISSING ===\n{}",
                     self.maybe_parent.map(|parent| parent.resolver()),
-                    boundary_fields
+                    grouped_fields
                         .keys()
                         .map(|id| self.schema.walk(*id))
                         .format_with("\n", |field, f| f(&format_args!("{field:#?}"))),
@@ -196,10 +226,10 @@ impl<'schema, 'a> BoundaryPlanner<'schema, 'a> {
                 output.push(flat_field);
             }
             let output = unplanned_selection_set.clone_with_fields(output);
-            self.push_child(candidate, requires, output, boundary_fields)?;
+            self.push_child(candidate, requires, output, grouped_fields)?;
         }
 
-        Ok(self.children)
+        Ok(self.children.into_iter().map(|(plan_id, _)| plan_id).collect())
     }
 
     fn push_child(
@@ -207,25 +237,20 @@ impl<'schema, 'a> BoundaryPlanner<'schema, 'a> {
         candidate: &mut ChildPlanCandidate<'schema>,
         requires: Cow<'_, RequiredFieldSet>,
         providable: FlatSelectionSet,
-        boundary_fields: &mut BoundaryFields,
+        grouped_fields: &mut GroupedProvidableFields,
     ) -> PlanningResult<()> {
         let path = self.query_path.clone();
         let plan_id = self.push_plan(path, candidate.resolver_id, candidate.entity_type, &providable)?;
         if !requires.is_empty() {
             let resolver = self.schema.walker().walk(candidate.resolver_id).with_own_names();
-            let input_selection_set = self.create_input_selection_set(plan_id, &resolver, &requires, boundary_fields);
+            let input_selection_set = self.create_input_selection_set(plan_id, &resolver, &requires);
             self.insert_plan_input_selection_set(plan_id, input_selection_set);
         };
-        let field_ids_grouped_by_definition_id = self
-            .walker()
-            .group_by_definition_id_sorted_by_query_position(providable.fields.iter().map(|field| field.id));
-        for (definition_id, field_ids) in field_ids_grouped_by_definition_id {
-            boundary_fields
-                .entry(definition_id)
-                .or_insert_with(|| BoundaryField::new(plan_id, field_ids));
+        for (definition_id, groups) in self.group_fields(providable) {
+            grouped_fields.insert(definition_id, groups);
         }
 
-        self.children.push(plan_id);
+        self.children.push((plan_id, candidate.resolver_id));
         Ok(())
     }
 
@@ -238,45 +263,34 @@ impl<'schema, 'a> BoundaryPlanner<'schema, 'a> {
         plan_id: PlanId,
         resolver: &ResolverWalker<'_>,
         requires: &RequiredFieldSet,
-        boundary_fields: &BoundaryFields,
     ) -> ReadSelectionSet {
         if requires.is_empty() {
             return ReadSelectionSet::default();
         }
         requires
             .iter()
-            .map(|field| {
-                let boundary_field = boundary_fields
-                    .get(&field.definition_id)
-                    .expect("field should be present, we could plan it");
-                let field_id = boundary_field.field_ids[0];
+            .map(|required_field| {
+                let field_id = self.required_field_id_to_field_id[&required_field.id];
                 // We add a bunch of fields during the planning to the operation when trying to
                 // satisfy requirements. But only those marked as read will be retrieved.
                 self.operation[field_id].mark_as_read();
+                let parent_plan_id = self.get_field_plan(field_id).expect("field should be planned");
                 self.insert_plan_dependency(ParentToChildEdge {
-                    parent: boundary_field.plan_id,
+                    parent: parent_plan_id,
                     child: plan_id,
                 });
                 ReadField {
                     edge: self.operation[field_id].response_edge(),
-                    name: resolver.walk(field.definition_id).name().to_string(),
-                    subselection: if field.subselection.is_empty() {
-                        ReadSelectionSet::default()
-                    } else {
-                        let subselection = boundary_field
-                            .lazy_subselection
-                            .as_ref()
-                            .expect("subselection should be present, we could plan the subselection");
-                        self.create_input_selection_set(plan_id, resolver, &field.subselection, subselection)
-                    },
+                    name: resolver.walk(required_field.definition_id).name().to_string(),
+                    subselection: self.create_input_selection_set(plan_id, resolver, &required_field.subselection),
                 }
             })
             .collect()
     }
 
-    fn build_unplanned_fields(&self, fields: Vec<FlatField>) -> HashMap<FieldId, UnplannedField> {
+    fn build_unplanned_fields(&self, flat_fields: Vec<FlatField>) -> HashMap<FieldId, UnplannedField> {
         let mut id_to_unplanned_fields = HashMap::default();
-        for flat_field in fields {
+        for flat_field in flat_fields {
             let entity_type = match self.operation[flat_field.parent_selection_set_id()].ty {
                 SelectionSetType::Object(id) => EntityType::Object(id),
                 SelectionSetType::Interface(id) => EntityType::Interface(id),
@@ -300,31 +314,32 @@ impl<'schema, 'a> BoundaryPlanner<'schema, 'a> {
     fn generate_all_candidates<'field>(
         &mut self,
         unplanned_fields: impl IntoIterator<Item = &'field UnplannedField>,
-        boundary_fields: &mut BoundaryFields,
+        grouped_fields: &mut GroupedProvidableFields,
         candidates: &mut HashMap<ResolverId, ChildPlanCandidate<'schema>>,
     ) -> PlanningResult<()>
     where
         'schema: 'field,
     {
-        for field in unplanned_fields {
-            let definition = self.schema.walk(field.definition_id);
+        for unplanned_field in unplanned_fields {
+            let definition = self.schema.walk(unplanned_field.definition_id);
             for resolver in definition.resolvers() {
+                tracing::trace!("Trying to plan '{}' with: {}", definition.name(), resolver.name());
                 let field_requires = definition.requires(resolver.subgraph_id());
                 match candidates.entry(resolver.id()) {
                     Entry::Occupied(mut entry) => {
                         let candidate = entry.get_mut();
-                        if self.could_plan_requirements(boundary_fields, field.id, field_requires)? {
-                            candidate.providable_fields.push((field.id, field_requires));
+                        if self.could_plan_requirements(grouped_fields, unplanned_field.id, field_requires)? {
+                            candidate.providable_fields.push((unplanned_field.id, field_requires));
                         }
                     }
                     Entry::Vacant(entry) => {
-                        if self.could_plan_requirements(boundary_fields, field.id, resolver.requires())?
-                            && self.could_plan_requirements(boundary_fields, field.id, field_requires)?
+                        if self.could_plan_requirements(grouped_fields, unplanned_field.id, resolver.requires())?
+                            && self.could_plan_requirements(grouped_fields, unplanned_field.id, field_requires)?
                         {
                             entry.insert(ChildPlanCandidate {
-                                entity_type: field.entity_type,
+                                entity_type: unplanned_field.entity_type,
                                 resolver_id: resolver.id(),
-                                providable_fields: vec![(field.id, field_requires)],
+                                providable_fields: vec![(unplanned_field.id, field_requires)],
                             });
                         }
                     }
@@ -338,8 +353,8 @@ impl<'schema, 'a> BoundaryPlanner<'schema, 'a> {
     /// candidates.
     fn could_plan_requirements(
         &mut self,
-        boundary_fields: &mut BoundaryFields,
-        origin_field_id: FieldId,
+        grouped_fields: &mut GroupedProvidableFields,
+        petitioner_field_id: FieldId,
         requires: &RequiredFieldSet,
     ) -> PlanningResult<bool> {
         if requires.is_empty() {
@@ -349,79 +364,98 @@ impl<'schema, 'a> BoundaryPlanner<'schema, 'a> {
             .maybe_parent
             .expect("Cannot have requirements without a parent plan")
             .plan_id();
-        self.could_plan_requirements_on_previous_plans(parent_field_plan_id, boundary_fields, origin_field_id, requires)
+        self.could_plan_requirements_on_previous_plans(
+            parent_field_plan_id,
+            grouped_fields,
+            petitioner_field_id,
+            requires,
+        )
     }
 
     fn could_plan_requirements_on_previous_plans(
         &mut self,
         parent_field_plan_id: PlanId,
-        boundary_fields: &mut BoundaryFields,
-        field_id: FieldId,
+        grouped_fields: &mut GroupedProvidableFields,
+        petitioner_field_id: FieldId,
         requires: &RequiredFieldSet,
     ) -> PlanningResult<bool> {
         if requires.is_empty() {
             return Ok(true);
         }
-        let parent_selection_set_id = self.operation.parent_selection_set_id(field_id);
-        'requires: for required_field in requires.iter() {
+        'requires: for required in requires {
+            // if we could already plan this requirement once, no need to do it again.
+            if self.required_field_id_to_field_id.contains_key(&required.id) {
+                continue;
+            }
+
             // -- Existing fields --
-            if let Some(boundary_field) = boundary_fields.get_mut(&required_field.definition_id) {
-                if required_field.subselection.is_empty() {
-                    continue;
-                }
-                if boundary_field.lazy_subselection.is_none() {
-                    let subselection_set_ids = boundary_field
-                        .field_ids
-                        .iter()
-                        .filter_map(|id| self.operation[*id].selection_set_id())
-                        .collect();
-                    let flat_selection_set = flatten_selection_sets(self.schema, &self.operation, subselection_set_ids);
-                    let fields = self.create_boundary_fields(flat_selection_set)?;
-                    boundary_field.lazy_subselection = Some(fields)
-                }
-                if self.could_plan_requirements_on_previous_plans(
-                    boundary_field.plan_id,
-                    boundary_field.lazy_subselection.as_mut().unwrap(),
-                    boundary_field.field_ids[0],
-                    &required_field.subselection,
-                )? {
-                    continue;
-                } else {
-                    return Ok(false);
+            if let Some(groups) = grouped_fields.get_mut(&required.definition_id) {
+                for group in groups.values_mut() {
+                    // TODO: we should likely validate explicitly that all fields for the same response key have
+                    // the same arguments. The GraphQL spec doesn't mention it, but during
+                    // in ExecuteField it just takes the first field and uses its arguments.
+                    // https://spec.graphql.org/October2021/#ExecuteField()
+                    let field_id = group.field_ids[0];
+
+                    // If argument don't match, trying another group
+                    if !self.walker().walk(field_id).arguments().eq(&required.arguments_id) {
+                        continue;
+                    }
+
+                    self.required_field_id_to_field_id.insert(required.id, field_id);
+
+                    // If there is no require sub-selection, we already have everything we need.
+                    if required.subselection.is_empty() {
+                        continue 'requires;
+                    }
+
+                    if group.lazy_subselection.is_none() {
+                        group.lazy_subselection = Some(self.group_subselection_fields(&group.field_ids));
+                    }
+
+                    // Now we only need to know whether we can plan the field, We don't bother with
+                    // other groups. I'm not sure whether having response key groups with different
+                    // plan ids for the same FieldDefinitionId would ever happen.
+                    // So either we can plan the necessary requirements with this group or we
+                    // don't.
+                    if self.could_plan_requirements_on_previous_plans(
+                        group.plan_id,
+                        group.lazy_subselection.as_mut().unwrap(),
+                        field_id,
+                        &required.subselection,
+                    )? {
+                        continue 'requires;
+                    } else {
+                        return Ok(false);
+                    }
                 }
             }
 
             // -- Plannable by the parent --
-            let field = self.schema.walker().walk(required_field.definition_id);
             let parent_logic = self
                 .maybe_parent
                 .expect("Cannot have requirements without a parent plan");
-            // no need to check for requires here, they're only relevant when it's a
-            // plan root field and this is a nested field. So we expect the data source
-            // to be able to provide anything it needed for a nested object it provides.
-            if parent_logic.plan_id() == parent_field_plan_id && parent_logic.is_providable(field.id()) {
-                if let Some(boundary_field) =
-                    self.try_planning_boundary_field(parent_logic, parent_selection_set_id, required_field)
-                {
-                    boundary_fields.insert(field.id(), boundary_field);
-                    continue;
-                }
+            // the parent field does come from the parent plan
+            if parent_logic.plan_id() == parent_field_plan_id
+                && self.could_plan_exra_field(grouped_fields, petitioner_field_id, parent_logic, required)
+            {
+                continue;
             }
 
             // -- Plannable by existing children --
             for i in 0..self.children.len() {
-                let plan_id = self.children[i];
+                let (plan_id, resolver_id) = self.children[i];
                 // ensures we don't have cycles between plans ensuring they can only depend on
                 // plan_ids lower than theirs. Could be better.
-                if plan_id <= parent_field_plan_id {
+                if plan_id < parent_field_plan_id {
                     continue;
                 }
-                let resolver_id = self.get_planned_resolver(plan_id).resolver_id;
-                let logic = &PlanningLogic::new(plan_id, self.schema.walk(resolver_id));
-                if let Some(boundary_field) =
-                    self.try_planning_boundary_field(logic, parent_selection_set_id, required_field)
-                {
-                    boundary_fields.insert(field.id(), boundary_field);
+                if self.could_plan_exra_field(
+                    grouped_fields,
+                    petitioner_field_id,
+                    &PlanningLogic::new(plan_id, self.schema.walk(resolver_id)),
+                    required,
+                ) {
                     continue 'requires;
                 }
             }
@@ -433,47 +467,59 @@ impl<'schema, 'a> BoundaryPlanner<'schema, 'a> {
         Ok(true)
     }
 
-    fn try_planning_boundary_field(
+    fn could_plan_exra_field(
         &mut self,
+        grouped_fields: &mut GroupedProvidableFields,
+        petitioner_field_id: FieldId,
         logic: &PlanningLogic<'schema>,
-        parent_selection_set_id: SelectionSetId,
-        item: &RequiredField,
-    ) -> Option<BoundaryField> {
-        self.try_planning_extra_fields_with_subselection(logic, Some(parent_selection_set_id), item)
-            .map(|field_id| BoundaryField {
+        required: &RequiredField,
+    ) -> bool {
+        let parent_selection_set_id = self.operation.parent_selection_set_id(petitioner_field_id);
+        let Some(field_id) =
+            self.try_plan_extra_field(petitioner_field_id, logic, Some(parent_selection_set_id), required)
+        else {
+            return false;
+        };
+        self.required_field_id_to_field_id.insert(required.id, field_id);
+        let field = &self.operation[field_id];
+        grouped_fields.entry(required.definition_id).or_default().insert(
+            field.response_key(),
+            GroupedByDefinitionThenResponseKey {
                 plan_id: logic.plan_id(),
                 field_ids: vec![field_id],
                 lazy_subselection: None,
-            })
+            },
+        );
+        true
     }
 
-    fn try_planning_extra_fields_with_subselection(
+    fn try_plan_extra_field(
         &mut self,
+        petitioner_field_id: FieldId,
         logic: &PlanningLogic<'schema>,
         parent_selection_set_id: Option<SelectionSetId>,
-        required_field: &RequiredField,
+        required: &RequiredField,
     ) -> Option<FieldId> {
-        // We don't
-        if !logic.is_providable(required_field.definition_id) {
+        if !logic.is_providable(required.definition_id) {
             return None;
         }
-        let field = logic.resolver().walk(required_field.definition_id);
+        let field = logic.resolver().walk(required.definition_id);
         let selection_set_id = if let Some(ty) = SelectionSetType::maybe_from(field.ty().inner().id()) {
             let logic = logic.child(field.id());
-            for _item in &required_field.subselection {
-                // Not need to check field requirements, it's nested a field, so the resolver is
-                // expected to provide anything it needs.
-                if !logic.is_providable(field.id()) {
-                    return None;
-                }
+            if required
+                .subselection
+                .iter()
+                .any(|nested| !logic.is_providable(nested.definition_id))
+            {
+                return None;
             }
             let selection_set = SelectionSet {
                 ty,
-                items: required_field
+                items: required
                     .subselection
                     .iter()
-                    .map(|item| {
-                        self.try_planning_extra_fields_with_subselection(&logic, None, item)
+                    .map(|nested| {
+                        self.try_plan_extra_field(petitioner_field_id, &logic, None, nested)
                             .map(Selection::Field)
                     })
                     .collect::<Option<Vec<_>>>()?,
@@ -482,19 +528,74 @@ impl<'schema, 'a> BoundaryPlanner<'schema, 'a> {
         } else {
             None
         };
-        tracing::debug!(
-            "Adding extra field '{}' provided by {}",
-            self.schema.walker().walk(required_field.definition_id).name(),
-            logic.plan_id()
+        tracing::trace!(
+            "Adding extra field '{}' provided by {} required by '{}'",
+            self.schema.walker().walk(required.definition_id).name(),
+            logic.plan_id(),
+            self.walker().walk(petitioner_field_id).response_key_str()
         );
-        let key = self.generate_unique_response_key_for(required_field.definition_id);
+        let key = self.generate_response_key_for(required.definition_id);
         let field = Field::Extra {
             edge: UnpackedResponseEdge::ExtraFieldResponseKey(key.into()).pack(),
-            field_definition_id: required_field.definition_id,
+            field_definition_id: required.definition_id,
             selection_set_id,
+            argument_ids: self.transform_arguments(&required.arguments_id),
+            petitioner_location: self.operation[petitioner_field_id].location(),
             is_read: true,
         };
         Some(self.push_extra_field(logic.plan_id(), parent_selection_set_id, field))
+    }
+
+    fn generate_response_key_for(&mut self, field_id: FieldDefinitionId) -> SafeResponseKey {
+        // Try just using the field name
+        let name = self.schema.walker().walk(field_id).name();
+        let response_keys = &mut self.operation.response_keys;
+        if !response_keys.contains(name) {
+            return response_keys.get_or_intern(name);
+        }
+
+        // Generate a likely unique key
+        let short_id = hex::encode(u32::from(field_id).to_be_bytes())
+            .trim_start_matches('0')
+            .to_uppercase();
+        let name = format!("_{}{}", name, short_id);
+        if !response_keys.contains(&name) {
+            return response_keys.get_or_intern(&name);
+        }
+
+        // Previous key may still not be enough if we need multiple times the same field with
+        // different arguments for example.
+        loop {
+            let candidate = format!("{name}{}", self.extra_response_key_suffix);
+            if !self.operation.response_keys.contains(&candidate) {
+                return self.operation.response_keys.get_or_intern(&candidate);
+            }
+            self.extra_response_key_suffix += 1;
+        }
+    }
+
+    fn transform_arguments(
+        &mut self,
+        required_arguments_id: &Option<RequiredFieldSetArgumentsId>,
+    ) -> IdRange<FieldArgumentId> {
+        let Some(required_args) = required_arguments_id.map(|id| &self.schema[id]) else {
+            return IdRange::empty();
+        };
+        let start = self.operation.field_arguments.len();
+        for &(input_value_definition_id, value_id) in required_args.iter() {
+            let input_value_id = self
+                .operation
+                .query_input_values
+                .push_value(QueryInputValue::DefaultValue(value_id));
+            self.operation.field_arguments.push(FieldArgument {
+                name_location: None,
+                value_location: None,
+                input_value_id,
+                input_value_definition_id,
+            });
+        }
+        let end = self.operation.field_arguments.len();
+        (start..end).into()
     }
 }
 

--- a/engine/crates/engine-v2/src/plan/planning/walker_ext.rs
+++ b/engine/crates/engine-v2/src/plan/planning/walker_ext.rs
@@ -1,5 +1,3 @@
-use schema::FieldDefinitionId;
-
 use std::collections::HashMap;
 
 use crate::{
@@ -18,28 +16,6 @@ impl<'a> OperationWalker<'a> {
             values.into_iter().fold(Default::default(), |mut groups, id| {
                 let field = &operation[id];
                 groups.entry(field.response_key()).or_default().push(id);
-                groups
-            });
-        for group in grouped.values_mut() {
-            group.sort_unstable_by_key(|id| operation[*id].query_position())
-        }
-        grouped
-    }
-}
-
-impl<'a> OperationWalker<'a> {
-    /// Sorting is used to ensure we always pick the BoundFieldId with the lowest query position.
-    pub(super) fn group_by_definition_id_sorted_by_query_position(
-        &self,
-        values: impl IntoIterator<Item = FieldId>,
-    ) -> HashMap<FieldDefinitionId, Vec<FieldId>> {
-        let operation = self.as_ref();
-        let mut grouped: HashMap<FieldDefinitionId, Vec<FieldId>> =
-            values.into_iter().fold(Default::default(), |mut groups, id| {
-                let field = &operation[id];
-                if let Some(definition_id) = field.definition_id() {
-                    groups.entry(definition_id).or_default().push(id);
-                }
                 groups
             });
         for group in grouped.values_mut() {

--- a/engine/crates/engine-v2/src/response/write/deserialize/field.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/field.rs
@@ -70,7 +70,7 @@ impl<'de, 'ctx, 'parent> DeserializeSeed<'de> for FieldSeed<'ctx, 'parent> {
             if !self.ctx.propagating_error.fetch_or(true, Ordering::Relaxed) {
                 self.ctx.response_part.borrow_mut().push_error(GraphqlError {
                     message: err.to_string(),
-                    locations: self.ctx.plan[self.field.id].name_location().into_iter().collect(),
+                    locations: vec![self.ctx.plan[self.field.id].location()],
                     path: Some(self.ctx.response_path()),
                     ..Default::default()
                 });

--- a/engine/crates/engine-v2/src/response/write/deserialize/list.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/list.rs
@@ -70,7 +70,7 @@ where
                         path.push(index.into());
                         self.ctx.response_part.borrow_mut().push_error(GraphqlError {
                             message: err.to_string(),
-                            locations: self.ctx.plan[self.field_id].name_location().into_iter().collect(),
+                            locations: vec![self.ctx.plan[self.field_id].location()],
                             path: Some(path),
                             ..Default::default()
                         });

--- a/engine/crates/engine-v2/src/response/write/deserialize/nullable.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/nullable.rs
@@ -65,7 +65,7 @@ where
                 if !self.ctx.propagating_error.fetch_and(false, Ordering::Relaxed) {
                     self.ctx.response_part.borrow_mut().push_error(GraphqlError {
                         message: err.to_string(),
-                        locations: self.ctx.plan[self.field_id].name_location().into_iter().collect(),
+                        locations: vec![self.ctx.plan[self.field_id].location()],
                         path: Some(self.ctx.response_path()),
                         ..Default::default()
                     });

--- a/engine/crates/graphql-mocks/src/federation/inventory.rs
+++ b/engine/crates/graphql-mocks/src/federation/inventory.rs
@@ -1,0 +1,77 @@
+use async_graphql::{ComplexObject, EmptyMutation, EmptySubscription, Object, Schema, SimpleObject};
+
+pub struct FakeFederationInventorySchema;
+
+impl FakeFederationInventorySchema {
+    fn schema() -> Schema<Query, EmptyMutation, EmptySubscription> {
+        Schema::build(Query, EmptyMutation, EmptySubscription)
+            .enable_federation()
+            .finish()
+    }
+}
+
+#[async_trait::async_trait]
+impl super::super::Schema for FakeFederationInventorySchema {
+    async fn execute(
+        &self,
+        _headers: Vec<(String, String)>,
+        request: async_graphql::Request,
+    ) -> async_graphql::Response {
+        Self::schema().execute(request).await
+    }
+
+    fn execute_stream(
+        &self,
+        request: async_graphql::Request,
+    ) -> futures::stream::BoxStream<'static, async_graphql::Response> {
+        Box::pin(Self::schema().execute_stream(request))
+    }
+
+    fn sdl(&self) -> String {
+        Self::schema().sdl_with_options(async_graphql::SDLExportOptions::new().federation())
+    }
+}
+
+#[derive(SimpleObject)]
+#[graphql(complex)]
+struct Product {
+    upc: String,
+    #[graphql(skip)]
+    weight: f64,
+}
+
+#[derive(async_graphql::Enum, Clone, Copy, PartialEq, Eq)]
+pub enum WeightUnit {
+    Kilogram,
+    Gram,
+}
+
+#[ComplexObject]
+impl Product {
+    #[graphql(requires = "weight(unit: KILOGRAM)")]
+    async fn shipping_estimate(&self) -> u64 {
+        if self.weight > 0.300 {
+            3
+        } else {
+            1
+        }
+    }
+
+    #[graphql(external)]
+    async fn weight(&self, _unit: WeightUnit) -> f64 {
+        0.0
+    }
+}
+
+struct Query;
+
+#[Object]
+impl Query {
+    #[graphql(entity)]
+    async fn find_product_by_upc(&self, #[graphql(key)] upc: String, weight: Option<f64>) -> Product {
+        Product {
+            upc,
+            weight: weight.unwrap_or(0.0),
+        }
+    }
+}

--- a/engine/crates/graphql-mocks/src/federation/mod.rs
+++ b/engine/crates/graphql-mocks/src/federation/mod.rs
@@ -1,9 +1,11 @@
 // Mostly taken from:
 // https://github.com/async-graphql/examples
 mod accounts;
+mod inventory;
 mod products;
 mod reviews;
 
 pub use accounts::FakeFederationAccountsSchema;
+pub use inventory::FakeFederationInventorySchema;
 pub use products::FakeFederationProductsSchema;
 pub use reviews::FakeFederationReviewsSchema;

--- a/engine/crates/graphql-mocks/src/federation/reviews.rs
+++ b/engine/crates/graphql-mocks/src/federation/reviews.rs
@@ -133,7 +133,7 @@ impl User {
 struct Product {
     upc: String,
     #[graphql(external)]
-    price: u32,
+    price: i32,
 }
 
 #[ComplexObject]

--- a/engine/crates/graphql-mocks/src/lib.rs
+++ b/engine/crates/graphql-mocks/src/lib.rs
@@ -15,13 +15,8 @@ mod federation;
 mod state_mutation;
 
 pub use {
-    almost_empty::AlmostEmptySchema,
-    disingenuous::DisingenuousSchema,
-    echo::EchoSchema,
-    error_schema::ErrorSchema,
-    fake_github::FakeGithubSchema,
-    federation::{FakeFederationAccountsSchema, FakeFederationProductsSchema, FakeFederationReviewsSchema},
-    state_mutation::StateMutationSchema,
+    almost_empty::AlmostEmptySchema, disingenuous::DisingenuousSchema, echo::EchoSchema, error_schema::ErrorSchema,
+    fake_github::FakeGithubSchema, federation::*, state_mutation::StateMutationSchema,
 };
 
 pub struct MockGraphQlServer {

--- a/engine/crates/integration-tests/tests/federation/introspection.rs
+++ b/engine/crates/integration-tests/tests/federation/introspection.rs
@@ -881,6 +881,7 @@ fn introspection_on_multiple_federation_subgraphs() {
       price: Int!
       reviews: [Review!]!
       upc: String!
+      weight(unit: WeightUnit!): Float!
     }
 
     type Query {
@@ -915,6 +916,11 @@ fn introspection_on_multiple_federation_subgraphs() {
       reviews: [Review!]!
       trustworthiness: Trustworthiness!
       username: String!
+    }
+
+    enum WeightUnit {
+      GRAM
+      KILOGRAM
     }
 
     "###)

--- a/engine/crates/integration-tests/tests/federation/subgraphs/mod.rs
+++ b/engine/crates/integration-tests/tests/federation/subgraphs/mod.rs
@@ -1,19 +1,22 @@
+mod requires;
+mod sibling_dependencies;
+mod simple_key;
+
 use gateway_v2::Gateway;
 use graphql_mocks::{
-    FakeFederationAccountsSchema, FakeFederationProductsSchema, FakeFederationReviewsSchema, MockGraphQlServer,
+    FakeFederationAccountsSchema, FakeFederationInventorySchema, FakeFederationProductsSchema,
+    FakeFederationReviewsSchema, MockGraphQlServer,
 };
 use integration_tests::{
     federation::{GatewayV2Ext, GraphqlResponse},
     runtime,
 };
 
-mod sibling_dependencies;
-mod simple_key;
-
 async fn execute(request: &str) -> GraphqlResponse {
     let accounts = MockGraphQlServer::new(FakeFederationAccountsSchema).await;
     let products = MockGraphQlServer::new(FakeFederationProductsSchema).await;
     let reviews = MockGraphQlServer::new(FakeFederationReviewsSchema).await;
+    let inventory = MockGraphQlServer::new(FakeFederationInventorySchema).await;
 
     let engine = Gateway::builder()
         .with_schema("accounts", &accounts)
@@ -21,6 +24,8 @@ async fn execute(request: &str) -> GraphqlResponse {
         .with_schema("products", &products)
         .await
         .with_schema("reviews", &reviews)
+        .await
+        .with_schema("inventory", &inventory)
         .await
         .finish()
         .await;

--- a/engine/crates/integration-tests/tests/federation/subgraphs/requires.rs
+++ b/engine/crates/integration-tests/tests/federation/subgraphs/requires.rs
@@ -1,0 +1,123 @@
+use integration_tests::runtime;
+
+#[test]
+fn simple_requires() {
+    let response = runtime().block_on(super::execute(
+        r"
+        query ExampleQuery {
+            topProducts {
+                name
+                reviews {
+                    author {
+                        username
+                        trustworthiness
+                    }
+                }
+            }
+        }
+        ",
+    ));
+
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": {
+        "topProducts": [
+          {
+            "name": "Trilby",
+            "reviews": [
+              {
+                "author": {
+                  "username": "Me",
+                  "trustworthiness": "REALLY_TRUSTED"
+                }
+              }
+            ]
+          },
+          {
+            "name": "Fedora",
+            "reviews": [
+              {
+                "author": {
+                  "username": "Me",
+                  "trustworthiness": "REALLY_TRUSTED"
+                }
+              }
+            ]
+          },
+          {
+            "name": "Boater",
+            "reviews": [
+              {
+                "author": {
+                  "username": "User 7777",
+                  "trustworthiness": "KINDA_TRUSTED"
+                }
+              }
+            ]
+          },
+          {
+            "name": "Jeans",
+            "reviews": []
+          },
+          {
+            "name": "Pink Jeans",
+            "reviews": [
+              {
+                "author": null
+              }
+            ]
+          }
+        ]
+      }
+    }
+    "###);
+}
+
+#[test]
+fn requires_with_arguments() {
+    let response = runtime().block_on(super::execute(
+        r"
+        query ExampleQuery {
+            topProducts {
+                name
+                weight(unit: GRAM)
+                shippingEstimate
+            }
+        }
+        ",
+    ));
+
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": {
+        "topProducts": [
+          {
+            "name": "Trilby",
+            "weight": 100.0,
+            "shippingEstimate": 1
+          },
+          {
+            "name": "Fedora",
+            "weight": 200.0,
+            "shippingEstimate": 1
+          },
+          {
+            "name": "Boater",
+            "weight": 300.0,
+            "shippingEstimate": 1
+          },
+          {
+            "name": "Jeans",
+            "weight": 400.0,
+            "shippingEstimate": 3
+          },
+          {
+            "name": "Pink Jeans",
+            "weight": 500.0,
+            "shippingEstimate": 3
+          }
+        ]
+      }
+    }
+    "###);
+}


### PR DESCRIPTION
This PR adds argument handling to the planner. Before I only cared whether a field with the right `FieldDefinitionId` existed. I compare arguments from the `@requires` to one in the `Operation` fields, if I don't find a match I create a new field.

