### PR TITLE
chore(engine-v2): improve schema builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2918,7 +2918,7 @@ dependencies = [
  "gateway",
  "grafbase-local-common",
  "graphql-federated-graph",
- "graphql-schema-validation 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "graphql-schema-validation",
  "handlebars 5.1.2",
  "hyper 1.2.0",
  "hyper-util",
@@ -3107,18 +3107,6 @@ dependencies = [
  "datatest-stable",
  "miette",
  "similar",
-]
-
-[[package]]
-name = "graphql-schema-validation"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b706701692e77c342cc7919c3b9c2236e0331e2c802936cf8ee68ed12abe5e7b"
-dependencies = [
- "async-graphql-parser",
- "async-graphql-value",
- "bitflags 2.5.0",
- "miette",
 ]
 
 [[package]]

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -62,7 +62,7 @@ parser-sdl = { path = "../../../engine/crates/parser-sdl", features = [
   "local",
 ] }
 graphql-federated-graph = { path = "../../../engine/crates/federated-graph", features = ["from_sdl"] }
-graphql-schema-validation.workspace = { path = "../../../engine/crates/validation" }
+graphql-schema-validation = { path = "../../../engine/crates/validation" }
 parser-openapi = { path = "../../../engine/crates/parser-openapi" }
 parser-graphql = { path = "../../../engine/crates/parser-graphql" }
 parser-postgres = { path = "../../../engine/crates/parser-postgres" }

--- a/engine/crates/engine-v2/id-newtypes/src/range.rs
+++ b/engine/crates/engine-v2/id-newtypes/src/range.rs
@@ -16,6 +16,15 @@ impl<Id: Copy + From<usize>> Default for IdRange<Id> {
     }
 }
 
+impl<Id: Copy + Into<usize>> From<IdRange<Id>> for Range<usize> {
+    fn from(value: IdRange<Id>) -> Self {
+        Range {
+            start: value.start.into(),
+            end: value.end.into(),
+        }
+    }
+}
+
 impl<Id> IdRange<Id>
 where
     Id: From<usize> + Copy,

--- a/engine/crates/engine-v2/schema/src/builder/coerce/mod.rs
+++ b/engine/crates/engine-v2/schema/src/builder/coerce/mod.rs
@@ -252,7 +252,7 @@ impl<'a> InputValueCoercer<'a> {
 
     fn type_name(&self, ty: Type) -> String {
         let mut s = String::new();
-        for _ in ty.wrapping.list_wrappings().rev() {
+        for _ in 0..ty.wrapping.list_wrappings().len() {
             s.push('[');
         }
         s.push_str(match ty.inner {

--- a/engine/crates/engine-v2/schema/src/builder/coerce/mod.rs
+++ b/engine/crates/engine-v2/schema/src/builder/coerce/mod.rs
@@ -2,7 +2,7 @@ mod error;
 mod path;
 
 use crate::{
-    Definition, EnumWalker, InputObjectWalker, InputValueDefinitionId, ScalarType, ScalarWalker, Schema,
+    Definition, EnumId, EnumValueId, Graph, InputObjectId, InputValueDefinitionId, ScalarId, ScalarType,
     SchemaInputValue, SchemaInputValueId, SchemaInputValues, StringId, Type,
 };
 pub use error::*;
@@ -11,17 +11,21 @@ use id_newtypes::IdRange;
 use path::*;
 use wrapping::ListWrapping;
 
+use super::BuildContext;
+
 pub(super) struct InputValueCoercer<'a> {
-    schema: &'a Schema,
+    ctx: &'a BuildContext,
+    graph: &'a Graph,
     input_values: &'a mut SchemaInputValues,
     value_path: Vec<ValuePathSegment>,
     input_fields_buffer_pool: Vec<Vec<(InputValueDefinitionId, SchemaInputValue)>>,
 }
 
 impl<'a> InputValueCoercer<'a> {
-    pub fn new(schema: &'a Schema, input_values: &'a mut SchemaInputValues) -> Self {
+    pub fn new(ctx: &'a BuildContext, graph: &'a Graph, input_values: &'a mut SchemaInputValues) -> Self {
         Self {
-            schema,
+            ctx,
+            graph,
             input_values,
             value_path: Vec::new(),
             input_fields_buffer_pool: Vec::new(),
@@ -52,7 +56,7 @@ impl<'a> InputValueCoercer<'a> {
 
         match (value, list_wrapping) {
             (Value::Null, ListWrapping::RequiredList) => Err(InputValueError::UnexpectedNull {
-                expected: self.schema.walk(ty.wrapped_by(list_wrapping)).to_string(),
+                expected: self.type_name(ty.wrapped_by(list_wrapping)),
                 path: self.path(),
             }),
             (Value::Null, ListWrapping::NullableList) => Ok(SchemaInputValue::Null),
@@ -67,7 +71,7 @@ impl<'a> InputValueCoercer<'a> {
             }
             (value, _) => Err(InputValueError::MissingList {
                 actual: value.into(),
-                expected: self.schema.walk(ty.wrapped_by(list_wrapping)).to_string(),
+                expected: self.type_name(ty.wrapped_by(list_wrapping)),
                 path: self.path(),
             }),
         }
@@ -77,7 +81,7 @@ impl<'a> InputValueCoercer<'a> {
         if value.is_null() {
             if ty.wrapping.is_required() {
                 return Err(InputValueError::UnexpectedNull {
-                    expected: self.schema.walk(ty).to_string(),
+                    expected: self.type_name(ty),
                     path: self.path(),
                 });
             }
@@ -85,21 +89,22 @@ impl<'a> InputValueCoercer<'a> {
         }
 
         match ty.inner {
-            Definition::Scalar(scalar) => self.coerce_scalar(self.schema.walk(scalar), value),
-            Definition::Enum(r#enum) => self.coerce_enum(self.schema.walk(r#enum), value),
-            Definition::InputObject(input_object) => self.coerce_input_objet(self.schema.walk(input_object), value),
+            Definition::Scalar(id) => self.coerce_scalar(id, value),
+            Definition::Enum(id) => self.coerce_enum(id, value),
+            Definition::InputObject(id) => self.coerce_input_objet(id, value),
             _ => unreachable!("Cannot be an output type."),
         }
     }
 
     fn coerce_input_objet(
         &mut self,
-        input_object: InputObjectWalker<'_>,
+        input_object_id: InputObjectId,
         value: Value,
     ) -> Result<SchemaInputValue, InputValueError> {
+        let input_object = &self.graph[input_object_id];
         let Value::Object(fields) = value else {
             return Err(InputValueError::MissingObject {
-                name: input_object.name().to_string(),
+                name: self.ctx.strings[input_object.name].to_string(),
                 actual: value.into(),
                 path: self.path(),
             });
@@ -112,21 +117,24 @@ impl<'a> InputValueCoercer<'a> {
             .collect::<Vec<_>>();
         fields.sort_unstable_by_key(|(id, _)| *id);
         let mut fields_buffer = self.input_fields_buffer_pool.pop().unwrap_or_default();
-        for input_field in input_object.input_fields() {
-            match fields.binary_search_by_key(&input_field.as_ref().name, |(id, _)| StringId::from(*id)) {
+        for (input_field, input_field_id) in self.graph[input_object.input_field_ids]
+            .iter()
+            .zip(input_object.input_field_ids)
+        {
+            match fields.binary_search_by_key(&input_field.name, |(id, _)| StringId::from(*id)) {
                 Ok(i) => {
                     let value = std::mem::take(&mut fields[i].1).unwrap();
-                    self.value_path.push(input_field.as_ref().name.into());
-                    let value = self.coerce_input_value(input_field.ty().into(), value)?;
-                    fields_buffer.push((input_field.id(), value));
+                    self.value_path.push(input_field.name.into());
+                    let value = self.coerce_input_value(input_field.ty, value)?;
+                    fields_buffer.push((input_field_id, value));
                     self.value_path.pop();
                 }
                 Err(_) => {
-                    if let Some(default_value_id) = input_field.as_ref().default_value {
-                        fields_buffer.push((input_field.id(), self.schema[default_value_id]));
-                    } else if input_field.ty().wrapping().is_required() {
+                    if let Some(default_value_id) = input_field.default_value {
+                        fields_buffer.push((input_field_id, self.graph.input_values[default_value_id]));
+                    } else if input_field.ty.wrapping.is_required() {
                         return Err(InputValueError::UnexpectedNull {
-                            expected: input_field.ty().to_string(),
+                            expected: self.type_name(input_field.ty),
                             path: self.path(),
                         });
                     }
@@ -139,8 +147,8 @@ impl<'a> InputValueCoercer<'a> {
             .next()
         {
             return Err(InputValueError::UnknownInputField {
-                input_object: input_object.name().to_string(),
-                name: self.schema[StringId::from(id)].to_string(),
+                input_object: self.ctx.strings[input_object.name].to_string(),
+                name: self.ctx.strings[StringId::from(id)].to_string(),
                 path: self.path(),
             });
         }
@@ -149,31 +157,33 @@ impl<'a> InputValueCoercer<'a> {
         Ok(SchemaInputValue::InputObject(ids))
     }
 
-    fn coerce_enum(&mut self, r#enum: EnumWalker<'_>, value: Value) -> Result<SchemaInputValue, InputValueError> {
+    fn coerce_enum(&mut self, enum_id: EnumId, value: Value) -> Result<SchemaInputValue, InputValueError> {
+        let r#enum = &self.graph[enum_id];
         let name = match &value {
-            Value::EnumValue(id) => &self.schema[StringId::from(*id)],
+            Value::EnumValue(id) => &self.ctx.strings[StringId::from(*id)],
             value => {
                 return Err(InputValueError::IncorrectEnumValueType {
-                    r#enum: r#enum.name().to_owned(),
+                    r#enum: self.ctx.strings[r#enum.name].to_string(),
                     actual: value.into(),
                     path: self.path(),
                 })
             }
         };
 
-        let Some(id) = r#enum.find_value_by_name(name) else {
-            return Err(InputValueError::UnknownEnumValue {
-                r#enum: r#enum.name().to_string(),
+        let value_ids = r#enum.value_ids;
+        match self.graph[value_ids].binary_search_by(|enum_value| self.ctx.strings[enum_value.name].as_str().cmp(name))
+        {
+            Ok(id) => Ok(SchemaInputValue::EnumValue(EnumValueId::from(id))),
+            Err(_) => Err(InputValueError::UnknownEnumValue {
+                r#enum: self.ctx.strings[r#enum.name].to_string(),
                 value: name.to_string(),
                 path: self.path(),
-            });
-        };
-
-        Ok(SchemaInputValue::EnumValue(id))
+            }),
+        }
     }
 
-    fn coerce_scalar(&mut self, scalar: ScalarWalker<'_>, value: Value) -> Result<SchemaInputValue, InputValueError> {
-        match scalar.as_ref().ty {
+    fn coerce_scalar(&mut self, scalar_id: ScalarId, value: Value) -> Result<SchemaInputValue, InputValueError> {
+        match self.graph[scalar_id].ty {
             ScalarType::String => match value {
                 Value::String(id) => Some(id.into()),
                 _ => None,
@@ -189,7 +199,7 @@ impl<'a> InputValueCoercer<'a> {
                 Value::Int(n) => {
                     let n = i32::try_from(n).map_err(|_| InputValueError::IncorrectScalarValue {
                         actual: n.to_string(),
-                        expected: scalar.name().to_string(),
+                        expected: self.ctx.strings[self.graph[scalar_id].name].to_string(),
                         path: self.path(),
                     })?;
                     Some(n)
@@ -218,14 +228,14 @@ impl<'a> InputValueCoercer<'a> {
                     Value::Object(fields) => {
                         let ids = self.input_values.reserve_map(fields.len());
                         for ((name, value), id) in fields.into_vec().into_iter().zip(ids) {
-                            self.input_values[id] = (name.into(), self.coerce_scalar(scalar, value)?);
+                            self.input_values[id] = (name.into(), self.coerce_scalar(scalar_id, value)?);
                         }
                         SchemaInputValue::Map(ids)
                     }
                     Value::List(list) => {
                         let ids = self.input_values.reserve_list(list.len());
                         for (value, id) in list.into_vec().into_iter().zip(ids) {
-                            let value = self.coerce_scalar(scalar, value)?;
+                            let value = self.coerce_scalar(scalar_id, value)?;
                             self.input_values[id] = value;
                         }
                         SchemaInputValue::List(ids)
@@ -235,12 +245,37 @@ impl<'a> InputValueCoercer<'a> {
         }
         .ok_or_else(|| InputValueError::IncorrectScalarType {
             actual: value.into(),
-            expected: scalar.name().to_string(),
+            expected: self.ctx.strings[self.graph[scalar_id].name].to_string(),
             path: self.path(),
         })
     }
 
+    fn type_name(&self, ty: Type) -> String {
+        let mut s = String::new();
+        for _ in ty.wrapping.list_wrappings().rev() {
+            s.push('[');
+        }
+        s.push_str(match ty.inner {
+            Definition::Scalar(id) => &self.ctx.strings[self.graph[id].name],
+            Definition::Object(id) => &self.ctx.strings[self.graph[id].name],
+            Definition::Interface(id) => &self.ctx.strings[self.graph[id].name],
+            Definition::Union(id) => &self.ctx.strings[self.graph[id].name],
+            Definition::Enum(id) => &self.ctx.strings[self.graph[id].name],
+            Definition::InputObject(id) => &self.ctx.strings[self.graph[id].name],
+        });
+        if ty.wrapping.inner_is_required() {
+            s.push('!');
+        }
+        for wrapping in ty.wrapping.list_wrappings() {
+            s.push(']');
+            if wrapping == ListWrapping::RequiredList {
+                s.push('!');
+            }
+        }
+        s
+    }
+
     fn path(&self) -> String {
-        value_path_to_string(self.schema, &self.value_path)
+        value_path_to_string(self.ctx, &self.value_path)
     }
 }

--- a/engine/crates/engine-v2/schema/src/builder/coerce/path.rs
+++ b/engine/crates/engine-v2/schema/src/builder/coerce/path.rs
@@ -1,4 +1,4 @@
-use crate::{Schema, StringId};
+use crate::{builder::BuildContext, StringId};
 use std::fmt::Write;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -19,7 +19,7 @@ impl From<StringId> for ValuePathSegment {
     }
 }
 
-pub(super) fn value_path_to_string(schema: &Schema, values: &[ValuePathSegment]) -> String {
+pub(super) fn value_path_to_string(ctx: &BuildContext, values: &[ValuePathSegment]) -> String {
     let mut output = String::new();
     if values.is_empty() {
         return output;
@@ -28,7 +28,7 @@ pub(super) fn value_path_to_string(schema: &Schema, values: &[ValuePathSegment])
     for segment in values {
         match segment {
             ValuePathSegment::Field(id) => {
-                write!(&mut output, ".{}", schema[*id]).unwrap();
+                write!(&mut output, ".{}", ctx.strings[*id]).unwrap();
             }
             ValuePathSegment::Index(idx) => {
                 write!(&mut output, ".{idx}").unwrap();

--- a/engine/crates/engine-v2/schema/src/builder/error.rs
+++ b/engine/crates/engine-v2/schema/src/builder/error.rs
@@ -1,6 +1,6 @@
-use crate::{SchemaWalker, StringId};
+use crate::StringId;
 
-use super::coerce::InputValueError;
+use super::{coerce::InputValueError, BuildContext};
 
 #[derive(Debug, Copy, Clone)]
 pub enum SchemaLocation {
@@ -8,11 +8,11 @@ pub enum SchemaLocation {
     Field { ty: StringId, name: StringId },
 }
 
-impl std::fmt::Display for SchemaWalker<'_, SchemaLocation> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.item {
-            SchemaLocation::Type { name } => f.write_str(&self.schema[name]),
-            SchemaLocation::Field { ty, name } => write!(f, "{}.{}", &self.schema[ty], &self.schema[name]),
+impl SchemaLocation {
+    pub fn to_string(self, ctx: &BuildContext) -> String {
+        match self {
+            SchemaLocation::Type { name } => ctx.strings[name].to_string(),
+            SchemaLocation::Field { ty, name } => format!("{}.{}", &ctx.strings[ty], &ctx.strings[name]),
         }
     }
 }

--- a/engine/crates/engine-v2/schema/src/builder/external_sources.rs
+++ b/engine/crates/engine-v2/schema/src/builder/external_sources.rs
@@ -1,0 +1,50 @@
+use std::mem::take;
+
+use config::latest::Config;
+
+use crate::sources;
+
+use super::BuildContext;
+
+pub struct ExternalDataSources {
+    pub graphql: sources::graphql::GraphqlEndpoints,
+}
+
+impl ExternalDataSources {
+    pub(super) fn build(ctx: &mut BuildContext, config: &mut Config) -> Self {
+        let endpoints = take(&mut config.graph.subgraphs)
+            .into_iter()
+            .enumerate()
+            .map(|(index, subgraph)| {
+                let subgraph_id = ctx.next_subgraph_id();
+                let name = subgraph.name.into();
+                let url = ctx
+                    .urls
+                    .insert(url::Url::parse(&ctx.strings[subgraph.url.into()]).expect("valid url"));
+                match config.subgraph_configs.remove(&federated_graph::SubgraphId(index)) {
+                    Some(config::latest::SubgraphConfig { websocket_url, headers }) => {
+                        sources::graphql::GraphqlEndpoint {
+                            name,
+                            subgraph_id,
+                            url,
+                            websocket_url: websocket_url
+                                .map(|url| ctx.urls.insert(url::Url::parse(&config[url]).expect("valid url"))),
+                            headers: headers.into_iter().map(Into::into).collect(),
+                        }
+                    }
+
+                    None => sources::graphql::GraphqlEndpoint {
+                        name,
+                        subgraph_id,
+                        url,
+                        websocket_url: None,
+                        headers: Vec::new(),
+                    },
+                }
+            })
+            .collect();
+        ExternalDataSources {
+            graphql: sources::GraphqlEndpoints { endpoints },
+        }
+    }
+}

--- a/engine/crates/engine-v2/schema/src/builder/graph.rs
+++ b/engine/crates/engine-v2/schema/src/builder/graph.rs
@@ -1,0 +1,546 @@
+use std::{
+    collections::{HashMap, HashSet},
+    mem::take,
+    ops::Range,
+};
+
+use config::latest::{CacheConfigTarget, Config};
+use id_newtypes::IdRange;
+
+use crate::{
+    sources::{self, graphql::GraphqlEndpointId, introspection::IntrospectionBuilder, IntrospectionMetadata},
+    CacheConfigId, Definition, Directive, Enum, EnumId, EnumValue, EnumValueId, FieldDefinition, FieldDefinitionId,
+    FieldProvides, FieldRequires, Graph, InputObject, InputObjectId, InputValueDefinition, Interface, InterfaceId,
+    Object, ObjectId, ProvidableField, ProvidableFieldSet, Resolver, ResolverId, RootOperationTypes, Scalar, ScalarId,
+    ScalarType, StringId, Type, Union, UnionId,
+};
+
+use super::{
+    ids::IdMap, interner::Interner, BuildContext, BuildError, ExternalDataSources, RequiredFieldSetBuffer,
+    SchemaLocation,
+};
+
+pub(crate) struct GraphBuilder<'a> {
+    ctx: &'a mut BuildContext,
+    sources: &'a ExternalDataSources,
+    required_field_sets_buffer: RequiredFieldSetBuffer,
+    graph: Graph,
+}
+
+impl<'a> GraphBuilder<'a> {
+    pub fn build(
+        ctx: &'a mut BuildContext,
+        sources: &ExternalDataSources,
+        config: &mut Config,
+    ) -> Result<(Graph, IntrospectionMetadata), BuildError> {
+        let mut builder = GraphBuilder {
+            ctx,
+            sources,
+            required_field_sets_buffer: Default::default(),
+            graph: Graph {
+                description: None,
+                root_operation_types: RootOperationTypes {
+                    query: config.graph.root_operation_types.query.into(),
+                    mutation: config.graph.root_operation_types.mutation.map(Into::into),
+                    subscription: config.graph.root_operation_types.subscription.map(Into::into),
+                },
+                object_definitions: Vec::new(),
+                interface_definitions: Vec::new(),
+                union_definitions: Vec::new(),
+                scalar_definitions: Vec::new(),
+                enum_definitions: Vec::new(),
+                enum_value_definitions: Vec::new(),
+                input_object_definitions: Vec::new(),
+                input_value_definitions: Vec::new(),
+                field_definitions: Vec::new(),
+                resolvers: Vec::new(),
+                definitions: Vec::new(),
+                directive_definitions: Vec::new(),
+                cache_configs: Vec::new(),
+                required_field_sets: Vec::new(),
+                required_fields_arguments: Vec::new(),
+                input_values: Default::default(),
+            },
+        };
+        builder.ingest_config(config);
+        builder.finalize()
+    }
+
+    fn ingest_config(&mut self, config: &mut Config) {
+        self.ingest_input_values(config);
+        self.ingest_input_objects(config);
+        self.ingest_unions(config);
+        self.ingest_enums(config);
+        self.ingest_scalars(config);
+        self.ingest_object_and_fields(config);
+        self.ingest_interfaces_after_objects(config);
+        self.ingest_directives_after_all(config);
+    }
+
+    fn ingest_input_values(&mut self, config: &mut Config) {
+        self.graph.input_value_definitions = take(&mut config.graph.input_value_definitions)
+            .into_iter()
+            .enumerate()
+            .filter_map(|(idx, definition)| {
+                if self.ctx.idmaps.input_value.contains(idx) {
+                    Some(definition.into())
+                } else {
+                    None
+                }
+            })
+            .collect();
+    }
+
+    fn ingest_input_objects(&mut self, config: &mut Config) {
+        self.graph.input_object_definitions = take(&mut config.graph.input_objects)
+            .into_iter()
+            .enumerate()
+            .filter_map(|(idx, definition)| {
+                if self.ctx.idmaps.input_value.contains(idx) {
+                    Some(InputObject {
+                        name: definition.name.into(),
+                        description: definition.description.map(Into::into),
+                        input_field_ids: self.ctx.idmaps.input_value.get_range(definition.fields),
+                        composed_directives: IdRange::from_start_and_length(definition.composed_directives),
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect();
+    }
+
+    fn ingest_unions(&mut self, config: &mut Config) {
+        self.graph.union_definitions = take(&mut config.graph.unions)
+            .into_iter()
+            .map(|union| Union {
+                name: union.name.into(),
+                description: None,
+                possible_types: union
+                    .members
+                    .into_iter()
+                    .filter(|object_id| !is_inaccessible(&config.graph, config.graph[*object_id].composed_directives))
+                    .map(Into::into)
+                    .collect(),
+                composed_directives: IdRange::from_start_and_length(union.composed_directives),
+            })
+            .collect();
+    }
+
+    fn ingest_enums(&mut self, config: &mut Config) {
+        let mut idmap = IdMap::<federated_graph::EnumValueId, EnumValueId>::default();
+        self.graph.enum_value_definitions = take(&mut config.graph.enum_values)
+            .into_iter()
+            .enumerate()
+            .filter_map(|(idx, enum_value)| {
+                if is_inaccessible(&config.graph, enum_value.composed_directives) {
+                    idmap.skip(federated_graph::EnumValueId(idx));
+                    None
+                } else {
+                    Some(EnumValue {
+                        name: enum_value.value.into(),
+                        description: None,
+                        composed_directives: IdRange::from_start_and_length(enum_value.composed_directives),
+                    })
+                }
+            })
+            .collect();
+
+        self.graph.enum_definitions = take(&mut config.graph.enums)
+            .into_iter()
+            .map(|federated_enum| Enum {
+                name: federated_enum.name.into(),
+                description: None,
+                value_ids: {
+                    let range = idmap.get_range(federated_enum.values);
+                    self.graph.enum_value_definitions[Range::<usize>::from(range)]
+                        .sort_unstable_by(|a, b| self.ctx.strings[a.name].cmp(&self.ctx.strings[b.name]));
+                    // The range is still valid even if individual ids don't match anymore.
+                    range
+                },
+                composed_directives: IdRange::from_start_and_length(federated_enum.composed_directives),
+            })
+            .collect();
+    }
+
+    fn ingest_scalars(&mut self, config: &mut Config) {
+        self.graph.scalar_definitions = take(&mut config.graph.scalars)
+            .into_iter()
+            .map(|scalar| {
+                let name = StringId::from(scalar.name);
+                Scalar {
+                    name,
+                    ty: ScalarType::from_scalar_name(&self.ctx.strings[name]),
+                    description: None,
+                    specified_by_url: None,
+                    composed_directives: IdRange::from_start_and_length(scalar.composed_directives),
+                }
+            })
+            .collect();
+    }
+
+    fn ingest_object_and_fields(&mut self, config: &mut Config) {
+        let schema = &mut self.graph;
+        let cache = take(&mut config.cache);
+        let graph = &mut config.graph;
+        let mut cache_configs = Interner::<config::latest::CacheConfig, CacheConfigId>::default();
+
+        // -- OBJECTS --
+        let mut entity_resolvers = HashMap::<ObjectId, Vec<(ResolverId, GraphqlEndpointId, ProvidableFieldSet)>>::new();
+        let mut unresolvable_keys = HashMap::<ObjectId, HashMap<GraphqlEndpointId, ProvidableFieldSet>>::new();
+        let mut field_id_to_maybe_object_id: Vec<Option<ObjectId>> = vec![None; graph.fields.len()];
+
+        for object in take(&mut graph.objects) {
+            let object_id = ObjectId::from(schema.object_definitions.len());
+            let cache_config = cache
+                .rule(CacheConfigTarget::Object(federated_graph::ObjectId(object_id.into())))
+                .map(|config| cache_configs.get_or_insert(config));
+
+            let fields = self
+                .ctx
+                .idmaps
+                .field
+                .get_range((object.fields.start, object.fields.end.0 - object.fields.start.0));
+
+            for field_id in fields {
+                field_id_to_maybe_object_id[usize::from(field_id)] = Some(object_id);
+            }
+
+            schema.object_definitions.push(Object {
+                name: object.name.into(),
+                description: None,
+                interfaces: object.implements_interfaces.into_iter().map(Into::into).collect(),
+                composed_directives: IdRange::from_start_and_length(object.composed_directives),
+                cache_config,
+                fields,
+            });
+
+            for key in object.keys {
+                let endpoint_id = key.subgraph_id.into();
+                // Some SDL are generated with empty keys, they're useless to us.
+                if key.fields.is_empty() {
+                    continue;
+                }
+                if key.resolvable {
+                    let providable = self.ctx.idmaps.field.convert_providable_field_set(&key.fields);
+                    let key = sources::graphql::FederationKey {
+                        fields: self.required_field_sets_buffer.push(
+                            SchemaLocation::Type {
+                                name: object.name.into(),
+                            },
+                            key.fields,
+                        ),
+                    };
+
+                    let resolver_id = ResolverId::from(schema.resolvers.len());
+                    schema.resolvers.push(Resolver::GraphqlFederationEntity(
+                        sources::graphql::FederationEntityResolver { endpoint_id, key },
+                    ));
+                    entity_resolvers
+                        .entry(object_id)
+                        .or_default()
+                        .push((resolver_id, endpoint_id, providable));
+                } else {
+                    // We don't need to differentiate between keys here. We'll be using this to add
+                    // those fields to `provides` in the relevant fields. It's the resolvable keys
+                    // that will determine which fields to retrieve during planning. And composition
+                    // ensures that keys between subgraphs are coherent.
+                    let field_set: ProvidableFieldSet = self.ctx.idmaps.field.convert_providable_field_set(&key.fields);
+                    unresolvable_keys
+                        .entry(object_id)
+                        .or_default()
+                        .entry(endpoint_id)
+                        .and_modify(|current| current.update(&field_set))
+                        .or_insert(field_set);
+                }
+            }
+        }
+
+        // -- ROOT FIELDS --
+        let root_fields = {
+            let mut root_fields = vec![];
+            root_fields.extend(schema[schema.root_operation_types.query].fields);
+
+            if let Some(mutation) = schema.root_operation_types.mutation {
+                root_fields.extend(schema[mutation].fields);
+            }
+            if let Some(subscription) = schema.root_operation_types.subscription {
+                root_fields.extend(schema[subscription].fields);
+            }
+            root_fields.sort_unstable();
+            root_fields
+        };
+
+        // Yeah it's ugly, conversion should be cleaned up once we got it working I guess.
+        // -- FIELDS & RESOLVERS --
+        // 1. The federated graph uses "resolvable_in" whenever a field is present in a subgraph.
+        //    But for resolvers we only want the "entrypoints", so root fields and later the `@key`
+        //    for federation entities.
+        // 2. Field arguments are converted to input values. That's how the GraphQL spec defines
+        //    them and having an id allows data sources to rename those more easily.
+        let mut root_field_resolvers = HashMap::<GraphqlEndpointId, ResolverId>::new();
+        for (i, field) in take(&mut graph.fields).into_iter().enumerate() {
+            let Some(field_id) = self.ctx.idmaps.field.get(federated_graph::FieldId(i)) else {
+                continue;
+            };
+            let mut resolvers = vec![];
+            let mut only_resolvable_in = field.resolvable_in.into_iter().map(Into::into).collect::<HashSet<_>>();
+
+            if root_fields.binary_search(&field_id).is_ok() {
+                for &endpoint_id in &only_resolvable_in {
+                    let resolver_id = *root_field_resolvers.entry(endpoint_id).or_insert_with(|| {
+                        let resolver_id = ResolverId::from(schema.resolvers.len());
+                        schema
+                            .resolvers
+                            .push(Resolver::GraphqlRootField(sources::graphql::RootFieldResolver {
+                                endpoint_id,
+                            }));
+                        resolver_id
+                    });
+                    resolvers.push(resolver_id);
+                }
+            } else if let Some(parent_object_id) = field_id_to_maybe_object_id[usize::from(field_id)] {
+                if let Some(entity_resolvers) = entity_resolvers.get(&parent_object_id) {
+                    // FederatedGraph does not include key fields in resolvable_in.
+                    for (_, endpoint_id, key_field_set) in entity_resolvers {
+                        if key_field_set.contains(field_id) {
+                            only_resolvable_in.insert(*endpoint_id);
+                        }
+                    }
+                    // if resolvable within a federation subgraph and not part of the keys
+                    // (requirements), we can use the resolver to retrieve this field.
+                    for (resolver_id, endpoint_id, key_field_set) in entity_resolvers {
+                        if !key_field_set.contains(field_id) && only_resolvable_in.contains(endpoint_id) {
+                            resolvers.push(*resolver_id);
+                        }
+                    }
+                }
+
+                // if unresolvable within this subgraph, it means we can't provide the entity
+                // directly but are able to provide the necessary key fields.
+                if let Some(keys) = unresolvable_keys.get(&parent_object_id) {
+                    for (endpoint_id, field_set) in keys {
+                        if field_set.contains(field_id) {
+                            only_resolvable_in.insert(*endpoint_id);
+                        }
+                    }
+                }
+            }
+
+            let field = FieldDefinition {
+                name: field.name.into(),
+                description: None,
+                ty: field.r#type.into(),
+                only_resolvable_in: only_resolvable_in
+                    .into_iter()
+                    .map(|endpoint_id| self.sources.graphql[endpoint_id].subgraph_id)
+                    .collect(),
+                resolvers,
+                provides: field
+                    .provides
+                    .into_iter()
+                    .filter(|provides| !provides.fields.is_empty())
+                    .map(|federated_graph::FieldProvides { subgraph_id, fields }| FieldProvides {
+                        subgraph_id: self.sources.graphql[GraphqlEndpointId::from(subgraph_id)].subgraph_id,
+                        field_set: self.ctx.idmaps.field.convert_providable_field_set(&fields),
+                    })
+                    .collect(),
+                requires: field
+                    .requires
+                    .into_iter()
+                    .filter(|requires| !requires.fields.is_empty())
+                    .map(|federated_graph::FieldRequires { subgraph_id, fields }| {
+                        let parent_object_id = field_id_to_maybe_object_id[usize::from(field_id)];
+                        let field_set_id = self.required_field_sets_buffer.push(
+                            SchemaLocation::Field {
+                                ty: parent_object_id.map(|id| schema[id].name).unwrap_or(field.name.into()),
+                                name: field.name.into(),
+                            },
+                            fields,
+                        );
+                        FieldRequires {
+                            subgraph_id: self.sources.graphql[GraphqlEndpointId::from(subgraph_id)].subgraph_id,
+                            field_set_id,
+                        }
+                    })
+                    .collect(),
+                argument_ids: self.ctx.idmaps.input_value.get_range(field.arguments),
+                composed_directives: IdRange::from_start_and_length(field.composed_directives),
+                cache_config: cache
+                    .rule(CacheConfigTarget::Field(federated_graph::FieldId(field_id.into())))
+                    .map(|config| cache_configs.get_or_insert(config)),
+            };
+            schema.field_definitions.push(field);
+        }
+
+        // -- CACHE CONFIG --
+        schema.cache_configs = cache_configs.into_iter().map(Into::into).collect();
+    }
+
+    fn ingest_interfaces_after_objects(&mut self, config: &mut Config) {
+        self.graph.interface_definitions = take(&mut config.graph.interfaces)
+            .into_iter()
+            .map(|interface| Interface {
+                name: interface.name.into(),
+                description: None,
+                interfaces: Vec::new(),
+                possible_types: Vec::new(),
+                composed_directives: IdRange::from_start_and_length(interface.composed_directives),
+                fields: self.ctx.idmaps.field.get_range((
+                    interface.fields.start,
+                    interface.fields.end.0 - interface.fields.start.0,
+                )),
+            })
+            .collect();
+
+        // Adding all implementations of an interface, used during introspection.
+        for object_id in (0..self.graph.object_definitions.len()).map(ObjectId::from) {
+            for interface_id in self.graph[object_id].interfaces.clone() {
+                self.graph[interface_id].possible_types.push(object_id);
+            }
+        }
+    }
+
+    fn ingest_directives_after_all(&mut self, config: &mut Config) {
+        // FIXME: remove stuff that isn't needed at runtime...
+        let mut directives = Vec::with_capacity(config.graph.directives.len());
+        for directive in take(&mut config.graph.directives) {
+            let directive = match directive {
+                federated_graph::Directive::Authenticated => Directive::Authenticated,
+                federated_graph::Directive::Policy(args) => Directive::Policy(
+                    args.into_iter()
+                        .map(|inner| inner.into_iter().map(|string| string.into()).collect())
+                        .collect(),
+                ),
+                federated_graph::Directive::RequiresScopes(args) => Directive::RequiresScopes(
+                    args.into_iter()
+                        .map(|inner| inner.into_iter().map(|string| string.into()).collect())
+                        .collect(),
+                ),
+                federated_graph::Directive::Inaccessible => Directive::Inaccessible,
+                federated_graph::Directive::Deprecated { reason } => Directive::Deprecated {
+                    reason: reason.map(Into::into),
+                },
+                federated_graph::Directive::Other { .. } => Directive::Other,
+            };
+            directives.push(directive);
+        }
+        self.graph.directive_definitions = directives;
+    }
+
+    fn finalize(self) -> Result<(Graph, IntrospectionMetadata), BuildError> {
+        let Self {
+            ctx,
+            required_field_sets_buffer,
+            mut graph,
+            ..
+        } = self;
+
+        required_field_sets_buffer.try_insert_into(ctx, &mut graph)?;
+
+        let introspection = IntrospectionBuilder::create_data_source_and_insert_fields(ctx, &mut graph);
+
+        let mut definitions = Vec::with_capacity(
+            graph.scalar_definitions.len()
+                + graph.object_definitions.len()
+                + graph.interface_definitions.len()
+                + graph.union_definitions.len()
+                + graph.enum_definitions.len()
+                + graph.input_object_definitions.len(),
+        );
+
+        // Adding all definitions for introspection & query binding
+        definitions.extend((0..graph.scalar_definitions.len()).map(|id| Definition::Scalar(ScalarId::from(id))));
+        definitions.extend((0..graph.object_definitions.len()).map(|id| Definition::Object(ObjectId::from(id))));
+        definitions
+            .extend((0..graph.interface_definitions.len()).map(|id| Definition::Interface(InterfaceId::from(id))));
+        definitions.extend((0..graph.union_definitions.len()).map(|id| Definition::Union(UnionId::from(id))));
+        definitions.extend((0..graph.enum_definitions.len()).map(|id| Definition::Enum(EnumId::from(id))));
+        definitions.extend(
+            (0..graph.input_object_definitions.len()).map(|id| Definition::InputObject(InputObjectId::from(id))),
+        );
+        definitions.sort_unstable_by_key(|definition| match *definition {
+            Definition::Scalar(id) => &ctx.strings[graph[id].name],
+            Definition::Object(id) => &ctx.strings[graph[id].name],
+            Definition::Interface(id) => &ctx.strings[graph[id].name],
+            Definition::Union(id) => &ctx.strings[graph[id].name],
+            Definition::Enum(id) => &ctx.strings[graph[id].name],
+            Definition::InputObject(id) => &ctx.strings[graph[id].name],
+        });
+        graph.definitions = definitions;
+
+        for interface in &mut graph.interface_definitions {
+            interface.possible_types.sort_unstable();
+        }
+        for union in &mut graph.union_definitions {
+            union.possible_types.sort_unstable();
+        }
+
+        Ok((graph, introspection))
+    }
+}
+
+fn is_inaccessible(graph: &federated_graph::FederatedGraphV3, directives: federated_graph::Directives) -> bool {
+    graph[directives]
+        .iter()
+        .any(|directive| matches!(directive, federated_graph::Directive::Inaccessible))
+}
+
+impl From<federated_graph::Definition> for Definition {
+    fn from(definition: federated_graph::Definition) -> Self {
+        match definition {
+            federated_graph::Definition::Scalar(id) => Definition::Scalar(id.into()),
+            federated_graph::Definition::Object(id) => Definition::Object(id.into()),
+            federated_graph::Definition::Interface(id) => Definition::Interface(id.into()),
+            federated_graph::Definition::Union(id) => Definition::Union(id.into()),
+            federated_graph::Definition::Enum(id) => Definition::Enum(id.into()),
+            federated_graph::Definition::InputObject(id) => Definition::InputObject(id.into()),
+        }
+    }
+}
+
+impl From<federated_graph::Type> for Type {
+    fn from(field_type: federated_graph::Type) -> Self {
+        Type {
+            inner: field_type.definition.into(),
+            wrapping: field_type.wrapping,
+        }
+    }
+}
+
+impl From<federated_graph::InputValueDefinition> for InputValueDefinition {
+    fn from(value: federated_graph::InputValueDefinition) -> Self {
+        InputValueDefinition {
+            name: value.name.into(),
+            description: value.description.map(Into::into),
+            ty: value.r#type.into(),
+            default_value: None,
+        }
+    }
+}
+
+impl From<federated_graph::EnumValue> for EnumValue {
+    fn from(enum_value: federated_graph::EnumValue) -> Self {
+        EnumValue {
+            name: enum_value.value.into(),
+            description: None,
+            composed_directives: IdRange::from_start_and_length(enum_value.composed_directives),
+        }
+    }
+}
+
+impl IdMap<federated_graph::FieldId, FieldDefinitionId> {
+    fn convert_providable_field_set(&self, field_set: &federated_graph::FieldSet) -> ProvidableFieldSet {
+        field_set
+            .iter()
+            .filter_map(|item| self.convert_providable_field_set_item(item))
+            .collect()
+    }
+
+    fn convert_providable_field_set_item(&self, item: &federated_graph::FieldSetItem) -> Option<ProvidableField> {
+        Some(ProvidableField {
+            id: self.get(item.field)?,
+            subselection: self.convert_providable_field_set(&item.subselection),
+        })
+    }
+}

--- a/engine/crates/engine-v2/schema/src/builder/mod.rs
+++ b/engine/crates/engine-v2/schema/src/builder/mod.rs
@@ -1,21 +1,22 @@
 mod coerce;
 mod error;
+mod external_sources;
+mod graph;
 mod ids;
 mod interner;
 mod requires;
 
-use std::collections::{HashMap, HashSet};
 use std::mem::take;
 
-use config::latest::{CacheConfigTarget, Config};
+use config::latest::Config;
 use url::Url;
 
+use self::external_sources::ExternalDataSources;
+use self::graph::GraphBuilder;
 use self::ids::IdMaps;
+use self::sources::graphql::GraphqlEndpointId;
 
 use super::*;
-use crate::sources;
-use crate::sources::graphql::GraphqlEndpointId;
-use crate::sources::introspection::IntrospectionSchemaBuilder;
 use error::*;
 use interner::Interner;
 use requires::*;
@@ -23,149 +24,132 @@ use requires::*;
 impl TryFrom<Config> for Schema {
     type Error = BuildError;
 
-    fn try_from(config: Config) -> Result<Self, Self::Error> {
-        SchemaBuilder::build_schema(config)
+    fn try_from(mut config: Config) -> Result<Self, Self::Error> {
+        let mut ctx = BuildContext::new(&mut config);
+        let sources = ExternalDataSources::build(&mut ctx, &mut config);
+        let (graph, introspection) = GraphBuilder::build(&mut ctx, &sources, &mut config)?;
+        let data_sources = DataSources {
+            graphql: sources.graphql,
+            introspection,
+        };
+        ctx.finalize(data_sources, graph, config)
     }
 }
 
-pub(crate) struct SchemaBuilder {
-    pub schema: Schema,
+pub(crate) struct BuildContext {
     pub strings: Interner<String, StringId>,
     urls: Interner<Url, UrlId>,
     idmaps: IdMaps,
-    required_field_sets_buffer: RequiredFieldSetBuffer,
     next_subraph_id: usize,
 }
 
-impl SchemaBuilder {
-    fn build_schema(mut config: Config) -> Result<Schema, BuildError> {
-        let mut builder = Self::initialize(&mut config);
-        builder.insert_graphql_datasource(&mut config);
-        builder.insert_headers(&mut config);
-
-        builder.insert_enums(&mut config);
-        builder.insert_graphql_schema(&mut config);
-        builder.insert_directives(&mut config);
-
-        let introspection_subgraph_id = builder.next_subraph_id();
-        IntrospectionSchemaBuilder::insert_introspection_fields(&mut builder, introspection_subgraph_id);
-
-        builder.build()
+impl BuildContext {
+    #[cfg(test)]
+    pub fn build_with<T>(build: impl FnOnce(&mut Self, &mut Graph) -> T) -> (Schema, T) {
+        let mut ctx = Self {
+            strings: Interner::from_vec(Vec::new()),
+            urls: Interner::default(),
+            idmaps: IdMaps::empty(),
+            next_subraph_id: 0,
+        };
+        let mut graph = Graph {
+            description: None,
+            root_operation_types: RootOperationTypes {
+                query: ObjectId::from(0),
+                mutation: None,
+                subscription: None,
+            },
+            definitions: Vec::new(),
+            object_definitions: vec![Object {
+                name: ctx.strings.get_or_insert("Query"),
+                description: None,
+                interfaces: Default::default(),
+                composed_directives: Default::default(),
+                cache_config: Default::default(),
+                fields: IdRange::from_start_and_length((0, 2)),
+            }],
+            interface_definitions: Vec::new(),
+            field_definitions: vec![
+                FieldDefinition {
+                    name: ctx.strings.get_or_insert("__type"),
+                    description: None,
+                    // will be replaced by introspection, doesn't matter.
+                    ty: Type {
+                        inner: Definition::Object(ObjectId::from(0)),
+                        wrapping: Default::default(),
+                    },
+                    resolvers: Default::default(),
+                    only_resolvable_in: Default::default(),
+                    requires: Default::default(),
+                    provides: Default::default(),
+                    argument_ids: Default::default(),
+                    composed_directives: Default::default(),
+                    cache_config: Default::default(),
+                },
+                FieldDefinition {
+                    name: ctx.strings.get_or_insert("__schema"),
+                    description: None,
+                    // will be replaced by introspection, doesn't matter.
+                    ty: Type {
+                        inner: Definition::Object(ObjectId::from(0)),
+                        wrapping: Default::default(),
+                    },
+                    resolvers: Default::default(),
+                    only_resolvable_in: Default::default(),
+                    requires: Default::default(),
+                    provides: Default::default(),
+                    argument_ids: Default::default(),
+                    composed_directives: Default::default(),
+                    cache_config: Default::default(),
+                },
+            ],
+            enum_definitions: Vec::new(),
+            union_definitions: Vec::new(),
+            scalar_definitions: Vec::new(),
+            input_object_definitions: Vec::new(),
+            input_value_definitions: Vec::new(),
+            directive_definitions: Vec::new(),
+            enum_value_definitions: Vec::new(),
+            cache_configs: Vec::new(),
+            resolvers: Vec::new(),
+            required_field_sets: Vec::new(),
+            required_fields_arguments: Vec::new(),
+            input_values: Default::default(),
+        };
+        let out = build(&mut ctx, &mut graph);
+        let introspection =
+            sources::introspection::IntrospectionBuilder::create_data_source_and_insert_fields(&mut ctx, &mut graph);
+        let schema = Schema {
+            data_sources: DataSources {
+                graphql: Default::default(),
+                introspection,
+            },
+            graph,
+            strings: ctx.strings.into(),
+            urls: Default::default(),
+            headers: Default::default(),
+            settings: Default::default(),
+        };
+        (schema, out)
     }
 
-    fn initialize(config: &mut Config) -> Self {
-        let mut builder = Self {
-            idmaps: IdMaps::default(),
-            required_field_sets_buffer: Default::default(),
-            next_subraph_id: 0,
+    fn new(config: &mut Config) -> Self {
+        Self {
             strings: Interner::from_vec(take(&mut config.graph.strings)),
             urls: Interner::default(),
-            schema: Schema {
-                description: None,
-                root_operation_types: RootOperationTypes {
-                    query: config.graph.root_operation_types.query.into(),
-                    mutation: config.graph.root_operation_types.mutation.map(Into::into),
-                    subscription: config.graph.root_operation_types.subscription.map(Into::into),
-                },
-                objects: Vec::with_capacity(config.graph.objects.len()),
-                field_definitions: Vec::with_capacity(config.graph.fields.len()),
-                interfaces: Vec::with_capacity(config.graph.interfaces.len()),
-                enums: Vec::new(),
-                unions: Vec::with_capacity(0),
-                scalars: Vec::with_capacity(config.graph.scalars.len()),
-                input_objects: Vec::new(),
-                directives: Vec::new(),
-                input_value_definitions: Vec::new(),
-                enum_values: Vec::new(),
-                headers: Vec::new(),
-                strings: Vec::new(),
-                resolvers: Vec::new(),
-                definitions: Vec::new(),
-                data_sources: DataSources::default(),
-                default_headers: Vec::new(),
-                cache_configs: Vec::new(),
-                auth_config: take(&mut config.auth),
-                operation_limits: take(&mut config.operation_limits),
-                disable_introspection: config.disable_introspection,
-                urls: Vec::new(),
-                input_values: SchemaInputValues::default(),
-                required_field_sets: Vec::new(),
-                required_fields_arguments: Vec::new(),
-            },
-        };
-
-        for (idx, input_value_definition) in take(&mut config.graph.input_value_definitions).into_iter().enumerate() {
-            if is_inaccessible(&config.graph, input_value_definition.directives) {
-                builder
-                    .idmaps
-                    .input_value
-                    .skip(federated_graph::InputValueDefinitionId(idx));
-            } else {
-                builder
-                    .schema
-                    .input_value_definitions
-                    .push(input_value_definition.into());
-            }
+            idmaps: IdMaps::new(config),
+            next_subraph_id: 0,
         }
-
-        for (i, field) in config.graph.fields.iter().enumerate() {
-            if is_inaccessible(&config.graph, field.composed_directives) {
-                builder.idmaps.field.skip(federated_graph::FieldId(i))
-            }
-        }
-
-        builder.schema.input_objects = take(&mut config.graph.input_objects)
-            .into_iter()
-            .map(|input_object| builder.convert_input_object(input_object))
-            .collect();
-
-        builder.schema.unions = take(&mut config.graph.unions)
-            .into_iter()
-            .map(|union| Union {
-                name: union.name.into(),
-                description: None,
-                possible_types: union
-                    .members
-                    .into_iter()
-                    .filter(|object_id| !is_inaccessible(&config.graph, config.graph[*object_id].composed_directives))
-                    .map(Into::into)
-                    .collect(),
-                composed_directives: IdRange::from_start_and_length(union.composed_directives),
-            })
-            .collect();
-
-        builder
     }
 
-    fn insert_directives(&mut self, config: &mut Config) {
-        // FIXME: remove stuff that isn't needed at runtime...
-        let mut directives = Vec::with_capacity(config.graph.directives.len());
-        for directive in take(&mut config.graph.directives) {
-            let directive = match directive {
-                federated_graph::Directive::Authenticated => Directive::Authenticated,
-                federated_graph::Directive::Policy(args) => Directive::Policy(
-                    args.into_iter()
-                        .map(|inner| inner.into_iter().map(|string| string.into()).collect())
-                        .collect(),
-                ),
-                federated_graph::Directive::RequiresScopes(args) => Directive::RequiresScopes(
-                    args.into_iter()
-                        .map(|inner| inner.into_iter().map(|string| string.into()).collect())
-                        .collect(),
-                ),
-                federated_graph::Directive::Inaccessible => Directive::Inaccessible,
-                federated_graph::Directive::Deprecated { reason } => Directive::Deprecated {
-                    reason: reason.map(Into::into),
-                },
-                federated_graph::Directive::Other { .. } => Directive::Other,
-            };
-            directives.push(directive);
-        }
-        self.schema.directives = directives;
+    pub fn next_subgraph_id(&mut self) -> SubgraphId {
+        let id = SubgraphId::from(self.next_subraph_id);
+        self.next_subraph_id += 1;
+        id
     }
 
-    fn insert_headers(&mut self, config: &mut Config) {
-        self.schema.headers = take(&mut config.headers)
+    fn finalize(mut self, data_sources: DataSources, graph: Graph, mut config: Config) -> Result<Schema, BuildError> {
+        let headers = take(&mut config.headers)
             .into_iter()
             .map(|header| Header {
                 name: self.strings.get_or_insert(&config[header.name]),
@@ -179,451 +163,20 @@ impl SchemaBuilder {
                 },
             })
             .collect();
-        self.schema.default_headers = take(&mut config.default_headers).into_iter().map(Into::into).collect();
-    }
 
-    fn next_subraph_id(&mut self) -> SubgraphId {
-        let id = SubgraphId::from(self.next_subraph_id);
-        self.next_subraph_id += 1;
-        id
-    }
-
-    fn insert_graphql_datasource(&mut self, config: &mut Config) {
-        self.schema.data_sources.graphql.endpoints = take(&mut config.graph.subgraphs)
-            .into_iter()
-            .enumerate()
-            .map(|(index, subgraph)| {
-                let subgraph_id = self.next_subraph_id();
-                let name = subgraph.name.into();
-                let url = self
-                    .urls
-                    .insert(url::Url::parse(&self.strings[subgraph.url.into()]).expect("valid url"));
-                match config.subgraph_configs.remove(&federated_graph::SubgraphId(index)) {
-                    Some(config::latest::SubgraphConfig { websocket_url, headers }) => {
-                        sources::graphql::GraphqlEndpoint {
-                            name,
-                            subgraph_id,
-                            url,
-                            websocket_url: websocket_url
-                                .map(|url| self.urls.insert(url::Url::parse(&config[url]).expect("valid url"))),
-                            headers: headers.into_iter().map(Into::into).collect(),
-                        }
-                    }
-
-                    None => sources::graphql::GraphqlEndpoint {
-                        name,
-                        subgraph_id,
-                        url,
-                        websocket_url: None,
-                        headers: Vec::new(),
-                    },
-                }
-            })
-            .collect();
-    }
-
-    fn insert_enums(&mut self, config: &mut Config) {
-        for (idx, enum_value) in take(&mut config.graph.enum_values).into_iter().enumerate() {
-            if is_inaccessible(&config.graph, enum_value.composed_directives) {
-                self.idmaps.enum_value.skip(federated_graph::EnumValueId(idx))
-            } else {
-                self.schema.enum_values.push(enum_value.into());
-            }
-        }
-        let mut enums: Vec<Enum> = Vec::with_capacity(config.graph.enums.len());
-        for federated_enum in take(&mut config.graph.enums) {
-            let r#enum = Enum {
-                name: federated_enum.name.into(),
-                description: None,
-                value_ids: {
-                    let range = self.idmaps.enum_value.get_range(federated_enum.values);
-                    self.schema[range].sort_unstable_by(|a, b| self.strings[a.name].cmp(&self.strings[b.name]));
-                    // The range is still valid even if individual ids don't match anymore.
-                    range
-                },
-                composed_directives: IdRange::from_start_and_length(federated_enum.composed_directives),
-            };
-            enums.push(r#enum);
-        }
-        self.schema.enums = enums;
-    }
-
-    fn insert_graphql_schema(&mut self, config: &mut Config) {
-        let cache = take(&mut config.cache);
-        let graph = &mut config.graph;
-        let schema = &mut self.schema;
-        let mut cache_configs = Interner::<config::latest::CacheConfig, CacheConfigId>::default();
-
-        // -- OBJECTS --
-        let mut entity_resolvers = HashMap::<ObjectId, Vec<(ResolverId, GraphqlEndpointId, ProvidableFieldSet)>>::new();
-        let mut unresolvable_keys = HashMap::<ObjectId, HashMap<GraphqlEndpointId, ProvidableFieldSet>>::new();
-        let mut field_id_to_maybe_object_id: Vec<Option<ObjectId>> = vec![None; graph.fields.len()];
-
-        for object in take(&mut graph.objects) {
-            let object_id = ObjectId::from(schema.objects.len());
-            let cache_config = cache
-                .rule(CacheConfigTarget::Object(federated_graph::ObjectId(object_id.into())))
-                .map(|config| cache_configs.get_or_insert(config));
-
-            let fields = self
-                .idmaps
-                .field
-                .get_range((object.fields.start, object.fields.end.0 - object.fields.start.0));
-
-            for field_id in fields {
-                field_id_to_maybe_object_id[usize::from(field_id)] = Some(object_id);
-            }
-
-            schema.objects.push(Object {
-                name: object.name.into(),
-                description: None,
-                interfaces: object.implements_interfaces.into_iter().map(Into::into).collect(),
-                composed_directives: IdRange::from_start_and_length(object.composed_directives),
-                cache_config,
-                fields,
-            });
-
-            for key in object.keys {
-                let endpoint_id = key.subgraph_id.into();
-                // Some SDL are generated with empty keys, they're useless to us.
-                if key.fields.is_empty() {
-                    continue;
-                }
-                if key.resolvable {
-                    let providable = self.idmaps.field.convert_providable_field_set(&key.fields);
-                    let key = sources::graphql::FederationKey {
-                        fields: self.required_field_sets_buffer.push(
-                            SchemaLocation::Type {
-                                name: object.name.into(),
-                            },
-                            key.fields,
-                        ),
-                    };
-
-                    let resolver_id = ResolverId::from(schema.resolvers.len());
-                    schema.resolvers.push(Resolver::GraphqlFederationEntity(
-                        sources::graphql::FederationEntityResolver { endpoint_id, key },
-                    ));
-                    entity_resolvers
-                        .entry(object_id)
-                        .or_default()
-                        .push((resolver_id, endpoint_id, providable));
-                } else {
-                    // We don't need to differentiate between keys here. We'll be using this to add
-                    // those fields to `provides` in the relevant fields. It's the resolvable keys
-                    // that will determine which fields to retrieve during planning. And composition
-                    // ensures that keys between subgraphs are coherent.
-                    let field_set: ProvidableFieldSet = self.idmaps.field.convert_providable_field_set(&key.fields);
-                    unresolvable_keys
-                        .entry(object_id)
-                        .or_default()
-                        .entry(endpoint_id)
-                        .and_modify(|current| current.update(&field_set))
-                        .or_insert(field_set);
-                }
-            }
-        }
-
-        // -- OBJECT FIELDS --
-        let root_fields = {
-            let mut root_fields = vec![];
-            let walker = schema.walker();
-            for field in walker.walk(schema.root_operation_types.query).fields() {
-                root_fields.push(field.item);
-            }
-            if let Some(mutation) = schema.root_operation_types.mutation {
-                for field in walker.walk(mutation).fields() {
-                    root_fields.push(field.item);
-                }
-            }
-            if let Some(subscription) = schema.root_operation_types.subscription {
-                for field in walker.walk(subscription).fields() {
-                    root_fields.push(field.item);
-                }
-            }
-            root_fields.sort_unstable();
-            root_fields
-        };
-
-        // Yeah it's ugly, conversion should be cleaned up once we got it working I guess.
-        // -- FIELDS & RESOLVERS --
-        // 1. The federated graph uses "resolvable_in" whenever a field is present in a subgraph.
-        //    But for resolvers we only want the "entrypoints", so root fields and later the `@key`
-        //    for federation entities.
-        // 2. Field arguments are converted to input values. That's how the GraphQL spec defines
-        //    them and having an id allows data sources to rename those more easily.
-        let mut root_field_resolvers = HashMap::<GraphqlEndpointId, ResolverId>::new();
-        for (i, field) in take(&mut graph.fields).into_iter().enumerate() {
-            let Some(field_id) = self.idmaps.field.get(federated_graph::FieldId(i)) else {
-                continue;
-            };
-            let mut resolvers = vec![];
-            let mut only_resolvable_in = field.resolvable_in.into_iter().map(Into::into).collect::<HashSet<_>>();
-
-            if root_fields.binary_search(&field_id).is_ok() {
-                for &endpoint_id in &only_resolvable_in {
-                    let resolver_id = *root_field_resolvers.entry(endpoint_id).or_insert_with(|| {
-                        let resolver_id = ResolverId::from(schema.resolvers.len());
-                        schema
-                            .resolvers
-                            .push(Resolver::GraphqlRootField(sources::graphql::RootFieldResolver {
-                                endpoint_id,
-                            }));
-                        resolver_id
-                    });
-                    resolvers.push(resolver_id);
-                }
-            } else if let Some(parent_object_id) = field_id_to_maybe_object_id[usize::from(field_id)] {
-                if let Some(entity_resolvers) = entity_resolvers.get(&parent_object_id) {
-                    // FederatedGraph does not include key fields in resolvable_in.
-                    for (_, endpoint_id, key_field_set) in entity_resolvers {
-                        if key_field_set.contains(field_id) {
-                            only_resolvable_in.insert(*endpoint_id);
-                        }
-                    }
-                    // if resolvable within a federation subgraph and not part of the keys
-                    // (requirements), we can use the resolver to retrieve this field.
-                    for (resolver_id, endpoint_id, key_field_set) in entity_resolvers {
-                        if !key_field_set.contains(field_id) && only_resolvable_in.contains(endpoint_id) {
-                            resolvers.push(*resolver_id);
-                        }
-                    }
-                }
-
-                // if unresolvable within this subgraph, it means we can't provide the entity
-                // directly but are able to provide the necessary key fields.
-                if let Some(keys) = unresolvable_keys.get(&parent_object_id) {
-                    for (endpoint_id, field_set) in keys {
-                        if field_set.contains(field_id) {
-                            only_resolvable_in.insert(*endpoint_id);
-                        }
-                    }
-                }
-            }
-
-            let field = FieldDefinition {
-                name: field.name.into(),
-                description: None,
-                ty: field.r#type.into(),
-                only_resolvable_in: only_resolvable_in
-                    .into_iter()
-                    .map(|endpoint_id| schema.data_sources.graphql[endpoint_id].subgraph_id)
-                    .collect(),
-                resolvers,
-                provides: field
-                    .provides
-                    .into_iter()
-                    .filter(|provides| !provides.fields.is_empty())
-                    .map(|federated_graph::FieldProvides { subgraph_id, fields }| FieldProvides {
-                        subgraph_id: schema.data_sources.graphql[GraphqlEndpointId::from(subgraph_id)].subgraph_id,
-                        field_set: self.idmaps.field.convert_providable_field_set(&fields),
-                    })
-                    .collect(),
-                requires: field
-                    .requires
-                    .into_iter()
-                    .filter(|requires| !requires.fields.is_empty())
-                    .map(|federated_graph::FieldRequires { subgraph_id, fields }| {
-                        let parent_object_id = field_id_to_maybe_object_id[usize::from(field_id)];
-                        let field_set_id = self.required_field_sets_buffer.push(
-                            SchemaLocation::Field {
-                                ty: parent_object_id.map(|id| schema[id].name).unwrap_or(field.name.into()),
-                                name: field.name.into(),
-                            },
-                            fields,
-                        );
-                        FieldRequires {
-                            subgraph_id: schema.data_sources.graphql[GraphqlEndpointId::from(subgraph_id)].subgraph_id,
-                            field_set_id,
-                        }
-                    })
-                    .collect(),
-                argument_ids: self.idmaps.input_value.get_range(field.arguments),
-                composed_directives: IdRange::from_start_and_length(field.composed_directives),
-                cache_config: cache
-                    .rule(CacheConfigTarget::Field(federated_graph::FieldId(field_id.into())))
-                    .map(|config| cache_configs.get_or_insert(config)),
-            };
-            schema.field_definitions.push(field);
-        }
-
-        // -- INPUT OBJECTS --
-        // Separating the input fields into a separate input_value Vec with an id. This additional
-        // indirection allows data sources to rename fields more easily.
-        for input_object in take(&mut graph.input_objects) {
-            let input_object = InputObject {
-                name: input_object.name.into(),
-                description: None,
-                input_field_ids: self.idmaps.input_value.get_range(input_object.fields),
-                composed_directives: IdRange::from_start_and_length(input_object.composed_directives),
-            };
-            schema.input_objects.push(input_object);
-        }
-
-        // -- INTERFACES --
-        for interface in take(&mut graph.interfaces) {
-            schema.interfaces.push(Interface {
-                name: interface.name.into(),
-                description: None,
-                interfaces: Vec::new(),
-                possible_types: Vec::new(),
-                composed_directives: IdRange::from_start_and_length(interface.composed_directives),
-                fields: self.idmaps.field.get_range((
-                    interface.fields.start,
-                    interface.fields.end.0 - interface.fields.start.0,
-                )),
-            })
-        }
-
-        // Adding all implementations of an interface, used during introspection.
-        for object_id in (0..schema.objects.len()).map(ObjectId::from) {
-            for interface_id in schema[object_id].interfaces.clone() {
-                schema[interface_id].possible_types.push(object_id);
-            }
-        }
-
-        // -- SCALARS --
-        schema.scalars = take(&mut graph.scalars)
-            .into_iter()
-            .map(|scalar| {
-                let name = StringId::from(scalar.name);
-                Scalar {
-                    name,
-                    ty: ScalarType::from_scalar_name(&self.strings[name]),
-                    description: None,
-                    specified_by_url: None,
-                    composed_directives: IdRange::from_start_and_length(scalar.composed_directives),
-                }
-            })
-            .collect();
-
-        // -- CACHE CONFIG --
-        schema.cache_configs = cache_configs.into_iter().map(Into::into).collect();
-    }
-
-    fn build(self) -> Result<Schema, BuildError> {
-        let SchemaBuilder { mut schema, .. } = self;
-        schema.strings = self.strings.into();
-        schema.urls = self.urls.into();
-
-        schema.definitions = Vec::with_capacity(
-            schema.scalars.len()
-                + schema.objects.len()
-                + schema.interfaces.len()
-                + schema.unions.len()
-                + schema.enums.len()
-                + schema.input_objects.len(),
-        );
-
-        // Adding all definitions for introspection & query binding
-        schema
-            .definitions
-            .extend((0..schema.scalars.len()).map(|id| Definition::Scalar(ScalarId::from(id))));
-        schema
-            .definitions
-            .extend((0..schema.objects.len()).map(|id| Definition::Object(ObjectId::from(id))));
-        schema
-            .definitions
-            .extend((0..schema.interfaces.len()).map(|id| Definition::Interface(InterfaceId::from(id))));
-        schema
-            .definitions
-            .extend((0..schema.unions.len()).map(|id| Definition::Union(UnionId::from(id))));
-        schema
-            .definitions
-            .extend((0..schema.enums.len()).map(|id| Definition::Enum(EnumId::from(id))));
-        schema
-            .definitions
-            .extend((0..schema.input_objects.len()).map(|id| Definition::InputObject(InputObjectId::from(id))));
-
-        let mut definitions = take(&mut schema.definitions);
-        definitions.sort_unstable_by_key(|definition| schema.definition_name(*definition));
-        schema.definitions = definitions;
-
-        for interface in &mut schema.interfaces {
-            interface.possible_types.sort_unstable();
-        }
-        for union in &mut schema.unions {
-            union.possible_types.sort_unstable();
-        }
-
-        self.required_field_sets_buffer
-            .try_insert_into(&mut schema, &self.idmaps)?;
-
-        Ok(schema)
-    }
-
-    fn convert_input_object(&self, value: federated_graph::InputObject) -> InputObject {
-        InputObject {
-            name: value.name.into(),
-            description: value.description.map(Into::into),
-            input_field_ids: self.idmaps.input_value.get_range(value.fields),
-            composed_directives: IdRange::from_start_and_length(value.composed_directives),
-        }
-    }
-}
-
-impl ids::IdMap<federated_graph::FieldId, FieldDefinitionId> {
-    fn convert_providable_field_set(&self, field_set: &federated_graph::FieldSet) -> ProvidableFieldSet {
-        field_set
-            .iter()
-            .filter_map(|item| self.convert_providable_field_set_item(item))
-            .collect()
-    }
-
-    fn convert_providable_field_set_item(&self, item: &federated_graph::FieldSetItem) -> Option<ProvidableField> {
-        Some(ProvidableField {
-            id: self.get(item.field)?,
-            subselection: self.convert_providable_field_set(&item.subselection),
+        Ok(Schema {
+            data_sources,
+            graph,
+            strings: self.strings.into(),
+            urls: self.urls.into(),
+            headers,
+            settings: Settings {
+                default_headers: take(&mut config.default_headers).into_iter().map(Into::into).collect(),
+                auth_config: take(&mut config.auth),
+                operation_limits: take(&mut config.operation_limits),
+                disable_introspection: config.disable_introspection,
+            },
         })
-    }
-}
-
-fn is_inaccessible(graph: &federated_graph::FederatedGraphV3, directives: federated_graph::Directives) -> bool {
-    graph[directives]
-        .iter()
-        .any(|directive| matches!(directive, federated_graph::Directive::Inaccessible))
-}
-
-impl From<federated_graph::Definition> for Definition {
-    fn from(definition: federated_graph::Definition) -> Self {
-        match definition {
-            federated_graph::Definition::Scalar(id) => Definition::Scalar(id.into()),
-            federated_graph::Definition::Object(id) => Definition::Object(id.into()),
-            federated_graph::Definition::Interface(id) => Definition::Interface(id.into()),
-            federated_graph::Definition::Union(id) => Definition::Union(id.into()),
-            federated_graph::Definition::Enum(id) => Definition::Enum(id.into()),
-            federated_graph::Definition::InputObject(id) => Definition::InputObject(id.into()),
-        }
-    }
-}
-
-impl From<federated_graph::Type> for Type {
-    fn from(field_type: federated_graph::Type) -> Self {
-        Type {
-            inner: field_type.definition.into(),
-            wrapping: field_type.wrapping,
-        }
-    }
-}
-
-impl From<federated_graph::InputValueDefinition> for InputValueDefinition {
-    fn from(value: federated_graph::InputValueDefinition) -> Self {
-        InputValueDefinition {
-            name: value.name.into(),
-            description: value.description.map(Into::into),
-            ty: value.r#type.into(),
-            default_value: None,
-        }
-    }
-}
-
-impl From<federated_graph::EnumValue> for EnumValue {
-    fn from(enum_value: federated_graph::EnumValue) -> Self {
-        EnumValue {
-            name: enum_value.value.into(),
-            description: None,
-            composed_directives: IdRange::from_start_and_length(enum_value.composed_directives),
-        }
     }
 }
 

--- a/engine/crates/engine-v2/schema/src/ids.rs
+++ b/engine/crates/engine-v2/schema/src/ids.rs
@@ -1,8 +1,8 @@
 /// Isolating ids from the rest to prevent misuse of the NonZeroU32.
 /// They can only be created by From<usize>
 use crate::{
-    CacheConfig, Definition, Directive, Enum, EnumValue, FieldDefinition, Header, InputObject, InputValueDefinition,
-    Interface, Object, RequiredFieldArguments, RequiredFieldSet, Resolver, Scalar, Schema, SchemaInputValues, Union,
+    CacheConfig, Definition, Directive, Enum, EnumValue, FieldDefinition, Graph, Header, InputObject,
+    InputValueDefinition, Interface, Object, RequiredFieldArguments, RequiredFieldSet, Resolver, Scalar, Schema, Union,
 };
 use url::Url;
 
@@ -12,35 +12,24 @@ use url::Url;
 pub(crate) const MAX_ID: usize = (1 << 29) - 1;
 
 id_newtypes::NonZeroU32! {
-    Schema.definitions[DefinitionId] => Definition | max MAX_ID,
-    Schema.directives[DirectiveId] => Directive | max MAX_ID,
-    Schema.enum_values[EnumValueId] => EnumValue | max MAX_ID,
-    Schema.enums[EnumId] => Enum | max MAX_ID,
-    Schema.field_definitions[FieldDefinitionId] => FieldDefinition | max MAX_ID,
-    Schema.headers[HeaderId] => Header | max MAX_ID,
-    Schema.input_objects[InputObjectId] => InputObject | max MAX_ID,
-    Schema.input_value_definitions[InputValueDefinitionId] => InputValueDefinition | max MAX_ID,
-    Schema.interfaces[InterfaceId] => Interface | max MAX_ID,
-    Schema.objects[ObjectId] => Object | max MAX_ID,
-    Schema.resolvers[ResolverId] => Resolver | max MAX_ID,
-    Schema.scalars[ScalarId] => Scalar | max MAX_ID,
-    Schema.unions[UnionId] => Union | max MAX_ID,
-    Schema.urls[UrlId] => Url | max MAX_ID,
-    Schema.strings[StringId] => String | max MAX_ID,
-    Schema.cache_configs[CacheConfigId] => CacheConfig | max MAX_ID,
-    Schema.required_field_sets[RequiredFieldSetId] => RequiredFieldSet | max MAX_ID,
-    Schema.required_fields_arguments[RequiredFieldSetArgumentsId] => RequiredFieldArguments | max MAX_ID,
-}
-
-impl<T> std::ops::Index<T> for Schema
-where
-    SchemaInputValues: std::ops::Index<T>,
-{
-    type Output = <SchemaInputValues as std::ops::Index<T>>::Output;
-
-    fn index(&self, index: T) -> &Self::Output {
-        &self.input_values[index]
-    }
+    Graph.definitions[DefinitionId] => Definition | max(MAX_ID) | index(Schema.graph),
+    Graph.directive_definitions[DirectiveId] => Directive | max(MAX_ID) | index(Schema.graph),
+    Graph.enum_value_definitions[EnumValueId] => EnumValue | max(MAX_ID) | index(Schema.graph),
+    Graph.enum_definitions[EnumId] => Enum | max(MAX_ID) | index(Schema.graph),
+    Graph.field_definitions[FieldDefinitionId] => FieldDefinition | max(MAX_ID) | index(Schema.graph),
+    Graph.input_object_definitions[InputObjectId] => InputObject | max(MAX_ID) | index(Schema.graph),
+    Graph.input_value_definitions[InputValueDefinitionId] => InputValueDefinition | max(MAX_ID) | index(Schema.graph),
+    Graph.interface_definitions[InterfaceId] => Interface | max(MAX_ID) | index(Schema.graph),
+    Graph.object_definitions[ObjectId] => Object | max(MAX_ID) | index(Schema.graph),
+    Graph.scalar_definitions[ScalarId] => Scalar | max(MAX_ID) | index(Schema.graph),
+    Graph.union_definitions[UnionId] => Union | max(MAX_ID) | index(Schema.graph),
+    Graph.resolvers[ResolverId] => Resolver | max(MAX_ID) | index(Schema.graph),
+    Graph.cache_configs[CacheConfigId] => CacheConfig | max(MAX_ID) | index(Schema.graph),
+    Graph.required_field_sets[RequiredFieldSetId] => RequiredFieldSet | max(MAX_ID) | index(Schema.graph),
+    Graph.required_fields_arguments[RequiredFieldSetArgumentsId] => RequiredFieldArguments | max(MAX_ID) | index(Schema.graph),
+    Schema.headers[HeaderId] => Header | max(MAX_ID),
+    Schema.urls[UrlId] => Url | max(MAX_ID),
+    Schema.strings[StringId] => String | max(MAX_ID),
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/engine/crates/engine-v2/schema/src/input_value/mod.rs
+++ b/engine/crates/engine-v2/schema/src/input_value/mod.rs
@@ -1,4 +1,4 @@
-use crate::{EnumValueId, IdRange, InputValueDefinitionId, SchemaWalker, StringId};
+use crate::{EnumValueId, IdRange, InputValueDefinitionId, Schema, SchemaWalker, StringId};
 
 mod de;
 mod display;
@@ -86,9 +86,9 @@ pub struct SchemaInputValues {
 }
 
 id_newtypes::NonZeroU32! {
-    SchemaInputValues.values[SchemaInputValueId] => SchemaInputValue,
-    SchemaInputValues.input_fields[SchemaInputObjectFieldValueId] => (InputValueDefinitionId, SchemaInputValue),
-    SchemaInputValues.key_values[SchemaInputKeyValueId] => (StringId, SchemaInputValue),
+    SchemaInputValues.values[SchemaInputValueId] => SchemaInputValue | index(Schema.graph.input_values),
+    SchemaInputValues.input_fields[SchemaInputObjectFieldValueId] => (InputValueDefinitionId, SchemaInputValue) | index(Schema.graph.input_values),
+    SchemaInputValues.key_values[SchemaInputKeyValueId] => (StringId, SchemaInputValue) | index(Schema.graph.input_values),
 }
 
 /// Represents a default input value and @requires arguments.

--- a/engine/crates/engine-v2/schema/src/input_value/tests.rs
+++ b/engine/crates/engine-v2/schema/src/input_value/tests.rs
@@ -3,101 +3,93 @@ use std::borrow::Cow;
 use serde::Deserialize;
 use wrapping::Wrapping;
 
-use crate::{EnumValue, InputValue, InputValueDefinition, Schema, StringId, Type};
+use crate::{builder::BuildContext, EnumValue, InputValue, InputValueDefinition, Schema, Type};
 
 use super::*;
 
-fn create_schema() -> Schema {
-    let mut schema = Schema::empty();
-    schema.input_value_definitions.extend([
-        InputValueDefinition {
-            name: StringId::from(4),
-            description: None,
-            ty: Type {
-                inner: crate::Definition::Object(0.into()),
-                wrapping: Wrapping::new(false),
-            }, // not used
-            default_value: None,
-        },
-        InputValueDefinition {
-            name: StringId::from(5),
-            description: None,
-            ty: Type {
-                inner: crate::Definition::Object(0.into()),
-                wrapping: Wrapping::new(false),
-            }, // not used
-            default_value: None,
-        },
-    ]);
-    schema.enum_values.extend([
-        EnumValue {
-            name: StringId::from(2),
-            description: None,
-            composed_directives: Default::default(),
-        },
-        EnumValue {
-            name: StringId::from(3),
-            description: None,
-            composed_directives: Default::default(),
-        },
-    ]);
-    schema.strings.extend([
-        "some string value".to_string(), // 1
-        "ACTIVE".to_string(),            // 2
-        "INACTIVE".to_string(),          // 3
-        "fieldA".to_string(),            // 4
-        "fieldB".to_string(),            // 5
-        // ---
-        "null".to_string(),        // 6
-        "string".to_string(),      // 7
-        "enumValue".to_string(),   // 8
-        "int".to_string(),         // 9
-        "bigInt".to_string(),      // 10
-        "u64".to_string(),         // 11
-        "float".to_string(),       // 12
-        "boolean".to_string(),     // 13
-        "inputObject".to_string(), // 14
-        "list".to_string(),        // 15
-        "object".to_string(),      // 16
-    ]);
-    let list = schema.input_values.push_list(vec![
-        SchemaInputValue::Null,
-        SchemaInputValue::EnumValue(EnumValueId::from(0)),
-        SchemaInputValue::Int(73),
-    ]);
-    let input_fields = schema.input_values.push_input_object(vec![
-        (
-            InputValueDefinitionId::from(0),
-            SchemaInputValue::EnumValue(EnumValueId::from(1)),
-        ),
-        (
-            InputValueDefinitionId::from(1),
-            SchemaInputValue::String(StringId::from(1)),
-        ),
-    ]);
-    let nested_fields = schema.input_values.push_map(vec![
-        (StringId::from(6), SchemaInputValue::Null),
-        (StringId::from(7), SchemaInputValue::String(StringId::from(1))),
-        (StringId::from(8), SchemaInputValue::EnumValue(EnumValueId::from(0))),
-        (StringId::from(9), SchemaInputValue::Int(7)),
-        (StringId::from(10), SchemaInputValue::BigInt(8)),
-        (StringId::from(11), SchemaInputValue::U64(9)),
-        (StringId::from(12), SchemaInputValue::Float(10.0)),
-        (StringId::from(13), SchemaInputValue::Boolean(true)),
-    ]);
-    let fields = schema.input_values.push_map(vec![
-        (StringId::from(14), SchemaInputValue::InputObject(input_fields)),
-        (StringId::from(15), SchemaInputValue::List(list)),
-        (StringId::from(16), SchemaInputValue::Map(nested_fields)),
-    ]);
-    schema.input_values.push_value(SchemaInputValue::Map(fields));
-    schema
+fn create_schema_and_input_value() -> (Schema, SchemaInputValueId) {
+    BuildContext::build_with(|ctx, graph| {
+        graph.input_value_definitions.extend([
+            InputValueDefinition {
+                name: ctx.strings.get_or_insert("fieldA"),
+                description: None,
+                ty: Type {
+                    inner: crate::Definition::Object(0.into()),
+                    wrapping: Wrapping::new(false),
+                }, // not used
+                default_value: None,
+            },
+            InputValueDefinition {
+                name: ctx.strings.get_or_insert("fieldB"),
+                description: None,
+                ty: Type {
+                    inner: crate::Definition::Object(0.into()),
+                    wrapping: Wrapping::new(false),
+                }, // not used
+                default_value: None,
+            },
+        ]);
+        graph.enum_value_definitions.extend([
+            EnumValue {
+                name: ctx.strings.get_or_insert("ACTIVE"),
+                description: None,
+                composed_directives: Default::default(),
+            },
+            EnumValue {
+                name: ctx.strings.get_or_insert("INACTIVE"),
+                description: None,
+                composed_directives: Default::default(),
+            },
+        ]);
+        let list = graph.input_values.push_list(vec![
+            SchemaInputValue::Null,
+            SchemaInputValue::EnumValue(EnumValueId::from(0)),
+            SchemaInputValue::Int(73),
+        ]);
+        let input_fields = graph.input_values.push_input_object(vec![
+            (
+                InputValueDefinitionId::from(0),
+                SchemaInputValue::EnumValue(EnumValueId::from(1)),
+            ),
+            (
+                InputValueDefinitionId::from(1),
+                SchemaInputValue::String(ctx.strings.get_or_insert("some string value")),
+            ),
+        ]);
+        let nested_fields = graph.input_values.push_map(vec![
+            (ctx.strings.get_or_insert("null"), SchemaInputValue::Null),
+            (
+                ctx.strings.get_or_insert("string"),
+                SchemaInputValue::String(ctx.strings.get_or_insert("some string value")),
+            ),
+            (
+                ctx.strings.get_or_insert("enumValue"),
+                SchemaInputValue::EnumValue(EnumValueId::from(0)),
+            ),
+            (ctx.strings.get_or_insert("int"), SchemaInputValue::Int(7)),
+            (ctx.strings.get_or_insert("bigInt"), SchemaInputValue::BigInt(8)),
+            (ctx.strings.get_or_insert("u64"), SchemaInputValue::U64(9)),
+            (ctx.strings.get_or_insert("float"), SchemaInputValue::Float(10.0)),
+            (ctx.strings.get_or_insert("boolean"), SchemaInputValue::Boolean(true)),
+        ]);
+        let fields = graph.input_values.push_map(vec![
+            (
+                ctx.strings.get_or_insert("inputObject"),
+                SchemaInputValue::InputObject(input_fields),
+            ),
+            (ctx.strings.get_or_insert("list"), SchemaInputValue::List(list)),
+            (
+                ctx.strings.get_or_insert("object"),
+                SchemaInputValue::Map(nested_fields),
+            ),
+        ]);
+        graph.input_values.push_value(SchemaInputValue::Map(fields))
+    })
 }
 
 #[test]
 fn test_display() {
-    let schema = create_schema();
-    let id = SchemaInputValueId::from(schema.input_values.values.len() - 1);
+    let (schema, id) = create_schema_and_input_value();
     let walker = schema.walk(&schema[id]);
 
     insta::assert_snapshot!(walker, @r###"{inputObject:{fieldA:INACTIVE,fieldB:"some string value"},list:[null,ACTIVE,73],object:{null:null,string:"some string value",enumValue:ACTIVE,int:7,bigInt:8,u64:9,float:10,boolean:true}}"###);
@@ -105,8 +97,7 @@ fn test_display() {
 
 #[test]
 fn test_serialize() {
-    let schema = create_schema();
-    let id = SchemaInputValueId::from(schema.input_values.values.len() - 1);
+    let (schema, id) = create_schema_and_input_value();
     let walker = schema.walk(&schema[id]);
 
     insta::assert_json_snapshot!(walker, @r###"
@@ -136,8 +127,7 @@ fn test_serialize() {
 
 #[test]
 fn test_deserializer() {
-    let schema = create_schema();
-    let id = SchemaInputValueId::from(schema.input_values.values.len() - 1);
+    let (schema, id) = create_schema_and_input_value();
     let walker = schema.walk(&schema[id]);
 
     let value = serde_json::Value::deserialize(walker).unwrap();
@@ -169,8 +159,7 @@ fn test_deserializer() {
 
 #[test]
 fn test_input_value() {
-    let schema = create_schema();
-    let id = SchemaInputValueId::from(schema.input_values.values.len() - 1);
+    let (schema, id) = create_schema_and_input_value();
     let walker = schema.walk(&schema[id]);
     let input_value = InputValue::from(walker);
 
@@ -294,8 +283,7 @@ fn test_input_value() {
 
 #[test]
 fn test_struct_deserializer() {
-    let schema = create_schema();
-    let id = SchemaInputValueId::from(schema.input_values.values.len() - 1);
+    let (schema, id) = create_schema_and_input_value();
     let walker = schema.walk(&schema[id]);
 
     #[allow(unused)]

--- a/engine/crates/engine-v2/schema/src/sources/graphql.rs
+++ b/engine/crates/engine-v2/schema/src/sources/graphql.rs
@@ -139,6 +139,7 @@ impl<'a> GraphqlEndpointWalker<'a> {
 
     pub fn headers(self) -> impl Iterator<Item = HeaderWalker<'a>> {
         self.schema
+            .settings
             .default_headers
             .iter()
             .chain(self.as_ref().headers.iter())

--- a/engine/crates/engine-v2/schema/src/sources/mod.rs
+++ b/engine/crates/engine-v2/schema/src/sources/mod.rs
@@ -2,4 +2,4 @@ pub mod graphql;
 pub mod introspection;
 
 pub use graphql::GraphqlEndpoints;
-pub use introspection::Introspection;
+pub use introspection::IntrospectionMetadata;

--- a/engine/crates/engine-v2/schema/src/walkers/mod.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/mod.rs
@@ -1,4 +1,4 @@
-use crate::{Names, Schema};
+use crate::{sources::IntrospectionMetadata, Names, Schema, StringId};
 
 mod definition;
 mod r#enum;
@@ -72,21 +72,34 @@ impl<'a> SchemaWalker<'a, ()> {
     pub fn definitions(&self) -> impl ExactSizeIterator<Item = DefinitionWalker<'a>> + 'a {
         let walker = *self;
         self.schema
+            .graph
             .definitions
             .iter()
             .map(move |definition| walker.walk(*definition))
     }
 
+    pub fn description_id(&self) -> Option<StringId> {
+        self.schema.graph.description
+    }
+
+    pub fn introspection_metadata(&self) -> &'a IntrospectionMetadata {
+        &self.schema.data_sources.introspection
+    }
+
     pub fn query(&self) -> ObjectWalker<'a> {
-        self.walk(self.schema.root_operation_types.query)
+        self.walk(self.schema.graph.root_operation_types.query)
     }
 
     pub fn mutation(&self) -> Option<ObjectWalker<'a>> {
-        self.schema.root_operation_types.mutation.map(|id| self.walk(id))
+        self.schema.graph.root_operation_types.mutation.map(|id| self.walk(id))
     }
 
     pub fn subscription(&self) -> Option<ObjectWalker<'a>> {
-        self.schema.root_operation_types.subscription.map(|id| self.walk(id))
+        self.schema
+            .graph
+            .root_operation_types
+            .subscription
+            .map(|id| self.walk(id))
     }
 
     pub fn names(&self) -> &'a dyn Names {

--- a/engine/crates/engine-v2/schema/src/walkers/type.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/type.rs
@@ -42,7 +42,7 @@ impl std::fmt::Display for TypeWalker<'_> {
 
 impl std::fmt::Display for Ty<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for _ in self.wrapping.list_wrappings().rev() {
+        for _ in 0..self.wrapping.list_wrappings().len() {
             write!(f, "[")?;
         }
         write!(f, "{}", self.inner.name())?;

--- a/engine/crates/engine-v2/src/operation/bind/mod.rs
+++ b/engine/crates/engine-v2/src/operation/bind/mod.rs
@@ -129,15 +129,13 @@ pub type BindResult<T> = Result<T, BindError>;
 
 pub fn bind(schema: &Schema, mut unbound: ParsedOperation) -> BindResult<Operation> {
     let root_object_id = match unbound.definition.ty {
-        OperationType::Query => schema.root_operation_types.query,
-        OperationType::Mutation => schema
-            .root_operation_types
-            .mutation
-            .ok_or(BindError::NoMutationDefined)?,
+        OperationType::Query => schema.walker().query().id(),
+        OperationType::Mutation => schema.walker().mutation().ok_or(BindError::NoMutationDefined)?.id(),
         OperationType::Subscription => schema
-            .root_operation_types
-            .subscription
-            .ok_or(BindError::NoSubscriptionDefined)?,
+            .walker()
+            .subscription()
+            .ok_or(BindError::NoSubscriptionDefined)?
+            .id(),
     };
 
     let mut binder = Binder {

--- a/engine/crates/engine-v2/src/operation/validation/introspection.rs
+++ b/engine/crates/engine-v2/src/operation/validation/introspection.rs
@@ -15,7 +15,7 @@ pub(super) fn ensure_introspection_is_accepted(
             engine::IntrospectionState::ForceEnabled => {}
             engine::IntrospectionState::ForceDisabled => detect_introspection(selection_set)?,
             engine::IntrospectionState::UserPreference => {
-                if schema.disable_introspection {
+                if schema.settings.disable_introspection {
                     detect_introspection(selection_set)?;
                 }
             }

--- a/engine/crates/engine-v2/src/operation/validation/operation_limits.rs
+++ b/engine/crates/engine-v2/src/operation/validation/operation_limits.rs
@@ -28,37 +28,38 @@ pub(super) fn enforce_operation_limits(
         return Ok(());
     }
 
+    let operation_limits = &schema.settings.operation_limits;
     let selection_set = operation.selection_set();
 
-    if let Some(depth_limit) = schema.operation_limits.depth {
+    if let Some(depth_limit) = operation_limits.depth {
         let max_depth = selection_set.max_depth();
         if max_depth > depth_limit {
             return Err(OperationLimitExceededError::QueryTooDeep);
         }
     }
 
-    if let Some(max_alias_count) = schema.operation_limits.aliases {
+    if let Some(max_alias_count) = operation_limits.aliases {
         let alias_count = selection_set.alias_count();
         if alias_count > max_alias_count {
             return Err(OperationLimitExceededError::QueryContainsTooManyAliases);
         }
     }
 
-    if let Some(max_root_field_count) = schema.operation_limits.root_fields {
+    if let Some(max_root_field_count) = operation_limits.root_fields {
         let root_field_count = selection_set.root_field_count();
         if root_field_count > max_root_field_count {
             return Err(OperationLimitExceededError::QueryContainsTooManyRootFields);
         }
     }
 
-    if let Some(max_height) = schema.operation_limits.height {
+    if let Some(max_height) = operation_limits.height {
         let height = selection_set.height(&mut Default::default());
         if height > max_height {
             return Err(OperationLimitExceededError::QueryTooHigh);
         }
     }
 
-    if let Some(max_complexity) = schema.operation_limits.complexity {
+    if let Some(max_complexity) = operation_limits.complexity {
         let complexity = selection_set.complexity();
         if complexity > max_complexity {
             return Err(OperationLimitExceededError::QueryTooComplex);

--- a/engine/crates/engine-v2/src/sources/introspection/mod.rs
+++ b/engine/crates/engine-v2/src/sources/introspection/mod.rs
@@ -1,7 +1,5 @@
 use std::cell::RefCell;
 
-use schema::sources::introspection::Metadata;
-
 use super::{ExecutionError, Executor, ExecutorInput};
 use crate::{
     execution::ExecutionContext,
@@ -27,7 +25,6 @@ impl IntrospectionExecutionPlan {
         Ok(Executor::Introspection(IntrospectionExecutor {
             ctx,
             response_object: root_response_objects.into_single_boundary_item(),
-            metadata: ctx.engine.schema.data_sources.introspection.metadata.as_ref().unwrap(),
             plan,
             output,
         }))
@@ -37,7 +34,6 @@ impl IntrospectionExecutionPlan {
 pub(crate) struct IntrospectionExecutor<'ctx> {
     ctx: ExecutionContext<'ctx>,
     response_object: ResponseBoundaryItem,
-    metadata: &'ctx Metadata,
     plan: PlanWalker<'ctx>,
     output: ResponsePart,
 }
@@ -46,7 +42,7 @@ impl<'ctx> IntrospectionExecutor<'ctx> {
     pub async fn execute(mut self) -> Result<ResponsePart, ExecutionError> {
         writer::IntrospectionWriter {
             schema: self.ctx.engine.schema.walker(),
-            metadata: self.metadata,
+            metadata: self.ctx.engine.schema.walker().introspection_metadata(),
             plan: self.plan,
             output: RefCell::new(&mut self.output),
         }

--- a/engine/crates/engine-v2/src/sources/introspection/writer.rs
+++ b/engine/crates/engine-v2/src/sources/introspection/writer.rs
@@ -1,8 +1,11 @@
 use std::cell::RefCell;
 
 use schema::{
-    sources::introspection::{
-        IntrospectionField, IntrospectionObject, Metadata, __EnumValue, __Field, __InputValue, __Schema, __Type,
+    sources::{
+        introspection::{
+            IntrospectionField, IntrospectionObject, __EnumValue, __Field, __InputValue, __Schema, __Type,
+        },
+        IntrospectionMetadata,
     },
     Definition, DefinitionWalker, Directive, EnumValueWalker, FieldDefinitionWalker, InputValueDefinitionWalker,
     ListWrapping, SchemaWalker, TypeWalker, Wrapping,
@@ -15,7 +18,7 @@ use crate::{
 
 pub(super) struct IntrospectionWriter<'a> {
     pub schema: SchemaWalker<'a, ()>,
-    pub metadata: &'a Metadata,
+    pub metadata: &'a IntrospectionMetadata,
     pub plan: PlanWalker<'a>,
     pub output: RefCell<&'a mut ResponsePart>,
 }
@@ -86,7 +89,7 @@ impl<'a> IntrospectionWriter<'a> {
     fn __schema(&self, selection_set: PlanCollectedSelectionSet<'_>) -> ResponseValue {
         self.object(&self.metadata.__schema, selection_set, |field, __schema| {
             match __schema {
-                __Schema::Description => self.schema.description.into(),
+                __Schema::Description => self.schema.description_id().into(),
                 __Schema::Types => {
                     let selection_set = field.concrete_selection_set().unwrap();
                     let values = self

--- a/engine/crates/federated-graph/src/federated_graph/v2.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v2.rs
@@ -258,6 +258,12 @@ impl From<InputValueDefinitionId> for usize {
     }
 }
 
+impl From<usize> for InputValueDefinitionId {
+    fn from(index: usize) -> Self {
+        InputValueDefinitionId(index)
+    }
+}
+
 pub const NO_INPUT_VALUE_DEFINITION: InputValueDefinitions = (InputValueDefinitionId(0), 0);
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -266,6 +272,12 @@ pub struct EnumValueId(pub usize);
 impl From<EnumValueId> for usize {
     fn from(EnumValueId(index): EnumValueId) -> Self {
         index
+    }
+}
+
+impl From<usize> for EnumValueId {
+    fn from(index: usize) -> Self {
+        EnumValueId(index)
     }
 }
 

--- a/engine/crates/federated-graph/src/render_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl.rs
@@ -454,19 +454,19 @@ fn render_field_type(field_type: &Type, graph: &FederatedGraphV3) -> String {
     let name = &graph[name_id];
     let mut out = String::with_capacity(name.len());
 
-    for _ in field_type.wrapping.list_wrappings().rev() {
-        write!(out, "[").unwrap();
+    for _ in 0..field_type.wrapping.list_wrappings().len() {
+        out.push('[');
     }
 
     write!(out, "{name}").unwrap();
     if field_type.wrapping.inner_is_required() {
-        write!(out, "!").unwrap();
+        out.push('!');
     }
 
     for wrapping in field_type.wrapping.list_wrappings() {
-        write!(out, "]").unwrap();
+        out.push(']');
         if wrapping == wrapping::ListWrapping::RequiredList {
-            write!(out, "!").unwrap();
+            out.push('!');
         }
     }
 

--- a/engine/crates/gateway-v2/src/lib.rs
+++ b/engine/crates/gateway-v2/src/lib.rs
@@ -48,7 +48,7 @@ pub struct Response {
 
 impl Gateway {
     pub fn new(schema: Schema, engine_env: EngineEnv, env: GatewayEnv) -> Self {
-        let auth = AuthService::new_v2(schema.auth_config.clone().unwrap_or_default(), env.kv.clone());
+        let auth = AuthService::new_v2(schema.settings.auth_config.clone().unwrap_or_default(), env.kv.clone());
         let engine = Arc::new(Engine::new(schema, engine_env));
         Self { engine, env, auth }
     }

--- a/engine/crates/wrapping/src/lib.rs
+++ b/engine/crates/wrapping/src/lib.rs
@@ -39,6 +39,12 @@ const INNER_IS_REQUIRED_FLAG: u32 = 0b1000_0000_0000_0000_0000_0000_0000_0000;
 #[derive(Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Wrapping(u32);
 
+impl Default for Wrapping {
+    fn default() -> Self {
+        Self::nullable()
+    }
+}
+
 impl From<Wrapping> for u32 {
     fn from(value: Wrapping) -> Self {
         value.0


### PR DESCRIPTION
Extracting most definitions to `Graph` struct which is built with introspection data sources. Avoids the need to have an `Option` for the introspection data source even though it's always present. And cleaned up a bunch of code.
