### PR TITLE
validation: revert newly added validation against empty objects, interfaces, input objects

### DIFF
--- a/engine/crates/validation/CHANGELOG.md
+++ b/engine/crates/validation/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- Properly validate that object, interface and input object types define at least one field (https://github.com/graphql/graphql-spec/blame/October2021/spec/Section%203%20--%20Type%20System.md#L868). Previously, we were validating against `type Test {}` but not `type Test`.
-
 ## [0.1.3] - 2024-02-06
 
 - fix typo in error (#1308)

--- a/engine/crates/validation/src/diagnostics/constructors.rs
+++ b/engine/crates/validation/src/diagnostics/constructors.rs
@@ -26,21 +26,3 @@ pub(crate) fn input_object_in_output_position(bad_type: &str, location: &str, ct
         r#"The type of "{location}" must be an output type, but got "{bad_type}", an input object."#
     ));
 }
-
-pub(crate) fn empty_object(bad_object: &str, ctx: &mut Context<'_>) {
-    ctx.push_error(miette::miette!(
-        "The object type {bad_object} has no fields. An object type must define one or more fields."
-    ))
-}
-
-pub(crate) fn empty_interface(bad_interface: &str, ctx: &mut Context<'_>) {
-    ctx.push_error(miette::miette!(
-        "The interface {bad_interface} has no fields. An interface must define one or more fields."
-    ))
-}
-
-pub(crate) fn empty_input_object(bad_input_object: &str, ctx: &mut Context<'_>) {
-    ctx.push_error(miette::miette!(
-        "The input object type {bad_input_object} has no fields. An input object type must define one or more fields."
-    ))
-}

--- a/engine/crates/validation/src/validate/input_objects.rs
+++ b/engine/crates/validation/src/validate/input_objects.rs
@@ -12,10 +12,6 @@ pub(crate) fn validate_input_object<'a>(
         ctx,
     );
 
-    if input_object.fields.is_empty() {
-        diagnostics::empty_input_object(parent_type_name, ctx);
-    }
-
     for field in &input_object.fields {
         validate_directives(
             &field.node.directives,

--- a/engine/crates/validation/src/validate/interfaces.rs
+++ b/engine/crates/validation/src/validate/interfaces.rs
@@ -11,10 +11,6 @@ pub(crate) fn validate_interface<'a>(
         interface_implementers::validate_implements_list(parent_type_name, implements, &iface.fields, ctx);
     });
 
-    if iface.fields.is_empty() {
-        diagnostics::empty_interface(parent_type_name, ctx)
-    }
-
     for field in &iface.fields {
         object_field::validate_object_field(parent_type_name, field, ctx);
         let field_name = &field.node.name.node;

--- a/engine/crates/validation/src/validate/objects.rs
+++ b/engine/crates/validation/src/validate/objects.rs
@@ -13,10 +13,6 @@ pub(crate) fn validate_object<'a>(
     });
 
     ctx.with_fields(parent_type_name, &obj.fields, |ctx, fields| {
-        if fields.is_empty() {
-            diagnostics::empty_object(parent_type_name, ctx)
-        }
-
         for field in fields {
             object_field::validate_object_field(parent_type_name, field, ctx);
             let type_name = extract_type_name(&field.node.ty.node.base);

--- a/engine/crates/validation/tests/validation_errors/input_object_no_fields.errors.txt
+++ b/engine/crates/validation/tests/validation_errors/input_object_no_fields.errors.txt
@@ -1,1 +1,0 @@
-  × The input object type Output has no fields. An input object type must define one or more fields.

--- a/engine/crates/validation/tests/validation_errors/input_object_no_fields.graphql
+++ b/engine/crates/validation/tests/validation_errors/input_object_no_fields.graphql
@@ -1,2 +1,0 @@
-input Output
-

--- a/engine/crates/validation/tests/validation_errors/interfaces_no_field.errors.txt
+++ b/engine/crates/validation/tests/validation_errors/interfaces_no_field.errors.txt
@@ -1,1 +1,0 @@
-  × The interface InterfaceOff has no fields. An interface must define one or more fields.

--- a/engine/crates/validation/tests/validation_errors/interfaces_no_field.graphql
+++ b/engine/crates/validation/tests/validation_errors/interfaces_no_field.graphql
@@ -1,2 +1,0 @@
-interface InterfaceOff
-

--- a/engine/crates/validation/tests/validation_errors/objects_no_field.errors.txt
+++ b/engine/crates/validation/tests/validation_errors/objects_no_field.errors.txt
@@ -1,4 +1,0 @@
-  × The object type Query has no fields. An object type must define one or more fields.
-
-
-  × The object type Yrueq has no fields. An object type must define one or more fields.

--- a/engine/crates/validation/tests/validation_errors/objects_no_field.graphql
+++ b/engine/crates/validation/tests/validation_errors/objects_no_field.graphql
@@ -1,3 +1,0 @@
-type Query
-
-type Yrueq


### PR DESCRIPTION
The validation is prescribed by the GraphQL spec, but we may be breaking existing user deployments with it. We should introduce it more carefully. This commit can be reverted to re-enable the validation.
