### PR TITLE
graphql-schema-validation: refuse references to nonexistent default roots

### DIFF
--- a/engine/crates/validation/CHANGELOG.md
+++ b/engine/crates/validation/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- When validating that the root types used in a schema definition exists,
+  we were skipping the validation whenever the type is the default one for
+  the root (Query, Mutation or Subscription). This commit makes the validation
+  stricter. If Query does not exist, it is an error. (#1502)
+
 - Properly validate that object, interface and input object types define at least one field (https://github.com/graphql/graphql-spec/blame/October2021/spec/Section%203%20--%20Type%20System.md#L868). Previously, we were validating against `type Test {}` but not `type Test`.
 
 ## [0.1.3] - 2024-02-06

--- a/engine/crates/validation/src/validate/schema_definition.rs
+++ b/engine/crates/validation/src/validate/schema_definition.rs
@@ -60,10 +60,6 @@ pub(crate) fn validate_schema_definition_references(ctx: &mut Context<'_>) {
     for (actual, default) in &names {
         let Some(actual) = actual else { continue };
 
-        if actual == default {
-            continue;
-        }
-
         match ctx.definition_names.get(actual) {
             None => {
                 let labels = vec![miette::LabeledSpan::new_with_span(

--- a/engine/crates/validation/tests/validation_errors/schema_definition_explicit_nonexistent_default_root.errors.txt
+++ b/engine/crates/validation/tests/validation_errors/schema_definition_explicit_nonexistent_default_root.errors.txt
@@ -1,0 +1,14 @@
+  × Cannot set schema query root to unknown type `Query`
+   ╭─[1:1]
+ 1 │ schema {
+   · ──────
+ 2 │     query: Query
+   ╰────
+
+
+  × Cannot set schema mutation root to unknown type `Mutation`
+   ╭─[1:1]
+ 1 │ schema {
+   · ──────
+ 2 │     query: Query
+   ╰────

--- a/engine/crates/validation/tests/validation_errors/schema_definition_explicit_nonexistent_default_root.graphql
+++ b/engine/crates/validation/tests/validation_errors/schema_definition_explicit_nonexistent_default_root.graphql
@@ -1,0 +1,4 @@
+schema {
+	query: Query
+  mutation: Mutation
+}

--- a/engine/crates/validation/tests/validation_errors/two_schema_definitions.graphql
+++ b/engine/crates/validation/tests/validation_errors/two_schema_definitions.graphql
@@ -8,3 +8,15 @@ schema {
     mutation: Mutation
     subscription: Subscription
 }
+
+type Query {
+    hi: String
+}
+
+type Mutation {
+    ahoy: String
+}
+
+type Subscription {
+    aloha: String
+}


### PR DESCRIPTION
When validating that the root types used in a schema definition exists, we were skipping the validation whenever the type is the default one for the root (Query, Mutation or Subscription). This commit makes the validation stricter. If Query does not exist, it is an error.

closes GB-6313