### PR TITLE
cli: validate the registry in grafbase dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2918,6 +2918,7 @@ dependencies = [
  "gateway",
  "grafbase-local-common",
  "graphql-federated-graph",
+ "graphql-schema-validation 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 5.1.2",
  "hyper 1.2.0",
  "hyper-util",
@@ -3106,6 +3107,18 @@ dependencies = [
  "datatest-stable",
  "miette",
  "similar",
+]
+
+[[package]]
+name = "graphql-schema-validation"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b706701692e77c342cc7919c3b9c2236e0331e2c802936cf8ee68ed12abe5e7b"
+dependencies = [
+ "async-graphql-parser",
+ "async-graphql-value",
+ "bitflags 2.5.0",
+ "miette",
 ]
 
 [[package]]

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -62,6 +62,7 @@ parser-sdl = { path = "../../../engine/crates/parser-sdl", features = [
   "local",
 ] }
 graphql-federated-graph = { path = "../../../engine/crates/federated-graph", features = ["from_sdl"] }
+graphql-schema-validation.workspace = { path = "../../../engine/crates/validation" }
 parser-openapi = { path = "../../../engine/crates/parser-openapi" }
 parser-graphql = { path = "../../../engine/crates/parser-graphql" }
 parser-postgres = { path = "../../../engine/crates/parser-postgres" }

--- a/cli/crates/server/src/config/mod.rs
+++ b/cli/crates/server/src/config/mod.rs
@@ -77,7 +77,10 @@ pub(crate) async fn build_config(
         federated_graph_config,
     } = parser::parse_sdl(&schema, environment_variables).await?;
 
-    validate_registry(&registry.export_sdl(false))?;
+    // Federated graphs have empty SDL schemas, from the config's perspective.
+    if federated_graph_config.is_none() {
+        validate_registry_sdl(&registry.export_sdl(false))?;
+    }
 
     let offset = REGISTRY_PARSED_EPOCH_OFFSET_MILLIS.load(Ordering::Acquire);
     let registry_mtime = SystemTime::UNIX_EPOCH.checked_add(Duration::from_millis(offset));
@@ -129,7 +132,7 @@ pub(crate) async fn build_config(
     })
 }
 
-fn validate_registry(schema: &str) -> Result<(), ConfigError> {
+fn validate_registry_sdl(schema: &str) -> Result<(), ConfigError> {
     let diagnostics = graphql_schema_validation::validate(schema);
 
     if diagnostics.has_errors() {

--- a/engine/crates/engine/src/registry/mod.rs
+++ b/engine/crates/engine/src/registry/mod.rs
@@ -1914,6 +1914,22 @@ impl Registry {
         }
     }
 
+    pub fn remove_empty_types(&mut self) {
+        let mut to_be_removed = Vec::new();
+
+        for r#type in self.types.values() {
+            match r#type.fields() {
+                None => to_be_removed.push(r#type.name().to_owned()),
+                Some(fields) if fields.is_empty() => to_be_removed.push(r#type.name().to_owned()),
+                Some(_) => (),
+            }
+        }
+
+        for type_name in to_be_removed {
+            self.types.remove(&type_name);
+        }
+    }
+
     pub fn find_visible_types(&self, ctx: &ContextField<'_>) -> HashSet<&str> {
         let mut visible_types = HashSet::new();
 

--- a/engine/crates/engine/src/registry/mod.rs
+++ b/engine/crates/engine/src/registry/mod.rs
@@ -1917,7 +1917,7 @@ impl Registry {
     pub fn remove_empty_types(&mut self) {
         let mut to_be_removed = Vec::new();
 
-        for r#type in self.types.values() {
+        for r#type in self.types.values().filter(|ty| ty.is_object()) {
             match r#type.fields() {
                 None => to_be_removed.push(r#type.name().to_owned()),
                 Some(fields) if fields.is_empty() => to_be_removed.push(r#type.name().to_owned()),

--- a/engine/crates/parser-sdl/src/connector_parsers.rs
+++ b/engine/crates/parser-sdl/src/connector_parsers.rs
@@ -61,6 +61,8 @@ impl ConnectorParsers for MockConnectorParsers {
 /// avoiding problems with multiple concurrent &mut Registry, or having to deal with
 /// mutexes etc.
 pub(crate) fn merge_registry(ctx: &mut VisitorContext<'_>, mut src_registry: Registry, position: Pos) {
+    src_registry.remove_empty_types();
+
     ctx.queries.extend(type_fields(
         src_registry.types.remove(&src_registry.query_type).unwrap(),
     ));

--- a/engine/crates/parser-sdl/src/connector_parsers.rs
+++ b/engine/crates/parser-sdl/src/connector_parsers.rs
@@ -63,9 +63,9 @@ impl ConnectorParsers for MockConnectorParsers {
 pub(crate) fn merge_registry(ctx: &mut VisitorContext<'_>, mut src_registry: Registry, position: Pos) {
     src_registry.remove_empty_types();
 
-    ctx.queries.extend(type_fields(
-        src_registry.types.remove(&src_registry.query_type).unwrap(),
-    ));
+    if let Some(query_type) = src_registry.types.remove(&src_registry.query_type) {
+        ctx.queries.extend(type_fields(query_type));
+    }
 
     if let Some(mutation_type) = &src_registry.mutation_type {
         ctx.mutations

--- a/engine/crates/parser-sdl/src/rules/visitor/context.rs
+++ b/engine/crates/parser-sdl/src/rules/visitor/context.rs
@@ -185,7 +185,6 @@ impl<'a> VisitorContext<'a> {
         }
 
         registry.remove_unused_types();
-        registry.remove_empty_types();
 
         registry.operation_limits = self
             .operation_limits_directive

--- a/engine/crates/parser-sdl/src/rules/visitor/context.rs
+++ b/engine/crates/parser-sdl/src/rules/visitor/context.rs
@@ -129,6 +129,7 @@ impl<'a> VisitorContext<'a> {
     /// Finish the Registry
     pub(crate) fn finish(mut self) -> ParseResult<'static> {
         let mut registry = self.registry.take();
+
         if self.federation.is_some() {
             registry.enable_federation = true;
         } else {
@@ -184,6 +185,7 @@ impl<'a> VisitorContext<'a> {
         }
 
         registry.remove_unused_types();
+        registry.remove_empty_types();
 
         registry.operation_limits = self
             .operation_limits_directive


### PR DESCRIPTION
Since we use graphql_schema_validation on the generated schemas in the API, we should also validate in `grafbase dev` to tighten the feedback loop.

The engine tends to produce empty types, so we also have to start pruning these when finalizing the registry.

closes GB-6335