### PR TITLE
Implement trusted documents configuration in SDK and registry

### DIFF
--- a/engine/crates/engine/src/registry/mod.rs
+++ b/engine/crates/engine/src/registry/mod.rs
@@ -1368,6 +1368,13 @@ impl OperationLimits {
     }
 }
 
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TrustedDocuments {
+    pub bypass_header_name: Option<String>,
+    pub bypass_header_value: Option<String>,
+}
+
 // TODO(@miaxos): Remove this to a separate create as we'll need to use it outside engine
 // for a LogicalQuery
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -1402,6 +1409,8 @@ pub struct Registry {
     pub is_federated: bool,
     #[serde(default)]
     pub operation_limits: OperationLimits,
+    #[serde(default)]
+    pub trusted_documents: Option<TrustedDocuments>,
 }
 
 impl Default for Registry {
@@ -1427,6 +1436,7 @@ impl Default for Registry {
             enable_codegen: false,
             is_federated: false,
             operation_limits: Default::default(),
+            trusted_documents: Default::default(),
         }
     }
 }

--- a/engine/crates/engine/src/registry/tests.rs
+++ b/engine/crates/engine/src/registry/tests.rs
@@ -4,7 +4,7 @@ use sha2::{Digest, Sha256};
 
 use super::*;
 
-const EXPECTED_SHA: &str = "4c0319e7e94656f5448cccf01cd34faf1f2060c2f1aec4c238375e27b9f4762e";
+const EXPECTED_SHA: &str = "3ffc6725cb934023084db3b6dfed559e05d7e769ebceace4853cc18f95ac45af";
 
 #[test]
 fn test_serde_roundtrip() {

--- a/engine/crates/parser-graphql/src/snapshots/parser_graphql__conversion__tests__array_input_value.snap
+++ b/engine/crates/parser-graphql/src/snapshots/parser_graphql__conversion__tests__array_input_value.snap
@@ -873,5 +873,6 @@ expression: registry_from_introspection(schema)
     "aliases": null,
     "rootFields": null,
     "complexity": null
-  }
+  },
+  "trusted_documents": null
 }

--- a/engine/crates/parser-graphql/src/snapshots/parser_graphql__conversion__tests__conversion.snap
+++ b/engine/crates/parser-graphql/src/snapshots/parser_graphql__conversion__tests__conversion.snap
@@ -2846,5 +2846,6 @@ expression: registry_from_introspection(schema)
     "aliases": null,
     "rootFields": null,
     "complexity": null
-  }
+  },
+  "trusted_documents": null
 }

--- a/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__flat_output-2.snap
+++ b/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__flat_output-2.snap
@@ -2255,4 +2255,5 @@ Registry {
         root_fields: None,
         complexity: None,
     },
+    trusted_documents: None,
 }

--- a/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__petstore_output-2.snap
+++ b/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__petstore_output-2.snap
@@ -2355,4 +2355,5 @@ Registry {
         root_fields: None,
         complexity: None,
     },
+    trusted_documents: None,
 }

--- a/engine/crates/parser-sdl/src/lib.rs
+++ b/engine/crates/parser-sdl/src/lib.rs
@@ -51,6 +51,7 @@ use rules::{
     resolver_directive::ResolverDirective,
     search_directive::SearchDirective,
     subgraph_directive::{SubgraphDirective, SubgraphDirectiveVisitor},
+    trusted_documents_directive::{TrustedDocumentsDirective, TrustedDocumentsVisitor},
     unique_directive::UniqueDirective,
     unique_fields::UniqueObjectFields,
     visitor::{visit, RuleError, Visitor, VisitorContext},
@@ -157,6 +158,7 @@ fn parse_schema(schema: &str) -> engine::parser::Result<ServiceDocument> {
         .with::<OneOfDirective>()
         .with::<OpenApiDirective>()
         .with::<OperationLimitsDirective>()
+        .with::<TrustedDocumentsDirective>()
         .with::<OverrideDirective>()
         .with::<PostgresDirective>()
         .with::<ProvidesDirective>()
@@ -223,7 +225,8 @@ pub async fn parse<'a>(
 async fn parse_basic<'a>(schema: &'a ServiceDocument, ctx: &mut VisitorContext<'a>) -> Result<(), Error> {
     let mut connector_rules = rules::visitor::VisitorNil
         .with(GraphVisitor)
-        .with(OperationLimitsVisitor);
+        .with(OperationLimitsVisitor)
+        .with(TrustedDocumentsVisitor);
 
     visit(&mut connector_rules, ctx, schema);
 

--- a/engine/crates/parser-sdl/src/rules/mod.rs
+++ b/engine/crates/parser-sdl/src/rules/mod.rs
@@ -37,6 +37,7 @@ pub mod resolver_directive;
 pub mod scalar_hydratation;
 pub mod search_directive;
 pub mod subgraph_directive;
+pub mod trusted_documents_directive;
 pub mod unique_directive;
 pub mod unique_fields;
 pub mod visitor;

--- a/engine/crates/parser-sdl/src/rules/trusted_documents_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/trusted_documents_directive.rs
@@ -1,0 +1,130 @@
+use engine_parser::types::SchemaDefinition;
+use itertools::Itertools;
+
+use super::{
+    directive::Directive,
+    visitor::{Visitor, VisitorContext},
+};
+use crate::directive_de::parse_directive;
+
+const TRUSTED_DOCUMENTS_DIRECTIVE_NAME: &str = "trustedDocuments";
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrustedDocumentsDirective {
+    bypass_header_name: Option<String>,
+    bypass_header_value: Option<String>,
+}
+
+impl From<TrustedDocumentsDirective> for engine::registry::TrustedDocuments {
+    fn from(value: TrustedDocumentsDirective) -> Self {
+        Self {
+            bypass_header_name: value.bypass_header_name,
+            bypass_header_value: value.bypass_header_value,
+        }
+    }
+}
+
+impl Directive for TrustedDocumentsDirective {
+    fn definition() -> String {
+        r#"
+        directive @trustedDocuments(
+          """
+          An HTTP header that can be used to send arbitrary queries.
+          """
+          bypassHeaderName: String
+
+          """
+          The value that must be taken by the header specified in bypassHeaderName.
+          """
+          bypassHeaderValue: String
+        ) on SCHEMA
+        "#
+        .to_string()
+    }
+}
+
+pub struct TrustedDocumentsVisitor;
+
+impl<'a> Visitor<'a> for TrustedDocumentsVisitor {
+    fn enter_schema(&mut self, ctx: &mut VisitorContext<'a>, doc: &'a engine::Positioned<SchemaDefinition>) {
+        let directives = doc
+            .node
+            .directives
+            .iter()
+            .filter(|d| d.node.name.node == TRUSTED_DOCUMENTS_DIRECTIVE_NAME);
+
+        match directives.at_most_one() {
+            Ok(None) => (),
+            Ok(Some(directive)) => {
+                match parse_directive::<TrustedDocumentsDirective>(&directive.node, ctx.variables)
+                    .map_err(|error| error.to_string())
+                {
+                    Ok(trusted_documents) => {
+                        ctx.trusted_documents_directive = Some(trusted_documents);
+                    }
+                    Err(error) => {
+                        ctx.report_error(vec![directive.pos], error);
+                    }
+                }
+            }
+            Err(duplicates) => {
+                for duplicate_directive in duplicates.skip(1) {
+                    ctx.report_error(
+                        vec![duplicate_directive.pos],
+                        "The @trustedDocuments directive can only appear once",
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::connector_parsers::MockConnectorParsers;
+    use futures::executor::block_on;
+    use std::collections::HashMap;
+
+    #[test]
+    fn parsing_trusted_documents_basic() {
+        let schema = r#"
+            extend schema
+              @trustedDocuments
+            "#;
+
+        let result = block_on(crate::parse(schema, &HashMap::new(), &MockConnectorParsers::default())).unwrap();
+
+        insta::assert_debug_snapshot!(result.registry.trusted_documents, @r###"
+        Some(
+            TrustedDocuments {
+                bypass_header_name: None,
+                bypass_header_value: None,
+            },
+        )
+        "###);
+    }
+
+    #[test]
+    fn parsing_trusted_documents_with_bypass_header() {
+        let schema = r#"
+            extend schema
+              @trustedDocuments(bypassHeaderName: "x-special-header", bypassHeaderValue: "special")
+            "#;
+
+        let result = block_on(crate::parse(schema, &HashMap::new(), &MockConnectorParsers::default())).unwrap();
+
+        insta::assert_debug_snapshot!(result.registry.trusted_documents, @r###"
+        Some(
+            TrustedDocuments {
+                bypass_header_name: Some(
+                    "x-special-header",
+                ),
+                bypass_header_value: Some(
+                    "special",
+                ),
+            },
+        )
+        "###);
+    }
+}

--- a/engine/crates/parser-sdl/src/rules/visitor/context.rs
+++ b/engine/crates/parser-sdl/src/rules/visitor/context.rs
@@ -22,7 +22,10 @@ use engine_value::Name;
 use super::{warnings::Warnings, RuleError, TypeStackType, MUTATION_TYPE, QUERY_TYPE};
 use crate::{
     federation::FederatedGraphConfig,
-    rules::{federation::FederationVersion, operation_limits_directive::OperationLimitsDirective},
+    rules::{
+        federation::FederationVersion, operation_limits_directive::OperationLimitsDirective,
+        trusted_documents_directive::TrustedDocumentsDirective,
+    },
     GlobalCacheRules, GlobalCacheTarget, GraphqlDirective, MongoDBDirective, OpenApiDirective, ParseResult,
     PostgresDirective,
 };
@@ -60,6 +63,7 @@ pub struct VisitorContext<'a> {
     pub(crate) postgres_directives: Vec<(PostgresDirective, Pos)>,
     pub(crate) global_cache_rules: GlobalCacheRules<'static>,
     pub(crate) operation_limits_directive: Option<OperationLimitsDirective>,
+    pub(crate) trusted_documents_directive: Option<TrustedDocumentsDirective>,
 
     pub federation: Option<FederationVersion>,
 
@@ -123,6 +127,7 @@ impl<'a> VisitorContext<'a> {
             federation: None,
             federated_graph_config: Default::default(),
             operation_limits_directive: None,
+            trusted_documents_directive: None,
         }
     }
 
@@ -191,6 +196,8 @@ impl<'a> VisitorContext<'a> {
             .take()
             .map(From::from)
             .unwrap_or_default();
+
+        registry.trusted_documents = self.trusted_documents_directive.take().map(From::from);
 
         let mut required_udfs = self
             .required_resolvers

--- a/packages/grafbase-sdk/src/config.ts
+++ b/packages/grafbase-sdk/src/config.ts
@@ -9,6 +9,7 @@ import { FederatedGraph, Graph } from './grafbase-schema'
 import { OperationLimits, OperationLimitsParams } from './operation-limits'
 import { Experimental, ExperimentalParams } from './experimental'
 import { Introspection } from './introspection'
+import { TrustedDocuments, TrustedDocumentsParams } from './trusted-documents'
 
 /**
  * An interface to create the complete config definition.
@@ -18,6 +19,7 @@ export interface GraphConfigInput {
   auth?: AuthParams
   cache?: CacheParams
   operationLimits?: OperationLimitsParams
+  trustedDocuments?: TrustedDocumentsParams
   experimental?: ExperimentalParams
   introspection?: boolean
 }
@@ -34,6 +36,7 @@ export interface DeprecatedGraphConfigInput {
   cache?: CacheParams
   experimental?: ExperimentalParams
   introspection?: boolean
+  trustedDocuments?: TrustedDocumentsParams
 }
 
 /**
@@ -56,6 +59,7 @@ export class GraphConfig {
   private readonly operationLimits?: OperationLimits
   private readonly experimental?: Experimental
   private readonly introspection?: Introspection
+  private readonly trustedDocuments?: TrustedDocuments
 
   /** @deprecated use `graph` instead of `schema` */
   constructor(input: GraphConfigInput | DeprecatedGraphConfigInput) {
@@ -73,6 +77,10 @@ export class GraphConfig {
       this.cache = new GlobalCache(input.cache)
     }
 
+    if (input.trustedDocuments) {
+      this.trustedDocuments = new TrustedDocuments(input.trustedDocuments)
+    }
+
     if (input.experimental) {
       this.experimental = new Experimental(input.experimental)
     }
@@ -87,6 +95,9 @@ export class GraphConfig {
     const operationLimits = this.operationLimits
       ? this.operationLimits.toString()
       : ''
+    const trustedDocuments = this.trustedDocuments
+      ? this.trustedDocuments.toString()
+      : ''
     const cache = this.cache ? this.cache.toString() : ''
     const experimental = this.experimental ? this.experimental.toString() : ''
     const introspection = this.introspection
@@ -95,7 +106,7 @@ export class GraphConfig {
         ? new Introspection({ enabled: true })
         : ''
 
-    return `${experimental}${auth}${operationLimits}${cache}${introspection}${graph}`
+    return `${experimental}${auth}${operationLimits}${trustedDocuments}${cache}${introspection}${graph}`
   }
 }
 

--- a/packages/grafbase-sdk/src/trusted-documents.ts
+++ b/packages/grafbase-sdk/src/trusted-documents.ts
@@ -1,0 +1,36 @@
+/**
+ * Configures [Trusted Documents](https://grafbase.com/docs/security/trusted-documents).
+ */
+export interface TrustedDocumentsParams {
+  /**
+   * Enforce the use of trusted documents.
+   */
+  enabled: boolean
+  /*
+   * A header that can be used to send arbitrary queries.
+   */
+  bypassHeader?: {
+    name: string
+    value: string
+  }
+}
+
+export class TrustedDocuments {
+  private params: TrustedDocumentsParams
+
+  constructor(params: TrustedDocumentsParams) {
+    this.params = params
+  }
+  
+  public toString(): string {
+    if (!this.params.enabled) {
+      return ''
+    }
+
+    const args = this.params.bypassHeader
+      ? `(bypassHeaderName: ${JSON.stringify(this.params.bypassHeader.name)}, byPassHeaderValue: ${JSON.stringify(this.params.bypassHeader.value)})`
+      : ''
+
+    return `extend schema\n  @trustedDocuments${args}`
+  }
+}

--- a/packages/grafbase-sdk/tests/unit/trusted-documents.test.ts
+++ b/packages/grafbase-sdk/tests/unit/trusted-documents.test.ts
@@ -1,0 +1,41 @@
+import { config, graph } from '../../src/index'
+import { describe, expect, it, beforeEach } from '@jest/globals'
+import { renderGraphQL } from '../utils'
+
+const g = graph.Standalone()
+
+describe('Trusted documents', () => {
+  beforeEach(() => g.clear())
+
+  it('renders when enabled', async () => {
+    const cfg = config({
+      graph: g,
+      trustedDocuments: {
+        enabled: true
+      }
+    })
+
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
+      "extend schema
+        @trustedDocuments"
+      `)
+  })
+ 
+  it('renders bypassHeader', async () => {
+    const cfg = config({
+      graph: g,
+      trustedDocuments: {
+        enabled: true,
+        bypassHeader: {
+          name: 'password',
+          value: 'm00se'
+        }
+      }
+    })
+
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
+      "extend schema
+        @trustedDocuments(bypassHeaderName: \"password\", byPassHeaderValue: \"m00se\")"
+      `)
+  })
+})


### PR DESCRIPTION
This is part of the work to enable trusted documents for managed standalone graphs.

The config looks like this:

```typescript
config({
      graph: g,
      trustedDocuments: {
        enabled: true
      }
    })
```

closes GB-6346