### PR TITLE
composition: fix bug on entity interfaces, support more directives

### DIFF
--- a/engine/crates/composition/src/compose/entity_interface.rs
+++ b/engine/crates/composition/src/compose/entity_interface.rs
@@ -122,23 +122,45 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
         }
 
         for field in definition.fields() {
-            let description = field.description().map(|description| ctx.insert_string(description.id));
-            fields.entry(field.name().id).or_insert_with(|| ir::FieldIr {
-                parent_definition: federated::Definition::Interface(interface_id),
-                field_name: field.name().id,
-                field_type: field.r#type().id,
-                arguments: translate_arguments(field, ctx),
-                resolvable_in: vec![graphql_federated_graph::SubgraphId(definition.subgraph_id().idx())],
-                provides: Vec::new(),
-                requires: Vec::new(),
-                composed_directives: federated::NO_DIRECTIVES,
-                overrides: Vec::new(),
-                description,
+            fields.entry(field.name().id).or_insert_with(|| {
+                let provides = field
+                    .directives()
+                    .provides()
+                    .is_some()
+                    .then(|| vec![field.id.0])
+                    .unwrap_or_default();
+
+                let requires = field
+                    .directives()
+                    .requires()
+                    .is_some()
+                    .then(|| vec![field.id.0])
+                    .unwrap_or_default();
+
+                let overrides = super::object::collect_overrides(&[field], ctx);
+
+                let description = field.description().map(|description| ctx.insert_string(description.id));
+
+                ir::FieldIr {
+                    parent_definition: federated::Definition::Interface(interface_id),
+                    field_name: field.name().id,
+                    field_type: field.r#type().id,
+                    arguments: translate_arguments(field, ctx),
+                    resolvable_in: vec![graphql_federated_graph::SubgraphId(definition.subgraph_id().idx())],
+                    provides,
+                    requires,
+                    composed_directives: federated::NO_DIRECTIVES,
+                    overrides,
+                    description,
+                }
             });
         }
     }
 
-    let field_ids: Vec<_> = fields.into_values().map(|field| ctx.insert_field(field)).collect();
+    let field_ids: Vec<(StringId, _)> = fields
+        .into_iter()
+        .map(|(name, field)| (name, ctx.insert_field(field)))
+        .collect();
 
     // Contribute the interface fields from the interface object definitions to the implementer of
     // that interface.
@@ -159,7 +181,14 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
         }
 
         let object_name = ctx.insert_string(object.name().id);
-        for field_id in &field_ids {
+
+        let fields_to_add = field_ids
+            .iter()
+            // Avoid adding fields that are already present on the object by virtue of the object implementing the interface.
+            .filter(|(name, _)| object.find_field(*name).is_none())
+            .map(|(_, field_id)| field_id);
+
+        for field_id in fields_to_add {
             ctx.insert_object_field_from_entity_interface(object_name, *field_id);
         }
     }

--- a/engine/crates/composition/src/compose/entity_interface.rs
+++ b/engine/crates/composition/src/compose/entity_interface.rs
@@ -70,13 +70,18 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
     for field in interface_def.fields() {
         fields.entry(field.name().id).or_insert_with(|| {
             let arguments = translate_arguments(field, ctx);
+            let resolvable_in = if field.is_part_of_key() {
+                Vec::new()
+            } else {
+                vec![federated::SubgraphId(interface_def.subgraph_id().idx())]
+            };
 
             ir::FieldIr {
                 parent_definition: federated::Definition::Interface(interface_id),
                 field_name: field.name().id,
                 field_type: field.r#type().id,
                 arguments,
-                resolvable_in: Vec::new(),
+                resolvable_in,
                 provides: Vec::new(),
                 requires: Vec::new(),
                 composed_directives: federated::NO_DIRECTIVES,

--- a/engine/crates/composition/src/compose/entity_interface.rs
+++ b/engine/crates/composition/src/compose/entity_interface.rs
@@ -75,6 +75,7 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
             } else {
                 vec![federated::SubgraphId(interface_def.subgraph_id().idx())]
             };
+            let composed_directives = collect_composed_directives(std::iter::once(field.directives()), ctx);
 
             ir::FieldIr {
                 parent_definition: federated::Definition::Interface(interface_id),
@@ -84,7 +85,7 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
                 resolvable_in,
                 provides: Vec::new(),
                 requires: Vec::new(),
-                composed_directives: federated::NO_DIRECTIVES,
+                composed_directives,
                 overrides: Vec::new(),
                 description: field.description().map(|description| ctx.insert_string(description.id)),
             }
@@ -143,6 +144,7 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
                     .unwrap_or_default();
 
                 let overrides = super::object::collect_overrides(&[field], ctx);
+                let composed_directives = collect_composed_directives(std::iter::once(field.directives()), ctx);
 
                 let description = field.description().map(|description| ctx.insert_string(description.id));
 
@@ -154,7 +156,7 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
                     resolvable_in: vec![graphql_federated_graph::SubgraphId(definition.subgraph_id().idx())],
                     provides,
                     requires,
-                    composed_directives: federated::NO_DIRECTIVES,
+                    composed_directives,
                     overrides,
                     description,
                 }

--- a/engine/crates/composition/src/compose/object.rs
+++ b/engine/crates/composition/src/compose/object.rs
@@ -255,7 +255,7 @@ fn resolvable_in(fields: &[FieldWalker<'_>], object_is_shareable: bool) -> Vec<f
         .collect()
 }
 
-fn collect_overrides(fields: &[FieldWalker<'_>], ctx: &mut Context<'_>) -> Vec<federated::Override> {
+pub(super) fn collect_overrides(fields: &[FieldWalker<'_>], ctx: &mut Context<'_>) -> Vec<federated::Override> {
     let mut overrides = Vec::new();
 
     for (field, override_directive) in fields.iter().filter_map(|f| Some(f).zip(f.directives().r#override())) {

--- a/engine/crates/composition/tests/composition/entity_interface_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_interface_basic/federated.graphql
@@ -31,7 +31,6 @@ type Cheetah implements Animal
 {
     favouriteFood: String @join__field(graph: FOREST)
     species: String!
-    species: String!
     topSpeed: Int! @join__field(graph: SAVANNA)
     weightGrams: Int @join__field(graph: STEPPE)
 }

--- a/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph/federated.graphql
@@ -55,6 +55,6 @@ interface Animal
 {
     favouriteFood: String @join__field(graph: FOREST)
     species: String!
-    swimSpeedKmh: Float
+    swimSpeedKmh: Float @join__field(graph: MANGROVE)
     weightGrams: Int @join__field(graph: STEPPE)
 }

--- a/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph/federated.graphql
@@ -34,9 +34,7 @@ type Cheetah implements Animal
     favouriteFood: String @join__field(graph: FOREST)
     runSpeedKmh: Float @join__field(graph: MANGROVE)
     species: String!
-    species: String!
     swimSpeedKmh: Float @join__field(graph: MANGROVE)
-    swimSpeedKmh: Float
     topSpeed: Int! @join__field(graph: SAVANA)
     weightGrams: Int @join__field(graph: STEPPE)
 }

--- a/engine/crates/composition/tests/composition/entity_interfaces_with_requires/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_interfaces_with_requires/federated.graphql
@@ -43,5 +43,5 @@ interface Media
 {
     id: ID!
     reviews: [Review!]! @join__field(graph: B, requires: "title")
-    title: String!
+    title: String! @join__field(graph: A)
 }

--- a/engine/crates/composition/tests/composition/entity_interfaces_with_requires/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_interfaces_with_requires/federated.graphql
@@ -1,0 +1,47 @@
+directive @core(feature: String!) repeatable on SCHEMA
+
+directive @join__owner(graph: join__Graph!) on OBJECT
+
+directive @join__type(
+    graph: join__Graph!
+    key: String!
+    resolvable: Boolean = true
+) repeatable on OBJECT | INTERFACE
+
+directive @join__field(
+    graph: join__Graph
+    requires: String
+    provides: String
+) on FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+enum join__Graph {
+    A @join__graph(name: "a", url: "http://example.com/a")
+    B @join__graph(name: "b", url: "http://example.com/b")
+}
+
+type Book implements Media
+    @join__type(graph: A, key: "id")
+{
+    id: ID!
+    reviews: [Review!]! @join__field(graph: B, requires: "title")
+    title: String! @join__field(graph: A)
+}
+
+type Review {
+    score: Int! @join__field(graph: B)
+}
+
+type Query {
+    topRatedMedia: [Media!]! @join__field(graph: B)
+}
+
+interface Media
+    @join__type(graph: A, key: "id")
+    @join__type(graph: B, key: "id", isInterfaceObject: true)
+{
+    id: ID!
+    reviews: [Review!]! @join__field(graph: B, requires: "title")
+    title: String!
+}

--- a/engine/crates/composition/tests/composition/entity_interfaces_with_requires/subgraphs/a.graphql
+++ b/engine/crates/composition/tests/composition/entity_interfaces_with_requires/subgraphs/a.graphql
@@ -1,0 +1,9 @@
+interface Media @key(fields: "id") {
+  id: ID!
+  title: String!
+}
+
+type Book implements Media @key(fields: "id") {
+  id: ID!
+  title: String!
+}

--- a/engine/crates/composition/tests/composition/entity_interfaces_with_requires/subgraphs/b.graphql
+++ b/engine/crates/composition/tests/composition/entity_interfaces_with_requires/subgraphs/b.graphql
@@ -1,0 +1,13 @@
+type Media @key(fields: "id") @interfaceObject {
+  id: ID!
+  title: String! @external
+  reviews: [Review!]! @requires(fields: "title")
+}
+
+type Review {
+  score: Int!
+}
+
+type Query {
+  topRatedMedia: [Media!]!
+}


### PR DESCRIPTION
Fields of entity interfaces were duplicated in entities defined in the
same subgraph as the entity interface, because we were adding the fields
from the interface _again_, while they were already guaranteed to be
there by the rules of GraphQL validation.

Also, we were not taking into account `@requires`, `@overrides` and
`@provides` on fields of objects with `@interfaceObject` in other subgraphs.# Description