### PR TITLE
feat: add resolver spans

### DIFF
--- a/engine/crates/engine/src/registry/resolvers/mod.rs
+++ b/engine/crates/engine/src/registry/resolvers/mod.rs
@@ -10,6 +10,7 @@
 //! A Resolver always know how to apply the associated transformers.
 
 use engine_parser::types::SelectionSet;
+use futures_util::TryFutureExt;
 use graphql_cursor::GraphqlCursor;
 use ulid::Ulid;
 
@@ -38,6 +39,8 @@ pub mod postgres;
 mod resolved_value;
 pub mod transformer;
 
+use grafbase_tracing::span::resolver::ResolverInvocationSpan;
+use grafbase_tracing::span::ResolverInvocationRecorderSpanExt;
 use tracing::{info_span, Instrument};
 
 /// Resolver Context
@@ -141,10 +144,17 @@ impl Resolver {
             Resolver::Parent => last_resolver_value.ok_or_else(|| Error::new("No data to propagate!")),
             Resolver::Transformer(ctx_data) => ctx_data.resolve(ctx, resolver_ctx, last_resolver_value).await,
             Resolver::CustomResolver(resolver) => {
-                resolver
+                let resolver_span = ResolverInvocationSpan::new(&resolver.resolver_name).into_span();
+
+                let response: Result<ResolvedValue, Error> = resolver
                     .resolve(ctx, last_resolver_value.as_ref())
-                    .instrument(info_span!("custom_resolver", resolver_name = resolver.resolver_name))
-                    .await
+                    .instrument(resolver_span.clone())
+                    .inspect_err(|err| {
+                        resolver_span.record_failure(&err.message);
+                    })
+                    .await;
+
+                response
             }
             Resolver::Composition(resolvers) => {
                 let [head, tail @ ..] = &resolvers[..] else {
@@ -157,15 +167,21 @@ impl Resolver {
                 Ok(current)
             }
             Resolver::Http(resolver) => {
+                let resolver_span = ResolverInvocationSpan::new(&resolver.api_name).into_span();
+
                 resolver
                     .resolve(ctx, resolver_ctx, last_resolver_value)
-                    .instrument(info_span!("http_resolver", api_name = resolver.api_name))
+                    .instrument(resolver_span.clone())
+                    .inspect_err(|err| {
+                        resolver_span.record_failure(&err.message);
+                    })
                     .await
             }
             Resolver::Graphql(resolver) => {
                 let runtime_ctx = ctx.data::<runtime::Context>()?;
                 let ray_id = runtime_ctx.ray_id();
                 let fetch_log_endpoint_url = runtime_ctx.log.fetch_log_endpoint_url.as_deref();
+                let resolver_span = ResolverInvocationSpan::new(resolver.name().as_ref()).into_span();
 
                 let registry = ctx.registry();
                 let request_headers = ctx.data::<RequestHeaders>().ok();
@@ -231,7 +247,10 @@ impl Resolver {
                         registry,
                         Some(batcher),
                     )
-                    .instrument(info_span!("graphql_resolver", name = resolver.name().as_ref()))
+                    .instrument(resolver_span.clone())
+                    .inspect_err(|err| {
+                        resolver_span.record_failure(&err.to_string());
+                    })
                     .await
                     .map_err(Into::into)
             }

--- a/engine/crates/integration-tests/tests/tracing/v1.rs
+++ b/engine/crates/integration-tests/tests/tracing/v1.rs
@@ -56,7 +56,8 @@ async fn query() {
             expect::field("gql.request.operation.type").with_value(&"query"),
         )
         .new_span(
-            resolver_span.clone()
+            resolver_span
+                .clone()
                 .with_field(expect::field("resolver.name").with_value(&"test")),
         )
         .enter(resolver_span.clone())
@@ -91,7 +92,8 @@ async fn query_named() {
     let (subscriber, handle) = subscriber::mock()
         .with_filter(|meta| meta.is_span() && meta.target() == "grafbase" && *meta.level() >= Level::INFO)
         .new_span(
-            graphql_span.clone()
+            graphql_span
+                .clone()
                 .with_field(expect::field("gql.document").with_value(&query)),
         )
         .enter(graphql_span.clone())
@@ -104,7 +106,8 @@ async fn query_named() {
             expect::field("gql.request.operation.type").with_value(&"query"),
         )
         .new_span(
-            resolver_span.clone()
+            resolver_span
+                .clone()
                 .with_field(expect::field("resolver.name").with_value(&"test")),
         )
         .enter(resolver_span.clone())
@@ -223,7 +226,8 @@ async fn resolvers_with_error() {
             expect::field("gql.request.operation.type").with_value(&"query"),
         )
         .new_span(
-            resolver_span_error.clone()
+            resolver_span_error
+                .clone()
                 .with_field(expect::field("resolver.name").with_value(&"error")),
         )
         .enter(resolver_span_error.clone())

--- a/engine/crates/tracing/src/span.rs
+++ b/engine/crates/tracing/src/span.rs
@@ -7,6 +7,8 @@ pub(crate) const GRAFBASE_TARGET: &str = "grafbase";
 pub mod gql;
 /// Request span
 pub mod request;
+/// Resolver span
+pub mod resolver;
 /// Subgraph span
 pub mod subgraph;
 
@@ -40,4 +42,10 @@ pub struct GqlRequestAttributes<'a> {
 pub struct GqlResponseAttributes {
     /// If the GraphQL response contains errors, record it in the span
     pub has_errors: bool,
+}
+
+/// Extension trait to record resolver invocation attributes
+pub trait ResolverInvocationRecorderSpanExt {
+    /// Recording error details in the span
+    fn record_failure(&self, error: &str);
 }

--- a/engine/crates/tracing/src/span/resolver.rs
+++ b/engine/crates/tracing/src/span/resolver.rs
@@ -1,0 +1,41 @@
+use tracing::{info_span, Span};
+
+use crate::span::ResolverInvocationRecorderSpanExt;
+
+/// Resolver span name
+pub const RESOLVER_SPAN_NAME: &str = "resolver";
+
+/// A span for a resolver invocation
+pub struct ResolverInvocationSpan<'a> {
+    name: &'a str,
+    error: Option<&'a str>,
+    is_error: bool,
+}
+impl<'a> ResolverInvocationSpan<'a> {
+    /// Create a new instance
+    pub fn new(name: &'a str) -> Self {
+        ResolverInvocationSpan {
+            name,
+            error: None,
+            is_error: false,
+        }
+    }
+
+    /// Consume self and turn into a [Span]
+    pub fn into_span(self) -> Span {
+        info_span!(
+            target: crate::span::GRAFBASE_TARGET,
+            RESOLVER_SPAN_NAME,
+            "resolver.name" = self.name,
+            "resolver.invocation.error" = self.error.as_ref(),
+            "resolver.invocation.is_error" = self.is_error,
+        )
+    }
+}
+
+impl ResolverInvocationRecorderSpanExt for Span {
+    fn record_failure(&self, error: &str) {
+        self.record("resolver.invocation.error", error);
+        self.record("resolver.invocation.is_error", true);
+    }
+}


### PR DESCRIPTION
# Description

Adds resolver spans for v1 graphs.

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
