### PR TITLE
fix: gb publish did not work without having http2 enabled for reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ num-traits = "0.2"
 once_cell = "1"
 openidconnect = "3"
 regex = "1"
-reqwest = { version = "0.11", default-features = false }
+reqwest = { version = "0.11", default-features = false, features = ["http2"] }
 rmp-serde = "1"
 rstest = "0.18"
 rustls = { version = "0.23", default-features = false }


### PR DESCRIPTION
Fixes: GB-6361