### PR TITLE
chore: bump cli to 0.64.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "engine-config-builder"
-version = "0.64.2"
+version = "0.64.3"
 dependencies = [
  "engine-v2-config",
  "graphql-federated-graph",
@@ -2200,7 +2200,7 @@ checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "federated-dev"
-version = "0.64.2"
+version = "0.64.3"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "0.64.2"
+version = "0.64.3"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -2728,7 +2728,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.64.2"
+version = "0.64.3"
 dependencies = [
  "assert_matches",
  "async-graphql",
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-graphql-introspection"
-version = "0.64.2"
+version = "0.64.3"
 dependencies = [
  "apollo-encoder",
  "apollo-parser",
@@ -2853,7 +2853,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.64.2"
+version = "0.64.3"
 dependencies = [
  "async-compression",
  "axum 0.7.5",
@@ -2883,7 +2883,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.64.2"
+version = "0.64.3"
 dependencies = [
  "chrono",
  "common-types",
@@ -2902,7 +2902,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.64.2"
+version = "0.64.3"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "graph-ref"
-version = "0.64.2"
+version = "0.64.3"
 
 [[package]]
 name = "graphql-composition"
@@ -3018,7 +3018,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-cursor"
-version = "0.64.2"
+version = "0.64.3"
 dependencies = [
  "serde",
  "serde_with",
@@ -4904,7 +4904,7 @@ dependencies = [
 
 [[package]]
 name = "operation-checks"
-version = "0.64.2"
+version = "0.64.3"
 dependencies = [
  "async-graphql-parser",
  "async-graphql-value",
@@ -4917,7 +4917,7 @@ dependencies = [
 
 [[package]]
 name = "operation-normalizer"
-version = "0.64.2"
+version = "0.64.3"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -7844,7 +7844,7 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typed-resolvers"
-version = "0.64.2"
+version = "0.64.3"
 dependencies = [
  "datatest-stable",
  "engine-parser",
@@ -8635,7 +8635,7 @@ dependencies = [
 
 [[package]]
 name = "wrapping"
-version = "0.64.2"
+version = "0.64.3"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ tracing-core = { git = "https://github.com/tokio-rs/tracing", branch = "v0.1.x" 
 tonic = { git = "https://github.com/grafbase/tonic", rev = "58de44e200af96defc4038701df9f18a177bc4c6" } # tokio-rustls-ring
 
 [workspace.package]
-version = "0.64.2"
+version = "0.64.3"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://grafbase.com"

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.64.3] - 2024-03-27
+
+[CHANGELOG](changelog/0.64.3.md)
+
 ## [0.64.2] - 2024-03-27
 
 [CHANGELOG](changelog/0.64.2.md)

--- a/cli/changelog/0.64.3.md
+++ b/cli/changelog/0.64.3.md
@@ -1,0 +1,3 @@
+### Fixes
+
+Crashes in many gb commands, complaining about missing http2 flag

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -36,8 +36,8 @@ ulid = "1"
 url = "2"
 urlencoding = "2"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.64.2" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.64.2" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.64.3" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.64.3" }
 
 [build-dependencies]
 cynic-codegen = { version = "3", features = ["rkyv"] }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -53,12 +53,12 @@ url = "2"
 uuid = { version = "1", features = ["v4"] }
 webbrowser = "0.8"
 
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.64.2" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.64.2" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.64.3" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.64.3" }
 federated-dev = { path = "../federated-dev" }
 grafbase-graphql-introspection.workspace = true
 graph-ref = { path = "../../../graph-ref" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.64.2" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.64.3" }
 
 [dev-dependencies]
 async-graphql-axum.workspace = true

--- a/cli/crates/federated-dev/Cargo.toml
+++ b/cli/crates/federated-dev/Cargo.toml
@@ -35,7 +35,7 @@ tower-http = { workspace = true, features = ["cors", "fs", "trace"] }
 ulid.workspace = true
 url = "2.5.0"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.64.2" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.64.3" }
 engine = { path = "../../../engine/crates/engine" }
 engine-config-builder = { path = "../../../engine/crates/engine-config-builder" }
 engine-v2 = { workspace = true, features = ["plan_cache"] }

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -53,7 +53,7 @@ tracing = "0.1"
 which.workspace = true
 zip = "0.6"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.64.2" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.64.3" }
 gateway = { path = "../gateway" }
 typed-resolvers = { path = "../typed-resolvers" }
 federated-dev = { path = "../federated-dev" }

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.64.2",
+  "version": "0.64.3",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.64.2",
+  "version": "0.64.3",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.64.2",
+  "version": "0.64.3",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.64.2",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.64.2",
+    "@grafbase/cli-aarch64-apple-darwin": "^0.64.3",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.64.3",
     "@grafbase/cli-x86_64-pc-windows-msvc": "0.53.0",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.64.2",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.64.2"
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.64.3",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.64.3"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.64.2",
+  "version": "0.64.3",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.64.2",
+  "version": "0.64.3",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.64.2",
+  "version": "0.64.3",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
Fixes the http2 crash on API calls.
