### PR TITLE
feat: join support for mongo db connector

### DIFF
--- a/engine/crates/engine/src/validation/utils.rs
+++ b/engine/crates/engine/src/validation/utils.rs
@@ -43,7 +43,10 @@ pub fn is_valid_input_value(
 ) -> Option<String> {
     match registry::MetaTypeName::create(type_name) {
         registry::MetaTypeName::NonNull(type_name) => match value {
-            ConstValue::Null => Some(valid_error(&path, format!("expected type \"{type_name}\""))),
+            ConstValue::Null => Some(valid_error(
+                &path,
+                format!("expected type \"{type_name}\" but found null"),
+            )),
             _ => is_valid_input_value(registry, type_name, value, path),
         },
         registry::MetaTypeName::List(type_name) => match value {
@@ -99,7 +102,10 @@ pub fn is_valid_input_value(
                             None
                         }
                     }
-                    _ => Some(valid_error(&path, format!("expected type \"{type_name}\""))),
+                    _ => Some(valid_error(
+                        &path,
+                        format!("expected type \"{type_name}\" but got {value}"),
+                    )),
                 },
                 registry::MetaType::InputObject(registry::InputObjectType {
                     input_fields,

--- a/engine/crates/engine/value/src/lib.rs
+++ b/engine/crates/engine/value/src/lib.rs
@@ -349,11 +349,7 @@ impl ConstValue {
     pub fn into_value(self) -> Value {
         match self {
             Self::Null => Value::Null,
-            Self::Number(num) => {
-                // We force it to be a f64 in the internal representation to generate the
-                // appropriate ArrowSchema
-                Value::Number(Number::from_f64(num.as_f64().expect("can't fail")).expect("can't fail"))
-            }
+            Self::Number(num) => Value::Number(num),
             Self::String(s) => Value::String(s),
             Self::Boolean(b) => Value::Boolean(b),
             Self::Binary(bytes) => Value::Binary(bytes),

--- a/engine/crates/integration-tests/src/mongodb.rs
+++ b/engine/crates/integration-tests/src/mongodb.rs
@@ -152,6 +152,10 @@ impl TestApi {
         self.inner.engine.execute(operation.as_ref()).await
     }
 
+    pub fn engine(&self) -> &Engine {
+        &self.inner.engine
+    }
+
     /// Insert a document directly to the underlying database.
     pub async fn insert_one(&self, collection: &str, document: serde_json::Value) -> MongoDBCreateOneResponse {
         let request = MongoDBCreateOneRequest {

--- a/engine/crates/integration-tests/tests/mongodb/joins.rs
+++ b/engine/crates/integration-tests/tests/mongodb/joins.rs
@@ -1,0 +1,126 @@
+//! Some tests for how the MongoDB connector interacts with the rest of the schema parsing
+
+use std::future::IntoFuture;
+
+use expect_test::expect;
+use indoc::indoc;
+use integration_tests::with_mongodb;
+use serde_json::json;
+
+#[test]
+fn join_with_mongo_collection_types() {
+    let schema = indoc! {r#"
+        type User @model(connector: "test", collection: "users") {
+          name: String!
+
+          selfList(first: Int, after: String): UserConnection @join(
+            select: "userCollection(first: $first, after: $after, filter: {id: {eq: $id}})"
+          )
+        }
+    "#};
+
+    let response = with_mongodb(schema, |api| async move {
+        let document = json!({
+            "name": "Bob",
+        });
+
+        let id = api.insert_one("users", document).await.inserted_id;
+
+        let query = indoc! {r#"
+            query($id: ID!) {
+              user(by: { id: $id }) {
+                name
+                selfList(first: 10) {
+                  edges {
+                    node {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+        "#};
+
+        api.engine()
+            .execute(query)
+            .variables(json!({
+                "id": id
+            }))
+            .into_future()
+            .await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "user": {
+              "name": "Bob",
+              "selfList": {
+                "edges": [
+                  {
+                    "node": {
+                      "name": "Bob"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test]
+fn join_with_mongo_model_type() {
+    let schema = indoc! {r#"
+        type User @model(connector: "test", collection: "users") {
+          name: String!
+
+          self: User @join(
+            select: "user(by: {id: $id})"
+          )
+        }
+    "#};
+
+    let response = with_mongodb(schema, |api| async move {
+        let document = json!({
+            "name": "Bob",
+        });
+
+        let id = api.insert_one("users", document).await.inserted_id;
+
+        let query = indoc! {r#"
+            query($id: ID!) {
+              user(by: { id: $id }) {
+                name
+                self {
+                    name
+                }
+              }
+            }
+        "#};
+
+        api.engine()
+            .execute(query)
+            .variables(json!({
+                "id": id
+            }))
+            .into_future()
+            .await
+    });
+
+    let expected = expect![[r#"
+        {
+          "data": {
+            "user": {
+              "name": "Bob",
+              "self": {
+                "name": "Bob"
+              }
+            }
+          }
+        }"#]];
+
+    expected.assert_eq(&response);
+}

--- a/engine/crates/integration-tests/tests/mongodb/mod.rs
+++ b/engine/crates/integration-tests/tests/mongodb/mod.rs
@@ -4,5 +4,7 @@ mod delete_many;
 mod delete_one;
 mod find_many;
 mod find_one;
+mod joins;
+mod schema;
 mod update_many;
 mod update_one;

--- a/engine/crates/integration-tests/tests/mongodb/schema.rs
+++ b/engine/crates/integration-tests/tests/mongodb/schema.rs
@@ -4,8 +4,7 @@ use cynic::QueryBuilder;
 use cynic_introspection::IntrospectionQuery;
 use expect_test::expect;
 use indoc::indoc;
-use integration_tests::{federation::GraphqlResponse, with_mongodb, with_namespaced_mongodb, ResponseExt};
-use serde_json::json;
+use integration_tests::with_mongodb;
 
 #[test]
 fn nested_sort_schema() {

--- a/engine/crates/integration-tests/tests/mongodb/schema.rs
+++ b/engine/crates/integration-tests/tests/mongodb/schema.rs
@@ -1,0 +1,319 @@
+//! Tests that the generated schema for mongo makes sense
+
+use cynic::QueryBuilder;
+use cynic_introspection::IntrospectionQuery;
+use expect_test::expect;
+use indoc::indoc;
+use integration_tests::{federation::GraphqlResponse, with_mongodb, with_namespaced_mongodb, ResponseExt};
+use serde_json::json;
+
+#[test]
+fn nested_sort_schema() {
+    // Some change I made broke the schema shape for this specific case, so
+    // here's a test to help me figure it out
+    let schema = indoc! {r#"
+        type Age {
+          number: Int! @map(name: "real_number")
+        }
+
+        type User @model(connector: "test", collection: "users") {
+          age: Age!
+        }
+    "#};
+
+    let response = with_mongodb(schema, |api| async move {
+        api.engine().execute(IntrospectionQuery::build(())).await
+    });
+
+    let sdl = serde_json::from_str::<cynic::GraphQlResponse<IntrospectionQuery>>(&response)
+        .unwrap()
+        .data
+        .unwrap()
+        .into_schema()
+        .unwrap()
+        .to_sdl();
+
+    let expected = expect![[r#"
+        type Age {
+          number: Int!
+        }
+
+        """
+        Age input type.
+        """
+        input AgeInput {
+          number: Int!
+        }
+
+        input AgeOrderByInput {
+          number: MongoOrderByDirection
+        }
+
+        input AgeUpdateInput {
+          number: MongoDBRequiredIntUpdateInput
+        }
+
+        input MongoDBAgeSearchFilterInput {
+          number: MongoDBIntSearchFilterInput
+        }
+
+        """
+        Search filter input for ID type.
+        """
+        input MongoDBIDSearchFilterInput {
+          """
+          The value is exactly the one given
+          """
+          eq: ID
+          """
+          The value is not the one given
+          """
+          ne: ID
+          """
+          The value is greater than the one given
+          """
+          gt: ID
+          """
+          The value is less than the one given
+          """
+          lt: ID
+          """
+          The value is greater than, or equal to the one given
+          """
+          gte: ID
+          """
+          The value is less than, or equal to the one given
+          """
+          lte: ID
+          """
+          The value does not match the filters.
+          """
+          not: MongoDBIDSearchFilterInput
+          """
+          The value is in the given array of values
+          """
+          in: [ID]
+          """
+          The value is not in the given array of values
+          """
+          nin: [ID]
+          """
+          The value exists in the document and is not null.
+          """
+          exists: Boolean
+        }
+
+        """
+        Search filter input for Int type.
+        """
+        input MongoDBIntSearchFilterInput {
+          """
+          The value is exactly the one given
+          """
+          eq: Int
+          """
+          The value is not the one given
+          """
+          ne: Int
+          """
+          The value is greater than the one given
+          """
+          gt: Int
+          """
+          The value is less than the one given
+          """
+          lt: Int
+          """
+          The value is greater than, or equal to the one given
+          """
+          gte: Int
+          """
+          The value is less than, or equal to the one given
+          """
+          lte: Int
+          """
+          The value does not match the filters.
+          """
+          not: MongoDBIntSearchFilterInput
+          """
+          The value is in the given array of values
+          """
+          in: [Int]
+          """
+          The value is not in the given array of values
+          """
+          nin: [Int]
+          """
+          The value exists in the document and is not null.
+          """
+          exists: Boolean
+        }
+
+        """
+        Update input for Int type.
+        """
+        input MongoDBRequiredIntUpdateInput {
+          """
+          Increments the value of the field by the specified amount.
+          """
+          increment: Int
+          """
+          Only updates the field if the specified value is less than the existing field value.
+          """
+          minimum: Int
+          """
+          Only updates the field if the specified value is greater than the existing field value.
+          """
+          maximum: Int
+          """
+          Multiplies the value of the field by the specified amount.
+          """
+          multiply: Int
+          """
+          Replaces the value of a field with the specified value.
+          """
+          set: Int
+        }
+
+        enum MongoOrderByDirection {
+          ASC
+          DESC
+        }
+
+        type Mutation {
+          """
+          Create a User
+          """
+          userCreate(input: UserCreateInput!): UserCreatePayload
+          """
+          Delete a unique User
+          """
+          userDelete(by: UserByInput!): UserDeletePayload
+          """
+          Delete many Users
+          """
+          userDeleteMany(filter: UserCollection!): UserDeletePayload
+          """
+          Create multiple Users
+          """
+          userCreateMany(input: [UserCreateInput!]!): UserCreateManyPayload
+          """
+          Update a unique User
+          """
+          userUpdate(by: UserByInput!, input: UserUpdateInput!): UserUpdatePayload
+          """
+          Update many Users
+          """
+          userUpdateMany(filter: UserCollection!, input: UserUpdateInput!): UserUpdatePayload
+        }
+
+        type PageInfo {
+          hasPreviousPage: Boolean!
+          hasNextPage: Boolean!
+          startCursor: String
+          endCursor: String
+        }
+
+        type Query {
+          """
+          Query a single User by a field
+          """
+          user(
+            """
+            The field and value by which to query the User
+            """
+            by: UserByInput!
+          ): User
+          """
+          Paginated query to fetch the whole list of User
+          """
+          userCollection(
+            filter: UserCollection
+            first: Int
+            last: Int
+            before: String
+            after: String
+            orderBy: [UserOrderByInput]
+          ): UserConnection
+        }
+
+        type User {
+          """
+          Unique identifier
+          """
+          id: ID!
+          age: Age!
+        }
+
+        input UserByInput {
+          id: ID
+        }
+
+        input UserCollection {
+          id: MongoDBIDSearchFilterInput
+          """
+          All of the filters must match
+          """
+          ALL: [UserCollection]
+          """
+          None of the filters must match
+          """
+          NONE: [UserCollection]
+          """
+          At least one of the filters must match
+          """
+          ANY: [UserCollection]
+          age: MongoDBAgeSearchFilterInput
+        }
+
+        type UserConnection {
+          """
+          Information to aid in pagination
+          """
+          pageInfo: PageInfo!
+          edges: [UserEdge]
+        }
+
+        """
+        Input to create a User
+        """
+        input UserCreateInput {
+          id: ID
+          age: AgeInput!
+        }
+
+        type UserCreateManyPayload {
+          insertedIds: [ID]
+        }
+
+        type UserCreatePayload {
+          insertedId: ID
+        }
+
+        type UserDeletePayload {
+          deletedCount: Int
+        }
+
+        type UserEdge {
+          node: User!
+          cursor: String!
+        }
+
+        input UserOrderByInput {
+          id: MongoOrderByDirection
+          age: AgeOrderByInput
+        }
+
+        input UserUpdateInput {
+          age: AgeUpdateInput
+        }
+
+        type UserUpdatePayload {
+          matchedCount: Int
+          modifiedCount: Int
+        }
+
+    "#]];
+
+    expected.assert_eq(&sdl);
+}

--- a/engine/crates/parser-sdl/src/lib.rs
+++ b/engine/crates/parser-sdl/src/lib.rs
@@ -57,6 +57,7 @@ use rules::{
 };
 
 pub mod federation;
+mod parser_extensions;
 mod schema_coord;
 mod type_names;
 mod validations;

--- a/engine/crates/parser-sdl/src/parser_extensions.rs
+++ b/engine/crates/parser-sdl/src/parser_extensions.rs
@@ -1,0 +1,44 @@
+use engine::{registry::MetaInputValue, Positioned};
+use engine_parser::types::FieldDefinition;
+use indexmap::IndexMap;
+
+pub trait FieldExtension {
+    /// Returns true if this field is "synthetic"
+    ///
+    /// e.g. a field that only exists inside the engine and not in any connected api/db
+    ///
+    /// Currently this means fields with resolvers or joined fieds, but may be expanded.
+    fn is_synthetic_field(&self) -> bool;
+
+    fn converted_arguments(&self) -> IndexMap<String, MetaInputValue>;
+}
+
+impl FieldExtension for FieldDefinition {
+    fn is_synthetic_field(&self) -> bool {
+        self.directives
+            .iter()
+            .any(|directive| directive.name.node == "join" || directive.name.node == "resolver")
+    }
+
+    fn converted_arguments(&self) -> IndexMap<String, MetaInputValue> {
+        self.arguments
+            .iter()
+            .map(|argument| {
+                let name = argument.node.name.to_string();
+                let input = MetaInputValue::new(name.clone(), argument.node.ty.to_string());
+
+                (name, input)
+            })
+            .collect()
+    }
+}
+
+impl FieldExtension for Positioned<FieldDefinition> {
+    fn is_synthetic_field(&self) -> bool {
+        self.node.is_synthetic_field()
+    }
+
+    fn converted_arguments(&self) -> IndexMap<String, MetaInputValue> {
+        self.node.converted_arguments()
+    }
+}

--- a/engine/crates/parser-sdl/src/rules/basic_type.rs
+++ b/engine/crates/parser-sdl/src/rules/basic_type.rs
@@ -8,7 +8,7 @@ use engine::registry::{
     self,
     federation::FederationKey,
     resolvers::{custom::CustomResolver, transformer::Transformer, Resolver},
-    MetaField, MetaInputValue, MetaType, ObjectType,
+    MetaField, MetaType, ObjectType,
 };
 use engine_parser::{
     types::{FieldDefinition, TypeKind},

--- a/engine/crates/parser-sdl/src/rules/basic_type.rs
+++ b/engine/crates/parser-sdl/src/rules/basic_type.rs
@@ -28,8 +28,8 @@ use super::{
     visitor::{RuleError, Visitor, VisitorContext},
 };
 use crate::{
-    directive_de::parse_directive, registry::add_input_type_non_primitive, rules::cache_directive::CacheDirective,
-    schema_coord::SchemaCoord,
+    directive_de::parse_directive, parser_extensions::FieldExtension, registry::add_input_type_non_primitive,
+    rules::cache_directive::CacheDirective, schema_coord::SchemaCoord,
 };
 
 pub struct BasicType;
@@ -102,14 +102,7 @@ impl<'a> Visitor<'a> for BasicType {
                     description: field.node.description.clone().map(|x| x.node),
                     ty: field.node.ty.clone().node.to_string().into(),
                     cache_control: CacheDirective::parse(&field.node.directives),
-                    args: field
-                        .arguments
-                        .iter()
-                        .map(|argument| {
-                            MetaInputValue::new(argument.node.name.to_string(), argument.node.ty.to_string())
-                        })
-                        .map(|arg| (arg.name.clone(), arg))
-                        .collect(),
+                    args: field.converted_arguments(),
                     resolver,
                     requires,
                     external,

--- a/engine/crates/parser-sdl/src/rules/check_type_validity.rs
+++ b/engine/crates/parser-sdl/src/rules/check_type_validity.rs
@@ -23,18 +23,15 @@ impl<'a> Visitor<'a> for CheckTypeValidity {
             return;
         }
 
-        match ctx.types.get(&base_type) {
-            Some(_ty) => {}
-            None => {
-                ctx.report_error(
-                    vec![field.pos],
-                    format!(
-                        "Field `{name}` got an undefined type: `{ty}`.",
-                        name = field.node.name.node,
-                        ty = base_type
-                    ),
-                );
-            }
+        if !ctx.types.contains_key(&base_type) && !ctx.registry.borrow().types.contains_key(&base_type) {
+            ctx.report_error(
+                vec![field.pos],
+                format!(
+                    "Field `{name}` got an undefined type: `{ty}`.",
+                    name = field.node.name.node,
+                    ty = base_type
+                ),
+            );
         }
     }
 }

--- a/engine/crates/parser-sdl/src/rules/extend_connector_types.rs
+++ b/engine/crates/parser-sdl/src/rules/extend_connector_types.rs
@@ -1,7 +1,7 @@
 use engine::registry::{
     self,
     resolvers::{custom::CustomResolver, Resolver},
-    MetaField, MetaInputValue, MetaType,
+    MetaField, MetaType,
 };
 use engine_parser::types::TypeKind;
 

--- a/engine/crates/parser-sdl/src/rules/extend_connector_types.rs
+++ b/engine/crates/parser-sdl/src/rules/extend_connector_types.rs
@@ -15,7 +15,9 @@ use super::{
     requires_directive::RequiresDirective,
     visitor::{Visitor, VisitorContext},
 };
-use crate::{rules::resolver_directive::ResolverDirective, schema_coord::SchemaCoord};
+use crate::{
+    parser_extensions::FieldExtension, rules::resolver_directive::ResolverDirective, schema_coord::SchemaCoord,
+};
 
 pub struct ExtendConnectorTypes;
 
@@ -94,14 +96,7 @@ impl<'a> Visitor<'a> for ExtendConnectorTypes {
                 Some(MetaField {
                     name,
                     description: field.description.clone().map(|x| x.node),
-                    args: field
-                        .arguments
-                        .iter()
-                        .map(|argument| {
-                            MetaInputValue::new(argument.node.name.to_string(), argument.node.ty.to_string())
-                        })
-                        .map(|arg| (arg.name.clone(), arg))
-                        .collect(),
+                    args: field.converted_arguments(),
                     ty: field.ty.clone().node.to_string().into(),
                     requires,
                     resolver,

--- a/engine/crates/parser-sdl/src/rules/extend_query_and_mutation_types.rs
+++ b/engine/crates/parser-sdl/src/rules/extend_query_and_mutation_types.rs
@@ -1,7 +1,7 @@
 use common_types::auth::Operations;
 use engine::registry::{
     resolvers::{custom::CustomResolver, Resolver},
-    MetaField, MetaInputValue,
+    MetaField,
 };
 use engine_parser::types::{ObjectType, TypeKind};
 

--- a/engine/crates/parser-sdl/src/rules/extend_query_and_mutation_types.rs
+++ b/engine/crates/parser-sdl/src/rules/extend_query_and_mutation_types.rs
@@ -10,7 +10,10 @@ use super::{
     federation::{InaccessibleDirective, TagDirective},
     visitor::{Visitor, VisitorContext, MUTATION_TYPE, QUERY_TYPE},
 };
-use crate::rules::{cache_directive::CacheDirective, resolver_directive::ResolverDirective};
+use crate::{
+    parser_extensions::FieldExtension,
+    rules::{cache_directive::CacheDirective, resolver_directive::ResolverDirective},
+};
 
 pub struct ExtendQueryAndMutationTypes;
 
@@ -65,17 +68,7 @@ impl<'a> Visitor<'a> for ExtendQueryAndMutationTypes {
                     name: name.clone(),
                     mapped_name: None,
                     description: field.node.description.clone().map(|x| x.node),
-                    args: field
-                        .node
-                        .arguments
-                        .iter()
-                        .map(|argument| {
-                            (
-                                argument.node.name.to_string(),
-                                MetaInputValue::new(argument.node.name.to_string(), argument.node.ty.to_string()),
-                            )
-                        })
-                        .collect(),
+                    args: field.converted_arguments(),
                     ty: field.node.ty.clone().node.to_string().into(),
                     deprecation,
                     cache_control,

--- a/engine/crates/parser-sdl/src/rules/mongodb_directive/model_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/mongodb_directive/model_directive.rs
@@ -8,6 +8,7 @@ use engine::{registry::MongoDBConfiguration, Positioned};
 use engine_parser::types::{ObjectType, TypeDefinition, TypeKind};
 
 use crate::{
+    parser_extensions::FieldExtension,
     registry::names::MetaNames,
     rules::{
         auth_directive::AuthDirective,
@@ -60,6 +61,11 @@ fn validate_fields(ctx: &mut VisitorContext<'_>, object: &ObjectType) {
                 vec![field.pos],
                 format!("Field name '{name}' is reserved and cannot be used."),
             );
+        }
+
+        if field.is_synthetic_field() {
+            // We shouldn't validate synthetic fields
+            continue;
         }
 
         let ty = field.ty.base.to_base_type_str();

--- a/engine/crates/parser-sdl/src/rules/mongodb_directive/model_directive/create_type_context.rs
+++ b/engine/crates/parser-sdl/src/rules/mongodb_directive/model_directive/create_type_context.rs
@@ -82,8 +82,8 @@ impl<'a> CreateTypeContext<'a> {
         &self.model_auth
     }
 
-    pub(super) fn fields(&self) -> impl ExactSizeIterator<Item = &FieldDefinition> + '_ {
-        self.object.fields.iter().map(|field| &field.node)
+    pub(super) fn fields(&self) -> impl ExactSizeIterator<Item = &Positioned<FieldDefinition>> + '_ {
+        self.object.fields.iter()
     }
 
     pub(super) fn unique_directives(&self) -> impl ExactSizeIterator<Item = &UniqueDirective> + '_ {

--- a/engine/crates/parser-sdl/src/rules/mongodb_directive/model_directive/model_type.rs
+++ b/engine/crates/parser-sdl/src/rules/mongodb_directive/model_directive/model_type.rs
@@ -8,13 +8,7 @@ use engine::{
 use resolver_data::ResolverData;
 
 use super::CreateTypeContext;
-use crate::{
-    parser_extensions::FieldExtension,
-    rules::{
-        auth_directive::AuthDirective, join_directive::JoinDirective, requires_directive::RequiresDirective,
-        resolver_directive::ResolverDirective, visitor::VisitorContext,
-    },
-};
+use crate::rules::{auth_directive::AuthDirective, visitor::VisitorContext};
 
 pub(super) fn create(visitor_ctx: &mut VisitorContext<'_>, create_ctx: &CreateTypeContext<'_>) {
     let type_name = create_ctx.model_name().to_string();

--- a/engine/crates/parser-sdl/src/rules/mongodb_directive/model_directive/model_type/resolver_data.rs
+++ b/engine/crates/parser-sdl/src/rules/mongodb_directive/model_directive/model_type/resolver_data.rs
@@ -11,11 +11,8 @@ use engine_parser::types::FieldDefinition;
 use crate::{
     parser_extensions::FieldExtension,
     rules::{
-        cache_directive::CacheDirective,
-        join_directive::{self, JoinDirective},
-        requires_directive::RequiresDirective,
-        resolver_directive::ResolverDirective,
-        visitor::VisitorContext,
+        cache_directive::CacheDirective, join_directive::JoinDirective, requires_directive::RequiresDirective,
+        resolver_directive::ResolverDirective, visitor::VisitorContext,
     },
 };
 


### PR DESCRIPTION
A potential customer was trying to use our join directive to hook up two mongo db models up, like so:

```typescript
g.extend("Customer", (extend) => {
  extend.addField(
    "customerContacts",
    g.ref("CustomerConnection").optional().join(
      "mongoDB { contactCollection(first: 10, filter:{businessid:{eq: $customerid}})"
    )
  )
})
```

But this was giving them the following error:

> Field customerContacts got an undefined type: CustomerConnection

This particular error is because the mongo connector doesn't put its generated types into `ctx.types` which is where the code responsible for the above error looks for types.  I've fixed that by updating the undefined type code to also look in `registry.types` instead of just `ctx.types`.

After fixing that I noticed that the connector doesn't parse join directives, so I added support for that.

Then my test started complaining that the `first` argument wasn't provided, which turned out to be because some code involved in joins was turning every number into a float, and that argument is an integer.  So some serde code that's involved was throwing an error which was being silently turned into `None`.  So that was fun.

I also updated a lot of the type generation code to filter out resolver & join fields from the generated input types, because users probably shouldn't be able to write fields that are computed.

Finally, I also discovered some ordering issues that are far too big a job for me to fix today.  For now users probably just need to be careful to define types before they're used.