### PR TITLE
engine-v1: remove references to empty types when removing empty types

### DIFF
--- a/engine/crates/engine/src/registry/mod.rs
+++ b/engine/crates/engine/src/registry/mod.rs
@@ -1933,13 +1933,20 @@ impl Registry {
                 match r#type.fields() {
                     None => types_to_be_removed.push(r#type.name().to_owned()),
                     Some(fields) if fields.is_empty() => types_to_be_removed.push(r#type.name().to_owned()),
-                    Some(fields) => {
-                        for field in fields.values() {
-                            if !self.types.contains_key(field.ty.base_type_name()) {
-                                fields_to_be_removed.push((r#type.name().to_owned(), field.name.clone()));
-                            }
-                        }
-                    }
+                    Some(_) => (),
+                }
+            }
+
+            types_to_be_removed.sort();
+
+            for r#type in self.types.values().filter(|ty| ty.is_object()) {
+                for field in r#type.fields().into_iter().flat_map(|fields| fields.values()) {
+                    if types_to_be_removed
+                        .binary_search_by_key(&field.ty.base_type_name(), |ty| ty.as_str())
+                        .is_ok()
+                    {
+                        fields_to_be_removed.push((r#type.name().to_owned(), field.name.clone()));
+                    };
                 }
             }
 

--- a/engine/crates/integration-tests/tests/openapi/transforms.rs
+++ b/engine/crates/integration-tests/tests/openapi/transforms.rs
@@ -40,6 +40,49 @@ fn test_openapi_with_transforms() {
     });
 }
 
+#[test]
+fn transforms_to_empty_type() {
+    runtime().block_on(async {
+        let mock_server = wiremock::MockServer::start().await;
+
+        let schema = format!(
+            r#"
+              extend schema @introspection(enable: true)
+              extend schema
+              @openapi(
+                name: "petstore",
+                url: "http://{address}",
+                schema: "http://example.com/petstore.json",
+                transforms: {{
+                  exclude: [
+                    "Pet.id",
+                    "Pet.name",
+                    "Pet.owner",
+                  ]
+                }}
+              )
+            "#,
+            address = mock_server.address(),
+        );
+
+        let engine = EngineBuilder::new(schema)
+            .with_openapi_schema("http://example.com/petstore.json", include_str!("transforms_spec.json"))
+            .with_env_var("API_KEY", "BLAH")
+            .build()
+            .await;
+
+        let introspection_query = IntrospectionQuery::build(());
+        let response = engine
+            .execute(introspection_query)
+            .await
+            .into_data::<IntrospectionQuery>();
+
+        insta::assert_snapshot!(response.into_schema().unwrap().to_sdl(), @r###"
+        type Query
+        "###);
+    });
+}
+
 fn petstore_schema_with_transforms(address: &SocketAddr) -> String {
     format!(
         r#"


### PR DESCRIPTION
- Remove fields that may return that type
- Remove query and mutation roots of that type

closes GB-6364