### PR TITLE
Fix (cloudflare) worker crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8538,9 +8538,9 @@ dependencies = [
 
 [[package]]
 name = "worker"
-version = "0.0.23"
+version = "0.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec770518dfe9a63f28548673f68c9fe190baff55813afd9c36c811eb46af80f1"
+checksum = "01e01575624501026eab70b650e742394801f13eeac45f51f27e3c6a335e4d84"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8585,9 +8585,9 @@ dependencies = [
 
 [[package]]
 name = "worker-macros"
-version = "0.0.15"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8810ad96b5e55a5ae6cd4c0df118bb2bde528ae8e8e4df65e25d235f5db36af1"
+checksum = "ba51b04dab6538cd7a6b6e1eb0795e65b63138c2d3b73686bc10d57d7770d0ec"
 dependencies = [
  "async-trait",
  "proc-macro2",
@@ -8601,9 +8601,9 @@ dependencies = [
 
 [[package]]
 name = "worker-sys"
-version = "0.0.15"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ee8668ebc5665df3f4bea3d241e949694da22f08b77895b08aaf5d5de5f3ea"
+checksum = "45f793beb4fd7038637cda24502769ae1d90a32b9cdb3b48ff73ce9cf007affe"
 dependencies = [
  "cfg-if",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ wasm-bindgen = "0.2"
 web-time = "1"
 which = "6"
 wiremock = "0.6.0"
-worker = "0.0.23"
+worker = "0.0.21"
 fnv = "1"
 sha2 = "0.10"
 

--- a/engine/crates/tracing/Cargo.toml
+++ b/engine/crates/tracing/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "1.0"
 tonic = { version = "0.11.0", optional = true }
 tower-http = { version = "0.5", optional = true, features = ["trace"] }
 url = { version = "2.5", features = ["serde"] }
-worker = { version = "0.0.23", optional = true }
+worker = { workspace = true, optional = true }
 
 # tracing
 tracing.workspace = true


### PR DESCRIPTION
Align on 0.21.0, like in API. This is a problem when trying to upgrade the deps from this repo, because other deps using the workers crate aren’t caught up to 0.23.0 yet.