### PR TITLE
feat: remove the query attribute from the gql span

### DIFF
--- a/engine/crates/engine/src/schema.rs
+++ b/engine/crates/engine/src/schema.rs
@@ -558,7 +558,7 @@ impl Schema {
     /// Execute a GraphQL query.
     pub async fn execute(&self, request: impl Into<Request>) -> Response {
         let request = request.into();
-        let gql_span = GqlRequestSpan::new().with_document(request.query()).into_span();
+        let gql_span = GqlRequestSpan::new().into_span();
 
         let extensions = self.create_extensions(Default::default());
         let request_fut = {
@@ -584,9 +584,9 @@ impl Schema {
         };
         futures_util::pin_mut!(request_fut);
 
-        let request = extensions.request(&mut request_fut).inspect(|_response: &Response| {
+        let request = extensions.request(&mut request_fut).inspect(|response: &Response| {
             Span::current().record_gql_response(GqlResponseAttributes {
-                has_errors: _response.is_err(),
+                has_errors: response.is_err(),
             });
         });
 
@@ -621,7 +621,7 @@ impl Schema {
         let schema = self.clone();
         let request = request.into();
         let extensions = self.create_extensions(session_data.clone());
-        let gql_span = GqlRequestSpan::new().with_document(request.query()).into_span();
+        let gql_span = GqlRequestSpan::new().into_span();
 
         let request = futures_util::stream::StreamExt::boxed({
             let extensions = extensions.clone();

--- a/engine/crates/integration-tests/tests/tracing/v1.rs
+++ b/engine/crates/integration-tests/tests/tracing/v1.rs
@@ -16,7 +16,7 @@ async fn query_bad_request() {
 
     let (subscriber, handle) = subscriber::mock()
         .with_filter(|meta| meta.is_span() && meta.target() == "grafbase" && *meta.level() >= Level::INFO)
-        .new_span(span.clone().with_field(expect::field("gql.document").with_value(&"")))
+        .new_span(span.clone())
         .enter(span.clone())
         .clone_span(span.clone())
         .record(span.clone(), expect::field("gql.response.has_errors").with_value(&true))
@@ -46,10 +46,7 @@ async fn query() {
 
     let (subscriber, handle) = subscriber::mock()
         .with_filter(|meta| meta.is_span() && meta.target() == "grafbase" && *meta.level() >= Level::INFO)
-        .new_span(
-            span.clone()
-                .with_field(expect::field("gql.document").with_value(&query)),
-        )
+        .new_span(span.clone())
         .enter(span.clone())
         .record(
             span.clone(),
@@ -91,11 +88,7 @@ async fn query_named() {
 
     let (subscriber, handle) = subscriber::mock()
         .with_filter(|meta| meta.is_span() && meta.target() == "grafbase" && *meta.level() >= Level::INFO)
-        .new_span(
-            graphql_span
-                .clone()
-                .with_field(expect::field("gql.document").with_value(&query)),
-        )
+        .new_span(graphql_span.clone())
         .enter(graphql_span.clone())
         .record(
             graphql_span.clone(),
@@ -140,10 +133,7 @@ async fn batch() {
     let (subscriber, handle) = subscriber::mock()
         .with_filter(move |meta| meta.is_span() && meta.target() == "grafbase" && *meta.level() >= Level::INFO)
         // span #1
-        .new_span(
-            span.clone()
-                .with_field(expect::field("gql.document").with_value(&"query-1")),
-        )
+        .new_span(span.clone())
         .enter(span.clone())
         .clone_span(span.clone())
         .record(span.clone(), expect::field("gql.response.has_errors").with_value(&true))
@@ -152,10 +142,7 @@ async fn batch() {
         .enter(span.clone())
         .exit(span.clone())
         // span #2
-        .new_span(
-            span.clone()
-                .with_field(expect::field("gql.document").with_value(&"query-2")),
-        )
+        .new_span(span.clone())
         .enter(span.clone())
         .clone_span(span.clone())
         .record(span.clone(), expect::field("gql.response.has_errors").with_value(&true))
@@ -190,7 +177,7 @@ async fn subscription() {
 
     let (subscriber, handle) = subscriber::mock()
         .with_filter(|meta| meta.is_span() && meta.target() == "grafbase" && *meta.level() >= Level::INFO)
-        .new_span(span.clone().with_field(expect::field("gql.document").with_value(&"")))
+        .new_span(span.clone())
         .only()
         .run_with_handle();
 
@@ -216,10 +203,7 @@ async fn resolvers_with_error() {
 
     let (subscriber, handle) = subscriber::mock()
         .with_filter(|meta| meta.is_span() && meta.target() == "grafbase" && *meta.level() >= Level::INFO)
-        .new_span(
-            span.clone()
-                .with_field(expect::field("gql.document").with_value(&query)),
-        )
+        .new_span(span.clone())
         .enter(span.clone())
         .record(
             span.clone(),


### PR DESCRIPTION
This PR removes the graphql document (query) from the tracing spans as they could potentially contain sensible data, be huge and potentially contributes to missing spans

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
