### PR TITLE
fix(parser-sdl): mongodb + extension types bugs

### DIFF
--- a/engine/crates/parser-sdl/src/rules/federation/key.rs
+++ b/engine/crates/parser-sdl/src/rules/federation/key.rs
@@ -220,7 +220,7 @@ mod tests {
                 id: ID!
             }
             "#,
-            "federation key `id` on the type User is trying to join with Query.blah, but those fields do not have compatible types"
+            "federation key `id` on the type User is trying to join with Query.blah, but those fields do not have compatible types: '[User!]!' and 'User'"
         );
     }
 }

--- a/engine/crates/parser-sdl/src/rules/join_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/join_directive.rs
@@ -451,7 +451,7 @@ mod tests {
                 nickname: String! @join(select: "blah(id: $id)")
             }
             "#,
-            "User.nickname is trying to join with Query.blah, but those fields do not have compatible types"
+            "User.nickname is trying to join with Query.blah, but those fields do not have compatible types: 'Int' and 'String!'"
         );
     }
 
@@ -513,7 +513,7 @@ mod tests {
                 nickname: String! @join(select: "blah(id: $id)")
             }
             "#,
-            "User.nickname is trying to join with Query.blah, but those fields do not have compatible types"
+            "User.nickname is trying to join with Query.blah, but those fields do not have compatible types: 'String' and 'String!'"
         );
     }
 
@@ -556,7 +556,7 @@ mod tests {
                 nickname: [String]! @join(select: "blah(id: $id)")
             }
             "#,
-            "User.nickname is trying to join with Query.blah, but those fields do not have compatible types"
+            "User.nickname is trying to join with Query.blah, but those fields do not have compatible types: '[String]' and '[String]!'"
         );
     }
 
@@ -575,7 +575,7 @@ mod tests {
                 nickname: String @join(select: "blah(id: $id)")
             }
             "#,
-            "User.nickname is trying to join with Query.blah, but those fields do not have compatible types"
+            "User.nickname is trying to join with Query.blah, but those fields do not have compatible types: '[String]' and 'String'"
         );
     }
 

--- a/engine/crates/parser-sdl/src/rules/mongodb_directive/type_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/mongodb_directive/type_directive.rs
@@ -7,25 +7,31 @@ use crate::rules::visitor::{Visitor, VisitorContext};
 pub struct MongoDBTypeDirective;
 
 impl<'a> Visitor<'a> for MongoDBTypeDirective {
-    fn enter_type_definition(&mut self, ctx: &mut VisitorContext<'a>, r#type: &'a Positioned<TypeDefinition>) {
+    fn enter_type_definition(&mut self, ctx: &mut VisitorContext<'a>, type_definition: &'a Positioned<TypeDefinition>) {
         if ctx.registry.borrow().mongodb_configurations.is_empty() {
             return;
         }
 
-        if r#type.node.directives.iter().any(|directive| directive.is_model()) {
+        if type_definition.node.extend
+            || type_definition
+                .node
+                .directives
+                .iter()
+                .any(|directive| directive.is_model())
+        {
             return;
         }
 
-        let type_name = r#type.name.as_str();
+        let type_name = type_definition.name.as_str();
 
-        match &r#type.node.kind {
+        match &type_definition.node.kind {
             TypeKind::Object(object) => {
                 let input_type_name = generic::filter_type_name(type_name);
                 filter::register_type_input(ctx, object, &input_type_name, std::iter::empty());
-                generic::register_array_type(ctx, r#type.name.as_str(), false);
-                generic::register_singular_type(ctx, r#type.name.as_str());
-                filter::register_orderby_input(ctx, object, r#type.node.name.as_str(), std::iter::empty());
-                input::register_type_input(ctx, object, &r#type.node);
+                generic::register_array_type(ctx, type_definition.name.as_str(), false);
+                generic::register_singular_type(ctx, type_definition.name.as_str());
+                filter::register_orderby_input(ctx, object, type_definition.node.name.as_str(), std::iter::empty());
+                input::register_type_input(ctx, object, &type_definition.node);
             }
             TypeKind::Enum(_enum) => {
                 generic::register_singular_type(ctx, type_name);

--- a/engine/crates/parser-sdl/src/tests.rs
+++ b/engine/crates/parser-sdl/src/tests.rs
@@ -120,3 +120,51 @@ fn test_experimental() {
 
     assert!(!result.enable_kv);
 }
+
+#[test]
+fn mongodb_join() {
+    super::parse_registry(r###"
+    extend schema
+      @mongodb(
+        namespace: false
+        name: "MongoDB"
+        url: "https://mongodb-api.com/something"
+        apiKey: "some-key"
+        dataSource: "Cluster0"
+        database: "sample_analytics"
+      )
+
+    extend type Customer {
+      customerContacts: ContactConnection @join(select: "contactCollection(first: 10, filter: { businessid: { eq: $customerid } })")
+    }
+
+    type Customer @model(connector: "MongoDB", collection: "customer") {
+      customerid: String!
+      category: String!
+      segment: String!
+      status: String!
+    }
+
+    type Contact @model(connector: "MongoDB", collection: "contacts") {
+      businessid: String!
+      parentbusinessid: String!
+      businessentitytype: String!
+      contactMedium: [ContactMedium!]
+    }
+
+    type ContactMedium {
+      type: String
+      emailid: String
+      mobilenumber: String
+      address: [Address!]
+    }
+
+    type Address {
+      address1: String
+      address2: String
+      city: String
+      pincode: String
+    }
+
+    "###).unwrap();
+}

--- a/engine/crates/parser-sdl/src/validations.rs
+++ b/engine/crates/parser-sdl/src/validations.rs
@@ -155,9 +155,11 @@ fn validate_join(
         errors.push(RuleError::new(
             vec![],
             format!(
-                "{coord} is trying to join with {}.{}, but those fields do not have compatible types",
+                "{coord} is trying to join with {}.{}, but those fields do not have compatible types: '{}' and '{}'",
                 containing_type.name(),
-                &destination_field.name
+                &destination_field.name,
+                destination_field.ty,
+                expected_return_type
             ),
         ));
     }


### PR DESCRIPTION
- incorrect ordering or validation rules
- mongodb type rule didn't guard against extension types
- better error message for incompatible types

Pretty sure all of this would be simpler if we generated the schema by connector and then merged it with composition, but well, for another life
