### PR TITLE
sdk: make g.ref() accept unions

### DIFF
--- a/packages/grafbase-sdk/src/define.ts
+++ b/packages/grafbase-sdk/src/define.ts
@@ -122,7 +122,7 @@ export default {
    *
    * @param type - A type to be referred.
    */
-  ref: (type: Type | string) => new ReferenceDefinition(type),
+  ref: (type: Type | Union | string) => new ReferenceDefinition(type),
 
   /**
    * Create a new enum field.

--- a/packages/grafbase-sdk/src/grafbase-schema.ts
+++ b/packages/grafbase-sdk/src/grafbase-schema.ts
@@ -423,7 +423,7 @@ export class Graph {
    *
    * @param type - A type to be referred.
    */
-  public ref(type: Type | string): ReferenceDefinition {
+  public ref(type: Type | Union | string): ReferenceDefinition {
     return define.ref(type)
   }
 

--- a/packages/grafbase-sdk/src/typedefs/reference.ts
+++ b/packages/grafbase-sdk/src/typedefs/reference.ts
@@ -11,12 +11,13 @@ import { ShareableDefinition } from './shareable'
 import { OverrideDefinition } from './override'
 import { ProvidesDefinition } from './provides'
 import { InputType } from '../query'
+import { Union } from '../union'
 
 export class ReferenceDefinition {
   private referencedType: string
   private isOptional: boolean
 
-  constructor(referencedType: Type | string) {
+  constructor(referencedType: Type | Union | string) {
     this.referencedType =
       typeof referencedType === 'string' ? referencedType : referencedType.name
     this.isOptional = false

--- a/packages/grafbase-sdk/src/union.ts
+++ b/packages/grafbase-sdk/src/union.ts
@@ -5,16 +5,23 @@ import { validateIdentifier } from './validation'
  * A builder to create a GraphQL union.
  */
 export class Union {
-  private name: string
+  private _name: string
   private _kind: 'union'
   private types: string[]
 
   constructor(name: string) {
     validateIdentifier(name)
 
-    this.name = name
+    this._name = name
     this.types = []
     this._kind = 'union'
+  }
+
+  /**
+   * The name of the type.
+   */
+  public get name(): string {
+    return this._name
   }
 
   /**

--- a/packages/grafbase-sdk/tests/unit/types.test.ts
+++ b/packages/grafbase-sdk/tests/unit/types.test.ts
@@ -230,7 +230,7 @@ describe('Type generator', () => {
     `)
   })
 
-  it('references another an enum', () => {
+  it('references an enum', () => {
     g.type('User', {
       name: g.string(),
       age: g.int().optional()
@@ -258,6 +258,43 @@ describe('Type generator', () => {
         street: String
         color: Color
       }"
+    `)
+  })
+
+  it('references a union', () => {
+    const user = g.type('User', {
+      name: g.string(),
+      age: g.int().optional()
+    })
+
+    const organization = g.type('Organization', {
+      domain: g.string(),
+      employeeCount: g.int()
+    })
+
+    const account = g.union('Account', { user, organization })
+
+    g.query('currentAccount', {
+      resolver: 'current-account',
+      returns: g.ref(account)
+    })
+
+    expect(renderGraphQL(config({ schema: g }))).toMatchInlineSnapshot(`
+      "type User {
+        name: String!
+        age: Int
+      }
+
+      type Organization {
+        domain: String!
+        employeeCount: Int!
+      }
+
+      extend type Query {
+        currentAccount: Account! @resolver(name: "current-account")
+      }
+
+      union Account = User | Organization"
     `)
   })
 


### PR DESCRIPTION
The following is currently a type error:

```
const user = g.type('User', {
  name: g.string(),
  age: g.int().optional()
})

const organization = g.type('Organization', {
  domain: g.string(),
  employeeCount: g.int()
})

const account = g.union('Account', { user, organization })

g.query('currentAccount', {
  resolver: 'current-account',
  returns: g.ref(account)
})
```

The solution in this commit is to make g.ref() accept union types. Alternatively, we could add g.unionRef() (similar to g.enumRef()), but that seems like unnecessary API sprawl.

closes GB-6390