### PR TITLE
sdk: release 0.19.1

### DIFF
--- a/packages/grafbase-sdk/CHANGELOG.md
+++ b/packages/grafbase-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.19.1] - Tue Apr 2 2024
+
+[CHANGELOG](changelog/0.19.1.md)
+
 ## [0.19.0] - Wed Mar 20 2024
 
 [CHANGELOG](changelog/0.19.0.md)

--- a/packages/grafbase-sdk/changelog/0.19.1.md
+++ b/packages/grafbase-sdk/changelog/0.19.1.md
@@ -1,0 +1,3 @@
+## Fixes
+
+- `g.ref()` now accepts union types as input. [1545](https://github.com/grafbase/grafbase/pull/1545)

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",


### PR DESCRIPTION

## Fixes

- `g.ref()` now accepts union types as input. [1545](https://github.com/grafbase/grafbase/pull/1545)