### PR TITLE
sdk: fix missing newline after trusted documents directive

### DIFF
--- a/packages/grafbase-sdk/CHANGELOG.md
+++ b/packages/grafbase-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.19.2] - Tue Apr 2 2024
+
+[CHANGELOG](changelog/0.19.2.md)
+
 ## [0.19.1] - Tue Apr 2 2024
 
 [CHANGELOG](changelog/0.19.1.md)

--- a/packages/grafbase-sdk/changelog/0.19.2.md
+++ b/packages/grafbase-sdk/changelog/0.19.2.md
@@ -1,0 +1,3 @@
+## Fixes
+
+- The SDL generated for `config.trustedDocuments` was missing a final newline. This is now fixed.

--- a/packages/grafbase-sdk/src/trusted-documents.ts
+++ b/packages/grafbase-sdk/src/trusted-documents.ts
@@ -31,6 +31,6 @@ export class TrustedDocuments {
       ? `(bypassHeaderName: ${JSON.stringify(this.params.bypassHeader.name)}, byPassHeaderValue: ${JSON.stringify(this.params.bypassHeader.value)})`
       : ''
 
-    return `extend schema\n  @trustedDocuments${args}`
+    return `extend schema\n  @trustedDocuments${args}\n`
   }
 }

--- a/packages/grafbase-sdk/tests/unit/trusted-documents.test.ts
+++ b/packages/grafbase-sdk/tests/unit/trusted-documents.test.ts
@@ -17,10 +17,11 @@ describe('Trusted documents', () => {
 
     expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
-        @trustedDocuments"
-      `)
+        @trustedDocuments
+      "
+    `)
   })
- 
+
   it('renders bypassHeader', async () => {
     const cfg = config({
       graph: g,
@@ -35,7 +36,8 @@ describe('Trusted documents', () => {
 
     expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
       "extend schema
-        @trustedDocuments(bypassHeaderName: \"password\", byPassHeaderValue: \"m00se\")"
-      `)
+        @trustedDocuments(bypassHeaderName: "password", byPassHeaderValue: "m00se")
+      "
+    `)
   })
 })


### PR DESCRIPTION
We would end up with something like `extend schema @trustedDocumentsextend schema...`.# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.