### PR TITLE
feat: reload otel layer based on graph updated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2814,6 +2814,7 @@ dependencies = [
  "anyhow",
  "ascii 1.1.0",
  "atty",
+ "cfg-if",
  "clap",
  "ctor",
  "duct",

--- a/engine/crates/tracing/src/otel/layer.rs
+++ b/engine/crates/tracing/src/otel/layer.rs
@@ -1,8 +1,8 @@
-use opentelemetry::global;
 use opentelemetry::trace::noop::NoopTracer;
 use opentelemetry::trace::TracerProvider;
+use opentelemetry::KeyValue;
 use opentelemetry_sdk::runtime::RuntimeChannel;
-use opentelemetry_sdk::trace::RandomIdGenerator;
+use opentelemetry_sdk::trace::IdGenerator;
 use tracing::Subscriber;
 use tracing_subscriber::filter::{FilterExt, Filtered};
 use tracing_subscriber::layer::Filter;
@@ -21,39 +21,61 @@ pub type BoxedFilter<S> = Box<dyn Filter<S> + Send + Sync + 'static>;
 /// Wrapper type for a filter layer over erased layer and filter
 pub type FilteredLayer<S> = Filtered<BoxedLayer<S>, BoxedFilter<S>, S>;
 
+/// Holds tracing reloadable layer components
+pub struct ReloadableLayer<S> {
+    /// A reloadable layer
+    pub layer: reload::Layer<BoxedLayer<S>, S>,
+    /// A reloadable handle to reload a tracing layer
+    pub handle: reload::Handle<BoxedLayer<S>, S>,
+    /// The tracer provider used for tracers attached to the layer
+    pub provider: Option<opentelemetry_sdk::trace::TracerProvider>,
+}
+
 /// Creates a new OTEL tracing layer that doesn't collect or export any tracing data.
 /// The main reason this exists is to act as a placeholder in the subscriber. It's wrapped in a [`reload::Layer`]
 /// enabling its replacement.
-// Note: this returns a `FilteredLayer` because of https://github.com/tokio-rs/tracing/issues/1629
-// it could very well just return `BoxedLayer<S>` and the handler for reload would just work with `.replace()` without panicking
-pub fn new_noop<S>() -> (reload::Layer<FilteredLayer<S>, S>, reload::Handle<FilteredLayer<S>, S>)
+pub fn new_noop<S>() -> ReloadableLayer<S>
 where
     S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync,
 {
     let otel_layer = tracing_opentelemetry::layer()
         .with_tracer(NoopTracer::new())
-        .boxed()
-        .with_filter(FilterExt::boxed(EnvFilter::new("off")));
+        .with_filter(FilterExt::boxed(EnvFilter::new("off")))
+        .boxed();
 
     let (otel_layer, reload_handle) = reload::Layer::new(otel_layer);
 
-    (otel_layer, reload_handle)
+    ReloadableLayer {
+        layer: otel_layer,
+        handle: reload_handle,
+        provider: None,
+    }
 }
 
-/// Creates a new OTEL tracing layer that uses a [`BatchSpanProcessor`] to collect and export traces
-pub fn new_batched<S, R>(
+/// Creates a new OTEL tracing layer that uses a [`BatchSpanProcessor`] to collect and export traces.
+/// It's wrapped in a [`reload::Layer`] enabling its replacement.
+pub fn new_batched<S, R, I>(
     service_name: impl Into<String>,
     config: TracingConfig,
+    id_generator: I,
     runtime: R,
-) -> Result<BoxedLayer<S>, TracingError>
+    resource_attributes: impl Into<Vec<KeyValue>>,
+) -> Result<ReloadableLayer<S>, TracingError>
 where
     S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync,
     R: RuntimeChannel,
+    I: IdGenerator + 'static,
 {
-    let provider = provider::create(service_name, config, RandomIdGenerator::default(), runtime)?;
+    let provider = provider::create(service_name, config, id_generator, runtime, resource_attributes)?;
     let tracer = provider.tracer("batched-otel");
 
-    let _ = global::set_tracer_provider(provider);
+    let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer).boxed();
 
-    Ok(tracing_opentelemetry::layer().with_tracer(tracer).boxed())
+    let (otel_layer, reload_handle) = reload::Layer::new(otel_layer);
+
+    Ok(ReloadableLayer {
+        layer: otel_layer,
+        handle: reload_handle,
+        provider: Some(provider),
+    })
 }

--- a/engine/crates/tracing/src/otel/provider.rs
+++ b/engine/crates/tracing/src/otel/provider.rs
@@ -19,12 +19,14 @@ pub fn create<R, I>(
     config: TracingConfig,
     id_generator: I,
     runtime: R,
+    resource_attributes: impl Into<Vec<KeyValue>>,
 ) -> Result<TracerProvider, TracingError>
 where
     R: RuntimeChannel,
     I: IdGenerator + 'static,
 {
-    let service_name = service_name.into();
+    let mut resource_attributes = resource_attributes.into();
+    resource_attributes.push(KeyValue::new("service.name", service_name.into()));
 
     let builder = opentelemetry_sdk::trace::TracerProvider::builder().with_config(
         opentelemetry_sdk::trace::config()
@@ -33,7 +35,7 @@ where
             .with_max_events_per_span(config.collect.max_events_per_span as u32)
             .with_max_attributes_per_span(config.collect.max_attributes_per_span as u32)
             .with_max_events_per_span(config.collect.max_events_per_span as u32)
-            .with_resource(Resource::new(vec![KeyValue::new("service.name", service_name)])),
+            .with_resource(Resource::new(resource_attributes)),
     );
 
     Ok(setup_exporters(builder, config, runtime)?.build())

--- a/gateway/crates/federated-server/src/config.rs
+++ b/gateway/crates/federated-server/src/config.rs
@@ -14,7 +14,7 @@ use url::Url;
 
 use self::dynamic_string::DynamicString;
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Default, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 /// Configuration struct to define settings for self-hosted
 /// Grafbase gateway.

--- a/gateway/crates/federated-server/src/config/telemetry.rs
+++ b/gateway/crates/federated-server/src/config/telemetry.rs
@@ -1,6 +1,7 @@
 use grafbase_tracing::config::TracingConfig;
 
-#[derive(Debug, PartialEq, serde::Deserialize)]
+/// Holds telemetry configuration
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TelemetryConfig {
     /// The name of the service

--- a/gateway/crates/federated-server/src/lib.rs
+++ b/gateway/crates/federated-server/src/lib.rs
@@ -4,9 +4,9 @@
 
 #![deny(missing_docs)]
 
-pub use crate::config::Config;
+pub use crate::config::{Config, TelemetryConfig};
 pub use error::Error;
-pub use server::GraphFetchMethod;
+pub use server::{GraphFetchMethod, OtelReload, OtelTracing};
 
 mod config;
 mod error;

--- a/gateway/crates/federated-server/src/server/otel.rs
+++ b/gateway/crates/federated-server/src/server/otel.rs
@@ -1,0 +1,21 @@
+use grafbase_tracing::otel::opentelemetry_sdk::trace::TracerProvider;
+use ulid::Ulid;
+
+/// Holds legos to deal with opentelemetry tracing
+pub struct OtelTracing {
+    /// The tracer provider attached to the otel layer
+    /// It's an optional because the layer related to the handler might be a noop_layer and
+    /// therefore has no provider attached
+    pub tracer_provider: Option<TracerProvider>,
+    /// A channel to trigger the otel layer reload with new data
+    pub reload_trigger: tokio::sync::oneshot::Sender<OtelReload>,
+}
+
+/// Payload sent when triggering an otel layer reload
+#[derive(Debug, Default)]
+pub struct OtelReload {
+    /// Account id
+    pub account_id: Ulid,
+    /// Branch id
+    pub branch_id: Ulid,
+}

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { workspace = true, features = ["rt-multi-thread"] }
 toml = "0.8.12"
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["json"] }
+cfg-if = "1.0.0"
 
 [lints]
 workspace = true

--- a/gateway/crates/gateway-binary/src/main.rs
+++ b/gateway/crates/gateway-binary/src/main.rs
@@ -1,18 +1,31 @@
 #![cfg_attr(test, allow(unused_crate_dependencies))]
 
 use std::fs;
+#[cfg(test)]
+use std::sync::OnceLock;
 
 use anyhow::Context;
-use args::Args;
 use clap::{crate_version, Parser};
-use federated_server::Config;
-use grafbase_tracing::{otel::opentelemetry_sdk::trace::TracerProvider, span::GRAFBASE_TARGET};
 use mimalloc::MiMalloc;
 use tokio::runtime;
-use tracing_subscriber::EnvFilter;
+use tokio::sync::oneshot;
+use tracing::{debug, error, Subscriber};
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::{reload, EnvFilter, Registry};
+
+use args::Args;
+use federated_server::{Config, OtelReload, OtelTracing, TelemetryConfig};
+use grafbase_tracing::error::TracingError;
+use grafbase_tracing::otel::layer;
+use grafbase_tracing::otel::layer::{BoxedLayer, ReloadableLayer};
+use grafbase_tracing::otel::opentelemetry_sdk::runtime::Tokio;
+use grafbase_tracing::{otel::opentelemetry_sdk::trace::TracerProvider, span::GRAFBASE_TARGET};
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
+
+#[cfg(test)]
+static RELOAD_PROVIDER: OnceLock<Option<TracerProvider>> = OnceLock::new();
 
 mod args;
 
@@ -33,15 +46,12 @@ fn main() -> anyhow::Result<()> {
         .build()?;
 
     runtime.block_on(async move {
-        // if this is not called from tokio context, you'll get:
-        // there is no reactor running, must be called from the context of a Tokio 1.x runtime
-        // but... only if telemetry is enabled, so be aware and read this when you have a failing test!
-        let provider = init_global_tracing(&args, &mut config)?;
+        let otel_tracing = setup_tracing(&mut config, &args)?;
 
         let crate_version = crate_version!();
         tracing::info!(target: GRAFBASE_TARGET, "Grafbase Gateway {crate_version}");
 
-        federated_server::serve(args.listen_address, config, args.fetch_method()?, provider).await?;
+        federated_server::serve(args.listen_address, config, args.fetch_method()?, otel_tracing).await?;
 
         Ok::<(), anyhow::Error>(())
     })?;
@@ -49,81 +59,186 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg(not(feature = "lambda"))]
-fn init_global_tracing(args: &Args, config: &mut Config) -> anyhow::Result<Option<TracerProvider>> {
-    use grafbase_tracing::otel::{layer, opentelemetry_sdk::runtime::Tokio};
+fn setup_tracing(config: &mut Config, args: &Args) -> anyhow::Result<Option<OtelTracing>> {
+    let telemetry_config = match config.telemetry.take() {
+        Some(telemetry_config) if telemetry_config.tracing.enabled => telemetry_config,
+        _ => return Ok(None),
+    };
+
+    // setup tracing globally
+    let OtelLegos {
+        provider,
+        reload_handle,
+    } = init_global_tracing(args, telemetry_config.clone())?;
+
+    // spawn the otel layer reload
+    let (sender, receiver) = oneshot::channel();
+    otel_layer_reload(reload_handle, receiver, telemetry_config);
+
+    Ok(Some(OtelTracing {
+        tracer_provider: provider,
+        reload_trigger: sender,
+    }))
+}
+
+struct OtelLegos<S> {
+    provider: Option<TracerProvider>,
+    reload_handle: reload::Handle<BoxedLayer<S>, S>,
+}
+
+fn init_global_tracing(args: &Args, config: TelemetryConfig) -> anyhow::Result<OtelLegos<Registry>> {
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
 
-    let (otel_layer, filter) = match config.telemetry.take() {
-        Some(config) => {
-            let filter = args
-                .log_level
-                .map(|l| l.as_filter_str())
-                .unwrap_or(config.tracing.filter.as_str());
+    let filter = args
+        .log_level
+        .map(|l| l.as_filter_str())
+        .unwrap_or(config.tracing.filter.as_str());
 
-            let env_filter = EnvFilter::new(filter);
-            let otel_layer = layer::new_batched(&config.service_name, config.tracing, Tokio)?;
-
-            (Some(otel_layer), env_filter)
-        }
-        None => (None, EnvFilter::new(args.log_level.unwrap_or_default().as_filter_str())),
-    };
+    let env_filter = EnvFilter::new(filter);
+    let otel_layer = build_otel_layer(config, Default::default())?;
 
     tracing_subscriber::registry()
-        .with(otel_layer)
+        .with(otel_layer.layer)
         .with(args.log_format())
-        .with(filter)
+        .with(env_filter)
         .init();
 
-    Ok(None)
+    Ok(OtelLegos {
+        provider: otel_layer.provider,
+        reload_handle: otel_layer.handle,
+    })
 }
 
-#[cfg(feature = "lambda")]
-fn init_global_tracing(args: &Args, config: &mut Config) -> anyhow::Result<Option<TracerProvider>> {
-    use grafbase_tracing::otel::opentelemetry::global;
-    use grafbase_tracing::otel::opentelemetry::trace::TracerProvider;
-    use grafbase_tracing::otel::tracing_opentelemetry;
-    use grafbase_tracing::otel::tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-    use grafbase_tracing::otel::{self, opentelemetry_sdk::runtime::Tokio};
-    use opentelemetry_aws::trace::{XrayIdGenerator, XrayPropagator};
+fn otel_layer_reload<S>(
+    reload_handle: reload::Handle<BoxedLayer<S>, S>,
+    reload_rx: oneshot::Receiver<OtelReload>,
+    config: TelemetryConfig,
+) where
+    S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync,
+{
+    use tracing_subscriber::Layer;
 
-    global::set_text_map_propagator(XrayPropagator::default());
+    tokio::spawn(async move {
+        let result = reload_rx.await;
 
-    let (provider, filter) = match config.telemetry.take() {
-        Some(config) => {
-            let filter = args
-                .log_level
-                .map(|l| l.as_filter_str())
-                .unwrap_or(config.tracing.filter.as_str());
+        let Ok(reload_data) = result else {
+            debug!("error waiting for otel reload");
+            return;
+        };
 
-            let filter = EnvFilter::new(filter);
+        let otel_layer = match build_otel_layer(config, reload_data) {
+            Ok(value) => value,
+            Err(err) => {
+                error!("error creating a new otel layer for reload: {err}");
+                return;
+            }
+        };
 
-            let provider =
-                otel::provider::create(&config.service_name, config.tracing, XrayIdGenerator::default(), Tokio)
-                    .expect("error creating otel provider");
+        reload_handle
+            .reload(otel_layer.layer.boxed())
+            .expect("should successfully reload otel layer");
 
-            (Some(provider), filter)
+        #[cfg(test)]
+        RELOAD_PROVIDER.set(otel_layer.provider).unwrap();
+    });
+}
+
+fn build_otel_layer<S>(config: TelemetryConfig, reload_data: OtelReload) -> Result<ReloadableLayer<S>, TracingError>
+where
+    S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync,
+{
+    let id_generator = {
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "lambda")] {
+                use opentelemetry_aws::trace::{XrayIdGenerator, XrayPropagator};
+                grafbase_tracing::otel::opentelemetry::global::set_text_map_propagator(XrayPropagator::default());
+
+                XrayIdGenerator::default()
+            } else {
+                use grafbase_tracing::otel::opentelemetry_sdk::trace::RandomIdGenerator;
+
+                RandomIdGenerator::default()
+            }
         }
-        None => (None, EnvFilter::new(args.log_level.unwrap_or_default().as_filter_str())),
     };
 
-    let subscriber = tracing_subscriber::registry();
+    let resource_attributes = vec![
+        grafbase_tracing::otel::opentelemetry::KeyValue::new("account_id", reload_data.account_id.to_string()),
+        grafbase_tracing::otel::opentelemetry::KeyValue::new("branch_id", reload_data.branch_id.to_string()),
+    ];
 
-    match provider {
-        Some(ref provider) => {
-            let tracer = provider.tracer("lambda-otel");
+    layer::new_batched::<S, _, _>(
+        config.service_name,
+        config.tracing,
+        id_generator,
+        Tokio,
+        resource_attributes,
+    )
+}
 
-            subscriber
-                .with(tracing_opentelemetry::layer().with_tracer(tracer))
-                .with(args.log_format())
-                .with(filter)
-                .init();
-        }
-        None => {
-            subscriber.with(args.log_format()).with(filter).init();
-        }
+#[cfg(test)]
+mod test {
+    use std::time::Duration;
+
+    use clap::Parser;
+
+    use federated_server::{Config, OtelReload, TelemetryConfig};
+    use grafbase_tracing::config::{TracingConfig, TracingExportersConfig, TracingStdoutExporterConfig};
+
+    use crate::args::Args;
+    use crate::{setup_tracing, RELOAD_PROVIDER};
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn otel_reload() {
+        // prepare
+        let mut config = Config {
+            telemetry: Some(TelemetryConfig {
+                service_name: "test".to_string(),
+                tracing: TracingConfig {
+                    enabled: true,
+                    filter: "info".to_string(),
+                    sampling: 100.0,
+                    exporters: TracingExportersConfig {
+                        stdout: Some(TracingStdoutExporterConfig {
+                            enabled: true,
+                            ..Default::default()
+                        }),
+                        otlp: None,
+                    },
+                    ..Default::default()
+                },
+            }),
+            ..Default::default()
+        };
+
+        let args = Args::try_parse_from(vec!["--schema", "schema.graphql", "--config", "grafbase.toml"]).unwrap();
+
+        // act
+        let otel_tracing = setup_tracing(&mut config, &args).unwrap().unwrap();
+
+        otel_tracing
+            .reload_trigger
+            .send(OtelReload {
+                account_id: 0.into(),
+                branch_id: 1.into(),
+            })
+            .unwrap();
+
+        // wait for the reload to happen
+        tokio::time::timeout(Duration::from_secs(5), async move {
+            while RELOAD_PROVIDER.get().is_none() {
+                tokio::time::sleep(Duration::from_millis(500)).await
+            }
+        })
+        .await
+        .unwrap();
+
+        // force a flush to check that the resulting span has the new resource attributes
+        let span = tracing::info_span!("test");
+        drop(span);
+
+        let provider = RELOAD_PROVIDER.get().unwrap().as_ref().unwrap();
+        provider.force_flush();
     }
-
-    Ok(provider)
 }

--- a/gateway/crates/gateway-binary/src/main.rs
+++ b/gateway/crates/gateway-binary/src/main.rs
@@ -220,8 +220,8 @@ mod test {
         otel_tracing
             .reload_trigger
             .send(OtelReload {
-                account_id: 0.into(),
-                branch_id: 1.into(),
+                account_id: 5.into(),
+                branch_id: 6.into(),
             })
             .unwrap();
 


### PR DESCRIPTION
# Description

Reload the otel layer when we receive a valid graph update. The reload will add updated resource attributes (account_id and branch_id) so these are present on exported spans.

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
