### PR TITLE
engine-(v1,v2): allow receiving trusted document ids under documentId

### DIFF
--- a/engine/crates/engine-v2/src/engine/trusted_documents.rs
+++ b/engine/crates/engine-v2/src/engine/trusted_documents.rs
@@ -18,9 +18,9 @@ impl Engine {
     ) -> Result<(), GraphqlError> {
         let trusted_documents_enabled = self.env.trusted_documents.is_enabled();
         let persisted_query_extension = mem::take(&mut request.extensions.persisted_query);
-        let doc_id = mem::take(&mut request.operation_plan_cache_key.doc_id);
+        let document_id = mem::take(&mut request.operation_plan_cache_key.document_id);
 
-        match (trusted_documents_enabled, persisted_query_extension, doc_id) {
+        match (trusted_documents_enabled, persisted_query_extension, document_id) {
             (true, None, None) => {
                 if self
                     .env
@@ -32,7 +32,7 @@ impl Engine {
                     Ok(())
                 } else {
                     Err(GraphqlError::new(
-                        "Cannot execute a trusted document query: missing doc_id or the persistedQuery extension.",
+                        "Cannot execute a trusted document query: missing documentId, doc_id or the persistedQuery extension.",
                     ))
                 }
             }

--- a/engine/crates/engine/src/request.rs
+++ b/engine/crates/engine/src/request.rs
@@ -85,8 +85,9 @@ pub struct OperationPlanCacheKey {
     pub operation_name: Option<String>,
 
     /// Used by [relay-style persisted queries](https://relay.dev/docs/guides/persisted-queries/).
-    #[serde(default, rename = "doc_id", skip_serializing_if = "Option::is_none")]
-    pub doc_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "doc_id")]
+    pub document_id: Option<String>,
 
     /// Force enable introspection queries for this request.
     #[serde(skip)]
@@ -109,7 +110,7 @@ impl Request {
                 operation_name: None,
                 introspection_state: IntrospectionState::UserPreference,
                 disable_operation_limits: false,
-                doc_id: None,
+                document_id: None,
             },
             ray_id: String::new(),
             variables: Variables::default(),
@@ -223,7 +224,7 @@ impl Debug for Request {
             .field("operation_name", &self.operation_name())
             .field("variables", &self.variables)
             .field("extensions", &self.extensions)
-            .field("doc_id", &self.operation_plan_cache_key.doc_id)
+            .field("document_id", &self.operation_plan_cache_key.document_id)
             .finish_non_exhaustive()
     }
 }

--- a/engine/crates/gateway-core/src/trusted_documents.rs
+++ b/engine/crates/gateway-core/src/trusted_documents.rs
@@ -22,7 +22,7 @@ where
     ) -> Result<(), PersistedQueryError> {
         let trusted_documents_enabled = self.trusted_documents.is_enabled();
         let persisted_query_extension = mem::take(&mut request.extensions.persisted_query);
-        let doc_id = mem::take(&mut request.operation_plan_cache_key.doc_id);
+        let doc_id = mem::take(&mut request.operation_plan_cache_key.document_id);
 
         match (trusted_documents_enabled, persisted_query_extension, doc_id) {
             (true, None, None) => {
@@ -197,7 +197,7 @@ pub(super) enum PersistedQueryError {
     UnsupportedVersion,
     #[error("Internal server error")]
     InternalServerError,
-    #[error("Cannot execute a trusted document query: missing doc_id or the persistedQuery extension.")]
+    #[error("Cannot execute a trusted document query: missing documentId, doc_id or the persistedQuery extension.")]
     BadRequest,
     #[error("Trusted document queries must include the {CLIENT_NAME_HEADER_NAME} header")]
     MissingClientName,

--- a/engine/crates/integration-tests/src/engine/mod.rs
+++ b/engine/crates/integration-tests/src/engine/mod.rs
@@ -134,7 +134,7 @@ impl GraphQlRequest {
         if let Some(extensions) = self.extensions {
             request.extensions = extensions;
         }
-        request.operation_plan_cache_key.doc_id = self.doc_id;
+        request.operation_plan_cache_key.document_id = self.doc_id;
         request
     }
 }

--- a/engine/crates/integration-tests/tests/federation/trusted_documents.rs
+++ b/engine/crates/integration-tests/tests/federation/trusted_documents.rs
@@ -110,7 +110,7 @@ fn regular_non_persisted_queries_are_rejected() {
         {
           "errors": [
             {
-              "message": "Cannot execute a trusted document query: missing doc_id or the persistedQuery extension."
+              "message": "Cannot execute a trusted document query: missing documentId, doc_id or the persistedQuery extension."
             }
           ]
         }
@@ -193,7 +193,7 @@ fn bypass_header() {
         {
           "errors": [
             {
-              "message": "Cannot execute a trusted document query: missing doc_id or the persistedQuery extension."
+              "message": "Cannot execute a trusted document query: missing documentId, doc_id or the persistedQuery extension."
             }
           ]
         }


### PR DESCRIPTION
In addition to the `doc_id` field documented in the relay docs and the apollo client extension format. The draft spec appendix (https://github.com/graphql/graphql-over-http/pull/264) uses the `documentId` key.

part of GB-6253 (the second part is docs)