### PR TITLE
chore: only use `codegen-units=1` for lambda releases

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -288,7 +288,7 @@ jobs:
       - name: Build gateway lambda release
         shell: bash
         run: |
-          RUSTFLAGS="-C opt-level=s" cargo build --release -p grafbase-gateway --target ${{ matrix.archs.target }} --features lambda
+          cargo build --profile lambda -p grafbase-gateway --target ${{ matrix.archs.target }} --features lambda
 
       - if: ${{ github.event_name == 'pull_request' && matrix.archs.runner != 'ubicloud-standard-8-arm' }}
         name: Upload lambda gateway binary to R2

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -288,7 +288,12 @@ jobs:
       - name: Build gateway lambda release
         shell: bash
         run: |
-          cargo build --profile lambda -p grafbase-gateway --target ${{ matrix.archs.target }} --features lambda
+          BUILD_PROFILE=release
+          if [[ $GITHUB_REF =~ ^refs/tags/gateway- ]]; then
+            BUILD_PROFILE=lambda
+          fi
+          echo "Building lambda with $BUILD_PROFILE profile"
+          cargo build --profile $BUILD_PROFILE -p grafbase-gateway --target ${{ matrix.archs.target }} --features lambda
 
       - if: ${{ github.event_name == 'pull_request' && matrix.archs.runner != 'ubicloud-standard-8-arm' }}
         name: Upload lambda gateway binary to R2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4944,7 +4944,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,6 +180,10 @@ strip = "symbols"
 # by telling cargo to optimize at the link stage (in addition to the
 # normal optimizations during the compilation stage)
 lto = "thin"
+
+[profile.lambda]
+inherits = "release"
+opt-level = "s"
 codegen-units = 1
 
 [workspace.lints.rust]


### PR DESCRIPTION
We recently added `codegen-units=1` to the release build config.  This was aimed at reducing the size of the binaries that we ship for lambdas, and it was successful in that regard.  It slows release builds down quite significantly though, which has had an impact on CI times, as you can see on this graph.

![CleanShot 2024-04-05 at 12 01 13@2x](https://github.com/grafbase/grafbase/assets/556490/c142187c-b067-4ed9-a1a0-0066ce27acb4)

That graph shows a day or two between the merge & a noticeable increase in CI times, but the merge was on friday and I assume it wasn't until the monday that every other piece of work had rebased onto `main` and pulled in the change.

This PR makes two changes:

- Creates a new cargo profile `lambda` that with `codegen-units=1` and updates CI to use this profile for building the lambda.  This shaved 5-6 minutes off.
- I then updated the lambda build to only use this profile when doing a tagged release build, which shaved another ~2:30 off.  Although I'm open to discussions if we'd rather not do this bit.