### PR TITLE
chore: report test results to datadog

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -12,6 +12,9 @@ inputs:
     required: false
     default: 'true'
     description: If enabled, runs integration tests and needs docker
+  datadog-api-key:
+    required: true
+    description: API key for datadog uploads
 
 runs:
   using: 'composite'
@@ -62,7 +65,8 @@ runs:
         username: ${{ inputs.dockerhub-username }}
         password: ${{ inputs.dockerhub-token }}
 
-    - name: Run all tests
+    - name: Run all non-gateway tests
+      id: all_tests
       if: ${{ inputs.with-integration-tests == 'true' }}
       shell: bash
       run: |
@@ -70,11 +74,41 @@ runs:
         RUST_BACKTRACE=1 cargo nextest run --workspace --profile ci --exclude grafbase-gateway
         docker-compose -f engine/crates/integration-tests/docker-compose.yml stop -t 3
 
+    - name: Upload the JUnit files
+      if: ${{ inputs.with-integration-tests == 'true' && ( success() || failure() ) && !contains(steps.all_tests.outputs.exitcode, '101') }}
+      uses: ./.github/actions/test_upload_datadog
+      with:
+        api_key: ${{ inputs.datadog-api-key }}
+        junit_path: target/nextest/ci/junit.xml
+        service: cli
+
+    - name: Run gateway tests
+      id: gateway_tests
+      if: ${{ inputs.with-integration-tests == 'true' }}
+      shell: bash
+      run: |
         docker-compose -f gateway/crates/gateway-binary/docker-compose.yml up -d
         RUST_BACKTRACE=1 cargo nextest run -p grafbase-gateway --profile ci
 
+    - name: Upload the gateway junit files
+      if: ${{ inputs.with-integration-tests == 'true' && ( success() || failure() ) && !contains(steps.gateway_tests.outputs.exitcode, '101') }}
+      uses: ./.github/actions/test_upload_datadog
+      with:
+        api_key: ${{ inputs.datadog-api-key }}
+        junit_path: target/nextest/ci/junit.xml
+        service: cli-gateway
+
     - name: Run tests without integration
+      id: tests_no_integration
       if: ${{ inputs.with-integration-tests == 'false' }}
       shell: bash
       run: |
         RUST_BACKTRACE=1 cargo nextest run --workspace --exclude integration-tests --exclude grafbase-gateway --profile ci
+
+    - name: Upload the non-integration JUnit files
+      if: ${{ inputs.with-integration-tests == 'false' && ( success() || failure() ) && !contains(steps.tests_no_integration.outputs.exitcode, '101') }}
+      uses: ./.github/actions/test_upload_datadog
+      with:
+        api_key: ${{ inputs.datadog-api-key }}
+        junit_path: target/nextest/ci/junit.xml
+        service: cli

--- a/.github/actions/test_upload_datadog/action.yml
+++ b/.github/actions/test_upload_datadog/action.yml
@@ -1,0 +1,34 @@
+name: datadog-test-upload
+description: Uploads tests to datadog
+inputs:
+  api_key:
+    description: Datadog api key
+    required: true
+  junit_path:
+    description: 'The path to a junit XML file'
+    required: true
+  service:
+    description: 'The service to report to datadog'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Get Datadog CLI
+      shell: bash
+      run: npm install -g @datadog/datadog-ci@2.10.0
+
+    - name: Upload the JUnit files
+      shell: bash
+      run: |
+        datadog-ci junit upload \
+          --service $SERVICE \
+          --max-concurrency 20 \
+          $JUNIT_PATH
+      env:
+        DATADOG_API_KEY: ${{ inputs.api_key }}
+        DATADOG_SITE: datadoghq.com
+        JUNIT_PATH: ${{ inputs.junit_path }}
+        SERVICE: ${{ inputs.service }}
+        DD_ENV: ci
+        DD_TAGS: 'os.platform:${{ runner.os }},os.architecture:${{ runner.arch }}'

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -103,6 +103,7 @@ jobs:
         with:
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          datadog-api-key: ${{ secrets.DATADOG_API_KEY }}
 
   individual-builds:
     needs: [detect-change-type]
@@ -337,6 +338,7 @@ jobs:
           with-integration-tests: 'false'
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          datadog-api-key: ${{ secrets.DATADOG_API_KEY }}
 
       - name: Build grafbase release
         shell: bash
@@ -392,6 +394,7 @@ jobs:
           with-integration-tests: 'false'
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          datadog-api-key: ${{ secrets.DATADOG_API_KEY }}
 
       - name: Build grafbase ${{ matrix.target }} release
         run: |

--- a/.github/workflows/sanitize-alert-schedule.yml
+++ b/.github/workflows/sanitize-alert-schedule.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          datadog-api-key: ${{ secrets.DATADOG_API_KEY }}
 
       - name: Report Status
         if: always()


### PR DESCRIPTION
We upload junit files to datadog in the API repo.  I fixed some of this in https://github.com/grafbase/api/pull/3459 but noticed that we weren't doing similar in this repo.  It can be useful to track failures, slow tests, flaky tests etc.

So, this PR adds the upload code to this repo as well.