### PR TITLE
cli: improve manifest parsing errors in grafbase trust

### DIFF
--- a/cli/crates/cli/src/errors.rs
+++ b/cli/crates/cli/src/errors.rs
@@ -57,8 +57,10 @@ pub enum CliError {
     LogsNoLinkedProject,
     #[error("error during graph introspection: {0}")]
     Introspection(String),
-    #[error("could not read the trusted documents manifest")]
+    #[error("could not read the trusted documents manifest: {0}")]
     TrustedDocumentsManifestReadError(#[source] io::Error),
+    #[error("could not parse the trusted documents manifest. Expecting a map from document id to GraphQL string or an Apollo Client manifest ({0})")]
+    TrustedDocumentsManifestParseError(#[source] serde_json::Error),
     #[error("could not read the GraphQL schema")]
     SchemaReadError(#[source] io::Error),
     #[error("error in publish: {0}")]

--- a/cli/crates/cli/src/trust.rs
+++ b/cli/crates/cli/src/trust.rs
@@ -14,9 +14,8 @@ pub(crate) fn trust(
     };
 
     let file = std::fs::File::open(manifest).map_err(CliError::TrustedDocumentsManifestReadError)?;
-    let manifest: TrustedDocumentsManifest = serde_json::from_reader(file).map_err(|err| {
-        CliError::TrustedDocumentsManifestReadError(std::io::Error::new(std::io::ErrorKind::InvalidData, err))
-    })?;
+    let manifest: TrustedDocumentsManifest =
+        serde_json::from_reader(file).map_err(CliError::TrustedDocumentsManifestParseError)?;
 
     report::trust_start(&manifest);
 


### PR DESCRIPTION
Before

![2024-04-08_09-04-17](https://github.com/grafbase/grafbase/assets/13155277/c5d74341-469a-4fdc-8872-afeb32242fbf)

After

![2024-04-08_09-04-14](https://github.com/grafbase/grafbase/assets/13155277/6eaef92f-0420-4a7c-89a0-a05daa79e2eb)

closes GB-6254

