### PR TITLE
composition: implement composition of field argument defaults

### DIFF
--- a/engine/crates/composition/src/compose/object.rs
+++ b/engine/crates/composition/src/compose/object.rs
@@ -99,6 +99,14 @@ pub(super) fn merge_field_arguments<'a>(
     ids.unwrap_or(federated::NO_INPUT_VALUE_DEFINITION)
 }
 
+/// Default values on arguments (e.g. `field(arg: String! = "N.A")`) are _not_
+/// present in the federated schema produced by composition. This function is only
+/// here for validation.
+///
+/// The rule to enforce is that between the subgraphs that define a default
+/// on the same fileld, the default must be the same. Other subgraphs can have the
+/// same argument without default, that is valid, but everywhere a default value is
+/// specified, it has to be the same.
 fn compose_field_argument_defaults(
     arguments: &[(StringId, subgraphs::FieldArgumentWalker<'_>)],
     ctx: &mut Context<'_>,

--- a/engine/crates/composition/src/ingest_subgraph/fields.rs
+++ b/engine/crates/composition/src/ingest_subgraph/fields.rs
@@ -49,7 +49,13 @@ fn ingest_field_arguments(
             .as_ref()
             .map(|description| subgraphs.strings.intern(description.node.as_str()));
 
-        subgraphs.insert_field_argument(field_id, name, r#type, argument_directives, description);
+        let default = argument
+            .node
+            .default_value
+            .as_ref()
+            .map(|default| ast_value_to_subgraph_value(&default.node, subgraphs));
+
+        subgraphs.insert_field_argument(field_id, name, r#type, argument_directives, description, default);
     }
 }
 

--- a/engine/crates/composition/src/subgraphs.rs
+++ b/engine/crates/composition/src/subgraphs.rs
@@ -21,7 +21,7 @@ pub(crate) use self::{
 };
 
 use crate::VecExt;
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 /// A set of subgraphs to be composed.
 pub struct Subgraphs {

--- a/engine/crates/composition/tests/composition/field_argument_default_mismatch/federated.graphql
+++ b/engine/crates/composition/tests/composition/field_argument_default_mismatch/federated.graphql
@@ -1,0 +1,1 @@
+# The argument Query.sayHi.language has incompatible defaults in subgraphs "paris" and "tokyo"

--- a/engine/crates/composition/tests/composition/field_argument_default_mismatch/subgraphs/paris.graphql
+++ b/engine/crates/composition/tests/composition/field_argument_default_mismatch/subgraphs/paris.graphql
@@ -1,0 +1,3 @@
+type Query {
+  sayHi(userId: ID!, language: String! = "FR" ): String!
+}

--- a/engine/crates/composition/tests/composition/field_argument_default_mismatch/subgraphs/tokyo.graphql
+++ b/engine/crates/composition/tests/composition/field_argument_default_mismatch/subgraphs/tokyo.graphql
@@ -1,0 +1,8 @@
+extend schema @link(
+	url: "https://specs.apollo.dev/federation/v2.7",
+	import: ["@override"]
+)
+
+type Query {
+  sayHi(userId: ID!, language: String! = "JA" ): String! @override(from: "paris")
+}


### PR DESCRIPTION
The rule is that they have to match exactly between subgraphs, otherwise it's an error.

closes GB-6159