### PR TITLE
Add basic request metrics

### DIFF
--- a/engine/crates/runtime/src/cache/cached.rs
+++ b/engine/crates/runtime/src/cache/cached.rs
@@ -28,14 +28,14 @@ impl Cache {
             .typed_get::<headers::CacheControl>()
             .unwrap_or_else(headers::CacheControl::new);
         let cache_span =
-            grafbase_tracing::span::cache::CacheSpan::new(CacheReadStatus::Bypass.as_header_value()).into_span();
+            grafbase_tracing::span::cache::CacheSpan::new(CacheReadStatus::Bypass.to_header_value()).into_span();
 
         if self.config.enabled {
             cached(self, cache_control, ctx, key, execution)
                 .inspect_ok(|cached_response| {
                     use grafbase_tracing::span::CacheRecorderSpanExt;
 
-                    cache_span.record_status(cached_response.read_status().as_header_value());
+                    cache_span.record_status(cached_response.read_status().to_header_value());
                 })
                 .inspect_err(|_| {
                     use grafbase_tracing::span::CacheRecorderSpanExt;

--- a/engine/crates/runtime/src/cache/mod.rs
+++ b/engine/crates/runtime/src/cache/mod.rs
@@ -86,7 +86,7 @@ pub enum CacheReadStatus {
 }
 
 impl CacheReadStatus {
-    pub fn as_header_value(&self) -> http::HeaderValue {
+    pub fn to_header_value(&self) -> http::HeaderValue {
         http::HeaderValue::from_static(match self {
             CacheReadStatus::Hit => "HIT",
             CacheReadStatus::Miss { .. } => "MISS",
@@ -103,7 +103,7 @@ impl CacheReadStatus {
 
     pub fn into_headers(self) -> http::HeaderMap {
         let mut headers = http::HeaderMap::new();
-        headers.insert(http::HeaderName::from_static(X_GRAFBASE_CACHE), self.as_header_value());
+        headers.insert(http::HeaderName::from_static(X_GRAFBASE_CACHE), self.to_header_value());
 
         if let CacheReadStatus::Miss { max_age } = self {
             headers.typed_insert(headers::CacheControl::new().with_public().with_max_age(max_age));

--- a/engine/crates/tracing/src/tower.rs
+++ b/engine/crates/tracing/src/tower.rs
@@ -6,6 +6,8 @@ use tower_http::classify::{ServerErrorsAsFailures, ServerErrorsFailureClass, Sha
 use tower_http::trace::{DefaultOnBodyChunk, DefaultOnEos, DefaultOnRequest};
 use tracing::Span;
 
+use crate::span::GRAFBASE_TARGET;
+
 /// A [tower_http::trace::TraceLayer] that creates [crate::span::request::HttpRequestSpan] for each incoming request
 /// and records request and response attributes in the span
 pub fn layer<B: Body>() -> tower_http::trace::TraceLayer<
@@ -19,14 +21,43 @@ pub fn layer<B: Body>() -> tower_http::trace::TraceLayer<
 > {
     tower_http::trace::TraceLayer::new_for_http()
         .make_span_with(crate::span::request::MakeHttpRequestSpan)
-        .on_response(|response: &Response<_>, _latency: Duration, span: &Span| {
+        .on_response(|response: &Response<_>, latency: Duration, span: &Span| {
             use crate::span::HttpRecorderSpanExt;
 
+            let cache_status = response
+                .headers()
+                .get("x-grafbase-cache")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default();
+            tracing::event!(
+                target: GRAFBASE_TARGET,
+                tracing::Level::INFO,
+                counter.request_count = 1,
+                http.response.status_code = response.status().as_u16(),
+                http.response.headers.cache_status = cache_status
+            );
+            tracing::event!(
+                target: GRAFBASE_TARGET,
+                tracing::Level::INFO,
+                histogram.latency = latency.as_millis(),
+            );
             span.record_response(response);
         })
         .on_failure(|error: ServerErrorsFailureClass, _latency: Duration, span: &Span| {
             use crate::span::HttpRecorderSpanExt;
 
+            let status = match error {
+                ServerErrorsFailureClass::StatusCode(code) => code.as_u16(),
+                ServerErrorsFailureClass::Error(_) => 500,
+            };
+            tracing::event!(
+                target: GRAFBASE_TARGET,
+                tracing::Level::INFO,
+                counter.request = 1,
+                http.response.status_code = status,
+                http.response.headers.cache_stauts = "BYPASS"
+
+            );
             span.record_failure(error.to_string().as_str());
         })
 }

--- a/gateway/crates/federated-server/src/server/engine.rs
+++ b/gateway/crates/federated-server/src/server/engine.rs
@@ -27,7 +27,6 @@ pub(super) async fn get(
     headers: HeaderMap,
     State(state): State<ServerState>,
 ) -> impl IntoResponse {
-    tracing::event!(target: "grafbase", tracing::Level::INFO, counter.request = 1);
     let request = engine::BatchRequest::Single(request.into());
     traced(headers, request, state.gateway().clone(), state.tracer_provider()).await
 }
@@ -37,7 +36,6 @@ pub(super) async fn post(
     headers: HeaderMap,
     Json(request): Json<engine::BatchRequest>,
 ) -> impl IntoResponse {
-    tracing::event!(target: "grafbase", tracing::Level::INFO, counter.request = 1);
     traced(headers, request, state.gateway().clone(), state.tracer_provider()).await
 }
 


### PR DESCRIPTION
Still thinking about how to propagate operation metadata. So adding those simple metrics for now to be able to move forward with the ClickHouse part.