### PR TITLE
composition: validate that keys match in entity interfaces

### DIFF
--- a/engine/crates/composition/tests/composition/entity_interface_different_key/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_interface_different_key/federated.graphql
@@ -1,1 +1,2 @@
-# [savanna] The object type `Cheetah` is annotated with @interfaceObject but has a different key than the entity interface `Animal`.
+# [steppe] The object type `Animal` is annotated with @interfaceObject but has a different key than the entity interface `Animal`.
+# [savanna] The object type `Cheetah` implements the entity interface `Animal` but does not have the same key. The key must match exactly.

--- a/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph_missing_implementer/subgraphs/savana.graphql
+++ b/engine/crates/composition/tests/composition/entity_interfaces_multi_subgraph_missing_implementer/subgraphs/savana.graphql
@@ -1,4 +1,4 @@
-extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@interfaceObject", "@key"])
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.8", import: ["@interfaceObject", "@key"])
 
 interface Animal @key(fields: "species") {
   species: String!


### PR DESCRIPTION
Before this commit, we were only validating that the implementers of the interface — in the subgraph where the interface is defined — have the same key, but the error message mentioned @interfaceObject, which is not about implementers, but about types in other subgraphs.

This commit

- resolves the confusion: the error message now mentions the right problem
- implements validation of matching key for interface objects in other subgraphs

closes gb-5825
