### PR TITLE
feat: allow defining custom resource attributes in otel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2883,6 +2883,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "serde_with",
  "tempfile",
  "tokio",
  "toml",

--- a/gateway/crates/federated-server/src/config.rs
+++ b/gateway/crates/federated-server/src/config.rs
@@ -817,6 +817,7 @@ mod tests {
         // prepare
         let telemetry_config = TelemetryConfig {
             service_name: "test".to_string(),
+            resource_attributes: Default::default(),
             tracing: Default::default(),
         };
 

--- a/gateway/crates/federated-server/src/config/telemetry.rs
+++ b/gateway/crates/federated-server/src/config/telemetry.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use grafbase_tracing::config::TracingConfig;
 
 /// Holds telemetry configuration
@@ -6,6 +8,9 @@ use grafbase_tracing::config::TracingConfig;
 pub struct TelemetryConfig {
     /// The name of the service
     pub service_name: String,
+    /// Additional resource attributes
+    #[serde(default)]
+    pub resource_attributes: HashMap<String, String>,
     /// Tracing config
     #[serde(default)]
     pub tracing: TracingConfig,

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -48,6 +48,7 @@ insta = { workspace = true, features = ["json", "redactions", "yaml"] }
 rand = "0.8"
 reqwest.workspace = true
 serde.workspace = true
+serde_with.workspace = true
 serde_json.workspace = true
 tempfile = "3.10.1"
 wiremock.workspace = true

--- a/gateway/crates/gateway-binary/src/main.rs
+++ b/gateway/crates/gateway-binary/src/main.rs
@@ -198,20 +198,20 @@ where
         }
     };
 
-    let resource_attributes = vec![
-        grafbase_tracing::otel::opentelemetry::KeyValue::new(
-            "grafbase.graph_id",
-            u128::from(reload_data.graph_id).to_string(),
-        ),
-        grafbase_tracing::otel::opentelemetry::KeyValue::new(
-            "grafbase.branch_id",
-            u128::from(reload_data.branch_id).to_string(),
-        ),
-        grafbase_tracing::otel::opentelemetry::KeyValue::new(
-            "grafbase.branch_name",
-            reload_data.branch_name.to_string(),
-        ),
-    ];
+    let mut resource_attributes = config.resource_attributes;
+    resource_attributes.insert(
+        "grafbase.graph_id".to_string(),
+        u128::from(reload_data.graph_id).to_string(),
+    );
+    resource_attributes.insert(
+        "grafbase.branch_id".to_string(),
+        u128::from(reload_data.branch_id).to_string(),
+    );
+    resource_attributes.insert("grafbase.branch_name".to_string(), reload_data.branch_name.to_string());
+    let resource_attributes = resource_attributes
+        .into_iter()
+        .map(|(key, value)| grafbase_tracing::otel::opentelemetry::KeyValue::new(key, value))
+        .collect::<Vec<_>>();
 
     layer::new_batched::<S, _, _>(
         config.service_name,

--- a/gateway/crates/gateway-binary/tests/telemetry/mod.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/mod.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use crate::{load_schema, with_static_server};
 use indoc::{formatdoc, indoc};
@@ -30,6 +30,14 @@ fn with_stdout_telemetry() {
     })
 }
 
+#[serde_with::serde_as]
+#[derive(clickhouse::Row, Deserialize)]
+struct Row {
+    #[serde(rename = "ResourceAttributes")]
+    #[serde_as(as = "Vec<(_, _)>")]
+    resource_attributes: HashMap<String, String>,
+}
+
 #[test]
 fn with_otel() {
     let service_name = format!("service-{}", rand::random::<u128>());
@@ -40,9 +48,6 @@ fn with_otel() {
         [telemetry.tracing]
         enabled = true
         sampling = 1
-
-        [telemetry.tracing.exporters.stdout]
-        enabled = true
 
         [telemetry.tracing.exporters.otlp]
         enabled = true
@@ -67,30 +72,105 @@ fn with_otel() {
             .with_user("default")
             .with_database("otel");
 
-        #[derive(clickhouse::Row, Deserialize)]
-        struct CountRow {
-            count: u32,
-        }
-
-        let CountRow { count } = client
-            .query("SELECT COUNT(1) as count FROM otel_traces WHERE ServiceName = ?")
+        let Row { resource_attributes } = client
+            .query("SELECT ResourceAttributes FROM otel_traces WHERE ServiceName = ?")
             .bind(&service_name)
-            .fetch_one::<CountRow>()
+            .fetch_one()
             .await
             .unwrap();
 
-        assert!(count > 0);
+        let expected_resource_attributes = [
+            ("service.name", service_name.as_str()),
+            ("grafbase.graph_id", "0"),
+            ("grafbase.branch_id", "0"),
+            ("grafbase.branch_name", ""),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect::<HashMap<_, _>>();
+
+        assert_eq!(resource_attributes, expected_resource_attributes);
 
         // takes a bit more time to push metrics, currently only every 10s
         tokio::time::sleep(Duration::from_secs(5)).await;
 
-        let CountRow { count } = client
-            .query("SELECT COUNT(1) as count FROM otel_metrics_sum WHERE ResourceAttributes['service.name'] = ?")
+        let Row { resource_attributes } = client
+            .query("SELECT ResourceAttributes FROM otel_metrics_sum WHERE ResourceAttributes['service.name'] = ?")
             .bind(&service_name)
-            .fetch_one::<CountRow>()
+            .fetch_one()
             .await
             .unwrap();
 
-        assert!(count > 0);
+        assert_eq!(resource_attributes, expected_resource_attributes);
+    });
+}
+#[test]
+fn extra_resource_attributes() {
+    let service_name = format!("service-{}", rand::random::<u128>());
+    let config = &formatdoc! {r#"
+        [telemetry]
+        service_name = "{service_name}"
+
+        [telemetry.resource_attributes]
+        my-favorite-app = "graphabase"
+
+        [telemetry.tracing]
+        enabled = true
+        sampling = 1
+
+        [telemetry.tracing.exporters.otlp]
+        enabled = true
+        endpoint = "http://localhost:4317"
+        protocol = "grpc"
+    "#};
+
+    let schema = load_schema("big");
+
+    let query = indoc! {r#"
+        { __typename }
+    "#};
+
+    with_static_server(config, &schema, None, None, |client| async move {
+        let result: serde_json::Value = client.gql(query).send().await;
+        serde_json::to_string_pretty(&result).unwrap();
+
+        tokio::time::sleep(Duration::from_secs(10)).await;
+
+        let client = clickhouse::Client::default()
+            .with_url("http://localhost:8123")
+            .with_user("default")
+            .with_database("otel");
+
+        let Row { resource_attributes } = client
+            .query("SELECT ResourceAttributes FROM otel_traces WHERE ServiceName = ?")
+            .bind(&service_name)
+            .fetch_one()
+            .await
+            .unwrap();
+
+        let expected_resource_attributes = [
+            ("service.name", service_name.as_str()),
+            ("my-favorite-app", "graphabase"),
+            ("grafbase.graph_id", "0"),
+            ("grafbase.branch_id", "0"),
+            ("grafbase.branch_name", ""),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect::<HashMap<_, _>>();
+
+        assert_eq!(resource_attributes, expected_resource_attributes);
+
+        // takes a bit more time to push metrics, currently only every 10s
+        tokio::time::sleep(Duration::from_secs(5)).await;
+
+        let Row { resource_attributes } = client
+            .query("SELECT ResourceAttributes FROM otel_metrics_sum WHERE ResourceAttributes['service.name'] = ?")
+            .bind(&service_name)
+            .fetch_one()
+            .await
+            .unwrap();
+
+        assert_eq!(resource_attributes, expected_resource_attributes);
     });
 }


### PR DESCRIPTION
Main purpose is to allow me in api integration tests to set `grafbase.account_id` etc. as I don't rely on the otel-gateway