### PR TITLE
feat: allow tests to define interfaces

### DIFF
--- a/engine/crates/engine/derive/src/interface.rs
+++ b/engine/crates/engine/derive/src/interface.rs
@@ -340,6 +340,7 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
                             #(#possible_types)*
                             possible_types
                         },
+                        cache_control: ::std::default::Default::default(),
                         extends: #extends,
                         visible: #visible,
                         rust_typename: ::std::borrow::ToOwned::to_owned(::std::any::type_name::<Self>()),

--- a/engine/crates/parser-graphql/src/conversion.rs
+++ b/engine/crates/parser-graphql/src/conversion.rs
@@ -200,6 +200,7 @@ fn interface_from_introspection(interface: cynic_introspection::InterfaceType) -
             .into_iter()
             .map(|v| (v.name.clone(), field_from_introspection(v)))
             .collect(),
+        cache_control: Default::default(),
         possible_types: interface.possible_types.into_iter().collect(),
         extends: false,
         visible: None,

--- a/engine/crates/parser-sdl/src/lib.rs
+++ b/engine/crates/parser-sdl/src/lib.rs
@@ -37,6 +37,7 @@ use rules::{
     graph_directive::GraphVisitor,
     graphql_directive::GraphqlVisitor,
     input_object::InputObjectVisitor,
+    interface::Interface,
     introspection::{IntrospectionDirective, IntrospectionDirectiveVisitor},
     join_directive::JoinDirective,
     length_directive::LengthDirective,
@@ -343,6 +344,7 @@ fn parse_types<'a>(schema: &'a ServiceDocument, ctx: &mut VisitorContext<'a>) {
         .with(CacheVisitor)
         .with(InputObjectVisitor)
         .with(BasicType)
+        .with(Interface)
         .with(ExtendQueryAndMutationTypes)
         .with(EnumType)
         .with(ScalarHydratation)

--- a/engine/crates/parser-sdl/src/rules/basic_type.rs
+++ b/engine/crates/parser-sdl/src/rules/basic_type.rs
@@ -133,6 +133,13 @@ impl<'a> Visitor<'a> for BasicType {
             &type_name,
         );
 
+        ctx.registry
+            .get_mut()
+            .implements
+            .entry(type_name.clone())
+            .or_default()
+            .extend(object.implements.iter().map(|name| name.to_string()));
+
         // If the type is a non primitive and also not modelized, it means we need to
         // create the Input version of it.
         // If the input is non used by other queries/mutation, it'll be removed from the

--- a/engine/crates/parser-sdl/src/rules/interface.rs
+++ b/engine/crates/parser-sdl/src/rules/interface.rs
@@ -1,0 +1,106 @@
+use engine::registry::{
+    self,
+    resolvers::{custom::CustomResolver, transformer::Transformer, Resolver},
+    MetaField,
+};
+use engine_parser::{
+    types::{FieldDefinition, TypeKind},
+    Positioned,
+};
+
+use super::{
+    join_directive::JoinDirective,
+    requires_directive::RequiresDirective,
+    resolver_directive::ResolverDirective,
+    visitor::{Visitor, VisitorContext},
+};
+use crate::{parser_extensions::FieldExtension, rules::cache_directive::CacheDirective, schema_coord::SchemaCoord};
+
+pub struct Interface;
+
+impl<'a> Visitor<'a> for Interface {
+    fn enter_type_definition(
+        &mut self,
+        ctx: &mut VisitorContext<'a>,
+        type_definition: &'a engine::Positioned<engine_parser::types::TypeDefinition>,
+    ) {
+        let TypeKind::Interface(object) = &type_definition.node.kind else {
+            return;
+        };
+
+        let type_name = type_definition.node.name.node.to_string();
+
+        let fields = object
+            .fields
+            .iter()
+            .map(|field| {
+                let name = field.name().to_string();
+                let mapped_name = field.mapped_name().map(ToString::to_string);
+
+                let mut resolver = field_resolver(field, mapped_name.as_deref());
+
+                let mut requires =
+                    RequiresDirective::from_directives(&field.directives, ctx).map(RequiresDirective::into_fields);
+
+                if let Some(join_directive) = JoinDirective::from_directives(&field.node.directives, ctx) {
+                    if resolver.is_custom() {
+                        ctx.report_error(vec![field.pos], "A field can't have a join and a custom resolver on it");
+                    }
+                    if requires.is_some() {
+                        // We could support this by merging the requires, but I don't want to implement it right now.
+                        // If someone asks we could do it
+                        ctx.report_error(vec![field.pos], "A field can't have a join and a requires on it");
+                    }
+                    requires = join_directive.select.required_fieldset(&field.arguments);
+
+                    ctx.warnings.extend(
+                        join_directive
+                            .validate_arguments(&field.arguments, SchemaCoord::Field(type_name.as_str(), field.name())),
+                    );
+
+                    resolver = Resolver::Join(join_directive.select.to_join_resolver());
+                }
+
+                MetaField {
+                    name: name.clone(),
+                    mapped_name,
+                    description: field.node.description.clone().map(|x| x.node),
+                    ty: field.node.ty.clone().node.to_string().into(),
+                    cache_control: CacheDirective::parse(&field.node.directives),
+                    args: field.converted_arguments(),
+                    resolver,
+                    requires,
+                    ..Default::default()
+                }
+            })
+            .collect::<Vec<_>>();
+
+        ctx.registry.get_mut().create_type(
+            |_| {
+                registry::InterfaceType::new(type_name.clone(), fields)
+                    .with_description(type_definition.node.description.clone().map(|x| x.node))
+                    .with_cache_control(CacheDirective::parse(&type_definition.node.directives))
+                    .into()
+            },
+            &type_name,
+            &type_name,
+        );
+
+        ctx.registry
+            .get_mut()
+            .implements
+            .entry(type_name)
+            .or_default()
+            .extend(object.implements.iter().map(|name| name.to_string()));
+    }
+}
+
+fn field_resolver(field: &Positioned<FieldDefinition>, mapped_name: Option<&str>) -> Resolver {
+    if let Some(resolver_name) = ResolverDirective::resolver_name(&field.node) {
+        return Resolver::CustomResolver(CustomResolver {
+            resolver_name: resolver_name.to_owned(),
+        });
+    }
+
+    Transformer::select(mapped_name.unwrap_or_else(|| field.name())).into()
+}

--- a/engine/crates/parser-sdl/src/rules/mod.rs
+++ b/engine/crates/parser-sdl/src/rules/mod.rs
@@ -22,6 +22,7 @@ pub mod federation;
 pub mod graph_directive;
 pub mod graphql_directive;
 pub mod input_object;
+pub mod interface;
 pub mod introspection;
 pub mod join_directive;
 pub mod length_directive;


### PR DESCRIPTION
Back in the days of `@model`, grafbase didn't support interfaces.  On adding the graphql connector, grafbase started having to support interfaces.

Hugo is currently trying to test some stuff around caching & interfaces, but he ran into difficulties testing, because `parser-sdl` still just ignores interfaces.  It's quite easy to fix this though, so that's what I've done.

At some point we'll probably need to do the same for union types as well, but that's for the future.  Also this doesn't techncially let users do interfaces because I've not updated the SDK, but we can do that if we want.