### PR TITLE
remove sparse cargo protocol as it is enabled by default

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,2 @@
 [target.'cfg(all())']
 rustflags = ["--cfg=web_sys_unstable_apis"]
-
-[net]
-git-fetch-with-cli = true
-
-[registries.crates-io]
-protocol = "sparse"


### PR DESCRIPTION
As of Rust 1.70.0 the sparse protocol is now enabled by default.

Also remove git via CLI config 