### PR TITLE
chore: Fix latency metric and reduce test sleep duration

### DIFF
--- a/engine/crates/tracing/src/tower.rs
+++ b/engine/crates/tracing/src/tower.rs
@@ -39,7 +39,7 @@ pub fn layer<B: Body>() -> tower_http::trace::TraceLayer<
             tracing::event!(
                 target: GRAFBASE_TARGET,
                 tracing::Level::INFO,
-                histogram.latency = latency.as_millis(),
+                histogram.latency = latency.as_millis() as u64,
             );
             span.record_response(response);
         })


### PR DESCRIPTION
I'm again re-usingthe configuration from tracing for the `scheduled_delay`, this one
should probably be different between traces and metrics but likely shouldn't for the
exporters. Unless we want users to copy paste the configuration twice? So well.

# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
