### PR TITLE
fix: add response content for failing HTTP requests in the GraphQL connector

### DIFF
--- a/engine/crates/engine/src/error.rs
+++ b/engine/crates/engine/src/error.rs
@@ -1,6 +1,7 @@
 use std::{
     any::Any,
     collections::BTreeMap,
+    convert::Infallible,
     fmt::{self, Debug, Display, Formatter},
     marker::PhantomData,
     sync::Arc,
@@ -313,13 +314,61 @@ impl Error {
     }
 }
 
-impl<T: Display + Send + Sync> From<T> for Error {
-    fn from(e: T) -> Self {
+impl From<serde_json::Error> for Error {
+    fn from(value: serde_json::Error) -> Self {
+        Self::new(value.to_string())
+    }
+}
+
+impl From<ServerError> for Error {
+    fn from(value: ServerError) -> Self {
         Self {
-            message: e.to_string(),
-            source: None,
-            extensions: None,
+            message: value.message,
+            source: value.source,
+            extensions: value.extensions,
         }
+    }
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(value: reqwest::Error) -> Self {
+        Self::new(value.to_string())
+    }
+}
+
+impl From<http::method::InvalidMethod> for Error {
+    fn from(value: http::method::InvalidMethod) -> Self {
+        Self::new(value.to_string())
+    }
+}
+
+impl From<Infallible> for Error {
+    fn from(value: Infallible) -> Self {
+        Self::new(value.to_string())
+    }
+}
+
+impl From<chrono::ParseError> for Error {
+    fn from(value: chrono::ParseError) -> Self {
+        Self::new(value.to_string())
+    }
+}
+
+impl From<std::net::AddrParseError> for Error {
+    fn from(value: std::net::AddrParseError) -> Self {
+        Self::new(value.to_string())
+    }
+}
+
+impl From<uuid::Error> for Error {
+    fn from(value: uuid::Error) -> Self {
+        Self::new(value.to_string())
+    }
+}
+
+impl From<url::ParseError> for Error {
+    fn from(value: url::ParseError) -> Self {
+        Self::new(value.to_string())
     }
 }
 

--- a/engine/crates/engine/src/registry/resolvers/custom.rs
+++ b/engine/crates/engine/src/registry/resolvers/custom.rs
@@ -14,6 +14,12 @@ pub struct CustomResolver {
     pub resolver_name: String,
 }
 
+impl From<UdfError> for crate::Error {
+    fn from(value: UdfError) -> Self {
+        Self::new(value.to_string())
+    }
+}
+
 impl CustomResolver {
     pub(super) async fn resolve(
         &self,

--- a/engine/crates/engine/src/registry/resolvers/graphql/response.rs
+++ b/engine/crates/engine/src/registry/resolvers/graphql/response.rs
@@ -75,7 +75,7 @@ fn handle_error_after_response(
     }
 
     if !status.is_success() {
-        return Error::HttpErrorResponse(status.as_u16());
+        return Error::HttpErrorResponse(status.as_u16(), response_body.unwrap_or_default().to_string());
     }
 
     error
@@ -142,13 +142,13 @@ mod tests {
 
     #[test]
     fn test_error_paths() {
-        let response = UpstreamResponse::from_response_text(
-            StatusCode::from_u16(500).unwrap(),
-            Ok::<_, Error>(r#"{"blah": {}}"#.into()),
-        )
-        .unwrap_err();
-        assert!(
-            matches!(response, Error::HttpErrorResponse(500)),
+        let text = r#"{"blah": {}}"#.to_string();
+        let response =
+            UpstreamResponse::from_response_text(StatusCode::from_u16(500).unwrap(), Ok::<_, Error>(text.clone()))
+                .unwrap_err();
+        assert_eq!(
+            response,
+            Error::HttpErrorResponse(500, text),
             "`{response}` does not match"
         );
         let response = UpstreamResponse::from_response_text(

--- a/engine/crates/engine/src/registry/resolvers/postgres.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres.rs
@@ -6,7 +6,7 @@ use std::{future::Future, pin::Pin};
 use async_runtime::make_send_on_wasm;
 pub use context::CollectionArgs;
 use context::PostgresContext;
-use runtime::pg::PgTransportFactory;
+use runtime::pg::{PgTransportFactory, PgTransportFactoryError};
 
 use super::{ResolvedValue, ResolverContext};
 use crate::{context::ContextExt, ContextField, Error};
@@ -36,6 +36,12 @@ impl AsRef<str> for Operation {
             Self::UpdateOne => "updateOne",
             Self::UpdateMany => "updateMany",
         }
+    }
+}
+
+impl From<PgTransportFactoryError> for crate::Error {
+    fn from(value: PgTransportFactoryError) -> Self {
+        Self::new(value.to_string())
     }
 }
 

--- a/engine/crates/integration-tests/tests/graphql_connector/errors.rs
+++ b/engine/crates/integration-tests/tests/graphql_connector/errors.rs
@@ -1,4 +1,4 @@
-use graphql_mocks::{ErrorSchema, MockGraphQlServer};
+use graphql_mocks::{ErrorSchema, FakeGithubSchema, MockGraphQlServer};
 use integration_tests::{runtime, udfs::RustUdfs, EngineBuilder, ResponseExt};
 use runtime::udf::UdfResponse;
 use serde_json::json;
@@ -327,6 +327,87 @@ fn graphql_connector_error_propagation_unnamespaced_no_grouping() {
                 1,
                 "brokenField"
               ]
+            }
+          ]
+        }
+        "###
+        );
+    });
+}
+
+#[test]
+fn should_populate_response_content_extension_on_http_errors() {
+    runtime().block_on(async {
+        let graphql_mock = MockGraphQlServer::new(FakeGithubSchema).await;
+        let port = graphql_mock.port();
+        let schema = format!(
+            r#"
+            extend schema
+                @graphql(
+                    name: "errors",
+                    namespace: false,
+                    url: "http://127.0.0.1:{port}",
+                )
+            "#
+        );
+
+        let engine = EngineBuilder::new(schema).build().await;
+        let value = engine
+            .execute(
+                r#"
+                query {
+                    one: serverVersion
+                }
+            "#,
+            )
+            .await
+            .into_value();
+
+        // Sanity check
+        insta::assert_json_snapshot!(
+            value,
+            @r###"
+        {
+          "data": {
+            "one": "1"
+          }
+        }
+        "###
+        );
+
+        graphql_mock.force_next_response((http::StatusCode::INTERNAL_SERVER_ERROR, "something failed"));
+        let value = engine
+            .execute(
+                r#"
+                query {
+                    one: serverVersion
+                }
+            "#,
+            )
+            .await
+            .into_value();
+
+        // Sanity check
+        insta::assert_json_snapshot!(
+            value,
+            @r###"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "received an unexpected status from the downstream server: 500",
+              "locations": [
+                {
+                  "line": 3,
+                  "column": 21
+                }
+              ],
+              "path": [
+                "one"
+              ],
+              "extensions": {
+                "response_content": "something failed"
+              }
             }
           ]
         }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
