### PR TITLE
Add means to track operation id/name in metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,6 +1138,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,6 +1333,12 @@ dependencies = [
  "cast",
  "itertools 0.10.5",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crossbeam-channel"
@@ -1883,6 +1904,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "encode_unicode"
@@ -3021,7 +3048,9 @@ dependencies = [
 name = "grafbase-tracing"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.0",
  "chrono",
+ "headers",
  "http 1.1.0",
  "http-body 1.0.0",
  "indoc",
@@ -3030,11 +3059,13 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-stdout",
  "opentelemetry_sdk",
+ "postcard",
  "serde",
  "tempfile",
  "thiserror",
  "toml",
  "tonic",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-opentelemetry",
@@ -3269,6 +3300,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3318,6 +3358,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http 1.1.0",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin 0.9.8",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -5605,6 +5659,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
+name = "postcard"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
+dependencies = [
+ "cobs",
+ "embedded-io",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "postgres-connector-types"
 version = "0.1.0"
 dependencies = [
@@ -6996,6 +7062,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ jsonwebtoken = "9"
 num-traits = "0.2"
 once_cell = "1"
 openidconnect = "4.0.0-alpha.1"
+postcard = "1"
 regex = "1"
 reqwest = { version = "0.12", default-features = false, features = ["http2"] }
 rmp-serde = "1"
@@ -108,6 +109,7 @@ tokio-postgres-rustls = "0.11"
 tokio-rustls = { version = "0.25", default-features = false }
 tokio-tungstenite = { version = "0.21.0", default-features = false }
 tungstenite = { version = "0.21.0", default-features = false }
+tower = "0.4"
 tower-http = "0.5"
 tower-service = "0.3"
 url = "2"

--- a/engine/crates/tracing/Cargo.toml
+++ b/engine/crates/tracing/Cargo.toml
@@ -12,15 +12,19 @@ keywords = ["tracing", "grafbase"]
 workspace = true
 
 [dependencies]
-chrono = "0.4"
+chrono.workspace = true
 http.workspace = true
 http-body = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-thiserror = "1.0"
+serde.workspace = true
+thiserror.workspace = true
 tonic = { version = "0.11.0", optional = true }
-tower-http = { version = "0.5", optional = true, features = ["trace"] }
-url = { version = "2.5", features = ["serde"] }
-worker = { version = "0.1.0", optional = true }
+tower = { workspace = true, optional = true }
+tower-http = { workspace = true, optional = true, features = ["trace"] }
+url = { workspace = true, features = ["serde"] }
+worker = { workspace = true, optional = true }
+base64.workspace = true
+headers.workspace = true
+postcard = { workspace = true, features = ["use-std"] }
 
 # tracing
 tracing.workspace = true
@@ -33,7 +37,7 @@ opentelemetry-otlp = { version = "0.15" , features = ["grpc-tonic", "tls", "toni
 
 [features]
 default = []
-tower = ["tower-http"]
+tower = ["dep:tower-http", "dep:tower"]
 otlp = ["dep:opentelemetry-otlp", "dep:tonic"]
 worker = ["dep:worker"]
 lambda = []

--- a/engine/crates/tracing/src/execution_metadata.rs
+++ b/engine/crates/tracing/src/execution_metadata.rs
@@ -1,0 +1,66 @@
+/// header name for execution metadata
+pub static X_GRAFBASE_GRAPHQL_EXECUTION_METADATA: http::HeaderName =
+    http::HeaderName::from_static("x-grafbase-execution-metadata");
+
+/// Execution metadata
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+pub struct GraphqlExecutionMetadata {
+    /// The operation id
+    pub operation_id: Option<String>,
+    /// The operation type
+    pub operation_type: Option<String>,
+    /// The operation name
+    pub operation_name: Option<String>,
+    /// Whether the operation has errors
+    pub has_errors: Option<bool>,
+}
+
+impl GraphqlExecutionMetadata {
+    /// Operation id
+    pub fn operation_id(&self) -> &str {
+        self.operation_id.as_deref().unwrap_or_default()
+    }
+
+    /// Operation type
+    pub fn operation_type(&self) -> &str {
+        self.operation_type.as_deref().unwrap_or_default()
+    }
+
+    /// Operation name
+    pub fn operation_name(&self) -> &str {
+        self.operation_name.as_deref().unwrap_or_default()
+    }
+
+    /// Whether the operation has errors
+    pub fn has_errors(&self) -> bool {
+        self.has_errors.unwrap_or_default()
+    }
+}
+
+impl headers::Header for GraphqlExecutionMetadata {
+    fn name() -> &'static http::HeaderName {
+        &X_GRAFBASE_GRAPHQL_EXECUTION_METADATA
+    }
+
+    fn decode<'i, I>(values: &mut I) -> Result<Self, headers::Error>
+    where
+        Self: Sized,
+        I: Iterator<Item = &'i http::HeaderValue>,
+    {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        values
+            .filter_map(|value| {
+                let decoded = URL_SAFE_NO_PAD.decode(value.as_bytes()).ok()?;
+                postcard::from_bytes(&decoded).ok()
+            })
+            .last()
+            .ok_or_else(headers::Error::invalid)
+    }
+
+    fn encode<E: Extend<http::HeaderValue>>(&self, values: &mut E) {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        let value = postcard::to_stdvec(self).unwrap();
+        let encoded = URL_SAFE_NO_PAD.encode(value);
+        values.extend(Some(http::HeaderValue::from_str(&encoded).unwrap()));
+    }
+}

--- a/engine/crates/tracing/src/lib.rs
+++ b/engine/crates/tracing/src/lib.rs
@@ -6,6 +6,8 @@
 pub mod config;
 /// Potential errors from this crate
 pub mod error;
+/// Execution metadata
+pub mod execution_metadata;
 /// Otel integration
 pub mod otel;
 /// Spans that are represented using types

--- a/engine/crates/tracing/src/tower.rs
+++ b/engine/crates/tracing/src/tower.rs
@@ -1,16 +1,47 @@
 use std::time::Duration;
 
+use headers::HeaderMapExt;
 use http::Response;
 use http_body::Body;
 use tower_http::classify::{ServerErrorsAsFailures, ServerErrorsFailureClass, SharedClassifier};
 use tower_http::trace::{DefaultOnBodyChunk, DefaultOnEos, DefaultOnRequest};
 use tracing::Span;
 
+use crate::execution_metadata::{GraphqlExecutionMetadata, X_GRAFBASE_GRAPHQL_EXECUTION_METADATA};
 use crate::span::GRAFBASE_TARGET;
+
+/// A [tower::Layer] that creates a [tracing::Span] for each incoming request and removes the execution metadata
+#[allow(clippy::type_complexity)]
+// super friendly type yes... Writing the proper impl is really hard with all the requirements of
+// axum.
+pub fn layer<B: Body>() -> tower::ServiceBuilder<
+    tower::layer::util::Stack<
+        tower::util::MapResponseLayer<impl Fn(Response<B>) -> Response<B> + Clone>,
+        tower::layer::util::Stack<
+            tower_http::trace::TraceLayer<
+                SharedClassifier<ServerErrorsAsFailures>,
+                crate::span::request::MakeHttpRequestSpan,
+                DefaultOnRequest,
+                impl Fn(&Response<B>, Duration, &Span) + Clone,
+                DefaultOnBodyChunk,
+                DefaultOnEos,
+                impl Fn(ServerErrorsFailureClass, Duration, &Span) + Clone,
+            >,
+            tower::layer::util::Identity,
+        >,
+    >,
+> {
+    tower::ServiceBuilder::new()
+        .layer(tracing_layer::<B>())
+        .map_response(|mut response: http::Response<B>| {
+            response.headers_mut().remove(&X_GRAFBASE_GRAPHQL_EXECUTION_METADATA);
+            response
+        })
+}
 
 /// A [tower_http::trace::TraceLayer] that creates [crate::span::request::HttpRequestSpan] for each incoming request
 /// and records request and response attributes in the span
-pub fn layer<B: Body>() -> tower_http::trace::TraceLayer<
+fn tracing_layer<B: Body>() -> tower_http::trace::TraceLayer<
     SharedClassifier<ServerErrorsAsFailures>,
     crate::span::request::MakeHttpRequestSpan,
     DefaultOnRequest,
@@ -29,17 +60,26 @@ pub fn layer<B: Body>() -> tower_http::trace::TraceLayer<
                 .get("x-grafbase-cache")
                 .and_then(|value| value.to_str().ok())
                 .unwrap_or_default();
+            let execution_metadata = response
+                .headers()
+                .typed_get::<GraphqlExecutionMetadata>()
+                .unwrap_or_default();
             tracing::event!(
                 target: GRAFBASE_TARGET,
                 tracing::Level::INFO,
                 counter.request_count = 1,
                 http.response.status_code = response.status().as_u16(),
-                http.response.headers.cache_status = cache_status
+                http.response.headers.cache_status = cache_status,
+                gql.request.operation.id = execution_metadata.operation_id(),
+                gql.request.operation.name = execution_metadata.operation_name(),
+                gql.response.has_errors = execution_metadata.has_errors(),
             );
             tracing::event!(
                 target: GRAFBASE_TARGET,
                 tracing::Level::INFO,
                 histogram.latency = latency.as_millis() as u64,
+                gql.request.operation.id = execution_metadata.operation_id(),
+                gql.request.operation.name = execution_metadata.operation_name(),
             );
             span.record_response(response);
         })


### PR DESCRIPTION
The tower layer is pretty handy to retrieve the most accurate latency but it does make passing information from the engine to the ote request_count & latency metric easy. So propagating it through an intermediate header that is removed after being read. So serializing the metadata with postcard & base64 into a header value. Using postcard because it's faster and smaller than `serde_json` (2x here and 10x if we include a long query string).