### PR TITLE
GB-6482: Project template extraction: Change the move operation to be a copy operation

### DIFF
--- a/cli/crates/backend/src/errors.rs
+++ b/cli/crates/backend/src/errors.rs
@@ -73,7 +73,7 @@ pub enum BackendError {
 
     /// returned if the extracted files from the template repository could not be moved
     #[error("could not move the extracted files from the template repository\nCaused by: {0}")]
-    MoveExtractedFiles(io::Error),
+    CopyTemplateFiles(io::Error),
 
     /// returned if the entries of the template repository archive could not be read
     #[error("could not read the entries of the template repository archive")]


### PR DESCRIPTION
# Description

Sometimes a move operation is impossible due to file system limitations.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [X] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
