### PR TITLE
feat: engine-v2 operation metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,6 +2002,7 @@ dependencies = [
  "strum",
  "thiserror",
  "tracing",
+ "web-time",
 ]
 
 [[package]]

--- a/cli/crates/federated-dev/src/dev.rs
+++ b/cli/crates/federated-dev/src/dev.rs
@@ -99,7 +99,9 @@ pub(super) async fn run(
         .route_service("/ws", WebsocketService::new(websocket_sender))
         .nest_service("/static", tower_http::services::ServeDir::new(static_asset_path))
         .layer(CorsLayer::permissive())
-        .layer(grafbase_tracing::tower::layer())
+        .layer(grafbase_tracing::tower::layer(
+            grafbase_tracing::metrics::meter_from_global_provider(),
+        ))
         .with_state(ProxyState {
             admin_pathfinder_html: Html(render_pathfinder(listen_address.port(), "/admin")),
             gateway,

--- a/cli/crates/federated-dev/src/dev/gateway_nanny.rs
+++ b/cli/crates/federated-dev/src/dev/gateway_nanny.rs
@@ -60,6 +60,7 @@ pub(super) fn new_gateway(graph: Option<FederatedGraph>, config: &FederatedGraph
                 runtime_noop::trusted_documents::NoopTrustedDocuments,
             ),
             kv: runtime_local::InMemoryKvStore::runtime(),
+            meter: grafbase_tracing::metrics::meter_from_global_provider(),
         },
     )))
 }

--- a/cli/crates/gateway/src/serving.rs
+++ b/cli/crates/gateway/src/serving.rs
@@ -18,7 +18,9 @@ pub(super) fn router(gateway: Gateway) -> Router {
         .route("/graphql", post(post_graphql).options(options_any).get(get_graphql))
         .with_state(gateway)
         .layer(CorsLayer::permissive())
-        .layer(grafbase_tracing::tower::layer())
+        .layer(grafbase_tracing::tower::layer(
+            grafbase_tracing::metrics::meter_from_global_provider(),
+        ))
 }
 
 async fn post_graphql(State(gateway): State<Gateway>, headers: HeaderMap, body: Bytes) -> crate::Response {

--- a/engine/crates/engine-v2/Cargo.toml
+++ b/engine/crates/engine-v2/Cargo.toml
@@ -35,6 +35,7 @@ tracing.workspace = true
 http.workspace = true
 headers.workspace = true
 gateway-core = { path = "../gateway-core" }
+web-time.workspace = true
 
 gateway-v2-auth = { path = "../gateway-v2/auth" }
 config = { package = "engine-v2-config", path = "./config" }

--- a/engine/crates/engine/parser/src/types/mod.rs
+++ b/engine/crates/engine/parser/src/types/mod.rs
@@ -43,13 +43,20 @@ pub enum OperationType {
     Subscription,
 }
 
-impl AsRef<str> for OperationType {
-    fn as_ref(&self) -> &str {
+impl OperationType {
+    /// Operation type as str
+    pub fn as_str(&self) -> &'static str {
         match self {
             Self::Query => "query",
             Self::Mutation => "mutation",
             Self::Subscription => "subscription",
         }
+    }
+}
+
+impl AsRef<str> for OperationType {
+    fn as_ref(&self) -> &str {
+        self.as_str()
     }
 }
 

--- a/engine/crates/integration-tests/src/federation/builder.rs
+++ b/engine/crates/integration-tests/src/federation/builder.rs
@@ -101,6 +101,7 @@ impl FederationGatewayBuilder {
                             trusted_documents_client::Client::new(runtime_noop::trusted_documents::NoopTrustedDocuments)
                         }),
                     kv: runtime_local::InMemoryKvStore::runtime(),
+                    meter: grafbase_tracing::metrics::meter_from_global_provider(),
                 },
             )),
         }

--- a/engine/crates/integration-tests/src/federation/builder/bench.rs
+++ b/engine/crates/integration-tests/src/federation/builder/bench.rs
@@ -51,6 +51,7 @@ impl<'a> FederationGatewayWithoutIO<'a> {
                     runtime_noop::trusted_documents::NoopTrustedDocuments,
                 ),
                 kv: runtime_local::InMemoryKvStore::runtime(),
+                meter: grafbase_tracing::metrics::meter_from_global_provider(),
             },
         );
         Self {

--- a/engine/crates/integration-tests/tests/tracing/tower.rs
+++ b/engine/crates/integration-tests/tests/tracing/tower.rs
@@ -25,7 +25,9 @@ async fn expect_gateway_span() {
     // axum server with our tower layer
     let app = Router::new()
         .route("/", get(|| async {}))
-        .layer(grafbase_tracing::tower::layer());
+        .layer(grafbase_tracing::tower::layer(
+            grafbase_tracing::metrics::meter_from_global_provider(),
+        ));
 
     let tcp_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = tcp_listener.local_addr().unwrap().port();

--- a/engine/crates/tracing/src/lib.rs
+++ b/engine/crates/tracing/src/lib.rs
@@ -1,11 +1,10 @@
-#![forbid(missing_docs)]
-
 //! Grafbase [tracing](https://docs.rs/tracing/latest/tracing/) integration
 
 /// Tracing configuration properties
 pub mod config;
 /// Potential errors from this crate
 pub mod error;
+pub mod metrics;
 /// Otel integration
 pub mod otel;
 /// Spans that are represented using types

--- a/engine/crates/tracing/src/metrics/mod.rs
+++ b/engine/crates/tracing/src/metrics/mod.rs
@@ -1,0 +1,16 @@
+mod operation;
+mod request;
+
+use opentelemetry::metrics::{Meter, MeterProvider};
+pub use operation::*;
+pub use request::*;
+
+const SCOPE: &str = "grafbase";
+
+pub fn meter_from_global_provider() -> Meter {
+    meter(opentelemetry::global::meter_provider())
+}
+
+pub fn meter(provider: impl MeterProvider) -> Meter {
+    provider.meter(SCOPE)
+}

--- a/engine/crates/tracing/src/metrics/operation.rs
+++ b/engine/crates/tracing/src/metrics/operation.rs
@@ -1,0 +1,35 @@
+use opentelemetry::metrics::{Counter, Histogram, Meter};
+
+#[derive(Clone)]
+pub struct GraphqlOperationMetrics {
+    count: Counter<u64>,
+    latency: Histogram<u64>,
+}
+
+pub struct GraphqlOperationMetricsAttributes {
+    pub id: String,
+    pub ty: &'static str,
+    pub name: Option<String>,
+}
+
+impl GraphqlOperationMetrics {
+    pub fn build(meter: &Meter) -> Self {
+        Self {
+            count: meter.u64_counter("gql_operation_count").init(),
+            latency: meter.u64_histogram("gql_operation_latency").init(),
+        }
+    }
+
+    pub fn record(
+        &self,
+        GraphqlOperationMetricsAttributes { id, name, .. }: GraphqlOperationMetricsAttributes,
+        latency: std::time::Duration,
+    ) {
+        let attributes = vec![
+            opentelemetry::KeyValue::new("gql.operation.id", id),
+            opentelemetry::KeyValue::new("gql.operation.name", name.unwrap_or_default()),
+        ];
+        self.count.add(1, &attributes);
+        self.latency.record(latency.as_millis() as u64, &attributes);
+    }
+}

--- a/engine/crates/tracing/src/metrics/request.rs
+++ b/engine/crates/tracing/src/metrics/request.rs
@@ -1,0 +1,40 @@
+use opentelemetry::{
+    metrics::{Counter, Histogram, Meter},
+    KeyValue,
+};
+
+#[derive(Clone)]
+pub struct RequestMetrics {
+    count: Counter<u64>,
+    latency: Histogram<u64>,
+}
+
+pub struct RequestMetricsAttributes {
+    pub status_code: u16,
+    pub cache_status: Option<String>,
+}
+
+impl RequestMetrics {
+    pub fn build(meter: &Meter) -> Self {
+        Self {
+            count: meter.u64_counter("request_count").init(),
+            latency: meter.u64_histogram("request_latency").init(),
+        }
+    }
+
+    pub fn record(
+        &self,
+        RequestMetricsAttributes {
+            status_code,
+            cache_status,
+        }: RequestMetricsAttributes,
+        latency: std::time::Duration,
+    ) {
+        let mut attributes = vec![KeyValue::new("http.response.status_code", status_code as i64)];
+        if let Some(cache_status) = cache_status {
+            attributes.push(KeyValue::new("http.response.headers.cache_status", cache_status));
+        }
+        self.count.add(1, &attributes);
+        self.latency.record(latency.as_millis() as u64, &[]);
+    }
+}

--- a/engine/crates/tracing/src/tower.rs
+++ b/engine/crates/tracing/src/tower.rs
@@ -2,15 +2,18 @@ use std::time::Duration;
 
 use http::Response;
 use http_body::Body;
+use opentelemetry::metrics::Meter;
 use tower_http::classify::{ServerErrorsAsFailures, ServerErrorsFailureClass, SharedClassifier};
 use tower_http::trace::{DefaultOnBodyChunk, DefaultOnEos, DefaultOnRequest};
 use tracing::Span;
 
-use crate::span::GRAFBASE_TARGET;
+use crate::metrics::{RequestMetrics, RequestMetricsAttributes};
 
 /// A [tower_http::trace::TraceLayer] that creates [crate::span::request::HttpRequestSpan] for each incoming request
 /// and records request and response attributes in the span
-pub fn layer<B: Body>() -> tower_http::trace::TraceLayer<
+pub fn layer<B: Body>(
+    meter: Meter,
+) -> tower_http::trace::TraceLayer<
     SharedClassifier<ServerErrorsAsFailures>,
     crate::span::request::MakeHttpRequestSpan,
     DefaultOnRequest,
@@ -19,44 +22,41 @@ pub fn layer<B: Body>() -> tower_http::trace::TraceLayer<
     DefaultOnEos,
     impl Fn(ServerErrorsFailureClass, Duration, &Span) + Clone,
 > {
+    let metrics = RequestMetrics::build(&meter);
     tower_http::trace::TraceLayer::new_for_http()
         .make_span_with(crate::span::request::MakeHttpRequestSpan)
-        .on_response(|response: &Response<_>, latency: Duration, span: &Span| {
-            use crate::span::HttpRecorderSpanExt;
+        .on_response({
+            let metrics = metrics.clone();
+            move |response: &Response<_>, latency: Duration, span: &Span| {
+                use crate::span::HttpRecorderSpanExt;
 
-            let cache_status = response
-                .headers()
-                .get("x-grafbase-cache")
-                .and_then(|value| value.to_str().ok())
-                .unwrap_or_default();
-            tracing::event!(
-                target: GRAFBASE_TARGET,
-                tracing::Level::INFO,
-                counter.request_count = 1,
-                http.response.status_code = response.status().as_u16(),
-                http.response.headers.cache_status = cache_status
-            );
-            tracing::event!(
-                target: GRAFBASE_TARGET,
-                tracing::Level::INFO,
-                histogram.latency = latency.as_millis() as u64,
-            );
-            span.record_response(response);
+                let cache_status = response
+                    .headers()
+                    .get("x-grafbase-cache")
+                    .and_then(|value| value.to_str().ok());
+                metrics.record(
+                    RequestMetricsAttributes {
+                        status_code: response.status().as_u16(),
+                        cache_status: cache_status.map(|s| s.to_string()),
+                    },
+                    latency,
+                );
+                span.record_response(response);
+            }
         })
-        .on_failure(|error: ServerErrorsFailureClass, _latency: Duration, span: &Span| {
+        .on_failure(move |error: ServerErrorsFailureClass, latency: Duration, span: &Span| {
             use crate::span::HttpRecorderSpanExt;
 
-            let status = match error {
+            let status_code = match error {
                 ServerErrorsFailureClass::StatusCode(code) => code.as_u16(),
                 ServerErrorsFailureClass::Error(_) => 500,
             };
-            tracing::event!(
-                target: GRAFBASE_TARGET,
-                tracing::Level::INFO,
-                counter.request = 1,
-                http.response.status_code = status,
-                http.response.headers.cache_stauts = "BYPASS"
-
+            metrics.record(
+                RequestMetricsAttributes {
+                    status_code,
+                    cache_status: None,
+                },
+                latency,
             );
             span.record_failure(error.to_string().as_str());
         })

--- a/gateway/crates/federated-server/src/server.rs
+++ b/gateway/crates/federated-server/src/server.rs
@@ -77,7 +77,9 @@ pub async fn serve(
         .route(path, get(engine::get).post(engine::post))
         .route_service("/ws", WebsocketService::new(websocket_sender))
         .layer(cors)
-        .layer(grafbase_tracing::tower::layer())
+        .layer(grafbase_tracing::tower::layer(
+            grafbase_tracing::metrics::meter_from_global_provider(),
+        ))
         .with_state(state);
 
     if config.csrf.enabled {

--- a/gateway/crates/federated-server/src/server/gateway.rs
+++ b/gateway/crates/federated-server/src/server/gateway.rs
@@ -119,6 +119,7 @@ pub(super) fn generate(
         cache: cache.clone(),
         kv: InMemoryKvStore::runtime(),
         trusted_documents,
+        meter: grafbase_tracing::metrics::meter_from_global_provider(),
     };
 
     Ok(Engine::new(

--- a/gateway/crates/federated-server/src/server/otel.rs
+++ b/gateway/crates/federated-server/src/server/otel.rs
@@ -1,4 +1,4 @@
-use grafbase_tracing::otel::opentelemetry_sdk::{metrics::SdkMeterProvider, trace::TracerProvider};
+use grafbase_tracing::otel::opentelemetry_sdk::trace::TracerProvider;
 use ulid::Ulid;
 
 /// Holds legos to deal with opentelemetry tracing
@@ -8,8 +8,6 @@ pub struct OtelTracing {
     ///     - the layer related to the handler might be a noop_layer and therefore has no provider attached
     ///     - it can be replaced on reload, and we want the latest
     pub tracer_provider: tokio::sync::watch::Receiver<TracerProvider>,
-    /// The meter provider attached to the otel layer
-    pub meter_provider: tokio::sync::watch::Receiver<SdkMeterProvider>,
     /// A channel to trigger the otel layer reload with new data
     pub reload_trigger: tokio::sync::oneshot::Sender<OtelReload>,
 }

--- a/gateway/crates/gateway-binary/tests/telemetry/metrics.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/metrics.rs
@@ -1,0 +1,180 @@
+use std::{collections::HashMap, time::Duration};
+
+use indoc::formatdoc;
+use serde::Deserialize;
+
+use crate::{load_schema, with_static_server};
+
+#[serde_with::serde_as]
+#[derive(clickhouse::Row, Deserialize)]
+struct SumMetricCountRow {
+    #[serde(rename = "Value")]
+    value: f64,
+    #[serde(rename = "Attributes")]
+    #[serde_as(as = "Vec<(_, _)>")]
+    attributes: HashMap<String, String>,
+}
+
+#[serde_with::serde_as]
+#[derive(clickhouse::Row, Deserialize)]
+struct ExponentialHistogramRow {
+    #[serde(rename = "Count")]
+    count: u64,
+    #[serde(rename = "Attributes")]
+    #[serde_as(as = "Vec<(_, _)>")]
+    attributes: HashMap<String, String>,
+}
+
+#[test]
+fn request_metrics() {
+    let service_name = format!("service-{}", rand::random::<u128>());
+    let config = &formatdoc! {r#"
+        [telemetry]
+        service_name = "{service_name}"
+
+        [telemetry.tracing]
+        enabled = true
+        sampling = 1
+
+        [telemetry.tracing.exporters.otlp]
+        enabled = true
+        endpoint = "http://localhost:4317"
+        protocol = "grpc"
+
+        [telemetry.tracing.exporters.otlp.batch_export]
+        scheduled_delay = 1
+        max_export_batch_size = 1
+    "#};
+
+    let schema = load_schema("big");
+    with_static_server(config, &schema, None, None, |client| async move {
+        client.gql::<serde_json::Value>("{ __typename }").send().await;
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let client = clickhouse::Client::default()
+            .with_url("http://localhost:8123")
+            .with_user("default")
+            .with_database("otel");
+
+        let SumMetricCountRow { value, attributes } = client
+            .query(
+                r#"
+                SELECT Value, Attributes
+                FROM otel_metrics_sum
+                WHERE ResourceAttributes['service.name'] = ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'request_count'
+                "#,
+            )
+            .bind(&service_name)
+            .fetch_one()
+            .await
+            .unwrap();
+        assert!(value >= 1.0); // initial polling also counts
+        assert_eq!(
+            attributes,
+            HashMap::from([("http.response.status_code".to_string(), "200".to_string())])
+        );
+
+        let ExponentialHistogramRow { count, attributes } = client
+            .query(
+                r#"
+                SELECT Count, Attributes
+                FROM otel_metrics_exponential_histogram
+                WHERE ResourceAttributes['service.name'] = ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'request_latency'
+                "#,
+            )
+            .bind(&service_name)
+            .fetch_one()
+            .await
+            .unwrap();
+        assert!(count >= 1); // Initial polling also counts
+        assert_eq!(attributes, HashMap::new())
+    });
+}
+
+#[test]
+fn operation_metrics() {
+    let service_name = format!("service-{}", rand::random::<u128>());
+    let config = &formatdoc! {r#"
+        [telemetry]
+        service_name = "{service_name}"
+
+        [telemetry.tracing]
+        enabled = true
+        sampling = 1
+
+        [telemetry.tracing.exporters.otlp]
+        enabled = true
+        endpoint = "http://localhost:4317"
+        protocol = "grpc"
+
+        [telemetry.tracing.exporters.otlp.batch_export]
+        scheduled_delay = 1
+        max_export_batch_size = 1
+    "#};
+
+    let schema = load_schema("big");
+    with_static_server(config, &schema, None, None, |client| async move {
+        client
+            .gql::<serde_json::Value>("query Simple { __typename }")
+            .send()
+            .await;
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let client = clickhouse::Client::default()
+            .with_url("http://localhost:8123")
+            .with_user("default")
+            .with_database("otel");
+
+        let SumMetricCountRow { value, attributes } = client
+            .query(
+                r#"
+                SELECT Value, Attributes
+                FROM otel_metrics_sum
+                WHERE ResourceAttributes['service.name'] = ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'gql_operation_count'
+                "#,
+            )
+            .bind(&service_name)
+            .fetch_one()
+            .await
+            .unwrap();
+        assert_eq!(value, 1.0);
+        assert_eq!(
+            attributes,
+            HashMap::from([
+                ("gql.operation.name".to_string(), "Simple".to_string()),
+                ("gql.operation.id".to_string(), "".to_string())
+            ])
+        );
+
+        let ExponentialHistogramRow { count, attributes } = client
+            .query(
+                r#"
+                SELECT Count, Attributes
+                FROM otel_metrics_exponential_histogram
+                WHERE ResourceAttributes['service.name'] = ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'gql_operation_latency'
+                "#,
+            )
+            .bind(&service_name)
+            .fetch_one()
+            .await
+            .unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(
+            attributes,
+            HashMap::from([
+                ("gql.operation.name".to_string(), "Simple".to_string()),
+                ("gql.operation.id".to_string(), "".to_string())
+            ])
+        );
+    });
+}


### PR DESCRIPTION
I'm refactoring the metrics removing the `tracing` integration. Now I just pass around an opentelemetry `Meter` to create the metrics, it's simpler and avoids metrics to appear in the logs.
I've also added operation metrics exposed by the engine.