### PR TITLE
fix: introspect when string literal ends in a double quote

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,31 +159,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
-name = "apollo-encoder"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee9f27b20841d14923dd5f0714a79f86360b23492d2f98ab5d1651471a56b7a4"
-dependencies = [
- "apollo-parser",
- "thiserror",
-]
-
-[[package]]
-name = "apollo-parser"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb7c8a9776825e5524b5ab3a7f478bf091a054180f244dff85814452cb87d90"
-dependencies = [
- "memchr",
- "rowan",
- "thiserror",
-]
-
-[[package]]
 name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
@@ -1264,12 +1249,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "countme"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,6 +1494,7 @@ dependencies = [
  "indexmap 2.2.6",
  "lalrpop-util",
  "logos",
+ "pretty",
 ]
 
 [[package]]
@@ -2925,10 +2905,9 @@ dependencies = [
 name = "grafbase-graphql-introspection"
 version = "0.67.2"
 dependencies = [
- "apollo-encoder",
- "apollo-parser",
  "cynic",
  "cynic-introspection",
+ "cynic-parser",
  "indoc",
  "reqwest",
  "serde",
@@ -4483,15 +4462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "miette"
 version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5752,6 +5722,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "pretty"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55c4d17d994b637e2f4daf6e5dc5d660d209d5642377d675d7a1c3ab69fa579"
+dependencies = [
+ "arrayvec 0.5.2",
+ "typed-arena",
+ "unicode-width",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6278,19 +6259,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rowan"
-version = "0.15.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a58fa8a7ccff2aec4f39cc45bf5f985cec7125ab271cf681c279fd00192b49"
-dependencies = [
- "countme",
- "hashbrown 0.14.3",
- "memoffset",
- "rustc-hash",
- "text-size",
-]
-
-[[package]]
 name = "rsa"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6424,7 +6392,7 @@ version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.4",
  "borsh",
  "bytes",
  "num-traits",
@@ -7497,12 +7465,6 @@ dependencies = [
  "rustix",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "text-size"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ chrono = { version = "0.4", default-features = false }
 ctor = "0.2"
 cynic = "3"
 cynic-introspection = "3"
+cynic-parser = "0.2"
 deadpool-postgres = "0.13"
 derive_more = "1.0.0-beta.6"
 jwt-compact = "0.8"

--- a/cli/crates/cli/tests/introspection.rs
+++ b/cli/crates/cli/tests/introspection.rs
@@ -225,34 +225,40 @@ async fn standard() {
     type Bot {
       id: ID!
     }
+
     type Header {
       name: String!
       value: String!
     }
+
     type Issue implements PullRequestOrIssue {
       title: String!
       author: UserOrBot!
     }
+
     type PullRequest implements PullRequestOrIssue {
       title: String!
       checks: [String!]!
       author: UserOrBot!
     }
+
+    interface PullRequestOrIssue {
+      title: String!
+      author: UserOrBot!
+    }
+
     type Query {
       serverVersion: String!
       pullRequestOrIssue(id: ID!): PullRequestOrIssue
       headers: [Header!]!
     }
+
     type User {
       name: String!
       email: String!
     }
-    interface PullRequestOrIssue {
-      title: String!
-      author: UserOrBot!
-    }
-    union UserOrBot = User | Bot
 
+    union UserOrBot = User | Bot
     "###);
 }
 

--- a/gateway/crates/gateway-binary/tests/integration_tests.rs
+++ b/gateway/crates/gateway-binary/tests/integration_tests.rs
@@ -443,21 +443,25 @@ fn introspect_enabled() {
         type Cart {
           products: [Product!]!
         }
+
         type Picture {
           url: String!
           width: Int!
           height: Int!
         }
+
         type Product {
           name: String!
           upc: String!
           price: Int!
           reviews: [Review!]!
         }
+
         type Query {
           me: User!
           topProducts: [Product!]!
         }
+
         type Review {
           id: ID!
           body: String!
@@ -465,9 +469,17 @@ fn introspect_enabled() {
           product: Product!
           author: User
         }
+
         type Subscription {
           newProducts: Product!
         }
+
+        enum Trustworthiness {
+          KINDA_TRUSTED
+          NOT_TRUSTED
+          REALLY_TRUSTED
+        }
+
         type User {
           id: ID!
           username: String!
@@ -477,11 +489,6 @@ fn introspect_enabled() {
           cart: Cart!
           reviews: [Review!]!
           trustworthiness: Trustworthiness!
-        }
-        enum Trustworthiness {
-          KINDA_TRUSTED
-          NOT_TRUSTED
-          REALLY_TRUSTED
         }
         "###);
     })

--- a/graphql-introspection/Cargo.toml
+++ b/graphql-introspection/Cargo.toml
@@ -15,7 +15,6 @@ indoc = "2.0.5"
 reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 cynic = { workspace = true, features = ["http-reqwest"] }
 cynic-introspection.workspace = true
+cynic-parser.workspace = true
+cynic-parser.features = ["print"]
 serde = "1.0.197"
-apollo-parser = "0.7.7"
-apollo-encoder = "0.8.0"
-

--- a/graphql-introspection/src/lib.rs
+++ b/graphql-introspection/src/lib.rs
@@ -10,10 +10,14 @@ pub async fn introspect(url: &str, headers: &[(impl AsRef<str>, impl AsRef<str>)
 }
 
 fn prettify(graphql: String) -> String {
-    let parsed = apollo_parser::Parser::new(&graphql).parse().document();
-
-    match apollo_encoder::Document::try_from(parsed) {
-        Ok(encoded) => encoded.to_string(),
-        Err(_) => graphql,
+    match cynic_parser::parse_type_system_document(&graphql) {
+        Ok(parsed) => parsed.to_sdl(),
+        Err(_) => {
+            // Don't really want to error out just because we couldn't prettify
+            // so return the original string.
+            // Definitely possible that it's broken, but at least if we return it
+            // a user can potentially fix it manually or w/e
+            graphql
+        }
     }
 }


### PR DESCRIPTION
An API we're working with contains the following directive:

```
@deprecated(reason: "Use \"urlSite\"")
```

When we run `grafbase introspect` we take whatever output we have and run it through `apollo_encoder` to prettify it.  Unfortunately `apollo_encoder` naively makes everything a block string, leading to this output:

```
@deprecated(reason: """Use "urlSite"""")
```

Note the 4 quotes on the end there.  I don't think this is valid GraphQL, I can't see any way this should parse based on the spec.

I tried to fix this by upgrading `apollo_encoder` but it turns out it's not even a thing anymore - the functionality has been rolled up into `apollo_compiler`.  I tried using this and it does fix the issue, but the output from `apollo_compiler` isn't particularly prettified:

```
newsletterSubscribe(email: String!, referer: String!, type: String!, siteOrigin: String!, sourcePage: String!, templateName: String!, ipCountry: String!, tpUuid: String!, ip: String): Boolean!
```

So, I've switched it out for `cynic-parser` which contains an actual pretty printer. My aim with that pretty printing is to replicate the output from prettier.  It's not _quite_ there yet, but it is pretty close and will get there sooner or later.  For example the above field is formatted correctly like this:

```
newsletterSubscribe(
  email: String!
  referer: String!
  type: String!
  siteOrigin: String!
  sourcePage: String!
  templateName: String!
  ipCountry: String!
  tpUuid: String!
  ip: String
): Boolean!
```