### PR TITLE
cli: return early with an error on missing schema in grafbase check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2783,7 +2783,6 @@ dependencies = [
  "async-graphql-axum",
  "async-trait",
  "async-tungstenite",
- "atty",
  "axum 0.7.5",
  "backtrace",
  "cfg-if",

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 
 [dependencies]
 assert_matches = "1"
-atty = "0.2"
 backtrace = "0.3"
 chrono = "0.4"
 clap = { version = "4", features = ["cargo", "wrap_help", "derive", "env"] }

--- a/cli/crates/cli/src/check.rs
+++ b/cli/crates/cli/src/check.rs
@@ -1,6 +1,10 @@
 use crate::{cli_input::CheckCommand, errors::CliError, report};
 use backend::api::check;
-use std::{fs, io::Read, process::Command};
+use std::{
+    fs,
+    io::{IsTerminal, Read},
+    process::Command,
+};
 
 const FAILED_CHECK_EXIT_STATUS: i32 = 1;
 
@@ -16,7 +20,7 @@ pub(crate) async fn check(command: CheckCommand) -> Result<(), CliError> {
 
     let schema = match schema {
         Some(schema) => fs::read_to_string(schema).map_err(CliError::SchemaReadError)?,
-        None if atty::is(atty::Stream::Stdin) => {
+        None if std::io::stdin().is_terminal() => {
             return Err(CliError::MissingArgument("--schema or a schema piped through stdin"))
         }
         None => {

--- a/cli/crates/cli/src/check.rs
+++ b/cli/crates/cli/src/check.rs
@@ -16,6 +16,9 @@ pub(crate) async fn check(command: CheckCommand) -> Result<(), CliError> {
 
     let schema = match schema {
         Some(schema) => fs::read_to_string(schema).map_err(CliError::SchemaReadError)?,
+        None if atty::is(atty::Stream::Stdin) => {
+            return Err(CliError::MissingArgument("--schema or a schema piped through stdin"))
+        }
         None => {
             let mut schema = String::new();
 

--- a/cli/crates/cli/src/introspect.rs
+++ b/cli/crates/cli/src/introspect.rs
@@ -1,6 +1,5 @@
-use std::io::Write;
-
 use crate::{cli_input::IntrospectCommand, errors::CliError, output::report};
+use std::io::{IsTerminal as _, Write};
 use tokio::runtime::Runtime;
 
 pub(crate) fn introspect(command: &IntrospectCommand) -> Result<(), CliError> {
@@ -48,7 +47,7 @@ fn print_introspected_schema(sdl: &str, no_color: bool) {
     let mut stdout = std::io::stdout();
 
     // No highlighting when stdout is not a tty (likely a pipe) or when explicitly requested.
-    if no_color || !atty::is(atty::Stream::Stdout) || no_color_env_var() {
+    if no_color || !std::io::stdout().is_terminal() || no_color_env_var() {
         stdout.write_all(sdl.as_bytes()).ok();
         return;
     }

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -48,7 +48,7 @@ use clap::Parser;
 use common::{analytics::Analytics, environment::Environment};
 use errors::CliError;
 use output::report;
-use std::{path::PathBuf, process};
+use std::{io::IsTerminal as _, path::PathBuf, process};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 use watercolor::ShouldColorize;
 
@@ -84,7 +84,7 @@ fn try_main(args: Args) -> Result<(), CliError> {
     trace!("subcommand: {}", args.command);
 
     // do not display header if we're in a pipe
-    if atty::is(atty::Stream::Stdout) {
+    if std::io::stdout().is_terminal() {
         report::cli_header();
     }
 

--- a/cli/crates/cli/src/publish.rs
+++ b/cli/crates/cli/src/publish.rs
@@ -1,5 +1,8 @@
 use crate::{cli_input::PublishCommand, errors::CliError, output::report};
-use std::{fs, io::Read};
+use std::{
+    fs,
+    io::{IsTerminal, Read},
+};
 
 #[tokio::main]
 pub(crate) async fn publish(
@@ -14,7 +17,7 @@ pub(crate) async fn publish(
     let project_ref = project_ref.ok_or_else(|| CliError::MissingArgument("PROJECT_REF"))?;
     let schema = match schema_path {
         Some(path) => fs::read_to_string(path).map_err(CliError::SchemaReadError)?,
-        None if atty::is(atty::Stream::Stdin) => {
+        None if std::io::stdin().is_terminal() => {
             return Err(CliError::MissingArgument("--schema or a schema piped through stdin"))
         }
         None => {


### PR DESCRIPTION
If you run grafbase check without the --schema argument, the CLI will wait for a schema from stdin, giving the impression it is hanging. Similar to what we already did for `grafbase publish`, this commit makes the CLI exit early in this situation by detecting if stdin is a tty.

Also replaces the `atty` crate in the CLI with the new `IsTerminal` trait from the standard library (thanks @obmarg for the tip).

closes GH 6494