### PR TITLE
feat: Add missing metrics for analytics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "arrayref"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +759,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.4",
+ "cc",
+ "cfg-if",
+ "constant_time_eq 0.3.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,6 +1210,12 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "core-foundation"
@@ -1977,6 +2002,7 @@ name = "engine-v2"
 version = "3.0.31"
 dependencies = [
  "async-runtime",
+ "blake3",
  "engine",
  "engine-parser",
  "engine-v2-config",
@@ -1994,6 +2020,7 @@ dependencies = [
  "im",
  "itertools 0.12.1",
  "lasso",
+ "operation-normalizer",
  "runtime",
  "serde",
  "serde-value",
@@ -2973,7 +3000,9 @@ dependencies = [
 name = "grafbase-tracing"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.0",
  "chrono",
+ "headers",
  "http 1.1.0",
  "http-body 1.0.0",
  "indoc",
@@ -8810,7 +8839,7 @@ dependencies = [
  "aes",
  "byteorder",
  "bzip2",
- "constant_time_eq",
+ "constant_time_eq 0.1.5",
  "crc32fast",
  "crossbeam-utils",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ tokio-postgres-rustls = "0.11"
 tokio-rustls = { version = "0.25", default-features = false }
 tokio-tungstenite = { version = "0.21.0", default-features = false }
 tungstenite = { version = "0.21.0", default-features = false }
+tower = "0.4"
 tower-http = "0.5"
 tower-service = "0.3"
 url = "2"

--- a/engine/crates/engine-v2/Cargo.toml
+++ b/engine/crates/engine-v2/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 
 [dependencies]
 async-runtime.workspace = true
+blake3.workspace = true
 futures-util.workspace = true
 futures.workspace = true
 hex.workspace = true
@@ -38,6 +39,7 @@ gateway-core = { path = "../gateway-core" }
 web-time.workspace = true
 
 gateway-v2-auth = { path = "../gateway-v2/auth" }
+operation-normalizer = { path = "../operation-normalizer" }
 config = { package = "engine-v2-config", path = "./config" }
 engine-parser = { path = "../engine/parser" }
 engine-value = { path = "../engine/value" }

--- a/engine/crates/engine-v2/axum/src/lib.rs
+++ b/engine/crates/engine-v2/axum/src/lib.rs
@@ -10,6 +10,7 @@ pub fn error(message: &str) -> axum::response::Response {
 
 pub fn into_response(response: HttpGraphqlResponse) -> axum::response::Response {
     let HttpGraphqlResponse { headers, body, .. } = response;
+
     match body {
         HttpGraphqlResponseBody::Bytes(bytes) => match bytes {
             OwnedOrSharedBytes::Owned(bytes) => (headers, bytes).into_response(),

--- a/engine/crates/engine-v2/src/response/mod.rs
+++ b/engine/crates/engine-v2/src/response/mod.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
 pub(crate) use error::GraphqlError;
+use grafbase_tracing::metrics::HasGraphqlErrors;
+use headers::HeaderMapExt;
 pub use key::*;
 pub use path::*;
 pub use read::*;
@@ -72,6 +74,10 @@ impl std::fmt::Debug for Response {
 
 impl From<Response> for HttpGraphqlResponse {
     fn from(response: Response) -> Self {
-        HttpGraphqlResponse::from_json(&response)
+        let mut resp = HttpGraphqlResponse::from_json(&response);
+        if response.has_errors() {
+            resp.headers.typed_insert(HasGraphqlErrors);
+        }
+        resp
     }
 }

--- a/engine/crates/engine/src/schema.rs
+++ b/engine/crates/engine/src/schema.rs
@@ -607,8 +607,7 @@ impl Schema {
             });
         });
 
-        let request = request.instrument(gql_span);
-        request.await
+        request.instrument(gql_span).await
     }
 
     /// Execute a GraphQL batch query.

--- a/engine/crates/integration-tests/tests/tracing/v1.rs
+++ b/engine/crates/integration-tests/tests/tracing/v1.rs
@@ -48,10 +48,7 @@ async fn query() {
         .with_filter(|meta| meta.is_span() && meta.target() == "grafbase" && *meta.level() >= Level::INFO)
         .new_span(span.clone())
         .enter(span.clone())
-        .record(
-            span.clone(),
-            expect::field("gql.request.operation.type").with_value(&"query"),
-        )
+        .record(span.clone(), expect::field("gql.operation.type").with_value(&"query"))
         .new_span(
             resolver_span
                 .clone()
@@ -92,11 +89,11 @@ async fn query_named() {
         .enter(graphql_span.clone())
         .record(
             graphql_span.clone(),
-            expect::field("gql.request.operation.name").with_value(&"Named"),
+            expect::field("gql.operation.name").with_value(&"Named"),
         )
         .record(
             graphql_span.clone(),
-            expect::field("gql.request.operation.type").with_value(&"query"),
+            expect::field("gql.operation.type").with_value(&"query"),
         )
         .new_span(
             resolver_span
@@ -205,10 +202,7 @@ async fn resolvers_with_error() {
         .with_filter(|meta| meta.is_span() && meta.target() == "grafbase" && *meta.level() >= Level::INFO)
         .new_span(span.clone())
         .enter(span.clone())
-        .record(
-            span.clone(),
-            expect::field("gql.request.operation.type").with_value(&"query"),
-        )
+        .record(span.clone(), expect::field("gql.operation.type").with_value(&"query"))
         .new_span(
             resolver_span_error
                 .clone()

--- a/engine/crates/integration-tests/tests/tracing/v2.rs
+++ b/engine/crates/integration-tests/tests/tracing/v2.rs
@@ -50,11 +50,11 @@ fn query_named() {
             .enter(graphql_span.clone())
             .record(
                 graphql_span.clone(),
-                expect::field("gql.request.operation.name").with_value(&"Named"),
+                expect::field("gql.operation.name").with_value(&"Named"),
             )
             .record(
                 graphql_span.clone(),
-                expect::field("gql.request.operation.type").with_value(&"query"),
+                expect::field("gql.operation.type").with_value(&"query"),
             )
             .new_span(
                 subgraphql_span
@@ -104,13 +104,10 @@ fn subscription() {
         let (subscriber, handle) = subscriber::mock()
             .with_filter(|meta| meta.is_span() && meta.target() == "grafbase" && *meta.level() >= Level::INFO)
             .enter(span.clone())
+            .record(span.clone(), expect::field("gql.operation.name").with_value(&"Sub"))
             .record(
                 span.clone(),
-                expect::field("gql.request.operation.name").with_value(&"Sub"),
-            )
-            .record(
-                span.clone(),
-                expect::field("gql.request.operation.type").with_value(&"subscription"),
+                expect::field("gql.operation.type").with_value(&"subscription"),
             )
             .run_with_handle();
 

--- a/engine/crates/tracing/Cargo.toml
+++ b/engine/crates/tracing/Cargo.toml
@@ -12,15 +12,17 @@ keywords = ["tracing", "grafbase"]
 workspace = true
 
 [dependencies]
-chrono = "0.4"
+chrono.workspace = true
+base64.workspace = true
 http.workspace = true
 http-body = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-thiserror = "1.0"
+serde.workspace = true
+thiserror.workspace = true
 tonic = { version = "0.11.0", optional = true }
-tower-http = { version = "0.5", optional = true, features = ["trace"] }
-url = { version = "2.5", features = ["serde"] }
-worker = { version = "0.1.0", optional = true }
+tower-http = { workspace = true, optional = true, features = ["trace"] }
+url = { workspace = true, features = ["serde"] }
+worker = { workspace = true, optional = true }
+headers.workspace = true
 
 # tracing
 tracing.workspace = true
@@ -33,7 +35,7 @@ opentelemetry-otlp = { version = "0.15" , features = ["grpc-tonic", "tls", "toni
 
 [features]
 default = []
-tower = ["tower-http"]
+tower = ["dep:tower-http"]
 otlp = ["dep:opentelemetry-otlp", "dep:tonic"]
 worker = ["dep:worker"]
 lambda = []

--- a/engine/crates/tracing/src/metrics/mod.rs
+++ b/engine/crates/tracing/src/metrics/mod.rs
@@ -1,16 +1,19 @@
 mod operation;
 mod request;
 
+use std::borrow::Cow;
+
 use opentelemetry::metrics::{Meter, MeterProvider};
 pub use operation::*;
 pub use request::*;
 
 const SCOPE: &str = "grafbase";
+const SCOPE_VERSION: &str = "1.0";
 
 pub fn meter_from_global_provider() -> Meter {
     meter(opentelemetry::global::meter_provider())
 }
 
 pub fn meter(provider: impl MeterProvider) -> Meter {
-    provider.meter(SCOPE)
+    provider.versioned_meter(SCOPE, Some(SCOPE_VERSION), None::<Cow<'static, str>>, None)
 }

--- a/engine/crates/tracing/src/metrics/request.rs
+++ b/engine/crates/tracing/src/metrics/request.rs
@@ -3,6 +3,37 @@ use opentelemetry::{
     KeyValue,
 };
 
+static X_GRAFBASE_HAS_GRAPHQL_ERRORS: http::HeaderName = http::HeaderName::from_static("x-grafbase-graphql-errors");
+
+pub struct HasGraphqlErrors;
+
+impl HasGraphqlErrors {
+    pub fn header_name() -> &'static http::HeaderName {
+        &X_GRAFBASE_HAS_GRAPHQL_ERRORS
+    }
+}
+
+impl headers::Header for HasGraphqlErrors {
+    fn name() -> &'static http::HeaderName {
+        &X_GRAFBASE_HAS_GRAPHQL_ERRORS
+    }
+
+    fn decode<'i, I>(values: &mut I) -> Result<Self, headers::Error>
+    where
+        Self: Sized,
+        I: Iterator<Item = &'i http::HeaderValue>,
+    {
+        values
+            .next()
+            .map(|_| HasGraphqlErrors)
+            .ok_or_else(headers::Error::invalid)
+    }
+
+    fn encode<E: Extend<http::HeaderValue>>(&self, values: &mut E) {
+        values.extend(Some(http::HeaderValue::from_static("t")))
+    }
+}
+
 #[derive(Clone)]
 pub struct RequestMetrics {
     count: Counter<u64>,
@@ -12,6 +43,7 @@ pub struct RequestMetrics {
 pub struct RequestMetricsAttributes {
     pub status_code: u16,
     pub cache_status: Option<String>,
+    pub has_graphql_errors: bool,
 }
 
 impl RequestMetrics {
@@ -27,12 +59,16 @@ impl RequestMetrics {
         RequestMetricsAttributes {
             status_code,
             cache_status,
+            has_graphql_errors,
         }: RequestMetricsAttributes,
         latency: std::time::Duration,
     ) {
         let mut attributes = vec![KeyValue::new("http.response.status_code", status_code as i64)];
         if let Some(cache_status) = cache_status {
             attributes.push(KeyValue::new("http.response.headers.cache_status", cache_status));
+        }
+        if has_graphql_errors {
+            attributes.push(KeyValue::new("gql.response.has_errors", "true"));
         }
         self.count.add(1, &attributes);
         self.latency.record(latency.as_millis() as u64, &[]);

--- a/engine/crates/tracing/src/otel/layer.rs
+++ b/engine/crates/tracing/src/otel/layer.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use opentelemetry::trace::noop::NoopTracer;
 use opentelemetry::trace::TracerProvider;
 use opentelemetry::KeyValue;
@@ -73,7 +75,12 @@ where
 
     let tracing_layer = if config.enabled {
         let tracer_provider = super::traces::create(config, id_generator, runtime, resource.clone())?;
-        let tracer = tracer_provider.tracer("batched-otel");
+        let tracer = tracer_provider.versioned_tracer(
+            crate::span::SCOPE,
+            Some(crate::span::SCOPE_VERSION),
+            None::<Cow<'static, str>>,
+            None,
+        );
         let tracer_layer = tracing_opentelemetry::layer().with_tracer(tracer).boxed();
         let (tracer_layer, tracer_layer_reload_handle) = reload::Layer::new(tracer_layer);
 

--- a/engine/crates/tracing/src/span.rs
+++ b/engine/crates/tracing/src/span.rs
@@ -3,6 +3,8 @@ use http_body::Body;
 
 /// Tracing target for logging
 pub const GRAFBASE_TARGET: &str = "grafbase";
+pub(crate) const SCOPE: &str = "grafbase";
+pub(crate) const SCOPE_VERSION: &str = "1.0";
 
 /// Cache span
 pub mod cache;

--- a/engine/crates/tracing/src/span/gql.rs
+++ b/engine/crates/tracing/src/span/gql.rs
@@ -52,8 +52,8 @@ impl<'a> GqlRequestSpan<'a> {
         info_span!(
             target: crate::span::GRAFBASE_TARGET,
             GRAPHQL_SPAN_NAME,
-            "gql.request.operation.name" = self.operation_name,
-            "gql.request.operation.type" = self.operation_type,
+            "gql.operation.name" = self.operation_name,
+            "gql.operation.type" = self.operation_type,
             "gql.response.has_errors" = self.has_errors,
             "gql.document" = self.document,
         )
@@ -63,9 +63,9 @@ impl<'a> GqlRequestSpan<'a> {
 impl GqlRecorderSpanExt for Span {
     fn record_gql_request(&self, attributes: GqlRequestAttributes<'_>) {
         if let Some(name) = attributes.operation_name {
-            self.record("gql.request.operation.name", name);
+            self.record("gql.operation.name", name);
         }
-        self.record("gql.request.operation.type", attributes.operation_type);
+        self.record("gql.operation.type", attributes.operation_type);
     }
 
     fn record_gql_response(&self, attributes: GqlResponseAttributes) {

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -50,7 +50,7 @@ itertools.workspace = true
 
 # Lambda dependencies
 axum-aws-lambda = { version = "0.7.0", optional = true }
-tower = { version = "0.4.13", optional = true }
+tower = { workspace = true, optional = true }
 lambda_http = { version = "0.11.1", optional = true }
 
 [dev-dependencies]

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -36,7 +36,7 @@ cfg-if = "1.0.0"
 workspace = true
 
 [dev-dependencies]
-clickhouse = "0.11"
+clickhouse = { version = "0.11" }
 ctor.workspace = true
 duct = "0.13.7"
 fslock = "0.2.1"

--- a/gateway/crates/gateway-binary/docker-compose.yml
+++ b/gateway/crates/gateway-binary/docker-compose.yml
@@ -8,8 +8,7 @@ services:
     volumes:
       - ./data/otel/otel-collector-config.yml:/etc/otel-collector-config.yml
     ports:
-      - '13133:13133' # health_check extension
-      - '4317:4317'
+      - '4318:4317'
     depends_on:
       - clickhouse
     networks:
@@ -24,8 +23,8 @@ services:
     restart: unless-stopped
     image: clickhouse/clickhouse-server:latest
     ports:
-      - '9000:9000'
-      - '8123:8123'
+      - '9001:9000'
+      - '8124:8123'
     networks:
       - otel-clickhouse
 

--- a/gateway/crates/gateway-binary/tests/telemetry/metrics.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/metrics.rs
@@ -1,9 +1,17 @@
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::BTreeMap,
+    sync::Arc,
+    time::{Duration, UNIX_EPOCH},
+};
 
+use futures_util::Future;
 use indoc::formatdoc;
 use serde::Deserialize;
 
-use crate::{load_schema, with_static_server};
+use crate::{load_schema, with_static_server, Client};
+
+mod operation;
+mod request;
 
 #[serde_with::serde_as]
 #[derive(clickhouse::Row, Deserialize)]
@@ -12,7 +20,7 @@ struct SumMetricCountRow {
     value: f64,
     #[serde(rename = "Attributes")]
     #[serde_as(as = "Vec<(_, _)>")]
-    attributes: HashMap<String, String>,
+    attributes: BTreeMap<String, String>,
 }
 
 #[serde_with::serde_as]
@@ -22,12 +30,15 @@ struct ExponentialHistogramRow {
     count: u64,
     #[serde(rename = "Attributes")]
     #[serde_as(as = "Vec<(_, _)>")]
-    attributes: HashMap<String, String>,
+    attributes: BTreeMap<String, String>,
 }
 
-#[test]
-fn request_metrics() {
-    let service_name = format!("service-{}", rand::random::<u128>());
+fn with_gateway<T, F>(test: T)
+where
+    T: FnOnce(String, u64, Arc<Client>, clickhouse::Client) -> F,
+    F: Future<Output = ()>,
+{
+    let service_name = format!("service_{}", ulid::Ulid::new());
     let config = &formatdoc! {r#"
         [telemetry]
         service_name = "{service_name}"
@@ -38,7 +49,7 @@ fn request_metrics() {
 
         [telemetry.tracing.exporters.otlp]
         enabled = true
-        endpoint = "http://localhost:4317"
+        endpoint = "http://localhost:4318"
         protocol = "grpc"
 
         [telemetry.tracing.exporters.otlp.batch_export]
@@ -47,134 +58,21 @@ fn request_metrics() {
     "#};
 
     let schema = load_schema("big");
-    with_static_server(config, &schema, None, None, |client| async move {
-        client.gql::<serde_json::Value>("{ __typename }").send().await;
+    let clickhouse = clickhouse::Client::default()
+        .with_url("http://localhost:8124")
+        .with_user("default")
+        .with_database("otel");
 
+    println!("service_name: {}", service_name);
+    with_static_server(config, &schema, None, None, |client| async move {
+        let start = std::time::SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        // wait for initial polling to be pushed
         tokio::time::sleep(Duration::from_secs(2)).await;
 
-        let client = clickhouse::Client::default()
-            .with_url("http://localhost:8123")
-            .with_user("default")
-            .with_database("otel");
-
-        let SumMetricCountRow { value, attributes } = client
-            .query(
-                r#"
-                SELECT Value, Attributes
-                FROM otel_metrics_sum
-                WHERE ResourceAttributes['service.name'] = ?
-                    AND ScopeName = 'grafbase'
-                    AND MetricName = 'request_count'
-                "#,
-            )
-            .bind(&service_name)
-            .fetch_one()
-            .await
-            .unwrap();
-        assert!(value >= 1.0); // initial polling also counts
-        assert_eq!(
-            attributes,
-            HashMap::from([("http.response.status_code".to_string(), "200".to_string())])
-        );
-
-        let ExponentialHistogramRow { count, attributes } = client
-            .query(
-                r#"
-                SELECT Count, Attributes
-                FROM otel_metrics_exponential_histogram
-                WHERE ResourceAttributes['service.name'] = ?
-                    AND ScopeName = 'grafbase'
-                    AND MetricName = 'request_latency'
-                "#,
-            )
-            .bind(&service_name)
-            .fetch_one()
-            .await
-            .unwrap();
-        assert!(count >= 1); // Initial polling also counts
-        assert_eq!(attributes, HashMap::new())
-    });
-}
-
-#[test]
-fn operation_metrics() {
-    let service_name = format!("service-{}", rand::random::<u128>());
-    let config = &formatdoc! {r#"
-        [telemetry]
-        service_name = "{service_name}"
-
-        [telemetry.tracing]
-        enabled = true
-        sampling = 1
-
-        [telemetry.tracing.exporters.otlp]
-        enabled = true
-        endpoint = "http://localhost:4317"
-        protocol = "grpc"
-
-        [telemetry.tracing.exporters.otlp.batch_export]
-        scheduled_delay = 1
-        max_export_batch_size = 1
-    "#};
-
-    let schema = load_schema("big");
-    with_static_server(config, &schema, None, None, |client| async move {
-        client
-            .gql::<serde_json::Value>("query Simple { __typename }")
-            .send()
-            .await;
-
-        tokio::time::sleep(Duration::from_secs(2)).await;
-
-        let client = clickhouse::Client::default()
-            .with_url("http://localhost:8123")
-            .with_user("default")
-            .with_database("otel");
-
-        let SumMetricCountRow { value, attributes } = client
-            .query(
-                r#"
-                SELECT Value, Attributes
-                FROM otel_metrics_sum
-                WHERE ResourceAttributes['service.name'] = ?
-                    AND ScopeName = 'grafbase'
-                    AND MetricName = 'gql_operation_count'
-                "#,
-            )
-            .bind(&service_name)
-            .fetch_one()
-            .await
-            .unwrap();
-        assert_eq!(value, 1.0);
-        assert_eq!(
-            attributes,
-            HashMap::from([
-                ("gql.operation.name".to_string(), "Simple".to_string()),
-                ("gql.operation.id".to_string(), "".to_string())
-            ])
-        );
-
-        let ExponentialHistogramRow { count, attributes } = client
-            .query(
-                r#"
-                SELECT Count, Attributes
-                FROM otel_metrics_exponential_histogram
-                WHERE ResourceAttributes['service.name'] = ?
-                    AND ScopeName = 'grafbase'
-                    AND MetricName = 'gql_operation_latency'
-                "#,
-            )
-            .bind(&service_name)
-            .fetch_one()
-            .await
-            .unwrap();
-        assert_eq!(count, 1);
-        assert_eq!(
-            attributes,
-            HashMap::from([
-                ("gql.operation.name".to_string(), "Simple".to_string()),
-                ("gql.operation.id".to_string(), "".to_string())
-            ])
-        );
-    });
+        test(service_name, start, client, clickhouse).await
+    })
 }

--- a/gateway/crates/gateway-binary/tests/telemetry/metrics/operation.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/metrics/operation.rs
@@ -1,0 +1,120 @@
+use std::time::Duration;
+
+use super::{with_gateway, ExponentialHistogramRow, SumMetricCountRow};
+
+#[test]
+fn basic() {
+    with_gateway(|service_name, start_time_unix, gateway, clickhouse| async move {
+        gateway
+            .gql::<serde_json::Value>("query Simple { __typename }")
+            .send()
+            .await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let SumMetricCountRow { value, attributes } = clickhouse
+            .query(
+                r#"
+                SELECT Value, Attributes
+                FROM otel_metrics_sum
+                WHERE ServiceName = ? AND StartTimeUnix >= ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'gql_operation_count'
+                "#,
+            )
+            .bind(&service_name)
+            .bind(start_time_unix)
+            .fetch_one()
+            .await
+            .unwrap();
+        assert_eq!(value, 1.0);
+        insta::assert_json_snapshot!(attributes, @r###"
+        {
+          "gql.operation.name": "Simple",
+          "gql.operation.normalized_query_hash": "cAe1+tBRHQLrF/EO1ul4CTx+q5SB9YD+YtG3VDU6VCM="
+        }
+        "###);
+        let ExponentialHistogramRow { count, attributes } = clickhouse
+            .query(
+                r#"
+                SELECT Count, Attributes
+                FROM otel_metrics_exponential_histogram
+                WHERE ServiceName = ? AND StartTimeUnix >= ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'gql_operation_latency'
+                "#,
+            )
+            .bind(&service_name)
+            .bind(start_time_unix)
+            .fetch_one()
+            .await
+            .unwrap();
+        assert_eq!(count, 1);
+        insta::assert_json_snapshot!(attributes, @r###"
+        {
+          "gql.operation.name": "Simple",
+          "gql.operation.normalized_query": "query Simple {\n  __typename\n}\n",
+          "gql.operation.normalized_query_hash": "cAe1+tBRHQLrF/EO1ul4CTx+q5SB9YD+YtG3VDU6VCM=",
+          "gql.operation.type": "query"
+        }
+        "###);
+    });
+}
+
+#[test]
+fn has_error() {
+    with_gateway(|service_name, start_time_unix, gateway, clickhouse| async move {
+        gateway
+            .gql::<serde_json::Value>("query Simple { me { id } }")
+            .send()
+            .await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let SumMetricCountRow { value, attributes } = clickhouse
+            .query(
+                r#"
+                SELECT Value, Attributes
+                FROM otel_metrics_sum
+                WHERE ServiceName = ? AND StartTimeUnix >= ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'gql_operation_count'
+                "#,
+            )
+            .bind(&service_name)
+            .bind(start_time_unix)
+            .fetch_one()
+            .await
+            .unwrap();
+        assert_eq!(value, 1.0);
+        insta::assert_json_snapshot!(attributes, @r###"
+        {
+          "gql.operation.name": "Simple",
+          "gql.operation.normalized_query_hash": "3Dn7H9sNlA2O2Wphw0R6wK0BiqcdP4oRlTiq0Ifq09M=",
+          "gql.response.has_errors": "true"
+        }
+        "###);
+        let ExponentialHistogramRow { count, attributes } = clickhouse
+            .query(
+                r#"
+                SELECT Count, Attributes
+                FROM otel_metrics_exponential_histogram
+                WHERE ServiceName = ? AND StartTimeUnix >= ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'gql_operation_latency'
+                "#,
+            )
+            .bind(&service_name)
+            .bind(start_time_unix)
+            .fetch_one()
+            .await
+            .unwrap();
+        assert_eq!(count, 1);
+        insta::assert_json_snapshot!(attributes, @r###"
+        {
+          "gql.operation.name": "Simple",
+          "gql.operation.normalized_query": "query Simple {\n  me {\n    id\n  }\n}\n",
+          "gql.operation.normalized_query_hash": "3Dn7H9sNlA2O2Wphw0R6wK0BiqcdP4oRlTiq0Ifq09M=",
+          "gql.operation.type": "query"
+        }
+        "###);
+    });
+}

--- a/gateway/crates/gateway-binary/tests/telemetry/metrics/request.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/metrics/request.rs
@@ -1,0 +1,129 @@
+use std::time::Duration;
+
+use super::{with_gateway, ExponentialHistogramRow, SumMetricCountRow};
+
+#[test]
+fn basic() {
+    with_gateway(|service_name, start_time_unix, gateway, clickhouse| async move {
+        gateway.gql::<serde_json::Value>("{ __typename }").send().await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let SumMetricCountRow { value, attributes } = clickhouse
+            .query(
+                r#"
+                SELECT Value, Attributes
+                FROM otel_metrics_sum
+                WHERE ServiceName = ? AND StartTimeUnix >= ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'request_count'
+                    AND Attributes['gql.response.has_errors'] = ''
+                "#,
+            )
+            .bind(&service_name)
+            .bind(start_time_unix)
+            .fetch_one()
+            .await
+            .unwrap();
+        assert_eq!(value, 1.0);
+        insta::assert_json_snapshot!(attributes, @r###"
+        {
+          "http.response.status_code": "200"
+        }
+        "###);
+        let ExponentialHistogramRow { count, attributes } = clickhouse
+            .query(
+                r#"
+                SELECT Count, Attributes
+                FROM otel_metrics_exponential_histogram
+                WHERE ServiceName = ? AND StartTimeUnix >= ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'request_latency'
+                "#,
+            )
+            .bind(&service_name)
+            .bind(start_time_unix)
+            .fetch_one()
+            .await
+            .unwrap();
+        assert_eq!(count, 1); // Initial polling also counts
+        insta::assert_json_snapshot!(attributes, @"{}");
+
+        gateway.gql::<serde_json::Value>("{ __typ__ename }").send().await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let SumMetricCountRow { value, attributes } = clickhouse
+            .query(
+                r#"
+                SELECT Value, Attributes
+                FROM otel_metrics_sum
+                WHERE ServiceName = ? AND StartTimeUnix >= ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'request_count'
+                    AND Attributes['gql.response.has_errors'] = 'true'
+                "#,
+            )
+            .bind(&service_name)
+            .bind(start_time_unix)
+            .fetch_one()
+            .await
+            .unwrap();
+        assert_eq!(value, 1.0);
+        insta::assert_json_snapshot!(attributes, @r###"
+        {
+          "gql.response.has_errors": "true",
+          "http.response.status_code": "200"
+        }
+        "###);
+    });
+}
+
+#[test]
+fn has_error() {
+    with_gateway(|service_name, start_time_unix, gateway, clickhouse| async move {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        gateway.gql::<serde_json::Value>("{ __typ__ename }").send().await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let SumMetricCountRow { value, attributes } = clickhouse
+            .query(
+                r#"
+                SELECT Value, Attributes
+                FROM otel_metrics_sum
+                WHERE ServiceName = ? AND StartTimeUnix >= ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'request_count'
+                    AND Attributes['gql.response.has_errors'] = 'true'
+                "#,
+            )
+            .bind(&service_name)
+            .bind(start_time_unix)
+            .fetch_one()
+            .await
+            .unwrap();
+        assert!(value >= 1.0); // Initial polling also counts
+        insta::assert_json_snapshot!(attributes, @r###"
+        {
+          "gql.response.has_errors": "true",
+          "http.response.status_code": "200"
+        }
+        "###);
+        let ExponentialHistogramRow { count, attributes } = clickhouse
+            .query(
+                r#"
+                SELECT Count, Attributes
+                FROM otel_metrics_exponential_histogram
+                WHERE ServiceName = ? AND StartTimeUnix >= ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'request_latency'
+                "#,
+            )
+            .bind(&service_name)
+            .bind(start_time_unix)
+            .fetch_one()
+            .await
+            .unwrap();
+        assert!(count >= 1); // Initial polling also counts
+        insta::assert_json_snapshot!(attributes, @"{}");
+    });
+}

--- a/gateway/crates/gateway-binary/tests/telemetry/mod.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/mod.rs
@@ -54,7 +54,7 @@ fn with_otel() {
 
         [telemetry.tracing.exporters.otlp]
         enabled = true
-        endpoint = "http://localhost:4317"
+        endpoint = "http://localhost:4318"
         protocol = "grpc"
 
         [telemetry.tracing.exporters.otlp.batch_export]
@@ -75,7 +75,7 @@ fn with_otel() {
         tokio::time::sleep(Duration::from_secs(2)).await;
 
         let client = clickhouse::Client::default()
-            .with_url("http://localhost:8123")
+            .with_url("http://localhost:8124")
             .with_user("default")
             .with_database("otel");
 
@@ -120,7 +120,7 @@ fn extra_resource_attributes() {
 
         [telemetry.tracing.exporters.otlp]
         enabled = true
-        endpoint = "http://localhost:4317"
+        endpoint = "http://localhost:4318"
         protocol = "grpc"
 
         [telemetry.tracing.exporters.otlp.batch_export]
@@ -141,7 +141,7 @@ fn extra_resource_attributes() {
         tokio::time::sleep(Duration::from_secs(2)).await;
 
         let client = clickhouse::Client::default()
-            .with_url("http://localhost:8123")
+            .with_url("http://localhost:8124")
             .with_user("default")
             .with_database("otel");
 
@@ -186,7 +186,7 @@ fn with_otel_reload_tracing() {
 
         [telemetry.tracing.exporters.otlp]
         enabled = true
-        endpoint = "http://localhost:4317"
+        endpoint = "http://localhost:4318"
         protocol = "grpc"
 
         [telemetry.tracing.exporters.otlp.batch_export]
@@ -205,7 +205,7 @@ fn with_otel_reload_tracing() {
         serde_json::to_string_pretty(&result).unwrap();
 
         let client = clickhouse::Client::default()
-            .with_url("http://localhost:8123")
+            .with_url("http://localhost:8124")
             .with_user("default")
             .with_database("otel");
 


### PR DESCRIPTION
Adding missing metrics to rebuild analytics

- for overall analytics graphql errors, I'm propagating back through a header whether the operation had an error or not. The tracing layer detects the presence of this header and the one after removes it. Couldn't figure out how to merge those into a single layer without going insane with the types.
- renaming `gql.request.operation.*` attributes to `gql.operation.*` because it's just shorter and also in traces for consistency
- Using a versioned meter & tracer (`1.0`) and setting traces scope to `grafbase` instead of `batch-otel` like metrics.
- Adding `normalized_query` & `normalized_query_hash` in metrics the same way we do in workers today. We can be more efficient, but it is what is for now. 