### PR TITLE
graphql-schema-diff: replace async-graphql-parser with cynic-parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "cynic-parser"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9306566c789ca3191dc025f2d25333a16880ad70e04cfd099071cba26d5aa78e"
+checksum = "46ee97b80d5b3a4957644122b5d467b38fd35dd9ba4e8e65ff1b3ac6ae784fe3"
 dependencies = [
  "indexmap 2.2.6",
  "lalrpop-util",
@@ -3155,8 +3155,7 @@ dependencies = [
 name = "graphql-schema-diff"
 version = "0.1.1"
 dependencies = [
- "async-graphql-parser",
- "async-graphql-value",
+ "cynic-parser",
  "datatest-stable",
  "miette 7.2.0",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "cynic-parser"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ee97b80d5b3a4957644122b5d467b38fd35dd9ba4e8e65ff1b3ac6ae784fe3"
+checksum = "411ab40d3f72ca1442d50a60e572838e5a2f0719b93a77a29647117ffdf67687"
 dependencies = [
  "indexmap 2.2.6",
  "lalrpop-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ chrono = { version = "0.4", default-features = false }
 ctor = "0.2"
 cynic = "3"
 cynic-introspection = "3"
-cynic-parser = "0.2"
+cynic-parser = "0.2.5"
 deadpool-postgres = "0.13"
 derive_more = "1.0.0-beta.6"
 jwt-compact = "0.8"

--- a/engine/crates/graphql-schema-diff/Cargo.toml
+++ b/engine/crates/graphql-schema-diff/Cargo.toml
@@ -9,8 +9,7 @@ keywords = ["graphql"]
 repository = "https://github.com/grafbase/grafbase/tree/main/engine/crates/graphql-schema-diff"
 
 [dependencies]
-async-graphql-parser.workspace = true
-async-graphql-value.workspace = true
+cynic-parser.workspace = true
 serde = { workspace = true, optional = true, features = ["derive"] }
 
 [features]

--- a/engine/crates/graphql-schema-diff/src/lib.rs
+++ b/engine/crates/graphql-schema-diff/src/lib.rs
@@ -9,17 +9,16 @@ mod traverse_schemas;
 pub use change::{Change, ChangeKind};
 
 use self::state::*;
-use async_graphql_parser::{types as ast, Positioned};
-use async_graphql_value::ConstValue;
+use cynic_parser::type_system as ast;
 use std::collections::HashMap;
 
 /// Diff two GraphQL schemas.
-pub fn diff(source: &str, target: &str) -> Result<Vec<Change>, async_graphql_parser::Error> {
-    let [source, target] = [source, target].map(|sdl| -> Result<_, async_graphql_parser::Error> {
+pub fn diff(source: &str, target: &str) -> Result<Vec<Change>, cynic_parser::Error> {
+    let [source, target] = [source, target].map(|sdl| -> Result<_, cynic_parser::Error> {
         if sdl.trim().is_empty() {
             Ok(None)
         } else {
-            Ok(Some(async_graphql_parser::parse_schema(sdl)?))
+            Ok(Some(cynic_parser::parse_type_system_document(sdl)?))
         }
     });
     let [source, target] = [source?, target?];

--- a/engine/crates/graphql-schema-diff/src/state.rs
+++ b/engine/crates/graphql-schema-diff/src/state.rs
@@ -272,18 +272,7 @@ fn opt_type_eq(a: Option<&ast::Type<'_>>, b: Option<&ast::Type<'_>>) -> bool {
 }
 
 fn type_eq(a: &ast::Type<'_>, b: &ast::Type<'_>) -> bool {
-    if a.name() != b.name() {
-        return false;
-    }
-
-    let mut a_wrappers = a.wrappers();
-    let mut b_wrappers = b.wrappers();
-
-    if (&mut a_wrappers).zip(&mut b_wrappers).any(|(a, b)| a != b) {
-        return false;
-    }
-
-    a_wrappers.next().is_none() && b_wrappers.next().is_none()
+    a.name() == b.name() && a.wrappers().eq(b.wrappers())
 }
 
 fn value_eq(a: &ast::Value<'_>, b: &ast::Value<'_>) -> bool {
@@ -297,7 +286,7 @@ fn value_eq(a: &ast::Value<'_>, b: &ast::Value<'_>) -> bool {
         (ast::Value::BlockString(a), ast::Value::String(b)) => a == b,
         (ast::Value::BlockString(a), ast::Value::BlockString(b)) => a == b,
         (ast::Value::Boolean(a), ast::Value::Boolean(b)) => a == b,
-        (ast::Value::Null, ast::Value::Null) => todo!(),
+        (ast::Value::Null, ast::Value::Null) => true,
         (ast::Value::Enum(a), ast::Value::Enum(b)) => a == b,
         (ast::Value::List(a), ast::Value::List(b)) => {
             a.len() == b.len() && a.iter().zip(b.iter()).all(|(a, b)| value_eq(a, b))

--- a/engine/crates/graphql-schema-diff/tests/diff/field_wrapping_type_changes.graphql
+++ b/engine/crates/graphql-schema-diff/tests/diff/field_wrapping_type_changes.graphql
@@ -1,0 +1,13 @@
+scalar Date
+
+type Mutation {
+  isTuesday(lat: Float, lon: Float, exceptions: [Date]): Boolean
+}
+
+# --- #
+
+scalar Date
+
+type Mutation {
+  isTuesday(lat: Float!, lon: Float!, exceptions: [[Date]]): Boolean!
+}

--- a/engine/crates/graphql-schema-diff/tests/diff/field_wrapping_type_changes.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/field_wrapping_type_changes.snapshot.json
@@ -1,0 +1,38 @@
+{
+  "src → target": [
+    {
+      "path": "Mutation.isTuesday",
+      "kind": "ChangeFieldType"
+    },
+    {
+      "path": "Mutation.isTuesday.exceptions",
+      "kind": "ChangeFieldArgumentType"
+    },
+    {
+      "path": "Mutation.isTuesday.lat",
+      "kind": "ChangeFieldArgumentType"
+    },
+    {
+      "path": "Mutation.isTuesday.lon",
+      "kind": "ChangeFieldArgumentType"
+    }
+  ],
+  "target → src": [
+    {
+      "path": "Mutation.isTuesday",
+      "kind": "ChangeFieldType"
+    },
+    {
+      "path": "Mutation.isTuesday.exceptions",
+      "kind": "ChangeFieldArgumentType"
+    },
+    {
+      "path": "Mutation.isTuesday.lat",
+      "kind": "ChangeFieldArgumentType"
+    },
+    {
+      "path": "Mutation.isTuesday.lon",
+      "kind": "ChangeFieldArgumentType"
+    }
+  ]
+}

--- a/engine/crates/graphql-schema-diff/tests/diff/schema_definition_basic.graphql
+++ b/engine/crates/graphql-schema-diff/tests/diff/schema_definition_basic.graphql
@@ -1,7 +1,11 @@
 extend schema @tag
 
-type Query
+type Query {
+  a: String!
+}
 
 # --- #
 
-type Query
+type Query {
+  a: String!
+}


### PR DESCRIPTION
The main reason is that we are dealing with large GraphQL schemas where async-graphql-parser blows up in size and memory usage in production. cynic-parser doesn't.

The other main reason is that cynic-parser has a much nicer API and sounder foundations to build on.

closes GB-6465