### PR TITLE
fix: hide access token env value from gateway help page (if set)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.2.1] - 2024-04-16
+
+[CHANGELOG](changelog/0.2.1.md)
+
 ## [0.2.0] - 2024-03-28
 
 [CHANGELOG](changelog/0.2.0.md)

--- a/gateway/changelog/0.2.1.md
+++ b/gateway/changelog/0.2.1.md
@@ -1,0 +1,5 @@
+### Fixes
+
+- Hide the access token environment variable from help screen, if set.
+- Add authenticated & requiredScopes support
+- Remove query from the tracing spans

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/src/args.rs
+++ b/gateway/crates/gateway-binary/src/args.rs
@@ -26,7 +26,7 @@ pub struct Args {
     pub graph_ref: Option<GraphRef>,
     /// An access token to the Grafbase API. The scope must allow operations on the given account,
     /// and graph defined in the graph-ref argument.
-    #[arg(env = "GRAFBASE_ACCESS_TOKEN")]
+    #[arg(env = "GRAFBASE_ACCESS_TOKEN", hide_env_values(true))]
     pub grafbase_access_token: Option<AsciiString>,
     /// Path to the TOML configuration file
     #[arg(long, short, env = "GRAFBASE_CONFIG_PATH", default_value = "./grafbase.toml")]


### PR DESCRIPTION
closes GB-6496
