### PR TITLE
engine-v1: introspect data sources concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2965,6 +2965,7 @@ dependencies = [
  "axum 0.7.5",
  "common-types",
  "const_format",
+ "criterion",
  "dotenv",
  "engine",
  "federated-dev",

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -71,8 +71,13 @@ common-types = { path = "../../../engine/crates/common-types" }
 
 [dev-dependencies]
 serde_json = "1"
+criterion = { version = "0.5" }
 
 [build-dependencies]
 flate2 = { version = "1", features = ["zlib"] }
 tar.workspace = true
 tempfile = "3"
+
+[[bench]]
+name = "parse_sdl_benchmark"
+harness = false

--- a/cli/crates/server/benches/parse_sdl_benchmark.rs
+++ b/cli/crates/server/benches/parse_sdl_benchmark.rs
@@ -1,0 +1,63 @@
+#![allow(unused_crate_dependencies)]
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn criterion_benchmark(criterion: &mut Criterion) {
+    let schema = r#"
+        extend schema
+            @graphql(
+                name: "SW1"
+                namespace: true
+                url: "https://swapi-graphql.netlify.app/.netlify/functions/index"
+            )
+            @graphql(
+                name: "SW2"
+                namespace: true
+                url: "https://swapi-graphql.netlify.app/.netlify/functions/index"
+            )
+            @graphql(
+                name: "SW3"
+                namespace: true
+                url: "https://swapi-graphql.netlify.app/.netlify/functions/index"
+            )
+            @graphql(
+                name: "SW4"
+                namespace: true
+                url: "https://swapi-graphql.netlify.app/.netlify/functions/index"
+            )
+            @graphql(
+                name: "SW5"
+                namespace: true
+                url: "https://swapi-graphql.netlify.app/.netlify/functions/index"
+            )
+            @graphql(
+                name: "SW6"
+                namespace: true
+                url: "https://swapi-graphql.netlify.app/.netlify/functions/index"
+            )
+            @graphql(
+                name: "SW7"
+                namespace: true
+                url: "https://swapi-graphql.netlify.app/.netlify/functions/index"
+            )
+            @graphql(
+                name: "SW8"
+                namespace: true
+                url: "https://swapi-graphql.netlify.app/.netlify/functions/index"
+            )
+    "#;
+
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let env = std::collections::HashMap::new();
+    let mut group = criterion.benchmark_group("parse_sdl() with IO");
+
+    group.sample_size(15).bench_function("parse_sdl", |b| {
+        b.iter(|| {
+            runtime
+                .block_on(grafbase_local_server::parse_sdl(schema, &env))
+                .unwrap()
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/cli/crates/server/src/config/mod.rs
+++ b/cli/crates/server/src/config/mod.rs
@@ -28,7 +28,7 @@ mod actor;
 mod error;
 mod parser;
 
-pub use self::{actor::ConfigActor, error::ConfigError};
+pub use self::{actor::ConfigActor, error::ConfigError, parser::parse_sdl};
 
 #[derive(Debug, Clone)]
 pub struct DetectedUdf {

--- a/cli/crates/server/src/config/parser.rs
+++ b/cli/crates/server/src/config/parser.rs
@@ -9,7 +9,7 @@ use postgres_connector_types::transport::DirectTcpTransport;
 use super::ConfigError;
 
 // Contract between this crate and CLI
-// #[derive(serde::Serialize)]
+#[derive(Debug)]
 pub struct ParserResult {
     pub registry: Registry,
     pub required_udfs: HashSet<(UdfKind, String)>,

--- a/cli/crates/server/src/lib.rs
+++ b/cli/crates/server/src/lib.rs
@@ -21,6 +21,9 @@ let server_handle = server::start(PORT).unwrap();
 #[macro_use]
 extern crate log;
 
+#[cfg(test)]
+use criterion as _;
+
 mod atomics;
 mod bridge;
 mod bun;
@@ -38,6 +41,10 @@ mod udf_builder;
 
 pub mod errors;
 pub mod types;
+
+/// Only for benchmarks.
+#[doc(hidden)]
+pub use config::parse_sdl;
 
 pub use dump_config::dump_config;
 pub use introspect_local::{introspect_local, IntrospectLocalOutput};


### PR DESCRIPTION
Introspection of data sources gets noticeably slow once you use enough connectors that require introspection when starting `grafbase dev` (openapi, postgres, graphql). We explicitly did not introspect concurrently until now because of memory usage concerns. So the solution here is a compromise:

- No multithreading. The CPU/memory bound work will all happen in the same thread, and it will run from start to end for each connector sequentially because that work does not yield. Only the IO is somewhat more concurrent.
- `FuturesOrdered` because although the order shouldn't matter, we should keep the same deterministic behaviour we had if we can.

If we wanted to parallelize more aggressively, potential candidates would be a thread per datasource or using tokio's spawn_blocking() for CPU work, but we would then expect memory usage to go up further, and it is more intrusive modification in parser-sdl. The solution proposed in this PR has the advantage of touching a single function and using dependencies we already have.

The benchmark included here, on main:

```
Benchmarking parse_sdl() with IO/parse_sdl: Collecting 15 samples in estimated 31.088 s (15 iterations
parse_sdl() with IO/parse_sdl                                                                         
                        time:   [2.0002 s 2.1014 s 2.2093 s]                         
```

On this branch:

```
Benchmarking parse_sdl() with IO/parse_sdl: Collecting 15 samples in estimated 14.234 s (15 iterations
parse_sdl() with IO/parse_sdl
                        time:   [962.22 ms 1.0299 s 1.0966 s]
                        change: [-55.071% -50.990% -46.499%] (p = 0.00 < 0.05)
                        Performance has improved.
```

The high water mark in memory usage is pretty consistently around 99.7MB on main, and 100.7MB on this branch, so the difference doesn't appear to be significant.

As another data point, in a customer setup I reproduced locally, `parse_sdl()` went from 8.5 to 2.5 seconds.

closes GB-6504