### PR TITLE
chore(cli): bump to 0.68.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "engine-config-builder"
-version = "0.67.3"
+version = "0.68.0"
 dependencies = [
  "engine-v2-config",
  "graphql-federated-graph",
@@ -2237,7 +2237,7 @@ checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "federated-dev"
-version = "0.67.3"
+version = "0.68.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "0.67.3"
+version = "0.68.0"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -2778,7 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.67.3"
+version = "0.68.0"
 dependencies = [
  "assert_matches",
  "async-graphql",
@@ -2897,7 +2897,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-graphql-introspection"
-version = "0.67.3"
+version = "0.68.0"
 dependencies = [
  "cynic",
  "cynic-introspection",
@@ -2909,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.67.3"
+version = "0.68.0"
 dependencies = [
  "async-compression",
  "axum 0.7.5",
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.67.3"
+version = "0.68.0"
 dependencies = [
  "chrono",
  "common-types",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.67.3"
+version = "0.68.0"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "graph-ref"
-version = "0.67.3"
+version = "0.68.0"
 
 [[package]]
 name = "graphql-composition"
@@ -3074,7 +3074,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-cursor"
-version = "0.67.3"
+version = "0.68.0"
 dependencies = [
  "serde",
  "serde_with",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-lint"
-version = "0.67.3"
+version = "0.68.0"
 dependencies = [
  "criterion",
  "cynic-parser",
@@ -5101,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "operation-checks"
-version = "0.67.3"
+version = "0.68.0"
 dependencies = [
  "async-graphql-parser",
  "async-graphql-value",
@@ -5114,7 +5114,7 @@ dependencies = [
 
 [[package]]
 name = "operation-normalizer"
-version = "0.67.3"
+version = "0.68.0"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -7991,7 +7991,7 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typed-resolvers"
-version = "0.67.3"
+version = "0.68.0"
 dependencies = [
  "datatest-stable",
  "engine-parser",
@@ -8788,7 +8788,7 @@ dependencies = [
 
 [[package]]
 name = "wrapping"
-version = "0.67.3"
+version = "0.68.0"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ tracing-core = { git = "https://github.com/tokio-rs/tracing", branch = "v0.1.x" 
 tonic = { git = "https://github.com/grafbase/tonic", rev = "58de44e200af96defc4038701df9f18a177bc4c6" } # tokio-rustls-ring
 
 [workspace.package]
-version = "0.67.3"
+version = "0.68.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://grafbase.com"

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.68.0] - 2024-04-17
+
+[CHANGELOG](changelog/0.68.0.md)
+
 ## [0.67.3] - 2024-04-15
 
 [CHANGELOG](changelog/0.67.3.md)

--- a/cli/changelog/0.68.0.md
+++ b/cli/changelog/0.68.0.md
@@ -1,0 +1,7 @@
+### Features
+
+- Support for the @cors directive.
+
+### Fixes
+
+- return early with an error on missing schema in grafbase check

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -36,8 +36,8 @@ ulid = "1"
 url = "2"
 urlencoding = "2"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.67.3" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.67.3" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.68.0" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.68.0" }
 
 [build-dependencies]
 cynic-codegen = { version = "3", features = ["rkyv"] }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -52,12 +52,12 @@ url = "2"
 uuid = { version = "1", features = ["v4"] }
 webbrowser = "0.8"
 
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.67.3" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.67.3" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.68.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.68.0" }
 federated-dev = { path = "../federated-dev" }
 grafbase-graphql-introspection.workspace = true
 graph-ref = { path = "../../../graph-ref" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.67.3" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.68.0" }
 
 [dev-dependencies]
 async-graphql-axum.workspace = true

--- a/cli/crates/federated-dev/Cargo.toml
+++ b/cli/crates/federated-dev/Cargo.toml
@@ -36,7 +36,7 @@ tower-http = { workspace = true, features = ["cors", "fs", "trace"] }
 ulid.workspace = true
 url = "2.5.0"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.67.3" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.68.0" }
 engine = { path = "../../../engine/crates/engine" }
 engine-config-builder = { path = "../../../engine/crates/engine-config-builder" }
 engine-v2 = { workspace = true, features = ["plan_cache"] }

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -53,7 +53,7 @@ tracing = "0.1"
 which.workspace = true
 zip = "0.6"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.67.3" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.68.0" }
 gateway = { path = "../gateway" }
 typed-resolvers = { path = "../typed-resolvers" }
 federated-dev = { path = "../federated-dev" }

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.67.3",
+  "version": "0.68.0",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.67.3",
+  "version": "0.68.0",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.67.3",
+  "version": "0.68.0",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.67.3",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.67.3",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.67.3",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.67.3",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.67.3"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.68.0",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.68.0",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.68.0",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.68.0",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.68.0"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.67.3",
+  "version": "0.68.0",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.67.3",
+  "version": "0.68.0",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.67.3",
+  "version": "0.68.0",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
We need to do this separately from SDK due to one test not finding the SDK which is not yet released.

Enables the CORS parsing.