### PR TITLE
fix: add missing http methods to parser-openapi

### DIFF
--- a/engine/crates/parser-openapi/src/graph/mod.rs
+++ b/engine/crates/parser-openapi/src/graph/mod.rs
@@ -299,6 +299,10 @@ pub enum HttpMethod {
     Put,
     Delete,
     Patch,
+    Head,
+    Trace,
+    Options,
+    Connect,
 }
 
 // The GraphQL spec calls the "NonNull"/"List" types "wrapping types" so I'm borrowing


### PR DESCRIPTION
Bit weird to see these in a spec, but ok I suppose