### PR TITLE
fix: federation subgraph SDL should have federation plumbing

### DIFF
--- a/cli/crates/server/src/config/mod.rs
+++ b/cli/crates/server/src/config/mod.rs
@@ -79,7 +79,7 @@ pub(crate) async fn build_config(
 
     // Federated graphs have empty SDL schemas, from the config's perspective.
     if federated_graph_config.is_none() {
-        validate_registry_sdl(&registry.export_sdl(false))?;
+        validate_registry_sdl(&registry.export_sdl(registry.enable_federation))?;
     }
 
     let offset = REGISTRY_PARSED_EPOCH_OFFSET_MILLIS.load(Ordering::Acquire);


### PR DESCRIPTION
We're doing validation on SDL printed from the registry in `grafbase dev`, but this wasn't printing the federation subgraph fields & directives, even when subgraph support was enabled.

This is problematic because a subgraph that defines no query fields is valid, but its schema won't be valid if you don't add the federation plumbing to it.