### PR TITLE
chore: put registry into an arc

### DIFF
--- a/cli/crates/gateway/src/executor.rs
+++ b/cli/crates/gateway/src/executor.rs
@@ -61,7 +61,7 @@ impl Executor {
 
         let resolver_engine = UdfInvokerImpl::custom_resolver(self.bridge.clone());
 
-        Ok(engine::Schema::build(engine::Registry::clone(&self.registry))
+        Ok(engine::Schema::build(Arc::clone(&self.registry))
             .data(engine::TraceId(ctx.ray_id().to_string()))
             .data(graphql::QueryBatcher::new())
             .data(resolver_engine)

--- a/engine/crates/engine/src/registry/mod.rs
+++ b/engine/crates/engine/src/registry/mod.rs
@@ -1729,7 +1729,7 @@ impl Registry {
         }
     }
 
-    pub(crate) fn has_entities(&self) -> bool {
+    pub fn has_entities(&self) -> bool {
         !self.federation_entities.is_empty()
     }
 
@@ -1788,7 +1788,7 @@ impl Registry {
         }
     }
 
-    pub(crate) fn create_federation_types(&mut self) {
+    pub fn create_federation_types(&mut self) {
         <Any as LegacyInputType>::create_type_info(self);
 
         self.types.insert(

--- a/engine/crates/engine/src/validation/test_harness.rs
+++ b/engine/crates/engine/src/validation/test_harness.rs
@@ -3,6 +3,8 @@
 #![allow(dead_code)]
 #![allow(unreachable_code)]
 
+use std::sync::Arc;
+
 use once_cell::sync::Lazy;
 
 use crate::{
@@ -340,8 +342,13 @@ impl Mutation {
 
 pub struct Subscription;
 
-static TEST_HARNESS: Lazy<Schema> =
-    Lazy::new(|| Schema::new(Schema::create_registry_static::<Query, Mutation, EmptySubscription>()));
+static TEST_HARNESS: Lazy<Schema> = Lazy::new(|| {
+    Schema::new(Arc::new(Schema::create_registry_static::<
+        Query,
+        Mutation,
+        EmptySubscription,
+    >()))
+});
 
 pub(crate) fn validate<'a, V, F>(doc: &'a ExecutableDocument, factory: F) -> Result<(), Vec<RuleError>>
 where

--- a/engine/crates/integration-tests/src/engine/builder.rs
+++ b/engine/crates/integration-tests/src/engine/builder.rs
@@ -120,7 +120,7 @@ impl EngineBuilder {
         // engine-v2 tests don't use wait_until so it's not a problem for the receiver to be
         // dropped immediately.
         let (sender, _) = tokio::sync::mpsc::unbounded_channel();
-        let mut schema_builder = Schema::build(registry)
+        let mut schema_builder = Schema::build(Arc::new(registry))
             .data(QueryBatcher::new())
             .data(runtime::Context::new(
                 &Arc::new(RequestContext {

--- a/engine/crates/integration-tests/tests/tracing/v1.rs
+++ b/engine/crates/integration-tests/tests/tracing/v1.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use serde_json::json;
 use tracing::Level;
 use tracing_mock::{expect, subscriber};
@@ -31,7 +33,10 @@ async fn query_bad_request() {
 
     // act
 
-    engine::Schema::build(Registry::new()).finish().execute("").await;
+    engine::Schema::build(Arc::new(Registry::new()))
+        .finish()
+        .execute("")
+        .await;
 
     // assert
     handle.assert_finished();
@@ -153,7 +158,7 @@ async fn batch() {
     let _default = tracing::subscriber::set_default(subscriber);
 
     // act
-    engine::Schema::build(Registry::new())
+    engine::Schema::build(Arc::new(Registry::new()))
         .finish()
         .execute_batch(BatchRequest::Batch(vec![
             Request::new("query-1"),
@@ -181,7 +186,7 @@ async fn subscription() {
     let _default = tracing::subscriber::set_default(subscriber);
 
     // act
-    let _: Vec<StreamingPayload> = engine::Schema::build(Registry::new())
+    let _: Vec<StreamingPayload> = engine::Schema::build(Arc::new(Registry::new()))
         .finish()
         .execute_stream("")
         .collect()

--- a/engine/crates/parser-sdl/src/rules/visitor/context.rs
+++ b/engine/crates/parser-sdl/src/rules/visitor/context.rs
@@ -189,6 +189,10 @@ impl<'a> VisitorContext<'a> {
             );
         }
 
+        if registry.enable_federation && registry.has_entities() {
+            registry.create_federation_types();
+        }
+
         registry.remove_unused_types();
 
         registry.operation_limits = self


### PR DESCRIPTION
I've hacked together an in memory cache in the executor to try and share registries between concurrent requests.  This means we need to use an `Arc<Engine>` most places we currently use an `Engine`.