### PR TITLE
feat: allow deleting and listing branches, allow deploying without linking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,7 +1188,7 @@ version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
 dependencies = [
- "encode_unicode",
+ "encode_unicode 0.3.6",
  "lazy_static",
  "libc",
  "unicode-width",
@@ -1762,6 +1762,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1771,6 +1781,17 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -1896,6 +1917,12 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -2833,6 +2860,7 @@ dependencies = [
  "multipart-stream",
  "once_cell",
  "os_type",
+ "prettytable",
  "rand 0.8.5",
  "regex",
  "reqwest",
@@ -5715,6 +5743,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettytable"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46480520d1b77c9a3482d39939fcf96831537a250ec62d4fd8fbdf8e0302e781"
+dependencies = [
+ "encode_unicode 1.0.0",
+ "is-terminal",
+ "lazy_static",
+ "term",
+ "unicode-width",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7382,6 +7423,17 @@ dependencies = [
  "fastrand 2.0.2",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]

--- a/cli/crates/backend/src/api/branch.rs
+++ b/cli/crates/backend/src/api/branch.rs
@@ -1,0 +1,92 @@
+use common::{consts::PROJECT_METADATA_FILE, environment::Project};
+use cynic::{http::ReqwestExt, MutationBuilder, QueryBuilder};
+use tokio::fs::read_to_string;
+
+use super::{
+    client::create_client,
+    consts::api_url,
+    errors::{ApiError, BranchError},
+    graphql::{
+        mutations::{BranchDelete, BranchDeleteArguments, BranchDeletePayload},
+        queries::list_branches::{ListBranches, ListBranchesArguments, Node},
+    },
+    types::ProjectMetadata,
+};
+
+/// # Errors
+///
+/// See [`ApiError`]
+pub async fn delete(account_slug: &str, project_slug: &str, branch_name: &str) -> Result<(), ApiError> {
+    let client = create_client().await?;
+
+    let operation = BranchDelete::build(BranchDeleteArguments {
+        account_slug,
+        project_slug,
+        branch_name,
+    });
+
+    let cynic::GraphQlResponse { data, errors } = client.post(api_url()).run_graphql(operation).await?;
+
+    if let Some(data) = data {
+        match data.branch_delete {
+            BranchDeletePayload::Success(_) => Ok(()),
+            BranchDeletePayload::BranchDoesNotExist(_) => {
+                Err(BranchError::BranchDoesNotExist(format!("{account_slug}/{project_slug}@{branch_name}")).into())
+            }
+            BranchDeletePayload::CannotDeleteProductionBranch(_) => Err(
+                BranchError::CannotDeleteProductionBranchError(format!("{account_slug}/{project_slug}@{branch_name}"))
+                    .into(),
+            ),
+            BranchDeletePayload::Unknown(error) => Err(BranchError::Unknown(error).into()),
+        }
+    } else {
+        Err(ApiError::RequestError(format!("{errors:#?}")))
+    }
+}
+
+pub async fn list() -> Result<Vec<(String, bool)>, ApiError> {
+    let project = Project::get();
+
+    let project_metadata_file_path = project.dot_grafbase_directory_path.join(PROJECT_METADATA_FILE);
+
+    match project_metadata_file_path.try_exists() {
+        Ok(true) => {}
+        Ok(false) => return Err(ApiError::UnlinkedProject),
+        Err(error) => return Err(ApiError::ReadProjectMetadataFile(error)),
+    }
+
+    let project_metadata_file = read_to_string(project_metadata_file_path)
+        .await
+        .map_err(ApiError::ReadProjectMetadataFile)?;
+
+    let project_metadata: ProjectMetadata =
+        serde_json::from_str(&project_metadata_file).map_err(|_| ApiError::CorruptProjectMetadataFile)?;
+
+    let operation = ListBranches::build(ListBranchesArguments {
+        project_id: project_metadata.project_id.into(),
+    });
+
+    let client = create_client().await?;
+    let cynic::GraphQlResponse { data, errors } = client.post(api_url()).run_graphql(operation).await?;
+
+    match (data.and_then(|d| d.node), errors) {
+        (Some(Node::Project(project)), _) => {
+            let project_ref = format!("{}/{}", project.account_slug, project.slug);
+
+            let branches = project
+                .branches
+                .edges
+                .into_iter()
+                .map(|edge| {
+                    (
+                        format!("{}@{}", project_ref, edge.node.name),
+                        edge.node.name == project.production_branch.name,
+                    )
+                })
+                .collect();
+
+            Ok(branches)
+        }
+        (_, errors) => Err(ApiError::RequestError(format!("{errors:#?}"))),
+    }
+}

--- a/cli/crates/backend/src/api/errors.rs
+++ b/cli/crates/backend/src/api/errors.rs
@@ -144,6 +144,10 @@ pub enum ApiError {
     #[error(transparent)]
     PublishError(#[from] PublishError),
 
+    /// wraps a [`BranchError`]
+    #[error(transparent)]
+    BranchError(#[from] BranchError),
+
     /// returned if the project does not exist
     #[error("could not find the project")]
     ProjectDoesNotExist,
@@ -248,4 +252,17 @@ impl From<CynicReqwestError> for ApiError {
             }
         }
     }
+}
+
+#[derive(Error, Debug)]
+pub enum BranchError {
+    /// returned if the given branch does not exist
+    #[error("branch {0} does not exist")]
+    BranchDoesNotExist(String),
+    /// returned, if trying to delete the production branch
+    #[error("branch `{0}` is the production branch of the graph, and cannot be deleted")]
+    CannotDeleteProductionBranchError(String),
+    /// returned if an unknown error occurs
+    #[error("could not delete branch, encountered an unknown error\nCaused by: {0}")]
+    Unknown(String),
 }

--- a/cli/crates/backend/src/api/graphql/api.graphql
+++ b/cli/crates/backend/src/api/graphql/api.graphql
@@ -1,3 +1,5 @@
+directive @oneOf on INPUT_OBJECT
+
 type AccessToken implements Node {
   id: ID!
   name: String!
@@ -10,12 +12,10 @@ type AccessTokenConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-
   """
   A list of edges.
   """
   edges: [AccessTokenEdge!]!
-
   """
   A list of nodes.
   """
@@ -61,7 +61,6 @@ type AccessTokenEdge {
   The item at the end of the edge
   """
   node: AccessToken!
-
   """
   A cursor for use in pagination
   """
@@ -73,7 +72,7 @@ enum AccessTokenKind {
   ACCOUNT
 }
 
-interface Account {
+interface Account implements Node {
   id: ID!
   slug: String!
   name: String!
@@ -112,7 +111,7 @@ type AccountIntegration {
 
 union AccountIntegrationAttributes = DatadogIntegration
 
-input AccountIntegrationAttributesInput {
+input AccountIntegrationAttributesInput @oneOf {
   datadog: DatadogIntegrationInput
 }
 
@@ -224,19 +223,17 @@ type BranchConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-
   """
   A list of edges.
   """
   edges: [BranchEdge!]!
-
   """
   A list of nodes.
   """
   nodes: [Branch!]!
 }
 
-union BranchDeletePayload = Query | BranchDoesNotExistError
+union BranchDeletePayload = Query | BranchDoesNotExistError | CannotDeleteProductionBranchError
 
 type BranchDoesNotExistError {
   query: Query!
@@ -250,7 +247,6 @@ type BranchEdge {
   The item at the end of the edge
   """
   node: Branch!
-
   """
   A cursor for use in pagination
   """
@@ -286,6 +282,10 @@ input BranchUpdateInput {
 union BranchUpdatePayload = Query | ProjectDoesNotExistError
 
 type CannotBeRenamedError {
+  query: Query!
+}
+
+type CannotDeleteProductionBranchError {
   query: Query!
 }
 
@@ -469,7 +469,6 @@ type Deployment implements Node {
   finishedAt: DateTime
   isRedeployable: Boolean!
   triggerType: DeploymentTriggerType!
-
   """
   The duration of the deployment in milliseconds.
   """
@@ -487,12 +486,10 @@ type DeploymentConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-
   """
   A list of edges.
   """
   edges: [DeploymentEdge!]!
-
   """
   A list of nodes.
   """
@@ -530,7 +527,6 @@ type DeploymentEdge {
   The item at the end of the edge
   """
   node: Deployment!
-
   """
   A cursor for use in pagination
   """
@@ -625,12 +621,10 @@ type EnvironmentVariableConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-
   """
   A list of edges.
   """
   edges: [EnvironmentVariableEdge!]!
-
   """
   A list of nodes.
   """
@@ -643,7 +637,6 @@ type EnvironmentVariableCountLimitExceededError {
 
 input EnvironmentVariableCreateInput {
   projectId: ID!
-
   """
   Must not be already assigned.
   """
@@ -689,7 +682,6 @@ type EnvironmentVariableEdge {
   The item at the end of the edge
   """
   node: EnvironmentVariable!
-
   """
   A cursor for use in pagination
   """
@@ -772,7 +764,6 @@ type GitAccount {
   id: ID!
   slug: String!
   type: GitAccountType!
-
   """
   Date when the app was authorized to access this account
   """
@@ -918,12 +909,10 @@ type InviteConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-
   """
   A list of edges.
   """
   edges: [InviteEdge!]!
-
   """
   A list of nodes.
   """
@@ -953,7 +942,6 @@ type InviteEdge {
   The item at the end of the edge
   """
   node: Invite!
-
   """
   A cursor for use in pagination
   """
@@ -1022,12 +1010,10 @@ type LogEventConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-
   """
   A list of edges.
   """
   edges: [LogEventEdge!]!
-
   """
   A list of nodes.
   """
@@ -1042,7 +1028,6 @@ type LogEventEdge {
   The item at the end of the edge
   """
   node: LogEvent!
-
   """
   A cursor for use in pagination
   """
@@ -1078,12 +1063,10 @@ type MemberConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-
   """
   A list of edges.
   """
   edges: [MemberEdge!]!
-
   """
   A list of nodes.
   """
@@ -1107,7 +1090,6 @@ type MemberEdge {
   The item at the end of the edge
   """
   node: Member!
-
   """
   A cursor for use in pagination
   """
@@ -1142,12 +1124,10 @@ type Mutation {
   Create a new access token.
   """
   accessTokenCreate(input: AccessTokenCreateInput!): AccessTokenCreatePayload!
-
   """
   Delete a given access token.
   """
   accessTokenDelete(input: AccessTokenDeleteInput!): AccessTokenDeletePayload!
-
   """
   Create new organization account owned by the current user. Slug must be unique.
   """
@@ -1166,28 +1146,23 @@ type Mutation {
   accountIntegrationCreate(accountId: ID!, input: AccountIntegrationInput!): AccountIntegrationMutationPayload!
   accountIntegrationUpdate(id: ID!, input: AccountIntegrationInput!): AccountIntegrationMutationPayload!
   accountIntegrationDelete(id: ID!): AccountIntegrationMutationPayload!
-
   """
   Add a new custom domain.
   """
   customDomainCreate(input: CustomDomainCreateInput!): CustomDomainCreatePayload!
-
   """
   Delete a custom domain.
   """
   customDomainDelete(input: CustomDomainDeleteInput!): CustomDomainDeletePayload!
-
   """
   Replace a configured custom domain with another one (domain and target branch) – or modify the target branch of an existing one
   without changing the domain name.
   """
   customDomainReplace(input: CustomDomainReplaceInput!): CustomDomainReplacePayload!
-
   """
   Create a new deployment for an existing project.
   """
   deploymentCreate(input: DeploymentCreateInput!): DeploymentCreatePayload!
-
   """
   Create a new deployment for an existing project.
   """
@@ -1197,17 +1172,14 @@ type Mutation {
     """
     id: ID!
   ): DeploymentRedeployPayload!
-
   """
   Create a new environment variable.
   """
   environmentVariableCreate(input: EnvironmentVariableCreateInput!): EnvironmentVariableCreatePayload!
-
   """
   Update an environment variable.
   """
   environmentVariableUpdate(input: EnvironmentVariableUpdateInput!): EnvironmentVariableUpdatePayload!
-
   """
   Delete an environment variable.
   """
@@ -1216,47 +1188,38 @@ type Mutation {
   inviteCancel(input: InviteCancelInput!): InviteCancelPayload!
   inviteAccept(input: InviteAcceptInput!): InviteAcceptPayload!
   inviteDecline(input: InviteDeclineInput!): InviteDeclinePayload!
-
   """
   Update role of an organization member
   """
   memberUpdate(input: MemberUpdateInput!): MemberUpdatePayload!
-
   """
   Remove member from an organization
   """
   memberDelete(input: MemberDeleteInput!): MemberDeletePayload!
-
   """
   Create a new project API key.
   """
   projectApiKeyCreate(input: ProjectApiKeyCreateInput!): ProjectApiKeyCreatePayload!
-
   """
   Update a given API key with a new name.
   """
   projectApiKeyUpdate(input: ProjectApiKeyUpdateInput!): ProjectApiKeyUpdatePayload!
-
   """
   Delete a given API key.
   """
   projectApiKeyDelete(input: ProjectApiKeyDeleteInput!): ProjectApiKeyDeletePayload!
-
   """
   Create a new project without any source for an initial deployment.
   """
   projectCreate(input: ProjectCreateInput!): ProjectCreatePayload!
-
   """
   Create a new project from a GitHub repository.
   """
   projectCreateFromSchema(input: ProjectCreateFromSchemaInput!): ProjectCreateFromSchemaPayload!
-
   """
   Create a new project from a GitHub repository.
   """
   projectCreateFromRepository(input: ProjectCreateFromRepositoryInput!): ProjectCreateFromRepositoryPayload!
-
   """
   Create a new project from a template in a newly created GitHub repository.
   """
@@ -1266,17 +1229,14 @@ type Mutation {
     input: ProjectOperationCheckConfigurationInput!
   ): ProjectOperationCheckConfigurationUpdatePayload!
   projectDelete(input: ProjectDeleteInput!): ProjectDeletePayload!
-
   """
   Run checks against the given schema
   """
   schemaCheckCreate(input: SchemaCheckCreateInput!): SchemaCheckPayload!
-
   """
   Publish a new subgraph.
   """
   publish(input: PublishInput!): PublishPayload!
-
   """
   Delete a subgraph
   """
@@ -1288,12 +1248,10 @@ type Mutation {
     slug of the account
     """
     accountSlug: String!
-
     """
     slug of the project
     """
     projectSlug: String!
-
     """
     name of the branch
     """
@@ -1397,12 +1355,10 @@ type OperationRequestMetricsConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-
   """
   A list of edges.
   """
   edges: [OperationRequestMetricsEdge!]!
-
   """
   A list of nodes.
   """
@@ -1417,7 +1373,6 @@ type OperationRequestMetricsEdge {
   The item at the end of the edge
   """
   node: OperationRequestMetrics!
-
   """
   A cursor for use in pagination
   """
@@ -1660,7 +1615,6 @@ type Organization implements Account {
   members(after: String, before: String, first: Int, last: Int): MemberConnection!
   projectsCountStatus: ResourceStatus!
   slackIntegration: SlackIntegration
-
   """
   The url for the UI button to install the Grafbase slack app. It is
   important to use this link and keep it private, since it contains the signed
@@ -1679,12 +1633,10 @@ type OrganizationConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-
   """
   A list of edges.
   """
   edges: [OrganizationEdge!]!
-
   """
   A list of nodes.
   """
@@ -1738,7 +1690,6 @@ type OrganizationEdge {
   The item at the end of the edge
   """
   node: Organization!
-
   """
   A cursor for use in pagination
   """
@@ -1816,17 +1767,14 @@ type PageInfo {
   When paginating backwards, are there more items?
   """
   hasPreviousPage: Boolean!
-
   """
   When paginating forwards, are there more items?
   """
   hasNextPage: Boolean!
-
   """
   When paginating backwards, the cursor to continue.
   """
   startCursor: String
-
   """
   When paginating forwards, the cursor to continue.
   """
@@ -1922,12 +1870,10 @@ type ProjectApiKeyConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-
   """
   A list of edges.
   """
   edges: [ProjectApiKeyEdge!]!
-
   """
   A list of nodes.
   """
@@ -1969,7 +1915,6 @@ type ProjectApiKeyEdge {
   The item at the end of the edge
   """
   node: ProjectApiKey!
-
   """
   A cursor for use in pagination
   """
@@ -1996,12 +1941,10 @@ type ProjectConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-
   """
   A list of edges.
   """
   edges: [ProjectEdge!]!
-
   """
   A list of nodes.
   """
@@ -2150,7 +2093,6 @@ type ProjectEdge {
   The item at the end of the edge
   """
   node: Project!
-
   """
   A cursor for use in pagination
   """
@@ -2178,24 +2120,20 @@ type ProjectOperationCheckConfiguration {
   Whether operation checks are enabled for the project.
   """
   enabled: Boolean! @deprecated(reason: "Operation checks are now enabled exclusively at the branch level")
-
   """
   The time range in days to consider for operation checks. Operations older than the specificied
   number of days are ignored.
   """
   timeRangeDays: Int!
-
   """
   The request count threshold to consider for operation checks. Operations that have been
   registered less than the specified number of occurrences are ignored.
   """
   requestCountThreshold: Int!
-
   """
   The clients to exclude from operation checks.
   """
   excludedClients: [String!]!
-
   """
   The operations to exclude from operation checks.
   """
@@ -2207,29 +2145,24 @@ input ProjectOperationCheckConfigurationInput {
   The project to update.
   """
   projectId: ID!
-
   """
   Whether operation checks are enabled for the project. This is ignored, since operation checks are now only enabled at the branch level.
   """
   enabled: Boolean
-
   """
   The time range in days to consider for operation checks. Operations older than the specificied
   number of days are ignored.
   """
   timeRangeDays: Int
-
   """
   The request count threshold to consider for operation checks. Operations that have been
   registered less than the specified number of occurrences are ignored.
   """
   requestCountThreshold: Int
-
   """
   The clients to exclude from operation checks.
   """
   excludedClients: [String!]
-
   """
   The operations to exclude from operation checks.
   """
@@ -2322,7 +2255,6 @@ type Query {
     startDate: DateTime!
     endDate: DateTime!
   ): BranchMetricsPayload!
-
   """
   Get branch by account slug, project slug and the name of the branch.
   """
@@ -2331,18 +2263,15 @@ type Query {
     slug of the account
     """
     accountSlug: String!
-
     """
     slug of the project
     """
     projectSlug: String!
-
     """
     name of the branch
     """
     name: String!
   ): Branch
-
   """
   Get branch by domain.
   """
@@ -2352,7 +2281,6 @@ type Query {
     """
     domain: String!
   ): Branch
-
   """
   Get custom domain by project id and name.
   """
@@ -2361,13 +2289,11 @@ type Query {
     id of the project
     """
     projectId: ID!
-
     """
     name of the domain
     """
     name: String!
   ): CustomDomain
-
   """
   Get deployment by ID.
   """
@@ -2377,30 +2303,25 @@ type Query {
     """
     id: ID!
   ): Deployment
-
   """
   Return a list of git accounts accessible by the current user sorted by the creation date.
   """
   gitAccounts(provider: GitProvider!): GitAccountsPayload!
-
   """
   Return a list of git repositories accessible by the current user, sorted by updatedAt.
   With `query` specified, the list will include up to 10 repos matching the query.
   Without `query`, the list will include the 10 most recently updated repos.
   """
   gitRepos(provider: GitProvider!, gitAccountId: String!, query: String): [GitRepository!]!
-
   """
   Returns details about a specific git repository identified by its URL.
   """
   gitRepoByUrl(url: Url!): GitRepository!
-
   """
   Returns the contents of the `schema.graphql` file located in a particular branch of a repository idenitifed by its URL.
   """
   schema(url: Url!, branch: String!): String
   invite(id: ID!): Invite
-
   """
   Get project by account slug and slug of the project itself.
   """
@@ -2409,13 +2330,11 @@ type Query {
     slug of the account
     """
     accountSlug: String!
-
     """
     slug of the project
     """
     projectSlug: String!
   ): Project
-
   """
   Get project by ID.
   """
@@ -2426,7 +2345,6 @@ type Query {
     id: ID!
   ): Project @deprecated(reason: "use the top-level `node` query")
   schemaCheck(id: ID!): SchemaCheck
-
   """
   Get subgraph.
   """
@@ -2435,17 +2353,14 @@ type Query {
     account slug
     """
     accountSlug: String!
-
     """
     project slug
     """
     projectSlug: String!
-
     """
     name of the branch
     """
     branch: String
-
     """
     name of the subgraph
     """
@@ -2457,17 +2372,14 @@ type Query {
     account slug
     """
     accountSlug: String!
-
     """
     project slug
     """
     projectSlug: String!
-
     """
     name of the branch
     """
     branch: String
-
     """
     name of the subgraph
     """
@@ -2477,7 +2389,6 @@ type Query {
     first: Int
     last: Int
   ): SchemaVersionConnection!
-
   """
   Give the actual connected user.
   """
@@ -2572,12 +2483,10 @@ type ReusedId {
   The document id
   """
   documentId: String!
-
   """
   The existing document body
   """
   existingDocumentText: String!
-
   """
   The different, newly submitted document body
   """
@@ -2681,12 +2590,10 @@ type SchemaCheckConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-
   """
   A list of edges.
   """
   edges: [SchemaCheckEdge!]!
-
   """
   A list of nodes.
   """
@@ -2710,7 +2617,6 @@ type SchemaCheckEdge {
   The item at the end of the edge
   """
   node: SchemaCheck!
-
   """
   A cursor for use in pagination
   """
@@ -2771,12 +2677,10 @@ type SchemaVersionChangeConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-
   """
   A list of edges.
   """
   edges: [SchemaVersionChangeEdge!]!
-
   """
   A list of nodes.
   """
@@ -2791,7 +2695,6 @@ type SchemaVersionChangeEdge {
   The item at the end of the edge
   """
   node: SchemaVersionChange!
-
   """
   A cursor for use in pagination
   """
@@ -2803,12 +2706,10 @@ type SchemaVersionConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
-
   """
   A list of edges.
   """
   edges: [SchemaVersionEdge!]!
-
   """
   A list of nodes.
   """
@@ -2820,12 +2721,10 @@ type SchemaVersionDelta {
   Additions.
   """
   added: Int!
-
   """
   Removals.
   """
   removed: Int!
-
   """
   Modifications.
   """
@@ -2840,7 +2739,6 @@ type SchemaVersionEdge {
   The item at the end of the edge
   """
   node: SchemaVersion!
-
   """
   A cursor for use in pagination
   """
@@ -3096,4 +2994,11 @@ type ValueTooLongError {
 type ViewerLimits {
   remainingProjects: Int
   totalProjects: Int
+}
+
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+schema {
+  query: Query
+  mutation: Mutation
 }

--- a/cli/crates/backend/src/api/graphql/api.graphql
+++ b/cli/crates/backend/src/api/graphql/api.graphql
@@ -481,6 +481,13 @@ type Deployment implements Node {
   diffAgainstLatestProductionDeployment: String
 }
 
+input DeploymentBySlugCreateInput {
+  accountSlug: String!
+  projectSlug: String!
+  archiveFileSize: Int!
+  branch: String
+}
+
 type DeploymentConnection {
   """
   Information to aid in pagination.
@@ -1159,6 +1166,10 @@ type Mutation {
   without changing the domain name.
   """
   customDomainReplace(input: CustomDomainReplaceInput!): CustomDomainReplacePayload!
+  """
+  Create a new deployment for an existing project by slugs.
+  """
+  deploymentCreateBySlug(input: DeploymentBySlugCreateInput!): DeploymentCreatePayload!
   """
   Create a new deployment for an existing project.
   """

--- a/cli/crates/backend/src/api/graphql/types/mutations.rs
+++ b/cli/crates/backend/src/api/graphql/types/mutations.rs
@@ -197,6 +197,12 @@ pub struct DeploymentCreate {
 pub struct DeploymentCreateSuccess {
     pub __typename: String,
     pub presigned_url: String,
+    pub deployment: Deployment,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct Deployment {
+    pub id: cynic::Id,
 }
 
 #[derive(cynic::QueryFragment, Debug)]

--- a/cli/crates/backend/src/api/graphql/types/mutations.rs
+++ b/cli/crates/backend/src/api/graphql/types/mutations.rs
@@ -7,6 +7,13 @@ pub struct ProjectCreateInput<'a> {
     pub account_id: cynic::Id,
     pub project_slug: &'a str,
     pub project_root_path: &'a str,
+    pub environment_variables: Vec<EnvironmentVariableSpecification<'a>>,
+}
+
+#[derive(cynic::InputObject, Clone, Debug)]
+pub struct EnvironmentVariableSpecification<'a> {
+    pub name: &'a str,
+    pub value: &'a str,
 }
 
 #[derive(cynic::QueryVariables)]
@@ -191,6 +198,27 @@ pub struct DeploymentCreateArguments<'a> {
 pub struct DeploymentCreate {
     #[arguments(input: $input)]
     pub deployment_create: DeploymentCreatePayload,
+}
+
+#[derive(cynic::InputObject, Clone, Debug)]
+#[cynic(rename_all = "camelCase")]
+pub struct DeploymentBySlugCreateInput<'a> {
+    pub archive_file_size: i32,
+    pub branch: Option<&'a str>,
+    pub project_slug: &'a str,
+    pub account_slug: &'a str,
+}
+
+#[derive(cynic::QueryVariables)]
+pub struct DeploymentCreateBySlugArguments<'a> {
+    pub input: DeploymentBySlugCreateInput<'a>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "Mutation", variables = "DeploymentCreateBySlugArguments")]
+pub struct DeploymentCreatebySlug {
+    #[arguments(input: $input)]
+    pub deployment_create_by_slug: DeploymentCreatePayload,
 }
 
 #[derive(cynic::QueryFragment, Debug)]

--- a/cli/crates/backend/src/api/graphql/types/mutations.rs
+++ b/cli/crates/backend/src/api/graphql/types/mutations.rs
@@ -134,6 +134,45 @@ pub struct ProjectDoesNotExistError {
     pub __typename: String,
 }
 
+#[derive(cynic::QueryFragment)]
+#[cynic(graphql_type = "Mutation", variables = "BranchDeleteArguments")]
+pub struct BranchDelete {
+    #[arguments(accountSlug: $account_slug, projectSlug: $project_slug, branchName: $branch_name)]
+    pub branch_delete: BranchDeletePayload,
+}
+
+#[derive(cynic::InlineFragments)]
+pub enum BranchDeletePayload {
+    Success(BranchDeleteSuccess),
+    BranchDoesNotExist(BranchDoesNotExistError),
+    CannotDeleteProductionBranch(CannotDeleteProductionBranchError),
+    #[cynic(fallback)]
+    Unknown(String),
+}
+
+#[derive(cynic::QueryFragment)]
+#[cynic(graphql_type = "Query")]
+pub struct BranchDeleteSuccess {
+    pub __typename: String,
+}
+
+#[derive(cynic::QueryFragment)]
+pub struct BranchDoesNotExistError {
+    pub __typename: String,
+}
+
+#[derive(cynic::QueryFragment)]
+pub struct CannotDeleteProductionBranchError {
+    pub __typename: String,
+}
+
+#[derive(cynic::QueryVariables)]
+pub struct BranchDeleteArguments<'a> {
+    pub account_slug: &'a str,
+    pub project_slug: &'a str,
+    pub branch_name: &'a str,
+}
+
 #[derive(cynic::InputObject, Clone, Debug)]
 #[cynic(rename_all = "camelCase")]
 pub struct DeploymentCreateInput<'a> {

--- a/cli/crates/backend/src/api/graphql/types/queries/deployment_poll.rs
+++ b/cli/crates/backend/src/api/graphql/types/queries/deployment_poll.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use chrono::{DateTime, Utc};
 
 use super::{super::schema, list_branches::DeploymentStatus};
@@ -32,4 +34,22 @@ pub struct Deployment {
 pub struct DeploymentLogEntry {
     pub created_at: DateTime<Utc>,
     pub message: String,
+    pub level: DeploymentLogLevel,
+}
+
+#[derive(cynic::Enum)]
+pub enum DeploymentLogLevel {
+    Error,
+    Warn,
+    Info,
+}
+
+impl fmt::Display for DeploymentLogLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DeploymentLogLevel::Error => f.write_str("ERROR"),
+            DeploymentLogLevel::Warn => f.write_str("WARN"),
+            DeploymentLogLevel::Info => f.write_str("INFO"),
+        }
+    }
 }

--- a/cli/crates/backend/src/api/graphql/types/queries/deployment_poll.rs
+++ b/cli/crates/backend/src/api/graphql/types/queries/deployment_poll.rs
@@ -1,0 +1,35 @@
+use chrono::{DateTime, Utc};
+
+use super::{super::schema, list_branches::DeploymentStatus};
+
+#[derive(cynic::QueryFragment)]
+#[cynic(graphql_type = "Query", variables = "DeploymentLogsArguments")]
+pub struct DeploymentLogs {
+    #[arguments(id: $deployment_id)]
+    pub node: Option<Node>,
+}
+
+#[derive(cynic::InlineFragments)]
+pub enum Node {
+    Deployment(Deployment),
+    #[cynic(fallback)]
+    Unknown,
+}
+
+#[derive(cynic::QueryVariables)]
+pub struct DeploymentLogsArguments {
+    pub deployment_id: cynic::Id,
+}
+
+#[derive(cynic::QueryFragment)]
+pub struct Deployment {
+    pub finished_at: Option<DateTime<Utc>>,
+    pub log_entries: Vec<DeploymentLogEntry>,
+    pub status: DeploymentStatus,
+}
+
+#[derive(cynic::QueryFragment)]
+pub struct DeploymentLogEntry {
+    pub created_at: DateTime<Utc>,
+    pub message: String,
+}

--- a/cli/crates/backend/src/api/graphql/types/queries/list_branches.rs
+++ b/cli/crates/backend/src/api/graphql/types/queries/list_branches.rs
@@ -1,0 +1,43 @@
+use super::super::schema;
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "Query", variables = "ListBranchesArguments")]
+pub struct ListBranches {
+    #[arguments(id: $project_id)]
+    pub node: Option<Node>,
+}
+
+#[derive(cynic::QueryVariables, Debug)]
+pub struct ListBranchesArguments {
+    pub project_id: cynic::Id,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct Project {
+    pub branches: BranchConnection,
+    pub account_slug: String,
+    pub slug: String,
+    pub production_branch: Branch,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct BranchConnection {
+    pub edges: Vec<BranchEdge>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct BranchEdge {
+    pub node: Branch,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct Branch {
+    pub name: String,
+}
+
+#[derive(cynic::InlineFragments, Debug)]
+pub enum Node {
+    Project(Project),
+    #[cynic(fallback)]
+    Unknown,
+}

--- a/cli/crates/backend/src/api/graphql/types/queries/list_branches.rs
+++ b/cli/crates/backend/src/api/graphql/types/queries/list_branches.rs
@@ -1,18 +1,22 @@
+use core::fmt;
+
+use chrono::{DateTime, Utc};
+
 use super::super::schema;
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment)]
 #[cynic(graphql_type = "Query", variables = "ListBranchesArguments")]
 pub struct ListBranches {
     #[arguments(id: $project_id)]
     pub node: Option<Node>,
 }
 
-#[derive(cynic::QueryVariables, Debug)]
+#[derive(cynic::QueryVariables)]
 pub struct ListBranchesArguments {
     pub project_id: cynic::Id,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment)]
 pub struct Project {
     pub branches: BranchConnection,
     pub account_slug: String,
@@ -20,22 +24,54 @@ pub struct Project {
     pub production_branch: Branch,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment)]
 pub struct BranchConnection {
     pub edges: Vec<BranchEdge>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment)]
 pub struct BranchEdge {
     pub node: Branch,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment)]
 pub struct Branch {
     pub name: String,
+    pub latest_deployment: Option<Deployment>,
 }
 
-#[derive(cynic::InlineFragments, Debug)]
+#[derive(cynic::QueryFragment)]
+pub struct Deployment {
+    pub created_at: DateTime<Utc>,
+    pub status: DeploymentStatus,
+}
+
+#[derive(cynic::Enum, Clone, Copy)]
+pub enum DeploymentStatus {
+    Queued,
+    InProgress,
+    Succeeded,
+    Failed,
+}
+
+impl DeploymentStatus {
+    pub fn failed(self) -> bool {
+        matches!(self, Self::Failed)
+    }
+}
+
+impl fmt::Display for DeploymentStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DeploymentStatus::Queued => f.write_str("queued"),
+            DeploymentStatus::InProgress => f.write_str("in progress"),
+            DeploymentStatus::Succeeded => f.write_str("succeeded"),
+            DeploymentStatus::Failed => f.write_str("failed"),
+        }
+    }
+}
+
+#[derive(cynic::InlineFragments)]
 pub enum Node {
     Project(Project),
     #[cynic(fallback)]

--- a/cli/crates/backend/src/api/graphql/types/queries/mod.rs
+++ b/cli/crates/backend/src/api/graphql/types/queries/mod.rs
@@ -1,6 +1,7 @@
 pub mod branch_by_domain;
 pub mod fetch_federated_graph_schema;
 pub mod fetch_subgraph_schema;
+pub mod list_branches;
 pub mod list_subgraphs;
 pub mod log_entries;
 pub mod project_slug_by_id;

--- a/cli/crates/backend/src/api/graphql/types/queries/mod.rs
+++ b/cli/crates/backend/src/api/graphql/types/queries/mod.rs
@@ -1,4 +1,5 @@
 pub mod branch_by_domain;
+pub mod deployment_poll;
 pub mod fetch_federated_graph_schema;
 pub mod fetch_subgraph_schema;
 pub mod list_branches;

--- a/cli/crates/backend/src/api/mod.rs
+++ b/cli/crates/backend/src/api/mod.rs
@@ -1,4 +1,4 @@
-mod graphql;
+pub mod graphql;
 mod utils;
 
 pub mod branch;

--- a/cli/crates/backend/src/api/mod.rs
+++ b/cli/crates/backend/src/api/mod.rs
@@ -1,6 +1,7 @@
 mod graphql;
 mod utils;
 
+pub mod branch;
 pub mod check;
 pub mod client;
 pub mod consts;

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -59,6 +59,7 @@ grafbase-graphql-introspection.workspace = true
 graphql-lint.workspace = true
 graph-ref = { path = "../../../graph-ref" }
 server = { package = "grafbase-local-server", path = "../server", version = "0.70.0" }
+prettytable = { version = "0.10.0", default-features = false, features = ["win_crlf"] }
 
 [dev-dependencies]
 async-graphql-axum.workspace = true

--- a/cli/crates/cli/src/branch.rs
+++ b/cli/crates/cli/src/branch.rs
@@ -1,0 +1,26 @@
+use backend::api::branch;
+
+use crate::{cli_input::BranchRef, errors::CliError, output::report};
+
+#[tokio::main]
+pub async fn delete(branch_ref: BranchRef) -> Result<(), CliError> {
+    report::delete_branch();
+
+    branch::delete(branch_ref.account(), branch_ref.project(), branch_ref.branch())
+        .await
+        .map_err(CliError::BackendApiError)?;
+
+    report::delete_branch_success();
+
+    Ok(())
+}
+
+#[tokio::main]
+pub async fn list() -> Result<(), CliError> {
+    report::listing_branches();
+
+    let branches = branch::list().await.map_err(CliError::BackendApiError)?;
+    report::list_branches(branches.as_slice());
+
+    Ok(())
+}

--- a/cli/crates/cli/src/branch.rs
+++ b/cli/crates/cli/src/branch.rs
@@ -17,10 +17,8 @@ pub async fn delete(branch_ref: BranchRef) -> Result<(), CliError> {
 
 #[tokio::main]
 pub async fn list() -> Result<(), CliError> {
-    report::listing_branches();
-
     let branches = branch::list().await.map_err(CliError::BackendApiError)?;
-    report::list_branches(branches.as_slice());
+    report::list_branches(branches);
 
     Ok(())
 }

--- a/cli/crates/cli/src/check.rs
+++ b/cli/crates/cli/src/check.rs
@@ -38,7 +38,7 @@ pub(crate) async fn check(command: CheckCommand) -> Result<(), CliError> {
 
     let result = check::check(
         project_ref.account(),
-        project_ref.project(),
+        project_ref.graph(),
         project_ref.branch(),
         subgraph_name.as_deref(),
         &schema,

--- a/cli/crates/cli/src/cli_input.rs
+++ b/cli/crates/cli/src/cli_input.rs
@@ -59,6 +59,15 @@ fn split_header(header: &str) -> Option<(&str, &str)> {
     })
 }
 
+fn split_env_var(env_var: &str) -> Option<(&str, &str)> {
+    env_var.find('=').map(|split_index| {
+        let key = env_var[0..split_index].trim();
+        let value = env_var[split_index + 1..].trim();
+
+        (key, value)
+    })
+}
+
 #[derive(Debug, Parser)]
 #[command(name = "Grafbase CLI", version)]
 /// The Grafbase command line interface

--- a/cli/crates/cli/src/cli_input.rs
+++ b/cli/crates/cli/src/cli_input.rs
@@ -1,4 +1,6 @@
 mod argument_names;
+mod branch;
+mod branch_ref;
 mod build;
 mod check;
 mod completions;
@@ -22,6 +24,8 @@ mod trust;
 
 pub(crate) use self::{check::CheckCommand, trust::TrustCommand};
 pub(crate) use argument_names::{filter_existing_arguments, ArgumentNames};
+pub(crate) use branch::BranchSubCommand;
+pub(crate) use branch_ref::BranchRef;
 pub(crate) use build::BuildCommand;
 pub(crate) use completions::CompletionsCommand;
 pub(crate) use create::CreateCommand;

--- a/cli/crates/cli/src/cli_input/branch.rs
+++ b/cli/crates/cli/src/cli_input/branch.rs
@@ -12,10 +12,10 @@ pub struct BranchCommand {
 #[strum(serialize_all = "lowercase")]
 pub enum BranchSubCommand {
     /// List all branches
-    #[clap(name = "ls")]
+    #[clap(name = "list", visible_alias = "ls")]
     List,
     /// Delete a branch
-    #[clap(name = "rm")]
+    #[clap(name = "remove", visible_alias = "rm")]
     Delete(BranchDeleteCommand),
 }
 

--- a/cli/crates/cli/src/cli_input/branch.rs
+++ b/cli/crates/cli/src/cli_input/branch.rs
@@ -1,0 +1,27 @@
+use clap::Parser;
+
+use super::BranchRef;
+
+#[derive(Debug, Parser)]
+pub struct BranchCommand {
+    #[command(subcommand)]
+    pub command: BranchSubCommand,
+}
+
+#[derive(Debug, Parser, strum::AsRefStr, strum::Display)]
+#[strum(serialize_all = "lowercase")]
+pub enum BranchSubCommand {
+    /// List all branches
+    #[clap(name = "ls")]
+    List,
+    /// Delete a branch
+    #[clap(name = "rm")]
+    Delete(BranchDeleteCommand),
+}
+
+#[derive(Debug, Parser)]
+pub struct BranchDeleteCommand {
+    /// Name of the branch
+    #[arg(help = BranchRef::ARG_DESCRIPTION)]
+    pub branch_ref: BranchRef,
+}

--- a/cli/crates/cli/src/cli_input/branch_ref.rs
+++ b/cli/crates/cli/src/cli_input/branch_ref.rs
@@ -1,0 +1,91 @@
+use std::{fmt, str};
+
+/// Parsed project reference. A project reference is a string of the form `account/project@branch`.
+#[derive(Clone, Debug)]
+pub struct BranchRef {
+    account: String,
+    project: String,
+    branch: String,
+}
+
+impl BranchRef {
+    pub(crate) const ARG_DESCRIPTION: &'static str =
+        r#"Branch reference following the format "account/project@branch""#;
+
+    pub(crate) fn account(&self) -> &str {
+        self.account.as_ref()
+    }
+
+    pub(crate) fn project(&self) -> &str {
+        self.project.as_ref()
+    }
+
+    pub(crate) fn branch(&self) -> &str {
+        self.branch.as_ref()
+    }
+}
+
+impl str::FromStr for BranchRef {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        const GENERIC_ERR: &str = r#"Invalid branch reference. The branch reference argument must follow the format: "account/project@branch""#;
+
+        let Some((account, rest)) = s.split_once('/') else {
+            return Err(GENERIC_ERR);
+        };
+
+        if account.is_empty() {
+            return Err("The account name is missing before '/'.");
+        }
+
+        let Some((project, branch)) = rest.split_once('@') else {
+            return Err(GENERIC_ERR);
+        };
+
+        if project.is_empty() {
+            return Err("The project name is missing.");
+        }
+
+        if branch.is_empty() {
+            return Err("The branch name is missing.");
+        }
+
+        Ok(BranchRef {
+            account: account.to_owned(),
+            project: project.to_owned(),
+            branch: branch.to_owned(),
+        })
+    }
+}
+
+impl fmt::Display for BranchRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.account)?;
+        f.write_str("/")?;
+        f.write_str(&self.project)?;
+        f.write_str("@")?;
+        f.write_str(&self.branch)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn branch_ref_ok() {
+        let cases = [
+            "microsoft/windows@main",
+            "test/project@master",
+            "__my__/_____project-with-things@branch-here",
+            "1/2@3",
+        ];
+
+        for case in cases {
+            assert_eq!(case, case.parse::<BranchRef>().unwrap().to_string());
+        }
+    }
+}

--- a/cli/crates/cli/src/cli_input/create.rs
+++ b/cli/crates/cli/src/cli_input/create.rs
@@ -5,12 +5,15 @@ use super::ArgumentNames;
 #[derive(Debug, clap::Args)]
 #[group(requires_all = ["name", "account"], multiple = true)]
 pub struct CreateCommand {
-    /// The name to use for the new project
+    /// The name to use for the new graph
     #[arg(short, long)]
     pub name: Option<String>,
-    /// The slug of the account in which the new project should be created
+    /// The slug of the account in which the new graph should be created
     #[arg(short, long, value_name = "SLUG")]
     pub account: Option<String>,
+    /// Adds an environment variable to the graph
+    #[clap(short = 'e', long = "env", value_parser, num_args = 0..)]
+    environment_variables: Vec<String>,
 }
 
 impl CreateCommand {
@@ -18,7 +21,17 @@ impl CreateCommand {
         self.name
             .as_deref()
             .zip(self.account.as_deref())
-            .map(|(name, account_slug)| CreateArguments { account_slug, name })
+            .map(|(name, account_slug)| CreateArguments {
+                account_slug,
+                name,
+                env_vars: self.environment_variables().collect(),
+            })
+    }
+
+    pub fn environment_variables(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.environment_variables
+            .iter()
+            .filter_map(|s| super::split_env_var(s))
     }
 }
 

--- a/cli/crates/cli/src/cli_input/deploy.rs
+++ b/cli/crates/cli/src/cli_input/deploy.rs
@@ -1,6 +1,13 @@
+use clap::ArgGroup;
+
+use super::ProjectRef;
+
 #[derive(Debug, clap::Args)]
+#[clap(group(ArgGroup::new("branch-or-graph-ref").required(false).args(["graph_ref", "branch"])))]
 pub struct DeployCommand {
-    /// The branch of the graph. If omitted, defaults to the production branch.
+    #[arg(short, long, help = ProjectRef::ARG_DESCRIPTION)]
+    pub graph_ref: Option<ProjectRef>,
+    /// The branch to deploy into, if running from a linked project
     #[arg(short, long)]
     pub branch: Option<String>,
 }

--- a/cli/crates/cli/src/cli_input/project_ref.rs
+++ b/cli/crates/cli/src/cli_input/project_ref.rs
@@ -6,24 +6,27 @@ use graph_ref::GraphRef;
 #[derive(Clone, Debug)]
 pub struct ProjectRef {
     account: String,
-    project: String,
+    graph: String,
     branch: Option<String>,
 }
 
 impl ProjectRef {
-    pub(crate) const ARG_DESCRIPTION: &'static str =
-        r#"Project reference following the format "account/project@branch""#;
+    pub(crate) const ARG_DESCRIPTION: &'static str = r#"Graph reference following the format "account/graph@branch""#;
 
     pub(crate) fn account(&self) -> &str {
         self.account.as_ref()
     }
 
-    pub(crate) fn project(&self) -> &str {
-        self.project.as_ref()
+    pub(crate) fn graph(&self) -> &str {
+        self.graph.as_ref()
     }
 
     pub(crate) fn branch(&self) -> Option<&str> {
         self.branch.as_deref()
+    }
+
+    pub(crate) fn into_parts(self) -> (String, String, Option<String>) {
+        (self.account, self.graph, self.branch)
     }
 }
 
@@ -31,7 +34,8 @@ impl str::FromStr for ProjectRef {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        const GENERIC_ERR: &str = r#"Invalid project reference. The project reference argument must follow the format: "account/project@branch""#;
+        const GENERIC_ERR: &str =
+            r#"Invalid graph reference. The graph reference argument must follow the format: "account/graph@branch""#;
 
         let Some((account, rest)) = s.split_once('/') else {
             return Err(GENERIC_ERR);
@@ -52,7 +56,7 @@ impl str::FromStr for ProjectRef {
 
         Ok(ProjectRef {
             account: account.to_owned(),
-            project: project.to_owned(),
+            graph: project.to_owned(),
             branch: branch.filter(|s| !s.is_empty()).map(String::from),
         })
     }
@@ -62,7 +66,7 @@ impl fmt::Display for ProjectRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.account)?;
         f.write_str("/")?;
-        f.write_str(&self.project)?;
+        f.write_str(&self.graph)?;
 
         if let Some(branch) = &self.branch {
             f.write_str("@")?;
@@ -96,7 +100,7 @@ impl ProjectRefOrGraphRef {
 
     pub(crate) fn project(&self) -> &str {
         match self {
-            ProjectRefOrGraphRef::ProjectRef(pr) => pr.project(),
+            ProjectRefOrGraphRef::ProjectRef(pr) => pr.graph(),
             ProjectRefOrGraphRef::GraphRef(gr) => gr.graph(),
         }
     }

--- a/cli/crates/cli/src/cli_input/sub_command.rs
+++ b/cli/crates/cli/src/cli_input/sub_command.rs
@@ -1,16 +1,18 @@
 use clap::Parser;
 
-use crate::is_not_direct_install;
+use crate::{cli_input::BranchSubCommand, is_not_direct_install};
 
 use super::{
-    trust::TrustCommand, ArgumentNames, BuildCommand, CheckCommand, CompletionsCommand, CreateCommand, DeployCommand,
-    DevCommand, InitCommand, IntrospectCommand, LinkCommand, LintCommand, LogsCommand, PublishCommand, SchemaCommand,
-    StartCommand, SubgraphsCommand,
+    branch::BranchCommand, trust::TrustCommand, ArgumentNames, BuildCommand, CheckCommand, CompletionsCommand,
+    CreateCommand, DeployCommand, DevCommand, InitCommand, IntrospectCommand, LinkCommand, LintCommand, LogsCommand,
+    PublishCommand, SchemaCommand, StartCommand, SubgraphsCommand,
 };
 
 #[derive(Debug, Parser, strum::AsRefStr, strum::Display)]
 #[strum(serialize_all = "lowercase")]
 pub enum SubCommand {
+    /// Graph branch management
+    Branch(BranchCommand),
     /// Start the Grafbase local development server
     Dev(DevCommand),
     /// Output completions for the chosen shell to use, write the output to the
@@ -64,6 +66,9 @@ impl SubCommand {
         matches!(
             self,
             Self::Create(_)
+                | Self::Branch(BranchCommand {
+                    command: BranchSubCommand::List
+                })
                 | Self::Deploy(_)
                 | Self::Dev(DevCommand { .. })
                 | Self::Link(_)
@@ -91,6 +96,7 @@ impl ArgumentNames for SubCommand {
             SubCommand::Init(command) => command.argument_names(),
             SubCommand::Create(command) => command.argument_names(),
             SubCommand::Schema(_)
+            | SubCommand::Branch(_)
             | SubCommand::Publish(_)
             | SubCommand::Check(_)
             | SubCommand::Subgraphs(_)

--- a/cli/crates/cli/src/create.rs
+++ b/cli/crates/cli/src/create.rs
@@ -1,4 +1,4 @@
-use crate::{errors::CliError, output::report, prompts::handle_inquire_error};
+use crate::{deploy, errors::CliError, output::report, prompts::handle_inquire_error};
 use backend::api::{create, types::Account};
 use common::environment::Project;
 use inquire::{validator::Validation, Confirm, Select, Text};
@@ -19,6 +19,7 @@ impl Display for AccountSelection {
 pub struct CreateArguments<'a> {
     pub account_slug: &'a str,
     pub name: &'a str,
+    pub env_vars: Vec<(&'a str, &'a str)>,
 }
 
 #[tokio::main]
@@ -47,10 +48,11 @@ async fn from_arguments(arguments: &CreateArguments<'_>) -> Result<(), CliError>
         .ok_or(CliError::NoAccountFound)?
         .id;
 
-    let domains = create::create(&account_id, arguments.name)
+    let (domains, deployment_id) = create::create(&account_id, arguments.name, arguments.env_vars.iter().copied())
         .await
         .map_err(CliError::BackendApiError)?;
 
+    deploy::report_progress(deployment_id.into_inner()).await?;
     report::create_success(arguments.name, &domains);
 
     Ok(())
@@ -67,7 +69,7 @@ async fn interactive() -> Result<(), CliError> {
 
     let dir_name = project.path.file_name().expect("must exist").to_string_lossy();
 
-    let project_name = Text::new("What should your new project be called?")
+    let project_name = Text::new("What should your new graph be called?")
         .with_default(&dir_name)
         .with_validator(|value: &str| {
             let slugified = slugify!(value, max_length = 48);
@@ -75,27 +77,59 @@ async fn interactive() -> Result<(), CliError> {
                 Ok(Validation::Valid)
             } else {
                 Ok(Validation::Invalid(
-                    format!("Invalid project name, try '{slugified}'").into(),
+                    format!("Invalid graph name, try '{slugified}'").into(),
                 ))
             }
         })
         .prompt()
         .map_err(handle_inquire_error)?;
 
-    let AccountSelection(selected_account) = Select::new("In which account should the project be created?", options)
+    let AccountSelection(selected_account) = Select::new("In which account should the graph be created?", options)
         .prompt()
         .map_err(handle_inquire_error)?;
 
-    let confirm = Confirm::new("Please confirm the above to create and deploy your new project")
+    let confirm_env_vars = Confirm::new("Would you like to add environment variables to the graph?")
+        .with_default(false)
+        .prompt()
+        .map_err(handle_inquire_error)?;
+
+    let mut env_vars = Vec::new();
+
+    if confirm_env_vars {
+        loop {
+            let key = Text::new("key (press enter to exit):")
+                .with_default("")
+                .prompt()
+                .map_err(handle_inquire_error)?;
+
+            if key.is_empty() {
+                break;
+            }
+
+            let value = Text::new("value:")
+                .with_default("")
+                .prompt()
+                .map_err(handle_inquire_error)?;
+
+            env_vars.push((key, value));
+        }
+    }
+
+    let confirm = Confirm::new("Please confirm the above to create and deploy your new graph")
         .with_default(true)
         .prompt()
         .map_err(handle_inquire_error)?;
 
     if confirm {
-        let domains = create::create(&selected_account.id, &project_name)
-            .await
-            .map_err(CliError::BackendApiError)?;
+        let (domains, deployment_id) = create::create(
+            &selected_account.id,
+            &project_name,
+            env_vars.iter().map(|(k, v)| (k.as_str(), v.as_str())),
+        )
+        .await
+        .map_err(CliError::BackendApiError)?;
 
+        deploy::report_progress(deployment_id.into_inner()).await?;
         report::create_success(&project_name, &domains);
     }
 

--- a/cli/crates/cli/src/deploy.rs
+++ b/cli/crates/cli/src/deploy.rs
@@ -5,7 +5,7 @@ use inquire::Select;
 use strum::{Display, VariantArray};
 
 #[derive(VariantArray, Display, Clone)]
-enum UnlinkedDeploymentMethod {
+pub enum UnlinkedDeploymentMethod {
     Link,
     Create,
 }

--- a/cli/crates/cli/src/deploy.rs
+++ b/cli/crates/cli/src/deploy.rs
@@ -1,5 +1,8 @@
+use std::time::Duration;
+
 use crate::{create::create_impl, errors::CliError, link::link_impl, output::report, prompts::handle_inquire_error};
 use backend::api::deploy;
+use chrono::{DateTime, Local, Utc};
 use common::{consts::PROJECT_METADATA_FILE, environment::Project};
 use inquire::Select;
 use strum::{Display, VariantArray};
@@ -38,8 +41,55 @@ pub async fn deploy(branch: Option<&str>) -> Result<(), CliError> {
     }
 
     report::deploy();
-    deploy::deploy(branch).await.map_err(CliError::BackendApiError)?;
+
+    let deployment_id = deploy::deploy(branch).await.map_err(CliError::BackendApiError)?;
+    report_progress(deployment_id.into_inner()).await?;
+
     report::deploy_success();
 
     Ok(())
+}
+
+async fn report_progress(deployment_id: String) -> Result<(), CliError> {
+    const WAIT_DURATION: Duration = Duration::from_secs(10);
+    const POLL_TIMEOUT: Duration = Duration::from_secs(1);
+
+    let mut finished = false;
+    let mut interval = tokio::time::interval(POLL_TIMEOUT);
+    let mut last_index = 0;
+    let mut failed = false;
+
+    while !finished {
+        interval.tick().await;
+
+        let deployment = deploy::fetch_logs(deployment_id.clone().into())
+            .await
+            .map_err(CliError::BackendApiError)?;
+
+        let mut seen_index = 0;
+
+        for (i, log) in deployment.log_entries.iter().enumerate() {
+            seen_index = i;
+
+            if i <= last_index {
+                continue;
+            }
+
+            let created_at: DateTime<Local> = log.created_at.into();
+            println!("{}    {}", created_at.format("%H:%M:%S%.3f"), log.message);
+        }
+
+        last_index = seen_index;
+
+        if let Some(finished_at) = deployment.finished_at {
+            failed = deployment.status.failed();
+            finished = (Utc::now() - finished_at).to_std().unwrap_or_default() > WAIT_DURATION;
+        }
+    }
+
+    if failed {
+        Err(CliError::DeploymentFailed)
+    } else {
+        Ok(())
+    }
 }

--- a/cli/crates/cli/src/errors.rs
+++ b/cli/crates/cli/src/errors.rs
@@ -85,6 +85,8 @@ pub enum CliError {
     /// returned if an unsupported extension is passed to lint
     #[error("attempted to lint a file with an unsupported extension: '{0}'")]
     LintUnsupportedFileExtension(String),
+    #[error("failed to deploy a graph")]
+    DeploymentFailed,
 }
 
 #[cfg(target_family = "windows")]

--- a/cli/crates/cli/src/init.rs
+++ b/cli/crates/cli/src/init.rs
@@ -19,7 +19,7 @@ pub fn init(name: Option<&str>, template: Option<&str>, graph_type: Option<Graph
     };
 
     project::init(name, template).map_err(CliError::BackendError)?;
-    report::project_created(name);
+    report::graph_created(name);
 
     Ok(())
 }

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(test, allow(unused_crate_dependencies))]
 #![forbid(unsafe_code)]
 
+mod branch;
 mod build;
 mod check;
 mod cli_input;
@@ -33,7 +34,7 @@ extern crate log;
 
 use crate::{
     build::build,
-    cli_input::{Args, ArgumentNames, LogsCommand, SubCommand},
+    cli_input::{Args, ArgumentNames, BranchSubCommand, LogsCommand, SubCommand},
     create::create,
     deploy::deploy,
     dev::dev,
@@ -196,6 +197,10 @@ fn try_main(args: Args) -> Result<(), CliError> {
             upgrade::install_grafbase().map_err(Into::into)
         }
         SubCommand::Lint(cmd) => lint::lint(cmd.schema),
+        SubCommand::Branch(cmd) => match cmd.command {
+            BranchSubCommand::List => branch::list(),
+            BranchSubCommand::Delete(cmd) => branch::delete(cmd.branch_ref),
+        },
     }
 }
 

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -126,7 +126,7 @@ fn try_main(args: Args) -> Result<(), CliError> {
         SubCommand::Login => login(),
         SubCommand::Logout => logout(),
         SubCommand::Create(cmd) => create(&cmd.create_arguments()),
-        SubCommand::Deploy(cmd) => deploy(cmd.branch.as_deref()),
+        SubCommand::Deploy(cmd) => deploy(cmd.graph_ref, cmd.branch),
         SubCommand::Link(cmd) => link(cmd.project),
         SubCommand::Unlink => unlink(),
         SubCommand::Logs(LogsCommand {

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -67,7 +67,7 @@ pub fn start_federated_dev_server(port: u16) {
     );
 }
 
-pub fn project_created(name: Option<&str>) {
+pub fn graph_created(name: Option<&str>) {
     let slash = std::path::MAIN_SEPARATOR.to_string();
 
     let schema_file_name = GRAFBASE_TS_CONFIG_FILE_NAME;
@@ -78,11 +78,11 @@ pub fn project_created(name: Option<&str>) {
         let schema_path = &[".", name, schema_file_name].join(&slash);
 
         println!(
-            "The configuration for your new project can be found at {}",
+            "The configuration for your new graph can be found at {}",
             watercolor!("{schema_path}", @BrightBlue)
         );
     } else {
-        watercolor::output!(r"✨ Your project was successfully set up for Grafbase!", @BrightBlue);
+        watercolor::output!(r"✨ Your graph was successfully set up for Grafbase!", @BrightBlue);
 
         let schema_path = &[".", schema_file_name].join(&slash);
 
@@ -365,7 +365,7 @@ pub fn logout() {
 
 // TODO change this to a spinner that is removed on success
 pub fn deploy() {
-    watercolor::output!("🕒 Your project is being deployed...", @BrightBlue);
+    watercolor::output!("🕒 Your graph is being deployed...", @BrightBlue);
 }
 
 // TODO change this to a spinner that is removed on success
@@ -379,23 +379,23 @@ pub fn delete_branch_success() {
 
 // TODO change this to a spinner that is removed on success
 pub fn create() {
-    watercolor::output!("🕒 Your project is being created...", @BrightBlue);
+    watercolor::output!("🕒 Your graph is being created...", @BrightBlue);
 }
 
 pub fn deploy_success() {
-    watercolor::output!("\n✨ Your project was successfully deployed!", @BrightBlue);
+    watercolor::output!("\n✨ Your graph was successfully deployed!", @BrightBlue);
 }
 
 pub fn linked(name: &str) {
-    watercolor::output!("\n✨ Successfully linked your local project to {name}!", @BrightBlue);
+    watercolor::output!("\n✨ Successfully linked your local graph to {name}!", @BrightBlue);
 }
 
 pub fn linked_non_interactive() {
-    watercolor::output!("✨ Successfully linked your local project!", @BrightBlue);
+    watercolor::output!("✨ Successfully linked your local graph!", @BrightBlue);
 }
 
 pub fn unlinked() {
-    watercolor::output!("✨ Successfully unlinked your project!", @BrightBlue);
+    watercolor::output!("✨ Successfully unlinked your graph!", @BrightBlue);
 }
 
 pub fn list_branches(branches: Vec<Branch>) {
@@ -662,7 +662,7 @@ pub(crate) fn trust_failed() {
 }
 
 pub(crate) fn old_access_token() {
-    watercolor::output!("❌ You must pass a project reference of the form <account>/<project>@<branch> (missing account)", @BrightRed)
+    watercolor::output!("❌ You must pass a graph reference of the form <account>/<graph>@<branch> (missing account)", @BrightRed)
 }
 
 pub(crate) fn trust_reused_ids(reused: &backend::api::submit_trusted_documents::ReusedIds) {

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -347,6 +347,15 @@ pub fn deploy() {
 }
 
 // TODO change this to a spinner that is removed on success
+pub fn delete_branch() {
+    watercolor::output!("🕒 Branch is being deleted...", @BrightBlue);
+}
+
+pub fn delete_branch_success() {
+    watercolor::output!("\n✨ The branch was successfully deleted!", @BrightBlue);
+}
+
+// TODO change this to a spinner that is removed on success
 pub fn create() {
     watercolor::output!("🕒 Your project is being created...", @BrightBlue);
 }
@@ -365,6 +374,27 @@ pub fn linked_non_interactive() {
 
 pub fn unlinked() {
     watercolor::output!("✨ Successfully unlinked your project!", @BrightBlue);
+}
+
+pub(crate) fn listing_branches() {
+    println!("⏳ Fetching graph branches...");
+}
+
+pub fn list_branches(branches: &[(String, bool)]) {
+    if branches.is_empty() {
+        watercolor::output!("⚠️  Found no branches.", @BrightYellow);
+        return;
+    }
+
+    watercolor::output!("✨ Branches for the graph:", @BrightBlue);
+
+    for (branch, is_production) in branches {
+        if *is_production {
+            watercolor::output!("- {branch} (production)", @BrightYellow);
+        } else {
+            watercolor::output!("- {branch}", @BrightBlue);
+        }
+    }
 }
 
 pub fn create_success(name: &str, urls: &[String]) {

--- a/cli/crates/cli/src/publish.rs
+++ b/cli/crates/cli/src/publish.rs
@@ -35,7 +35,7 @@ pub(crate) async fn publish(
 
     let outcome = backend::api::publish::publish(
         project_ref.account(),
-        project_ref.project(),
+        project_ref.graph(),
         project_ref.branch(),
         &subgraph_name,
         url.as_str(),

--- a/cli/crates/cli/src/schema.rs
+++ b/cli/crates/cli/src/schema.rs
@@ -8,7 +8,7 @@ pub(crate) async fn schema(cmd: SchemaCommand) -> Result<(), CliError> {
     } = cmd;
     let schema = backend::api::schema::schema(
         project_ref.account(),
-        project_ref.project(),
+        project_ref.graph(),
         project_ref.branch(),
         subgraph_name.as_deref(),
     )

--- a/cli/crates/cli/src/subgraphs.rs
+++ b/cli/crates/cli/src/subgraphs.rs
@@ -4,7 +4,7 @@ use crate::{cli_input::SubgraphsCommand, errors::CliError, output::report};
 pub(super) async fn subgraphs(cmd: SubgraphsCommand) -> Result<(), CliError> {
     let project_ref = cmd.project_ref;
     let (branch, subgraphs) =
-        backend::api::subgraphs::subgraphs(project_ref.account(), project_ref.project(), project_ref.branch())
+        backend::api::subgraphs::subgraphs(project_ref.account(), project_ref.graph(), project_ref.branch())
             .await
             .map_err(CliError::BackendApiError)?;
 


### PR DESCRIPTION
Videos tell more than words here:

Creating a new graph interactively, we can now add env vars from this dialog. The deployment errors, because we can't introspect the postgres with the given connection string:
[Screencast_20240425_185634.webm](https://github.com/grafbase/grafbase/assets/34967/63f4f0c8-39b8-42bc-848c-ae6404a0b95a)

Creating a new graph with env vars directly using CLI arguments. Now it works.
[Screencast_20240425_190139.webm](https://github.com/grafbase/grafbase/assets/34967/dd395759-e1ff-410d-91f9-978a5a6267e6)

Deploying from a linked project with branch, then listing branches, deleting the `.grafbase` directory and deploying with the graph ref that does not need a linked project.

[Screencast_20240425_190251.webm](https://github.com/grafbase/grafbase/assets/34967/1e6d6868-d32b-468e-8987-cbec0b03f6f0)

closes: GB-6546
