### PR TITLE
graphql-schema-validation: fix stack overflow on input type cycles

### DIFF
--- a/engine/crates/validation/CHANGELOG.md
+++ b/engine/crates/validation/CHANGELOG.md
@@ -8,6 +8,7 @@
   stricter. If Query does not exist, it is an error. (#1502)
 
 - Properly validate that object, interface and input object types define at least one field (https://github.com/graphql/graphql-spec/blame/October2021/spec/Section%203%20--%20Type%20System.md#L868). Previously, we were validating against `type Test {}` but not `type Test`.
+- Whenever we had a graph of input objects with multiple cycles in graphql-schema-validation, we would go into an infinite loop and stack overflow. This is fixed in this release.
 
 ## [0.1.3] - 2024-02-06
 

--- a/engine/crates/validation/tests/validation_errors/input_object_cycles_two.errors.txt
+++ b/engine/crates/validation/tests/validation_errors/input_object_cycles_two.errors.txt
@@ -1,0 +1,4 @@
+  × Cannot reference Input Object A within itself through a series of non-null fields: "aa"
+
+
+  × Cannot reference Input Object B within itself through a series of non-null fields: "ba.ab"

--- a/engine/crates/validation/tests/validation_errors/input_object_cycles_two.graphql
+++ b/engine/crates/validation/tests/validation_errors/input_object_cycles_two.graphql
@@ -1,0 +1,16 @@
+# Regression test. This caused an infinite loop.
+
+input A {
+  aa: A!
+  ab: B!
+}
+
+input B {
+  ba: A!
+  bb: B!
+}
+
+input C {
+  ca: A!
+  cb: B!
+}


### PR DESCRIPTION
Whenever we had a graph of input objects with multiple cycles in graphql-schema-validation, we would go into an infinite loop and stack overflow. This commit changes the function at fault to do a proper BFS.

closes GB-6570