### PR TITLE
cli: implement minimum support for NixOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2933,6 +2933,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "ulid",
+ "which",
 ]
 
 [[package]]

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -107,7 +107,7 @@ tempfile = "3"
 tokio = { version = "1", features = ["full"] }
 tower-http = "0.5"
 url = "2"
-which = "6"
+which.workspace = true
 wiremock.workspace = true
 
 [[bin]]

--- a/cli/crates/common/Cargo.toml
+++ b/cli/crates/common/Cargo.toml
@@ -24,6 +24,7 @@ strum = { version = "0.26", features = ["derive"] }
 thiserror = "1"
 tokio.workspace = true
 ulid = { version = "1", features = ["serde"] }
+which.workspace = true
 
 common-types = { path = "../../../engine/crates/common-types" }
 

--- a/cli/crates/common/src/errors.rs
+++ b/cli/crates/common/src/errors.rs
@@ -35,4 +35,10 @@ pub enum CommonError {
     RegistryRead(std::path::PathBuf, std::io::Error),
     #[error("could not deserialize to json the contents of '{0}':\nCaused by: {1}")]
     RegistryDeserialization(std::path::PathBuf, serde_json::Error),
+    #[error(transparent)]
+    BunNotFound(#[from] BunNotFound),
 }
+
+#[derive(Debug, thiserror::Error, Clone, Copy)]
+#[error("Could not find a `bun` executable in PATH. Bun is required in order to evaluate your TypeScript configuration. Please install `bun` or run `nix shell nixpkgs#bun`.")]
+pub struct BunNotFound;

--- a/cli/crates/server/src/bridge/udf.rs
+++ b/cli/crates/server/src/bridge/udf.rs
@@ -182,7 +182,7 @@ impl UdfRuntime {
         );
 
         let environment = Environment::get();
-        let mut bun = Command::new(&environment.bun_executable_path);
+        let mut bun = Command::new(environment.bun_executable_path()?);
         bun.args(bun_arguments)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -428,7 +428,7 @@ async fn spawn_bun(
         let bun_arguments = vec!["run", &script_path];
 
         let environment = Environment::get();
-        let mut bun = Command::new(&environment.bun_executable_path);
+        let mut bun = Command::new(environment.bun_executable_path()?);
         bun.args(bun_arguments)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/cli/crates/server/src/config/mod.rs
+++ b/cli/crates/server/src/config/mod.rs
@@ -181,19 +181,23 @@ async fn parse_and_generate_config_from_ts(
         generated_config_path.to_string_lossy().to_string(),
     ];
 
-    let bun_command = Command::new(&environment.bun_executable_path)
-        .args(args)
-        .env(
-            "GRAFBASE_ENV",
-            match environment_name {
-                EnvironmentName::Production => "production",
-                EnvironmentName::Dev => "dev",
-                EnvironmentName::None => "",
-            },
-        )
-        .stderr(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()?;
+    let bun_command = Command::new(
+        environment
+            .bun_executable_path()
+            .map_err(|err| ConfigError::LoadTsConfig(err.to_string()))?,
+    )
+    .args(args)
+    .env(
+        "GRAFBASE_ENV",
+        match environment_name {
+            EnvironmentName::Production => "production",
+            EnvironmentName::Dev => "dev",
+            EnvironmentName::None => "",
+        },
+    )
+    .stderr(Stdio::piped())
+    .stdout(Stdio::piped())
+    .spawn()?;
 
     let output = bun_command.wait_with_output().await?;
 

--- a/cli/crates/server/src/errors.rs
+++ b/cli/crates/server/src/errors.rs
@@ -201,6 +201,9 @@ pub enum UdfBuildError {
 
     #[error("bun encountered an error: \n{output}")]
     BunBuildFailed { output: String },
+
+    #[error(transparent)]
+    BunNotFound(#[from] common::errors::BunNotFound),
 }
 
 impl IntoResponse for ServerError {


### PR DESCRIPTION
Currently, if you start `grafbase dev` or any command that reads the configuration with configuration in a grafbase.config.ts file, on NixOS, you will see this:

```
Grafbase CLI 0.69.1

Error: could not load grafbase/grafbase.config.ts
Caused by: Could not start dynamically linked executable: /home/tom/.grafbase/bun/bun
NixOS cannot run dynamically linked executables intended for generic
linux environments out of the box. For more information, see:
https://nix.dev/permalink/stub-ld
```

This is because the CLI downloads a bun binary from GitHub releases. That will not work on NixOS.

This commit implements the minimum version of NixOS support: use the `bun` executable from `$PATH`, and if that is missing, fail with a helpful error.

Ideally, we would want to run the exact version of bun the CLI is tested with, but we do not want to run `nix` on behalf of the user. We could point them to the right command, or even better, start enforcing that the derivation for the CLI in this repo is working in CI. In the meantime, this commit is an improvement on the status quo.