### PR TITLE
sdk: add ability to pass GraphQL SDL type definitions to standalone graphs

### DIFF
--- a/packages/grafbase-sdk/src/grafbase-schema.ts
+++ b/packages/grafbase-sdk/src/grafbase-schema.ts
@@ -76,8 +76,9 @@ export class Graph {
   private extendedTypes: TypeExtension[]
   private inputs: Input[]
   private subgraph: boolean
+  private typeDefs?: string
 
-  constructor(subgraph: boolean) {
+  constructor(subgraph: boolean, typeDefs?: string) {
     this.enums = []
     this.types = []
     this.unions = []
@@ -87,6 +88,7 @@ export class Graph {
     this.extendedTypes = []
     this.inputs = []
     this.subgraph = subgraph
+    this.typeDefs = typeDefs
   }
 
   /**
@@ -545,7 +547,9 @@ export class Graph {
       models
     ]
 
-    return renderOrder.filter(Boolean).flat().map(String).join('\n\n')
+    const sdkRendered = renderOrder.filter(Boolean).flat().map(String).join('\n\n')
+
+    return [sdkRendered, this.typeDefs].filter(Boolean).join('\n\n')
   }
 }
 

--- a/packages/grafbase-sdk/src/graph.ts
+++ b/packages/grafbase-sdk/src/graph.ts
@@ -1,7 +1,54 @@
 import { FederatedGraph, FederatedGraphInput, Graph } from './grafbase-schema'
 
 export interface StandaloneInput {
-  subgraph: boolean
+  subgraph?: boolean
+  /**
+    * Optional GraphQL SDL to add to your configuration. This lets you define parts of your configuration in GraphQL and others in TypeScript, depending on your preferences.
+    *
+    * For example, the two configurations are equivalent:
+    *
+    * ```
+    * const g = graph.Standalone()
+    *
+    *  const Invoice = g.type('Invoice', {
+    *   id: g.id(),
+    *   invoiceNumber: g.string(),
+    *   dueDate: g.date(),
+    *   totalAmount: g.int(),
+    * })
+    *
+    * g.query('invoiceByNumber', {
+    *   args: { invoiceNumber: g.string() },
+    *   returns: g.ref(Invoice).optional(),
+    *   resolver: 'invoice/byNumber'
+    * })
+    *
+    * export default config({ graph: g })
+    * ```
+    *
+    * and
+    *
+    * ```
+    * const g = graph.Standalone({
+    *   typeDefs: `
+    *     type Invoice {
+    *       id: ID!
+    *       invoiceNumber: String!
+    *       dueDate: Date!
+    *       totalAmount: Int!
+    *     }
+    *
+    *     extend type Query {
+    *       invoiceByNumber(invoiceNumber: String!): Invoice @resolver(name: "invoice/byNumber")
+    *     }
+    *   `
+    * })
+    *
+    * export default config({ graph: g })
+    * ```
+    *
+    */
+  typeDefs?: string
 }
 
 /**
@@ -9,5 +56,5 @@ export interface StandaloneInput {
  */
 export const graph = {
   Federated: (input?: FederatedGraphInput) => new FederatedGraph(input),
-  Standalone: (input?: StandaloneInput) => new Graph(Boolean(input?.subgraph))
+  Standalone: (input?: StandaloneInput) => new Graph(Boolean(input?.subgraph), input?.typeDefs)
 }

--- a/packages/grafbase-sdk/tests/unit/typeDef.test.ts
+++ b/packages/grafbase-sdk/tests/unit/typeDef.test.ts
@@ -1,0 +1,41 @@
+import { config, graph } from '../../src/index'
+import { describe, expect, it } from '@jest/globals'
+import { renderGraphQL } from '../utils'
+
+const g = graph.Standalone({ subgraph: true })
+
+describe('graph.Standalone() typeDef argument', () => {
+  it('renders the content of typeDefs at the end', () => {
+    const g = graph.Standalone({
+      typeDefs: /* GraphQL */ `
+        type Invoice {
+          id: ID!
+          invoiceNumber: String!
+          dueDate: Date!
+          totalAmount: Int!
+        }
+
+        extend type Query {
+          invoiceByNumber(invoiceNumber: String!): Invoice @resolver(name: "invoice/byNumber")
+        }
+      `
+    })
+
+    const cfg = config({ graph: g })
+
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
+      "
+              type Invoice {
+                id: ID!
+                invoiceNumber: String!
+                dueDate: Date!
+                totalAmount: Int!
+              }
+
+              extend type Query {
+                invoiceByNumber(invoiceNumber: String!): Invoice @resolver(name: "invoice/byNumber")
+              }
+            "
+    `)
+  })
+})


### PR DESCRIPTION
This lets users mix GraphQL SDL and SDK to their preference when defining their configuration. The idea and implementation are both very basic.

The API takes the shape of a new argument to `graph.Standalone()`:

```typescript
const g = graph.Standalone({
  typeDefs: /* GraphQL */ `
    type Invoice {
      id: ID!
      invoiceNumber: String!
      dueDate: Date!
      totalAmount: Int!
    }

    extend type Query {
      invoiceByNumber(invoiceNumber: String!): Invoice @resolver(name: "invoice/byNumber")
    }
  `
})

```

The implementation is equally straightforward: we append the GraphQL that was passed in at the end of the generated SDL configuration.

Potential issues:

- Ordering: we have a set ordering for schema items in the SDK. Appending the string as-is will not respect it.
- Error message: it will not be clear where the error originated, but this is no worse than if you defined your whole config in SDL in the first place.

The issues seem to be minor enough to overlook, since it's a small change that enables new use cases.

closes GB-6547
