### PR TITLE
sdk: release 0.22.0

### DIFF
--- a/packages/grafbase-sdk/CHANGELOG.md
+++ b/packages/grafbase-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.22.0] - Wed Apr 25 2024
+
+[CHANGELOG](changelog/0.22.0.md)
+
 ## [0.21.0] - Wed Apr 17 2024
 
 [CHANGELOG](changelog/0.21.0.md)

--- a/packages/grafbase-sdk/changelog/0.22.0.md
+++ b/packages/grafbase-sdk/changelog/0.22.0.md
@@ -1,0 +1,3 @@
+## Features
+
+- graph.Standalone() now optionally takes GraphQL SDL definitions to include in the configuration. See [#1645](https://github.com/grafbase/grafbase/pull/1645) for details.

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Features

- graph.Standalone() now optionally takes GraphQL SDL definitions to include in the configuration. See [#1645](https://github.com/grafbase/grafbase/pull/1645) for details.