### PR TITLE
chore: Add missing gql.operation.type in operation metrics

### DIFF
--- a/engine/crates/runtime-local/src/fetch.rs
+++ b/engine/crates/runtime-local/src/fetch.rs
@@ -60,7 +60,9 @@ impl FetcherInner for NativeFetcher {
                 HeaderValue::from_str("graphql-transport-ws").unwrap(),
             );
 
-            async_tungstenite::tokio::connect_async(request).await.unwrap()
+            async_tungstenite::tokio::connect_async(request)
+                .await
+                .map_err(FetchError::any)?
         };
 
         let headers = request.headers.iter().copied().collect::<HashMap<_, _>>();

--- a/engine/crates/tracing/src/metrics/operation.rs
+++ b/engine/crates/tracing/src/metrics/operation.rs
@@ -43,6 +43,7 @@ impl GraphqlOperationMetrics {
         let name = name.unwrap_or_default();
         let mut attributes = vec![
             KeyValue::new("gql.operation.normalized_query_hash", normalized_query_hash.clone()),
+            KeyValue::new("gql.operation.type", ty),
             KeyValue::new("gql.operation.name", name.clone()),
         ];
         if let Some(cache_status) = cache_status {
@@ -52,9 +53,8 @@ impl GraphqlOperationMetrics {
             attributes.push(KeyValue::new("gql.response.has_errors", "true"));
         }
         self.count.add(1, &attributes);
-        // We're only sending the type & normalized_query for the latency. Operation name &
-        // normalized_query_hash are enough to uniquely identify the operation currently, so no need to send
-        // this additional metadata twice.
+        // We're only sending the normalized_query for the latency. It's only send as additional
+        // metadata.
         self.latency.record(
             latency.as_millis() as u64,
             &[

--- a/gateway/crates/gateway-binary/tests/telemetry/metrics/operation.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/metrics/operation.rs
@@ -30,7 +30,8 @@ fn basic() {
         insta::assert_json_snapshot!(attributes, @r###"
         {
           "gql.operation.name": "Simple",
-          "gql.operation.normalized_query_hash": "cAe1+tBRHQLrF/EO1ul4CTx+q5SB9YD+YtG3VDU6VCM="
+          "gql.operation.normalized_query_hash": "cAe1+tBRHQLrF/EO1ul4CTx+q5SB9YD+YtG3VDU6VCM=",
+          "gql.operation.type": "query"
         }
         "###);
         let ExponentialHistogramRow { count, attributes } = clickhouse
@@ -89,6 +90,7 @@ fn has_error() {
         {
           "gql.operation.name": "Simple",
           "gql.operation.normalized_query_hash": "3Dn7H9sNlA2O2Wphw0R6wK0BiqcdP4oRlTiq0Ifq09M=",
+          "gql.operation.type": "query",
           "gql.response.has_errors": "true"
         }
         "###);


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
