### PR TITLE
feat: add registry-v2 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6074,6 +6074,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
+name = "registry-v2"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "common-types",
+ "engine-value",
+ "gateway-v2-auth-config",
+ "indexmap 2.2.6",
+ "postgres-connector-types",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "url",
+]
+
+[[package]]
 name = "relative-path"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "engine/crates/engine/derive",
   "engine/crates/engine/parser",
   "engine/crates/engine/value",
+  "engine/crates/engine/registry-v2",
   "graph-ref",
   "graphql-lint",
 ]
@@ -168,6 +169,8 @@ jwt-verifier = { path = "engine/crates/jwt-verifier" }
 parser-graphql = { path = "engine/crates/parser-graphql" }
 parser-openapi = { path = "engine/crates/parser-openapi" }
 parser-postgres = { path = "engine/crates/parser-postgres" }
+postgres-connector-types = { path = "engine/crates/postgres-connector-types" }
+registry-v2 = { path = "engine/crates/engine/registry-v2" }
 runtime-local = { path = "engine/crates/runtime-local" }
 runtime-noop = { path = "engine/crates/runtime-noop" }
 runtime = { path = "engine/crates/runtime" }

--- a/engine/crates/engine/registry-v2/Cargo.toml
+++ b/engine/crates/engine/registry-v2/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "registry-v2"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1"
+common-types.workspace = true
+engine-value.workspace = true
+gateway-v2-auth-config.workspace = true
+indexmap.workspace = true
+postgres-connector-types.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_with.workspace = true
+url.workspace = true

--- a/engine/crates/engine/registry-v2/src/cache_control.rs
+++ b/engine/crates/engine/registry-v2/src/cache_control.rs
@@ -1,0 +1,87 @@
+use std::collections::BTreeSet;
+
+#[serde_with::minify_field_names(serialize = "minified", deserialize = "minified")]
+#[serde_with::skip_serializing_defaults(Option, bool, usize)]
+#[derive(Default, Hash, Clone, PartialEq, Eq, Debug, serde::Deserialize, serde::Serialize)]
+pub struct CacheControl {
+    /// Scope is public, default is false.
+    pub public: bool,
+
+    /// Cache max age, default is 0.
+    pub max_age: usize,
+
+    /// Cache stale_while_revalidate, default is 0.
+    pub stale_while_revalidate: usize,
+
+    /// Invalidation policy for mutations, default is None.
+    pub invalidation_policy: Option<CacheInvalidationPolicy>,
+
+    /// Access scopes
+    pub access_scopes: Option<BTreeSet<CacheAccessScope>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, serde::Serialize, serde::Deserialize)]
+/// Represents cache purge behaviour for mutations
+/// The order of variants is significant, from highest to lowest specificity
+pub enum CacheInvalidationPolicy {
+    /// Mutations for the target type will invalidate all cache values that have the chosen identifier
+    /// E.g:
+    /// with a mutation policy { policy: Entity, field: id }
+    /// a mutation for a Post returns a Post { id: "1234" }, all cache values that have a Post#id:1234 will be invalidated
+    Entity { field: String },
+    /// Mutations for the target type will invalidate all cache values that have lists of the type in them
+    /// Post#List
+    List,
+    /// Mutations for the target type will invalidate all cache values that have Type in them
+    /// Post
+    Type,
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, Hash, PartialEq, Eq, Ord, PartialOrd)]
+pub enum CacheAccessScope {
+    ApiKey,
+    Jwt { claim: String },
+    Header { header: String },
+    Public,
+}
+
+impl CacheControl {
+    pub fn merge(&mut self, mut other: CacheControl) {
+        *self = CacheControl {
+            public: self.public && other.public,
+            max_age: if self.max_age == 0 {
+                other.max_age
+            } else if other.max_age == 0 {
+                self.max_age
+            } else {
+                self.max_age.min(other.max_age)
+            },
+            stale_while_revalidate: if self.stale_while_revalidate == 0 {
+                other.stale_while_revalidate
+            } else if other.stale_while_revalidate == 0 {
+                self.stale_while_revalidate
+            } else {
+                self.stale_while_revalidate.min(other.stale_while_revalidate)
+            },
+            invalidation_policy: if self.invalidation_policy.is_none() {
+                other.invalidation_policy
+            } else if other.invalidation_policy.is_none() {
+                self.invalidation_policy.take()
+            } else {
+                let self_policy = self.invalidation_policy.take().unwrap();
+                let other_policy = other.invalidation_policy.take().unwrap();
+                Some(self_policy.max(other_policy))
+            },
+            access_scopes: if self.access_scopes.is_none() {
+                other.access_scopes
+            } else if other.access_scopes.is_none() {
+                self.access_scopes.take()
+            } else {
+                let mut self_scopes = self.access_scopes.take().unwrap();
+                let other_scopes = other.access_scopes.unwrap();
+                self_scopes.extend(other_scopes);
+                Some(self_scopes)
+            },
+        };
+    }
+}

--- a/engine/crates/engine/registry-v2/src/common/directive_locations.rs
+++ b/engine/crates/engine/registry-v2/src/common/directive_locations.rs
@@ -1,0 +1,46 @@
+/// Where a directive can apply to.
+///
+/// [Reference](https://spec.graphql.org/October2021/#DirectiveLocation).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum DirectiveLocation {
+    /// A [query](enum.OperationType.html#variant.Query) [operation](struct.OperationDefinition.html).
+    Query,
+    /// A [mutation](enum.OperationType.html#variant.Mutation) [operation](struct.OperationDefinition.html).
+    Mutation,
+    /// A [subscription](enum.OperationType.html#variant.Subscription) [operation](struct.OperationDefinition.html).
+    Subscription,
+    /// A [field](struct.Field.html).
+    Field,
+    /// A [fragment definition](struct.FragmentDefinition.html).
+    FragmentDefinition,
+    /// A [fragment spread](struct.FragmentSpread.html).
+    FragmentSpread,
+    /// An [inline fragment](struct.InlineFragment.html).
+    InlineFragment,
+    /// A [schema](struct.Schema.html).
+    Schema,
+    /// A [scalar](enum.TypeKind.html#variant.Scalar).
+    Scalar,
+    /// An [object](struct.ObjectType.html).
+    Object,
+    /// A [field definition](struct.FieldDefinition.html).
+    FieldDefinition,
+    /// An [input value definition](struct.InputFieldDefinition.html) as the arguments of a field
+    /// but not an input object.
+    ArgumentDefinition,
+    /// An [interface](struct.InterfaceType.html).
+    Interface,
+    /// A [union](struct.UnionType.html).
+    Union,
+    /// An [enum](struct.EnumType.html).
+    Enum,
+    /// A [value on an enum](struct.EnumValueDefinition.html).
+    EnumValue,
+    /// An [input object](struct.InputObjectType.html).
+    InputObject,
+    /// An [input value definition](struct.InputValueDefinition.html) on an input object but not a
+    /// field.
+    InputFieldDefinition,
+    /// An [variable definition](struct.VariableDefinition.html).
+    VariableDefinition,
+}

--- a/engine/crates/engine/registry-v2/src/common/id_range.rs
+++ b/engine/crates/engine/registry-v2/src/common/id_range.rs
@@ -1,0 +1,57 @@
+use std::cmp::Ordering;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug)]
+/// A half open range of Ids.
+pub struct IdRange<Id> {
+    pub(crate) start: Id,
+    pub(crate) end: Id,
+}
+
+pub trait IdOperations: Copy {
+    fn forward(self) -> Option<Self>;
+    fn back(self) -> Option<Self>;
+    fn cmp(self, other: Self) -> Ordering;
+    fn distance(lhs: Self, rhs: Self) -> usize;
+}
+
+impl<Id> IdRange<Id> {
+    pub(crate) fn new(start: Id, end: Id) -> Self {
+        IdRange { start, end }
+    }
+
+    pub(crate) fn next(&self, current: Id) -> Option<Id>
+    where
+        Id: IdOperations,
+    {
+        let next = current.forward()?;
+        matches!(next.cmp(self.end), Ordering::Less).then_some(next)
+    }
+}
+
+impl<T> serde::Serialize for IdRange<T>
+where
+    T: Serialize + Copy,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        [self.start, self.end].serialize(serializer)
+    }
+}
+
+impl<'de, T> serde::Deserialize<'de> for IdRange<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let [start, end] = <[T; 2]>::deserialize(deserializer)?;
+
+        Ok(IdRange { start, end })
+    }
+}

--- a/engine/crates/engine/registry-v2/src/common/id_range.rs
+++ b/engine/crates/engine/registry-v2/src/common/id_range.rs
@@ -21,11 +21,11 @@ impl<Id> IdRange<Id> {
         IdRange { start, end }
     }
 
-    pub(crate) fn next(&self, current: Id) -> Option<Id>
+    pub(crate) fn next(&self) -> Option<Id>
     where
         Id: IdOperations,
     {
-        let next = current.forward()?;
+        let next = self.start;
         matches!(next.cmp(self.end), Ordering::Less).then_some(next)
     }
 }

--- a/engine/crates/engine/registry-v2/src/common/iter.rs
+++ b/engine/crates/engine/registry-v2/src/common/iter.rs
@@ -1,0 +1,75 @@
+use std::iter::FusedIterator;
+
+use crate::{
+    common::{IdOperations, IdRange},
+    Registry, RegistryId,
+};
+
+/// Iterator for readers
+///
+/// T indicates the type that will be yielded by the Iterator
+#[derive(Clone, Copy)]
+pub struct Iter<'a, T>
+where
+    T: IdReader,
+{
+    range: IdRange<T::Id>,
+    current: Option<T::Id>,
+    document: &'a crate::Registry,
+}
+
+impl<'a, T> Iter<'a, T>
+where
+    T: IdReader,
+    T::Id: IdOperations,
+{
+    pub(crate) fn new(range: IdRange<T::Id>, document: &'a Registry) -> Self {
+        Iter {
+            current: (IdOperations::distance(range.start, range.end) > 0).then_some(range.start),
+            range,
+            document,
+        }
+    }
+}
+
+pub trait IdReader {
+    type Id: RegistryId;
+}
+
+impl<'a, T> Iterator for Iter<'a, T>
+where
+    T: IdReader,
+    T::Id: IdOperations,
+{
+    type Item = <T::Id as RegistryId>::Reader<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let current = self.current?;
+        let next = self.range.next(current);
+        self.current = next;
+
+        Some(self.document.read(current))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let Some(current) = self.current else {
+            return (0, Some(0));
+        };
+        let remaining = IdOperations::distance(current, self.range.end);
+        (remaining, Some(remaining))
+    }
+}
+
+impl<'a, T> ExactSizeIterator for Iter<'a, T>
+where
+    T: IdReader,
+    T::Id: IdOperations,
+{
+}
+
+impl<'a, T> FusedIterator for Iter<'a, T>
+where
+    T: IdReader,
+    T::Id: IdOperations,
+{
+}

--- a/engine/crates/engine/registry-v2/src/common/mod.rs
+++ b/engine/crates/engine/registry-v2/src/common/mod.rs
@@ -1,0 +1,32 @@
+mod directive_locations;
+mod id_range;
+mod iter;
+mod types;
+
+pub use directive_locations::DirectiveLocation;
+pub use id_range::{IdOperations, IdRange};
+pub use iter::*;
+pub use types::*;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OperationType {
+    Query,
+    Mutation,
+    Subscription,
+}
+
+impl OperationType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            OperationType::Query => "query",
+            OperationType::Mutation => "mutation",
+            OperationType::Subscription => "subscription",
+        }
+    }
+}
+
+impl std::fmt::Display for OperationType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}

--- a/engine/crates/engine/registry-v2/src/common/types.rs
+++ b/engine/crates/engine/registry-v2/src/common/types.rs
@@ -1,0 +1,207 @@
+use std::fmt::Write;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WrappingType {
+    NonNull,
+    List,
+}
+
+/// GraphQL wrappers encoded into a single u32
+///
+/// Bit 0: Whether the inner type is null
+/// Bits 1..5: Number of list wrappers
+/// Bits 5..21: List wrappers, where 0 is nullable 1 is non-null
+/// The rest: dead bits
+#[derive(Debug, Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
+pub struct TypeWrappers(u32);
+
+static INNER_NULLABILITY_MASK: u32 = 1;
+static NUM_LISTS_MASK: u32 = 32 - 2;
+static NON_NUM_LISTS_MASK: u32 = u32::MAX ^ NUM_LISTS_MASK;
+
+impl TypeWrappers {
+    pub fn none() -> Self {
+        TypeWrappers(0)
+    }
+
+    pub fn wrap_list(&self) -> Self {
+        let current_wrappers = self.num_list_wrappers();
+
+        let new_wrappers = current_wrappers + 1;
+        assert!(new_wrappers < 16, "list wrapper overflow");
+
+        Self((new_wrappers << 1) | (self.0 & NON_NUM_LISTS_MASK))
+    }
+
+    pub fn wrap_non_null(&self) -> Self {
+        let index = self.num_list_wrappers();
+        if index == 0 {
+            return Self(INNER_NULLABILITY_MASK);
+        }
+
+        let new = self.0 | (1 << (4 + index));
+
+        TypeWrappers(new)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0 == 0
+    }
+
+    /// iterates oveer the type wrappers from outermost to innermost
+    pub fn iter(&self) -> TypeWrappersIter {
+        let current_wrappers = self.num_list_wrappers();
+        TypeWrappersIter {
+            encoded: self.0,
+            mask: (1 << (4 + current_wrappers)),
+            next: None,
+            last: ((INNER_NULLABILITY_MASK & self.0) == INNER_NULLABILITY_MASK).then_some(WrappingType::NonNull),
+        }
+    }
+
+    pub(crate) fn write_type_string(
+        self,
+        name: &str,
+        mut formatter: &mut std::fmt::Formatter<'_>,
+    ) -> Result<(), std::fmt::Error> {
+        let wrappers = self.iter().collect::<Vec<_>>();
+
+        for wrapping in &wrappers {
+            if let WrappingType::List = wrapping {
+                write!(formatter, "[")?;
+            }
+        }
+        write!(formatter, "{name}")?;
+        for wrapping in wrappers.iter().rev() {
+            match wrapping {
+                WrappingType::NonNull => write!(&mut formatter, "!")?,
+                WrappingType::List => write!(&mut formatter, "]")?,
+            };
+        }
+
+        Ok(())
+    }
+
+    fn num_list_wrappers(&self) -> u32 {
+        (self.0 & NUM_LISTS_MASK) >> 1
+    }
+}
+
+/// Takes type wrappers from outermost to innermost
+impl FromIterator<WrappingType> for TypeWrappers {
+    fn from_iter<T: IntoIterator<Item = WrappingType>>(iter: T) -> Self {
+        let wrappers = iter.into_iter().collect::<Vec<_>>();
+
+        wrappers
+            .into_iter()
+            .rev()
+            .fold(TypeWrappers::none(), |wrappers, wrapping| match wrapping {
+                WrappingType::NonNull => wrappers.wrap_non_null(),
+                WrappingType::List => wrappers.wrap_list(),
+            })
+    }
+}
+
+pub struct TypeWrappersIter {
+    encoded: u32,
+    mask: u32,
+    next: Option<WrappingType>,
+    last: Option<WrappingType>,
+}
+
+impl Iterator for TypeWrappersIter {
+    type Item = WrappingType;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(next) = self.next.take() {
+            return Some(next);
+        }
+        if (self.mask & NUM_LISTS_MASK) != 0 {
+            if let Some(last) = self.last.take() {
+                return Some(last);
+            }
+            return None;
+        }
+
+        // Otherwise we still have list wrappers
+        let current_is_non_null = (self.encoded & self.mask) != 0;
+        self.mask >>= 1;
+
+        if current_is_non_null {
+            self.next = Some(WrappingType::List);
+            Some(WrappingType::NonNull)
+        } else {
+            Some(WrappingType::List)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TypeWrappers, WrappingType};
+
+    #[test]
+    fn test_wrappers() {
+        assert_eq!(TypeWrappers::none().iter().collect::<Vec<_>>(), vec![]);
+        assert_eq!(
+            TypeWrappers::none().wrap_non_null().iter().collect::<Vec<_>>(),
+            vec![WrappingType::NonNull]
+        );
+
+        assert_eq!(
+            TypeWrappers::none().wrap_list().iter().collect::<Vec<_>>(),
+            vec![WrappingType::List]
+        );
+
+        assert_eq!(
+            TypeWrappers::none()
+                .wrap_non_null()
+                .wrap_list()
+                .iter()
+                .collect::<Vec<_>>(),
+            vec![WrappingType::List, WrappingType::NonNull]
+        );
+
+        assert_eq!(
+            TypeWrappers::none()
+                .wrap_non_null()
+                .wrap_list()
+                .wrap_non_null()
+                .iter()
+                .collect::<Vec<_>>(),
+            vec![WrappingType::NonNull, WrappingType::List, WrappingType::NonNull]
+        );
+
+        assert_eq!(
+            TypeWrappers::none()
+                .wrap_list()
+                .wrap_list()
+                .wrap_list()
+                .wrap_non_null()
+                .iter()
+                .collect::<Vec<_>>(),
+            vec![
+                WrappingType::NonNull,
+                WrappingType::List,
+                WrappingType::List,
+                WrappingType::List,
+            ]
+        );
+
+        assert_eq!(
+            TypeWrappers::none()
+                .wrap_non_null()
+                .wrap_list()
+                .wrap_non_null()
+                .wrap_list()
+                .iter()
+                .collect::<Vec<_>>(),
+            vec![
+                WrappingType::List,
+                WrappingType::NonNull,
+                WrappingType::List,
+                WrappingType::NonNull
+            ]
+        );
+    }
+}

--- a/engine/crates/engine/registry-v2/src/cors.rs
+++ b/engine/crates/engine/registry-v2/src/cors.rs
@@ -1,0 +1,6 @@
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CorsConfig {
+    pub max_age: Option<u32>,
+    pub allowed_origins: Option<Vec<String>>,
+}

--- a/engine/crates/engine/registry-v2/src/extensions.rs
+++ b/engine/crates/engine/registry-v2/src/extensions.rs
@@ -1,0 +1,226 @@
+//! Additional functionality for generated types
+
+use crate::{
+    ids::{MetaEnumValueId, MetaFieldId, MetaInputValueId},
+    EnumType, InputObjectType, InterfaceType, Iter, MetaDirective, MetaEnumValue, MetaField, MetaInputValue, MetaType,
+    ObjectType, RecordLookup, UnionType,
+};
+
+impl<'a> MetaType<'a> {
+    pub fn name(&self) -> &'a str {
+        match self {
+            MetaType::Object(inner) => inner.name(),
+            MetaType::Interface(inner) => inner.name(),
+            MetaType::Union(inner) => inner.name(),
+            MetaType::Enum(inner) => inner.name(),
+            MetaType::InputObject(inner) => inner.name(),
+            MetaType::Scalar(inner) => inner.name(),
+        }
+    }
+
+    pub fn description(&self) -> Option<&'a str> {
+        match self {
+            MetaType::Object(inner) => inner.description(),
+            MetaType::Interface(inner) => inner.description(),
+            MetaType::Union(inner) => inner.description(),
+            MetaType::Enum(inner) => inner.description(),
+            MetaType::InputObject(inner) => inner.description(),
+            MetaType::Scalar(inner) => inner.description(),
+        }
+    }
+
+    pub fn fields(&self) -> Option<Iter<'a, MetaField<'a>>> {
+        match self {
+            MetaType::Object(inner) => Some(inner.fields()),
+            MetaType::Interface(inner) => Some(inner.fields()),
+            _ => None,
+        }
+    }
+
+    pub fn as_input_object(&self) -> Option<InputObjectType<'a>> {
+        match self {
+            MetaType::InputObject(inner) => Some(*inner),
+            _ => None,
+        }
+    }
+
+    pub fn is_composite(&self) -> bool {
+        matches!(self, MetaType::Object(_) | MetaType::Interface(_) | MetaType::Union(_))
+    }
+
+    pub fn is_abstract(&self) -> bool {
+        matches!(self, MetaType::Interface(_) | MetaType::Union(_))
+    }
+
+    pub fn is_leaf(&self) -> bool {
+        matches!(self, MetaType::Enum(_) | MetaType::Scalar(_))
+    }
+
+    pub fn is_input(&self) -> bool {
+        matches!(self, MetaType::Enum(_) | MetaType::Scalar(_) | MetaType::InputObject(_))
+    }
+
+    pub fn possible_types(&self) -> Option<Box<dyn ExactSizeIterator<Item = MetaType<'a>> + 'a>> {
+        match self {
+            MetaType::Interface(iface) => Some(Box::new(iface.possible_types())),
+            MetaType::Union(union) => Some(Box::new(union.possible_types())),
+            _ => None,
+        }
+    }
+
+    pub fn is_possible_type(&self, other: &str) -> bool {
+        match self {
+            MetaType::Interface(inner) => inner.possible_types().any(|ty| ty.name() == other),
+            MetaType::Union(inner) => inner.possible_types().any(|ty| ty.name() == other),
+            MetaType::Object(inner) => inner.name() == other,
+            _ => false,
+        }
+    }
+}
+
+impl<'a> MetaType<'a> {
+    pub fn field(&self, name: &str) -> Option<MetaField<'a>> {
+        match self {
+            MetaType::Object(obj) => obj.field(name),
+            MetaType::Interface(iface) => iface.field(name),
+            _ => None,
+        }
+    }
+}
+
+impl<'a> ObjectType<'a> {
+    pub fn field(&self, name: &str) -> Option<MetaField<'a>> {
+        if name == "__typename" {
+            return Some(self.0.registry.read(self.0.registry.typename_index));
+        }
+
+        let object = self.0.registry.lookup(self.0.id);
+        let index = self.0.registry.object_fields[object.fields.start.to_index()..object.fields.end.to_index()]
+            .binary_search_by(|field| self.0.registry.string_cmp(field.name, name))
+            .ok()?;
+
+        Some(
+            self.0
+                .registry
+                .read(MetaFieldId::new(object.fields.start.to_index() + index)),
+        )
+    }
+}
+
+impl<'a> MetaField<'a> {
+    pub fn is_deprecated(&self) -> bool {
+        self.deprecation()
+            .map(|deprecation| deprecation.is_deprecated())
+            .unwrap_or_default()
+    }
+
+    pub fn deprecation_reason(&self) -> Option<&'a str> {
+        self.deprecation().and_then(|deprecation| deprecation.reason())
+    }
+}
+
+impl<'a> InterfaceType<'a> {
+    pub fn field(&self, name: &str) -> Option<MetaField<'a>> {
+        if name == "__typename" {
+            return Some(self.0.registry.read(self.0.registry.typename_index));
+        }
+
+        let object = self.0.registry.lookup(self.0.id);
+        let index = self.0.registry.object_fields[object.fields.start.to_index()..object.fields.end.to_index()]
+            .binary_search_by(|field| self.0.registry.string_cmp(field.name, name))
+            .ok()?;
+
+        Some(
+            self.0
+                .registry
+                .read(MetaFieldId::new(object.fields.start.to_index() + index)),
+        )
+    }
+}
+
+impl<'a> UnionType<'a> {
+    /// Unions don't really have fields, but we implement this just for __typename
+    pub fn field(&self, name: &str) -> Option<MetaField<'a>> {
+        if name == "__typename" {
+            return Some(self.0.registry.read(self.0.registry.typename_index));
+        }
+        None
+    }
+}
+
+impl<'a> EnumType<'a> {
+    pub fn value(&self, name: &str) -> Option<MetaEnumValue<'a>> {
+        let enum_type = self.0.registry.lookup(self.0.id);
+        let index = self.0.registry.enum_values[enum_type.values.start.to_index()..enum_type.values.end.to_index()]
+            .binary_search_by(|value| self.0.registry.string_cmp(value.name, name))
+            .ok()?;
+
+        Some(
+            self.0
+                .registry
+                .read(MetaEnumValueId::new(enum_type.values.start.to_index() + index)),
+        )
+    }
+}
+
+impl<'a> MetaEnumValue<'a> {
+    pub fn is_deprecated(&self) -> bool {
+        self.deprecation()
+            .map(|deprecation| deprecation.is_deprecated())
+            .unwrap_or_default()
+    }
+
+    pub fn deprecation_reason(&self) -> Option<&'a str> {
+        self.deprecation().and_then(|deprecation| deprecation.reason())
+    }
+}
+
+impl<'a> InputObjectType<'a> {
+    pub fn field(&self, name: &str) -> Option<MetaInputValue<'a>> {
+        let object = self.0.registry.lookup(self.0.id);
+        let index = self.0.registry.input_values
+            [object.input_fields.start.to_index()..object.input_fields.end.to_index()]
+            .binary_search_by(|field| self.0.registry.string_cmp(field.name, name))
+            .ok()?;
+
+        Some(
+            self.0
+                .registry
+                .read(MetaInputValueId::new(object.input_fields.start.to_index() + index)),
+        )
+    }
+}
+
+impl<'a> MetaField<'a> {
+    pub fn argument(&self, name: &str) -> Option<MetaInputValue<'a>> {
+        let field = self.0.registry.lookup(self.0.id);
+        let index = self.0.registry.input_values[field.args.start.to_index()..field.args.end.to_index()]
+            .binary_search_by(|value| self.0.registry.string_cmp(value.name, name))
+            .ok()?;
+
+        Some(
+            self.0
+                .registry
+                .read(MetaInputValueId::new(field.args.start.to_index() + index)),
+        )
+    }
+
+    pub fn target_field_name(&self) -> &str {
+        self.mapped_name().unwrap_or(self.name())
+    }
+}
+
+impl<'a> MetaDirective<'a> {
+    pub fn argument(&self, name: &str) -> Option<MetaInputValue<'a>> {
+        let directive = self.0.registry.lookup(self.0.id);
+        let index = self.0.registry.input_values[directive.args.start.to_index()..directive.args.end.to_index()]
+            .binary_search_by(|value| self.0.registry.string_cmp(value.name, name))
+            .ok()?;
+
+        Some(
+            self.0
+                .registry
+                .read(MetaInputValueId::new(directive.args.start.to_index() + index)),
+        )
+    }
+}

--- a/engine/crates/engine/registry-v2/src/federation_entity.rs
+++ b/engine/crates/engine/registry-v2/src/federation_entity.rs
@@ -1,0 +1,96 @@
+use crate::{
+    misc_types::FieldSet,
+    resolvers::{http::HttpResolver, join::JoinResolver},
+    Selection,
+};
+
+/// Federation details for a particular entity
+///
+/// There should be one instance of this for each MetaType that represents
+/// a federation entity.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Default)]
+pub struct FederationEntity {
+    pub keys: Vec<FederationKey>,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub enum FederationResolver {
+    /// Makes an HTTP call to resolve
+    Http(Box<HttpResolver>),
+    /// This "resolver" doesn't actually resolve data in the same way the others do.
+    ///
+    /// This should be put on entities where the primary representation lives in
+    /// another subgraph but we contribute fields to it - the result of resolution
+    /// will be the representation we are passed from the router.
+    ///
+    /// This should only ever be applied to types where all the fields on that type
+    /// are present in the representation or resolvable from the representation (e.g.
+    /// fields with custom resolvers)
+    BasicType,
+    /// This entity resolves to a specific field in the schema using the same mechanism
+    /// as a JoinResolver
+    Join(Box<JoinResolver>),
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde_with::minify_field_names(serialize = "minified", deserialize = "minified")]
+#[serde_with::skip_serializing_defaults(Option, Vec, ConstraintType)]
+pub struct FederationKey {
+    pub selections: FieldSet,
+    pub resolver: Option<FederationResolver>,
+}
+
+impl FederationKey {
+    pub fn single(field: impl Into<String>, resolver: FederationResolver) -> Self {
+        FederationKey {
+            selections: FieldSet::new([Selection {
+                field: field.into(),
+                selections: vec![],
+            }]),
+            resolver: Some(resolver),
+        }
+    }
+
+    pub fn multiple(fields: Vec<String>, resolver: FederationResolver) -> Self {
+        FederationKey {
+            selections: FieldSet::new(fields.into_iter().map(|field| Selection {
+                field,
+                selections: vec![],
+            })),
+            resolver: Some(resolver),
+        }
+    }
+
+    pub fn unresolvable(selections: FieldSet) -> Self {
+        FederationKey {
+            selections,
+            resolver: None,
+        }
+    }
+
+    pub fn basic_type(selections: FieldSet) -> Self {
+        FederationKey {
+            selections,
+            resolver: Some(FederationResolver::BasicType),
+        }
+    }
+
+    pub fn join(selections: FieldSet, resolver: JoinResolver) -> Self {
+        FederationKey {
+            selections,
+            resolver: Some(FederationResolver::Join(Box::new(resolver))),
+        }
+    }
+
+    pub fn resolver(&self) -> Option<&FederationResolver> {
+        self.resolver.as_ref()
+    }
+
+    pub fn is_resolvable(&self) -> bool {
+        self.resolver.is_some()
+    }
+
+    pub fn includes_field(&self, field: &str) -> bool {
+        self.selections.0.iter().any(|selection| selection.field == field)
+    }
+}

--- a/engine/crates/engine/registry-v2/src/field_types.rs
+++ b/engine/crates/engine/registry-v2/src/field_types.rs
@@ -1,0 +1,157 @@
+mod serde_impls;
+
+use crate::{
+    ids::MetaTypeId, MetaField, MetaInputValue, MetaType, ReadContext, RecordLookup, RegistryId, WrappingType,
+};
+
+impl<'a> MetaField<'a> {
+    pub fn ty(&self) -> MetaFieldType<'a> {
+        let registry = &self.0.registry;
+        registry.read(registry.lookup(self.0.id).ty)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct MetaFieldTypeRecord {
+    pub wrappers: crate::common::TypeWrappers,
+    pub target: MetaTypeId,
+}
+
+pub struct MetaFieldType<'a>(pub(crate) ReadContext<'a, MetaFieldTypeRecord>);
+
+impl<'a> MetaFieldType<'a> {
+    pub fn id(&self) -> MetaFieldTypeRecord {
+        self.0.id
+    }
+
+    pub fn is_list(&self) -> bool {
+        self.0
+            .id
+            .wrappers
+            .iter()
+            .any(|wrapper| matches!(wrapper, WrappingType::List))
+    }
+
+    pub fn is_non_null(&self) -> bool {
+        self.0
+            .id
+            .wrappers
+            .iter()
+            .next()
+            .map(|wrapper| matches!(wrapper, WrappingType::NonNull))
+            .unwrap_or_default()
+    }
+
+    pub fn is_nullable(&self) -> bool {
+        !self.is_non_null()
+    }
+
+    pub fn typename(&self) -> &'a str {
+        self.named_type().name()
+    }
+
+    pub fn named_type(&self) -> MetaType<'a> {
+        let registry = self.0.registry;
+        let MetaFieldTypeRecord { target, .. } = self.0.id;
+        registry.read(target)
+    }
+}
+
+impl std::fmt::Display for MetaFieldType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.id.wrappers.write_type_string(self.typename(), f)
+    }
+}
+
+impl std::fmt::Debug for MetaFieldType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self}")
+    }
+}
+
+impl RegistryId for MetaFieldTypeRecord {
+    // This isn't technically an id but implementing this makes things work consistently
+    type Reader<'a> = MetaFieldType<'a>;
+}
+
+impl<'a> From<ReadContext<'a, MetaFieldTypeRecord>> for MetaFieldType<'a> {
+    fn from(value: ReadContext<'a, MetaFieldTypeRecord>) -> Self {
+        Self(value)
+    }
+}
+
+impl<'a> MetaInputValue<'a> {
+    pub fn ty(&self) -> MetaInputValueType<'a> {
+        let registry = &self.0.registry;
+        registry.read(registry.lookup(self.0.id).ty)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct MetaInputValueTypeRecord {
+    pub wrappers: crate::common::TypeWrappers,
+    pub target: MetaTypeId,
+}
+
+pub struct MetaInputValueType<'a>(pub(crate) ReadContext<'a, MetaInputValueTypeRecord>);
+
+impl<'a> MetaInputValueType<'a> {
+    pub fn id(&self) -> MetaInputValueTypeRecord {
+        self.0.id
+    }
+
+    pub fn is_list(&self) -> bool {
+        self.0
+            .id
+            .wrappers
+            .iter()
+            .any(|wrapper| matches!(wrapper, WrappingType::List))
+    }
+
+    pub fn is_non_null(&self) -> bool {
+        self.0
+            .id
+            .wrappers
+            .iter()
+            .next()
+            .map(|wrapper| matches!(wrapper, WrappingType::NonNull))
+            .unwrap_or_default()
+    }
+
+    pub fn is_nullable(&self) -> bool {
+        !self.is_non_null()
+    }
+
+    pub fn typename(&self) -> &'a str {
+        self.named_type().name()
+    }
+
+    pub fn named_type(&self) -> MetaType<'a> {
+        let registry = self.0.registry;
+        let MetaInputValueTypeRecord { target, .. } = self.0.id;
+        registry.read(target)
+    }
+}
+
+impl std::fmt::Display for MetaInputValueType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.id.wrappers.write_type_string(self.typename(), f)
+    }
+}
+
+impl std::fmt::Debug for MetaInputValueType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self}")
+    }
+}
+
+impl RegistryId for MetaInputValueTypeRecord {
+    // This isn't technically an id but implementing this makes things work consistently
+    type Reader<'a> = MetaInputValueType<'a>;
+}
+
+impl<'a> From<ReadContext<'a, MetaInputValueTypeRecord>> for MetaInputValueType<'a> {
+    fn from(value: ReadContext<'a, MetaInputValueTypeRecord>) -> Self {
+        Self(value)
+    }
+}

--- a/engine/crates/engine/registry-v2/src/field_types/serde_impls.rs
+++ b/engine/crates/engine/registry-v2/src/field_types/serde_impls.rs
@@ -1,0 +1,89 @@
+use serde::de::Error;
+
+use crate::{ids::MetaTypeId, TypeWrappers};
+
+use super::{MetaFieldTypeRecord, MetaInputValueTypeRecord};
+
+impl serde::Serialize for MetaFieldTypeRecord {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if self.wrappers.is_empty() {
+            self.target.serialize(serializer)
+        } else {
+            (self.target, self.wrappers).serialize(serializer)
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for MetaFieldTypeRecord {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // This is only going to work for self describing formats
+        let (wrappers, target) = deserializer.deserialize_any(Visitor)?;
+
+        Ok(MetaFieldTypeRecord { wrappers, target })
+    }
+}
+
+impl serde::Serialize for MetaInputValueTypeRecord {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if self.wrappers.is_empty() {
+            self.target.serialize(serializer)
+        } else {
+            (self.target, self.wrappers).serialize(serializer)
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for MetaInputValueTypeRecord {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // This is only going to work for self describing formats
+        let (wrappers, target) = deserializer.deserialize_any(Visitor)?;
+
+        Ok(MetaInputValueTypeRecord { wrappers, target })
+    }
+}
+
+struct Visitor;
+impl<'de> serde::de::Visitor<'de> for Visitor {
+    type Value = (TypeWrappers, MetaTypeId);
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "a single integer or a pair of integers")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'de>,
+    {
+        let target = seq.next_element::<MetaTypeId>()?;
+        let wrappers = seq.next_element::<TypeWrappers>()?;
+        let done = seq.next_element::<u64>()?;
+
+        if target.is_none() || wrappers.is_none() || done.is_some() {
+            return Err(A::Error::custom("Malformed field record list"));
+        }
+        Ok((wrappers.unwrap(), target.unwrap()))
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok((
+            TypeWrappers::none(),
+            // I am not happy about this - 1 but it's the easiest solution :/
+            MetaTypeId::new((v - 1) as usize),
+        ))
+    }
+}

--- a/engine/crates/engine/registry-v2/src/generated.rs
+++ b/engine/crates/engine/registry-v2/src/generated.rs
@@ -1,0 +1,37 @@
+//! This file isn't generated, but every other file in this module is
+
+/// A prelude module for all the generated modules
+///
+/// Anything in here will be pulled into scope for the modules
+///
+/// This makes the generator simpler as it doesn't need to dynamically
+/// figure out how to import everything external it needs - it can just
+/// `use prelude::*` and be done with it.
+mod prelude {
+    pub(super) use crate::{
+        cache_control::CacheControl,
+        common::{DirectiveLocation, IdRange, IdReader, Iter},
+        field_types::{MetaFieldTypeRecord, MetaInputValueTypeRecord},
+        ids::{self, StringId},
+        misc_types::*,
+        resolvers::Resolver,
+        validators::DynValidator,
+        ReadContext, RecordLookup, RegistryId,
+    };
+    pub(super) use common_types::auth::Operations;
+    pub(super) use engine_value::ConstValue;
+    pub(super) use gateway_v2_auth_config::v1::AuthConfig;
+}
+
+// The actual generated modules.
+//
+// If you add a new one you'll need to import it here.
+pub mod directives;
+pub mod enums;
+pub mod field;
+pub mod inputs;
+pub mod interface;
+pub mod metatype;
+pub mod objects;
+pub mod scalar;
+pub mod union;

--- a/engine/crates/engine/registry-v2/src/generated/directives.rs
+++ b/engine/crates/engine/registry-v2/src/generated/directives.rs
@@ -1,0 +1,80 @@
+use super::prelude::*;
+use super::{
+    inputs::MetaInputValue,
+    prelude::ids::{MetaDirectiveId, MetaInputValueId},
+};
+#[allow(unused_imports)]
+use std::fmt::{self, Write};
+
+#[derive(serde :: Serialize, serde :: Deserialize)]
+pub struct MetaDirectiveRecord {
+    #[serde(rename = "0")]
+    pub name: StringId,
+    #[serde(rename = "1", skip_serializing_if = "Option::is_none", default)]
+    pub description: Option<StringId>,
+    #[serde(rename = "2", skip_serializing_if = "crate::Container::is_empty", default)]
+    pub locations: Vec<DirectiveLocation>,
+    #[serde(rename = "3", skip_serializing_if = "crate::Container::is_empty", default)]
+    pub args: IdRange<MetaInputValueId>,
+    #[serde(rename = "4", skip_serializing_if = "crate::is_false", default)]
+    pub is_repeatable: bool,
+}
+
+#[derive(Clone, Copy)]
+pub struct MetaDirective<'a>(pub(crate) ReadContext<'a, MetaDirectiveId>);
+
+impl<'a> MetaDirective<'a> {
+    pub fn name(&self) -> &'a str {
+        let registry = &self.0.registry;
+        registry.lookup(registry.lookup(self.0.id).name)
+    }
+    pub fn description(&self) -> Option<&'a str> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).description.map(|id| registry.lookup(id))
+    }
+    pub fn locations(&self) -> impl ExactSizeIterator<Item = DirectiveLocation> + 'a {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).locations.iter().copied()
+    }
+    pub fn args(&self) -> Iter<'a, MetaInputValue<'a>> {
+        let registry = self.0.registry;
+        Iter::new(registry.lookup(self.0.id).args, registry)
+    }
+    pub fn is_repeatable(&self) -> bool {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).is_repeatable
+    }
+}
+
+impl fmt::Debug for MetaDirective<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MetaDirective")
+            .field("name", &self.name())
+            .field("description", &self.description())
+            .field("locations", &self.locations().collect::<Vec<_>>())
+            .field("args", &self.args().collect::<Vec<_>>())
+            .field("is_repeatable", &self.is_repeatable())
+            .finish()
+    }
+}
+
+impl std::cmp::PartialEq for MetaDirective<'_> {
+    fn eq(&self, other: &MetaDirective<'_>) -> bool {
+        std::ptr::eq(self.0.registry, other.0.registry) && self.0.id == other.0.id
+    }
+}
+impl std::cmp::Eq for MetaDirective<'_> {}
+
+impl RegistryId for MetaDirectiveId {
+    type Reader<'a> = MetaDirective<'a>;
+}
+
+impl IdReader for MetaDirective<'_> {
+    type Id = MetaDirectiveId;
+}
+
+impl<'a> From<ReadContext<'a, MetaDirectiveId>> for MetaDirective<'a> {
+    fn from(value: ReadContext<'a, MetaDirectiveId>) -> Self {
+        Self(value)
+    }
+}

--- a/engine/crates/engine/registry-v2/src/generated/enums.rs
+++ b/engine/crates/engine/registry-v2/src/generated/enums.rs
@@ -1,0 +1,122 @@
+use super::prelude::ids::{EnumTypeId, MetaEnumValueId};
+use super::prelude::*;
+#[allow(unused_imports)]
+use std::fmt::{self, Write};
+
+#[derive(serde :: Serialize, serde :: Deserialize)]
+pub struct EnumTypeRecord {
+    #[serde(rename = "0")]
+    pub name: StringId,
+    #[serde(rename = "1", skip_serializing_if = "Option::is_none", default)]
+    pub description: Option<StringId>,
+    #[serde(rename = "2", skip_serializing_if = "crate::Container::is_empty", default)]
+    pub values: IdRange<MetaEnumValueId>,
+}
+
+#[derive(Clone, Copy)]
+pub struct EnumType<'a>(pub(crate) ReadContext<'a, EnumTypeId>);
+
+impl<'a> EnumType<'a> {
+    pub fn name(&self) -> &'a str {
+        let registry = &self.0.registry;
+        registry.lookup(registry.lookup(self.0.id).name)
+    }
+    pub fn description(&self) -> Option<&'a str> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).description.map(|id| registry.lookup(id))
+    }
+    pub fn values(&self) -> Iter<'a, MetaEnumValue<'a>> {
+        let registry = self.0.registry;
+        Iter::new(registry.lookup(self.0.id).values, registry)
+    }
+}
+
+impl fmt::Debug for EnumType<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EnumType")
+            .field("name", &self.name())
+            .field("description", &self.description())
+            .field("values", &self.values().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+impl std::cmp::PartialEq for EnumType<'_> {
+    fn eq(&self, other: &EnumType<'_>) -> bool {
+        std::ptr::eq(self.0.registry, other.0.registry) && self.0.id == other.0.id
+    }
+}
+impl std::cmp::Eq for EnumType<'_> {}
+
+impl RegistryId for EnumTypeId {
+    type Reader<'a> = EnumType<'a>;
+}
+
+impl IdReader for EnumType<'_> {
+    type Id = EnumTypeId;
+}
+
+impl<'a> From<ReadContext<'a, EnumTypeId>> for EnumType<'a> {
+    fn from(value: ReadContext<'a, EnumTypeId>) -> Self {
+        Self(value)
+    }
+}
+
+#[derive(serde :: Serialize, serde :: Deserialize)]
+pub struct MetaEnumValueRecord {
+    #[serde(rename = "0")]
+    pub name: StringId,
+    #[serde(rename = "1", skip_serializing_if = "Option::is_none", default)]
+    pub description: Option<StringId>,
+    #[serde(rename = "2", skip_serializing_if = "Option::is_none", default)]
+    pub deprecation: Option<Box<Deprecation>>,
+    #[serde(rename = "3", skip_serializing_if = "Option::is_none", default)]
+    pub value: Option<StringId>,
+}
+
+#[derive(Clone, Copy)]
+pub struct MetaEnumValue<'a>(pub(crate) ReadContext<'a, MetaEnumValueId>);
+
+impl<'a> MetaEnumValue<'a> {
+    pub fn name(&self) -> &'a str {
+        let registry = &self.0.registry;
+        registry.lookup(registry.lookup(self.0.id).name)
+    }
+    pub fn description(&self) -> Option<&'a str> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).description.map(|id| registry.lookup(id))
+    }
+    pub fn deprecation(&self) -> Option<&'a Deprecation> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).deprecation.as_deref()
+    }
+    pub fn value(&self) -> Option<&'a str> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).value.map(|id| registry.lookup(id))
+    }
+}
+
+impl fmt::Debug for MetaEnumValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MetaEnumValue")
+            .field("name", &self.name())
+            .field("description", &self.description())
+            .field("deprecation", &self.deprecation())
+            .field("value", &self.value())
+            .finish()
+    }
+}
+
+impl RegistryId for MetaEnumValueId {
+    type Reader<'a> = MetaEnumValue<'a>;
+}
+
+impl IdReader for MetaEnumValue<'_> {
+    type Id = MetaEnumValueId;
+}
+
+impl<'a> From<ReadContext<'a, MetaEnumValueId>> for MetaEnumValue<'a> {
+    fn from(value: ReadContext<'a, MetaEnumValueId>) -> Self {
+        Self(value)
+    }
+}

--- a/engine/crates/engine/registry-v2/src/generated/field.rs
+++ b/engine/crates/engine/registry-v2/src/generated/field.rs
@@ -1,0 +1,118 @@
+use super::prelude::*;
+use super::{
+    inputs::MetaInputValue,
+    prelude::ids::{MetaFieldId, MetaInputValueId},
+};
+#[allow(unused_imports)]
+use std::fmt::{self, Write};
+
+#[derive(serde :: Serialize, serde :: Deserialize)]
+pub struct MetaFieldRecord {
+    #[serde(rename = "0")]
+    pub name: StringId,
+    #[serde(rename = "1", skip_serializing_if = "Option::is_none", default)]
+    pub mapped_name: Option<StringId>,
+    #[serde(rename = "2", skip_serializing_if = "Option::is_none", default)]
+    pub description: Option<StringId>,
+    #[serde(rename = "3", skip_serializing_if = "crate::Container::is_empty", default)]
+    pub args: IdRange<MetaInputValueId>,
+    #[serde(rename = "4")]
+    pub ty: MetaFieldTypeRecord,
+    #[serde(rename = "5", skip_serializing_if = "Option::is_none", default)]
+    pub deprecation: Option<Box<Deprecation>>,
+    #[serde(rename = "6", skip_serializing_if = "Option::is_none", default)]
+    pub cache_control: Option<Box<CacheControl>>,
+    #[serde(rename = "7", skip_serializing_if = "Option::is_none", default)]
+    pub requires: Option<Box<FieldSet>>,
+    #[serde(rename = "8", skip_serializing_if = "Option::is_none", default)]
+    pub federation: Option<Box<FederationProperties>>,
+    #[serde(rename = "9")]
+    pub resolver: Resolver,
+    #[serde(rename = "10", skip_serializing_if = "Option::is_none", default)]
+    pub required_operation: Option<Box<Operations>>,
+    #[serde(rename = "11", skip_serializing_if = "Option::is_none", default)]
+    pub auth: Option<Box<AuthConfig>>,
+}
+
+#[derive(Clone, Copy)]
+pub struct MetaField<'a>(pub(crate) ReadContext<'a, MetaFieldId>);
+
+impl<'a> MetaField<'a> {
+    pub fn name(&self) -> &'a str {
+        let registry = &self.0.registry;
+        registry.lookup(registry.lookup(self.0.id).name)
+    }
+    pub fn mapped_name(&self) -> Option<&'a str> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).mapped_name.map(|id| registry.lookup(id))
+    }
+    pub fn description(&self) -> Option<&'a str> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).description.map(|id| registry.lookup(id))
+    }
+    pub fn args(&self) -> Iter<'a, MetaInputValue<'a>> {
+        let registry = self.0.registry;
+        Iter::new(registry.lookup(self.0.id).args, registry)
+    }
+    pub fn deprecation(&self) -> Option<&'a Deprecation> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).deprecation.as_deref()
+    }
+    pub fn cache_control(&self) -> Option<&'a CacheControl> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).cache_control.as_deref()
+    }
+    pub fn requires(&self) -> Option<&'a FieldSet> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).requires.as_deref()
+    }
+    pub fn federation(&self) -> Option<&'a FederationProperties> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).federation.as_deref()
+    }
+    pub fn resolver(&self) -> &'a Resolver {
+        let registry = self.0.registry;
+        &registry.lookup(self.0.id).resolver
+    }
+    pub fn required_operation(&self) -> Option<&'a Operations> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).required_operation.as_deref()
+    }
+    pub fn auth(&self) -> Option<&'a AuthConfig> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).auth.as_deref()
+    }
+}
+
+impl fmt::Debug for MetaField<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MetaField")
+            .field("name", &self.name())
+            .field("mapped_name", &self.mapped_name())
+            .field("description", &self.description())
+            .field("args", &self.args().collect::<Vec<_>>())
+            .field("ty", &self.ty())
+            .field("deprecation", &self.deprecation())
+            .field("cache_control", &self.cache_control())
+            .field("requires", &self.requires())
+            .field("federation", &self.federation())
+            .field("resolver", &self.resolver())
+            .field("required_operation", &self.required_operation())
+            .field("auth", &self.auth())
+            .finish()
+    }
+}
+
+impl RegistryId for MetaFieldId {
+    type Reader<'a> = MetaField<'a>;
+}
+
+impl IdReader for MetaField<'_> {
+    type Id = MetaFieldId;
+}
+
+impl<'a> From<ReadContext<'a, MetaFieldId>> for MetaField<'a> {
+    fn from(value: ReadContext<'a, MetaFieldId>) -> Self {
+        Self(value)
+    }
+}

--- a/engine/crates/engine/registry-v2/src/generated/inputs.rs
+++ b/engine/crates/engine/registry-v2/src/generated/inputs.rs
@@ -1,0 +1,177 @@
+use super::prelude::ids::{InputObjectTypeId, InputValidatorId, MetaInputValueId};
+use super::prelude::*;
+#[allow(unused_imports)]
+use std::fmt::{self, Write};
+
+#[derive(serde :: Serialize, serde :: Deserialize)]
+pub struct MetaInputValueRecord {
+    #[serde(rename = "0")]
+    pub name: StringId,
+    #[serde(rename = "1", skip_serializing_if = "Option::is_none", default)]
+    pub description: Option<StringId>,
+    #[serde(rename = "2")]
+    pub ty: MetaInputValueTypeRecord,
+    #[serde(rename = "3", skip_serializing_if = "Option::is_none", default)]
+    pub default_value: Option<Box<ConstValue>>,
+    #[serde(rename = "4", skip_serializing_if = "Option::is_none", default)]
+    pub rename: Option<StringId>,
+    #[serde(rename = "5", skip_serializing_if = "crate::Container::is_empty", default)]
+    pub validators: IdRange<InputValidatorId>,
+}
+
+#[derive(Clone, Copy)]
+pub struct MetaInputValue<'a>(pub(crate) ReadContext<'a, MetaInputValueId>);
+
+impl<'a> MetaInputValue<'a> {
+    pub fn name(&self) -> &'a str {
+        let registry = &self.0.registry;
+        registry.lookup(registry.lookup(self.0.id).name)
+    }
+    pub fn description(&self) -> Option<&'a str> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).description.map(|id| registry.lookup(id))
+    }
+    pub fn default_value(&self) -> Option<&'a ConstValue> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).default_value.as_deref()
+    }
+    pub fn rename(&self) -> Option<&'a str> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).rename.map(|id| registry.lookup(id))
+    }
+    pub fn validators(&self) -> Iter<'a, InputValidator<'a>> {
+        let registry = self.0.registry;
+        Iter::new(registry.lookup(self.0.id).validators, registry)
+    }
+}
+
+impl fmt::Debug for MetaInputValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MetaInputValue")
+            .field("name", &self.name())
+            .field("description", &self.description())
+            .field("ty", &self.ty())
+            .field("default_value", &self.default_value())
+            .field("rename", &self.rename())
+            .field("validators", &self.validators().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+impl RegistryId for MetaInputValueId {
+    type Reader<'a> = MetaInputValue<'a>;
+}
+
+impl IdReader for MetaInputValue<'_> {
+    type Id = MetaInputValueId;
+}
+
+impl<'a> From<ReadContext<'a, MetaInputValueId>> for MetaInputValue<'a> {
+    fn from(value: ReadContext<'a, MetaInputValueId>) -> Self {
+        Self(value)
+    }
+}
+
+#[derive(serde :: Serialize, serde :: Deserialize)]
+pub struct InputObjectTypeRecord {
+    #[serde(rename = "0")]
+    pub name: StringId,
+    #[serde(rename = "1", skip_serializing_if = "Option::is_none", default)]
+    pub description: Option<StringId>,
+    #[serde(rename = "2", skip_serializing_if = "crate::Container::is_empty", default)]
+    pub input_fields: IdRange<MetaInputValueId>,
+    #[serde(rename = "3", skip_serializing_if = "crate::is_false", default)]
+    pub oneof: bool,
+}
+
+#[derive(Clone, Copy)]
+pub struct InputObjectType<'a>(pub(crate) ReadContext<'a, InputObjectTypeId>);
+
+impl<'a> InputObjectType<'a> {
+    pub fn name(&self) -> &'a str {
+        let registry = &self.0.registry;
+        registry.lookup(registry.lookup(self.0.id).name)
+    }
+    pub fn description(&self) -> Option<&'a str> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).description.map(|id| registry.lookup(id))
+    }
+    pub fn input_fields(&self) -> Iter<'a, MetaInputValue<'a>> {
+        let registry = self.0.registry;
+        Iter::new(registry.lookup(self.0.id).input_fields, registry)
+    }
+    pub fn oneof(&self) -> bool {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).oneof
+    }
+}
+
+impl fmt::Debug for InputObjectType<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InputObjectType")
+            .field("name", &self.name())
+            .field("description", &self.description())
+            .field("input_fields", &self.input_fields().collect::<Vec<_>>())
+            .field("oneof", &self.oneof())
+            .finish()
+    }
+}
+
+impl std::cmp::PartialEq for InputObjectType<'_> {
+    fn eq(&self, other: &InputObjectType<'_>) -> bool {
+        std::ptr::eq(self.0.registry, other.0.registry) && self.0.id == other.0.id
+    }
+}
+impl std::cmp::Eq for InputObjectType<'_> {}
+
+impl RegistryId for InputObjectTypeId {
+    type Reader<'a> = InputObjectType<'a>;
+}
+
+impl IdReader for InputObjectType<'_> {
+    type Id = InputObjectTypeId;
+}
+
+impl<'a> From<ReadContext<'a, InputObjectTypeId>> for InputObjectType<'a> {
+    fn from(value: ReadContext<'a, InputObjectTypeId>) -> Self {
+        Self(value)
+    }
+}
+
+#[derive(serde :: Serialize, serde :: Deserialize)]
+pub struct InputValidatorRecord {
+    #[serde(rename = "0")]
+    pub validator: DynValidator,
+}
+
+#[derive(Clone, Copy)]
+pub struct InputValidator<'a>(pub(crate) ReadContext<'a, InputValidatorId>);
+
+impl<'a> InputValidator<'a> {
+    pub fn validator(&self) -> &'a DynValidator {
+        let registry = self.0.registry;
+        &registry.lookup(self.0.id).validator
+    }
+}
+
+impl fmt::Debug for InputValidator<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InputValidator")
+            .field("validator", &self.validator())
+            .finish()
+    }
+}
+
+impl RegistryId for InputValidatorId {
+    type Reader<'a> = InputValidator<'a>;
+}
+
+impl IdReader for InputValidator<'_> {
+    type Id = InputValidatorId;
+}
+
+impl<'a> From<ReadContext<'a, InputValidatorId>> for InputValidator<'a> {
+    fn from(value: ReadContext<'a, InputValidatorId>) -> Self {
+        Self(value)
+    }
+}

--- a/engine/crates/engine/registry-v2/src/generated/interface.rs
+++ b/engine/crates/engine/registry-v2/src/generated/interface.rs
@@ -1,0 +1,85 @@
+use super::prelude::*;
+use super::{
+    field::MetaField,
+    metatype::MetaType,
+    prelude::ids::{InterfaceTypeId, MetaFieldId, MetaTypeId},
+};
+#[allow(unused_imports)]
+use std::fmt::{self, Write};
+
+#[derive(serde :: Serialize, serde :: Deserialize)]
+pub struct InterfaceTypeRecord {
+    #[serde(rename = "0")]
+    pub name: StringId,
+    #[serde(rename = "1", skip_serializing_if = "Option::is_none", default)]
+    pub description: Option<StringId>,
+    #[serde(rename = "2", skip_serializing_if = "crate::Container::is_empty", default)]
+    pub fields: IdRange<MetaFieldId>,
+    #[serde(rename = "3", skip_serializing_if = "Option::is_none", default)]
+    pub cache_control: Option<Box<CacheControl>>,
+    #[serde(rename = "4", skip_serializing_if = "crate::Container::is_empty", default)]
+    pub possible_types: Vec<MetaTypeId>,
+}
+
+#[derive(Clone, Copy)]
+pub struct InterfaceType<'a>(pub(crate) ReadContext<'a, InterfaceTypeId>);
+
+impl<'a> InterfaceType<'a> {
+    pub fn name(&self) -> &'a str {
+        let registry = &self.0.registry;
+        registry.lookup(registry.lookup(self.0.id).name)
+    }
+    pub fn description(&self) -> Option<&'a str> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).description.map(|id| registry.lookup(id))
+    }
+    pub fn fields(&self) -> Iter<'a, MetaField<'a>> {
+        let registry = self.0.registry;
+        Iter::new(registry.lookup(self.0.id).fields, registry)
+    }
+    pub fn cache_control(&self) -> Option<&'a CacheControl> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).cache_control.as_deref()
+    }
+    pub fn possible_types(&self) -> impl ExactSizeIterator<Item = MetaType<'a>> + 'a {
+        let registry = self.0.registry;
+        registry
+            .lookup(self.0.id)
+            .possible_types
+            .iter()
+            .map(|id| registry.read(*id))
+    }
+}
+
+impl fmt::Debug for InterfaceType<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InterfaceType")
+            .field("name", &self.name())
+            .field("description", &self.description())
+            .field("fields", &self.fields().collect::<Vec<_>>())
+            .field("cache_control", &self.cache_control())
+            .field("possible_types", &self.possible_types().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+impl std::cmp::PartialEq for InterfaceType<'_> {
+    fn eq(&self, other: &InterfaceType<'_>) -> bool {
+        std::ptr::eq(self.0.registry, other.0.registry) && self.0.id == other.0.id
+    }
+}
+impl std::cmp::Eq for InterfaceType<'_> {}
+
+impl RegistryId for InterfaceTypeId {
+    type Reader<'a> = InterfaceType<'a>;
+}
+
+impl IdReader for InterfaceType<'_> {
+    type Id = InterfaceTypeId;
+}
+
+impl<'a> From<ReadContext<'a, InterfaceTypeId>> for InterfaceType<'a> {
+    fn from(value: ReadContext<'a, InterfaceTypeId>) -> Self {
+        Self(value)
+    }
+}

--- a/engine/crates/engine/registry-v2/src/generated/metatype.rs
+++ b/engine/crates/engine/registry-v2/src/generated/metatype.rs
@@ -1,0 +1,61 @@
+use super::prelude::*;
+use super::{
+    enums::EnumType,
+    inputs::InputObjectType,
+    interface::InterfaceType,
+    objects::ObjectType,
+    prelude::ids::{
+        EnumTypeId, InputObjectTypeId, InterfaceTypeId, MetaTypeId, ObjectTypeId, ScalarTypeId, UnionTypeId,
+    },
+    scalar::ScalarType,
+    union::UnionType,
+};
+#[allow(unused_imports)]
+use std::fmt::{self, Write};
+
+#[derive(serde :: Serialize, serde :: Deserialize)]
+pub enum MetaTypeRecord {
+    #[serde(rename = "0")]
+    Object(ObjectTypeId),
+    #[serde(rename = "1")]
+    Interface(InterfaceTypeId),
+    #[serde(rename = "2")]
+    Union(UnionTypeId),
+    #[serde(rename = "3")]
+    Enum(EnumTypeId),
+    #[serde(rename = "4")]
+    InputObject(InputObjectTypeId),
+    #[serde(rename = "5")]
+    Scalar(ScalarTypeId),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MetaType<'a> {
+    Object(ObjectType<'a>),
+    Interface(InterfaceType<'a>),
+    Union(UnionType<'a>),
+    Enum(EnumType<'a>),
+    InputObject(InputObjectType<'a>),
+    Scalar(ScalarType<'a>),
+}
+
+impl RegistryId for MetaTypeId {
+    type Reader<'a> = MetaType<'a>;
+}
+
+impl IdReader for MetaType<'_> {
+    type Id = MetaTypeId;
+}
+
+impl<'a> From<ReadContext<'a, MetaTypeId>> for MetaType<'a> {
+    fn from(value: ReadContext<'a, MetaTypeId>) -> Self {
+        match value.registry.lookup(value.id) {
+            MetaTypeRecord::Object(id) => MetaType::Object(value.registry.read(*id)),
+            MetaTypeRecord::Interface(id) => MetaType::Interface(value.registry.read(*id)),
+            MetaTypeRecord::Union(id) => MetaType::Union(value.registry.read(*id)),
+            MetaTypeRecord::Enum(id) => MetaType::Enum(value.registry.read(*id)),
+            MetaTypeRecord::InputObject(id) => MetaType::InputObject(value.registry.read(*id)),
+            MetaTypeRecord::Scalar(id) => MetaType::Scalar(value.registry.read(*id)),
+        }
+    }
+}

--- a/engine/crates/engine/registry-v2/src/generated/objects.rs
+++ b/engine/crates/engine/registry-v2/src/generated/objects.rs
@@ -1,0 +1,87 @@
+use super::prelude::*;
+use super::{
+    field::MetaField,
+    prelude::ids::{MetaFieldId, ObjectTypeId},
+};
+#[allow(unused_imports)]
+use std::fmt::{self, Write};
+
+#[derive(serde :: Serialize, serde :: Deserialize)]
+pub struct ObjectTypeRecord {
+    #[serde(rename = "0")]
+    pub name: StringId,
+    #[serde(rename = "1", skip_serializing_if = "Option::is_none", default)]
+    pub description: Option<StringId>,
+    #[serde(rename = "2", skip_serializing_if = "crate::Container::is_empty", default)]
+    pub fields: IdRange<MetaFieldId>,
+    #[serde(rename = "3", skip_serializing_if = "Option::is_none", default)]
+    pub cache_control: Option<Box<CacheControl>>,
+    #[serde(rename = "4", skip_serializing_if = "crate::is_false", default)]
+    pub external: bool,
+    #[serde(rename = "5", skip_serializing_if = "crate::is_false", default)]
+    pub shareable: bool,
+}
+
+#[derive(Clone, Copy)]
+pub struct ObjectType<'a>(pub(crate) ReadContext<'a, ObjectTypeId>);
+
+impl<'a> ObjectType<'a> {
+    pub fn name(&self) -> &'a str {
+        let registry = &self.0.registry;
+        registry.lookup(registry.lookup(self.0.id).name)
+    }
+    pub fn description(&self) -> Option<&'a str> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).description.map(|id| registry.lookup(id))
+    }
+    pub fn fields(&self) -> Iter<'a, MetaField<'a>> {
+        let registry = self.0.registry;
+        Iter::new(registry.lookup(self.0.id).fields, registry)
+    }
+    pub fn cache_control(&self) -> Option<&'a CacheControl> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).cache_control.as_deref()
+    }
+    pub fn external(&self) -> bool {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).external
+    }
+    pub fn shareable(&self) -> bool {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).shareable
+    }
+}
+
+impl fmt::Debug for ObjectType<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ObjectType")
+            .field("name", &self.name())
+            .field("description", &self.description())
+            .field("fields", &self.fields().collect::<Vec<_>>())
+            .field("cache_control", &self.cache_control())
+            .field("external", &self.external())
+            .field("shareable", &self.shareable())
+            .finish()
+    }
+}
+
+impl std::cmp::PartialEq for ObjectType<'_> {
+    fn eq(&self, other: &ObjectType<'_>) -> bool {
+        std::ptr::eq(self.0.registry, other.0.registry) && self.0.id == other.0.id
+    }
+}
+impl std::cmp::Eq for ObjectType<'_> {}
+
+impl RegistryId for ObjectTypeId {
+    type Reader<'a> = ObjectType<'a>;
+}
+
+impl IdReader for ObjectType<'_> {
+    type Id = ObjectTypeId;
+}
+
+impl<'a> From<ReadContext<'a, ObjectTypeId>> for ObjectType<'a> {
+    fn from(value: ReadContext<'a, ObjectTypeId>) -> Self {
+        Self(value)
+    }
+}

--- a/engine/crates/engine/registry-v2/src/generated/scalar.rs
+++ b/engine/crates/engine/registry-v2/src/generated/scalar.rs
@@ -1,0 +1,73 @@
+use super::prelude::ids::ScalarTypeId;
+use super::prelude::*;
+#[allow(unused_imports)]
+use std::fmt::{self, Write};
+
+#[derive(serde :: Serialize, serde :: Deserialize)]
+pub struct ScalarTypeRecord {
+    #[serde(rename = "0")]
+    pub name: StringId,
+    #[serde(rename = "1", skip_serializing_if = "Option::is_none", default)]
+    pub description: Option<StringId>,
+    #[serde(rename = "2", skip_serializing_if = "Option::is_none", default)]
+    pub specified_by_url: Option<StringId>,
+    #[serde(rename = "3")]
+    pub parser: ScalarParser,
+}
+
+#[derive(Clone, Copy)]
+pub struct ScalarType<'a>(pub(crate) ReadContext<'a, ScalarTypeId>);
+
+impl<'a> ScalarType<'a> {
+    pub fn name(&self) -> &'a str {
+        let registry = &self.0.registry;
+        registry.lookup(registry.lookup(self.0.id).name)
+    }
+    pub fn description(&self) -> Option<&'a str> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).description.map(|id| registry.lookup(id))
+    }
+    pub fn specified_by_url(&self) -> Option<&'a str> {
+        let registry = self.0.registry;
+        registry
+            .lookup(self.0.id)
+            .specified_by_url
+            .map(|id| registry.lookup(id))
+    }
+    pub fn parser(&self) -> ScalarParser {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).parser
+    }
+}
+
+impl fmt::Debug for ScalarType<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ScalarType")
+            .field("name", &self.name())
+            .field("description", &self.description())
+            .field("specified_by_url", &self.specified_by_url())
+            .field("parser", &self.parser())
+            .finish()
+    }
+}
+
+impl std::cmp::PartialEq for ScalarType<'_> {
+    fn eq(&self, other: &ScalarType<'_>) -> bool {
+        std::ptr::eq(self.0.registry, other.0.registry) && self.0.id == other.0.id
+    }
+}
+impl std::cmp::Eq for ScalarType<'_> {}
+
+impl RegistryId for ScalarTypeId {
+    type Reader<'a> = ScalarType<'a>;
+}
+
+impl IdReader for ScalarType<'_> {
+    type Id = ScalarTypeId;
+}
+
+impl<'a> From<ReadContext<'a, ScalarTypeId>> for ScalarType<'a> {
+    fn from(value: ReadContext<'a, ScalarTypeId>) -> Self {
+        Self(value)
+    }
+}

--- a/engine/crates/engine/registry-v2/src/generated/union.rs
+++ b/engine/crates/engine/registry-v2/src/generated/union.rs
@@ -1,0 +1,77 @@
+use super::prelude::*;
+use super::{
+    metatype::MetaType,
+    prelude::ids::{MetaTypeId, UnionTypeId},
+};
+#[allow(unused_imports)]
+use std::fmt::{self, Write};
+
+#[derive(serde :: Serialize, serde :: Deserialize)]
+pub struct UnionTypeRecord {
+    #[serde(rename = "0")]
+    pub name: StringId,
+    #[serde(rename = "1", skip_serializing_if = "Option::is_none", default)]
+    pub description: Option<StringId>,
+    #[serde(rename = "2", skip_serializing_if = "crate::Container::is_empty", default)]
+    pub possible_types: Vec<MetaTypeId>,
+    #[serde(rename = "3")]
+    pub discriminators: UnionDiscriminators,
+}
+
+#[derive(Clone, Copy)]
+pub struct UnionType<'a>(pub(crate) ReadContext<'a, UnionTypeId>);
+
+impl<'a> UnionType<'a> {
+    pub fn name(&self) -> &'a str {
+        let registry = &self.0.registry;
+        registry.lookup(registry.lookup(self.0.id).name)
+    }
+    pub fn description(&self) -> Option<&'a str> {
+        let registry = self.0.registry;
+        registry.lookup(self.0.id).description.map(|id| registry.lookup(id))
+    }
+    pub fn possible_types(&self) -> impl ExactSizeIterator<Item = MetaType<'a>> + 'a {
+        let registry = self.0.registry;
+        registry
+            .lookup(self.0.id)
+            .possible_types
+            .iter()
+            .map(|id| registry.read(*id))
+    }
+    pub fn discriminators(&self) -> &'a UnionDiscriminators {
+        let registry = self.0.registry;
+        &registry.lookup(self.0.id).discriminators
+    }
+}
+
+impl fmt::Debug for UnionType<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnionType")
+            .field("name", &self.name())
+            .field("description", &self.description())
+            .field("possible_types", &self.possible_types().collect::<Vec<_>>())
+            .field("discriminators", &self.discriminators())
+            .finish()
+    }
+}
+
+impl std::cmp::PartialEq for UnionType<'_> {
+    fn eq(&self, other: &UnionType<'_>) -> bool {
+        std::ptr::eq(self.0.registry, other.0.registry) && self.0.id == other.0.id
+    }
+}
+impl std::cmp::Eq for UnionType<'_> {}
+
+impl RegistryId for UnionTypeId {
+    type Reader<'a> = UnionType<'a>;
+}
+
+impl IdReader for UnionType<'_> {
+    type Id = UnionTypeId;
+}
+
+impl<'a> From<ReadContext<'a, UnionTypeId>> for UnionType<'a> {
+    fn from(value: ReadContext<'a, UnionTypeId>) -> Self {
+        Self(value)
+    }
+}

--- a/engine/crates/engine/registry-v2/src/ids.rs
+++ b/engine/crates/engine/registry-v2/src/ids.rs
@@ -1,0 +1,113 @@
+use std::num::NonZeroU32;
+
+use crate::{
+    common::IdRange,
+    generated::{
+        enums::{EnumTypeRecord, MetaEnumValueRecord},
+        inputs::{InputObjectTypeRecord, InputValidatorRecord},
+    },
+    storage::*,
+    RecordLookup, Registry,
+};
+
+macro_rules! make_id {
+    ($name:ident, $output:ident, $field:ident) => {
+        #[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash, Ord, PartialOrd)]
+        pub struct $name(NonZeroU32);
+
+        impl $name {
+            pub(super) fn new(index: usize) -> Self {
+                Self(
+                    NonZeroU32::new(u32::try_from(index + 1).expect("too many indices"))
+                        .expect("also too many indices"),
+                )
+            }
+
+            pub(super) fn to_index(self) -> usize {
+                (self.0.get() - 1) as usize
+            }
+        }
+
+        impl RecordLookup<$name> for Registry {
+            type Output = $output;
+
+            fn lookup(&self, index: $name) -> &Self::Output {
+                &self.$field[index.to_index()]
+            }
+
+            // fn lookup_mut(&mut self, index: $name) -> &mut Self::Output {
+            //     &mut self.$field[(index.0.get() - 1) as usize]
+            // }
+        }
+    };
+}
+
+macro_rules! impl_id_range {
+    ($name: ident) => {
+        impl IdRange<$name> {
+            pub fn len(&self) -> usize {
+                (self.end.0.get() - self.start.0.get()) as usize
+            }
+
+            pub fn is_empty(&self) -> bool {
+                (self.end.0.get() - self.start.0.get()) == 0
+            }
+
+            pub fn iter(&self) -> impl ExactSizeIterator<Item = $name> {
+                (self.start.0.get()..self.end.0.get())
+                    .map(|num| $name(NonZeroU32::new(num).expect("range is too large")))
+            }
+        }
+
+        impl Default for IdRange<$name> {
+            fn default() -> Self {
+                Self::new($name::new(0), $name::new(0))
+            }
+        }
+
+        impl crate::common::IdOperations for $name {
+            fn forward(self) -> Option<Self> {
+                Some(Self(NonZeroU32::new(self.0.get() + 1)?))
+            }
+            fn back(self) -> Option<Self> {
+                Some(Self(NonZeroU32::new(self.0.get() - 1)?))
+            }
+            fn cmp(self, other: Self) -> std::cmp::Ordering {
+                self.0.get().cmp(&other.0.get())
+            }
+            fn distance(lhs: Self, rhs: Self) -> usize {
+                rhs.0.get().saturating_sub(lhs.0.get()) as usize
+            }
+        }
+    };
+}
+
+make_id!(MetaTypeId, MetaTypeRecord, types);
+impl_id_range!(MetaTypeId);
+
+make_id!(ObjectTypeId, ObjectTypeRecord, objects);
+make_id!(MetaFieldId, MetaFieldRecord, object_fields);
+impl_id_range!(MetaFieldId);
+
+make_id!(MetaInputValueId, MetaInputValueRecord, input_values);
+impl_id_range!(MetaInputValueId);
+
+make_id!(InputValidatorId, InputValidatorRecord, input_validators);
+impl_id_range!(InputValidatorId);
+
+make_id!(InputObjectTypeId, InputObjectTypeRecord, input_objects);
+
+make_id!(EnumTypeId, EnumTypeRecord, enums);
+make_id!(MetaEnumValueId, MetaEnumValueRecord, enum_values);
+impl_id_range!(MetaEnumValueId);
+
+make_id!(InterfaceTypeId, InterfaceTypeRecord, interfaces);
+
+make_id!(ScalarTypeId, ScalarTypeRecord, scalars);
+
+make_id!(UnionTypeId, UnionTypeRecord, unions);
+
+make_id!(MetaDirectiveId, MetaDirectiveRecord, directives);
+impl_id_range!(MetaDirectiveId);
+
+make_id!(StringId, str, strings);

--- a/engine/crates/engine/registry-v2/src/lib.rs
+++ b/engine/crates/engine/registry-v2/src/lib.rs
@@ -1,0 +1,282 @@
+use std::{
+    cmp::Ordering,
+    collections::{BTreeMap, HashMap},
+};
+
+use gateway_v2_auth_config::v1::AuthConfig;
+use ids::{MetaDirectiveId, MetaFieldId, MetaTypeId, StringId};
+use indexmap::IndexSet;
+use postgres_connector_types::database_definition::DatabaseDefinition;
+
+mod common;
+mod cors;
+mod extensions;
+mod federation_entity;
+mod field_types;
+mod generated;
+mod misc_types;
+mod operation_limits;
+mod trusted_docs;
+
+pub mod cache_control;
+pub mod ids;
+pub mod mongodb;
+pub mod resolvers;
+pub mod validators;
+pub mod writer;
+
+pub use self::{
+    cache_control::CacheControl,
+    common::*,
+    cors::CorsConfig,
+    federation_entity::*,
+    field_types::{MetaFieldType, MetaInputValueType},
+    generated::{
+        directives::MetaDirective,
+        enums::{EnumType, MetaEnumValue},
+        field::MetaField,
+        inputs::{InputObjectType, MetaInputValue},
+        interface::InterfaceType,
+        metatype::MetaType,
+        objects::ObjectType,
+        scalar::ScalarType,
+        union::UnionType,
+    },
+    misc_types::*,
+    mongodb::MongoDBConfiguration,
+    operation_limits::*,
+    trusted_docs::*,
+};
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct Registry {
+    strings: IndexSet<Box<str>>,
+
+    types: Vec<storage::MetaTypeRecord>,
+
+    objects: Vec<storage::ObjectTypeRecord>,
+    object_fields: Vec<storage::MetaFieldRecord>,
+
+    input_objects: Vec<storage::InputObjectTypeRecord>,
+    input_values: Vec<storage::MetaInputValueRecord>,
+    input_validators: Vec<storage::InputValidatorRecord>,
+
+    enums: Vec<storage::EnumTypeRecord>,
+    enum_values: Vec<storage::MetaEnumValueRecord>,
+
+    interfaces: Vec<storage::InterfaceTypeRecord>,
+    scalars: Vec<storage::ScalarTypeRecord>,
+    unions: Vec<storage::UnionTypeRecord>,
+
+    directives: Vec<storage::MetaDirectiveRecord>,
+
+    typename_index: MetaFieldId,
+
+    implements: HashMap<MetaTypeId, Vec<MetaTypeId>>,
+    query_type: MetaTypeId,
+    mutation_type: Option<MetaTypeId>,
+    subscription_type: Option<MetaTypeId>,
+    pub disable_introspection: bool,
+    pub enable_federation: bool,
+    pub federation_subscription: bool,
+
+    pub auth: AuthConfig,
+    // #[serde(default)]
+    pub mongodb_configurations: HashMap<String, MongoDBConfiguration>,
+    // #[serde(default)]
+    pub http_headers: BTreeMap<String, ConnectorHeaders>,
+    // #[serde(default)]
+    pub postgres_databases: HashMap<String, DatabaseDefinition>,
+    // #[serde(default)]
+    pub enable_caching: bool,
+    // #[serde(default)]
+    pub enable_kv: bool,
+    // #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub federation_entities: BTreeMap<String, FederationEntity>,
+    // #[serde(default)]
+    pub enable_codegen: bool,
+    // FIXME: Make an enum.
+    pub is_federated: bool,
+    // #[serde(default)]
+    pub operation_limits: OperationLimits,
+    // #[serde(default)]
+    pub trusted_documents: Option<TrustedDocuments>,
+    // #[serde(default)]
+    pub cors_config: Option<CorsConfig>,
+}
+
+impl Registry {
+    pub fn types(&self) -> Iter<'_, MetaType<'_>> {
+        Iter::new(
+            IdRange::new(MetaTypeId::new(0), MetaTypeId::new(self.types.len())),
+            self,
+        )
+    }
+
+    pub fn directives(&self) -> Iter<'_, MetaDirective<'_>> {
+        Iter::new(
+            IdRange::new(MetaDirectiveId::new(0), MetaDirectiveId::new(self.directives.len())),
+            self,
+        )
+    }
+
+    pub fn lookup_type<'a>(&'a self, name: &str) -> Option<MetaType<'a>> {
+        Some(self.read(self.lookup_type_id(name)?))
+    }
+
+    pub fn lookup_directive<'a>(&'a self, name: &str) -> Option<MetaDirective<'a>> {
+        // This isn't that efficient, but I'm assuming small numbers of directives
+        self.directives().find(|directive| directive.name() == name)
+    }
+
+    pub fn query_type(&self) -> MetaType<'_> {
+        self.read(self.query_type)
+    }
+
+    pub fn mutation_type(&self) -> Option<MetaType<'_>> {
+        self.mutation_type.map(|id| self.read(id))
+    }
+
+    pub fn subscription_type(&self) -> Option<MetaType<'_>> {
+        self.subscription_type.map(|id| self.read(id))
+    }
+
+    pub fn root_type(&self, operation_type: OperationType) -> Option<MetaType<'_>> {
+        match operation_type {
+            OperationType::Query => Some(self.query_type()),
+            OperationType::Mutation => self.mutation_type(),
+            OperationType::Subscription => self.subscription_type(),
+        }
+    }
+
+    pub fn interfaces_implemented<'a>(&'a self, name: &str) -> impl ExactSizeIterator<Item = MetaType<'a>> {
+        self.lookup_type_id(name)
+            .and_then(|type_id| self.implements.get(&type_id))
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
+            .iter()
+            .map(|id| self.read(*id))
+    }
+
+    pub fn has_entities(&self) -> bool {
+        !self.federation_entities.is_empty()
+    }
+
+    fn lookup_type_id(&self, name: &str) -> Option<MetaTypeId> {
+        let string_id = StringId::new(self.strings.get_index_of(name)?);
+        let type_id = self
+            .types
+            .binary_search_by_key(&string_id, |ty| match ty {
+                storage::MetaTypeRecord::Object(id) => self.lookup(*id).name,
+                storage::MetaTypeRecord::Interface(id) => self.lookup(*id).name,
+                storage::MetaTypeRecord::Union(id) => self.lookup(*id).name,
+                storage::MetaTypeRecord::Enum(id) => self.lookup(*id).name,
+                storage::MetaTypeRecord::InputObject(id) => self.lookup(*id).name,
+                storage::MetaTypeRecord::Scalar(id) => self.lookup(*id).name,
+            })
+            .ok()?;
+
+        Some(MetaTypeId::new(type_id))
+    }
+
+    pub(crate) fn string_cmp(&self, lhs: StringId, rhs: &str) -> Ordering {
+        self.strings.get_index(lhs.to_index()).unwrap().as_ref().cmp(rhs)
+    }
+}
+
+pub trait RegistryId: Copy {
+    type Reader<'a>: From<ReadContext<'a, Self>>;
+
+    fn read(self, ast: &Registry) -> Self::Reader<'_> {
+        ReadContext {
+            id: self,
+            registry: ast,
+        }
+        .into()
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct ReadContext<'a, I> {
+    id: I,
+    registry: &'a Registry,
+}
+
+impl Registry {
+    pub fn read<T>(&self, id: T) -> T::Reader<'_>
+    where
+        T: RegistryId,
+    {
+        ReadContext { id, registry: self }.into()
+    }
+}
+
+trait RecordLookup<Id> {
+    type Output: ?Sized;
+
+    fn lookup(&self, index: Id) -> &Self::Output;
+    // fn lookup_mut(&mut self, index: Id) -> &mut Self::Output;
+}
+
+/// Convenience module for writing to the registry.
+///
+/// Generally you don't need these types, but if you need one you probably need several (or all) of
+/// them, so having them exposed as a single module makes them just a `use storage::*` away.
+pub mod storage {
+    pub use super::{
+        field_types::{MetaFieldTypeRecord, MetaInputValueTypeRecord},
+        generated::{
+            directives::MetaDirectiveRecord,
+            enums::{EnumTypeRecord, MetaEnumValueRecord},
+            field::MetaFieldRecord,
+            inputs::{InputObjectTypeRecord, InputValidatorRecord, MetaInputValueRecord},
+            interface::InterfaceTypeRecord,
+            metatype::MetaTypeRecord,
+            objects::ObjectTypeRecord,
+            scalar::ScalarTypeRecord,
+            union::UnionTypeRecord,
+        },
+    };
+}
+
+// Hacky trait used by serialzation code
+trait Container {
+    fn is_empty(&self) -> bool;
+}
+
+impl<T> Container for IdRange<T>
+where
+    T: PartialEq,
+{
+    fn is_empty(&self) -> bool {
+        self.start == self.end
+    }
+}
+
+impl<T> Container for Vec<T> {
+    fn is_empty(&self) -> bool {
+        self.is_empty()
+    }
+}
+
+pub fn is_false(value: &bool) -> bool {
+    !value
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::resolvers::Resolver;
+
+    use super::*;
+
+    #[test]
+    fn types_should_have_reasonable_sizes() {
+        // We do some testing on the exact size of these.
+        // If the size goes up think very carefully about it.
+        // If it goes down - yay, just update the test so we can keep the new low water mark.
+
+        assert_eq!(std::mem::size_of::<CacheControl>(), 80);
+
+        assert_eq!(std::mem::size_of::<Resolver>(), 56);
+    }
+}

--- a/engine/crates/engine/registry-v2/src/misc_types.rs
+++ b/engine/crates/engine/registry-v2/src/misc_types.rs
@@ -1,0 +1,111 @@
+//! Some imported types from the old registry.
+//!
+//! Could look at improving these sometime but for now I'm just copying them into here.
+
+#[serde_with::minify_field_names(serialize = "minified", deserialize = "minified")]
+#[serde_with::minify_variant_names(serialize = "minified", deserialize = "minified")]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, Hash, PartialEq, Eq, Default)]
+pub enum Deprecation {
+    #[default]
+    NoDeprecated,
+    Deprecated {
+        reason: Option<String>,
+    },
+}
+
+impl Deprecation {
+    pub fn is_deprecated(&self) -> bool {
+        matches!(self, Deprecation::Deprecated { .. })
+    }
+
+    pub fn reason(&self) -> Option<&str> {
+        match self {
+            Deprecation::NoDeprecated => None,
+            Deprecation::Deprecated { reason } => reason.as_deref(),
+        }
+    }
+}
+
+#[serde_with::minify_field_names(serialize = "minified", deserialize = "minified")]
+#[serde_with::skip_serializing_defaults(Option, Vec, bool, CacheControl, Deprecation)]
+#[derive(Clone, Default, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq, Hash)]
+pub struct FederationProperties {
+    pub provides: Option<String>,
+    pub tags: Vec<String>,
+    pub r#override: Option<String>,
+    pub external: bool,
+    pub shareable: bool,
+    pub inaccessible: bool,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Hash, PartialEq)]
+pub struct FieldSet(pub Vec<Selection>);
+
+impl FieldSet {
+    pub fn new(selections: impl IntoIterator<Item = Selection>) -> Self {
+        FieldSet(selections.into_iter().collect())
+    }
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Hash, PartialEq)]
+#[serde_with::minify_field_names(serialize = "minified", deserialize = "minified")]
+#[serde_with::skip_serializing_defaults(Option, Vec, ConstraintType)]
+pub struct Selection {
+    pub field: String,
+    pub selections: Vec<Selection>,
+}
+
+#[derive(Default, Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+pub enum ScalarParser {
+    /// Do not parse scalars, instead match the [`serde_json::Value`] type directly to the relevant
+    /// [`Value`] type.
+    PassThrough,
+
+    /// Parse the scalar based on a list of well-known formats, trying to match the value to one of
+    /// the formats. If no match is found, an error is returned.
+    ///
+    /// See [`PossibleScalar`] for more details.
+    #[default]
+    BestEffort,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct UnionDiscriminators(pub Vec<(String, UnionDiscriminator)>);
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum UnionDiscriminator {
+    /// If the named field is present then this is the correct variant
+    FieldPresent(String),
+    /// This is the correct variant if the given field has one of the provided values
+    FieldHasValue(String, Vec<serde_json::Value>),
+    /// This is the correct variant if the input is of a particular type
+    IsAScalar(ScalarKind),
+    /// Fallback on this type if no others match
+    Fallback,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum ScalarKind {
+    String,
+    Number,
+    Boolean,
+}
+
+#[derive(Clone, Default, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+/// Headers we should send to a connectors downstream server
+pub struct ConnectorHeaders(pub Vec<(String, ConnectorHeaderValue)>);
+
+impl ConnectorHeaders {
+    pub fn new(headers: impl IntoIterator<Item = (String, ConnectorHeaderValue)>) -> Self {
+        ConnectorHeaders(headers.into_iter().collect())
+    }
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub enum ConnectorHeaderValue {
+    /// We should send a static value for this header
+    Static(String),
+    /// We should pull the value for this header from the named header in the incoming
+    /// request
+    Forward(String),
+}

--- a/engine/crates/engine/registry-v2/src/mongodb.rs
+++ b/engine/crates/engine/registry-v2/src/mongodb.rs
@@ -1,0 +1,9 @@
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct MongoDBConfiguration {
+    pub name: String,
+    pub api_key: String,
+    pub url: String,
+    pub data_source: String,
+    pub database: String,
+    pub namespace: bool,
+}

--- a/engine/crates/engine/registry-v2/src/operation_limits.rs
+++ b/engine/crates/engine/registry-v2/src/operation_limits.rs
@@ -1,0 +1,15 @@
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationLimits {
+    pub depth: Option<u16>,
+    pub height: Option<u16>,
+    pub aliases: Option<u16>,
+    pub root_fields: Option<u16>,
+    pub complexity: Option<u16>,
+}
+
+impl OperationLimits {
+    pub fn any_enabled(&self) -> bool {
+        *self != Default::default()
+    }
+}

--- a/engine/crates/engine/registry-v2/src/resolvers.rs
+++ b/engine/crates/engine/registry-v2/src/resolvers.rs
@@ -1,0 +1,66 @@
+//! Data structues for resolvers.
+//!
+//! Actual logic should not be implemented in this crate, as many crates pull this in.
+//! Implement your logic elsewhere (probably the engine crate or a crate the engine pulls in)
+//!
+
+pub mod atlas_data_api;
+pub mod custom;
+pub mod graphql;
+pub mod http;
+pub mod introspection;
+pub mod join;
+pub mod postgres;
+pub mod transformer;
+pub mod variable_resolve_definition;
+
+#[serde_with::minify_variant_names(serialize = "minified", deserialize = "minified")]
+#[derive(Default, Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub enum Resolver {
+    // By default a resolver will just return its parent value
+    #[default]
+    Parent,
+    Typename,
+    Transformer(transformer::Transformer),
+    CustomResolver(custom::CustomResolver),
+    Composition(Vec<Resolver>),
+    Http(Box<http::HttpResolver>),
+    Graphql(Box<graphql::Resolver>),
+    MongoResolver(atlas_data_api::AtlasDataApiResolver),
+    PostgresResolver(postgres::PostgresResolver),
+    FederationEntitiesResolver,
+    Introspection(introspection::IntrospectionResolver),
+    Join(join::JoinResolver),
+}
+
+impl Resolver {
+    pub fn and_then(mut self, resolver: impl Into<Resolver>) -> Self {
+        let resolver = resolver.into();
+        match &mut self {
+            Resolver::Composition(resolvers) => {
+                resolvers.push(resolver);
+                self
+            }
+            _ => Resolver::Composition(vec![self, resolver]),
+        }
+    }
+
+    pub fn and_then_maybe(self, resolver: Option<impl Into<Resolver>>) -> Self {
+        match resolver {
+            Some(other) => self.and_then(other),
+            None => self,
+        }
+    }
+
+    pub fn is_parent(&self) -> bool {
+        matches!(self, Self::Parent)
+    }
+
+    pub fn is_custom(&self) -> bool {
+        matches!(self, Self::CustomResolver(_))
+    }
+
+    pub fn is_join(&self) -> bool {
+        matches!(self, Self::Join(_))
+    }
+}

--- a/engine/crates/engine/registry-v2/src/resolvers/atlas_data_api.rs
+++ b/engine/crates/engine/registry-v2/src/resolvers/atlas_data_api.rs
@@ -1,0 +1,49 @@
+use std::fmt;
+
+/// Resolver for the MongoDB Atlas Data API, which is a MongoDB endpoint using
+/// HTTP protocol for transfer.
+///
+/// # Internal documentation
+/// https://www.notion.so/grafbase/MongoDB-Connector-b4d134d2dd0f41ef88dd25cf19143be8
+#[serde_with::minify_field_names(serialize = "minified", deserialize = "minified")]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, Hash, PartialEq, Eq)]
+pub struct AtlasDataApiResolver {
+    /// The type of operation to execute in the target.
+    pub operation_type: OperationType,
+    pub directive_name: String,
+    pub collection: String,
+}
+
+#[derive(Clone, Copy, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub enum OperationType {
+    FindOne,
+    FindMany,
+    InsertOne,
+    InsertMany,
+    DeleteOne,
+    DeleteMany,
+    UpdateOne,
+    UpdateMany,
+}
+
+impl AsRef<str> for OperationType {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::FindOne => "findOne",
+            Self::FindMany => "find",
+            Self::InsertOne => "insertOne",
+            Self::InsertMany => "insertMany",
+            Self::DeleteOne => "deleteOne",
+            Self::DeleteMany => "deleteMany",
+            Self::UpdateOne => "updateOne",
+            Self::UpdateMany => "updateMany",
+        }
+    }
+}
+
+impl fmt::Display for OperationType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_ref().fmt(f)
+    }
+}

--- a/engine/crates/engine/registry-v2/src/resolvers/custom.rs
+++ b/engine/crates/engine/registry-v2/src/resolvers/custom.rs
@@ -1,0 +1,4 @@
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, Hash, PartialEq, Eq)]
+pub struct CustomResolver {
+    pub resolver_name: String,
+}

--- a/engine/crates/engine/registry-v2/src/resolvers/graphql.rs
+++ b/engine/crates/engine/registry-v2/src/resolvers/graphql.rs
@@ -1,0 +1,74 @@
+use std::borrow::Cow;
+
+use url::Url;
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, Hash, PartialEq, Eq)]
+#[serde(untagged)]
+enum IdOrName {
+    LegacyId { id: u16 },
+    Name { name: String },
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, Hash, PartialEq, Eq)]
+pub struct Resolver {
+    /// A unique name for the given GraphQL resolver instance.
+    #[serde(flatten)]
+    id_or_name: IdOrName,
+
+    /// The name of this GraphQL resolver instance.
+    ///
+    /// Each instance is expected to have a unique name, as the name of the instance is used as the
+    /// field name within which the root upstream fields are exposed.
+    pub namespace: Option<String>,
+
+    /// The prefix for this GraphQL resolver if any.
+    ///
+    /// If not present this will default to the namespace above, mostly for backwards
+    /// compatability reasons.
+    ///
+    /// This is used by the serializer to make sure there is no collision between global
+    /// types. E.g. if a `User` type exists, it won't be overwritten by the same type of the
+    /// upstream server, as it'll be prefixed as `MyPrefixUser`.
+    pub type_prefix: Option<String>,
+
+    /// The URL of the upstream GraphQL API.
+    ///
+    /// This should point to the actual query endpoint, not a publicly available playground or any
+    /// other destination.
+    pub url: Url,
+}
+
+impl Resolver {
+    #[must_use]
+    pub fn new(name: String, url: Url, namespace: Option<String>, type_prefix: Option<String>) -> Self {
+        Self {
+            id_or_name: IdOrName::Name { name },
+            url,
+            namespace,
+            type_prefix,
+        }
+    }
+
+    #[must_use]
+    pub fn name(&self) -> Cow<'_, String> {
+        match &self.id_or_name {
+            IdOrName::LegacyId { id } => Cow::Owned(id.to_string()),
+            IdOrName::Name { name } => Cow::Borrowed(name),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn stub(name: &str, namespace: impl AsRef<str>, url: impl AsRef<str>) -> Self {
+        let namespace = match namespace.as_ref() {
+            "" => None,
+            v => Some(v.to_owned()),
+        };
+
+        Self {
+            id_or_name: IdOrName::Name { name: name.to_string() },
+            type_prefix: namespace.clone(),
+            namespace,
+            url: Url::parse(url.as_ref()).expect("valid url"),
+        }
+    }
+}

--- a/engine/crates/engine/registry-v2/src/resolvers/http.rs
+++ b/engine/crates/engine/registry-v2/src/resolvers/http.rs
@@ -1,0 +1,62 @@
+use std::collections::BTreeMap;
+
+use super::variable_resolve_definition::VariableResolveDefinition;
+
+#[serde_with::minify_field_names(serialize = "minified", deserialize = "minified")]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct HttpResolver {
+    pub method: String,
+    pub url: String,
+    pub api_name: String,
+    pub path_parameters: Vec<PathParameter>,
+    pub query_parameters: Vec<QueryParameter>,
+    pub request_body: Option<RequestBody>,
+    pub expected_status: ExpectedStatusCode,
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct PathParameter {
+    pub name: String,
+    pub variable_resolve_definition: VariableResolveDefinition,
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct QueryParameter {
+    pub name: String,
+    pub variable_resolve_definition: VariableResolveDefinition,
+    pub encoding_style: QueryParameterEncodingStyle,
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct RequestBody {
+    pub variable_resolve_definition: VariableResolveDefinition,
+    pub content_type: RequestBodyContentType,
+}
+
+#[derive(Clone, Copy, Debug, serde::Deserialize, serde::Serialize, PartialEq)]
+pub enum QueryParameterEncodingStyle {
+    Form,
+    FormExploded,
+    DeepObject,
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub enum RequestBodyContentType {
+    Json,
+    FormEncoded(BTreeMap<String, QueryParameterEncodingStyle>),
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq)]
+pub enum ExpectedStatusCode {
+    Exact(u16),
+    Range(std::ops::Range<u16>),
+}
+
+impl ExpectedStatusCode {
+    pub fn is_success(&self) -> bool {
+        match self {
+            ExpectedStatusCode::Exact(code) => 200 <= *code && *code < 300,
+            ExpectedStatusCode::Range(code_range) => code_range.contains(&200) && code_range.end < 300,
+        }
+    }
+}

--- a/engine/crates/engine/registry-v2/src/resolvers/introspection.rs
+++ b/engine/crates/engine/registry-v2/src/resolvers/introspection.rs
@@ -1,0 +1,11 @@
+/// Some resolvers for implementing introspection
+///
+/// Currently most introspection is _not_ handled by these resolvers,
+/// but instead by some legacy async_graphql code.  We want to get rid
+/// of that sometime (ideally soon) though so expect we'll fill this out
+/// sooner or later
+#[serde_with::minify_variant_names(serialize = "minified", deserialize = "minified")]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, Hash, PartialEq, Eq)]
+pub enum IntrospectionResolver {
+    FederationServiceField,
+}

--- a/engine/crates/engine/registry-v2/src/resolvers/join.rs
+++ b/engine/crates/engine/registry-v2/src/resolvers/join.rs
@@ -1,0 +1,18 @@
+use engine_value::{argument_set::ArgumentSet, Name, Value};
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
+#[serde_with::minify_field_names(serialize = "minified", deserialize = "minified")]
+pub struct JoinResolver {
+    pub fields: Vec<(String, ArgumentSet)>,
+}
+
+impl JoinResolver {
+    pub fn new(fields: impl IntoIterator<Item = (String, Vec<(Name, Value)>)>) -> Self {
+        JoinResolver {
+            fields: fields
+                .into_iter()
+                .map(|(name, arguments)| (name, ArgumentSet::new(arguments)))
+                .collect(),
+        }
+    }
+}

--- a/engine/crates/engine/registry-v2/src/resolvers/postgres.rs
+++ b/engine/crates/engine/registry-v2/src/resolvers/postgres.rs
@@ -1,0 +1,43 @@
+#[serde_with::minify_field_names(serialize = "minified", deserialize = "minified")]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, Hash, PartialEq, Eq)]
+pub struct PostgresResolver {
+    pub operation: Operation,
+    pub directive_name: String,
+}
+
+impl PostgresResolver {
+    pub fn new(operation: Operation, directive_name: &str) -> Self {
+        Self {
+            operation,
+            directive_name: directive_name.to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub enum Operation {
+    FindOne,
+    FindMany,
+    DeleteOne,
+    DeleteMany,
+    CreateOne,
+    CreateMany,
+    UpdateOne,
+    UpdateMany,
+}
+
+impl AsRef<str> for Operation {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::FindOne => "findOne",
+            Self::FindMany => "findMany",
+            Self::DeleteOne => "deleteOne",
+            Self::DeleteMany => "deleteMany",
+            Self::CreateOne => "createOne",
+            Self::CreateMany => "createMany",
+            Self::UpdateOne => "updateOne",
+            Self::UpdateMany => "updateMany",
+        }
+    }
+}

--- a/engine/crates/engine/registry-v2/src/resolvers/transformer.rs
+++ b/engine/crates/engine/registry-v2/src/resolvers/transformer.rs
@@ -1,0 +1,54 @@
+use super::Resolver;
+
+#[serde_with::minify_field_names(serialize = "minified", deserialize = "minified")]
+#[serde_with::minify_variant_names(serialize = "minified", deserialize = "minified")]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, Hash, PartialEq, Eq)]
+pub enum Transformer {
+    GraphqlField,
+    /// Key based Resolver for ResolverContext
+    Select {
+        key: String,
+    },
+    /// This resolver get the PaginationData
+    PaginationData,
+    /// Resolves the correct values of a remote enum using the given enum name
+    RemoteEnum,
+    /// Resolves the __typename of a remote union type
+    RemoteUnion,
+    /// Convert MongoDB timestamp as number
+    MongoTimestamp,
+    /// A special transformer to fetch Postgres page info for the current results.
+    PostgresPageInfo,
+    /// Calculate cursor value for a Postgres row.
+    PostgresCursor,
+    /// Set Postgres selection data.
+    PostgresSelectionData {
+        directive_name: String,
+        table_id: TableId,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
+pub struct TableId(pub u32);
+
+impl From<TableId> for u32 {
+    fn from(value: TableId) -> Self {
+        value.0
+    }
+}
+
+impl Transformer {
+    pub fn and_then(self, resolver: impl Into<Resolver>) -> Resolver {
+        Resolver::Transformer(self).and_then(resolver)
+    }
+
+    pub fn select(key: &str) -> Self {
+        Self::Select { key: key.to_string() }
+    }
+}
+
+impl From<Transformer> for Resolver {
+    fn from(value: Transformer) -> Self {
+        Resolver::Transformer(value)
+    }
+}

--- a/engine/crates/engine/registry-v2/src/resolvers/variable_resolve_definition.rs
+++ b/engine/crates/engine/registry-v2/src/resolvers/variable_resolve_definition.rs
@@ -1,0 +1,42 @@
+#![allow(deprecated)]
+use std::borrow::Cow;
+
+/// Describe what should be done by the GraphQL Server to resolve this Variable.
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub enum VariableResolveDefinition {
+    /// A Debug VariableResolveDefinition where you can just put the Value you
+    /// would like to have.
+    DebugString(Cow<'static, str>),
+    /// Check the last Resolver in the Query Graph and try to resolve the
+    /// variable defined in this field.
+    InputTypeName(Cow<'static, str>),
+    /// Check the last Resolver in the Query Graph, try to resolve the
+    /// variable defined in this field and then apply connector transforms
+    ConnectorInputTypeName(Cow<'static, str>),
+    /// Resolve a Value by querying the ResolverContextData with a key_id.
+    /// What is store in the ResolverContextData is described on each Resolver
+    /// implementation.
+    #[deprecated = "Should not use Context anymore in SDL def"]
+    ResolverData(Cow<'static, str>),
+    /// Resolve a Value by querying the most recent ancestor resolver property.
+    LocalData(Cow<'static, str>),
+    /// Resolve a Value of a specific type by querying the most recent ancestor resolver property
+    ///
+    /// This particular branch expects the data to come from an external source and will
+    /// apply the transforms associated with the InputValueType to that data.
+    LocalDataWithTransforms(Box<(Cow<'static, str>, String)>),
+}
+
+impl VariableResolveDefinition {
+    pub fn connector_input_type_name(value: impl Into<Cow<'static, str>>) -> Self {
+        Self::ConnectorInputTypeName(value.into())
+    }
+
+    pub fn local_data(value: impl Into<Cow<'static, str>>) -> Self {
+        Self::LocalData(value.into())
+    }
+
+    pub fn local_data_with_transforms(value: impl Into<Cow<'static, str>>, ty: String) -> Self {
+        Self::LocalDataWithTransforms(Box::new((value.into(), ty)))
+    }
+}

--- a/engine/crates/engine/registry-v2/src/trusted_docs.rs
+++ b/engine/crates/engine/registry-v2/src/trusted_docs.rs
@@ -1,0 +1,6 @@
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TrustedDocuments {
+    pub bypass_header_name: Option<String>,
+    pub bypass_header_value: Option<String>,
+}

--- a/engine/crates/engine/registry-v2/src/validators/length.rs
+++ b/engine/crates/engine/registry-v2/src/validators/length.rs
@@ -1,0 +1,11 @@
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct LengthValidator {
+    pub min: Option<usize>,
+    pub max: Option<usize>,
+}
+
+impl LengthValidator {
+    pub fn new(min: Option<usize>, max: Option<usize>) -> Self {
+        LengthValidator { min, max }
+    }
+}

--- a/engine/crates/engine/registry-v2/src/validators/mod.rs
+++ b/engine/crates/engine/registry-v2/src/validators/mod.rs
@@ -1,0 +1,15 @@
+mod length;
+
+pub use length::LengthValidator;
+
+// Wrap Validators up in an enum to avoid having to box the context data
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub enum DynValidator {
+    Length(LengthValidator),
+}
+
+impl DynValidator {
+    pub fn length(min: Option<usize>, max: Option<usize>) -> Self {
+        Self::Length(LengthValidator::new(min, max))
+    }
+}

--- a/engine/crates/engine/registry-v2/src/writer.rs
+++ b/engine/crates/engine/registry-v2/src/writer.rs
@@ -1,0 +1,328 @@
+use std::collections::{BTreeMap, HashMap};
+
+use anyhow::anyhow;
+use gateway_v2_auth_config::v1::AuthConfig;
+use indexmap::IndexSet;
+use postgres_connector_types::database_definition::DatabaseDefinition;
+
+use crate::{
+    ids::*,
+    resolvers::Resolver,
+    storage::{self, *},
+    ConnectorHeaders, CorsConfig, FederationEntity, IdRange, MongoDBConfiguration, OperationLimits, Registry,
+    TrustedDocuments, TypeWrappers,
+};
+
+/// Writes to a registry.
+///
+/// Note that this is a very low level interface.  We'd want some sort of friendly builders
+/// built on top of this if we were ever to use it directly in parsers
+#[derive(Default)]
+pub struct RegistryWriter {
+    strings: IndexSet<Box<str>>,
+
+    // Optional so we can preallocate
+    types: Vec<Option<storage::MetaTypeRecord>>,
+
+    objects: Vec<storage::ObjectTypeRecord>,
+    object_fields: Vec<storage::MetaFieldRecord>,
+
+    input_objects: Vec<storage::InputObjectTypeRecord>,
+    input_values: Vec<storage::MetaInputValueRecord>,
+    input_validators: Vec<storage::InputValidatorRecord>,
+
+    enums: Vec<storage::EnumTypeRecord>,
+    enum_values: Vec<storage::MetaEnumValueRecord>,
+
+    interfaces: Vec<storage::InterfaceTypeRecord>,
+    scalars: Vec<storage::ScalarTypeRecord>,
+    unions: Vec<storage::UnionTypeRecord>,
+
+    directives: Vec<storage::MetaDirectiveRecord>,
+
+    pub implements: HashMap<MetaTypeId, Vec<MetaTypeId>>,
+    pub query_type: Option<MetaTypeId>,
+    pub mutation_type: Option<MetaTypeId>,
+    pub subscription_type: Option<MetaTypeId>,
+    pub disable_introspection: bool,
+    pub enable_federation: bool,
+    pub federation_subscription: bool,
+
+    pub auth: AuthConfig,
+    pub mongodb_configurations: HashMap<String, MongoDBConfiguration>,
+    pub http_headers: BTreeMap<String, ConnectorHeaders>,
+    pub postgres_databases: HashMap<String, DatabaseDefinition>,
+    pub enable_caching: bool,
+    pub enable_kv: bool,
+    pub federation_entities: BTreeMap<String, FederationEntity>,
+    pub enable_codegen: bool,
+    pub is_federated: bool,
+    pub operation_limits: OperationLimits,
+    pub trusted_documents: Option<TrustedDocuments>,
+    pub cors_config: Option<CorsConfig>,
+}
+
+impl RegistryWriter {
+    pub fn new() -> Self {
+        RegistryWriter::default()
+    }
+
+    pub fn preallocate_type_ids(&mut self, capacity: usize) -> impl ExactSizeIterator<Item = MetaTypeId> {
+        let starting_id = MetaTypeId::new(self.types.len());
+        self.types.extend(std::iter::repeat_with(|| None).take(capacity));
+
+        IdRange::new(starting_id, MetaTypeId::new(self.types.len())).iter()
+    }
+
+    pub fn populate_preallocated_type(&mut self, id: MetaTypeId, record: MetaTypeRecord) {
+        let index = id.to_index();
+        if self.types[index].is_some() {
+            panic!("Tried to populate an already populated index");
+        }
+        self.types[index] = Some(record);
+    }
+
+    #[must_use]
+    pub fn insert_scalar(&mut self, details: ScalarTypeRecord) -> MetaTypeRecord {
+        let id = ScalarTypeId::new(self.scalars.len());
+        self.scalars.push(details);
+        MetaTypeRecord::Scalar(id)
+    }
+
+    #[must_use]
+    pub fn insert_object(&mut self, details: ObjectTypeRecord) -> MetaTypeRecord {
+        let id = ObjectTypeId::new(self.objects.len());
+        self.objects.push(details);
+        MetaTypeRecord::Object(id)
+    }
+
+    #[must_use]
+    pub fn insert_interface(&mut self, details: InterfaceTypeRecord) -> MetaTypeRecord {
+        let id = InterfaceTypeId::new(self.interfaces.len());
+        self.interfaces.push(details);
+        MetaTypeRecord::Interface(id)
+    }
+
+    #[must_use]
+    pub fn insert_union(&mut self, details: UnionTypeRecord) -> MetaTypeRecord {
+        let id = UnionTypeId::new(self.unions.len());
+        self.unions.push(details);
+        MetaTypeRecord::Union(id)
+    }
+
+    #[must_use]
+    pub fn insert_enum(&mut self, details: EnumTypeRecord) -> MetaTypeRecord {
+        let id = EnumTypeId::new(self.enums.len());
+        self.enums.push(details);
+        MetaTypeRecord::Enum(id)
+    }
+
+    #[must_use]
+    pub fn insert_enum_values(&mut self, mut values: Vec<MetaEnumValueRecord>) -> IdRange<MetaEnumValueId> {
+        let starting_id = MetaEnumValueId::new(self.enum_values.len());
+
+        // Sort the values so we can binary search later
+        values.sort_by_key(|val| &self.strings[val.name.to_index()]);
+
+        self.enum_values.append(&mut values);
+
+        IdRange::new(starting_id, MetaEnumValueId::new(self.enum_values.len()))
+    }
+
+    #[must_use]
+    pub fn insert_input_object(&mut self, details: InputObjectTypeRecord) -> MetaTypeRecord {
+        let id = InputObjectTypeId::new(self.input_objects.len());
+        self.input_objects.push(details);
+        MetaTypeRecord::InputObject(id)
+    }
+
+    #[must_use]
+    pub fn insert_fields(&mut self, mut fields: Vec<MetaFieldRecord>) -> IdRange<MetaFieldId> {
+        let starting_id = MetaFieldId::new(self.object_fields.len());
+
+        // Sort the fields so we can binary search later
+        fields.sort_by_key(|val| &self.strings[val.name.to_index()]);
+
+        self.object_fields.append(&mut fields);
+
+        IdRange::new(starting_id, MetaFieldId::new(self.object_fields.len()))
+    }
+
+    #[must_use]
+    pub fn insert_input_values(&mut self, mut values: Vec<MetaInputValueRecord>) -> IdRange<MetaInputValueId> {
+        let starting_id = MetaInputValueId::new(self.input_values.len());
+
+        // Sort the values so we can binary search later
+        values.sort_by_key(|val| &self.strings[val.name.to_index()]);
+
+        self.input_values.append(&mut values);
+
+        IdRange::new(starting_id, MetaInputValueId::new(self.input_values.len()))
+    }
+
+    #[must_use]
+    pub fn insert_input_validators(&mut self, mut values: Vec<InputValidatorRecord>) -> IdRange<InputValidatorId> {
+        let starting_id = InputValidatorId::new(self.input_validators.len());
+
+        self.input_validators.append(&mut values);
+
+        IdRange::new(starting_id, InputValidatorId::new(self.input_validators.len()))
+    }
+
+    pub fn insert_directive(&mut self, details: MetaDirectiveRecord) -> MetaDirectiveId {
+        let id = MetaDirectiveId::new(self.directives.len());
+        self.directives.push(details);
+        id
+    }
+
+    #[must_use]
+    pub fn intern_str(&mut self, string: &str) -> StringId {
+        let (id, _) = self.strings.insert_full(string.into());
+        StringId::new(id)
+    }
+
+    #[must_use]
+    pub fn intern_string(&mut self, string: String) -> StringId {
+        let (id, _) = self.strings.insert_full(string.into());
+        StringId::new(id)
+    }
+
+    pub fn finish(mut self) -> anyhow::Result<Registry> {
+        let typename_index = self.insert_typename_field();
+
+        let RegistryWriter {
+            strings,
+            types,
+            objects,
+            object_fields,
+            input_objects,
+            input_values,
+            input_validators,
+            enums,
+            enum_values,
+            interfaces,
+            scalars,
+            unions,
+            directives,
+            implements,
+            query_type,
+            mutation_type,
+            subscription_type,
+            disable_introspection,
+            enable_federation,
+            federation_subscription,
+            auth,
+            mongodb_configurations,
+            http_headers,
+            postgres_databases,
+            enable_caching,
+            enable_kv,
+            federation_entities,
+            enable_codegen,
+            is_federated,
+            operation_limits,
+            trusted_documents,
+            cors_config,
+        } = self;
+
+        let types = types
+            .into_iter()
+            .map(|ty| ty.ok_or_else(|| anyhow!("All preallocated types must be allocated")))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let query_type = query_type.ok_or_else(|| anyhow!("Root query type was not defined"))?;
+
+        Ok(Registry {
+            strings,
+            types,
+            objects,
+            object_fields,
+            input_objects,
+            input_values,
+            input_validators,
+            enums,
+            enum_values,
+            interfaces,
+            scalars,
+            unions,
+            directives,
+            typename_index,
+            implements,
+            query_type,
+            mutation_type,
+            subscription_type,
+            disable_introspection,
+            enable_federation,
+            federation_subscription,
+            auth,
+            mongodb_configurations,
+            http_headers,
+            postgres_databases,
+            enable_caching,
+            enable_kv,
+            federation_entities,
+            enable_codegen,
+            is_federated,
+            operation_limits,
+            trusted_documents,
+            cors_config,
+        })
+    }
+
+    // __typename doesn't usually exist in the schema, but it's handy if we have a
+    // MetaFieldRecord for it, so we insert a fake field here and don't associated
+    // it with any particular object
+    fn insert_typename_field(&mut self) -> MetaFieldId {
+        let name = self.intern_str("__typename");
+        let index = self
+            .types
+            .binary_search_by_key(&"String", |key| {
+                self.meta_type_name(key.as_ref().expect("to be prepopulated"))
+            })
+            .expect("String to be a defined type");
+        let string = MetaTypeId::new(index);
+        let ty = MetaFieldTypeRecord {
+            wrappers: TypeWrappers::none().wrap_non_null(),
+            target: string,
+        };
+
+        let range = self.insert_fields(vec![MetaFieldRecord {
+            name,
+            mapped_name: None,
+            description: None,
+            args: IdRange::default(),
+            ty,
+            deprecation: None,
+            cache_control: None,
+            requires: None,
+            federation: None,
+            resolver: Resolver::Typename,
+            required_operation: None,
+            auth: None,
+        }]);
+
+        range.start
+    }
+
+    #[allow(dead_code)]
+    fn meta_type_name_by_id(&self, id: MetaTypeId) -> &str {
+        self.meta_type_name(
+            self.types[id.to_index()]
+                .as_ref()
+                .expect("to be preopulated before this call"),
+        )
+    }
+
+    fn meta_type_name(&self, record: &MetaTypeRecord) -> &str {
+        let string_id = match record {
+            MetaTypeRecord::Object(inner) => self.objects[inner.to_index()].name,
+            MetaTypeRecord::Interface(inner) => self.interfaces[inner.to_index()].name,
+            MetaTypeRecord::Union(inner) => self.unions[inner.to_index()].name,
+            MetaTypeRecord::InputObject(inner) => self.input_objects[inner.to_index()].name,
+            MetaTypeRecord::Enum(inner) => self.enums[inner.to_index()].name,
+            MetaTypeRecord::Scalar(inner) => self.scalars[inner.to_index()].name,
+        };
+
+        &self.strings[string_id.to_index()]
+    }
+}


### PR DESCRIPTION
As I mentioned in the meeting this morning, I've been working on refactoring the registry to a more compact & performant representation (hopefully also easier to use, but time will tell).

I've done this in a new crate `registry-v2`.  Separated from the `engine` because having the registry inside engine always limited how modular we could be: if the engine needed to call code that needed the registry that code usually to live inside the `engine` crate: leading to a severely bloated crate that takes an age to compile (waiting 30 seconds for feedback on my changes while working on this was not fun)

The structure of this crate follows the same pattern I've been using in cynic-parser (which is itself similar to patterns used in engine-v2 & elsewhere).  Each data type:

- Is stored as a "record" in an array in the Regsitry struct.
- Has an ID that is just a thin wrapper around index into the array.
- References other records by id where it makes sense.
- Has reader structs built on top of IDs that provide a reasonably ergonomic API for reading the data (known as walkers in some of our other implementations of this pattern).  Since these are the primary way to interact with the data, they just take the name of the data, no reader/walker postfix.
- Functions on a shared Writer struct that can be used to populate the Registry.

Writing code for all of the above is quite laborious (but not that complicated) so I've borrowed a generator that I wrote for cynic-parser to do a lot of it. All the code in the `generated` folder was produced by this.  The generator will be in a separate PR.  Note that not everything is worth generating - any special cases that are easier to write by hand should be.

Some of the code in this crate is just copied & pasted from the old registry. We could update that code to use the above pattern sometime, but this change is already massive.

Any questions, comments, criticisms - give them to me.