### PR TITLE
feat: code generator for registry-v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "ariadne"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44055e597c674aef7cb903b2b9f6e4cba1277ed0d2d61dae7cd52d7ffa81f8e2"
+dependencies = [
+ "unicode-width",
+ "yansi 1.0.1",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1501,6 +1511,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "411ab40d3f72ca1442d50a60e572838e5a2f0719b93a77a29647117ffdf67687"
 dependencies = [
+ "ariadne",
  "indexmap 2.2.6",
  "lalrpop-util",
  "logos",
@@ -6131,6 +6142,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "registry-v2-generator"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cynic-parser",
+ "indexmap 2.2.6",
+ "indoc",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "xshell",
+]
+
+[[package]]
 name = "relative-path"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8881,6 +8906,21 @@ dependencies = [
  "linux-raw-sys",
  "rustix",
 ]
+
+[[package]]
+name = "xshell"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db0ab86eae739efd1b054a8d3d16041914030ac4e01cd1dca0cf252fd8b6437"
+dependencies = [
+ "xshell-macros",
+]
+
+[[package]]
+name = "xshell-macros"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d422e8e38ec76e2f06ee439ccc765e9c6a9638b9e7c9f2e8255e4d41e8bd852"
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "engine/crates/engine/parser",
   "engine/crates/engine/value",
   "engine/crates/engine/registry-v2",
+  "engine/crates/engine/registry-v2-generator",
   "graph-ref",
   "graphql-lint",
 ]

--- a/engine/crates/engine/registry-v2-generator/Cargo.toml
+++ b/engine/crates/engine/registry-v2-generator/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "registry-v2-generator"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1"
+indexmap = "2"
+indoc = "2"
+itertools = "0.12"
+proc-macro2 = "1"
+quote = "1"
+xshell = "0.2"
+
+cynic-parser.version = "0.2"
+cynic-parser.features = ["report"]

--- a/engine/crates/engine/registry-v2-generator/README.md
+++ b/engine/crates/engine/registry-v2-generator/README.md
@@ -1,0 +1,12 @@
+A generator for much of the code in registry-v2. When you run this it'll read
+the graphql in domain and update the corresponding files in registry-v2.
+
+### Running
+
+Run this from the root of the repo:
+
+```sh
+cargo run -p registry-v2-generator && cargo fmt
+```
+
+It will write directly to the registry-v2 codebase.

--- a/engine/crates/engine/registry-v2-generator/domain/registry.graphql
+++ b/engine/crates/engine/registry-v2-generator/domain/registry.graphql
@@ -1,0 +1,234 @@
+# type SchemaDefinition @file(name: "schemas") {
+#   description: StringLiteral
+#   directives: [Directive!]!
+#   root_operations: [RootOperationTypeDefinition!]!
+# }
+
+# type RootOperationTypeDefinition @file(name: "schemas") {
+#   operation_type: OperationType!
+#   named_type: String!
+# }
+
+# type ScalarDefinition @file(name: "scalars") {
+#   name: String!
+#   description: StringLiteral
+#   directives: [Directive]
+#   span: Span!
+# }
+
+union MetaType
+  @distinct
+  @file(name: "metatype")
+  @variant(names: ["Object", "Interface", "Union", "Enum", "InputObject", "Scalar"]) =
+    ObjectType
+  | InterfaceType
+  | UnionType
+  | EnumType
+  | InputObjectType
+  | ScalarType
+
+type ObjectType @file(name: "objects") @distinct {
+  name: String!
+  description: String
+  fields: [MetaField!]!
+  cache_control: CacheControl
+  external: bool!
+  shareable: bool!
+  # directives: [Directive]
+  # implements_interfaces: [String]
+  # span: Span!
+}
+
+type MetaField @file(name: "field") {
+  name: String!
+  mapped_name: String
+  description: String
+  args: [MetaInputValue!]!
+  ty: MetaFieldTypeRecord! @noreader
+  deprecation: Deprecation
+  cache_control: CacheControl
+  requires: FieldSet
+  federation: FederationProperties # inline Box this maybe?
+  resolver: Resolver!
+  required_operation: Operations
+  auth: AuthConfig # inline box this also?
+}
+
+# TODO: Think about whether these should be inline or not...
+# TODO: implement @box
+scalar Deprecation @box @inline
+scalar CacheControl @box @inline
+scalar FieldSet @box @inline
+scalar FederationProperties @box @inline
+scalar Resolver @inline @ref
+scalar Operations @box @inline
+scalar AuthConfig @box @inline
+scalar MetaFieldTypeRecord @inline
+
+scalar ConstValue @inline @box
+
+type MetaInputValue @file(name: "inputs") {
+  name: String!
+  description: String
+  ty: MetaInputValueTypeRecord! @noreader
+  default_value: ConstValue
+  rename: String
+  validators: [InputValidator!]!
+}
+
+scalar MetaInputValueTypeRecord @inline
+
+type ScalarType @file(name: "scalar") @distinct {
+  name: String!
+  description: String
+  specified_by_url: String
+  parser: ScalarParser!
+}
+
+scalar ScalarParser @inline
+
+type InterfaceType @file(name: "interface") @distinct {
+  name: String!
+  description: String
+  fields: [MetaField!]!
+  cache_control: CacheControl
+  possible_types: [MetaType] @inline
+}
+
+type UnionType @file(name: "union") @distinct {
+  name: String!
+  description: String
+  possible_types: [MetaType] @inline
+  discriminators: UnionDiscriminators!
+}
+
+scalar UnionDiscriminators @inline @ref
+
+type EnumType @file(name: "enums") @distinct {
+  name: String!
+  description: String
+  values: [MetaEnumValue!]!
+}
+
+type MetaEnumValue @file(name: "enums") {
+  name: String!
+  description: String
+  deprecation: Deprecation
+  value: String
+}
+
+type InputObjectType @file(name: "inputs") @distinct {
+  name: String!
+  description: String
+  input_fields: [MetaInputValue!]!
+  oneof: bool!
+}
+
+type MetaDirective @file(name: "directives") @distinct {
+  name: String!
+  description: String
+  locations: [DirectiveLocation!]!
+  args: [MetaInputValue!]!
+  is_repeatable: bool!
+}
+
+scalar DirectiveLocation @inline
+
+type InputValidator @file(name: "inputs") {
+  validator: DynValidator!
+}
+
+scalar DynValidator @inline @ref
+
+# type FieldDefinition @file(name: "fields") {
+#   name: String!
+#   ty: Type!
+#   arguments: [InputValueDefinition!]!
+#   description: StringLiteral
+#   directives: [Directive!]!
+#   span: Span!
+# }
+
+# type InterfaceDefinition @file(name: "interfaces") {
+#   name: String!
+#   description: StringLiteral
+#   fields: [FieldDefinition!]!
+#   directives: [Directive!]!
+#   implements_interfaces: [String]
+#   span: Span!
+# }
+
+# type UnionDefinition @file(name: "unions") {
+#   name: String!
+#   description: StringLiteral
+#   members: [String]
+#   directives: [Directive!]!
+#   span: Span!
+# }
+
+# type EnumDefinition @file(name: "enums") {
+#   name: String!
+#   description: StringLiteral
+#   values: [EnumValueDefinition!]!
+#   directives: [Directive!]!
+#   span: Span!
+# }
+
+# type EnumValueDefinition @file(name: "enums") {
+#   value: String!
+#   description: StringLiteral
+#   directives: [Directive!]!
+#   span: Span!
+# }
+
+# type InputObjectDefinition @file(name: "input_objects") {
+#   name: String!
+#   description: StringLiteral
+#   fields: [InputValueDefinition!]!
+#   directives: [Directive!]!
+#   span: Span!
+# }
+
+# type InputValueDefinition @file(name: "input_values") {
+#   name: String!
+#   ty: Type!
+#   description: StringLiteral
+#   default_value: Value
+#   directives: [Directive!]!
+#   span: Span!
+# }
+
+# type DirectiveDefinition @file(name: "directives") {
+#   name: String!
+#   description: StringLiteral
+#   arguments: [InputValueDefinition!]!
+#   is_repeatable: bool!
+#   locations: [DirectiveLocation!]!
+#   span: Span!
+# }
+
+# type Directive @file(name: "directives") {
+#   name: String!
+#   arguments: [Argument!]!
+# }
+
+# type Argument @file(name: "arguments") {
+#   name: String!
+#   value: Value!
+# }
+
+# scalar Span @inline
+# scalar DirectiveLocation @inline
+# scalar OperationType @inline
+
+# Type & Value are kind of special cases that aren't worth automating
+# so we make them scalars and implement them by hand
+# scalar Type @file(name: "types")
+# scalar Value @file(name: "value")
+
+# String is built in, but easier to implement stuff if its just in the .graphql file
+# It is also special cased a bit in the rust code
+scalar String
+scalar bool @inline
+
+scalar WrapperTypes

--- a/engine/crates/engine/registry-v2-generator/src/exts.rs
+++ b/engine/crates/engine/registry-v2-generator/src/exts.rs
@@ -1,0 +1,98 @@
+use cynic_parser::type_system::{FieldDefinition, ObjectDefinition, ScalarDefinition, TypeDefinition, UnionDefinition};
+use quote::quote;
+
+pub trait DistinctExt {
+    fn is_distinct(&self) -> bool;
+}
+
+impl DistinctExt for ObjectDefinition<'_> {
+    fn is_distinct(&self) -> bool {
+        // Indicates that a type is "distinct" i.e. no other instances of this type can
+        // have the same values.  We can use this to generate an optimised PartialEq
+        self.directives().any(|directive| directive.name() == "distinct")
+    }
+}
+
+impl DistinctExt for UnionDefinition<'_> {
+    fn is_distinct(&self) -> bool {
+        // Indicates that a type is "distinct" i.e. no other instances of this type can
+        // have the same values.  We can use this to generate an optimised PartialEq
+        self.directives().any(|directive| directive.name() == "distinct")
+    }
+}
+
+pub trait ScalarExt {
+    fn is_inline(&self) -> bool;
+    fn should_box(&self) -> bool;
+    fn reader_returns_ref(&self) -> bool;
+    fn reader_fn_override(&self) -> Option<proc_macro2::TokenStream>;
+}
+
+impl ScalarExt for ScalarDefinition<'_> {
+    fn should_box(&self) -> bool {
+        self.directives().any(|directive| directive.name() == "box")
+    }
+
+    fn is_inline(&self) -> bool {
+        self.directives().any(|directive| directive.name() == "inline")
+    }
+
+    fn reader_returns_ref(&self) -> bool {
+        self.directives().any(|directive| directive.name() == "ref")
+    }
+
+    fn reader_fn_override(&self) -> Option<proc_macro2::TokenStream> {
+        if self.name() == "String" {
+            return Some(quote! { &'a str });
+        }
+        None
+    }
+}
+
+pub trait FileDirectiveExt<'a> {
+    fn file_name(&self) -> &'a str;
+}
+
+impl<'a> FileDirectiveExt<'a> for TypeDefinition<'a> {
+    fn file_name(&self) -> &'a str {
+        self.directives()
+            .find(|directive| directive.name() == "file")
+            .and_then(|directive| directive.arguments().next()?.value().as_str())
+            .unwrap_or(self.name())
+    }
+}
+
+pub trait UnionExt<'a> {
+    fn variant_name_override(&self, index: usize) -> Option<&'a str>;
+}
+
+impl<'a> UnionExt<'a> for UnionDefinition<'a> {
+    fn variant_name_override(&self, index: usize) -> Option<&'a str> {
+        self.directives()
+            .find(|directive| directive.name() == "variant")?
+            .arguments()
+            .next()?
+            .value()
+            .as_list_iter()?
+            .nth(index)?
+            .as_str()
+    }
+}
+
+pub trait FieldExt {
+    fn is_inline(&self) -> bool;
+    fn should_have_reader_fn(&self) -> bool;
+    fn should_default(&self) -> bool;
+}
+
+impl FieldExt for FieldDefinition<'_> {
+    fn is_inline(&self) -> bool {
+        self.directives().any(|directive| directive.name() == "inline")
+    }
+    fn should_have_reader_fn(&self) -> bool {
+        !self.directives().any(|directive| directive.name() == "noreader")
+    }
+    fn should_default(&self) -> bool {
+        self.directives().any(|directive| directive.name() == "default")
+    }
+}

--- a/engine/crates/engine/registry-v2-generator/src/file.rs
+++ b/engine/crates/engine/registry-v2-generator/src/file.rs
@@ -1,0 +1,96 @@
+use std::collections::BTreeSet;
+
+use cynic_parser::type_system::TypeDefinition;
+use proc_macro2::{Ident, Span};
+use quote::quote;
+
+use crate::{
+    exts::{FileDirectiveExt, ScalarExt},
+    format_code,
+    idents::IdIdent,
+};
+
+#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq)]
+pub struct EntityRef {
+    module_name: String,
+    name: String,
+    has_id: bool,
+}
+
+impl EntityRef {
+    pub fn new(ty: TypeDefinition<'_>) -> Option<Self> {
+        match ty {
+            TypeDefinition::Scalar(scalar) if scalar.is_inline() => None,
+            TypeDefinition::Scalar(scalar) if scalar.reader_fn_override().is_some() => None,
+            TypeDefinition::Scalar(_) => Some(EntityRef {
+                module_name: ty.file_name().to_string(),
+                name: ty.name().to_string(),
+                has_id: true,
+            }),
+            TypeDefinition::Object(_) => Some(EntityRef {
+                module_name: ty.file_name().to_string(),
+                name: ty.name().to_string(),
+                has_id: true,
+            }),
+            TypeDefinition::Union(_) => Some(EntityRef {
+                module_name: ty.file_name().to_string(),
+                name: ty.name().to_string(),
+                has_id: true,
+            }),
+            _ => unimplemented!(),
+        }
+    }
+}
+
+pub struct EntityOutput {
+    pub requires: BTreeSet<EntityRef>,
+    pub id: EntityRef,
+    pub contents: String,
+    pub kind: EntityKind,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum EntityKind {
+    Union,
+    Object,
+}
+
+pub fn imports(
+    mut requires: BTreeSet<EntityRef>,
+    current_file_entities: Vec<EntityRef>,
+    shared_imports: proc_macro2::TokenStream,
+) -> anyhow::Result<String> {
+    for id in &current_file_entities {
+        requires.remove(id);
+    }
+
+    let reader_imports = requires
+        .iter()
+        .map(|entity| {
+            let module_name = Ident::new(&entity.module_name, Span::call_site());
+            let entity_name = Ident::new(&entity.name, Span::call_site());
+            quote! { #module_name::#entity_name, }
+        })
+        .collect::<Vec<_>>();
+
+    let id_imports = requires
+        .iter()
+        .chain(current_file_entities.iter())
+        .map(|entity| IdIdent(&entity.name))
+        .map(|id| {
+            quote! { #id, }
+        })
+        .collect::<Vec<_>>();
+
+    format_code(quote! {
+        #[allow(unused_imports)]
+        use std::fmt::{self, Write};
+
+        #shared_imports
+
+        use super::{
+            #(#reader_imports)*
+            prelude::ids::{#(#id_imports)*},
+        };
+    })
+}

--- a/engine/crates/engine/registry-v2-generator/src/idents.rs
+++ b/engine/crates/engine/registry-v2-generator/src/idents.rs
@@ -1,0 +1,13 @@
+use proc_macro2::{Ident, Span};
+use quote::{quote, TokenStreamExt};
+
+#[derive(Clone, Copy)]
+pub struct IdIdent<'a>(pub &'a str);
+
+impl quote::ToTokens for IdIdent<'_> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let ident = Ident::new(&format!("{}Id", self.0), Span::call_site());
+
+        tokens.append_all(quote! { #ident })
+    }
+}

--- a/engine/crates/engine/registry-v2-generator/src/main.rs
+++ b/engine/crates/engine/registry-v2-generator/src/main.rs
@@ -1,0 +1,110 @@
+mod exts;
+mod file;
+mod idents;
+mod object;
+mod union;
+
+use anyhow::Context;
+use indexmap::IndexMap;
+use indoc::formatdoc;
+use itertools::Itertools;
+
+use cynic_parser::type_system::{Definition, TypeDefinition};
+
+use crate::{exts::FileDirectiveExt, file::imports};
+
+const ENGINE_DIR: &str = "engine/crates/engine";
+
+fn main() -> anyhow::Result<()> {
+    eprintln!("{:?}", std::env::current_dir());
+    for module in ["registry"] {
+        let module_path = format!("{ENGINE_DIR}/registry-v2/src/generated");
+        std::fs::create_dir_all(&module_path).with_context(|| format!("creating {module_path}"))?;
+
+        let document = std::fs::read_to_string(format!("{ENGINE_DIR}/registry-v2-generator/domain/{module}.graphql"))?;
+
+        let domain = match cynic_parser::parse_type_system_document(&document) {
+            Ok(domain) => domain,
+            Err(error) => {
+                eprintln!("Error parsing document");
+                eprintln!("{}", error.to_report(&document));
+                return Err(anyhow::anyhow!(""));
+            }
+        };
+
+        let mut model_index = IndexMap::new();
+
+        for definition in domain.definitions() {
+            match definition {
+                Definition::Type(ty) => {
+                    model_index.insert(ty.name(), ty);
+                }
+                _ => anyhow::bail!("unsupported definition"),
+            }
+        }
+
+        let id_trait = match module {
+            "registry" => "RegistryId",
+            _ => unimplemented!("id_trait for {module} needs defined (see the location of this panic)"),
+        };
+
+        let outputs = model_index
+            .values()
+            .map(|model| {
+                let output = match model {
+                    TypeDefinition::Object(object) => object::object_output(*object, &model_index, id_trait)?,
+                    TypeDefinition::Scalar(_) => {
+                        return Ok(None);
+                    }
+                    TypeDefinition::Union(union) => union::union_output(*union, &model_index, id_trait)?,
+                    _ => anyhow::bail!("unsupported definition"),
+                };
+
+                Ok(Some((model.file_name(), output)))
+            })
+            .filter_map(Result::transpose)
+            .collect::<Result<Vec<(_, _)>, _>>()
+            .unwrap()
+            .into_iter()
+            .into_group_map();
+
+        for (file_name, output) in outputs {
+            let requires = output
+                .iter()
+                .flat_map(|entity| entity.requires.clone().into_iter())
+                .collect();
+            let current_entities = output.iter().map(|entity| entity.id.clone()).collect();
+
+            let imports = imports(requires, current_entities, shared_imports()).unwrap();
+
+            let doc = format_code(formatdoc!(
+                r#"
+                {imports}
+
+                {}
+                "#,
+                output.into_iter().map(|entity| entity.contents).join("\n\n")
+            ))
+            .unwrap();
+
+            std::fs::write(format!("{module_path}/{file_name}.rs"), doc).unwrap();
+        }
+    }
+
+    Ok(())
+}
+
+fn format_code(text: impl ToString) -> anyhow::Result<String> {
+    use xshell::{cmd, Shell};
+    let sh = Shell::new()?;
+
+    let stdout = cmd!(sh, "rustfmt").stdin(&text.to_string()).read()?;
+
+    Ok(stdout)
+}
+
+fn shared_imports() -> proc_macro2::TokenStream {
+    quote::quote! {
+        use super::prelude::*;
+    }
+}

--- a/engine/crates/engine/registry-v2-generator/src/object.rs
+++ b/engine/crates/engine/registry-v2-generator/src/object.rs
@@ -1,0 +1,368 @@
+use indexmap::IndexMap;
+use proc_macro2::{Ident, Literal, Span};
+use quote::{quote, ToTokens, TokenStreamExt};
+
+use cynic_parser::type_system::{FieldDefinition, ObjectDefinition, TypeDefinition};
+
+use crate::{
+    exts::{DistinctExt, FieldExt, ScalarExt},
+    file::{EntityKind, EntityOutput, EntityRef},
+    format_code,
+    idents::IdIdent,
+};
+
+use self::{debug::ObjectDebug, equal::ObjectEqual};
+
+mod debug;
+mod equal;
+
+pub fn object_output(
+    object: ObjectDefinition<'_>,
+    model_index: &IndexMap<&str, TypeDefinition<'_>>,
+    id_trait: &str,
+) -> anyhow::Result<EntityOutput> {
+    let record_name = Ident::new(&format!("{}Record", object.name()), Span::call_site());
+    let reader_name = Ident::new(object.name(), Span::call_site());
+    let id_name = IdIdent(object.name());
+
+    let edges = object
+        .fields()
+        .enumerate()
+        .map(|(index, field)| -> anyhow::Result<FieldEdge> {
+            Ok(FieldEdge {
+                container: object,
+                field,
+                index,
+                target: *model_index
+                    .get(field.ty().name())
+                    .ok_or_else(|| anyhow::anyhow!("Could not find type {}", field.ty().name()))?,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    let record_fields = edges.iter().copied().map(ObjectField);
+    let reader_functions = edges.iter().copied().map(ReaderFunction);
+
+    let record = format_code(quote! {
+        #[derive(serde::Serialize, serde::Deserialize)]
+        pub struct #record_name {
+            #(#record_fields),*
+        }
+    })?;
+
+    let reader = format_code(quote! {
+        #[derive(Clone, Copy)]
+        pub struct #reader_name<'a>(pub(crate) ReadContext<'a, #id_name>);
+    })?;
+
+    let reader_debug = format_code(ObjectDebug(&reader_name, &edges).to_token_stream())?;
+
+    let reader_impl = format_code(quote! {
+        impl <'a> #reader_name<'a> {
+            #(#reader_functions)*
+        }
+    })?;
+
+    let id_trait = Ident::new(id_trait, Span::call_site());
+
+    let id_trait_impl = format_code(quote! {
+        impl #id_trait for #id_name {
+            type Reader<'a> = #reader_name<'a>;
+        }
+    })?;
+
+    let id_reader_impl = format_code(quote! {
+        impl IdReader for #reader_name<'_> {
+            type Id = #id_name;
+        }
+    })?;
+
+    let from_impl = format_code(quote! {
+        impl <'a> From<ReadContext<'a, #id_name>> for #reader_name<'a> {
+            fn from(value: ReadContext<'a, #id_name>) -> Self {
+                Self(value)
+            }
+        }
+    })?;
+
+    let reader_eq = if object.is_distinct() {
+        let eq = ObjectEqual(&reader_name, &edges);
+        format_code(eq.to_token_stream())?
+    } else {
+        "".to_string()
+    };
+
+    let contents = indoc::formatdoc!(
+        r#"
+        {record}
+
+        {reader}
+
+        {reader_impl}
+
+        {reader_debug}
+
+        {reader_eq}
+
+        {id_trait_impl}
+
+        {id_reader_impl}
+
+        {from_impl}
+    "#
+    );
+
+    Ok(EntityOutput {
+        requires: edges
+            .iter()
+            .copied()
+            .filter_map(|edge| EntityRef::new(edge.target))
+            .collect(),
+        id: EntityRef::new(TypeDefinition::Object(object)).unwrap(),
+        contents,
+        kind: EntityKind::Object,
+    })
+}
+
+#[derive(Clone, Copy)]
+pub struct FieldEdge<'a> {
+    #[allow(dead_code)]
+    container: ObjectDefinition<'a>,
+    index: usize,
+    field: FieldDefinition<'a>,
+    target: TypeDefinition<'a>,
+}
+
+pub struct ObjectField<'a>(FieldEdge<'a>);
+
+impl quote::ToTokens for ObjectField<'_> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let field_name = Ident::new(self.0.field.name(), Span::call_site());
+
+        let target_id = IdIdent(self.0.target.name());
+
+        let ty = match self.0.target {
+            TypeDefinition::Scalar(scalar) if scalar.should_box() => {
+                if self.0.field.ty().is_list() || self.0.field.ty().is_non_null() {
+                    unimplemented!("boxed scalars cant be non-null or lists ")
+                }
+                let ident = Ident::new(self.0.target.name(), Span::call_site());
+                quote! { Option<Box<#ident>> }
+            }
+            TypeDefinition::Scalar(scalar) if scalar.is_inline() => {
+                // I'm assuming inline scalars are copy here.
+                let ident = Ident::new(self.0.target.name(), Span::call_site());
+                if self.0.field.ty().is_list() {
+                    quote! { Vec<#ident> }
+                } else if self.0.field.ty().is_non_null() {
+                    quote! { #ident }
+                } else {
+                    quote! { Option<#ident> }
+                }
+            }
+            TypeDefinition::Scalar(scalar) if scalar.reader_fn_override().is_some() => {
+                if self.0.field.ty().is_list() {
+                    quote! { Vec<#target_id> }
+                } else if self.0.field.ty().is_non_null() {
+                    quote! { #target_id }
+                } else {
+                    quote! { Option<#target_id> }
+                }
+            }
+            TypeDefinition::Object(_) | TypeDefinition::Union(_) | TypeDefinition::Scalar(_) => {
+                if self.0.field.is_inline() {
+                    if !self.0.field.ty().is_list() {
+                        unimplemented!("need to add non list inline types apparently")
+                    }
+                    quote! { Vec<#target_id> }
+                } else if self.0.field.ty().is_list() {
+                    quote! { IdRange<#target_id> }
+                } else if self.0.field.ty().is_non_null() {
+                    quote! { #target_id }
+                } else {
+                    quote! { Option<#target_id> }
+                }
+            }
+            _ => unimplemented!(),
+        };
+
+        let rename = Literal::string(&self.0.index.to_string());
+        let other_attrs = if self.0.field.ty().is_list() {
+            quote! { , skip_serializing_if = "crate::Container::is_empty", default }
+        } else if !self.0.field.ty().is_non_null() {
+            quote! { , skip_serializing_if = "Option::is_none", default }
+        } else if self.0.field.ty().is_non_null() && self.0.target.name() == "bool" {
+            quote! { , skip_serializing_if = "crate::is_false", default }
+        } else {
+            quote! {}
+        };
+
+        tokens.append_all(quote! {
+            #[serde(rename = #rename #other_attrs )]
+            pub #field_name: #ty
+        });
+    }
+}
+
+pub struct ReaderFunction<'a>(FieldEdge<'a>);
+
+impl quote::ToTokens for ReaderFunction<'_> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        if !self.0.field.should_have_reader_fn() {
+            return;
+        }
+        let field_name = Ident::new(self.0.field.name(), Span::call_site());
+        let target_type = Ident::new(self.0.target.name(), Span::call_site());
+
+        let inner_ty = match self.0.target {
+            TypeDefinition::Scalar(scalar) if scalar.is_inline() => {
+                // I'm assuming inline scalars are copy here.
+                quote! { #target_type }
+            }
+            TypeDefinition::Scalar(scalar) if scalar.reader_fn_override().is_some() => {
+                scalar.reader_fn_override().unwrap()
+            }
+            TypeDefinition::Object(_) | TypeDefinition::Union(_) | TypeDefinition::Scalar(_) => {
+                quote! { #target_type<'a> }
+            }
+            _ => unimplemented!(),
+        };
+
+        // This match is a monster, sorry about that.
+        tokens.append_all(match self.0.target {
+            TypeDefinition::Scalar(scalar) if scalar.should_box() => {
+                if self.0.field.ty().is_list() || self.0.field.ty().is_non_null() {
+                    unimplemented!("boxed scalars cant be non-null or lists ")
+                }
+                quote! {
+                    pub fn #field_name(&self) -> Option<&'a #inner_ty> {
+                        let registry = self.0.registry;
+
+                        registry.lookup(self.0.id).#field_name.as_deref()
+                    }
+                }
+            }
+            TypeDefinition::Scalar(scalar) if scalar.reader_returns_ref() => {
+                if self.0.field.ty().is_list() || !self.0.field.ty().is_non_null() {
+                    unimplemented!("ref scalars cant be optional or lists unless you implement it");
+                }
+
+                quote! {
+                    pub fn #field_name(&self) -> &'a #inner_ty {
+                        let registry = self.0.registry;
+
+                        &registry.lookup(self.0.id).#field_name
+                    }
+                }
+            }
+            TypeDefinition::Scalar(scalar) if scalar.is_inline() && self.0.field.ty().is_list() => {
+                // I'm assuming inline scalars are copy here.
+                quote! {
+                    pub fn #field_name(&self) -> impl ExactSizeIterator<Item = #inner_ty> + 'a {
+                        let registry = self.0.registry;
+
+                        registry.lookup(self.0.id).#field_name.iter().copied()
+                    }
+                }
+            }
+            TypeDefinition::Scalar(scalar) if scalar.is_inline() => {
+                let ty = if self.0.field.ty().is_non_null() || self.0.field.should_default() {
+                    quote! { #inner_ty }
+                } else {
+                    quote! { Option<#inner_ty> }
+                };
+
+                let default_unwrap = if self.0.field.should_default() {
+                    quote! { .unwrap_or_default() }
+                } else {
+                    quote! {}
+                };
+
+                // I'm assuming inline scalars are copy here.
+                quote! {
+                    pub fn #field_name(&self) -> #ty {
+                        let registry = self.0.registry;
+
+                        registry.lookup(self.0.id).#field_name #default_unwrap
+                    }
+                }
+            }
+            TypeDefinition::Scalar(scalar) if scalar.reader_fn_override().is_some() && self.0.field.ty().is_list() => {
+                // Scalars with reader_fn_override return the scalar directly _not_ a reader
+                quote! {
+                    pub fn #field_name(&self) -> impl ExactSizeIterator<Item = #inner_ty> + 'a {
+                        let registry = &self.0.registry;
+
+                        registry.lookup(self.0.id).#field_name.iter().map(|id| registry.lookup(*id))
+                    }
+                }
+            }
+            TypeDefinition::Scalar(scalar)
+                if scalar.reader_fn_override().is_some() && self.0.field.ty().is_non_null() =>
+            {
+                // Scalars with reader_fn_override return the scalar directly _not_ a reader
+                quote! {
+                    pub fn #field_name(&self) -> #inner_ty {
+                        let registry = &self.0.registry;
+
+                        registry.lookup(registry.lookup(self.0.id).#field_name)
+                    }
+                }
+            }
+            TypeDefinition::Scalar(scalar) if scalar.reader_fn_override().is_some() => {
+                // Scalars with reader_fn_override return the scalar directly _not_ a reader
+                quote! {
+                    pub fn #field_name(&self) -> Option<#inner_ty> {
+                        let registry = self.0.registry;
+
+                        registry.lookup(self.0.id).#field_name.map(|id| registry.lookup(id))
+                    }
+                }
+            }
+            TypeDefinition::Object(_) | TypeDefinition::Union(_) | TypeDefinition::Scalar(_)
+                if self.0.field.is_inline() =>
+            {
+                quote! {
+                    pub fn #field_name(&self) -> impl ExactSizeIterator<Item = #inner_ty> + 'a {
+                        let registry = self.0.registry;
+
+                        registry.lookup(self.0.id).#field_name.iter().map(|id| registry.read(*id))
+                    }
+                }
+            }
+            TypeDefinition::Object(_) | TypeDefinition::Union(_) | TypeDefinition::Scalar(_)
+                if self.0.field.ty().is_list() =>
+            {
+                quote! {
+                    pub fn #field_name(&self) -> Iter<'a, #inner_ty> {
+                        let registry = self.0.registry;
+
+                        Iter::new(registry.lookup(self.0.id).#field_name, registry)
+                    }
+                }
+            }
+            TypeDefinition::Object(_) | TypeDefinition::Union(_) | TypeDefinition::Scalar(_)
+                if self.0.field.ty().is_non_null() =>
+            {
+                quote! {
+                    pub fn #field_name(&self) -> #inner_ty {
+                        let registry = self.0.registry;
+
+                        registry.read(registry.lookup(self.0.id).#field_name)
+                    }
+                }
+            }
+            TypeDefinition::Object(_) | TypeDefinition::Union(_) | TypeDefinition::Scalar(_) => {
+                quote! {
+                    pub fn #field_name(&self) -> Option<#inner_ty> {
+                        let registry = self.0.registry;
+
+                        registry.lookup(self.0.id).#field_name.map(|id| registry.read(id))
+                    }
+                }
+            }
+            _ => unimplemented!("No support for this target type"),
+        });
+    }
+}

--- a/engine/crates/engine/registry-v2-generator/src/object/debug.rs
+++ b/engine/crates/engine/registry-v2-generator/src/object/debug.rs
@@ -1,0 +1,43 @@
+use proc_macro2::{Ident, Span};
+use quote::{quote, ToTokens, TokenStreamExt};
+
+use super::FieldEdge;
+
+pub struct ObjectDebug<'a>(pub &'a Ident, pub &'a [FieldEdge<'a>]);
+
+impl ToTokens for ObjectDebug<'_> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let ObjectDebug(reader_name, fields) = self;
+
+        let name_string = proc_macro2::Literal::string(&reader_name.to_string());
+
+        let fields = fields.iter().copied().map(DebugField);
+
+        tokens.append_all(quote! {
+            impl fmt::Debug for #reader_name<'_> {
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    f.debug_struct(#name_string)
+                        #(#fields)*.finish()
+                }
+            }
+        });
+    }
+}
+
+pub struct DebugField<'a>(FieldEdge<'a>);
+
+impl ToTokens for DebugField<'_> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let DebugField(edge) = self;
+
+        let name_string = edge.field.name();
+        let name = Ident::new(name_string, Span::call_site());
+        let name_string = proc_macro2::Literal::string(name_string);
+
+        if edge.field.ty().is_list() {
+            tokens.append_all(quote! { .field(#name_string, &self.#name().collect::<Vec<_>>()) });
+        } else {
+            tokens.append_all(quote! { .field(#name_string, &self.#name()) });
+        }
+    }
+}

--- a/engine/crates/engine/registry-v2-generator/src/object/equal.rs
+++ b/engine/crates/engine/registry-v2-generator/src/object/equal.rs
@@ -1,0 +1,24 @@
+use proc_macro2::Ident;
+use quote::{quote, ToTokens, TokenStreamExt};
+
+use super::FieldEdge;
+
+pub struct ObjectEqual<'a>(pub &'a Ident, pub &'a [FieldEdge<'a>]);
+
+impl ToTokens for ObjectEqual<'_> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let ObjectEqual(reader_name, _) = self;
+
+        tokens.append_all(quote! {
+            impl std::cmp::PartialEq for #reader_name<'_> {
+                fn eq(&self, other: &#reader_name<'_>) -> bool {
+                    // We could generate comparisons for the contents, but for now I'm just
+                    // going to go with comparing IDs and assuming that means they're different
+                    std::ptr::eq(self.0.registry, other.0.registry) && self.0.id == other.0.id
+                }
+            }
+
+            impl std::cmp::Eq for #reader_name<'_> {}
+        });
+    }
+}

--- a/engine/crates/engine/registry-v2-generator/src/union.rs
+++ b/engine/crates/engine/registry-v2-generator/src/union.rs
@@ -1,0 +1,165 @@
+use indexmap::IndexMap;
+use proc_macro2::{Ident, Literal, Span};
+use quote::{quote, TokenStreamExt};
+
+use cynic_parser::type_system::{TypeDefinition, UnionDefinition};
+
+use crate::{
+    exts::{DistinctExt, UnionExt},
+    file::{EntityKind, EntityOutput, EntityRef},
+    format_code,
+    idents::IdIdent,
+};
+
+pub fn union_output(
+    union_definition: UnionDefinition<'_>,
+    model_index: &IndexMap<&str, TypeDefinition<'_>>,
+    id_trait: &str,
+) -> anyhow::Result<EntityOutput> {
+    let record_name = Ident::new(&format!("{}Record", union_definition.name()), Span::call_site());
+    let reader_name = Ident::new(union_definition.name(), Span::call_site());
+    let id_name = IdIdent(union_definition.name());
+
+    let edges = union_definition
+        .members()
+        .enumerate()
+        .map(|(variant_index, ty)| -> anyhow::Result<TypeEdge> {
+            let target = *model_index
+                .get(ty)
+                .ok_or_else(|| anyhow::anyhow!("Could not find type {ty}"))?;
+
+            Ok(TypeEdge {
+                index: variant_index,
+                container: union_definition,
+                variant_name: union_definition
+                    .variant_name_override(variant_index)
+                    .unwrap_or(target.name()),
+                target,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    let record_variants = edges.iter().copied().map(RecordVariant);
+    let reader_variants = edges.iter().copied().map(ReaderVariant);
+    let from_branches = edges.iter().copied().map(FromBranch);
+
+    let record = format_code(quote! {
+        #[derive(serde::Serialize, serde::Deserialize)]
+        pub enum #record_name {
+            #(#record_variants),*
+        }
+    })?;
+
+    let additional_derives = if union_definition.is_distinct() {
+        quote! { , PartialEq, Eq }
+    } else {
+        quote! {}
+    };
+
+    let reader = format_code(quote! {
+        #[derive(Clone, Copy, Debug #additional_derives)]
+        pub enum #reader_name<'a> {
+            #(#reader_variants),*
+        }
+    })?;
+
+    let id_trait = Ident::new(id_trait, Span::call_site());
+
+    let id_trait_impl = format_code(quote! {
+        impl #id_trait for #id_name {
+            type Reader<'a> = #reader_name<'a>;
+        }
+    })?;
+
+    let id_reader_impl = format_code(quote! {
+        impl IdReader for #reader_name<'_> {
+            type Id = #id_name;
+        }
+    })?;
+
+    let from_impl = format_code(quote! {
+        impl <'a> From<ReadContext<'a, #id_name>> for #reader_name<'a> {
+            fn from(value: ReadContext<'a, #id_name>) -> Self {
+                match value.registry.lookup(value.id) {
+                    #(#from_branches),*
+                }
+            }
+        }
+    })?;
+
+    let contents = indoc::formatdoc!(
+        r#"
+        {record}
+
+        {reader}
+
+        {id_trait_impl}
+
+        {id_reader_impl}
+
+        {from_impl}
+    "#
+    );
+
+    Ok(EntityOutput {
+        requires: edges
+            .iter()
+            .copied()
+            .filter_map(|edge| EntityRef::new(edge.target))
+            .collect(),
+        id: EntityRef::new(TypeDefinition::Union(union_definition)).unwrap(),
+        contents,
+        kind: EntityKind::Union,
+    })
+}
+
+#[derive(Clone, Copy)]
+pub struct TypeEdge<'a> {
+    index: usize,
+    container: UnionDefinition<'a>,
+    variant_name: &'a str,
+    target: TypeDefinition<'a>,
+}
+
+pub struct RecordVariant<'a>(TypeEdge<'a>);
+
+impl quote::ToTokens for RecordVariant<'_> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let variant_name = Ident::new(self.0.variant_name, Span::call_site());
+        let id = IdIdent(self.0.target.name());
+        let rename = Literal::string(&self.0.index.to_string());
+
+        tokens.append_all(quote! {
+            #[serde(rename = #rename)]
+            #variant_name(#id)
+        });
+    }
+}
+
+pub struct ReaderVariant<'a>(TypeEdge<'a>);
+
+impl quote::ToTokens for ReaderVariant<'_> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let variant_name = Ident::new(self.0.variant_name, Span::call_site());
+        let reader = Ident::new(self.0.target.name(), Span::call_site());
+
+        tokens.append_all(quote! {
+            #variant_name(#reader<'a>)
+        });
+    }
+}
+
+pub struct FromBranch<'a>(TypeEdge<'a>);
+
+impl quote::ToTokens for FromBranch<'_> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let this_record = Ident::new(&format!("{}Record", self.0.container.name()), Span::call_site());
+        let this_reader = Ident::new(self.0.container.name(), Span::call_site());
+        let variant_name = Ident::new(self.0.variant_name, Span::call_site());
+
+        tokens.append_all(quote! {
+            #this_record::#variant_name(id) => #this_reader::#variant_name(value.registry.read(*id))
+        });
+    }
+}


### PR DESCRIPTION
As outlined in [the PR that adds registy-v2][1] a lot of that crate is generated. This PR contains the generator.  It:

- Reads the data structure from a GraphQL file (SDL for life).
- Generates the records, readers and neccesary plumbing for everything to work.
- Manually implements some things that would usually be derived (i.e. `Debug` & `PartialEq`), but can't because of the patterns being used.
- Adds some serde annotations on things to make our JSON smaller.  We've used serde_as for this in the past, but why have a macro do work on every compile when you can have a generator do it once (with the bonus that it's more obvious what transforms are taking place)

This crate started as a c&p from cynic-parser and is very quick & dirty. it does what it needs to do and nothing more, it probably has bugs or strange behaviour if you try to do new things with it.  But it's worked so far, and is far easier than writing all this by hand (and makes changing things en masse relatively easy).

[1]: https://github.com/grafbase/grafbase/pull/1651