### PR TITLE
Stabilize resolver type code generation (codegen experimental feature)

### DIFF
--- a/cli/crates/cli/tests/dev_watch.rs
+++ b/cli/crates/cli/tests/dev_watch.rs
@@ -1,10 +1,9 @@
 #![allow(unused_crate_dependencies)]
 mod utils;
 
-use std::time::Duration;
-
 use backend::project::GraphType;
 use serde_json::Value;
+use std::time::Duration;
 use utils::environment::Environment;
 
 #[ctor::ctor]
@@ -100,6 +99,8 @@ async fn dev_watch_with_custom_codegen_path() {
     env.write_resolver("hello.js", "export default function Resolver() { return 'hello'; }");
 
     env.grafbase_dev_watch();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     // Check that the TS resolver types are being generated.
     let generated_types_path = env.directory_path.join("custom-generated/directory/index.ts");

--- a/cli/crates/common/src/environment.rs
+++ b/cli/crates/common/src/environment.rs
@@ -57,7 +57,7 @@ impl GrafbaseSchemaPath {
         }
     }
 
-    fn parent(&self) -> Option<&Path> {
+    pub fn parent(&self) -> Option<&Path> {
         self.path().parent()
     }
 
@@ -142,11 +142,6 @@ impl Project {
             UdfKind::Authorizer => AUTHORIZERS_DIRECTORY_NAME,
         };
         self.dot_grafbase_directory_path.join(subdirectory_name)
-    }
-
-    /// The target directory for generated code.
-    pub fn generated_directory_path(&self) -> std::path::PathBuf {
-        self.schema_path.parent().expect("must have a parent").join("generated")
     }
 
     // reads and deserializes to json the contents of `&self.registry_path` in a blocking fashion

--- a/cli/crates/server/src/codegen_server.rs
+++ b/cli/crates/server/src/codegen_server.rs
@@ -61,7 +61,7 @@ async fn codegen_worker_task(
         resolvers,
     }) = last_seen_config.as_ref()
     {
-        generate_ts_resolver_types(sdl, resolvers, &resolver_codegen_path);
+        generate_ts_resolver_types(sdl, resolvers, resolver_codegen_path);
     }
 
     let mut stream = config_changes
@@ -78,7 +78,7 @@ async fn codegen_worker_task(
                     resolvers,
                 }) = &last_seen_config
                 {
-                    generate_ts_resolver_types(sdl, resolvers, &generated_ts_resolver_types_path);
+                    generate_ts_resolver_types(sdl, resolvers, generated_ts_resolver_types_path);
                 }
             }
             CodegenIncomingEvent::FileChange(Ok(path)) => {

--- a/cli/crates/typed-resolvers/src/lib.rs
+++ b/cli/crates/typed-resolvers/src/lib.rs
@@ -14,6 +14,7 @@ pub use engine_parser::parse_schema;
 use self::error::CodegenError;
 use std::{ffi, fmt, path::Path};
 
+#[derive(Debug)]
 pub struct CustomResolver {
     pub parent_type_name: String,
     pub field_name: String,

--- a/engine/crates/engine/src/registry/mod.rs
+++ b/engine/crates/engine/src/registry/mod.rs
@@ -1394,6 +1394,13 @@ pub struct TrustedDocuments {
 
 #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
+pub struct CodegenConfig {
+    pub enabled: bool,
+    pub path: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct CorsConfig {
     pub max_age: Option<u32>,
     pub allowed_origins: Option<Vec<String>>,
@@ -1427,14 +1434,14 @@ pub struct Registry {
     pub federation_entities: BTreeMap<String, FederationEntity>,
     #[serde(default)]
     pub enable_ai: bool,
-    #[serde(default)]
-    pub enable_codegen: bool,
     // FIXME: Make an enum.
     pub is_federated: bool,
     #[serde(default)]
     pub operation_limits: OperationLimits,
     #[serde(default)]
     pub trusted_documents: Option<TrustedDocuments>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codegen: Option<CodegenConfig>,
     #[serde(default)]
     pub cors_config: Option<CorsConfig>,
 }
@@ -1459,11 +1466,11 @@ impl Default for Registry {
             enable_kv: false,
             federation_entities: Default::default(),
             enable_ai: false,
-            enable_codegen: false,
             is_federated: false,
             operation_limits: Default::default(),
             trusted_documents: Default::default(),
             cors_config: Default::default(),
+            codegen: None,
         }
     }
 }

--- a/engine/crates/engine/src/registry/tests.rs
+++ b/engine/crates/engine/src/registry/tests.rs
@@ -4,7 +4,7 @@ use sha2::{Digest, Sha256};
 
 use super::*;
 
-const EXPECTED_SHA: &str = "e6b38585432832f53a25f44a549ad6a4bdfd969983992b5bb7274aeaf85ddaa8";
+const EXPECTED_SHA: &str = "7e7bd6644c51d7b6ffcb1aad5b6cdb37660d0d05cb835d417d8e79d2a08bbd74";
 
 #[test]
 fn test_serde_roundtrip() {

--- a/engine/crates/parser-graphql/src/snapshots/parser_graphql__conversion__tests__array_input_value.snap
+++ b/engine/crates/parser-graphql/src/snapshots/parser_graphql__conversion__tests__array_input_value.snap
@@ -865,7 +865,6 @@ expression: registry_from_introspection(schema)
   "enable_caching": false,
   "enable_kv": false,
   "enable_ai": false,
-  "enable_codegen": false,
   "is_federated": false,
   "operation_limits": {
     "depth": null,

--- a/engine/crates/parser-graphql/src/snapshots/parser_graphql__conversion__tests__conversion.snap
+++ b/engine/crates/parser-graphql/src/snapshots/parser_graphql__conversion__tests__conversion.snap
@@ -2838,7 +2838,6 @@ expression: registry_from_introspection(schema)
   "enable_caching": false,
   "enable_kv": false,
   "enable_ai": false,
-  "enable_codegen": false,
   "is_federated": false,
   "operation_limits": {
     "depth": null,

--- a/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__flat_output-2.snap
+++ b/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__flat_output-2.snap
@@ -1730,7 +1730,6 @@ Registry {
         },
     },
     enable_ai: false,
-    enable_codegen: false,
     is_federated: false,
     operation_limits: OperationLimits {
         depth: None,
@@ -1740,5 +1739,6 @@ Registry {
         complexity: None,
     },
     trusted_documents: None,
+    codegen: None,
     cors_config: None,
 }

--- a/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__petstore_output-2.snap
+++ b/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__petstore_output-2.snap
@@ -1794,7 +1794,6 @@ Registry {
         },
     },
     enable_ai: false,
-    enable_codegen: false,
     is_federated: false,
     operation_limits: OperationLimits {
         depth: None,
@@ -1804,5 +1803,6 @@ Registry {
         complexity: None,
     },
     trusted_documents: None,
+    codegen: None,
     cors_config: None,
 }

--- a/engine/crates/parser-sdl/src/lib.rs
+++ b/engine/crates/parser-sdl/src/lib.rs
@@ -21,6 +21,7 @@ use rules::{
     check_known_directives::CheckAllDirectivesAreKnown,
     check_type_validity::CheckTypeValidity,
     check_types_underscore::CheckBeginsWithDoubleUnderscore,
+    codegen_directive::CodegenDirective,
     connector_transforms::run_transforms,
     cors_directive::{CorsDirective, CorsVisitor},
     default_directive::DefaultDirective,
@@ -143,6 +144,7 @@ fn parse_schema(schema: &str) -> engine::parser::Result<ServiceDocument> {
         .with::<AuthDirective>()
         .with::<AuthV2Directive>()
         .with::<CacheDirective>()
+        .with::<CodegenDirective>()
         .with::<CorsDirective>()
         .with::<DefaultDirective>()
         .with::<DeprecatedDirective>()

--- a/engine/crates/parser-sdl/src/lib.rs
+++ b/engine/crates/parser-sdl/src/lib.rs
@@ -21,7 +21,7 @@ use rules::{
     check_known_directives::CheckAllDirectivesAreKnown,
     check_type_validity::CheckTypeValidity,
     check_types_underscore::CheckBeginsWithDoubleUnderscore,
-    codegen_directive::CodegenDirective,
+    codegen_directive::{CodegenDirective, CodegenVisitor},
     connector_transforms::run_transforms,
     cors_directive::{CorsDirective, CorsVisitor},
     default_directive::DefaultDirective,
@@ -361,6 +361,7 @@ fn parse_types<'a>(schema: &'a ServiceDocument, ctx: &mut VisitorContext<'a>) {
         .with(AuthV2DirectiveVisitor)
         .with(ResolverDirective)
         .with(CacheVisitor)
+        .with(CodegenVisitor)
         .with(CorsVisitor)
         .with(InputObjectVisitor)
         .with(BasicType)

--- a/engine/crates/parser-sdl/src/rules/codegen_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/codegen_directive.rs
@@ -66,7 +66,7 @@ mod tests {
     fn parse_schema(schema: &str) -> crate::ParseResult<'_> {
         let connector_parsers = crate::connector_parsers::MockConnectorParsers::default();
         let variables = HashMap::default();
-        futures::executor::block_on(crate::parse(&schema, &variables, &connector_parsers)).unwrap()
+        futures::executor::block_on(crate::parse(schema, &variables, &connector_parsers)).unwrap()
     }
 
     #[test]

--- a/engine/crates/parser-sdl/src/rules/codegen_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/codegen_directive.rs
@@ -3,6 +3,7 @@ use crate::directive_de::parse_directive;
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct CodegenDirective {
     pub enabled: bool,
     /// The target file path for the generated code.

--- a/engine/crates/parser-sdl/src/rules/codegen_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/codegen_directive.rs
@@ -1,0 +1,86 @@
+use super::{directive::Directive, visitor::Visitor};
+use crate::directive_de::parse_directive;
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodegenDirective {
+    pub enabled: bool,
+    /// The target file path for the generated code.
+    pub path: Option<String>,
+}
+
+impl Directive for CodegenDirective {
+    fn definition() -> String {
+        r#"
+            directive @codegen(
+                enabled: Boolean! = true
+                """The target file path for the generated code."""
+                path: String
+            ) on SCHEMA
+            
+        "#
+        .to_owned()
+    }
+}
+
+const CODEGEN_DIRECTIVE_NAME: &str = "codegen";
+
+pub struct CodegenVisitor;
+
+impl<'a> Visitor<'a> for CodegenVisitor {
+    fn enter_schema(
+        &mut self,
+        ctx: &mut super::visitor::VisitorContext<'a>,
+        doc: &'a engine::Positioned<engine_parser::types::SchemaDefinition>,
+    ) {
+        let directives = doc
+            .node
+            .directives
+            .iter()
+            .filter(|d| d.node.name.node == CODEGEN_DIRECTIVE_NAME);
+
+        for directive in directives {
+            match parse_directive::<CodegenDirective>(&directive.node, ctx.variables) {
+                Ok(parsed_directive) => {
+                    ctx.codegen_directive = Some(parsed_directive);
+                }
+                Err(err) => ctx.report_error(vec![directive.pos], err.to_string()),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    fn parse_schema(schema: &str) -> crate::ParseResult<'_> {
+        let connector_parsers = crate::connector_parsers::MockConnectorParsers::default();
+        let variables = HashMap::default();
+        futures::executor::block_on(crate::parse(&schema, &variables, &connector_parsers)).unwrap()
+    }
+
+    #[test]
+    fn test_codegen_directive_enabled_with_path() {
+        let schema = r#"
+            extend schema @codegen(enabled: true, path: "/dev/null")
+        "#;
+        let parsed = parse_schema(schema);
+
+        let config = parsed.registry.codegen.unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.path.as_deref(), Some("/dev/null"));
+    }
+
+    #[test]
+    fn test_codegen_directive_disabled() {
+        let schema = r#"
+            extend schema @codegen(enabled: false)
+        "#;
+        let parsed = parse_schema(schema);
+
+        let config = parsed.registry.codegen.unwrap();
+        assert!(!config.enabled);
+        assert!(config.path.is_none());
+    }
+}

--- a/engine/crates/parser-sdl/src/rules/codegen_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/codegen_directive.rs
@@ -9,6 +9,15 @@ pub struct CodegenDirective {
     pub path: Option<String>,
 }
 
+impl From<CodegenDirective> for engine::registry::CodegenConfig {
+    fn from(value: CodegenDirective) -> Self {
+        engine::registry::CodegenConfig {
+            enabled: value.enabled,
+            path: value.path,
+        }
+    }
+}
+
 impl Directive for CodegenDirective {
     fn definition() -> String {
         r#"

--- a/engine/crates/parser-sdl/src/rules/experimental.rs
+++ b/engine/crates/parser-sdl/src/rules/experimental.rs
@@ -41,7 +41,10 @@ impl<'a> Visitor<'a> for ExperimentalDirectiveVisitor {
             Ok(experimental_directive) => {
                 ctx.registry.get_mut().enable_kv = experimental_directive.kv.unwrap_or_default();
                 ctx.registry.get_mut().enable_ai = experimental_directive.ai.unwrap_or_default();
-                ctx.registry.get_mut().enable_codegen = experimental_directive.codegen.unwrap_or_default();
+
+                if let Some(enabled) = experimental_directive.codegen {
+                    ctx.registry.get_mut().codegen = Some(engine::registry::CodegenConfig { enabled, path: None });
+                }
             }
             Err(err) => {
                 ctx.report_error(
@@ -123,7 +126,7 @@ mod tests {
         match target {
             "ai" => assert_eq!(ctx.registry.borrow().enable_ai, expected),
             "kv" => assert_eq!(ctx.registry.borrow().enable_kv, expected),
-            "codegen" => assert_eq!(ctx.registry.borrow().enable_codegen, expected),
+            "codegen" => assert_eq!(ctx.registry.borrow().codegen.as_ref().unwrap().enabled, expected),
             _ => {}
         }
     }

--- a/engine/crates/parser-sdl/src/rules/mod.rs
+++ b/engine/crates/parser-sdl/src/rules/mod.rs
@@ -7,6 +7,7 @@ pub mod check_known_directives;
 pub mod check_type_collision;
 pub mod check_type_validity;
 pub mod check_types_underscore;
+pub mod codegen_directive;
 mod connector_headers;
 pub mod connector_transforms;
 pub mod cors_directive;

--- a/engine/crates/parser-sdl/src/rules/visitor/context.rs
+++ b/engine/crates/parser-sdl/src/rules/visitor/context.rs
@@ -197,6 +197,10 @@ impl<'a> VisitorContext<'a> {
 
         registry.remove_unused_types();
 
+        if let Some(directive) = self.codegen_directive.take() {
+            registry.codegen = Some(directive.into())
+        }
+
         registry.operation_limits = self
             .operation_limits_directive
             .take()

--- a/engine/crates/parser-sdl/src/rules/visitor/context.rs
+++ b/engine/crates/parser-sdl/src/rules/visitor/context.rs
@@ -23,8 +23,8 @@ use super::{warnings::Warnings, RuleError, TypeStackType, MUTATION_TYPE, QUERY_T
 use crate::{
     federation::FederatedGraphConfig,
     rules::{
-        federation::FederationVersion, operation_limits_directive::OperationLimitsDirective,
-        trusted_documents_directive::TrustedDocumentsDirective,
+        codegen_directive::CodegenDirective, federation::FederationVersion,
+        operation_limits_directive::OperationLimitsDirective, trusted_documents_directive::TrustedDocumentsDirective,
     },
     GlobalCacheRules, GlobalCacheTarget, GraphqlDirective, MongoDBDirective, OpenApiDirective, ParseResult,
     PostgresDirective,
@@ -64,6 +64,7 @@ pub struct VisitorContext<'a> {
     pub(crate) global_cache_rules: GlobalCacheRules<'static>,
     pub(crate) operation_limits_directive: Option<OperationLimitsDirective>,
     pub(crate) trusted_documents_directive: Option<TrustedDocumentsDirective>,
+    pub(crate) codegen_directive: Option<CodegenDirective>,
 
     pub federation: Option<FederationVersion>,
 
@@ -128,6 +129,7 @@ impl<'a> VisitorContext<'a> {
             federated_graph_config: Default::default(),
             operation_limits_directive: None,
             trusted_documents_directive: None,
+            codegen_directive: None,
         }
     }
 

--- a/packages/grafbase-sdk/src/codegen.ts
+++ b/packages/grafbase-sdk/src/codegen.ts
@@ -1,0 +1,28 @@
+/**
+ * Typescript resolver code generation
+ */
+export interface CodegenParams {
+  enabled: boolean
+  /**
+   * A directory path where the types for resolvers should be generated. `generated` by default.
+   */
+  path?: string
+}
+
+export class Codegen {
+  private params: CodegenParams
+
+  constructor(params: CodegenParams) {
+    this.params = params
+  }
+
+  public toString(): string {
+    const enabled = `\n    enabled: ${this.params.enabled}`
+    const path = this.params.path
+      ? `,\n    path: ${JSON.stringify(this.params.path)}`
+      : ''
+
+    return `extend schema\n  @codegen(${enabled}${path}\n  )\n\n`
+  }
+}
+

--- a/packages/grafbase-sdk/src/config.ts
+++ b/packages/grafbase-sdk/src/config.ts
@@ -11,6 +11,7 @@ import { OperationLimits, OperationLimitsParams } from './operation-limits'
 import { Experimental, ExperimentalParams } from './experimental'
 import { Introspection } from './introspection'
 import { TrustedDocuments, TrustedDocumentsParams } from './trusted-documents'
+import { Codegen, CodegenParams } from './codegen'
 
 /**
  * An interface to create the complete config definition.
@@ -20,6 +21,7 @@ export interface GraphConfigInput {
   auth?: AuthParams
   cache?: CacheParams
   cors?: CorsParams
+  codegen?: CodegenParams
   operationLimits?: OperationLimitsParams
   trustedDocuments?: TrustedDocumentsParams
   experimental?: ExperimentalParams
@@ -36,6 +38,7 @@ export interface DeprecatedGraphConfigInput {
   auth?: AuthParams
   operationLimits?: OperationLimitsParams
   cache?: CacheParams
+  codegen?: CodegenParams
   cors?: CorsParams
   experimental?: ExperimentalParams
   introspection?: boolean
@@ -59,6 +62,7 @@ export class GraphConfig {
   private graph: Graph
   private readonly auth?: Authentication
   private readonly cache?: GlobalCache
+  private readonly codegen?: Codegen
   private readonly cors?: Cors
   private readonly operationLimits?: OperationLimits
   private readonly experimental?: Experimental
@@ -93,6 +97,10 @@ export class GraphConfig {
       this.introspection = new Introspection({ enabled: input.introspection })
     }
 
+    if (input.codegen) {
+      this.codegen = new Codegen(input.codegen)
+    }
+
     if (input.cors) {
       this.cors = new Cors(input.cors)
     }
@@ -119,9 +127,10 @@ export class GraphConfig {
         ? new Introspection({ enabled: true })
         : ''
 
+    const codegen = this.codegen ? this.codegen.toString() : ''
     const cors = this.cors ? this.cors.toString() : ''
 
-    return `${experimental}${auth}${operationLimits}${trustedDocuments}${cache}${cors}${introspection}${graph}`
+    return `${experimental}${auth}${operationLimits}${trustedDocuments}${cache}${codegen}${cors}${introspection}${graph}`
   }
 }
 

--- a/packages/grafbase-sdk/src/experimental.ts
+++ b/packages/grafbase-sdk/src/experimental.ts
@@ -4,6 +4,9 @@
 export interface ExperimentalParams {
   kv?: boolean
   ai?: boolean
+  /**
+   * @deprecated Codegen was stabilized. Use the `codegen` key in the config object.
+   */
   codegen?: boolean
 }
 

--- a/packages/grafbase-sdk/tests/unit/codegen.test.ts
+++ b/packages/grafbase-sdk/tests/unit/codegen.test.ts
@@ -1,0 +1,47 @@
+import { config, graph, auth } from '../../src/index'
+import { describe, expect, it, beforeEach } from '@jest/globals'
+import { renderGraphQL } from '../utils'
+
+const g = graph.Standalone()
+
+describe('Codegen settings', () => {
+  beforeEach(() => {
+    g.clear()
+  })
+
+  it('with all settings', () => {
+    const cfg = config({
+      graph: g,
+      codegen: {
+        enabled: false,
+        path: 'test/my/path'
+      }
+    })
+
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
+      "extend schema
+        @codegen(
+          enabled: false,
+          path: "test/my/path"
+        )
+
+      "
+    `)
+  })
+
+  it('with just enabled', () => {
+    const cfg = config({
+      graph: g,
+      codegen: { enabled: true }
+    })
+
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
+      "extend schema
+        @codegen(
+          enabled: true
+        )
+
+      "
+    `)
+  })
+})


### PR DESCRIPTION
This stabilization PR does two things:

- Introduce the internal `@codegen` directive to configure codegen, replacing `@experimental(codegen: true)`. The experimental flag continues working for now but it is marked as deprecated in the SDK, so it will be a visible warning in users' IDE.
- Make the path where the generated code is written configurable.

We will need a SDK release after this is merged to expose the new configuration. In practice, it looks like this:

```ts
export default config({
  graph: g,
  codegen: {
     enabled: true,
     path: 'cat/meow'
  }
});
```

closes GB-6468
closes GB-5246
closes GB-5245
closes GB-5244