### PR TITLE
cli: rename GraphType::Single to GraphType::Standalone

### DIFF
--- a/cli/crates/backend/src/project.rs
+++ b/cli/crates/backend/src/project.rs
@@ -10,41 +10,31 @@ use http_cache_reqwest::{CACacheManager, Cache, CacheMode, HttpCache, HttpCacheO
 use reqwest::{header, Client};
 use reqwest_middleware::ClientBuilder;
 use serde::Deserialize;
-use std::fs;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::iter::Iterator;
 use std::path::{Path, PathBuf};
-use std::{env, fmt};
+use std::{env, fs};
 use tokio_stream::StreamExt;
 use tokio_util::io::StreamReader;
 use url::Url;
 
 #[derive(Debug, Clone, Copy)]
 pub enum GraphType {
-    Single,
+    Standalone,
     Federated,
 }
 
 impl AsRef<str> for GraphType {
     fn as_ref(&self) -> &str {
         match self {
-            GraphType::Single => "single",
+            GraphType::Standalone => "standalone",
             GraphType::Federated => "federated",
         }
     }
 }
 
-impl fmt::Display for GraphType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            GraphType::Single => f.write_str("Single"),
-            GraphType::Federated => f.write_str("Federated"),
-        }
-    }
-}
-
 impl GraphType {
-    pub const VARIANTS: &'static [GraphType] = &[Self::Single, Self::Federated];
+    pub const VARIANTS: &'static [GraphType] = &[Self::Standalone, Self::Federated];
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -155,7 +145,7 @@ pub fn init(name: Option<&str>, template: Template<'_>) -> Result<(), BackendErr
                 let dot_env_path = project_path.join(GRAFBASE_ENV_FILE_NAME);
 
                 let schema_write_result = match graph_type {
-                    GraphType::Single => {
+                    GraphType::Standalone => {
                         let schema_path = project_path.join(GRAFBASE_TS_CONFIG_FILE_NAME);
 
                         let add_sdk = environment::add_dev_dependency_to_package_json(

--- a/cli/crates/cli/src/cli_input/init.rs
+++ b/cli/crates/cli/src/cli_input/init.rs
@@ -7,8 +7,8 @@ use super::{filter_existing_arguments, ArgumentNames};
 pub enum GraphType {
     /// Creates a federated graph
     Federated,
-    /// Creates a single graph
-    Single,
+    /// Creates a standalone graph
+    Standalone,
 }
 
 #[derive(Debug, Parser)]

--- a/cli/crates/cli/src/init.rs
+++ b/cli/crates/cli/src/init.rs
@@ -4,7 +4,7 @@ use backend::project::{self, Template};
 pub fn init(name: Option<&str>, template: Option<&str>, graph_type: Option<GraphType>) -> Result<(), CliError> {
     let template = match (template, graph_type) {
         (Some(template), _) => Template::FromUrl(template),
-        (None, Some(GraphType::Single)) => Template::FromDefault(project::GraphType::Single),
+        (None, Some(GraphType::Standalone)) => Template::FromDefault(project::GraphType::Standalone),
         (None, Some(GraphType::Federated)) => Template::FromDefault(project::GraphType::Federated),
         (None, None) => {
             // let graph_type = Select::new(
@@ -14,7 +14,7 @@ pub fn init(name: Option<&str>, template: Option<&str>, graph_type: Option<Graph
             // .prompt()
             // .map_err(handle_inquire_error)?;
 
-            Template::FromDefault(project::GraphType::Single)
+            Template::FromDefault(project::GraphType::Standalone)
         }
     };
 

--- a/cli/crates/cli/tests/apq.rs
+++ b/cli/crates/cli/tests/apq.rs
@@ -27,7 +27,7 @@ fn setup_rustls() {
 #[tokio::test(flavor = "multi_thread")]
 async fn automatic_persisted_queries(#[case] method: reqwest::Method) {
     let mut env = Environment::init_async().await;
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(SCHEMA);
     env.grafbase_dev_watch();
     env.write_file(

--- a/cli/crates/cli/tests/auth.rs
+++ b/cli/crates/cli/tests/auth.rs
@@ -39,7 +39,7 @@ fn setup_rustls() {
 #[tokio::test(flavor = "multi_thread")]
 async fn simple_authorizer() {
     let mut env = Environment::init_async().await;
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(
         r###"
         schema
@@ -106,7 +106,7 @@ async fn simple_authorizer() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_naming_clash() {
     let mut env = Environment::init_async().await;
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(
         r###"
         schema
@@ -168,7 +168,7 @@ async fn test_naming_clash() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn jwt_provider() {
     let mut env = Environment::init();
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(AUTH_JWT_PROVIDER_SCHEMA);
     env.set_variables(HashMap::from([
         ("ISSUER_URL".to_string(), JWT_ISSUER_URL.to_string()),
@@ -359,7 +359,7 @@ async fn set_up_oidc_with_path(path: Option<&str>) -> SetUpOidc {
     };
     set_up_oidc_server(&issuer_url, &server, key_set).await;
     let mut env = Environment::init_async().await;
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(AUTH_OIDC_PROVIDER_SCHEMA);
     env.set_variables(HashMap::from([("ISSUER_URL".to_string(), issuer_url.to_string())]));
     env.grafbase_dev();
@@ -387,7 +387,7 @@ async fn set_up_jwks<F: Fn(&Url) -> HashMap<String, String>>(
     let jwks_uri = issuer_url.join(jwks_path).unwrap();
     set_up_jwks_server(jwks_uri.path(), &server, key_set).await;
     let mut env = Environment::init_async().await;
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(schema);
     env.set_variables(variables_fn(&issuer_url));
     env.grafbase_dev();
@@ -593,7 +593,7 @@ async fn jwks_endpoint_and_issuer_token_with_valid_group_should_work() {
 #[tokio::test(flavor = "multi_thread")]
 async fn public_global() {
     let mut env = Environment::init_async().await;
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(AUTH_PUBLIC_GLOBAL_SCHEMA);
     env.set_variables(HashMap::from([
         ("ISSUER_URL".to_string(), JWT_ISSUER_URL.to_string()),
@@ -610,7 +610,7 @@ async fn public_global() {
 #[tokio::test(flavor = "multi_thread")]
 async fn public_type() {
     let mut env = Environment::init_async().await;
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(AUTH_PUBLIC_TYPE_SCHEMA);
     env.set_variables(HashMap::from([
         ("ISSUER_URL".to_string(), JWT_ISSUER_URL.to_string()),
@@ -632,7 +632,7 @@ const RESOLVER_CONTENT: &str = r#"export default function Resolver(parent, args,
 #[tokio::test(flavor = "multi_thread")]
 async fn type_field_resolver_mixed() {
     let mut env = Environment::init_async().await;
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(AUTH_TYPE_FIELD_RESOLVER_SCHEMA);
     env.write_resolver(RESOLVER_FILE_NAME, RESOLVER_CONTENT);
     env.set_variables(HashMap::from([
@@ -673,7 +673,7 @@ async fn type_field_resolver_mixed() {
 #[tokio::test(flavor = "multi_thread")]
 async fn entrypoint_query_field_resolver() {
     let mut env = Environment::init_async().await;
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(AUTH_ENTRYPOINT_FIELD_RESOLVER_SCHEMA);
     env.write_resolver(RESOLVER_FILE_NAME, RESOLVER_CONTENT);
     env.set_variables(HashMap::from([
@@ -713,7 +713,7 @@ async fn entrypoint_query_field_resolver() {
 #[tokio::test(flavor = "multi_thread")]
 async fn entrypoint_mutation_field_resolver_mixed() {
     let mut env = Environment::init_async().await;
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(AUTH_ENTRYPOINT_FIELD_RESOLVER_SCHEMA);
     env.write_resolver(RESOLVER_FILE_NAME, RESOLVER_CONTENT);
     env.set_variables(HashMap::from([
@@ -754,7 +754,7 @@ async fn entrypoint_mutation_field_resolver_mixed() {
 #[tokio::test(flavor = "multi_thread")]
 async fn authorizer_with_no_headers_should_work() {
     let mut env = Environment::init_async().await;
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(AUTHORIZER_SCHEMA);
     let authorizer_name = "a1";
     let authorizer_content = r"export default function(context) {
@@ -779,7 +779,7 @@ async fn authorizer_with_no_headers_should_work() {
 #[tokio::test(flavor = "multi_thread")]
 async fn authorizer_with_headers_should_work() {
     let mut env = Environment::init_async().await;
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(AUTHORIZER_SCHEMA);
     let authorizer_name = "a1";
     let authorizer_content = r"export default function(context) {
@@ -804,7 +804,7 @@ async fn authorizer_with_headers_should_work() {
 #[tokio::test(flavor = "multi_thread")]
 async fn authorizer_with_public_access_should_work() {
     let mut env = Environment::init_async().await;
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(AUTHORIZER_SCHEMA);
     let authorizer_name = "a1";
     let authorizer_content = r"export default function(context) {

--- a/cli/crates/cli/tests/batching.rs
+++ b/cli/crates/cli/tests/batching.rs
@@ -62,7 +62,7 @@ async fn batching() {
 }
 
 async fn start_grafbase(env: &mut Environment, schema: impl AsRef<str>) -> AsyncClient {
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(schema);
     env.set_variables([("API_KEY", "BLAH")]);
     env.grafbase_dev_watch();

--- a/cli/crates/cli/tests/caching.rs
+++ b/cli/crates/cli/tests/caching.rs
@@ -332,7 +332,7 @@ async fn no_cache_header_when_caching_is_not_used() {
 }
 
 async fn start_grafbase(env: &mut Environment, schema: impl AsRef<str> + Display) -> AsyncClient {
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(schema);
     env.grafbase_dev_watch();
 

--- a/cli/crates/cli/tests/coercion.rs
+++ b/cli/crates/cli/tests/coercion.rs
@@ -10,7 +10,7 @@ use utils::environment::Environment;
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn coercion() {
     let mut env = Environment::init();
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(COERCION_SCHEMA);
     env.grafbase_dev();
     let client = env.create_client().with_api_key();

--- a/cli/crates/cli/tests/compilation_error.rs
+++ b/cli/crates/cli/tests/compilation_error.rs
@@ -21,7 +21,7 @@ fn setup_rustls() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn compilation_error_schema() {
     let mut env = Environment::init();
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema("type Xyz e");
 
     env.grafbase_dev_watch();
@@ -55,7 +55,7 @@ async fn compilation_error_schema() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn post_startup_compilation_error() {
     let mut env = Environment::init();
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema("");
 
     env.grafbase_dev_watch();
@@ -81,7 +81,7 @@ async fn post_startup_compilation_error() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn compilation_error_resolvers() {
     let mut env = Environment::init();
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(SCHEMA);
     env.write_resolver(
         "hello.js",

--- a/cli/crates/cli/tests/concurrency_process.rs
+++ b/cli/crates/cli/tests/concurrency_process.rs
@@ -14,7 +14,7 @@ async fn concurrency_process() {
     let mut env1 = Environment::init_async().await;
     let mut env2 = Environment::from(&env1);
 
-    env1.grafbase_init(GraphType::Single);
+    env1.grafbase_init(GraphType::Standalone);
     env1.write_schema(CONCURRENCY_SCHEMA);
     env1.grafbase_dev();
 

--- a/cli/crates/cli/tests/concurrency_thread.rs
+++ b/cli/crates/cli/tests/concurrency_thread.rs
@@ -13,7 +13,7 @@ use utils::environment::Environment;
 async fn concurrency_thread() {
     let mut env = Environment::init_async().await;
 
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(CONCURRENCY_SCHEMA);
     env.grafbase_dev();
 

--- a/cli/crates/cli/tests/custom_resolvers.rs
+++ b/cli/crates/cli/tests/custom_resolvers.rs
@@ -381,7 +381,7 @@ async fn test_field_resolver(
 ) {
     let (subdirectory_path, package_json_path) = variant;
     let mut env = Environment::init_in_subdirectory(subdirectory_path);
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     std::fs::write(
         env.directory_path.join(subdirectory_path).join(".env"),
         "MY_OWN_VARIABLE=test_value",
@@ -571,7 +571,7 @@ async fn test_query_mutation_resolver_dev(
     queries: &[(&str, &str)],
 ) {
     let mut env = Environment::init();
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(schema);
     for (file_name, file_contents) in resolver_files {
         env.write_resolver(file_name, file_contents);
@@ -605,7 +605,7 @@ async fn test_query_mutation_resolver_start(
     queries: &[(&str, &str)],
 ) {
     let mut env = Environment::init();
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(schema);
     for (file_name, file_contents) in resolver_files {
         env.write_resolver(file_name, file_contents);

--- a/cli/crates/cli/tests/default_directive.rs
+++ b/cli/crates/cli/tests/default_directive.rs
@@ -10,7 +10,7 @@ use utils::environment::Environment;
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn default_directive() {
     let mut env = Environment::init();
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(DEFAULT_DIRECTIVE_SCHEMA);
     env.grafbase_dev();
     let client = env.create_client().with_api_key();

--- a/cli/crates/cli/tests/defer/main.rs
+++ b/cli/crates/cli/tests/defer/main.rs
@@ -183,7 +183,7 @@ const JWT_SECRET: &str = "topsecret";
 #[tokio::test(flavor = "multi_thread")]
 async fn test_auth_with_multipart() {
     let mut env = Environment::init_async().await;
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(JWT_SCHEMA);
     env.set_variables(HashMap::from([
         ("ISSUER_URL".to_string(), JWT_ISSUER_URL.to_string()),
@@ -219,7 +219,7 @@ async fn test_auth_with_sse() {
     // Tests that authentication with the SSE transport works..
 
     let mut env = Environment::init_async().await;
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(JWT_SCHEMA);
     env.set_variables(HashMap::from([
         ("ISSUER_URL".to_string(), JWT_ISSUER_URL.to_string()),
@@ -262,7 +262,7 @@ async fn test_auth_with_sse() {
 }
 
 async fn start_grafbase(env: &mut Environment, schema: impl AsRef<str> + Display) -> AsyncClient {
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(schema);
     env.set_variables([("API_KEY", "BLAH")]);
     env.grafbase_dev_watch();

--- a/cli/crates/cli/tests/dev_watch.rs
+++ b/cli/crates/cli/tests/dev_watch.rs
@@ -15,7 +15,7 @@ fn setup_rustls() {
 async fn dev_watch() {
     let mut env = Environment::init();
 
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
 
     env.write_schema(
         r#"
@@ -85,7 +85,7 @@ async fn dev_watch() {
 async fn dev_watch_with_custom_codegen_path() {
     let mut env = Environment::init();
 
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
 
     env.write_schema(
         r#"

--- a/cli/crates/cli/tests/environment_file.rs
+++ b/cli/crates/cli/tests/environment_file.rs
@@ -15,7 +15,7 @@ fn setup_rustls() {
 async fn environment_file() {
     let mut env = Environment::init();
 
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
 
     env.write_schema(ENVIRONMENT_SCHEMA);
 

--- a/cli/crates/cli/tests/environment_process.rs
+++ b/cli/crates/cli/tests/environment_process.rs
@@ -14,7 +14,7 @@ fn setup_rustls() {
 async fn environment_process() {
     let mut env = Environment::init();
 
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
 
     env.write_schema(ENVIRONMENT_SCHEMA);
 

--- a/cli/crates/cli/tests/graphql-directive/headers.rs
+++ b/cli/crates/cli/tests/graphql-directive/headers.rs
@@ -69,7 +69,7 @@ async fn test_header_forwarding() {
 }
 
 async fn start_grafbase(env: &mut Environment, schema: impl AsRef<str> + Display) -> AsyncClient {
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(schema);
     env.set_variables([("API_KEY", "BLAH")]);
     env.grafbase_dev_watch();

--- a/cli/crates/cli/tests/graphql-directive/main.rs
+++ b/cli/crates/cli/tests/graphql-directive/main.rs
@@ -168,7 +168,7 @@ async fn graphql_test_without_namespace() {
 }
 
 async fn start_grafbase(env: &mut Environment, schema: impl AsRef<str> + Display) -> AsyncClient {
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(schema);
     env.set_variables([("API_KEY", "BLAH")]);
     env.grafbase_dev_watch();

--- a/cli/crates/cli/tests/graphql-directive/transforms.rs
+++ b/cli/crates/cli/tests/graphql-directive/transforms.rs
@@ -50,7 +50,7 @@ async fn graphql_test_with_transforms() {
 }
 
 async fn start_grafbase(env: &mut Environment, schema: impl AsRef<str> + Display) -> AsyncClient {
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(schema);
     env.set_variables([("API_KEY", "BLAH")]);
     env.grafbase_dev_watch();

--- a/cli/crates/cli/tests/home.rs
+++ b/cli/crates/cli/tests/home.rs
@@ -41,7 +41,7 @@ async fn env_var(#[case] case_path: PathBuf) {
     std::env::set_var("GRAFBASE_HOME", case_path.as_os_str());
 
     let mut env = Environment::init();
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(
         r#"
         type Post @model {

--- a/cli/crates/cli/tests/init_ts.rs
+++ b/cli/crates/cli/tests/init_ts.rs
@@ -22,7 +22,7 @@ fn init_ts_existing_package_json() {
         }),
     );
 
-    let output = env.grafbase_init_output(GraphType::Single);
+    let output = env.grafbase_init_output(GraphType::Standalone);
     println!("stdout: `{}`", String::from_utf8_lossy(&output.stdout));
     assert!(
         output.stderr.is_empty(),
@@ -60,7 +60,7 @@ fn init_ts_existing_package_json() {
 #[cfg_attr(target_os = "windows", ignore)]
 fn init_ts_new_project() {
     let env = Environment::init();
-    let output = env.grafbase_init_output(GraphType::Single);
+    let output = env.grafbase_init_output(GraphType::Standalone);
     println!("stdout: `{}`", String::from_utf8_lossy(&output.stdout));
     assert!(
         output.stderr.is_empty(),

--- a/cli/crates/cli/tests/introspection.rs
+++ b/cli/crates/cli/tests/introspection.rs
@@ -302,7 +302,7 @@ fn introspect_dev_with_federation_directives() {
     extend schema @introspection(enable: true)
     "#;
 
-    // env.grafbase_init(backend::project::GraphType::Single);
+    // env.grafbase_init(backend::project::GraphType::Standalone);
     env.write_schema(config);
 
     let output = env.grafbase_introspect_dev();

--- a/cli/crates/cli/tests/introspection_configuration.rs
+++ b/cli/crates/cli/tests/introspection_configuration.rs
@@ -16,7 +16,7 @@ fn setup_rustls() {
 async fn introspection_configuration() {
     let mut env = Environment::init();
 
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
 
     env.write_schema_without_introspection(
         r#"

--- a/cli/crates/cli/tests/kv.rs
+++ b/cli/crates/cli/tests/kv.rs
@@ -14,7 +14,7 @@ fn setup_rustls() {
 async fn test_kv_integration() {
     // prepare
     let mut env = Environment::init();
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(
         r#"
                 extend schema @experimental(kv: true)

--- a/cli/crates/cli/tests/length.rs
+++ b/cli/crates/cli/tests/length.rs
@@ -12,7 +12,7 @@ use utils::environment::Environment;
 async fn length() {
     let mut env = Environment::init();
 
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
 
     env.write_schema(LENGTH_SCHEMA);
 

--- a/cli/crates/cli/tests/mongodb/main.rs
+++ b/cli/crates/cli/tests/mongodb/main.rs
@@ -287,7 +287,7 @@ impl Server {
             .await;
 
         let mut env = Environment::init_async().await;
-        env.grafbase_init(GraphType::Single);
+        env.grafbase_init(GraphType::Standalone);
         env.write_schema(&self.config);
         env.set_variables([("API_KEY", "BLAH")]);
         env.grafbase_dev_watch();

--- a/cli/crates/cli/tests/openapi/main.rs
+++ b/cli/crates/cli/tests/openapi/main.rs
@@ -214,7 +214,7 @@ async fn openapi_flat_namespace() {
 }
 
 async fn start_grafbase(env: &mut Environment, schema: impl AsRef<str> + Display) -> AsyncClient {
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(schema);
     env.set_variables([("API_KEY", "BLAH")]);
     env.grafbase_dev_watch();

--- a/cli/crates/cli/tests/owner.rs
+++ b/cli/crates/cli/tests/owner.rs
@@ -22,7 +22,7 @@ mod global {
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn entity_should_be_visible_only_to_the_owner() {
             let mut env = Environment::init();
-            env.grafbase_init(GraphType::Single);
+            env.grafbase_init(GraphType::Standalone);
             env.write_schema(OWNER_TODO_SCHEMA);
             env.grafbase_dev();
             let client = env.create_client();
@@ -153,7 +153,7 @@ mod global {
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn owner_create_group_all_should_work() {
             let mut env = Environment::init();
-            env.grafbase_init(GraphType::Single);
+            env.grafbase_init(GraphType::Standalone);
             env.write_schema(OWNER_TODO_OWNER_CREATE_SCHEMA);
             env.grafbase_dev();
             let client = env.create_client();
@@ -251,7 +251,7 @@ mod global {
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn group_should_supersede_owner_when_listing_entities() {
             let mut env = Environment::init();
-            env.grafbase_init(GraphType::Single);
+            env.grafbase_init(GraphType::Standalone);
             env.write_schema(OWNER_TODO_MIXED_SCHEMA);
             env.grafbase_dev();
             let client = env.create_client();
@@ -361,7 +361,7 @@ mod global {
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_by_id_should_be_filtered_by_the_owner() {
             let mut env = Environment::init();
-            env.grafbase_init(GraphType::Single);
+            env.grafbase_init(GraphType::Standalone);
             env.write_schema(OWNER_TWITTER_SCHEMA);
             env.grafbase_dev();
             let client = env.create_client();
@@ -409,7 +409,7 @@ mod global {
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_by_email_should_be_filtered_by_the_owner() {
             let mut env = Environment::init();
-            env.grafbase_init(GraphType::Single);
+            env.grafbase_init(GraphType::Standalone);
             env.write_schema(OWNER_TWITTER_SCHEMA);
             env.grafbase_dev();
             let client = env.create_client();
@@ -453,7 +453,7 @@ mod global {
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn test_linking() {
             let mut env = Environment::init();
-            env.grafbase_init(GraphType::Single);
+            env.grafbase_init(GraphType::Standalone);
             env.write_schema(OWNER_TWITTER_SCHEMA);
             env.grafbase_dev();
             let client = env.create_client();

--- a/cli/crates/cli/tests/reserved_dates.rs
+++ b/cli/crates/cli/tests/reserved_dates.rs
@@ -14,7 +14,7 @@ use utils::environment::Environment;
 async fn reserved_dates() {
     // TODO: Create simpler client setup (one-line)
     let mut env = Environment::init();
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(RESERVED_DATES_SCHEMA);
     env.grafbase_dev();
     let client = env.create_client().with_api_key();

--- a/cli/crates/cli/tests/scalars.rs
+++ b/cli/crates/cli/tests/scalars.rs
@@ -61,7 +61,7 @@ fn error_matching(pattern: &str) -> Result<Value, Regex> {
 #[ignore]
 async fn scalars() {
     let mut env = Environment::init();
-    env.grafbase_init(GraphType::Single);
+    env.grafbase_init(GraphType::Standalone);
     env.write_schema(SCALARS_SCHEMA);
     env.grafbase_dev();
     let client = env.create_client().with_api_key();


### PR DESCRIPTION
The only user-facing change here is that the `grafbase init -g single` option becomes `grafbase init -g standalone`. I checked that it still works.