### PR TITLE
sdk: release 0.23.0

### DIFF
--- a/packages/grafbase-sdk/CHANGELOG.md
+++ b/packages/grafbase-sdk/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [0.22.0] - Wed Apr 25 2024
+## [0.23.0] - Fri Apr 26 2024
+
+[CHANGELOG](changelog/0.23.0.md)
+
+## [0.22.0] - Wed Apr 24 2024
 
 [CHANGELOG](changelog/0.22.0.md)
 

--- a/packages/grafbase-sdk/changelog/0.23.0.md
+++ b/packages/grafbase-sdk/changelog/0.23.0.md
@@ -1,0 +1,18 @@
+## Features
+
+- The `codegen` experimental feature is stabilized. The `codegen` option can be used in this way now:
+
+```ts
+export default config({
+  graph: g,
+  codegen: {
+    enabled: true,
+    // Optional: define the directory path where you want the generated code to be written, relative to your grafbase configuration. Default: "generated".
+    path: 'generated',
+  },
+})
+```
+
+## Deprecations
+
+- The `kv`, `ai` and `codegen` experimental feature options are deprecated. Codegen is stabilized, but `kv` and `ai` are being removed.

--- a/packages/grafbase-sdk/package.json
+++ b/packages/grafbase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/sdk",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "The Grafbase SDK",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Features

- The `codegen` experimental feature is stabilized. The `codegen` option can be used in this way now:

```ts
export default config({
  graph: g,
  codegen: {
    enabled: true,
    // Optional: define the directory path where you want the generated code to be written, relative to your grafbase configuration. Default: "generated".
    path: 'generated',
  },
})
```

Deprecations

- The `kv`, `ai` and `codegen` experimental feature options are deprecated. Codegen is stabilized, but `kv` and `ai` are being removed.
