### PR TITLE
cli: silently ignore schema.graphql when grafbase.config.ts exists

### DIFF
--- a/cli/crates/common/src/environment.rs
+++ b/cli/crates/common/src/environment.rs
@@ -373,7 +373,7 @@ fn find_grafbase_configuration(path: &Path, warnings: &mut Vec<Warning>) -> Opti
         match (tsconfig_file_path.is_file(), schema_graphql_file_path.is_file()) {
             (true, true) => {
                 let warning = Warning::new("Found both grafbase.config.ts and schema.graphql files")
-                    .with_hint("Delete one of them to avoid conflicts");
+                    .with_hint("schema.graphql will be ignored");
                 warnings.push(warning);
                 Some(GrafbaseSchemaPath::ts_config(tsconfig_file_path))
             }

--- a/cli/crates/common/src/environment.rs
+++ b/cli/crates/common/src/environment.rs
@@ -371,12 +371,7 @@ fn find_grafbase_configuration(path: &Path, warnings: &mut Vec<Warning>) -> Opti
         let tsconfig_file_path = search_path.join(GRAFBASE_TS_CONFIG_FILE_NAME);
         let schema_graphql_file_path = search_path.join(GRAFBASE_SCHEMA_FILE_NAME);
         match (tsconfig_file_path.is_file(), schema_graphql_file_path.is_file()) {
-            (true, true) => {
-                let warning = Warning::new("Found both grafbase.config.ts and schema.graphql files")
-                    .with_hint("schema.graphql will be ignored");
-                warnings.push(warning);
-                Some(GrafbaseSchemaPath::ts_config(tsconfig_file_path))
-            }
+            (true, true) => Some(GrafbaseSchemaPath::ts_config(tsconfig_file_path)),
             (true, false) => Some(GrafbaseSchemaPath::ts_config(tsconfig_file_path)),
             (false, true) => Some(GrafbaseSchemaPath::graphql(schema_graphql_file_path)),
             (false, false) => None,


### PR DESCRIPTION
The Linear task is about implementing that behaviour, but I think this is already what we do, from reading the code. The warning is misleading, so it got removed.

closes GB-6600