### PR TITLE
chore: port CodegenConfig to new registry code

### DIFF
--- a/engine/crates/engine/registry-upgrade/src/lib.rs
+++ b/engine/crates/engine/registry-upgrade/src/lib.rs
@@ -34,6 +34,7 @@ pub fn convert_v1_to_v2(v1: registry_v1::Registry) -> registry_v2::Registry {
         operation_limits,
         trusted_documents,
         cors_config,
+        codegen,
     } = v1;
 
     // First, copy over the fields that are the same.
@@ -51,6 +52,7 @@ pub fn convert_v1_to_v2(v1: registry_v1::Registry) -> registry_v2::Registry {
     writer.is_federated = is_federated;
     writer.operation_limits = operation_limits;
     writer.trusted_documents = trusted_documents;
+    writer.codegen = codegen;
     writer.cors_config = cors_config;
 
     let types = {

--- a/engine/crates/engine/registry-v1/src/lib.rs
+++ b/engine/crates/engine/registry-v1/src/lib.rs
@@ -13,7 +13,8 @@ mod types;
 use gateway_v2_auth_config::v1::AuthConfig;
 use postgres_connector_types::database_definition::DatabaseDefinition;
 use registry_v2::{
-    ConnectorHeaders, CorsConfig, FederationEntity, MongoDBConfiguration, OperationLimits, TrustedDocuments,
+    CodegenConfig, ConnectorHeaders, CorsConfig, FederationEntity, MongoDBConfiguration, OperationLimits,
+    TrustedDocuments,
 };
 
 pub use registry_v2::resolvers;
@@ -60,6 +61,8 @@ pub struct Registry {
     pub operation_limits: OperationLimits,
     #[serde(default)]
     pub trusted_documents: Option<TrustedDocuments>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codegen: Option<CodegenConfig>,
     #[serde(default)]
     pub cors_config: Option<CorsConfig>,
 }
@@ -89,6 +92,7 @@ impl Default for Registry {
             operation_limits: Default::default(),
             trusted_documents: Default::default(),
             cors_config: Default::default(),
+            codegen: Default::default(),
         }
     }
 }

--- a/engine/crates/engine/registry-v2/src/codegen.rs
+++ b/engine/crates/engine/registry-v2/src/codegen.rs
@@ -1,0 +1,6 @@
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CodegenConfig {
+    pub enabled: bool,
+    pub path: Option<String>,
+}

--- a/engine/crates/engine/registry-v2/src/lib.rs
+++ b/engine/crates/engine/registry-v2/src/lib.rs
@@ -8,6 +8,7 @@ use ids::{MetaDirectiveId, MetaFieldId, MetaTypeId, StringId};
 use indexmap::IndexSet;
 use postgres_connector_types::database_definition::DatabaseDefinition;
 
+mod codegen;
 mod common;
 mod cors;
 mod extensions;
@@ -27,6 +28,7 @@ pub mod writer;
 
 pub use self::{
     cache_control::CacheControl,
+    codegen::*,
     common::*,
     cors::CorsConfig,
     federation_entity::*,
@@ -101,6 +103,8 @@ pub struct Registry {
     pub operation_limits: OperationLimits,
     // #[serde(default)]
     pub trusted_documents: Option<TrustedDocuments>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codegen: Option<CodegenConfig>,
     // #[serde(default)]
     pub cors_config: Option<CorsConfig>,
 }

--- a/engine/crates/engine/registry-v2/src/writer.rs
+++ b/engine/crates/engine/registry-v2/src/writer.rs
@@ -9,8 +9,8 @@ use crate::{
     ids::*,
     resolvers::Resolver,
     storage::{self, *},
-    ConnectorHeaders, CorsConfig, FederationEntity, IdRange, MongoDBConfiguration, OperationLimits, Registry,
-    TrustedDocuments, TypeWrappers,
+    CodegenConfig, ConnectorHeaders, CorsConfig, FederationEntity, IdRange, MongoDBConfiguration, OperationLimits,
+    Registry, TrustedDocuments, TypeWrappers,
 };
 
 /// Writes to a registry.
@@ -59,6 +59,7 @@ pub struct RegistryWriter {
     pub is_federated: bool,
     pub operation_limits: OperationLimits,
     pub trusted_documents: Option<TrustedDocuments>,
+    pub codegen: Option<CodegenConfig>,
     pub cors_config: Option<CorsConfig>,
 }
 
@@ -223,6 +224,7 @@ impl RegistryWriter {
             operation_limits,
             trusted_documents,
             cors_config,
+            codegen,
         } = self;
 
         let types = types
@@ -265,6 +267,7 @@ impl RegistryWriter {
             is_federated,
             operation_limits,
             trusted_documents,
+            codegen,
             cors_config,
         })
     }


### PR DESCRIPTION
This was added to the original Registry on friday, so porting it over to the new registry setup while I remember.