### PR TITLE
cli: improve error handling in two cases

### DIFF
--- a/cli/crates/backend/src/api/graphql/types/mutations.rs
+++ b/cli/crates/backend/src/api/graphql/types/mutations.rs
@@ -346,9 +346,15 @@ pub enum SchemaCheckErrorSeverity {
     Warning,
 }
 
+#[derive(cynic::QueryFragment, Debug)]
+pub struct SubgraphNameMissingOnFederatedProjectError {
+    __typename: String,
+}
+
 #[derive(cynic::InlineFragments, Debug)]
 pub enum SchemaCheckPayload {
     SchemaCheck(SchemaCheck),
+    SubgraphNameMissingOnFederatedProjectError(SubgraphNameMissingOnFederatedProjectError),
     #[cynic(fallback)]
     Unknown(String),
 }

--- a/cli/crates/backend/src/api/graphql/types/mutations.rs
+++ b/cli/crates/backend/src/api/graphql/types/mutations.rs
@@ -273,6 +273,7 @@ pub struct SchemaRegistryBranchDoesNotExistError {
 #[derive(cynic::InlineFragments, Debug)]
 pub enum PublishPayload {
     PublishSuccess(PublishSuccess),
+    ProjectDoesNotExistError(ProjectDoesNotExistError),
     FederatedGraphCompositionError(FederatedGraphCompositionError),
     BranchDoesNotExistError(SchemaRegistryBranchDoesNotExistError),
     #[cynic(fallback)]

--- a/cli/crates/cli/src/check.rs
+++ b/cli/crates/cli/src/check.rs
@@ -54,7 +54,13 @@ pub(crate) async fn check(command: CheckCommand) -> Result<(), CliError> {
         composition_check_errors,
         operation_check_errors,
         lint_check_errors,
-    } = result;
+    } = match result {
+        check::SchemaCheckResult::Ok(check) => check,
+        check::SchemaCheckResult::SubgraphNameMissingOnFederatedProjectError => {
+            report::check_name_missing_on_federated_project();
+            std::process::exit(1);
+        }
+    };
 
     if validation_check_errors.is_empty()
         && composition_check_errors.is_empty()

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -625,6 +625,10 @@ pub(crate) fn federated_schema_local_introspection_not_implemented() {
     eprintln!("⚠️ The introspected schema is empty. Introspecting federated graphs is not implemented yet.")
 }
 
+pub(crate) fn publish_project_does_not_exist(account_slug: &str, project_slug: &str) {
+    watercolor::output!("❌ Could not publish: there is no project named {project_slug} in the account {account_slug}\n", @BrightRed);
+}
+
 pub(crate) fn publish_command_composition_failure(messages: &[String]) {
     assert_matches::assert_matches!(messages, [_, ..]);
 

--- a/cli/crates/cli/src/output/report.rs
+++ b/cli/crates/cli/src/output/report.rs
@@ -448,6 +448,10 @@ pub fn create_success(name: &str, urls: &[String]) {
     }
 }
 
+pub(crate) fn check_name_missing_on_federated_project() {
+    watercolor::output!("❌ The project is federated, but you did not provide a subgraph name to check against. Please pass a subgraph name with the --name argument to the check command.", @BrightRed);
+}
+
 pub(crate) fn check_success() {
     watercolor::output!("\n✨ Successful check!", @BrightBlue);
 }

--- a/cli/crates/cli/src/publish.rs
+++ b/cli/crates/cli/src/publish.rs
@@ -44,11 +44,18 @@ pub(crate) async fn publish(
     .await
     .map_err(CliError::BackendApiError)?;
 
-    if outcome.composition_errors.is_empty() {
-        report::publish_command_success(&subgraph_name);
-    } else {
-        report::publish_command_composition_failure(&outcome.composition_errors);
-    }
+    match &outcome {
+        backend::api::publish::PublishOutcome::Success { composition_errors } if composition_errors.is_empty() => {
+            report::publish_command_success(&subgraph_name);
+        }
+        backend::api::publish::PublishOutcome::Success { composition_errors } => {
+            report::publish_command_composition_failure(composition_errors);
+        }
+        backend::api::publish::PublishOutcome::ProjectDoesNotExist {
+            account_name,
+            project_name,
+        } => report::publish_project_does_not_exist(account_name, project_name),
+    };
 
     Ok(())
 }


### PR DESCRIPTION
Both cases were not handled specifically and we showed the Debug impl for the whole GraphQL response before this commit. Now:

- In `publish`, when the project to publish to does not exist, we now return the following error.
![2024-04-29_19-04-07](https://github.com/grafbase/grafbase/assets/13155277/a0a4f25d-8e99-419a-862e-25bb6b64aa6d)

- In `check`, when you do not pass a `--name` argument, but the project is federated (that would work for a standalone project), you get the following error:
![2024-04-29_19-04-29](https://github.com/grafbase/grafbase/assets/13155277/b4db1f31-3c94-4894-822b-cb2e7343ef82)

closes GB-6488
closes GB-6489