### PR TITLE
GB-6628 - Update Bun to 1.1.6

### DIFF
--- a/cli/crates/server/src/bun.rs
+++ b/cli/crates/server/src/bun.rs
@@ -83,7 +83,7 @@ impl From<ZipError> for BunError {
     }
 }
 
-const BUN_VERSION: &str = "1.1.5";
+const BUN_VERSION: &str = "1.1.6";
 
 #[cfg(target_arch = "aarch64")]
 const ARCH: &str = "aarch64";


### PR DESCRIPTION
# Description

## Tooling

- Updates Bun to 1.1.6

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [x] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
