### PR TITLE
engine-v2: implement and test empty schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3944,6 +3944,7 @@ dependencies = [
  "grafbase-graphql-introspection",
  "grafbase-tracing",
  "graphql-composition",
+ "graphql-federated-graph",
  "graphql-mocks",
  "graphql-parser 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "headers",

--- a/engine/crates/federated-graph/src/federated_graph/v3.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v3.rs
@@ -428,3 +428,66 @@ id_newtypes! {
     SubgraphId + subgraphs + Subgraph,
     UnionId + unions + Union,
 }
+
+impl Default for FederatedGraphV3 {
+    fn default() -> Self {
+        FederatedGraphV3 {
+            subgraphs: Vec::new(),
+            root_operation_types: RootOperationTypes {
+                query: ObjectId(0),
+                mutation: None,
+                subscription: None,
+            },
+            objects: vec![Object {
+                name: StringId(0),
+                implements_interfaces: Vec::new(),
+                keys: Vec::new(),
+                composed_directives: NO_DIRECTIVES,
+                fields: FieldId(0)..FieldId(2),
+                description: None,
+            }],
+            interfaces: Vec::new(),
+            fields: vec![
+                Field {
+                    name: StringId(1),
+                    r#type: Type {
+                        wrapping: Default::default(),
+                        definition: Definition::Scalar(ScalarId(0)),
+                    },
+                    arguments: NO_INPUT_VALUE_DEFINITION,
+                    resolvable_in: Vec::new(),
+                    provides: Vec::new(),
+                    requires: Vec::new(),
+                    overrides: Vec::new(),
+                    composed_directives: NO_DIRECTIVES,
+                    description: None,
+                },
+                Field {
+                    name: StringId(2),
+                    r#type: Type {
+                        wrapping: Default::default(),
+                        definition: Definition::Scalar(ScalarId(0)),
+                    },
+                    arguments: NO_INPUT_VALUE_DEFINITION,
+                    resolvable_in: Vec::new(),
+                    provides: Vec::new(),
+                    requires: Vec::new(),
+                    overrides: Vec::new(),
+                    composed_directives: NO_DIRECTIVES,
+                    description: None,
+                },
+            ],
+            enums: Vec::new(),
+            unions: Vec::new(),
+            scalars: Vec::new(),
+            input_objects: Vec::new(),
+            enum_values: Vec::new(),
+            input_value_definitions: Vec::new(),
+            strings: ["Query", "__type", "__schema"]
+                .into_iter()
+                .map(|string| string.to_owned())
+                .collect(),
+            directives: Vec::new(),
+        }
+    }
+}

--- a/engine/crates/integration-tests/Cargo.toml
+++ b/engine/crates/integration-tests/Cargo.toml
@@ -86,6 +86,7 @@ path = "../tracing"
 features = ["tower"]
 
 [dev-dependencies]
+graphql-federated-graph.path = "../federated-graph"
 similar-asserts = "1.5"
 base64.workspace = true
 rstest.workspace = true

--- a/engine/crates/integration-tests/src/federation/builder.rs
+++ b/engine/crates/integration-tests/src/federation/builder.rs
@@ -88,23 +88,21 @@ impl FederationGatewayBuilder {
             ..Default::default()
         });
 
-        TestFederationGateway {
-            gateway: Arc::new(engine_v2::Engine::new(
-                config.try_into().unwrap(),
-                engine_v2::EngineEnv {
-                    fetcher: runtime_local::NativeFetcher::runtime_fetcher(),
-                    cache: cache.clone(),
-                    trusted_documents: self
-                        .trusted_documents
-                        .map(trusted_documents_client::Client::new)
-                        .unwrap_or_else(|| {
-                            trusted_documents_client::Client::new(runtime_noop::trusted_documents::NoopTrustedDocuments)
-                        }),
-                    kv: runtime_local::InMemoryKvStore::runtime(),
-                    meter: grafbase_tracing::metrics::meter_from_global_provider(),
-                },
-            )),
-        }
+        TestFederationGateway::new(Arc::new(engine_v2::Engine::new(
+            config.try_into().unwrap(),
+            engine_v2::EngineEnv {
+                fetcher: runtime_local::NativeFetcher::runtime_fetcher(),
+                cache: cache.clone(),
+                trusted_documents: self
+                    .trusted_documents
+                    .map(trusted_documents_client::Client::new)
+                    .unwrap_or_else(|| {
+                        trusted_documents_client::Client::new(runtime_noop::trusted_documents::NoopTrustedDocuments)
+                    }),
+                kv: runtime_local::InMemoryKvStore::runtime(),
+                meter: grafbase_tracing::metrics::meter_from_global_provider(),
+            },
+        )))
     }
 }
 

--- a/engine/crates/integration-tests/src/federation/mod.rs
+++ b/engine/crates/integration-tests/src/federation/mod.rs
@@ -13,7 +13,7 @@ use serde::de::Error;
 use crate::engine::GraphQlRequest;
 
 pub struct TestFederationGateway {
-    gateway: Arc<engine_v2::Engine>,
+    pub gateway: Arc<engine_v2::Engine>,
 }
 
 impl TestFederationGateway {

--- a/engine/crates/integration-tests/src/federation/mod.rs
+++ b/engine/crates/integration-tests/src/federation/mod.rs
@@ -13,10 +13,14 @@ use serde::de::Error;
 use crate::engine::GraphQlRequest;
 
 pub struct TestFederationGateway {
-    pub gateway: Arc<engine_v2::Engine>,
+    gateway: Arc<engine_v2::Engine>,
 }
 
 impl TestFederationGateway {
+    pub fn new(gateway: Arc<engine_v2::Engine>) -> Self {
+        TestFederationGateway { gateway }
+    }
+
     pub fn execute(&self, operation: impl Into<GraphQlRequest>) -> ExecutionRequest {
         ExecutionRequest {
             graphql: operation.into(),

--- a/engine/crates/integration-tests/tests/federation/basic/empty_config.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/empty_config.rs
@@ -1,0 +1,37 @@
+use integration_tests::{federation::TestFederationGateway, runtime};
+use parser_sdl::federation::FederatedGraphConfig;
+use runtime::trusted_documents_client;
+use std::{future::IntoFuture, sync::Arc};
+
+#[test]
+fn works_with_empty_config() {
+    let federated_graph =
+        graphql_federated_graph::FederatedGraph::V3(graphql_federated_graph::FederatedGraphV3::default());
+
+    let cache = runtime_local::InMemoryCache::runtime(runtime::cache::GlobalCacheConfig {
+        enabled: true,
+        ..Default::default()
+    });
+
+    let federated_graph_config = FederatedGraphConfig::default();
+
+    let config = engine_config_builder::build_config(&federated_graph_config, federated_graph);
+    let gateway = TestFederationGateway::new(Arc::new(engine_v2::Engine::new(
+        engine_v2::Schema::try_from(config.into_latest()).unwrap(),
+        engine_v2::EngineEnv {
+            fetcher: runtime_local::NativeFetcher::runtime_fetcher(),
+            cache: cache.clone(),
+            trusted_documents: trusted_documents_client::Client::new(
+                runtime_noop::trusted_documents::NoopTrustedDocuments,
+            ),
+            kv: runtime_local::InMemoryKvStore::runtime(),
+            meter: grafbase_tracing::metrics::meter_from_global_provider(),
+        },
+    )));
+
+    let request = r#"{ __typename }"#;
+
+    let response = runtime().block_on(gateway.execute(request).into_future());
+
+    assert_eq!("Query", response.body["data"]["__typename"]);
+}

--- a/engine/crates/integration-tests/tests/federation/basic/mod.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/mod.rs
@@ -4,6 +4,7 @@
 //! that our engine supports all the things a normal GraphQL server should.
 
 // mod caching;
+mod empty_config;
 mod errors;
 mod fragments;
 mod headers;
@@ -15,50 +16,7 @@ mod variables;
 
 use engine_v2::Engine;
 use graphql_mocks::{FakeGithubSchema, MockGraphQlServer};
-use integration_tests::{
-    federation::{GatewayV2Ext, TestFederationGateway},
-    runtime,
-};
-use parser_sdl::federation::FederatedGraphConfig;
-use runtime::trusted_documents_client;
-use std::sync::Arc;
-
-#[test]
-fn works_with_empty_config() {
-    let federated_graph =
-        graphql_federated_graph::FederatedGraph::V3(graphql_federated_graph::FederatedGraphV3::default());
-
-    let cache = runtime_local::InMemoryCache::runtime(runtime::cache::GlobalCacheConfig {
-        enabled: true,
-        ..Default::default()
-    });
-
-    let federated_graph_config = FederatedGraphConfig::default();
-
-    let config = engine_config_builder::build_config(&federated_graph_config, federated_graph);
-    let gateway = TestFederationGateway {
-        gateway: Arc::new(engine_v2::Engine::new(
-            engine_v2::Schema::try_from(config.into_latest()).unwrap(),
-            engine_v2::EngineEnv {
-                fetcher: runtime_local::NativeFetcher::runtime_fetcher(),
-                cache: cache.clone(),
-                trusted_documents: trusted_documents_client::Client::new(
-                    runtime_noop::trusted_documents::NoopTrustedDocuments,
-                ),
-                kv: runtime_local::InMemoryKvStore::runtime(),
-                meter: grafbase_tracing::metrics::meter_from_global_provider(),
-            },
-        )),
-    };
-
-    let request: engine::Request = serde_json::from_value(serde_json::json!({"query": "{ __typename }"})).unwrap();
-
-    runtime().block_on(
-        gateway
-            .gateway
-            .execute(Default::default(), engine::BatchRequest::Single(request)),
-    );
-}
+use integration_tests::{federation::GatewayV2Ext, runtime};
 
 #[test]
 fn single_field_from_single_server() {


### PR DESCRIPTION
We want to clean up the empty state for federated graphs in the API. This is the state right after the federated graph is created, when no subgraph has been published yet. This commit implements an "empty" state for FederatedGraph that cleanly converts to an engine_v2::Schema, with a test to check that the engine can start with that schema.

Part of GB-6537