### PR TITLE
GB-6512 - Add `gqlint` binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,6 +2818,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gqlint"
+version = "0.1.1"
+dependencies = [
+ "clap",
+ "colored",
+ "graphql-lint 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+]
+
+[[package]]
 name = "grafbase"
 version = "0.70.1"
 dependencies = [
@@ -2849,7 +2859,7 @@ dependencies = [
  "grafbase-local-common",
  "grafbase-local-server",
  "graph-ref",
- "graphql-lint",
+ "graphql-lint 0.1.3",
  "graphql-mocks",
  "graphql-ws-client",
  "headers",
@@ -3156,9 +3166,20 @@ dependencies = [
 
 [[package]]
 name = "graphql-lint"
-version = "0.70.1"
+version = "0.1.3"
 dependencies = [
  "criterion",
+ "cynic-parser",
+ "heck 0.5.0",
+ "thiserror",
+]
+
+[[package]]
+name = "graphql-lint"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f471b7a105553bc432d405b90ea7737b1a611de7d3741718daffa5f62ac4ddde"
+dependencies = [
  "cynic-parser",
  "heck 0.5.0",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ members = [
   "engine/crates/engine/registry-v2",
   "engine/crates/engine/registry-v2-generator",
   "graph-ref",
-  "graphql-lint",
+  "graphql-lint", 
+  "gqlint",
 ]
 exclude = ["engine/crates/gateway-v2"]
 

--- a/gqlint/Cargo.toml
+++ b/gqlint/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "gqlint"
+version = "0.1.1"
+description = "A GraphQL SDL linting CLI"
+keywords = ["graphql", "linter"]
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+clap = {version = "4.5.4", features = ["derive"] }
+colored = "2.1.0"
+graphql-lint = "0.1.3"
+thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/gqlint/README.md
+++ b/gqlint/README.md
@@ -1,0 +1,63 @@
+# `gqlint`
+
+A GraphQL SDL linting CLI
+
+## Install
+
+```sh
+cargo install gqlint
+```
+
+## Usage
+
+```sh
+$ gqlint schema.graphql
+
+⚠️ [Warning]: directive 'WithDeprecatedArgs' should be renamed to 'withDeprecatedArgs'
+⚠️ [Warning]: argument 'ARG' on directive 'WithDeprecatedArgs' should be renamed to 'arg'
+⚠️ [Warning]: enum 'Enum_lowercase' should be renamed to 'EnumLowercase'
+⚠️ [Warning]: enum 'Enum_lowercase' has a forbidden prefix: 'Enum'
+⚠️ [Warning]: usage of directive 'deprecated' on enum 'Enum_lowercase' does not populate the 'reason' argument
+⚠️ [Warning]: value 'an_enum_member' on enum 'Enum_lowercase' should be renamed to 'AN_ENUM_MEMBER'
+⚠️ [Warning]: usage of directive 'deprecated' on enum value 'an_enum_member' on enum 'Enum_lowercase' does not populate the 'reason' argument
+⚠️ [Warning]: enum 'lowercase_Enum' should be renamed to 'LowercaseEnum'
+⚠️ [Warning]: enum 'lowercase_Enum' has a forbidden suffix: 'Enum'
+⚠️ [Warning]: value 'an_enum_member' on enum 'lowercase_Enum' should be renamed to 'AN_ENUM_MEMBER'
+⚠️ [Warning]: usage of directive 'deprecated' on enum value 'an_enum_member' on enum 'lowercase_Enum' does not populate the 'reason' argument
+⚠️ [Warning]: field 'getHello' on type 'Query' has a forbidden prefix: 'get'
+⚠️ [Warning]: field 'queryHello' on type 'Query' has a forbidden prefix: 'query'
+⚠️ [Warning]: field 'listHello' on type 'Query' has a forbidden prefix: 'list'
+⚠️ [Warning]: field 'helloQuery' on type 'Query' has a forbidden suffix: 'Query'
+⚠️ [Warning]: field 'putHello' on type 'Mutation' has a forbidden prefix: 'put'
+⚠️ [Warning]: field 'mutationHello' on type 'Mutation' has a forbidden prefix: 'mutation'
+⚠️ [Warning]: field 'postHello' on type 'Mutation' has a forbidden prefix: 'post'
+⚠️ [Warning]: field 'patchHello' on type 'Mutation' has a forbidden prefix: 'patch'
+⚠️ [Warning]: field 'helloMutation' on type 'Mutation' has a forbidden suffix: 'Mutation'
+⚠️ [Warning]: field 'subscriptionHello' on type 'Subscription' has a forbidden prefix: 'subscription'
+⚠️ [Warning]: field 'helloSubscription' on type 'Subscription' has a forbidden suffix: 'Subscription'
+⚠️ [Warning]: type 'TypeTest' has a forbidden prefix: 'Type'
+⚠️ [Warning]: usage of directive 'deprecated' on field 'name' on type 'TypeTest' does not populate the 'reason' argument
+⚠️ [Warning]: type 'TestType' has a forbidden suffix: 'Type'
+⚠️ [Warning]: type 'other' should be renamed to 'Other'
+⚠️ [Warning]: usage of directive 'deprecated' on scalar 'CustomScalar' does not populate the 'reason' argument
+⚠️ [Warning]: union 'UnionTest' has a forbidden prefix: 'Union'
+⚠️ [Warning]: usage of directive 'deprecated' on union 'UnionTest' does not populate the 'reason' argument
+⚠️ [Warning]: union 'TestUnion' has a forbidden suffix: 'Union'
+⚠️ [Warning]: interface 'GameInterface' has a forbidden suffix: 'Interface'
+⚠️ [Warning]: usage of directive 'deprecated' on field 'publisher' on interface 'GameInterface' does not populate the 'reason' argument
+⚠️ [Warning]: interface 'InterfaceGame' has a forbidden prefix: 'Interface'
+⚠️ [Warning]: usage of directive 'deprecated' on interface 'InterfaceGame' does not populate the 'reason' argument
+⚠️ [Warning]: usage of directive 'deprecated' on input 'TEST' does not populate the 'reason' argument
+⚠️ [Warning]: input value 'OTHER' on input 'TEST' should be renamed to 'other'
+⚠️ [Warning]: usage of directive 'deprecated' on input value 'OTHER' on input 'TEST' does not populate the 'reason' argument
+⚠️ [Warning]: type 'hello' should be renamed to 'Hello'
+⚠️ [Warning]: usage of directive 'deprecated' on type 'hello' does not populate the 'reason' argument
+⚠️ [Warning]: field 'Test' on type 'hello' should be renamed to 'test'
+⚠️ [Warning]: argument 'NAME' on field 'Test' on type 'hello' should be renamed to 'name'
+⚠️ [Warning]: type 'hello' should be renamed to 'Hello'
+⚠️ [Warning]: field 'GOODBYE' on type 'hello' should be renamed to 'goodbye'
+```
+
+## Rules
+
+See [`graphql-lint`](https://crates.io/crates/graphql-lint)

--- a/gqlint/src/main.rs
+++ b/gqlint/src/main.rs
@@ -1,0 +1,64 @@
+use clap::Parser;
+use colored::Colorize;
+use graphql_lint::{lint, LinterError, Severity};
+use std::{fs, path::PathBuf, process};
+
+#[derive(Debug, Parser)]
+#[command(name = "gqlint", version)]
+struct Interface {
+    /// The GraphQL SDL file to lint
+    schema: PathBuf,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum Error {
+    #[error("Could not read the provided schema file\nCaused by: {0}")]
+    ReadSchemaFile(#[from] std::io::Error),
+    #[error(transparent)]
+    Lint(#[from] LinterError),
+}
+
+fn report_error(error: Error) {
+    eprintln!("{}", format!("Error: {error}").bright_red());
+}
+
+fn report_diagnostic(message: String, severity: Severity) {
+    let label = match severity {
+        Severity::Warning => "Warning",
+    };
+    println!("{}", format!("⚠️ [{label}]: {message}").bright_yellow());
+}
+
+fn report_success() {
+    println!("{}", "✅ No issues were found in your schema".bright_green())
+}
+
+fn main() {
+    let arguments = Interface::parse();
+
+    let exit_code = match try_main(arguments) {
+        Ok(()) => 0,
+        Err(error) => {
+            report_error(error);
+            1
+        }
+    };
+
+    process::exit(exit_code);
+}
+
+fn try_main(arguments: Interface) -> Result<(), Error> {
+    let schema = fs::read_to_string(arguments.schema)?;
+    let diagnostics = lint(&schema)?;
+
+    if diagnostics.is_empty() {
+        report_success();
+        return Ok(());
+    }
+
+    for (message, severity) in diagnostics {
+        report_diagnostic(message, severity);
+    }
+
+    Ok(())
+}

--- a/graphql-lint/Cargo.toml
+++ b/graphql-lint/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "graphql-lint"
-version.workspace = true
+version = "0.1.3"
+description = "A GraphQL SDL linter"
+keywords = ["graphql", "linter"]
 edition.workspace = true
 license.workspace = true
-homepage.workspace = true
-keywords.workspace = true
 repository.workspace = true
 
 [dependencies]
@@ -21,4 +21,3 @@ harness = false
 
 [lints]
 workspace = true
-

--- a/graphql-lint/README.md
+++ b/graphql-lint/README.md
@@ -1,0 +1,57 @@
+# `graphql-lint`
+
+A Rust based linter for GraphQL SDL schemas.
+
+`graphql-lint` is used in the [Grafbase](https://grafbase.com) Platform and CLI.
+
+## Currently Supported Lints
+
+- Naming conventions
+  - Types: `PascalCase`
+    - Forbidden prefixes: `"Type"`
+    - Forbidden suffixes: `"Type"`
+  - Fields: `camelCase`
+  - Input values: `camelCase`
+  - Arguments: `camelCase`
+  - Directives: `camelCase`
+  - Enums: `PascalCase`
+    - Forbidden prefixes: `"Enum"`
+    - Forbidden suffixes: `"Enum"`
+  - Unions
+    - Forbidden prefixes: `"Union"`
+    - Forbidden suffixes: `"Union"`
+  - Enum values: `SCREAMING_SNAKE_CASE`
+  - Interfaces
+    - Forbidden prefixes: `"Interface"`
+    - Forbidden suffixes: `"Interface"`
+  - Query fields
+    - Forbidden prefixes: `["query", "get", "list"]`
+    - Forbidden suffixes: `"Query"`
+  - Mutation fields
+    - Forbidden prefixes: `["mutation", "put", "post", "patch"]`
+    - Forbidden suffixes: `"Mutation"`
+  - Subscription fields
+    - Forbidden prefixes: `"subscription"`
+    - Forbidden suffixes: `"Subscription"`
+- Usage of the `@deprecated` directive requires specifying the `reason` argument
+
+## Usage
+
+```toml
+[dependencies]
+graphql-lint = "0.1.3"
+```
+
+```rust
+use graphql_lint::lint;
+
+fn main () {
+    let schema = r#"
+        type Query {
+          hello: String!
+        }
+    "#;
+
+    let violations = lint(schema).unwrap();
+}
+```


### PR DESCRIPTION
# Description

## Features

- Adds a `gqlint` binary that runs `graphql-lint`

# Type of change

- [ ] 💔 Breaking
- [x] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
