### PR TITLE
fix: correctly prune the caching registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6271,6 +6271,7 @@ dependencies = [
  "gateway-v2-auth-config",
  "indexmap 2.2.6",
  "indoc",
+ "petgraph",
  "postgres-connector-types",
  "registry-v2",
  "serde",

--- a/engine/crates/engine/derive/src/complex_object.rs
+++ b/engine/crates/engine/derive/src/complex_object.rs
@@ -329,7 +329,7 @@ pub fn generate(object_args: &args::ComplexObject, item_impl: &mut ItemImpl) -> 
                     },
                     ty: <#schema_ty as #crate_name::LegacyOutputType>::create_type_info(registry),
                     deprecation: #field_deprecation,
-                    cache_control: Some(Box::new(#cache_control)),
+                    cache_control: None,
                     provides: #provides,
                     requires: #requires,
                     ..Default::default()

--- a/engine/crates/engine/derive/src/object.rs
+++ b/engine/crates/engine/derive/src/object.rs
@@ -342,7 +342,7 @@ pub fn generate(object_args: &args::Object, item_impl: &mut ItemImpl) -> Generat
                         },
                         ty: <#schema_ty as #crate_name::LegacyOutputType>::create_type_info(registry),
                         deprecation: #field_deprecation,
-                        cache_control: Some(Box::new(#cache_control)),
+                        cache_control: None,
                         resolver: #crate_name::registry::resolvers::Resolver::Parent,
                         ..Default::default()
                     });
@@ -473,7 +473,7 @@ pub fn generate(object_args: &args::Object, item_impl: &mut ItemImpl) -> Generat
                                 #(#schema_fields)*
                                 fields
                             },
-                            cache_control: Some(Box::new(#cache_control)),
+                            cache_control: None,
                             extends: #extends,
                             is_node: false,
 
@@ -516,7 +516,7 @@ pub fn generate(object_args: &args::Object, item_impl: &mut ItemImpl) -> Generat
                                 #(#schema_fields)*
                                 fields
                             },
-                            cache_control: Some(Box::new(#cache_control)),
+                            cache_control: None,
                             extends: #extends,
 
                             is_node: false,

--- a/engine/crates/engine/derive/src/simple_object.rs
+++ b/engine/crates/engine/derive/src/simple_object.rs
@@ -313,7 +313,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
                                 #concat_complex_fields
                                 fields
                             },
-                            cache_control: Some(Box::new(#cache_control)),
+                            cache_control: None,
                             extends: #extends,
 
                             is_subscription: false,
@@ -383,7 +383,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
                                 ::std::iter::Extend::extend(&mut fields, complex_fields.clone());
                                 fields
                             },
-                            cache_control: Some(Box::new(#cache_control)),
+                            cache_control: None,
                             extends: #extends,
 
                             is_subscription: false,

--- a/engine/crates/engine/registry-for-cache/src/extensions.rs
+++ b/engine/crates/engine/registry-for-cache/src/extensions.rs
@@ -7,6 +7,7 @@ impl<'a> MetaType<'a> {
         match self {
             MetaType::Object(object) => object.name(),
             MetaType::Interface(iface) => iface.name(),
+            MetaType::Other(other) => other.name(),
         }
     }
 
@@ -14,6 +15,7 @@ impl<'a> MetaType<'a> {
         match self {
             MetaType::Object(inner) => Some(inner.fields()),
             MetaType::Interface(inner) => Some(inner.fields()),
+            MetaType::Other(_) => None,
         }
     }
 
@@ -21,6 +23,7 @@ impl<'a> MetaType<'a> {
         match self {
             MetaType::Object(object) => object.cache_control(),
             MetaType::Interface(iface) => iface.cache_control(),
+            MetaType::Other(_) => None,
         }
     }
 }
@@ -30,6 +33,7 @@ impl<'a> MetaType<'a> {
         match self {
             MetaType::Object(obj) => obj.field(name),
             MetaType::Interface(iface) => iface.field(name),
+            MetaType::Other(_) => None,
         }
     }
 }

--- a/engine/crates/engine/registry-for-cache/src/generated.rs
+++ b/engine/crates/engine/registry-for-cache/src/generated.rs
@@ -24,3 +24,4 @@ pub mod field;
 pub mod interface;
 pub mod metatype;
 pub mod objects;
+pub mod others;

--- a/engine/crates/engine/registry-for-cache/src/generated/metatype.rs
+++ b/engine/crates/engine/registry-for-cache/src/generated/metatype.rs
@@ -2,7 +2,8 @@ use super::prelude::*;
 use super::{
     interface::InterfaceType,
     objects::ObjectType,
-    prelude::ids::{InterfaceTypeId, MetaTypeId, ObjectTypeId},
+    others::OtherType,
+    prelude::ids::{InterfaceTypeId, MetaTypeId, ObjectTypeId, OtherTypeId},
 };
 #[allow(unused_imports)]
 use std::fmt::{self, Write};
@@ -13,12 +14,15 @@ pub enum MetaTypeRecord {
     Object(ObjectTypeId),
     #[serde(rename = "1")]
     Interface(InterfaceTypeId),
+    #[serde(rename = "2")]
+    Other(OtherTypeId),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MetaType<'a> {
     Object(ObjectType<'a>),
     Interface(InterfaceType<'a>),
+    Other(OtherType<'a>),
 }
 
 impl RegistryId for MetaTypeId {
@@ -34,6 +38,7 @@ impl<'a> From<ReadContext<'a, MetaTypeId>> for MetaType<'a> {
         match value.registry.lookup(value.id) {
             MetaTypeRecord::Object(id) => MetaType::Object(value.registry.read(*id)),
             MetaTypeRecord::Interface(id) => MetaType::Interface(value.registry.read(*id)),
+            MetaTypeRecord::Other(id) => MetaType::Other(value.registry.read(*id)),
         }
     }
 }

--- a/engine/crates/engine/registry-for-cache/src/generated/others.rs
+++ b/engine/crates/engine/registry-for-cache/src/generated/others.rs
@@ -1,0 +1,47 @@
+use super::prelude::ids::OtherTypeId;
+use super::prelude::*;
+#[allow(unused_imports)]
+use std::fmt::{self, Write};
+
+#[derive(serde :: Serialize, serde :: Deserialize)]
+pub struct OtherTypeRecord {
+    #[serde(rename = "0")]
+    pub name: StringId,
+}
+
+#[derive(Clone, Copy)]
+pub struct OtherType<'a>(pub(crate) ReadContext<'a, OtherTypeId>);
+
+impl<'a> OtherType<'a> {
+    pub fn name(&self) -> &'a str {
+        let registry = &self.0.registry;
+        registry.lookup(registry.lookup(self.0.id).name)
+    }
+}
+
+impl fmt::Debug for OtherType<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OtherType").field("name", &self.name()).finish()
+    }
+}
+
+impl std::cmp::PartialEq for OtherType<'_> {
+    fn eq(&self, other: &OtherType<'_>) -> bool {
+        std::ptr::eq(self.0.registry, other.0.registry) && self.0.id == other.0.id
+    }
+}
+impl std::cmp::Eq for OtherType<'_> {}
+
+impl RegistryId for OtherTypeId {
+    type Reader<'a> = OtherType<'a>;
+}
+
+impl IdReader for OtherType<'_> {
+    type Id = OtherTypeId;
+}
+
+impl<'a> From<ReadContext<'a, OtherTypeId>> for OtherType<'a> {
+    fn from(value: ReadContext<'a, OtherTypeId>) -> Self {
+        Self(value)
+    }
+}

--- a/engine/crates/engine/registry-for-cache/src/ids.rs
+++ b/engine/crates/engine/registry-for-cache/src/ids.rs
@@ -11,4 +11,6 @@ impl_id_range!(MetaFieldId);
 
 make_id!(InterfaceTypeId, InterfaceTypeRecord, interfaces, PartialCacheRegistry);
 
+make_id!(OtherTypeId, OtherTypeRecord, others, PartialCacheRegistry);
+
 make_id!(StringId, str, strings, PartialCacheRegistry);

--- a/engine/crates/engine/registry-for-cache/src/lib.rs
+++ b/engine/crates/engine/registry-for-cache/src/lib.rs
@@ -18,7 +18,9 @@ pub mod writer;
 
 pub use self::{
     common::*,
-    generated::{field::MetaField, interface::InterfaceType, metatype::MetaType, objects::ObjectType},
+    generated::{
+        field::MetaField, interface::InterfaceType, metatype::MetaType, objects::ObjectType, others::OtherType,
+    },
 };
 pub use engine_id_newtypes::IdRange;
 
@@ -32,6 +34,8 @@ pub struct PartialCacheRegistry {
     object_fields: Vec<storage::MetaFieldRecord>,
 
     interfaces: Vec<storage::InterfaceTypeRecord>,
+
+    others: Vec<storage::OtherTypeRecord>,
 
     query_type: MetaTypeId,
     mutation_type: Option<MetaTypeId>,
@@ -71,6 +75,7 @@ impl PartialCacheRegistry {
             .binary_search_by_key(&string_id, |ty| match ty {
                 storage::MetaTypeRecord::Object(id) => self.lookup(*id).name,
                 storage::MetaTypeRecord::Interface(id) => self.lookup(*id).name,
+                storage::MetaTypeRecord::Other(id) => self.lookup(*id).name,
             })
             .ok()?;
 
@@ -124,7 +129,8 @@ pub mod storage {
     pub use super::{
         field_types::MetaFieldTypeRecord,
         generated::{
-            field::MetaFieldRecord, interface::InterfaceTypeRecord, metatype::MetaTypeRecord, objects::ObjectTypeRecord,
+            field::MetaFieldRecord, interface::InterfaceTypeRecord, metatype::MetaTypeRecord,
+            objects::ObjectTypeRecord, others::OtherTypeRecord,
         },
     };
 }

--- a/engine/crates/engine/registry-for-cache/src/writer.rs
+++ b/engine/crates/engine/registry-for-cache/src/writer.rs
@@ -23,6 +23,8 @@ pub struct RegistryWriter {
 
     interfaces: Vec<storage::InterfaceTypeRecord>,
 
+    others: Vec<storage::OtherTypeRecord>,
+
     pub query_type: Option<MetaTypeId>,
     pub mutation_type: Option<MetaTypeId>,
     pub subscription_type: Option<MetaTypeId>,
@@ -77,6 +79,13 @@ impl RegistryWriter {
     }
 
     #[must_use]
+    pub fn insert_other(&mut self, details: OtherTypeRecord) -> MetaTypeRecord {
+        let id = OtherTypeId::new(self.others.len());
+        self.others.push(details);
+        MetaTypeRecord::Other(id)
+    }
+
+    #[must_use]
     pub fn intern_str(&mut self, string: &str) -> StringId {
         let (id, _) = self.strings.insert_full(string.into());
         StringId::new(id)
@@ -99,6 +108,7 @@ impl RegistryWriter {
             subscription_type,
             interfaces,
             enable_caching,
+            others,
         } = self;
 
         let types = types
@@ -118,6 +128,7 @@ impl RegistryWriter {
             subscription_type,
             interfaces,
             enable_caching,
+            others,
         })
     }
 
@@ -134,6 +145,7 @@ impl RegistryWriter {
         let string_id = match record {
             MetaTypeRecord::Object(inner) => self.objects[inner.to_index()].name,
             MetaTypeRecord::Interface(inner) => self.interfaces[inner.to_index()].name,
+            MetaTypeRecord::Other(inner) => self.others[inner.to_index()].name,
         };
 
         &self.strings[string_id.to_index()]

--- a/engine/crates/engine/registry-v1/Cargo.toml
+++ b/engine/crates/engine/registry-v1/Cargo.toml
@@ -12,6 +12,7 @@ engine-value.workspace = true
 gateway-v2-auth-config.workspace = true
 indexmap.workspace = true
 indoc = "2.0.5"
+petgraph = "0.6"
 postgres-connector-types.workspace = true
 registry-v2.workspace = true
 serde.workspace = true

--- a/engine/crates/engine/registry-v1/src/cache_pruning.rs
+++ b/engine/crates/engine/registry-v1/src/cache_pruning.rs
@@ -1,0 +1,167 @@
+use indexmap::{IndexMap, IndexSet};
+use petgraph::{graphmap::GraphMap, visit::EdgeRef};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+enum Node<'a> {
+    Type(&'a str),
+    Field(&'a str, &'a str),
+}
+
+type Graph<'a> = GraphMap<Node<'a>, (), petgraph::Directed>;
+
+use crate::{MetaType, Registry};
+
+impl super::Registry {
+    /// Prunes the Registry to only types that we need for caching.
+    ///
+    /// This means any types that:
+    /// - Have cache_control on them
+    /// - Have any fields with cache_control on them
+    /// - Are used on any fields with cache_control.
+    /// - Have any descendants that have cache_control on them.
+    pub fn prune_for_caching_registry(self) -> Self {
+        let types = self.types;
+
+        // This algorithm is basically just a big DFS on the type graph,
+        // so lets use petgraph to save implementing it by hand.
+        let graph = build_type_graph(&types);
+
+        // Map where keys are types to retain, value is list of fields we should retain on that type
+        let mut retain_map = dbg!(types_and_fields_marked_cache(&types));
+        let specifically_cached_types = retain_map.keys().map(|key| Node::Type(key)).collect::<Vec<_>>();
+
+        let graph = petgraph::visit::EdgeFiltered::from_fn(&graph, |edge| {
+            // Stop the traversal when we hit the Query type.
+            edge.source() != Node::Type(&self.query_type)
+        });
+        let mut dfs = petgraph::visit::Dfs::empty(&graph);
+        dfs.stack.extend(specifically_cached_types);
+        while let Some(node) = dfs.next(&graph) {
+            match node {
+                Node::Type(ty) => {
+                    retain_map.entry(ty).or_default();
+
+                    if let Some(MetaType::Interface(iface)) = types.get(ty) {
+                        for ty in &iface.possible_types {
+                            retain_map.entry(ty);
+                        }
+                    }
+                }
+                Node::Field(ty, field) => {
+                    retain_map.entry(ty).or_default().push(field);
+                }
+            }
+        }
+
+        retain_field_targets(&mut retain_map, &types);
+
+        let types_with_cache = types
+            .iter()
+            .filter_map(|(type_name, type_value)| {
+                let keys_to_retain = retain_map.get(type_name.as_str())?;
+
+                let type_name = type_name.clone();
+                let mut type_value = type_value.clone();
+
+                if let Some(fields) = type_value.fields_mut() {
+                    fields.retain(|name, _| keys_to_retain.contains(&name.as_str()));
+                }
+
+                Some((type_name, type_value))
+            })
+            .collect();
+
+        Registry {
+            enable_caching: self.enable_caching,
+            types: types_with_cache,
+            ..Default::default()
+        }
+    }
+}
+
+fn build_type_graph(types: &std::collections::BTreeMap<String, MetaType>) -> Graph<'_> {
+    // This won't be accurate, but its a starting point
+    let mut graph = Graph::with_capacity(types.len(), types.len());
+
+    for ty in types.values() {
+        graph.add_node(Node::Type(ty.name()));
+    }
+
+    for ty in types.values() {
+        let Some(fields) = ty.fields() else { continue };
+        let container_type = Node::Type(ty.name());
+        for field in fields.values() {
+            let field_node = Node::Field(ty.name(), field.name.as_str());
+            let field_type = Node::Type(field.ty.base_type_name());
+            graph.add_node(field_node);
+
+            // We're interested in walking the tree from cacheable fields/types to
+            // the root, so we add our edges in that direction.
+            graph.add_edge(field_type, field_node, ());
+            graph.add_edge(field_node, container_type, ());
+        }
+    }
+
+    graph
+}
+
+/// Finds the types and fields that need to be handled for caching
+fn types_and_fields_marked_cache(types: &std::collections::BTreeMap<String, MetaType>) -> IndexMap<&str, Vec<&str>> {
+    types
+        .iter()
+        .filter_map(|(type_name, type_value)| {
+            // it is expected that the Query node is always present as it is the starting point
+            // for validation visiting. check rules/visitor.rs:588
+            if *type_name == "Query" {
+                return Some((type_name.as_str(), vec![]));
+            }
+
+            match type_value {
+                MetaType::Object(object) if object.cache_control.is_some() => {
+                    let fields = object
+                        .fields
+                        .values()
+                        .filter(|field| field.cache_control.is_some())
+                        .map(|field| field.name.as_str())
+                        .collect();
+
+                    Some((type_name.as_str(), fields))
+                }
+                MetaType::Interface(interface) if interface.cache_control.is_some() => {
+                    let fields = interface
+                        .fields
+                        .values()
+                        .filter(|field| field.cache_control.is_some())
+                        .map(|field| field.name.as_str())
+                        .collect();
+
+                    Some((type_name.as_str(), fields))
+                }
+                _ => None,
+            }
+        })
+        .collect()
+}
+
+// At this point we have a map of all the types & fields specifically marked for caching.
+// We need to go through any of those fields and make sure that their target types
+// are also marked for retention
+fn retain_field_targets<'a>(
+    retain_map: &mut IndexMap<&'a str, Vec<&'a str>>,
+    types: &'a std::collections::BTreeMap<String, MetaType>,
+) {
+    let mut retain_types = IndexSet::new();
+    for (ty, fields) in retain_map.iter() {
+        let meta_type = &types[*ty];
+        for field_name in fields {
+            let Some(fields) = meta_type.fields() else {
+                continue;
+            };
+            retain_types.insert(fields[*field_name].ty.base_type_name());
+        }
+    }
+
+    for ty in retain_types {
+        retain_map.entry(ty).or_default();
+    }
+}

--- a/engine/crates/engine/registry-v1/src/lib.rs
+++ b/engine/crates/engine/registry-v1/src/lib.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
+mod cache_pruning;
 mod constraint;
 mod directives;
 mod enums;

--- a/engine/crates/engine/registry-v1/src/registry_impl.rs
+++ b/engine/crates/engine/registry-v1/src/registry_impl.rs
@@ -533,47 +533,6 @@ impl Registry {
             }
         }
     }
-
-    pub fn prune_for_caching_registry(self) -> Self {
-        let types_with_cache = self
-            .types
-            .iter()
-            .filter_map(|(type_name, type_value)| {
-                // it is expected that the Query node is always present as it is the starting point
-                // for validation visiting. check rules/visitor.rs:588
-                if *type_name == "Query" {
-                    return Some((type_name.to_string(), type_value.clone()));
-                }
-
-                match type_value {
-                    MetaType::Object(o) => {
-                        if o.cache_control != Default::default() {
-                            return Some((type_name.clone(), MetaType::Object(o.clone())));
-                        }
-                        None
-                    }
-                    MetaType::Interface(i) => {
-                        let has_relevant_cache_control = i
-                            .fields
-                            .values()
-                            .find(|value| value.cache_control != Default::default());
-
-                        if has_relevant_cache_control.is_some() {
-                            return Some((type_name.clone(), MetaType::Interface(i.clone())));
-                        }
-                        None
-                    }
-                    _ => None,
-                }
-            })
-            .collect();
-
-        Registry {
-            enable_caching: self.enable_caching,
-            types: types_with_cache,
-            ..Default::default()
-        }
-    }
 }
 
 fn is_system_type(name: &str) -> bool {

--- a/engine/crates/engine/registry-v2-generator/domain/registry-for-cache.graphql
+++ b/engine/crates/engine/registry-v2-generator/domain/registry-for-cache.graphql
@@ -1,4 +1,7 @@
-union MetaType @distinct @file(name: "metatype") @variant(names: ["Object", "Interface"]) = ObjectType | InterfaceType
+union MetaType @distinct @file(name: "metatype") @variant(names: ["Object", "Interface", "Other"]) =
+    ObjectType
+  | InterfaceType
+  | OtherType
 
 type ObjectType @file(name: "objects") @distinct {
   name: String!
@@ -22,6 +25,12 @@ type InterfaceType @file(name: "interface") @distinct {
   fields: [MetaField!]!
   cache_control: CacheControl
   possible_types: [MetaType] @inline
+}
+
+# We do still need to reference scalar etc. types in this schema
+# so here's a catch all
+type OtherType @file(name: "others") @distinct {
+  name: String!
 }
 
 # String is built in, but easier to implement stuff if its just in the .graphql file

--- a/engine/crates/engine/src/registry/tests.rs
+++ b/engine/crates/engine/src/registry/tests.rs
@@ -4,7 +4,7 @@ use sha2::{Digest, Sha256};
 
 use super::*;
 
-const EXPECTED_SHA: &str = "7e7bd6644c51d7b6ffcb1aad5b6cdb37660d0d05cb835d417d8e79d2a08bbd74";
+const EXPECTED_SHA: &str = "e6b38585432832f53a25f44a549ad6a4bdfd969983992b5bb7274aeaf85ddaa8";
 
 #[test]
 fn test_serde_roundtrip() {

--- a/engine/crates/engine/validation/src/registries/partial_caching_registry.rs
+++ b/engine/crates/engine/validation/src/registries/partial_caching_registry.rs
@@ -54,6 +54,7 @@ impl<'a> AnyMetaType<'a> for MetaType<'a> {
         match self {
             MetaType::Object(_) => None,
             MetaType::Interface(interface) => Some(interface.possible_types()),
+            MetaType::Other(_) => None,
         }
     }
 

--- a/engine/crates/gateway-core/src/cache/build_key.rs
+++ b/engine/crates/gateway-core/src/cache/build_key.rs
@@ -334,6 +334,8 @@ mod tests {
 
     fn config(cache_control: Option<engine::CacheControl>) -> CacheConfig {
         let mut registry = Registry::new();
+        registry.add_builtins_to_registry();
+
         registry.create_type(
             |_| {
                 MetaType::Object({
@@ -351,6 +353,8 @@ mod tests {
         );
         registry.enable_caching = true;
 
+        registry.remove_unused_types();
+        let registry = dbg!(registry.prune_for_caching_registry());
         let partial_registry = registry_upgrade::convert_v1_to_partial_cache_registry(registry);
 
         CacheConfig {

--- a/engine/crates/parser-graphql/src/snapshots/parser_graphql__conversion__tests__array_input_value.snap
+++ b/engine/crates/parser-graphql/src/snapshots/parser_graphql__conversion__tests__array_input_value.snap
@@ -780,10 +780,10 @@ expression: registry_from_introspection(schema)
       "name": "deprecated",
       "description": "Marks an element of a GraphQL schema as no longer supported.",
       "locations": [
-        "ARGUMENT_DEFINITION",
-        "ENUM_VALUE",
-        "FIELD_DEFINITION",
-        "INPUT_FIELD_DEFINITION"
+        "ArgumentDefinition",
+        "EnumValue",
+        "FieldDefinition",
+        "InputFieldDefinition"
       ],
       "args": {
         "reason": {
@@ -799,9 +799,9 @@ expression: registry_from_introspection(schema)
       "name": "include",
       "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
       "locations": [
-        "FIELD",
-        "FRAGMENT_SPREAD",
-        "INLINE_FRAGMENT"
+        "Field",
+        "FragmentSpread",
+        "InlineFragment"
       ],
       "args": {
         "if": {
@@ -816,9 +816,9 @@ expression: registry_from_introspection(schema)
       "name": "skip",
       "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
       "locations": [
-        "FIELD",
-        "FRAGMENT_SPREAD",
-        "INLINE_FRAGMENT"
+        "Field",
+        "FragmentSpread",
+        "InlineFragment"
       ],
       "args": {
         "if": {
@@ -833,7 +833,7 @@ expression: registry_from_introspection(schema)
       "name": "specifiedBy",
       "description": "Exposes a URL that specifies the behavior of this scalar.",
       "locations": [
-        "SCALAR"
+        "Scalar"
       ],
       "args": {
         "url": {
@@ -865,6 +865,7 @@ expression: registry_from_introspection(schema)
   "enable_caching": false,
   "enable_kv": false,
   "enable_ai": false,
+  "enable_codegen": false,
   "is_federated": false,
   "operation_limits": {
     "depth": null,

--- a/engine/crates/parser-graphql/src/snapshots/parser_graphql__conversion__tests__conversion.snap
+++ b/engine/crates/parser-graphql/src/snapshots/parser_graphql__conversion__tests__conversion.snap
@@ -2751,8 +2751,8 @@ expression: registry_from_introspection(schema)
       "name": "deprecated",
       "description": "Marks an element of a GraphQL schema as no longer supported.",
       "locations": [
-        "FIELD_DEFINITION",
-        "ENUM_VALUE"
+        "FieldDefinition",
+        "EnumValue"
       ],
       "args": {
         "reason": {
@@ -2768,9 +2768,9 @@ expression: registry_from_introspection(schema)
       "name": "include",
       "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
       "locations": [
-        "FIELD",
-        "FRAGMENT_SPREAD",
-        "INLINE_FRAGMENT"
+        "Field",
+        "FragmentSpread",
+        "InlineFragment"
       ],
       "args": {
         "if": {
@@ -2785,9 +2785,9 @@ expression: registry_from_introspection(schema)
       "name": "skip",
       "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
       "locations": [
-        "FIELD",
-        "FRAGMENT_SPREAD",
-        "INLINE_FRAGMENT"
+        "Field",
+        "FragmentSpread",
+        "InlineFragment"
       ],
       "args": {
         "if": {
@@ -2838,6 +2838,7 @@ expression: registry_from_introspection(schema)
   "enable_caching": false,
   "enable_kv": false,
   "enable_ai": false,
+  "enable_codegen": false,
   "is_federated": false,
   "operation_limits": {
     "depth": null,

--- a/engine/crates/parser-openapi/src/output/federation.rs
+++ b/engine/crates/parser-openapi/src/output/federation.rs
@@ -164,10 +164,9 @@ impl ResourceOperation {
                 // input_name without applying transforms
                 let variable_resolve_definition = match input_value_type {
                     None => VariableResolveDefinition::local_data(input_name),
-                    Some(input_value_type) => VariableResolveDefinition::local_data_with_transforms(
-                        input_name,
-                        input_value_type.base_type_name().to_string(),
-                    ),
+                    Some(input_value_type) => {
+                        VariableResolveDefinition::local_data_with_transforms(input_name, input_value_type.to_string())
+                    }
                 };
 
                 http::PathParameter {

--- a/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__flat_output-2.snap
+++ b/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__flat_output-2.snap
@@ -1710,9 +1710,7 @@ Registry {
                                         variable_resolve_definition: LocalDataWithTransforms(
                                             (
                                                 "username",
-                                                InputValueType(
-                                                    "String!",
-                                                ),
+                                                "String!",
                                             ),
                                         ),
                                     },
@@ -1730,6 +1728,7 @@ Registry {
         },
     },
     enable_ai: false,
+    enable_codegen: false,
     is_federated: false,
     operation_limits: OperationLimits {
         depth: None,

--- a/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__petstore_output-2.snap
+++ b/engine/crates/parser-openapi/src/tests/snapshots/parser_openapi__tests__petstore_output-2.snap
@@ -1774,9 +1774,7 @@ Registry {
                                         variable_resolve_definition: LocalDataWithTransforms(
                                             (
                                                 "username",
-                                                InputValueType(
-                                                    "String!",
-                                                ),
+                                                "String!",
                                             ),
                                         ),
                                     },
@@ -1794,6 +1792,7 @@ Registry {
         },
     },
     enable_ai: false,
+    enable_codegen: false,
     is_federated: false,
     operation_limits: OperationLimits {
         depth: None,

--- a/gateway/crates/gateway-binary/tests/.integration_tests.rs.pending-snap
+++ b/gateway/crates/gateway-binary/tests/.integration_tests.rs.pending-snap
@@ -1,0 +1,6 @@
+{"run_id":"2bab5e53-b736-4e31-ab0b-c6c6ef41dfbf","line":621,"new":{"module_name":"integration_tests","snapshot_name":"hybrid_graph","metadata":{"source":"gateway/crates/gateway-binary/tests/integration_tests.rs","assertion_line":621,"expression":"&result"},"snapshot":"{\n  \"errors\": [\n    {\n      \"message\": \"there are no subgraphs registered currently\"\n    }\n  ]\n}"},"old":{"module_name":"integration_tests","metadata":{},"snapshot":"{\n  \"data\": {},\n  \"errors\": [\n    {\n      \"message\": \"error sending request for url (http://127.0.0.1:46697/)\"\n    }\n  ]\n}"}}
+{"run_id":"2bab5e53-b736-4e31-ab0b-c6c6ef41dfbf","line":533,"new":null,"old":null}
+{"run_id":"2bab5e53-b736-4e31-ab0b-c6c6ef41dfbf","line":417,"new":null,"old":null}
+{"run_id":"2bab5e53-b736-4e31-ab0b-c6c6ef41dfbf","line":592,"new":null,"old":null}
+{"run_id":"2bab5e53-b736-4e31-ab0b-c6c6ef41dfbf","line":508,"new":null,"old":null}
+{"run_id":"2bab5e53-b736-4e31-ab0b-c6c6ef41dfbf","line":442,"new":null,"old":null}


### PR DESCRIPTION
The caching registry was just stripping out types that didn't have a cache_config on them.  This was too simple and had some problems:

- If a field on a cached type contains e.g. `String!` then the registry is invalid as `String!` isn't a cached type and isn't included in the registry.
- If a cached type is nested inside a non-cached type then the path to that cached type won't be in the `Registry` so the visitor in `validation` won't have `current_type` info and that type won't be correctly included in the cache key in the gateway.
- Possibly other problems, but those are the main ones.

This PR fixes that: we now do a proper traversal of the type graph to make sure we include all the cached types, their cached fields, the types their cached fields point to and any intermediate types between the cached type and the root.  

For some schemas this might lead to a lot more stuff being included in the registry, which might have impacts on loading times etc.  Hopefully nobody is caching any seriously nested types, but we might need to keep an eye on this.

There's also some unrelated snapshot changes in here, pay them no mind.