### PR TITLE
fix: the rest of the tests for new registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1987,6 +1987,7 @@ dependencies = [
  "multer",
  "pin-project-lite",
  "postgres-connector-types",
+ "registry-upgrade",
  "registry-v1",
  "registry-v2",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5478,6 +5478,7 @@ dependencies = [
  "insta",
  "itertools 0.12.1",
  "maplit",
+ "meta-type-name",
  "nom",
  "pretty_assertions",
  "regex",

--- a/cli/crates/cli/tests/graphql-directive/transforms.rs
+++ b/cli/crates/cli/tests/graphql-directive/transforms.rs
@@ -32,8 +32,8 @@ async fn graphql_test_with_transforms() {
     }
 
     type PullRequest implements PullRequestOrIssue {
-      title: String!
       checks: [String!]!
+      title: String!
     }
 
     interface PullRequestOrIssue {
@@ -41,9 +41,9 @@ async fn graphql_test_with_transforms() {
     }
 
     type Query {
-      serverVersion: String!
-      pullRequestOrIssue(id: ID!): PullRequestOrIssue
       headers: [Header!]!
+      pullRequestOrIssue(id: ID!): PullRequestOrIssue
+      serverVersion: String!
     }
 
     "###);

--- a/cli/crates/cli/tests/openapi/main.rs
+++ b/cli/crates/cli/tests/openapi/main.rs
@@ -105,12 +105,12 @@ async fn openapi_test() {
 
     insta::assert_yaml_snapshot!(mock_guard.received_json_bodies().await, @r###"
     ---
-    - status: available
-      tags: []
-      photoUrls: []
-      category: {}
-      name: Doggie
+    - category: {}
       id: 123
+      name: Doggie
+      photoUrls: []
+      status: available
+      tags: []
     "###);
 }
 

--- a/cli/crates/gateway/src/lib.rs
+++ b/cli/crates/gateway/src/lib.rs
@@ -35,7 +35,7 @@ impl Gateway {
             global_enabled: true,
             subdomain: "localhost".to_string(),
             host_name: "localhost".to_string(),
-            partial_registry: caching_registry,
+            partial_registry: Arc::new(caching_registry),
             common_cache_tags: vec![],
         };
         let authorizer = Box::new(auth::Authorizer);

--- a/engine/crates/engine/Cargo.toml
+++ b/engine/crates/engine/Cargo.toml
@@ -89,6 +89,7 @@ reqwest = { workspace = true, features = [
 [dev-dependencies]
 indoc = "2.0.5"
 insta.workspace = true
+registry-upgrade.workspace = true
 rstest.workspace = true
 runtime = { workspace = true, features = ["test-utils"] }
 sha2.workspace = true

--- a/engine/crates/engine/registry-for-cache/src/lib.rs
+++ b/engine/crates/engine/registry-for-cache/src/lib.rs
@@ -3,7 +3,7 @@
 //! We don't use the full registry for this because it's large and caching
 //! needs to be fast.
 
-use std::cmp::Ordering;
+use std::{cmp::Ordering, fmt};
 
 use ids::{MetaTypeId, StringId};
 use indexmap::IndexSet;
@@ -44,6 +44,15 @@ pub struct PartialCacheRegistry {
     pub enable_caching: bool,
 }
 
+impl fmt::Debug for PartialCacheRegistry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Not convinced there's any point in printing the contents of this.
+        // We could probably use the Debug impls of all the Readers if neccesary,
+        // but for now I'm just going to skip.
+        f.debug_struct("PartialCacheRegistry").finish_non_exhaustive()
+    }
+}
+
 impl PartialCacheRegistry {
     pub fn types(&self) -> Iter<'_, MetaType<'_>> {
         Iter::new(
@@ -68,14 +77,43 @@ impl PartialCacheRegistry {
         self.subscription_type.map(|id| self.read(id))
     }
 
+    /// There are some api tests that need an empty PartialCacheRegistry simply
+    /// for serialization.  This function allows those tests to do that, but is
+    /// marked unsafe, because if you actually try to use this registry things are
+    /// going to blow up.
+    ///
+    /// ### Safety
+    ///
+    /// tldr: don't use this function.
+    ///
+    /// The Registry it creates is safe to do serde things with.  It is not safe
+    /// to use for much else.
+    pub unsafe fn empty() -> PartialCacheRegistry {
+        PartialCacheRegistry {
+            strings: Default::default(),
+            types: Default::default(),
+            objects: Default::default(),
+            object_fields: Default::default(),
+            interfaces: Default::default(),
+            others: Default::default(),
+            // This is the unsafe bit - referencing a type that doesn't exist.
+            query_type: MetaTypeId::new(0),
+            mutation_type: Default::default(),
+            subscription_type: Default::default(),
+            enable_caching: Default::default(),
+        }
+    }
+
     fn lookup_type_id(&self, name: &str) -> Option<MetaTypeId> {
-        let string_id = StringId::new(self.strings.get_index_of(name)?);
         let type_id = self
             .types
-            .binary_search_by_key(&string_id, |ty| match ty {
-                storage::MetaTypeRecord::Object(id) => self.lookup(*id).name,
-                storage::MetaTypeRecord::Interface(id) => self.lookup(*id).name,
-                storage::MetaTypeRecord::Other(id) => self.lookup(*id).name,
+            .binary_search_by(|ty| {
+                let type_name_id = match ty {
+                    storage::MetaTypeRecord::Object(id) => self.lookup(*id).name,
+                    storage::MetaTypeRecord::Interface(id) => self.lookup(*id).name,
+                    storage::MetaTypeRecord::Other(id) => self.lookup(*id).name,
+                };
+                self.string_cmp(type_name_id, name)
             })
             .ok()?;
 

--- a/engine/crates/engine/registry-v2/src/common/iter.rs
+++ b/engine/crates/engine/registry-v2/src/common/iter.rs
@@ -1,4 +1,4 @@
-use std::iter::FusedIterator;
+use std::{fmt, iter::FusedIterator};
 
 use crate::{Registry, RegistryId};
 use engine_id_newtypes::{IdOperations, IdRange};
@@ -61,4 +61,17 @@ where
     T::Id: IdOperations,
     IdRange<T::Id>: FusedIterator,
 {
+}
+
+impl<'a, T> fmt::Debug for Iter<'a, T>
+where
+    T: IdReader,
+    T::Id: IdOperations,
+    IdRange<T::Id>: ExactSizeIterator,
+    <T::Id as RegistryId>::Reader<'a>: fmt::Debug,
+    Self: Copy,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(*self).finish()
+    }
 }

--- a/engine/crates/engine/registry-v2/src/lib.rs
+++ b/engine/crates/engine/registry-v2/src/lib.rs
@@ -168,16 +168,18 @@ impl Registry {
     }
 
     fn lookup_type_id(&self, name: &str) -> Option<MetaTypeId> {
-        let string_id = StringId::new(self.strings.get_index_of(name)?);
         let type_id = self
             .types
-            .binary_search_by_key(&string_id, |ty| match ty {
-                storage::MetaTypeRecord::Object(id) => self.lookup(*id).name,
-                storage::MetaTypeRecord::Interface(id) => self.lookup(*id).name,
-                storage::MetaTypeRecord::Union(id) => self.lookup(*id).name,
-                storage::MetaTypeRecord::Enum(id) => self.lookup(*id).name,
-                storage::MetaTypeRecord::InputObject(id) => self.lookup(*id).name,
-                storage::MetaTypeRecord::Scalar(id) => self.lookup(*id).name,
+            .binary_search_by(|ty| {
+                let type_name_id = match ty {
+                    storage::MetaTypeRecord::Object(id) => self.lookup(*id).name,
+                    storage::MetaTypeRecord::Interface(id) => self.lookup(*id).name,
+                    storage::MetaTypeRecord::Union(id) => self.lookup(*id).name,
+                    storage::MetaTypeRecord::Enum(id) => self.lookup(*id).name,
+                    storage::MetaTypeRecord::InputObject(id) => self.lookup(*id).name,
+                    storage::MetaTypeRecord::Scalar(id) => self.lookup(*id).name,
+                };
+                self.string_cmp(type_name_id, name)
             })
             .ok()?;
 

--- a/engine/crates/engine/scalars/src/lib.rs
+++ b/engine/crates/engine/scalars/src/lib.rs
@@ -3,6 +3,8 @@ use std::marker::PhantomData;
 
 use engine_value::ConstValue;
 
+pub mod simple_json;
+pub use simple_json::SimpleJSON;
 mod string;
 pub use string::StringScalar;
 mod id;
@@ -344,5 +346,6 @@ pub type PossibleScalar = merge_scalar!(
     TimeScalar,
     NaiveDateTimeScalar,
     UuidScalar,
-    FederationAnyScalar
+    FederationAnyScalar,
+    SimpleJSON
 );

--- a/engine/crates/engine/scalars/src/simple_json.rs
+++ b/engine/crates/engine/scalars/src/simple_json.rs
@@ -1,0 +1,32 @@
+use engine_value::ConstValue;
+use serde::Deserialize;
+
+use super::{DynamicParse, SDLDefinitionScalar};
+use crate::{Error, InputValueError, InputValueResult};
+
+pub struct SimpleJSON;
+
+impl<'a> SDLDefinitionScalar<'a> for SimpleJSON {
+    fn name() -> Option<&'a str> {
+        Some("SimpleJSON")
+    }
+
+    fn description() -> Option<&'a str> {
+        // honestly not sure what this is, this is the comment I could find.
+        Some("virtual type for non-JSONB operations (only set)")
+    }
+}
+
+impl DynamicParse for SimpleJSON {
+    fn is_valid(_: &ConstValue) -> bool {
+        true
+    }
+
+    fn to_value(value: serde_json::Value) -> Result<ConstValue, Error> {
+        ConstValue::deserialize(value).map_err(|error| Error::new(error.to_string()))
+    }
+
+    fn parse(value: ConstValue) -> InputValueResult<serde_json::Value> {
+        serde_json::Value::deserialize(value).map_err(|error| InputValueError::ty_custom("JSON", error.to_string()))
+    }
+}

--- a/engine/crates/engine/src/registry/mod.rs
+++ b/engine/crates/engine/src/registry/mod.rs
@@ -227,7 +227,7 @@ impl ConnectorIdGenerator {
 
 #[derive(Deserialize, Serialize)]
 pub struct VersionedRegistry<'a> {
-    pub registry: Cow<'a, Registry>,
+    pub registry: registry_v2::Registry,
     pub deployment_id: Cow<'a, str>,
 }
 

--- a/engine/crates/engine/src/registry/tests.rs
+++ b/engine/crates/engine/src/registry/tests.rs
@@ -24,7 +24,7 @@ fn test_serde_roundtrip() {
             the new output presented in the test result.
         ";
 
-    let registry = Cow::Owned(Registry::new().with_sample_data());
+    let registry = registry_upgrade::convert_v1_to_v2(Registry::new().with_sample_data());
     let versioned_registry = VersionedRegistry {
         registry,
         deployment_id: Cow::Borrowed(id),

--- a/engine/crates/engine/src/resolver_utils/container.rs
+++ b/engine/crates/engine/src/resolver_utils/container.rs
@@ -342,7 +342,7 @@ impl<'a> FieldExecutionSet<'a> {
                     Some(ty) => ty,
                     None => {
                         return Err(ServerError::new(
-                            format!(r#"Cannot query field "{field_name}" on type "{type_name}"self."#),
+                            format!(r#"Cannot query field "{field_name}" on type "{type_name}"."#),
                             Some(ctx_field.item.pos),
                         ));
                     }

--- a/engine/crates/engine/validation/src/utils.rs
+++ b/engine/crates/engine/validation/src/utils.rs
@@ -62,7 +62,7 @@ pub fn is_valid_input_value(
 
             match registry
                 .lookup_type(type_name)
-                .unwrap_or_else(|| panic!("{type_name} unknown"))
+                .unwrap_or_else(|| panic!("{type_name} unknown at path {path}"))
             {
                 MetaType::Scalar(scalar) => match scalar.parser() {
                     ScalarParser::PassThrough => None,

--- a/engine/crates/gateway-core/src/cache/build_key.rs
+++ b/engine/crates/gateway-core/src/cache/build_key.rs
@@ -97,7 +97,10 @@ fn get_cache_control(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{hash_map::DefaultHasher, BTreeMap, BTreeSet};
+    use std::{
+        collections::{hash_map::DefaultHasher, BTreeMap, BTreeSet},
+        sync::Arc,
+    };
 
     use futures_util::future::BoxFuture;
     use tokio::sync::Mutex;
@@ -354,8 +357,8 @@ mod tests {
         registry.enable_caching = true;
 
         registry.remove_unused_types();
-        let registry = dbg!(registry.prune_for_caching_registry());
-        let partial_registry = registry_upgrade::convert_v1_to_partial_cache_registry(registry);
+        let registry = registry.prune_for_caching_registry();
+        let partial_registry = Arc::new(registry_upgrade::convert_v1_to_partial_cache_registry(registry));
 
         CacheConfig {
             global_enabled: false,

--- a/engine/crates/gateway-core/src/cache/mod.rs
+++ b/engine/crates/gateway-core/src/cache/mod.rs
@@ -12,7 +12,7 @@ pub struct CacheConfig {
     pub global_enabled: bool,
     pub subdomain: String,
     pub host_name: String,
-    pub partial_registry: PartialCacheRegistry,
+    pub partial_registry: Arc<PartialCacheRegistry>,
     pub common_cache_tags: Vec<String>,
 }
 

--- a/engine/crates/integration-tests/tests/postgres/introspection.rs
+++ b/engine/crates/integration-tests/tests/postgres/introspection.rs
@@ -3547,6 +3547,11 @@ fn table_with_json_column() {
         }
 
         """
+          virtual type for non-JSONB operations (only set)
+        """
+        scalar SimpleJSON
+
+        """
           Update input for SimpleJSON type.
         """
         input SimpleJSONUpdateInput {

--- a/engine/crates/parser-sdl/Cargo.toml
+++ b/engine/crates/parser-sdl/Cargo.toml
@@ -28,6 +28,7 @@ if_chain = "1.0.2"
 indexmap.workspace = true
 Inflector = { version = "0.11.4", default-features = false }
 itertools.workspace = true
+meta-type-name = { path = "../engine/meta-type-name" }
 nom = "7.1.3"
 regex.workspace = true
 secrecy.workspace = true

--- a/engine/crates/parser-sdl/src/lib.rs
+++ b/engine/crates/parser-sdl/src/lib.rs
@@ -182,8 +182,6 @@ fn parse_schema(schema: &str) -> engine::parser::Result<ServiceDocument> {
         directives.to_definition(),
     );
 
-    eprintln!("{}", schema);
-
     engine::parser::parse_schema(schema)
 }
 

--- a/engine/crates/parser-sdl/src/lib.rs
+++ b/engine/crates/parser-sdl/src/lib.rs
@@ -182,6 +182,8 @@ fn parse_schema(schema: &str) -> engine::parser::Result<ServiceDocument> {
         directives.to_definition(),
     );
 
+    eprintln!("{}", schema);
+
     engine::parser::parse_schema(schema)
 }
 

--- a/engine/crates/parser-sdl/src/rules/connector_transforms/mod.rs
+++ b/engine/crates/parser-sdl/src/rules/connector_transforms/mod.rs
@@ -45,6 +45,7 @@ fn lookup_fields(registry: &Registry, lookup: &FieldLookup) -> HashSet<SelectedF
         .types
         .keys()
         .filter(|name| lookup.starting_type.is_match(name))
+        .map(|name| name.as_str())
         .collect::<HashSet<_>>();
 
     for segment in &lookup.path {
@@ -53,10 +54,22 @@ fn lookup_fields(registry: &Registry, lookup: &FieldLookup) -> HashSet<SelectedF
             let ty = registry.types.get(type_name).unwrap();
             match ty {
                 MetaType::Object(_) | MetaType::Interface(_) => {
-                    next_types.extend(ty.fields().unwrap().keys().filter(|name| segment.is_match(name)));
+                    next_types.extend(
+                        ty.fields()
+                            .unwrap()
+                            .values()
+                            .filter(|field| segment.is_match(&field.name))
+                            .map(|field| field.ty.base_type_name()),
+                    );
                 }
                 MetaType::InputObject(input) => {
-                    next_types.extend(input.input_fields.keys().filter(|name| segment.is_match(name)));
+                    next_types.extend(
+                        input
+                            .input_fields
+                            .values()
+                            .filter(|field| segment.is_match(&field.name))
+                            .map(|field| field.ty.base_type_name()),
+                    );
                 }
                 _ => {}
             }

--- a/engine/crates/parser-sdl/src/rules/default_directive_types.rs
+++ b/engine/crates/parser-sdl/src/rules/default_directive_types.rs
@@ -1,5 +1,11 @@
-use engine::Positioned;
+use std::collections::HashSet;
+
+use engine::{Positioned, QueryPath};
 use engine_parser::types::{FieldDefinition, TypeDefinition};
+use engine_scalars::{DynamicScalar, PossibleScalar};
+use engine_value::ConstValue;
+use meta_type_name::MetaTypeName;
+use registry_v2::ScalarParser;
 
 use super::{
     model_directive::ModelDirective,
@@ -44,26 +50,156 @@ impl<'a> Visitor<'a> for DefaultDirectiveTypes {
             }
 
             if let Ok(mut arguments) = super::directive::extract_arguments(ctx, directive, &[&[VALUE_ARGUMENT]], None) {
-                let _default_value = arguments.remove(VALUE_ARGUMENT).unwrap();
+                let default_value = arguments.remove(VALUE_ARGUMENT).unwrap();
 
-                // let error = {
-                //     let ctx_registry = ctx.registry.borrow();
-                //     engine::validation::utils::is_valid_input_value(
-                //         &ctx_registry,
-                //         &field.node.ty.node.to_string(),
-                //         &default_value,
-                //         QueryPath::empty().child(field.node.name.node.as_str()),
-                //     )
-                // };
-                // if let Some(err) = error {
-                //     ctx.report_error(
-                //         vec![directive.pos],
-                //         format!("The @default value is of a wrong type: {err}"),
-                //     );
-                // }
+                let error = {
+                    let ctx_registry = ctx.registry.borrow();
+                    is_valid_input_value(
+                        &ctx_registry,
+                        &field.node.ty.node.to_string(),
+                        &default_value,
+                        QueryPath::empty().child(field.node.name.node.as_str()),
+                    )
+                };
+                if let Some(err) = error {
+                    ctx.report_error(
+                        vec![directive.pos],
+                        format!("The @default value is of a wrong type: {err}"),
+                    );
+                }
             }
         }
     }
+}
+
+pub fn is_valid_input_value(
+    registry: &registry_v1::Registry,
+    type_name: &str,
+    value: &ConstValue,
+    path: QueryPath,
+) -> Option<String> {
+    match MetaTypeName::create(type_name) {
+        MetaTypeName::NonNull(type_name) => match value {
+            ConstValue::Null => Some(valid_error(
+                &path,
+                format!("expected type \"{type_name}\" but found null"),
+            )),
+            _ => is_valid_input_value(registry, type_name, value, path),
+        },
+        MetaTypeName::List(type_name) => match value {
+            ConstValue::List(elems) => elems
+                .iter()
+                .enumerate()
+                .find_map(|(idx, elem)| is_valid_input_value(registry, type_name, elem, path.clone().child(idx))),
+            ConstValue::Null => None,
+            _ => is_valid_input_value(registry, type_name, value, path),
+        },
+        MetaTypeName::Named(type_name) => {
+            if let ConstValue::Null = value {
+                return None;
+            }
+
+            match registry.types.get(type_name)? {
+                registry_v1::MetaType::Scalar(scalar) => match scalar.parser {
+                    ScalarParser::PassThrough => None,
+                    ScalarParser::BestEffort => {
+                        if PossibleScalar::is_valid(type_name, value) {
+                            None
+                        } else {
+                            Some(valid_error(&path, format!("expected type \"{type_name}\"")))
+                        }
+                    }
+                },
+                registry_v1::MetaType::Enum(enum_type) => {
+                    let enum_name = &enum_type.name;
+                    match value {
+                        ConstValue::Enum(name) => {
+                            if enum_type.enum_values.values().all(|value| value.name.as_str() == name) {
+                                Some(valid_error(
+                                    &path,
+                                    format!("enumeration type \"{enum_name}\" does not contain the value \"{name}\""),
+                                ))
+                            } else {
+                                None
+                            }
+                        }
+                        ConstValue::String(name) => {
+                            if enum_type.enum_values.values().all(|value| value.name.as_str() == name) {
+                                Some(valid_error(
+                                    &path,
+                                    format!("enumeration type \"{enum_name}\" does not contain the value \"{name}\""),
+                                ))
+                            } else {
+                                None
+                            }
+                        }
+                        _ => Some(valid_error(
+                            &path,
+                            format!("expected type \"{type_name}\" but got {value}"),
+                        )),
+                    }
+                }
+                registry_v1::MetaType::InputObject(input_object) => match value {
+                    ConstValue::Object(values) => {
+                        if input_object.oneof {
+                            if values.len() != 1 {
+                                return Some(valid_error(
+                                    &path,
+                                    "oneOf input objects require exactly one field".to_string(),
+                                ));
+                            }
+
+                            if let ConstValue::Null = values[0] {
+                                return Some(valid_error(
+                                    &path,
+                                    "oneOf input objects require a non null argument".to_string(),
+                                ));
+                            }
+                        }
+
+                        let mut input_names: HashSet<&str> = values.keys().map(AsRef::as_ref).collect::<HashSet<_>>();
+
+                        for field in input_object.input_fields.values() {
+                            input_names.remove::<str>(&field.name);
+                            if let Some(value) = values.get::<str>(&field.name) {
+                                if let Some(reason) = is_valid_input_value(
+                                    registry,
+                                    &field.ty.to_string(),
+                                    value,
+                                    path.clone().child(field.name.as_str()),
+                                ) {
+                                    return Some(reason);
+                                }
+                            } else if field.ty.is_non_null() && field.default_value.is_none() {
+                                return Some(valid_error(
+                                    &path,
+                                    format!(
+                                        "field \"{}\" of type \"{}\" is required but not provided",
+                                        field.name, input_object.name
+                                    ),
+                                ));
+                            }
+                        }
+
+                        if let Some(name) = input_names.iter().next() {
+                            return Some(valid_error(
+                                &path,
+                                format!("unknown field \"{name}\" of type \"{}\"", input_object.name),
+                            ));
+                        }
+
+                        None
+                    }
+                    _ => None,
+                },
+                _ => None,
+            }
+        }
+    }
+}
+
+fn valid_error(path_node: &QueryPath, msg: String) -> String {
+    format!("\"{path_node}\", {msg}")
 }
 
 #[cfg(test)]

--- a/gateway/crates/gateway-binary/tests/.integration_tests.rs.pending-snap
+++ b/gateway/crates/gateway-binary/tests/.integration_tests.rs.pending-snap
@@ -1,6 +1,0 @@
-{"run_id":"2bab5e53-b736-4e31-ab0b-c6c6ef41dfbf","line":621,"new":{"module_name":"integration_tests","snapshot_name":"hybrid_graph","metadata":{"source":"gateway/crates/gateway-binary/tests/integration_tests.rs","assertion_line":621,"expression":"&result"},"snapshot":"{\n  \"errors\": [\n    {\n      \"message\": \"there are no subgraphs registered currently\"\n    }\n  ]\n}"},"old":{"module_name":"integration_tests","metadata":{},"snapshot":"{\n  \"data\": {},\n  \"errors\": [\n    {\n      \"message\": \"error sending request for url (http://127.0.0.1:46697/)\"\n    }\n  ]\n}"}}
-{"run_id":"2bab5e53-b736-4e31-ab0b-c6c6ef41dfbf","line":533,"new":null,"old":null}
-{"run_id":"2bab5e53-b736-4e31-ab0b-c6c6ef41dfbf","line":417,"new":null,"old":null}
-{"run_id":"2bab5e53-b736-4e31-ab0b-c6c6ef41dfbf","line":592,"new":null,"old":null}
-{"run_id":"2bab5e53-b736-4e31-ab0b-c6c6ef41dfbf","line":508,"new":null,"old":null}
-{"run_id":"2bab5e53-b736-4e31-ab0b-c6c6ef41dfbf","line":442,"new":null,"old":null}


### PR DESCRIPTION
- Some snapshot updates (because new registry does things alphabetically)
- Added SimpleJSON scalar, which postgres uses but didn't exist.
- Re-implemented validation for default values
- Fixed some incorrect binary searches
- Added a way to create an empty PartialCacheRegistry
- Some other misc things the api repo needed