### PR TITLE
fix: wait for GDN reload to happen before retrieving the meter prodiver for OTEL metrics

### DIFF
--- a/gateway/crates/federated-server/src/server/otel.rs
+++ b/gateway/crates/federated-server/src/server/otel.rs
@@ -8,8 +8,11 @@ pub struct OtelTracing {
     ///     - the layer related to the handler might be a noop_layer and therefore has no provider attached
     ///     - it can be replaced on reload, and we want the latest
     pub tracer_provider: tokio::sync::watch::Receiver<TracerProvider>,
-    /// A channel to trigger the otel layer reload with new data
+    /// A channel to trigger the otel layer reload with new data. While it's a mpsc, only the first
+    /// reload will be taken into account.
     pub reload_trigger: tokio::sync::oneshot::Sender<OtelReload>,
+    /// A channel to receive confirmation that the OTEL reload happened.
+    pub reload_ack_receiver: tokio::sync::oneshot::Receiver<()>,
 }
 
 /// Payload sent when triggering an otel layer reload

--- a/gateway/crates/gateway-binary/tests/.integration_tests.rs.pending-snap
+++ b/gateway/crates/gateway-binary/tests/.integration_tests.rs.pending-snap
@@ -1,6 +1,0 @@
-{"run_id":"2bab5e53-b736-4e31-ab0b-c6c6ef41dfbf","line":621,"new":{"module_name":"integration_tests","snapshot_name":"hybrid_graph","metadata":{"source":"gateway/crates/gateway-binary/tests/integration_tests.rs","assertion_line":621,"expression":"&result"},"snapshot":"{\n  \"errors\": [\n    {\n      \"message\": \"there are no subgraphs registered currently\"\n    }\n  ]\n}"},"old":{"module_name":"integration_tests","metadata":{},"snapshot":"{\n  \"data\": {},\n  \"errors\": [\n    {\n      \"message\": \"error sending request for url (http://127.0.0.1:46697/)\"\n    }\n  ]\n}"}}
-{"run_id":"2bab5e53-b736-4e31-ab0b-c6c6ef41dfbf","line":533,"new":null,"old":null}
-{"run_id":"2bab5e53-b736-4e31-ab0b-c6c6ef41dfbf","line":417,"new":null,"old":null}
-{"run_id":"2bab5e53-b736-4e31-ab0b-c6c6ef41dfbf","line":592,"new":null,"old":null}
-{"run_id":"2bab5e53-b736-4e31-ab0b-c6c6ef41dfbf","line":508,"new":null,"old":null}
-{"run_id":"2bab5e53-b736-4e31-ab0b-c6c6ef41dfbf","line":442,"new":null,"old":null}

--- a/gateway/crates/gateway-binary/tests/telemetry/mod.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/mod.rs
@@ -234,7 +234,26 @@ fn with_otel_reload_tracing() {
             .fetch_one::<CountRow>()
             .await
             .unwrap();
+        assert!(count > 0);
 
+        let CountRow { count } = client
+            .query(
+                r#"
+                    SELECT COUNT(1) as count
+                    FROM otel_metrics_sum
+                    WHERE ResourceAttributes['service.name'] = ?
+                    AND ResourceAttributes['grafbase.branch_name'] = ?
+                    AND ResourceAttributes['grafbase.branch_id'] = ?
+                    AND ResourceAttributes['grafbase.graph_id'] = ?
+                "#,
+            )
+            .bind(&service_name)
+            .bind(&gdn_mock.branch)
+            .bind(gdn_mock.branch_id.to_string())
+            .bind(gdn_mock.graph_id.to_string())
+            .fetch_one::<CountRow>()
+            .await
+            .unwrap();
         assert!(count > 0);
     });
 }


### PR DESCRIPTION
Currently when the gateway is bootstrapped as follows:
1. Immediately setup OTEL metrics & tracing
2. Set up a watcher for the engine and a background task that loads GDN data to update it at regular intervals
3. Start the HTTP server

However, as we do need metadata from the GDN (branch_id typically), there is an async reload mechanism that is used to update the OTEL/tracing setup. Unfortunately, this doesn't work well for the HTTP request metrics as we need a `MeterProvider` at step 3., because it's used to setup a `tower::Layer`, even though neither the GDN call nor the OTEL reload may have happened yet.

So we need to wait for the reload mechanism to happen before starting the HTTP server. We could be lazy with the `MeterProvider`, a bit like the `tracing` integration of metrics is, but it only replaces the problem. If a HTTP request comes in before the OTEL reload we wouldn't have the right resource attributes either.