### PR TITLE
sdk: better error reporting for the empty object case

### DIFF
--- a/packages/grafbase-sdk/src/type.ts
+++ b/packages/grafbase-sdk/src/type.ts
@@ -126,6 +126,10 @@ export class Type {
   }
 
   public toString(): string {
+    if (this.fields.length === 0) {
+      throw new Error(`The ${this.name} type has no field. GraphQL types must have at least one field.`)
+    }
+
     const interfaces = this.interfaces.map((i) => i.name).join(' & ')
     const cache = this.cacheDirective ? ` ${this.cacheDirective}` : ''
     const keys =

--- a/packages/grafbase-sdk/tests/unit/types.test.ts
+++ b/packages/grafbase-sdk/tests/unit/types.test.ts
@@ -35,6 +35,14 @@ describe('Type generator', () => {
     `)
   })
 
+  it('errors on types with no field', () => {
+    const t = g.type('User', {})
+
+    expect(() => renderGraphQL(t)).toThrowErrorMatchingInlineSnapshot(
+      `"The User type has no field. GraphQL types must have at least one field."`
+    )
+  })
+
   it('generates one with cache', () => {
     const t = g
       .type('User', {


### PR DESCRIPTION
Before this commit, we show a very vague and unhelpful error from async-graphql-parser. This commit moves the error earlier on in the process when rendering SDL from SDK.

The potentially controversial bit in this PR is that I think we don't throw in any other case in that stage of the process. But better handling on the engine side is not possible without replacing async-graphql-parser.

closes GB-6604