### PR TITLE
feat: hardcode grafbase otel endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,48 +106,47 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -473,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "aws_lambda_events"
@@ -807,15 +806,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block2"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ff7d91d3c1d568065b06c899777d1e48dcf76103a672a0adbc238a7f247f1e"
-dependencies = [
- "objc2",
-]
-
-[[package]]
 name = "borsh"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,9 +961,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.97"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
+checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
 dependencies = [
  "jobserver",
  "libc",
@@ -1145,9 +1135,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
@@ -1635,9 +1625,9 @@ dependencies = [
 
 [[package]]
 name = "deadpool"
-version = "0.12.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3c3845002cd8dec1e045bc3fc076d1e467a123794cf56326d804489df1896"
+checksum = "ff0fc28638c21092aba483136debc6e177fff3dace8c835d715866923b03323e"
 dependencies = [
  "deadpool-runtime",
  "num_cpus",
@@ -1646,11 +1636,11 @@ dependencies = [
 
 [[package]]
 name = "deadpool-postgres"
-version = "0.13.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10566d25f606cc5f2dee63311af0eb2dc861cba4a5a7dee2daa4c2b181a42862"
+checksum = "4aa08f5c838496cbabb672e3614534444145fc6632995f102e13d30a29a25a13"
 dependencies = [
- "deadpool 0.12.0",
+ "deadpool 0.11.2",
  "tokio",
  "tokio-postgres",
  "tracing",
@@ -1658,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "deadpool-runtime"
-version = "0.1.4"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+checksum = "63dfa964fe2a66f3fde91fc70b267fe193d822c7e603e2a675a49a7f46ad3f49"
 dependencies = [
  "tokio",
 ]
@@ -1850,7 +1840,7 @@ dependencies = [
  "serde",
  "thiserror",
  "time",
- "winnow 0.6.8",
+ "winnow 0.6.7",
 ]
 
 [[package]]
@@ -3609,9 +3599,9 @@ dependencies = [
 
 [[package]]
 name = "http-range-header"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a397c49fec283e3d6211adbe480be95aae5f304cfb923e9970e08956d5168a"
+checksum = "3ce4ef31cda248bbdb6e6820603b82dfcd9e833db65a43e997a0ccec777d11fe"
 
 [[package]]
 name = "http-serde"
@@ -4076,12 +4066,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4477,6 +4461,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4642,15 +4635,16 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "multer"
-version = "3.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+checksum = "a15d522be0a9c3e46fd2632e272d178f56387bdb5c9fbb3a36c649062e9b5219"
 dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
  "http 1.1.0",
  "httparse",
+ "log",
  "memchr",
  "mime",
  "spin 0.9.8",
@@ -4833,9 +4827,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -4844,9 +4838,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.19"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
@@ -4910,35 +4904,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc-sys"
-version = "0.3.3"
+name = "objc"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da284c198fb9b7b0603f8635185e85fbd5b64ee154b1ed406d489077de2d6d60"
-
-[[package]]
-name = "objc2"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b25e1034d0e636cd84707ccdaa9f81243d399196b8a773946dcffec0401659"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
- "objc-sys",
- "objc2-encode",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88658da63e4cc2c8adb1262902cd6af51094df0488b760d6fd27194269c0950a"
-
-[[package]]
-name = "objc2-foundation"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfaefe14254871ea16c7d88968c0ff14ba554712a20d76421eec52f0a7fb8904"
-dependencies = [
- "block2",
- "objc2",
+ "malloc_buf",
 ]
 
 [[package]]
@@ -6072,6 +6043,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-window-handle"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6269,9 +6246,9 @@ dependencies = [
 
 [[package]]
 name = "relative-path"
-version = "1.9.3"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
 
 [[package]]
 name = "rend"
@@ -6763,11 +6740,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -6776,9 +6753,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6807,9 +6784,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.200"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
+checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
 dependencies = [
  "serde_derive",
 ]
@@ -6848,9 +6825,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.200"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
+checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7537,9 +7514,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.30.12"
+version = "0.30.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732ffa00f53e6b2af46208fba5718d9662a421049204e156328b66791ffa15ae"
+checksum = "87341a165d73787554941cd5ef55ad728011566fe714e987d1b976c15dbc3a83"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -7847,9 +7824,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
@@ -7857,6 +7834,7 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -7912,7 +7890,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.8",
+ "winnow 0.6.7",
 ]
 
 [[package]]
@@ -7933,6 +7911,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-native-certs",
  "rustls-pemfile",
  "rustls-pki-types",
  "tokio",
@@ -8496,18 +8475,17 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "425ba64c1e13b1c6e8c5d2541c8fac10022ca584f33da781db01b5756aef1f4e"
+checksum = "60b6f804e41d0852e16d2eaee61c7e4f7d3e8ffdb7b8ed85886aeb0791fe9fcd"
 dependencies = [
- "block2",
  "core-foundation",
  "home",
  "jni",
  "log",
  "ndk-context",
- "objc2",
- "objc2-foundation",
+ "objc",
+ "raw-window-handle",
  "url",
  "web-sys",
 ]
@@ -8863,9 +8841,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.8"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+checksum = "14b9415ee827af173ebb3f15f9083df5a122eb93572ec28741fb153356ea2578"
 dependencies = [
  "memchr",
 ]
@@ -9074,18 +9052,18 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.33"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "087eca3c1eaf8c47b94d02790dd086cd594b912d2043d4de4bfdd466b3befb7c"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.33"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f4b6c273f496d8fd4eaf18853e6b448760225dc030ff2c485a786859aea6393"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/engine/crates/tracing/Cargo.toml
+++ b/engine/crates/tracing/Cargo.toml
@@ -18,7 +18,7 @@ http.workspace = true
 http-body = "1.0"
 serde.workspace = true
 thiserror.workspace = true
-tonic = { version = "0.11.0", optional = true }
+tonic = { version = "0.11.0", optional = true, features = ["tls-roots"] }
 tower-http = { workspace = true, optional = true, features = ["trace"] }
 url = { workspace = true, features = ["serde"] }
 worker = { workspace = true, optional = true }

--- a/engine/crates/tracing/src/config.rs
+++ b/engine/crates/tracing/src/config.rs
@@ -199,6 +199,9 @@ pub struct TracingExportersConfig {
     pub stdout: Option<TracingStdoutExporterConfig>,
     /// Otlp exporter configuration
     pub otlp: Option<TracingOtlpExporterConfig>,
+    /// Grafbase OTEL exporter configuration when an access token is used.
+    #[serde(skip)]
+    pub grafbase: Option<TracingOtlpExporterConfig>,
 }
 
 /// Stdout exporter configuration
@@ -370,6 +373,13 @@ impl Headers {
             .collect::<Result<HashMap<_, _>, _>>()
     }
 }
+
+impl From<Vec<(HeaderName, HeaderValue)>> for Headers {
+    fn from(headers: Vec<(HeaderName, HeaderValue)>) -> Self {
+        Self(headers)
+    }
+}
+
 impl<'de> Deserialize<'de> for Headers {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/engine/crates/tracing/src/otel/traces.rs
+++ b/engine/crates/tracing/src/otel/traces.rs
@@ -67,7 +67,23 @@ where
             otlp_exporter_config.timeout,
             &otlp_exporter_config.batch_export,
             span_exporter,
-            runtime,
+            runtime.clone(),
+        );
+        tracer_provider_builder = tracer_provider_builder.with_span_processor(span_processor);
+    }
+
+    #[cfg(feature = "otlp")]
+    if let Some(otlp_exporter_config) = config.exporters.grafbase {
+        use opentelemetry_otlp::SpanExporterBuilder;
+        let span_exporter = super::exporter::build_otlp_exporter::<SpanExporterBuilder>(&otlp_exporter_config)?
+            .build_span_exporter()
+            .map_err(|err| TracingError::SpanExporterSetup(err.to_string()))?;
+
+        let span_processor = build_batched_span_processor(
+            otlp_exporter_config.timeout,
+            &otlp_exporter_config.batch_export,
+            span_exporter,
+            runtime.clone(),
         );
         tracer_provider_builder = tracer_provider_builder.with_span_processor(span_processor);
     }

--- a/gateway/crates/federated-server/src/config/telemetry.rs
+++ b/gateway/crates/federated-server/src/config/telemetry.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use grafbase_tracing::config::TracingConfig;
 
 /// Holds telemetry configuration
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TelemetryConfig {
     /// The name of the service

--- a/gateway/crates/federated-server/src/server/graph_fetch_method.rs
+++ b/gateway/crates/federated-server/src/server/graph_fetch_method.rs
@@ -8,7 +8,6 @@ use tokio::sync::{oneshot, watch};
 /// The method of running the gateway.
 pub enum GraphFetchMethod {
     /// The schema is fetched in regular intervals from the Grafbase API.
-    #[cfg(not(feature = "lambda"))]
     FromApi {
         /// The access token for accessing the the API.
         access_token: ascii::AsciiString,
@@ -37,12 +36,12 @@ impl GraphFetchMethod {
         sender: watch::Sender<Option<Arc<Engine>>>,
     ) -> crate::Result<()> {
         match self {
-            #[cfg(not(feature = "lambda"))]
             GraphFetchMethod::FromApi {
                 access_token,
                 graph_name,
                 branch,
             } => {
+                #[cfg(not(feature = "lambda"))]
                 tokio::spawn(async move {
                     use super::graph_updater::GraphUpdater;
 

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -23,6 +23,7 @@ clap = { version = "4.5.4", features = ["cargo", "wrap_help", "derive", "env"] }
 federated-server.workspace = true
 grafbase-tracing = { workspace = true, features = ["otlp"] }
 graph-ref.workspace = true
+http.workspace = true
 mimalloc = "0.1.41"
 opentelemetry-aws = { version = "0.10.0", optional = true }
 rustls = { workspace = true, features = ["ring"] }

--- a/gateway/crates/gateway-binary/src/args.rs
+++ b/gateway/crates/gateway-binary/src/args.rs
@@ -1,13 +1,32 @@
-#[cfg(feature = "lambda")]
 mod lambda;
 mod log;
-#[cfg(not(feature = "lambda"))]
 mod std;
 
+use ::std::net::SocketAddr;
+
+use clap::Parser;
+use federated_server::{Config, GraphFetchMethod};
+use grafbase_tracing::otel::layer::BoxedLayer;
 pub(crate) use log::LogLevel;
+use tracing::Subscriber;
+use tracing_subscriber::registry::LookupSpan;
 
-#[cfg(feature = "lambda")]
-pub(crate) use lambda::Args;
+pub(crate) trait Args {
+    fn listen_address(&self) -> Option<SocketAddr>;
+    fn log_level(&self) -> Option<LogLevel>;
+    fn fetch_method(&self) -> anyhow::Result<GraphFetchMethod>;
+    fn config(&self) -> anyhow::Result<Config>;
+    fn log_format<S>(&self) -> BoxedLayer<S>
+    where
+        S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync;
+}
 
-#[cfg(not(feature = "lambda"))]
-pub(crate) use self::std::Args;
+pub(crate) fn parse() -> impl Args {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "lambda")] {
+            lambda::Args::parse()
+        } else {
+            std::Args::parse()
+        }
+    }
+}

--- a/gateway/crates/gateway-binary/src/args/lambda.rs
+++ b/gateway/crates/gateway-binary/src/args/lambda.rs
@@ -28,9 +28,9 @@ pub struct Args {
     log_style: LogStyle,
 }
 
-impl Args {
+impl super::Args for Args {
     /// The method of fetching a graph
-    pub fn fetch_method(&self) -> anyhow::Result<GraphFetchMethod> {
+    fn fetch_method(&self) -> anyhow::Result<GraphFetchMethod> {
         let federated_graph = fs::read_to_string(&self.schema).context("could not read federated schema file")?;
 
         Ok(GraphFetchMethod::FromLocal {
@@ -39,7 +39,7 @@ impl Args {
     }
 
     /// The gateway configuration
-    pub fn config(&self) -> anyhow::Result<Config> {
+    fn config(&self) -> anyhow::Result<Config> {
         match fs::read_to_string(&self.config) {
             Ok(config) => Ok(toml::from_str(&config)?),
             Err(e) => match e.kind() {
@@ -49,7 +49,7 @@ impl Args {
         }
     }
 
-    pub fn log_format<S>(&self) -> BoxedLayer<S>
+    fn log_format<S>(&self) -> BoxedLayer<S>
     where
         S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync,
     {
@@ -62,5 +62,13 @@ impl Args {
             LogStyle::Text => layer.with_ansi(false).with_target(false).boxed(),
             LogStyle::Json => layer.json().boxed(),
         }
+    }
+
+    fn listen_address(&self) -> Option<std::net::SocketAddr> {
+        None
+    }
+
+    fn log_level(&self) -> Option<LogLevel> {
+        self.log_level
     }
 }


### PR DESCRIPTION
I'm hardcoding our OTEL endpoint whenever a graph reference is used. We don't fail if the token isn't present because the gateway will fail later with a better error message anyway. Using native certs ended up being as easy as just adding the right feature flag in `tonic`...