### PR TITLE
gateway: move handle_persisted_query span one level deeper and rename

### DIFF
--- a/engine/crates/gateway-core/src/trusted_documents.rs
+++ b/engine/crates/gateway-core/src/trusted_documents.rs
@@ -15,7 +15,6 @@ where
     Executor::StreamingResponse: super::ConstructableResponse<Error = Executor::Error>,
 {
     /// Handle a request making use of APQ or trusted documents.
-    #[instrument(skip_all)]
     pub(super) async fn handle_persisted_query(
         &self,
         request: &mut engine::Request,
@@ -74,6 +73,7 @@ where
             .await
     }
 
+    #[instrument(skip_all)]
     async fn handle_trusted_document_query(
         &self,
         request: &mut engine::Request,
@@ -134,6 +134,7 @@ where
     }
 
     /// Handle a request using Automatic Persisted Queries.
+    #[instrument(skip_all)]
     async fn handle_apq(
         &self,
         request: &mut engine::Request,


### PR DESCRIPTION
Rename to handle_trusted_document_query / handle_apq.

Move one level deeper so we only have that span when trusted documents or APQ are actually relevant for the query.

Current traces:

![2024-04-22_06-04-01](https://github.com/grafbase/grafbase/assets/13155277/167b7e21-1990-4237-a035-af6673c82128)
