### PR TITLE
fix: make registry-upgrade more tolerant of problems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6251,10 +6251,12 @@ dependencies = [
 name = "registry-upgrade"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "indexmap 2.2.6",
  "registry-for-cache",
  "registry-v1",
  "registry-v2",
+ "tracing",
  "wrapping",
 ]
 

--- a/cli/crates/server/src/errors.rs
+++ b/cli/crates/server/src/errors.rs
@@ -71,6 +71,10 @@ pub enum ServerError {
     #[error("{0}")]
     ParseSchema(String),
 
+    /// returned if the schema parser command exits unsuccessfully
+    #[error("Schema error: {0}")]
+    SchemaUpgradeError(String),
+
     /// returned if the typescript config parser command exits unsuccessfully
     #[error("could not load grafbase/grafbase.config.ts\nCaused by: {0}")]
     LoadTsConfig(String),

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -85,9 +85,11 @@ impl ProductionServer {
             })
         } else {
             let cache_registry = registry.clone().prune_for_caching_registry();
-            let cache_registry = registry_upgrade::convert_v1_to_partial_cache_registry(cache_registry);
+            let cache_registry = registry_upgrade::convert_v1_to_partial_cache_registry(cache_registry)
+                .map_err(|e| ServerError::SchemaUpgradeError(e.to_string()))?;
 
-            let registry = registry_upgrade::convert_v1_to_v2(registry);
+            let registry = registry_upgrade::convert_v1_to_v2(registry)
+                .map_err(|e| ServerError::SchemaUpgradeError(e.to_string()))?;
             let registry = Arc::new(registry);
 
             let (bridge_app, bridge_state) = bridge::build_router(
@@ -376,9 +378,11 @@ async fn spawn_servers(
     } = config;
 
     let cache_registry = registry.clone().prune_for_caching_registry();
-    let cache_registry = registry_upgrade::convert_v1_to_partial_cache_registry(cache_registry);
+    let cache_registry = registry_upgrade::convert_v1_to_partial_cache_registry(cache_registry)
+        .map_err(|e| ServerError::SchemaUpgradeError(e.to_string()))?;
 
-    let registry = registry_upgrade::convert_v1_to_v2(registry);
+    let registry =
+        registry_upgrade::convert_v1_to_v2(registry).map_err(|e| ServerError::SchemaUpgradeError(e.to_string()))?;
     let registry = Arc::new(registry);
 
     // If the rebuild has been triggered by a change in the schema file, we can honour the freshness of resolvers

--- a/engine/crates/engine/registry-upgrade/Cargo.toml
+++ b/engine/crates/engine/registry-upgrade/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1"
 indexmap.workspace = true
 registry-for-cache.workspace = true
 registry-v1.workspace = true
 registry-v2.workspace = true
+tracing.workspace = true
 wrapping.workspace = true

--- a/engine/crates/engine/src/registry/tests.rs
+++ b/engine/crates/engine/src/registry/tests.rs
@@ -24,7 +24,7 @@ fn test_serde_roundtrip() {
             the new output presented in the test result.
         ";
 
-    let registry = registry_upgrade::convert_v1_to_v2(Registry::new().with_sample_data());
+    let registry = registry_upgrade::convert_v1_to_v2(Registry::new().with_sample_data()).unwrap();
     let versioned_registry = VersionedRegistry {
         registry,
         deployment_id: Cow::Borrowed(id),

--- a/engine/crates/engine/validation/src/test_harness.rs
+++ b/engine/crates/engine/validation/src/test_harness.rs
@@ -326,7 +326,7 @@ pub struct Subscription;
 
 static TEST_HARNESS: Lazy<Schema> = Lazy::new(|| {
     let v1 = Schema::create_registry_static::<Query, Mutation, engine::EmptySubscription>();
-    let v2 = registry_upgrade::convert_v1_to_v2(v1);
+    let v2 = registry_upgrade::convert_v1_to_v2(v1).unwrap();
     Schema::new(Arc::new(v2))
 });
 

--- a/engine/crates/engine/validation/src/visitors/alias_count.rs
+++ b/engine/crates/engine/validation/src/visitors/alias_count.rs
@@ -79,7 +79,7 @@ mod tests {
 
     fn check_alias_count(query: &str, expect_alias_count: usize) {
         let registry = Schema::create_registry_static::<Query, EmptyMutation, EmptySubscription>();
-        let registry = registry_upgrade::convert_v1_to_v2(registry);
+        let registry = registry_upgrade::convert_v1_to_v2(registry).unwrap();
 
         let doc = parse_query(query).unwrap();
         let mut ctx = VisitorContext::new(&registry, &doc, None);

--- a/engine/crates/engine/validation/src/visitors/depth.rs
+++ b/engine/crates/engine/validation/src/visitors/depth.rs
@@ -82,7 +82,7 @@ mod tests {
 
     fn check_depth(query: &str, expect_depth: usize) {
         let registry = Schema::create_registry_static::<Query, EmptyMutation, EmptySubscription>();
-        let registry = registry_upgrade::convert_v1_to_v2(registry);
+        let registry = registry_upgrade::convert_v1_to_v2(registry).unwrap();
 
         let doc = parse_query(query).unwrap();
         let mut ctx = VisitorContext::new(&registry, &doc, None);

--- a/engine/crates/engine/validation/src/visitors/height.rs
+++ b/engine/crates/engine/validation/src/visitors/height.rs
@@ -95,7 +95,7 @@ mod tests {
 
     fn check_height(query: &str, expect_height: usize) {
         let registry = Schema::create_registry_static::<Query, EmptyMutation, EmptySubscription>();
-        let registry = registry_upgrade::convert_v1_to_v2(registry);
+        let registry = registry_upgrade::convert_v1_to_v2(registry).unwrap();
 
         let doc = parse_query(query).unwrap();
         let mut ctx = VisitorContext::new(&registry, &doc, None);

--- a/engine/crates/engine/validation/src/visitors/root_field_count.rs
+++ b/engine/crates/engine/validation/src/visitors/root_field_count.rs
@@ -89,7 +89,7 @@ mod tests {
 
     fn check_root_field_count(query: &str, expect_root_field_count: usize) {
         let registry = Schema::create_registry_static::<Query, EmptyMutation, EmptySubscription>();
-        let registry = registry_upgrade::convert_v1_to_v2(registry);
+        let registry = registry_upgrade::convert_v1_to_v2(registry).unwrap();
 
         let doc = parse_query(query).unwrap();
         let mut ctx = VisitorContext::new(&registry, &doc, None);

--- a/engine/crates/gateway-core/src/cache/build_key.rs
+++ b/engine/crates/gateway-core/src/cache/build_key.rs
@@ -358,7 +358,7 @@ mod tests {
 
         registry.remove_unused_types();
         let registry = registry.prune_for_caching_registry();
-        let partial_registry = Arc::new(registry_upgrade::convert_v1_to_partial_cache_registry(registry));
+        let partial_registry = Arc::new(registry_upgrade::convert_v1_to_partial_cache_registry(registry).unwrap());
 
         CacheConfig {
             global_enabled: false,

--- a/engine/crates/integration-tests/src/engine/builder.rs
+++ b/engine/crates/integration-tests/src/engine/builder.rs
@@ -106,7 +106,7 @@ impl EngineBuilder {
         // TODO: Can almost certainly get rid of/move this serde roudntrip
         let registry: Registry = serde_json::from_value(serde_json::to_value(registry).unwrap()).unwrap();
 
-        let registry = registry_upgrade::convert_v1_to_v2(registry);
+        let registry = registry_upgrade::convert_v1_to_v2(registry).unwrap();
 
         let postgres = {
             let mut transports = HashMap::new();

--- a/engine/crates/integration-tests/tests/tracing/v1.rs
+++ b/engine/crates/integration-tests/tests/tracing/v1.rs
@@ -33,7 +33,7 @@ async fn query_bad_request() {
 
     let mut registry = Registry::new();
     registry.add_builtins_to_registry();
-    let registry = Arc::new(registry_upgrade::convert_v1_to_v2(registry));
+    let registry = Arc::new(registry_upgrade::convert_v1_to_v2(registry).unwrap());
 
     // act
     //
@@ -161,7 +161,7 @@ async fn batch() {
 
     let mut registry = Registry::new();
     registry.add_builtins_to_registry();
-    let registry = Arc::new(registry_upgrade::convert_v1_to_v2(registry));
+    let registry = Arc::new(registry_upgrade::convert_v1_to_v2(registry).unwrap());
 
     // act
     engine::Schema::build(registry)
@@ -193,7 +193,7 @@ async fn subscription() {
 
     let mut registry = Registry::new();
     registry.add_builtins_to_registry();
-    let registry = Arc::new(registry_upgrade::convert_v1_to_v2(registry));
+    let registry = Arc::new(registry_upgrade::convert_v1_to_v2(registry).unwrap());
 
     // act
     let _: Vec<StreamingPayload> = engine::Schema::build(registry)


### PR DESCRIPTION
registry-upgrade currently panics if you pass it a registry that references a type that dopesn't exist.  The thinking here was that _ideally_ we validate schemas before we even parse them, so that we can give the users a good error message.  And then hopefully our code doesn't do anything to make the registry invalid between validation and passing it to registry-upgrade.

This was wishful thinking - I'm not sure we _do_ validate the schema, and parser-sdl (and probably the connectors) are also perfectly capable of generating bad registries.

This updates registry-upgrade to be more tolerant of these kinds of problems:

1. Where possible it'll just skip any fields with missing types.  We could raise these as errors to the user, but I think they're _usually_ a sign of a bug elsewhere - either we're generating invalid registries, or we're not catching invalid schemas.  So I kind of think a best effort approach to getting _something_ deployed is appropriate.
2. If the user doesn't provide a root `Query` type there's no graceful way to handle that - so for that case I've updated the crate to return an error.