### PR TITLE
fix: allow users to extend federation types

### DIFF
--- a/engine/crates/parser-sdl/src/lib.rs
+++ b/engine/crates/parser-sdl/src/lib.rs
@@ -211,6 +211,11 @@ pub async fn parse<'a>(
         return Err(ctx.errors.into());
     }
 
+    ctx.validate();
+    if !ctx.errors.is_empty() {
+        return Err(ctx.errors.into());
+    }
+
     if !ctx.warnings.is_empty() {
         println!("{}", ctx.warnings);
     }

--- a/engine/crates/parser-sdl/src/rules/extend_field.rs
+++ b/engine/crates/parser-sdl/src/rules/extend_field.rs
@@ -177,9 +177,7 @@ mod tests {
         Registry,
     };
 
-    use crate::{
-        tests::assert_validation_error, ConnectorParsers, GraphqlDirective, OpenApiDirective, PostgresDirective,
-    };
+    use crate::{ConnectorParsers, GraphqlDirective, OpenApiDirective, PostgresDirective};
 
     #[test]
     fn test_extending_field_on_connector_types() {
@@ -217,22 +215,6 @@ mod tests {
         	blah: Blah
         }
         "###)
-    }
-
-    #[test]
-    fn test_missing_type_error() {
-        assert_validation_error!(
-            r#"
-            extend type Blah
-              @extendField(
-                name: "foo"
-                external: true
-                override: {from: "Blah"}
-                provides: {fields: "id"}
-              )
-            "#,
-            "Type 'Blah' does not exist"
-        );
     }
 
     #[test]

--- a/engine/crates/parser-sdl/src/rules/federation/field_set.rs
+++ b/engine/crates/parser-sdl/src/rules/federation/field_set.rs
@@ -14,7 +14,7 @@ use registry_v2::Selection;
 use serde::de::Error;
 
 /// Newtype wrapper around registry::FieldSet that Deserializes from a String
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct FieldSet(pub registry_v2::FieldSet);
 
 impl<'de> serde::Deserialize<'de> for FieldSet {

--- a/engine/crates/parser-sdl/src/rules/federation/key.rs
+++ b/engine/crates/parser-sdl/src/rules/federation/key.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use super::field_set::FieldSet;
 use crate::rules::{directive::Directive, join_directive::FieldSelection};
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct KeyDirective {
     pub fields: FieldSet,

--- a/engine/crates/parser-sdl/src/rules/join_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/join_directive.rs
@@ -21,13 +21,13 @@ pub struct JoinDirective {
     pub select: FieldSelection,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FieldSelection {
     selections: Vec<Selection>,
     variables_used: Vec<String>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct Selection {
     field_name: String,
     arguments: Vec<(Name, Value)>,


### PR DESCRIPTION
I was helping Fredrik setup for a sales demo last week, and we ran into some problems with the fairly common pattern of extending types from another subgraph:

```graphql
extend type Whatever @key(fields: "id") {
  id: String,
  someField: String @join(...)
}
```

1. It would complain that `id` didn't have a join or custom resolver on it.
2. It'd complain that `Whatever` didn't exist for extension.

It's quite easy to work around this by removing the `extend` keyword, but we should probably be friendlier to users and just let them do this.

Fixes GB-6682
Fixes GB-6678