### PR TITLE
fix: remove to_plural from postgres connector runtime

### DIFF
--- a/engine/crates/postgres-connector-types/src/database_definition.rs
+++ b/engine/crates/postgres-connector-types/src/database_definition.rs
@@ -174,6 +174,8 @@ impl DatabaseDefinition {
             schema_id: table.schema_id(),
             database_name: self.names.intern_string(table.database_name()),
             client_name: self.names.intern_string(table.client_name()),
+            client_field_name: self.names.intern_string(table.client_field_name()),
+            client_field_name_plural: self.names.intern_string(table.client_field_name_plural()),
         });
 
         id
@@ -379,11 +381,15 @@ impl DatabaseDefinition {
             let schema_name = &self.schemas[table.schema_id().0 as usize];
             let client_name = self.names.get_name(table.client_name());
 
-            let client_name = self
-                .names
-                .intern_string(&format!("{schema_name}_{client_name}").to_pascal_case());
+            let new_client_name = format!("{schema_name}_{client_name}").to_pascal_case();
+            let client_name = self.names.intern_string(&new_client_name);
+
+            let new_client_field_name = self.names.intern_string(&new_client_name.to_camel_case());
+            let new_client_field_name_plural = self.names.intern_string(&new_client_name.to_camel_case().to_plural());
 
             table.set_client_name(client_name);
+            table.set_client_field_name(new_client_field_name);
+            table.set_client_field_name_plural(new_client_field_name_plural);
         }
 
         names.clear();

--- a/engine/crates/postgres-connector-types/src/database_definition/table.rs
+++ b/engine/crates/postgres-connector-types/src/database_definition/table.rs
@@ -8,6 +8,8 @@ pub struct Table<T> {
     pub(super) schema_id: SchemaId,
     pub(super) database_name: T,
     pub(super) client_name: T,
+    pub(super) client_field_name: T,
+    pub(super) client_field_name_plural: T,
 }
 
 impl<T> Copy for Table<T> where T: Copy {}
@@ -20,16 +22,28 @@ impl<T> Table<T> {
     pub(super) fn set_client_name(&mut self, client_name: T) {
         self.client_name = client_name;
     }
+
+    pub(super) fn set_client_field_name(&mut self, client_field_name: T) {
+        self.client_field_name = client_field_name;
+    }
+
+    pub(super) fn set_client_field_name_plural(&mut self, client_field_name_plural: T) {
+        self.client_field_name_plural = client_field_name_plural;
+    }
 }
 
 impl Table<String> {
     pub fn new(schema_id: SchemaId, name: String) -> Self {
         let client_name = name.to_pascal_case();
+        let client_field_name = client_name.to_camel_case();
+        let client_field_name_plural = client_field_name.to_plural();
 
         Self {
             schema_id,
             database_name: name,
             client_name,
+            client_field_name,
+            client_field_name_plural,
         }
     }
 
@@ -40,14 +54,30 @@ impl Table<String> {
     pub(crate) fn client_name(&self) -> &str {
         &self.client_name
     }
+
+    pub(crate) fn client_field_name(&self) -> &str {
+        &self.client_field_name
+    }
+
+    pub(crate) fn client_field_name_plural(&self) -> &str {
+        &self.client_field_name_plural
+    }
 }
 
 impl Table<StringId> {
-    pub fn new(schema_id: SchemaId, database_name: StringId, client_name: StringId) -> Self {
+    pub fn new(
+        schema_id: SchemaId,
+        database_name: StringId,
+        client_name: StringId,
+        client_field_name: StringId,
+        client_field_name_plural: StringId,
+    ) -> Self {
         Self {
             schema_id,
             database_name,
             client_name,
+            client_field_name,
+            client_field_name_plural,
         }
     }
 
@@ -57,5 +87,13 @@ impl Table<StringId> {
 
     pub(crate) fn client_name(&self) -> StringId {
         self.client_name
+    }
+
+    pub(crate) fn client_field_name(&self) -> StringId {
+        self.client_field_name
+    }
+
+    pub(crate) fn client_field_name_plural(&self) -> StringId {
+        self.client_field_name_plural
     }
 }

--- a/engine/crates/postgres-connector-types/src/database_definition/walkers/relation.rs
+++ b/engine/crates/postgres-connector-types/src/database_definition/walkers/relation.rs
@@ -61,12 +61,10 @@ impl<'a> RelationWalker<'a> {
 
     /// The name of the relation field.
     pub fn client_field_name(self) -> String {
-        let base_name = self.referenced_table().client_name().to_camel_case();
-
         let base_name = if self.is_referenced_row_unique() {
-            base_name
+            self.referenced_table().client_field_name()
         } else {
-            base_name.to_plural()
+            self.referenced_table().client_field_name_plural()
         };
 
         let is_name_collision = self
@@ -78,7 +76,7 @@ impl<'a> RelationWalker<'a> {
             let referencing_columns = self.referencing_columns().map(|column| column.client_name()).join("_");
             format!("{base_name}_by_{referencing_columns}").to_camel_case()
         } else {
-            base_name
+            base_name.to_string()
         }
     }
 

--- a/engine/crates/postgres-connector-types/src/database_definition/walkers/table.rs
+++ b/engine/crates/postgres-connector-types/src/database_definition/walkers/table.rs
@@ -24,6 +24,16 @@ impl<'a> TableWalker<'a> {
         self.get_name(self.get().client_name())
     }
 
+    /// The name of fields relating to the table in the GraphQL APIs.
+    pub fn client_field_name(self) -> &'a str {
+        self.get_name(self.get().client_field_name())
+    }
+
+    /// The name of plural fields relating to the table in the GraphQL APIs.
+    pub fn client_field_name_plural(self) -> &'a str {
+        self.get_name(self.get().client_field_name_plural())
+    }
+
     /// An iterator over all the columns in the table.
     pub fn columns(self) -> impl Iterator<Item = TableColumnWalker<'a>> + 'a {
         let range = super::range_for_key(&self.database_definition.table_columns, self.id, |column| {


### PR DESCRIPTION
I was digging into the binary sizes of the gateway & executor last week.  One of the things I noticed was that the regex crate (a known space waster) was being pulled into the executor, so I dug into that.  Turns out this was from a single innocent looking call to `Inflector::to_plural` in the postgres connector.

So, this works the connector to do that call at deploy time in the postgres-parser instead of at runtime, which should reduce the executor payload by a fair bit.

I've approached this by just storing the singular & plural relation field names against every table and storing that.  I'm not 100% happy with this implementation: these are technically only required for tables with relations, and even then a given relation might only need one of the forms.  But I'm not familiar enough with the code to figure out the best place to do _exactly_ what we need.  Particularly since tables names can change later in the process if their name clashes, so we'd then need to propagate that into our memoised relation names.  If anyone knows of a better way to do this (or wants to revisit) feel free.