### PR TITLE
federated-graph: do not render empty types, empty enums in SDL

### DIFF
--- a/engine/crates/federated-graph/src/render_sdl/render_api_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl/render_api_sdl.rs
@@ -63,6 +63,13 @@ impl fmt::Display for Renderer<'_> {
                 continue;
             }
 
+            if graph[object.fields.clone()].iter().all(|field| {
+                let field_name = &graph[field.name];
+                field_name.starts_with("__") || has_inaccessible(&field.composed_directives, graph)
+            }) {
+                continue;
+            }
+
             write_leading_whitespace(f)?;
 
             write_description(f, object.description, "", graph)?;
@@ -245,4 +252,16 @@ fn write_enum_variant(f: &mut fmt::Formatter<'_>, enum_variant: &EnumValue, grap
     f.write_str(&graph[enum_variant.value])?;
     write_public_directives(f, enum_variant.composed_directives, graph)?;
     f.write_char('\n')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty() {
+        let empty = FederatedGraphV3::default();
+        let sdl = render_api_sdl(&empty);
+        assert!(sdl.is_empty());
+    }
 }

--- a/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
@@ -28,68 +28,68 @@ pub fn render_federated_sdl(graph: &FederatedGraphV3) -> Result<String, fmt::Err
         sdl.push('\n');
     }
 
-    for (idx, object) in graph.objects.iter().enumerate() {
+    for object in &graph.objects {
         let object_name = &graph[object.name];
-        let is_query_root = graph.root_operation_types.query == ObjectId(idx);
 
         let mut fields = graph[object.fields.clone()]
             .iter()
             .filter(|field| !graph[field.name].starts_with("__"))
             .peekable();
 
-        if fields.peek().is_some() {
-            if let Some(description) = object.description {
-                write!(sdl, "{}", Description(&graph[description], ""))?;
-            }
-
-            sdl.push_str("type ");
-            sdl.push_str(object_name);
-
-            if !object.implements_interfaces.is_empty() {
-                sdl.push_str(" implements ");
-
-                for (idx, interface) in object.implements_interfaces.iter().enumerate() {
-                    let interface_name = &graph[graph[*interface].name];
-                    sdl.push_str(interface_name);
-
-                    if idx < object.implements_interfaces.len() - 1 {
-                        sdl.push_str(" & ");
-                    }
-                }
-            }
-
-            write_composed_directives(object.composed_directives, graph, &mut sdl)?;
-
-            if !object.keys.is_empty() {
-                sdl.push('\n');
-                for key in &object.keys {
-                    let selection_set = FieldSetDisplay(&key.fields, graph);
-                    let subgraph_name = GraphEnumVariantName(&graph[graph[key.subgraph_id].name]);
-                    if key.resolvable {
-                        writeln!(
-                            sdl,
-                            r#"{INDENT}@join__type(graph: {subgraph_name}, key: {selection_set})"#
-                        )?;
-                    } else {
-                        writeln!(
-                            sdl,
-                            r#"{INDENT}@join__type(graph: {subgraph_name}, key: {selection_set}, resolvable: false)"#
-                        )?;
-                    }
-                }
-            }
-
-            if object.keys.is_empty() {
-                sdl.push(' ');
-            }
-            sdl.push_str("{\n");
-            for field in fields {
-                write_field(field, graph, &mut sdl)?;
-            }
-            writeln!(sdl, "}}\n")?;
-        } else {
+        if fields.peek().is_none() {
             sdl.push_str("\n\n");
+            continue;
         }
+
+        if let Some(description) = object.description {
+            write!(sdl, "{}", Description(&graph[description], ""))?;
+        }
+
+        sdl.push_str("type ");
+        sdl.push_str(object_name);
+
+        if !object.implements_interfaces.is_empty() {
+            sdl.push_str(" implements ");
+
+            for (idx, interface) in object.implements_interfaces.iter().enumerate() {
+                let interface_name = &graph[graph[*interface].name];
+                sdl.push_str(interface_name);
+
+                if idx < object.implements_interfaces.len() - 1 {
+                    sdl.push_str(" & ");
+                }
+            }
+        }
+
+        write_composed_directives(object.composed_directives, graph, &mut sdl)?;
+
+        if !object.keys.is_empty() {
+            sdl.push('\n');
+            for key in &object.keys {
+                let selection_set = FieldSetDisplay(&key.fields, graph);
+                let subgraph_name = GraphEnumVariantName(&graph[graph[key.subgraph_id].name]);
+                if key.resolvable {
+                    writeln!(
+                        sdl,
+                        r#"{INDENT}@join__type(graph: {subgraph_name}, key: {selection_set})"#
+                    )?;
+                } else {
+                    writeln!(
+                        sdl,
+                        r#"{INDENT}@join__type(graph: {subgraph_name}, key: {selection_set}, resolvable: false)"#
+                    )?;
+                }
+            }
+        }
+
+        if object.keys.is_empty() {
+            sdl.push(' ');
+        }
+        sdl.push_str("{\n");
+        for field in fields {
+            write_field(field, graph, &mut sdl)?;
+        }
+        writeln!(sdl, "}}\n")?;
     }
 
     for interface in &graph.interfaces {


### PR DESCRIPTION
They are not valid GraphQL. It's better to render an empty string, so let's do that.

closes GB-6715