### PR TITLE
Revert rust toolchain downgrade

### DIFF
--- a/cli/crates/backend/src/api/types.rs
+++ b/cli/crates/backend/src/api/types.rs
@@ -36,7 +36,7 @@ pub struct Credentials<'a> {
     pub access_token: &'a str,
 }
 
-// #[allow(clippy::to_string_trait_impl)]
+#[allow(clippy::to_string_trait_impl)]
 impl<'a> ToString for Credentials<'a> {
     fn to_string(&self) -> String {
         serde_json::to_string(&self).expect("must parse")
@@ -49,7 +49,7 @@ pub struct ProjectMetadata {
     pub project_id: String,
 }
 
-// #[allow(clippy::to_string_trait_impl)]
+#[allow(clippy::to_string_trait_impl)]
 impl ToString for ProjectMetadata {
     fn to_string(&self) -> String {
         serde_json::to_string(&self).expect("must parse")

--- a/engine/crates/engine/src/registry/mod.rs
+++ b/engine/crates/engine/src/registry/mod.rs
@@ -170,7 +170,7 @@ pub async fn check_field_cache_tag(
 #[derive(Debug)]
 pub struct Edge<'a>(pub &'a str);
 
-// #[allow(clippy::to_string_trait_impl)]
+#[allow(clippy::to_string_trait_impl)]
 impl<'a> ToString for Edge<'a> {
     fn to_string(&self) -> String {
         self.0.to_string()

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 profile = "default"
-channel = "1.77.2"
+channel = "1.78.0"
 targets = [
     "aarch64-apple-darwin",
     "x86_64-apple-darwin",


### PR DESCRIPTION
That was an attempt at fixing the windows CLI build in https://github.com/grafbase/grafbase/pull/1727 that I forgot to revert. This commit brings us back to the latest stable release.