### PR TITLE
feat: partial cache fetching logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2827,6 +2827,7 @@ dependencies = [
  "mime",
  "multipart-stream",
  "operation-normalizer",
+ "partial-caching",
  "registry-for-cache",
  "registry-upgrade",
  "runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5634,12 +5634,21 @@ name = "partial-caching"
 version = "0.73.0"
 dependencies = [
  "anyhow",
+ "blake3",
+ "common-types",
  "cynic-parser 0.4.0",
+ "engine-value",
+ "headers",
+ "http 1.1.0",
  "indexmap 2.2.6",
  "insta",
  "parser-sdl",
  "registry-for-cache",
  "registry-upgrade",
+ "runtime",
+ "serde",
+ "serde_json",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,6 +187,7 @@ parser-graphql = { path = "engine/crates/parser-graphql" }
 parser-openapi = { path = "engine/crates/parser-openapi" }
 parser-postgres = { path = "engine/crates/parser-postgres" }
 parser-sdl = { path = "engine/crates/parser-sdl" }
+partial-caching = { path = "engine/crates/partial-caching" }
 postgres-connector-types = { path = "engine/crates/postgres-connector-types" }
 registry-for-cache = { path = "engine/crates/engine/registry-for-cache" }
 registry-upgrade = { path = "engine/crates/engine/registry-upgrade" }

--- a/cli/crates/gateway/Cargo.toml
+++ b/cli/crates/gateway/Cargo.toml
@@ -26,7 +26,7 @@ engine = { path = "../../../engine/crates/engine" }
 graphql-extensions = { path = "../../../engine/crates/graphql-extensions", features = [
   "local",
 ] }
-gateway-core = { path = "../../../engine/crates/gateway-core" }
+gateway-core = { path = "../../../engine/crates/gateway-core", features = ["partial-caching"] }
 grafbase-tracing = { workspace = true , features = ["tower"] }
 registry-v2.workspace = true
 registry-for-cache.workspace = true

--- a/engine/crates/common-types/src/auth.rs
+++ b/engine/crates/common-types/src/auth.rs
@@ -93,6 +93,13 @@ impl ExecutionAuth {
     pub fn is_introspection_allowed(&self) -> bool {
         self.global_ops().contains(Operations::INTROSPECTION)
     }
+
+    pub fn as_token(&self) -> Option<&ExecutionAuthToken> {
+        match self {
+            ExecutionAuth::Token(token) => Some(token),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]

--- a/engine/crates/engine/registry-for-cache/src/lib.rs
+++ b/engine/crates/engine/registry-for-cache/src/lib.rs
@@ -23,7 +23,7 @@ pub use self::{
     },
 };
 pub use engine_id_newtypes::IdRange;
-pub use registry_v2::CacheControl;
+pub use registry_v2::{cache_control::CacheAccessScope, CacheControl};
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct PartialCacheRegistry {

--- a/engine/crates/gateway-core/Cargo.toml
+++ b/engine/crates/gateway-core/Cargo.toml
@@ -10,6 +10,10 @@ homepage = "https://grafbase.com"
 repository = "https://github.com/grafbase/grafbase"
 keywords = ["graphql", "gateway", "grafbase"]
 
+[features]
+default = []
+partial-caching = ["dep:partial-caching"]
+
 [lints]
 workspace = true
 
@@ -33,6 +37,7 @@ mediatype = "0.19.18"
 mime = "0.3.17"
 multipart-stream = "0.1.2"
 operation-normalizer = { path = "../operation-normalizer" }
+partial-caching = { workspace = true, optional = true }
 registry-for-cache.workspace = true
 runtime = { workspace = true, features = ["test-utils"] }
 serde.workspace = true

--- a/engine/crates/gateway-core/src/cache/mod.rs
+++ b/engine/crates/gateway-core/src/cache/mod.rs
@@ -8,6 +8,9 @@ use runtime::cache::{Cache, Cacheable, CachedExecutionResponse};
 mod build_key;
 mod key;
 
+#[cfg(feature = "partial-caching")]
+pub mod partial;
+
 #[derive(Clone)]
 pub struct CacheConfig {
     pub global_enabled: bool,

--- a/engine/crates/gateway-core/src/cache/partial.rs
+++ b/engine/crates/gateway-core/src/cache/partial.rs
@@ -1,0 +1,32 @@
+use common_types::auth::ExecutionAuth;
+use futures_util::future::join_all;
+use partial_caching::CachingPlan;
+use runtime::{cache::Cache, context::RequestContext};
+
+pub async fn partial_caching_execution(
+    plan: CachingPlan,
+    cache: &Cache,
+    auth: &ExecutionAuth,
+    request: engine::Request,
+    ctx: &impl RequestContext,
+) {
+    let mut fetch_phase = plan.start_fetch_phase(auth, ctx.headers(), &request.variables);
+    let cache_keys = fetch_phase.cache_keys();
+
+    let cache_fetches = cache_keys.iter().map(|key| {
+        let key = cache.build_key(&key.to_string());
+        async move { cache.get_json::<serde_json::Value>(&key).await }
+    });
+
+    for (fetch_result, key) in join_all(cache_fetches).await.into_iter().zip(cache_keys) {
+        match fetch_result {
+            Ok(entry) => fetch_phase.record_cache_entry(&key, entry),
+            Err(error) => {
+                // We basically just log and then pretend this is a miss
+                tracing::warn!("error when fetching from cache: {error}");
+            }
+        }
+    }
+
+    todo!("finish this in a future PR")
+}

--- a/engine/crates/gateway-core/src/lib.rs
+++ b/engine/crates/gateway-core/src/lib.rs
@@ -230,7 +230,26 @@ where
 
         #[cfg(feature = "partial-caching")]
         if self.cache_config.partial_registry.enable_partial_caching {
-            todo!("implement this")
+            let cache_plan = partial_caching::build_plan(
+                request.query(),
+                request.operation_name(),
+                &self.cache_config.partial_registry,
+            );
+
+            match cache_plan {
+                Ok(Some(_cache_plan)) => {
+                    todo!("implement this");
+                }
+                Ok(None) => {
+                    // None means we should proceed with a normal execution.
+                }
+                Err(error) => {
+                    // This probably indicates a malformed query, but the cache planning doesn't have
+                    // especially thorough error reporting in it. So for now I want to pass this to
+                    // the actual execution where it'll get a better error message.
+                    tracing::warn!("error when building cache plan: {error:?}");
+                }
+            }
         }
 
         match build_cache_key(&self.cache_config, ctx.as_ref(), &request, &auth) {

--- a/engine/crates/gateway-core/src/lib.rs
+++ b/engine/crates/gateway-core/src/lib.rs
@@ -228,6 +228,11 @@ where
             return Ok((Arc::new(response), Default::default()));
         }
 
+        #[cfg(feature = "partial-caching")]
+        if self.cache_config.partial_registry.enable_partial_caching {
+            todo!("implement this")
+        }
+
         match build_cache_key(&self.cache_config, ctx.as_ref(), &request, &auth) {
             Ok(cache_key) => {
                 let execution_fut = Arc::clone(&self.executor)

--- a/engine/crates/gateway-core/src/lib.rs
+++ b/engine/crates/gateway-core/src/lib.rs
@@ -230,15 +230,16 @@ where
 
         #[cfg(feature = "partial-caching")]
         if self.cache_config.partial_registry.enable_partial_caching {
-            let cache_plan = partial_caching::build_plan(
+            let cache_plan = ::partial_caching::build_plan(
                 request.query(),
                 request.operation_name(),
                 &self.cache_config.partial_registry,
             );
 
             match cache_plan {
-                Ok(Some(_cache_plan)) => {
-                    todo!("implement this");
+                Ok(Some(plan)) => {
+                    cache::partial::partial_caching_execution(plan, &self.cache, &auth, request, ctx.as_ref()).await;
+                    todo!("finish this")
                 }
                 Ok(None) => {
                     // None means we should proceed with a normal execution.

--- a/engine/crates/partial-caching/Cargo.toml
+++ b/engine/crates/partial-caching/Cargo.toml
@@ -9,11 +9,19 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-cynic-parser.workspace = true
+blake3.workspace = true
+common-types.workspace = true
 cynic-parser.features = ["print"]
-
+cynic-parser.workspace = true
+engine-value.workspace = true
+headers.workspace = true
+http.workspace = true
 indexmap.workspace = true
 registry-for-cache.workspace = true
+runtime.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/engine/crates/partial-caching/src/execution.rs
+++ b/engine/crates/partial-caching/src/execution.rs
@@ -1,0 +1,44 @@
+//! Implements the execution phase of caching - quite a simple one this, it just
+//! takes the original query, removes any parts for which we have cache it and
+//! provides whatever is left.  This can be passed to the executor to run the
+//! query.
+
+use cynic_parser::ExecutableDocument;
+use registry_for_cache::CacheControl;
+
+use crate::QuerySubset;
+
+use super::fetching::CacheFetchPhase;
+
+#[allow(unused)] // Going to update things to use this later
+pub struct ExecutionPhase {
+    document: ExecutableDocument,
+    cache_partitions: Vec<(CacheControl, QuerySubset)>,
+    executor_subset: QuerySubset,
+}
+
+impl ExecutionPhase {
+    pub(crate) fn new(fetch_phase: CacheFetchPhase) -> Self {
+        let plan = fetch_phase.plan;
+
+        let mut executor_subset = plan.nocache_partition;
+        for (entry, (_, partition_subset)) in fetch_phase.cache_entries.iter().zip(plan.cache_partitions.iter()) {
+            if entry.is_miss() {
+                executor_subset.extend(partition_subset);
+            }
+        }
+
+        Self {
+            document: plan.document,
+            cache_partitions: plan.cache_partitions,
+            executor_subset,
+        }
+    }
+
+    pub fn query(&self) -> String {
+        self.executor_subset
+            .as_display(&self.document)
+            .include_query_name()
+            .to_string()
+    }
+}

--- a/engine/crates/partial-caching/src/fetching/keys.rs
+++ b/engine/crates/partial-caching/src/fetching/keys.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeSet;
-
 use common_types::auth::ExecutionAuth;
 use engine_value::{ConstValue, Variables};
 use registry_for_cache::{CacheAccessScope, CacheControl};
@@ -48,14 +46,14 @@ fn cache_scopes<'a>(
 
     let actual_scopes = scopes
         .iter()
-        .filter_map(|scope| match scope {
+        .map(|scope| match scope {
             CacheAccessScope::Public | CacheAccessScope::ApiKey => Some(auth.global_ops().to_string()),
             CacheAccessScope::Jwt { claim } => auth.as_token().and_then(|token| token.get_claim(claim)),
             CacheAccessScope::Header { header: header_name } => headers
                 .get(header_name)
                 .and_then(|header| Some(header.to_str().ok()?.to_string())),
         })
-        .collect::<BTreeSet<_>>();
+        .collect::<Vec<_>>();
 
     if actual_scopes.is_empty() {
         tracing::warn!("Could not find any scopes for cache_control {cache_control:?}");
@@ -67,7 +65,7 @@ fn cache_scopes<'a>(
 
 #[derive(Debug, Hash, serde::Serialize)]
 enum CacheAccess<'a> {
-    Scoped(BTreeSet<String>),
+    Scoped(Vec<Option<String>>),
     Default(&'a ExecutionAuth),
 }
 

--- a/engine/crates/partial-caching/src/fetching/keys.rs
+++ b/engine/crates/partial-caching/src/fetching/keys.rs
@@ -1,0 +1,115 @@
+use std::collections::BTreeSet;
+
+use common_types::auth::ExecutionAuth;
+use engine_value::{ConstValue, Variables};
+use registry_for_cache::{CacheAccessScope, CacheControl};
+
+use super::CachingPlan;
+use crate::query_subset::QuerySubsetDisplay;
+
+pub fn build_cache_keys(
+    plan: &CachingPlan,
+    auth: &ExecutionAuth,
+    headers: &http::HeaderMap,
+    variables: &Variables,
+) -> Vec<Option<String>> {
+    plan.cache_partitions
+        .iter()
+        .map(|(cache_control, query_subset)| {
+            // If we can't figure out the scope for a cache_control entry we just skip it.
+            // This will force it to always be fetched from the cache.
+            let scopes = cache_scopes(cache_control, auth, headers)?;
+
+            let serializer = CacheKeySerializer {
+                query: query_subset.as_display(&plan.document),
+                scopes,
+                variables: variables_required(query_subset, &plan.document, variables),
+            };
+
+            match serializer.build_key_string() {
+                Ok(key) => Some(key),
+                Err(err) => {
+                    tracing::error!("Could not build key string for {cache_control:?}: {err:?}");
+                    None
+                }
+            }
+        })
+        .collect()
+}
+
+fn cache_scopes<'a>(
+    cache_control: &CacheControl,
+    auth: &'a ExecutionAuth,
+    headers: &http::HeaderMap,
+) -> Option<CacheAccess<'a>> {
+    let Some(scopes) = &cache_control.access_scopes else {
+        return Some(CacheAccess::Default(auth));
+    };
+
+    let actual_scopes = scopes
+        .iter()
+        .filter_map(|scope| match scope {
+            CacheAccessScope::Public | CacheAccessScope::ApiKey => Some(auth.global_ops().to_string()),
+            CacheAccessScope::Jwt { claim } => auth.as_token().and_then(|token| token.get_claim(claim)),
+            CacheAccessScope::Header { header: header_name } => headers
+                .get(header_name)
+                .and_then(|header| Some(header.to_str().ok()?.to_string())),
+        })
+        .collect::<BTreeSet<_>>();
+
+    if actual_scopes.is_empty() {
+        tracing::warn!("Could not find any scopes for cache_control {cache_control:?}");
+        return None;
+    }
+
+    Some(CacheAccess::Scoped(actual_scopes))
+}
+
+#[derive(Debug, Hash, serde::Serialize)]
+enum CacheAccess<'a> {
+    Scoped(BTreeSet<String>),
+    Default(&'a ExecutionAuth),
+}
+
+fn variables_required<'a>(
+    query_subset: &'a crate::QuerySubset,
+    document: &'a cynic_parser::ExecutableDocument,
+    variables: &'a Variables,
+) -> Vec<(&'a str, &'a ConstValue)> {
+    query_subset
+        .variables(document)
+        .filter_map(|definition| Some((definition.name(), variables.get(definition.name())?)))
+        .collect()
+}
+
+/// All the components of an individual cache key go in here
+///
+/// We use Serialize to create a JSON string, then hash that
+#[derive(serde::Serialize)]
+struct CacheKeySerializer<'a> {
+    query: QuerySubsetDisplay<'a>,
+    scopes: CacheAccess<'a>,
+    variables: Vec<(&'a str, &'a ConstValue)>,
+}
+
+impl CacheKeySerializer<'_> {
+    fn build_key_string(&self) -> anyhow::Result<String> {
+        let mut hasher = blake3::Hasher::new();
+
+        serde_json::to_writer(&mut hasher, self)?;
+
+        Ok(hasher.finalize().to_hex().to_string())
+    }
+}
+
+// Doing a manual impl here because then we can call collect_str which
+// will _hopefully_ stream the query string instead of allocating a whole String
+// for it
+impl serde::Serialize for QuerySubsetDisplay<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}

--- a/engine/crates/partial-caching/src/fetching/mod.rs
+++ b/engine/crates/partial-caching/src/fetching/mod.rs
@@ -1,0 +1,98 @@
+//! This module handles the fetching phase of partial caching, where we're looking up things
+//! in the cache and refining the exeuction query further based on what we find.
+
+mod keys;
+
+use std::fmt;
+
+use common_types::auth::ExecutionAuth;
+use engine_value::Variables;
+use headers::HeaderMapExt;
+use runtime::cache::Entry;
+
+use self::keys::build_cache_keys;
+use super::CachingPlan;
+use crate::{execution::ExecutionPhase, CacheControlHeaders, FetchPhaseResult};
+
+impl CachingPlan {
+    pub fn start_fetch_phase(
+        self,
+        auth: &ExecutionAuth,
+        headers: &http::HeaderMap,
+        variables: &Variables,
+    ) -> CacheFetchPhase {
+        let cache_headers = headers
+            .typed_get::<headers::CacheControl>()
+            .unwrap_or_else(headers::CacheControl::new);
+
+        // TODO: don't forget to use CacheControlHeaders
+        CacheFetchPhase {
+            cache_keys: build_cache_keys(&self, auth, headers, variables),
+            cache_entries: std::iter::repeat_with(|| Entry::Miss)
+                .take(self.cache_partitions.len())
+                .collect(),
+            plan: self,
+            cache_headers,
+        }
+    }
+}
+
+/// This struct should be used to manage the cache fetching phase.
+pub struct CacheFetchPhase {
+    /// The CachingPlan that we're doing a fetch for.
+    pub(crate) plan: CachingPlan,
+
+    /// The keys for each cache_query in the plan.
+    ///
+    /// Will be None if we couldn't determine a key for whatever reason, in
+    /// which case we'll always query the executor for those fields
+    pub(crate) cache_keys: Vec<Option<String>>,
+
+    /// The cache control headers a user has provided
+    #[allow(unused)]
+    cache_headers: CacheControlHeaders,
+
+    pub(crate) cache_entries: Vec<Entry<serde_json::Value>>,
+}
+
+/// The externally visible representation of a cache key
+#[derive(Clone)]
+pub struct CacheKey {
+    index: usize,
+    key: String,
+}
+
+impl fmt::Display for CacheKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.key)
+    }
+}
+
+impl CacheFetchPhase {
+    /// The keys that we need to fetch from the cache
+    pub fn cache_keys(&self) -> Vec<CacheKey> {
+        self.cache_keys
+            .iter()
+            .enumerate()
+            .filter_map(|(index, key)| {
+                Some(CacheKey {
+                    index,
+                    key: key.as_ref()?.to_string(),
+                })
+            })
+            .collect()
+    }
+
+    /// Records the response from the cache for a given key
+    pub fn record_cache_entry(&mut self, key: &CacheKey, entry: Entry<serde_json::Value>) {
+        self.cache_entries[key.index] = entry;
+    }
+
+    pub fn finish(self) -> FetchPhaseResult {
+        if self.cache_entries.iter().any(|entry| entry.is_miss()) || !self.plan.nocache_partition.is_empty() {
+            FetchPhaseResult::PartialHit(ExecutionPhase::new(self))
+        } else {
+            FetchPhaseResult::CompleteHit
+        }
+    }
+}

--- a/engine/crates/partial-caching/src/lib.rs
+++ b/engine/crates/partial-caching/src/lib.rs
@@ -1,15 +1,48 @@
+//! This crate implements the logic for partial caching.
+//!
+//! To make things easier to test this crate is side effect free - the crate that integrates this
+//! (gateway_core currently) is resposible for reading & writing to the cache, and running the
+//! actual execution.  This crate just determines what to read/write/execute/return to the
+//! user.
+//!
+//! The process is a little bit involved, so it's broken up into phases:
+//!
+//! 1. First we build a CachingPlan from the incoming query.
+//! 2. Then we move into the CacheFetchPhase, which provides keys to a consumer,
+//! 3. Then we run an ExecutionPhase if it's required.
+//! 4. TBC after that (need to write the code first)
+
 use cynic_parser::ExecutableDocument;
 use registry_for_cache::CacheControl;
 
+mod execution;
+mod fetching;
 mod planning;
 mod query_subset;
 
-pub use self::{planning::build_plan, query_subset::QuerySubset};
+pub use self::{execution::ExecutionPhase, planning::build_plan, query_subset::QuerySubset};
+
+// Renaming this because we have registry_for_cache::CacheControl & headers::CacheControl and
+// it's confusing when you're working with both of them.  Hopefully the alias doesn't add
+// it's own confusion :|
+pub use headers::CacheControl as CacheControlHeaders;
 
 pub struct CachingPlan {
     pub document: ExecutableDocument,
-    pub cache_queries: Vec<(CacheControl, QuerySubset)>,
-    pub executor_query: QuerySubset,
+    pub cache_partitions: Vec<(CacheControl, QuerySubset)>,
+    pub nocache_partition: QuerySubset,
+}
+
+/// The output of the fetch phase of partial caching
+pub enum FetchPhaseResult {
+    /// We've only fetched some of the query from the cache, so we need
+    /// to enter an ExecutionPhase
+    PartialHit(ExecutionPhase),
+
+    /// We fetched all the results from the cache, so can just return a response
+    ///
+    /// Note that I've not implemented this bit yet - it'll come later.
+    CompleteHit,
 }
 
 #[cfg(test)]

--- a/engine/crates/partial-caching/src/planning/mod.rs
+++ b/engine/crates/partial-caching/src/planning/mod.rs
@@ -53,11 +53,11 @@ pub fn build_plan(
     let operation = operation.id();
 
     Ok(Some(CachingPlan {
-        cache_queries: cache_groups
+        cache_partitions: cache_groups
             .into_iter()
             .map(|(control, group)| (control, QuerySubset::new(operation, group, &document)))
             .collect(),
-        executor_query: QuerySubset::new(operation, uncached_group, &document),
+        nocache_partition: QuerySubset::new(operation, uncached_group, &document),
         document,
     }))
 }

--- a/engine/crates/partial-caching/tests/cache-fetching.rs
+++ b/engine/crates/partial-caching/tests/cache-fetching.rs
@@ -1,0 +1,151 @@
+#![allow(unused_crate_dependencies, clippy::panic)]
+
+use common_types::auth::ExecutionAuth;
+use http::HeaderMap;
+use insta::{assert_json_snapshot, assert_snapshot};
+use partial_caching::FetchPhaseResult;
+use serde::Deserialize;
+use serde_json::json;
+
+const SCHEMA: &str = r#"
+    type Query {
+        user: User @resolver(name: "whatever")
+    }
+
+    type User {
+        name: String @cache(maxAge: 140)
+        email: String @cache(maxAge: 130)
+        someConstant: String @cache(maxAge: 120)
+        uncached: String
+    }
+"#;
+
+const QUERY: &str = r#"query SomeName { user { name email someConstant uncached } }"#;
+
+#[test]
+fn cache_partitions_need_cache_fetched() {
+    let registry = build_registry(SCHEMA);
+    let plan = partial_caching::build_plan(QUERY, None, &registry).unwrap().unwrap();
+    let fetch_phase = plan.start_fetch_phase(&auth(), &headers(), &variables());
+
+    let cache_keys = fetch_phase
+        .cache_keys()
+        .iter()
+        .map(|key| key.to_string())
+        .collect::<Vec<_>>();
+
+    assert_json_snapshot!(cache_keys, @r###"
+    [
+      "e89684018782de6720bd7d3788879b9f6edfd38ac310798298e0ade57bb35120",
+      "710ae8fca46776cd4dbec55725b7a92453bd9ef2e82735807329ab86aa14a900",
+      "e0221b10004e1c356f27a8983a5a26a6b41c7afe99d7283ebba5ff2c834839c8"
+    ]
+    "###);
+}
+
+#[test]
+fn correct_query_when_some_miss_some_hits() {
+    let registry = build_registry(SCHEMA);
+    let plan = partial_caching::build_plan(QUERY, None, &registry).unwrap().unwrap();
+    let mut fetch_phase = plan.start_fetch_phase(&auth(), &headers(), &variables());
+
+    let cache_keys = fetch_phase.cache_keys();
+    fetch_phase.record_cache_entry(
+        &cache_keys[0],
+        runtime::cache::Entry::Hit(json!({"user": {"name": "Jane"}})),
+    );
+    fetch_phase.record_cache_entry(&cache_keys[1], runtime::cache::Entry::Miss);
+
+    let FetchPhaseResult::PartialHit(execution) = fetch_phase.finish() else {
+        panic!("We didn't hit everything so this should always be a partial");
+    };
+
+    assert_snapshot!(execution.query(), @r###"
+    query SomeName {
+      user {
+        email
+        someConstant
+        uncached
+      }
+    }
+    "###)
+}
+
+#[test]
+fn nocache_fields_are_always_in_query() {
+    let registry = build_registry(SCHEMA);
+    let plan = partial_caching::build_plan(QUERY, None, &registry).unwrap().unwrap();
+    let mut fetch_phase = plan.start_fetch_phase(&auth(), &headers(), &variables());
+
+    let cache_keys = fetch_phase.cache_keys();
+    for key in &cache_keys {
+        fetch_phase.record_cache_entry(key, runtime::cache::Entry::Hit(json!("whatever")));
+    }
+
+    let FetchPhaseResult::PartialHit(execution) = fetch_phase.finish() else {
+        panic!("We have no cache fields hit everything so this should always be a partial");
+    };
+
+    assert_snapshot!(execution.query(), @r###"
+    query SomeName {
+      user {
+        uncached
+      }
+    }
+    "###)
+}
+
+#[test]
+fn test_complete_cache_hits() {
+    let registry = build_registry(SCHEMA);
+    let plan = partial_caching::build_plan("query { user { name } }", None, &registry)
+        .unwrap()
+        .unwrap();
+    let mut fetch_phase = plan.start_fetch_phase(&auth(), &headers(), &variables());
+
+    let cache_keys = fetch_phase.cache_keys();
+    assert_eq!(cache_keys.len(), 1);
+    fetch_phase.record_cache_entry(&cache_keys[0], runtime::cache::Entry::Hit(json!("whatever")));
+
+    let FetchPhaseResult::CompleteHit = fetch_phase.finish() else {
+        panic!("We hit all the cached fields so should have a complete hit");
+    };
+}
+
+#[test]
+fn query_name_does_not_factor_into_cache_key() {
+    let registry = build_registry(SCHEMA);
+    let plan = partial_caching::build_plan("query Hello { user { name } }", None, &registry)
+        .unwrap()
+        .unwrap();
+    let fetch_phase = plan.start_fetch_phase(&auth(), &headers(), &variables());
+
+    let cache_keys = fetch_phase.cache_keys();
+    let cache_key_one = cache_keys.first().unwrap();
+
+    let plan = partial_caching::build_plan("query { user { name } }", None, &registry)
+        .unwrap()
+        .unwrap();
+    let fetch_phase = plan.start_fetch_phase(&auth(), &headers(), &variables());
+
+    let cache_keys = fetch_phase.cache_keys();
+    let cache_key_two = cache_keys.first().unwrap();
+
+    assert_eq!(cache_key_one.to_string(), cache_key_two.to_string())
+}
+
+fn build_registry(schema: &str) -> registry_for_cache::PartialCacheRegistry {
+    registry_upgrade::convert_v1_to_partial_cache_registry(parser_sdl::parse_registry(schema).unwrap()).unwrap()
+}
+
+fn auth() -> ExecutionAuth {
+    ExecutionAuth::ApiKey
+}
+
+fn headers() -> HeaderMap {
+    http::HeaderMap::new()
+}
+
+fn variables() -> engine_value::Variables {
+    engine_value::Variables::deserialize(json!({})).unwrap()
+}

--- a/engine/crates/partial-caching/tests/query-splitting.rs
+++ b/engine/crates/partial-caching/tests/query-splitting.rs
@@ -26,13 +26,9 @@ fn test_basic_split() {
     let plan = partial_caching::build_plan(QUERY, None, &registry).unwrap().unwrap();
 
     let result = plan
-        .cache_queries
+        .cache_partitions
         .into_iter()
-        .map(|(_, query)| {
-            let mut s = String::new();
-            query.write(&plan.document, &mut s).unwrap();
-            s
-        })
+        .map(|(_, query)| query.as_display(&plan.document).to_string())
         .collect::<Vec<_>>();
 
     assert_eq!(result.len(), 3, "{result:?}");
@@ -102,13 +98,9 @@ fn test_split_with_absurd_fragments() {
     let plan = partial_caching::build_plan(QUERY, None, &registry).unwrap().unwrap();
 
     let result = plan
-        .cache_queries
+        .cache_partitions
         .into_iter()
-        .map(|(_, query)| {
-            let mut s = String::new();
-            query.write(&plan.document, &mut s).unwrap();
-            s
-        })
+        .map(|(_, query)| query.as_display(&plan.document).to_string())
         .collect::<Vec<_>>();
 
     assert_eq!(result.len(), 3, "{result:?}");
@@ -213,10 +205,9 @@ fn test_arguments_and_directives_preserved() {
 
     let plan = partial_caching::build_plan(QUERY, None, &registry).unwrap().unwrap();
 
-    assert!(plan.cache_queries.is_empty());
+    assert!(plan.cache_partitions.is_empty());
 
-    let mut result = String::new();
-    plan.executor_query.write(&plan.document, &mut result).unwrap();
+    let result = plan.nocache_partition.as_display(&plan.document).to_string();
 
     insta::assert_snapshot!(result)
 }

--- a/engine/crates/runtime/src/cache/mod.rs
+++ b/engine/crates/runtime/src/cache/mod.rs
@@ -66,6 +66,10 @@ impl<T> Entry<T> {
             Entry::Stale(StaleEntry { value, .. }) => Some(value),
         }
     }
+
+    pub fn is_miss(&self) -> bool {
+        matches!(self, Entry::Miss)
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]


### PR DESCRIPTION
This implements the logic for building cache keys out of the various cachable query partitions, along with fetching them from the cache and then determining the final query to send along to the executor.

I've introduce the notion of "phases" to the partial-caching crate - we enter a "CacheFetchPhase", represented by a struct, that exposes functions to handle all the logic of this phase.  When done you can call ".finish()" which will either move to an execution phase or some as yet unnamed final phase.

I've also started integrating this with the gateway_core crate.  This is a very broken implementation, but one that will only be called if you enable partial caching in your registry (don't do that) and you have the cargo feature flag enabled (which it is in the CLI, so that I can work on this easier, but won't be in production till this is closer to ready).

The cache key calculations in this differ in a couple of ways from the existing setup:

1. I'm using blake3 for the hashing instead of SipHash.  I didn't feel comfortable using a non-cryptographic hash function - from a security standpoint, and also because collisions will mess this partial caching thing up horrendously, and I do not fancy debugging that down the line.
2. I'm hashing the JSON serialised form of the data, instead of doing order agnostic things with Objects like we do in the existing hash functions.  This is a bit annoying, although I'm not sure how much of an issue this is in practice. It was way faster to implement though. I've raised a linear issue to revisit this if I get time/we decide that it matters.

Fixes GB-6741
