### PR TITLE
feat: tracing tweaks for CLI

### DIFF
--- a/cli/crates/cli/src/cli_input.rs
+++ b/cli/crates/cli/src/cli_input.rs
@@ -49,7 +49,7 @@ pub(crate) use sub_command::SubCommand;
 pub(crate) use subgraphs::SubgraphsCommand;
 
 use clap::Parser;
-use common::consts::{DEFAULT_LOG_FILTER, TRACE_LOG_FILTER};
+use common::consts::TRACE_LOG_FILTER;
 use std::path::PathBuf;
 
 const DEFAULT_SUBGRAPH_PORT: u16 = 4000;
@@ -79,6 +79,8 @@ pub struct Args {
     /// Set the tracing level
     #[arg(short, long, default_value_t = 0)]
     pub trace: u16,
+    #[arg(long, hide = true)]
+    pub custom_trace_filter: Option<String>,
     #[command(subcommand)]
     pub command: SubCommand,
     /// An optional replacement path for the home directory
@@ -87,11 +89,13 @@ pub struct Args {
 }
 
 impl Args {
-    pub fn log_filter(&self) -> &str {
-        if self.trace >= 1 {
-            TRACE_LOG_FILTER
+    pub fn log_filter(&self) -> Option<&str> {
+        if let Some(custom_trace) = &self.custom_trace_filter {
+            Some(custom_trace.as_str())
+        } else if self.trace >= 1 {
+            Some(TRACE_LOG_FILTER)
         } else {
-            DEFAULT_LOG_FILTER
+            None
         }
     }
 }

--- a/cli/crates/cli/src/main.rs
+++ b/cli/crates/cli/src/main.rs
@@ -80,7 +80,13 @@ fn main() {
 }
 
 fn try_main(args: Args) -> Result<(), CliError> {
-    let filter = EnvFilter::builder().parse_lossy(args.log_filter());
+    let filter = {
+        let builder = EnvFilter::builder();
+        match args.log_filter() {
+            Some(argument_filter) => builder.parse_lossy(argument_filter),
+            None => builder.from_env_lossy(),
+        }
+    };
 
     tracing_subscriber::registry().with(fmt::layer()).with(filter).init();
 

--- a/cli/crates/common/src/consts.rs
+++ b/cli/crates/common/src/consts.rs
@@ -23,9 +23,7 @@ pub const AUTHORIZERS_DIRECTORY_NAME: &str = "auth";
 /// the bun installation directory within ~/.grafbase
 pub const BUN_DIRECTORY_NAME: &str = "bun";
 /// the tracing filter to be used when tracing is on
-pub const TRACE_LOG_FILTER: &str = "grafbase=trace,grafbase_local_common=trace,grafbase_local_server=trace,grafbase_local_backend=trace,tower_http=debug,federated_dev=trace,postgres-connector-types=trace,engine_v2=debug";
-/// the tracing filter to be used when tracing is off
-pub const DEFAULT_LOG_FILTER: &str = "off";
+pub const TRACE_LOG_FILTER: &str = "info,grafbase=trace,grafbase_local_common=trace,grafbase_local_server=trace,grafbase_local_backend=trace,federated_dev=trace,postgres-connector-types=trace,engine_v2=debug";
 /// an environment variable that sets the path of the home directory
 pub const GRAFBASE_HOME: &str = "GRAFBASE_HOME";
 /// the name of the Grafbase SDK npm package


### PR DESCRIPTION
I was trying to debug partial caching yesterday but my `trace::info!` calls weren't appearing in my terminal, causing much confusion.  This turned out to be because my trace calls were in `gateway_core` which is not in the log filter that's set when you do `--trace 2`.  So, I've done a few things to fix:

1. Added a default of info to the `--trace 2` filter, to make it easier to get everything.  We have too many crates (and introduce new ones all the time) to expect this list to always be exhaustive.
2. I've added a hidden `--custom-trace-filter` argument that lets you provide a specific filter on the CLI.
3. I've added support for the `RUST_LOG` env var if neither of the CLI arguments are provided.

This made it much easier to debug my code, as I could ask for `gateway_core` traces specifically, and avoid the noise that all the other log filter flags introduce.  It was _so much easier_ from that point on.

Some questions for the team though:

1. `--trace` is a bit weird in that it takes a number, where 1 doesn't do anything and anything up from 2 does the same thing.  Should we rethink this?  Either ditch the number or make 1 do something?
2. `--custom-trace-filter` is hidden, because I didn't feel like changing public interfaces.  But should we make it shown?  Or should I just remove it in favour of always using the env var?
3. I debated using a grafbase specific env var like `GRAFBASE_LOG` instead of `RUST_LOG`.  Thoughts?

Also welcome any other thoughts anyone has.