### PR TITLE
fix: support variables in partial caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,7 +1515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f3f1953f4590381034d75c49a568665567f19ee393d4292835d35bac9724dca"
 dependencies = [
  "counter",
- "cynic-parser 0.4.0",
+ "cynic-parser 0.4.1",
  "darling",
  "once_cell",
  "ouroboros",
@@ -1552,9 +1552,9 @@ dependencies = [
 
 [[package]]
 name = "cynic-parser"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdd04fb7248e4ef439cc373564fcdec5b14140b8240e727c264fb85a6f729ee"
+checksum = "7b9f36eeb1107059bea01cc5db8492737c98e9fdf570f909846b8c9fc274aa94"
 dependencies = [
  "ariadne",
  "indexmap 2.2.6",
@@ -2813,7 +2813,7 @@ dependencies = [
  "blake3",
  "bytes",
  "common-types",
- "cynic-parser 0.4.0",
+ "cynic-parser 0.4.1",
  "engine",
  "engine-parser",
  "engine-validation",
@@ -3084,7 +3084,7 @@ version = "0.73.0"
 dependencies = [
  "cynic",
  "cynic-introspection",
- "cynic-parser 0.4.0",
+ "cynic-parser 0.4.1",
  "indoc",
  "reqwest",
  "serde",
@@ -3150,7 +3150,7 @@ dependencies = [
  "common-types",
  "const_format",
  "criterion",
- "cynic-parser 0.4.0",
+ "cynic-parser 0.4.1",
  "dotenv",
  "engine",
  "federated-dev",
@@ -3305,7 +3305,7 @@ name = "graphql-lint"
 version = "0.1.3"
 dependencies = [
  "criterion",
- "cynic-parser 0.4.0",
+ "cynic-parser 0.4.1",
  "heck 0.5.0",
  "thiserror",
 ]
@@ -3358,7 +3358,7 @@ dependencies = [
 name = "graphql-schema-diff"
 version = "0.1.1"
 dependencies = [
- "cynic-parser 0.4.0",
+ "cynic-parser 0.4.1",
  "datatest-stable",
  "miette 7.2.0",
  "serde",
@@ -5637,7 +5637,7 @@ dependencies = [
  "anyhow",
  "blake3",
  "common-types",
- "cynic-parser 0.4.0",
+ "cynic-parser 0.4.1",
  "engine-value",
  "graph-entities",
  "headers",
@@ -6444,7 +6444,7 @@ name = "registry-v2-generator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cynic-parser 0.4.0",
+ "cynic-parser 0.4.1",
  "indexmap 2.2.6",
  "indoc",
  "itertools 0.13.0",

--- a/engine/crates/partial-caching/src/planning/variables.rs
+++ b/engine/crates/partial-caching/src/planning/variables.rs
@@ -1,0 +1,59 @@
+use cynic_parser::{
+    executable::{ids::VariableDefinitionId, Argument, Directive, OperationDefinition},
+    ExecutableDocument,
+};
+use indexmap::IndexSet;
+
+use crate::query_subset::CacheGroup;
+
+pub fn variables_required(
+    partition: &CacheGroup,
+    document: &ExecutableDocument,
+    operation: OperationDefinition<'_>,
+) -> IndexSet<VariableDefinitionId> {
+    let mut variables = partition
+        .selections
+        .iter()
+        .flat_map(|id| -> Box<dyn Iterator<Item = &str>> {
+            match document.read(*id) {
+                cynic_parser::executable::Selection::Field(field) => Box::new(
+                    variables_used_in_argument(field.arguments())
+                        .chain(variables_used_in_directive(field.directives())),
+                ),
+                cynic_parser::executable::Selection::InlineFragment(fragment) => {
+                    Box::new(variables_used_in_directive(fragment.directives()))
+                }
+                cynic_parser::executable::Selection::FragmentSpread(spread) => {
+                    Box::new(variables_used_in_directive(spread.directives()))
+                }
+            }
+        })
+        .collect::<IndexSet<_>>();
+
+    variables.extend(partition.fragments.iter().flat_map(|id| {
+        let fragment = document.read(*id);
+        variables_used_in_directive(fragment.directives())
+    }));
+
+    variables.extend(variables_used_in_directive(operation.directives()));
+
+    variables
+        .into_iter()
+        .flat_map(|name| {
+            Some(
+                operation
+                    .variable_definitions()
+                    .find(|variable| variable.name() == name)?
+                    .id(),
+            )
+        })
+        .collect()
+}
+
+fn variables_used_in_directive<'a>(directives: impl Iterator<Item = Directive<'a>>) -> impl Iterator<Item = &'a str> {
+    directives.flat_map(|directive| variables_used_in_argument(directive.arguments()))
+}
+
+fn variables_used_in_argument<'a>(arguments: impl Iterator<Item = Argument<'a>>) -> impl Iterator<Item = &'a str> {
+    arguments.flat_map(|argument| argument.value().variables_used().collect::<Vec<_>>())
+}

--- a/engine/crates/partial-caching/src/query_subset.rs
+++ b/engine/crates/partial-caching/src/query_subset.rs
@@ -19,7 +19,7 @@ use indexmap::IndexSet;
 pub struct QuerySubset {
     pub(crate) operation: OperationDefinitionId,
     cache_group: CacheGroup,
-    variables: Vec<VariableDefinitionId>,
+    variables: IndexSet<VariableDefinitionId>,
 }
 
 #[derive(Default, Debug)]
@@ -32,14 +32,12 @@ impl QuerySubset {
     pub(crate) fn new(
         operation: OperationDefinitionId,
         cache_group: CacheGroup,
-        _document: &ExecutableDocument,
+        variables: IndexSet<VariableDefinitionId>,
     ) -> Self {
         QuerySubset {
             operation,
             cache_group,
-
-            // TODO: do this
-            variables: vec![],
+            variables,
         }
     }
 


### PR DESCRIPTION
For the sake of time I skipped figuring out which variables apply to which query partitions earlier in the week.  This revisits and fixes those.

Fixes GB-6776