### PR TITLE
composition: ignore subgraph federation mandated fields and types

### DIFF
--- a/engine/crates/composition/CHANGELOG.md
+++ b/engine/crates/composition/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Ignore federation mandated fields (_entities, _service) and types (https://github.com/grafbase/grafbase/pull/1743)
 - Validate that required arguments are provided in @requires selections (https://github.com/grafbase/grafbase/pull/1683)
 - More context for error messages regarding `@requires` fields validations (https://github.com/grafbase/grafbase/pull/1683)
 - Subgraph names must now start with an alphabetic character and be entirely alphanumeric characters and hyphens (https://github.com/grafbase/grafbase/pull/1685)

--- a/engine/crates/composition/src/compose.rs
+++ b/engine/crates/composition/src/compose.rs
@@ -103,6 +103,7 @@ fn merge_object_definitions<'a>(
 
     fields::for_each_field_group(definitions, |fields| {
         let Some(first) = fields.first() else { return };
+
         object::compose_object_fields(object_id, is_shareable, *first, fields, ctx);
     });
 }

--- a/engine/crates/composition/src/ingest_subgraph/schema_definitions.rs
+++ b/engine/crates/composition/src/ingest_subgraph/schema_definitions.rs
@@ -31,6 +31,10 @@ pub(super) struct RootTypeMatcher<'a> {
 }
 
 impl RootTypeMatcher<'_> {
+    pub(crate) fn is_query(&self, name: &str) -> bool {
+        matches!(self.match_name(name), RootTypeMatch::Query)
+    }
+
     pub(crate) fn match_name(&self, name: &str) -> RootTypeMatch {
         for (name_from_definition, default_name, match_case) in [
             (self.query, "Query", RootTypeMatch::Query),

--- a/engine/crates/composition/tests/composition/subgraph_query_fields_service_entities/api.graphql
+++ b/engine/crates/composition/tests/composition/subgraph_query_fields_service_entities/api.graphql
@@ -1,0 +1,52 @@
+type Lentil {
+    color: String!
+    id: ID!
+    name: String!
+    nutritionalInfo: NutritionalInfo
+    origin: String
+}
+
+type NutritionalInfo {
+    calories: Int
+    carbohydrates: Float
+    fat: Float
+    fiber: Float
+    protein: Float
+}
+
+type Rice {
+    id: ID!
+    name: String!
+    nutritionalInfo: NutritionalInfo
+    origin: String
+    variety: String!
+}
+
+type Query {
+    lentil: Lentil
+    lentils: [Lentil]
+    rice: Rice
+    rices: [Rice]
+}
+
+type Mutation {
+    addLentil: Lentil
+    deleteLentil: Lentil
+}
+
+input AddLentilInput {
+    name: String!
+    color: String!
+    origin: String
+    nutritionalInfo: NutritionalInfoInput
+}
+
+input NutritionalInfoInput {
+    calories: Int
+    protein: Float
+    carbohydrates: Float
+    fiber: Float
+    fat: Float
+}
+
+scalar _Any

--- a/engine/crates/composition/tests/composition/subgraph_query_fields_service_entities/federated.graphql
+++ b/engine/crates/composition/tests/composition/subgraph_query_fields_service_entities/federated.graphql
@@ -1,0 +1,77 @@
+directive @core(feature: String!) repeatable on SCHEMA
+
+directive @join__owner(graph: join__Graph!) on OBJECT
+
+directive @join__type(
+    graph: join__Graph!
+    key: String!
+    resolvable: Boolean = true
+) repeatable on OBJECT | INTERFACE
+
+directive @join__field(
+    graph: join__Graph
+    requires: String
+    provides: String
+) on FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+enum join__Graph {
+    LENTILS @join__graph(name: "lentils", url: "http://example.com/lentils")
+    RICE @join__graph(name: "rice", url: "http://example.com/rice")
+}
+
+scalar _Any
+
+type Lentil
+    @join__type(graph: LENTILS, key: "id")
+{
+    color: String! @join__field(graph: LENTILS)
+    id: ID!
+    name: String! @join__field(graph: LENTILS)
+    nutritionalInfo: NutritionalInfo @join__field(graph: LENTILS)
+    origin: String @join__field(graph: LENTILS)
+}
+
+type NutritionalInfo {
+    calories: Int
+    carbohydrates: Float
+    fat: Float
+    fiber: Float
+    protein: Float
+}
+
+type Rice {
+    id: ID! @join__field(graph: RICE)
+    name: String! @join__field(graph: RICE)
+    nutritionalInfo: NutritionalInfo @join__field(graph: RICE)
+    origin: String @join__field(graph: RICE)
+    variety: String! @join__field(graph: RICE)
+}
+
+type Query {
+    lentil(id: ID!): Lentil @join__field(graph: LENTILS)
+    lentils: [Lentil] @join__field(graph: LENTILS)
+    rice(id: ID!): Rice @join__field(graph: RICE)
+    rices: [Rice] @join__field(graph: RICE)
+}
+
+type Mutation {
+    addLentil(input: AddLentilInput!): Lentil @join__field(graph: LENTILS)
+    deleteLentil(id: ID!): Lentil @join__field(graph: LENTILS)
+}
+
+input AddLentilInput {
+    name: String!
+    color: String!
+    origin: String
+    nutritionalInfo: NutritionalInfoInput
+}
+
+input NutritionalInfoInput {
+    calories: Int
+    protein: Float
+    carbohydrates: Float
+    fiber: Float
+    fat: Float
+}

--- a/engine/crates/composition/tests/composition/subgraph_query_fields_service_entities/subgraphs/lentils.graphql
+++ b/engine/crates/composition/tests/composition/subgraph_query_fields_service_entities/subgraphs/lentils.graphql
@@ -1,0 +1,54 @@
+union _Entity = Lentil
+
+type _Service {
+  sdl: String!
+}
+
+scalar _Any
+
+type Qwery {
+  lentils: [Lentil]
+  lentil(id: ID!): Lentil
+  _service: _Service!
+  _entities(representations: [_Any!]!): [_Entity]!
+}
+
+type Mutation {
+  addLentil(input: AddLentilInput!): Lentil
+  deleteLentil(id: ID!): Lentil
+}
+
+type Lentil @key(fields: "id") {
+  id: ID!
+  name: String!
+  color: String!
+  origin: String
+  nutritionalInfo: NutritionalInfo
+}
+
+type NutritionalInfo @shareable {
+  calories: Int
+  protein: Float
+  carbohydrates: Float
+  fiber: Float
+  fat: Float
+}
+
+input AddLentilInput {
+  name: String!
+  color: String!
+  origin: String
+  nutritionalInfo: NutritionalInfoInput
+}
+
+input NutritionalInfoInput {
+  calories: Int
+  protein: Float
+  carbohydrates: Float
+  fiber: Float
+  fat: Float
+}
+
+schema {
+  query: Qwery
+}

--- a/engine/crates/composition/tests/composition/subgraph_query_fields_service_entities/subgraphs/rice.graphql
+++ b/engine/crates/composition/tests/composition/subgraph_query_fields_service_entities/subgraphs/rice.graphql
@@ -1,0 +1,30 @@
+type Query {
+  rices: [Rice]
+  rice(id: ID!): Rice
+  _service: _Service!
+  _entities(representations: [_Any!]!): [_Entity]!
+}
+
+type Rice {
+  id: ID!
+  name: String!
+  variety: String!
+  origin: String
+  nutritionalInfo: NutritionalInfo
+}
+
+type NutritionalInfo @shareable {
+  calories: Int
+  protein: Float
+  carbohydrates: Float
+  fiber: Float
+  fat: Float
+}
+
+scalar _Any
+
+union _Entity = Rice
+
+type _Service {
+  sdl: String!
+}


### PR DESCRIPTION
Subgraphs must expose the _entities and _service fields (and the corresponding _Entity and _Service types) in order to function as subgraphs behind the federated gateway. Depending on how you introspect them, these fields and types may end up in the subgraph SDL sent for composition. Since these fields are not part of the domain API, and they do not compose cleanly (duplicated fields and types across subgraphs), composition can and should ignore them.

This is what is implemented in this commit.

closes GB-6830