### PR TITLE
cli: release 0.74.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "engine-config-builder"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "engine-v2-config",
  "graphql-federated-graph",
@@ -2429,7 +2429,7 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "federated-dev"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2775,7 +2775,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "assert_matches",
  "async-graphql",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-graphql-introspection"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "cynic",
  "cynic-introspection",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "async-compression",
  "axum 0.7.5",
@@ -3122,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "chrono",
  "common-types",
@@ -3142,7 +3142,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "graph-ref"
-version = "0.73.0"
+version = "0.74.0"
 
 [[package]]
 name = "graphql-composition"
@@ -3266,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-cursor"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "serde",
  "serde_with",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "operation-checks"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "async-graphql-parser",
  "async-graphql-value",
@@ -5366,7 +5366,7 @@ dependencies = [
 
 [[package]]
 name = "operation-normalizer"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -5632,7 +5632,7 @@ dependencies = [
 
 [[package]]
 name = "partial-caching"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -8347,7 +8347,7 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typed-resolvers"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "datatest-stable",
  "engine-parser",
@@ -9175,7 +9175,7 @@ dependencies = [
 
 [[package]]
 name = "wrapping"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ tracing-core = { git = "https://github.com/tokio-rs/tracing", branch = "v0.1.x" 
 tonic = { git = "https://github.com/grafbase/tonic", rev = "58de44e200af96defc4038701df9f18a177bc4c6" } # tokio-rustls-ring
 
 [workspace.package]
-version = "0.73.0"
+version = "0.74.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://grafbase.com"

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.74.0] - 2024-06-03
+
+[CHANGELOG](changelog/0.72.0.md)
+
+## [0.73.0] - 2024-05-27
+
+[CHANGELOG](changelog/0.72.0.md)
+
 ## [0.72.0] - 2024-05-16
 
 [CHANGELOG](changelog/0.72.0.md)

--- a/cli/changelog/0.74.0.md
+++ b/cli/changelog/0.74.0.md
@@ -1,0 +1,3 @@
+# Fixes
+
+- Ignore subgraph federation mandated fields and types in federated graph composition (#1743). This is only relevant in `grafbase dev` in federated graphs.

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -36,8 +36,8 @@ ulid = "1.1.2"
 url = "2.5.0"
 urlencoding = "2.1.3"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.73.0" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.73.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.74.0" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.74.0" }
 
 [build-dependencies]
 cynic-codegen = { version = "3.7.0", features = ["rkyv"] }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -52,13 +52,13 @@ url = "2.5.0"
 uuid = { version = "1.8.0", features = ["v4"] }
 webbrowser = "1.0"
 
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.73.0" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.73.0" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.74.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.74.0" }
 federated-dev = { path = "../federated-dev" }
 grafbase-graphql-introspection.workspace = true
 graphql-lint.workspace = true
 graph-ref = { path = "../../../graph-ref" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.73.0" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.74.0" }
 prettytable = { version = "0.10.0", default-features = false, features = ["win_crlf"] }
 
 [dev-dependencies]

--- a/cli/crates/federated-dev/Cargo.toml
+++ b/cli/crates/federated-dev/Cargo.toml
@@ -33,7 +33,7 @@ tokio-stream = { version = "0.1.15", features = ["sync"] }
 tower-http = { workspace = true, features = ["cors", "fs", "trace"] }
 url = "2.5.0"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.73.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.74.0" }
 engine = { path = "../../../engine/crates/engine" }
 engine-config-builder = { path = "../../../engine/crates/engine-config-builder" }
 engine-v2.workspace = true

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -62,7 +62,7 @@ tracing = "0.1.40"
 which.workspace = true
 zip = "2.0.0"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.73.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.74.0" }
 gateway = { path = "../gateway" }
 typed-resolvers = { path = "../typed-resolvers" }
 federated-dev = { path = "../federated-dev" }

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.73.0",
+  "version": "0.74.0",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.73.0",
+  "version": "0.74.0",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.73.0",
+  "version": "0.74.0",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.73.0",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.73.0",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.73.0",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.73.0",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.73.0"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.74.0",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.74.0",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.74.0",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.74.0",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.74.0"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.73.0",
+  "version": "0.74.0",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.73.0",
+  "version": "0.74.0",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.73.0",
+  "version": "0.74.0",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
**Fixes**

-  Ignore subgraph federation mandated fields and types in federated graph composition (#1743). This is only relevant in `grafbase dev` in federated graphs.
