### PR TITLE
feat: partial cache settings propagation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,7 +1515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f3f1953f4590381034d75c49a568665567f19ee393d4292835d35bac9724dca"
 dependencies = [
  "counter",
- "cynic-parser 0.4.2",
+ "cynic-parser 0.4.3",
  "darling",
  "once_cell",
  "ouroboros",
@@ -1552,9 +1552,9 @@ dependencies = [
 
 [[package]]
 name = "cynic-parser"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ac6fe3f275572a06ab37e7a3b363eb581381f124e689fbe48aa9d6a2b897a2"
+checksum = "ea1e7d71e5579e12cef1c9defba9cc16c9450c4ca9e15044ac06b1169326d886"
 dependencies = [
  "ariadne",
  "indexmap 2.2.6",
@@ -2813,7 +2813,7 @@ dependencies = [
  "blake3",
  "bytes",
  "common-types",
- "cynic-parser 0.4.2",
+ "cynic-parser 0.4.3",
  "engine",
  "engine-parser",
  "engine-validation",
@@ -3084,7 +3084,7 @@ version = "0.74.0"
 dependencies = [
  "cynic",
  "cynic-introspection",
- "cynic-parser 0.4.2",
+ "cynic-parser 0.4.3",
  "indoc",
  "reqwest",
  "serde",
@@ -3150,7 +3150,7 @@ dependencies = [
  "common-types",
  "const_format",
  "criterion",
- "cynic-parser 0.4.2",
+ "cynic-parser 0.4.3",
  "dotenv",
  "engine",
  "federated-dev",
@@ -3305,7 +3305,7 @@ name = "graphql-lint"
 version = "0.1.3"
 dependencies = [
  "criterion",
- "cynic-parser 0.4.2",
+ "cynic-parser 0.4.3",
  "heck 0.5.0",
  "thiserror",
 ]
@@ -3358,7 +3358,7 @@ dependencies = [
 name = "graphql-schema-diff"
 version = "0.1.1"
 dependencies = [
- "cynic-parser 0.4.2",
+ "cynic-parser 0.4.3",
  "datatest-stable",
  "miette 7.2.0",
  "serde",
@@ -5637,7 +5637,7 @@ dependencies = [
  "anyhow",
  "blake3",
  "common-types",
- "cynic-parser 0.4.2",
+ "cynic-parser 0.4.3",
  "engine-value",
  "graph-entities",
  "headers",
@@ -6444,7 +6444,7 @@ name = "registry-v2-generator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cynic-parser 0.4.2",
+ "cynic-parser 0.4.3",
  "indexmap 2.2.6",
  "indoc",
  "itertools 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,7 +1515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f3f1953f4590381034d75c49a568665567f19ee393d4292835d35bac9724dca"
 dependencies = [
  "counter",
- "cynic-parser 0.4.1",
+ "cynic-parser 0.4.2",
  "darling",
  "once_cell",
  "ouroboros",
@@ -1552,9 +1552,9 @@ dependencies = [
 
 [[package]]
 name = "cynic-parser"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b9f36eeb1107059bea01cc5db8492737c98e9fdf570f909846b8c9fc274aa94"
+checksum = "11ac6fe3f275572a06ab37e7a3b363eb581381f124e689fbe48aa9d6a2b897a2"
 dependencies = [
  "ariadne",
  "indexmap 2.2.6",
@@ -2813,7 +2813,7 @@ dependencies = [
  "blake3",
  "bytes",
  "common-types",
- "cynic-parser 0.4.1",
+ "cynic-parser 0.4.2",
  "engine",
  "engine-parser",
  "engine-validation",
@@ -3084,7 +3084,7 @@ version = "0.74.0"
 dependencies = [
  "cynic",
  "cynic-introspection",
- "cynic-parser 0.4.1",
+ "cynic-parser 0.4.2",
  "indoc",
  "reqwest",
  "serde",
@@ -3150,7 +3150,7 @@ dependencies = [
  "common-types",
  "const_format",
  "criterion",
- "cynic-parser 0.4.1",
+ "cynic-parser 0.4.2",
  "dotenv",
  "engine",
  "federated-dev",
@@ -3305,7 +3305,7 @@ name = "graphql-lint"
 version = "0.1.3"
 dependencies = [
  "criterion",
- "cynic-parser 0.4.1",
+ "cynic-parser 0.4.2",
  "heck 0.5.0",
  "thiserror",
 ]
@@ -3358,7 +3358,7 @@ dependencies = [
 name = "graphql-schema-diff"
 version = "0.1.1"
 dependencies = [
- "cynic-parser 0.4.1",
+ "cynic-parser 0.4.2",
  "datatest-stable",
  "miette 7.2.0",
  "serde",
@@ -5637,7 +5637,7 @@ dependencies = [
  "anyhow",
  "blake3",
  "common-types",
- "cynic-parser 0.4.1",
+ "cynic-parser 0.4.2",
  "engine-value",
  "graph-entities",
  "headers",
@@ -6444,7 +6444,7 @@ name = "registry-v2-generator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cynic-parser 0.4.1",
+ "cynic-parser 0.4.2",
  "indexmap 2.2.6",
  "indoc",
  "itertools 0.13.0",

--- a/engine/crates/partial-caching/src/planning/fragments/ancestry.rs
+++ b/engine/crates/partial-caching/src/planning/fragments/ancestry.rs
@@ -9,7 +9,7 @@ use super::{
 /// The complete ancestry of a particular fragment
 ///
 /// We use FragmentGraph to build one of these for each fragment.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct FragmentAncestry {
     /// All the fragments that contain spreads this fragment, directly or indirectly.
     ///

--- a/engine/crates/partial-caching/src/planning/fragments/ancestry.rs
+++ b/engine/crates/partial-caching/src/planning/fragments/ancestry.rs
@@ -3,7 +3,7 @@ use indexmap::{IndexMap, IndexSet};
 
 use super::{
     graph::{AncestorEdge, FragmentGraph},
-    FragmentSpreadSet,
+    FragmentKey, FragmentSpreadSet,
 };
 
 /// The complete ancestry of a particular fragment
@@ -23,40 +23,40 @@ pub struct FragmentAncestry {
 }
 
 pub fn calculate_ancestry(
-    fragments_in_fragments: IndexMap<FragmentDefinitionId, FragmentSpreadSet>,
+    fragments_in_fragments: IndexMap<FragmentKey, FragmentSpreadSet>,
     fragments_in_query: FragmentSpreadSet,
-) -> IndexMap<FragmentDefinitionId, FragmentAncestry> {
+) -> IndexMap<FragmentKey, FragmentAncestry> {
     let graph = FragmentGraph::new(&fragments_in_fragments, &fragments_in_query);
 
-    let mut ancestor_map = IndexMap::<FragmentDefinitionId, FragmentAncestry>::new();
+    let mut ancestor_map = IndexMap::<FragmentKey, FragmentAncestry>::new();
 
     for fragment in graph.fragments() {
         let mut ancestry = FragmentAncestry::default();
 
         for edge in fragment.ancestor_edges() {
-            let AncestorEdge { parent_id, child_id } = edge;
+            let AncestorEdge { parent_key, child_key } = edge;
 
-            match parent_id {
-                Some(parent_id) => {
-                    ancestry.fragments.insert(parent_id);
+            match parent_key {
+                Some(parent_key) => {
+                    ancestry.fragments.insert(parent_key.id);
 
                     if let Some(parent_selections) = fragments_in_fragments
-                        .get(&parent_id)
-                        .and_then(|spread_set| spread_set.spreads_for_fragment(child_id))
+                        .get(parent_key)
+                        .and_then(|spread_set| spread_set.spreads_for_fragment(child_key))
                     {
                         ancestry.selections.extend(parent_selections);
                     }
                 }
                 None => {
                     // No parent indicates this is an edge to the query
-                    if let Some(selections) = fragments_in_query.spreads_for_fragment(child_id) {
+                    if let Some(selections) = fragments_in_query.spreads_for_fragment(child_key) {
                         ancestry.selections.extend(selections);
                     }
                 }
             }
         }
 
-        ancestor_map.insert(fragment.id, ancestry);
+        ancestor_map.insert(fragment.key.clone(), ancestry);
     }
     ancestor_map
 }

--- a/engine/crates/partial-caching/src/planning/fragments/graph.rs
+++ b/engine/crates/partial-caching/src/planning/fragments/graph.rs
@@ -1,21 +1,21 @@
 use std::collections::HashSet;
 
-use cynic_parser::executable::ids::FragmentDefinitionId;
 use indexmap::{IndexMap, IndexSet};
 
-use super::FragmentSpreadSet;
+use super::{FragmentKey, FragmentSpreadSet};
 
 /// A graph of dependencies between fragments, used to calculate which fields/fragments
 /// need to be included if a particular fragment is included.
+#[derive(Debug)]
 pub struct FragmentGraph {
     /// All fragments in the query, and a set of fragments that contain that fragment.
     /// None in the set indicates this fragment is contained in the query
-    direct_parents: IndexMap<FragmentDefinitionId, IndexSet<Option<FragmentDefinitionId>>>,
+    direct_parents: IndexMap<FragmentKey, IndexSet<Option<FragmentKey>>>,
 }
 
 impl FragmentGraph {
     pub fn new(
-        fragments_in_fragments: &IndexMap<FragmentDefinitionId, FragmentSpreadSet>,
+        fragments_in_fragments: &IndexMap<FragmentKey, FragmentSpreadSet>,
         fragments_in_query: &FragmentSpreadSet,
     ) -> Self {
         let mut this = FragmentGraph {
@@ -24,39 +24,39 @@ impl FragmentGraph {
 
         // Invert fragments_in_fragments so we have a map from child -> parents
         for (parent_id, children) in fragments_in_fragments {
-            for child_id in children.fragment_ids() {
+            for child_id in children.fragment_keys() {
                 this.direct_parents
-                    .entry(child_id)
+                    .entry(child_id.clone())
                     .or_default()
-                    .insert(Some(*parent_id));
+                    .insert(Some(parent_id.clone()));
             }
         }
 
         // Add in the nodes that point to our query
-        for child_id in fragments_in_query.fragment_ids() {
-            this.direct_parents.entry(child_id).or_default().insert(None);
+        for child_id in fragments_in_query.fragment_keys() {
+            this.direct_parents.entry(child_id.clone()).or_default().insert(None);
         }
 
         this
     }
 
     pub fn fragments(&self) -> impl Iterator<Item = Fragment<'_>> {
-        self.direct_parents.keys().map(|id| Fragment { graph: self, id: *id })
+        self.direct_parents.keys().map(|id| Fragment { graph: self, key: id })
     }
 }
 
 pub struct Fragment<'a> {
     graph: &'a FragmentGraph,
-    pub id: FragmentDefinitionId,
+    pub key: &'a FragmentKey,
 }
 
 impl<'a> Fragment<'a> {
     pub fn ancestor_edges(&self) -> AncestorEdgeIterator<'a> {
-        let stack = self.graph.direct_parents[&self.id]
+        let stack = self.graph.direct_parents[self.key]
             .iter()
-            .map(|parent_id| AncestorEdge {
-                child_id: self.id,
-                parent_id: *parent_id,
+            .map(|parent_key| AncestorEdge {
+                child_key: self.key,
+                parent_key: parent_key.as_ref(),
             })
             .collect::<Vec<_>>();
 
@@ -70,12 +70,12 @@ impl<'a> Fragment<'a> {
 
 pub struct AncestorEdgeIterator<'a> {
     graph: &'a FragmentGraph,
-    edges_seen: HashSet<AncestorEdge>,
-    stack: Vec<AncestorEdge>,
+    edges_seen: HashSet<AncestorEdge<'a>>,
+    stack: Vec<AncestorEdge<'a>>,
 }
 
-impl Iterator for AncestorEdgeIterator<'_> {
-    type Item = AncestorEdge;
+impl<'a> Iterator for AncestorEdgeIterator<'a> {
+    type Item = AncestorEdge<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -88,12 +88,12 @@ impl Iterator for AncestorEdgeIterator<'_> {
             }
             self.edges_seen.insert(edge);
 
-            if let Some(parent) = edge.parent_id {
-                if let Some(grandparents) = self.graph.direct_parents.get(&parent) {
+            if let Some(parent) = edge.parent_key {
+                if let Some(grandparents) = self.graph.direct_parents.get(parent) {
                     self.stack
                         .extend(grandparents.iter().map(|grandparent_id| AncestorEdge {
-                            child_id: parent,
-                            parent_id: *grandparent_id,
+                            child_key: parent,
+                            parent_key: grandparent_id.as_ref(),
                         }));
                 }
             }
@@ -104,7 +104,7 @@ impl Iterator for AncestorEdgeIterator<'_> {
 }
 
 #[derive(Hash, PartialEq, Eq, Clone, Copy)]
-pub struct AncestorEdge {
-    pub parent_id: Option<FragmentDefinitionId>,
-    pub child_id: FragmentDefinitionId,
+pub struct AncestorEdge<'a> {
+    pub parent_key: Option<&'a FragmentKey>,
+    pub child_key: &'a FragmentKey,
 }

--- a/engine/crates/partial-caching/src/planning/fragments/graph.rs
+++ b/engine/crates/partial-caching/src/planning/fragments/graph.rs
@@ -23,25 +23,25 @@ impl FragmentGraph {
         };
 
         // Invert fragments_in_fragments so we have a map from child -> parents
-        for (parent_id, children) in fragments_in_fragments {
-            for child_id in children.fragment_keys() {
+        for (parent_key, children) in fragments_in_fragments {
+            for child_key in children.fragment_keys() {
                 this.direct_parents
-                    .entry(child_id.clone())
+                    .entry(child_key)
                     .or_default()
-                    .insert(Some(parent_id.clone()));
+                    .insert(Some(parent_key.clone()));
             }
         }
 
         // Add in the nodes that point to our query
-        for child_id in fragments_in_query.fragment_keys() {
-            this.direct_parents.entry(child_id.clone()).or_default().insert(None);
+        for child_key in fragments_in_query.fragment_keys() {
+            this.direct_parents.entry(child_key).or_default().insert(None);
         }
 
         this
     }
 
     pub fn fragments(&self) -> impl Iterator<Item = Fragment<'_>> {
-        self.direct_parents.keys().map(|id| Fragment { graph: self, key: id })
+        self.direct_parents.keys().map(|key| Fragment { graph: self, key })
     }
 }
 

--- a/engine/crates/partial-caching/src/planning/fragments/mod.rs
+++ b/engine/crates/partial-caching/src/planning/fragments/mod.rs
@@ -3,8 +3,28 @@ mod graph;
 mod spread_set;
 mod tracker;
 
+use cynic_parser::executable::ids::FragmentDefinitionId;
+use registry_for_cache::CacheControl;
+
 pub(super) use self::{
     ancestry::{calculate_ancestry, FragmentAncestry},
     spread_set::FragmentSpreadSet,
     tracker::FragmentTracker,
 };
+
+#[derive(Debug, Hash, Eq, PartialEq, Clone)]
+pub struct FragmentKey {
+    pub id: FragmentDefinitionId,
+
+    // The cache control that was active when this fragment was spread
+    pub spread_cache_control: Option<CacheControl>,
+}
+
+impl FragmentKey {
+    pub fn new(id: FragmentDefinitionId, spread_cache_control: Option<CacheControl>) -> Self {
+        Self {
+            id,
+            spread_cache_control,
+        }
+    }
+}

--- a/engine/crates/partial-caching/src/planning/fragments/spread_set.rs
+++ b/engine/crates/partial-caching/src/planning/fragments/spread_set.rs
@@ -1,41 +1,26 @@
-use cynic_parser::{
-    executable::ids::{FragmentDefinitionId, SelectionId},
-    ExecutableDocument,
-};
+use cynic_parser::executable::ids::SelectionId;
 use indexmap::{IndexMap, IndexSet};
 
-use super::tracker::FragmentTracker;
+use super::FragmentKey;
 
 #[derive(Default)]
 pub struct FragmentSpreadSet {
     /// Fragments selected in an operation or fragment, and the
     /// selections that need to be included from that operation or fragment
     /// if the nested fragment needs to be included
-    spreads: IndexMap<FragmentDefinitionId, IndexSet<SelectionId>>,
+    spreads: IndexMap<FragmentKey, IndexSet<SelectionId>>,
 }
 
 impl FragmentSpreadSet {
-    pub fn spreads_for_fragment(&self, id: FragmentDefinitionId) -> Option<impl Iterator<Item = SelectionId> + '_> {
-        Some(self.spreads.get(&id)?.iter().copied())
+    pub fn insert(&mut self, key: FragmentKey, selections: IndexSet<SelectionId>) {
+        self.spreads.entry(key).or_default().extend(selections)
     }
 
-    pub fn from_tracker(tracker: FragmentTracker, document: &ExecutableDocument) -> anyhow::Result<Self> {
-        let mut this = Self::default();
-        for (fragment_name, selections) in tracker.used_fragments {
-            let fragment = document
-                .fragments()
-                .find(|fragment| fragment.name() == fragment_name)
-                .ok_or_else(|| {
-                    anyhow::anyhow!("The query contained a spread for a missing fragment: {fragment_name}")
-                })?;
-
-            this.spreads.insert(fragment.id(), selections);
-        }
-
-        Ok(this)
+    pub fn spreads_for_fragment(&self, id: &FragmentKey) -> Option<impl Iterator<Item = SelectionId> + '_> {
+        Some(self.spreads.get(id)?.iter().copied())
     }
 
-    pub fn fragment_ids(&self) -> impl Iterator<Item = FragmentDefinitionId> + '_ {
-        self.spreads.keys().copied()
+    pub fn fragment_keys(&self) -> impl Iterator<Item = FragmentKey> + '_ {
+        self.spreads.keys().cloned()
     }
 }

--- a/engine/crates/partial-caching/src/planning/fragments/tracker.rs
+++ b/engine/crates/partial-caching/src/planning/fragments/tracker.rs
@@ -27,10 +27,10 @@ impl FragmentTracker {
     }
 
     fn key_for(&self, spread: FragmentSpread<'_>) -> Option<FragmentKey> {
-        Some(FragmentKey {
-            id: spread.fragment()?.id(),
-            spread_cache_control: self.cache_control_stack.last().cloned(),
-        })
+        Some(FragmentKey::new(
+            spread.fragment()?.id(),
+            self.cache_control_stack.last().cloned(),
+        ))
     }
 
     pub fn into_spreads(self) -> anyhow::Result<FragmentSpreadSet> {

--- a/engine/crates/partial-caching/src/planning/fragments/tracker.rs
+++ b/engine/crates/partial-caching/src/planning/fragments/tracker.rs
@@ -1,19 +1,53 @@
 use cynic_parser::executable::{ids::SelectionId, FragmentSpread, Selection};
-use indexmap::{IndexMap, IndexSet};
+use registry_for_cache::CacheControl;
+
+use crate::planning::visitor::FieldEdge;
+
+use super::{FragmentKey, FragmentSpreadSet};
 
 /// A visitor that tracks used fragments in a query, and which selections are
 /// ancestors of spreads of those fragments
 pub struct FragmentTracker {
+    cache_control_stack: Vec<CacheControl>,
+
     selection_stack: Vec<SelectionId>,
-    pub used_fragments: IndexMap<String, IndexSet<SelectionId>>,
+
+    spreads: FragmentSpreadSet,
+    missing_fragments: Vec<String>,
 }
 
 impl FragmentTracker {
-    pub fn new() -> Self {
+    pub fn new(root_cache_control: Option<&CacheControl>) -> Self {
         FragmentTracker {
             selection_stack: vec![],
-            used_fragments: IndexMap::new(),
+            cache_control_stack: root_cache_control.into_iter().cloned().collect::<Vec<_>>(),
+            spreads: FragmentSpreadSet::default(),
+            missing_fragments: vec![],
         }
+    }
+
+    fn key_for(&self, spread: FragmentSpread<'_>) -> Option<FragmentKey> {
+        Some(FragmentKey {
+            id: spread.fragment()?.id(),
+            spread_cache_control: self.cache_control_stack.last().cloned(),
+        })
+    }
+
+    pub fn into_spreads(self) -> anyhow::Result<FragmentSpreadSet> {
+        if !self.missing_fragments.is_empty() {
+            if self.missing_fragments.len() == 1 {
+                return Err(anyhow::anyhow!(
+                    "Could not find a fragment named {}",
+                    self.missing_fragments[0]
+                ));
+            } else {
+                return Err(anyhow::anyhow!(
+                    "Could not find fragments named: {}",
+                    self.missing_fragments.join(", ")
+                ));
+            }
+        }
+        Ok(self.spreads)
     }
 }
 
@@ -26,10 +60,24 @@ impl super::super::visitor::Visitor for FragmentTracker {
         self.selection_stack.pop();
     }
 
+    fn enter_field(&mut self, edge: FieldEdge<'_>) {
+        if let Some(cache_control) = edge.cache_control() {
+            self.cache_control_stack.push((*cache_control).clone());
+        }
+    }
+
+    fn exit_field(&mut self, edge: FieldEdge<'_>) {
+        if edge.cache_control().is_some() {
+            self.cache_control_stack.pop();
+        }
+    }
+
     fn fragment_spread(&mut self, spread: FragmentSpread<'_>) {
-        self.used_fragments
-            .entry(spread.fragment_name().to_string())
-            .or_default()
-            .extend(self.selection_stack.iter().copied())
+        let Some(key) = self.key_for(spread) else {
+            self.missing_fragments.push(spread.fragment_name().to_string());
+            return;
+        };
+
+        self.spreads.insert(key, self.selection_stack.iter().copied().collect())
     }
 }

--- a/engine/crates/partial-caching/src/planning/query_partitioner.rs
+++ b/engine/crates/partial-caching/src/planning/query_partitioner.rs
@@ -3,18 +3,21 @@ use cynic_parser::executable::{
     Selection,
 };
 use indexmap::IndexMap;
+use registry_for_cache::CacheControl;
 
 use super::visitor::FieldEdge;
 use crate::query_subset::CacheGroup;
 
 /// A visitor that groups fields by their caching rules
 pub(crate) struct QueryPartitioner {
-    /// A stack of selections the current traversal
+    /// A stack of selections of the current traversal
     selection_stack: Vec<SelectionId>,
+
+    cache_control_stack: Vec<CacheControl>,
 
     current_fragment: Option<FragmentDefinitionId>,
 
-    pub cache_partitions: IndexMap<registry_for_cache::CacheControl, CacheGroup>,
+    pub cache_partitions: IndexMap<CacheControl, CacheGroup>,
     pub nocache_partition: CacheGroup,
 }
 
@@ -25,6 +28,7 @@ impl QueryPartitioner {
             current_fragment: None,
             cache_partitions: IndexMap::new(),
             nocache_partition: CacheGroup::default(),
+            cache_control_stack: vec![],
         }
     }
 
@@ -49,13 +53,17 @@ impl super::visitor::Visitor for QueryPartitioner {
     }
 
     fn enter_field(&mut self, edge: FieldEdge<'_>) {
+        if let Some(cache_control) = edge.cache_control() {
+            self.cache_control_stack.push((*cache_control).clone());
+        }
+
         if edge.selection.selection_set().len() != 0 {
-            // We're only concerned with the cache control settings of leaf fields
-            // at the moment
+            // If this field has child selections then its not a leaf,
+            // and the partitioner only acts on leaves, so just return.
             return;
         }
 
-        match edge.field.and_then(|field| field.cache_control()) {
+        match self.cache_control_stack.last() {
             Some(cache_control) => self
                 .cache_partitions
                 .entry(cache_control.clone())
@@ -66,6 +74,22 @@ impl super::visitor::Visitor for QueryPartitioner {
                 .nocache_partition
                 .update(&self.selection_stack, self.current_fragment),
         }
+    }
+
+    fn exit_field(&mut self, edge: FieldEdge<'_>) {
+        if edge.cache_control().is_some() {
+            self.cache_control_stack.pop();
+        }
+    }
+}
+
+impl<'a> FieldEdge<'a> {
+    fn cache_control(&self) -> Option<&'a CacheControl> {
+        let field_cache_control = self.field.and_then(|field| field.cache_control());
+        let type_cache_control = self.field_type.and_then(|ty| ty.cache_control());
+
+        // Field cache control takes precedence
+        field_cache_control.or(type_cache_control)
     }
 }
 

--- a/engine/crates/partial-caching/src/planning/variables.rs
+++ b/engine/crates/partial-caching/src/planning/variables.rs
@@ -4,10 +4,10 @@ use cynic_parser::{
 };
 use indexmap::IndexSet;
 
-use crate::query_subset::CacheGroup;
+use crate::query_subset::Partition;
 
 pub fn variables_required(
-    partition: &CacheGroup,
+    partition: &Partition,
     document: &ExecutableDocument,
     operation: OperationDefinition<'_>,
 ) -> IndexSet<VariableDefinitionId> {

--- a/engine/crates/partial-caching/src/updating/ser.rs
+++ b/engine/crates/partial-caching/src/updating/ser.rs
@@ -158,13 +158,7 @@ impl<'a> Iterator for FieldIter<'a> {
                         .push(self.subset.selection_iter(self.document, fragment.selection_set()));
                 }
                 Selection::FragmentSpread(spread) => {
-                    let Some(fragment) = self
-                        .document
-                        .fragments()
-                        .find(|fragment| fragment.name() == spread.fragment_name())
-                    else {
-                        continue;
-                    };
+                    let Some(fragment) = spread.fragment() else { continue };
 
                     self.iter_stack
                         .push(self.subset.selection_iter(self.document, fragment.selection_set()));

--- a/engine/crates/partial-caching/tests/query-splitting.rs
+++ b/engine/crates/partial-caching/tests/query-splitting.rs
@@ -371,6 +371,11 @@ fn test_cache_control_propagation() {
     "###);
 }
 
+#[test]
+fn test_cache_control_propagation_across_fragments() {
+    todo!("need to implement this somehow...")
+}
+
 fn build_registry(schema: &str) -> registry_for_cache::PartialCacheRegistry {
     registry_upgrade::convert_v1_to_partial_cache_registry(parser_sdl::parse_registry(schema).unwrap()).unwrap()
 }

--- a/engine/crates/partial-caching/tests/query-splitting.rs
+++ b/engine/crates/partial-caching/tests/query-splitting.rs
@@ -336,6 +336,7 @@ fn test_cache_control_propagation() {
     let plan = partial_caching::build_plan(QUERY, None, &registry).unwrap().unwrap();
 
     assert_eq!(plan.cache_partitions.len(), 3);
+    assert!(plan.nocache_partition.is_empty());
 
     assert_eq!(plan.cache_partitions[0].0.max_age, 60);
     insta::assert_snapshot!(plan.cache_partitions[0].1.as_display(&plan.document), @r###"
@@ -372,8 +373,133 @@ fn test_cache_control_propagation() {
 }
 
 #[test]
+fn test_cache_control_propagation_from_root() {
+    let registry = build_registry(
+        r#"
+            extend schema @cache(
+                rules: [
+                    {maxAge: 60, types: [{name: "Query"}]},
+                ]
+            )
+
+            type Query {
+                user: User @resolver(name: "whatever")
+            }
+            type User {
+                name: String
+            }
+    "#,
+    );
+
+    const QUERY: &str = "query { user { name } }";
+
+    let plan = partial_caching::build_plan(QUERY, None, &registry).unwrap().unwrap();
+
+    assert!(plan.nocache_partition.is_empty());
+    assert_eq!(plan.cache_partitions.len(), 1);
+
+    assert_eq!(plan.cache_partitions[0].0.max_age, 60);
+    insta::assert_snapshot!(plan.cache_partitions[0].1.as_display(&plan.document), @r###"
+    query {
+      user {
+        name
+      }
+    }
+    "###);
+}
+
+#[test]
 fn test_cache_control_propagation_across_fragments() {
-    todo!("need to implement this somehow...")
+    let registry = build_registry(
+        r#"
+            type Query {
+                user: User @resolver(name: "whatever")
+                nested: Nested @resolver(name: "whatever")
+            }
+
+            type User @cache(maxAge: 60) {
+                name: String
+                nested: Nested @resolver(name: "whatever") @cache(maxAge: 80)
+            }
+
+            type Nested @cache(maxAge: 120) {
+                foo: String
+                bar(arg: String): String
+            }
+            "#,
+    );
+
+    const QUERY: &str = r#"
+        query {
+            user {
+                ...UserFragment
+            }
+            nested {
+                ...NestedFragment
+            }
+        }
+
+        fragment UserFragment on User {
+            name
+            nested {
+                ...NestedFragment
+            }
+        }
+
+        fragment NestedFragment on Nested {
+            foo
+        }
+    "#;
+
+    let plan = partial_caching::build_plan(QUERY, None, &registry).unwrap().unwrap();
+
+    assert_eq!(plan.cache_partitions.len(), 3);
+    assert!(plan.nocache_partition.is_empty());
+
+    assert_eq!(plan.cache_partitions[0].0.max_age, 120);
+    insta::assert_snapshot!(plan.cache_partitions[0].1.as_display(&plan.document), @r###"
+    query {
+      nested {
+        ... NestedFragment
+      }
+    }
+
+    fragment NestedFragment on Nested {
+      foo
+    }
+    "###);
+
+    assert_eq!(plan.cache_partitions[1].0.max_age, 60);
+    insta::assert_snapshot!(plan.cache_partitions[1].1.as_display(&plan.document), @r###"
+    query {
+      user {
+        ... UserFragment
+      }
+    }
+
+    fragment UserFragment on User {
+      name
+    }
+    "###);
+
+    assert_eq!(plan.cache_partitions[2].0.max_age, 80);
+    insta::assert_snapshot!(plan.cache_partitions[2].1.as_display(&plan.document), @r###"
+    query {
+      user {
+        ... UserFragment
+      }
+    }
+
+    fragment NestedFragment on Nested {
+      foo
+    }
+
+    fragment UserFragment on User {
+      nested {
+        ... NestedFragment
+      }
+    }
+    "###);
 }
 
 fn build_registry(schema: &str) -> registry_for_cache::PartialCacheRegistry {


### PR DESCRIPTION
This updates the partial caching implementation to handle propagate settings from types & settings onto their descendants.  So if a type `User` as a cache control, then all the fields inside `User` will inherit those settings.

If a field _and_ the type that field contains both have a cache control then we'll give preference to the field setting, as it's more specific.

This complicated the fragment logic a bit, as we have to propagate through a fragment spread as well - which means we potentially need to process fragments multiple times if they are spread multiple times with different inherited cache settings. So were we were before just keying fragments by their id, we're now using a `FragmentKey` - which takes the inhereted cache control value into account as well. 

Fixes GB-6777