### PR TITLE
fix: some issues with join

### DIFF
--- a/engine/crates/engine/src/registry/resolvers/mod.rs
+++ b/engine/crates/engine/src/registry/resolvers/mod.rs
@@ -32,7 +32,6 @@ mod federation;
 pub mod graphql;
 pub mod http;
 mod introspection;
-pub mod join;
 mod logged_fetch;
 mod pagination;
 pub mod postgres;

--- a/engine/crates/parser-sdl/src/rules/join_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/join_directive.rs
@@ -93,15 +93,21 @@ impl FieldSelection {
             .map(|argument| argument.node.name.node.as_str())
             .collect::<HashSet<_>>();
 
-        Some(FieldSet::new(
-            self.variables_used
-                .iter()
-                .filter(|field| !arguments.contains(field.as_str()))
-                .map(|field| registry_v2::Selection {
-                    field: field.clone(),
-                    selections: vec![],
-                }),
-        ))
+        let mut selections = self
+            .variables_used
+            .iter()
+            .filter(|field| !arguments.contains(field.as_str()))
+            .map(|field| registry_v2::Selection {
+                field: field.clone(),
+                selections: vec![],
+            })
+            .peekable();
+
+        // If there are no selections then all of the variables referred to arguments
+        // and we don't need to require a fieldset
+        selections.peek()?;
+
+        Some(FieldSet::new(selections))
     }
 
     pub fn to_join_resolver(&self) -> JoinResolver {


### PR DESCRIPTION
After #1744 yesterday we support schemas joins on fields of the root query, but there were a couple of further issues:

1. We were generating a `@requires` on any join that uses variables, even if those variables actually all refer to arguments.
2. The argument resolution code for joins did an early return if there's no parent resolve data (as is the case in root fields) - this meant that the arguments weren't being resolvd.

This commit fixes both of those, as well as adding an integration-test for this scenario.
