### PR TITLE
fix: non-partial caching behaviour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,8 +455,9 @@ dependencies = [
 
 [[package]]
 name = "async-tungstenite"
-version = "0.25.1"
-source = "git+https://github.com/grafbase/async-tungstenite?rev=02222f222532b5cf01bba77e6d1cc8a142fe5593#02222f222532b5cf01bba77e6d1cc8a142fe5593"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cf3e0ba34d3cf04731e376a1cf6c16c357396ab66da227bd283e74d49890b2a"
 dependencies = [
  "futures-io",
  "futures-util",
@@ -464,7 +465,7 @@ dependencies = [
  "pin-project-lite",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.0",
  "tungstenite",
  "webpki-roots",
 ]
@@ -539,8 +540,7 @@ dependencies = [
 [[package]]
 name = "axum"
 version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+source = "git+https://github.com/grafbase/axum?rev=c3146f9ca921907d9884fbf7549a1520e9e72eac#c3146f9ca921907d9884fbf7549a1520e9e72eac"
 dependencies = [
  "async-trait",
  "axum-core 0.4.3",
@@ -611,8 +611,7 @@ dependencies = [
 [[package]]
 name = "axum-core"
 version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+source = "git+https://github.com/grafbase/axum?rev=c3146f9ca921907d9884fbf7549a1520e9e72eac#c3146f9ca921907d9884fbf7549a1520e9e72eac"
 dependencies = [
  "async-trait",
  "bytes",
@@ -623,7 +622,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -632,8 +631,7 @@ dependencies = [
 [[package]]
 name = "axum-macros"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c055ee2d014ae5981ce1016374e8213682aa14d9bf40e48ab48b5f3ef20eaa"
+source = "git+https://github.com/grafbase/axum?rev=c3146f9ca921907d9884fbf7549a1520e9e72eac#c3146f9ca921907d9884fbf7549a1520e9e72eac"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -658,7 +656,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.25.0",
  "tower",
  "tower-service",
 ]
@@ -2087,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "engine-config-builder"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "engine-v2-config",
  "graphql-federated-graph",
@@ -2429,7 +2427,7 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "federated-dev"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2775,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -2959,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "assert_matches",
  "async-graphql",
@@ -3080,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-graphql-introspection"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "cynic",
  "cynic-introspection",
@@ -3092,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "async-compression",
  "axum 0.7.5",
@@ -3122,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "chrono",
  "common-types",
@@ -3142,7 +3140,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -3248,7 +3246,7 @@ dependencies = [
 
 [[package]]
 name = "graph-ref"
-version = "0.73.0"
+version = "0.74.0"
 
 [[package]]
 name = "graphql-composition"
@@ -3266,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-cursor"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "serde",
  "serde_with",
@@ -3381,11 +3379,11 @@ dependencies = [
 [[package]]
 name = "graphql-ws-client"
 version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7802310624d21a55797a3bc442dbe405424e9b2c967f86fb415634976f9a97"
+source = "git+https://github.com/grafbase/graphql-ws-client?rev=84aa4e3629ffcf0141702faef37324cd41d64291#84aa4e3629ffcf0141702faef37324cd41d64291"
 dependencies = [
  "async-trait",
  "futures",
+ "futures-timer",
  "log",
  "pin-project",
  "serde",
@@ -3814,7 +3812,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.25.0",
  "tower-service",
 ]
 
@@ -4111,6 +4109,7 @@ dependencies = [
  "runtime-local",
  "runtime-noop",
  "rustls",
+ "secrecy",
  "serde",
  "serde_json",
  "sha2",
@@ -5353,7 +5352,7 @@ dependencies = [
 
 [[package]]
 name = "operation-checks"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "async-graphql-parser",
  "async-graphql-value",
@@ -5366,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "operation-normalizer"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -5632,7 +5631,7 @@ dependencies = [
 
 [[package]]
 name = "partial-caching"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -6500,7 +6499,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.25.0",
  "tokio-util",
  "tower-service",
  "url",
@@ -6619,9 +6618,9 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5316d2a1479eeef1ea21e7f9ddc67c191d497abc8fc3ba2467857abbb68330"
+checksum = "9afd55a67069d6e434a95161415f5beeada95a01c7b815508a82dcb0e1593682"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6631,12 +6630,13 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04a9df72cc1f67020b0d63ad9bfe4a323e459ea7eb68e03bd9824db49f9a4c25"
+checksum = "4165dfae59a39dd41d8dec720d3cbfbc71f69744efb480a3920f5d4e0cc6798d"
 dependencies = [
  "cfg-if",
  "glob",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -6648,13 +6648,12 @@ dependencies = [
 
 [[package]]
 name = "rstest_reuse"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88530b681abe67924d42cca181d070e3ac20e0740569441a9e35a7cedd2b34a4"
+checksum = "b3a8fb4672e840a587a66fc577a5491375df51ddb88f2a2c2a792598c326fe14"
 dependencies = [
  "quote",
  "rand 0.8.5",
- "rustc_version",
  "syn 2.0.66",
 ]
 
@@ -6686,6 +6685,7 @@ dependencies = [
  "headers",
  "http 1.1.0",
  "postgres-connector-types",
+ "secrecy",
  "serde",
  "serde_json",
  "strum",
@@ -6713,6 +6713,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "tungstenite",
  "ulid",
 ]
 
@@ -7989,7 +7990,7 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-postgres",
- "tokio-rustls",
+ "tokio-rustls 0.25.0",
  "x509-certificate",
 ]
 
@@ -7997,6 +7998,17 @@ dependencies = [
 name = "tokio-rustls"
 version = "0.25.0"
 source = "git+https://github.com/rustls/tokio-rustls?rev=3a153acec6c4d189eb5de501b2155b4484b8651b#3a153acec6c4d189eb5de501b2155b4484b8651b"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
@@ -8017,9 +8029,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+checksum = "becd34a233e7e31a3dbf7c7241b38320f57393dcae8e7324b0167d21b8e320b0"
 dependencies = [
  "futures-util",
  "log",
@@ -8119,7 +8131,7 @@ dependencies = [
  "rustls-pemfile",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.25.0",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -8311,8 +8323,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.21.0"
-source = "git+https://github.com/grafbase/tungstenite-rs?rev=783940b2e6cc02c7067efb07dc72ae49d75571b0#783940b2e6cc02c7067efb07dc72ae49d75571b0"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
 dependencies = [
  "byteorder",
  "bytes",
@@ -8347,7 +8360,7 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typed-resolvers"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "datatest-stable",
  "engine-parser",
@@ -9175,7 +9188,7 @@ dependencies = [
 
 [[package]]
 name = "wrapping"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.11"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd066d0b4ef8ecb03a55319dc13aa6910616d0f44008a045bb1835af830abff5"
+checksum = "9c90a406b4495d129f00461241616194cb8a032c8d1c53c657f0961d5f8e0498"
 dependencies = [
  "flate2",
  "futures-core",
@@ -370,11 +370,11 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.4.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener 4.0.3",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -455,9 +455,8 @@ dependencies = [
 
 [[package]]
 name = "async-tungstenite"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf3e0ba34d3cf04731e376a1cf6c16c357396ab66da227bd283e74d49890b2a"
+version = "0.25.1"
+source = "git+https://github.com/grafbase/async-tungstenite?rev=02222f222532b5cf01bba77e6d1cc8a142fe5593#02222f222532b5cf01bba77e6d1cc8a142fe5593"
 dependencies = [
  "futures-io",
  "futures-util",
@@ -465,7 +464,7 @@ dependencies = [
  "pin-project-lite",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls",
  "tungstenite",
  "webpki-roots",
 ]
@@ -540,7 +539,8 @@ dependencies = [
 [[package]]
 name = "axum"
 version = "0.7.5"
-source = "git+https://github.com/grafbase/axum?rev=c3146f9ca921907d9884fbf7549a1520e9e72eac#c3146f9ca921907d9884fbf7549a1520e9e72eac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
 dependencies = [
  "async-trait",
  "axum-core 0.4.3",
@@ -611,7 +611,8 @@ dependencies = [
 [[package]]
 name = "axum-core"
 version = "0.4.3"
-source = "git+https://github.com/grafbase/axum?rev=c3146f9ca921907d9884fbf7549a1520e9e72eac#c3146f9ca921907d9884fbf7549a1520e9e72eac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -622,7 +623,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.1",
+ "sync_wrapper 0.1.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -631,7 +632,8 @@ dependencies = [
 [[package]]
 name = "axum-macros"
 version = "0.4.1"
-source = "git+https://github.com/grafbase/axum?rev=c3146f9ca921907d9884fbf7549a1520e9e72eac#c3146f9ca921907d9884fbf7549a1520e9e72eac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00c055ee2d014ae5981ce1016374e8213682aa14d9bf40e48ab48b5f3ef20eaa"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -656,16 +658,16 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls",
  "tower",
  "tower-service",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.72"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -830,19 +832,19 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
+checksum = "dbe5b10e214954177fb1dc9fbd20a1a2608fe99e6c832033bdc7cea287a20d77"
 dependencies = [
  "borsh-derive",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
+checksum = "d7a8646f94ab393e43e8b35a2558b1624bed28b97ee09c5d15456e3c9463f46d"
 dependencies = [
  "once_cell",
  "proc-macro-crate 3.1.0",
@@ -1010,12 +1012,6 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -1918,7 +1914,7 @@ dependencies = [
  "serde",
  "thiserror",
  "time",
- "winnow 0.6.9",
+ "winnow 0.6.8",
 ]
 
 [[package]]
@@ -2091,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "engine-config-builder"
-version = "0.74.0"
+version = "0.73.0"
 dependencies = [
  "engine-v2-config",
  "graphql-federated-graph",
@@ -2322,9 +2318,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.3.1"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -2333,11 +2329,11 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener 4.0.3",
  "pin-project-lite",
 ]
 
@@ -2433,7 +2429,7 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "federated-dev"
-version = "0.74.0"
+version = "0.73.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2779,7 +2775,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "0.74.0"
+version = "0.73.0"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -2916,9 +2912,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glob"
@@ -2963,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.74.0"
+version = "0.73.0"
 dependencies = [
  "assert_matches",
  "async-graphql",
@@ -3084,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-graphql-introspection"
-version = "0.74.0"
+version = "0.73.0"
 dependencies = [
  "cynic",
  "cynic-introspection",
@@ -3096,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.74.0"
+version = "0.73.0"
 dependencies = [
  "async-compression",
  "axum 0.7.5",
@@ -3126,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.74.0"
+version = "0.73.0"
 dependencies = [
  "chrono",
  "common-types",
@@ -3146,7 +3142,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.74.0"
+version = "0.73.0"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -3252,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "graph-ref"
-version = "0.74.0"
+version = "0.73.0"
 
 [[package]]
 name = "graphql-composition"
@@ -3270,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-cursor"
-version = "0.74.0"
+version = "0.73.0"
 dependencies = [
  "serde",
  "serde_with",
@@ -3385,11 +3381,11 @@ dependencies = [
 [[package]]
 name = "graphql-ws-client"
 version = "0.8.2"
-source = "git+https://github.com/grafbase/graphql-ws-client?rev=84aa4e3629ffcf0141702faef37324cd41d64291#84aa4e3629ffcf0141702faef37324cd41d64291"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db7802310624d21a55797a3bc442dbe405424e9b2c967f86fb415634976f9a97"
 dependencies = [
  "async-trait",
  "futures",
- "futures-timer",
  "log",
  "pin-project",
  "serde",
@@ -3715,9 +3711,9 @@ checksum = "08a397c49fec283e3d6211adbe480be95aae5f304cfb923e9970e08956d5168a"
 
 [[package]]
 name = "http-serde"
-version = "2.1.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
+checksum = "1133cafcce27ea69d35e56b3a8772e265633e04de73c5f4e1afdffc1d19b5419"
 dependencies = [
  "http 1.1.0",
  "serde",
@@ -3818,7 +3814,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -3849,9 +3845,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.5"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+checksum = "3d8d52be92d09acc2e01dddb7fde3ad983fc6489c7db4837e605bc3fca4cb63e"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -4115,7 +4111,6 @@ dependencies = [
  "runtime-local",
  "runtime-noop",
  "rustls",
- "secrecy",
  "serde",
  "serde_json",
  "sha2",
@@ -4838,10 +4833,11 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.12"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
+ "lazy_static",
  "libc",
  "log",
  "openssl",
@@ -4882,7 +4878,7 @@ checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -5101,9 +5097,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.35.0"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
@@ -5357,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "operation-checks"
-version = "0.74.0"
+version = "0.73.0"
 dependencies = [
  "async-graphql-parser",
  "async-graphql-value",
@@ -5370,7 +5366,7 @@ dependencies = [
 
 [[package]]
 name = "operation-normalizer"
-version = "0.74.0"
+version = "0.73.0"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -5636,7 +5632,7 @@ dependencies = [
 
 [[package]]
 name = "partial-caching"
-version = "0.74.0"
+version = "0.73.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -6062,9 +6058,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -6504,7 +6500,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
@@ -6623,9 +6619,9 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.21.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afd55a67069d6e434a95161415f5beeada95a01c7b815508a82dcb0e1593682"
+checksum = "9d5316d2a1479eeef1ea21e7f9ddc67c191d497abc8fc3ba2467857abbb68330"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6635,13 +6631,12 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.21.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4165dfae59a39dd41d8dec720d3cbfbc71f69744efb480a3920f5d4e0cc6798d"
+checksum = "04a9df72cc1f67020b0d63ad9bfe4a323e459ea7eb68e03bd9824db49f9a4c25"
 dependencies = [
  "cfg-if",
  "glob",
- "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -6653,12 +6648,13 @@ dependencies = [
 
 [[package]]
 name = "rstest_reuse"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a8fb4672e840a587a66fc577a5491375df51ddb88f2a2c2a792598c326fe14"
+checksum = "88530b681abe67924d42cca181d070e3ac20e0740569441a9e35a7cedd2b34a4"
 dependencies = [
  "quote",
  "rand 0.8.5",
+ "rustc_version",
  "syn 2.0.66",
 ]
 
@@ -6690,7 +6686,6 @@ dependencies = [
  "headers",
  "http 1.1.0",
  "postgres-connector-types",
- "secrecy",
  "serde",
  "serde_json",
  "strum",
@@ -6718,7 +6713,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tungstenite",
  "ulid",
 ]
 
@@ -7484,11 +7478,11 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.26.3"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7993a8e3a9e88a00351486baae9522c91b123a088f76469e5bd5cc17198ea87"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -7561,9 +7555,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.113.5"
+version = "0.113.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa77fca9412729a3fe634e55c354f6c70c7983f127411ce8684e4c7edf32ed3"
+checksum = "dc1690cc0c9ab60b44ac0225ba1e231ac532f7ba1d754df761c6ee607561afae"
 dependencies = [
  "bitflags 2.5.0",
  "is-macro",
@@ -7913,9 +7907,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7942,9 +7936,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7995,7 +7989,7 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-postgres",
- "tokio-rustls 0.25.0",
+ "tokio-rustls",
  "x509-certificate",
 ]
 
@@ -8003,17 +7997,6 @@ dependencies = [
 name = "tokio-rustls"
 version = "0.25.0"
 source = "git+https://github.com/rustls/tokio-rustls?rev=3a153acec6c4d189eb5de501b2155b4484b8651b#3a153acec6c4d189eb5de501b2155b4484b8651b"
-dependencies = [
- "rustls",
- "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
@@ -8034,9 +8017,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.23.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "becd34a233e7e31a3dbf7c7241b38320f57393dcae8e7324b0167d21b8e320b0"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
 dependencies = [
  "futures-util",
  "log",
@@ -8111,7 +8094,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.9",
+ "winnow 0.6.8",
 ]
 
 [[package]]
@@ -8136,7 +8119,7 @@ dependencies = [
  "rustls-pemfile",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -8312,9 +8295,9 @@ dependencies = [
 
 [[package]]
 name = "triomphe"
-version = "0.1.12"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2cb4fbb9995eeb36ac86fadf24031ccd58f99d6b4b2d7b911db70bddb80d90"
+checksum = "859eb650cfee7434994602c3a68b25d77ad9e68c8a6cd491616ef86661382eb3"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8328,9 +8311,8 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+version = "0.21.0"
+source = "git+https://github.com/grafbase/tungstenite-rs?rev=783940b2e6cc02c7067efb07dc72ae49d75571b0#783940b2e6cc02c7067efb07dc72ae49d75571b0"
 dependencies = [
  "byteorder",
  "bytes",
@@ -8365,7 +8347,7 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typed-resolvers"
-version = "0.74.0"
+version = "0.73.0"
 dependencies = [
  "datatest-stable",
  "engine-parser",
@@ -9070,9 +9052,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.9"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86c949fede1d13936a99f14fafd3e76fd642b556dd2ce96287fbe2e0151bfac6"
+checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
 dependencies = [
  "memchr",
 ]
@@ -9193,7 +9175,7 @@ dependencies = [
 
 [[package]]
 name = "wrapping"
-version = "0.74.0"
+version = "0.73.0"
 dependencies = [
  "serde",
 ]
@@ -9321,9 +9303,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.1.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098d5d7737fb0b70814faa73c17df84f047d38dd31d13bbf2ec3fb354b5abf45"
+checksum = "e2568cd0f20e86cd9a7349fe05178f7bd22f22724678448ae5a9bac266df2689"
 dependencies = [
  "aes",
  "arbitrary",

--- a/engine/crates/engine/registry-v2/src/cache_control.rs
+++ b/engine/crates/engine/registry-v2/src/cache_control.rs
@@ -49,20 +49,8 @@ impl CacheControl {
     pub fn merge(&mut self, mut other: CacheControl) {
         *self = CacheControl {
             public: self.public && other.public,
-            max_age: if self.max_age == 0 {
-                other.max_age
-            } else if other.max_age == 0 {
-                self.max_age
-            } else {
-                self.max_age.min(other.max_age)
-            },
-            stale_while_revalidate: if self.stale_while_revalidate == 0 {
-                other.stale_while_revalidate
-            } else if other.stale_while_revalidate == 0 {
-                self.stale_while_revalidate
-            } else {
-                self.stale_while_revalidate.min(other.stale_while_revalidate)
-            },
+            max_age: self.max_age.min(other.max_age),
+            stale_while_revalidate: self.stale_while_revalidate.min(other.stale_while_revalidate),
             invalidation_policy: if self.invalidation_policy.is_none() {
                 other.invalidation_policy
             } else if other.invalidation_policy.is_none() {

--- a/engine/crates/engine/validation/src/lib.rs
+++ b/engine/crates/engine/validation/src/lib.rs
@@ -61,7 +61,7 @@ pub fn check_strict_rules(
     variables: Option<&Variables>,
 ) -> Result<ValidationResult, Vec<RuleError>> {
     let mut ctx = VisitorContext::new(registry, doc, variables);
-    let mut cache_control = registry_v2::cache_control::CacheControl::default();
+    let mut cache_control = None;
     let mut cache_invalidation_policies = Default::default();
     let complexity = 0;
     let mut depth = 0;
@@ -108,7 +108,7 @@ pub fn check_strict_rules(
     }
 
     Ok(ValidationResult {
-        cache_control,
+        cache_control: cache_control.unwrap_or_default(),
         cache_invalidation_policies,
         complexity,
         depth,
@@ -124,7 +124,7 @@ pub fn check_fast_rules(
     variables: Option<&Variables>,
 ) -> Result<ValidationResult, Vec<RuleError>> {
     let mut ctx = VisitorContext::new(registry, doc, variables);
-    let mut cache_control = registry_v2::cache_control::CacheControl::default();
+    let mut cache_control = None;
     let mut cache_invalidation_policies = Default::default();
     let complexity = 0;
     let mut depth = 0;
@@ -150,7 +150,7 @@ pub fn check_fast_rules(
     }
 
     Ok(ValidationResult {
-        cache_control,
+        cache_control: cache_control.unwrap_or_default(),
         cache_invalidation_policies,
         complexity,
         depth,

--- a/engine/crates/engine/validation/src/lib.rs
+++ b/engine/crates/engine/validation/src/lib.rs
@@ -91,10 +91,10 @@ pub fn check_strict_rules(
         .with(rules::KnownDirectives::default())
         .with(rules::DirectivesUnique)
         .with(rules::OverlappingFieldsCanBeMerged)
-        .with(visitors::CacheControlCalculate {
-            cache_control: &mut cache_control,
-            invalidation_policies: &mut cache_invalidation_policies,
-        })
+        .with(visitors::CacheControlCalculate::new(
+            &mut cache_control,
+            &mut cache_invalidation_policies,
+        ))
         .with(visitors::DepthCalculate::new(&mut depth))
         .with(visitors::HeightCalculate::new(&mut height))
         .with(visitors::AliasCountCalculate::new(&mut alias_count))
@@ -134,10 +134,10 @@ pub fn check_fast_rules(
 
     let mut visitor = VisitorNil
         .with(rules::NoFragmentCycles::default())
-        .with(visitors::CacheControlCalculate {
-            cache_control: &mut cache_control,
-            invalidation_policies: &mut cache_invalidation_policies,
-        })
+        .with(visitors::CacheControlCalculate::new(
+            &mut cache_control,
+            &mut cache_invalidation_policies,
+        ))
         .with(visitors::DepthCalculate::new(&mut depth))
         .with(visitors::HeightCalculate::new(&mut height))
         .with(visitors::AliasCountCalculate::new(&mut alias_count))

--- a/engine/crates/engine/validation/src/visitors/cache_control.rs
+++ b/engine/crates/engine/validation/src/visitors/cache_control.rs
@@ -1,4 +1,5 @@
 use engine_parser::Positioned;
+use registry_v2::cache_control::CacheControl;
 use std::collections::HashSet;
 
 use crate::{
@@ -12,8 +13,21 @@ use {
 };
 
 pub struct CacheControlCalculate<'a> {
-    pub cache_control: &'a mut registry_v2::cache_control::CacheControl,
+    pub cache_control: &'a mut CacheControl,
     pub invalidation_policies: &'a mut HashSet<CacheInvalidation>,
+    pub cache_control_stack: Vec<CacheControl>,
+    default_cache_control: CacheControl,
+}
+
+impl<'a> CacheControlCalculate<'a> {
+    pub fn new(cache_control: &'a mut CacheControl, invalidation_policies: &'a mut HashSet<CacheInvalidation>) -> Self {
+        CacheControlCalculate {
+            cache_control,
+            invalidation_policies,
+            cache_control_stack: vec![],
+            default_cache_control: CacheControl::default(),
+        }
+    }
 }
 
 impl<'ctx, 'a, Registry> Visitor<'ctx, Registry> for CacheControlCalculate<'a>
@@ -29,13 +43,19 @@ where
         ctx: &mut VisitorContext<'_, Registry>,
         _selection_set: &Positioned<SelectionSet>,
     ) {
-        let Some(current_type) = ctx.current_type() else { return };
-        let Some(cache_control) = current_type.cache_control() else {
-            return;
+        let cache_control = match ctx.current_type().and_then(|ty| ty.cache_control()) {
+            Some(cache_control) => {
+                self.cache_control_stack.push(cache_control.clone());
+                cache_control
+            }
+            None if self.cache_control_stack.is_empty() => &self.default_cache_control,
+            None => self.cache_control_stack.last().unwrap(),
         };
 
         self.cache_control.merge(cache_control.clone());
         if let Some(policy) = &cache_control.invalidation_policy {
+            let Some(current_type) = ctx.current_type() else { return };
+
             self.invalidation_policies.insert(CacheInvalidation {
                 ty: current_type.name().to_string(),
                 policy: policy.clone(),
@@ -48,25 +68,51 @@ where
                         policy: policy.clone(),
                     });
                 });
-            }
+            };
+        }
+    }
+
+    fn exit_selection_set(
+        &mut self,
+        ctx: &mut VisitorContext<'ctx, Registry>,
+        _selection_set: &'ctx Positioned<SelectionSet>,
+    ) {
+        if ctx.current_type().and_then(|ty| ty.cache_control()).is_some() {
+            self.cache_control_stack.pop();
         }
     }
 
     fn enter_field(&mut self, ctx: &mut VisitorContext<'_, Registry>, field: &Positioned<Field>) {
-        if let Some((registry_field, parent_type)) = ctx
+        let cache_control = match ctx
             .parent_type()
-            .and_then(|parent| parent.field(&field.node.name.node).map(|field| (field, parent.name())))
+            .and_then(|parent| parent.field(&field.node.name.node)?.cache_control())
         {
-            if let Some(cache_control) = registry_field.cache_control() {
-                self.cache_control.merge(cache_control.clone());
-
-                if let Some(policy) = &cache_control.invalidation_policy {
-                    self.invalidation_policies.insert(CacheInvalidation {
-                        ty: parent_type.to_string(),
-                        policy: policy.clone(),
-                    });
-                }
+            Some(cache_control) => {
+                self.cache_control_stack.push(cache_control.clone());
+                cache_control
             }
+            None if self.cache_control_stack.is_empty() => &self.default_cache_control,
+            None => self.cache_control_stack.last().unwrap(),
+        };
+
+        self.cache_control.merge(cache_control.clone());
+
+        if let Some(policy) = &cache_control.invalidation_policy {
+            let Some(parent_type) = ctx.parent_type() else { return };
+            self.invalidation_policies.insert(CacheInvalidation {
+                ty: parent_type.name().to_string(),
+                policy: policy.clone(),
+            });
+        }
+    }
+
+    fn exit_field(&mut self, ctx: &mut VisitorContext<'ctx, Registry>, field: &'ctx Positioned<Field>) {
+        if ctx
+            .parent_type()
+            .and_then(|parent| parent.field(&field.node.name.node)?.cache_control())
+            .is_some()
+        {
+            self.cache_control_stack.pop();
         }
     }
 }

--- a/engine/crates/engine/validation/src/visitors/cache_control.rs
+++ b/engine/crates/engine/validation/src/visitors/cache_control.rs
@@ -13,14 +13,17 @@ use {
 };
 
 pub struct CacheControlCalculate<'a> {
-    pub cache_control: &'a mut CacheControl,
+    pub cache_control: &'a mut Option<CacheControl>,
     pub invalidation_policies: &'a mut HashSet<CacheInvalidation>,
     pub cache_control_stack: Vec<CacheControl>,
     default_cache_control: CacheControl,
 }
 
 impl<'a> CacheControlCalculate<'a> {
-    pub fn new(cache_control: &'a mut CacheControl, invalidation_policies: &'a mut HashSet<CacheInvalidation>) -> Self {
+    pub fn new(
+        cache_control: &'a mut Option<CacheControl>,
+        invalidation_policies: &'a mut HashSet<CacheInvalidation>,
+    ) -> Self {
         CacheControlCalculate {
             cache_control,
             invalidation_policies,
@@ -43,28 +46,15 @@ where
         ctx: &mut VisitorContext<'_, Registry>,
         _selection_set: &Positioned<SelectionSet>,
     ) {
-        let query_type_name = ctx.registry.query_type().name();
-        let is_query_root = ctx
-            .current_type()
-            .map(|ty| ty.name() == query_type_name)
-            .unwrap_or_default();
         let cache_control = match ctx.current_type().and_then(|ty| ty.cache_control()) {
             Some(cache_control) => {
                 self.cache_control_stack.push(cache_control.clone());
                 cache_control
             }
-            None if is_query_root => {
-                // If the Query type doesn't have an explicit cache control we don't fall
-                // back to the Default.  Without this rule caching would be all or nothing:
-                // without a CacheControl on Query nothing would ever be cached, but a CacheControl
-                // on Query turns on caching for everything.  Not ideal.
-                return;
-            }
             None if self.cache_control_stack.is_empty() => &self.default_cache_control,
             None => self.cache_control_stack.last().unwrap(),
         };
 
-        self.cache_control.merge(cache_control.clone());
         if let Some(policy) = &cache_control.invalidation_policy {
             let Some(current_type) = ctx.current_type() else { return };
 
@@ -95,24 +85,29 @@ where
     }
 
     fn enter_field(&mut self, ctx: &mut VisitorContext<'_, Registry>, field: &Positioned<Field>) {
-        let field = ctx.parent_type().and_then(|parent| parent.field(&field.node.name.node));
-        let cache_control = field.and_then(|field| field.cache_control());
-        let cache_control = match (cache_control, field) {
+        let schema_field = ctx.parent_type().and_then(|parent| parent.field(&field.node.name.node));
+        let cache_control = schema_field.and_then(|field| field.cache_control());
+        let cache_control = match (cache_control, schema_field) {
             (Some(cache_control), _) => {
                 self.cache_control_stack.push(cache_control.clone());
                 cache_control
             }
             (None, _) if !self.cache_control_stack.is_empty() => self.cache_control_stack.last().unwrap(),
             (None, Some(field)) if field.named_type().cache_control().is_some() => {
-                // If the field has no cache control but the type of the field do,
-                // we don't use a default cache control.  This saves users from having to mark
-                // a Type _and_ all the places it appears in the schema as cacheable
-                return;
+                // If the field has no cache control but the type of the field does,
+                // we take that cache control into account here
+                field.named_type().cache_control().unwrap()
             }
             _ => &self.default_cache_control,
         };
 
-        self.cache_control.merge(cache_control.clone());
+        if field.selection_set.items.is_empty() {
+            // This field is a leaf so we merge in whatever the current cache control is
+            match self.cache_control {
+                Some(cache_control) => cache_control.merge(cache_control.clone()),
+                None => *self.cache_control = Some(cache_control.clone()),
+            }
+        }
 
         if let Some(policy) = &cache_control.invalidation_policy {
             let Some(parent_type) = ctx.parent_type() else { return };

--- a/engine/crates/integration-tests/tests/caching/mod.rs
+++ b/engine/crates/integration-tests/tests/caching/mod.rs
@@ -13,8 +13,8 @@ fn should_cache_with_entity_mutation_invalidation_custom_field() {
         }
 
         extend schema @cache(rules: [
-                { maxAge: 60, staleWhileRevalidate: 10, types: [{name: "Post", fields: ["seconds"]}],  mutationInvalidation: { field: "seconds" } },
-            ]
+            { maxAge: 60, staleWhileRevalidate: 10, types: [{name: "Post", fields: ["seconds"]}],  mutationInvalidation: { field: "seconds" } },
+        ]
         )
 
         type Post {


### PR DESCRIPTION
When demoing partial caching last week, I first showed an example of how things work with non-partial caching.  While doing this we came to the conclusion that the current behaviour is confusing: if you have 2 fields in a query `cacheMe` and `noCache` - then the query will always be cached, even though `noCache` is not marked to be cached.

This was harder to fix than you'd think.  I needed to make enough changes that I suspect caching has always behaved like this.  Or if this was a regression, it's not clear when it regressed.

To fix this:

1. If a field doesn't have a `CacheControl` we need to treat it as having the default cache control (i.e. one with `maxAge: 0`).
2. I needed to update the `CacheControl::merge` function to not ignore `maxAge: 0`.  Previously if one of the cache controls had `maxAge: 0` then it would always prefer the other.  But now if we see `maxAge: 0` then the merged cache control will also have `maxAge: 0`
3. We now only do a merge on the cache controls when we reach a leaf field, rather than doing it for every type & field we encounter on the traversal.  This was necessary, as otherwise every type & field in the hierarchy needs to be marked as cachable.  So if you only wanted to cache the `email` field in `query { user { email } }` you would also have to mark `type Query` and `type User` as cacheable, which would in turn make the whole schema cacheable.  Not what we want.
4. I had to add a cache control stack into the CacheControlVisitor, so that we can propagate cache controls down from parent types & fields.

Fixes GB-6822