### PR TITLE
fix: handle headers in partial caching

### DIFF
--- a/engine/crates/integration-tests/tests/tracing/cache.rs
+++ b/engine/crates/integration-tests/tests/tracing/cache.rs
@@ -1,5 +1,6 @@
 use std::convert::Infallible;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use http::HeaderMap;
@@ -44,7 +45,10 @@ pub fn cache_status_hit() {
     #[async_trait]
     impl CacheInner for TestCache {
         async fn get(&self, _key: &Key) -> runtime::cache::Result<Entry<Vec<u8>>> {
-            Ok(Entry::Hit(serde_json::to_vec(&TestResponse).unwrap()))
+            Ok(Entry::Hit(
+                serde_json::to_vec(&TestResponse).unwrap(),
+                Duration::from_millis(500),
+            ))
         }
 
         async fn put(

--- a/engine/crates/partial-caching/src/headers.rs
+++ b/engine/crates/partial-caching/src/headers.rs
@@ -1,0 +1,25 @@
+pub struct RequestCacheControl {
+    /// Whether the cache code should use the cache to provide responses
+    ///
+    /// Controlled by the `no-cache` directive in headers
+    ///
+    /// The MDN description of `no-cache` seems to say that you can fetch
+    /// the cache but need to "revalidate" when this directive is present.
+    /// But we currently have no revalidation mechanism so this seems the
+    /// closest option
+    pub should_read_from_cache: bool,
+
+    /// Whether the cache code should store responses in the cache
+    ///
+    /// Controlled by the `no-store` directive in headers
+    pub should_write_to_cache: bool,
+}
+
+impl From<headers::CacheControl> for RequestCacheControl {
+    fn from(value: headers::CacheControl) -> Self {
+        RequestCacheControl {
+            should_read_from_cache: !value.no_cache(),
+            should_write_to_cache: !value.no_store(),
+        }
+    }
+}

--- a/engine/crates/partial-caching/src/hit.rs
+++ b/engine/crates/partial-caching/src/hit.rs
@@ -49,10 +49,10 @@ impl CompleteHit {
         // Merge in the rest of the entries
         for entry in cache_entries {
             match entry {
-                Entry::Hit(value, max_age) => {
+                Entry::Hit(value, time_till_miss) => {
                     merge_json(&mut body, value);
 
-                    response_max_age.merge(max_age);
+                    response_max_age.merge(time_till_miss);
                 }
                 Entry::Miss => {
                     // This is an obvious invariant so lets panic

--- a/engine/crates/partial-caching/src/hit.rs
+++ b/engine/crates/partial-caching/src/hit.rs
@@ -27,10 +27,10 @@ impl CompleteHit {
         let mut response_max_age = MaxAge::default();
 
         match first_entry {
-            Entry::Hit(value, max_age) => {
+            Entry::Hit(value, time_till_miss) => {
                 let root_id = body.from_serde_value(value);
                 body.set_root_unchecked(root_id);
-                response_max_age.merge(max_age);
+                response_max_age.merge(time_till_miss);
             }
             Entry::Miss => {
                 // This is an obvious invariant so lets panic

--- a/engine/crates/partial-caching/src/hit.rs
+++ b/engine/crates/partial-caching/src/hit.rs
@@ -1,7 +1,7 @@
 use graph_entities::QueryResponse;
 use runtime::cache::Entry;
 
-use crate::{execution::merge_json, CacheUpdatePhase};
+use crate::{execution::merge_json, response::MaxAge, CacheUpdatePhase, Response};
 
 /// This struct is used when we found everything we needed in the cache
 /// and don't need to make a call to the executor at all.
@@ -14,43 +14,60 @@ impl CompleteHit {
         CompleteHit { cache_entries }
     }
 
-    pub fn response_and_updates(self) -> (QueryResponse, Option<CacheUpdatePhase>) {
-        let mut response = QueryResponse::default();
+    pub fn response_and_updates(self) -> (Response, Option<CacheUpdatePhase>) {
+        let mut body = QueryResponse::default();
         let mut cache_entries = self.cache_entries.into_iter();
 
         let Some(first_entry) = cache_entries.next() else {
             // This really shouldn't happen, but not much else we can do.
             // I'd rather not panic for this case as its not an obvious invariant
-            return (response, None);
+            return (Response::hit(body, MaxAge::None), None);
         };
 
+        let mut response_max_age = MaxAge::default();
+
         match first_entry {
-            Entry::Hit(value) => {
-                let root_id = response.from_serde_value(value);
-                response.set_root_unchecked(root_id);
+            Entry::Hit(value, max_age) => {
+                let root_id = body.from_serde_value(value);
+                body.set_root_unchecked(root_id);
+                response_max_age.merge(max_age);
             }
             Entry::Miss => {
                 // This is an obvious invariant so lets panic
                 unreachable!("a complete hit should have no misses")
             }
             Entry::Stale(stale) => {
-                let root_id = response.from_serde_value(stale.value);
-                response.set_root_unchecked(root_id);
+                let root_id = body.from_serde_value(stale.value);
+                body.set_root_unchecked(root_id);
+
+                // This entry was stale so instruct downstreams not to cache
+                // until we have revalidated
+                response_max_age.set_none();
             }
         }
 
         // Merge in the rest of the entries
         for entry in cache_entries {
             match entry {
-                Entry::Hit(value) => merge_json(&mut response, value),
+                Entry::Hit(value, max_age) => {
+                    merge_json(&mut body, value);
+
+                    response_max_age.merge(max_age);
+                }
                 Entry::Miss => {
                     // This is an obvious invariant so lets panic
                     unreachable!("a complete hit should have no misses")
                 }
-                Entry::Stale(stale) => merge_json(&mut response, stale.value),
+                Entry::Stale(stale) => {
+                    merge_json(&mut body, stale.value);
+
+                    // This entry was stale so clear the current maxAge
+                    // until we have revalidated
+                    response_max_age.set_none();
+                }
             }
         }
 
-        (response, None)
+        (Response::hit(body, response_max_age), None)
     }
 }

--- a/engine/crates/partial-caching/src/lib.rs
+++ b/engine/crates/partial-caching/src/lib.rs
@@ -19,19 +19,17 @@ use registry_for_cache::CacheControl;
 
 mod execution;
 mod fetching;
+mod headers;
 mod hit;
 mod planning;
 mod query_subset;
+mod response;
 mod updating;
 
 pub use self::{
-    execution::ExecutionPhase, planning::build_plan, query_subset::QuerySubset, updating::CacheUpdatePhase,
+    execution::ExecutionPhase, planning::build_plan, query_subset::QuerySubset, response::Response,
+    updating::CacheUpdatePhase,
 };
-
-// Renaming this because we have registry_for_cache::CacheControl & headers::CacheControl and
-// it's confusing when you're working with both of them.  Hopefully the alias doesn't add
-// it's own confusion :|
-pub use headers::CacheControl as CacheControlHeaders;
 
 pub struct CachingPlan {
     pub document: ExecutableDocument,

--- a/engine/crates/partial-caching/src/response.rs
+++ b/engine/crates/partial-caching/src/response.rs
@@ -1,0 +1,86 @@
+use std::time::Duration;
+
+use graph_entities::QueryResponse;
+use headers::HeaderMapExt;
+use runtime::cache::X_GRAFBASE_CACHE;
+
+pub struct Response {
+    pub body: QueryResponse,
+    pub headers: http::HeaderMap,
+}
+
+impl Response {
+    pub(crate) fn hit(body: QueryResponse, max_age: MaxAge) -> Self {
+        Response {
+            body,
+            headers: headers("HIT", max_age),
+        }
+    }
+
+    pub(crate) fn partial_hit(body: QueryResponse, max_age: MaxAge) -> Self {
+        Response {
+            body,
+            headers: headers("PARTIAL_HIT", max_age),
+        }
+    }
+
+    pub(crate) fn miss(body: QueryResponse, max_age: MaxAge) -> Self {
+        Response {
+            body,
+            headers: headers("MISS", max_age),
+        }
+    }
+}
+
+fn headers(grafbase_cache: &'static str, max_age: MaxAge) -> http::HeaderMap {
+    let mut headers = http::HeaderMap::new();
+    headers.insert(
+        http::HeaderName::from_static(X_GRAFBASE_CACHE),
+        http::HeaderValue::from_static(grafbase_cache),
+    );
+
+    if let Some(max_age) = max_age.into_duration() {
+        headers.typed_insert(headers::CacheControl::new().with_public().with_max_age(max_age));
+    }
+
+    headers
+}
+
+/// The maximum age that will be returned in headers
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) enum MaxAge {
+    #[default]
+    /// A max age has not yet been set
+    Unknown,
+
+    Known(Duration),
+
+    /// Max age has explicitly been set to none
+    None,
+}
+
+impl MaxAge {
+    pub fn merge(&mut self, other: Duration) {
+        // Clamp to seconds, because that's what the maxAge header is measured in
+        let other = Duration::from_secs(other.as_secs());
+
+        *self = match self {
+            MaxAge::Unknown => MaxAge::Known(other),
+            MaxAge::Known(this) => MaxAge::Known(std::cmp::min(*this, other)),
+            MaxAge::None => MaxAge::None,
+        };
+    }
+
+    /// This can be used to ensure no max age will be sent
+    pub fn set_none(&mut self) {
+        *self = MaxAge::None;
+    }
+
+    fn into_duration(self) -> Option<Duration> {
+        match self {
+            MaxAge::Unknown | MaxAge::None => None,
+            MaxAge::Known(duration) if duration.is_zero() => None,
+            MaxAge::Known(duration) => Some(duration),
+        }
+    }
+}

--- a/engine/crates/partial-caching/tests/response-merging.rs
+++ b/engine/crates/partial-caching/tests/response-merging.rs
@@ -291,6 +291,6 @@ fn variables() -> engine_value::Variables {
     engine_value::Variables::deserialize(json!({})).unwrap()
 }
 
-fn hit(value: serde_json::Value, current_max_age: u64) -> Entry<serde_json::Value> {
-    Entry::Hit(value, Duration::from_secs(current_max_age))
+fn hit(value: serde_json::Value, time_till_miss: u64) -> Entry<serde_json::Value> {
+    Entry::Hit(value, Duration::from_secs(time_till_miss))
 }

--- a/engine/crates/partial-caching/tests/response-merging.rs
+++ b/engine/crates/partial-caching/tests/response-merging.rs
@@ -1,8 +1,11 @@
 #![allow(unused_crate_dependencies, clippy::panic)]
 
+use std::time::Duration;
+
 use common_types::auth::ExecutionAuth;
 use graph_entities::QueryResponse;
-use http::HeaderMap;
+use headers::HeaderMapExt;
+use http::{HeaderMap, HeaderValue};
 use insta::assert_json_snapshot;
 use partial_caching::FetchPhaseResult;
 use runtime::cache::Entry;
@@ -35,10 +38,10 @@ fn test_simple_response_merging() {
     let mut fetch_phase = plan.start_fetch_phase(&auth(), &headers(), &variables());
 
     let cache_keys = fetch_phase.cache_keys();
-    fetch_phase.record_cache_entry(&cache_keys[0], Entry::Hit(json!({"user": {"name": "Jane"}})));
+    fetch_phase.record_cache_entry(&cache_keys[0], hit(json!({"user": {"name": "Jane"}}), 10));
     fetch_phase.record_cache_entry(
         &cache_keys[3],
-        Entry::Hit(json!({"user": {"nested": {"someThing": "hello"}}})),
+        hit(json!({"user": {"nested": {"someThing": "hello"}}}), 10),
     );
 
     let FetchPhaseResult::PartialHit(execution) = fetch_phase.finish() else {
@@ -53,7 +56,7 @@ fn test_simple_response_merging() {
 
     // Note: This is technically wrong because the order of the fields doesn't match the query.
     // Have raised GB-6813 to look into this (or not, we'll see)
-    assert_json_snapshot!(response.as_graphql_data(), @r###"
+    assert_json_snapshot!(response.body.as_graphql_data(), @r###"
     {
       "user": {
         "email": "whatever",
@@ -74,10 +77,10 @@ fn test_handles_nulls_gracefull() {
     let mut fetch_phase = plan.start_fetch_phase(&auth(), &headers(), &variables());
 
     let cache_keys = fetch_phase.cache_keys();
-    fetch_phase.record_cache_entry(&cache_keys[0], Entry::Hit(json!({"user": {"name": "Jane"}})));
+    fetch_phase.record_cache_entry(&cache_keys[0], hit(json!({"user": {"name": "Jane"}}), 10));
     fetch_phase.record_cache_entry(
         &cache_keys[3],
-        Entry::Hit(json!({"user": {"nested": {"someThing": "hello"}}})),
+        hit(json!({"user": {"nested": {"someThing": "hello"}}}), 10),
     );
 
     let FetchPhaseResult::PartialHit(execution) = fetch_phase.finish() else {
@@ -90,7 +93,7 @@ fn test_handles_nulls_gracefull() {
 
     let (response, _updates) = execution.handle_response(query_response, false);
 
-    assert_json_snapshot!(response.as_graphql_data(), @r###"
+    assert_json_snapshot!(response.body.as_graphql_data(), @r###"
     {
       "user": null
     }
@@ -104,12 +107,12 @@ fn test_complete_hit() {
     let mut fetch_phase = plan.start_fetch_phase(&auth(), &headers(), &variables());
 
     let cache_keys = fetch_phase.cache_keys();
-    fetch_phase.record_cache_entry(&cache_keys[0], Entry::Hit(json!({"user": {"name": "Jane"}})));
-    fetch_phase.record_cache_entry(&cache_keys[1], Entry::Hit(json!({"user": {"email": "whatever"}})));
-    fetch_phase.record_cache_entry(&cache_keys[2], Entry::Hit(json!({"user": {"someConstant": "123"}})));
+    fetch_phase.record_cache_entry(&cache_keys[0], hit(json!({"user": {"name": "Jane"}}), 10));
+    fetch_phase.record_cache_entry(&cache_keys[1], hit(json!({"user": {"email": "whatever"}}), 100));
+    fetch_phase.record_cache_entry(&cache_keys[2], hit(json!({"user": {"someConstant": "123"}}), 200));
     fetch_phase.record_cache_entry(
         &cache_keys[3],
-        Entry::Hit(json!({"user": {"nested": {"someThing": "hello"}}})),
+        hit(json!({"user": {"nested": {"someThing": "hello"}}}), 10),
     );
 
     let FetchPhaseResult::CompleteHit(hit) = fetch_phase.finish() else {
@@ -118,7 +121,15 @@ fn test_complete_hit() {
 
     let (response, _updates) = hit.response_and_updates();
 
-    assert_json_snapshot!(response.as_graphql_data(), @r###"
+    assert_eq!(
+        response.headers.get("x-grafbase-cache"),
+        Some(&HeaderValue::from_static("HIT"))
+    );
+
+    let response_cache_control = response.headers.typed_get::<headers::CacheControl>().unwrap();
+    assert_eq!(response_cache_control.max_age().unwrap().as_secs(), 10);
+
+    assert_json_snapshot!(response.body.as_graphql_data(), @r###"
     {
       "user": {
         "name": "Jane",
@@ -130,6 +141,106 @@ fn test_complete_hit() {
       }
     }
     "###);
+}
+
+#[test]
+fn test_partial_hit_when_lowest_max_age_is_hit() {
+    let registry = build_registry(SCHEMA);
+    let plan = partial_caching::build_plan(QUERY, None, &registry).unwrap().unwrap();
+    let mut fetch_phase = plan.start_fetch_phase(&auth(), &headers(), &variables());
+
+    let cache_keys = fetch_phase.cache_keys();
+    fetch_phase.record_cache_entry(&cache_keys[0], hit(json!({"user": {"name": "Jane"}}), 10));
+
+    let FetchPhaseResult::PartialHit(execution) = fetch_phase.finish() else {
+        panic!("We didn't hit everything so this should always be a partial");
+    };
+
+    let mut query_response = QueryResponse::default();
+    let root_node = query_response.from_serde_value(json!({
+        "user": {
+            "email": "whatever",
+            "someConstant": "123",
+            "nested": {"someThing": "hello"}
+        }
+    }));
+    query_response.set_root_unchecked(root_node);
+
+    let (response, _updates) = execution.handle_response(query_response, false);
+
+    assert_eq!(
+        response.headers.get("x-grafbase-cache"),
+        Some(&HeaderValue::from_static("PARTIAL_HIT"))
+    );
+
+    let response_cache_control = response.headers.typed_get::<headers::CacheControl>().unwrap();
+    assert_eq!(response_cache_control.max_age().unwrap().as_secs(), 10);
+}
+
+#[test]
+fn test_partial_hit_when_lowest_max_age_is_miss() {
+    let registry = build_registry(SCHEMA);
+    let plan = partial_caching::build_plan(QUERY, None, &registry).unwrap().unwrap();
+    let mut fetch_phase = plan.start_fetch_phase(&auth(), &headers(), &variables());
+
+    let cache_keys = fetch_phase.cache_keys();
+    fetch_phase.record_cache_entry(&cache_keys[2], hit(json!({"user": {"someConstant": "123"}}), 5000));
+
+    let FetchPhaseResult::PartialHit(execution) = fetch_phase.finish() else {
+        panic!("We didn't hit everything so this should always be a partial");
+    };
+
+    let mut query_response = QueryResponse::default();
+    let root_node = query_response.from_serde_value(json!({
+        "user": {
+            "name": "G",
+            "email": "whatever",
+            "nested": {"someThing": "hello"}
+        }
+    }));
+    query_response.set_root_unchecked(root_node);
+
+    let (response, _updates) = execution.handle_response(query_response, false);
+
+    assert_eq!(
+        response.headers.get("x-grafbase-cache"),
+        Some(&HeaderValue::from_static("PARTIAL_HIT"))
+    );
+
+    let response_cache_control = response.headers.typed_get::<headers::CacheControl>().unwrap();
+    assert_eq!(response_cache_control.max_age().unwrap().as_secs(), 130);
+}
+
+#[test]
+fn test_miss_headers() {
+    let registry = build_registry(SCHEMA);
+    let plan = partial_caching::build_plan(QUERY, None, &registry).unwrap().unwrap();
+    let fetch_phase = plan.start_fetch_phase(&auth(), &headers(), &variables());
+
+    let FetchPhaseResult::PartialHit(execution) = fetch_phase.finish() else {
+        panic!("We didn't hit everything so this should always be a partial");
+    };
+
+    let mut query_response = QueryResponse::default();
+    let root_node = query_response.from_serde_value(json!({
+        "user": {
+            "name": "G",
+            "email": "whatever",
+            "someConstant": "123",
+            "nested": {"someThing": "hello"}
+        }
+    }));
+    query_response.set_root_unchecked(root_node);
+
+    let (response, _updates) = execution.handle_response(query_response, false);
+
+    assert_eq!(
+        response.headers.get("x-grafbase-cache"),
+        Some(&HeaderValue::from_static("MISS"))
+    );
+
+    let response_cache_control = response.headers.typed_get::<headers::CacheControl>().unwrap();
+    assert_eq!(response_cache_control.max_age().unwrap().as_secs(), 120);
 }
 
 fn build_registry(schema: &str) -> registry_for_cache::PartialCacheRegistry {
@@ -146,4 +257,8 @@ fn headers() -> HeaderMap {
 
 fn variables() -> engine_value::Variables {
     engine_value::Variables::deserialize(json!({})).unwrap()
+}
+
+fn hit(value: serde_json::Value, current_max_age: u64) -> Entry<serde_json::Value> {
+    Entry::Hit(value, Duration::from_secs(current_max_age))
 }

--- a/engine/crates/runtime/src/cache/cached.rs
+++ b/engine/crates/runtime/src/cache/cached.rs
@@ -104,7 +104,7 @@ where
                 cache_revalidation: revalidated,
             })
         }
-        Entry::Hit(value) => {
+        Entry::Hit(value, _) => {
             tracing::debug!(ray_id = ctx.ray_id(), "Cache HIT - {}", key);
 
             Ok(CachedExecutionResponse::Cached(Arc::new(value)))
@@ -489,6 +489,7 @@ mod tests {
                         ..Default::default()
                     })
                     .unwrap(),
+                    Duration::from_millis(500),
                 ))
             }
         }

--- a/engine/crates/runtime/src/cache/mod.rs
+++ b/engine/crates/runtime/src/cache/mod.rs
@@ -38,7 +38,7 @@ pub enum EntryState {
 /// Wraps an entry from cache when getting it from there
 #[derive(Debug, PartialEq, Eq)]
 pub enum Entry<T> {
-    /// A hit, and the current time till stale of that hit
+    /// A hit, and the time remaining until this hit becomes a miss
     Hit(T, Duration),
     Miss,
     Stale(StaleEntry<T>),

--- a/engine/crates/runtime/src/cache/mod.rs
+++ b/engine/crates/runtime/src/cache/mod.rs
@@ -47,7 +47,7 @@ pub enum Entry<T> {
 impl<T> Entry<T> {
     fn try_map<V, F: FnOnce(T) -> Result<V>>(self, f: F) -> Result<Entry<V>> {
         match self {
-            Entry::Hit(value, max_age) => f(value).map(|new_value| Entry::Hit(new_value, max_age)),
+            Entry::Hit(value, time_till_miss) => f(value).map(|new_value| Entry::Hit(new_value, time_till_miss)),
             Entry::Miss => Ok(Entry::Miss),
             Entry::Stale(entry) => f(entry.value).map(|value| {
                 Entry::Stale(StaleEntry {


### PR DESCRIPTION
This updates partial caching to respect an incoming `Cache-Control` header and also provide outgoing `x-grafbase-cache` & `Cache-Control` headers.

The maxAge of a returned `Cache-Control` header is set to whatever the lowest `maxAge` of the individual partitions is. As part of this I had to update the `Entry` interface to return the current TTLof a hit, as otherwise we'd have no way to know whether that TTL is actually lower than any of the maxAge values of the freshly fetched partitions.

Fixes GB-6806
Fixes GB-6819