### PR TITLE
chore: pull in graphql-ws-client 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,8 +424,8 @@ version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e6fa871e4334a622afd6bb2f611635e8083a6f5e2936c0f90f37c7ef9856298"
 dependencies = [
- "async-channel",
- "futures-lite",
+ "async-channel 1.9.0",
+ "futures-lite 1.13.0",
  "http-types",
  "log",
  "memchr",
@@ -2664,7 +2676,7 @@ checksum = "51ee14e256b9143bfafbf2fddeede6f396650bacf95d06fc1b3f2b503df129a0"
 dependencies = [
  "bitvec",
  "futures-core",
- "futures-lite",
+ "futures-lite 1.13.0",
  "pin-project",
  "slab",
  "smallvec",
@@ -2706,6 +2718,19 @@ dependencies = [
  "parking",
  "pin-project-lite",
  "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+dependencies = [
+ "fastrand 2.1.0",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -3384,11 +3409,13 @@ dependencies = [
 
 [[package]]
 name = "graphql-ws-client"
-version = "0.8.2"
-source = "git+https://github.com/grafbase/graphql-ws-client?rev=84aa4e3629ffcf0141702faef37324cd41d64291#84aa4e3629ffcf0141702faef37324cd41d64291"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00939632e84140d4b14b9048049c68b955600d215429433bbbfeaec0a80d2fa4"
 dependencies = [
- "async-trait",
- "futures",
+ "async-channel 2.3.1",
+ "futures-lite 2.3.0",
+ "futures-sink",
  "futures-timer",
  "log",
  "pin-project",
@@ -3730,9 +3757,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
 dependencies = [
  "anyhow",
- "async-channel",
+ "async-channel 1.9.0",
  "base64 0.13.1",
- "futures-lite",
+ "futures-lite 1.13.0",
  "infer",
  "pin-project-lite",
  "rand 0.7.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ exclude = ["engine/crates/gateway-v2"]
 axum = { git = "https://github.com/grafbase/axum", rev = "c3146f9ca921907d9884fbf7549a1520e9e72eac" } # axum-tungstenite-upgrade
 # Drop when https://github.com/programatik29/axum-server/pull/112 is merged.
 axum-server = { git = "https://github.com/grafbase/axum-server", rev = "fdce3d3dc71dc69597689cc28003cc0533b47dba" } # rustls-0.23
-graphql-ws-client = { git = "https://github.com/grafbase/graphql-ws-client", rev = "84aa4e3629ffcf0141702faef37324cd41d64291" } # upgrade-tungstenite-0.23
 hyper-rustls = { git = "https://github.com/grafbase/hyper-rustls", rev = "e8e14ba34c081702297c74e544109be6c8ea5232" } # rustls-0.23
 multipart-stream = { git = "https://github.com/grafbase/multipart-stream-rs-fork", rev = "06ff198e4041c8a8c1c93e580c260d597727c193" } # http-1.0-fix-multipart-mixed
 names = { git = "https://github.com/grafbase/names", rev = "443800fbb7bc2936c1f2c16f3a5e116698b1454a" } # main

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -78,7 +78,7 @@ duct = "0.13.7"
 fslock = "0.2.1"
 futures-util = "0.3.30"
 graphql-mocks.workspace = true
-graphql-ws-client = { version = "0.8.2", features = ["async-tungstenite"] }
+graphql-ws-client = { version = "0.10.0", features = ["tungstenite"] }
 headers.workspace = true
 hex.workspace = true
 http.workspace = true

--- a/engine/crates/runtime-local/Cargo.toml
+++ b/engine/crates/runtime-local/Cargo.toml
@@ -17,7 +17,7 @@ async-runtime.workspace = true
 async-trait = "0.1.80"
 async-tungstenite = { version = "0.26.0", features = ["tokio-runtime", "tokio-rustls-webpki-roots"] }
 futures-util.workspace = true
-graphql-ws-client = { version = "0.8.2", features = ["async-tungstenite"] }
+graphql-ws-client = { version = "0.10.0", features = ["tungstenite"] }
 ulid.workspace = true
 serde.workspace = true
 serde_json.workspace  = true


### PR DESCRIPTION
I just released a new version of this with some small breaking changes, so doing this manually instead of waiting for renovate.