### PR TITLE
chore: Add cli docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,4 +11,11 @@ grafbase
 .direnv
 .idea
 /cli/target
+/cli/Dockerfile
 /engine/target
+/engine/crates/**/snapshots
+/engine/crates/**/tests/**/txt
+/engine/crates/**/tests/**/graphql
+/engine/crates/**/tests/**/json
+/cli/crates/**/snapshots
+/**/changelog

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -71,7 +71,7 @@ runs:
       shell: bash
       run: |
         docker-compose -f engine/crates/integration-tests/docker-compose.yml up -d
-        RUST_BACKTRACE=1 cargo nextest run --workspace --profile ci --exclude grafbase-gateway
+        RUST_BACKTRACE=1 cargo nextest run --workspace --profile ci --exclude grafbase-gateway --exclude grafbase-docker-tests
         docker-compose -f engine/crates/integration-tests/docker-compose.yml stop -t 3
 
     - name: Upload the JUnit files
@@ -103,7 +103,7 @@ runs:
       if: ${{ inputs.with-integration-tests == 'false' }}
       shell: bash
       run: |
-        RUST_BACKTRACE=1 cargo nextest run --workspace --exclude integration-tests --exclude grafbase-gateway --profile ci
+        RUST_BACKTRACE=1 cargo nextest run --workspace --exclude integration-tests --exclude grafbase-docker-tests --exclude grafbase-gateway --profile ci
 
     - name: Upload the non-integration JUnit files
       if: ${{ inputs.with-integration-tests == 'false' && ( success() || failure() ) && !contains(steps.tests_no_integration.outputs.exitcode, '101') }}

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -153,7 +153,7 @@ jobs:
           set -euo pipefail
           cargo check --package ${{ matrix.package }}
 
-  docker:
+  docker-grafbase:
     needs: [test]
     if: ${{ needs.detect-change-type.outputs.build == 'true' || startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubicloud-standard-8
@@ -163,8 +163,62 @@ jobs:
       - name: Get sources
         uses: actions/checkout@v4
 
-      - name: Build assets
-        uses: ./.github/actions/cli_assets
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build docker images
+        run: |
+          # Re-use the latest layers if possible
+          docker pull ghcr.io/grafbase/grafbase:latest || true
+          docker build -f cli/Dockerfile -t ghcr.io/grafbase/grafbase:$COMMIT_SHA .
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+
+      - name: Rust job init
+        uses: ./.github/actions/init_rust_job
+        with:
+          platform: linux
+          cache-key: ${{ runner.os }}-${{ runner.arch }}-cargo-dev-${{ hashFiles('Cargo.lock') }}
+          restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-dev
+
+      - name: Docker tests
+        run: |
+          GRAFBASE_DOCKER_IMAGE="ghcr.io/grafbase/grafbase:$COMMIT_SHA" RUST_BACKTRACE=1 cargo nextest run -p grafbase-docker-tests
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+
+      - name: Tag latest version
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          docker tag ghcr.io/grafbase/grafbase:$COMMIT_SHA ghcr.io/grafbase/grafbase:latest
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+
+      - name: Tag released grafbase version
+        if: ${{ startsWith(github.ref, 'refs/tags') && startsWith(github.ref_name, 'grafbase-') }}
+        run: |
+          docker tag ghcr.io/grafbase/grafbase:$COMMIT_SHA ghcr.io/grafbase/grafbase:$(echo "$REF" | sed -e "s/^refs\/tags\/grafbase-//")
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          REF: ${{ github.ref }}
+
+      - name: Push docker image
+        run: |
+          docker push --all-tags ghcr.io/grafbase/grafbase
+
+  docker-gateway:
+    needs: [test]
+    if: ${{ needs.detect-change-type.outputs.build == 'true' || startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubicloud-standard-8
+    permissions:
+      packages: write
+    steps:
+      - name: Get sources
+        uses: actions/checkout@v4
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -173,24 +227,33 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build docker image
+      - name: Build docker images
         run: |
-          docker build -t ghcr.io/grafbase/gateway:$SHA_TAG .
+          # Re-use the latest layers if possible
+          docker pull ghcr.io/grafbase/gateway:latest || true
+          docker build -t ghcr.io/grafbase/gateway:$COMMIT_SHA .
         env:
-          SHA_TAG: ${{ github.sha }}
+          COMMIT_SHA: ${{ github.sha }}
 
-      - name: Tag released version
+      - name: Tag latest version
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          docker tag ghcr.io/grafbase/gateway:$COMMIT_SHA ghcr.io/grafbase/gateway:latest
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+
+      - name: Tag released gateway version
         if: ${{ startsWith(github.ref, 'refs/tags') && startsWith(github.ref_name, 'gateway-') }}
         run: |
-          docker tag ghcr.io/grafbase/gateway:$SHA_TAG ghcr.io/grafbase/gateway:latest
-          docker tag ghcr.io/grafbase/gateway:$SHA_TAG ghcr.io/grafbase/gateway:$(echo "$REF" | sed -e "s/^refs\/tags\/gateway-//")
+          docker tag ghcr.io/grafbase/gateway:$COMMIT_SHA ghcr.io/grafbase/gateway:$(echo "$REF" | sed -e "s/^refs\/tags\/gateway-//")
         env:
-          SHA_TAG: ${{ github.sha }}
+          COMMIT_SHA: ${{ github.sha }}
           REF: ${{ github.ref }}
 
       - name: Push docker image
         run: |
           docker push --all-tags ghcr.io/grafbase/gateway
+
   linux:
     needs: [test]
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,6 +850,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aed08d3adb6ebe0eff737115056652670ae290f177759aac19c30456135f94c"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-named-pipe",
+ "hyper-util",
+ "hyperlocal-next",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.44.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709d9aa1c37abb89d40f19f5d0ad6f0d88cb1581264e571c9350fc5bb89cf1c5"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
+]
+
+[[package]]
 name = "borsh"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3147,6 +3191,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "grafbase-docker-tests"
+version = "0.75.0"
+dependencies = [
+ "anyhow",
+ "bollard",
+ "ctor",
+ "futures-util",
+ "insta",
+ "reqwest",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing-subscriber",
+ "ulid",
+]
+
+[[package]]
 name = "grafbase-gateway"
 version = "0.3.1"
 dependencies = [
@@ -3941,6 +4002,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper 1.3.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4001,6 +4077,21 @@ dependencies = [
  "tower",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyperlocal-next"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -7313,6 +7404,17 @@ dependencies = [
  "percent-encoding",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,6 @@ members = [
   "engine/crates/engine/query-path",
   "engine/crates/engine/registry-for-cache",
   "engine/crates/engine/registry-upgrade",
-  "engine/crates/engine/registry-upgrade",
-  "engine/crates/engine/registry-upgrade",
   "engine/crates/engine/registry-v2",
   "engine/crates/engine/registry-v2-generator",
   "engine/crates/engine/scalars",

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,0 +1,101 @@
+#
+# === Pathfinder & UDF wrapper ===
+#
+FROM oven/bun:1.1.6-alpine AS assets
+WORKDIR /grafbase
+COPY ./cli/wrappers ./cli/wrappers
+COPY ./packages/cli-app ./packages/cli-app
+RUN apk add --no-cache git npm && \
+    cd packages/cli-app && \
+    npx --yes pnpm i && \
+    npx --yes pnpm run cli-app:build && \
+    cd ../../cli/wrappers && \
+    bun i && \
+    bun run build 
+
+#
+# === Grafbase CLI ===
+#
+# Using the same alpine image as oven/bun
+# https://github.com/oven-sh/bun/blob/bun-v1.1.6/dockerhub/alpine/Dockerfile
+FROM rust:1.78-alpine3.18 AS chef
+COPY rust-toolchain.toml rust-toolchain.toml
+RUN apk add --no-cache musl-dev && cargo install cargo-chef
+WORKDIR /grafbase
+
+FROM chef AS planner
+# At this stage we don't really bother selecting anything specific, it's fast enough.
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /grafbase/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+
+COPY Cargo.lock Cargo.lock
+COPY Cargo.toml Cargo.toml
+COPY ./gateway ./gateway
+COPY ./cli ./cli
+COPY ./graphql-introspection ./graphql-introspection
+COPY ./graph-ref ./graph-ref
+COPY ./graphql-lint ./graphql-lint
+COPY ./gqlint ./gqlint
+COPY ./engine ./engine
+COPY ./packages/grafbase-sdk/package.json ./packages/grafbase-sdk/package.json
+COPY --from=assets /grafbase/packages/cli-app/dist ./packages/cli-app/dist
+COPY --from=assets /grafbase/cli/wrappers/dist.js ./cli/wrappers/dist.js
+RUN cargo build --release --bin grafbase
+
+#
+# === Final image ===
+#
+FROM oven/bun:1.1.6-alpine
+
+# gosu is a better sudo/su to step down from root into the service user in the docker-entrypoint.sh script
+# See https://github.com/tianon/gosu/blob/master/INSTALL.md
+ENV GOSU_VERSION 1.17
+RUN set -eux; \
+    \
+    apk add --no-cache --virtual .gosu-deps \
+        ca-certificates \
+        dpkg \
+        gnupg \
+    ; \
+    \
+    dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+    wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    \
+# verify the signature
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+    gpgconf --kill all; \
+    rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+    \
+# clean up fetch dependencies
+    apk del --no-network .gosu-deps; \
+    \
+    chmod +x /usr/local/bin/gosu; \
+# verify that the binary works
+    gosu --version; \
+    gosu nobody true
+
+RUN mkdir /etc/grafbase && \
+    touch /etc/grafbase/inside-docker && \
+    adduser -g wheel -D grafbase -h "/home/grafbase" && \
+    mkdir /data && \
+    chown grafbase:grafbase /data
+
+COPY --from=builder /grafbase/target/release/grafbase /bin/
+COPY ./cli/docker-entrypoint.sh /bin/
+
+VOLUME /data
+WORKDIR /data
+
+EXPOSE 4000
+
+ENTRYPOINT ["/bin/docker-entrypoint.sh"]
+CMD ["start", "--listen-address", "0.0.0.0:4000"]
+
+

--- a/cli/crates/docker-tests/Cargo.toml
+++ b/cli/crates/docker-tests/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "grafbase-docker-tests"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+ctor.workspace = true
+ulid.workspace = true
+bollard = "0.16"
+anyhow = "1"
+futures-util.workspace = true
+tempfile = "3"
+tokio = { workspace = true, features = ["full"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = [
+  "fmt",
+  "tracing-log",
+  "env-filter",
+  "ansi",
+] }
+
+[dev-dependencies]
+reqwest = { workspace = true, features = ["json"] }
+serde_json.workspace = true
+insta = { workspace = true, features = ["json", "redactions", "yaml"] }
+

--- a/cli/crates/docker-tests/README.md
+++ b/cli/crates/docker-tests/README.md
@@ -1,0 +1,9 @@
+On MacOS with Colima you'll need to setup the following env vars for the test:
+
+```bash
+# our docker client doesn't use docker context to detect colima
+export DOCKER_HOST="unix://$HOME/.colima/default/docker.sock"
+# Colima only mounts $HOME & /tmp/colima inside the VM
+export TMPDIR=/tmp/colima
+cargo nextest run -p grafbase-docker-tests
+```

--- a/cli/crates/docker-tests/src/lib.rs
+++ b/cli/crates/docker-tests/src/lib.rs
@@ -1,0 +1,197 @@
+#![allow(unused_crate_dependencies)]
+
+use std::{
+    future::Future,
+    panic::{catch_unwind, AssertUnwindSafe},
+    sync::OnceLock,
+    time::Duration,
+};
+
+use bollard::{
+    container::{Config, CreateContainerOptions, LogOutput, LogsOptions, StopContainerOptions},
+    secret::HostConfig,
+    Docker,
+};
+use futures_util::TryStreamExt;
+use tokio::{runtime::Runtime, time::sleep};
+
+#[ctor::ctor]
+fn setup_logging() {
+    let filter = tracing_subscriber::filter::EnvFilter::builder()
+        .parse(std::env::var("RUST_LOG").unwrap_or("grafbase_clickhouse_client=debug".to_string()))
+        .unwrap();
+    tracing_subscriber::fmt()
+        .pretty()
+        .with_env_filter(filter)
+        .with_file(true)
+        .with_line_number(true)
+        .with_target(true)
+        .without_time()
+        .init();
+}
+
+pub fn runtime() -> &'static Runtime {
+    static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    })
+}
+
+pub fn docker() -> &'static Docker {
+    static DOCKER: OnceLock<Docker> = OnceLock::new();
+    DOCKER.get_or_init(|| Docker::connect_with_local_defaults().unwrap())
+}
+
+pub fn with_grafbase<F>(data_dir: tempfile::TempDir, test: impl FnOnce(String) -> F)
+where
+    F: Future<Output = ()>,
+{
+    let Ok(docker_image) = std::env::var("GRAFBASE_DOCKER_IMAGE") else {
+        unimplemented!("Please set GRAFBASE_DOCKER_IMAGE env var");
+    };
+
+    let (url, cleanup) = runtime().block_on(start_container(docker_image, data_dir));
+
+    let result = catch_unwind(AssertUnwindSafe(|| runtime().block_on(test(url))));
+
+    runtime().block_on(cleanup);
+
+    if let Err(err) = result {
+        std::panic::resume_unwind(err);
+    }
+}
+
+#[allow(clippy::panic)]
+async fn start_container(image_name: String, data_dir: tempfile::TempDir) -> (String, impl Future<Output = ()>) {
+    let skip_cleanup = std::env::var("SKIP_CLEANUP").is_ok();
+    let name = format!("grafbase_{}", ulid::Ulid::new()).to_lowercase();
+
+    println!(
+        "Using docker image: {image_name}\nContainer name: {name}\nData dir: {}",
+        data_dir.path().display()
+    );
+
+    let docker = docker();
+    docker
+        .create_container(
+            Some(CreateContainerOptions {
+                name: name.clone(),
+                platform: None,
+            }),
+            Config {
+                image: Some(image_name),
+                host_config: Some(HostConfig {
+                    publish_all_ports: Some(true),
+                    auto_remove: Some(true),
+                    binds: Some(vec![format!("{}:/data", data_dir.path().display())]),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    docker.start_container::<&str>(&name, None).await.unwrap();
+    let inspection = docker.inspect_container(&name, None).await.unwrap();
+
+    let binding = inspection
+        .network_settings
+        .and_then(|network| network.ports)
+        .unwrap()
+        .into_values()
+        .find_map(|binding| binding)
+        .unwrap()
+        .into_iter()
+        .next()
+        .unwrap();
+
+    let addr = format!("{}:{}", binding.host_ip.unwrap(), binding.host_port.unwrap());
+    let cleanup = async move {
+        print_logs(&name).await;
+        if skip_cleanup {
+            println!("Skipping cleanup");
+            std::mem::forget(data_dir);
+        } else {
+            let _ = docker.stop_container(&name, Some(StopContainerOptions { t: 1 })).await;
+        }
+    };
+
+    // Leave some time for the gateway to fully start and port to be bound
+    let wait_for_container = async {
+        let start = std::time::Instant::now();
+        println!("Waiting for grafbase to be available at {addr}...");
+        // On MacOS port mapping takes forever (with colima at least), but on Linux it's sub
+        // millisecond. CI is however not fast enough for the whole gateway to be fully started
+        // before the test starts. So ensuring we always give the gateway some time.
+        sleep(Duration::from_millis(100)).await;
+        while tokio::net::TcpStream::connect(&addr).await.is_err() {
+            sleep(Duration::from_millis(100)).await;
+        }
+        println!("Waited for {} ms", start.elapsed().as_millis());
+    };
+
+    // Leave some time for the gateway to fully start.
+    tokio::select! {
+        () = wait_for_container => {},
+        () = sleep(Duration::from_secs(5)) => {
+            cleanup.await;
+            panic!("grafbase did not start in time");
+        }
+    }
+
+    let url = format!("http://{addr}/graphql");
+    (url, cleanup)
+}
+
+async fn print_logs(container_name: &str) {
+    let result = crate::docker()
+        .logs(
+            container_name,
+            Some(LogsOptions::<String> {
+                stdout: true,
+                stderr: true,
+                ..Default::default()
+            }),
+        )
+        .try_collect::<Vec<_>>()
+        .await;
+    if let Ok(logs) = result {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        for log in logs {
+            match log {
+                LogOutput::StdErr { message } => stderr.extend_from_slice(&message),
+                LogOutput::StdOut { message } => stdout.extend_from_slice(&message),
+                _ => {}
+            }
+        }
+        if !stdout.is_empty() {
+            println!("\n=== stdout ===\n{}", String::from_utf8_lossy(&stdout));
+        }
+        if !stderr.is_empty() {
+            println!("\n=== stderr ===\n{}", String::from_utf8_lossy(&stderr));
+        }
+    }
+}
+
+pub async fn retry_for<T, F>(mut count: usize, delay: Duration, f: impl Fn() -> F) -> anyhow::Result<T>
+where
+    F: Future<Output = anyhow::Result<T>>,
+{
+    loop {
+        match f().await {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                count -= 1;
+                if count == 0 {
+                    return Err(e);
+                }
+                tokio::time::sleep(delay).await;
+            }
+        }
+    }
+}

--- a/cli/crates/docker-tests/tests/docker_tests.rs
+++ b/cli/crates/docker-tests/tests/docker_tests.rs
@@ -1,0 +1,8 @@
+use anyhow as _;
+use bollard as _;
+use ctor as _;
+use futures_util as _;
+use tracing_subscriber as _;
+use ulid as _;
+
+mod resolvers;

--- a/cli/crates/docker-tests/tests/resolvers/hello_world.rs
+++ b/cli/crates/docker-tests/tests/resolvers/hello_world.rs
@@ -1,0 +1,68 @@
+use std::time::Duration;
+
+use grafbase_docker_tests::{retry_for, with_grafbase};
+
+#[test]
+fn hello_world_resolver() {
+    let tmp_dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp_dir.path().join("grafbase.config.ts"),
+        r###"
+        import { g, config } from '@grafbase/sdk'
+
+        g.query('hello', {
+          args: { name: g.string().optional() },
+          returns: g.string(),
+          resolver: 'hello',
+        })
+
+        export default config({
+          graph: g,
+          auth: {
+            rules: (rules) => {
+              rules.public()
+            }
+          }
+        })
+        "###,
+    )
+    .unwrap();
+    std::fs::create_dir(tmp_dir.path().join("resolvers")).unwrap();
+    std::fs::write(
+        tmp_dir.path().join("resolvers").join("hello.js"),
+        r###"
+        export default function Resolver(_, { name }) {
+          return `Hello ${name || 'world'}!`
+        }
+        "###,
+    )
+    .unwrap();
+
+    with_grafbase(tmp_dir, |url| async move {
+        // quick hack to let grafbase start.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let client = reqwest::Client::new();
+        let response = retry_for(10, Duration::from_secs(1), || async {
+            client
+                .post(&url)
+                .json(&serde_json::json!({
+                    "query": "{ hello }"
+                }))
+                .send()
+                .await
+                .map_err(Into::into)
+        })
+        .await
+        .unwrap();
+        assert_eq!(response.status(), 200);
+        let body: serde_json::Value = response.json().await.unwrap();
+        insta::assert_json_snapshot!(body, @r###"
+        {
+          "data": {
+            "hello": "Hello world!"
+          }
+        }
+        "###);
+    })
+}

--- a/cli/crates/docker-tests/tests/resolvers/mod.rs
+++ b/cli/crates/docker-tests/tests/resolvers/mod.rs
@@ -1,0 +1,1 @@
+mod hello_world;

--- a/cli/crates/server/src/bridge/udf.rs
+++ b/cli/crates/server/src/bridge/udf.rs
@@ -421,13 +421,15 @@ async fn spawn_bun(
         let bun_arguments = vec!["run", &script_path];
 
         let environment = Environment::get();
-        let mut bun = Command::new(environment.bun_executable_path()?);
+        let bun_path = environment.bun_executable_path()?;
+        trace!("Calling bun ({}) with: {:?}", bun_path.to_string_lossy(), bun_arguments);
+        let mut bun = Command::new(bun_path);
         bun.args(bun_arguments)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
-        trace!("Spawning {udf_kind} '{udf_name}'");
 
+        trace!("Spawning {udf_kind} '{udf_name}'");
         let mut bun = bun.spawn().unwrap();
         let bound_port = {
             let stdout = bun.stdout.as_mut().unwrap();

--- a/cli/crates/server/src/bun.rs
+++ b/cli/crates/server/src/bun.rs
@@ -164,7 +164,7 @@ pub(crate) async fn install_bun() -> Result<(), BunError> {
         return Ok(());
     }
 
-    if common::environment::is_nixos() {
+    if common::environment::is_nixos() || common::environment::is_in_docker_image() {
         BUN_INSTALLED_FOR_SESSION.store(true, Ordering::Relaxed);
         return Ok(());
     }

--- a/cli/crates/server/src/udf_builder.rs
+++ b/cli/crates/server/src/udf_builder.rs
@@ -36,7 +36,7 @@ pub(crate) async fn build(
         .await?
         .replace("\"/invoke\"", &format!("\"{}\"", udf_url_path(udf_kind, udf_name)));
 
-    trace!("building {udf_kind} '{udf_name}'");
+    trace!("building {udf_kind} '{udf_name}'\n");
 
     let udf_input_file_path_without_extension = project.udfs_source_path(udf_kind).join(udf_name);
     let udf_build_artifact_directory_path = project.udfs_build_artifact_path(udf_kind).join(udf_name);

--- a/cli/docker-entrypoint.sh
+++ b/cli/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -eu
+
+# allow the container to be started with `--user`
+if [ "$(id -u)" = '0' ]; then
+    mkdir -p .grafbase
+    chmod 777 .grafbase
+    find .grafbase \! -user grafbase -exec chmod 777 '{}' +
+    exec gosu grafbase "$0" "$@"
+fi
+
+# set an appropriate umask (if one isn't set already)
+# - https://github.com/docker-library/redis/issues/305
+# - https://github.com/redis/redis/blob/bb875603fb7ff3f9d19aad906bd45d7db98d9a39/utils/systemd-redis_server.service#L37
+um="$(umask)"
+if [ "$um" = '0022' ]; then
+    umask 0077
+fi
+
+# Add grafbase as first command
+if [ "${1:-}" != "/bin/grafbase" ]; then
+    set -- "/bin/grafbase" "$@"
+fi
+
+exec "$@"

--- a/cli/nix/wrappers.nix
+++ b/cli/nix/wrappers.nix
@@ -1,16 +1,16 @@
-{ pkgs, ... }: {
+{pkgs, ...}: {
   packages.wrappers = pkgs.buildNpmPackage {
     src = ../wrappers;
     name = "wrappers";
-    npmDepsHash = "sha256-ywx1TXl8WJW4YOSHJHkC7XktwQKnNakCLtjyTff293Q=";
+    npmDepsHash = "sha256-CFF1bNRbji5V6+VhFdYt6eptFZd1+QsOOj9tUu3xqdg=";
 
-    nativeBuildInputs = [ pkgs.bun ];
+    nativeBuildInputs = [pkgs.bun];
 
     installPhase = ''
       mkdir $out
       cp dist.js bun-multi-wrapper.ts parse-config.*ts $out/
     '';
 
-    npmFlags = [ "--ignore-scripts" ];
+    npmFlags = ["--ignore-scripts"];
   };
 }


### PR DESCRIPTION
A user had trouble setting up a docker image with Grafbase, so I thought I would just revive an older docker PR and add a simple sanity check test. I didn't realize how much time I would spend on it 😅 

It took me an absurd amount of time to have a working docker image because of permissions issues, missing assets, and just incredibly slow build times. What I expect to be the linking stage still stakes forever in Docker in release, but I improved as much as I reasonably could the Dockerfile by using a separate step for building dependencies and using https://github.com/LukeMathWalker/cargo-chef. Unfortunately, limiting the preparation step to a single binary didn't work,  but it still avoids dependency download and some of the compilations. A bunch of those are recompiled likely because of feature flags. Did the same to the gateway image.

I considered not adding any tests given the amount of time I had already spent, but we have no tests that check that resolvers work with TS config. So inspired by clickhouse integration tests I've added a simple one that uses the docker image.
