### PR TITLE
chore(engine-v2): fix error management & add metrics for bad requests

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -161,6 +161,8 @@ jobs:
     runs-on: ubicloud-standard-8
     permissions:
       packages: write
+    env:
+      COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - name: Get sources
         uses: actions/checkout@v4
@@ -177,8 +179,6 @@ jobs:
           # Re-use the latest layers if possible
           docker pull ghcr.io/grafbase/grafbase:latest || true
           docker build -f cli/Dockerfile -t ghcr.io/grafbase/grafbase:$COMMIT_SHA .
-        env:
-          COMMIT_SHA: ${{ github.sha }}
 
       - name: Rust job init
         uses: ./.github/actions/init_rust_job
@@ -190,22 +190,17 @@ jobs:
       - name: Docker tests
         run: |
           GRAFBASE_DOCKER_IMAGE="ghcr.io/grafbase/grafbase:$COMMIT_SHA" RUST_BACKTRACE=1 cargo nextest run -p grafbase-docker-tests
-        env:
-          COMMIT_SHA: ${{ github.sha }}
 
       - name: Tag latest version
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           docker tag ghcr.io/grafbase/grafbase:$COMMIT_SHA ghcr.io/grafbase/grafbase:latest
-        env:
-          COMMIT_SHA: ${{ github.sha }}
 
       - name: Tag released grafbase version
         if: ${{ startsWith(github.ref, 'refs/tags') && startsWith(github.ref_name, 'grafbase-') }}
         run: |
           docker tag ghcr.io/grafbase/grafbase:$COMMIT_SHA ghcr.io/grafbase/grafbase:$(echo "$REF" | sed -e "s/^refs\/tags\/grafbase-//")
         env:
-          COMMIT_SHA: ${{ github.sha }}
           REF: ${{ github.ref }}
 
       - name: Push docker image
@@ -218,6 +213,8 @@ jobs:
     runs-on: ubicloud-standard-8
     permissions:
       packages: write
+    env:
+      COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - name: Get sources
         uses: actions/checkout@v4
@@ -234,22 +231,17 @@ jobs:
           # Re-use the latest layers if possible
           docker pull ghcr.io/grafbase/gateway:latest || true
           docker build -t ghcr.io/grafbase/gateway:$COMMIT_SHA .
-        env:
-          COMMIT_SHA: ${{ github.sha }}
 
       - name: Tag latest version
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           docker tag ghcr.io/grafbase/gateway:$COMMIT_SHA ghcr.io/grafbase/gateway:latest
-        env:
-          COMMIT_SHA: ${{ github.sha }}
 
       - name: Tag released gateway version
         if: ${{ startsWith(github.ref, 'refs/tags') && startsWith(github.ref_name, 'gateway-') }}
         run: |
           docker tag ghcr.io/grafbase/gateway:$COMMIT_SHA ghcr.io/grafbase/gateway:$(echo "$REF" | sed -e "s/^refs\/tags\/gateway-//")
         env:
-          COMMIT_SHA: ${{ github.sha }}
           REF: ${{ github.ref }}
 
       - name: Push docker image

--- a/engine/crates/engine-v2/axum/src/lib.rs
+++ b/engine/crates/engine-v2/axum/src/lib.rs
@@ -5,7 +5,7 @@ use runtime::bytes::OwnedOrSharedBytes;
 pub mod websocket;
 
 pub fn error(message: &str) -> axum::response::Response {
-    into_response(HttpGraphqlResponse::error(message))
+    into_response(HttpGraphqlResponse::request_error(message))
 }
 
 pub fn into_response(response: HttpGraphqlResponse) -> axum::response::Response {

--- a/engine/crates/engine-v2/schema/src/lib.rs
+++ b/engine/crates/engine-v2/schema/src/lib.rs
@@ -28,7 +28,7 @@ mod built_info {
 }
 
 impl Schema {
-    pub fn serde_version() -> Vec<u8> {
+    pub fn commit_sha() -> Vec<u8> {
         hex::decode(built_info::GIT_COMMIT_HASH.expect("No git commit hash found")).expect("Expect hex format")
     }
 }

--- a/engine/crates/engine-v2/schema/tests/conversion.rs
+++ b/engine/crates/engine-v2/schema/tests/conversion.rs
@@ -318,5 +318,5 @@ fn serde_roundtrip(#[case] sdl: &str) {
 
 #[test]
 fn non_empty_version() {
-    assert!(!Schema::serde_version().is_empty());
+    assert!(!Schema::commit_sha().is_empty());
 }

--- a/engine/crates/engine-v2/src/engine.rs
+++ b/engine/crates/engine-v2/src/engine.rs
@@ -17,7 +17,7 @@ use grafbase_tracing::{
 use headers::HeaderMapExt;
 use runtime::auth::AccessToken;
 use schema::Schema;
-use tracing::{Instrument, Span};
+use tracing::Instrument;
 
 use crate::{
     execution::{ExecutionContext, ExecutionCoordinator},
@@ -70,9 +70,9 @@ impl Engine {
             self.execute_with_access_token(RequestMetadata::new(headers, access_token), batch_request)
                 .await
         } else if let Some(streaming_format) = headers.typed_get::<StreamingFormat>() {
-            HttpGraphqlResponse::stream_error(streaming_format, "Unauthorized")
+            HttpGraphqlResponse::stream_request_error(streaming_format, "Unauthorized")
         } else {
-            HttpGraphqlResponse::error("Unauthorized")
+            HttpGraphqlResponse::request_error("Unauthorized")
         }
     }
 
@@ -92,17 +92,20 @@ impl Engine {
         match batch_request {
             BatchRequest::Single(request) => {
                 if let Some(streaming_format) = streaming_format {
-                    HttpGraphqlResponse::from_stream(
+                    convert_stream_to_http_response(
                         streaming_format,
                         self.execute_stream(Arc::new(request_metadata), request),
                     )
+                    .await
                 } else {
                     self.execute_single(&request_metadata, request).await
                 }
             }
             BatchRequest::Batch(requests) => {
                 if streaming_format.is_some() {
-                    return HttpGraphqlResponse::error("batch requests can't use multipart or event-stream responses");
+                    return HttpGraphqlResponse::request_error(
+                        "batch requests can't use multipart or event-stream responses",
+                    );
                 }
                 HttpGraphqlResponse::batch_response(
                     futures_util::stream::iter(requests.into_iter())
@@ -115,135 +118,142 @@ impl Engine {
     }
 
     async fn execute_single(&self, request_metadata: &RequestMetadata, request: Request) -> HttpGraphqlResponse {
-        let span = GqlRequestSpan::new().into_span();
         let start = Instant::now();
-        let ctx = ExecutionContext {
-            engine: self,
-            request_metadata,
-        };
-        let (metrics_attributes, response) = ctx.execute_single(span.clone(), request).instrument(span).await;
-
-        let mut metadata = OperationMetadata {
-            operation_name: None,
-            operation_type: None,
-            has_errors: response.has_errors(),
-        };
-        if let Some(metrics_attributes) = metrics_attributes {
-            metadata.operation_name.clone_from(&metrics_attributes.name);
-            metadata.operation_type = Some(metrics_attributes.ty);
-            self.operation_metrics.record(metrics_attributes, start.elapsed());
+        let span = GqlRequestSpan::new().into_span();
+        async {
+            let ctx = ExecutionContext {
+                engine: self,
+                request_metadata,
+            };
+            let (operation_attributes, response) = ctx.execute_single(request).await;
+            let status = response.status();
+            let mut metadata = OperationMetadata {
+                operation_name: None,
+                operation_type: None,
+                has_errors: !status.is_success(),
+            };
+            if let Some(mut attrs) = operation_attributes {
+                span.record_gql_request(GqlRequestAttributes {
+                    operation_type: attrs.ty,
+                    operation_name: attrs.name.clone(),
+                });
+                metadata.operation_name.clone_from(&attrs.name);
+                metadata.operation_type = Some(attrs.ty);
+                attrs.status = status;
+                self.operation_metrics.record(attrs, start.elapsed());
+            }
+            span.record_gql_status(status);
+            HttpGraphqlResponse::from(response).with_metadata(metadata)
         }
-
-        HttpGraphqlResponse::from(response).with_metadata(metadata)
+        .instrument(span.clone())
+        .await
     }
 
     fn execute_stream(
         self: &Arc<Self>,
         request_metadata: Arc<RequestMetadata>,
         request: Request,
-    ) -> impl Stream<Item = Response> {
+    ) -> impl Stream<Item = Response> + Send + 'static {
+        let start = Instant::now();
         let engine = Arc::clone(self);
-        let span = GqlRequestSpan::new().into_span();
         let (sender, receiver) = mpsc::channel(2);
 
-        receiver.join(async move {
-            let start = Instant::now();
-            let ctx = ExecutionContext {
-                engine: &engine,
-                request_metadata: &request_metadata,
-            };
-            let metrics_attributes = ctx.execute_stream(span.clone(), request, sender).instrument(span).await;
+        let span = GqlRequestSpan::new().into_span();
+        let span_clone = span.clone();
+        receiver.join(
+            async move {
+                let ctx = ExecutionContext {
+                    engine: &engine,
+                    request_metadata: &request_metadata,
+                };
+                let (operation_attributes, status) = ctx.execute_stream(request, sender).await;
+                if let Some(mut attrs) = operation_attributes {
+                    span.record_gql_request(GqlRequestAttributes {
+                        operation_type: attrs.ty,
+                        operation_name: attrs.name.clone(),
+                    });
+                    attrs.status = status;
+                    engine.operation_metrics.record(attrs, start.elapsed());
+                }
 
-            if let Some(metrics_attributes) = metrics_attributes {
-                engine.operation_metrics.record(metrics_attributes, start.elapsed());
+                span.record_gql_status(status);
             }
-        })
+            .instrument(span_clone),
+        )
     }
 }
 
+async fn convert_stream_to_http_response(
+    streaming_format: StreamingFormat,
+    stream: impl Stream<Item = Response> + Send + 'static,
+) -> HttpGraphqlResponse {
+    let mut stream = Box::pin(stream);
+    let Some(first_response) = stream.next().await else {
+        return HttpGraphqlResponse::request_error("Empty stream");
+    };
+    HttpGraphqlResponse::from_stream(
+        streaming_format,
+        // Not perfect for the errors count, but good enough to detect a request error
+        first_response.status(),
+        futures_util::stream::iter(std::iter::once(first_response)).chain(stream),
+    )
+}
+
 impl<'ctx> ExecutionContext<'ctx> {
-    async fn execute_single(
-        self,
-        span: Span,
-        mut request: Request,
-    ) -> (Option<GraphqlOperationMetricsAttributes>, Response) {
-        let operation = match self.prepare_operation(&mut request).await {
-            Ok(operation) => operation,
-            Err(err) => {
-                return (None, Response::from_error(err));
+    async fn execute_single(self, mut request: Request) -> (Option<GraphqlOperationMetricsAttributes>, Response) {
+        if let Err(err) = self.handle_persisted_query(&mut request).await {
+            return (None, Response::bad_request(err));
+        }
+        let (operation, operation_attributes) = match Operation::build(self, &request) {
+            Ok(res) => res,
+            Err(mut err) => {
+                return (err.take_operation_attributes(), Response::bad_request(err));
             }
         };
 
-        // Same behavior as in our workers for now
-        // If the query didn't parse, or didn't have the named/unnamed operation (or any operations),
-        // we skip it from the analytics.
-        let metrics_attributes = operation_normalizer::normalize(request.query(), request.operation_name())
-            .ok()
-            .map(|normalized_query| GraphqlOperationMetricsAttributes {
-                normalized_query_hash: blake3::hash(normalized_query.as_bytes()).into(),
-                name: operation.name.clone(),
-                ty: operation.ty.as_str(),
-                normalized_query,
-                status: GraphqlResponseStatus::Success,
-                cache_status: None,
-                client: self.request_metadata.client.clone(),
-            });
-        span.record_gql_request(GqlRequestAttributes {
-            operation_type: operation.ty.as_str(),
-            operation_name: operation.name.clone(),
-        });
-
         let response = if matches!(operation.ty, OperationType::Subscription) {
-            Response::from_error(GraphqlError::new(
+            Response::bad_request(GraphqlError::new(
                 "Subscriptions are only suported on streaming transports. Try making a request with SSE or WebSockets",
             ))
         } else {
             match self.prepare_coordinator(operation, request.variables) {
                 Ok(coordinator) => coordinator.execute().await,
-                Err(errors) => Response::from_errors(errors),
+                Err(errors) => Response::bad_request_from_errors(errors),
             }
         };
 
-        (metrics_attributes, response)
+        (operation_attributes, response)
     }
 
     async fn execute_stream(
         self,
-        span: Span,
         mut request: Request,
         mut sender: mpsc::Sender<Response>,
-    ) -> Option<GraphqlOperationMetricsAttributes> {
-        let operation = match self.prepare_operation(&mut request).await {
-            Ok(operation) => operation,
-            Err(err) => {
-                sender.send(Response::from_error(err)).await.ok();
-                return None;
+    ) -> (Option<GraphqlOperationMetricsAttributes>, GraphqlResponseStatus) {
+        if let Err(err) = self.handle_persisted_query(&mut request).await {
+            let response = Response::bad_request(err);
+            let status = response.status();
+            sender.send(response).await.ok();
+            return (None, status);
+        }
+        let (operation, operation_attributes) = match Operation::build(self, &request) {
+            Ok(res) => res,
+            Err(mut err) => {
+                let attrs = err.take_operation_attributes();
+                let response = Response::bad_request(err);
+                let status = response.status();
+                sender.send(response).await.ok();
+                return (attrs, status);
             }
         };
-        // Same behavior as in our workers for now
-        // If the query didn't parse, or didn't have the named/unnamed operation (or any operations),
-        // we skip it from the analytics.
-        let metrics_attributes = operation_normalizer::normalize(request.query(), request.operation_name())
-            .ok()
-            .map(|normalized_query| GraphqlOperationMetricsAttributes {
-                normalized_query_hash: blake3::hash(normalized_query.as_bytes()).into(),
-                name: operation.name.clone(),
-                ty: operation.ty.as_str(),
-                normalized_query,
-                status: GraphqlResponseStatus::Success,
-                cache_status: None,
-                client: self.request_metadata.client.clone(),
-            });
-        span.record_gql_request(GqlRequestAttributes {
-            operation_type: operation.ty.as_str(),
-            operation_name: operation.name.clone(),
-        });
 
         let coordinator = match self.prepare_coordinator(operation, request.variables) {
             Ok(coordinator) => coordinator,
             Err(errors) => {
-                sender.send(Response::from_errors(errors)).await.ok();
-                return metrics_attributes;
+                let response = Response::bad_request_from_errors(errors);
+                let status = response.status();
+                sender.send(response).await.ok();
+                return (operation_attributes, status);
             }
         };
 
@@ -251,23 +261,33 @@ impl<'ctx> ExecutionContext<'ctx> {
             coordinator.operation().ty,
             OperationType::Query | OperationType::Mutation
         ) {
-            sender.send(coordinator.execute().await).await.ok();
-            return metrics_attributes;
+            let response = coordinator.execute().await;
+            let status = response.status();
+            sender.send(response).await.ok();
+            return (operation_attributes, status);
         }
 
-        struct Sender {
+        let mut status: GraphqlResponseStatus = GraphqlResponseStatus::Success;
+        struct Sender<'a> {
             sender: mpsc::Sender<Response>,
+            status: &'a mut GraphqlResponseStatus,
         }
 
-        impl crate::execution::ResponseSender for Sender {
+        impl crate::execution::ResponseSender for Sender<'_> {
             type Error = mpsc::SendError;
             async fn send(&mut self, response: Response) -> Result<(), Self::Error> {
+                *self.status = self.status.union(response.status());
                 self.sender.send(response).await
             }
         }
 
-        coordinator.execute_subscription(Sender { sender }).await;
-        metrics_attributes
+        coordinator
+            .execute_subscription(Sender {
+                sender,
+                status: &mut status,
+            })
+            .await;
+        (operation_attributes, status)
     }
 
     fn prepare_coordinator(
@@ -282,12 +302,6 @@ impl<'ctx> ExecutionContext<'ctx> {
             Arc::new(OperationPlan::prepare(&self.schema, &variables, operation).map_err(|err| vec![err.into()])?);
 
         Ok(ExecutionCoordinator::new(self, operation_plan, variables))
-    }
-
-    async fn prepare_operation(self, request: &mut engine::Request) -> Result<Operation, GraphqlError> {
-        self.handle_persisted_query(request).await?;
-        let operation = Operation::build(self, request)?;
-        Ok(operation)
     }
 }
 

--- a/engine/crates/engine-v2/src/execution/error.rs
+++ b/engine/crates/engine-v2/src/execution/error.rs
@@ -4,6 +4,8 @@ use crate::response::GraphqlError;
 pub enum ExecutionError {
     #[error("Internal error: {0}")]
     Internal(String),
+    #[error("Deserialization error: {0}")]
+    DeserializationError(String),
     #[error(transparent)]
     Fetch(#[from] runtime::fetch::FetchError),
 }
@@ -28,5 +30,11 @@ impl From<&str> for ExecutionError {
 impl From<String> for ExecutionError {
     fn from(message: String) -> Self {
         Self::Internal(message)
+    }
+}
+
+impl From<serde_json::Error> for ExecutionError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::DeserializationError(err.to_string())
     }
 }

--- a/engine/crates/engine-v2/src/operation/mod.rs
+++ b/engine/crates/engine-v2/src/operation/mod.rs
@@ -27,6 +27,7 @@ pub(crate) use walkers::*;
 pub(crate) struct Operation {
     pub ty: OperationType,
     pub root_object_id: ObjectId,
+    #[allow(dead_code)]
     pub name: Option<String>,
     pub response_keys: ResponseKeys,
     pub root_selection_set_id: SelectionSetId,

--- a/engine/crates/engine-v2/src/plan/walkers/collected.rs
+++ b/engine/crates/engine-v2/src/plan/walkers/collected.rs
@@ -1,12 +1,12 @@
 use schema::Definition;
 
 use crate::{
-    operation::SelectionSetTypeWalker,
+    operation::{SelectionSetType, SelectionSetTypeWalker},
     plan::{
         AnyCollectedSelectionSet, CollectedField, CollectedFieldId, CollectedSelectionSet, CollectedSelectionSetId,
         ConditionalField, ConditionalFieldId, ConditionalSelectionSet, ConditionalSelectionSetId, FieldType,
     },
-    response::UnpackedResponseEdge,
+    response::{ResponseEdge, ResponseValue, UnpackedResponseEdge},
 };
 
 use super::{PlanField, PlanWalker};
@@ -37,6 +37,31 @@ impl<'a> PlanCollectedSelectionSet<'a> {
 
     pub fn fields(self) -> impl ExactSizeIterator<Item = PlanCollectedField<'a>> + 'a {
         self.as_ref().field_ids.map(move |id| self.walk(id))
+    }
+
+    /// Create a list of response fields with all the response edges and their default value (null,
+    /// as of today 2024-06-13). If any field is required or can't be trivially computed
+    /// (__typename for objects), None is returned.
+    /// Used when a plan execution failed to fill the field values if possible.
+    pub fn maybe_default_object(self) -> Option<Vec<(ResponseEdge, ResponseValue)>> {
+        let mut fields = Vec::new();
+        if !self.as_ref().typename_fields.is_empty() {
+            if let SelectionSetType::Object(id) = self.as_ref().ty {
+                let name: ResponseValue = self.schema_walker.walk(id).as_ref().name.into();
+                fields.extend(self.as_ref().typename_fields.iter().map(|&edge| (edge, name.clone())))
+            } else {
+                return None;
+            }
+        }
+        for field in self.fields() {
+            let field = field.as_ref();
+            if field.wrapping.is_required() {
+                return None;
+            }
+            fields.push((field.edge, ResponseValue::Null))
+        }
+
+        Some(fields)
     }
 }
 

--- a/engine/crates/engine-v2/src/plan/walkers/field.rs
+++ b/engine/crates/engine-v2/src/plan/walkers/field.rs
@@ -2,7 +2,7 @@ use schema::{FieldDefinitionId, FieldDefinitionWalker};
 
 use crate::{
     operation::{FieldArgumentsWalker, FieldId, QueryInputValueWalker},
-    response::{ResponseEdge, ResponseKey},
+    response::ResponseKey,
 };
 
 use super::{PlanSelectionSet, PlanWalker};
@@ -14,10 +14,6 @@ impl<'a> PlanField<'a> {
         self.as_ref()
             .selection_set_id()
             .map(|id| PlanSelectionSet::SelectionSet(self.walk_with(id, ())))
-    }
-
-    pub fn response_edge(&self) -> ResponseEdge {
-        self.as_ref().response_edge()
     }
 
     pub fn response_key(&self) -> ResponseKey {

--- a/engine/crates/engine-v2/src/plan/walkers/mod.rs
+++ b/engine/crates/engine-v2/src/plan/walkers/mod.rs
@@ -7,7 +7,7 @@ use crate::{
         FieldId, Operation, OperationWalker, QueryInputValueId, QueryInputValueWalker, SelectionSetType, Variables,
     },
     plan::{CollectedField, FieldType, RuntimeMergedConditionals},
-    response::{ResponseEdge, ResponseKey, ResponseKeys, ResponsePart, ResponsePath, SafeResponseKey, SeedContext},
+    response::{ResponseEdge, ResponseKey, ResponseKeys, SafeResponseKey},
 };
 
 use super::{
@@ -57,7 +57,7 @@ where
 }
 
 impl<'a> PlanWalker<'a> {
-    pub fn schema(&self) -> SchemaWalker<'a> {
+    pub fn schema(&self) -> SchemaWalker<'a, ()> {
         self.schema_walker
     }
 
@@ -83,22 +83,6 @@ impl<'a> PlanWalker<'a> {
 
     pub fn collected_selection_set(&self) -> PlanWalker<'a, CollectedSelectionSetId, ()> {
         self.walk(self.output().collected_selection_set_id)
-    }
-
-    pub fn new_seed<'out>(self, output: &'out mut ResponsePart) -> SeedContext<'out>
-    where
-        'a: 'out,
-    {
-        SeedContext::new(self, output)
-    }
-
-    pub fn root_error_path(&self, parent: &ResponsePath) -> ResponsePath {
-        let mut fields = self.collected_selection_set().fields();
-        if fields.len() == 1 {
-            parent.child(fields.next().unwrap().as_operation_field().response_edge())
-        } else {
-            parent.clone()
-        }
     }
 }
 

--- a/engine/crates/engine-v2/src/response/error.rs
+++ b/engine/crates/engine-v2/src/response/error.rs
@@ -9,7 +9,6 @@ pub(crate) struct GraphqlError {
     pub message: String,
     pub locations: Vec<crate::operation::Location>,
     pub path: Option<ResponsePath>,
-    // ensures consistent ordering for tests
     pub extensions: BTreeMap<String, serde_json::Value>,
 }
 

--- a/engine/crates/engine-v2/src/response/error.rs
+++ b/engine/crates/engine-v2/src/response/error.rs
@@ -9,6 +9,7 @@ pub(crate) struct GraphqlError {
     pub message: String,
     pub locations: Vec<crate::operation::Location>,
     pub path: Option<ResponsePath>,
+    // ensures consistent ordering for tests
     pub extensions: BTreeMap<String, serde_json::Value>,
 }
 

--- a/engine/crates/engine-v2/src/response/key/mod.rs
+++ b/engine/crates/engine-v2/src/response/key/mod.rs
@@ -158,6 +158,12 @@ impl UnpackedResponseEdge {
     }
 }
 
+impl From<UnpackedResponseEdge> for ResponseEdge {
+    fn from(value: UnpackedResponseEdge) -> Self {
+        value.pack()
+    }
+}
+
 impl std::fmt::Debug for BoundResponseKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BoundResponseKey")

--- a/engine/crates/engine-v2/src/response/key/private.rs
+++ b/engine/crates/engine-v2/src/response/key/private.rs
@@ -32,6 +32,10 @@ impl Default for ResponseKeys {
 }
 
 impl ResponseKeys {
+    pub fn get(&self, key: &str) -> Option<SafeResponseKey> {
+        self.0.get(key)
+    }
+
     pub fn get_or_intern(&mut self, s: &str) -> SafeResponseKey {
         self.0.get_or_intern(s)
     }

--- a/engine/crates/engine-v2/src/response/path.rs
+++ b/engine/crates/engine-v2/src/response/path.rs
@@ -4,22 +4,21 @@ use super::{BoundResponseKey, ResponseEdge, UnpackedResponseEdge};
 pub struct ResponsePath(Vec<ResponseEdge>);
 
 impl ResponsePath {
-    pub fn child(&self, segment: impl Into<ResponseEdge>) -> ResponsePath {
-        let mut path = self.0.clone();
-        path.push(segment.into());
-        ResponsePath(path)
+    pub fn child(&self, edge: impl Into<ResponseEdge>) -> ResponsePath {
+        let mut path = self.clone();
+        path.push(edge);
+        path
     }
 
-    pub fn push(&mut self, edge: ResponseEdge) {
-        self.0.push(edge);
+    pub fn push(&mut self, edge: impl Into<ResponseEdge>) {
+        self.0.push(edge.into());
     }
+}
 
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = &ResponseEdge> {
-        self.0.iter()
+impl std::ops::Deref for ResponsePath {
+    type Target = [ResponseEdge];
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 

--- a/engine/crates/engine-v2/src/response/read/mod.rs
+++ b/engine/crates/engine-v2/src/response/read/mod.rs
@@ -7,19 +7,19 @@ mod view;
 
 use schema::SchemaWalker;
 pub use selection_set::{ReadField, ReadSelectionSet};
-pub use view::{ResponseBoundaryItem, ResponseBoundaryObjectsView};
+pub use view::{ResponseObjectRef, ResponseObjectsView};
 
 impl ResponseBuilder {
     pub fn read<'a>(
         &'a self,
         schema: SchemaWalker<'a, ()>,
-        items: Arc<Vec<ResponseBoundaryItem>>,
+        refs: Arc<Vec<ResponseObjectRef>>,
         selection_set: Cow<'a, ReadSelectionSet>,
-    ) -> ResponseBoundaryObjectsView<'a> {
-        ResponseBoundaryObjectsView {
+    ) -> ResponseObjectsView<'a> {
+        ResponseObjectsView {
             schema,
             response: self,
-            items,
+            refs,
             selection_set,
             extra_constant_fields: vec![],
         }

--- a/engine/crates/engine-v2/src/response/write/deserialize/field.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/field.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::Ordering;
 use schema::{ListWrapping, Wrapping};
 use serde::de::DeserializeSeed;
 
-use super::{ListSeed, NullableSeed, ScalarTypeSeed, SeedContextInner, SelectionSetSeed};
+use super::{ListSeed, NullableSeed, ScalarTypeSeed, SeedContext, SelectionSetSeed};
 use crate::{
     plan::{CollectedField, FieldType},
     response::{GraphqlError, ResponseValue},
@@ -11,7 +11,7 @@ use crate::{
 
 #[derive(Clone)]
 pub(super) struct FieldSeed<'ctx, 'parent> {
-    pub ctx: &'parent SeedContextInner<'ctx>,
+    pub ctx: &'parent SeedContext<'ctx>,
     pub field: &'parent CollectedField,
     pub wrapping: Wrapping,
 }
@@ -68,7 +68,7 @@ impl<'de, 'ctx, 'parent> DeserializeSeed<'de> for FieldSeed<'ctx, 'parent> {
 
         result.map_err(move |err| {
             if !self.ctx.propagating_error.fetch_or(true, Ordering::Relaxed) {
-                self.ctx.response_part.borrow_mut().push_error(GraphqlError {
+                self.ctx.writer.push_error(GraphqlError {
                     message: err.to_string(),
                     locations: vec![self.ctx.plan[self.field.id].location()],
                     path: Some(self.ctx.response_path()),

--- a/engine/crates/engine-v2/src/response/write/deserialize/list.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/list.rs
@@ -5,7 +5,7 @@ use serde::{
     Deserializer,
 };
 
-use super::SeedContextInner;
+use super::SeedContext;
 use crate::{
     operation::FieldId,
     response::{GraphqlError, ResponseValue},
@@ -13,7 +13,7 @@ use crate::{
 
 pub(super) struct ListSeed<'ctx, 'parent, Seed> {
     pub field_id: FieldId,
-    pub ctx: &'parent SeedContextInner<'ctx>,
+    pub ctx: &'parent SeedContext<'ctx>,
     pub seed: &'parent Seed,
 }
 
@@ -67,8 +67,8 @@ where
                 Err(err) => {
                     if !self.ctx.propagating_error.fetch_or(true, Ordering::Relaxed) {
                         let mut path = self.ctx.response_path();
-                        path.push(index.into());
-                        self.ctx.response_part.borrow_mut().push_error(GraphqlError {
+                        path.push(index);
+                        self.ctx.writer.push_error(GraphqlError {
                             message: err.to_string(),
                             locations: vec![self.ctx.plan[self.field_id].location()],
                             path: Some(path),
@@ -82,6 +82,6 @@ where
             }
         }
 
-        Ok(self.ctx.response_part.borrow_mut().push_list(&values).into())
+        Ok(self.ctx.writer.push_list(&values).into())
     }
 }

--- a/engine/crates/engine-v2/src/response/write/deserialize/nullable.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/nullable.rs
@@ -5,7 +5,7 @@ use serde::{
     Deserializer,
 };
 
-use super::SeedContextInner;
+use super::SeedContext;
 use crate::{
     operation::FieldId,
     response::{GraphqlError, ResponseValue},
@@ -13,7 +13,7 @@ use crate::{
 
 pub(super) struct NullableSeed<'ctx, 'parent, Seed> {
     pub field_id: FieldId,
-    pub ctx: &'parent SeedContextInner<'ctx>,
+    pub ctx: &'parent SeedContext<'ctx>,
     pub seed: Seed,
 }
 
@@ -63,7 +63,7 @@ where
             Ok(value) => Ok(value.into_nullable()),
             Err(err) => {
                 if !self.ctx.propagating_error.fetch_and(false, Ordering::Relaxed) {
-                    self.ctx.response_part.borrow_mut().push_error(GraphqlError {
+                    self.ctx.writer.push_error(GraphqlError {
                         message: err.to_string(),
                         locations: vec![self.ctx.plan[self.field_id].location()],
                         path: Some(self.ctx.response_path()),

--- a/engine/crates/engine-v2/src/response/write/deserialize/selection_set/conditional.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/selection_set/conditional.rs
@@ -7,7 +7,7 @@ use crate::{
     operation::SelectionSetType,
     plan::ConditionalSelectionSetId,
     response::{
-        write::deserialize::{key::Key, SeedContextInner},
+        write::deserialize::{key::Key, SeedContext},
         ResponseValue,
     },
 };
@@ -15,7 +15,7 @@ use crate::{
 use super::{CollectedSelectionSetSeed, ObjectIdentifier};
 
 pub(crate) struct ConditionalSelectionSetSeed<'ctx, 'parent> {
-    pub ctx: &'parent SeedContextInner<'ctx>,
+    pub ctx: &'parent SeedContext<'ctx>,
     pub selection_set_ty: SelectionSetType,
     pub selection_set_ids: Cow<'parent, [ConditionalSelectionSetId]>,
 }

--- a/engine/crates/engine-v2/src/response/write/deserialize/selection_set/mod.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/selection_set/mod.rs
@@ -8,7 +8,7 @@ use conditional::*;
 use schema::{ObjectId, SchemaWalker};
 use serde::de::DeserializeSeed;
 
-use super::SeedContextInner;
+use super::SeedContext;
 use crate::{
     operation::SelectionSetType,
     plan::{AnyCollectedSelectionSet, RuntimeMergedConditionals},
@@ -16,7 +16,7 @@ use crate::{
 };
 
 pub(super) struct SelectionSetSeed<'ctx, 'parent> {
-    pub ctx: &'parent SeedContextInner<'ctx>,
+    pub ctx: &'parent SeedContext<'ctx>,
     pub collected: &'parent AnyCollectedSelectionSet,
 }
 
@@ -60,7 +60,7 @@ struct ObjectIdentifier<'ctx> {
 }
 
 impl<'ctx> ObjectIdentifier<'ctx> {
-    fn new(ctx: &SeedContextInner<'ctx>, root: SelectionSetType) -> Self {
+    fn new(ctx: &SeedContext<'ctx>, root: SelectionSetType) -> Self {
         let schema = ctx.plan.schema();
         match root {
             SelectionSetType::Interface(interface_id) => Self {

--- a/engine/crates/engine-v2/src/response/write/ids.rs
+++ b/engine/crates/engine-v2/src/response/write/ids.rs
@@ -1,4 +1,4 @@
-use super::{ResponseBuilder, ResponseDataPart, ResponsePart};
+use super::{ResponseBuilder, ResponseDataPart};
 use crate::response::{ResponseData, ResponseObject, ResponseValue};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
@@ -107,10 +107,10 @@ impl std::ops::IndexMut<ResponseListId> for ResponseDataPart {
     }
 }
 
-impl ResponsePart {
+impl ResponseDataPart {
     pub fn push_object(&mut self, object: ResponseObject) -> ResponseObjectId {
-        let offset = self.data.objects.len() as u32;
-        self.data.objects.push(object);
+        let offset = self.objects.len() as u32;
+        self.objects.push(object);
         ResponseObjectId {
             part_id: self.id,
             index: offset,
@@ -118,9 +118,9 @@ impl ResponsePart {
     }
 
     pub fn push_list(&mut self, value: &[ResponseValue]) -> ResponseListId {
-        let offset = self.data.lists.len() as u32;
+        let offset = self.lists.len() as u32;
         let length = value.len() as u32;
-        self.data.lists.extend_from_slice(value);
+        self.lists.extend_from_slice(value);
         ResponseListId {
             part_id: self.id,
             offset,

--- a/engine/crates/engine-v2/src/response/write/mod.rs
+++ b/engine/crates/engine-v2/src/response/write/mod.rs
@@ -1,29 +1,45 @@
 mod deserialize;
 mod ids;
 
-use std::sync::Arc;
+use std::{
+    cell::{Ref, RefCell, RefMut},
+    rc::Rc,
+    sync::Arc,
+};
 
-pub(crate) use deserialize::SeedContext;
 use id_newtypes::IdRange;
 pub use ids::*;
 use itertools::Either;
 use schema::{ObjectId, Schema};
 
+use self::deserialize::UpdateSeed;
+
 use super::{
-    GraphqlError, InitialResponse, Response, ResponseBoundaryItem, ResponseData, ResponseEdge, ResponseObject,
+    GraphqlError, InitialResponse, Response, ResponseData, ResponseEdge, ResponseObject, ResponseObjectRef,
     ResponsePath, ResponseValue, UnpackedResponseEdge,
 };
-use crate::plan::{OperationPlan, PlanBoundaryId};
+use crate::{
+    execution::ExecutionError,
+    plan::{OperationPlan, PlanBoundaryId, PlanWalker},
+};
 
-#[derive(Default)]
 pub(crate) struct ResponseDataPart {
+    id: ResponseDataPartId,
     objects: Vec<ResponseObject>,
     lists: Vec<ResponseValue>,
 }
 
 impl ResponseDataPart {
+    fn new(id: ResponseDataPartId) -> Self {
+        Self {
+            id,
+            objects: Vec::new(),
+            lists: Vec::new(),
+        }
+    }
+
     fn is_empty(&self) -> bool {
-        self.objects.is_empty()
+        self.objects.is_empty() && self.lists.is_empty()
     }
 }
 
@@ -41,57 +57,157 @@ pub(crate) struct ResponseBuilder {
 // happen.
 impl ResponseBuilder {
     pub fn new(root_object_id: ObjectId) -> Self {
-        let mut builder = ResponsePart::new(ResponseDataPartId::from(0), IdRange::empty());
-        let root_id = builder.push_object(ResponseObject::default());
+        let mut initial_part = ResponseDataPart {
+            id: ResponseDataPartId::from(0),
+            objects: Vec::new(),
+            lists: Vec::new(),
+        };
+        let root_id = initial_part.push_object(ResponseObject::default());
         Self {
             root: Some((root_id, root_object_id)),
-            parts: vec![builder.data],
-            errors: vec![],
+            parts: vec![initial_part],
+            errors: Vec::new(),
         }
     }
 
-    pub fn new_part(&mut self, boundary_ids: IdRange<PlanBoundaryId>) -> ResponsePart {
+    pub fn new_part(
+        &mut self,
+        root_response_object_refs: Arc<Vec<ResponseObjectRef>>,
+        plan_boundary_ids: IdRange<PlanBoundaryId>,
+    ) -> ResponsePart {
         let id = ResponseDataPartId::from(self.parts.len());
         // reserving the spot until the actual data is written. It's safe as no one can reference
         // any data in this part before it's added. And a part can only be overwritten if it's
         // empty.
-        self.parts.push(ResponseDataPart::default());
-        ResponsePart::new(id, boundary_ids)
+        self.parts.push(ResponseDataPart::new(id));
+        ResponsePart::new(ResponseDataPart::new(id), root_response_object_refs, plan_boundary_ids)
     }
 
-    pub fn root_response_boundary_item(&self) -> Option<ResponseBoundaryItem> {
-        self.root.map(|(response_object_id, object_id)| ResponseBoundaryItem {
-            response_object_id,
-            response_path: ResponsePath::default(),
-            object_id,
+    pub fn root_response_object(&self) -> Option<ResponseObjectRef> {
+        self.root.map(|(response_object_id, object_id)| ResponseObjectRef {
+            id: response_object_id,
+            path: ResponsePath::default(),
+            definition_id: object_id,
         })
     }
 
-    pub fn ingest(&mut self, output: ResponsePart) -> Vec<(PlanBoundaryId, Vec<ResponseBoundaryItem>)> {
-        let reservation = &mut self.parts[usize::from(output.id)];
+    pub fn propagate_execution_error(
+        &mut self,
+        root_response_object_refs: &[ResponseObjectRef],
+        edge: ResponseEdge,
+        error: ExecutionError,
+        default_object: Option<Vec<(ResponseEdge, ResponseValue)>>,
+    ) {
+        if let Some(fields) = default_object {
+            for obj_ref in root_response_object_refs {
+                self[obj_ref.id].extend(fields.clone());
+                // Definitely not ideal (for the client) to have a new error each time in the response.
+                // Not exactly sure how we should best deal with it.
+                self.errors.push(GraphqlError {
+                    message: error.to_string(),
+                    path: Some(obj_ref.path.child(edge)),
+                    ..Default::default()
+                });
+            }
+        } else {
+            let mut invalidated_paths = Vec::<&[ResponseEdge]>::new();
+            for obj_ref in root_response_object_refs {
+                if !invalidated_paths.iter().any(|path| obj_ref.path.starts_with(path)) {
+                    if let Some(invalidated_path) = self.propagate_error(&obj_ref.path) {
+                        self.errors.push(GraphqlError {
+                            message: error.to_string(),
+                            path: Some(obj_ref.path.child(edge)),
+                            ..Default::default()
+                        });
+                        invalidated_paths.push(invalidated_path);
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn ingest(
+        &mut self,
+        part: ResponsePart,
+        edge: ResponseEdge,
+        default_object: Option<Vec<(ResponseEdge, ResponseValue)>>,
+    ) -> Vec<(PlanBoundaryId, Vec<ResponseObjectRef>)> {
+        let reservation = &mut self.parts[usize::from(part.data.id)];
         assert!(reservation.is_empty(), "Part already has data");
-        *reservation = output.data;
-        self.errors.extend(output.errors);
-        for update in output.updates {
-            self[update.id].extend(update.fields);
-        }
-        for path in output.error_paths_to_propagate {
-            self.propagate_error(&path);
-        }
-        // The boundary objects are only accessible after we ingested them
-        output.plan_boundaries
-    }
+        *reservation = part.data;
 
-    // FIXME: this method is improperly used, when pushing an error we need to propagate it which
-    // parent callers never do currently. It's a bit tricky to handle that correctly in the
-    // Coordinator during the planning phase.
-    pub fn push_error(&mut self, error: impl Into<GraphqlError>) {
-        self.errors.push(error.into());
-    }
+        let mut invalidated_paths = Vec::<&[ResponseEdge]>::new();
+        for (update, obj_ref) in part.updates.into_iter().zip(part.root_response_object_refs.iter()) {
+            match update {
+                UpdateSlot::Reserved => {
+                    if let Some(fields) = &default_object {
+                        self[obj_ref.id].extend(fields.clone());
+                        // If there isn't any existing error within the response object path,
+                        // we create one. Errors without any path are considering to be
+                        // execution errors which are also enough.
+                        if !part.errors.iter().any(|error| {
+                            error
+                                .path
+                                .as_ref()
+                                .map(|p| p.starts_with(&obj_ref.path))
+                                .unwrap_or(true)
+                        }) {
+                            self.errors.push(GraphqlError {
+                                message: "Missing data from subgraph".to_string(),
+                                path: Some(obj_ref.path.child(edge)),
+                                ..Default::default()
+                            });
+                        }
+                    } else if !invalidated_paths.iter().any(|path| obj_ref.path.starts_with(path)) {
+                        if let Some(invalidated_path) = self.propagate_error(&obj_ref.path) {
+                            // If there isn't any existing error within the response object path,
+                            // we create one. Errors without any path are considering to be
+                            // execution errors which are also enough.
+                            if !part.errors.iter().any(|error| {
+                                error
+                                    .path
+                                    .as_ref()
+                                    .map(|p| p.starts_with(&obj_ref.path))
+                                    .unwrap_or(true)
+                            }) {
+                                self.errors.push(GraphqlError {
+                                    message: "Missing data from subgraph".to_string(),
+                                    path: Some(obj_ref.path.child(edge)),
+                                    ..Default::default()
+                                });
+                            }
+                            invalidated_paths.push(invalidated_path);
+                        }
+                    }
+                }
+                UpdateSlot::Fields(fields) => {
+                    self[obj_ref.id].extend(fields);
+                }
+                UpdateSlot::Error => {
+                    if !invalidated_paths.iter().any(|path| obj_ref.path.starts_with(path)) {
+                        if let Some(invalidated_path) = self.propagate_error(&obj_ref.path) {
+                            invalidated_paths.push(invalidated_path);
+                        }
+                    }
+                }
+            }
+        }
+        self.errors.extend(part.errors);
 
-    pub fn with_error(mut self, error: impl Into<GraphqlError>) -> Self {
-        self.push_error(error);
-        self
+        let mut boundaries = part.plan_boundaries;
+        if !invalidated_paths.is_empty() {
+            boundaries = boundaries
+                .into_iter()
+                .map(|(id, refs)| {
+                    let refs = refs
+                        .into_iter()
+                        .filter(|obj| !invalidated_paths.iter().any(|path| obj.path.starts_with(path)))
+                        .collect();
+                    (id, refs)
+                })
+                .collect();
+        }
+        boundaries
     }
 
     pub fn build(self, schema: Arc<Schema>, operation: Arc<OperationPlan>) -> Response {
@@ -110,41 +226,41 @@ impl ResponseBuilder {
     // was in a different part (provided by a parent plan).
     // To correctly propagate error we're finding the last nullable element in the path and make it
     // nullable. If there's nothing, then root will be null.
-    fn propagate_error(&mut self, path: &ResponsePath) {
-        let Some((root, _)) = self.root else {
-            return;
-        };
+    fn propagate_error<'p>(&mut self, path: &'p ResponsePath) -> Option<&'p [ResponseEdge]> {
+        let (root, _) = self.root?;
+
+        let mut last_nullable_path_end = 0;
         let mut last_nullable: Option<ResponseValueId> = None;
         let mut previous: Either<ResponseObjectId, ResponseListId> = Either::Left(root);
-        for &edge in path.iter() {
-            let (unique_id, value) = match (previous, edge.unpack()) {
+        for (i, &edge) in path.iter().enumerate() {
+            let (id, value) = match (previous, edge.unpack()) {
                 (
                     Either::Left(object_id),
                     UnpackedResponseEdge::BoundResponseKey(_) | UnpackedResponseEdge::ExtraFieldResponseKey(_),
                 ) => {
                     let Some(field_position) = self[object_id].field_position(edge) else {
                         // Shouldn't happen but equivalent to null
-                        return;
+                        return None;
                     };
-                    let unique_id = ResponseValueId::ObjectField {
+                    let id = ResponseValueId::ObjectField {
                         object_id,
                         field_position,
                     };
                     let value = &self[object_id][field_position];
-                    (unique_id, value)
+                    (id, value)
                 }
                 (Either::Right(list_id), UnpackedResponseEdge::Index(index)) => {
-                    let unique_id = ResponseValueId::ListItem { list_id, index };
+                    let id = ResponseValueId::ListItem { list_id, index };
                     let Some(value) = self[list_id].get(index) else {
                         // Shouldn't happen but equivalent to null
-                        return;
+                        return None;
                     };
-                    (unique_id, value)
+                    (id, value)
                 }
-                _ => return,
+                _ => return None,
             };
             if value.is_null() {
-                return;
+                return None;
             }
             match *value {
                 ResponseValue::Object {
@@ -153,7 +269,8 @@ impl ResponseBuilder {
                     index,
                 } => {
                     if nullable {
-                        last_nullable = Some(unique_id);
+                        last_nullable_path_end = i;
+                        last_nullable = Some(id);
                     }
                     previous = Either::Left(ResponseObjectId { part_id, index });
                 }
@@ -164,7 +281,8 @@ impl ResponseBuilder {
                     length,
                 } => {
                     if nullable {
-                        last_nullable = Some(unique_id);
+                        last_nullable_path_end = i;
+                        last_nullable = Some(id);
                     }
                     previous = Either::Right(ResponseListId {
                         part_id,
@@ -190,10 +308,11 @@ impl ResponseBuilder {
         } else {
             self.root = None;
         }
+        Some(&path[..last_nullable_path_end])
     }
 }
 
-pub enum ResponseValueId {
+enum ResponseValueId {
     ObjectField {
         object_id: ResponseObjectId,
         field_position: usize,
@@ -204,57 +323,137 @@ pub enum ResponseValueId {
     },
 }
 
+#[derive(Clone)]
+pub(crate) struct ResponsePartMut<'resp> {
+    /// We end up writing objects or lists at various step of the de-serialization / query
+    /// traversal, so having a RefCell is by far the easiest. We don't need a lock as executor are
+    /// not expected to parallelize their work.
+    /// The Rc makes it possible to write errors at one place and the data in another.
+    inner: Rc<RefCell<&'resp mut ResponsePart>>,
+}
+
 pub(crate) struct ResponsePart {
-    id: ResponseDataPartId,
     data: ResponseDataPart,
+    root_response_object_refs: Arc<Vec<ResponseObjectRef>>,
     errors: Vec<GraphqlError>,
-    updates: Vec<ResponseObjectUpdate>,
-    error_paths_to_propagate: Vec<ResponsePath>,
+    updates: Vec<UpdateSlot>,
     plan_boundary_ids_start: usize,
-    plan_boundaries: Vec<(PlanBoundaryId, Vec<ResponseBoundaryItem>)>,
+    plan_boundaries: Vec<(PlanBoundaryId, Vec<ResponseObjectRef>)>,
 }
 
 impl ResponsePart {
-    pub fn new(id: ResponseDataPartId, plan_boundary_ids: IdRange<PlanBoundaryId>) -> ResponsePart {
-        ResponsePart {
-            id,
-            data: ResponseDataPart::default(),
+    fn new(
+        data: ResponseDataPart,
+        root_response_object_refs: Arc<Vec<ResponseObjectRef>>,
+        plan_boundary_ids: IdRange<PlanBoundaryId>,
+    ) -> Self {
+        Self {
+            data,
+            root_response_object_refs,
             errors: Vec::new(),
             updates: Vec::new(),
-            error_paths_to_propagate: Vec::new(),
             plan_boundary_ids_start: usize::from(plan_boundary_ids.start),
             plan_boundaries: plan_boundary_ids.map(|id| (id, Vec::new())).collect(),
         }
     }
 
-    pub fn push_update(&mut self, update: ResponseObjectUpdate) {
-        self.updates.push(update);
+    /// Executors manipulate the response part within a Send future, so we can't use Rc/RefCell
+    /// initially to send the response part. However, once within
+    pub fn as_mut(&mut self) -> ResponsePartMut<'_> {
+        ResponsePartMut {
+            inner: Rc::new(RefCell::new(self)),
+        }
+    }
+}
+
+impl<'resp> ResponsePartMut<'resp> {
+    pub fn next_seed<'ctx>(&self, plan: PlanWalker<'ctx>) -> Option<UpdateSeed<'resp>>
+    where
+        'ctx: 'resp,
+    {
+        self.next_writer().map(|writer| UpdateSeed::new(plan, writer))
     }
 
-    pub fn push_error(&mut self, error: impl Into<GraphqlError>) {
-        self.errors.push(error.into());
+    pub fn next_writer(&self) -> Option<ResponseWriter<'resp>> {
+        let index = {
+            let mut inner = self.inner.borrow_mut();
+            if inner.updates.len() == inner.root_response_object_refs.len() {
+                return None;
+            }
+            inner.updates.push(UpdateSlot::Reserved);
+            inner.updates.len() - 1
+        };
+        Some(ResponseWriter {
+            index,
+            part: self.clone(),
+        })
     }
 
-    pub fn push_errors(&mut self, errors: Vec<GraphqlError>) {
-        self.errors.extend(errors);
+    pub fn root_response_object_refs(&self) -> Ref<'_, [ResponseObjectRef]> {
+        Ref::map(self.inner.borrow(), |inner| inner.root_response_object_refs.as_slice())
     }
 
-    pub fn push_error_path_to_propagate(&mut self, path: ResponsePath) {
-        self.error_paths_to_propagate.push(path);
+    pub fn push_error(&self, error: impl Into<GraphqlError>) {
+        self.inner.borrow_mut().errors.push(error.into());
     }
 
-    pub fn has_errors(&self) -> bool {
-        !self.errors.is_empty()
+    pub fn push_errors(&self, errors: Vec<GraphqlError>) {
+        self.inner.borrow_mut().errors.extend(errors);
+    }
+}
+
+pub struct ResponseWriter<'resp> {
+    index: usize,
+    part: ResponsePartMut<'resp>,
+}
+
+impl<'resp> ResponseWriter<'resp> {
+    fn part(&self) -> RefMut<'_, &'resp mut ResponsePart> {
+        self.part.inner.borrow_mut()
     }
 
-    /// This does not change how errors were propagated.
-    pub fn replace_errors(&mut self, errors: Vec<GraphqlError>) {
-        self.errors = errors;
+    pub fn root_path(&self) -> ResponsePath {
+        RefCell::borrow(&self.part.inner).root_response_object_refs[self.index]
+            .path
+            .clone()
+    }
+
+    pub fn push_object(&self, object: ResponseObject) -> ResponseObjectId {
+        self.part().data.push_object(object)
+    }
+
+    pub fn push_list(&self, value: &[ResponseValue]) -> ResponseListId {
+        self.part().data.push_list(value)
+    }
+
+    pub fn update_root_object_with(&self, fields: Vec<(ResponseEdge, ResponseValue)>) {
+        self.part().updates[self.index] = UpdateSlot::Fields(fields);
+    }
+
+    pub fn propagate_error(&self, error: impl Into<GraphqlError>) {
+        let mut part = self.part();
+        part.errors.push(error.into());
+        part.updates[self.index] = UpdateSlot::Error;
+    }
+
+    pub fn continue_error_propagation(&self) {
+        self.part().updates[self.index] = UpdateSlot::Error;
+    }
+
+    pub fn push_error(&self, error: impl Into<GraphqlError>) {
+        self.part().errors.push(error.into());
+    }
+
+    pub fn push_boundary_response_object(&self, boundary_ids: &[PlanBoundaryId], obj: ResponseObjectRef) {
+        let mut part = self.part();
+        for boundary_id in boundary_ids {
+            part[*boundary_id].push(obj.clone());
+        }
     }
 }
 
 impl std::ops::Index<PlanBoundaryId> for ResponsePart {
-    type Output = Vec<ResponseBoundaryItem>;
+    type Output = Vec<ResponseObjectRef>;
 
     fn index(&self, id: PlanBoundaryId) -> &Self::Output {
         let n = usize::from(id) - self.plan_boundary_ids_start;
@@ -269,7 +468,8 @@ impl std::ops::IndexMut<PlanBoundaryId> for ResponsePart {
     }
 }
 
-pub struct ResponseObjectUpdate {
-    pub id: ResponseObjectId,
-    pub fields: Vec<(ResponseEdge, ResponseValue)>,
+enum UpdateSlot {
+    Reserved,
+    Fields(Vec<(ResponseEdge, ResponseValue)>),
+    Error,
 }

--- a/engine/crates/engine-v2/src/sources/graphql/deserialize/entities.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/deserialize/entities.rs
@@ -6,13 +6,16 @@ use serde::{
 };
 
 use crate::{
-    response::{ResponseBoundaryItem, SeedContext},
+    plan::PlanWalker,
+    response::{ResponseKeys, ResponsePartMut, ResponsePath, UnpackedResponseEdge},
     sources::ExecutionError,
 };
 
+use super::errors::GraphqlErrorsSeed;
+
 pub(in crate::sources::graphql) struct EntitiesDataSeed<'a> {
-    pub ctx: SeedContext<'a>,
-    pub response_boundary: &'a Vec<ResponseBoundaryItem>,
+    pub response_part: &'a ResponsePartMut<'a>,
+    pub plan: PlanWalker<'a>,
 }
 
 impl<'de, 'a> DeserializeSeed<'de> for EntitiesDataSeed<'a> {
@@ -41,8 +44,8 @@ impl<'de, 'a> Visitor<'de> for EntitiesDataSeed<'a> {
             match key {
                 EntitiesKey::Entities => {
                     map.next_value_seed(EntitiesSeed {
-                        ctx: &self.ctx,
-                        response_boundary: self.response_boundary,
+                        response_part: self.response_part,
+                        plan: self.plan,
                     })?;
                 }
                 EntitiesKey::Unknown => {
@@ -62,12 +65,12 @@ enum EntitiesKey {
     Unknown,
 }
 
-struct EntitiesSeed<'ctx, 'parent> {
-    ctx: &'parent SeedContext<'ctx>,
-    response_boundary: &'ctx Vec<ResponseBoundaryItem>,
+struct EntitiesSeed<'a> {
+    response_part: &'a ResponsePartMut<'a>,
+    plan: PlanWalker<'a>,
 }
 
-impl<'de, 'ctx, 'parent> DeserializeSeed<'de> for EntitiesSeed<'ctx, 'parent> {
+impl<'de, 'a> DeserializeSeed<'de> for EntitiesSeed<'a> {
     type Value = ();
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -78,7 +81,7 @@ impl<'de, 'ctx, 'parent> DeserializeSeed<'de> for EntitiesSeed<'ctx, 'parent> {
     }
 }
 
-impl<'de, 'ctx, 'parent> Visitor<'de> for EntitiesSeed<'ctx, 'parent> {
+impl<'de, 'a> Visitor<'de> for EntitiesSeed<'a> {
     type Value = ();
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -89,22 +92,9 @@ impl<'de, 'ctx, 'parent> Visitor<'de> for EntitiesSeed<'ctx, 'parent> {
     where
         A: SeqAccess<'de>,
     {
-        let mut index = 0;
-        loop {
-            if index >= self.response_boundary.len() {
-                if seq.next_element::<IgnoredAny>()?.is_some() {
-                    self.ctx.borrow_mut_response_part().push_error(ExecutionError::Internal(
-                        "Received more entities than expected".to_string(),
-                    ));
-                    while seq.next_element::<IgnoredAny>()?.is_some() {}
-                }
-                break;
-            }
-            let seed = self.ctx.create_root_seed(&self.response_boundary[index]);
+        while let Some(seed) = self.response_part.next_seed(self.plan) {
             match seq.next_element_seed(seed) {
-                Ok(Some(_)) => {
-                    index += 1;
-                }
+                Ok(Some(_)) => continue,
                 Ok(None) => break,
                 Err(err) => {
                     // Discarding the rest of the list
@@ -113,6 +103,57 @@ impl<'de, 'ctx, 'parent> Visitor<'de> for EntitiesSeed<'ctx, 'parent> {
                 }
             }
         }
+        if seq.next_element::<IgnoredAny>()?.is_some() {
+            self.response_part.push_error(ExecutionError::Internal(
+                "Received more entities than expected".to_string(),
+            ));
+            while seq.next_element::<IgnoredAny>()?.is_some() {}
+        }
         Ok(())
+    }
+}
+
+pub(in crate::sources::graphql) struct EntitiesErrorsSeed<'a> {
+    pub response_part: &'a ResponsePartMut<'a>,
+    pub response_keys: &'a ResponseKeys,
+}
+
+impl<'a> GraphqlErrorsSeed<'a> for EntitiesErrorsSeed<'a> {
+    fn response_part(&self) -> &'a ResponsePartMut<'a> {
+        self.response_part
+    }
+
+    fn convert_path(&self, path: &serde_json::Value) -> Option<ResponsePath> {
+        let mut path = path.as_array()?.iter();
+        if path.next()?.as_str()? != "_entities" {
+            return None;
+        }
+
+        let mut out = self
+            .response_part
+            .root_response_object_refs()
+            .get(path.next()?.as_u64()? as usize)?
+            .path
+            .clone();
+
+        for edge in path {
+            if let Some(index) = edge.as_u64() {
+                out.push(index as usize);
+            } else {
+                let key = edge.as_str()?;
+                let response_key = self.response_keys.get(key)?;
+                // We need this path for two reasons only:
+                // - To report nicely in the error message
+                // - To know whether an error exist if we're missing the appropriate data for a
+                //   response object.
+                // For the latter we only check whether there is an error at all, not if it's one
+                // that could actually propagate up to the root response object. That's a lot more
+                // work and very likely useless.
+                // So, currently, we'll never read those fields and treat them as extra field
+                // to cram them into an ResponseEdge.
+                out.push(UnpackedResponseEdge::ExtraFieldResponseKey(response_key.into()))
+            }
+        }
+        Some(out)
     }
 }

--- a/engine/crates/engine-v2/src/sources/graphql/deserialize/errors.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/deserialize/errors.rs
@@ -2,10 +2,49 @@ use std::collections::BTreeMap;
 
 use serde::{de::DeserializeSeed, Deserializer};
 
-use crate::response::{GraphqlError, ResponsePath};
+use crate::response::{GraphqlError, ResponseKeys, ResponsePartMut, ResponsePath, UnpackedResponseEdge};
+
+pub(super) trait GraphqlErrorsSeed<'a> {
+    fn response_part(&self) -> &ResponsePartMut<'a>;
+    fn convert_path(&self, path: &serde_json::Value) -> Option<ResponsePath>;
+}
+
+pub(in crate::sources::graphql) struct RootGraphqlErrors<'a> {
+    pub response_part: &'a ResponsePartMut<'a>,
+    pub response_keys: &'a ResponseKeys,
+}
+
+impl<'a> GraphqlErrorsSeed<'a> for RootGraphqlErrors<'a> {
+    fn response_part(&self) -> &ResponsePartMut<'a> {
+        self.response_part
+    }
+
+    fn convert_path(&self, path: &serde_json::Value) -> Option<ResponsePath> {
+        let mut out = ResponsePath::default();
+        for edge in path.as_array()? {
+            if let Some(index) = edge.as_u64() {
+                out.push(index as usize);
+            } else {
+                let key = edge.as_str()?;
+                let response_key = self.response_keys.get(key)?;
+                // We need this path for two reasons only:
+                // - To report nicely in the error message
+                // - To know whether an error exist if we're missing the appropriate data for a
+                //   response object.
+                // For the latter we only check whether there is an error at all, not if it's one
+                // that could actually propagate up to the root response object. That's a lot more
+                // work and very likely useless.
+                // So, currently, we'll never read those fields and treat them as extra field
+                // to cram them into an ResponseEdge.
+                out.push(UnpackedResponseEdge::ExtraFieldResponseKey(response_key.into()))
+            }
+        }
+        Some(out)
+    }
+}
 
 #[derive(serde::Deserialize)]
-pub(super) struct UpstreamGraphqlError {
+pub(super) struct SubgraphGraphqlError {
     pub message: String,
     #[serde(default)]
     pub locations: serde_json::Value,
@@ -15,37 +54,43 @@ pub(super) struct UpstreamGraphqlError {
     pub extensions: serde_json::Value,
 }
 
-pub(super) struct UpstreamGraphqlErrorsSeed<'a> {
-    pub path: &'a ResponsePath,
-    pub errors: &'a mut Vec<GraphqlError>,
-}
+pub(super) struct ConcreteGraphqlErrorsSeed<T>(pub(super) T);
 
-impl<'de, 'a> DeserializeSeed<'de> for UpstreamGraphqlErrorsSeed<'a> {
-    type Value = ();
+impl<'de, T> DeserializeSeed<'de> for ConcreteGraphqlErrorsSeed<T>
+where
+    T: GraphqlErrorsSeed<'de>,
+{
+    type Value = usize;
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let errors = <Vec<UpstreamGraphqlError> as serde::Deserialize>::deserialize(deserializer)?;
-        for error in errors {
-            let mut extensions = BTreeMap::new();
-            if !error.locations.is_null() {
-                extensions.insert("upstream_locations".to_string(), error.locations);
-            }
-            if !error.path.is_null() {
-                extensions.insert("upstream_path".to_string(), error.path);
-            }
-            if !error.extensions.is_null() {
-                extensions.insert("upstream_extensions".to_string(), error.extensions);
-            }
-            self.errors.push(GraphqlError {
-                message: format!("Upstream error: {}", error.message),
-                locations: vec![],
-                path: Some(self.path.clone()),
-                extensions,
-            });
-        }
-        Ok(())
+        let errors = <Vec<SubgraphGraphqlError> as serde::Deserialize>::deserialize(deserializer)?;
+        let errors_count = errors.len();
+        let errors = errors
+            .into_iter()
+            .map(|error| {
+                let mut extensions = BTreeMap::new();
+                if !error.locations.is_null() {
+                    extensions.insert("upstream_locations".to_string(), error.locations);
+                }
+                let path = self.0.convert_path(&error.path);
+                if path.is_none() && !error.path.is_null() {
+                    extensions.insert("upstream_path".to_string(), error.path);
+                }
+                if !error.extensions.is_null() {
+                    extensions.insert("upstream_extensions".to_string(), error.extensions);
+                }
+                GraphqlError {
+                    message: format!("Upstream error: {}", error.message),
+                    path,
+                    extensions,
+                    ..Default::default()
+                }
+            })
+            .collect();
+        self.0.response_part().push_errors(errors);
+        Ok(errors_count)
     }
 }

--- a/engine/crates/engine-v2/src/sources/graphql/deserialize/errors.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/deserialize/errors.rs
@@ -47,8 +47,6 @@ impl<'a> GraphqlErrorsSeed<'a> for RootGraphqlErrors<'a> {
 pub(super) struct SubgraphGraphqlError {
     pub message: String,
     #[serde(default)]
-    pub locations: serde_json::Value,
-    #[serde(default)]
     pub path: serde_json::Value,
     #[serde(default)]
     pub extensions: serde_json::Value,
@@ -72,9 +70,6 @@ where
             .into_iter()
             .map(|error| {
                 let mut extensions = BTreeMap::new();
-                if !error.locations.is_null() {
-                    extensions.insert("upstream_locations".to_string(), error.locations);
-                }
                 let path = self.0.convert_path(&error.path);
                 if path.is_none() && !error.path.is_null() {
                     extensions.insert("upstream_path".to_string(), error.path);

--- a/engine/crates/engine-v2/src/sources/graphql/deserialize/mod.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/deserialize/mod.rs
@@ -2,5 +2,6 @@ mod entities;
 mod errors;
 mod response;
 
-pub(super) use entities::EntitiesDataSeed;
-pub(super) use response::ingest_deserializer_into_response;
+pub(super) use entities::*;
+pub(super) use errors::*;
+pub(super) use response::*;

--- a/engine/crates/engine-v2/src/sources/graphql/variables.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/variables.rs
@@ -1,13 +1,13 @@
 use serde::ser::SerializeMap;
 
-use crate::{plan::PlanWalker, response::ResponseBoundaryObjectsView};
+use crate::{plan::PlanWalker, response::ResponseObjectsView};
 
 use super::query::QueryVariables;
 
 pub(super) struct SubgraphVariables<'a> {
     pub plan: PlanWalker<'a>,
     pub variables: &'a QueryVariables,
-    pub inputs: Vec<(&'a str, ResponseBoundaryObjectsView<'a>)>,
+    pub inputs: Vec<(&'a str, ResponseObjectsView<'a>)>,
 }
 
 impl<'a> serde::Serialize for SubgraphVariables<'a> {

--- a/engine/crates/engine-v2/src/sources/introspection/mod.rs
+++ b/engine/crates/engine-v2/src/sources/introspection/mod.rs
@@ -1,11 +1,5 @@
-use std::cell::RefCell;
-
 use super::{ExecutionError, Executor, ExecutorInput};
-use crate::{
-    execution::ExecutionContext,
-    plan::PlanWalker,
-    response::{ResponseBoundaryItem, ResponsePart},
-};
+use crate::{execution::ExecutionContext, plan::PlanWalker, response::ResponsePart};
 
 mod writer;
 
@@ -15,38 +9,26 @@ impl IntrospectionExecutionPlan {
     #[allow(clippy::unnecessary_wraps)]
     pub fn new_executor<'ctx>(
         &'ctx self,
-        ExecutorInput {
-            ctx,
-            boundary_objects_view: root_response_objects,
-            plan,
-            response_part: output,
-        }: ExecutorInput<'ctx, '_>,
+        ExecutorInput { ctx, plan, .. }: ExecutorInput<'ctx, '_>,
     ) -> Result<Executor<'ctx>, ExecutionError> {
-        Ok(Executor::Introspection(IntrospectionExecutor {
-            ctx,
-            response_object: root_response_objects.into_single_boundary_item(),
-            plan,
-            output,
-        }))
+        Ok(Executor::Introspection(IntrospectionExecutor { ctx, plan }))
     }
 }
 
 pub(crate) struct IntrospectionExecutor<'ctx> {
     ctx: ExecutionContext<'ctx>,
-    response_object: ResponseBoundaryItem,
     plan: PlanWalker<'ctx>,
-    output: ResponsePart,
 }
 
 impl<'ctx> IntrospectionExecutor<'ctx> {
-    pub async fn execute(mut self) -> Result<ResponsePart, ExecutionError> {
+    pub async fn execute(self, mut response_part: ResponsePart) -> Result<ResponsePart, ExecutionError> {
         writer::IntrospectionWriter {
             schema: self.ctx.engine.schema.walker(),
             metadata: self.ctx.engine.schema.walker().introspection_metadata(),
             plan: self.plan,
-            output: RefCell::new(&mut self.output),
+            response: response_part.as_mut().next_writer().ok_or("No objects to update")?,
         }
-        .update_output(self.response_object);
-        Ok(self.output)
+        .execute();
+        Ok(response_part)
     }
 }

--- a/engine/crates/engine-v2/src/sources/introspection/writer.rs
+++ b/engine/crates/engine-v2/src/sources/introspection/writer.rs
@@ -1,5 +1,3 @@
-use std::cell::RefCell;
-
 use schema::{
     sources::{
         introspection::{IntrospectionField, IntrospectionObject, _Field, __EnumValue, __InputValue, __Schema, __Type},
@@ -11,18 +9,18 @@ use schema::{
 
 use crate::{
     plan::{CollectedField, PlanCollectedField, PlanCollectedSelectionSet, PlanWalker},
-    response::{ResponseBoundaryItem, ResponseObject, ResponseObjectUpdate, ResponsePart, ResponseValue},
+    response::{ResponseObject, ResponseValue, ResponseWriter},
 };
 
 pub(super) struct IntrospectionWriter<'a> {
     pub schema: SchemaWalker<'a, ()>,
     pub metadata: &'a IntrospectionMetadata,
     pub plan: PlanWalker<'a>,
-    pub output: RefCell<&'a mut ResponsePart>,
+    pub response: ResponseWriter<'a>,
 }
 
 impl<'a> IntrospectionWriter<'a> {
-    pub(super) fn update_output(&self, response_object: ResponseBoundaryItem) {
+    pub(super) fn execute(self) {
         let selection_set = self.plan.collected_selection_set();
         let mut fields =
             Vec::with_capacity(selection_set.as_ref().field_ids.len() + selection_set.as_ref().typename_fields.len());
@@ -54,10 +52,7 @@ impl<'a> IntrospectionWriter<'a> {
                 fields.push((*edge, name.into()));
             }
         }
-        self.output.borrow_mut().push_update(ResponseObjectUpdate {
-            id: response_object.response_object_id,
-            fields,
-        });
+        self.response.update_root_object_with(fields);
     }
 
     fn object<E: Copy, const N: usize>(
@@ -81,7 +76,7 @@ impl<'a> IntrospectionWriter<'a> {
             }
         }
 
-        self.output.borrow_mut().push_object(ResponseObject::new(fields)).into()
+        self.response.push_object(ResponseObject::new(fields)).into()
     }
 
     fn __schema(&self, selection_set: PlanCollectedSelectionSet<'_>) -> ResponseValue {
@@ -95,7 +90,7 @@ impl<'a> IntrospectionWriter<'a> {
                         .definitions()
                         .map(|definition| self.__type_inner(definition, selection_set))
                         .collect::<Vec<_>>();
-                    self.output.borrow_mut().push_list(&values).into()
+                    self.response.push_list(&values).into()
                 }
                 __Schema::QueryType => {
                     self.__type_inner(self.schema.query().into(), field.concrete_selection_set().unwrap())
@@ -111,7 +106,7 @@ impl<'a> IntrospectionWriter<'a> {
                     .map(|subscription| self.__type_inner(subscription.into(), field.concrete_selection_set().unwrap()))
                     .unwrap_or_default(),
                 // TODO: Need to implemented directives...
-                __Schema::Directives => self.output.borrow_mut().push_list(&[]).into(),
+                __Schema::Directives => self.response.push_list(&[]).into(),
             }
         })
     }
@@ -197,7 +192,7 @@ impl<'a> IntrospectionWriter<'a> {
                         })
                         .map(|field| self.__field(field, selection_set))
                         .collect::<Vec<_>>();
-                    self.output.borrow_mut().push_list(&values)
+                    self.response.push_list(&values)
                 })
                 .into(),
             __Type::Interfaces => definition
@@ -207,7 +202,7 @@ impl<'a> IntrospectionWriter<'a> {
                     let values = interfaces
                         .map(|interface| self.__type_inner(interface.into(), selection_set))
                         .collect::<Vec<_>>();
-                    self.output.borrow_mut().push_list(&values)
+                    self.response.push_list(&values)
                 })
                 .into(),
             __Type::PossibleTypes => definition
@@ -217,7 +212,7 @@ impl<'a> IntrospectionWriter<'a> {
                     let values = possible_types
                         .map(|interface| self.__type_inner(interface.into(), selection_set))
                         .collect::<Vec<_>>();
-                    self.output.borrow_mut().push_list(&values)
+                    self.response.push_list(&values)
                 })
                 .into(),
             __Type::EnumValues => definition
@@ -230,7 +225,7 @@ impl<'a> IntrospectionWriter<'a> {
                         .filter(|value| (!value.directives().has_deprecated() || include_deprecated))
                         .map(|value| self.__enum_value(value, selection_set))
                         .collect::<Vec<_>>();
-                    self.output.borrow_mut().push_list(&values)
+                    self.response.push_list(&values)
                 })
                 .into(),
             __Type::InputFields => definition
@@ -241,7 +236,7 @@ impl<'a> IntrospectionWriter<'a> {
                         .input_fields()
                         .map(|input_field| self.__input_value(input_field, selection_set))
                         .collect::<Vec<_>>();
-                    self.output.borrow_mut().push_list(&values)
+                    self.response.push_list(&values)
                 })
                 .into(),
             __Type::OfType => ResponseValue::Null,
@@ -267,7 +262,7 @@ impl<'a> IntrospectionWriter<'a> {
                     .map(|argument| self.__input_value(argument, selection_set))
                     .collect::<Vec<_>>();
 
-                self.output.borrow_mut().push_list(&values).into()
+                self.response.push_list(&values).into()
             }
             _Field::Type => self.__type(target.ty(), field.concrete_selection_set().unwrap()),
             _Field::IsDeprecated => target.directives().has_deprecated().into(),

--- a/engine/crates/integration-tests/data/federated-graph-schema.graphql
+++ b/engine/crates/integration-tests/data/federated-graph-schema.graphql
@@ -2,87 +2,75 @@ directive @core(feature: String!) repeatable on SCHEMA
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 
-directive @join__type(
-    graph: join__Graph!
-    key: String!
-    resolvable: Boolean = true
-) repeatable on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph!, key: String!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-directive @join__field(
-    graph: join__Graph
-    requires: String
-    provides: String
-) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: String, provides: String) on FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
 enum join__Graph {
-    ACCOUNTS @join__graph(name: "accounts", url: "http://127.0.0.1:46697")
-    PRODUCTS @join__graph(name: "products", url: "http://127.0.0.1:45399")
-    REVIEWS @join__graph(name: "reviews", url: "http://127.0.0.1:45899")
+  ACCOUNTS @join__graph(name: "accounts", url: "http://127.0.0.1:46697")
+  PRODUCTS @join__graph(name: "products", url: "http://127.0.0.1:45399")
+  REVIEWS @join__graph(name: "reviews", url: "http://127.0.0.1:45899")
 }
 
 type Cart {
-    products: [Product!]! @join__field(graph: ACCOUNTS)
+  products: [Product!]! @join__field(graph: ACCOUNTS)
 }
 
 type Picture {
-    url: String!
-    width: Int!
-    height: Int!
-    altText: String! @inaccessible
+  url: String!
+  width: Int!
+  height: Int!
+  altText: String! @inaccessible
 }
 
 type Product
-    @join__type(graph: ACCOUNTS, key: "name", resolvable: false)
-    @join__type(graph: PRODUCTS, key: "upc")
-    @join__type(graph: PRODUCTS, key: "name")
-    @join__type(graph: REVIEWS, key: "upc")
-{
-    name: String!
-    upc: String!
-    price: Int! @join__field(graph: PRODUCTS)
-    reviews: [Review!]! @join__field(graph: REVIEWS)
+  @join__type(graph: ACCOUNTS, key: "name", resolvable: false)
+  @join__type(graph: PRODUCTS, key: "upc")
+  @join__type(graph: PRODUCTS, key: "name")
+  @join__type(graph: REVIEWS, key: "upc") {
+  name: String!
+  upc: String!
+  price: Int! @join__field(graph: PRODUCTS)
+  reviews: [Review!]! @join__field(graph: REVIEWS)
 }
 
-type User
-    @join__type(graph: ACCOUNTS, key: "id")
-    @join__type(graph: REVIEWS, key: "id")
-{
-    id: ID!
-    username: String! @join__field(graph: ACCOUNTS)
-    profilePicture: Picture @join__field(graph: ACCOUNTS)
-    """
-    This used to be part of this subgraph, but is now being overridden from
-    `reviews`
-    """
-    reviewCount: Int! @join__field(graph: reviews, overrides: "accounts")
-    joinedTimestamp: Int! @join__field(graph: ACCOUNTS)
-    cart: Cart! @join__field(graph: ACCOUNTS)
-    reviews: [Review!]! @join__field(graph: REVIEWS)
-    trustworthiness: Trustworthiness! @join__field(graph: REVIEWS, requires: "joinedTimestamp")
+type User @join__type(graph: ACCOUNTS, key: "id") @join__type(graph: REVIEWS, key: "id") {
+  id: ID!
+  username: String! @join__field(graph: ACCOUNTS)
+  profilePicture: Picture @join__field(graph: ACCOUNTS)
+  """
+  This used to be part of this subgraph, but is now being overridden from
+  `reviews`
+  """
+  reviewCount: Int! @join__field(graph: reviews, overrides: "accounts")
+  joinedTimestamp: Int! @join__field(graph: ACCOUNTS)
+  cart: Cart! @join__field(graph: ACCOUNTS)
+  reviews: [Review!]! @join__field(graph: REVIEWS)
+  trustworthiness: Trustworthiness! @join__field(graph: REVIEWS, requires: "joinedTimestamp")
 }
 
 type Review {
-    id: ID! @join__field(graph: REVIEWS)
-    body: String! @join__field(graph: REVIEWS)
-    pictures: [Picture!]! @join__field(graph: REVIEWS)
-    product: Product! @join__field(graph: REVIEWS, provides: "price")
-    author: User @join__field(graph: REVIEWS)
+  id: ID! @join__field(graph: REVIEWS)
+  body: String! @join__field(graph: REVIEWS)
+  pictures: [Picture!]! @join__field(graph: REVIEWS)
+  product: Product! @join__field(graph: REVIEWS, provides: "price")
+  author: User @join__field(graph: REVIEWS)
 }
 
 type Query {
-    me: User! @join__field(graph: ACCOUNTS)
-    topProducts: [Product!]! @join__field(graph: PRODUCTS)
+  name: String @join__field(graph: ACCOUNTS)
+  me: User! @join__field(graph: ACCOUNTS)
+  topProducts: [Product!]! @join__field(graph: PRODUCTS)
 }
 
 type Subscription {
-    newProducts: Product! @join__field(graph: PRODUCTS)
+  newProducts: Product! @join__field(graph: PRODUCTS)
 }
 
 enum Trustworthiness {
-    REALLY_TRUSTED
-    KINDA_TRUSTED
-    NOT_TRUSTED
+  REALLY_TRUSTED
+  KINDA_TRUSTED
+  NOT_TRUSTED
 }
-

--- a/engine/crates/integration-tests/tests/federation/basic/errors.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/errors.rs
@@ -4,6 +4,175 @@ use serde_json::json;
 const SCHEMA: &str = include_str!("../../../data/federated-graph-schema.graphql");
 
 #[test]
+fn subgraph_no_response() {
+    let engine = FederationGatewayWithoutIO::new(
+        SCHEMA,
+        r#"
+        query ExampleQuery {
+            me {
+                id
+            }
+        }
+        "#,
+        &[json!(null)],
+    );
+    let response = integration_tests::runtime().block_on(engine.execute());
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": null,
+      "errors": [
+        {
+          "message": "Deserialization error: invalid type: null, expected a valid GraphQL response at line 1 column 4",
+          "path": [
+            "me"
+          ]
+        }
+      ]
+    }
+    "###);
+
+    let engine = FederationGatewayWithoutIO::new(
+        SCHEMA,
+        r#"
+        query ExampleQuery {
+            me {
+                id
+            }
+        }
+        "#,
+        &[json!({})],
+    );
+    let response = integration_tests::runtime().block_on(engine.execute());
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": null,
+      "errors": [
+        {
+          "message": "Missing data from subgraph",
+          "path": [
+            "me"
+          ]
+        }
+      ]
+    }
+    "###);
+}
+
+#[test]
+fn request_error() {
+    let engine = FederationGatewayWithoutIO::new(
+        SCHEMA,
+        r#"
+        query ExampleQuery {
+            _typean_
+        }
+        "#,
+        &[json!({})],
+    );
+    let response = integration_tests::runtime().block_on(engine.execute());
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "errors": [
+        {
+          "message": "Query does not have a field named '_typean_'",
+          "locations": [
+            {
+              "line": 3,
+              "column": 13
+            }
+          ]
+        }
+      ]
+    }
+    "###);
+}
+
+#[test]
+fn sugraph_request_error() {
+    let engine = FederationGatewayWithoutIO::new(
+        SCHEMA,
+        r#"
+        query ExampleQuery {
+            me {
+                id
+            }
+        }
+        "#,
+        &[json!({"errors": [{"message": "failed!"}]})],
+    );
+    let response = integration_tests::runtime().block_on(engine.execute());
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": null,
+      "errors": [
+        {
+          "message": "Upstream error: failed!"
+        }
+      ]
+    }
+    "###);
+}
+
+#[test]
+fn invalid_response_for_nullable_field() {
+    let engine = FederationGatewayWithoutIO::new(
+        SCHEMA,
+        r#"
+        query ExampleQuery {
+            name
+        }
+        "#,
+        &[json!({})],
+    );
+    let response = integration_tests::runtime().block_on(engine.execute());
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": {
+        "name": null
+      },
+      "errors": [
+        {
+          "message": "Missing data from subgraph",
+          "path": [
+            "name"
+          ]
+        }
+      ]
+    }
+    "###);
+}
+
+#[test]
+fn subgraph_field_error() {
+    let engine = FederationGatewayWithoutIO::new(
+        SCHEMA,
+        r#"
+        query ExampleQuery {
+            me {
+                id
+            }
+        }
+        "#,
+        &[json!({"data": null, "errors": [{"message": "failed!", "path": ["me", "id"]}]})],
+    );
+    let response = integration_tests::runtime().block_on(engine.execute());
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": null,
+      "errors": [
+        {
+          "message": "Upstream error: failed!",
+          "path": [
+            "me",
+            "id"
+          ]
+        }
+      ]
+    }
+    "###);
+}
+
+#[test]
 fn simple_error() {
     let engine = FederationGatewayWithoutIO::new(
         SCHEMA,
@@ -30,7 +199,12 @@ fn simple_error() {
         &[
             json!({"data":{"me":{"id":"1234","username":"Me"}}}),
             // Missing author.id
-            json!({"data":{"_entities":[{"__typename":"User","reviews":[{"body":"A highly effective form of birth control.","product":{"reviews":[{"author":{},"body":"A highly effective form of birth control."}]}},{"body":"Fedoras are one of the most fashionable hats around and can look great with a variety of outfits.","product":{"reviews":[{"author":{"id":"1234"},"body":"Fedoras are one of the most fashionable hats around and can look great with a variety of outfits."}]}}]}]}}),
+            json!({"data":{"_entities":[
+            {"__typename":"User",
+             "reviews":[
+                {"body":"A highly effective form of birth control.","product":{"reviews":[{"author":{},"body":"A highly effective form of birth control."}]}},
+                {"body":"Fedoras are one of the most fashionable hats around and can look great with a variety of outfits.","product":{"reviews":[{"author":{"id":"1234"},"body":"Fedoras are one of the most fashionable hats around and can look great with a variety of outfits."}]}}
+            ]}]}}),
             json!({"data":{"_entities":[{"__typename":"User","username":"Me"}]}}),
         ],
     );
@@ -111,7 +285,7 @@ fn null_entity_with_error() {
         "#,
         &[
             json!({"data":{"me":{"id":"1234","username":"Me"}}}),
-            json!({"data":{"_entities":[null]}, "errors": [{"message":"I'm broken!", "path": ["_entities", 0, "body"]}]}),
+            json!({"data":{"_entities":[null]}, "errors": [{"message":"I'm broken!", "path": ["_entities", 0, "reviews", 0, "body"]}]}),
         ],
     );
     let response = integration_tests::runtime().block_on(engine.execute());
@@ -120,25 +294,13 @@ fn null_entity_with_error() {
       "data": null,
       "errors": [
         {
-          "message": "Error decoding response from upstream: Missing required field named 'reviews'",
-          "path": [
-            "me",
-            "reviews"
-          ]
-        },
-        {
           "message": "Upstream error: I'm broken!",
           "path": [
             "me",
-            "reviews"
-          ],
-          "extensions": {
-            "upstream_path": [
-              "_entities",
-              0,
-              "body"
-            ]
-          }
+            "reviews",
+            0,
+            "body"
+          ]
         }
       ]
     }

--- a/engine/crates/integration-tests/tests/federation/basic/mutation.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/mutation.rs
@@ -103,15 +103,7 @@ fn mutation_failure_should_stop_later_executions_if_required() {
               "message": "Upstream error: This mutation always fails",
               "path": [
                 "faillible"
-              ],
-              "extensions": {
-                "upstream_locations": [
-                  {
-                    "line": 2,
-                    "column": 3
-                  }
-                ]
-              }
+              ]
             }
           ]
         }
@@ -148,15 +140,7 @@ fn mutation_failure_should_stop_later_executions_if_required() {
               "message": "Upstream error: This mutation always fails",
               "path": [
                 "fail"
-              ],
-              "extensions": {
-                "upstream_locations": [
-                  {
-                    "line": 2,
-                    "column": 3
-                  }
-                ]
-              }
+              ]
             }
           ]
         }

--- a/engine/crates/integration-tests/tests/federation/basic/mutation.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/mutation.rs
@@ -110,9 +110,6 @@ fn mutation_failure_should_stop_later_executions_if_required() {
                     "line": 2,
                     "column": 3
                   }
-                ],
-                "upstream_path": [
-                  "faillible"
                 ]
               }
             }
@@ -158,9 +155,6 @@ fn mutation_failure_should_stop_later_executions_if_required() {
                     "line": 2,
                     "column": 3
                   }
-                ],
-                "upstream_path": [
-                  "fail"
                 ]
               }
             }

--- a/engine/crates/tracing/src/config.rs
+++ b/engine/crates/tracing/src/config.rs
@@ -131,20 +131,20 @@ pub struct TracingBatchExportConfig {
         deserialize_with = "deserialize_duration",
         default = "TracingBatchExportConfig::default_scheduled_delay"
     )]
-    pub(crate) scheduled_delay: chrono::Duration,
+    pub scheduled_delay: chrono::Duration,
 
     /// The maximum queue size to buffer spans for delayed processing. If the
     /// queue gets full it drops the spans.
     /// The default value of is 2048.
     #[serde(default = "TracingBatchExportConfig::default_max_queue_size")]
-    pub(crate) max_queue_size: usize,
+    pub max_queue_size: usize,
 
     /// The maximum number of spans to process in a single batch. If there are
     /// more than one batch worth of spans then it processes multiple batches
     /// of spans one batch after the other without any delay.
     /// The default value is 512.
     #[serde(default = "TracingBatchExportConfig::default_max_export_batch_size")]
-    pub(crate) max_export_batch_size: usize,
+    pub max_export_batch_size: usize,
 
     /// Maximum number of concurrent exports
     ///
@@ -153,7 +153,7 @@ pub struct TracingBatchExportConfig {
     /// synchronously on the [`BatchSpanProcessor`] task.
     /// The default is 1.
     #[serde(default = "TracingBatchExportConfig::default_max_concurrent_exports")]
-    pub(crate) max_concurrent_exports: usize,
+    pub max_concurrent_exports: usize,
 }
 
 impl TracingBatchExportConfig {

--- a/engine/crates/tracing/src/grafbase_client.rs
+++ b/engine/crates/tracing/src/grafbase_client.rs
@@ -1,7 +1,7 @@
 pub static X_GRAFBASE_CLIENT_NAME: http::HeaderName = http::HeaderName::from_static("x-grafbase-client-name");
 pub static X_GRAFBASE_CLIENT_VERSION: http::HeaderName = http::HeaderName::from_static("x-grafbase-client-version");
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone)]
 pub struct Client {
     pub name: String,
     pub version: Option<String>,

--- a/engine/crates/tracing/src/metrics/operation.rs
+++ b/engine/crates/tracing/src/metrics/operation.rs
@@ -10,6 +10,7 @@ pub struct GraphqlOperationMetrics {
     latency: Histogram<u64>,
 }
 
+#[derive(Debug)]
 pub struct GraphqlOperationMetricsAttributes {
     pub ty: &'static str,
     pub name: Option<String>,

--- a/engine/crates/tracing/src/metrics/operation.rs
+++ b/engine/crates/tracing/src/metrics/operation.rs
@@ -54,10 +54,7 @@ impl GraphqlOperationMetrics {
         if let Some(cache_status) = cache_status {
             attributes.push(KeyValue::new("gql.response.cache_status", cache_status));
         }
-        // Not present will simply be assumed to be a success.
-        if !status.is_success() {
-            attributes.push(KeyValue::new("gql.response.status", status.as_str()));
-        }
+        attributes.push(KeyValue::new("gql.response.status", status.as_str()));
         if let Some(client) = client {
             attributes.push(KeyValue::new("http.headers.x-grafbase-client-name", client.name));
             if let Some(version) = client.version {

--- a/engine/crates/tracing/src/metrics/request.rs
+++ b/engine/crates/tracing/src/metrics/request.rs
@@ -35,10 +35,7 @@ impl RequestMetrics {
         latency: std::time::Duration,
     ) {
         let mut attributes = Vec::new();
-        // No status code is simply assumed to be 200
-        if status_code != 200 {
-            attributes.push(KeyValue::new("http.response.status_code", status_code as i64));
-        }
+        attributes.push(KeyValue::new("http.response.status_code", status_code as i64));
         if let Some(cache_status) = cache_status {
             attributes.push(KeyValue::new("http.response.headers.cache_status", cache_status));
         }
@@ -48,8 +45,7 @@ impl RequestMetrics {
                 attributes.push(KeyValue::new("http.headers.x-grafbase-client-version", version));
             }
         }
-        // We only really care about keeping track of errors.
-        if let Some(status) = gql_status.filter(|s| !s.is_success()) {
+        if let Some(status) = gql_status {
             attributes.push(KeyValue::new("gql.response.status", status.as_str()));
         }
         self.latency.record(latency.as_millis() as u64, &attributes);

--- a/gateway/crates/gateway-binary/tests/telemetry/metrics/operation.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/metrics/operation.rs
@@ -39,7 +39,8 @@ fn basic() {
             "gql.operation.name": "Simple",
             "gql.operation.normalized_query": "query Simple {\n  __typename\n}\n",
             "gql.operation.normalized_query_hash": "cAe1+tBRHQLrF/EO1ul4CTx+q5SB9YD+YtG3VDU6VCM=",
-            "gql.operation.type": "query"
+            "gql.operation.type": "query",
+            "gql.response.status": "SUCCESS"
           }
         }
         "###);
@@ -246,6 +247,7 @@ fn client() {
             "gql.operation.normalized_query": "query SimpleQuery {\n  __typename\n}\n",
             "gql.operation.normalized_query_hash": "qIzPxtWwHz0t+aJjvOljljbR3aGLQAA0LI5VXjW/FwQ=",
             "gql.operation.type": "query",
+            "gql.response.status": "SUCCESS",
             "http.headers.x-grafbase-client-name": "test",
             "http.headers.x-grafbase-client-version": "1.0.0"
           }

--- a/gateway/crates/gateway-binary/tests/telemetry/metrics/operation.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/metrics/operation.rs
@@ -1,41 +1,23 @@
 use std::time::Duration;
 
-use super::{with_gateway, ExponentialHistogramRow, SumMetricCountRow};
+use super::{with_gateway, ExponentialHistogramRow};
 
 #[test]
 fn basic() {
     with_gateway(|service_name, start_time_unix, gateway, clickhouse| async move {
-        gateway
+        let response = gateway
             .gql::<serde_json::Value>("query Simple { __typename }")
             .send()
             .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "__typename": "Query"
+          }
+        }"###);
         tokio::time::sleep(Duration::from_secs(2)).await;
 
-        let SumMetricCountRow { value, attributes } = clickhouse
-            .query(
-                r#"
-                SELECT Value, Attributes
-                FROM otel_metrics_sum
-                WHERE ServiceName = ? AND StartTimeUnix >= ?
-                    AND ScopeName = 'grafbase'
-                    AND MetricName = 'gql_operation_count'
-                "#,
-            )
-            .bind(&service_name)
-            .bind(start_time_unix)
-            .fetch_one()
-            .await
-            .unwrap();
-        assert_eq!(value, 1.0);
-        insta::assert_json_snapshot!(attributes, @r###"
-        {
-          "gql.operation.name": "Simple",
-          "gql.operation.normalized_query": "query Simple {\n  __typename\n}\n",
-          "gql.operation.normalized_query_hash": "cAe1+tBRHQLrF/EO1ul4CTx+q5SB9YD+YtG3VDU6VCM=",
-          "gql.operation.type": "query"
-        }
-        "###);
-        let ExponentialHistogramRow { count, attributes } = clickhouse
+        let row = clickhouse
             .query(
                 r#"
                 SELECT Count, Attributes
@@ -47,56 +29,48 @@ fn basic() {
             )
             .bind(&service_name)
             .bind(start_time_unix)
-            .fetch_one()
+            .fetch_one::<ExponentialHistogramRow>()
             .await
             .unwrap();
-        assert_eq!(count, 1);
-        insta::assert_json_snapshot!(attributes, @r###"
+        insta::assert_json_snapshot!(row, @r###"
         {
-          "gql.operation.name": "Simple",
-          "gql.operation.normalized_query": "query Simple {\n  __typename\n}\n",
-          "gql.operation.normalized_query_hash": "cAe1+tBRHQLrF/EO1ul4CTx+q5SB9YD+YtG3VDU6VCM=",
-          "gql.operation.type": "query"
+          "Count": 1,
+          "Attributes": {
+            "gql.operation.name": "Simple",
+            "gql.operation.normalized_query": "query Simple {\n  __typename\n}\n",
+            "gql.operation.normalized_query_hash": "cAe1+tBRHQLrF/EO1ul4CTx+q5SB9YD+YtG3VDU6VCM=",
+            "gql.operation.type": "query"
+          }
         }
         "###);
     });
 }
 
 #[test]
-fn has_error() {
+fn request_error() {
     with_gateway(|service_name, start_time_unix, gateway, clickhouse| async move {
-        gateway
-            .gql::<serde_json::Value>("query Simple { me { id } }")
+        let resp = gateway
+            .gql::<serde_json::Value>("query Faulty { __typ__ename }")
             .send()
             .await;
-        tokio::time::sleep(Duration::from_secs(2)).await;
-
-        let SumMetricCountRow { value, attributes } = clickhouse
-            .query(
-                r#"
-                SELECT Value, Attributes
-                FROM otel_metrics_sum
-                WHERE ServiceName = ? AND StartTimeUnix >= ?
-                    AND ScopeName = 'grafbase'
-                    AND MetricName = 'gql_operation_count'
-                "#,
-            )
-            .bind(&service_name)
-            .bind(start_time_unix)
-            .fetch_one()
-            .await
-            .unwrap();
-        assert_eq!(value, 1.0);
-        insta::assert_json_snapshot!(attributes, @r###"
+        insta::assert_json_snapshot!(resp, @r###"
         {
-          "gql.operation.name": "Simple",
-          "gql.operation.normalized_query": "query Simple {\n  me {\n    id\n  }\n}\n",
-          "gql.operation.normalized_query_hash": "3Dn7H9sNlA2O2Wphw0R6wK0BiqcdP4oRlTiq0Ifq09M=",
-          "gql.operation.type": "query",
-          "gql.response.has_errors": "true"
+          "errors": [
+            {
+              "message": "Query does not have a field named '__typ__ename'",
+              "locations": [
+                {
+                  "line": 1,
+                  "column": 16
+                }
+              ]
+            }
+          ]
         }
         "###);
-        let ExponentialHistogramRow { count, attributes } = clickhouse
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let row = clickhouse
             .query(
                 r#"
                 SELECT Count, Attributes
@@ -108,17 +82,123 @@ fn has_error() {
             )
             .bind(&service_name)
             .bind(start_time_unix)
-            .fetch_one()
+            .fetch_one::<ExponentialHistogramRow>()
             .await
             .unwrap();
-        assert_eq!(count, 1);
-        insta::assert_json_snapshot!(attributes, @r###"
+        insta::assert_json_snapshot!(row, @r###"
         {
-          "gql.operation.name": "Simple",
-          "gql.operation.normalized_query": "query Simple {\n  me {\n    id\n  }\n}\n",
-          "gql.operation.normalized_query_hash": "3Dn7H9sNlA2O2Wphw0R6wK0BiqcdP4oRlTiq0Ifq09M=",
-          "gql.operation.type": "query",
-          "gql.response.has_errors": "true"
+          "Count": 1,
+          "Attributes": {
+            "gql.operation.name": "Faulty",
+            "gql.operation.normalized_query": "query Faulty {\n  __typ__ename\n}\n",
+            "gql.operation.normalized_query_hash": "er/VMZUszb2iQhlPMx46c+flOdO8hXv8PjV1Pk/6u2A=",
+            "gql.operation.type": "query",
+            "gql.response.status": "REQUEST_ERROR"
+          }
+        }
+        "###);
+    });
+}
+
+#[test]
+fn field_error() {
+    with_gateway(|service_name, start_time_unix, gateway, clickhouse| async move {
+        let resp = gateway
+            .gql::<serde_json::Value>("query Faulty { __typename me { id } }")
+            .send()
+            .await;
+        insta::assert_json_snapshot!(resp, @r###"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "error sending request for url (http://127.0.0.1:46697/)",
+              "path": [
+                "me"
+              ]
+            }
+          ]
+        }
+        "###);
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let row = clickhouse
+            .query(
+                r#"
+                SELECT Count, Attributes
+                FROM otel_metrics_exponential_histogram
+                WHERE ServiceName = ? AND StartTimeUnix >= ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'gql_operation_latency'
+                "#,
+            )
+            .bind(&service_name)
+            .bind(start_time_unix)
+            .fetch_one::<ExponentialHistogramRow>()
+            .await
+            .unwrap();
+        insta::assert_json_snapshot!(row, @r###"
+        {
+          "Count": 1,
+          "Attributes": {
+            "gql.operation.name": "Faulty",
+            "gql.operation.normalized_query": "query Faulty {\n  __typename\n  me {\n    id\n  }\n}\n",
+            "gql.operation.normalized_query_hash": "M4bDtLPhj8uQPEFBdDWqalBphwVy7V5WPXOPHrzyikE=",
+            "gql.operation.type": "query",
+            "gql.response.status": "FIELD_ERROR_NULL_DATA"
+          }
+        }
+        "###);
+    });
+}
+
+#[test]
+fn field_error_data_null() {
+    with_gateway(|service_name, start_time_unix, gateway, clickhouse| async move {
+        let resp = gateway
+            .gql::<serde_json::Value>("query Faulty { me { id } }")
+            .send()
+            .await;
+        insta::assert_json_snapshot!(resp, @r###"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "error sending request for url (http://127.0.0.1:46697/)",
+              "path": [
+                "me"
+              ]
+            }
+          ]
+        }
+        "###);
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let row = clickhouse
+            .query(
+                r#"
+                SELECT Count, Attributes
+                FROM otel_metrics_exponential_histogram
+                WHERE ServiceName = ? AND StartTimeUnix >= ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'gql_operation_latency'
+                "#,
+            )
+            .bind(&service_name)
+            .bind(start_time_unix)
+            .fetch_one::<ExponentialHistogramRow>()
+            .await
+            .unwrap();
+        insta::assert_json_snapshot!(row, @r###"
+        {
+          "Count": 1,
+          "Attributes": {
+            "gql.operation.name": "Faulty",
+            "gql.operation.normalized_query": "query Faulty {\n  me {\n    id\n  }\n}\n",
+            "gql.operation.normalized_query_hash": "Txoer8zp21WTkEG253qN503QOPQP7Pb9utIDx55IVD8=",
+            "gql.operation.type": "query",
+            "gql.response.status": "FIELD_ERROR_NULL_DATA"
+          }
         }
         "###);
     });
@@ -127,42 +207,21 @@ fn has_error() {
 #[test]
 fn client() {
     with_gateway(|service_name, start_time_unix, gateway, clickhouse| async move {
-        gateway
+        let resp = gateway
             .gql::<serde_json::Value>("query SimpleQuery { __typename }")
             .header("x-grafbase-client-name", "test")
             .header("x-grafbase-client-version", "1.0.0")
             .send()
             .await;
-        tokio::time::sleep(Duration::from_secs(2)).await;
-
-        let row = clickhouse
-            .query(
-                r#"
-                SELECT Value, Attributes
-                FROM otel_metrics_sum
-                WHERE ServiceName = ? AND StartTimeUnix >= ?
-                    AND ScopeName = 'grafbase'
-                    AND MetricName = 'gql_operation_count'
-                "#,
-            )
-            .bind(&service_name)
-            .bind(start_time_unix)
-            .fetch_one::<SumMetricCountRow>()
-            .await
-            .unwrap();
-        insta::assert_json_snapshot!(row, @r###"
+        insta::assert_json_snapshot!(resp, @r###"
         {
-          "Value": 1.0,
-          "Attributes": {
-            "gql.operation.name": "SimpleQuery",
-            "gql.operation.normalized_query": "query SimpleQuery {\n  __typename\n}\n",
-            "gql.operation.normalized_query_hash": "qIzPxtWwHz0t+aJjvOljljbR3aGLQAA0LI5VXjW/FwQ=",
-            "gql.operation.type": "query",
-            "http.headers.x-grafbase-client-name": "test",
-            "http.headers.x-grafbase-client-version": "1.0.0"
+          "data": {
+            "__typename": "Query"
           }
         }
         "###);
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
 
         let row = clickhouse
             .query(

--- a/gateway/crates/gateway-binary/tests/telemetry/metrics/request.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/metrics/request.rs
@@ -1,173 +1,20 @@
 use std::time::Duration;
 
-use super::{with_gateway, ExponentialHistogramRow, SumMetricCountRow};
+use super::{with_gateway, ExponentialHistogramRow};
 
 #[test]
 fn basic() {
     with_gateway(|service_name, start_time_unix, gateway, clickhouse| async move {
-        gateway.gql::<serde_json::Value>("{ __typename }").send().await;
-        tokio::time::sleep(Duration::from_secs(2)).await;
-
-        let SumMetricCountRow { value, attributes } = clickhouse
-            .query(
-                r#"
-                SELECT Value, Attributes
-                FROM otel_metrics_sum
-                WHERE ServiceName = ? AND StartTimeUnix >= ?
-                    AND ScopeName = 'grafbase'
-                    AND MetricName = 'request_count'
-                    AND Attributes['gql.response.has_errors'] = ''
-                "#,
-            )
-            .bind(&service_name)
-            .bind(start_time_unix)
-            .fetch_one()
-            .await
-            .unwrap();
-        assert_eq!(value, 1.0);
-        insta::assert_json_snapshot!(attributes, @r###"
+        let resp = gateway.gql::<serde_json::Value>("{ __typename }").send().await;
+        insta::assert_json_snapshot!(resp, @r###"
         {
-          "http.response.status_code": "200"
+          "data": {
+            "__typename": "Query"
+          }
         }
         "###);
-        let ExponentialHistogramRow { count, attributes } = clickhouse
-            .query(
-                r#"
-                SELECT Count, Attributes
-                FROM otel_metrics_exponential_histogram
-                WHERE ServiceName = ? AND StartTimeUnix >= ?
-                    AND ScopeName = 'grafbase'
-                    AND MetricName = 'request_latency'
-                "#,
-            )
-            .bind(&service_name)
-            .bind(start_time_unix)
-            .fetch_one()
-            .await
-            .unwrap();
-        assert_eq!(count, 1); // Initial polling also counts
-        insta::assert_json_snapshot!(attributes, @r###"
-        {
-          "http.response.status_code": "200"
-        }
-        "###);
-
-        gateway.gql::<serde_json::Value>("{ __typ__ename }").send().await;
         tokio::time::sleep(Duration::from_secs(2)).await;
 
-        let SumMetricCountRow { value, attributes } = clickhouse
-            .query(
-                r#"
-                SELECT Value, Attributes
-                FROM otel_metrics_sum
-                WHERE ServiceName = ? AND StartTimeUnix >= ?
-                    AND ScopeName = 'grafbase'
-                    AND MetricName = 'request_count'
-                    AND Attributes['gql.response.has_errors'] = 'true'
-                "#,
-            )
-            .bind(&service_name)
-            .bind(start_time_unix)
-            .fetch_one()
-            .await
-            .unwrap();
-        assert_eq!(value, 1.0);
-        insta::assert_json_snapshot!(attributes, @r###"
-        {
-          "gql.response.has_errors": "true",
-          "http.response.status_code": "200"
-        }
-        "###);
-    });
-}
-
-#[test]
-fn has_error() {
-    with_gateway(|service_name, start_time_unix, gateway, clickhouse| async move {
-        tokio::time::sleep(Duration::from_secs(2)).await;
-
-        gateway.gql::<serde_json::Value>("{ __typ__ename }").send().await;
-        tokio::time::sleep(Duration::from_secs(2)).await;
-
-        let SumMetricCountRow { value, attributes } = clickhouse
-            .query(
-                r#"
-                SELECT Value, Attributes
-                FROM otel_metrics_sum
-                WHERE ServiceName = ? AND StartTimeUnix >= ?
-                    AND ScopeName = 'grafbase'
-                    AND MetricName = 'request_count'
-                    AND Attributes['gql.response.has_errors'] = 'true'
-                "#,
-            )
-            .bind(&service_name)
-            .bind(start_time_unix)
-            .fetch_one()
-            .await
-            .unwrap();
-        assert!(value >= 1.0); // Initial polling also counts
-        insta::assert_json_snapshot!(attributes, @r###"
-        {
-          "gql.response.has_errors": "true",
-          "http.response.status_code": "200"
-        }
-        "###);
-        let ExponentialHistogramRow { count, attributes } = clickhouse
-            .query(
-                r#"
-                SELECT Count, Attributes
-                FROM otel_metrics_exponential_histogram
-                WHERE ServiceName = ? AND StartTimeUnix >= ?
-                    AND ScopeName = 'grafbase'
-                    AND MetricName = 'request_latency'
-                "#,
-            )
-            .bind(&service_name)
-            .bind(start_time_unix)
-            .fetch_one()
-            .await
-            .unwrap();
-        assert!(count >= 1); // Initial polling also counts
-        insta::assert_json_snapshot!(attributes, @r###"
-        {
-          "gql.response.has_errors": "true",
-          "http.response.status_code": "200"
-        }
-        "###);
-    });
-}
-
-#[test]
-fn client() {
-    with_gateway(|service_name, start_time_unix, gateway, clickhouse| async move {
-        gateway
-            .gql::<serde_json::Value>("{ __typename }")
-            .header("x-grafbase-client-name", "test")
-            .header("x-grafbase-client-version", "1.0.0")
-            .send()
-            .await;
-        tokio::time::sleep(Duration::from_secs(2)).await;
-
-        //
-        // Unknown client
-        //
-        let row = clickhouse
-            .query(
-                r#"
-                SELECT Value, Attributes
-                FROM otel_metrics_sum
-                WHERE ServiceName = ? AND StartTimeUnix >= ?
-                    AND ScopeName = 'grafbase'
-                    AND MetricName = 'request_count'
-                    AND Attributes['http.headers.x-grafbase-client-name'] = 'unknown'
-                "#,
-            )
-            .bind(&service_name)
-            .bind(start_time_unix)
-            .fetch_optional::<SumMetricCountRow>()
-            .await
-            .unwrap();
-        assert_eq!(row, None);
         let row = clickhouse
             .query(
                 r#"
@@ -176,86 +23,43 @@ fn client() {
                 WHERE ServiceName = ? AND StartTimeUnix >= ?
                     AND ScopeName = 'grafbase'
                     AND MetricName = 'request_latency'
-                    AND Attributes['http.headers.x-grafbase-client-name'] = 'unknown'
                 "#,
             )
             .bind(&service_name)
             .bind(start_time_unix)
-            .fetch_optional::<ExponentialHistogramRow>()
-            .await
-            .unwrap();
-        assert_eq!(row, None);
-
-        //
-        // Unknown version
-        //
-        let row = clickhouse
-            .query(
-                r#"
-                SELECT Value, Attributes
-                FROM otel_metrics_sum
-                WHERE ServiceName = ? AND StartTimeUnix >= ?
-                    AND ScopeName = 'grafbase'
-                    AND MetricName = 'request_count'
-                    AND Attributes['http.headers.x-grafbase-client-name'] = 'test'
-                    AND Attributes['http.headers.x-grafbase-client-version'] = 'unknown'
-                "#,
-            )
-            .bind(&service_name)
-            .bind(start_time_unix)
-            .fetch_optional::<SumMetricCountRow>()
-            .await
-            .unwrap();
-        assert_eq!(row, None);
-        let row = clickhouse
-            .query(
-                r#"
-                SELECT Count, Attributes
-                FROM otel_metrics_exponential_histogram
-                WHERE ServiceName = ? AND StartTimeUnix >= ?
-                    AND ScopeName = 'grafbase'
-                    AND MetricName = 'request_latency'
-                    AND Attributes['http.headers.x-grafbase-client-name'] = 'test'
-                    AND Attributes['http.headers.x-grafbase-client-version'] = 'unknown'
-                "#,
-            )
-            .bind(&service_name)
-            .bind(start_time_unix)
-            .fetch_optional::<ExponentialHistogramRow>()
-            .await
-            .unwrap();
-        assert_eq!(row, None);
-
-        //
-        // Known client & version
-        //
-        let row = clickhouse
-            .query(
-                r#"
-                SELECT Value, Attributes
-                FROM otel_metrics_sum
-                WHERE ServiceName = ? AND StartTimeUnix >= ?
-                    AND ScopeName = 'grafbase'
-                    AND MetricName = 'request_count'
-                    AND Attributes['http.headers.x-grafbase-client-name'] = 'test'
-                    AND Attributes['http.headers.x-grafbase-client-version'] = '1.0.0'
-                "#,
-            )
-            .bind(&service_name)
-            .bind(start_time_unix)
-            .fetch_one::<SumMetricCountRow>()
+            .fetch_one::<ExponentialHistogramRow>()
             .await
             .unwrap();
         insta::assert_json_snapshot!(row, @r###"
         {
-          "Value": 1.0,
-          "Attributes": {
-            "http.headers.x-grafbase-client-name": "test",
-            "http.headers.x-grafbase-client-version": "1.0.0",
-            "http.response.status_code": "200"
-          }
+          "Count": 1,
+          "Attributes": {}
         }
         "###);
+    });
+}
+
+#[test]
+fn request_error() {
+    with_gateway(|service_name, start_time_unix, gateway, clickhouse| async move {
+        let resp = gateway.gql::<serde_json::Value>(" __typ__ename }").send().await;
+        insta::assert_json_snapshot!(resp, @r###"
+        {
+          "errors": [
+            {
+              "message": " --> 1:2\n  |\n1 |  __typ__ename }\n  |  ^---\n  |\n  = expected executable_definition",
+              "locations": [
+                {
+                  "line": 1,
+                  "column": 2
+                }
+              ]
+            }
+          ]
+        }
+        "###);
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
         let row = clickhouse
             .query(
                 r#"
@@ -264,8 +68,6 @@ fn client() {
                 WHERE ServiceName = ? AND StartTimeUnix >= ?
                     AND ScopeName = 'grafbase'
                     AND MetricName = 'request_latency'
-                    AND Attributes['http.headers.x-grafbase-client-name'] = 'test'
-                    AND Attributes['http.headers.x-grafbase-client-version'] = '1.0.0'
                 "#,
             )
             .bind(&service_name)
@@ -277,9 +79,145 @@ fn client() {
         {
           "Count": 1,
           "Attributes": {
+            "gql.response.status": "REQUEST_ERROR"
+          }
+        }
+        "###);
+    });
+}
+
+#[test]
+fn field_error() {
+    with_gateway(|service_name, start_time_unix, gateway, clickhouse| async move {
+        let resp = gateway
+            .gql::<serde_json::Value>("{ __typename me { id } }")
+            .send()
+            .await;
+        insta::assert_json_snapshot!(resp, @r###"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "error sending request for url (http://127.0.0.1:46697/)",
+              "path": [
+                "me"
+              ]
+            }
+          ]
+        }
+        "###);
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let row = clickhouse
+            .query(
+                r#"
+                SELECT Count, Attributes
+                FROM otel_metrics_exponential_histogram
+                WHERE ServiceName = ? AND StartTimeUnix >= ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'request_latency'
+                "#,
+            )
+            .bind(&service_name)
+            .bind(start_time_unix)
+            .fetch_one::<ExponentialHistogramRow>()
+            .await
+            .unwrap();
+        insta::assert_json_snapshot!(row, @r###"
+        {
+          "Count": 1,
+          "Attributes": {
+            "gql.response.status": "FIELD_ERROR_NULL_DATA"
+          }
+        }
+        "###);
+    });
+}
+
+#[test]
+fn field_error_data_null() {
+    with_gateway(|service_name, start_time_unix, gateway, clickhouse| async move {
+        let resp = gateway.gql::<serde_json::Value>("{ me { id } }").send().await;
+        insta::assert_json_snapshot!(resp, @r###"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "error sending request for url (http://127.0.0.1:46697/)",
+              "path": [
+                "me"
+              ]
+            }
+          ]
+        }
+        "###);
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let row = clickhouse
+            .query(
+                r#"
+                SELECT Count, Attributes
+                FROM otel_metrics_exponential_histogram
+                WHERE ServiceName = ? AND StartTimeUnix >= ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'request_latency'
+                "#,
+            )
+            .bind(&service_name)
+            .bind(start_time_unix)
+            .fetch_one::<ExponentialHistogramRow>()
+            .await
+            .unwrap();
+        insta::assert_json_snapshot!(row, @r###"
+        {
+          "Count": 1,
+          "Attributes": {
+            "gql.response.status": "FIELD_ERROR_NULL_DATA"
+          }
+        }
+        "###);
+    });
+}
+
+#[test]
+fn client() {
+    with_gateway(|service_name, start_time_unix, gateway, clickhouse| async move {
+        let resp = gateway
+            .gql::<serde_json::Value>("{ __typename }")
+            .header("x-grafbase-client-name", "test")
+            .header("x-grafbase-client-version", "1.0.0")
+            .send()
+            .await;
+        insta::assert_json_snapshot!(resp, @r###"
+        {
+          "data": {
+            "__typename": "Query"
+          }
+        }
+        "###);
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let row = clickhouse
+            .query(
+                r#"
+                SELECT Count, Attributes
+                FROM otel_metrics_exponential_histogram
+                WHERE ServiceName = ? AND StartTimeUnix >= ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'request_latency'
+                "#,
+            )
+            .bind(&service_name)
+            .bind(start_time_unix)
+            .fetch_optional::<ExponentialHistogramRow>()
+            .await
+            .unwrap();
+        insta::assert_json_snapshot!(row, @r###"
+        {
+          "Count": 1,
+          "Attributes": {
             "http.headers.x-grafbase-client-name": "test",
-            "http.headers.x-grafbase-client-version": "1.0.0",
-            "http.response.status_code": "200"
+            "http.headers.x-grafbase-client-version": "1.0.0"
           }
         }
         "###);

--- a/gateway/crates/gateway-binary/tests/telemetry/metrics/request.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/metrics/request.rs
@@ -33,7 +33,10 @@ fn basic() {
         insta::assert_json_snapshot!(row, @r###"
         {
           "Count": 1,
-          "Attributes": {}
+          "Attributes": {
+            "gql.response.status": "SUCCESS",
+            "http.response.status_code": "200"
+          }
         }
         "###);
     });
@@ -79,7 +82,8 @@ fn request_error() {
         {
           "Count": 1,
           "Attributes": {
-            "gql.response.status": "REQUEST_ERROR"
+            "gql.response.status": "REQUEST_ERROR",
+            "http.response.status_code": "200"
           }
         }
         "###);
@@ -127,7 +131,8 @@ fn field_error() {
         {
           "Count": 1,
           "Attributes": {
-            "gql.response.status": "FIELD_ERROR_NULL_DATA"
+            "gql.response.status": "FIELD_ERROR_NULL_DATA",
+            "http.response.status_code": "200"
           }
         }
         "###);
@@ -172,7 +177,8 @@ fn field_error_data_null() {
         {
           "Count": 1,
           "Attributes": {
-            "gql.response.status": "FIELD_ERROR_NULL_DATA"
+            "gql.response.status": "FIELD_ERROR_NULL_DATA",
+            "http.response.status_code": "200"
           }
         }
         "###);
@@ -216,8 +222,10 @@ fn client() {
         {
           "Count": 1,
           "Attributes": {
+            "gql.response.status": "SUCCESS",
             "http.headers.x-grafbase-client-name": "test",
-            "http.headers.x-grafbase-client-version": "1.0.0"
+            "http.headers.x-grafbase-client-version": "1.0.0",
+            "http.response.status_code": "200"
           }
         }
         "###);


### PR DESCRIPTION
So this PR is pretty big because errors were not entirely well handled in engine-v2. 

The original goal was to handle correctly bad requests for operation metrics. Even if the operation was parsed correctly, we wouldn't generate any metrics if validation failed or an unknown field was used. So had to tweak stuff in both engines. This PR focuses on engine-v2.

While adding this feature I realized that we don't handle a few error cases, like execution failure propagating up to the root field ending up `null`. We would always return `{}` in those cases. So from there went down the rabbit hole of fixing various stuf...

v2 partitions the query into different plans, for each of those a response part is created which contains the data. So for errors, there are three cases:

- errors propagating within a response part, that was well handled
- errors that need to propagate across response parts, that worked more or less
- plan execution failure which results in an error for fields we were supposed to retrieve. That was poorly handled.

So this PR adds the latest and reworks some of the response part writing to simplify the actual plan code with fewer edge cases. Error paths from subgraphs are now also handled and only add an `upstream_path` error extension if they don't match anything on my side.

I also ended up tweaking a bit the subscription execution to not have an error special case and parallelize a bit more work.

And I'm also fixing operation metrics for bad requests. So now as long as we manage to parse an operation, we'll return operation metrics