### PR TITLE
feat: support unions in SDL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
 dependencies = [
  "concurrent-queue",
- "event-listener-strategy",
+ "event-listener-strategy 0.5.2",
  "futures-core",
  "pin-project-lite",
 ]
@@ -387,7 +387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
 dependencies = [
  "event-listener 4.0.3",
- "event-listener-strategy",
+ "event-listener-strategy 0.4.0",
  "pin-project-lite",
 ]
 
@@ -2338,12 +2338,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "event-listener-strategy"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
 dependencies = [
  "event-listener 4.0.3",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+dependencies = [
+ "event-listener 5.3.1",
  "pin-project-lite",
 ]
 

--- a/engine/crates/engine/registry-v1/src/types.rs
+++ b/engine/crates/engine/registry-v1/src/types.rs
@@ -207,6 +207,13 @@ impl UnionType {
             discriminators: None,
         }
     }
+
+    pub fn with_description(self, description: impl Into<Option<String>>) -> Self {
+        UnionType {
+            description: description.into(),
+            ..self
+        }
+    }
 }
 
 impl From<UnionType> for MetaType {

--- a/engine/crates/integration-tests/tests/execution/interfaces.rs
+++ b/engine/crates/integration-tests/tests/execution/interfaces.rs
@@ -1,0 +1,141 @@
+//! Tests of union types
+
+use integration_tests::{runtime, udfs::RustUdfs, Engine, EngineBuilder, ResponseExt};
+use runtime::udf::{CustomResolverRequestPayload, UdfResponse};
+use serde_json::{json, Value};
+
+const QUERY: &str = r#"
+query($name: String!) {
+    fetchAPet(name: $name) {
+        __typename
+        name
+        ... on Cat {
+            claws
+        }
+        ... on Dog {
+            friend
+        }
+    }
+}
+"#;
+
+#[test]
+fn interface_type_fetching_dog() {
+    runtime().block_on(async {
+        let engine = setup_engine().await;
+
+        insta::assert_json_snapshot!(
+            engine
+                .execute(QUERY)
+                .variables(json!({"name": "Fido"}))
+                .await
+                .into_data::<Value>(),
+                @r###"
+        {
+          "fetchAPet": {
+            "__typename": "Dog",
+            "name": "Fido",
+            "friend": "EVERYONE_IS_FRIEND"
+          }
+        }
+        "###
+        );
+    });
+}
+
+#[test]
+fn interface_type_fetching_cat() {
+    runtime().block_on(async {
+        let engine = setup_engine().await;
+
+        insta::assert_json_snapshot!(
+            engine
+                .execute(QUERY)
+                .variables(json!({"name": "Luna"}))
+                .await
+                .into_data::<Value>(),
+                @r###"
+        {
+          "fetchAPet": {
+            "__typename": "Cat",
+            "name": "Luna",
+            "claws": "VerySharp"
+          }
+        }
+        "###
+        );
+    });
+}
+
+#[test]
+fn interface_type_fetching_null() {
+    runtime().block_on(async {
+        let engine = setup_engine().await;
+
+        insta::assert_json_snapshot!(
+            engine
+                .execute(QUERY)
+                .variables(json!({"name": "Fuzz"}))
+                .await
+                .into_data::<Value>(),
+                @r###"
+        {
+          "fetchAPet": null
+        }
+        "###
+        );
+    });
+}
+
+async fn setup_engine() -> Engine {
+    let schema = r#"
+        extend type Query {
+            fetchAPet(name: String!): Pet @resolver(name: "fetchPet")
+        }
+
+        interface Pet {
+            name: String!
+        }
+
+        type Cat implements Pet {
+            name: String!
+            claws: Sharpness!
+        }
+
+        enum Sharpness {
+            VerySharp
+        }
+
+        type Dog implements Pet {
+            name: String!
+            friend: Friendliness
+        }
+
+        enum Friendliness {
+            EveryoneIsFriend
+        }
+    "#;
+
+    EngineBuilder::new(schema)
+        .with_custom_resolvers(
+            RustUdfs::new().resolver("fetchPet", |input: CustomResolverRequestPayload| {
+                Ok(UdfResponse::Success(if input.arguments["name"] == json!("Fido") {
+                    json!({
+                        "__typename": "Dog",
+                        "name": "Fido",
+                        "friend": "EVERYONE_IS_FRIEND"
+                    })
+                } else if input.arguments["name"] == json!("Luna") {
+                    json!({
+                        "__typename": "Cat",
+                        "name": "Luna",
+                        "claws": "VerySharp"
+                    })
+                } else {
+                    json!(null)
+                }))
+            }),
+        )
+        .build()
+        .await
+}

--- a/engine/crates/integration-tests/tests/execution/mod.rs
+++ b/engine/crates/integration-tests/tests/execution/mod.rs
@@ -8,6 +8,7 @@
 
 use std::net::SocketAddr;
 
+mod interfaces;
 mod joins;
 mod requires;
 mod unions;

--- a/engine/crates/integration-tests/tests/execution/mod.rs
+++ b/engine/crates/integration-tests/tests/execution/mod.rs
@@ -10,6 +10,7 @@ use std::net::SocketAddr;
 
 mod joins;
 mod requires;
+mod unions;
 
 use graphql_mocks::{FakeGithubSchema, MockGraphQlServer};
 use integration_tests::{runtime, udfs::RustUdfs, Engine, EngineBuilder, ResponseExt};

--- a/engine/crates/integration-tests/tests/execution/unions.rs
+++ b/engine/crates/integration-tests/tests/execution/unions.rs
@@ -1,0 +1,140 @@
+//! Tests of union types
+
+use integration_tests::{runtime, udfs::RustUdfs, Engine, EngineBuilder, ResponseExt};
+use runtime::udf::{CustomResolverRequestPayload, UdfResponse};
+use serde_json::{json, Value};
+
+const QUERY: &str = r#"
+query($name: String!) {
+    fetchAPet(name: $name) {
+        __typename
+        ... on Cat {
+            name
+            claws
+        }
+        ... on Dog {
+            name
+            friend
+        }
+    }
+}
+"#;
+
+#[test]
+fn union_type_fetching_dog() {
+    runtime().block_on(async {
+        let engine = setup_engine().await;
+
+        insta::assert_json_snapshot!(
+            engine
+                .execute(QUERY)
+                .variables(json!({"name": "Fido"}))
+                .await
+                .into_data::<Value>(),
+                @r###"
+        {
+          "fetchAPet": {
+            "__typename": "Dog",
+            "name": "Fido",
+            "friend": "EVERYONE_IS_FRIEND"
+          }
+        }
+        "###
+        );
+    });
+}
+
+#[test]
+fn union_type_fetching_cat() {
+    runtime().block_on(async {
+        let engine = setup_engine().await;
+
+        insta::assert_json_snapshot!(
+            engine
+                .execute(QUERY)
+                .variables(json!({"name": "Luna"}))
+                .await
+                .into_data::<Value>(),
+                @r###"
+        {
+          "fetchAPet": {
+            "__typename": "Cat",
+            "name": "Luna",
+            "claws": "VerySharp"
+          }
+        }
+        "###
+        );
+    });
+}
+
+#[test]
+fn union_type_fetching_null() {
+    runtime().block_on(async {
+        let engine = setup_engine().await;
+
+        insta::assert_json_snapshot!(
+            engine
+                .execute(QUERY)
+                .variables(json!({"name": "Fuzz"}))
+                .await
+                .into_data::<Value>(),
+                @r###"
+        {
+          "fetchAPet": null
+        }
+        "###
+        );
+    });
+}
+
+async fn setup_engine() -> Engine {
+    let schema = r#"
+        extend type Query {
+            fetchAPet(name: String!): Pet @resolver(name: "fetchPet")
+        }
+
+        union Pet = Cat | Dog
+
+        type Cat {
+            name: String!
+            claws: Sharpness!
+        }
+
+        enum Sharpness {
+            VerySharp
+        }
+
+        type Dog {
+            name: String!
+            friend: Friendliness
+        }
+
+        enum Friendliness {
+            EveryoneIsFriend
+        }
+    "#;
+
+    EngineBuilder::new(schema)
+        .with_custom_resolvers(
+            RustUdfs::new().resolver("fetchPet", |input: CustomResolverRequestPayload| {
+                Ok(UdfResponse::Success(if input.arguments["name"] == json!("Fido") {
+                    json!({
+                        "__typename": "Dog",
+                        "name": "Fido",
+                        "friend": "EVERYONE_IS_FRIEND"
+                    })
+                } else if input.arguments["name"] == json!("Luna") {
+                    json!({
+                        "__typename": "Cat",
+                        "name": "Luna",
+                        "claws": "VerySharp"
+                    })
+                } else {
+                    json!(null)
+                }))
+            }),
+        )
+        .build()
+        .await
+}

--- a/engine/crates/parser-sdl/src/lib.rs
+++ b/engine/crates/parser-sdl/src/lib.rs
@@ -52,6 +52,7 @@ use rules::{
     search_directive::SearchDirective,
     subgraph_directive::{SubgraphDirective, SubgraphDirectiveVisitor},
     trusted_documents_directive::{TrustedDocumentsDirective, TrustedDocumentsVisitor},
+    union::UnionType,
     unique_directive::UniqueDirective,
     unique_fields::UniqueObjectFields,
     visitor::{visit, RuleError, Visitor, VisitorContext},
@@ -380,7 +381,8 @@ fn parse_types<'a>(schema: &'a ServiceDocument, ctx: &mut VisitorContext<'a>) {
         .with(ExtendFieldVisitor)
         .with(SubgraphDirectiveVisitor)
         .with(AllSubgraphsDirectiveVisitor)
-        .with(IntrospectionDirectiveVisitor);
+        .with(IntrospectionDirectiveVisitor)
+        .with(UnionType);
 
     visit(&mut types_definitions_rules, ctx, schema);
 

--- a/engine/crates/parser-sdl/src/rules/mod.rs
+++ b/engine/crates/parser-sdl/src/rules/mod.rs
@@ -41,6 +41,7 @@ pub mod scalar_hydratation;
 pub mod search_directive;
 pub mod subgraph_directive;
 pub mod trusted_documents_directive;
+pub mod union;
 pub mod unique_directive;
 pub mod unique_fields;
 pub mod visitor;

--- a/engine/crates/parser-sdl/src/rules/union.rs
+++ b/engine/crates/parser-sdl/src/rules/union.rs
@@ -1,0 +1,37 @@
+//! Imports union types
+use engine::registry;
+use engine_parser::types::TypeKind;
+
+use super::visitor::{Visitor, VisitorContext};
+
+pub struct UnionType;
+
+impl<'a> Visitor<'a> for UnionType {
+    fn enter_type_definition(
+        &mut self,
+        ctx: &mut VisitorContext<'a>,
+        type_definition: &'a engine::Positioned<engine_parser::types::TypeDefinition>,
+    ) {
+        let TypeKind::Union(enum_ty) = &type_definition.node.kind else {
+            return;
+        };
+
+        let type_name = type_definition.node.name.node.to_string();
+
+        let members = enum_ty
+            .members
+            .iter()
+            .map(|value| value.node.to_string())
+            .collect::<Vec<_>>();
+
+        ctx.registry.get_mut().create_type(
+            |_| {
+                registry::UnionType::new(type_name.clone(), members)
+                    .with_description(type_definition.node.description.clone().map(|x| x.node))
+                    .into()
+            },
+            &type_name,
+            &type_name,
+        );
+    }
+}


### PR DESCRIPTION
For a while grafbase didn't support unions, because our execution was based around our old database feature and we hadn't built support for unions into that.  That changed when we added our OpenAPI & GraphQL connectors though - both of those connectors make use of union types, so execution needed to support union types.

However, we didn't come back and allow users to add unions into their schemas when doing this - they're only supported via one of the connectors.

A user on discord is trying to use unions now and is running into this limitation.

This PR updates parser-sdl to pull in unions, solving this problem.  It does not add support for them to the SDK for now - if we want that it'll need to be a separate PR.