### PR TITLE
nix: restore cli-app and cli derivations

### DIFF
--- a/cli/nix/cli.nix
+++ b/cli/nix/cli.nix
@@ -72,6 +72,7 @@ in
       "-C linker=clang -C link-arg=-fuse-ld=lld"
     ];
 
+    GRAFBASE_CLI_PATHFINDER_BUNDLE_PATH = config.packages.cli-app;
     GRAFBASE_CLI_WRAPPERS_PATH = config.packages.wrappers;
 
     doCheck = false;

--- a/cli/nix/wrappers.nix
+++ b/cli/nix/wrappers.nix
@@ -1,16 +1,16 @@
-{pkgs, ...}: {
+{ pkgs, ... }: {
   packages.wrappers = pkgs.buildNpmPackage {
     src = ../wrappers;
     name = "wrappers";
-    npmDepsHash = "sha256-jZ1BC1A2rKASBbRqku3MSRasACUuebi1ekLm/aCkcDI=";
+    npmDepsHash = "sha256-ywx1TXl8WJW4YOSHJHkC7XktwQKnNakCLtjyTff293Q=";
 
-    nativeBuildInputs = [pkgs.bun];
+    nativeBuildInputs = [ pkgs.bun ];
 
     installPhase = ''
       mkdir $out
-      cp dist.js bun-multi-wrapper.ts $out/
+      cp dist.js bun-multi-wrapper.ts parse-config.*ts $out/
     '';
 
-    npmFlags = ["--ignore-scripts"];
+    npmFlags = [ "--ignore-scripts" ];
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713459701,
-        "narHash": "sha256-LjQ11ASxnv/FXfb8QnrIyMkyqSqcBPX+lFK8gu0jSQE=",
+        "lastModified": 1718078026,
+        "narHash": "sha256-LbQabH6h86ZzTvDnaZHmMwedRZNB2jYtUQzmoqWQoJ8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "45ea0059fb325132fdc3c39faffb0941d25d08d3",
+        "rev": "a3f0c63eed74a516298932b9b1627dd80b9c3892",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "lastModified": 1717285511,
+        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713442664,
-        "narHash": "sha256-LoExypse3c/uun/39u4bPTN4wejIF7hNsdITZO41qTw=",
+        "lastModified": 1717893485,
+        "narHash": "sha256-WMU6ZRZrBgEUDIF0siu2aIyVAXcxfElSwzZtS/mSpN4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d764f230634fa4f86dc8d01c6af9619c7cc5d225",
+        "rev": "3bcedce9f4de37570242faf16e1e143583407eab",
         "type": "github"
       },
       "original": {
@@ -74,20 +74,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "dir": "lib",
-        "lastModified": 1711703276,
-        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
-        "type": "github"
+        "lastModified": 1717284937,
+        "narHash": "sha256-lIbdfCsf8LMFloheeE6N31+BMIeixqyQWbSr2vk79EQ=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
       },
       "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
       }
     },
     "root": {
@@ -109,11 +103,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713492869,
-        "narHash": "sha256-Zv+ZQq3X+EH6oogkXaJ8dGN8t1v26kPZgC5bki04GnM=",
+        "lastModified": 1718072316,
+        "narHash": "sha256-p33h73iQ1HkLalCplV5MH0oP3HXRaH3zufnFqb5//ps=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "1e9264d1214d3db00c795b41f75d55b5e153758e",
+        "rev": "bedc47af18fc41bb7d2edc2b212d59ca36253f59",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -126,7 +126,7 @@
           };
         };
 
-        imports = [./cli/nix/cli.nix];
+        imports = [./cli/nix/cli.nix  ./nix/cli-app.nix];
       };
     };
 }

--- a/nix/cli-app.nix
+++ b/nix/cli-app.nix
@@ -1,0 +1,37 @@
+{ pkgs, ... }:
+
+let
+  src = pkgs.nix-gitignore.gitignoreSourcePure [ ".gitignore" ] ../packages;
+  pname = "cli-app";
+  version = "1";
+
+  inherit (pkgs) jq nodejs pnpm_9 stdenv;
+in
+{
+  packages.cli-app = stdenv.mkDerivation {
+    inherit pname version src;
+
+    pnpmDeps = pnpm_9.fetchDeps {
+      inherit src pname version;
+      hash = "sha256-BGiSFr2Fm6610g6zPMo0Rw3c1MWE/zqxr2YEY9MEdbk=";
+    };
+
+    buildInputs = [ jq ];
+
+    nativeBuildInputs = [
+      nodejs
+      pnpm_9.configHook
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      jq ".packageManager = \"pnpm@${pnpm_9.version}\"" package.json > tmp.$$.json && mv tmp.$$.json package.json
+
+      pnpm run build-cli-app
+      cp -r ./cli-app/dist $out
+
+      runHook postBuild
+    '';
+  };
+}


### PR DESCRIPTION
Since https://github.com/grafbase/grafbase/commit/c896aa3a842119d476936bb8665b5a35792c9bfb, we haven't been able to
build the Grafbase CLI as a nix derivation, due to the breaking upgrade
to pnpm 9 and the lack of support for pnpm 9 in pnpm2nix. Fortunately,
https://github.com/NixOS/nixpkgs/pull/290715 was recently merging into
nixpkgs, so we can use pnpm_9.fetchDeps to re-instate the cli-app
derivation, and as a cascading effect build the cli derivation again.