### PR TITLE
postgres connector: implement "like" filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5639,6 +5639,7 @@ dependencies = [
  "Inflector",
  "common-types",
  "indexmap 2.2.6",
+ "indoc",
  "itertools 0.13.0",
  "parser-sdl",
  "postgres-connector-types",

--- a/engine/crates/engine/registry-v1/src/types.rs
+++ b/engine/crates/engine/registry-v1/src/types.rs
@@ -24,6 +24,14 @@ impl MetaType {
         }
     }
 
+    pub fn as_input_object_mut(&mut self) -> Option<&mut InputObjectType> {
+        if let MetaType::InputObject(object) = self {
+            Some(object)
+        } else {
+            None
+        }
+    }
+
     pub fn is_object(&self) -> bool {
         matches!(self, MetaType::Object(_))
     }

--- a/engine/crates/engine/src/registry/resolvers/postgres/context/filter/complex.rs
+++ b/engine/crates/engine/src/registry/resolvers/postgres/context/filter/complex.rs
@@ -162,6 +162,7 @@ fn generate_conditions(operations: Map<String, Value>, column: TableColumnWalker
 
                 continue;
             }
+            "like" => table_column.like(value),
             _ => todo!(),
         };
 

--- a/engine/crates/integration-tests/tests/postgres/introspection.rs
+++ b/engine/crates/integration-tests/tests/postgres/introspection.rs
@@ -1681,6 +1681,14 @@ fn table_with_serial_primary_key_string_unique() {
             The value is not in the given array of values
           """ nin: [String]
           not: StringSearchFilterInput
+          """
+            	The string matches the given pattern.
+
+            Example: "%ear%" would match strings containing the substring "ear".
+
+            See the reference at https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE
+
+          """ like: String
         }
 
         """
@@ -1929,6 +1937,14 @@ fn table_with_composite_primary_key() {
             The value is not in the given array of values
           """ nin: [String]
           not: StringSearchFilterInput
+          """
+            	The string matches the given pattern.
+
+            Example: "%ear%" would match strings containing the substring "ear".
+
+            See the reference at https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE
+
+          """ like: String
         }
 
         """
@@ -4044,6 +4060,14 @@ fn two_tables_with_single_column_foreign_key() {
             The value is not in the given array of values
           """ nin: [String]
           not: StringSearchFilterInput
+          """
+            	The string matches the given pattern.
+
+            Example: "%ear%" would match strings containing the substring "ear".
+
+            See the reference at https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE
+
+          """ like: String
         }
 
         """
@@ -4293,6 +4317,14 @@ fn foreign_key_to_a_table_without_a_key_should_not_create_a_relation() {
             The value is not in the given array of values
           """ nin: [String]
           not: PgStringSearchFilterInput
+          """
+            	The string matches the given pattern.
+
+            Example: "%ear%" would match strings containing the substring "ear".
+
+            See the reference at https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE
+
+          """ like: String
         }
 
         """

--- a/engine/crates/parser-postgres/Cargo.toml
+++ b/engine/crates/parser-postgres/Cargo.toml
@@ -19,6 +19,7 @@ serde_json.workspace = true
 serde.workspace = true
 registry-v1.workspace = true
 registry-v2.workspace = true
+indoc = "2"
 Inflector = "0.11.4"
 itertools.workspace = true
 common-types.workspace = true

--- a/engine/crates/parser-postgres/src/registry/context/output.rs
+++ b/engine/crates/parser-postgres/src/registry/context/output.rs
@@ -131,6 +131,19 @@ impl OutputContext {
         self.registry.create_type(|_| input_object.into(), &name, &name);
     }
 
+    pub(crate) fn mutate_input_type(&mut self, name: &str, f: impl FnOnce(&mut InputObjectType)) {
+        let Some(input_type) = self
+            .registry
+            .types
+            .get_mut(name)
+            .and_then(|ty| ty.as_input_object_mut())
+        else {
+            unreachable!("expected {name} to exist");
+        };
+
+        f(input_type)
+    }
+
     pub fn with_enum<F>(&mut self, name: &str, enum_id: EnumId, f: F)
     where
         F: FnOnce(&mut EnumBuilder),

--- a/engine/crates/parser-postgres/src/registry/types/scalar.rs
+++ b/engine/crates/parser-postgres/src/registry/types/scalar.rs
@@ -90,6 +90,26 @@ pub(super) fn register(input_ctx: &InputContext<'_>, output_ctx: &mut OutputCont
         create_scalar_update_type(input_ctx, TypeKind::Scalar(scalar), output_ctx);
         create_array_update_type(input_ctx, TypeKind::Scalar(scalar), output_ctx);
     }
+
+    register_string_filters(input_ctx, output_ctx);
+}
+
+fn register_string_filters(input_ctx: &InputContext<'_>, output_ctx: &mut OutputContext) {
+    const LIKE: &str = "like";
+
+    let string_filter_type_name = input_ctx.filter_type_name("String");
+
+    output_ctx.mutate_input_type(&string_filter_type_name, |ty| {
+        let mut input_value = MetaInputValue::new(LIKE, "String".to_owned());
+        input_value.description = Some(indoc::formatdoc! {r#"
+            The string matches the given pattern.
+
+            Example: "%ear%" would match strings containing the substring "ear".
+
+            See the reference at https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE
+        "#});
+        ty.input_fields.insert(LIKE.to_owned(), input_value);
+    });
 }
 
 pub(super) fn create_array_update_type(


### PR DESCRIPTION
It produces a `LIKE` clause (https://www.postgresql.org/docs/current/functions-matching.html).

The feature request was for a `contains` filter, but:

1. The `contains` name is already used for the array membership filter
2. "like" better matches database terminology
3. LIKE is more powerful. It can also serve as `startsWith`, `endsWith`, ...

closes GB-6869