### PR TITLE
grafbase start: use a postgres connection pool instead of a single connection

### DIFF
--- a/cli/crates/gateway/Cargo.toml
+++ b/cli/crates/gateway/Cargo.toml
@@ -34,7 +34,7 @@ runtime = { path = "../../../engine/crates/runtime" }
 runtime-noop = { path = "../../../engine/crates/runtime-noop" }
 runtime-local = { path = "../../../engine/crates/runtime-local" }
 common-types = { path = "../../../engine/crates/common-types" }
-postgres-connector-types = { path = "../../../engine/crates/postgres-connector-types" }
+postgres-connector-types = { path = "../../../engine/crates/postgres-connector-types", features = ["pooling"] }
 gateway-v2-auth.workspace = true
 
 [features]

--- a/engine/crates/integration-tests/src/engine_v1/builder.rs
+++ b/engine/crates/integration-tests/src/engine_v1/builder.rs
@@ -116,10 +116,11 @@ impl EngineBuilder {
         let registry = registry_upgrade::convert_v1_to_v2(registry).unwrap();
 
         let postgres = {
-            let mut transports = HashMap::new();
+            let mut transports: HashMap<String, Arc<dyn postgres_connector_types::transport::Transport>> =
+                HashMap::new();
             for (name, definition) in &registry.postgres_databases {
                 let transport = DirectTcpTransport::new(definition.connection_string()).await.unwrap();
-                transports.insert(name.to_string(), transport);
+                transports.insert(name.to_string(), Arc::new(transport));
             }
             runtime::pg::PgTransportFactory::new(Box::new(runtime_local::LocalPgTransportFactory::new(transports)))
         };

--- a/engine/crates/postgres-connector-types/src/transport/tcp/pooled.rs
+++ b/engine/crates/postgres-connector-types/src/transport/tcp/pooled.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use deadpool_postgres::{Object, Pool, Runtime, Timeouts};
 use futures::stream::BoxStream;
+use futures::StreamExt as _;
 use serde_json::Value;
 use tokio_postgres::GenericClient;
 
@@ -11,8 +12,9 @@ use crate::transport::ext::TransportTransactionExt;
 use crate::transport::tcp::executor;
 use crate::transport::{Transport, TransportTransaction};
 
+#[derive(Default)]
 pub struct PoolingConfig {
-    pub max_size: usize,
+    pub max_size: Option<usize>,
     pub wait_timeout: Option<Duration>,
     pub create_timeout: Option<Duration>,
     pub recycle_timeout: Option<Duration>,
@@ -38,16 +40,17 @@ impl PooledTcpTransport {
         let mut config = deadpool_postgres::Config::new();
         config.url = Some(connection_string.to_string());
 
-        let pool = config
-            .builder(tls)?
-            .runtime(Runtime::Tokio1)
-            .max_size(pool_config.max_size)
-            .timeouts(Timeouts {
-                wait: pool_config.wait_timeout,
-                create: pool_config.create_timeout,
-                recycle: pool_config.recycle_timeout,
-            })
-            .build()?;
+        let mut pool_builder = config.builder(tls)?.runtime(Runtime::Tokio1).timeouts(Timeouts {
+            wait: pool_config.wait_timeout,
+            create: pool_config.create_timeout,
+            recycle: pool_config.recycle_timeout,
+        });
+
+        if let Some(max_size) = pool_config.max_size {
+            pool_builder = pool_builder.max_size(max_size);
+        }
+
+        let pool = pool_builder.build()?;
 
         Ok(Self {
             connection_string: connection_string.to_string(),
@@ -61,6 +64,33 @@ impl PooledTcpTransport {
             connection,
             connection_string: self.connection_string.clone(),
         })
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl Transport for PooledTcpTransport {
+    async fn close(self) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn parameterized_execute(&self, query: &str, params: Vec<Value>) -> crate::Result<i64> {
+        self.connection().await?.parameterized_execute(query, params).await
+    }
+
+    fn parameterized_query<'a>(&'a self, query: &'a str, params: Vec<Value>) -> BoxStream<'a, Result<Value, Error>> {
+        Box::pin(async_stream::try_stream! {
+            let connection = self.connection().await?;
+            let mut stream = connection.parameterized_query(query, params);
+
+            while let Some(Ok(row)) = stream.next().await {
+                yield row;
+            }
+        })
+    }
+
+    fn connection_string(&self) -> &str {
+        &self.connection_string
     }
 }
 

--- a/engine/crates/runtime-local/src/pg.rs
+++ b/engine/crates/runtime-local/src/pg.rs
@@ -1,22 +1,17 @@
 use std::{collections::HashMap, sync::Arc};
 
-use postgres_connector_types::transport::{DirectTcpTransport, Transport};
+use postgres_connector_types::transport::Transport;
 use runtime::pg::{PgTransportFactoryError, PgTransportFactoryInner, PgTransportFactoryResult};
 
 #[derive(Clone)]
 pub struct LocalPgTransportFactory {
-    transports: Arc<HashMap<String, Arc<DirectTcpTransport>>>,
+    transports: Arc<HashMap<String, Arc<dyn Transport>>>,
 }
 
 impl LocalPgTransportFactory {
-    pub fn new(transports: HashMap<String, DirectTcpTransport>) -> Self {
+    pub fn new(transports: HashMap<String, Arc<dyn Transport>>) -> Self {
         LocalPgTransportFactory {
-            transports: Arc::new(
-                transports
-                    .into_iter()
-                    .map(|(name, transport)| (name, Arc::new(transport)))
-                    .collect(),
-            ),
+            transports: Arc::new(transports),
         }
     }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -97,6 +97,8 @@
 
         shellHook = ''
           project_root="$(git rev-parse --show-toplevel 2>/dev/null || jj workspace root 2>/dev/null)"
+          export POSTGRES_URL=postgresql://postgres:grafbase@localhost:5432
+          export PGBOUNCER_URL=postgresql://postgres:grafbase@localhost:6432
           export CARGO_INSTALL_ROOT="$project_root/cli/.cargo";
           export PATH="$CARGO_INSTALL_ROOT/bin:$project_root/node_modules/.bin:$PATH";
           if [[ "${system}" == "aarch64-darwin" ]]; then


### PR DESCRIPTION
This is a problem as soon as concurrent requests are involved.

We defer the size of the pool to the pooling library (deadpool). It defaults to  cpu_count * 4 ([source](https://docs.rs/deadpool/latest/deadpool/managed/struct.PoolConfig.html#structfield.max_size)).

closes GB-6874