### PR TITLE
cli: release 0.75.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "engine-config-builder"
-version = "0.74.3"
+version = "0.75.0"
 dependencies = [
  "engine-v2-config",
  "graphql-federated-graph",
@@ -2509,7 +2509,7 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "federated-dev"
-version = "0.74.3"
+version = "0.75.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2868,7 +2868,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "0.74.3"
+version = "0.75.0"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.74.3"
+version = "0.75.0"
 dependencies = [
  "assert_matches",
  "async-graphql",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-graphql-introspection"
-version = "0.74.3"
+version = "0.75.0"
 dependencies = [
  "cynic",
  "cynic-introspection",
@@ -3198,7 +3198,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.74.3"
+version = "0.75.0"
 dependencies = [
  "async-compression",
  "axum 0.7.5",
@@ -3228,7 +3228,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.74.3"
+version = "0.75.0"
 dependencies = [
  "chrono",
  "common-types",
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.74.3"
+version = "0.75.0"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "graph-ref"
-version = "0.74.3"
+version = "0.75.0"
 
 [[package]]
 name = "graphql-composition"
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-cursor"
-version = "0.74.3"
+version = "0.75.0"
 dependencies = [
  "serde",
  "serde_with",
@@ -5508,7 +5508,7 @@ dependencies = [
 
 [[package]]
 name = "operation-checks"
-version = "0.74.3"
+version = "0.75.0"
 dependencies = [
  "async-graphql-parser",
  "async-graphql-value",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "operation-normalizer"
-version = "0.74.3"
+version = "0.75.0"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -5788,7 +5788,7 @@ dependencies = [
 
 [[package]]
 name = "partial-caching"
-version = "0.74.3"
+version = "0.75.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -8581,7 +8581,7 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typed-resolvers"
-version = "0.74.3"
+version = "0.75.0"
 dependencies = [
  "datatest-stable",
  "engine-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ tracing-core = { git = "https://github.com/tokio-rs/tracing", branch = "v0.1.x" 
 tonic = { git = "https://github.com/grafbase/tonic", rev = "58de44e200af96defc4038701df9f18a177bc4c6" } # tokio-rustls-ring
 
 [workspace.package]
-version = "0.74.3"
+version = "0.75.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://grafbase.com"

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.75.0] - 2024-06-13
+
+[CHANGELOG](changelog/0.75.0.md)
+
 ## [0.74.3] - 2024-06-11
 
 [CHANGELOG](changelog/0.74.3.md)

--- a/cli/changelog/0.75.0.md
+++ b/cli/changelog/0.75.0.md
@@ -1,0 +1,7 @@
+# Features
+
+- You can now filter on text columns with the LIKE operator on the postgres connector (https://www.postgresql.org/docs/current/functions-matching.html). #1764
+- The postgres connector now uses a connection pool instead of a single connection in `grafbase start`. #1771
+- The postgres connector now supports multiple relations between two tables. See the pull request (https://github.com/grafbase/grafbase/pull/1770) for an example.
+- Fixed a bug with enum values sent to subgraphs in `grafbase dev` for federated graphs. #1766
+- Expand the scope of files watched for changes in `grafbase dev`. #1774

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -36,8 +36,8 @@ ulid = "1.1.2"
 url = "2.5.0"
 urlencoding = "2.1.3"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.74.3" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.74.3" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.75.0" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.75.0" }
 
 [build-dependencies]
 cynic-codegen = { version = "3.7.0", features = ["rkyv"] }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -52,13 +52,13 @@ url = "2.5.0"
 uuid = { version = "1.8.0", features = ["v4"] }
 webbrowser = "1.0"
 
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.74.3" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.74.3" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.75.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.75.0" }
 federated-dev = { path = "../federated-dev" }
 grafbase-graphql-introspection.workspace = true
 graphql-lint.workspace = true
 graph-ref = { path = "../../../graph-ref" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.74.3" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.75.0" }
 prettytable = { version = "0.10.0", default-features = false, features = ["win_crlf"] }
 
 [dev-dependencies]

--- a/cli/crates/federated-dev/Cargo.toml
+++ b/cli/crates/federated-dev/Cargo.toml
@@ -33,7 +33,7 @@ tokio-stream = { version = "0.1.15", features = ["sync"] }
 tower-http = { workspace = true, features = ["cors", "fs", "trace"] }
 url = "2.5.0"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.74.3" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.75.0" }
 engine = { path = "../../../engine/crates/engine" }
 engine-config-builder = { path = "../../../engine/crates/engine-config-builder" }
 engine-v2.workspace = true

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -62,7 +62,7 @@ tracing = "0.1.40"
 which.workspace = true
 zip = "2.0.0"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.74.3" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.75.0" }
 gateway = { path = "../gateway" }
 typed-resolvers = { path = "../typed-resolvers" }
 federated-dev = { path = "../federated-dev" }

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.74.3",
+  "version": "0.75.0",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.74.3",
+  "version": "0.75.0",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.74.3",
+  "version": "0.75.0",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.74.3",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.74.3",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.74.3",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.74.3",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.74.3"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.75.0",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.75.0",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.75.0",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.75.0",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.75.0"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.74.3",
+  "version": "0.75.0",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.74.3",
+  "version": "0.75.0",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.74.3",
+  "version": "0.75.0",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
Features

- You can now filter on text columns with the LIKE operator on the postgres connector (https://www.postgresql.org/docs/current/functions-matching.html). #1764
- The postgres connector now uses a connection pool instead of a single connection in `grafbase start`. #1771
- The postgres connector now supports multiple relations between two tables. See the pull request (https://github.com/grafbase/grafbase/pull/1770) for an example.
- Fixed a bug with enum values sent to subgraphs in `grafbase dev` for federated graphs. #1766
- Expand the scope of files watched for changes in `grafbase dev`. #1774
