### PR TITLE
chore: reorg some partial caching stuff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,7 +1560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c0ec86f960a00ce087e96ff6f073f6ff28b6876d69ce8caa06c03fb4143981c"
 dependencies = [
  "counter",
- "cynic-parser 0.4.4",
+ "cynic-parser 0.4.5",
  "darling",
  "once_cell",
  "ouroboros",
@@ -1597,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "cynic-parser"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788995c98ccd25dca93902ea8742b6fcff4cb867d08b2ae475b163916c7cb3a4"
+checksum = "718f6cd8c54ae5249fd42b0c86639df0100b8a86eea2e5f1b915cde2e1481453"
 dependencies = [
  "ariadne",
  "indexmap 2.2.6",
@@ -2896,7 +2896,7 @@ dependencies = [
  "blake3",
  "bytes",
  "common-types",
- "cynic-parser 0.4.4",
+ "cynic-parser 0.4.5",
  "engine",
  "engine-parser",
  "engine-validation",
@@ -3197,7 +3197,7 @@ version = "0.75.0"
 dependencies = [
  "cynic",
  "cynic-introspection",
- "cynic-parser 0.4.4",
+ "cynic-parser 0.4.5",
  "indoc",
  "reqwest",
  "serde",
@@ -3263,7 +3263,7 @@ dependencies = [
  "common-types",
  "const_format",
  "criterion",
- "cynic-parser 0.4.4",
+ "cynic-parser 0.4.5",
  "dotenv",
  "engine",
  "federated-dev",
@@ -3419,7 +3419,7 @@ name = "graphql-lint"
 version = "0.1.3"
 dependencies = [
  "criterion",
- "cynic-parser 0.4.4",
+ "cynic-parser 0.4.5",
  "heck 0.5.0",
  "thiserror",
 ]
@@ -3472,7 +3472,7 @@ dependencies = [
 name = "graphql-schema-diff"
 version = "0.1.1"
 dependencies = [
- "cynic-parser 0.4.4",
+ "cynic-parser 0.4.5",
  "datatest-stable",
  "miette 7.2.0",
  "serde",
@@ -5933,7 +5933,7 @@ dependencies = [
  "anyhow",
  "blake3",
  "common-types",
- "cynic-parser 0.4.4",
+ "cynic-parser 0.4.5",
  "engine-value",
  "graph-entities",
  "headers",
@@ -6799,7 +6799,7 @@ name = "registry-v2-generator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cynic-parser 0.4.4",
+ "cynic-parser 0.4.5",
  "indexmap 2.2.6",
  "indoc",
  "itertools 0.13.0",

--- a/engine/crates/partial-caching/src/fetching/keys.rs
+++ b/engine/crates/partial-caching/src/fetching/keys.rs
@@ -2,8 +2,9 @@ use common_types::auth::ExecutionAuth;
 use engine_value::{ConstValue, Variables};
 use registry_for_cache::{CacheAccessScope, CacheControl};
 
-use super::CachingPlan;
 use crate::query_subset::QuerySubsetDisplay;
+
+use super::CachingPlan;
 
 pub fn build_cache_keys(
     plan: &CachingPlan,

--- a/engine/crates/partial-caching/src/lib.rs
+++ b/engine/crates/partial-caching/src/lib.rs
@@ -53,8 +53,6 @@ pub enum FetchPhaseResult {
     PartialHit(ExecutionPhase),
 
     /// We fetched all the results from the cache, so can just return a response
-    ///
-    /// Note that I've not implemented this bit yet - it'll come later.
     CompleteHit(hit::CompleteHit),
 }
 

--- a/engine/crates/partial-caching/src/query_subset/display.rs
+++ b/engine/crates/partial-caching/src/query_subset/display.rs
@@ -1,113 +1,17 @@
 use std::fmt;
 
 use cynic_parser::{
-    executable::{
-        ids::{FragmentDefinitionId, OperationDefinitionId, SelectionId, VariableDefinitionId},
-        iter::{IdIter, Iter},
-        Selection, VariableDefinition,
-    },
+    executable::{ids::SelectionId, iter::Iter, Selection},
     ExecutableDocument,
 };
 use indexmap::IndexSet;
 
-/// Part of a query that was submitted to the API.
-///
-/// This is a group of fields with the same cache settings, and all the
-/// ancestors, variables & fragments required for those fields to make a
-/// valid query
-pub struct QuerySubset {
-    pub(crate) operation: OperationDefinitionId,
-    partition: Partition,
-    variables: IndexSet<VariableDefinitionId>,
-}
-
-#[derive(Default, Debug)]
-pub(crate) struct Partition {
-    pub selections: IndexSet<SelectionId>,
-    pub fragments: IndexSet<FragmentDefinitionId>,
-}
-
-impl QuerySubset {
-    pub(crate) fn new(
-        operation: OperationDefinitionId,
-        cache_group: Partition,
-        variables: IndexSet<VariableDefinitionId>,
-    ) -> Self {
-        QuerySubset {
-            operation,
-            partition: cache_group,
-            variables,
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.partition.selections.is_empty()
-    }
-
-    pub fn extend(&mut self, other: &QuerySubset) {
-        self.partition
-            .selections
-            .extend(other.partition.selections.iter().copied());
-        self.partition
-            .fragments
-            .extend(other.partition.fragments.iter().copied());
-        self.variables.extend(other.variables.iter().cloned());
-    }
-
-    pub fn as_display<'a>(&'a self, document: &'a ExecutableDocument) -> QuerySubsetDisplay<'a> {
-        QuerySubsetDisplay {
-            subset: self,
-            document,
-            include_query_name: false,
-        }
-    }
-
-    pub fn variables<'a>(
-        &'a self,
-        document: &'a ExecutableDocument,
-    ) -> impl Iterator<Item = VariableDefinition<'a>> + 'a {
-        self.variables.iter().map(|id| document.read(*id))
-    }
-
-    fn selection_set_display<'a>(&'a self, selections: Iter<'a, Selection<'a>>) -> SelectionSetDisplay<'a> {
-        SelectionSetDisplay {
-            visible_selections: &self.partition.selections,
-            selections: self.selection_iter(selections),
-            indent_level: 0,
-        }
-    }
-
-    pub(crate) fn selection_iter<'a>(&'a self, selection_set: Iter<'a, Selection<'a>>) -> FilteredSelections<'a> {
-        FilteredSelections {
-            visible_ids: &self.partition.selections,
-            selections: selection_set.with_ids(),
-        }
-    }
-}
-
-#[derive(Clone, Copy)]
-pub(crate) struct FilteredSelections<'a> {
-    visible_ids: &'a IndexSet<SelectionId>,
-    selections: IdIter<'a, Selection<'a>>,
-}
-
-impl<'a> Iterator for FilteredSelections<'a> {
-    type Item = Selection<'a>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        for (id, selection) in self.selections.by_ref() {
-            if self.visible_ids.contains(&id) {
-                return Some(selection);
-            }
-        }
-        None
-    }
-}
+use super::{FilteredSelectionSet, QuerySubset};
 
 pub struct QuerySubsetDisplay<'a> {
-    subset: &'a QuerySubset,
-    document: &'a ExecutableDocument,
-    include_query_name: bool,
+    pub(super) subset: &'a QuerySubset,
+    pub(super) document: &'a ExecutableDocument,
+    pub(super) include_query_name: bool,
 }
 
 impl QuerySubsetDisplay<'_> {
@@ -119,10 +23,10 @@ impl QuerySubsetDisplay<'_> {
     }
 }
 
-struct SelectionSetDisplay<'a> {
-    selections: FilteredSelections<'a>,
-    visible_selections: &'a IndexSet<SelectionId>,
-    indent_level: usize,
+pub(super) struct SelectionSetDisplay<'a> {
+    pub(super) selections: FilteredSelectionSet<'a, 'a>,
+    pub(super) visible_selections: &'a IndexSet<SelectionId>,
+    pub(super) indent_level: usize,
 }
 
 struct SelectionDisplay<'a> {
@@ -135,7 +39,7 @@ impl<'a> SelectionDisplay<'a> {
     fn wrap_set(&self, selections: Iter<'a, Selection<'a>>) -> SelectionSetDisplay<'a> {
         SelectionSetDisplay {
             visible_selections: self.visible_selections,
-            selections: FilteredSelections {
+            selections: FilteredSelectionSet {
                 visible_ids: self.visible_selections,
                 selections: selections.with_ids(),
             },

--- a/engine/crates/partial-caching/src/query_subset/field_iter.rs
+++ b/engine/crates/partial-caching/src/query_subset/field_iter.rs
@@ -1,0 +1,49 @@
+use cynic_parser::executable::{FieldSelection, Selection};
+
+use crate::{query_subset::FilteredSelectionSet, QuerySubset};
+
+/// An iterator over the fields of a selection set.
+///
+/// This will recurse into any selection sets nested inside fragments.
+pub struct FieldIter<'a> {
+    iter_stack: Vec<FilteredSelectionSet<'a, 'a>>,
+    subset: &'a QuerySubset,
+}
+
+impl<'a> FieldIter<'a> {
+    pub fn new(selection_set: FilteredSelectionSet<'a, 'a>, subset: &'a QuerySubset) -> Self {
+        FieldIter {
+            iter_stack: vec![selection_set],
+            subset,
+        }
+    }
+}
+
+impl<'a> Iterator for FieldIter<'a> {
+    type Item = FieldSelection<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(current_iter) = self.iter_stack.last_mut() {
+            let Some(selection) = current_iter.next() else {
+                self.iter_stack.pop();
+                continue;
+            };
+
+            match selection {
+                Selection::Field(field) => return Some(field),
+                Selection::InlineFragment(fragment) => {
+                    self.iter_stack
+                        .push(self.subset.selection_iter(fragment.selection_set()));
+                }
+                Selection::FragmentSpread(spread) => {
+                    let Some(fragment) = spread.fragment() else { continue };
+
+                    self.iter_stack
+                        .push(self.subset.selection_iter(fragment.selection_set()));
+                }
+            }
+        }
+
+        None
+    }
+}

--- a/engine/crates/partial-caching/src/query_subset/mod.rs
+++ b/engine/crates/partial-caching/src/query_subset/mod.rs
@@ -1,0 +1,112 @@
+use cynic_parser::{
+    executable::{
+        ids::{FragmentDefinitionId, OperationDefinitionId, SelectionId, VariableDefinitionId},
+        iter::{IdIter, Iter},
+        Selection, VariableDefinition,
+    },
+    ExecutableDocument,
+};
+use display::SelectionSetDisplay;
+use indexmap::IndexSet;
+
+mod display;
+mod field_iter;
+
+pub use self::{display::QuerySubsetDisplay, field_iter::FieldIter};
+
+/// Part of a query that was submitted to the API.
+///
+/// This is a group of fields with the same cache settings, and all the
+/// ancestors, variables & fragments required for those fields to make a
+/// valid query
+pub struct QuerySubset {
+    pub(crate) operation: OperationDefinitionId,
+    partition: Partition,
+    variables: IndexSet<VariableDefinitionId>,
+}
+
+#[derive(Default, Debug)]
+pub(crate) struct Partition {
+    pub selections: IndexSet<SelectionId>,
+    pub fragments: IndexSet<FragmentDefinitionId>,
+}
+
+impl QuerySubset {
+    pub(crate) fn new(
+        operation: OperationDefinitionId,
+        cache_group: Partition,
+        variables: IndexSet<VariableDefinitionId>,
+    ) -> Self {
+        QuerySubset {
+            operation,
+            partition: cache_group,
+            variables,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.partition.selections.is_empty()
+    }
+
+    pub fn extend(&mut self, other: &QuerySubset) {
+        self.partition
+            .selections
+            .extend(other.partition.selections.iter().copied());
+        self.partition
+            .fragments
+            .extend(other.partition.fragments.iter().copied());
+        self.variables.extend(other.variables.iter().cloned());
+    }
+
+    pub fn as_display<'a>(&'a self, document: &'a ExecutableDocument) -> QuerySubsetDisplay<'a> {
+        QuerySubsetDisplay {
+            subset: self,
+            document,
+            include_query_name: false,
+        }
+    }
+
+    pub fn variables<'a>(
+        &'a self,
+        document: &'a ExecutableDocument,
+    ) -> impl Iterator<Item = VariableDefinition<'a>> + 'a {
+        self.variables.iter().map(|id| document.read(*id))
+    }
+
+    fn selection_set_display<'a>(&'a self, selections: Iter<'a, Selection<'a>>) -> SelectionSetDisplay<'a> {
+        SelectionSetDisplay {
+            visible_selections: &self.partition.selections,
+            selections: self.selection_iter(selections),
+            indent_level: 0,
+        }
+    }
+
+    pub(crate) fn selection_iter<'doc, 'subset>(
+        &'subset self,
+        selection_set: Iter<'doc, Selection<'doc>>,
+    ) -> FilteredSelectionSet<'doc, 'subset> {
+        FilteredSelectionSet {
+            visible_ids: &self.partition.selections,
+            selections: selection_set.with_ids(),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct FilteredSelectionSet<'doc, 'subset> {
+    visible_ids: &'subset IndexSet<SelectionId>,
+    selections: IdIter<'doc, Selection<'doc>>,
+}
+
+impl<'doc, 'subset> Iterator for FilteredSelectionSet<'doc, 'subset> {
+    type Item = Selection<'doc>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        for (id, selection) in self.selections.by_ref() {
+            if self.visible_ids.contains(&id) {
+                return Some(selection);
+            }
+        }
+        None
+    }
+}

--- a/engine/crates/partial-caching/src/updating/ser.rs
+++ b/engine/crates/partial-caching/src/updating/ser.rs
@@ -1,15 +1,11 @@
-use cynic_parser::{
-    executable::{iter::Iter, FieldSelection, Selection},
-    ExecutableDocument,
-};
+use cynic_parser::executable::{iter::Iter, FieldSelection, Selection};
 use graph_entities::{QueryResponse, QueryResponseNode, ResponseContainer};
 use serde::ser::{Error, SerializeMap};
 
-use crate::{query_subset::FilteredSelections, QuerySubset};
+use crate::{query_subset::FieldIter, QuerySubset};
 
 #[derive(Clone, Copy)]
 struct SerializeContext<'a> {
-    document: &'a ExecutableDocument,
     subset: &'a QuerySubset,
     response: &'a QueryResponse,
 }
@@ -20,7 +16,6 @@ impl serde::Serialize for super::CacheUpdate<'_> {
         S: serde::Serializer,
     {
         let ctx = SerializeContext {
-            document: self.document,
             subset: self.subset,
             response: self.response,
         };
@@ -124,46 +119,6 @@ impl FieldExt for FieldSelection<'_> {
 
 impl<'a> ObjectSerializer<'a> {
     pub fn field_iter(&self) -> FieldIter<'a> {
-        FieldIter {
-            iter_stack: vec![self.ctx.subset.selection_iter(self.selection_set)],
-            subset: self.ctx.subset,
-        }
-    }
-}
-
-/// An iterator over the fields of a selection set.
-///
-/// This will recurse into any selection sets nested inside fragments.
-struct FieldIter<'a> {
-    iter_stack: Vec<FilteredSelections<'a>>,
-    subset: &'a QuerySubset,
-}
-
-impl<'a> Iterator for FieldIter<'a> {
-    type Item = FieldSelection<'a>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        while let Some(current_iter) = self.iter_stack.last_mut() {
-            let Some(selection) = current_iter.next() else {
-                self.iter_stack.pop();
-                continue;
-            };
-
-            match selection {
-                Selection::Field(field) => return Some(field),
-                Selection::InlineFragment(fragment) => {
-                    self.iter_stack
-                        .push(self.subset.selection_iter(fragment.selection_set()));
-                }
-                Selection::FragmentSpread(spread) => {
-                    let Some(fragment) = spread.fragment() else { continue };
-
-                    self.iter_stack
-                        .push(self.subset.selection_iter(fragment.selection_set()));
-                }
-            }
-        }
-
-        None
+        FieldIter::new(self.ctx.subset.selection_iter(self.selection_set), self.ctx.subset)
     }
 }

--- a/engine/crates/partial-caching/src/updating/ser.rs
+++ b/engine/crates/partial-caching/src/updating/ser.rs
@@ -125,8 +125,7 @@ impl FieldExt for FieldSelection<'_> {
 impl<'a> ObjectSerializer<'a> {
     pub fn field_iter(&self) -> FieldIter<'a> {
         FieldIter {
-            iter_stack: vec![self.ctx.subset.selection_iter(self.ctx.document, self.selection_set)],
-            document: self.ctx.document,
+            iter_stack: vec![self.ctx.subset.selection_iter(self.selection_set)],
             subset: self.ctx.subset,
         }
     }
@@ -137,7 +136,6 @@ impl<'a> ObjectSerializer<'a> {
 /// This will recurse into any selection sets nested inside fragments.
 struct FieldIter<'a> {
     iter_stack: Vec<FilteredSelections<'a>>,
-    document: &'a ExecutableDocument,
     subset: &'a QuerySubset,
 }
 
@@ -155,13 +153,13 @@ impl<'a> Iterator for FieldIter<'a> {
                 Selection::Field(field) => return Some(field),
                 Selection::InlineFragment(fragment) => {
                     self.iter_stack
-                        .push(self.subset.selection_iter(self.document, fragment.selection_set()));
+                        .push(self.subset.selection_iter(fragment.selection_set()));
                 }
                 Selection::FragmentSpread(spread) => {
                     let Some(fragment) = spread.fragment() else { continue };
 
                     self.iter_stack
-                        .push(self.subset.selection_iter(self.document, fragment.selection_set()));
+                        .push(self.subset.selection_iter(fragment.selection_set()));
                 }
             }
         }


### PR DESCRIPTION
Splitting out some reorganisation from my defer work so it's easier to review.

There's no functional changes here, so should be fairly easy to review.

- Moved query_subset to a folder
- Split it up a bit
- Moved FieldIter into the query_subset module so it can be shared in a few places.