### PR TITLE
feat: calculate output shapes in partial caching

### DIFF
--- a/engine/crates/partial-caching/src/lib.rs
+++ b/engine/crates/partial-caching/src/lib.rs
@@ -21,6 +21,8 @@ mod execution;
 mod fetching;
 mod headers;
 mod hit;
+mod output;
+mod parser_extensions;
 mod planning;
 mod query_subset;
 mod response;

--- a/engine/crates/partial-caching/src/output/mod.rs
+++ b/engine/crates/partial-caching/src/output/mod.rs
@@ -1,0 +1,2 @@
+#[allow(unused)] // TODO: Remove me when this is used
+mod shapes;

--- a/engine/crates/partial-caching/src/output/shapes/building.rs
+++ b/engine/crates/partial-caching/src/output/shapes/building.rs
@@ -1,0 +1,355 @@
+use cynic_parser::executable::{FieldSelection, Selection};
+use indexmap::{IndexMap, IndexSet};
+
+use crate::{
+    parser_extensions::{DeferExt, FieldExt},
+    query_subset::FilteredSelectionSet,
+    CachingPlan, QuerySubset,
+};
+
+use super::{fragment_iter::FragmentIter, FieldRecord, ObjectShapeId, ObjectShapeRecord, OutputShapes};
+
+pub fn build_output_shapes(plan: CachingPlan) -> OutputShapes {
+    let mut objects = vec![];
+    let mut cache_partition_roots = vec![];
+
+    for (subset, selection_set) in plan.cache_partitions() {
+        let selections = selection_set
+            .map(|selection| MergedSelection {
+                selection,
+                propagate_defer_label: None,
+            })
+            .collect();
+
+        cache_partition_roots.push(build_output_shape(&mut objects, selections, subset));
+    }
+
+    let nocache_partition_root = {
+        let (subset, selection_set) = plan.nocache_partition();
+        let selections = selection_set
+            .map(|selection| MergedSelection {
+                selection,
+                propagate_defer_label: None,
+            })
+            .collect();
+
+        build_output_shape(&mut objects, selections, subset)
+    };
+
+    OutputShapes {
+        objects,
+        cache_partition_roots,
+        nocache_partition_root,
+    }
+}
+
+fn build_output_shape(
+    objects: &mut Vec<ObjectShapeRecord>,
+    selections: Vec<MergedSelection<'_>>,
+    subset: &QuerySubset,
+) -> super::ObjectShapeId {
+    let type_conditions = FragmentIter::new(&selections, subset)
+        .filter_map(|fragment| fragment.type_condition())
+        .collect::<IndexSet<_>>();
+
+    if type_conditions.is_empty() {
+        let field_shapes = field_shapes_for_typename(&selections, subset, objects, None);
+
+        insert_record(objects, ObjectShapeRecord::Concrete { fields: field_shapes })
+    } else {
+        let mut types = Vec::with_capacity(type_conditions.len() + 1);
+
+        types.push((None, field_shapes_for_typename(&selections, subset, objects, None)));
+
+        for typename in type_conditions {
+            types.push((
+                Some(typename.to_string()),
+                field_shapes_for_typename(&selections, subset, objects, Some(typename)),
+            ));
+        }
+
+        insert_record(objects, ObjectShapeRecord::Polymorphic { types })
+    }
+}
+
+fn field_shapes_for_typename(
+    selections: &[MergedSelection<'_>],
+    subset: &QuerySubset,
+    objects: &mut Vec<ObjectShapeRecord>,
+    typename: Option<&str>,
+) -> Vec<FieldRecord> {
+    let mut grouped_fields = IndexMap::new();
+
+    collect_fields(&mut grouped_fields, &mut vec![], selections, subset, typename);
+
+    let merged_fields = merge_selection_sets(grouped_fields, subset);
+
+    let mut field_shapes = vec![];
+
+    for field in merged_fields {
+        let mut child_object = None;
+        if !field.selections.is_empty() {
+            child_object = Some(build_output_shape(objects, field.selections, subset));
+        }
+        field_shapes.push(FieldRecord {
+            response_key: field.response_key.to_string(),
+            defer_label: field.defer_label.map(ToString::to_string),
+            child_object,
+        });
+    }
+
+    field_shapes
+}
+
+struct CollectedField<'a> {
+    field: FieldSelection<'a>,
+
+    /// The label of the defer this selection is in if any
+    defer_label: Option<&'a str>,
+}
+
+/// A defer aware implementation of CollectFields from the GraphQL spec:
+///
+/// Note that this doesn't process include or skip currently.  I think this
+/// is fine and we can leave that up to the actual GraphQL server, but may
+/// need revisited if that's wrong.
+///
+/// http://spec.graphql.org/October2021/#CollectFields()
+fn collect_fields<'a>(
+    grouped_fields: &mut IndexMap<&'a str, Vec<CollectedField<'a>>>,
+    defer_stack: &mut Vec<&'a str>,
+    selections: &[MergedSelection<'a>],
+    // selection_set: FilteredSelectionSet<'a, 'a>,
+    subset: &'a QuerySubset,
+    typename: Option<&'a str>,
+) {
+    for selection in selections {
+        match selection.selection {
+            Selection::Field(field) => {
+                // If the current selection has applied a defer we take that, otherwise we take the propagated
+                // defer label (if present)
+                let defer_label = defer_stack.last().copied().or(selection.propagate_defer_label);
+
+                grouped_fields
+                    .entry(field.response_key())
+                    .or_default()
+                    .push(CollectedField { field, defer_label });
+            }
+            Selection::InlineFragment(fragment) => {
+                if fragment.type_condition() != typename {
+                    // TODO: This needs to be smarter.  If there's no type_condition it doesn't matter what typename
+                    // is. We also need to handle implements properly, which will require the registry.
+                    //
+                    // Will revisit later though...
+                    continue;
+                }
+
+                let defer = fragment.defer_directive();
+                if let Some(defer) = &defer {
+                    defer_stack.push(defer.label);
+                }
+
+                collect_fields(
+                    grouped_fields,
+                    defer_stack,
+                    &subset
+                        .selection_iter(fragment.selection_set())
+                        .map(|nested_selection| MergedSelection {
+                            selection: nested_selection,
+                            propagate_defer_label: selection.propagate_defer_label,
+                        })
+                        .collect::<Vec<_>>(),
+                    subset,
+                    typename,
+                );
+
+                if defer.is_some() {
+                    defer_stack.pop();
+                }
+            }
+            Selection::FragmentSpread(spread) => {
+                let Some(fragment) = spread.fragment() else { continue };
+
+                if typename != Some(fragment.type_condition()) {
+                    // TODO: This needs to be smarter.  If there's no type_condition it doesn't matter what typename
+                    // is. We also need to handle implements properly, which will require the registry.
+                    //
+                    // Will revisit later though...
+                    continue;
+                }
+
+                let defer = spread.defer_directive();
+                if let Some(defer) = &defer {
+                    defer_stack.push(defer.label);
+                }
+
+                collect_fields(
+                    grouped_fields,
+                    defer_stack,
+                    &subset
+                        .selection_iter(fragment.selection_set())
+                        .map(|nested_selection| MergedSelection {
+                            selection: nested_selection,
+                            propagate_defer_label: selection.propagate_defer_label,
+                        })
+                        .collect::<Vec<_>>(),
+                    subset,
+                    typename,
+                );
+
+                if defer.is_some() {
+                    defer_stack.pop();
+                }
+            }
+        }
+    }
+}
+
+struct MergedField<'a> {
+    response_key: &'a str,
+
+    /// The label of the defer for this selection.
+    ///
+    /// This should only be set if none of the parent fields have the same defer_label
+    defer_label: Option<&'a str>,
+
+    selections: Vec<MergedSelection<'a>>,
+}
+
+pub(super) struct MergedSelection<'a> {
+    pub(super) selection: Selection<'a>,
+
+    propagate_defer_label: Option<&'a str>,
+}
+
+/// An implementation of MergeSelectionSets from the GraphQL spec.
+///
+/// This is a bit more complicated than the GraphQL spec outlines, because
+/// we need to handle propagating the defer label in certain cases.
+///
+/// For example with this query:
+///
+/// ```graphql
+/// query {
+///   foo {
+///     bar {
+///       baz {
+///         zap
+///       }
+///     }
+///     ... @defer(name: "whatever") {
+///       bar {
+///         baz {
+///           blorp
+///         }
+///       }
+///     }
+///   }
+/// }
+/// ```
+///
+/// In this scenario `bar` & `bar.baz` appear in both a deferred and
+/// a non-deferred context - so rather than marking `bar` as deferred,
+/// we need to propagate the label down into the next selection set. By
+/// doing this recursively we should end up only marking fields that
+/// are exclusively in a defer as deferrable.
+///
+/// This would have problems if we needed to know what the root of a
+/// defer is, but I think we can mostly leave that up to the executor -
+/// we generally just need to know whether fields are part of a defer
+/// or not, and this should let us do that.
+///
+/// http://spec.graphql.org/October2021/#MergeSelectionSets()
+fn merge_selection_sets<'a>(
+    grouped_fields: IndexMap<&'a str, Vec<CollectedField<'a>>>,
+    subset: &'a QuerySubset,
+) -> Vec<MergedField<'a>> {
+    let mut output = Vec::with_capacity(grouped_fields.len());
+    for (response_key, fields) in grouped_fields {
+        if fields.len() == 1 {
+            // Hooray, the easy case
+            output.push(MergedField {
+                response_key,
+                defer_label: fields[0].defer_label,
+                selections: subset
+                    .selection_iter(fields[0].field.selection_set())
+                    .map(|selection| MergedSelection {
+                        selection,
+                        propagate_defer_label: None,
+                    })
+                    .collect(),
+            });
+            continue;
+        }
+
+        if fields[0].field.selection_set().len() == 0 {
+            // This looks like a leaf field so we can't merge selection sets.
+            // Lets just pick the properties of the first field
+            output.push(MergedField {
+                response_key,
+                defer_label: fields[0].defer_label,
+                selections: vec![],
+            });
+            continue;
+        }
+
+        // If there's any mismatch on defer labels we want to propagate them to child fields instead
+        // of putting them on this level of the heirarchy.
+        let all_defers_match = match fields.as_slice() {
+            [head, tail @ ..] => tail.iter().all(|x| x.defer_label == head.defer_label),
+            [] => unreachable!(),
+        };
+
+        let mut merged_field = MergedField {
+            response_key: "",
+            defer_label: None,
+            selections: vec![],
+        };
+
+        for field in fields {
+            merged_field.response_key = field.field.response_key();
+            let selections = subset.selection_iter(field.field.selection_set());
+            if !all_defers_match {
+                merged_field.defer_label = field.defer_label;
+                merged_field
+                    .selections
+                    .extend(selections.map(|selection| MergedSelection {
+                        selection,
+                        propagate_defer_label: None,
+                    }));
+            } else {
+                merged_field
+                    .selections
+                    .extend(selections.map(|selection| MergedSelection {
+                        selection,
+                        propagate_defer_label: merged_field.defer_label,
+                    }));
+            }
+        }
+    }
+
+    output
+}
+
+fn insert_record(records: &mut Vec<ObjectShapeRecord>, record: ObjectShapeRecord) -> ObjectShapeId {
+    let id = ObjectShapeId(u16::try_from(records.len()).expect("too many objects, what the hell"));
+    records.push(record);
+    id
+}
+
+impl CachingPlan {
+    fn cache_partitions(&self) -> impl Iterator<Item = (&QuerySubset, FilteredSelectionSet<'_, '_>)> + '_ {
+        self.cache_partitions.iter().map(|(_, subset)| {
+            let operation = self.document.read(subset.operation);
+            (subset, subset.selection_iter(operation.selection_set()))
+        })
+    }
+
+    fn nocache_partition(&self) -> (&QuerySubset, FilteredSelectionSet<'_, '_>) {
+        let operation = self.document.read(self.nocache_partition.operation);
+        (
+            &self.nocache_partition,
+            self.nocache_partition.selection_iter(operation.selection_set()),
+        )
+    }
+}

--- a/engine/crates/partial-caching/src/output/shapes/fragment_iter.rs
+++ b/engine/crates/partial-caching/src/output/shapes/fragment_iter.rs
@@ -2,13 +2,13 @@ use cynic_parser::executable::{FragmentDefinition, InlineFragment, Selection};
 
 use crate::{query_subset::FilteredSelectionSet, QuerySubset};
 
-use super::building::MergedSelection;
+use super::building::DeferrableSelection;
 
 /// An iterator over the fragments of a selection set.
 ///
 /// This will recurse into any selection sets nested inside fragments, but not fields.
 pub struct FragmentIter<'doc, 'ctx> {
-    root_selection: std::slice::Iter<'ctx, MergedSelection<'doc>>,
+    root_selection: std::slice::Iter<'ctx, DeferrableSelection<'doc>>,
     iter_stack: Vec<FilteredSelectionSet<'doc, 'ctx>>,
     subset: &'ctx QuerySubset,
 }
@@ -19,7 +19,7 @@ pub enum Fragment<'a> {
 }
 
 impl<'doc, 'ctx> FragmentIter<'doc, 'ctx> {
-    pub fn new(root_selection: &'ctx [MergedSelection<'doc>], subset: &'ctx QuerySubset) -> Self {
+    pub fn new(root_selection: &'ctx [DeferrableSelection<'doc>], subset: &'ctx QuerySubset) -> Self {
         FragmentIter {
             root_selection: root_selection.iter(),
             iter_stack: vec![],

--- a/engine/crates/partial-caching/src/output/shapes/fragment_iter.rs
+++ b/engine/crates/partial-caching/src/output/shapes/fragment_iter.rs
@@ -1,0 +1,83 @@
+use cynic_parser::executable::{FragmentDefinition, InlineFragment, Selection};
+
+use crate::{query_subset::FilteredSelectionSet, QuerySubset};
+
+use super::building::MergedSelection;
+
+/// An iterator over the fragments of a selection set.
+///
+/// This will recurse into any selection sets nested inside fragments, but not fields.
+pub struct FragmentIter<'doc, 'ctx> {
+    root_selection: std::slice::Iter<'ctx, MergedSelection<'doc>>,
+    iter_stack: Vec<FilteredSelectionSet<'doc, 'ctx>>,
+    subset: &'ctx QuerySubset,
+}
+
+pub enum Fragment<'a> {
+    Inline(InlineFragment<'a>),
+    Named(FragmentDefinition<'a>),
+}
+
+impl<'doc, 'ctx> FragmentIter<'doc, 'ctx> {
+    pub fn new(root_selection: &'ctx [MergedSelection<'doc>], subset: &'ctx QuerySubset) -> Self {
+        FragmentIter {
+            root_selection: root_selection.iter(),
+            iter_stack: vec![],
+            subset,
+        }
+    }
+
+    fn handle_selection(&mut self, selection: Selection<'doc>) -> Option<Fragment<'doc>> {
+        match selection {
+            Selection::Field(_) => None,
+            Selection::InlineFragment(fragment) => {
+                self.iter_stack
+                    .push(self.subset.selection_iter(fragment.selection_set()));
+
+                Some(Fragment::Inline(fragment))
+            }
+            Selection::FragmentSpread(spread) => {
+                let fragment = spread.fragment()?;
+
+                self.iter_stack
+                    .push(self.subset.selection_iter(fragment.selection_set()));
+
+                Some(Fragment::Named(fragment))
+            }
+        }
+    }
+}
+
+impl<'doc, 'ctx> Iterator for FragmentIter<'doc, 'ctx> {
+    type Item = Fragment<'doc>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(current_iter) = self.iter_stack.last_mut() {
+            let Some(selection) = current_iter.next() else {
+                self.iter_stack.pop();
+                continue;
+            };
+
+            if let Some(fragment) = self.handle_selection(selection) {
+                return Some(fragment);
+            };
+        }
+
+        while let Some(merged_selection) = self.root_selection.next() {
+            if let Some(fragment) = self.handle_selection(merged_selection.selection) {
+                return Some(fragment);
+            };
+        }
+
+        None
+    }
+}
+
+impl<'a> Fragment<'a> {
+    pub fn type_condition(&self) -> Option<&'a str> {
+        match self {
+            Fragment::Inline(fragment) => fragment.type_condition(),
+            Fragment::Named(fragment) => Some(fragment.type_condition()),
+        }
+    }
+}

--- a/engine/crates/partial-caching/src/output/shapes/mod.rs
+++ b/engine/crates/partial-caching/src/output/shapes/mod.rs
@@ -1,0 +1,93 @@
+mod building;
+mod fragment_iter;
+
+/// Contains the schemas of all the objects we could see in our output,
+/// based on the shape of the query
+pub struct OutputShapes {
+    objects: Vec<ObjectShapeRecord>,
+
+    // The root object of each of the query partitions.
+    cache_partition_roots: Vec<ObjectShapeId>,
+    nocache_partition_root: ObjectShapeId,
+}
+
+/// PartitionShape is the root of a partitions output shape heirarchy.
+pub struct PartitionShape<'a> {
+    object_id: ObjectShapeId,
+    plans: &'a OutputShapes,
+}
+
+impl<'a> PartitionShape<'a> {
+    pub fn root_object(&self) -> ObjectShape<'a> {
+        match self.plans.objects[self.object_id.0 as usize] {
+            ObjectShapeRecord::Concrete { .. } => ObjectShape::Concrete(ConcreteShape {
+                plans: self.plans,
+                id: self.object_id,
+            }),
+            ObjectShapeRecord::Polymorphic { .. } => ObjectShape::Polymorphic(PolymorphicShape {
+                plans: self.plans,
+                id: self.object_id,
+            }),
+        }
+    }
+}
+
+/// The shape an object in the response can have
+#[derive(Clone, Copy)]
+pub enum ObjectShape<'a> {
+    /// If a selection set has no type conditions in it then we know up front
+    /// all the fields that can be present, and we use this ConcreteShape type
+    Concrete(ConcreteShape<'a>),
+    /// If a selection set has type conditions in it we enumerate all the
+    /// possible shapes in a PolymorphicShape
+    Polymorphic(PolymorphicShape<'a>),
+}
+
+impl<'a> ObjectShape<'a> {
+    pub fn id(&self) -> ObjectShapeId {
+        match self {
+            ObjectShape::Concrete(plan) => plan.id,
+            ObjectShape::Polymorphic(plan) => plan.id,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct Field<'a> {
+    plans: &'a OutputShapes,
+    id: ObjectShapeId,
+    field_index: FieldIndex,
+}
+
+#[derive(Clone, Copy)]
+pub struct FieldIndex(pub(super) u16);
+
+#[derive(Clone, Copy)]
+pub struct ObjectShapeId(u16);
+
+enum ObjectShapeRecord {
+    Concrete {
+        fields: Vec<FieldRecord>,
+    },
+    Polymorphic {
+        types: Vec<(Option<String>, Vec<FieldRecord>)>,
+    },
+}
+
+pub struct FieldRecord {
+    response_key: String,
+    defer_label: Option<String>,
+    child_object: Option<ObjectShapeId>,
+}
+
+#[derive(Clone, Copy)]
+pub struct ConcreteShape<'a> {
+    plans: &'a OutputShapes,
+    id: ObjectShapeId,
+}
+
+#[derive(Clone, Copy)]
+pub struct PolymorphicShape<'a> {
+    plans: &'a OutputShapes,
+    id: ObjectShapeId,
+}

--- a/engine/crates/partial-caching/src/output/shapes/mod.rs
+++ b/engine/crates/partial-caching/src/output/shapes/mod.rs
@@ -14,18 +14,18 @@ pub struct OutputShapes {
 /// PartitionShape is the root of a partitions output shape heirarchy.
 pub struct PartitionShape<'a> {
     object_id: ObjectShapeId,
-    plans: &'a OutputShapes,
+    shapes: &'a OutputShapes,
 }
 
 impl<'a> PartitionShape<'a> {
     pub fn root_object(&self) -> ObjectShape<'a> {
-        match self.plans.objects[self.object_id.0 as usize] {
+        match self.shapes.objects[self.object_id.0 as usize] {
             ObjectShapeRecord::Concrete { .. } => ObjectShape::Concrete(ConcreteShape {
-                plans: self.plans,
+                shapes: self.shapes,
                 id: self.object_id,
             }),
             ObjectShapeRecord::Polymorphic { .. } => ObjectShape::Polymorphic(PolymorphicShape {
-                plans: self.plans,
+                shapes: self.shapes,
                 id: self.object_id,
             }),
         }
@@ -46,15 +46,15 @@ pub enum ObjectShape<'a> {
 impl<'a> ObjectShape<'a> {
     pub fn id(&self) -> ObjectShapeId {
         match self {
-            ObjectShape::Concrete(plan) => plan.id,
-            ObjectShape::Polymorphic(plan) => plan.id,
+            ObjectShape::Concrete(shape) => shape.id,
+            ObjectShape::Polymorphic(shape) => shape.id,
         }
     }
 }
 
 #[derive(Clone, Copy)]
 pub struct Field<'a> {
-    plans: &'a OutputShapes,
+    shapes: &'a OutputShapes,
     id: ObjectShapeId,
     field_index: FieldIndex,
 }
@@ -77,17 +77,17 @@ enum ObjectShapeRecord {
 pub struct FieldRecord {
     response_key: String,
     defer_label: Option<String>,
-    child_object: Option<ObjectShapeId>,
+    subselection_shape: Option<ObjectShapeId>,
 }
 
 #[derive(Clone, Copy)]
 pub struct ConcreteShape<'a> {
-    plans: &'a OutputShapes,
+    shapes: &'a OutputShapes,
     id: ObjectShapeId,
 }
 
 #[derive(Clone, Copy)]
 pub struct PolymorphicShape<'a> {
-    plans: &'a OutputShapes,
+    shapes: &'a OutputShapes,
     id: ObjectShapeId,
 }

--- a/engine/crates/partial-caching/src/parser_extensions.rs
+++ b/engine/crates/partial-caching/src/parser_extensions.rs
@@ -1,0 +1,42 @@
+use cynic_parser::executable::{iter::Iter, Directive, FieldSelection, FragmentSpread, InlineFragment, Value};
+
+pub trait FieldExt<'a> {
+    fn response_key(&self) -> &'a str;
+}
+
+impl<'a> FieldExt<'a> for FieldSelection<'a> {
+    fn response_key(&self) -> &'a str {
+        self.alias().unwrap_or(self.name())
+    }
+}
+
+pub struct DeferDirective<'a> {
+    pub label: &'a str,
+}
+
+pub trait DeferExt<'a> {
+    fn defer_directive(&self) -> Option<DeferDirective<'a>>;
+}
+
+impl<'a> DeferExt<'a> for FragmentSpread<'a> {
+    fn defer_directive(&self) -> Option<DeferDirective<'a>> {
+        find_defer(self.directives())
+    }
+}
+
+impl<'a> DeferExt<'a> for InlineFragment<'a> {
+    fn defer_directive(&self) -> Option<DeferDirective<'a>> {
+        find_defer(self.directives())
+    }
+}
+
+fn find_defer<'a>(mut directives: Iter<'a, Directive<'a>>) -> Option<DeferDirective<'a>> {
+    directives
+        .find(|directive| directive.name() == "defer")
+        .and_then(|directive| {
+            let value = directive.arguments().find(|arg| arg.name() == "label")?.value();
+            let Value::String(label) = value else { return None };
+
+            Some(DeferDirective { label })
+        })
+}


### PR DESCRIPTION
I'm adding support for `@defer` to our partial caching.  When handling responses & cache entries in the presence of `@defer` we need to be able to tell whether or not the field we're currently processing is inside a `@defer` or not.

This sounds simple but has a lot of complicating factors:

1. The JSON structure of responses & cache chunks doesn't always match the GraphQL AST structure.  Fragments add an additional level of nested to the AST, but not to the JSON.
2. Type conditions on fragments add branching into the equation.
3. A given field of an object could theoretically be present both inside and outside a defer, with the difference between those selections being nested several levels deep in the GraphQL AST.

At present most of the partial caching response handling is a fairly simple deep merge over the JSON of the response & the cache entry.  But handling these extra concerns while doing that sounds extremely difficult, and there's likely going to be a few different merge implementations, so we might even need to handle it in several places.

This commit adds my solution for this: we precaclulate the output shape of the individual query partitions.  This:

1. Gives us a heirarchy with the same structure as the JSON output, for easy traversal when doing a merge.
2. Should make handling fragments easier - we just need to read the `__typename` and select a shape based on that.
3. Handles propagating the defer label to fields that are exclusively in the defer.

Which should make implementing the rest of the defer stuff easier.  Hopefully... 🤞 

Fixes GB-6747