### PR TITLE
feat: add OutputStore to partial-caching

### DIFF
--- a/engine/crates/graph-entities/src/response/mod.rs
+++ b/engine/crates/graph-entities/src/response/mod.rs
@@ -350,6 +350,14 @@ impl ResponseList {
         self.0.iter().copied()
     }
 
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub fn with_children(children: Vec<ResponseNodeId>) -> Box<Self> {
         Box::new(Self(children))
     }
@@ -366,7 +374,7 @@ impl ResponseList {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct ResponsePrimitive(CompactValue);
+pub struct ResponsePrimitive(pub CompactValue);
 
 impl ResponsePrimitive {
     pub fn new(value: CompactValue) -> Box<Self> {
@@ -375,6 +383,17 @@ impl ResponsePrimitive {
 
     pub fn is_null(&self) -> bool {
         matches!(self.0, CompactValue::Null)
+    }
+
+    pub fn is_string(&self) -> bool {
+        matches!(self.0, CompactValue::String(_))
+    }
+
+    pub fn as_str(&self) -> Option<&str> {
+        match &self.0 {
+            CompactValue::String(s) => Some(s.as_str()),
+            _ => None,
+        }
     }
 }
 

--- a/engine/crates/partial-caching/src/output/engine_response.rs
+++ b/engine/crates/partial-caching/src/output/engine_response.rs
@@ -1,0 +1,134 @@
+//! This file deals with importing the engines response into the OutputStore
+
+use graph_entities::{CompactValue, QueryResponse, QueryResponseNode, ResponseContainer, ResponseList, ResponseNodeId};
+
+use super::{
+    shapes::ObjectShape,
+    store::{ValueId, ValueRecord},
+    OutputStore, PartitionShape,
+};
+
+impl OutputStore {
+    pub fn new(response: QueryResponse, shape: PartitionShape<'_>) -> Self {
+        let mut output = OutputStore::default();
+        let root_object = shape.root_object();
+
+        let Some(root) = response.root else {
+            todo!("do something about this");
+        };
+
+        let root_field_id = output.new_value();
+
+        match response.get_node(root) {
+            Some(QueryResponseNode::Container(container)) => copy_container(
+                container,
+                &response,
+                &mut output,
+                root_field_id,
+                ObjectShape::Concrete(root_object),
+            ),
+            _ => todo!("error"),
+        }
+
+        output
+    }
+}
+
+fn copy_container(
+    container: &ResponseContainer,
+    response: &QueryResponse,
+    output: &mut OutputStore,
+    dest_value_id: ValueId,
+    object_shape: ObjectShape<'_>,
+) {
+    let concrete_shape = match object_shape {
+        ObjectShape::Concrete(concrete) => concrete,
+        ObjectShape::Polymorphic(_) => {
+            // This requires typeinfo from the caching registry, which is missing just now.
+            // Will revisit in GB-6949
+            todo!("figure out which branch matches based on the __typename")
+        }
+    };
+
+    let object_id = output.insert_object(concrete_shape);
+    output.write_value(dest_value_id, ValueRecord::Object(object_id));
+
+    for (name, src_id) in container.iter() {
+        let Some(field_shape) = concrete_shape.field(name.as_str()) else {
+            // TODO: Somethings probably gone wrong if we hit this branch...
+            continue;
+        };
+
+        // TODO: We need to record whether a field is associated with a defer,
+        // and if so record that defer as "active" so we know to merge in cache fields associated
+        // with that defer
+
+        let Some(subselection_shape) = field_shape.subselection_shape() else {
+            // This must be a leaf field, process it as such
+            let field_dest_id = output.field_value_id(object_id, field_shape.index());
+            copy_leaf_value(response, output, *src_id, field_dest_id);
+            continue;
+        };
+
+        let dest_id = output.field_value_id(object_id, field_shape.index());
+
+        copy_node(*src_id, dest_id, response, output, subselection_shape);
+    }
+}
+
+fn copy_node(
+    src_id: ResponseNodeId,
+    dest_id: ValueId,
+    response: &QueryResponse,
+    output: &mut OutputStore,
+    subselection_shape: ObjectShape<'_>,
+) {
+    match response.get_node(src_id) {
+        Some(QueryResponseNode::Container(container)) => {
+            copy_container(container, response, output, dest_id, subselection_shape);
+        }
+        Some(QueryResponseNode::List(list)) => copy_list(list, response, output, dest_id, subselection_shape),
+        Some(QueryResponseNode::Primitive(_)) => {
+            todo!("this definitely looks like an error")
+        }
+        None => todo!("error?  continue?  not sure"),
+    }
+}
+
+fn copy_list(
+    list: &ResponseList,
+    response: &QueryResponse,
+    output: &mut OutputStore,
+    dest_value_id: ValueId,
+    subselection_shape: ObjectShape<'_>,
+) {
+    let dest_ids = output.new_list(list.len());
+    output.write_value(dest_value_id, ValueRecord::List(dest_ids));
+
+    for (src_id, dest_id) in list.iter().zip(dest_ids) {
+        copy_node(src_id, dest_id, response, output, subselection_shape)
+    }
+}
+
+fn copy_leaf_value(response: &QueryResponse, output: &mut OutputStore, src_id: ResponseNodeId, dest_id: ValueId) {
+    match response.get_node(src_id) {
+        Some(QueryResponseNode::Primitive(primitive)) => {
+            let value = match &primitive.0 {
+                CompactValue::Null => ValueRecord::Null,
+                CompactValue::Number(inner) => ValueRecord::Number(inner.clone()),
+                CompactValue::String(inner) => ValueRecord::String(inner.as_str().into()),
+                CompactValue::Boolean(inner) => ValueRecord::Boolean(*inner),
+                CompactValue::Binary(_) => todo!("do we even use binaries?  not sure we do"),
+                CompactValue::Enum(inner) => ValueRecord::String(inner.as_str().into()),
+                value @ (CompactValue::List(_) | CompactValue::Object(_)) => {
+                    ValueRecord::InlineValue(Box::new(value.clone()))
+                }
+            };
+            output.write_value(dest_id, value);
+        }
+        _ => {
+            // Will revisit this.
+            todo!("should probably convert lists and objects into ValueRecord::InlineValue");
+        }
+    }
+}

--- a/engine/crates/partial-caching/src/output/mod.rs
+++ b/engine/crates/partial-caching/src/output/mod.rs
@@ -1,2 +1,11 @@
-#[allow(unused)] // TODO: Remove me when this is used
+#![allow(dead_code)] // TODO: Remove me once this module is being used
+
+mod engine_response;
+mod ser;
 mod shapes;
+mod store;
+
+#[cfg(test)]
+mod tests;
+
+pub use self::{shapes::PartitionShape, store::OutputStore};

--- a/engine/crates/partial-caching/src/output/ser.rs
+++ b/engine/crates/partial-caching/src/output/ser.rs
@@ -1,0 +1,48 @@
+use serde::{ser::SerializeMap, Serialize};
+
+use super::{shapes::OutputShapes, store::Value, OutputStore};
+
+impl OutputStore {
+    pub fn serialize_all<S>(&self, shapes: &OutputShapes, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(object) = self.reader(shapes) else {
+            return serializer.serialize_none();
+        };
+
+        let mut map = serializer.serialize_map(Some(object.len()))?;
+        for (name, reader) in object.fields() {
+            map.serialize_entry(name, &ValueSerializer { reader })?;
+        }
+        map.end()
+    }
+}
+
+struct ValueSerializer<'a> {
+    reader: Value<'a>,
+}
+
+impl Serialize for ValueSerializer<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.reader {
+            Value::Null => serializer.serialize_none(),
+            Value::Integer(inner) => inner.serialize(serializer),
+            Value::Float(inner) => inner.serialize(serializer),
+            Value::String(inner) => inner.serialize(serializer),
+            Value::Boolean(inner) => inner.serialize(serializer),
+            Value::List(items) => serializer.collect_seq(items.map(|reader| ValueSerializer { reader })),
+            Value::Object(object) => {
+                let mut map = serializer.serialize_map(Some(object.len()))?;
+                for (name, reader) in object.fields() {
+                    map.serialize_entry(name, &ValueSerializer { reader })?;
+                }
+                map.end()
+            }
+            Value::Inline(value) => value.serialize(serializer),
+        }
+    }
+}

--- a/engine/crates/partial-caching/src/output/shapes/building.rs
+++ b/engine/crates/partial-caching/src/output/shapes/building.rs
@@ -7,34 +7,40 @@ use crate::{
     CachingPlan, QuerySubset,
 };
 
-use super::{fragment_iter::FragmentIter, FieldRecord, ObjectShapeId, ObjectShapeRecord, OutputShapes};
+use super::{
+    fragment_iter::FragmentIter, ConcreteShapeId, FieldRecord, ObjectShapeId, ObjectShapeRecord, OutputShapes,
+};
 
 pub fn build_output_shapes(plan: CachingPlan) -> OutputShapes {
-    let mut objects = vec![];
+    let mut builder = OutputShapesBuilder::default();
     let mut cache_partition_roots = vec![];
 
     for (subset, selection_set) in plan.cache_partitions() {
         let selections = selection_set.map(DeferrableSelection::without_defer).collect();
 
-        cache_partition_roots.push(build_output_shape(&mut objects, selections, subset));
+        let shape_id = build_output_shape(&mut builder, selections, subset);
+        let concrete_id = ConcreteShapeId(shape_id.0);
+
+        cache_partition_roots.push(concrete_id);
     }
 
     let nocache_partition_root = {
         let (subset, selection_set) = plan.nocache_partition();
         let selections = selection_set.map(DeferrableSelection::without_defer).collect();
 
-        build_output_shape(&mut objects, selections, subset)
+        let shape_id = build_output_shape(&mut builder, selections, subset);
+        ConcreteShapeId(shape_id.0)
     };
 
     OutputShapes {
-        objects,
+        objects: builder.objects,
         cache_partition_roots,
         nocache_partition_root,
     }
 }
 
 fn build_output_shape(
-    objects: &mut Vec<ObjectShapeRecord>,
+    builder: &mut OutputShapesBuilder,
     selections: Vec<DeferrableSelection<'_>>,
     subset: &QuerySubset,
 ) -> super::ObjectShapeId {
@@ -43,29 +49,30 @@ fn build_output_shape(
         .collect::<IndexSet<_>>();
 
     if type_conditions.is_empty() {
-        let field_shapes = field_shapes_for_typename(&selections, subset, objects, None);
+        let field_shapes = field_shapes_for_typename(builder, &selections, subset, None);
 
-        insert_record(objects, ObjectShapeRecord::Concrete { fields: field_shapes })
+        builder.insert_concrete_object(field_shapes)
     } else {
-        let mut types = Vec::with_capacity(type_conditions.len() + 1);
+        let unknown_typename_fields = field_shapes_for_typename(builder, &selections, subset, None);
 
-        types.push((None, field_shapes_for_typename(&selections, subset, objects, None)));
+        let known_typename_fields = type_conditions
+            .into_iter()
+            .map(|typename| {
+                (
+                    typename.to_string(),
+                    field_shapes_for_typename(builder, &selections, subset, Some(typename)),
+                )
+            })
+            .collect::<Vec<_>>();
 
-        for typename in type_conditions {
-            types.push((
-                Some(typename.to_string()),
-                field_shapes_for_typename(&selections, subset, objects, Some(typename)),
-            ));
-        }
-
-        insert_record(objects, ObjectShapeRecord::Polymorphic { types })
+        builder.insert_polymorphic_object(unknown_typename_fields, known_typename_fields)
     }
 }
 
 fn field_shapes_for_typename(
+    builder: &mut OutputShapesBuilder,
     selections: &[DeferrableSelection<'_>],
     subset: &QuerySubset,
-    objects: &mut Vec<ObjectShapeRecord>,
     typename: Option<&str>,
 ) -> Vec<FieldRecord> {
     let mut grouped_fields = IndexMap::new();
@@ -79,7 +86,7 @@ fn field_shapes_for_typename(
     for field in merged_fields {
         let mut subselection_shape = None;
         if !field.merged_selections.is_empty() {
-            subselection_shape = Some(build_output_shape(objects, field.merged_selections, subset));
+            subselection_shape = Some(build_output_shape(builder, field.merged_selections, subset));
         }
         field_shapes.push(FieldRecord {
             response_key: field.response_key.to_string(),
@@ -109,7 +116,6 @@ fn collect_fields<'a>(
     grouped_fields: &mut IndexMap<&'a str, Vec<CollectedField<'a>>>,
     defer_stack: &mut Vec<&'a str>,
     selections: &[DeferrableSelection<'a>],
-    // selection_set: FilteredSelectionSet<'a, 'a>,
     subset: &'a QuerySubset,
     typename: Option<&'a str>,
 ) {
@@ -331,10 +337,35 @@ fn merge_selection_sets<'a>(
     output
 }
 
-fn insert_record(records: &mut Vec<ObjectShapeRecord>, record: ObjectShapeRecord) -> ObjectShapeId {
-    let id = ObjectShapeId(u16::try_from(records.len()).expect("too many objects, what the hell"));
-    records.push(record);
-    id
+#[derive(Default)]
+struct OutputShapesBuilder {
+    objects: Vec<ObjectShapeRecord>,
+}
+
+impl OutputShapesBuilder {
+    fn insert_concrete_object(&mut self, fields: Vec<FieldRecord>) -> ObjectShapeId {
+        self.insert_record(ObjectShapeRecord::Concrete { fields })
+    }
+
+    fn insert_polymorphic_object(
+        &mut self,
+        unknown_typename_fields: Vec<FieldRecord>,
+        typename_fields: Vec<(String, Vec<FieldRecord>)>,
+    ) -> ObjectShapeId {
+        let mut types = Vec::with_capacity(typename_fields.len() + 1);
+        types.push((None, self.insert_concrete_object(unknown_typename_fields)));
+        for (typename, fields) in typename_fields {
+            types.push((Some(typename), self.insert_concrete_object(fields)));
+        }
+
+        self.insert_record(ObjectShapeRecord::Polymorphic { types })
+    }
+
+    fn insert_record(&mut self, record: ObjectShapeRecord) -> ObjectShapeId {
+        let id = ObjectShapeId(u16::try_from(self.objects.len()).expect("too many objects, what the hell"));
+        self.objects.push(record);
+        id
+    }
 }
 
 impl CachingPlan {

--- a/engine/crates/partial-caching/src/output/shapes/mod.rs
+++ b/engine/crates/partial-caching/src/output/shapes/mod.rs
@@ -1,33 +1,53 @@
 mod building;
 mod fragment_iter;
 
+#[cfg(test)]
+pub use building::build_output_shapes;
+
 /// Contains the schemas of all the objects we could see in our output,
 /// based on the shape of the query
 pub struct OutputShapes {
     objects: Vec<ObjectShapeRecord>,
 
     // The root object of each of the query partitions.
-    cache_partition_roots: Vec<ObjectShapeId>,
-    nocache_partition_root: ObjectShapeId,
+    cache_partition_roots: Vec<ConcreteShapeId>,
+    nocache_partition_root: ConcreteShapeId,
+}
+
+impl OutputShapes {
+    pub fn nocache_shape(&self) -> PartitionShape<'_> {
+        PartitionShape {
+            object_id: self.nocache_partition_root,
+            shapes: self,
+        }
+    }
+
+    pub fn concrete_object(&self, id: ConcreteShapeId) -> ConcreteShape<'_> {
+        ConcreteShape { shapes: self, id }
+    }
+
+    pub fn object(&self, id: ObjectShapeId) -> ObjectShape<'_> {
+        match self.objects[id.0 as usize] {
+            ObjectShapeRecord::Concrete { .. } => ObjectShape::Concrete(ConcreteShape {
+                shapes: self,
+                id: ConcreteShapeId(id.0),
+            }),
+            ObjectShapeRecord::Polymorphic { .. } => ObjectShape::Polymorphic(PolymorphicShape { shapes: self, id }),
+        }
+    }
 }
 
 /// PartitionShape is the root of a partitions output shape heirarchy.
 pub struct PartitionShape<'a> {
-    object_id: ObjectShapeId,
+    object_id: ConcreteShapeId,
     shapes: &'a OutputShapes,
 }
 
 impl<'a> PartitionShape<'a> {
-    pub fn root_object(&self) -> ObjectShape<'a> {
-        match self.shapes.objects[self.object_id.0 as usize] {
-            ObjectShapeRecord::Concrete { .. } => ObjectShape::Concrete(ConcreteShape {
-                shapes: self.shapes,
-                id: self.object_id,
-            }),
-            ObjectShapeRecord::Polymorphic { .. } => ObjectShape::Polymorphic(PolymorphicShape {
-                shapes: self.shapes,
-                id: self.object_id,
-            }),
+    pub fn root_object(&self) -> ConcreteShape<'a> {
+        ConcreteShape {
+            shapes: self.shapes,
+            id: self.object_id,
         }
     }
 }
@@ -46,17 +66,10 @@ pub enum ObjectShape<'a> {
 impl<'a> ObjectShape<'a> {
     pub fn id(&self) -> ObjectShapeId {
         match self {
-            ObjectShape::Concrete(shape) => shape.id,
+            ObjectShape::Concrete(shape) => ObjectShapeId(shape.id.0),
             ObjectShape::Polymorphic(shape) => shape.id,
         }
     }
-}
-
-#[derive(Clone, Copy)]
-pub struct Field<'a> {
-    shapes: &'a OutputShapes,
-    id: ObjectShapeId,
-    field_index: FieldIndex,
 }
 
 #[derive(Clone, Copy)]
@@ -65,12 +78,15 @@ pub struct FieldIndex(pub(super) u16);
 #[derive(Clone, Copy)]
 pub struct ObjectShapeId(u16);
 
+#[derive(Clone, Copy)]
+pub struct ConcreteShapeId(u16);
+
 enum ObjectShapeRecord {
     Concrete {
         fields: Vec<FieldRecord>,
     },
     Polymorphic {
-        types: Vec<(Option<String>, Vec<FieldRecord>)>,
+        types: Vec<(Option<String>, ObjectShapeId)>,
     },
 }
 
@@ -83,11 +99,75 @@ pub struct FieldRecord {
 #[derive(Clone, Copy)]
 pub struct ConcreteShape<'a> {
     shapes: &'a OutputShapes,
-    id: ObjectShapeId,
+    id: ConcreteShapeId,
+}
+
+impl<'a> ConcreteShape<'a> {
+    pub fn id(&self) -> ConcreteShapeId {
+        self.id
+    }
+
+    pub fn field_count(&self) -> usize {
+        self.field_records().len()
+    }
+
+    pub fn field(&self, name: &str) -> Option<Field<'a>> {
+        // This might not be very efficient if there's a lot of fields, but can optimise later
+        let (index, _) = self
+            .field_records()
+            .iter()
+            .enumerate()
+            .find(|(_, field)| field.response_key == name)?;
+
+        Some(Field {
+            shapes: self.shapes,
+            object_id: self.id,
+            field_index: FieldIndex(index as u16),
+        })
+    }
+
+    pub fn response_keys(&self) -> impl Iterator<Item = &'a str> + 'a {
+        self.field_records().iter().map(|field| field.response_key.as_str())
+    }
+
+    fn field_records(&self) -> &'a [FieldRecord] {
+        let ObjectShapeRecord::Concrete { fields } = &self.shapes.objects[self.id.0 as usize] else {
+            unreachable!()
+        };
+        fields
+    }
 }
 
 #[derive(Clone, Copy)]
 pub struct PolymorphicShape<'a> {
     shapes: &'a OutputShapes,
     id: ObjectShapeId,
+}
+
+#[derive(Clone, Copy)]
+pub struct Field<'a> {
+    shapes: &'a OutputShapes,
+    object_id: ConcreteShapeId,
+    field_index: FieldIndex,
+}
+
+impl<'a> Field<'a> {
+    pub fn index(&self) -> FieldIndex {
+        self.field_index
+    }
+
+    pub fn is_leaf(&self) -> bool {
+        self.record().subselection_shape.is_none()
+    }
+
+    pub fn subselection_shape(&self) -> Option<ObjectShape<'a>> {
+        Some(self.shapes.object(self.record().subselection_shape?))
+    }
+
+    fn record(&self) -> &'a FieldRecord {
+        let ObjectShapeRecord::Concrete { fields } = &self.shapes.objects[self.object_id.0 as usize] else {
+            unreachable!()
+        };
+        &fields[self.field_index.0 as usize]
+    }
 }

--- a/engine/crates/partial-caching/src/output/store.rs
+++ b/engine/crates/partial-caching/src/output/store.rs
@@ -1,0 +1,226 @@
+use graph_entities::CompactValue;
+use serde_json::Number;
+
+use super::shapes::{ConcreteShape, ConcreteShapeId, FieldIndex, OutputShapes};
+
+// TODO: Docstring etc.
+#[derive(Default)]
+pub struct OutputStore {
+    values: Vec<ValueRecord>,
+    objects: Vec<ObjectRecord>,
+}
+
+struct ObjectRecord {
+    /// The shape of the object.
+    shape: ConcreteShapeId,
+
+    fields: IdRange<ValueId>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ValueId(usize);
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ObjectId(usize);
+
+#[derive(Clone)]
+pub enum ValueRecord {
+    Unset,
+    Null,
+    Number(Number),
+    String(Box<str>),
+    Boolean(bool),
+    List(IdRange<ValueId>),
+    Object(ObjectId),
+
+    /// This variant shouldn't be needed _most_ of the time.  But in the presence of
+    /// JSON scalars or similar we might get lists and objects for which we don't have any
+    /// shape information.  Those go into this branch unchanged.
+    InlineValue(Box<CompactValue>),
+}
+
+#[derive(Clone, Copy)]
+pub struct IdRange<T: Copy> {
+    start: T,
+    end: T,
+}
+
+impl IdRange<ValueId> {
+    pub fn len(&self) -> usize {
+        self.end.0.saturating_sub(self.start.0)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl Iterator for IdRange<ValueId> {
+    type Item = ValueId;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.start == self.end {
+            return None;
+        }
+
+        let next = self.start;
+        self.start = ValueId(self.start.0 + 1);
+
+        Some(next)
+    }
+}
+
+impl OutputStore {
+    fn root_object(&self) -> Option<ObjectId> {
+        match self.values.first()? {
+            ValueRecord::Object(id) => Some(*id),
+            _ => None,
+        }
+    }
+
+    pub(super) fn insert_object(&mut self, object_shape: ConcreteShape<'_>) -> ObjectId {
+        let shape = object_shape.id();
+        let object_id = ObjectId(self.objects.len());
+
+        let fields = self.insert_empty_fields(object_shape.field_count());
+        self.objects.push(ObjectRecord { shape, fields });
+
+        object_id
+    }
+
+    pub(super) fn new_value(&mut self) -> ValueId {
+        let id = ValueId(self.values.len());
+        self.values.push(ValueRecord::Unset);
+        id
+    }
+
+    pub(super) fn write_value(&mut self, id: ValueId, data: ValueRecord) {
+        self.values[id.0] = data;
+    }
+
+    pub(super) fn new_list(&mut self, len: usize) -> IdRange<ValueId> {
+        self.insert_empty_fields(len)
+    }
+
+    pub(super) fn insert_empty_fields(&mut self, size: usize) -> IdRange<ValueId> {
+        let start = ValueId(self.values.len());
+        self.values.extend(std::iter::repeat(ValueRecord::Unset).take(size));
+        let end = ValueId(self.values.len());
+
+        IdRange { start, end }
+    }
+
+    pub(super) fn field_value_id(&self, object_id: ObjectId, index: FieldIndex) -> ValueId {
+        let object = &self.objects[object_id.0];
+        assert!((index.0 as usize) < object.fields.len());
+
+        ValueId(object.fields.start.0 + (index.0 as usize))
+    }
+
+    // TODO: Should this be Value?  Not sure.
+    pub(super) fn value(&self, id: ValueId) -> &ValueRecord {
+        &self.values[id.0]
+    }
+
+    pub(super) fn object(&self, id: ValueId) -> &ValueRecord {
+        &self.values[id.0]
+    }
+
+    pub(super) fn reader<'a>(&'a self, shapes: &'a OutputShapes) -> Option<Object<'a>> {
+        Some(Object {
+            id: self.root_object()?,
+            shapes,
+            store: self,
+        })
+    }
+
+    fn read_value<'a>(&'a self, id: ValueId, shapes: &'a OutputShapes) -> Value<'a> {
+        match &self.values[id.0] {
+            ValueRecord::Unset | ValueRecord::Null => Value::Null,
+            ValueRecord::Number(number) if number.is_f64() => Value::Float(number.as_f64().unwrap()),
+            ValueRecord::Number(number) => Value::Integer(number.as_i64().unwrap()),
+            ValueRecord::String(string) => Value::String(string.as_ref()),
+            ValueRecord::Boolean(inner) => Value::Boolean(*inner),
+            ValueRecord::InlineValue(inner) => Value::Inline(inner.as_ref()),
+            ValueRecord::List(ids) => Value::List(List {
+                ids: *ids,
+                store: self,
+                shapes,
+            }),
+            ValueRecord::Object(id) => Value::Object(Object {
+                id: *id,
+                store: self,
+                shapes,
+            }),
+        }
+    }
+}
+
+/// Reader for Values
+#[derive(Clone, Copy)]
+pub enum Value<'a> {
+    Null,
+    Float(f64),
+    Integer(i64),
+    String(&'a str),
+    Boolean(bool),
+    List(List<'a>),
+    Object(Object<'a>),
+    Inline(&'a CompactValue),
+}
+
+#[derive(Clone, Copy)]
+pub struct List<'a> {
+    ids: IdRange<ValueId>,
+    store: &'a OutputStore,
+    shapes: &'a OutputShapes,
+}
+
+impl<'a> Iterator for List<'a> {
+    type Item = Value<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(self.store.read_value(self.ids.next()?, self.shapes))
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct Object<'a> {
+    id: ObjectId,
+    store: &'a OutputStore,
+    shapes: &'a OutputShapes,
+}
+
+impl<'a> Object<'a> {
+    pub fn len(&self) -> usize {
+        self.record().fields.len()
+    }
+
+    pub fn fields(&self) -> impl Iterator<Item = (&'a str, Value<'a>)> + 'a {
+        let record = self.record();
+        let shapes = self.shapes;
+        let shape = shapes.concrete_object(record.shape);
+        let store = self.store;
+
+        shape
+            .response_keys()
+            .zip(record.fields)
+            .map(move |(key, id)| (key, store.read_value(id, shapes)))
+    }
+
+    fn record(&self) -> &'a ObjectRecord {
+        &self.store.objects[self.id.0]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sizes() {
+        // There will be tons of these, so they should be as small as possible
+        assert_eq!(std::mem::size_of::<ValueRecord>(), 24);
+        assert_eq!(std::mem::size_of::<ObjectRecord>(), 24);
+    }
+}

--- a/engine/crates/partial-caching/src/output/tests.rs
+++ b/engine/crates/partial-caching/src/output/tests.rs
@@ -1,0 +1,73 @@
+//! Unit tests for the output module.
+//!
+//! These might get deleted in favour of integration tests at some point, but
+//! this module isn't hooked up at all just now so they're kinda useful
+
+use graph_entities::QueryResponse;
+use serde_json::json;
+
+use super::{shapes::build_output_shapes, OutputStore};
+
+// For ease of testing none of these things are cacheable
+const SCHEMA: &str = r#"
+    type Query {
+        user: User @resolver(name: "whatever")
+    }
+
+    type User {
+        name: String
+        email: String
+        someConstant: String
+        nested: [Nested]
+    }
+
+    type Nested {
+        someThing: String
+    }
+"#;
+
+const QUERY: &str = r#"{ user { name email someConstant nested { someThing } } }"#;
+
+#[test]
+fn test_initial_response_handling() {
+    let registry = build_registry(SCHEMA);
+    let plan = crate::build_plan(QUERY, None, &registry).unwrap().unwrap();
+
+    let shapes = build_output_shapes(plan);
+    let nocache_shape = shapes.nocache_shape();
+
+    let mut query_response = QueryResponse::default();
+    let root_node = query_response.from_serde_value(json!({
+        "user": {
+            "name": "G",
+            "email": "whatever",
+            "someConstant": "123",
+            "nested": [{"someThing": "hello"}, {"someThing": "goodbye"}]
+        }
+    }));
+    query_response.set_root_unchecked(root_node);
+
+    let output = OutputStore::new(query_response, nocache_shape);
+
+    insta::assert_json_snapshot!(output.serialize_all(&shapes, serde_json::value::Serializer).unwrap(), @r###"
+    {
+      "user": {
+        "name": "G",
+        "email": "whatever",
+        "someConstant": "123",
+        "nested": [
+          {
+            "someThing": "hello"
+          },
+          {
+            "someThing": "goodbye"
+          }
+        ]
+      }
+    }
+    "###);
+}
+
+fn build_registry(schema: &str) -> registry_for_cache::PartialCacheRegistry {
+    registry_upgrade::convert_v1_to_partial_cache_registry(parser_sdl::parse_registry(schema).unwrap()).unwrap()
+}

--- a/engine/crates/partial-caching/src/updating/ser.rs
+++ b/engine/crates/partial-caching/src/updating/ser.rs
@@ -2,7 +2,7 @@ use cynic_parser::executable::{iter::Iter, FieldSelection, Selection};
 use graph_entities::{QueryResponse, QueryResponseNode, ResponseContainer};
 use serde::ser::{Error, SerializeMap};
 
-use crate::{query_subset::FieldIter, QuerySubset};
+use crate::{parser_extensions::FieldExt, query_subset::FieldIter, QuerySubset};
 
 #[derive(Clone, Copy)]
 struct SerializeContext<'a> {
@@ -104,16 +104,6 @@ impl serde::Serialize for ValueSerializer<'_> {
             }
             QueryResponseNode::Primitive(value) => value.serialize(serializer),
         }
-    }
-}
-
-trait FieldExt {
-    fn response_key(&self) -> &str;
-}
-
-impl FieldExt for FieldSelection<'_> {
-    fn response_key(&self) -> &str {
-        self.alias().unwrap_or(self.name())
     }
 }
 


### PR DESCRIPTION
Adding defer support to partial caching is going to mean keeping response values around in memory for a while.  We can't write to the cache until the full request is finished, so we need to keep the initial response and all it's deferred chunks in memory until the request is finished, when we can write the whole thing into the cache.

Because of this, I want to keep the memory footprint of this data small.  This PR contains an `OutputStore` type that I'll use to store the output, code for writing a QueryResponse into this structure, and a quick sanity test to make sure it works.

There's a lot of todos in this PR, which I'll come back to later.

Part of GB-6940