### PR TITLE
fix: feature-gate wasi things

### DIFF
--- a/cli/crates/federated-dev/Cargo.toml
+++ b/cli/crates/federated-dev/Cargo.toml
@@ -22,7 +22,7 @@ indoc = "2.0.5"
 log = "0.4.21"
 reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 runtime.workspace = true
-runtime-local.workspace = true
+runtime-local = { workspace = true, features = ["wasi"] }
 runtime-noop.workspace = true
 serde = "1.0.199"
 serde_json.workspace = true

--- a/cli/crates/gateway/Cargo.toml
+++ b/cli/crates/gateway/Cargo.toml
@@ -32,7 +32,7 @@ registry-v2.workspace = true
 registry-for-cache.workspace = true
 runtime = { path = "../../../engine/crates/runtime" }
 runtime-noop = { path = "../../../engine/crates/runtime-noop" }
-runtime-local = { path = "../../../engine/crates/runtime-local" }
+runtime-local = { path = "../../../engine/crates/runtime-local", features = ["wasi"] }
 common-types = { path = "../../../engine/crates/common-types" }
 postgres-connector-types = { path = "../../../engine/crates/postgres-connector-types", features = ["pooling"] }
 gateway-v2-auth.workspace = true

--- a/engine/crates/integration-tests/Cargo.toml
+++ b/engine/crates/integration-tests/Cargo.toml
@@ -39,7 +39,7 @@ ulid.workspace = true
 url.workspace = true
 wiremock.workspace = true
 registry-upgrade.workspace = true
-runtime-local.workspace = true
+runtime-local = { workspace = true, features = ["wasi"] }
 runtime-noop.workspace = true
 ory-client = "1.9.0"
 tracing-subscriber = { version = "0.3.18", default-features = false, features = [

--- a/engine/crates/runtime-local/Cargo.toml
+++ b/engine/crates/runtime-local/Cargo.toml
@@ -12,6 +12,9 @@ keywords = ["local", "runtime", "grafbase"]
 [lints]
 workspace = true
 
+[features]
+wasi = ["wasi-component-loader"]
+
 [dependencies]
 async-runtime.workspace = true
 async-trait = "0.1.80"
@@ -32,5 +35,5 @@ reqwest = { workspace = true, features = [
   "json",
   "rustls-tls",
 ] }
-wasi-component-loader = { version = "0.75.0", path = "../wasi-component-loader" }
+wasi-component-loader = { version = "0.75.0", path = "../wasi-component-loader", optional = true }
 

--- a/engine/crates/runtime-local/src/lib.rs
+++ b/engine/crates/runtime-local/src/lib.rs
@@ -5,6 +5,8 @@ mod kv;
 mod log;
 mod pg;
 mod ufd_invoker;
+
+#[cfg(feature = "wasi")]
 mod user_hooks;
 
 pub use bridge::Bridge;
@@ -13,6 +15,8 @@ pub use fetch::NativeFetcher;
 pub use kv::*;
 pub use pg::{LazyPgConnectionsPool, LocalPgTransportFactory};
 pub use ufd_invoker::UdfInvokerImpl;
+
+#[cfg(feature = "wasi")]
 pub use user_hooks::{ComponentLoader, UserHooksWasi, WasiConfig};
 
 pub use crate::log::LogEventReceiverImpl;

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -35,7 +35,7 @@ http.workspace = true
 parser-sdl = { version = "0.1.0", path = "../../../engine/crates/parser-sdl" }
 reqwest = { workspace = true, features = ["http2", "json", "rustls-tls"] }
 runtime.workspace = true
-runtime-local.workspace = true
+runtime-local = { workspace = true, features = ["wasi"] }
 runtime-noop.workspace = true
 serde.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
API depends on runtime-local for things, we don't want to compile the whole wasmtime toolchain there.

Part of: GB-6901
