### PR TITLE
fix: a single shape hierarchy per query in partial-caching

### DIFF
--- a/engine/crates/partial-caching/src/output/engine_response.rs
+++ b/engine/crates/partial-caching/src/output/engine_response.rs
@@ -3,15 +3,14 @@
 use graph_entities::{CompactValue, QueryResponse, QueryResponseNode, ResponseContainer, ResponseList, ResponseNodeId};
 
 use super::{
-    shapes::ObjectShape,
+    shapes::{ConcreteShape, ObjectShape},
     store::{ValueId, ValueRecord},
-    OutputStore, PartitionShape,
+    OutputStore,
 };
 
 impl OutputStore {
-    pub fn new(response: QueryResponse, shape: PartitionShape<'_>) -> Self {
+    pub fn new(response: QueryResponse, root_object: ConcreteShape<'_>) -> Self {
         let mut output = OutputStore::default();
-        let root_object = shape.root_object();
 
         let Some(root) = response.root else {
             todo!("do something about this");

--- a/engine/crates/partial-caching/src/output/mod.rs
+++ b/engine/crates/partial-caching/src/output/mod.rs
@@ -8,4 +8,4 @@ mod store;
 #[cfg(test)]
 mod tests;
 
-pub use self::{shapes::PartitionShape, store::OutputStore};
+pub use self::store::OutputStore;

--- a/engine/crates/partial-caching/src/output/shapes/mod.rs
+++ b/engine/crates/partial-caching/src/output/shapes/mod.rs
@@ -9,16 +9,14 @@ pub use building::build_output_shapes;
 pub struct OutputShapes {
     objects: Vec<ObjectShapeRecord>,
 
-    // The root object of each of the query partitions.
-    cache_partition_roots: Vec<ConcreteShapeId>,
-    nocache_partition_root: ConcreteShapeId,
+    root: ConcreteShapeId,
 }
 
 impl OutputShapes {
-    pub fn nocache_shape(&self) -> PartitionShape<'_> {
-        PartitionShape {
-            object_id: self.nocache_partition_root,
+    pub fn root(&self) -> ConcreteShape<'_> {
+        ConcreteShape {
             shapes: self,
+            id: self.root,
         }
     }
 
@@ -33,21 +31,6 @@ impl OutputShapes {
                 id: ConcreteShapeId(id.0),
             }),
             ObjectShapeRecord::Polymorphic { .. } => ObjectShape::Polymorphic(PolymorphicShape { shapes: self, id }),
-        }
-    }
-}
-
-/// PartitionShape is the root of a partitions output shape heirarchy.
-pub struct PartitionShape<'a> {
-    object_id: ConcreteShapeId,
-    shapes: &'a OutputShapes,
-}
-
-impl<'a> PartitionShape<'a> {
-    pub fn root_object(&self) -> ConcreteShape<'a> {
-        ConcreteShape {
-            shapes: self.shapes,
-            id: self.object_id,
         }
     }
 }


### PR DESCRIPTION
In #1786 I started calculating the shape of output for partial-caching, which we can use to tell whether or not we're inside a defer when traversing some JSON.

In #1791 I added an "OutputStore" that ties into this, which stores objects something like this:

```
struct Object {
  shape_id: ObjectShapeId,
  fields: Vec<Value>
}
```

This saves having to store the keys of objects alongside the data, as you can just grab them from the associated shape.

The problem is, in #1786 I was building up multiple shape heirarchies - one for each partition of the query.  So when it comes time to merge those partitions together there's no single object shape that has all the fields we need an object to have.  Oops.

This PR fixes that by generating a single heirarchy for the entire query.  This is also simpler, so that's nice.