### PR TITLE
chore(engine-v2): Refactor required fields

### DIFF
--- a/engine/crates/engine-v2/schema/src/builder/coerce/mod.rs
+++ b/engine/crates/engine-v2/schema/src/builder/coerce/mod.rs
@@ -152,6 +152,7 @@ impl<'a> InputValueCoercer<'a> {
                 path: self.path(),
             });
         }
+        fields_buffer.sort_unstable_by_key(|(id, _)| *id);
         let ids = self.input_values.append_input_object(&mut fields_buffer);
         self.input_fields_buffer_pool.push(fields_buffer);
         Ok(SchemaInputValue::InputObject(ids))
@@ -230,6 +231,12 @@ impl<'a> InputValueCoercer<'a> {
                         for ((name, value), id) in fields.into_vec().into_iter().zip(ids) {
                             self.input_values[id] = (name.into(), self.coerce_scalar(scalar_id, value)?);
                         }
+                        self.input_values[ids].sort_unstable_by(|(left_key, _), (right_key, _)| {
+                            self.ctx
+                                .strings
+                                .get_by_id(*left_key)
+                                .cmp(&self.ctx.strings.get_by_id(*right_key))
+                        });
                         SchemaInputValue::Map(ids)
                     }
                     Value::List(list) => {

--- a/engine/crates/engine-v2/schema/src/builder/graph.rs
+++ b/engine/crates/engine-v2/schema/src/builder/graph.rs
@@ -62,7 +62,7 @@ impl<'a> GraphBuilder<'a> {
                 type_definitions: Vec::new(),
                 type_system_directives: Vec::new(),
                 required_field_sets: Vec::new(),
-                required_fields_arguments: Vec::new(),
+                required_fields: Vec::new(),
                 cache_control: Vec::new(),
                 input_values: Default::default(),
                 required_scopes: Vec::new(),

--- a/engine/crates/engine-v2/schema/src/builder/mod.rs
+++ b/engine/crates/engine-v2/schema/src/builder/mod.rs
@@ -109,7 +109,7 @@ impl BuildContext {
             enum_value_definitions: Vec::new(),
             resolvers: Vec::new(),
             required_field_sets: Vec::new(),
-            required_fields_arguments: Vec::new(),
+            required_fields: Vec::new(),
             cache_control: Vec::new(),
             input_values: Default::default(),
             required_scopes: Vec::new(),

--- a/engine/crates/engine-v2/schema/src/ids.rs
+++ b/engine/crates/engine-v2/schema/src/ids.rs
@@ -2,8 +2,8 @@
 /// They can only be created by From<usize>
 use crate::{
     CacheControl, Definition, Enum, EnumValue, FieldDefinition, Graph, Header, InputObject, InputValueDefinition,
-    Interface, Object, RequiredFieldArguments, RequiredFieldSet, RequiredScopes, Resolver, Scalar, Schema,
-    TypeSystemDirective, Union,
+    Interface, Object, RequiredField, RequiredFieldSet, RequiredScopes, Resolver, Scalar, Schema, TypeSystemDirective,
+    Union,
 };
 use url::Url;
 
@@ -26,7 +26,7 @@ id_newtypes::NonZeroU32! {
     Graph.union_definitions[UnionId] => Union | max(MAX_ID) | index(Schema.graph),
     Graph.resolvers[ResolverId] => Resolver | max(MAX_ID) | index(Schema.graph),
     Graph.required_field_sets[RequiredFieldSetId] => RequiredFieldSet | max(MAX_ID) | index(Schema.graph),
-    Graph.required_fields_arguments[RequiredFieldSetArgumentsId] => RequiredFieldArguments | max(MAX_ID) | index(Schema.graph),
+    Graph.required_fields[RequiredFieldId] => RequiredField | max(MAX_ID) | index(Schema.graph),
     Graph.cache_control[CacheControlId] => CacheControl | max(MAX_ID) | index(Schema.graph),
     Graph.required_scopes[RequiredScopesId] => RequiredScopes | max(MAX_ID) | index(Schema.graph),
     Schema.headers[HeaderId] => Header | max(MAX_ID),

--- a/engine/crates/engine-v2/schema/src/input_value/mod.rs
+++ b/engine/crates/engine-v2/schema/src/input_value/mod.rs
@@ -105,8 +105,8 @@ pub enum SchemaInputValue {
     InputObject(IdRange<SchemaInputObjectFieldValueId>),
     List(IdRange<SchemaInputValueId>),
 
-    /// for JSON
-    // sorted by StringId
+    // for JSON
+    // sorted by the key (actual String, not the StringId)
     Map(IdRange<SchemaInputKeyValueId>),
     U64(u64),
 }

--- a/engine/crates/engine-v2/schema/src/lib.rs
+++ b/engine/crates/engine-v2/schema/src/lib.rs
@@ -80,7 +80,7 @@ pub struct Graph {
     resolvers: Vec<Resolver>,
     required_field_sets: Vec<RequiredFieldSet>,
     // deduplicated
-    required_fields_arguments: Vec<RequiredFieldArguments>,
+    required_fields: Vec<RequiredField>,
     /// Default input values & directive arguments
     input_values: SchemaInputValues,
     cache_control: Vec<CacheControl>,

--- a/engine/crates/engine-v2/schema/src/walkers/requires.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/requires.rs
@@ -1,9 +1,7 @@
-use std::cmp::Ordering;
-
-use crate::{RequiredField, RequiredFieldSet, RequiredFieldSetArgumentsId, SchemaWalker};
+use crate::{FieldDefinitionWalker, RequiredFieldId, RequiredFieldSet, RequiredFieldSetItem, SchemaWalker};
 
 pub type RequiredFieldsWalker<'a> = SchemaWalker<'a, &'a RequiredFieldSet>;
-pub type RequiredFieldWalker<'a> = SchemaWalker<'a, &'a RequiredField>;
+pub type RequiredFieldSetItemWalker<'a> = SchemaWalker<'a, &'a RequiredFieldSetItem>;
 
 impl std::fmt::Debug for RequiredFieldsWalker<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -13,64 +11,32 @@ impl std::fmt::Debug for RequiredFieldsWalker<'_> {
     }
 }
 
-impl std::fmt::Debug for RequiredFieldWalker<'_> {
+impl<'a> RequiredFieldSetItemWalker<'a> {
+    pub fn required_field_id(&self) -> RequiredFieldId {
+        self.item.id
+    }
+
+    pub fn name(&self) -> &'a str {
+        self.definition().name()
+    }
+
+    pub fn definition(&self) -> FieldDefinitionWalker<'a> {
+        self.walk(self.schema[self.item.id].definition_id)
+    }
+
+    pub fn subselection(&self) -> impl Iterator<Item = RequiredFieldSetItemWalker<'a>> + '_ {
+        self.item.subselection.iter().map(move |id| self.walk(id))
+    }
+}
+
+impl std::fmt::Debug for RequiredFieldSetItemWalker<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut f = f.debug_struct("RequiredField");
-        f.field("name", &self.walk(self.item.definition_id).name());
-        if let Some(arguments_id) = self.item.arguments_id {
-            f.field("arguments", &self.walk(arguments_id));
-        }
+        f.field("name", &self.name());
+        // FIXME: add arguments back in Debug.
+        f.field("arguments", &"FIXME!!");
         if !self.item.subselection.is_empty() {
             f.field("subselection", &self.walk(&self.item.subselection));
-        }
-        f.finish()
-    }
-}
-
-pub type RequiredFieldArgumentsWalker<'a> = SchemaWalker<'a, RequiredFieldSetArgumentsId>;
-
-impl<'a> Ord for RequiredFieldArgumentsWalker<'a> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        let left = self.as_ref();
-        let right = other.as_ref();
-        left.len().cmp(&right.len()).then_with(|| {
-            // arguments are sorted by InputValueDefinitionId
-            for ((lid, lvalue), (rid, rvalue)) in left.iter().zip(right.iter()) {
-                match lid
-                    .cmp(rid)
-                    .then_with(|| self.walk(&self.schema[*lvalue]).cmp(&self.walk(&self.schema[*rvalue])))
-                {
-                    Ordering::Equal => (),
-                    other => return other,
-                }
-            }
-            Ordering::Equal
-        })
-    }
-}
-
-impl PartialEq for RequiredFieldArgumentsWalker<'_> {
-    fn eq(&self, other: &Self) -> bool {
-        self.cmp(other).is_eq()
-    }
-}
-
-impl Eq for RequiredFieldArgumentsWalker<'_> {}
-
-impl PartialOrd for RequiredFieldArgumentsWalker<'_> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl std::fmt::Debug for RequiredFieldArgumentsWalker<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut f = f.debug_struct("RequiredFieldArguments");
-        for (input_value_definition_id, value_id) in self.as_ref().iter() {
-            f.field(
-                self.walk(*input_value_definition_id).name(),
-                &self.walk(&self.schema[*value_id]),
-            );
         }
         f.finish()
     }

--- a/engine/crates/engine-v2/src/operation/bind/mod.rs
+++ b/engine/crates/engine-v2/src/operation/bind/mod.rs
@@ -494,7 +494,6 @@ impl<'a> Binder<'a> {
             }
         }
         let end = self.field_arguments.len();
-        self.field_arguments[start..end].sort_unstable_by_key(|arg| arg.input_value_definition_id);
         Ok((start..end).into())
     }
 

--- a/engine/crates/engine-v2/src/operation/build.rs
+++ b/engine/crates/engine-v2/src/operation/build.rs
@@ -81,7 +81,7 @@ impl Operation {
         };
 
         // Creating a walker with no variables enabling validation to use them
-        let variables = Variables::empty_for(&operation);
+        let variables = Variables::create_unavailable_for(&operation);
         operation.cache_control = compute_cache_control(operation.walker_with(schema.walker(), &variables), request);
         if let Err(err) =
             super::validation::validate_operation(ctx, operation.walker_with(schema.walker(), &variables), request)

--- a/engine/crates/engine-v2/src/operation/variables.rs
+++ b/engine/crates/engine-v2/src/operation/variables.rs
@@ -19,14 +19,21 @@ pub struct VariableDefinition {
 
 pub struct Variables {
     pub input_values: VariableInputValues,
-    pub definition_to_input_value: Vec<Option<VariableInputValueId>>,
+    pub definition_to_value: Vec<VariableValue>,
+}
+
+#[derive(Clone)]
+pub enum VariableValue {
+    Unavailable,
+    Undefined,
+    InputValue(VariableInputValueId),
 }
 
 impl std::ops::Index<VariableDefinitionId> for Variables {
-    type Output = Option<VariableInputValueId>;
+    type Output = VariableValue;
 
     fn index(&self, index: VariableDefinitionId) -> &Self::Output {
-        &self.definition_to_input_value[usize::from(index)]
+        &self.definition_to_value[usize::from(index)]
     }
 }
 
@@ -50,10 +57,17 @@ impl Variables {
         bind_variables(schema, operation, request_variables)
     }
 
-    pub(super) fn empty_for(operation: &Operation) -> Self {
+    pub(super) fn new_for(operation: &Operation) -> Self {
         Variables {
             input_values: VariableInputValues::default(),
-            definition_to_input_value: vec![None; operation.variable_definitions.len()],
+            definition_to_value: vec![VariableValue::Undefined; operation.variable_definitions.len()],
+        }
+    }
+
+    pub(super) fn create_unavailable_for(operation: &Operation) -> Self {
+        Variables {
+            input_values: VariableInputValues::default(),
+            definition_to_value: vec![VariableValue::Unavailable; operation.variable_definitions.len()],
         }
     }
 }

--- a/engine/crates/engine-v2/src/operation/walkers/argument.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/argument.rs
@@ -1,5 +1,5 @@
 use id_newtypes::IdRange;
-use schema::{InputValueDefinitionId, InputValueDefinitionWalker, InputValueSerdeError, RequiredFieldSetArgumentsId};
+use schema::{InputValueDefinitionId, InputValueDefinitionWalker, InputValueSerdeError};
 use serde::{de::value::MapDeserializer, forward_to_deserialize_any};
 
 use crate::operation::{FieldArgumentId, QueryInputValueWalker};
@@ -91,26 +91,5 @@ impl<'de> serde::Deserializer<'de> for FieldArgumentsWalker<'de> {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf unit unit_struct newtype_struct seq tuple
         tuple_struct map struct enum identifier option ignored_any
-    }
-}
-
-impl PartialEq<Option<RequiredFieldSetArgumentsId>> for FieldArgumentsWalker<'_> {
-    fn eq(&self, required_arguments_id: &Option<RequiredFieldSetArgumentsId>) -> bool {
-        let Some(required_args) = required_arguments_id.map(|id| &self.schema_walker.as_ref()[id]) else {
-            return self.is_empty();
-        };
-        let input_values = self
-            .into_iter()
-            .filter_map(|arg| Some((arg.as_ref().input_value_definition_id, arg.value()?)))
-            .collect::<Vec<_>>();
-        if input_values.len() != required_args.len() {
-            return false;
-        }
-        for ((lid, lvalue), (rid, rvalue_id)) in input_values.into_iter().zip(required_args.iter()) {
-            if lid != *rid || !lvalue.eq(&self.schema_walker[*rvalue_id]) {
-                return false;
-            }
-        }
-        true
     }
 }

--- a/engine/crates/engine-v2/src/plan/planning/planner.rs
+++ b/engine/crates/engine-v2/src/plan/planning/planner.rs
@@ -462,7 +462,7 @@ impl<'schema> Planner<'schema> {
 
 // Utilities
 impl<'schema> Planner<'schema> {
-    pub fn walker(&self) -> OperationWalker<'_> {
+    pub fn walker(&self) -> OperationWalker<'_, (), ()> {
         self.operation.walker_with(self.schema.walker(), self.variables)
     }
 


### PR DESCRIPTION
In a next PR I'll need required field to be deduplicated, before I only
deduplicated arguments, not the full field itself. This makes it a lot
easier to track requirements later.

I'm also adding a `Unavailable` case for variables, planning will be
done without variables to be cache-able. This can lead us to add extra
fields which aren't actually required for some variables, but that's
something to optimize for later.

I've fixed what would definitely be bugs in field comparison between
required ones and operation ones. I was assuming a specific ordering
of input values at various places that wasn't guaranteed. I really
need to add tests for this...
