### PR TITLE
feat: passable context object for hooks

### DIFF
--- a/engine/crates/engine-v2/axum/src/websocket/accepter.rs
+++ b/engine/crates/engine-v2/axum/src/websocket/accepter.rs
@@ -167,12 +167,15 @@ async fn accept_websocket(websocket: &mut WebSocket, engine: &EngineWatcher) -> 
                     return None;
                 };
 
-                let Some(session) = engine.create_session(headers).await else {
-                    websocket
-                        .send(Message::close(4403, "Forbidden").to_axum_message().unwrap())
-                        .await
-                        .ok();
-                    return None;
+                let session = match engine.create_session(headers).await {
+                    Ok(session) => session,
+                    Err(e) => {
+                        websocket
+                            .send(Message::close(4403, e).to_axum_message().unwrap())
+                            .await
+                            .ok();
+                        return None;
+                    }
                 };
 
                 websocket

--- a/engine/crates/integration-tests/src/federation/builder/user_hooks.rs
+++ b/engine/crates/integration-tests/src/federation/builder/user_hooks.rs
@@ -1,9 +1,10 @@
-use std::pin::Pin;
+use std::{collections::HashMap, pin::Pin};
 
 use http::HeaderMap;
 use runtime::user_hooks::{UserHookError, UserHooksImpl};
 
-type GatewayCallback = Pin<Box<dyn Fn(HeaderMap) -> Result<HeaderMap, UserHookError> + Send + Sync + 'static>>;
+type GatewayCallback =
+    Pin<Box<dyn Fn(HeaderMap) -> Result<(HashMap<String, String>, HeaderMap), UserHookError> + Send + Sync + 'static>>;
 
 #[derive(Default)]
 pub struct UserHooksTest {
@@ -13,7 +14,7 @@ pub struct UserHooksTest {
 impl UserHooksTest {
     pub fn on_gateway_request<F>(mut self, callback: F) -> Self
     where
-        F: Fn(HeaderMap) -> Result<HeaderMap, UserHookError> + Send + Sync + 'static,
+        F: Fn(HeaderMap) -> Result<(HashMap<String, String>, HeaderMap), UserHookError> + Send + Sync + 'static,
     {
         self.on_gateway_request = Some(Box::pin(callback));
         self
@@ -22,10 +23,12 @@ impl UserHooksTest {
 
 #[async_trait::async_trait]
 impl UserHooksImpl for UserHooksTest {
-    async fn on_gateway_request(&self, headers: HeaderMap) -> Result<HeaderMap, UserHookError> {
+    type Context = HashMap<String, String>;
+
+    async fn on_gateway_request(&self, headers: HeaderMap) -> Result<(Self::Context, HeaderMap), UserHookError> {
         match self.on_gateway_request {
             Some(ref callback) => callback(headers),
-            None => Ok(headers),
+            None => Ok((HashMap::new(), headers)),
         }
     }
 }

--- a/engine/crates/integration-tests/tests/federation/user_hooks.rs
+++ b/engine/crates/integration-tests/tests/federation/user_hooks.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use engine_v2::Engine;
 use graphql_mocks::{FakeGithubSchema, MockGraphQlServer};
@@ -13,7 +13,7 @@ use serde_json::Value;
 fn a_gateway_request_no_op() {
     let response = runtime().block_on(async move {
         let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
-        let user_hooks = UserHooksTest::default().on_gateway_request(Ok);
+        let user_hooks = UserHooksTest::default().on_gateway_request(|headers| Ok((HashMap::new(), headers)));
 
         let engine = Engine::builder()
             .with_user_hooks(user_hooks)

--- a/engine/crates/runtime-local/src/user_hooks.rs
+++ b/engine/crates/runtime-local/src/user_hooks.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use runtime::user_hooks::{HeaderMap, UserError, UserHookError, UserHooksImpl};
 pub use wasi_component_loader::{ComponentLoader, Config as WasiConfig};
 
@@ -11,8 +13,16 @@ impl UserHooksWasi {
 
 #[async_trait::async_trait]
 impl UserHooksImpl for UserHooksWasi {
-    async fn on_gateway_request(&self, headers: HeaderMap) -> Result<HeaderMap, UserHookError> {
-        Ok(self.0.on_gateway_request(headers).await.map_err(to_local_error)?)
+    type Context = HashMap<String, String>;
+
+    async fn on_gateway_request(&self, headers: HeaderMap) -> Result<(Self::Context, HeaderMap), UserHookError> {
+        let context = Self::Context::new();
+
+        Ok(self
+            .0
+            .on_gateway_request(context, headers)
+            .await
+            .map_err(to_local_error)?)
     }
 }
 

--- a/engine/crates/runtime-noop/src/user_hooks.rs
+++ b/engine/crates/runtime-noop/src/user_hooks.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use runtime::user_hooks::{HeaderMap, UserHookError, UserHooksImpl};
 
 #[derive(Clone)]
@@ -5,7 +7,9 @@ pub struct UserHooksNoop;
 
 #[async_trait::async_trait]
 impl UserHooksImpl for UserHooksNoop {
-    async fn on_gateway_request(&self, headers: HeaderMap) -> Result<HeaderMap, UserHookError> {
-        Ok(headers)
+    type Context = HashMap<String, String>;
+
+    async fn on_gateway_request(&self, headers: HeaderMap) -> Result<(Self::Context, HeaderMap), UserHookError> {
+        Ok((HashMap::new(), headers))
     }
 }

--- a/engine/crates/wasi-component-loader/examples/crates/dir_access/src/bindings.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/dir_access/src/bindings.rs
@@ -2,12 +2,16 @@
 // Options used:
 pub type Headers = component::grafbase::types::Headers;
 pub type ErrorResponse = component::grafbase::types::ErrorResponse;
+pub type Context = component::grafbase::types::Context;
 #[doc(hidden)]
 #[allow(non_snake_case)]
-pub unsafe fn _export_on_gateway_request_cabi<T: Guest>(arg0: i32) -> *mut u8 {
+pub unsafe fn _export_on_gateway_request_cabi<T: Guest>(arg0: i32, arg1: i32) -> *mut u8 {
     #[cfg(target_arch = "wasm32")]
     _rt::run_ctors_once();
-    let result0 = T::on_gateway_request(component::grafbase::types::Headers::from_handle(arg0 as u32));
+    let result0 = T::on_gateway_request(
+        component::grafbase::types::Context::from_handle(arg0 as u32),
+        component::grafbase::types::Headers::from_handle(arg1 as u32),
+    );
     let ptr1 = _RET_AREA.0.as_mut_ptr().cast::<u8>();
     match result0 {
         Ok(_) => {
@@ -93,7 +97,7 @@ pub unsafe fn __post_return_on_gateway_request<T: Guest>(arg0: *mut u8) {
     }
 }
 pub trait Guest {
-    fn on_gateway_request(headers: Headers) -> Result<(), ErrorResponse>;
+    fn on_gateway_request(context: Context, headers: Headers) -> Result<(), ErrorResponse>;
 }
 #[doc(hidden)]
 
@@ -101,8 +105,8 @@ macro_rules! __export_world_gateway_cabi{
   ($ty:ident with_types_in $($path_to_types:tt)*) => (const _: () = {
 
     #[export_name = "on-gateway-request"]
-    unsafe extern "C" fn export_on_gateway_request(arg0: i32,) -> *mut u8 {
-      $($path_to_types)*::_export_on_gateway_request_cabi::<$ty>(arg0)
+    unsafe extern "C" fn export_on_gateway_request(arg0: i32,arg1: i32,) -> *mut u8 {
+      $($path_to_types)*::_export_on_gateway_request_cabi::<$ty>(arg0, arg1)
     }
     #[export_name = "cabi_post_on-gateway-request"]
     unsafe extern "C" fn _post_return_on_gateway_request(arg0: *mut u8,) {
@@ -181,6 +185,50 @@ pub mod component {
 
             #[derive(Debug)]
             #[repr(transparent)]
+            pub struct Context {
+                handle: _rt::Resource<Context>,
+            }
+
+            impl Context {
+                #[doc(hidden)]
+                pub unsafe fn from_handle(handle: u32) -> Self {
+                    Self {
+                        handle: _rt::Resource::from_handle(handle),
+                    }
+                }
+
+                #[doc(hidden)]
+                pub fn take_handle(&self) -> u32 {
+                    _rt::Resource::take_handle(&self.handle)
+                }
+
+                #[doc(hidden)]
+                pub fn handle(&self) -> u32 {
+                    _rt::Resource::handle(&self.handle)
+                }
+            }
+
+            unsafe impl _rt::WasmResource for Context {
+                #[inline]
+                unsafe fn drop(_handle: u32) {
+                    #[cfg(not(target_arch = "wasm32"))]
+                    unreachable!();
+
+                    #[cfg(target_arch = "wasm32")]
+                    {
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[resource-drop]context"]
+                            fn drop(_: u32);
+                        }
+
+                        drop(_handle);
+                    }
+                }
+            }
+
+            #[derive(Debug)]
+            #[repr(transparent)]
             pub struct Headers {
                 handle: _rt::Resource<Headers>,
             }
@@ -242,6 +290,116 @@ pub mod component {
                 }
             }
             impl std::error::Error for ErrorResponse {}
+            impl Context {
+                #[allow(unused_unsafe, clippy::all)]
+                pub fn get(&self, name: &str) -> Option<_rt::String> {
+                    unsafe {
+                        #[repr(align(4))]
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 12]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 12]);
+                        let vec0 = name;
+                        let ptr0 = vec0.as_ptr().cast::<u8>();
+                        let len0 = vec0.len();
+                        let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[method]context.get"]
+                            fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8);
+                        }
+
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
+                        let l2 = i32::from(*ptr1.add(0).cast::<u8>());
+                        match l2 {
+                            0 => None,
+                            1 => {
+                                let e = {
+                                    let l3 = *ptr1.add(4).cast::<*mut u8>();
+                                    let l4 = *ptr1.add(8).cast::<usize>();
+                                    let len5 = l4;
+                                    let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
+
+                                    _rt::string_lift(bytes5)
+                                };
+                                Some(e)
+                            }
+                            _ => _rt::invalid_enum_discriminant(),
+                        }
+                    }
+                }
+            }
+            impl Context {
+                #[allow(unused_unsafe, clippy::all)]
+                pub fn set(&self, name: &str, value: &str) {
+                    unsafe {
+                        let vec0 = name;
+                        let ptr0 = vec0.as_ptr().cast::<u8>();
+                        let len0 = vec0.len();
+                        let vec1 = value;
+                        let ptr1 = vec1.as_ptr().cast::<u8>();
+                        let len1 = vec1.len();
+
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[method]context.set"]
+                            fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8, _: usize);
+                        }
+
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8, _: usize) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1.cast_mut(), len1);
+                    }
+                }
+            }
+            impl Context {
+                #[allow(unused_unsafe, clippy::all)]
+                pub fn delete(&self, name: &str) -> Option<_rt::String> {
+                    unsafe {
+                        #[repr(align(4))]
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 12]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 12]);
+                        let vec0 = name;
+                        let ptr0 = vec0.as_ptr().cast::<u8>();
+                        let len0 = vec0.len();
+                        let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[method]context.delete"]
+                            fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8);
+                        }
+
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
+                        let l2 = i32::from(*ptr1.add(0).cast::<u8>());
+                        match l2 {
+                            0 => None,
+                            1 => {
+                                let e = {
+                                    let l3 = *ptr1.add(4).cast::<*mut u8>();
+                                    let l4 = *ptr1.add(8).cast::<usize>();
+                                    let len5 = l4;
+                                    let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
+
+                                    _rt::string_lift(bytes5)
+                                };
+                                Some(e)
+                            }
+                            _ => _rt::invalid_enum_discriminant(),
+                        }
+                    }
+                }
+            }
             impl Headers {
                 #[allow(unused_unsafe, clippy::all)]
                 pub fn get(&self, name: &str) -> Result<Option<_rt::String>, HeaderError> {
@@ -574,19 +732,23 @@ pub(crate) use __export_gateway_impl as export;
 #[cfg(target_arch = "wasm32")]
 #[link_section = "component-type:wit-bindgen:0.25.0:gateway:encoded world"]
 #[doc(hidden)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 563] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xb5\x03\x01A\x02\x01\
-A\x0a\x01B\x10\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
-header-error\x03\0\0\x04\0\x07headers\x03\x01\x01o\x02ss\x01p\x03\x01r\x02\x0aex\
-tensions\x04\x07messages\x04\0\x0eerror-response\x03\0\x05\x01h\x02\x01ks\x01j\x01\
-\x08\x01\x01\x01@\x02\x04self\x07\x04names\0\x09\x04\0\x13[method]headers.get\x01\
-\x0a\x01j\0\x01\x01\x01@\x03\x04self\x07\x04names\x05values\0\x0b\x04\0\x13[meth\
-od]headers.set\x01\x0c\x04\0\x16[method]headers.delete\x01\x0a\x03\x01\x18compon\
-ent:grafbase/types\x05\0\x02\x03\0\0\x07headers\x03\0\x07headers\x03\0\x01\x02\x03\
-\0\0\x0eerror-response\x03\0\x0eerror-response\x03\0\x03\x01i\x02\x01j\0\x01\x04\
-\x01@\x01\x07headers\x05\0\x06\x04\0\x12on-gateway-request\x01\x07\x04\x01\x1aco\
-mponent:grafbase/gateway\x04\0\x0b\x0d\x01\0\x07gateway\x03\0\0\0G\x09producers\x01\
-\x0cprocessed-by\x02\x0dwit-component\x070.208.1\x10wit-bindgen-rust\x060.25.0";
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 731] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xdd\x04\x01A\x02\x01\
+A\x0d\x01B\x17\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
+header-error\x03\0\0\x04\0\x07context\x03\x01\x04\0\x07headers\x03\x01\x01o\x02s\
+s\x01p\x04\x01r\x02\x0aextensions\x05\x07messages\x04\0\x0eerror-response\x03\0\x06\
+\x01h\x02\x01ks\x01@\x02\x04self\x08\x04names\0\x09\x04\0\x13[method]context.get\
+\x01\x0a\x01@\x03\x04self\x08\x04names\x05values\x01\0\x04\0\x13[method]context.\
+set\x01\x0b\x04\0\x16[method]context.delete\x01\x0a\x01h\x03\x01j\x01\x09\x01\x01\
+\x01@\x02\x04self\x0c\x04names\0\x0d\x04\0\x13[method]headers.get\x01\x0e\x01j\0\
+\x01\x01\x01@\x03\x04self\x0c\x04names\x05values\0\x0f\x04\0\x13[method]headers.\
+set\x01\x10\x04\0\x16[method]headers.delete\x01\x0e\x03\x01\x18component:grafbas\
+e/types\x05\0\x02\x03\0\0\x07headers\x03\0\x07headers\x03\0\x01\x02\x03\0\0\x0ee\
+rror-response\x03\0\x0eerror-response\x03\0\x03\x02\x03\0\0\x07context\x03\0\x07\
+context\x03\0\x05\x01i\x06\x01i\x02\x01j\0\x01\x04\x01@\x02\x07context\x07\x07he\
+aders\x08\0\x09\x04\0\x12on-gateway-request\x01\x0a\x04\x01\x1acomponent:grafbas\
+e/gateway\x04\0\x0b\x0d\x01\0\x07gateway\x03\0\0\0G\x09producers\x01\x0cprocesse\
+d-by\x02\x0dwit-component\x070.208.1\x10wit-bindgen-rust\x060.25.0";
 
 #[inline(never)]
 #[doc(hidden)]

--- a/engine/crates/wasi-component-loader/examples/crates/dir_access/src/lib.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/dir_access/src/lib.rs
@@ -1,12 +1,12 @@
 #[allow(warnings)]
 mod bindings;
 
-use bindings::{ErrorResponse, Guest, Headers};
+use bindings::{ErrorResponse, Guest, Context, Headers};
 
 struct Component;
 
 impl Guest for Component {
-    fn on_gateway_request(headers: Headers) -> Result<(), ErrorResponse> {
+    fn on_gateway_request(_: Context, headers: Headers) -> Result<(), ErrorResponse> {
         match std::fs::read_to_string("./contents.txt") {
             Ok(contents) => headers.set("READ_CONTENTS", &contents).unwrap(),
             Err(e) => eprintln!("error reading file contents: {}", e.to_string()),

--- a/engine/crates/wasi-component-loader/examples/crates/error/src/bindings.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/error/src/bindings.rs
@@ -2,12 +2,16 @@
 // Options used:
 pub type Headers = component::grafbase::types::Headers;
 pub type ErrorResponse = component::grafbase::types::ErrorResponse;
+pub type Context = component::grafbase::types::Context;
 #[doc(hidden)]
 #[allow(non_snake_case)]
-pub unsafe fn _export_on_gateway_request_cabi<T: Guest>(arg0: i32) -> *mut u8 {
+pub unsafe fn _export_on_gateway_request_cabi<T: Guest>(arg0: i32, arg1: i32) -> *mut u8 {
     #[cfg(target_arch = "wasm32")]
     _rt::run_ctors_once();
-    let result0 = T::on_gateway_request(component::grafbase::types::Headers::from_handle(arg0 as u32));
+    let result0 = T::on_gateway_request(
+        component::grafbase::types::Context::from_handle(arg0 as u32),
+        component::grafbase::types::Headers::from_handle(arg1 as u32),
+    );
     let ptr1 = _RET_AREA.0.as_mut_ptr().cast::<u8>();
     match result0 {
         Ok(_) => {
@@ -93,7 +97,7 @@ pub unsafe fn __post_return_on_gateway_request<T: Guest>(arg0: *mut u8) {
     }
 }
 pub trait Guest {
-    fn on_gateway_request(headers: Headers) -> Result<(), ErrorResponse>;
+    fn on_gateway_request(context: Context, headers: Headers) -> Result<(), ErrorResponse>;
 }
 #[doc(hidden)]
 
@@ -101,8 +105,8 @@ macro_rules! __export_world_gateway_cabi{
   ($ty:ident with_types_in $($path_to_types:tt)*) => (const _: () = {
 
     #[export_name = "on-gateway-request"]
-    unsafe extern "C" fn export_on_gateway_request(arg0: i32,) -> *mut u8 {
-      $($path_to_types)*::_export_on_gateway_request_cabi::<$ty>(arg0)
+    unsafe extern "C" fn export_on_gateway_request(arg0: i32,arg1: i32,) -> *mut u8 {
+      $($path_to_types)*::_export_on_gateway_request_cabi::<$ty>(arg0, arg1)
     }
     #[export_name = "cabi_post_on-gateway-request"]
     unsafe extern "C" fn _post_return_on_gateway_request(arg0: *mut u8,) {
@@ -181,6 +185,50 @@ pub mod component {
 
             #[derive(Debug)]
             #[repr(transparent)]
+            pub struct Context {
+                handle: _rt::Resource<Context>,
+            }
+
+            impl Context {
+                #[doc(hidden)]
+                pub unsafe fn from_handle(handle: u32) -> Self {
+                    Self {
+                        handle: _rt::Resource::from_handle(handle),
+                    }
+                }
+
+                #[doc(hidden)]
+                pub fn take_handle(&self) -> u32 {
+                    _rt::Resource::take_handle(&self.handle)
+                }
+
+                #[doc(hidden)]
+                pub fn handle(&self) -> u32 {
+                    _rt::Resource::handle(&self.handle)
+                }
+            }
+
+            unsafe impl _rt::WasmResource for Context {
+                #[inline]
+                unsafe fn drop(_handle: u32) {
+                    #[cfg(not(target_arch = "wasm32"))]
+                    unreachable!();
+
+                    #[cfg(target_arch = "wasm32")]
+                    {
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[resource-drop]context"]
+                            fn drop(_: u32);
+                        }
+
+                        drop(_handle);
+                    }
+                }
+            }
+
+            #[derive(Debug)]
+            #[repr(transparent)]
             pub struct Headers {
                 handle: _rt::Resource<Headers>,
             }
@@ -242,6 +290,116 @@ pub mod component {
                 }
             }
             impl std::error::Error for ErrorResponse {}
+            impl Context {
+                #[allow(unused_unsafe, clippy::all)]
+                pub fn get(&self, name: &str) -> Option<_rt::String> {
+                    unsafe {
+                        #[repr(align(4))]
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 12]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 12]);
+                        let vec0 = name;
+                        let ptr0 = vec0.as_ptr().cast::<u8>();
+                        let len0 = vec0.len();
+                        let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[method]context.get"]
+                            fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8);
+                        }
+
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
+                        let l2 = i32::from(*ptr1.add(0).cast::<u8>());
+                        match l2 {
+                            0 => None,
+                            1 => {
+                                let e = {
+                                    let l3 = *ptr1.add(4).cast::<*mut u8>();
+                                    let l4 = *ptr1.add(8).cast::<usize>();
+                                    let len5 = l4;
+                                    let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
+
+                                    _rt::string_lift(bytes5)
+                                };
+                                Some(e)
+                            }
+                            _ => _rt::invalid_enum_discriminant(),
+                        }
+                    }
+                }
+            }
+            impl Context {
+                #[allow(unused_unsafe, clippy::all)]
+                pub fn set(&self, name: &str, value: &str) {
+                    unsafe {
+                        let vec0 = name;
+                        let ptr0 = vec0.as_ptr().cast::<u8>();
+                        let len0 = vec0.len();
+                        let vec1 = value;
+                        let ptr1 = vec1.as_ptr().cast::<u8>();
+                        let len1 = vec1.len();
+
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[method]context.set"]
+                            fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8, _: usize);
+                        }
+
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8, _: usize) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1.cast_mut(), len1);
+                    }
+                }
+            }
+            impl Context {
+                #[allow(unused_unsafe, clippy::all)]
+                pub fn delete(&self, name: &str) -> Option<_rt::String> {
+                    unsafe {
+                        #[repr(align(4))]
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 12]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 12]);
+                        let vec0 = name;
+                        let ptr0 = vec0.as_ptr().cast::<u8>();
+                        let len0 = vec0.len();
+                        let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[method]context.delete"]
+                            fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8);
+                        }
+
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
+                        let l2 = i32::from(*ptr1.add(0).cast::<u8>());
+                        match l2 {
+                            0 => None,
+                            1 => {
+                                let e = {
+                                    let l3 = *ptr1.add(4).cast::<*mut u8>();
+                                    let l4 = *ptr1.add(8).cast::<usize>();
+                                    let len5 = l4;
+                                    let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
+
+                                    _rt::string_lift(bytes5)
+                                };
+                                Some(e)
+                            }
+                            _ => _rt::invalid_enum_discriminant(),
+                        }
+                    }
+                }
+            }
             impl Headers {
                 #[allow(unused_unsafe, clippy::all)]
                 pub fn get(&self, name: &str) -> Result<Option<_rt::String>, HeaderError> {
@@ -574,19 +732,23 @@ pub(crate) use __export_gateway_impl as export;
 #[cfg(target_arch = "wasm32")]
 #[link_section = "component-type:wit-bindgen:0.25.0:gateway:encoded world"]
 #[doc(hidden)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 563] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xb5\x03\x01A\x02\x01\
-A\x0a\x01B\x10\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
-header-error\x03\0\0\x04\0\x07headers\x03\x01\x01o\x02ss\x01p\x03\x01r\x02\x0aex\
-tensions\x04\x07messages\x04\0\x0eerror-response\x03\0\x05\x01h\x02\x01ks\x01j\x01\
-\x08\x01\x01\x01@\x02\x04self\x07\x04names\0\x09\x04\0\x13[method]headers.get\x01\
-\x0a\x01j\0\x01\x01\x01@\x03\x04self\x07\x04names\x05values\0\x0b\x04\0\x13[meth\
-od]headers.set\x01\x0c\x04\0\x16[method]headers.delete\x01\x0a\x03\x01\x18compon\
-ent:grafbase/types\x05\0\x02\x03\0\0\x07headers\x03\0\x07headers\x03\0\x01\x02\x03\
-\0\0\x0eerror-response\x03\0\x0eerror-response\x03\0\x03\x01i\x02\x01j\0\x01\x04\
-\x01@\x01\x07headers\x05\0\x06\x04\0\x12on-gateway-request\x01\x07\x04\x01\x1aco\
-mponent:grafbase/gateway\x04\0\x0b\x0d\x01\0\x07gateway\x03\0\0\0G\x09producers\x01\
-\x0cprocessed-by\x02\x0dwit-component\x070.208.1\x10wit-bindgen-rust\x060.25.0";
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 731] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xdd\x04\x01A\x02\x01\
+A\x0d\x01B\x17\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
+header-error\x03\0\0\x04\0\x07context\x03\x01\x04\0\x07headers\x03\x01\x01o\x02s\
+s\x01p\x04\x01r\x02\x0aextensions\x05\x07messages\x04\0\x0eerror-response\x03\0\x06\
+\x01h\x02\x01ks\x01@\x02\x04self\x08\x04names\0\x09\x04\0\x13[method]context.get\
+\x01\x0a\x01@\x03\x04self\x08\x04names\x05values\x01\0\x04\0\x13[method]context.\
+set\x01\x0b\x04\0\x16[method]context.delete\x01\x0a\x01h\x03\x01j\x01\x09\x01\x01\
+\x01@\x02\x04self\x0c\x04names\0\x0d\x04\0\x13[method]headers.get\x01\x0e\x01j\0\
+\x01\x01\x01@\x03\x04self\x0c\x04names\x05values\0\x0f\x04\0\x13[method]headers.\
+set\x01\x10\x04\0\x16[method]headers.delete\x01\x0e\x03\x01\x18component:grafbas\
+e/types\x05\0\x02\x03\0\0\x07headers\x03\0\x07headers\x03\0\x01\x02\x03\0\0\x0ee\
+rror-response\x03\0\x0eerror-response\x03\0\x03\x02\x03\0\0\x07context\x03\0\x07\
+context\x03\0\x05\x01i\x06\x01i\x02\x01j\0\x01\x04\x01@\x02\x07context\x07\x07he\
+aders\x08\0\x09\x04\0\x12on-gateway-request\x01\x0a\x04\x01\x1acomponent:grafbas\
+e/gateway\x04\0\x0b\x0d\x01\0\x07gateway\x03\0\0\0G\x09producers\x01\x0cprocesse\
+d-by\x02\x0dwit-component\x070.208.1\x10wit-bindgen-rust\x060.25.0";
 
 #[inline(never)]
 #[doc(hidden)]

--- a/engine/crates/wasi-component-loader/examples/crates/error/src/lib.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/error/src/lib.rs
@@ -1,12 +1,12 @@
 #[allow(warnings)]
 mod bindings;
 
-use bindings::{ErrorResponse, Guest, Headers};
+use bindings::{ErrorResponse, Guest, Context, Headers};
 
 struct Component;
 
 impl Guest for Component {
-    fn on_gateway_request(_: Headers) -> Result<(), ErrorResponse> {
+    fn on_gateway_request(_: Context, _: Headers) -> Result<(), ErrorResponse> {
         Err(ErrorResponse {
             message: String::from("not found"),
             extensions: vec![(String::from("my"), String::from("extension"))],

--- a/engine/crates/wasi-component-loader/examples/crates/missing_callback/src/bindings.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/missing_callback/src/bindings.rs
@@ -2,12 +2,16 @@
 // Options used:
 pub type Headers = component::grafbase::types::Headers;
 pub type ErrorResponse = component::grafbase::types::ErrorResponse;
+pub type Context = component::grafbase::types::Context;
 #[doc(hidden)]
 #[allow(non_snake_case)]
-pub unsafe fn _export_on_subgraph_request_cabi<T: Guest>(arg0: i32) -> *mut u8 {
+pub unsafe fn _export_on_subgraph_request_cabi<T: Guest>(arg0: i32, arg1: i32) -> *mut u8 {
     #[cfg(target_arch = "wasm32")]
     _rt::run_ctors_once();
-    let result0 = T::on_subgraph_request(component::grafbase::types::Headers::from_handle(arg0 as u32));
+    let result0 = T::on_subgraph_request(
+        component::grafbase::types::Context::from_handle(arg0 as u32),
+        component::grafbase::types::Headers::from_handle(arg1 as u32),
+    );
     let ptr1 = _RET_AREA.0.as_mut_ptr().cast::<u8>();
     match result0 {
         Ok(_) => {
@@ -52,7 +56,7 @@ pub unsafe fn __post_return_on_subgraph_request<T: Guest>(arg0: *mut u8) {
     }
 }
 pub trait Guest {
-    fn on_subgraph_request(headers: Headers) -> Result<(), ErrorResponse>;
+    fn on_subgraph_request(context: Context, headers: Headers) -> Result<(), ErrorResponse>;
 }
 #[doc(hidden)]
 
@@ -60,8 +64,8 @@ macro_rules! __export_world_gateway_cabi{
   ($ty:ident with_types_in $($path_to_types:tt)*) => (const _: () = {
 
     #[export_name = "on-subgraph-request"]
-    unsafe extern "C" fn export_on_subgraph_request(arg0: i32,) -> *mut u8 {
-      $($path_to_types)*::_export_on_subgraph_request_cabi::<$ty>(arg0)
+    unsafe extern "C" fn export_on_subgraph_request(arg0: i32,arg1: i32,) -> *mut u8 {
+      $($path_to_types)*::_export_on_subgraph_request_cabi::<$ty>(arg0, arg1)
     }
     #[export_name = "cabi_post_on-subgraph-request"]
     unsafe extern "C" fn _post_return_on_subgraph_request(arg0: *mut u8,) {
@@ -140,6 +144,50 @@ pub mod component {
 
             #[derive(Debug)]
             #[repr(transparent)]
+            pub struct Context {
+                handle: _rt::Resource<Context>,
+            }
+
+            impl Context {
+                #[doc(hidden)]
+                pub unsafe fn from_handle(handle: u32) -> Self {
+                    Self {
+                        handle: _rt::Resource::from_handle(handle),
+                    }
+                }
+
+                #[doc(hidden)]
+                pub fn take_handle(&self) -> u32 {
+                    _rt::Resource::take_handle(&self.handle)
+                }
+
+                #[doc(hidden)]
+                pub fn handle(&self) -> u32 {
+                    _rt::Resource::handle(&self.handle)
+                }
+            }
+
+            unsafe impl _rt::WasmResource for Context {
+                #[inline]
+                unsafe fn drop(_handle: u32) {
+                    #[cfg(not(target_arch = "wasm32"))]
+                    unreachable!();
+
+                    #[cfg(target_arch = "wasm32")]
+                    {
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[resource-drop]context"]
+                            fn drop(_: u32);
+                        }
+
+                        drop(_handle);
+                    }
+                }
+            }
+
+            #[derive(Debug)]
+            #[repr(transparent)]
             pub struct Headers {
                 handle: _rt::Resource<Headers>,
             }
@@ -201,6 +249,116 @@ pub mod component {
                 }
             }
             impl std::error::Error for ErrorResponse {}
+            impl Context {
+                #[allow(unused_unsafe, clippy::all)]
+                pub fn get(&self, name: &str) -> Option<_rt::String> {
+                    unsafe {
+                        #[repr(align(4))]
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 12]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 12]);
+                        let vec0 = name;
+                        let ptr0 = vec0.as_ptr().cast::<u8>();
+                        let len0 = vec0.len();
+                        let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[method]context.get"]
+                            fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8);
+                        }
+
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
+                        let l2 = i32::from(*ptr1.add(0).cast::<u8>());
+                        match l2 {
+                            0 => None,
+                            1 => {
+                                let e = {
+                                    let l3 = *ptr1.add(4).cast::<*mut u8>();
+                                    let l4 = *ptr1.add(8).cast::<usize>();
+                                    let len5 = l4;
+                                    let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
+
+                                    _rt::string_lift(bytes5)
+                                };
+                                Some(e)
+                            }
+                            _ => _rt::invalid_enum_discriminant(),
+                        }
+                    }
+                }
+            }
+            impl Context {
+                #[allow(unused_unsafe, clippy::all)]
+                pub fn set(&self, name: &str, value: &str) {
+                    unsafe {
+                        let vec0 = name;
+                        let ptr0 = vec0.as_ptr().cast::<u8>();
+                        let len0 = vec0.len();
+                        let vec1 = value;
+                        let ptr1 = vec1.as_ptr().cast::<u8>();
+                        let len1 = vec1.len();
+
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[method]context.set"]
+                            fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8, _: usize);
+                        }
+
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8, _: usize) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1.cast_mut(), len1);
+                    }
+                }
+            }
+            impl Context {
+                #[allow(unused_unsafe, clippy::all)]
+                pub fn delete(&self, name: &str) -> Option<_rt::String> {
+                    unsafe {
+                        #[repr(align(4))]
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 12]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 12]);
+                        let vec0 = name;
+                        let ptr0 = vec0.as_ptr().cast::<u8>();
+                        let len0 = vec0.len();
+                        let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[method]context.delete"]
+                            fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8);
+                        }
+
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
+                        let l2 = i32::from(*ptr1.add(0).cast::<u8>());
+                        match l2 {
+                            0 => None,
+                            1 => {
+                                let e = {
+                                    let l3 = *ptr1.add(4).cast::<*mut u8>();
+                                    let l4 = *ptr1.add(8).cast::<usize>();
+                                    let len5 = l4;
+                                    let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
+
+                                    _rt::string_lift(bytes5)
+                                };
+                                Some(e)
+                            }
+                            _ => _rt::invalid_enum_discriminant(),
+                        }
+                    }
+                }
+            }
             impl Headers {
                 #[allow(unused_unsafe, clippy::all)]
                 pub fn get(&self, name: &str) -> Result<Option<_rt::String>, HeaderError> {
@@ -603,19 +761,23 @@ pub(crate) use __export_gateway_impl as export;
 #[cfg(target_arch = "wasm32")]
 #[link_section = "component-type:wit-bindgen:0.25.0:gateway:encoded world"]
 #[doc(hidden)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 555] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xad\x03\x01A\x02\x01\
-A\x0a\x01B\x0f\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
-header-error\x03\0\0\x04\0\x07headers\x03\x01\x01k{\x01r\x02\x06status\x03\x07me\
-ssages\x04\0\x0eerror-response\x03\0\x04\x01h\x02\x01ks\x01j\x01\x07\x01\x01\x01\
-@\x02\x04self\x06\x04names\0\x08\x04\0\x13[method]headers.get\x01\x09\x01j\0\x01\
-\x01\x01@\x03\x04self\x06\x04names\x05values\0\x0a\x04\0\x13[method]headers.set\x01\
-\x0b\x04\0\x16[method]headers.delete\x01\x09\x03\x01\x18component:grafbase/types\
-\x05\0\x02\x03\0\0\x07headers\x03\0\x07headers\x03\0\x01\x02\x03\0\0\x0eerror-re\
-sponse\x03\0\x0eerror-response\x03\0\x03\x01i\x02\x01j\0\x01\x04\x01@\x01\x07hea\
-ders\x05\0\x06\x04\0\x13on-subgraph-request\x01\x07\x04\x01\x1acomponent:grafbas\
-e/gateway\x04\0\x0b\x0d\x01\0\x07gateway\x03\0\0\0G\x09producers\x01\x0cprocesse\
-d-by\x02\x0dwit-component\x070.208.1\x10wit-bindgen-rust\x060.25.0";
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 723] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xd5\x04\x01A\x02\x01\
+A\x0d\x01B\x16\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
+header-error\x03\0\0\x04\0\x07context\x03\x01\x04\0\x07headers\x03\x01\x01k{\x01\
+r\x02\x06status\x04\x07messages\x04\0\x0eerror-response\x03\0\x05\x01h\x02\x01ks\
+\x01@\x02\x04self\x07\x04names\0\x08\x04\0\x13[method]context.get\x01\x09\x01@\x03\
+\x04self\x07\x04names\x05values\x01\0\x04\0\x13[method]context.set\x01\x0a\x04\0\
+\x16[method]context.delete\x01\x09\x01h\x03\x01j\x01\x08\x01\x01\x01@\x02\x04sel\
+f\x0b\x04names\0\x0c\x04\0\x13[method]headers.get\x01\x0d\x01j\0\x01\x01\x01@\x03\
+\x04self\x0b\x04names\x05values\0\x0e\x04\0\x13[method]headers.set\x01\x0f\x04\0\
+\x16[method]headers.delete\x01\x0d\x03\x01\x18component:grafbase/types\x05\0\x02\
+\x03\0\0\x07headers\x03\0\x07headers\x03\0\x01\x02\x03\0\0\x0eerror-response\x03\
+\0\x0eerror-response\x03\0\x03\x02\x03\0\0\x07context\x03\0\x07context\x03\0\x05\
+\x01i\x06\x01i\x02\x01j\0\x01\x04\x01@\x02\x07context\x07\x07headers\x08\0\x09\x04\
+\0\x13on-subgraph-request\x01\x0a\x04\x01\x1acomponent:grafbase/gateway\x04\0\x0b\
+\x0d\x01\0\x07gateway\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-com\
+ponent\x070.208.1\x10wit-bindgen-rust\x060.25.0";
 
 #[inline(never)]
 #[doc(hidden)]

--- a/engine/crates/wasi-component-loader/examples/crates/missing_callback/src/lib.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/missing_callback/src/lib.rs
@@ -1,12 +1,12 @@
 #[allow(warnings)]
 mod bindings;
 
-use bindings::{ErrorResponse, Guest, Headers};
+use bindings::{ErrorResponse, Guest, Context, Headers};
 
 struct Component;
 
 impl Guest for Component {
-    fn on_subgraph_request(headers: Headers) -> Result<(), ErrorResponse> {
+    fn on_subgraph_request(_: Context, headers: Headers) -> Result<(), ErrorResponse> {
         headers.set("direct", "call").unwrap();
 
         Ok(())

--- a/engine/crates/wasi-component-loader/examples/crates/missing_callback/wit/world.wit
+++ b/engine/crates/wasi-component-loader/examples/crates/missing_callback/wit/world.wit
@@ -6,6 +6,12 @@ interface types {
         invalid-header-name,
     }
 
+    resource context {
+        get: func(name: string) -> option<string>;
+        set: func(name: string, value: string);
+        delete: func(name: string) -> option<string>;
+    }
+
     resource headers {
         get: func(name: string) -> result<option<string>, header-error>;
         set: func(name: string, value: string) -> result<_, header-error>;
@@ -19,7 +25,7 @@ interface types {
 }
 
 world gateway {
-    use types.{headers, error-response};
+    use types.{headers, error-response, context};
 
-    export on-subgraph-request: func(headers: headers) -> result<_, error-response>;
+    export on-subgraph-request: func(context: context, headers: headers) -> result<_, error-response>;
 }

--- a/engine/crates/wasi-component-loader/examples/crates/networking/src/bindings.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/networking/src/bindings.rs
@@ -2,12 +2,16 @@
 // Options used:
 pub type Headers = component::grafbase::types::Headers;
 pub type ErrorResponse = component::grafbase::types::ErrorResponse;
+pub type Context = component::grafbase::types::Context;
 #[doc(hidden)]
 #[allow(non_snake_case)]
-pub unsafe fn _export_on_gateway_request_cabi<T: Guest>(arg0: i32) -> *mut u8 {
+pub unsafe fn _export_on_gateway_request_cabi<T: Guest>(arg0: i32, arg1: i32) -> *mut u8 {
     #[cfg(target_arch = "wasm32")]
     _rt::run_ctors_once();
-    let result0 = T::on_gateway_request(component::grafbase::types::Headers::from_handle(arg0 as u32));
+    let result0 = T::on_gateway_request(
+        component::grafbase::types::Context::from_handle(arg0 as u32),
+        component::grafbase::types::Headers::from_handle(arg1 as u32),
+    );
     let ptr1 = _RET_AREA.0.as_mut_ptr().cast::<u8>();
     match result0 {
         Ok(_) => {
@@ -93,7 +97,7 @@ pub unsafe fn __post_return_on_gateway_request<T: Guest>(arg0: *mut u8) {
     }
 }
 pub trait Guest {
-    fn on_gateway_request(headers: Headers) -> Result<(), ErrorResponse>;
+    fn on_gateway_request(context: Context, headers: Headers) -> Result<(), ErrorResponse>;
 }
 #[doc(hidden)]
 
@@ -101,8 +105,8 @@ macro_rules! __export_world_gateway_cabi{
   ($ty:ident with_types_in $($path_to_types:tt)*) => (const _: () = {
 
     #[export_name = "on-gateway-request"]
-    unsafe extern "C" fn export_on_gateway_request(arg0: i32,) -> *mut u8 {
-      $($path_to_types)*::_export_on_gateway_request_cabi::<$ty>(arg0)
+    unsafe extern "C" fn export_on_gateway_request(arg0: i32,arg1: i32,) -> *mut u8 {
+      $($path_to_types)*::_export_on_gateway_request_cabi::<$ty>(arg0, arg1)
     }
     #[export_name = "cabi_post_on-gateway-request"]
     unsafe extern "C" fn _post_return_on_gateway_request(arg0: *mut u8,) {
@@ -181,6 +185,50 @@ pub mod component {
 
             #[derive(Debug)]
             #[repr(transparent)]
+            pub struct Context {
+                handle: _rt::Resource<Context>,
+            }
+
+            impl Context {
+                #[doc(hidden)]
+                pub unsafe fn from_handle(handle: u32) -> Self {
+                    Self {
+                        handle: _rt::Resource::from_handle(handle),
+                    }
+                }
+
+                #[doc(hidden)]
+                pub fn take_handle(&self) -> u32 {
+                    _rt::Resource::take_handle(&self.handle)
+                }
+
+                #[doc(hidden)]
+                pub fn handle(&self) -> u32 {
+                    _rt::Resource::handle(&self.handle)
+                }
+            }
+
+            unsafe impl _rt::WasmResource for Context {
+                #[inline]
+                unsafe fn drop(_handle: u32) {
+                    #[cfg(not(target_arch = "wasm32"))]
+                    unreachable!();
+
+                    #[cfg(target_arch = "wasm32")]
+                    {
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[resource-drop]context"]
+                            fn drop(_: u32);
+                        }
+
+                        drop(_handle);
+                    }
+                }
+            }
+
+            #[derive(Debug)]
+            #[repr(transparent)]
             pub struct Headers {
                 handle: _rt::Resource<Headers>,
             }
@@ -242,6 +290,116 @@ pub mod component {
                 }
             }
             impl std::error::Error for ErrorResponse {}
+            impl Context {
+                #[allow(unused_unsafe, clippy::all)]
+                pub fn get(&self, name: &str) -> Option<_rt::String> {
+                    unsafe {
+                        #[repr(align(4))]
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 12]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 12]);
+                        let vec0 = name;
+                        let ptr0 = vec0.as_ptr().cast::<u8>();
+                        let len0 = vec0.len();
+                        let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[method]context.get"]
+                            fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8);
+                        }
+
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
+                        let l2 = i32::from(*ptr1.add(0).cast::<u8>());
+                        match l2 {
+                            0 => None,
+                            1 => {
+                                let e = {
+                                    let l3 = *ptr1.add(4).cast::<*mut u8>();
+                                    let l4 = *ptr1.add(8).cast::<usize>();
+                                    let len5 = l4;
+                                    let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
+
+                                    _rt::string_lift(bytes5)
+                                };
+                                Some(e)
+                            }
+                            _ => _rt::invalid_enum_discriminant(),
+                        }
+                    }
+                }
+            }
+            impl Context {
+                #[allow(unused_unsafe, clippy::all)]
+                pub fn set(&self, name: &str, value: &str) {
+                    unsafe {
+                        let vec0 = name;
+                        let ptr0 = vec0.as_ptr().cast::<u8>();
+                        let len0 = vec0.len();
+                        let vec1 = value;
+                        let ptr1 = vec1.as_ptr().cast::<u8>();
+                        let len1 = vec1.len();
+
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[method]context.set"]
+                            fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8, _: usize);
+                        }
+
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8, _: usize) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1.cast_mut(), len1);
+                    }
+                }
+            }
+            impl Context {
+                #[allow(unused_unsafe, clippy::all)]
+                pub fn delete(&self, name: &str) -> Option<_rt::String> {
+                    unsafe {
+                        #[repr(align(4))]
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 12]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 12]);
+                        let vec0 = name;
+                        let ptr0 = vec0.as_ptr().cast::<u8>();
+                        let len0 = vec0.len();
+                        let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[method]context.delete"]
+                            fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8);
+                        }
+
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
+                        let l2 = i32::from(*ptr1.add(0).cast::<u8>());
+                        match l2 {
+                            0 => None,
+                            1 => {
+                                let e = {
+                                    let l3 = *ptr1.add(4).cast::<*mut u8>();
+                                    let l4 = *ptr1.add(8).cast::<usize>();
+                                    let len5 = l4;
+                                    let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
+
+                                    _rt::string_lift(bytes5)
+                                };
+                                Some(e)
+                            }
+                            _ => _rt::invalid_enum_discriminant(),
+                        }
+                    }
+                }
+            }
             impl Headers {
                 #[allow(unused_unsafe, clippy::all)]
                 pub fn get(&self, name: &str) -> Result<Option<_rt::String>, HeaderError> {
@@ -574,19 +732,23 @@ pub(crate) use __export_gateway_impl as export;
 #[cfg(target_arch = "wasm32")]
 #[link_section = "component-type:wit-bindgen:0.25.0:gateway:encoded world"]
 #[doc(hidden)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 563] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xb5\x03\x01A\x02\x01\
-A\x0a\x01B\x10\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
-header-error\x03\0\0\x04\0\x07headers\x03\x01\x01o\x02ss\x01p\x03\x01r\x02\x0aex\
-tensions\x04\x07messages\x04\0\x0eerror-response\x03\0\x05\x01h\x02\x01ks\x01j\x01\
-\x08\x01\x01\x01@\x02\x04self\x07\x04names\0\x09\x04\0\x13[method]headers.get\x01\
-\x0a\x01j\0\x01\x01\x01@\x03\x04self\x07\x04names\x05values\0\x0b\x04\0\x13[meth\
-od]headers.set\x01\x0c\x04\0\x16[method]headers.delete\x01\x0a\x03\x01\x18compon\
-ent:grafbase/types\x05\0\x02\x03\0\0\x07headers\x03\0\x07headers\x03\0\x01\x02\x03\
-\0\0\x0eerror-response\x03\0\x0eerror-response\x03\0\x03\x01i\x02\x01j\0\x01\x04\
-\x01@\x01\x07headers\x05\0\x06\x04\0\x12on-gateway-request\x01\x07\x04\x01\x1aco\
-mponent:grafbase/gateway\x04\0\x0b\x0d\x01\0\x07gateway\x03\0\0\0G\x09producers\x01\
-\x0cprocessed-by\x02\x0dwit-component\x070.208.1\x10wit-bindgen-rust\x060.25.0";
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 731] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xdd\x04\x01A\x02\x01\
+A\x0d\x01B\x17\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
+header-error\x03\0\0\x04\0\x07context\x03\x01\x04\0\x07headers\x03\x01\x01o\x02s\
+s\x01p\x04\x01r\x02\x0aextensions\x05\x07messages\x04\0\x0eerror-response\x03\0\x06\
+\x01h\x02\x01ks\x01@\x02\x04self\x08\x04names\0\x09\x04\0\x13[method]context.get\
+\x01\x0a\x01@\x03\x04self\x08\x04names\x05values\x01\0\x04\0\x13[method]context.\
+set\x01\x0b\x04\0\x16[method]context.delete\x01\x0a\x01h\x03\x01j\x01\x09\x01\x01\
+\x01@\x02\x04self\x0c\x04names\0\x0d\x04\0\x13[method]headers.get\x01\x0e\x01j\0\
+\x01\x01\x01@\x03\x04self\x0c\x04names\x05values\0\x0f\x04\0\x13[method]headers.\
+set\x01\x10\x04\0\x16[method]headers.delete\x01\x0e\x03\x01\x18component:grafbas\
+e/types\x05\0\x02\x03\0\0\x07headers\x03\0\x07headers\x03\0\x01\x02\x03\0\0\x0ee\
+rror-response\x03\0\x0eerror-response\x03\0\x03\x02\x03\0\0\x07context\x03\0\x07\
+context\x03\0\x05\x01i\x06\x01i\x02\x01j\0\x01\x04\x01@\x02\x07context\x07\x07he\
+aders\x08\0\x09\x04\0\x12on-gateway-request\x01\x0a\x04\x01\x1acomponent:grafbas\
+e/gateway\x04\0\x0b\x0d\x01\0\x07gateway\x03\0\0\0G\x09producers\x01\x0cprocesse\
+d-by\x02\x0dwit-component\x070.208.1\x10wit-bindgen-rust\x060.25.0";
 
 #[inline(never)]
 #[doc(hidden)]

--- a/engine/crates/wasi-component-loader/examples/crates/networking/src/lib.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/networking/src/lib.rs
@@ -1,17 +1,17 @@
 #[allow(warnings)]
 mod bindings;
 
-use bindings::{ErrorResponse, Guest, Headers};
+use bindings::{ErrorResponse, Guest, Context, Headers};
 
 struct Component;
 
 impl Guest for Component {
-    fn on_gateway_request(headers: Headers) -> Result<(), ErrorResponse> {
+    fn on_gateway_request(context: Context, _: Headers) -> Result<(), ErrorResponse> {
         let address = std::env::var("MOCK_SERVER_ADDRESS").unwrap();
         let response = waki::Client::new().get(&address).send().unwrap().body().unwrap();
         let body = String::from_utf8(response).unwrap();
 
-        headers.set("HTTP_RESPONSE", &body).unwrap();
+        context.set("HTTP_RESPONSE", &body);
 
         Ok(())
     }

--- a/engine/crates/wasi-component-loader/examples/crates/simple/src/bindings.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/simple/src/bindings.rs
@@ -2,12 +2,16 @@
 // Options used:
 pub type Headers = component::grafbase::types::Headers;
 pub type ErrorResponse = component::grafbase::types::ErrorResponse;
+pub type Context = component::grafbase::types::Context;
 #[doc(hidden)]
 #[allow(non_snake_case)]
-pub unsafe fn _export_on_gateway_request_cabi<T: Guest>(arg0: i32) -> *mut u8 {
+pub unsafe fn _export_on_gateway_request_cabi<T: Guest>(arg0: i32, arg1: i32) -> *mut u8 {
     #[cfg(target_arch = "wasm32")]
     _rt::run_ctors_once();
-    let result0 = T::on_gateway_request(component::grafbase::types::Headers::from_handle(arg0 as u32));
+    let result0 = T::on_gateway_request(
+        component::grafbase::types::Context::from_handle(arg0 as u32),
+        component::grafbase::types::Headers::from_handle(arg1 as u32),
+    );
     let ptr1 = _RET_AREA.0.as_mut_ptr().cast::<u8>();
     match result0 {
         Ok(_) => {
@@ -93,7 +97,7 @@ pub unsafe fn __post_return_on_gateway_request<T: Guest>(arg0: *mut u8) {
     }
 }
 pub trait Guest {
-    fn on_gateway_request(headers: Headers) -> Result<(), ErrorResponse>;
+    fn on_gateway_request(context: Context, headers: Headers) -> Result<(), ErrorResponse>;
 }
 #[doc(hidden)]
 
@@ -101,8 +105,8 @@ macro_rules! __export_world_gateway_cabi{
   ($ty:ident with_types_in $($path_to_types:tt)*) => (const _: () = {
 
     #[export_name = "on-gateway-request"]
-    unsafe extern "C" fn export_on_gateway_request(arg0: i32,) -> *mut u8 {
-      $($path_to_types)*::_export_on_gateway_request_cabi::<$ty>(arg0)
+    unsafe extern "C" fn export_on_gateway_request(arg0: i32,arg1: i32,) -> *mut u8 {
+      $($path_to_types)*::_export_on_gateway_request_cabi::<$ty>(arg0, arg1)
     }
     #[export_name = "cabi_post_on-gateway-request"]
     unsafe extern "C" fn _post_return_on_gateway_request(arg0: *mut u8,) {
@@ -181,6 +185,50 @@ pub mod component {
 
             #[derive(Debug)]
             #[repr(transparent)]
+            pub struct Context {
+                handle: _rt::Resource<Context>,
+            }
+
+            impl Context {
+                #[doc(hidden)]
+                pub unsafe fn from_handle(handle: u32) -> Self {
+                    Self {
+                        handle: _rt::Resource::from_handle(handle),
+                    }
+                }
+
+                #[doc(hidden)]
+                pub fn take_handle(&self) -> u32 {
+                    _rt::Resource::take_handle(&self.handle)
+                }
+
+                #[doc(hidden)]
+                pub fn handle(&self) -> u32 {
+                    _rt::Resource::handle(&self.handle)
+                }
+            }
+
+            unsafe impl _rt::WasmResource for Context {
+                #[inline]
+                unsafe fn drop(_handle: u32) {
+                    #[cfg(not(target_arch = "wasm32"))]
+                    unreachable!();
+
+                    #[cfg(target_arch = "wasm32")]
+                    {
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[resource-drop]context"]
+                            fn drop(_: u32);
+                        }
+
+                        drop(_handle);
+                    }
+                }
+            }
+
+            #[derive(Debug)]
+            #[repr(transparent)]
             pub struct Headers {
                 handle: _rt::Resource<Headers>,
             }
@@ -242,6 +290,116 @@ pub mod component {
                 }
             }
             impl std::error::Error for ErrorResponse {}
+            impl Context {
+                #[allow(unused_unsafe, clippy::all)]
+                pub fn get(&self, name: &str) -> Option<_rt::String> {
+                    unsafe {
+                        #[repr(align(4))]
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 12]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 12]);
+                        let vec0 = name;
+                        let ptr0 = vec0.as_ptr().cast::<u8>();
+                        let len0 = vec0.len();
+                        let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[method]context.get"]
+                            fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8);
+                        }
+
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
+                        let l2 = i32::from(*ptr1.add(0).cast::<u8>());
+                        match l2 {
+                            0 => None,
+                            1 => {
+                                let e = {
+                                    let l3 = *ptr1.add(4).cast::<*mut u8>();
+                                    let l4 = *ptr1.add(8).cast::<usize>();
+                                    let len5 = l4;
+                                    let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
+
+                                    _rt::string_lift(bytes5)
+                                };
+                                Some(e)
+                            }
+                            _ => _rt::invalid_enum_discriminant(),
+                        }
+                    }
+                }
+            }
+            impl Context {
+                #[allow(unused_unsafe, clippy::all)]
+                pub fn set(&self, name: &str, value: &str) {
+                    unsafe {
+                        let vec0 = name;
+                        let ptr0 = vec0.as_ptr().cast::<u8>();
+                        let len0 = vec0.len();
+                        let vec1 = value;
+                        let ptr1 = vec1.as_ptr().cast::<u8>();
+                        let len1 = vec1.len();
+
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[method]context.set"]
+                            fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8, _: usize);
+                        }
+
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8, _: usize) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1.cast_mut(), len1);
+                    }
+                }
+            }
+            impl Context {
+                #[allow(unused_unsafe, clippy::all)]
+                pub fn delete(&self, name: &str) -> Option<_rt::String> {
+                    unsafe {
+                        #[repr(align(4))]
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 12]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 12]);
+                        let vec0 = name;
+                        let ptr0 = vec0.as_ptr().cast::<u8>();
+                        let len0 = vec0.len();
+                        let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[method]context.delete"]
+                            fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8);
+                        }
+
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
+                        let l2 = i32::from(*ptr1.add(0).cast::<u8>());
+                        match l2 {
+                            0 => None,
+                            1 => {
+                                let e = {
+                                    let l3 = *ptr1.add(4).cast::<*mut u8>();
+                                    let l4 = *ptr1.add(8).cast::<usize>();
+                                    let len5 = l4;
+                                    let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
+
+                                    _rt::string_lift(bytes5)
+                                };
+                                Some(e)
+                            }
+                            _ => _rt::invalid_enum_discriminant(),
+                        }
+                    }
+                }
+            }
             impl Headers {
                 #[allow(unused_unsafe, clippy::all)]
                 pub fn get(&self, name: &str) -> Result<Option<_rt::String>, HeaderError> {
@@ -574,19 +732,23 @@ pub(crate) use __export_gateway_impl as export;
 #[cfg(target_arch = "wasm32")]
 #[link_section = "component-type:wit-bindgen:0.25.0:gateway:encoded world"]
 #[doc(hidden)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 563] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xb5\x03\x01A\x02\x01\
-A\x0a\x01B\x10\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
-header-error\x03\0\0\x04\0\x07headers\x03\x01\x01o\x02ss\x01p\x03\x01r\x02\x0aex\
-tensions\x04\x07messages\x04\0\x0eerror-response\x03\0\x05\x01h\x02\x01ks\x01j\x01\
-\x08\x01\x01\x01@\x02\x04self\x07\x04names\0\x09\x04\0\x13[method]headers.get\x01\
-\x0a\x01j\0\x01\x01\x01@\x03\x04self\x07\x04names\x05values\0\x0b\x04\0\x13[meth\
-od]headers.set\x01\x0c\x04\0\x16[method]headers.delete\x01\x0a\x03\x01\x18compon\
-ent:grafbase/types\x05\0\x02\x03\0\0\x07headers\x03\0\x07headers\x03\0\x01\x02\x03\
-\0\0\x0eerror-response\x03\0\x0eerror-response\x03\0\x03\x01i\x02\x01j\0\x01\x04\
-\x01@\x01\x07headers\x05\0\x06\x04\0\x12on-gateway-request\x01\x07\x04\x01\x1aco\
-mponent:grafbase/gateway\x04\0\x0b\x0d\x01\0\x07gateway\x03\0\0\0G\x09producers\x01\
-\x0cprocessed-by\x02\x0dwit-component\x070.208.1\x10wit-bindgen-rust\x060.25.0";
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 731] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xdd\x04\x01A\x02\x01\
+A\x0d\x01B\x17\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
+header-error\x03\0\0\x04\0\x07context\x03\x01\x04\0\x07headers\x03\x01\x01o\x02s\
+s\x01p\x04\x01r\x02\x0aextensions\x05\x07messages\x04\0\x0eerror-response\x03\0\x06\
+\x01h\x02\x01ks\x01@\x02\x04self\x08\x04names\0\x09\x04\0\x13[method]context.get\
+\x01\x0a\x01@\x03\x04self\x08\x04names\x05values\x01\0\x04\0\x13[method]context.\
+set\x01\x0b\x04\0\x16[method]context.delete\x01\x0a\x01h\x03\x01j\x01\x09\x01\x01\
+\x01@\x02\x04self\x0c\x04names\0\x0d\x04\0\x13[method]headers.get\x01\x0e\x01j\0\
+\x01\x01\x01@\x03\x04self\x0c\x04names\x05values\0\x0f\x04\0\x13[method]headers.\
+set\x01\x10\x04\0\x16[method]headers.delete\x01\x0e\x03\x01\x18component:grafbas\
+e/types\x05\0\x02\x03\0\0\x07headers\x03\0\x07headers\x03\0\x01\x02\x03\0\0\x0ee\
+rror-response\x03\0\x0eerror-response\x03\0\x03\x02\x03\0\0\x07context\x03\0\x07\
+context\x03\0\x05\x01i\x06\x01i\x02\x01j\0\x01\x04\x01@\x02\x07context\x07\x07he\
+aders\x08\0\x09\x04\0\x12on-gateway-request\x01\x0a\x04\x01\x1acomponent:grafbas\
+e/gateway\x04\0\x0b\x0d\x01\0\x07gateway\x03\0\0\0G\x09producers\x01\x0cprocesse\
+d-by\x02\x0dwit-component\x070.208.1\x10wit-bindgen-rust\x060.25.0";
 
 #[inline(never)]
 #[doc(hidden)]

--- a/engine/crates/wasi-component-loader/examples/crates/simple/src/lib.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/simple/src/lib.rs
@@ -1,12 +1,12 @@
 #[allow(warnings)]
 mod bindings;
 
-use bindings::{ErrorResponse, Guest, Headers};
+use bindings::{Context, ErrorResponse, Guest, Headers};
 
 struct Component;
 
 impl Guest for Component {
-    fn on_gateway_request(headers: Headers) -> Result<(), ErrorResponse> {
+    fn on_gateway_request(context: Context, headers: Headers) -> Result<(), ErrorResponse> {
         headers.set("direct", "call").unwrap();
 
         assert_eq!(Ok(Some("call".to_string())), headers.get("direct"));
@@ -14,6 +14,10 @@ impl Guest for Component {
         if let Ok(var) = std::env::var("GRAFBASE_WASI_TEST") {
             headers.set("fromEnv", &var).unwrap();
         }
+
+        assert_eq!(Some("lol".to_string()), context.get("kekw"));
+
+        context.set("call", "direct");
 
         Ok(())
     }

--- a/engine/crates/wasi-component-loader/examples/wit/world.wit
+++ b/engine/crates/wasi-component-loader/examples/wit/world.wit
@@ -6,6 +6,12 @@ interface types {
         invalid-header-name,
     }
 
+    resource context {
+        get: func(name: string) -> option<string>;
+        set: func(name: string, value: string);
+        delete: func(name: string) -> option<string>;
+    }
+
     resource headers {
         get: func(name: string) -> result<option<string>, header-error>;
         set: func(name: string, value: string) -> result<_, header-error>;
@@ -19,7 +25,7 @@ interface types {
 }
 
 world gateway {
-    use types.{headers, error-response};
+    use types.{headers, error-response, context};
 
-    export on-gateway-request: func(headers: headers) -> result<_, error-response>;
+    export on-gateway-request: func(context: context, headers: headers) -> result<_, error-response>;
 }

--- a/engine/crates/wasi-component-loader/src/context.rs
+++ b/engine/crates/wasi-component-loader/src/context.rs
@@ -1,0 +1,74 @@
+use std::collections::HashMap;
+
+use wasmtime::{
+    component::{LinkerInstance, Resource, ResourceType},
+    StoreContextMut,
+};
+
+use crate::{
+    names::{CONTEXT_DELETE_METHOD, CONTEXT_GET_METHOD, CONTEXT_RESOURCE, CONTEXT_SET_METHOD},
+    state::WasiState,
+};
+
+/// The internal per-request context storage. Accessible from all hooks throughout a single request
+pub type ContextMap = HashMap<String, String>;
+
+/// Map context resource, with get and set accessors to the guest component.
+///
+/// ```ignore
+/// interface types {
+///     resource context {
+///         get: func(key: string) -> option<string>;
+///         set: func(key: string, value: string);
+///         delete: func(key: string) -> option<string>;
+///     }    
+/// }
+/// ```
+pub(crate) fn map(types: &mut LinkerInstance<'_, WasiState>) -> crate::Result<()> {
+    types.resource(CONTEXT_RESOURCE, ResourceType::host::<ContextMap>(), |_, _| Ok(()))?;
+    types.func_wrap(CONTEXT_SET_METHOD, set)?;
+    types.func_wrap(CONTEXT_GET_METHOD, get)?;
+    types.func_wrap(CONTEXT_DELETE_METHOD, delete)?;
+
+    Ok(())
+}
+
+/// Modify or add to the context wwith the given key and value.
+///
+/// `set: func(key: string, value: string)`
+fn set(
+    mut store: StoreContextMut<'_, WasiState>,
+    (this, key, value): (Resource<ContextMap>, String, String),
+) -> anyhow::Result<()> {
+    let context = store.data_mut().get_mut(&this).expect("must exist");
+    context.insert(key, value);
+
+    Ok(())
+}
+
+/// Look for a context value with the given key, returning a copy of the value if found.
+///
+/// `get: func(key: string) -> option<string>`
+fn get(
+    store: StoreContextMut<'_, WasiState>,
+    (this, key): (Resource<ContextMap>, String),
+) -> anyhow::Result<(Option<String>,)> {
+    let context = store.data().get(&this).expect("must exist");
+    let val = context.get(&key).cloned();
+
+    Ok((val,))
+}
+
+/// Look for a context value with the given key, returning a copy of the value if found. Will remove
+/// the value from the headers.
+///
+/// `delete: func(key: string) -> result<option<string>, header-error>`
+fn delete(
+    mut store: StoreContextMut<'_, WasiState>,
+    (this, key): (Resource<ContextMap>, String),
+) -> anyhow::Result<(Option<String>,)> {
+    let context = store.data_mut().get_mut(&this).expect("must exist");
+    let val = context.remove(&key);
+
+    Ok((val,))
+}

--- a/engine/crates/wasi-component-loader/src/lib.rs
+++ b/engine/crates/wasi-component-loader/src/lib.rs
@@ -10,6 +10,7 @@
 
 mod callbacks;
 mod config;
+mod context;
 mod error;
 mod headers;
 mod names;
@@ -19,6 +20,7 @@ mod state;
 mod tests;
 
 pub use config::Config;
+pub use context::ContextMap;
 pub use error::{Error, ErrorResponse};
 
 /// The crate result type
@@ -76,6 +78,7 @@ impl ComponentLoader {
 
                 let mut types = linker.instance(COMPONENT_TYPES)?;
                 headers::map(&mut types)?;
+                context::map(&mut types)?;
 
                 Some(Self {
                     engine,
@@ -99,8 +102,8 @@ impl ComponentLoader {
     /// for every request.
     ///
     /// Calls the user-defined callback from the guest, if the function is defined.
-    pub async fn on_gateway_request(&self, headers: HeaderMap) -> Result<HeaderMap> {
-        let callback = GatewayCallbackInstance::new(self, headers).await?;
+    pub async fn on_gateway_request(&self, context: ContextMap, headers: HeaderMap) -> Result<(ContextMap, HeaderMap)> {
+        let callback = GatewayCallbackInstance::new(self, context, headers).await?;
 
         callback.call().await
     }

--- a/engine/crates/wasi-component-loader/src/names.rs
+++ b/engine/crates/wasi-component-loader/src/names.rs
@@ -5,3 +5,8 @@ pub(crate) static HEADERS_RESOURCE: &str = "headers";
 pub(crate) static HEADERS_SET_METHOD: &str = "[method]headers.set";
 pub(crate) static HEADERS_GET_METHOD: &str = "[method]headers.get";
 pub(crate) static HEADERS_DELETE_METHOD: &str = "[method]headers.delete";
+
+pub(crate) static CONTEXT_RESOURCE: &str = "context";
+pub(crate) static CONTEXT_SET_METHOD: &str = "[method]context.set";
+pub(crate) static CONTEXT_GET_METHOD: &str = "[method]context.get";
+pub(crate) static CONTEXT_DELETE_METHOD: &str = "[method]context.delete";


### PR DESCRIPTION
We need a context object for the full request lifecycle which can be used for storing and retrieving data in the engine hooks. The issue is that we need to pass it by-value, and the request metadata is either passed by reference or as an Arc. So, to plan for that, we store the context data in a mutex. Yes, I know, but this data is always per-request, meaning the locks will not block other requests anyhow. In the upcoming hooks, we need to lock the mutex, get a mutable reference to the context object, use some `std::mem` tricks to get a value out of it and again return the possible changes to the request metadata.

Or, all the calls need to have a mutable reference to the metadata struct (which will be annoying in the websocket code)...

Closes: GB-6958
