### PR TITLE
chore(engine-v2): Split query plan solver from output shape computation

### DIFF
--- a/engine/crates/engine-v2/schema/src/builder/mod.rs
+++ b/engine/crates/engine-v2/schema/src/builder/mod.rs
@@ -100,6 +100,7 @@ impl BuildContext {
                     directives: Default::default(),
                 },
             ],
+            field_to_parent_entity: vec![EntityId::Object(0.into()); 2],
             enum_definitions: Vec::new(),
             union_definitions: Vec::new(),
             scalar_definitions: Vec::new(),

--- a/engine/crates/engine-v2/schema/src/lib.rs
+++ b/engine/crates/engine-v2/schema/src/lib.rs
@@ -69,6 +69,7 @@ pub struct Graph {
     object_definitions: Vec<Object>,
     interface_definitions: Vec<Interface>,
     field_definitions: Vec<FieldDefinition>,
+    field_to_parent_entity: Vec<EntityId>,
     enum_definitions: Vec<Enum>,
     union_definitions: Vec<Union>,
     scalar_definitions: Vec<Scalar>,
@@ -180,6 +181,31 @@ pub struct FieldProvides {
 pub struct FieldRequires {
     subgraph_id: SubgraphId,
     field_set_id: RequiredFieldSetId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
+pub enum EntityId {
+    Object(ObjectId),
+    Interface(InterfaceId),
+}
+
+impl From<EntityId> for Definition {
+    fn from(value: EntityId) -> Self {
+        match value {
+            EntityId::Interface(id) => Definition::Interface(id),
+            EntityId::Object(id) => Definition::Object(id),
+        }
+    }
+}
+
+impl EntityId {
+    pub fn maybe_from(definition: Definition) -> Option<EntityId> {
+        match definition {
+            Definition::Object(id) => Some(EntityId::Object(id)),
+            Definition::Interface(id) => Some(EntityId::Interface(id)),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]

--- a/engine/crates/engine-v2/schema/src/walkers/field.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/field.rs
@@ -1,6 +1,6 @@
 use super::{resolver::ResolverWalker, SchemaWalker};
 use crate::{
-    FieldDefinitionId, InputValueDefinitionWalker, ProvidableFieldSet, RequiredFieldSet, SubgraphId,
+    EntityId, FieldDefinitionId, InputValueDefinitionWalker, ProvidableFieldSet, RequiredFieldSet, SubgraphId,
     TypeSystemDirectivesWalker, TypeWalker,
 };
 
@@ -46,6 +46,10 @@ impl<'a> FieldDefinitionWalker<'a> {
                 }
             })
             .unwrap_or(&crate::requires::EMPTY)
+    }
+
+    pub fn parent_entity(&self) -> EntityId {
+        self.schema.graph.field_to_parent_entity[usize::from(self.item)]
     }
 
     pub fn arguments(self) -> impl ExactSizeIterator<Item = InputValueDefinitionWalker<'a>> + 'a {

--- a/engine/crates/engine-v2/src/operation/bind/mod.rs
+++ b/engine/crates/engine-v2/src/operation/bind/mod.rs
@@ -172,6 +172,7 @@ pub fn bind(schema: &Schema, mut unbound: ParsedOperation) -> BindResult<Operati
         root_object_id,
         name: unbound.name,
         root_selection_set_id,
+        selection_set_to_plan_id: vec![None; binder.selection_sets.len()],
         selection_sets: binder.selection_sets,
         fragments: {
             let mut fragment_definitions = binder.fragments.into_values().collect::<Vec<_>>();
@@ -180,6 +181,7 @@ pub fn bind(schema: &Schema, mut unbound: ParsedOperation) -> BindResult<Operati
         },
         field_arguments: binder.field_arguments,
         response_keys: binder.response_keys,
+        field_to_plan_id: vec![None; binder.fields.len()],
         fields: binder.fields,
         variable_definitions: binder.variable_definitions,
         cache_control: None,
@@ -187,6 +189,9 @@ pub fn bind(schema: &Schema, mut unbound: ParsedOperation) -> BindResult<Operati
         inline_fragments: binder.inline_fragments,
         field_to_parent: binder.field_to_parent,
         query_input_values: binder.input_values,
+        plans: Vec::new(),
+        plan_edges: Vec::new(),
+        field_dependencies: Vec::new(),
     })
 }
 

--- a/engine/crates/engine-v2/src/operation/ids.rs
+++ b/engine/crates/engine-v2/src/operation/ids.rs
@@ -2,7 +2,7 @@ use id_newtypes::IdRange;
 use schema::InputValueDefinitionId;
 
 use super::{
-    Field, FieldArgument, Fragment, FragmentSpread, InlineFragment, Operation, QueryInputKeyValueId,
+    Field, FieldArgument, Fragment, FragmentSpread, InlineFragment, Operation, Plan, QueryInputKeyValueId,
     QueryInputObjectFieldValueId, QueryInputValue, QueryInputValueId, SelectionSet, VariableDefinition,
 };
 
@@ -14,6 +14,7 @@ id_newtypes::NonZeroU16! {
     Operation.inline_fragments[InlineFragmentId] => InlineFragment,
     Operation.variable_definitions[VariableDefinitionId] => VariableDefinition,
     Operation.field_arguments[FieldArgumentId] => FieldArgument,
+    Operation.plans[PlanId] => Plan,
 }
 
 impl std::ops::Index<QueryInputValueId> for Operation {

--- a/engine/crates/engine-v2/src/operation/mod.rs
+++ b/engine/crates/engine-v2/src/operation/mod.rs
@@ -11,6 +11,8 @@ mod validation;
 mod variables;
 mod walkers;
 
+use std::num::NonZeroU16;
+
 use crate::response::ResponseKeys;
 pub use cache_control::OperationCacheControl;
 pub(crate) use engine_parser::types::OperationType;
@@ -18,12 +20,15 @@ pub(crate) use ids::*;
 pub(crate) use input_value::*;
 pub(crate) use location::Location;
 pub(crate) use path::QueryPath;
-use schema::{ObjectId, SchemaWalker};
+use schema::{ObjectId, RequiredFieldId, ResolverId, SchemaWalker};
 pub(crate) use selection_set::*;
 pub(crate) use variables::*;
 pub(crate) use walkers::*;
 
-#[derive(Clone)]
+pub(crate) struct Plan {
+    pub resolver_id: ResolverId,
+}
+
 pub(crate) struct Operation {
     pub ty: OperationType,
     pub root_object_id: ObjectId,
@@ -41,6 +46,42 @@ pub(crate) struct Operation {
     pub cache_control: Option<OperationCacheControl>,
     pub field_arguments: Vec<FieldArgument>,
     pub query_input_values: QueryInputValues,
+    // -- Added during planning --
+    pub plans: Vec<Plan>,
+    /// Sorted
+    pub plan_edges: Vec<ParentToChildEdge>,
+    pub field_dependencies: Vec<FieldDependency>,
+    pub field_to_plan_id: Vec<Option<PlanId>>,
+    pub selection_set_to_plan_id: Vec<Option<PlanId>>,
+}
+
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ParentToChildEdge {
+    // Ordering of the fields matter and is relied upon to find the boundary_id between two plans.
+    pub parent: PlanId,
+    pub child: PlanId,
+    pub boundary: PlanBoundaryId,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct FieldDependency {
+    pub plan_boundary_id: PlanBoundaryId,
+    pub required_field_id: RequiredFieldId,
+    pub field_id: FieldId,
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct PlanBoundaryId(NonZeroU16);
+
+impl From<usize> for PlanBoundaryId {
+    fn from(value: usize) -> Self {
+        Self(
+            u16::try_from(value)
+                .ok()
+                .and_then(|value| NonZeroU16::new(value + 1))
+                .expect("Too many plan boundaries"),
+        )
+    }
 }
 
 impl Operation {
@@ -62,5 +103,28 @@ impl Operation {
             schema_walker,
             item: (),
         }
+    }
+
+    pub fn find_matching_field(
+        &self,
+        plan_boundary_id: PlanBoundaryId,
+        required_field_id: RequiredFieldId,
+    ) -> Option<FieldId> {
+        self.field_dependencies
+            .binary_search_by(|field_dependency| {
+                field_dependency
+                    .plan_boundary_id
+                    .cmp(&plan_boundary_id)
+                    .then(field_dependency.required_field_id.cmp(&required_field_id))
+            })
+            .ok()
+            .map(|index| self.field_dependencies[index].field_id)
+    }
+
+    pub fn find_boundary_between(&self, parent: PlanId, child: PlanId) -> Option<PlanBoundaryId> {
+        self.plan_edges
+            .binary_search_by(|edge| edge.parent.cmp(&parent).then(edge.child.cmp(&child)))
+            .ok()
+            .map(|index| self.plan_edges[index].boundary)
     }
 }

--- a/engine/crates/engine-v2/src/operation/selection_set.rs
+++ b/engine/crates/engine-v2/src/operation/selection_set.rs
@@ -107,6 +107,8 @@ pub enum Field {
         // sorted by InputValueDefinitionId
         argument_ids: IdRange<FieldArgumentId>,
         petitioner_location: Location,
+        // FIXME: Could probably avoid having those by having those additional extra fields be in a
+        // temporary struct instead.
         /// During the planning we may add more extra fields than necessary. To prevent retrieving
         /// unnecessary data, only those marked as read are part of the operation.
         is_read: bool,

--- a/engine/crates/engine-v2/src/operation/walkers/field.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/field.rs
@@ -6,7 +6,7 @@ use crate::{
     response::ResponseKey,
 };
 
-pub type FieldWalker<'a> = OperationWalker<'a, FieldId>;
+pub type FieldWalker<'a> = OperationWalker<'a, FieldId, ()>;
 
 impl<'a> FieldWalker<'a> {
     pub fn name(&self) -> &'a str {

--- a/engine/crates/engine-v2/src/operation/walkers/fragment.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/fragment.rs
@@ -1,7 +1,7 @@
 use super::{OperationWalker, SelectionSetWalker};
 use crate::operation::{FragmentId, FragmentSpreadId};
 
-pub type FragmentSpreadWalker<'a> = OperationWalker<'a, FragmentSpreadId>;
+pub type FragmentSpreadWalker<'a> = OperationWalker<'a, FragmentSpreadId, ()>;
 
 impl<'a> FragmentSpreadWalker<'a> {
     pub fn selection_set(&self) -> SelectionSetWalker<'a> {

--- a/engine/crates/engine-v2/src/operation/walkers/inline_fragment.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/inline_fragment.rs
@@ -1,7 +1,7 @@
 use super::{OperationWalker, SelectionSetWalker};
 use crate::operation::InlineFragmentId;
 
-pub type InlineFragmentWalker<'a> = OperationWalker<'a, InlineFragmentId>;
+pub type InlineFragmentWalker<'a> = OperationWalker<'a, InlineFragmentId, ()>;
 
 impl<'a> InlineFragmentWalker<'a> {
     pub fn selection_set(&self) -> SelectionSetWalker<'a> {

--- a/engine/crates/engine-v2/src/operation/walkers/mod.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/mod.rs
@@ -54,6 +54,10 @@ impl<'a> OperationWalker<'a, (), ()> {
         matches!(self.as_ref().ty, OperationType::Query)
     }
 
+    pub(crate) fn is_mutation(&self) -> bool {
+        matches!(self.as_ref().ty, OperationType::Mutation)
+    }
+
     pub(crate) fn selection_set(&self) -> SelectionSetWalker<'a> {
         self.walk(self.operation.root_selection_set_id)
     }

--- a/engine/crates/engine-v2/src/operation/walkers/query_path.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/query_path.rs
@@ -4,7 +4,7 @@ use crate::operation::QueryPath;
 
 use super::OperationWalker;
 
-pub type QueryPathWalker<'a> = OperationWalker<'a, &'a QueryPath>;
+pub type QueryPathWalker<'a> = OperationWalker<'a, &'a QueryPath, ()>;
 
 impl<'a> QueryPathWalker<'a> {
     pub fn iter(&self) -> impl Iterator<Item = &'a str> + 'a {

--- a/engine/crates/engine-v2/src/operation/walkers/selection_set.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/selection_set.rs
@@ -3,7 +3,7 @@ use schema::{Definition, DefinitionWalker};
 use super::{FieldWalker, FragmentSpreadWalker, InlineFragmentWalker, OperationWalker};
 use crate::operation::{Selection, SelectionSetId, SelectionSetType};
 
-pub type SelectionSetWalker<'a> = OperationWalker<'a, SelectionSetId>;
+pub type SelectionSetWalker<'a> = OperationWalker<'a, SelectionSetId, ()>;
 pub type SelectionSetTypeWalker<'a> = OperationWalker<'a, SelectionSetType, Definition>;
 
 impl<'a> SelectionSetWalker<'a> {

--- a/engine/crates/engine-v2/src/plan/collected.rs
+++ b/engine/crates/engine-v2/src/plan/collected.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 
 use super::{
-    CollectedFieldId, CollectedSelectionSetId, ConditionalFieldId, ConditionalSelectionSetId, FlatTypeCondition,
-    PlanBoundaryId,
+    CollectedFieldId, CollectedSelectionSetId, ConditionalFieldId, ConditionalSelectionSetId, ExecutionPlanBoundaryId,
+    FlatTypeCondition,
 };
 
 // TODO: The two AnyCollectedSelectionSet aren't great, need to split better the ones which are computed
@@ -39,7 +39,7 @@ pub struct ConditionalSelectionSet {
     pub ty: SelectionSetType,
     // Plan boundary associated with this selection set. If present we need to push the a
     // ResponseObjectBoundaryItem into the ResponsePart everytime for children plans.
-    pub maybe_boundary_id: Option<PlanBoundaryId>,
+    pub maybe_boundary_id: Option<ExecutionPlanBoundaryId>,
     pub field_ids: IdRange<ConditionalFieldId>,
     // Selection sets can have multiple __typename fields and eventually type conditions.
     // {
@@ -78,7 +78,7 @@ pub struct CollectedSelectionSet {
     pub ty: SelectionSetType,
     // Plan boundary associated with this selection set. If present we need to push the a
     // ResponseObjectBoundaryItem into the ResponsePart everytime for children plans.
-    pub maybe_boundary_id: Option<PlanBoundaryId>,
+    pub maybe_boundary_id: Option<ExecutionPlanBoundaryId>,
     // the fields we point to are sorted by their expected_key
     pub field_ids: IdRange<CollectedFieldId>,
     // Selection sets can have multiple __typename fields.
@@ -103,7 +103,7 @@ pub struct CollectedField {
 #[derive(Debug)]
 pub struct RuntimeCollectedSelectionSet {
     pub object_id: ObjectId,
-    pub boundary_ids: Vec<PlanBoundaryId>,
+    pub boundary_ids: Vec<ExecutionPlanBoundaryId>,
     // sorted by expected key
     pub fields: Vec<CollectedField>,
     pub typename_fields: Vec<ResponseEdge>,

--- a/engine/crates/engine-v2/src/plan/flat.rs
+++ b/engine/crates/engine-v2/src/plan/flat.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use itertools::Itertools;
-use schema::{Definition, InterfaceId, ObjectId, Schema};
+use schema::{Definition, EntityId, InterfaceId, ObjectId, Schema};
 
 use crate::operation::{FieldId, Operation, Selection, SelectionSetId, SelectionSetType, TypeCondition};
 
@@ -172,45 +172,29 @@ impl FlatField {
     }
 }
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub enum EntityType {
-    Interface(InterfaceId),
-    Object(ObjectId),
-}
-
-impl From<EntityType> for Definition {
-    fn from(value: EntityType) -> Self {
+impl From<EntityId> for SelectionSetType {
+    fn from(value: EntityId) -> Self {
         match value {
-            EntityType::Interface(id) => Definition::Interface(id),
-            EntityType::Object(id) => Definition::Object(id),
+            EntityId::Interface(id) => SelectionSetType::Interface(id),
+            EntityId::Object(id) => SelectionSetType::Object(id),
         }
     }
 }
 
-impl From<EntityType> for SelectionSetType {
-    fn from(value: EntityType) -> Self {
+impl From<EntityId> for TypeCondition {
+    fn from(value: EntityId) -> Self {
         match value {
-            EntityType::Interface(id) => SelectionSetType::Interface(id),
-            EntityType::Object(id) => SelectionSetType::Object(id),
+            EntityId::Interface(id) => TypeCondition::Interface(id),
+            EntityId::Object(id) => TypeCondition::Object(id),
         }
     }
 }
 
-impl From<EntityType> for TypeCondition {
-    fn from(value: EntityType) -> Self {
+impl From<EntityId> for FlatTypeCondition {
+    fn from(value: EntityId) -> Self {
         match value {
-            EntityType::Interface(id) => TypeCondition::Interface(id),
-            EntityType::Object(id) => TypeCondition::Object(id),
-        }
-    }
-}
-
-impl EntityType {
-    pub fn maybe_from(definition: Definition) -> Option<EntityType> {
-        match definition {
-            Definition::Object(id) => Some(EntityType::Object(id)),
-            Definition::Interface(id) => Some(EntityType::Interface(id)),
-            _ => None,
+            EntityId::Interface(id) => FlatTypeCondition::Interface(id),
+            EntityId::Object(id) => FlatTypeCondition::Objects(Box::new([id])),
         }
     }
 }

--- a/engine/crates/engine-v2/src/plan/ids.rs
+++ b/engine/crates/engine-v2/src/plan/ids.rs
@@ -1,11 +1,11 @@
 use std::num::NonZeroU16;
 
-use crate::sources::Plan;
-
-use super::{CollectedField, CollectedSelectionSet, ConditionalField, ConditionalSelectionSet, OperationPlan};
+use super::{
+    CollectedField, CollectedSelectionSet, ConditionalField, ConditionalSelectionSet, ExecutionPlan, OperationPlan,
+};
 
 id_newtypes::NonZeroU16! {
-    OperationPlan.plans[PlanId] => Plan,
+    OperationPlan.execution_plans[ExecutionPlanId] => ExecutionPlan,
     OperationPlan.conditional_fields[ConditionalFieldId] => ConditionalField,
     OperationPlan.conditional_selection_sets[ConditionalSelectionSetId] => ConditionalSelectionSet,
     OperationPlan.collected_selection_sets[CollectedSelectionSetId] => CollectedSelectionSet,
@@ -13,15 +13,15 @@ id_newtypes::NonZeroU16! {
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
-pub struct PlanBoundaryId(NonZeroU16);
+pub struct ExecutionPlanBoundaryId(NonZeroU16);
 
-impl From<PlanBoundaryId> for usize {
-    fn from(id: PlanBoundaryId) -> usize {
+impl From<ExecutionPlanBoundaryId> for usize {
+    fn from(id: ExecutionPlanBoundaryId) -> usize {
         (id.0.get() - 1) as usize
     }
 }
 
-impl From<usize> for PlanBoundaryId {
+impl From<usize> for ExecutionPlanBoundaryId {
     fn from(value: usize) -> Self {
         Self(
             u16::try_from(value)

--- a/engine/crates/engine-v2/src/plan/planning/collect.rs
+++ b/engine/crates/engine-v2/src/plan/planning/collect.rs
@@ -1,85 +1,338 @@
 use id_newtypes::IdRange;
 use itertools::Itertools;
-use schema::Schema;
-use std::collections::HashSet;
+use schema::{Definition, RequiredFieldSet, Schema};
+use std::{
+    borrow::Cow,
+    collections::{HashMap, HashSet},
+};
 
 use crate::{
-    operation::{FieldId, OperationWalker, SelectionSetId, SelectionSetType, Variables},
+    operation::{
+        FieldId, Operation, OperationWalker, PlanBoundaryId, PlanId, SelectionSetId, SelectionSetType, Variables,
+    },
     plan::{
         flatten_selection_sets, AnyCollectedSelectionSet, AnyCollectedSelectionSetId, CollectedField, CollectedFieldId,
         CollectedSelectionSet, CollectedSelectionSetId, ConditionalField, ConditionalFieldId, ConditionalSelectionSet,
-        ConditionalSelectionSetId, EntityType, FieldType, FlatField, FlatTypeCondition, OperationPlan, PlanBoundaryId,
-        PlanId,
+        ConditionalSelectionSetId, EntityId, ExecutionPlan, ExecutionPlanBoundaryId, ExecutionPlanId, FieldType,
+        FlatField, FlatTypeCondition, OperationPlan, ParentToChildEdge, PlanInput, PlanOutput,
     },
+    response::{ReadField, ReadSelectionSet},
+    sources::PreparedExecutor,
 };
 
-use super::PlanningResult;
+use super::{PlanningError, PlanningResult};
 
-pub(super) struct Collector<'a> {
+pub(super) struct OperationPlanBuilder<'a> {
     schema: &'a Schema,
-    operation: &'a mut OperationPlan,
     variables: &'a Variables,
+    operation_plan: OperationPlan,
+    to_be_planned: Vec<ToBePlanned>,
+    plan_parent_to_child_edges: HashSet<UnfinalizedParentToChildEdge>,
+    plan_id_to_execution_plan_id: Vec<Option<ExecutionPlanId>>,
+}
+
+#[derive(Debug, Hash, PartialEq, Eq)]
+struct UnfinalizedParentToChildEdge {
+    parent: PlanId,
+    child: PlanId,
+}
+
+struct ToBePlanned {
+    maybe_boundary_id: Option<ExecutionPlanBoundaryId>,
+    plan_boundary_id: PlanBoundaryId,
+    plan_id: PlanId,
+    fields: Vec<FieldId>,
+}
+
+impl<'a> OperationPlanBuilder<'a> {
+    pub(super) fn new(schema: &'a Schema, variables: &'a Variables, operation: Operation) -> Self {
+        OperationPlanBuilder {
+            schema,
+            variables,
+            to_be_planned: Vec::new(),
+            plan_parent_to_child_edges: HashSet::new(),
+            plan_id_to_execution_plan_id: vec![None; operation.plans.len()],
+            operation_plan: OperationPlan {
+                selection_set_to_collected: vec![None; operation.selection_sets.len()],
+                execution_plans: Vec::new(),
+                plan_parent_to_child_edges: Vec::new(),
+                plan_dependencies_count: Vec::new(),
+                plan_boundary_consummers_count: Vec::new(),
+                conditional_selection_sets: Vec::new(),
+                conditional_fields: Vec::new(),
+                collected_selection_sets: Vec::new(),
+                collected_fields: Vec::new(),
+                operation,
+            },
+        }
+    }
+
+    pub(super) fn build(mut self) -> PlanningResult<OperationPlan> {
+        self.generate_root_execution_plans()?;
+        let mut operation_plan = self.operation_plan;
+        operation_plan.plan_parent_to_child_edges = self
+            .plan_parent_to_child_edges
+            .into_iter()
+            .map(|edge| {
+                let parent = self.plan_id_to_execution_plan_id[usize::from(edge.parent)];
+                let child = self.plan_id_to_execution_plan_id[usize::from(edge.child)];
+                match (parent, child) {
+                    (Some(parent), Some(child)) => Ok(ParentToChildEdge { parent, child }),
+                    pc => Err(PlanningError::InternalError(format!(
+                        "Unplanned depedency: {edge:?} -> {pc:?}"
+                    ))),
+                }
+            })
+            .collect::<Result<_, _>>()?;
+        operation_plan.plan_parent_to_child_edges.sort_unstable();
+        for ParentToChildEdge { child, .. } in &operation_plan.plan_parent_to_child_edges {
+            operation_plan.plan_dependencies_count[usize::from(*child)] += 1;
+        }
+        tracing::trace!(
+            "== Dependency Summary ==\nEdges:\n{}\nIncoming degree:\n{}",
+            operation_plan
+                .plan_parent_to_child_edges
+                .iter()
+                .format_with("\n", |edge, f| f(&format_args!("{} -> {}", edge.parent, edge.child))),
+            operation_plan
+                .plan_dependencies_count
+                .iter()
+                .enumerate()
+                .format_with("\n", |(i, count), f| f(&format_args!(
+                    "{} <- {}",
+                    ExecutionPlanId::from(i),
+                    count
+                )))
+        );
+
+        Ok(operation_plan)
+    }
+
+    fn generate_root_execution_plans(&mut self) -> PlanningResult<()> {
+        let walker = self.walker();
+        let root_plans =
+            walker
+                .selection_set()
+                .fields()
+                .fold(HashMap::<PlanId, Vec<FieldId>>::default(), |mut acc, field| {
+                    let plan_id = self.operation_plan.operation.field_to_plan_id[usize::from(field.id())]
+                        .expect("Should be planned");
+                    acc.entry(plan_id).or_default().push(field.id());
+                    acc
+                });
+        if walker.is_mutation() {
+            let mut maybe_previous_plan_id: Option<PlanId> = None;
+            let mut plan_ids = root_plans
+                .iter()
+                .map(|(plan_id, fields)| (walker.walk(fields[0]).as_ref().query_position(), plan_id))
+                .collect::<Vec<_>>();
+            plan_ids.sort_unstable();
+            for (_, &plan_id) in plan_ids {
+                tracing::info!(
+                    "Planning {} for {}",
+                    plan_id,
+                    self.walker().walk((&root_plans[&plan_id])[0]).response_key_str(),
+                );
+                if let Some(previous_plan_id) = maybe_previous_plan_id {
+                    self.plan_parent_to_child_edges.insert(UnfinalizedParentToChildEdge {
+                        parent: previous_plan_id,
+                        child: plan_id,
+                    });
+                }
+                maybe_previous_plan_id = Some(plan_id);
+            }
+        }
+
+        self.to_be_planned = root_plans
+            .into_iter()
+            .map(|(plan_id, fields)| ToBePlanned {
+                plan_boundary_id: PlanBoundaryId::from(0),
+                maybe_boundary_id: None,
+                plan_id,
+                fields,
+            })
+            .collect();
+
+        while let Some(ToBePlanned {
+            maybe_boundary_id,
+            plan_boundary_id,
+            plan_id,
+            fields,
+        }) = self.to_be_planned.pop()
+        {
+            ExecutionPlanBuildContext::new(self, plan_boundary_id, plan_id).create_plan(maybe_boundary_id, fields)?;
+        }
+
+        Ok(())
+    }
+
+    fn walker(&self) -> OperationWalker<'_, (), ()> {
+        // yes looks weird, will be improved
+        self.operation_plan
+            .operation
+            .walker_with(self.schema.walker(), self.variables)
+    }
+
+    fn new_boundary(&mut self) -> ExecutionPlanBoundaryId {
+        let id = ExecutionPlanBoundaryId::from(self.operation_plan.plan_boundary_consummers_count.len());
+        self.operation_plan.plan_boundary_consummers_count.push(0);
+        id
+    }
+}
+
+pub(super) struct ExecutionPlanBuildContext<'parent, 'ctx> {
+    builder: &'parent mut OperationPlanBuilder<'ctx>,
+    plan_boundary_id: PlanBoundaryId,
     plan_id: PlanId,
     support_aliases: bool,
 }
 
-impl<'a> Collector<'a> {
+impl<'parent, 'ctx> std::ops::Deref for ExecutionPlanBuildContext<'parent, 'ctx> {
+    type Target = OperationPlanBuilder<'ctx>;
+    fn deref(&self) -> &Self::Target {
+        self.builder
+    }
+}
+
+impl<'parent, 'ctx> std::ops::DerefMut for ExecutionPlanBuildContext<'parent, 'ctx> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.builder
+    }
+}
+
+impl<'parent, 'ctx> ExecutionPlanBuildContext<'parent, 'ctx> {
     pub(super) fn new(
-        schema: &'a Schema,
-        variables: &'a Variables,
-        operation: &'a mut OperationPlan,
+        builder: &'parent mut OperationPlanBuilder<'ctx>,
+        plan_boundary_id: PlanBoundaryId,
         plan_id: PlanId,
     ) -> Self {
-        let support_aliases = schema
-            .walk(operation.planned_resolvers[usize::from(plan_id)].resolver_id)
+        let support_aliases = builder
+            .schema
+            .walk(builder.operation_plan.operation.plans[usize::from(plan_id)].resolver_id)
             .supports_aliases();
-        Collector {
-            schema,
-            operation,
-            variables,
+        ExecutionPlanBuildContext {
+            builder,
+            plan_boundary_id,
             plan_id,
             support_aliases,
         }
     }
 
-    pub fn walker(&self) -> OperationWalker<'_> {
-        // yes looks weird, will be improved
-        self.operation
-            .operation
-            .walker_with(self.schema.walker(), self.variables)
-    }
-
-    pub(super) fn collect(
+    fn create_plan(
         &mut self,
-        root_selection_set_ids: Vec<SelectionSetId>,
-    ) -> PlanningResult<CollectedSelectionSetId> {
-        let ty = self.operation[root_selection_set_ids[0]].ty;
-        let fields = self.find_root_fields(root_selection_set_ids);
-        tracing::trace!(
-            "Collecting output for plan {} from root fields: {}",
-            self.plan_id,
-            fields
-                .iter()
-                .map(|id| self.walker().walk(*id).response_key_str())
-                .join(", ")
-        );
-        self.collect_fields(ty, fields, None)
+        maybe_boundary_id: Option<ExecutionPlanBoundaryId>,
+        fields: Vec<FieldId>,
+    ) -> PlanningResult<()> {
+        self.operation_plan.plan_dependencies_count.push(0);
+
+        let input = if let Some(boundary_id) = maybe_boundary_id {
+            self.operation_plan.plan_boundary_consummers_count[usize::from(boundary_id)] += 1;
+            let selection_set = self.create_plan_input(&fields);
+            Some(PlanInput {
+                boundary_id,
+                selection_set,
+            })
+        } else {
+            None
+        };
+
+        // Currently a resolver is tied to only one entity (object/interface), so retrieving the
+        // parent entity of any field is enough for this part.
+        let selection_set_id = self.operation_plan.operation.parent_selection_set_id(fields[0]);
+        let entity_id =
+            EntityId::maybe_from(Definition::from(self.operation_plan.operation[selection_set_id].ty)).unwrap();
+
+        let boundaries_start = self.operation_plan.plan_boundary_consummers_count.len();
+        let collected_selection_set_id = self.collect_fields(entity_id.into(), fields, maybe_boundary_id)?;
+        let boundaries_end = self.operation_plan.plan_boundary_consummers_count.len();
+        let output = PlanOutput {
+            type_condition: Some(entity_id.into()),
+            entity_type: entity_id,
+            collected_selection_set_id,
+            boundary_ids: IdRange::from(boundaries_start..boundaries_end),
+        };
+
+        let resolver_id = self.operation_plan.operation[self.plan_id].resolver_id;
+        let resolver = self.schema.walker().walk(resolver_id).with_own_names();
+
+        let plan_id = self.plan_id;
+        let execution_plan = ExecutionPlan {
+            plan_id,
+            resolver_id,
+            input,
+            output,
+            prepared_executor: PreparedExecutor::Unreachable,
+        };
+        self.operation_plan.execution_plans.push(execution_plan);
+        let execution_plan_id = ExecutionPlanId::from(self.operation_plan.execution_plans.len() - 1);
+        let prepared_executor = PreparedExecutor::prepare(
+            resolver,
+            self.operation_plan.ty,
+            self.operation_plan
+                .walker_with(self.schema, self.variables, execution_plan_id),
+        )?;
+        self.operation_plan.execution_plans[usize::from(execution_plan_id)].prepared_executor = prepared_executor;
+        self.plan_id_to_execution_plan_id[usize::from(plan_id)] = Some(execution_plan_id);
+
+        Ok(())
     }
 
-    fn find_root_fields(&self, root_selection_set_ids: Vec<SelectionSetId>) -> Vec<FieldId> {
-        let walker = self.walker();
-        root_selection_set_ids
-            .into_iter()
-            .flat_map(|id| walker.walk(id).fields())
-            .filter_map(|field| {
-                let field_plan_id = self.operation.field_to_plan_id[usize::from(field.id())];
-                if field_plan_id == self.plan_id {
-                    Some(field.id())
-                } else {
-                    None
+    fn create_plan_input(&mut self, root_fields: &Vec<FieldId>) -> ReadSelectionSet {
+        let resolver = self
+            .schema
+            .walk(self.operation_plan.operation[self.plan_id].resolver_id)
+            .with_own_names();
+        let mut requires = Cow::Borrowed(resolver.requires());
+        for field_id in root_fields {
+            if let Some(definition) = self.walker().walk(*field_id).definition() {
+                let field_requires = definition.requires(resolver.subgraph_id());
+                if !field_requires.is_empty() {
+                    requires = Cow::Owned(requires.union(field_requires));
                 }
+            }
+        }
+        self.create_input_selection_set(&requires)
+    }
+
+    /// Create the input selection set of a Plan given its resolver and requirements.
+    /// We iterate over the requirements and find the matching fields inside the boundary fields,
+    /// which contains all providable & extra fields. During the iteration we track all the dependency
+    /// plans.
+    fn create_input_selection_set(&mut self, requires: &RequiredFieldSet) -> ReadSelectionSet {
+        if requires.is_empty() {
+            return ReadSelectionSet::default();
+        }
+        requires
+            .iter()
+            .map(|required_field| {
+                let field_id = self
+                    .operation_plan
+                    .operation
+                    .find_matching_field(self.plan_boundary_id, required_field.id)
+                    .expect("Should be planned");
+                let parent_plan_id = self.operation_plan.operation.field_to_plan_id[usize::from(field_id)]
+                    .expect("field should be planned");
+                let edge = UnfinalizedParentToChildEdge {
+                    parent: parent_plan_id,
+                    child: self.plan_id,
+                };
+                self.plan_parent_to_child_edges.insert(edge);
+                let resolver = self
+                    .schema
+                    .walk(self.operation_plan.operation[self.plan_id].resolver_id)
+                    .with_own_names();
+                let f = ReadField {
+                    edge: self.operation_plan.operation[field_id].response_edge(),
+                    name: resolver
+                        .walk(self.schema[required_field.id].definition_id)
+                        .name()
+                        .to_string(),
+                    subselection: self.create_input_selection_set(&required_field.subselection),
+                };
+                tracing::info!("Plan {} depends on {} for {}", self.plan_id, parent_plan_id, f.name);
+                f
             })
-            .collect::<Vec<_>>()
+            .collect()
     }
 
     fn collect_selection_set(
@@ -87,39 +340,63 @@ impl<'a> Collector<'a> {
         selection_set_ids: Vec<SelectionSetId>,
         concrete_parent: bool,
     ) -> PlanningResult<AnyCollectedSelectionSet> {
-        let selection_set = flatten_selection_sets(self.schema, self.operation, selection_set_ids);
+        let selection_set = flatten_selection_sets(self.schema, &self.operation_plan, selection_set_ids);
 
-        let mut maybe_boundary_id = None;
         let mut plan_fields = Vec::new();
+        let mut children_plan: HashMap<PlanId, Vec<FieldId>> = HashMap::new();
+        let mut maybe_plan_boundary_id = None;
         for field in selection_set.fields {
-            if !self.operation[field.id].is_read() {
+            if !self.operation_plan[field.id].is_read() {
                 continue;
             }
 
-            let field_plan_id = self.operation.field_to_plan_id[usize::from(field.id)];
+            let field_plan_id =
+                self.operation_plan.operation.field_to_plan_id[usize::from(field.id)].expect("Should be planned");
             if field_plan_id == self.plan_id {
                 plan_fields.push(field);
-            } else if maybe_boundary_id.is_none() {
-                maybe_boundary_id = Some(
-                    self.operation.plan_inputs[usize::from(field_plan_id)]
-                        .as_ref()
-                        .map(|input| input.boundary_id)
-                        .expect("Children always have inputs"),
-                );
+            } else {
+                if let Some(plan_boundary_id) = self
+                    .operation_plan
+                    .operation
+                    .find_boundary_between(self.plan_id, field_plan_id)
+                {
+                    maybe_plan_boundary_id = Some(plan_boundary_id);
+                }
+
+                children_plan.entry(field_plan_id).or_default().push(field.id);
             }
         }
+        let maybe_boundary_id = if children_plan.is_empty() {
+            None
+        } else {
+            let maybe_boundary_id = Some(self.new_boundary());
+            // Not all plans at this boundary necessarily have the current plan as a parent,
+            // intermediate plans may also exist. But at least one of them will be a child.
+            let plan_boundary_id = maybe_plan_boundary_id.expect("At least one plan must be a child");
+            let to_be_planned = children_plan
+                .into_iter()
+                .map(|(plan_id, fields)| ToBePlanned {
+                    maybe_boundary_id,
+                    plan_boundary_id,
+                    plan_id,
+                    fields,
+                })
+                .collect::<Vec<_>>();
+            self.to_be_planned.extend(to_be_planned);
+            maybe_boundary_id
+        };
 
-        let mut conditions = HashSet::<Option<EntityType>>::default();
+        let mut conditions = HashSet::<Option<EntityId>>::default();
         let mut too_complex = false;
         for field in &plan_fields {
             match &field.type_condition {
                 Some(type_condition) => match type_condition {
                     FlatTypeCondition::Interface(id) => {
-                        conditions.insert(Some(EntityType::Interface(*id)));
+                        conditions.insert(Some(EntityId::Interface(*id)));
                     }
                     FlatTypeCondition::Objects(ids) => {
                         if ids.len() == 1 {
-                            conditions.insert(Some(EntityType::Object(ids[0])));
+                            conditions.insert(Some(EntityId::Object(ids[0])));
                         } else {
                             too_complex = true;
                         }
@@ -153,7 +430,7 @@ impl<'a> Collector<'a> {
         // We keep track of which collected selection set matches which bound selection sets.
         // This allows us to know whether `__typename` is necessary in the generated subgraph query.
         for root_id in selection_set.root_selection_set_ids {
-            self.operation.selection_set_to_collected[usize::from(root_id)] = Some(id);
+            self.operation_plan.selection_set_to_collected[usize::from(root_id)] = Some(id);
         }
         Ok(match id {
             AnyCollectedSelectionSetId::Collected(id) => AnyCollectedSelectionSet::Collected(id),
@@ -165,7 +442,7 @@ impl<'a> Collector<'a> {
         &mut self,
         ty: SelectionSetType,
         fields: Vec<FieldId>,
-        maybe_boundary_id: Option<PlanBoundaryId>,
+        maybe_boundary_id: Option<ExecutionPlanBoundaryId>,
     ) -> PlanningResult<CollectedSelectionSetId> {
         let grouped_by_response_key = self
             .walker()
@@ -176,20 +453,20 @@ impl<'a> Collector<'a> {
         let mut typename_fields = vec![];
         for field_ids in grouped_by_response_key {
             let field_id: FieldId = field_ids[0];
-            let field = self.operation[field_id].clone();
+            let field = self.operation_plan[field_id].clone();
             if let Some(definition_id) = field.definition_id() {
                 let definition = self.schema.walk(definition_id);
                 let expected_key = if self.support_aliases {
-                    self.operation.response_keys.ensure_safety(field.response_key())
+                    self.operation_plan.response_keys.ensure_safety(field.response_key())
                 } else {
-                    self.operation.response_keys.get_or_intern(definition.name())
+                    self.operation_plan.response_keys.get_or_intern(definition.name())
                 };
                 let ty = match definition.ty().inner().scalar_type() {
                     Some(scalar_type) => FieldType::Scalar(scalar_type),
                     None => {
                         let subselection_set_ids = field_ids
                             .into_iter()
-                            .filter_map(|id| self.operation[id].selection_set_id())
+                            .filter_map(|id| self.operation_plan[id].selection_set_id())
                             .collect();
                         FieldType::SelectionSet(self.collect_selection_set(subselection_set_ids, true)?)
                     }
@@ -208,7 +485,7 @@ impl<'a> Collector<'a> {
         }
 
         // Sorting by expected_key for deserialization
-        let keys = &self.operation.response_keys;
+        let keys = &self.operation_plan.response_keys;
         fields.sort_unstable_by(|a, b| keys[a.expected_key].cmp(&keys[b.expected_key]));
         let field_ids = self.push_collecteded_fields(fields);
         Ok(self.push_collected_selection_set(CollectedSelectionSet {
@@ -223,18 +500,18 @@ impl<'a> Collector<'a> {
         &mut self,
         ty: SelectionSetType,
         flat_fields: Vec<FlatField>,
-        maybe_boundary_id: Option<PlanBoundaryId>,
+        maybe_boundary_id: Option<ExecutionPlanBoundaryId>,
     ) -> PlanningResult<ConditionalSelectionSetId> {
         let mut typename_fields = Vec::new();
         let mut conditional_fields = Vec::new();
         for flat_field in flat_fields {
-            let field = self.operation[flat_field.id].clone();
+            let field = self.operation_plan[flat_field.id].clone();
             if let Some(definition_id) = field.definition_id() {
                 let definition = self.schema.walker().walk(definition_id);
                 let expected_key = if self.support_aliases {
-                    self.operation.response_keys.ensure_safety(field.response_key())
+                    self.operation_plan.response_keys.ensure_safety(field.response_key())
                 } else {
-                    self.operation.response_keys.get_or_intern(definition.name())
+                    self.operation_plan.response_keys.get_or_intern(definition.name())
                 };
                 let ty = match definition.ty().inner().scalar_type() {
                     Some(data_type) => FieldType::Scalar(data_type),
@@ -271,8 +548,8 @@ impl<'a> Collector<'a> {
     }
 
     fn push_conditional_selection_set(&mut self, selection_set: ConditionalSelectionSet) -> ConditionalSelectionSetId {
-        let id = ConditionalSelectionSetId::from(self.operation.conditional_selection_sets.len());
-        self.operation.conditional_selection_sets.push(selection_set);
+        let id = ConditionalSelectionSetId::from(self.operation_plan.conditional_selection_sets.len());
+        self.operation_plan.conditional_selection_sets.push(selection_set);
         id
     }
 
@@ -281,17 +558,17 @@ impl<'a> Collector<'a> {
         if fields.is_empty() {
             return IdRange::empty();
         }
-        let start = ConditionalFieldId::from(self.operation.conditional_fields.len());
-        self.operation.conditional_fields.extend(fields);
+        let start = ConditionalFieldId::from(self.operation_plan.conditional_fields.len());
+        self.operation_plan.conditional_fields.extend(fields);
         IdRange {
             start,
-            end: ConditionalFieldId::from(self.operation.conditional_fields.len()),
+            end: ConditionalFieldId::from(self.operation_plan.conditional_fields.len()),
         }
     }
 
     fn push_collected_selection_set(&mut self, selection_set: CollectedSelectionSet) -> CollectedSelectionSetId {
-        let id = CollectedSelectionSetId::from(self.operation.collected_selection_sets.len());
-        self.operation.collected_selection_sets.push(selection_set);
+        let id = CollectedSelectionSetId::from(self.operation_plan.collected_selection_sets.len());
+        self.operation_plan.collected_selection_sets.push(selection_set);
         id
     }
 
@@ -300,11 +577,11 @@ impl<'a> Collector<'a> {
         if fields.is_empty() {
             return IdRange::empty();
         }
-        let start = CollectedFieldId::from(self.operation.collected_fields.len());
-        self.operation.collected_fields.extend(fields);
+        let start = CollectedFieldId::from(self.operation_plan.collected_fields.len());
+        self.operation_plan.collected_fields.extend(fields);
         IdRange {
             start,
-            end: CollectedFieldId::from(self.operation.collected_fields.len()),
+            end: CollectedFieldId::from(self.operation_plan.collected_fields.len()),
         }
     }
 }

--- a/engine/crates/engine-v2/src/plan/planning/logic.rs
+++ b/engine/crates/engine-v2/src/plan/planning/logic.rs
@@ -1,6 +1,6 @@
 use schema::{FieldDefinitionId, ProvidableFieldSet, ResolverWalker};
 
-use crate::plan::PlanId;
+use crate::operation::PlanId;
 
 /// Defines whether a field can be provided or not for a given resolver.
 #[derive(Debug, Clone)]

--- a/engine/crates/engine-v2/src/plan/planning/mod.rs
+++ b/engine/crates/engine-v2/src/plan/planning/mod.rs
@@ -65,7 +65,5 @@ pub(super) fn plan_operation(
     variables: &Variables,
     operation: Operation,
 ) -> PlanningResult<OperationPlan> {
-    let mut planner = planner::Planner::new(schema, variables, operation);
-    planner.plan_all_fields()?;
-    planner.finalize_operation()
+    planner::Planner::new(schema, variables, operation).plan()
 }

--- a/engine/crates/engine-v2/src/plan/planning/planner.rs
+++ b/engine/crates/engine-v2/src/plan/planning/planner.rs
@@ -1,25 +1,19 @@
 use engine_parser::types::OperationType;
-use id_newtypes::IdRange;
+use im::HashSet;
 use itertools::Itertools;
 use schema::{ResolverId, Schema};
-use std::{
-    collections::{HashMap, HashSet},
-    num::NonZeroU16,
-};
+use std::num::NonZeroU16;
 
 use super::{
-    boundary::BoundarySelectionSetPlanner, collect::Collector, logic::PlanningLogic, PlanningError, PlanningResult,
+    boundary::BoundarySelectionSetPlanner, collect::OperationPlanBuilder, logic::PlanningLogic, PlanningError,
+    PlanningResult,
 };
 use crate::{
     operation::{
-        Field, FieldId, Operation, OperationWalker, QueryPath, Selection, SelectionSet, SelectionSetId, Variables,
+        Field, FieldId, Operation, OperationWalker, ParentToChildEdge, Plan, PlanBoundaryId, PlanId, QueryPath,
+        Selection, SelectionSet, SelectionSetId, Variables,
     },
-    plan::{
-        flatten_selection_sets, EntityType, FlatField, FlatSelectionSet, FlatTypeCondition, OperationPlan,
-        ParentToChildEdge, PlanBoundaryId, PlanId, PlanInput, PlanOutput, PlannedResolver,
-    },
-    response::ReadSelectionSet,
-    sources::Plan,
+    plan::{flatten_selection_sets, EntityId, FlatField, FlatSelectionSet, OperationPlan},
 };
 
 /// The planner is responsible to attribute a plan id for every field & selection set in the
@@ -44,37 +38,12 @@ use crate::{
 ///    During execution, those Plans create Executors with the actual response objects that do the
 ///    real work.
 ///
-pub(super) struct Planner<'ctx> {
-    pub(super) schema: &'ctx Schema,
-    pub(super) variables: &'ctx Variables,
+pub(super) struct Planner<'a> {
+    pub(super) schema: &'a Schema,
+    pub(super) variables: &'a Variables,
     pub(super) operation: Operation,
-
-    // -- Operation --
-    // Associates for each field/selection a plan. Attributions is added incrementally
-    // and used to determine dependencies between plans. It's later used in OperationPlan
-    // to filter the selection that Executors see, only for their plan.
-    // BoundFieldId -> Option<PlanId>
-    field_to_plan_id: Vec<Option<PlanId>>,
-    // BoundSelectionSetId -> Option<PlanId>
-    selection_set_to_plan_id: Vec<Option<PlanId>>,
-
-    // -- Plans --
-    planned_resolvers: Vec<PlannedResolver>,
-    plan_input_selection_sets: Vec<Option<ReadSelectionSet>>,
-    // PlanId -> PlanRootSelectionSet
-    plan_root_selection_sets: Vec<PlanRootSelectionSet>,
-    // Child -> Parent(s)
-    plan_to_dependencies: HashMap<PlanId, HashSet<PlanId>>,
-    plan_boundaries_count: usize,
-    // PlanId -> Vec<PlanBoundaryId>
-    plan_to_children_tmp_boundary_ids: Vec<Vec<TemporaryPlanBoundaryId>>,
-    // PlanId -> Option<PlanBoundaryId>
-    plan_to_parent_tmp_boundary_id: Vec<Option<TemporaryPlanBoundaryId>>,
-}
-
-pub(super) struct PlanRootSelectionSet {
-    pub ids: Vec<SelectionSetId>,
-    pub entity_type: EntityType,
+    plan_edges: HashSet<ParentToChildEdge>,
+    next_plan_boundary_id: usize,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -92,28 +61,27 @@ impl From<TemporaryPlanBoundaryId> for usize {
     }
 }
 
-impl<'ctx> Planner<'ctx> {
-    pub(super) fn new(schema: &'ctx Schema, variables: &'ctx Variables, operation: Operation) -> Self {
+impl<'a> Planner<'a> {
+    pub(super) fn new(schema: &'a Schema, variables: &'a Variables, operation: Operation) -> Self {
         Self {
             schema,
             variables,
-            field_to_plan_id: vec![None; operation.fields.len()],
-            selection_set_to_plan_id: vec![None; operation.selection_sets.len()],
             operation,
-            planned_resolvers: Vec::new(),
-            plan_input_selection_sets: Vec::new(),
-            plan_root_selection_sets: Vec::new(),
-            plan_boundaries_count: 0,
-            plan_to_children_tmp_boundary_ids: Vec::new(),
-            plan_to_parent_tmp_boundary_id: Vec::new(),
-            plan_to_dependencies: HashMap::default(),
+            plan_edges: HashSet::new(),
+            next_plan_boundary_id: 0,
         }
     }
-}
 
-impl<'schema> Planner<'schema> {
+    pub(super) fn plan(mut self) -> PlanningResult<OperationPlan> {
+        self.plan_all_fields()?;
+        self.operation.field_dependencies.sort_unstable();
+        self.operation.plan_edges = self.plan_edges.into_iter().collect();
+        self.operation.plan_edges.sort_unstable();
+        OperationPlanBuilder::new(self.schema, self.variables, self.operation).build()
+    }
+
     /// Step 1 of the planning, attributed all fields to a plan and satisfying their requirements.
-    pub(super) fn plan_all_fields(&mut self) -> PlanningResult<()> {
+    fn plan_all_fields(&mut self) -> PlanningResult<()> {
         // The root plan is always introspection which also lets us handle operations like:
         // query { __typename }
         let introspection = self.schema.walker().introspection_metadata();
@@ -135,7 +103,7 @@ impl<'schema> Planner<'schema> {
             self.push_plan(
                 QueryPath::default(),
                 introspection.resolver_id,
-                EntityType::Object(self.operation.root_object_id),
+                EntityId::Object(self.operation.root_object_id),
                 &introspection_selection_set,
             )?;
         }
@@ -159,15 +127,14 @@ impl<'schema> Planner<'schema> {
             None,
             FlatSelectionSet::empty(selection_set.ty),
             selection_set,
-        )?;
-        Ok(())
+        )
     }
 
     /// Mutation is a special case because root fields need to execute in order. So planning each
     /// field individually and setting up plan dependencies between them to ensures proper
     /// execution order.
     fn plan_mutation(&mut self, mut selection_set: FlatSelectionSet) -> PlanningResult<()> {
-        let entity_type = EntityType::Object(self.operation.root_object_id);
+        let entity_type = EntityId::Object(self.operation.root_object_id);
 
         let fields = std::mem::take(&mut selection_set.fields);
         let mut groups = self
@@ -179,7 +146,10 @@ impl<'schema> Planner<'schema> {
         groups.sort_unstable_by_key(|field_ids| self.operation[field_ids[0]].query_position());
 
         let mut maybe_previous_plan_id: Option<PlanId> = None;
+        let boundary_id = self.next_plan_boundary_id();
 
+        // FIXME: generates one plan per field, should be aggregated if consecutive fields can be
+        // planned by a single resolver.
         for field_ids in groups {
             let field = &self.operation[field_ids[0]];
             let definition_id = field
@@ -214,7 +184,11 @@ impl<'schema> Planner<'schema> {
             )?;
 
             if let Some(parent) = maybe_previous_plan_id {
-                self.insert_plan_dependency(ParentToChildEdge { parent, child: plan_id });
+                self.push_plan_dependency(ParentToChildEdge {
+                    parent,
+                    child: plan_id,
+                    boundary: boundary_id,
+                });
             }
             maybe_previous_plan_id = Some(plan_id);
         }
@@ -225,7 +199,7 @@ impl<'schema> Planner<'schema> {
     fn plan_providable_subselections(
         &mut self,
         path: &QueryPath,
-        logic: &PlanningLogic<'schema>,
+        logic: &PlanningLogic<'a>,
         providable: &FlatSelectionSet,
     ) -> PlanningResult<()> {
         let plan_id = logic.plan_id();
@@ -261,7 +235,7 @@ impl<'schema> Planner<'schema> {
     fn plan_selection_set(
         &mut self,
         path: &QueryPath,
-        logic: &PlanningLogic<'schema>,
+        logic: &PlanningLogic<'a>,
         selection_set: FlatSelectionSet,
     ) -> PlanningResult<()> {
         let walker = self.walker();
@@ -288,180 +262,13 @@ impl<'schema> Planner<'schema> {
     fn plan_boundary_selection_set(
         &mut self,
         query_path: &QueryPath,
-        logic: &PlanningLogic<'schema>,
+        logic: &PlanningLogic<'a>,
         providable: FlatSelectionSet,
         missing: FlatSelectionSet,
     ) -> PlanningResult<()> {
-        let children = BoundarySelectionSetPlanner::plan(self, query_path, Some(logic), providable, missing)?;
-
-        let parent = logic.plan_id();
-        let plan_boundary_id = self.new_boundary(parent)?;
-        for child in children {
-            self.insert_parent_plan(plan_boundary_id, ParentToChildEdge { parent, child });
-        }
-
-        Ok(())
+        BoundarySelectionSetPlanner::plan(self, query_path, Some(logic), providable, missing)
     }
-}
 
-impl<'schema> Planner<'schema> {
-    /// This function is a bit... heavy. it generates the OperationPlan and several parts need some
-    /// post-processing to return something that makes sense. It does the step 2 & 3 of the
-    /// planning.
-    pub(super) fn finalize_operation(mut self) -> PlanningResult<OperationPlan> {
-        //
-        // -- Ensuring we attributed all fields & selection set --
-        //
-        let field_attribution = self
-            .field_to_plan_id
-            .iter()
-            .enumerate()
-            .map(|(i, maybe_plan_id)| match maybe_plan_id {
-                Some(plan_id) => *plan_id,
-                None => {
-                    let field = &self.walker().walk(FieldId::from(i));
-                    unreachable!("No plan was associated with field:\n{field:#?}");
-                }
-            })
-            .collect();
-
-        self.selection_set_to_plan_id[usize::from(self.operation.root_selection_set_id)] = Some(PlanId::from(0));
-        let selection_set_attribution = self
-            .selection_set_to_plan_id
-            .iter()
-            .enumerate()
-            .map(|(i, maybe_plan_id)| match maybe_plan_id {
-                Some(plan_id) => *plan_id,
-                None => {
-                    let selection_set_id = SelectionSetId::from(i);
-                    let selection_set = self.walker().walk(selection_set_id);
-                    unreachable!("No plan was associated with selection set:\n{selection_set:#?})");
-                }
-            })
-            .collect();
-
-        let Self {
-            schema,
-            operation,
-            variables,
-            planned_resolvers,
-            plan_input_selection_sets,
-            plan_root_selection_sets,
-            plan_to_dependencies,
-            plan_boundaries_count,
-            plan_to_children_tmp_boundary_ids,
-            plan_to_parent_tmp_boundary_id,
-            ..
-        } = self;
-
-        //
-        // -- Generating the plan boundaries, dependencies & inputs --
-        //
-        // Before we used TemporaryPlanBoundaryId to keep track of the boundaries. But we need them
-        // to be sequential for a given plan. This allows us to access store boundaries in Vec and
-        // access them with an offset when ingesting data into the response.
-        // We also need plan boundary ids to be unique for the OperationExecutionState which needs
-        // the number of consummers (children plan) for a given boundary.
-        let mut plan_to_output_boundary_ids = Vec::with_capacity(planned_resolvers.len());
-        let tmp_boundary_id_to_boundary_id = {
-            let mut mapping = vec![PlanBoundaryId::from(0); plan_boundaries_count];
-            let mut n: usize = 0;
-            for tmp_boundary_ids in &plan_to_children_tmp_boundary_ids {
-                let start = PlanBoundaryId::from(n);
-                for tmp_boundary_id in tmp_boundary_ids {
-                    let id = PlanBoundaryId::from(n);
-                    n += 1;
-                    mapping[usize::from(*tmp_boundary_id)] = id;
-                }
-                let end = PlanBoundaryId::from(n);
-                plan_to_output_boundary_ids.push(IdRange { start, end });
-            }
-            mapping
-        };
-
-        let mut plan_boundary_consummers_count = vec![0; plan_boundaries_count];
-        let mut plan_inputs = Vec::with_capacity(planned_resolvers.len());
-        for (maybe_tmp_id, maybe_selection_set) in plan_to_parent_tmp_boundary_id
-            .into_iter()
-            .zip(plan_input_selection_sets)
-        {
-            if let Some(tmp_id) = maybe_tmp_id {
-                let boundary_id = tmp_boundary_id_to_boundary_id[usize::from(tmp_id)];
-                plan_boundary_consummers_count[usize::from(boundary_id)] += 1;
-                plan_inputs.push(Some(PlanInput {
-                    selection_set: maybe_selection_set.expect("Missing input selection set"),
-                    boundary_id,
-                }));
-            } else {
-                plan_inputs.push(None);
-            }
-        }
-
-        let mut plan_dependencies_count = vec![0; planned_resolvers.len()];
-        let mut plans_parent_to_child_edges = Vec::with_capacity(planned_resolvers.len());
-        for (&child, dependencies) in &plan_to_dependencies {
-            for &parent in dependencies {
-                plan_dependencies_count[usize::from(child)] += 1;
-                plans_parent_to_child_edges.push(ParentToChildEdge { parent, child });
-            }
-        }
-
-        //
-        // -- Collecting fields for the plan output --
-        //
-        let mut operation_plan = OperationPlan {
-            field_to_plan_id: field_attribution,
-            selection_to_plan_id: selection_set_attribution,
-            plan_inputs,
-            plan_outputs: Vec::with_capacity(planned_resolvers.len()),
-            collected_selection_sets: Vec::with_capacity(planned_resolvers.len()),
-            collected_fields: Vec::with_capacity(planned_resolvers.len()),
-            selection_set_to_collected: vec![None; operation.selection_sets.len()],
-            operation,
-            conditional_selection_sets: Vec::new(),
-            conditional_fields: Vec::new(),
-            plans: Vec::with_capacity(planned_resolvers.len()),
-            planned_resolvers,
-            plan_parent_to_child_edges: plans_parent_to_child_edges,
-            plan_dependencies_count,
-            plan_boundary_consummers_count,
-        };
-        operation_plan.plan_parent_to_child_edges.sort_unstable();
-
-        for (i, PlanRootSelectionSet { ids, entity_type }) in plan_root_selection_sets.into_iter().enumerate() {
-            let plan_id = PlanId::from(i);
-            let ty = operation_plan[ids[0]].ty;
-            let collected_selection_set_id =
-                Collector::new(schema, variables, &mut operation_plan, plan_id).collect(ids)?;
-            operation_plan.plan_outputs.push(PlanOutput {
-                type_condition: FlatTypeCondition::flatten(schema, ty, vec![entity_type.into()]),
-                entity_type,
-                collected_selection_set_id,
-                boundary_ids: plan_to_output_boundary_ids[i],
-            });
-        }
-
-        //
-        // -- Generating the actual plans --
-        //
-        let mut execution_plans = Vec::with_capacity(operation_plan.plans.len());
-        for (i, PlannedResolver { resolver_id, .. }) in operation_plan.planned_resolvers.iter().enumerate() {
-            let resolver = schema.walker().walk(*resolver_id).with_own_names();
-            let plan_id = PlanId::from(i);
-            execution_plans.push(Plan::build(
-                resolver,
-                operation_plan.ty,
-                operation_plan.walker_with(schema, variables, plan_id),
-            )?);
-        }
-        operation_plan.plans = execution_plans;
-
-        Ok(operation_plan)
-    }
-}
-
-// Utilities
-impl<'schema> Planner<'schema> {
     pub fn walker(&self) -> OperationWalker<'_, (), ()> {
         self.operation.walker_with(self.schema.walker(), self.variables)
     }
@@ -473,10 +280,10 @@ impl<'schema> Planner<'schema> {
         field: Field,
     ) -> FieldId {
         let id = FieldId::from(self.operation.fields.len());
-        self.field_to_plan_id.push(Some(plan_id));
+        self.operation.field_to_plan_id.push(Some(plan_id));
         self.operation.fields.push(field);
         if let Some(selection_set_id) = parent_selection_set_id {
-            self.selection_set_to_plan_id[usize::from(selection_set_id)] = Some(plan_id);
+            self.operation.selection_set_to_plan_id[usize::from(selection_set_id)] = Some(plan_id);
             self.operation[selection_set_id].items.push(Selection::Field(id));
             self.operation.field_to_parent.push(selection_set_id);
         }
@@ -491,7 +298,7 @@ impl<'schema> Planner<'schema> {
             }
         }
         self.operation.selection_sets.push(selection_set);
-        self.selection_set_to_plan_id.push(Some(plan_id));
+        self.operation.selection_set_to_plan_id.push(Some(plan_id));
         id
     }
 
@@ -499,10 +306,10 @@ impl<'schema> Planner<'schema> {
         &mut self,
         path: QueryPath,
         resolver_id: ResolverId,
-        entity_type: EntityType,
+        entity_type: EntityId,
         providable: &FlatSelectionSet,
     ) -> PlanningResult<PlanId> {
-        let plan_id = PlanId::from(self.planned_resolvers.len());
+        let plan_id = PlanId::from(self.operation.plans.len());
         tracing::trace!(
             "Creating {plan_id} ({}) for entity '{}': {}",
             self.schema.walk(resolver_id).name(),
@@ -512,62 +319,36 @@ impl<'schema> Planner<'schema> {
                 self.walker().walk(field.id).response_key_str()
             )))
         );
-        self.planned_resolvers.push(PlannedResolver {
-            resolver_id,
-            path: path.clone(),
-        });
-        self.plan_to_children_tmp_boundary_ids.push(Vec::new());
-        self.plan_to_parent_tmp_boundary_id.push(None);
-        self.plan_input_selection_sets.push(None);
-        self.plan_root_selection_sets.push(PlanRootSelectionSet {
-            ids: providable.root_selection_set_ids.clone(),
-            entity_type,
-        });
+        self.operation.plans.push(Plan { resolver_id });
         let logic = PlanningLogic::new(plan_id, self.schema.walk(resolver_id));
         self.plan_providable_subselections(&path, &logic, providable)?;
         Ok(plan_id)
     }
 
-    pub fn new_boundary(&mut self, plan_id: PlanId) -> PlanningResult<TemporaryPlanBoundaryId> {
-        let id = TemporaryPlanBoundaryId::from(self.plan_boundaries_count);
-        self.plan_boundaries_count += 1;
-        self.plan_to_children_tmp_boundary_ids[usize::from(plan_id)].push(id);
-        Ok(id)
+    pub fn next_plan_boundary_id(&mut self) -> PlanBoundaryId {
+        let id = self.next_plan_boundary_id;
+        self.next_plan_boundary_id += 1;
+        PlanBoundaryId::from(id)
     }
 
-    pub fn insert_plan_input_selection_set(&mut self, plan_id: PlanId, selection_set: ReadSelectionSet) {
-        self.plan_input_selection_sets[usize::from(plan_id)] = Some(selection_set);
-    }
-
-    pub fn insert_plan_dependency(&mut self, edge: ParentToChildEdge) {
-        self.plan_to_dependencies
-            .entry(edge.child)
-            .or_default()
-            .insert(edge.parent);
-    }
-
-    pub fn insert_parent_plan(&mut self, plan_boundary_id: TemporaryPlanBoundaryId, edge: ParentToChildEdge) {
-        self.insert_plan_dependency(edge);
-        self.plan_to_parent_tmp_boundary_id[usize::from(edge.child)] = Some(plan_boundary_id);
+    pub fn push_plan_dependency(&mut self, edge: ParentToChildEdge) {
+        self.plan_edges.insert(edge);
     }
 
     pub fn get_field_plan(&self, id: FieldId) -> Option<PlanId> {
-        self.field_to_plan_id[usize::from(id)]
+        self.operation.field_to_plan_id[usize::from(id)]
     }
 
     pub fn attribute_selection_set(&mut self, selection_set: &FlatSelectionSet, plan_id: PlanId) {
         for field in selection_set {
-            self.field_to_plan_id[usize::from(field.id)] = Some(plan_id);
-            // Ignoring the first selection_set which comes from the parent plan.
-            for id in &field.selection_set_path {
-                self.selection_set_to_plan_id[usize::from(*id)].get_or_insert(plan_id);
-            }
+            self.operation.field_to_plan_id[usize::from(field.id)] = Some(plan_id);
+            self.attribute_selection_sets(&field.selection_set_path, plan_id)
         }
     }
 
     pub fn attribute_selection_sets(&mut self, selection_set_ids: &[SelectionSetId], plan_id: PlanId) {
         for id in selection_set_ids {
-            self.selection_set_to_plan_id[usize::from(*id)].get_or_insert(plan_id);
+            self.operation.selection_set_to_plan_id[usize::from(*id)].get_or_insert(plan_id);
         }
     }
 }

--- a/engine/crates/engine-v2/src/plan/planning/walker_ext.rs
+++ b/engine/crates/engine-v2/src/plan/planning/walker_ext.rs
@@ -5,9 +5,9 @@ use crate::{
     response::ResponseKey,
 };
 
-impl<'a> OperationWalker<'a> {
+impl<'a> OperationWalker<'a, (), ()> {
     /// Sorting is used to ensure we always pick the BoundFieldId with the lowest query position.
-    pub(super) fn group_by_response_key_sorted_by_query_position(
+    pub(crate) fn group_by_response_key_sorted_by_query_position(
         &self,
         values: impl IntoIterator<Item = FieldId>,
     ) -> HashMap<ResponseKey, Vec<FieldId>> {

--- a/engine/crates/engine-v2/src/plan/walkers/mod.rs
+++ b/engine/crates/engine-v2/src/plan/walkers/mod.rs
@@ -11,8 +11,8 @@ use crate::{
 };
 
 use super::{
-    AnyCollectedSelectionSet, CollectedSelectionSetId, ConditionalSelectionSetId, FlatTypeCondition, OperationPlan,
-    PlanId, PlanInput, PlanOutput, RuntimeCollectedSelectionSet,
+    AnyCollectedSelectionSet, CollectedSelectionSetId, ConditionalSelectionSetId, ExecutionPlanId, FlatTypeCondition,
+    OperationPlan, PlanInput, PlanOutput, RuntimeCollectedSelectionSet,
 };
 
 mod collected;
@@ -32,7 +32,7 @@ pub(crate) struct PlanWalker<'a, Item = (), SchemaItem = ()> {
     pub(super) schema_walker: SchemaWalker<'a, SchemaItem>,
     pub(super) operation_plan: &'a OperationPlan,
     pub(super) variables: &'a Variables,
-    pub(super) plan_id: PlanId,
+    pub(super) execution_plan_id: ExecutionPlanId,
     pub(super) item: Item,
 }
 
@@ -56,7 +56,7 @@ where
     }
 }
 
-impl<'a> PlanWalker<'a> {
+impl<'a> PlanWalker<'a, (), ()> {
     pub fn schema(&self) -> SchemaWalker<'a, ()> {
         self.schema_walker
     }
@@ -69,16 +69,12 @@ impl<'a> PlanWalker<'a> {
         PlanSelectionSet::RootFields(self)
     }
 
-    pub fn id(&self) -> PlanId {
-        self.plan_id
-    }
-
     pub fn output(&self) -> &'a PlanOutput {
-        &self.operation_plan.plan_outputs[usize::from(self.plan_id)]
+        &self.operation_plan[self.execution_plan_id].output
     }
 
     pub fn input(&self) -> Option<&'a PlanInput> {
-        self.operation_plan.plan_inputs[usize::from(self.plan_id)].as_ref()
+        self.operation_plan[self.execution_plan_id].input.as_ref()
     }
 
     pub fn collected_selection_set(&self) -> PlanWalker<'a, CollectedSelectionSetId, ()> {
@@ -104,7 +100,7 @@ impl<'a, I, SI> PlanWalker<'a, I, SI> {
         PlanWalker {
             operation_plan: self.operation_plan,
             variables: self.variables,
-            plan_id: self.plan_id,
+            execution_plan_id: self.execution_plan_id,
             schema_walker: self.schema_walker,
             item,
         }
@@ -114,7 +110,7 @@ impl<'a, I, SI> PlanWalker<'a, I, SI> {
         PlanWalker {
             operation_plan: self.operation_plan,
             variables: self.variables,
-            plan_id: self.plan_id,
+            execution_plan_id: self.execution_plan_id,
             schema_walker: self.schema_walker.walk(schema_item),
             item,
         }

--- a/engine/crates/engine-v2/src/response/write/deserialize/selection_set/collected.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/selection_set/collected.rs
@@ -5,7 +5,7 @@ use serde::de::{DeserializeSeed, IgnoredAny, MapAccess, Visitor};
 
 use crate::{
     operation::SelectionSetType,
-    plan::{CollectedField, CollectedSelectionSetId, PlanBoundaryId, RuntimeCollectedSelectionSet},
+    plan::{CollectedField, CollectedSelectionSetId, ExecutionPlanBoundaryId, RuntimeCollectedSelectionSet},
     response::{
         value::{ResponseObjectFields, RESPONSE_OBJECT_FIELDS_BINARY_SEARCH_THRESHOLD},
         write::deserialize::{key::Key, FieldSeed, SeedContext},
@@ -17,7 +17,7 @@ use crate::{
 /// or not. There is no field with type conditions anymore.
 pub(crate) struct CollectedSelectionSetSeed<'ctx, 'parent> {
     pub ctx: &'parent SeedContext<'ctx>,
-    pub boundary_ids: &'parent [PlanBoundaryId],
+    pub boundary_ids: &'parent [ExecutionPlanBoundaryId],
     pub fields_seed: CollectedFieldsSeed<'ctx, 'parent>,
 }
 

--- a/engine/crates/engine-v2/src/sources/graphql/subscription.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/subscription.rs
@@ -7,7 +7,7 @@ use super::{
     deserialize::{GraphqlResponseSeed, RootGraphqlErrors},
     query::PreparedGraphqlOperation,
     variables::SubgraphVariables,
-    ExecutionContext, GraphqlExecutionPlan,
+    ExecutionContext, GraphqlPreparedExecutor,
 };
 use crate::{
     execution::OperationRootPlanExecution,
@@ -22,7 +22,7 @@ pub(crate) struct GraphqlSubscriptionExecutor<'ctx> {
     plan: PlanWalker<'ctx>,
 }
 
-impl GraphqlExecutionPlan {
+impl GraphqlPreparedExecutor {
     pub fn new_subscription_executor<'ctx>(
         &'ctx self,
         input: SubscriptionInput<'ctx>,

--- a/engine/crates/engine-v2/src/sources/introspection/mod.rs
+++ b/engine/crates/engine-v2/src/sources/introspection/mod.rs
@@ -3,9 +3,9 @@ use crate::{execution::ExecutionContext, plan::PlanWalker, response::ResponsePar
 
 mod writer;
 
-pub(crate) struct IntrospectionExecutionPlan;
+pub(crate) struct IntrospectionPreparedExecutor;
 
-impl IntrospectionExecutionPlan {
+impl IntrospectionPreparedExecutor {
     #[allow(clippy::unnecessary_wraps)]
     pub fn new_executor<'ctx>(
         &'ctx self,


### PR DESCRIPTION
In this PR I'm separating the query plan "solver", which ensures we have a working plan with all requirements fulfilled, from the "output shape" computation.
So now I have `Plan` for the first step, which is kind of akin to partial cache query partitions with an associated resolver, and `ExecutionPlan` which defines the actual execution that will happen.

The solving step traverses the operation and splits it into different plans, adding extra fields as necessary with eventually a new plan. We keep track of which operation field matches which `RequiredField` for a given boundary (object resolved by multiple plans)

The second step re-traverses the query and requirements again and with the help of the previous step's metadata defines the actual plans and their dependencies. We know which resolver to use for which field, which operation field to use for which requirement etc.

Currently, ExecutionPlan and Plan are equivalent, but this allows us to modify the execution selection with directives like `@requiresScopes`, etc. after creating the plans but before the execution plans. The tricky part for this will be to ensure we modify the selection set in a consistent way.
