### PR TITLE
chore(engine-v2): Simplify FlatSelectionSet + fix requires within plan

### DIFF
--- a/engine/crates/engine-v2/schema/src/builder/graph.rs
+++ b/engine/crates/engine-v2/schema/src/builder/graph.rs
@@ -58,7 +58,6 @@ impl<'a> GraphBuilder<'a> {
                 input_object_definitions: Vec::new(),
                 input_value_definitions: Vec::new(),
                 field_definitions: Vec::new(),
-                field_to_parent_entity: Vec::new(),
                 resolvers: Vec::new(),
                 type_definitions: Vec::new(),
                 type_system_directives: Vec::new(),
@@ -422,7 +421,7 @@ impl<'a> GraphBuilder<'a> {
                     cache_config_target: Some(CacheConfigTarget::Field(federated_id)),
                 },
             );
-            let parent_entity = if let Some(object_id) =
+            let parent_entity_id = if let Some(object_id) =
                 object_metadata.field_id_to_maybe_object_id[usize::from(field_id)]
             {
                 EntityId::Object(object_id)
@@ -433,10 +432,10 @@ impl<'a> GraphBuilder<'a> {
                 // TODO: better guarantee this never fails.
                 unreachable!()
             };
-            self.graph.field_to_parent_entity.push(parent_entity);
             self.graph.field_definitions.push(FieldDefinition {
                 name: field.name.into(),
                 description: None,
+                parent_entity: parent_entity_id,
                 ty: field.r#type.into(),
                 only_resolvable_in: only_resolvable_in
                     .into_iter()
@@ -459,7 +458,7 @@ impl<'a> GraphBuilder<'a> {
                     .map(|federated_graph::FieldRequires { subgraph_id, fields }| {
                         let field_set_id = self.required_field_sets_buffer.push(
                             SchemaLocation::Field {
-                                ty: match parent_entity {
+                                ty: match parent_entity_id {
                                     EntityId::Object(id) => self.graph[id].name,
                                     EntityId::Interface(id) => self.graph[id].name,
                                 },

--- a/engine/crates/engine-v2/schema/src/builder/mod.rs
+++ b/engine/crates/engine-v2/schema/src/builder/mod.rs
@@ -71,6 +71,7 @@ impl BuildContext {
             field_definitions: vec![
                 FieldDefinition {
                     name: ctx.strings.get_or_insert("__type"),
+                    parent_entity: EntityId::Object(0.into()),
                     description: None,
                     // will be replaced by introspection, doesn't matter.
                     ty: Type {
@@ -86,6 +87,7 @@ impl BuildContext {
                 },
                 FieldDefinition {
                     name: ctx.strings.get_or_insert("__schema"),
+                    parent_entity: EntityId::Object(0.into()),
                     description: None,
                     // will be replaced by introspection, doesn't matter.
                     ty: Type {
@@ -100,7 +102,6 @@ impl BuildContext {
                     directives: Default::default(),
                 },
             ],
-            field_to_parent_entity: vec![EntityId::Object(0.into()); 2],
             enum_definitions: Vec::new(),
             union_definitions: Vec::new(),
             scalar_definitions: Vec::new(),

--- a/engine/crates/engine-v2/schema/src/lib.rs
+++ b/engine/crates/engine-v2/schema/src/lib.rs
@@ -69,7 +69,6 @@ pub struct Graph {
     object_definitions: Vec<Object>,
     interface_definitions: Vec<Interface>,
     field_definitions: Vec<FieldDefinition>,
-    field_to_parent_entity: Vec<EntityId>,
     enum_definitions: Vec<Enum>,
     union_definitions: Vec<Union>,
     scalar_definitions: Vec<Scalar>,
@@ -157,6 +156,7 @@ pub struct Object {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct FieldDefinition {
     pub name: StringId,
+    pub parent_entity: EntityId,
     pub description: Option<StringId>,
     pub ty: Type,
     pub resolvers: Vec<ResolverId>,

--- a/engine/crates/engine-v2/schema/src/sources/introspection.rs
+++ b/engine/crates/engine-v2/schema/src/sources/introspection.rs
@@ -1,8 +1,8 @@
 use std::ops::{Deref, DerefMut};
 
 use crate::{
-    builder::BuildContext, Definition, EnumId, EnumValue, EnumValueId, FieldDefinition, FieldDefinitionId, Graph,
-    IdRange, InputValueDefinition, InputValueDefinitionId, ObjectId, ResolverId, ScalarId, ScalarType,
+    builder::BuildContext, Definition, EntityId, EnumId, EnumValue, EnumValueId, FieldDefinition, FieldDefinitionId,
+    Graph, IdRange, InputValueDefinition, InputValueDefinitionId, ObjectId, ResolverId, ScalarId, ScalarType,
     SchemaInputValue, SchemaInputValueId, SchemaWalker, StringId, SubgraphId, Type, Wrapping,
 };
 use strum::EnumCount;
@@ -693,6 +693,7 @@ impl<'a> IntrospectionBuilder<'a> {
             self.field_definitions.push(FieldDefinition {
                 name,
                 ty: r#type,
+                parent_entity: EntityId::Object(object_id),
                 only_resolvable_in: vec![subgraph_id],
                 requires: Vec::new(),
                 provides: Vec::new(),

--- a/engine/crates/engine-v2/schema/src/walkers/field.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/field.rs
@@ -49,7 +49,7 @@ impl<'a> FieldDefinitionWalker<'a> {
     }
 
     pub fn parent_entity(&self) -> EntityId {
-        self.schema.graph.field_to_parent_entity[usize::from(self.item)]
+        self.as_ref().parent_entity
     }
 
     pub fn arguments(self) -> impl ExactSizeIterator<Item = InputValueDefinitionWalker<'a>> + 'a {

--- a/engine/crates/engine-v2/src/operation/selection_set.rs
+++ b/engine/crates/engine-v2/src/operation/selection_set.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use id_newtypes::IdRange;
-use schema::{Definition, FieldDefinitionId, InputValueDefinitionId, InterfaceId, ObjectId, Schema, UnionId};
+use schema::{Definition, EntityId, FieldDefinitionId, InputValueDefinitionId, InterfaceId, ObjectId, Schema, UnionId};
 
 use crate::response::{BoundResponseKey, ResponseEdge, ResponseKey};
 
@@ -22,6 +22,12 @@ pub enum SelectionSetType {
     Object(ObjectId),
     Interface(InterfaceId),
     Union(UnionId),
+}
+
+impl SelectionSetType {
+    pub fn is_union(&self) -> bool {
+        matches!(self, Self::Union(_))
+    }
 }
 
 impl From<SelectionSetType> for TypeCondition {
@@ -68,6 +74,14 @@ impl SelectionSetType {
         match self {
             SelectionSetType::Object(id) => Some(*id),
             _ => None,
+        }
+    }
+
+    pub fn as_entity_id(&self) -> Option<EntityId> {
+        match self {
+            SelectionSetType::Object(id) => Some(EntityId::Object(*id)),
+            SelectionSetType::Interface(id) => Some(EntityId::Interface(*id)),
+            SelectionSetType::Union(_) => None,
         }
     }
 }

--- a/engine/crates/engine-v2/src/plan/collected.rs
+++ b/engine/crates/engine-v2/src/plan/collected.rs
@@ -1,5 +1,5 @@
 use id_newtypes::IdRange;
-use schema::{FieldDefinitionId, ObjectId, ScalarType, Wrapping};
+use schema::{EntityId, FieldDefinitionId, ObjectId, ScalarType, Wrapping};
 
 use crate::{
     operation::{FieldId, SelectionSetType},
@@ -8,7 +8,6 @@ use crate::{
 
 use super::{
     CollectedFieldId, CollectedSelectionSetId, ConditionalFieldId, ConditionalSelectionSetId, ExecutionPlanBoundaryId,
-    FlatTypeCondition,
 };
 
 // TODO: The two AnyCollectedSelectionSet aren't great, need to split better the ones which are computed
@@ -49,13 +48,13 @@ pub struct ConditionalSelectionSet {
     //     myalias: __typename
     //     __typename
     // }
-    pub typename_fields: Vec<(Option<FlatTypeCondition>, ResponseEdge)>,
+    pub typename_fields: Vec<(Option<EntityId>, ResponseEdge)>,
 }
 
 #[derive(Debug)]
 pub struct ConditionalField {
     pub edge: ResponseEdge,
-    pub type_condition: Option<FlatTypeCondition>,
+    pub entity_id: EntityId,
     /// Expected key from the upstream response when deserializing
     pub expected_key: SafeResponseKey,
     pub id: FieldId,

--- a/engine/crates/engine-v2/src/plan/mod.rs
+++ b/engine/crates/engine-v2/src/plan/mod.rs
@@ -130,8 +130,7 @@ pub struct PlanInput {
 
 #[derive(Debug)]
 pub struct PlanOutput {
-    pub type_condition: Option<FlatTypeCondition>,
-    pub entity_type: EntityId,
+    pub entity_id: EntityId,
     pub collected_selection_set_id: CollectedSelectionSetId,
     pub boundary_ids: IdRange<ExecutionPlanBoundaryId>,
 }

--- a/engine/crates/engine-v2/src/response/write/deserialize/mod.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/mod.rs
@@ -98,6 +98,7 @@ impl<'de, 'ctx> DeserializeSeed<'de> for UpdateSeed<'ctx> {
     {
         let UpdateSeed { ctx } = self;
         let selection_set_id = ctx.plan.collected_selection_set().id();
+        tracing::info!("{:#?}", ctx.plan.collected_selection_set());
         let result = deserializer.deserialize_option(NullableVisitor(
             CollectedSelectionSetSeed::new_from_id(&ctx, selection_set_id).fields_seed,
         ));

--- a/engine/crates/engine-v2/src/sources/graphql/federation.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/federation.rs
@@ -52,7 +52,7 @@ impl FederationEntityPreparedExecutor {
                 ctx.engine
                     .schema
                     .walker()
-                    .walk(schema::Definition::from(plan.output().entity_type))
+                    .walk(schema::Definition::from(plan.output().entity_id))
                     .name()
                     .to_string(),
             ),


### PR DESCRIPTION
The current implementation wasn't handling properly requires within a
plan, it would have tried to create a new plan with resolvers that don't
exist if the fields were only providable by the current subgraph. This
will only happen with directives like `@authorized` which isn't tied to
subgraph boundaries.

The initial goal of this PR was to simplify the flatten of selection
sets I'm relying on during planning. It had complex logic to deal with
chains of type conditions, but it's actually irrelevant. Type conditions
are only useful to construct an appropriate query. Once we've identified
the field definitions, they will present if the response object matches
the field parent entity (object/interface).

Fixes: GB-6977
