### PR TITLE
chore(engine-v2): Replace plan boundaries by entity locations

### DIFF
--- a/engine/crates/engine-v2/src/operation/bind/mod.rs
+++ b/engine/crates/engine-v2/src/operation/bind/mod.rs
@@ -186,6 +186,7 @@ pub fn bind(schema: &Schema, mut unbound: ParsedOperation) -> BindResult<Operati
         field_arguments: binder.field_arguments,
         response_keys: binder.response_keys,
         field_to_plan_id: vec![None; binder.fields.len()],
+        field_to_entity_location: vec![None; binder.fields.len()],
         fields: binder.fields,
         variable_definitions: binder.variable_definitions,
         cache_control: None,

--- a/engine/crates/engine-v2/src/operation/ids.rs
+++ b/engine/crates/engine-v2/src/operation/ids.rs
@@ -1,5 +1,6 @@
 use id_newtypes::IdRange;
 use schema::InputValueDefinitionId;
+use std::num::NonZeroU16;
 
 use super::{
     Field, FieldArgument, Fragment, FragmentSpread, InlineFragment, Operation, Plan, QueryInputKeyValueId,
@@ -15,6 +16,26 @@ id_newtypes::NonZeroU16! {
     Operation.variable_definitions[VariableDefinitionId] => VariableDefinition,
     Operation.field_arguments[FieldArgumentId] => FieldArgument,
     Operation.plans[PlanId] => Plan,
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct EntityLocation(NonZeroU16);
+
+impl From<usize> for EntityLocation {
+    fn from(value: usize) -> Self {
+        Self(
+            u16::try_from(value)
+                .ok()
+                .and_then(|value| NonZeroU16::new(value + 1))
+                .expect("Too many entity locations"),
+        )
+    }
+}
+
+impl From<EntityLocation> for usize {
+    fn from(value: EntityLocation) -> Self {
+        usize::from(value.0.get()) - 1
+    }
 }
 
 impl std::ops::Index<QueryInputValueId> for Operation {

--- a/engine/crates/engine-v2/src/operation/path.rs
+++ b/engine/crates/engine-v2/src/operation/path.rs
@@ -28,9 +28,9 @@ impl QueryPath {
         Self::default()
     }
 
-    pub fn child(&self, id: ResponseKey) -> Self {
+    pub fn child(&self, key: ResponseKey) -> Self {
         let mut child = self.clone();
-        child.0.push_back(id);
+        child.0.push_back(key);
         child
     }
 }

--- a/engine/crates/engine-v2/src/operation/walkers/field.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/field.rs
@@ -2,7 +2,7 @@ use schema::{FieldDefinitionWalker, RequiredField};
 
 use super::{FieldArgumentsWalker, OperationWalker, SelectionSetWalker};
 use crate::{
-    operation::{Field, FieldId, Location},
+    operation::{EntityLocation, Field, FieldId, Location},
     response::ResponseKey,
 };
 
@@ -46,6 +46,10 @@ impl<'a> FieldWalker<'a> {
 
     pub fn is_extra(&self) -> bool {
         matches!(self.as_ref(), Field::Extra { .. })
+    }
+
+    pub fn entity_location(&self) -> Option<EntityLocation> {
+        self.operation.field_to_entity_location[usize::from(self.item)]
     }
 }
 

--- a/engine/crates/engine-v2/src/plan/collected.rs
+++ b/engine/crates/engine-v2/src/plan/collected.rs
@@ -2,13 +2,11 @@ use id_newtypes::IdRange;
 use schema::{EntityId, FieldDefinitionId, ObjectId, ScalarType, Wrapping};
 
 use crate::{
-    operation::{FieldId, SelectionSetType},
+    operation::{EntityLocation, FieldId, SelectionSetType},
     response::{ResponseEdge, SafeResponseKey},
 };
 
-use super::{
-    CollectedFieldId, CollectedSelectionSetId, ConditionalFieldId, ConditionalSelectionSetId, ExecutionPlanBoundaryId,
-};
+use super::{CollectedFieldId, CollectedSelectionSetId, ConditionalFieldId, ConditionalSelectionSetId};
 
 // TODO: The two AnyCollectedSelectionSet aren't great, need to split better the ones which are computed
 // during planning and the others.
@@ -38,7 +36,7 @@ pub struct ConditionalSelectionSet {
     pub ty: SelectionSetType,
     // Plan boundary associated with this selection set. If present we need to push the a
     // ResponseObjectBoundaryItem into the ResponsePart everytime for children plans.
-    pub maybe_boundary_id: Option<ExecutionPlanBoundaryId>,
+    pub maybe_tracked_entity_location: Option<EntityLocation>,
     pub field_ids: IdRange<ConditionalFieldId>,
     // Selection sets can have multiple __typename fields and eventually type conditions.
     // {
@@ -77,7 +75,7 @@ pub struct CollectedSelectionSet {
     pub ty: SelectionSetType,
     // Plan boundary associated with this selection set. If present we need to push the a
     // ResponseObjectBoundaryItem into the ResponsePart everytime for children plans.
-    pub maybe_boundary_id: Option<ExecutionPlanBoundaryId>,
+    pub maybe_tracked_entity_location: Option<EntityLocation>,
     // the fields we point to are sorted by their expected_key
     pub field_ids: IdRange<CollectedFieldId>,
     // Selection sets can have multiple __typename fields.
@@ -102,7 +100,7 @@ pub struct CollectedField {
 #[derive(Debug)]
 pub struct RuntimeCollectedSelectionSet {
     pub object_id: ObjectId,
-    pub boundary_ids: Vec<ExecutionPlanBoundaryId>,
+    pub tracked_entity_locations: Vec<EntityLocation>,
     // sorted by expected key
     pub fields: Vec<CollectedField>,
     pub typename_fields: Vec<ResponseEdge>,

--- a/engine/crates/engine-v2/src/plan/ids.rs
+++ b/engine/crates/engine-v2/src/plan/ids.rs
@@ -1,5 +1,3 @@
-use std::num::NonZeroU16;
-
 use super::{
     CollectedField, CollectedSelectionSet, ConditionalField, ConditionalSelectionSet, ExecutionPlan, OperationPlan,
 };
@@ -10,24 +8,4 @@ id_newtypes::NonZeroU16! {
     OperationPlan.conditional_selection_sets[ConditionalSelectionSetId] => ConditionalSelectionSet,
     OperationPlan.collected_selection_sets[CollectedSelectionSetId] => CollectedSelectionSet,
     OperationPlan.collected_fields[CollectedFieldId] => CollectedField,
-}
-
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
-pub struct ExecutionPlanBoundaryId(NonZeroU16);
-
-impl From<ExecutionPlanBoundaryId> for usize {
-    fn from(id: ExecutionPlanBoundaryId) -> usize {
-        (id.0.get() - 1) as usize
-    }
-}
-
-impl From<usize> for ExecutionPlanBoundaryId {
-    fn from(value: usize) -> Self {
-        Self(
-            u16::try_from(value)
-                .ok()
-                .and_then(|value| NonZeroU16::new(value + 1))
-                .expect("Too many plan boundaries"),
-        )
-    }
 }

--- a/engine/crates/engine-v2/src/plan/mod.rs
+++ b/engine/crates/engine-v2/src/plan/mod.rs
@@ -1,8 +1,7 @@
-use id_newtypes::IdRange;
 use schema::{EntityId, ResolverId, Schema};
 
 use crate::{
-    operation::{Operation, PlanId, Variables},
+    operation::{EntityLocation, Operation, PlanId, Variables},
     response::ReadSelectionSet,
     sources::PreparedExecutor,
 };
@@ -40,8 +39,8 @@ pub(crate) struct OperationPlan {
     plan_parent_to_child_edges: Vec<ParentToChildEdge>,
     // PlanId -> u8
     plan_dependencies_count: Vec<u8>,
-    // PlanBoundaryId -> u8
-    plan_boundary_consummers_count: Vec<u8>,
+    // EntityLocation -> u8
+    entities_consummers_count: Vec<u8>,
 
     // -- Collected fields & selection sets --
     // Once all fields have been planned, we collect fields to know what to expect from the
@@ -63,7 +62,7 @@ pub(crate) struct OperationPlan {
 pub(crate) struct ExecutionPlan {
     pub plan_id: PlanId,
     pub resolver_id: ResolverId,
-    pub input: Option<PlanInput>,
+    pub input: PlanInput,
     pub output: PlanOutput,
     pub prepared_executor: PreparedExecutor,
 }
@@ -123,7 +122,7 @@ impl OperationPlan {
 
 #[derive(Debug)]
 pub struct PlanInput {
-    pub boundary_id: ExecutionPlanBoundaryId,
+    pub entity_location: EntityLocation,
     /// if the plan `@requires` any data it will be included in the ReadSelectionSet.
     pub selection_set: ReadSelectionSet,
 }
@@ -132,7 +131,7 @@ pub struct PlanInput {
 pub struct PlanOutput {
     pub entity_id: EntityId,
     pub collected_selection_set_id: CollectedSelectionSetId,
-    pub boundary_ids: IdRange<ExecutionPlanBoundaryId>,
+    pub tracked_entity_locations: Vec<EntityLocation>,
 }
 
 #[derive(Hash, PartialEq, Eq, Clone, Copy, Debug, PartialOrd, Ord)]

--- a/engine/crates/engine-v2/src/plan/walkers/mod.rs
+++ b/engine/crates/engine-v2/src/plan/walkers/mod.rs
@@ -73,8 +73,8 @@ impl<'a> PlanWalker<'a, (), ()> {
         &self.operation_plan[self.execution_plan_id].output
     }
 
-    pub fn input(&self) -> Option<&'a PlanInput> {
-        self.operation_plan[self.execution_plan_id].input.as_ref()
+    pub fn input(&self) -> &'a PlanInput {
+        &self.operation_plan[self.execution_plan_id].input
     }
 
     pub fn collected_selection_set(&self) -> PlanWalker<'a, CollectedSelectionSetId, ()> {
@@ -223,9 +223,9 @@ impl<'a> PlanWalker<'a, (), ()> {
         fields.sort_unstable_by(|a, b| keys[a.expected_key].cmp(&keys[b.expected_key]));
         RuntimeCollectedSelectionSet {
             object_id,
-            boundary_ids: selection_sets
+            tracked_entity_locations: selection_sets
                 .iter()
-                .filter_map(|id| self.operation_plan[*id].maybe_boundary_id)
+                .filter_map(|id| self.operation_plan[*id].maybe_tracked_entity_location)
                 .collect(),
             fields,
             typename_fields: typename_fields.into_values().collect(),

--- a/engine/crates/engine-v2/src/plan/walkers/selection_set.rs
+++ b/engine/crates/engine-v2/src/plan/walkers/selection_set.rs
@@ -49,7 +49,7 @@ impl<'a> PlanSelectionSet<'a> {
                 // fields, we need to have it
                 let collected = &walker.operation_plan[id];
                 collected.ty.as_object_id().is_none()
-                    && (!collected.typename_fields.is_empty() || collected.maybe_boundary_id.is_some())
+                    && (!collected.typename_fields.is_empty() || collected.maybe_tracked_entity_location.is_some())
             }
         }
     }

--- a/engine/crates/engine-v2/src/response/read/mod.rs
+++ b/engine/crates/engine-v2/src/response/read/mod.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, sync::Arc};
+use std::sync::Arc;
 
 use super::ResponseBuilder;
 mod selection_set;
@@ -14,7 +14,7 @@ impl ResponseBuilder {
         &'a self,
         schema: SchemaWalker<'a, ()>,
         refs: Arc<Vec<ResponseObjectRef>>,
-        selection_set: Cow<'a, ReadSelectionSet>,
+        selection_set: &'a ReadSelectionSet,
     ) -> ResponseObjectsView<'a> {
         ResponseObjectsView {
             schema,

--- a/engine/crates/engine-v2/src/response/read/view.rs
+++ b/engine/crates/engine-v2/src/response/read/view.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, sync::Arc};
+use std::sync::Arc;
 
 use schema::{ObjectId, SchemaWalker};
 use serde::ser::{SerializeMap, SerializeSeq};
@@ -10,7 +10,7 @@ pub struct ResponseObjectsView<'a> {
     pub(super) schema: SchemaWalker<'a, ()>,
     pub(super) response: &'a ResponseBuilder,
     pub(super) refs: Arc<Vec<ResponseObjectRef>>,
-    pub(super) selection_set: Cow<'a, ReadSelectionSet>,
+    pub(super) selection_set: &'a ReadSelectionSet,
     pub(super) extra_constant_fields: Vec<(String, serde_json::Value)>,
 }
 
@@ -42,7 +42,7 @@ impl<'a> serde::Serialize for ResponseObjectsView<'a> {
                 schema: self.schema,
                 response: self.response,
                 response_object: &self.response[item.id],
-                selection_set: &self.selection_set,
+                selection_set: self.selection_set,
                 extra_constant_fields: &self.extra_constant_fields,
             })?;
         }


### PR DESCRIPTION
To read the necessary input for children plan we keep track of the
root response objects for those. This avoids the need to traverse the
response graph with complex logic. As we would only track those at plan
boundaries the term "plan boundary" objects, refs, items etc. were used.

Now with features like `@authenticated` we'll need to track response
objects at various places. The immediate need was to be able to identify
which extra fields were added for a `@authenticated` requirements to
avoid retrieving those if access was denied. Those extra field would be
retrieved through the tuple `(PlanBoundaryId, RequiredFieldId)`, now
it's `(EntityLocation, RequiredFieldId)` making it work even outside
plan boundaries.

Fixes: GB-6978
