### PR TITLE
fix: provide GatewayBuilder with an actual partial_cache_registry

### DIFF
--- a/engine/crates/integration-tests/src/engine_v1/gateway.rs
+++ b/engine/crates/integration-tests/src/engine_v1/gateway.rs
@@ -24,15 +24,16 @@ pub struct GatewayBuilder {
 }
 
 impl GatewayBuilder {
-    pub fn new(engine: super::Engine) -> Self {
+    pub(super) fn new(engine: super::Engine, partial_cache_registry: PartialCacheRegistry) -> Self {
         Self {
             engine: Arc::new(engine),
-            partial_cache_registry: unsafe { PartialCacheRegistry::empty() },
+            partial_cache_registry,
             trusted_documents: None,
             auth_config: Default::default(),
             authorizers: None,
         }
     }
+
     pub fn with_authorizers(self, authorizers: RustUdfs) -> Self {
         Self {
             authorizers: Some(authorizers),


### PR DESCRIPTION
I was trying to integration test partial caching, but the partial cache registry inside the tests always had partial caching disabled, no matter what I put into my schema. This turned out to be because it was always hardcoded to empty.  

This PR fixes that - instead of constructing a GatewayBuilder directly we construct it from the EngineBuilder, which allows us to pass through the correct partial caching registry.