### PR TITLE
test: basic integration test of partial caching

### DIFF
--- a/engine/crates/gateway-core/src/lib.rs
+++ b/engine/crates/gateway-core/src/lib.rs
@@ -290,7 +290,7 @@ where
         &self,
         ctx: &Arc<Executor::Context>,
         mut request: engine::Request,
-    ) -> Result<BoxStream<'_, engine::StreamingPayload>, Executor::Error>
+    ) -> Result<BoxStream<'static, engine::StreamingPayload>, Executor::Error>
     where
         Executor::Error: From<runtime::rate_limiting::Error>,
     {

--- a/engine/crates/integration-tests/Cargo.toml
+++ b/engine/crates/integration-tests/Cargo.toml
@@ -21,7 +21,7 @@ graphql-mocks.workspace = true
 engine-config-builder = { path = "../engine-config-builder" }
 expect-test = "1.5"
 futures = "0.3.30"
-gateway-core.workspace = true
+gateway-core = { workspace = true, features = ["partial-caching"] }
 grafbase-graphql-introspection.workspace = true
 graphql-composition.workspace = true
 graphql-parser = "0.4.0"

--- a/engine/crates/integration-tests/src/engine_v1/gateway.rs
+++ b/engine/crates/integration-tests/src/engine_v1/gateway.rs
@@ -2,14 +2,20 @@
 
 use std::{collections::HashMap, future::IntoFuture, str::FromStr, sync::Arc};
 
-use engine::{AuthConfig, Variables};
-use futures::{future::BoxFuture, stream::BoxStream};
+use async_runtime::stream::StreamExt as _;
+use engine::{AuthConfig, RequestHeaders, StreamingPayload, Variables};
+use futures::{
+    future::{join_all, BoxFuture},
+    stream::BoxStream,
+    Future, Stream, StreamExt,
+};
 use gateway_core::{AuthService, CacheConfig, ConstructableResponse, ExecutionAuth, RequestContext, StreamingFormat};
 use http::HeaderMap;
 use registry_for_cache::PartialCacheRegistry;
 use registry_v2::rate_limiting::RateLimitConfig;
 use runtime::{kv::KvStore, trusted_documents_client, udf::UdfInvoker};
 use runtime_noop::kv::NoopKvStore;
+use tokio::sync::mpsc;
 
 use crate::{mock_trusted_documents::MockTrustedDocumentsClient, udfs::RustUdfs, TestTrustedDocument};
 
@@ -130,6 +136,40 @@ impl gateway_core::Authorizer for AnythingGoes {
 
 pub struct GatewayTesterRequestContext {
     headers: http::HeaderMap,
+    wait_until_sender: mpsc::UnboundedSender<BoxFuture<'static, ()>>,
+}
+
+impl GatewayTesterRequestContext {
+    pub fn new(headers: HashMap<String, String>) -> (Arc<Self>, impl Future<Output = ()>) {
+        let headers = headers
+            .into_iter()
+            .map(|(k, v)| {
+                (
+                    http::HeaderName::from_str(&k).expect("valid header name"),
+                    http::HeaderValue::from_str(&v).expect("valid header value"),
+                )
+            })
+            .collect();
+
+        let (wait_until_sender, mut wait_until_receiver) = mpsc::unbounded_channel();
+
+        let wait_until_future = async move {
+            // Wait simultaneously on everything immediately accessible
+            join_all(std::iter::from_fn(|| wait_until_receiver.try_recv().ok())).await;
+            // Wait sequentially on the rest
+            while let Some(fut) = wait_until_receiver.recv().await {
+                fut.await;
+            }
+        };
+
+        (
+            Arc::new(GatewayTesterRequestContext {
+                headers,
+                wait_until_sender,
+            }),
+            wait_until_future,
+        )
+    }
 }
 
 #[async_trait::async_trait]
@@ -138,8 +178,8 @@ impl RequestContext for GatewayTesterRequestContext {
         "what-do-you-mean-im-not-a-ray-id-how-very-dare-you"
     }
 
-    async fn wait_until(&self, _fut: BoxFuture<'static, ()>) {
-        todo!("probably want to implement this")
+    async fn wait_until(&self, fut: BoxFuture<'static, ()>) {
+        self.wait_until_sender.send(fut).unwrap();
     }
 
     fn headers(&self) -> &http::HeaderMap {
@@ -192,29 +232,49 @@ impl IntoFuture for GatewayTesterExecutionRequest {
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {
-            let request = self.graphql.into_engine_request();
-            // .data(RequestHeaders::from(&self.headers));
+            let request = self
+                .graphql
+                .into_engine_request()
+                .data(RequestHeaders::from(&self.headers));
 
-            // TODO: Do something with headers...
-            self.gateway
-                .execute(
-                    &Arc::new(GatewayTesterRequestContext {
-                        headers: self
-                            .headers
-                            .into_iter()
-                            .map(|(k, v)| {
-                                (
-                                    http::HeaderName::from_str(&k).expect("valid header name"),
-                                    http::HeaderValue::from_str(&v).expect("valid header value"),
-                                )
-                            })
-                            .collect(),
-                    }),
-                    request,
-                )
-                .await
-            // TODO: Probably want to do any wait_untils here as well...
+            let (request_context, wait_until_future) = GatewayTesterRequestContext::new(self.headers);
+
+            let result = self.gateway.execute(&request_context, request).await;
+
+            // Need to drop request_context to drop the wait_until_sender - otherwise we just hang forever
+            // in wait_until_future
+            drop(request_context);
+
+            wait_until_future.await;
+
+            result
         })
+    }
+}
+
+impl GatewayTesterExecutionRequest {
+    /// Runs a streaming request and returns a stream of the responses
+    pub async fn into_stream(self) -> impl Stream<Item = StreamingPayload> {
+        let request = self
+            .graphql
+            .into_engine_request()
+            .data(RequestHeaders::from(&self.headers));
+
+        let (request_context, wait_until_future) = GatewayTesterRequestContext::new(self.headers);
+
+        let stream = self.gateway.execute_stream_v2(&request_context, request).await.unwrap();
+
+        stream.join(wait_until_future)
+    }
+
+    // Runs a streaming request and collects responses into a vec
+    pub async fn collect(self) -> Vec<StreamingPayload> {
+        self.into_stream().await.collect().await
+    }
+
+    /// Runs a streaming request, returning an iterator over the responses
+    pub async fn into_iter(self) -> impl Iterator<Item = StreamingPayload> {
+        self.collect().await.into_iter()
     }
 }
 

--- a/engine/crates/integration-tests/src/udfs.rs
+++ b/engine/crates/integration-tests/src/udfs.rs
@@ -52,7 +52,7 @@ impl runtime::udf::UdfInvokerInner<CustomResolverRequestPayload> for RustUdfs {
         self.custom_resolvers
             .lock()
             .unwrap()
-            .get(name)
+            .get_mut(name)
             .unwrap_or_else(|| panic!("Resolver named {name} doesn't exist"))
             .invoke(request.payload)
     }
@@ -87,26 +87,26 @@ impl runtime::udf::UdfInvokerInner<AuthorizerRequestPayload> for RustUdfs {
 /// - UdfResponse if you just want to hard code a response
 /// - serde_json::Value if you just want to hardcode a successful response
 pub trait RustResolver: Send + Sync {
-    fn invoke(&self, payload: CustomResolverRequestPayload) -> Result<UdfResponse, UdfError>;
+    fn invoke(&mut self, payload: CustomResolverRequestPayload) -> Result<UdfResponse, UdfError>;
 }
 
 impl<F> RustResolver for F
 where
     F: Fn(CustomResolverRequestPayload) -> Result<UdfResponse, UdfError> + Send + Sync,
 {
-    fn invoke(&self, payload: CustomResolverRequestPayload) -> Result<UdfResponse, UdfError> {
+    fn invoke(&mut self, payload: CustomResolverRequestPayload) -> Result<UdfResponse, UdfError> {
         self(payload)
     }
 }
 
 impl RustResolver for UdfResponse {
-    fn invoke(&self, _: CustomResolverRequestPayload) -> Result<UdfResponse, UdfError> {
+    fn invoke(&mut self, _: CustomResolverRequestPayload) -> Result<UdfResponse, UdfError> {
         Ok(self.clone())
     }
 }
 
 impl RustResolver for serde_json::Value {
-    fn invoke(&self, _: CustomResolverRequestPayload) -> Result<UdfResponse, UdfError> {
+    fn invoke(&mut self, _: CustomResolverRequestPayload) -> Result<UdfResponse, UdfError> {
         Ok(UdfResponse::Success(self.clone()))
     }
 }

--- a/engine/crates/integration-tests/tests/caching/mod.rs
+++ b/engine/crates/integration-tests/tests/caching/mod.rs
@@ -1,3 +1,5 @@
+mod partial_caching_defer;
+
 use integration_tests::udfs::RustUdfs;
 use integration_tests::{runtime, EngineBuilder};
 use runtime::cache::Cacheable;

--- a/engine/crates/integration-tests/tests/caching/partial_caching_defer.rs
+++ b/engine/crates/integration-tests/tests/caching/partial_caching_defer.rs
@@ -1,0 +1,117 @@
+use integration_tests::{
+    runtime,
+    udfs::{RustResolver, RustUdfs},
+    EngineBuilder,
+};
+use runtime::udf::UdfResponse;
+use serde_json::json;
+
+#[test]
+fn smoke_test() {
+    const SCHEMA: &str = r#"
+    extend schema @experimental(partialCaching: true)
+
+    type Query {
+        user: User @resolver(name: "user")
+    }
+
+    type User {
+        name: String @cache(maxAge: 140)
+        email: String @cache(maxAge: 130)
+        someConstant: String @cache(maxAge: 120)
+        uncached: String
+    }
+    "#;
+
+    runtime().block_on(async {
+        let gateway = EngineBuilder::new(SCHEMA)
+            .with_custom_resolvers(RustUdfs::new().resolver("user", UserResolver::default()))
+            .gateway_builder()
+            .await
+            .build();
+
+        const QUERY: &str = r#"
+            query {
+                user {
+                    name
+                    ... @defer(label: "woo") {
+                        email
+                        someConstant
+                    }
+                }
+            }
+        "#;
+
+        let responses = gateway.execute(QUERY).collect().await;
+
+        insta::assert_json_snapshot!(responses, @r###"
+        [
+          {
+            "data": {
+              "user": {
+                "name": "Jo 1"
+              }
+            },
+            "hasNext": true
+          },
+          {
+            "data": {
+              "name": "Jo 1",
+              "email": "1@example.com",
+              "someConstant": "blah 1"
+            },
+            "path": [
+              "user"
+            ],
+            "hasNext": false,
+            "label": "woo"
+          }
+        ]
+        "###);
+
+        // Call it again and see what has been cached/not
+        let responses = gateway.execute(QUERY).collect().await;
+
+        insta::assert_json_snapshot!(responses, @r###"
+        [
+          {
+            "data": {
+              "user": {
+                "name": "Jo 1",
+                "email": "1@example.com",
+                "someConstant": "blah 1"
+              }
+            },
+            "hasNext": false
+          }
+        ]
+        "###);
+    });
+}
+
+#[derive(Default)]
+pub struct UserResolver {
+    call_count: usize,
+}
+
+impl RustResolver for UserResolver {
+    fn invoke(
+        &mut self,
+        _payload: runtime::udf::CustomResolverRequestPayload,
+    ) -> Result<UdfResponse, runtime::udf::UdfError> {
+        self.call_count += 1;
+        let call_count = self.call_count;
+
+        let name = format!("Jo {call_count}");
+        let email = format!("{call_count}@example.com");
+        let constant = format!("blah {call_count}");
+        let uncached = format!("dont cache me bro {call_count}");
+
+        Ok(UdfResponse::Success(json!({
+            "name": name,
+            "email": email,
+            "someConstant": constant,
+            "uncached": uncached
+        })))
+    }
+}

--- a/engine/crates/partial-caching/src/output/cache_merging.rs
+++ b/engine/crates/partial-caching/src/output/cache_merging.rs
@@ -198,7 +198,7 @@ impl<'a> CacheMerge<'a> {
                     let new_defer_label = field_shape.defer_label().or(current_defer_label);
 
                     if self.should_skip_field(field_shape, new_defer_label) {
-                        return;
+                        continue;
                     }
 
                     let field_id = self.store.field_value_id(dest_object_id, field_shape.index());

--- a/engine/crates/partial-caching/src/output/store.rs
+++ b/engine/crates/partial-caching/src/output/store.rs
@@ -17,13 +17,13 @@ struct ObjectRecord {
     fields: IdRange<ValueId>,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct ValueId(usize);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct ObjectId(usize);
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum ValueRecord {
     Unset,
     Null,
@@ -39,7 +39,7 @@ pub enum ValueRecord {
     InlineValue(Box<CompactValue>),
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct IdRange<T: Copy> {
     start: T,
     end: T,


### PR DESCRIPTION
This adds a very simple integration test of partial caching w/ defer.  Had to add support for streaming requests to the gateway testing infra for this, but nothing too complicated.

This is just a really simple test - I don't want to do anything more in-depth, because I know there's a lot of broken things, and I want to get the transport code written for the demo first.  I've made a linear issue to ensure I revisit once more things are working.