### PR TITLE
composition: make metadata field on `@authorized` an arbitrary value

### DIFF
--- a/engine/crates/composition/src/emit_federated_graph.rs
+++ b/engine/crates/composition/src/emit_federated_graph.rs
@@ -286,9 +286,7 @@ fn emit_fields<'a>(
             .fields
             .as_ref()
             .map(|fields| attach_selection(fields, definition, ctx));
-        let metadata = authorized
-            .metadata
-            .map(|metadata| ctx.insert_string(ctx.subgraphs.walk(metadata)));
+        let metadata = authorized.metadata.as_ref().map(|metadata| ctx.insert_value(metadata));
 
         let arguments = authorized
             .arguments

--- a/engine/crates/composition/src/ingest_subgraph/directives/authorized.rs
+++ b/engine/crates/composition/src/ingest_subgraph/directives/authorized.rs
@@ -30,10 +30,9 @@ pub(super) fn ingest(
         .map(|fields| subgraphs.selection_set_from_str(fields))
         .transpose()?;
 
-    let metadata = directive.get_argument("metadata").and_then(|arg| match &arg.node {
-        ConstValue::String(value) => Some(subgraphs.strings.intern(value.as_str())),
-        _ => None,
-    });
+    let metadata = directive
+        .get_argument("metadata")
+        .map(|value| ast_value_to_subgraph_value(&value.node, subgraphs));
 
     subgraphs.insert_authorized(
         directive_site_id,

--- a/engine/crates/composition/src/subgraphs/directives.rs
+++ b/engine/crates/composition/src/subgraphs/directives.rs
@@ -262,8 +262,7 @@ pub(crate) struct AuthorizedDirective {
     pub(crate) rule: StringId,
     pub(crate) arguments: Option<Vec<Selection>>,
     pub(crate) fields: Option<Vec<Selection>>,
-    /// We expect JSON here, but since this will be passed as-is, we don't need to parse.
-    pub(crate) metadata: Option<StringId>,
+    pub(crate) metadata: Option<Value>,
 }
 
 /// Corresponds to an `@deprecated` directive.

--- a/engine/crates/federated-graph/src/federated_graph/v3.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v3.rs
@@ -76,7 +76,7 @@ pub struct AuthorizedDirective {
     pub rule: StringId,
     pub fields: Option<FieldSet>,
     pub arguments: Option<InputValueDefinitionSet>,
-    pub metadata: Option<StringId>,
+    pub metadata: Option<Value>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq)]

--- a/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
@@ -431,8 +431,8 @@ fn write_authorized(field_id: FieldId, graph: &FederatedGraphV3, sdl: &mut Strin
             write!(sdl, ", arguments: {arguments}")?;
         }
 
-        if let Some(metadata) = directive.metadata {
-            write!(sdl, ", metadata: {}", ValueDisplay(&Value::String(metadata), graph))?;
+        if let Some(metadata) = directive.metadata.as_ref() {
+            write!(sdl, ", metadata: {}", ValueDisplay(metadata, graph))?;
         }
 
         sdl.push(')');


### PR DESCRIPTION
We previously expected a serialized JSON string.

closes GB-6993