### PR TITLE
fix: revert change to websocket forbidden message

### DIFF
--- a/engine/crates/engine-v2/axum/src/websocket/accepter.rs
+++ b/engine/crates/engine-v2/axum/src/websocket/accepter.rs
@@ -167,15 +167,12 @@ async fn accept_websocket(websocket: &mut WebSocket, engine: &EngineWatcher) -> 
                     return None;
                 };
 
-                let session = match engine.create_session(headers).await {
-                    Ok(session) => session,
-                    Err(e) => {
-                        websocket
-                            .send(Message::close(4403, e).to_axum_message().unwrap())
-                            .await
-                            .ok();
-                        return None;
-                    }
+                let Ok(session) = engine.create_session(headers).await else {
+                    websocket
+                        .send(Message::close(4403, "Forbidden").to_axum_message().unwrap())
+                        .await
+                        .ok();
+                    return None;
                 };
 
                 websocket


### PR DESCRIPTION
#1798 changed the websocket accepter to return a custom error message - I don't think this is the right thing to do, the spec is pretty specific that the error reason should be "Forbidden":

https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverWebSocket.md#connectioninit