### PR TITLE
fix: support defers without labels in partial caching

### DIFF
--- a/engine/crates/gateway-core/src/cache/partial.rs
+++ b/engine/crates/gateway-core/src/cache/partial.rs
@@ -156,14 +156,15 @@ async fn run_execution_phase_stream(
         let StreamingPayload::Incremental(mut payload) = next_chunk else {
             todo!("GB-6966");
         };
-        let Some(label) = payload.label.as_deref() else {
-            todo!("GB-6981");
-        };
 
         let path = payload.path.iter().collect::<Vec<_>>();
 
-        payload.data =
-            execution_phase.record_incremental_response(label, &path, payload.data, !payload.errors.is_empty());
+        payload.data = execution_phase.record_incremental_response(
+            payload.label.as_deref(),
+            &path,
+            payload.data,
+            !payload.errors.is_empty(),
+        );
 
         if response_sender
             .send(StreamingPayload::Incremental(payload))

--- a/engine/crates/graph-entities/src/response/mod.rs
+++ b/engine/crates/graph-entities/src/response/mod.rs
@@ -453,6 +453,15 @@ pub enum QueryResponseNode {
     Primitive(Box<ResponsePrimitive>),
 }
 
+impl QueryResponseNode {
+    pub fn as_container(&self) -> Option<&ResponseContainer> {
+        match self {
+            QueryResponseNode::Container(container) => Some(container.as_ref()),
+            _ => None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use internment::ArcIntern;

--- a/engine/crates/integration-tests/tests/caching/partial_caching_defer.rs
+++ b/engine/crates/integration-tests/tests/caching/partial_caching_defer.rs
@@ -6,9 +6,7 @@ use integration_tests::{
 use runtime::udf::UdfResponse;
 use serde_json::json;
 
-#[test]
-fn smoke_test() {
-    const SCHEMA: &str = r#"
+const SCHEMA: &str = r#"
     extend schema @experimental(partialCaching: true)
 
     type Query {
@@ -21,8 +19,10 @@ fn smoke_test() {
         someConstant: String @cache(maxAge: 120)
         uncached: String
     }
-    "#;
+"#;
 
+#[test]
+fn smoke_test() {
     runtime().block_on(async {
         let gateway = EngineBuilder::new(SCHEMA)
             .with_custom_resolvers(RustUdfs::new().resolver("user", UserResolver::default()))
@@ -91,21 +91,6 @@ fn smoke_test() {
 
 #[test]
 fn test_defer_with_uncached_field() {
-    const SCHEMA: &str = r#"
-    extend schema @experimental(partialCaching: true)
-
-    type Query {
-        user: User @resolver(name: "user")
-    }
-
-    type User {
-        name: String @cache(maxAge: 140)
-        email: String @cache(maxAge: 130)
-        someConstant: String @cache(maxAge: 120)
-        uncached: String
-    }
-    "#;
-
     runtime().block_on(async {
         let gateway = EngineBuilder::new(SCHEMA)
             .with_custom_resolvers(RustUdfs::new().resolver("user", UserResolver::default()))
@@ -180,6 +165,136 @@ fn test_defer_with_uncached_field() {
             ],
             "hasNext": false,
             "label": "woo"
+          }
+        ]
+        "###);
+    });
+}
+
+#[test]
+fn test_unnamed_defer() {
+    runtime().block_on(async {
+        let gateway = EngineBuilder::new(SCHEMA)
+            .with_custom_resolvers(RustUdfs::new().resolver("user", UserResolver::default()))
+            .gateway_builder()
+            .await
+            .build();
+
+        const QUERY: &str = r#"
+            query {
+                user {
+                    name
+                    ... @defer {
+                        email
+                        someConstant
+                        uncached
+                    }
+                }
+            }
+        "#;
+
+        let responses = gateway.execute(QUERY).collect().await;
+
+        insta::assert_json_snapshot!(responses, @r###"
+        [
+          {
+            "data": {
+              "user": {
+                "name": "Jo 1"
+              }
+            },
+            "hasNext": true
+          },
+          {
+            "data": {
+              "name": "Jo 1",
+              "email": "1@example.com",
+              "someConstant": "blah 1",
+              "uncached": "dont cache me bro 1"
+            },
+            "path": [
+              "user"
+            ],
+            "hasNext": false
+          }
+        ]
+        "###);
+    });
+}
+
+#[test]
+fn test_multiple_unnamed_defers() {
+    runtime().block_on(async {
+        let gateway = EngineBuilder::new(SCHEMA)
+            .with_custom_resolvers(RustUdfs::new().resolver("user", UserResolver::default()))
+            .gateway_builder()
+            .await
+            .build();
+
+        const QUERY: &str = r#"
+            query {
+                user {
+                    name
+                    ... @defer {
+                        email
+                    }
+                    ... @defer {
+                        someConstant
+                    }
+                    ... @defer {
+                        uncached
+                    }
+                }
+            }
+        "#;
+
+        let responses = gateway.execute(QUERY).collect().await;
+
+        // Note: technically this is wrong - since each defer chunk ends up containing
+        // the fields of all the defers that happened before.  But I'll revisit that
+        // in GB-6982
+        insta::assert_json_snapshot!(responses, @r###"
+        [
+          {
+            "data": {
+              "user": {
+                "name": "Jo 1"
+              }
+            },
+            "hasNext": true
+          },
+          {
+            "data": {
+              "name": "Jo 1",
+              "email": "1@example.com"
+            },
+            "path": [
+              "user"
+            ],
+            "hasNext": true
+          },
+          {
+            "data": {
+              "name": "Jo 1",
+              "email": "1@example.com",
+              "someConstant": "blah 1"
+            },
+            "path": [
+              "user"
+            ],
+            "hasNext": true
+          },
+          {
+            "data": {
+              "name": "Jo 1",
+              "email": "1@example.com",
+              "someConstant": "blah 1",
+              "uncached": "dont cache me bro 1"
+            },
+            "path": [
+              "user"
+            ],
+            "hasNext": false
           }
         ]
         "###);

--- a/engine/crates/partial-caching/src/lib.rs
+++ b/engine/crates/partial-caching/src/lib.rs
@@ -14,7 +14,10 @@
 
 use std::fmt;
 
-use cynic_parser::{executable::ids::OperationDefinitionId, ExecutableDocument};
+use cynic_parser::{
+    executable::{ids::OperationDefinitionId, OperationDefinition},
+    ExecutableDocument,
+};
 use registry_for_cache::CacheControl;
 
 mod execution;
@@ -41,7 +44,14 @@ pub struct CachingPlan {
     pub document: ExecutableDocument,
     pub cache_partitions: Vec<(CacheControl, QuerySubset)>,
     pub nocache_partition: QuerySubset,
-    pub operation_id: OperationDefinitionId,
+    operation_id: OperationDefinitionId,
+    defers: Vec<planning::defers::DeferRecord>,
+}
+
+impl CachingPlan {
+    fn operation(&self) -> OperationDefinition<'_> {
+        self.document.read(self.operation_id)
+    }
 }
 
 impl fmt::Debug for CachingPlan {

--- a/engine/crates/partial-caching/src/output/mod.rs
+++ b/engine/crates/partial-caching/src/output/mod.rs
@@ -11,6 +11,6 @@ mod tests;
 
 pub(crate) use self::{
     engine_response::InitialOutput,
-    shapes::OutputShapes,
-    store::{OutputStore, Value},
+    shapes::{ObjectShape, OutputShapes},
+    store::{Object, OutputStore, Value},
 };

--- a/engine/crates/partial-caching/src/parser_extensions.rs
+++ b/engine/crates/partial-caching/src/parser_extensions.rs
@@ -11,7 +11,7 @@ impl<'a> FieldExt<'a> for FieldSelection<'a> {
 }
 
 pub struct DeferDirective<'a> {
-    pub label: &'a str,
+    pub label: Option<&'a str>,
 }
 
 pub trait DeferExt<'a> {
@@ -33,10 +33,16 @@ impl<'a> DeferExt<'a> for InlineFragment<'a> {
 fn find_defer<'a>(mut directives: Iter<'a, Directive<'a>>) -> Option<DeferDirective<'a>> {
     directives
         .find(|directive| directive.name() == "defer")
-        .and_then(|directive| {
-            let value = directive.arguments().find(|arg| arg.name() == "label")?.value();
-            let Value::String(label) = value else { return None };
+        .map(|directive| {
+            let label = directive
+                .arguments()
+                .find(|arg| arg.name() == "label")
+                .and_then(|argument| {
+                    let value = argument.value();
+                    let Value::String(label) = value else { return None };
+                    Some(label)
+                });
 
-            Some(DeferDirective { label })
+            DeferDirective { label }
         })
 }

--- a/engine/crates/partial-caching/src/planning/defers.rs
+++ b/engine/crates/partial-caching/src/planning/defers.rs
@@ -1,0 +1,74 @@
+use std::collections::HashSet;
+
+use cynic_parser::executable::ids::SelectionId;
+
+use crate::{parser_extensions::DeferExt, CachingPlan};
+
+use super::visitor::Visitor;
+
+impl crate::CachingPlan {
+    pub fn defers(&self) -> impl ExactSizeIterator<Item = Defer<'_>> + '_ {
+        self.defers.iter().enumerate().map(|(i, _)| Defer {
+            id: DeferId(i.try_into().expect("there were more than 2^16 defers?  wtf")),
+            plan: self,
+        })
+    }
+}
+
+pub(crate) struct DeferRecord {
+    label: Option<String>,
+    spread_id: SelectionId,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DeferId(u16);
+
+pub struct Defer<'a> {
+    pub id: DeferId,
+    plan: &'a CachingPlan,
+}
+
+impl<'a> Defer<'a> {
+    pub fn spread_id(&self) -> SelectionId {
+        self.record().spread_id
+    }
+
+    pub fn label(&self) -> Option<&'a str> {
+        self.record().label.as_deref()
+    }
+
+    fn record(&self) -> &'a DeferRecord {
+        &self.plan.defers[self.id.0 as usize]
+    }
+}
+
+#[derive(Default)]
+pub(super) struct DeferVisitor {
+    pub defers: Vec<DeferRecord>,
+    seen_selections: HashSet<SelectionId>,
+}
+
+impl DeferVisitor {
+    pub fn new() -> Self {
+        DeferVisitor::default()
+    }
+}
+
+impl Visitor for DeferVisitor {
+    fn enter_selection(&mut self, id: SelectionId, selection: cynic_parser::executable::Selection<'_>) {
+        let directive = match selection {
+            cynic_parser::executable::Selection::Field(_) => None,
+            cynic_parser::executable::Selection::InlineFragment(fragment) => fragment.defer_directive(),
+            cynic_parser::executable::Selection::FragmentSpread(spread) => spread.defer_directive(),
+        };
+        let Some(directive) = directive else { return };
+        if !self.seen_selections.insert(id) {
+            return;
+        }
+
+        self.defers.push(DeferRecord {
+            label: directive.label.map(str::to_string),
+            spread_id: id,
+        })
+    }
+}

--- a/engine/crates/partial-caching/src/query_subset/mod.rs
+++ b/engine/crates/partial-caching/src/query_subset/mod.rs
@@ -19,13 +19,14 @@ pub use self::{display::QuerySubsetDisplay, field_iter::FieldIter};
 /// This is a group of fields with the same cache settings, and all the
 /// ancestors, variables & fragments required for those fields to make a
 /// valid query
+#[derive(Clone)]
 pub struct QuerySubset {
     pub(crate) operation: OperationDefinitionId,
     partition: Partition,
     variables: IndexSet<VariableDefinitionId>,
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub(crate) struct Partition {
     pub selections: IndexSet<SelectionId>,
     pub fragments: IndexSet<FragmentDefinitionId>,


### PR DESCRIPTION
While writing the partial caching defer support, I made the assumpption that defers always have labels.  That was incorrect, they can be unlabelled.

This updates the code to account for that: instead of using the defer label to refer to defers we parse them out as part of the planning phase, assign them ids and then use those ids to refer to them.

One place this got complicated is when we receive deferred payloads for a defer without a label: we need to figure out which defer it's referring to based on the path.  This is relatively easy if there's only one defer inside an object, but gets complicated if there's more than one.  Managed it in the end though.

Fixes GB-6981