### PR TITLE
fix: defaults on CacheControl

### DIFF
--- a/engine/crates/engine/response/src/cache_control.rs
+++ b/engine/crates/engine/response/src/cache_control.rs
@@ -1,12 +1,15 @@
 #[derive(Default, Clone, PartialEq, Eq, Debug, serde::Deserialize, serde::Serialize)]
 pub struct CacheControl {
     /// Scope is public, default is false.
+    #[serde(default)]
     pub public: bool,
 
     /// Cache max age, default is 0.
+    #[serde(default)]
     pub max_age: usize,
 
     /// Cache stale_while_revalidate, default is 0.
+    #[serde(default)]
     pub stale_while_revalidate: usize,
 }
 


### PR DESCRIPTION
I changed the CacheControl struct that's being used as part of caching.  I did not notice that the old one has skip serializing defaults on it, so the new struct is potentially incompatible with the old one.