### PR TITLE
cli: error early when we fail to find bun on NixOS

### DIFF
--- a/cli/crates/server/src/bun.rs
+++ b/cli/crates/server/src/bun.rs
@@ -164,7 +164,16 @@ pub(crate) async fn install_bun() -> Result<(), BunError> {
         return Ok(());
     }
 
-    if common::environment::is_nixos() || common::environment::is_in_docker_image() {
+    if common::environment::is_nixos() {
+        if let Err(which::Error::CannotFindBinaryPath) = which::which("bun") {
+            return Err(BunError::BunNotFound(common::errors::BunNotFound));
+        }
+
+        BUN_INSTALLED_FOR_SESSION.store(true, Ordering::Relaxed);
+        return Ok(());
+    }
+
+    if common::environment::is_in_docker_image() {
         BUN_INSTALLED_FOR_SESSION.store(true, Ordering::Relaxed);
         return Ok(());
     }


### PR DESCRIPTION
We already had the error ("Could not find a `bun` executable in PATH. Bun is required in order to evaluate your TypeScript configuration. Please install `bun` or run `nix shell nixpkgs#bun`."), so this is a short fix.

closes GB-7005
