### PR TITLE
chore: update wasmtime crates to 22.0.0

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -281,6 +281,11 @@ jobs:
       - name: Prepare Grafbase assets
         uses: ./.github/actions/cli_assets
 
+      - name: Install musl
+        run: |
+          sudo apt update
+          sudo apt install musl
+
       - name: Build grafbase release
         run: |
           cd cli

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,8 +1470,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bforest"
 version = "0.109.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6b33d7e757a887989eb18b35712b2a67d96171ec3149d1bfb657b29b7b367c"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "cranelift-entity",
 ]
@@ -1479,8 +1478,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.109.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9acf15cb22be42d07c3b57d7856329cb228b7315d385346149df2566ad5e4aa"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -1501,8 +1499,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.109.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e934d301392b73b3f8b0540391fb82465a0f179a3cee7c726482ac4727efcc97"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "cranelift-codegen-shared",
 ]
@@ -1510,14 +1507,12 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.109.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb2a2566b3d54b854dfb288b3b187f6d3d17d6f762c92898207eba302931da"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 
 [[package]]
 name = "cranelift-control"
 version = "0.109.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0100f33b704cdacd01ad66ff41f8c5030d57cbff078e2a4e49ab1822591299fa"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "arbitrary",
 ]
@@ -1525,8 +1520,7 @@ dependencies = [
 [[package]]
 name = "cranelift-entity"
 version = "0.109.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8cfdc315e5d18997093e040a8d234bea1ac1e118a716d3e30f40d449e78207b"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1535,8 +1529,7 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.109.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f74b84f16af2e982b0c0c72233503d9d55cbfe3865dbe807ca28dc6642a28b5"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1547,14 +1540,12 @@ dependencies = [
 [[package]]
 name = "cranelift-isle"
 version = "0.109.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adf306d3dde705fb94bd48082f01d38c4ededc74293a4c007805f610bf08bc6e"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 
 [[package]]
 name = "cranelift-native"
 version = "0.109.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea0ebdef7aff4a79bcbc8b6495f31315f16b3bf311152f472eaa8d679352581"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1564,8 +1555,7 @@ dependencies = [
 [[package]]
 name = "cranelift-wasm"
 version = "0.109.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d549108a1942065cdbac3bb96c2952afa0e1b9a3beff4b08c4308ac72257576d"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -6910,7 +6900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.66",
@@ -9791,9 +9781,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.210.0"
+version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e3764d9d6edabd8c9e16195e177be0d20f6ab942ad18af52860f12f82bc59a"
+checksum = "501940df4418b8929eb6d52f1aade1fdd15a5b86c92453cb696e3c906bd3fc33"
 dependencies = [
  "leb128",
 ]
@@ -9838,8 +9828,7 @@ dependencies = [
 [[package]]
 name = "wasmtime"
 version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d8b5e7a4d54917c5ebe555b9667337e5f93383f49bddaaeec2eba68093b45"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -9894,8 +9883,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-asm-macros"
 version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d697d99c341d4a9ffb72f3af7a02124d233eeb59aee010f36d88e97cca553d5e"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "cfg-if",
 ]
@@ -9903,8 +9891,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-cache"
 version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916610f9ae9a6c22deb25bba2e6247ba9f00b093d30620875203b91328a1adfa"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -9923,8 +9910,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-component-macro"
 version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b29b462b068e73b5b27fae092a27f47e5937cabf6b26be2779c978698a52feca"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -9938,14 +9924,12 @@ dependencies = [
 [[package]]
 name = "wasmtime-component-util"
 version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d2912c53d9054984b380dfbd7579f9c3681b2a73b903a56bd71a1c4f175f1e"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 
 [[package]]
 name = "wasmtime-cranelift"
 version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3975deafea000457ba84355c7c0fce0372937204f77026510b7b454f28a3a65"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -9968,8 +9952,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-environ"
 version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f444e900e848b884d8a8a2949b6f5b92af642a3e663ff8fbe78731143a55be61"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -9993,8 +9976,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-fiber"
 version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ded58eb2d1bf0dcd2182d0ccd7055c4b10b50d711514f1d73f61515d0fa829d"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "anyhow",
  "cc",
@@ -10008,8 +9990,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit-debug"
 version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bc54198c6720f098210a85efb3ba8c078d1de4d373cdb6778850a66ae088d11"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "object",
  "once_cell",
@@ -10020,8 +10001,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit-icache-coherence"
 version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5afe2f0499542f9a4bcfa1b55bfdda803b6ade4e7c93c6b99e0f39dba44b0a91"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -10032,14 +10012,12 @@ dependencies = [
 [[package]]
 name = "wasmtime-slab"
 version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7de1f2bec5bbb35d532e61c85c049dc84ae671df60492f90b954ecf21169e7"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 
 [[package]]
 name = "wasmtime-types"
 version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "412463e9000e14cf6856be48628d2213c20c153e29ffc22b036980c892ea6964"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -10051,8 +10029,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-versioned-export-macros"
 version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5a9bc4f44ceeb168e9e8e3be4e0b4beb9095b468479663a9e24c667e36826f"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10062,8 +10039,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi"
 version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8abb1301089ed8e0b4840f539cba316a73ac382090f1b25d22d8c8eed8df49c7"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10092,8 +10068,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi-http"
 version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "315cadc284b808cfbd6be9295da4009144c106723f09b421ce6c6d89275cfdb7"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10115,8 +10090,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-winch"
 version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed4db238a0241df2d15f79ad17b3a37a27f2ea6cb885894d81b42ae107544466"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -10132,8 +10106,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wit-bindgen"
 version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc077306b38288262e5ba01d4b21532a6987416cdc0aedf04bb06c22a68fdc"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -10143,22 +10116,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "210.0.0"
+version = "212.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa835c59bd615e00f16be65705d85517d40b44b3c831d724e450244685176c3c"
+checksum = "4606a05fb0aae5d11dd7d8280a640d88a63ee019360ba9be552da3d294b8d1f5"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.210.0",
+ "wasm-encoder 0.212.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.210.0"
+version = "1.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67faece8487996430c6812be7f8776dc563ca0efcd3db77f8839070480c0d1a6"
+checksum = "c74ca7f93f11a5d6eed8499f2a8daaad6e225cab0151bc25a091fff3b987532f"
 dependencies = [
  "wast",
 ]
@@ -10267,8 +10240,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "winch-codegen"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c6915884e731b2db0d8cf08cb64474cb69221a161675fd3c135f91febc3daa"
+source = "git+https://github.com/grafbase/wasmtime?branch=fix-linking-issues-with-musl#e55186fe62b56ceb5a168a79ecd773dea6bdcca6"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.36.0",
+ "object",
  "rustc-demangle",
 ]
 
@@ -1469,18 +1469,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29daf137addc15da6bab6eae2c4a11e274b1d270bf2759508e62f6145e863ef6"
+checksum = "0b6b33d7e757a887989eb18b35712b2a67d96171ec3149d1bfb657b29b7b367c"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de619867d5de4c644b7fd9904d6e3295269c93d8a71013df796ab338681222d4"
+checksum = "b9acf15cb22be42d07c3b57d7856329cb228b7315d385346149df2566ad5e4aa"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -1500,33 +1500,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f5cf277490037d8dae9513d35e0ee8134670ae4a964a5ed5b198d4249d7c10"
+checksum = "e934d301392b73b3f8b0540391fb82465a0f179a3cee7c726482ac4727efcc97"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3e22ecad1123343a3c09ac6ecc532bb5c184b6fcb7888df0ea953727f79924"
+checksum = "8afb2a2566b3d54b854dfb288b3b187f6d3d17d6f762c92898207eba302931da"
 
 [[package]]
 name = "cranelift-control"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ca3ec6d30bce84ccf59c81fead4d16381a3ef0ef75e8403bc1e7385980da09"
+checksum = "0100f33b704cdacd01ad66ff41f8c5030d57cbff078e2a4e49ab1822591299fa"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eabb8d36b0ca8906bec93c78ea516741cac2d7e6b266fa7b0ffddcc09004990"
+checksum = "a8cfdc315e5d18997093e040a8d234bea1ac1e118a716d3e30f40d449e78207b"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1534,9 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b42630229e49a8cfcae90bdc43c8c4c08f7a7aa4618b67f79265cd2f996dd2"
+checksum = "0f74b84f16af2e982b0c0c72233503d9d55cbfe3865dbe807ca28dc6642a28b5"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1546,15 +1546,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "918d1e36361805dfe0b6cdfd5a5ffdb5d03fa796170c5717d2727cbe623b93a0"
+checksum = "adf306d3dde705fb94bd48082f01d38c4ededc74293a4c007805f610bf08bc6e"
 
 [[package]]
 name = "cranelift-native"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75aea85a0d7e1800b14ce9d3f53adf8ad4d1ee8a9e23b0269bdc50285e93b9b3"
+checksum = "1ea0ebdef7aff4a79bcbc8b6495f31315f16b3bf311152f472eaa8d679352581"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1563,9 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac491fd3473944781f0cf9528c90cc899d18ad438da21961a839a3a44d57dfb"
+checksum = "d549108a1942065cdbac3bb96c2952afa0e1b9a3beff4b08c4308ac72257576d"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -5893,22 +5893,13 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8dd6c0cdf9429bce006e1362bfce61fa1bfd8c898a643ed8d2b471934701d3d"
-dependencies = [
- "crc32fast",
- "hashbrown 0.14.5",
- "indexmap 2.2.6",
- "memchr",
-]
-
-[[package]]
-name = "object"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
 dependencies = [
+ "crc32fast",
+ "hashbrown 0.14.5",
+ "indexmap 2.2.6",
  "memchr",
 ]
 
@@ -9791,9 +9782,9 @@ checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.207.0"
+version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d996306fb3aeaee0d9157adbe2f670df0236caf19f6728b221e92d0f27b3fe17"
+checksum = "7b4a05336882dae732ce6bd48b7e11fe597293cb72c13da4f35d7d5f8d53b2a7"
 dependencies = [
  "leb128",
 ]
@@ -9822,22 +9813,23 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.207.0"
+version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19bb9f8ab07616da582ef8adb24c54f1424c7ec876720b7da9db8ec0626c92c"
+checksum = "07035cc9a9b41e62d3bb3a3815a66ab87c993c06fe1cf6b2a3f2a18499d937db"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.5.0",
  "hashbrown 0.14.5",
  "indexmap 2.2.6",
  "semver",
+ "serde",
 ]
 
 [[package]]
 name = "wasmprinter"
-version = "0.207.0"
+version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2d8a7b4dabb460208e6b4334d9db5766e84505038b2529e69c3d07ac619115"
+checksum = "ceca8ae6eaa8c7c87b33c25c53bdf299f8c2a764aee1179402ff7652ef3a6859"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -9845,9 +9837,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92a1370c66a0022e6d92dcc277e2c84f5dece19569670b8ce7db8162560d8b6"
+checksum = "786d8b5e7a4d54917c5ebe555b9667337e5f93383f49bddaaeec2eba68093b45"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -9867,7 +9859,7 @@ dependencies = [
  "mach2",
  "memfd",
  "memoffset",
- "object 0.33.0",
+ "object",
  "once_cell",
  "paste",
  "postcard",
@@ -9881,7 +9873,7 @@ dependencies = [
  "smallvec",
  "sptr",
  "target-lexicon",
- "wasm-encoder 0.207.0",
+ "wasm-encoder 0.209.1",
  "wasmparser",
  "wasmtime-asm-macros",
  "wasmtime-cache",
@@ -9901,18 +9893,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dee8679c974a7f258c03d60d3c747c426ed219945b6d08cbc77fd2eab15b2d1"
+checksum = "d697d99c341d4a9ffb72f3af7a02124d233eeb59aee010f36d88e97cca553d5e"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00103ffaf7ee980f4e750fe272b6ada79d9901659892e457c7ca316b16df9ec"
+checksum = "916610f9ae9a6c22deb25bba2e6247ba9f00b093d30620875203b91328a1adfa"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -9930,9 +9922,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cae30035f1cf97dcc6657c979cf39f99ce6be93583675eddf4aeaa5548509c"
+checksum = "b29b462b068e73b5b27fae092a27f47e5937cabf6b26be2779c978698a52feca"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -9945,15 +9937,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7ae611f08cea620c67330925be28a96115bf01f8f393a6cbdf4856a86087134"
+checksum = "f9d2912c53d9054984b380dfbd7579f9c3681b2a73b903a56bd71a1c4f175f1e"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2909406a6007e28be964067167890bca4574bd48a9ff18f1fa9f4856d89ea40"
+checksum = "a3975deafea000457ba84355c7c0fce0372937204f77026510b7b454f28a3a65"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -9965,7 +9957,7 @@ dependencies = [
  "cranelift-wasm",
  "gimli 0.28.1",
  "log",
- "object 0.33.0",
+ "object",
  "target-lexicon",
  "thiserror",
  "wasmparser",
@@ -9975,9 +9967,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e227f9ed2f5421473723d6c0352b5986e6e6044fde5410a274a394d726108f"
+checksum = "f444e900e848b884d8a8a2949b6f5b92af642a3e663ff8fbe78731143a55be61"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -9985,13 +9977,13 @@ dependencies = [
  "gimli 0.28.1",
  "indexmap 2.2.6",
  "log",
- "object 0.33.0",
+ "object",
  "postcard",
  "rustc-demangle",
  "serde",
  "serde_derive",
  "target-lexicon",
- "wasm-encoder 0.207.0",
+ "wasm-encoder 0.209.1",
  "wasmparser",
  "wasmprinter",
  "wasmtime-component-util",
@@ -10000,9 +9992,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42edb392586d07038c1638e854382db916b6ca7845a2e6a7f8dc49e08907acdd"
+checksum = "4ded58eb2d1bf0dcd2182d0ccd7055c4b10b50d711514f1d73f61515d0fa829d"
 dependencies = [
  "anyhow",
  "cc",
@@ -10015,11 +10007,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b26ef7914af0c0e3ca811bdc32f5f66fbba0fd21e1f8563350e8a7951e3598"
+checksum = "9bc54198c6720f098210a85efb3ba8c078d1de4d373cdb6778850a66ae088d11"
 dependencies = [
- "object 0.33.0",
+ "object",
  "once_cell",
  "rustix",
  "wasmtime-versioned-export-macros",
@@ -10027,9 +10019,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe088f9b56bb353adaf837bf7e10f1c2e1676719dd5be4cac8e37f2ba1ee5bc"
+checksum = "5afe2f0499542f9a4bcfa1b55bfdda803b6ade4e7c93c6b99e0f39dba44b0a91"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -10039,15 +10031,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ff75cafffe47b04b036385ce3710f209153525b0ed19d57b0cf44a22d446460"
+checksum = "0a7de1f2bec5bbb35d532e61c85c049dc84ae671df60492f90b954ecf21169e7"
 
 [[package]]
 name = "wasmtime-types"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f2fa462bfea3220711c84e2b549f147e4df89eeb49b8a2a3d89148f6cc4a8b1"
+checksum = "412463e9000e14cf6856be48628d2213c20c153e29ffc22b036980c892ea6964"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -10058,9 +10050,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4cedc5bfef3db2a85522ee38564b47ef3b7fc7c92e94cacbce99808e63cdd47"
+checksum = "de5a9bc4f44ceeb168e9e8e3be4e0b4beb9095b468479663a9e24c667e36826f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10069,9 +10061,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbbe94245904d4c96c7c5f7b55bad896cc27908644efd9442063c0748b631fc"
+checksum = "8abb1301089ed8e0b4840f539cba316a73ac382090f1b25d22d8c8eed8df49c7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10099,9 +10091,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c05f0c23ba135aab39bd2cfe1d433744522591acec552f44842dbee589b0e2"
+checksum = "315cadc284b808cfbd6be9295da4009144c106723f09b421ce6c6d89275cfdb7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10122,14 +10114,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b27054fed6be4f3800aba5766f7ef435d4220ce290788f021a08d4fa573108"
+checksum = "ed4db238a0241df2d15f79ad17b3a37a27f2ea6cb885894d81b42ae107544466"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
  "gimli 0.28.1",
- "object 0.33.0",
+ "object",
  "target-lexicon",
  "wasmparser",
  "wasmtime-cranelift",
@@ -10139,9 +10131,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936a52ce69c28de2aa3b5fb4f2dbbb2966df304f04cccb7aca4ba56d915fda0"
+checksum = "70dc077306b38288262e5ba01d4b21532a6987416cdc0aedf04bb06c22a68fdc"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -10274,9 +10266,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dc69899ccb2da7daa4df31426dcfd284b104d1a85e1dae35806df0c46187f87"
+checksum = "85c6915884e731b2db0d8cf08cb64474cb69221a161675fd3c135f91febc3daa"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -10636,9 +10628,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.207.0"
+version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c83dab33a9618d86cfe3563cc864deffd08c17efc5db31a3b7cd1edeffe6e1"
+checksum = "3e79b9e3c0b6bb589dec46317e645851e0db2734c44e2be5e251b03ff4a51269"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/engine/crates/wasi-component-loader/Cargo.toml
+++ b/engine/crates/wasi-component-loader/Cargo.toml
@@ -14,9 +14,9 @@ http.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-wasmtime = "21.0.1"
-wasmtime-wasi = { version = "21.0.1", default-features = false }
-wasmtime-wasi-http = "21.0.1"
+wasmtime = "22.0.0"
+wasmtime-wasi = { version = "22.0.0", default-features = false }
+wasmtime-wasi-http = "22.0.0"
 
 [lints]
 workspace = true

--- a/engine/crates/wasi-component-loader/Cargo.toml
+++ b/engine/crates/wasi-component-loader/Cargo.toml
@@ -14,9 +14,19 @@ http.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-wasmtime = "22.0.0"
-wasmtime-wasi = { version = "22.0.0", default-features = false }
-wasmtime-wasi-http = "22.0.0"
+
+[dependencies.wasmtime]
+git = "https://github.com/grafbase/wasmtime"
+branch = "fix-linking-issues-with-musl"
+
+[dependencies.wasmtime-wasi]
+git = "https://github.com/grafbase/wasmtime"
+branch = "fix-linking-issues-with-musl"
+default-features = false
+
+[dependencies.wasmtime-wasi-http]
+git = "https://github.com/grafbase/wasmtime"
+branch = "fix-linking-issues-with-musl"
 
 [lints]
 workspace = true


### PR DESCRIPTION
https://github.com/bytecodealliance/wasmtime/releases/tag/v22.0.0

This release has a regression preventing linking if compiling against musl. I bisected and found the issue in wasmtime that caused this. What we do here is we remove the three lines in wasmtime build.rs which link against libm, and we have a working build.

Context: https://github.com/bytecodealliance/wasmtime/issues/8898
Changes against wasmtime 22: https://github.com/grafbase/wasmtime/commit/e55186fe62b56ceb5a168a79ecd773dea6bdcca6

Closes: GB-7038