### PR TITLE
composition: implement input value definition defaults in FederatedGraph

### DIFF
--- a/engine/crates/composition/CHANGELOG.md
+++ b/engine/crates/composition/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
+- Added composition for default values of output field arguments and input fields. They are now reflected in the federated graph.
 - Support the experimental @authorized directive
+- Fixed the ingestion of numeric literals when creating a federated graph from a string.
 
 ## 0.4.0 - 2024-06-11
 

--- a/engine/crates/composition/src/compose/entity_interface.rs
+++ b/engine/crates/composition/src/compose/entity_interface.rs
@@ -228,6 +228,7 @@ fn translate_arguments(
             r#type: arg.r#type().id,
             directives,
             description: None,
+            default: arg.default().cloned(),
         });
 
         if let Some((_start, len)) = &mut ids {

--- a/engine/crates/composition/src/compose/input_object.rs
+++ b/engine/crates/composition/src/compose/input_object.rs
@@ -61,12 +61,15 @@ pub(super) fn merge_input_object_definitions(
             continue;
         };
 
+        let default = fields.iter().find_map(|(_, field)| field.default_value()).cloned();
+
         let name = ctx.insert_string(field_name);
         let id = ctx.insert_input_value_definition(ir::InputValueDefinitionIr {
             name,
             r#type: field_type,
             directives: composed_directives,
             description,
+            default,
         });
 
         if let Some((_start, len)) = &mut fields_range {

--- a/engine/crates/composition/src/compose/object.rs
+++ b/engine/crates/composition/src/compose/object.rs
@@ -35,7 +35,7 @@ pub(super) fn merge_field_arguments<'a>(
 
         start = end;
 
-        compose_field_argument_defaults(arguments, ctx);
+        let default = compose_field_argument_defaults(arguments, ctx).cloned();
 
         if !intersection.contains(&argument_name) {
             if let Some((_, required)) = arguments.iter().find(|(_name, arg)| arg.r#type().is_required()) {
@@ -87,6 +87,7 @@ pub(super) fn merge_field_arguments<'a>(
             r#type: argument_type,
             directives: composed_directives,
             description: None,
+            default,
         });
 
         if let Some((_start, len)) = &mut ids {
@@ -107,10 +108,10 @@ pub(super) fn merge_field_arguments<'a>(
 /// on the same fileld, the default must be the same. Other subgraphs can have the
 /// same argument without default, that is valid, but everywhere a default value is
 /// specified, it has to be the same.
-fn compose_field_argument_defaults(
-    arguments: &[(StringId, subgraphs::FieldArgumentWalker<'_>)],
-    ctx: &mut Context<'_>,
-) {
+fn compose_field_argument_defaults<'a>(
+    arguments: &[(StringId, subgraphs::FieldArgumentWalker<'a>)],
+    ctx: &mut Context<'a>,
+) -> Option<&'a subgraphs::Value> {
     let mut default: Option<(&subgraphs::Value, subgraphs::FieldArgumentWalker<'_>)> = None;
 
     for (_, argument) in arguments {
@@ -131,6 +132,8 @@ fn compose_field_argument_defaults(
             )),
         }
     }
+
+    default.map(|(default, _)| default)
 }
 
 fn required_argument_not_in_intersection_error(

--- a/engine/crates/composition/src/composition_ir.rs
+++ b/engine/crates/composition/src/composition_ir.rs
@@ -78,6 +78,7 @@ pub(crate) struct InputValueDefinitionIr {
     pub(crate) r#type: subgraphs::FieldTypeId,
     pub(crate) directives: federated::Directives,
     pub(crate) description: Option<federated::StringId>,
+    pub(crate) default: Option<subgraphs::Value>,
 }
 
 #[derive(Default)]

--- a/engine/crates/composition/src/emit_federated_graph.rs
+++ b/engine/crates/composition/src/emit_federated_graph.rs
@@ -98,11 +98,13 @@ fn emit_input_value_definitions(input_value_definitions: &[InputValueDefinitionI
                  r#type,
                  directives,
                  description,
+                 default,
              }| federated::InputValueDefinition {
                 name: *name,
                 r#type: ctx.insert_field_type(ctx.subgraphs.walk(*r#type)),
                 directives: *directives,
                 description: *description,
+                default: default.as_ref().map(|default| ctx.insert_value(default)),
             },
         )
         .collect()

--- a/engine/crates/composition/src/ingest_subgraph/fields.rs
+++ b/engine/crates/composition/src/ingest_subgraph/fields.rs
@@ -34,12 +34,19 @@ pub(super) fn ingest_input_fields(
             .as_ref()
             .map(|description| subgraphs.strings.intern(description.node.as_str()));
 
+        let default = field
+            .node
+            .default_value
+            .as_ref()
+            .map(|default| crate::ast_value_to_subgraph_value(&default.node, subgraphs));
+
         subgraphs.push_field(subgraphs::FieldIngest {
             parent_definition_id,
             field_name,
             field_type,
             directives,
             description,
+            default,
         });
     }
 }
@@ -121,6 +128,7 @@ pub(super) fn ingest_fields(
             field_type,
             description,
             directives,
+            default: None,
         });
 
         directives::ingest_directives(

--- a/engine/crates/composition/src/subgraphs/directives.rs
+++ b/engine/crates/composition/src/subgraphs/directives.rs
@@ -5,7 +5,7 @@ pub(crate) struct DirectiveSiteId(usize);
 
 type Arguments = Vec<(StringId, Value)>;
 
-#[derive(Debug, PartialEq, PartialOrd)]
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub(crate) enum Value {
     String(StringId),
     Int(i64),

--- a/engine/crates/composition/tests/composition/authorized_basic/api.graphql
+++ b/engine/crates/composition/tests/composition/authorized_basic/api.graphql
@@ -27,22 +27,22 @@ type Transaction {
 }
 
 type Query {
-    account: Account
+    account(id: ID!): Account
     accounts: [Account!]!
-    transaction: Transaction
+    transaction(id: ID!): Transaction
     transactions: [Transaction!]!
-    user: User
+    user(id: ID!): User
     users: [User!]!
 }
 
 type Mutation {
-    createAccount: Account
-    createTransaction: Transaction!
-    createUser: User!
-    deleteAccount: Account!
-    deleteTransaction: Transaction!
-    deleteUser: User!
-    updateUser: User!
+    createAccount(userId: ID!, type: AccountType!, initialBalance: Float!, input: CreateAccountInput, included: Boolean, notIncluded: String): Account
+    createTransaction(amount: Float!, description: String, accountId: ID!): Transaction!
+    createUser(name: String!, email: String!): User!
+    deleteAccount(id: ID!): Account!
+    deleteTransaction(id: ID!): Transaction!
+    deleteUser(id: ID!, soft: Boolean): User!
+    updateUser(name: String, email: String, id: ID!): User!
 }
 
 input CreateAccountInput {

--- a/engine/crates/composition/tests/composition/composed_directives_basic/api.graphql
+++ b/engine/crates/composition/tests/composition/composed_directives_basic/api.graphql
@@ -34,10 +34,10 @@ type BirdSighting @deprecated(reason: "we haven't seen any birds in a while :(")
 }
 
 type Query {
-    bird: Bird
-    birdObservation: BirdObservation
-    birdObservations: [BirdObservation]
-    birdSighting: BirdSighting
+    bird(id: ID!): Bird
+    birdObservation(observationID: ID!): BirdObservation
+    birdObservations(filters: BirdObservationFilters): [BirdObservation]
+    birdSighting(sightingID: ID!, private: Boolean @deprecated): BirdSighting
     birdSightings: [BirdSighting]
     birds: [Bird]
 }

--- a/engine/crates/composition/tests/composition/custom_query_root/api.graphql
+++ b/engine/crates/composition/tests/composition/custom_query_root/api.graphql
@@ -35,8 +35,8 @@ type WasteTypeBreakdown {
 }
 
 type Query {
-    hazardousWasteData: HazardousWasteStats
-    recyclingCenters: [RecyclingCenter]
-    wasteCollectionPoints: [CollectionPoint]
-    wasteStatistics: WasteStats
+    hazardousWasteData(city: String!): HazardousWasteStats
+    recyclingCenters(city: String!): [RecyclingCenter]
+    wasteCollectionPoints(city: String!): [CollectionPoint]
+    wasteStatistics(city: String!): WasteStats
 }

--- a/engine/crates/composition/tests/composition/custom_query_root_as_non_root_in_other_subgraph/api.graphql
+++ b/engine/crates/composition/tests/composition/custom_query_root_as_non_root_in_other_subgraph/api.graphql
@@ -40,8 +40,8 @@ type WasteTypeBreakdown {
 }
 
 type Query {
-    hazardousWasteData: HazardousWasteStats
-    recyclingCenters: [RecyclingCenter]
-    wasteCollectionPoints: [CollectionPoint]
-    wasteStatistics: WasteStats
+    hazardousWasteData(city: String!): HazardousWasteStats
+    recyclingCenters(city: String!): [RecyclingCenter]
+    wasteCollectionPoints(city: String!): [CollectionPoint]
+    wasteStatistics(city: String!): WasteStats
 }

--- a/engine/crates/composition/tests/composition/default_values/api.graphql
+++ b/engine/crates/composition/tests/composition/default_values/api.graphql
@@ -1,0 +1,20 @@
+type Book {
+    author: String!
+    id: ID!
+    title: String!
+    yearPublished: Int
+}
+
+type Query {
+    books(limit: Int = 10): [Book!]!
+}
+
+type Mutation {
+    addBook(input: AddBookInput!): Book
+}
+
+input AddBookInput {
+    title: String!
+    author: String!
+    yearPublished: Int = 2023
+}

--- a/engine/crates/composition/tests/composition/default_values/federated.graphql
+++ b/engine/crates/composition/tests/composition/default_values/federated.graphql
@@ -1,0 +1,43 @@
+directive @core(feature: String!) repeatable on SCHEMA
+
+directive @join__owner(graph: join__Graph!) on OBJECT
+
+directive @join__type(
+    graph: join__Graph!
+    key: String!
+    resolvable: Boolean = true
+) repeatable on OBJECT | INTERFACE
+
+directive @join__field(
+    graph: join__Graph
+    requires: String
+    provides: String
+) on FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+enum join__Graph {
+    OTHER_SCHEMA @join__graph(name: "other-schema", url: "http://example.com/other-schema")
+    SCHEMA @join__graph(name: "schema", url: "http://example.com/schema")
+}
+
+type Book {
+    author: String! @join__field(graph: SCHEMA)
+    id: ID! @join__field(graph: SCHEMA)
+    title: String! @join__field(graph: SCHEMA)
+    yearPublished: Int @join__field(graph: SCHEMA)
+}
+
+type Query {
+    books(limit: Int = 10): [Book!]! @join__field(graph: OTHER_SCHEMA) @join__field(graph: SCHEMA)
+}
+
+type Mutation {
+    addBook(input: AddBookInput!): Book @join__field(graph: SCHEMA)
+}
+
+input AddBookInput {
+    title: String!
+    author: String!
+    yearPublished: Int = 2023
+}

--- a/engine/crates/composition/tests/composition/default_values/subgraphs/other_schema.graphql
+++ b/engine/crates/composition/tests/composition/default_values/subgraphs/other_schema.graphql
@@ -1,0 +1,9 @@
+input AddBookInput {
+  title: String!
+  author: String!
+  yearPublished: Int
+}
+
+type Query {
+  books(limit: Int): [Book!]! @shareable
+}

--- a/engine/crates/composition/tests/composition/default_values/subgraphs/schema.graphql
+++ b/engine/crates/composition/tests/composition/default_values/subgraphs/schema.graphql
@@ -1,0 +1,20 @@
+type Mutation {
+  addBook(input: AddBookInput!): Book
+}
+
+type Book {
+  id: ID!
+  title: String!
+  author: String!
+  yearPublished: Int
+}
+
+input AddBookInput {
+  title: String!
+  author: String!
+  yearPublished: Int = 2023
+}
+
+type Query {
+  books(limit: Int = 10): [Book!]! @shareable
+}

--- a/engine/crates/composition/tests/composition/descriptions_basic/api.graphql
+++ b/engine/crates/composition/tests/composition/descriptions_basic/api.graphql
@@ -26,7 +26,7 @@ type Tofu {
     """
     List of recipes that include this tofu.
     """
-    recipes: [Recipe]
+    recipes(filter: RecipeFilter): [Recipe]
     """
     The texture profile of the tofu, expressed through a custom scalar.
     """

--- a/engine/crates/composition/tests/composition/entity_composite_key_basic/api.graphql
+++ b/engine/crates/composition/tests/composition/entity_composite_key_basic/api.graphql
@@ -27,9 +27,9 @@ type Student {
 }
 
 type Query {
-    course: Course
-    courseRating: [CourseRating]
+    course(id: ID!): Course
+    courseRating(courseId: ID!): [CourseRating]
     courses: [Course]
-    student: Student
+    student(id: ID!): Student
     students: [Student]
 }

--- a/engine/crates/composition/tests/composition/entity_composite_key_nested/api.graphql
+++ b/engine/crates/composition/tests/composition/entity_composite_key_nested/api.graphql
@@ -15,8 +15,8 @@ type PatientRecord {
 }
 
 type Query {
-    patient: Patient
-    patientRecord: PatientRecord
+    patient(id: ID!): Patient
+    patientRecord(recordId: ID!, patientId: ID!): PatientRecord
     patientRecords: [PatientRecord]
     patients: [Patient]
 }

--- a/engine/crates/composition/tests/composition/entity_multiple_keys_basic/api.graphql
+++ b/engine/crates/composition/tests/composition/entity_multiple_keys_basic/api.graphql
@@ -19,6 +19,6 @@ type Post {
 }
 
 type Query {
-    getUser: User
-    getUserComments: User
+    getUser(id: ID!): User
+    getUserComments(name: String!, email: String!): User
 }

--- a/engine/crates/composition/tests/composition/entity_unresolvable_keys/api.graphql
+++ b/engine/crates/composition/tests/composition/entity_unresolvable_keys/api.graphql
@@ -9,5 +9,5 @@ type Post {
 }
 
 type Query {
-    getUser: User
+    getUser(id: ID!): User
 }

--- a/engine/crates/composition/tests/composition/enum_only_inputs/api.graphql
+++ b/engine/crates/composition/tests/composition/enum_only_inputs/api.graphql
@@ -4,7 +4,7 @@ enum FilterName {
 }
 
 type Query {
-    searchFood: [String!]
-    searchProduct: [String!]
-    searchUser: [String!]
+    searchFood(filterName: FilterName, filterValue: String): [String!]
+    searchProduct(filterName: FilterName, filterValue: String): [String!]
+    searchUser(filterName: FilterName, filterValue: String): [String!]
 }

--- a/engine/crates/composition/tests/composition/enum_only_outputs/api.graphql
+++ b/engine/crates/composition/tests/composition/enum_only_outputs/api.graphql
@@ -35,7 +35,7 @@ type Episode {
 }
 
 type Query {
-    getActivity: Activity
-    getEpisode: Episode
-    getTeletubby: Teletubby
+    getActivity(name: String!): Activity
+    getEpisode(title: String!): Episode
+    getTeletubby(name: String!): Teletubby
 }

--- a/engine/crates/composition/tests/composition/field_type_composition/api.graphql
+++ b/engine/crates/composition/tests/composition/field_type_composition/api.graphql
@@ -11,7 +11,7 @@ type Manufacturer {
 }
 
 type Query {
-    fidgetSpinners: [FidgetSpinner]
+    fidgetSpinners(filter: SpinnerFilter!): [FidgetSpinner]
 }
 
 interface Spinner {

--- a/engine/crates/composition/tests/composition/inaccessible_basic/api.graphql
+++ b/engine/crates/composition/tests/composition/inaccessible_basic/api.graphql
@@ -41,12 +41,12 @@ type Cubic {
 }
 
 type Query {
-    getBook: Book
-    getNew: New
-    getUngulate: Ungulate
+    getBook(id: ID!): Book
+    getNew(name: String!): New
+    getUngulate(id: ID!): Ungulate
 }
 
 type Mutation {
-    addBook: Book
-    updateBook: Book
+    addBook(input: BookInput!): Book
+    updateBook(id: ID!, input: BookInput!): Book
 }

--- a/engine/crates/composition/tests/composition/input_object_basic/api.graphql
+++ b/engine/crates/composition/tests/composition/input_object_basic/api.graphql
@@ -8,8 +8,8 @@ type Person {
 }
 
 type Query {
-    getPersonInfo: Person
-    searchPerson: [Person]
+    getPersonInfo(input: InputPerson!): Person
+    searchPerson(input: InputPerson!): [Person]
 }
 
 input InputPerson {

--- a/engine/crates/composition/tests/composition/interface_implementing_interface_basic/api.graphql
+++ b/engine/crates/composition/tests/composition/interface_implementing_interface_basic/api.graphql
@@ -14,7 +14,7 @@ type User {
 }
 
 type Query {
-    user: User
+    user(id: ID!): User
 }
 
 interface Node {

--- a/engine/crates/composition/tests/composition/kebab_case_subgraph_names/api.graphql
+++ b/engine/crates/composition/tests/composition/kebab_case_subgraph_names/api.graphql
@@ -27,12 +27,12 @@ type Schaschlik {
 }
 
 type Query {
-    brochette: Brochette
+    brochette(id: ID!): Brochette
     brochettes: [Brochette]
-    kebab: Kebab
+    kebab(id: ID!): Kebab
     kebabs: [Kebab]
-    kushi: Kushi
+    kushi(id: ID!): Kushi
     kushis: [Kushi]
-    schaschlik: Schaschlik
+    schaschlik(id: ID!): Schaschlik
     schaschliks: [Schaschlik]
 }

--- a/engine/crates/composition/tests/composition/object_field_arguments_basic/api.graphql
+++ b/engine/crates/composition/tests/composition/object_field_arguments_basic/api.graphql
@@ -13,5 +13,5 @@ type HistoricalData {
 }
 
 type Query {
-    getRollerCoaster: RollerCoaster
+    getRollerCoaster(id: ID!): RollerCoaster
 }

--- a/engine/crates/composition/tests/composition/provides_basic/api.graphql
+++ b/engine/crates/composition/tests/composition/provides_basic/api.graphql
@@ -17,6 +17,6 @@ type User {
 }
 
 type Query {
-    product: Product
-    user: User
+    product(id: ID!): Product
+    user(id: ID!): User
 }

--- a/engine/crates/composition/tests/composition/requires_basic/api.graphql
+++ b/engine/crates/composition/tests/composition/requires_basic/api.graphql
@@ -15,7 +15,7 @@ type ChiliVariety {
 
 type Query {
     chiliVarieties: [ChiliVariety]
-    chiliVariety: ChiliVariety
-    farm: Farm
+    chiliVariety(id: ID!): ChiliVariety
+    farm(id: ID!): Farm
     farms: [Farm]
 }

--- a/engine/crates/composition/tests/composition/requires_with_arguments/api.graphql
+++ b/engine/crates/composition/tests/composition/requires_with_arguments/api.graphql
@@ -9,7 +9,7 @@ type WasabiPlant {
     cultivationArea: String
     harvestTime: String
     id: ID!
-    name: String!
+    name(language: String!): String!
     variety: String!
 }
 
@@ -23,5 +23,5 @@ type WasabiProduct {
 
 type Query {
     wasabiPlants: [WasabiPlant]
-    wasabiProduct: WasabiProduct
+    wasabiProduct(id: ID!): WasabiProduct
 }

--- a/engine/crates/composition/tests/composition/shareable_basic/api.graphql
+++ b/engine/crates/composition/tests/composition/shareable_basic/api.graphql
@@ -9,5 +9,5 @@ type Customer {
 }
 
 type Query {
-    customer: Customer
+    customer(id: ID!): Customer
 }

--- a/engine/crates/composition/tests/composition/subgraph_query_fields_service_entities/api.graphql
+++ b/engine/crates/composition/tests/composition/subgraph_query_fields_service_entities/api.graphql
@@ -23,15 +23,15 @@ type Rice {
 }
 
 type Query {
-    lentil: Lentil
+    lentil(id: ID!): Lentil
     lentils: [Lentil]
-    rice: Rice
+    rice(id: ID!): Rice
     rices: [Rice]
 }
 
 type Mutation {
-    addLentil: Lentil
-    deleteLentil: Lentil
+    addLentil(input: AddLentilInput!): Lentil
+    deleteLentil(id: ID!): Lentil
 }
 
 input AddLentilInput {

--- a/engine/crates/composition/tests/composition/tag_directive_basic/api.graphql
+++ b/engine/crates/composition/tests/composition/tag_directive_basic/api.graphql
@@ -17,7 +17,7 @@ type Orange {
 }
 
 type Query {
-    tags: [String]
+    tags(filter: String): [String]
 }
 
 interface HasId {

--- a/engine/crates/composition/tests/composition/unions_basic/api.graphql
+++ b/engine/crates/composition/tests/composition/unions_basic/api.graphql
@@ -33,7 +33,7 @@ type Omelet {
 }
 
 type Query {
-    pizza: Pizza
+    pizza(id: ID!): Pizza
 }
 
 union Topping = Onion | Cheese | Pineapple | Salmon | Omelet

--- a/engine/crates/federated-graph/src/federated_graph/v3.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v3.rs
@@ -173,12 +173,14 @@ pub struct Interface {
     pub description: Option<StringId>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq)]
 pub struct InputValueDefinition {
     pub name: StringId,
     pub r#type: Type,
     pub directives: Directives,
     pub description: Option<StringId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<Value>,
 }
 
 pub type InputValueDefinitionSet = Vec<InputValueDefinitionSetItem>;
@@ -223,6 +225,7 @@ impl From<super::v2::FederatedGraphV2> for FederatedGraphV3 {
                 r#type: (&value[input_value.type_id]).into(),
                 directives: input_value.directives,
                 description: input_value.description,
+                default: None,
             })
             .collect();
 

--- a/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
@@ -291,6 +291,10 @@ fn write_input_field(field: &InputValueDefinition, graph: &FederatedGraphV3, sdl
 
     write!(sdl, "{INDENT}{field_name}: {field_type}")?;
 
+    if let Some(default) = &field.default {
+        write!(sdl, " = {}", ValueDisplay(default, graph))?;
+    }
+
     write_composed_directives(field.directives, graph, sdl)?;
 
     sdl.push('\n');
@@ -433,15 +437,21 @@ fn render_field_arguments(args: &[InputValueDefinition], graph: &FederatedGraphV
                 let name = &graph[arg.name];
                 let r#type = render_field_type(&arg.r#type, graph);
                 let directives = arg.directives;
-                (name, r#type, directives)
+                let default = arg.default.as_ref();
+                (name, r#type, directives, default)
             })
             .peekable();
         let mut out = String::from('(');
 
-        while let Some((name, ty, directives)) = inner.next() {
+        while let Some((name, ty, directives, default)) = inner.next() {
             out.push_str(name);
             out.push_str(": ");
             out.push_str(&ty);
+
+            if let Some(default) = default {
+                out.push_str(" = ");
+                write!(out, "{}", ValueDisplay(default, graph)).unwrap();
+            }
 
             write_composed_directives(directives, graph, &mut out).unwrap();
 


### PR DESCRIPTION
For both arguments and fields of input types.

Additionally, fix the ingestion of numeric literals when building a FederatedGraph from SDL (they were ingested as strings).

closes GB-7006