### PR TITLE
fix(engine-v2): Properly handle authorize nodes on root types

### DIFF
--- a/engine/crates/engine-v2/src/operation/mod.rs
+++ b/engine/crates/engine-v2/src/operation/mod.rs
@@ -30,6 +30,7 @@ pub(crate) struct Plan {
 pub(crate) struct Operation {
     pub ty: OperationType,
     pub root_object_id: ObjectId,
+    pub root_condition_id: Option<ConditionId>,
     #[allow(dead_code)]
     pub name: Option<String>,
     pub response_keys: ResponseKeys,

--- a/engine/crates/engine-v2/src/plan/mod.rs
+++ b/engine/crates/engine-v2/src/plan/mod.rs
@@ -3,7 +3,7 @@ use schema::{EntityId, ResolverId, Schema};
 use crate::{
     execution::ExecutionContext,
     operation::{EntityLocation, Operation, PlanId, Variables},
-    response::ReadSelectionSet,
+    response::{GraphqlError, ReadSelectionSet},
     sources::PreparedExecutor,
     Runtime,
 };
@@ -24,6 +24,7 @@ pub(crate) use walkers::*;
 /// All the necessary information for the operation to be executed that can be prepared & cached.
 pub(crate) struct OperationPlan {
     operation: Operation,
+    pub(crate) root_errors: Vec<GraphqlError>,
 
     // Association between fields & selection sets and plans. Used when traversing the operation
     // for a plan filtering out other plans fields and to build the collected selection set.

--- a/engine/crates/engine-v2/src/response/write/mod.rs
+++ b/engine/crates/engine-v2/src/response/write/mod.rs
@@ -70,6 +70,11 @@ impl ResponseBuilder {
         }
     }
 
+    pub fn push_root_errors(&mut self, errors: &[GraphqlError]) {
+        self.errors.extend_from_slice(errors);
+        self.root = None;
+    }
+
     pub fn new_part(
         &mut self,
         root_response_object_refs: Arc<Vec<ResponseObjectRef>>,

--- a/engine/crates/integration-tests/benches/federation.rs
+++ b/engine/crates/integration-tests/benches/federation.rs
@@ -1,14 +1,14 @@
 #![allow(unused_crate_dependencies)]
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use integration_tests::federation::FederationGatewayWithoutIO;
+use integration_tests::federation::DeterministicEngine;
 use serde_json::json;
 
 const SCHEMA: &str = include_str!("../data/federated-graph-schema.graphql");
 const PATHFINDER_INTROSPECTION_QUERY: &str = include_str!("../data/introspection.graphql");
 
 pub fn introspection(c: &mut Criterion) {
-    let bench = FederationGatewayWithoutIO::new(SCHEMA, PATHFINDER_INTROSPECTION_QUERY, &[json!({"data": null})]);
+    let bench = DeterministicEngine::new(SCHEMA, PATHFINDER_INTROSPECTION_QUERY, &[json!({"data": null})]);
     let response = integration_tests::runtime().block_on(bench.execute());
 
     // Sanity check it works.
@@ -28,7 +28,7 @@ pub fn introspection(c: &mut Criterion) {
 }
 
 pub fn basic_federation(c: &mut Criterion) {
-    let bench = FederationGatewayWithoutIO::new(
+    let bench = DeterministicEngine::new(
         SCHEMA,
         r#"
         query ExampleQuery {

--- a/engine/crates/integration-tests/src/federation/builder/bench.rs
+++ b/engine/crates/integration-tests/src/federation/builder/bench.rs
@@ -5,40 +5,59 @@ use std::sync::{
 
 use engine::BatchRequest;
 use engine_v2::HttpGraphqlResponse;
-use futures::stream::BoxStream;
+use futures::{stream::BoxStream, StreamExt, TryStreamExt};
+use gateway_core::StreamingFormat;
 use graphql_composition::FederatedGraph;
+use headers::HeaderMapExt;
 use runtime::{
     fetch::{FetchError, FetchRequest, FetchResponse, FetchResult, GraphqlRequest},
     hooks::DynamicHooks,
 };
 
-use crate::federation::GraphqlResponse;
+use crate::federation::{GraphqlResponse, GraphqlStreamingResponse};
 
 use super::TestRuntime;
 
 #[derive(Clone)]
-pub struct FederationGatewayWithoutIO<'a> {
+pub struct DeterministicEngine<'a> {
     engine: Arc<engine_v2::Engine<TestRuntime>>,
     query: &'a str,
     dummy_responses_index: Arc<AtomicUsize>,
 }
 
-impl<'a> FederationGatewayWithoutIO<'a> {
-    pub fn new<T: serde::Serialize, I>(schema: &str, query: &'a str, subgraphs_responses: I) -> Self
-    where
-        I: IntoIterator<Item = T>,
-    {
+pub struct DeterministicEngineBuilder<'a> {
+    hooks: DynamicHooks,
+    schema: &'a str,
+    query: &'a str,
+    subgraphs_json_responses: Vec<String>,
+}
+
+impl<'a> DeterministicEngineBuilder<'a> {
+    #[must_use]
+    pub fn with_subgraph_response<T: serde::Serialize>(mut self, resp: T) -> Self {
+        self.subgraphs_json_responses
+            .push(serde_json::to_string(&resp).unwrap());
+        self
+    }
+
+    #[must_use]
+    pub fn with_hooks(mut self, hooks: impl Into<DynamicHooks>) -> Self {
+        self.hooks = hooks.into();
+        self
+    }
+
+    pub fn build(self) -> DeterministicEngine<'a> {
         let dummy_responses_index = Arc::new(AtomicUsize::new(0));
         let fetcher = DummyFetcher::create(
-            subgraphs_responses
+            self.subgraphs_json_responses
                 .into_iter()
                 .map(|resp| FetchResponse {
-                    bytes: serde_json::to_vec(&resp).unwrap().into(),
+                    bytes: resp.into_bytes().into(),
                 })
                 .collect(),
             dummy_responses_index.clone(),
         );
-        let federated_graph = FederatedGraph::from_sdl(schema).unwrap().into_latest();
+        let federated_graph = FederatedGraph::from_sdl(self.schema).unwrap().into_latest();
         let config =
             engine_v2::VersionedConfig::V4(engine_v2::config::Config::from_graph(federated_graph)).into_latest();
 
@@ -57,14 +76,36 @@ impl<'a> FederationGatewayWithoutIO<'a> {
                 ),
                 kv: runtime_local::InMemoryKvStore::runtime(),
                 meter: grafbase_tracing::metrics::meter_from_global_provider(),
-                hooks: DynamicHooks::default(),
+                hooks: self.hooks,
             },
         );
-        Self {
+        DeterministicEngine {
             engine: Arc::new(engine),
-            query,
+            query: self.query,
             dummy_responses_index,
         }
+    }
+}
+
+impl<'a> DeterministicEngine<'a> {
+    pub fn builder(schema: &'a str, query: &'a str) -> DeterministicEngineBuilder<'a> {
+        DeterministicEngineBuilder {
+            hooks: DynamicHooks::default(),
+            schema,
+            query,
+            subgraphs_json_responses: Vec::new(),
+        }
+    }
+
+    pub fn new<T: serde::Serialize, I>(schema: &'a str, query: &'a str, subgraphs_responses: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let mut builder = Self::builder(schema, query);
+        for resp in subgraphs_responses {
+            builder = builder.with_subgraph_response(resp);
+        }
+        builder.build()
     }
 
     pub async fn raw_execute(&self) -> HttpGraphqlResponse {
@@ -79,6 +120,22 @@ impl<'a> FederationGatewayWithoutIO<'a> {
 
     pub async fn execute(&self) -> GraphqlResponse {
         self.raw_execute().await.try_into().unwrap()
+    }
+
+    pub async fn execute_stream(&self) -> GraphqlStreamingResponse {
+        self.dummy_responses_index.store(0, Ordering::Relaxed);
+        let mut headers = http::HeaderMap::new();
+        headers.typed_insert(StreamingFormat::IncrementalDelivery);
+        let response = self
+            .engine
+            .execute(headers, BatchRequest::Single(engine::Request::new(self.query)))
+            .await;
+        let stream = multipart_stream::parse(response.body.into_stream().map_ok(Into::into), "-")
+            .map(|result| serde_json::from_slice(&result.unwrap().body).unwrap());
+        GraphqlStreamingResponse {
+            stream: Box::pin(stream),
+            headers: response.headers,
+        }
     }
 }
 

--- a/engine/crates/integration-tests/tests/federation/basic/errors.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/errors.rs
@@ -1,11 +1,11 @@
-use integration_tests::federation::FederationGatewayWithoutIO;
+use integration_tests::federation::DeterministicEngine;
 use serde_json::json;
 
 const SCHEMA: &str = include_str!("../../../data/federated-graph-schema.graphql");
 
 #[test]
 fn subgraph_no_response() {
-    let engine = FederationGatewayWithoutIO::new(
+    let engine = DeterministicEngine::new(
         SCHEMA,
         r#"
         query ExampleQuery {
@@ -31,7 +31,7 @@ fn subgraph_no_response() {
     }
     "###);
 
-    let engine = FederationGatewayWithoutIO::new(
+    let engine = DeterministicEngine::new(
         SCHEMA,
         r#"
         query ExampleQuery {
@@ -60,7 +60,7 @@ fn subgraph_no_response() {
 
 #[test]
 fn request_error() {
-    let engine = FederationGatewayWithoutIO::new(
+    let engine = DeterministicEngine::new(
         SCHEMA,
         r#"
         query ExampleQuery {
@@ -89,7 +89,7 @@ fn request_error() {
 
 #[test]
 fn sugraph_request_error() {
-    let engine = FederationGatewayWithoutIO::new(
+    let engine = DeterministicEngine::new(
         SCHEMA,
         r#"
         query ExampleQuery {
@@ -115,7 +115,7 @@ fn sugraph_request_error() {
 
 #[test]
 fn invalid_response_for_nullable_field() {
-    let engine = FederationGatewayWithoutIO::new(
+    let engine = DeterministicEngine::new(
         SCHEMA,
         r#"
         query ExampleQuery {
@@ -144,7 +144,7 @@ fn invalid_response_for_nullable_field() {
 
 #[test]
 fn subgraph_field_error() {
-    let engine = FederationGatewayWithoutIO::new(
+    let engine = DeterministicEngine::new(
         SCHEMA,
         r#"
         query ExampleQuery {
@@ -174,7 +174,7 @@ fn subgraph_field_error() {
 
 #[test]
 fn simple_error() {
-    let engine = FederationGatewayWithoutIO::new(
+    let engine = DeterministicEngine::new(
         SCHEMA,
         r#"
         query ExampleQuery {
@@ -270,7 +270,7 @@ fn simple_error() {
 
 #[test]
 fn null_entity_with_error() {
-    let engine = FederationGatewayWithoutIO::new(
+    let engine = DeterministicEngine::new(
         SCHEMA,
         r#"
         query ExampleQuery {


### PR DESCRIPTION
Ugly commit, but works.

`@authorized` directive on a root type (Query, Mutation, etc..) wouldn't be taken into account as they no field within the query.

So adding a root condition, if it fails it populates errors that will be immediately used to generate a response. Reworked a bit the no IO/deterministic test utilities but they're not great yet.