### PR TITLE
cli: make grafbase schema return federated SDL

### DIFF
--- a/cli/crates/backend/src/api/graphql/types/queries/fetch_federated_graph_schema.rs
+++ b/cli/crates/backend/src/api/graphql/types/queries/fetch_federated_graph_schema.rs
@@ -22,5 +22,26 @@ pub struct BranchConnection {
 #[derive(cynic::QueryFragment, Debug)]
 pub struct Branch {
     pub name: String,
-    pub schema: Option<String>,
+    pub federated_schema: Option<String>,
+}
+
+#[derive(cynic::QueryVariables)]
+pub struct FetchFederatedGraphSchemaProductionBranchArguments<'a> {
+    pub account: &'a str,
+    pub graph: &'a str,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    graphql_type = "Query",
+    variables = "FetchFederatedGraphSchemaProductionBranchArguments"
+)]
+pub struct FetchFederatedGraphSchemaProductionBranchQuery {
+    #[arguments(accountSlug: $account, graphSlug: $graph)]
+    pub graph_by_account_slug: Option<Graph>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct Graph {
+    pub production_branch: Branch,
 }


### PR DESCRIPTION
The `grafbase schema` command returns the API schema for federated graphs, but that can already be fetched with `grafbase introspect`.

This commit:

- Makes it return the federated SDL for federated graphs
- Makes it work with graph refs that don't contain a branch (it then defaults to the graph's production branch)

Alternatively, we could add a flag to return either api schema or federated sdl.

closes GB-7015