### PR TITLE
chore(wasi): rename error-response to error

### DIFF
--- a/engine/crates/wasi-component-loader/examples/crates/authorization/src/bindings.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/authorization/src/bindings.rs
@@ -221,24 +221,24 @@ pub mod component {
                 }
             }
             #[derive(Clone)]
-            pub struct ErrorResponse {
+            pub struct Error {
                 pub extensions: _rt::Vec<(_rt::String, _rt::String)>,
                 pub message: _rt::String,
             }
-            impl ::core::fmt::Debug for ErrorResponse {
+            impl ::core::fmt::Debug for Error {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                    f.debug_struct("ErrorResponse")
+                    f.debug_struct("Error")
                         .field("extensions", &self.extensions)
                         .field("message", &self.message)
                         .finish()
                 }
             }
-            impl ::core::fmt::Display for ErrorResponse {
+            impl ::core::fmt::Display for Error {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                     write!(f, "{:?}", self)
                 }
             }
-            impl std::error::Error for ErrorResponse {}
+            impl std::error::Error for Error {}
             impl Context {
                 #[allow(unused_unsafe, clippy::all)]
                 pub fn get(&self, name: &str) -> Option<_rt::String> {
@@ -580,7 +580,7 @@ pub mod exports {
                 static __FORCE_SECTION_REF: fn() = super::super::super::super::__link_custom_section_describing_imports;
                 use super::super::super::super::_rt;
                 pub type Headers = super::super::super::super::component::grafbase::types::Headers;
-                pub type ErrorResponse = super::super::super::super::component::grafbase::types::ErrorResponse;
+                pub type Error = super::super::super::super::component::grafbase::types::Error;
                 pub type Context = super::super::super::super::component::grafbase::types::Context;
                 #[doc(hidden)]
                 #[allow(non_snake_case)]
@@ -598,7 +598,7 @@ pub mod exports {
                         }
                         Err(e) => {
                             *ptr1.add(0).cast::<u8>() = (1i32) as u8;
-                            let super::super::super::super::component::grafbase::types::ErrorResponse {
+                            let super::super::super::super::component::grafbase::types::Error {
                                 extensions: extensions2,
                                 message: message2,
                             } = e;
@@ -676,7 +676,7 @@ pub mod exports {
                     }
                 }
                 pub trait Guest {
-                    fn on_gateway_request(context: Context, headers: Headers) -> Result<(), ErrorResponse>;
+                    fn on_gateway_request(context: Context, headers: Headers) -> Result<(), Error>;
                 }
                 #[doc(hidden)]
 
@@ -707,7 +707,7 @@ pub mod exports {
                 #[cfg(target_arch = "wasm32")]
                 static __FORCE_SECTION_REF: fn() = super::super::super::super::__link_custom_section_describing_imports;
                 use super::super::super::super::_rt;
-                pub type ErrorResponse = super::super::super::super::component::grafbase::types::ErrorResponse;
+                pub type Error = super::super::super::super::component::grafbase::types::Error;
                 pub type SharedContext = super::super::super::super::component::grafbase::types::SharedContext;
                 pub type EdgeDefinition = super::super::super::super::component::grafbase::types::EdgeDefinition;
                 pub type NodeDefinition = super::super::super::super::component::grafbase::types::NodeDefinition;
@@ -750,7 +750,7 @@ pub mod exports {
                         }
                         Err(e) => {
                             *ptr5.add(0).cast::<u8>() = (1i32) as u8;
-                            let super::super::super::super::component::grafbase::types::ErrorResponse {
+                            let super::super::super::super::component::grafbase::types::Error {
                                 extensions: extensions6,
                                 message: message6,
                             } = e;
@@ -856,7 +856,7 @@ pub mod exports {
                         }
                         Err(e) => {
                             *ptr3.add(0).cast::<u8>() = (1i32) as u8;
-                            let super::super::super::super::component::grafbase::types::ErrorResponse {
+                            let super::super::super::super::component::grafbase::types::Error {
                                 extensions: extensions4,
                                 message: message4,
                             } = e;
@@ -939,12 +939,12 @@ pub mod exports {
                         definition: EdgeDefinition,
                         arguments: _rt::String,
                         metadata: _rt::String,
-                    ) -> Result<(), ErrorResponse>;
+                    ) -> Result<(), Error>;
                     fn authorize_node_pre_execution(
                         context: SharedContext,
                         definition: NodeDefinition,
                         metadata: _rt::String,
-                    ) -> Result<(), ErrorResponse>;
+                    ) -> Result<(), Error>;
                 }
                 #[doc(hidden)]
 
@@ -1136,36 +1136,35 @@ pub(crate) use __export_hooks_impl as export;
 #[cfg(target_arch = "wasm32")]
 #[link_section = "component-type:wit-bindgen:0.25.0:hooks:encoded world"]
 #[doc(hidden)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 1301] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\x99\x09\x01A\x02\x01\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 1265] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xf5\x08\x01A\x02\x01\
 A\x0c\x01B\x1f\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
 header-error\x03\0\0\x04\0\x07context\x03\x01\x04\0\x0eshared-context\x03\x01\x04\
 \0\x07headers\x03\x01\x01r\x02\x10parent-type-names\x0afield-names\x04\0\x0fedge\
 -definition\x03\0\x05\x01r\x01\x09type-names\x04\0\x0fnode-definition\x03\0\x07\x01\
-o\x02ss\x01p\x09\x01r\x02\x0aextensions\x0a\x07messages\x04\0\x0eerror-response\x03\
-\0\x0b\x01h\x02\x01ks\x01@\x02\x04self\x0d\x04names\0\x0e\x04\0\x13[method]conte\
-xt.get\x01\x0f\x01@\x03\x04self\x0d\x04names\x05values\x01\0\x04\0\x13[method]co\
-ntext.set\x01\x10\x04\0\x16[method]context.delete\x01\x0f\x01h\x03\x01@\x02\x04s\
-elf\x11\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01j\
-\x01\x0e\x01\x01\x01@\x02\x04self\x13\x04names\0\x14\x04\0\x13[method]headers.ge\
-t\x01\x15\x01j\0\x01\x01\x01@\x03\x04self\x13\x04names\x05values\0\x16\x04\0\x13\
-[method]headers.set\x01\x17\x04\0\x16[method]headers.delete\x01\x15\x03\x01\x18c\
-omponent:grafbase/types\x05\0\x02\x03\0\0\x07headers\x02\x03\0\0\x0eerror-respon\
-se\x02\x03\0\0\x07context\x01B\x0b\x02\x03\x02\x01\x01\x04\0\x07headers\x03\0\0\x02\
-\x03\x02\x01\x02\x04\0\x0eerror-response\x03\0\x02\x02\x03\x02\x01\x03\x04\0\x07\
-context\x03\0\x04\x01i\x05\x01i\x01\x01j\0\x01\x03\x01@\x02\x07context\x06\x07he\
-aders\x07\0\x08\x04\0\x12on-gateway-request\x01\x09\x04\x01\"component:grafbase/\
-gateway-request\x05\x04\x02\x03\0\0\x0eshared-context\x02\x03\0\0\x0fedge-defini\
-tion\x02\x03\0\0\x0fnode-definition\x01B\x0e\x02\x03\x02\x01\x02\x04\0\x0eerror-\
-response\x03\0\0\x02\x03\x02\x01\x05\x04\0\x0eshared-context\x03\0\x02\x02\x03\x02\
-\x01\x06\x04\0\x0fedge-definition\x03\0\x04\x02\x03\x02\x01\x07\x04\0\x0fnode-de\
-finition\x03\0\x06\x01i\x03\x01j\0\x01\x01\x01@\x04\x07context\x08\x0adefinition\
-\x05\x09argumentss\x08metadatas\0\x09\x04\0\x1cauthorize-edge-pre-execution\x01\x0a\
-\x01@\x03\x07context\x08\x0adefinition\x07\x08metadatas\0\x09\x04\0\x1cauthorize\
--node-pre-execution\x01\x0b\x04\x01\x20component:grafbase/authorization\x05\x08\x04\
-\x01\x18component:grafbase/hooks\x04\0\x0b\x0b\x01\0\x05hooks\x03\0\0\0G\x09prod\
-ucers\x01\x0cprocessed-by\x02\x0dwit-component\x070.208.1\x10wit-bindgen-rust\x06\
-0.25.0";
+o\x02ss\x01p\x09\x01r\x02\x0aextensions\x0a\x07messages\x04\0\x05error\x03\0\x0b\
+\x01h\x02\x01ks\x01@\x02\x04self\x0d\x04names\0\x0e\x04\0\x13[method]context.get\
+\x01\x0f\x01@\x03\x04self\x0d\x04names\x05values\x01\0\x04\0\x13[method]context.\
+set\x01\x10\x04\0\x16[method]context.delete\x01\x0f\x01h\x03\x01@\x02\x04self\x11\
+\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01j\x01\x0e\
+\x01\x01\x01@\x02\x04self\x13\x04names\0\x14\x04\0\x13[method]headers.get\x01\x15\
+\x01j\0\x01\x01\x01@\x03\x04self\x13\x04names\x05values\0\x16\x04\0\x13[method]h\
+eaders.set\x01\x17\x04\0\x16[method]headers.delete\x01\x15\x03\x01\x18component:\
+grafbase/types\x05\0\x02\x03\0\0\x07headers\x02\x03\0\0\x05error\x02\x03\0\0\x07\
+context\x01B\x0b\x02\x03\x02\x01\x01\x04\0\x07headers\x03\0\0\x02\x03\x02\x01\x02\
+\x04\0\x05error\x03\0\x02\x02\x03\x02\x01\x03\x04\0\x07context\x03\0\x04\x01i\x05\
+\x01i\x01\x01j\0\x01\x03\x01@\x02\x07context\x06\x07headers\x07\0\x08\x04\0\x12o\
+n-gateway-request\x01\x09\x04\x01\"component:grafbase/gateway-request\x05\x04\x02\
+\x03\0\0\x0eshared-context\x02\x03\0\0\x0fedge-definition\x02\x03\0\0\x0fnode-de\
+finition\x01B\x0e\x02\x03\x02\x01\x02\x04\0\x05error\x03\0\0\x02\x03\x02\x01\x05\
+\x04\0\x0eshared-context\x03\0\x02\x02\x03\x02\x01\x06\x04\0\x0fedge-definition\x03\
+\0\x04\x02\x03\x02\x01\x07\x04\0\x0fnode-definition\x03\0\x06\x01i\x03\x01j\0\x01\
+\x01\x01@\x04\x07context\x08\x0adefinition\x05\x09argumentss\x08metadatas\0\x09\x04\
+\0\x1cauthorize-edge-pre-execution\x01\x0a\x01@\x03\x07context\x08\x0adefinition\
+\x07\x08metadatas\0\x09\x04\0\x1cauthorize-node-pre-execution\x01\x0b\x04\x01\x20\
+component:grafbase/authorization\x05\x08\x04\x01\x18component:grafbase/hooks\x04\
+\0\x0b\x0b\x01\0\x05hooks\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit\
+-component\x070.208.1\x10wit-bindgen-rust\x060.25.0";
 
 #[inline(never)]
 #[doc(hidden)]

--- a/engine/crates/wasi-component-loader/examples/crates/authorization/src/lib.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/authorization/src/lib.rs
@@ -2,14 +2,14 @@
 mod bindings;
 
 use bindings::{
-    component::grafbase::types::{Context, EdgeDefinition, ErrorResponse, Headers, NodeDefinition, SharedContext},
+    component::grafbase::types::{Context, EdgeDefinition, Error, Headers, NodeDefinition, SharedContext},
     exports::component::grafbase::{authorization, gateway_request},
 };
 
 struct Component;
 
 impl gateway_request::Guest for Component {
-    fn on_gateway_request(context: Context, headers: Headers) -> Result<(), ErrorResponse> {
+    fn on_gateway_request(context: Context, headers: Headers) -> Result<(), Error> {
         if let Ok(Some(auth_header)) = headers.get("Authorization") {
             context.set("entitlement", &auth_header);
         }
@@ -24,11 +24,11 @@ impl authorization::Guest for Component {
         _: EdgeDefinition,
         arguments: String,
         _: String,
-    ) -> Result<(), ErrorResponse> {
+    ) -> Result<(), Error> {
         let auth_header = context.get("entitlement");
 
         if Some(arguments) != auth_header {
-            return Err(ErrorResponse {
+            return Err(Error {
                 message: String::from("not authorized"),
                 extensions: Vec::new(),
             });
@@ -37,15 +37,11 @@ impl authorization::Guest for Component {
         Ok(())
     }
 
-    fn authorize_node_pre_execution(
-        context: SharedContext,
-        _: NodeDefinition,
-        metadata: String,
-    ) -> Result<(), ErrorResponse> {
+    fn authorize_node_pre_execution(context: SharedContext, _: NodeDefinition, metadata: String) -> Result<(), Error> {
         let auth_header = context.get("entitlement");
 
         if Some(metadata) != auth_header {
-            return Err(ErrorResponse {
+            return Err(Error {
                 message: String::from("not authorized"),
                 extensions: Vec::new(),
             });

--- a/engine/crates/wasi-component-loader/examples/crates/authorization/wit/world.wit
+++ b/engine/crates/wasi-component-loader/examples/crates/authorization/wit/world.wit
@@ -31,33 +31,33 @@ interface types {
         type-name: string,
     }
 
-    record error-response {
+    record error {
         extensions: list<tuple<string, string>>,
         message: string,
     }
 }
 
 interface gateway-request {
-    use types.{headers, error-response, context};
+    use types.{headers, error, context};
 
-    on-gateway-request: func(context: context, headers: headers) -> result<_, error-response>;
+    on-gateway-request: func(context: context, headers: headers) -> result<_, error>;
 }
 
 interface authorization {
-    use types.{error-response, shared-context, edge-definition, node-definition};
+    use types.{error, shared-context, edge-definition, node-definition};
 
     authorize-edge-pre-execution: func(
         context: shared-context,
         definition: edge-definition,
         arguments: string,
         metadata: string
-    ) -> result<_, error-response>;
+    ) -> result<_, error>;
 
     authorize-node-pre-execution: func(
         context: shared-context,
         definition: node-definition,
         metadata: string
-    ) -> result<_, error-response>;
+    ) -> result<_, error>;
 }
  
 world hooks {

--- a/engine/crates/wasi-component-loader/examples/crates/dir_access/src/bindings.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/dir_access/src/bindings.rs
@@ -197,24 +197,24 @@ pub mod component {
             }
 
             #[derive(Clone)]
-            pub struct ErrorResponse {
+            pub struct Error {
                 pub extensions: _rt::Vec<(_rt::String, _rt::String)>,
                 pub message: _rt::String,
             }
-            impl ::core::fmt::Debug for ErrorResponse {
+            impl ::core::fmt::Debug for Error {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                    f.debug_struct("ErrorResponse")
+                    f.debug_struct("Error")
                         .field("extensions", &self.extensions)
                         .field("message", &self.message)
                         .finish()
                 }
             }
-            impl ::core::fmt::Display for ErrorResponse {
+            impl ::core::fmt::Display for Error {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                     write!(f, "{:?}", self)
                 }
             }
-            impl std::error::Error for ErrorResponse {}
+            impl std::error::Error for Error {}
             impl Context {
                 #[allow(unused_unsafe, clippy::all)]
                 pub fn get(&self, name: &str) -> Option<_rt::String> {
@@ -556,7 +556,7 @@ pub mod exports {
                 static __FORCE_SECTION_REF: fn() = super::super::super::super::__link_custom_section_describing_imports;
                 use super::super::super::super::_rt;
                 pub type Headers = super::super::super::super::component::grafbase::types::Headers;
-                pub type ErrorResponse = super::super::super::super::component::grafbase::types::ErrorResponse;
+                pub type Error = super::super::super::super::component::grafbase::types::Error;
                 pub type Context = super::super::super::super::component::grafbase::types::Context;
                 #[doc(hidden)]
                 #[allow(non_snake_case)]
@@ -574,7 +574,7 @@ pub mod exports {
                         }
                         Err(e) => {
                             *ptr1.add(0).cast::<u8>() = (1i32) as u8;
-                            let super::super::super::super::component::grafbase::types::ErrorResponse {
+                            let super::super::super::super::component::grafbase::types::Error {
                                 extensions: extensions2,
                                 message: message2,
                             } = e;
@@ -652,7 +652,7 @@ pub mod exports {
                     }
                 }
                 pub trait Guest {
-                    fn on_gateway_request(context: Context, headers: Headers) -> Result<(), ErrorResponse>;
+                    fn on_gateway_request(context: Context, headers: Headers) -> Result<(), Error>;
                 }
                 #[doc(hidden)]
 
@@ -835,28 +835,28 @@ pub(crate) use __export_hooks_impl as export;
 #[cfg(target_arch = "wasm32")]
 #[link_section = "component-type:wit-bindgen:0.25.0:hooks:encoded world"]
 #[doc(hidden)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 943] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xb3\x06\x01A\x02\x01\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 916] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\x98\x06\x01A\x02\x01\
 A\x07\x01B\x1f\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
 header-error\x03\0\0\x04\0\x07context\x03\x01\x04\0\x0eshared-context\x03\x01\x04\
 \0\x07headers\x03\x01\x01r\x02\x10parent-type-names\x0afield-names\x04\0\x0fedge\
 -definition\x03\0\x05\x01r\x01\x09type-names\x04\0\x0fnode-definition\x03\0\x07\x01\
-o\x02ss\x01p\x09\x01r\x02\x0aextensions\x0a\x07messages\x04\0\x0eerror-response\x03\
-\0\x0b\x01h\x02\x01ks\x01@\x02\x04self\x0d\x04names\0\x0e\x04\0\x13[method]conte\
-xt.get\x01\x0f\x01@\x03\x04self\x0d\x04names\x05values\x01\0\x04\0\x13[method]co\
-ntext.set\x01\x10\x04\0\x16[method]context.delete\x01\x0f\x01h\x03\x01@\x02\x04s\
-elf\x11\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01j\
-\x01\x0e\x01\x01\x01@\x02\x04self\x13\x04names\0\x14\x04\0\x13[method]headers.ge\
-t\x01\x15\x01j\0\x01\x01\x01@\x03\x04self\x13\x04names\x05values\0\x16\x04\0\x13\
-[method]headers.set\x01\x17\x04\0\x16[method]headers.delete\x01\x15\x03\x01\x18c\
-omponent:grafbase/types\x05\0\x02\x03\0\0\x07headers\x02\x03\0\0\x0eerror-respon\
-se\x02\x03\0\0\x07context\x01B\x0b\x02\x03\x02\x01\x01\x04\0\x07headers\x03\0\0\x02\
-\x03\x02\x01\x02\x04\0\x0eerror-response\x03\0\x02\x02\x03\x02\x01\x03\x04\0\x07\
-context\x03\0\x04\x01i\x05\x01i\x01\x01j\0\x01\x03\x01@\x02\x07context\x06\x07he\
-aders\x07\0\x08\x04\0\x12on-gateway-request\x01\x09\x04\x01\"component:grafbase/\
-gateway-request\x05\x04\x04\x01\x18component:grafbase/hooks\x04\0\x0b\x0b\x01\0\x05\
-hooks\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\x070.208.\
-1\x10wit-bindgen-rust\x060.25.0";
+o\x02ss\x01p\x09\x01r\x02\x0aextensions\x0a\x07messages\x04\0\x05error\x03\0\x0b\
+\x01h\x02\x01ks\x01@\x02\x04self\x0d\x04names\0\x0e\x04\0\x13[method]context.get\
+\x01\x0f\x01@\x03\x04self\x0d\x04names\x05values\x01\0\x04\0\x13[method]context.\
+set\x01\x10\x04\0\x16[method]context.delete\x01\x0f\x01h\x03\x01@\x02\x04self\x11\
+\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01j\x01\x0e\
+\x01\x01\x01@\x02\x04self\x13\x04names\0\x14\x04\0\x13[method]headers.get\x01\x15\
+\x01j\0\x01\x01\x01@\x03\x04self\x13\x04names\x05values\0\x16\x04\0\x13[method]h\
+eaders.set\x01\x17\x04\0\x16[method]headers.delete\x01\x15\x03\x01\x18component:\
+grafbase/types\x05\0\x02\x03\0\0\x07headers\x02\x03\0\0\x05error\x02\x03\0\0\x07\
+context\x01B\x0b\x02\x03\x02\x01\x01\x04\0\x07headers\x03\0\0\x02\x03\x02\x01\x02\
+\x04\0\x05error\x03\0\x02\x02\x03\x02\x01\x03\x04\0\x07context\x03\0\x04\x01i\x05\
+\x01i\x01\x01j\0\x01\x03\x01@\x02\x07context\x06\x07headers\x07\0\x08\x04\0\x12o\
+n-gateway-request\x01\x09\x04\x01\"component:grafbase/gateway-request\x05\x04\x04\
+\x01\x18component:grafbase/hooks\x04\0\x0b\x0b\x01\0\x05hooks\x03\0\0\0G\x09prod\
+ucers\x01\x0cprocessed-by\x02\x0dwit-component\x070.208.1\x10wit-bindgen-rust\x06\
+0.25.0";
 
 #[inline(never)]
 #[doc(hidden)]

--- a/engine/crates/wasi-component-loader/examples/crates/dir_access/src/lib.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/dir_access/src/lib.rs
@@ -2,14 +2,14 @@
 mod bindings;
 
 use bindings::{
-    component::grafbase::types::{Context, ErrorResponse, Headers},
+    component::grafbase::types::{Context, Error, Headers},
     exports::component::grafbase::gateway_request,
 };
 
 struct Component;
 
 impl gateway_request::Guest for Component {
-    fn on_gateway_request(_: Context, headers: Headers) -> Result<(), ErrorResponse> {
+    fn on_gateway_request(_: Context, headers: Headers) -> Result<(), Error> {
         match std::fs::read_to_string("./contents.txt") {
             Ok(contents) => headers.set("READ_CONTENTS", &contents).unwrap(),
             Err(e) => eprintln!("error reading file contents: {}", e.to_string()),

--- a/engine/crates/wasi-component-loader/examples/crates/error/src/bindings.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/error/src/bindings.rs
@@ -197,24 +197,24 @@ pub mod component {
             }
 
             #[derive(Clone)]
-            pub struct ErrorResponse {
+            pub struct Error {
                 pub extensions: _rt::Vec<(_rt::String, _rt::String)>,
                 pub message: _rt::String,
             }
-            impl ::core::fmt::Debug for ErrorResponse {
+            impl ::core::fmt::Debug for Error {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                    f.debug_struct("ErrorResponse")
+                    f.debug_struct("Error")
                         .field("extensions", &self.extensions)
                         .field("message", &self.message)
                         .finish()
                 }
             }
-            impl ::core::fmt::Display for ErrorResponse {
+            impl ::core::fmt::Display for Error {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                     write!(f, "{:?}", self)
                 }
             }
-            impl std::error::Error for ErrorResponse {}
+            impl std::error::Error for Error {}
             impl Context {
                 #[allow(unused_unsafe, clippy::all)]
                 pub fn get(&self, name: &str) -> Option<_rt::String> {
@@ -556,7 +556,7 @@ pub mod exports {
                 static __FORCE_SECTION_REF: fn() = super::super::super::super::__link_custom_section_describing_imports;
                 use super::super::super::super::_rt;
                 pub type Headers = super::super::super::super::component::grafbase::types::Headers;
-                pub type ErrorResponse = super::super::super::super::component::grafbase::types::ErrorResponse;
+                pub type Error = super::super::super::super::component::grafbase::types::Error;
                 pub type Context = super::super::super::super::component::grafbase::types::Context;
                 #[doc(hidden)]
                 #[allow(non_snake_case)]
@@ -574,7 +574,7 @@ pub mod exports {
                         }
                         Err(e) => {
                             *ptr1.add(0).cast::<u8>() = (1i32) as u8;
-                            let super::super::super::super::component::grafbase::types::ErrorResponse {
+                            let super::super::super::super::component::grafbase::types::Error {
                                 extensions: extensions2,
                                 message: message2,
                             } = e;
@@ -652,7 +652,7 @@ pub mod exports {
                     }
                 }
                 pub trait Guest {
-                    fn on_gateway_request(context: Context, headers: Headers) -> Result<(), ErrorResponse>;
+                    fn on_gateway_request(context: Context, headers: Headers) -> Result<(), Error>;
                 }
                 #[doc(hidden)]
 
@@ -835,28 +835,28 @@ pub(crate) use __export_hooks_impl as export;
 #[cfg(target_arch = "wasm32")]
 #[link_section = "component-type:wit-bindgen:0.25.0:hooks:encoded world"]
 #[doc(hidden)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 943] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xb3\x06\x01A\x02\x01\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 916] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\x98\x06\x01A\x02\x01\
 A\x07\x01B\x1f\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
 header-error\x03\0\0\x04\0\x07context\x03\x01\x04\0\x0eshared-context\x03\x01\x04\
 \0\x07headers\x03\x01\x01r\x02\x10parent-type-names\x0afield-names\x04\0\x0fedge\
 -definition\x03\0\x05\x01r\x01\x09type-names\x04\0\x0fnode-definition\x03\0\x07\x01\
-o\x02ss\x01p\x09\x01r\x02\x0aextensions\x0a\x07messages\x04\0\x0eerror-response\x03\
-\0\x0b\x01h\x02\x01ks\x01@\x02\x04self\x0d\x04names\0\x0e\x04\0\x13[method]conte\
-xt.get\x01\x0f\x01@\x03\x04self\x0d\x04names\x05values\x01\0\x04\0\x13[method]co\
-ntext.set\x01\x10\x04\0\x16[method]context.delete\x01\x0f\x01h\x03\x01@\x02\x04s\
-elf\x11\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01j\
-\x01\x0e\x01\x01\x01@\x02\x04self\x13\x04names\0\x14\x04\0\x13[method]headers.ge\
-t\x01\x15\x01j\0\x01\x01\x01@\x03\x04self\x13\x04names\x05values\0\x16\x04\0\x13\
-[method]headers.set\x01\x17\x04\0\x16[method]headers.delete\x01\x15\x03\x01\x18c\
-omponent:grafbase/types\x05\0\x02\x03\0\0\x07headers\x02\x03\0\0\x0eerror-respon\
-se\x02\x03\0\0\x07context\x01B\x0b\x02\x03\x02\x01\x01\x04\0\x07headers\x03\0\0\x02\
-\x03\x02\x01\x02\x04\0\x0eerror-response\x03\0\x02\x02\x03\x02\x01\x03\x04\0\x07\
-context\x03\0\x04\x01i\x05\x01i\x01\x01j\0\x01\x03\x01@\x02\x07context\x06\x07he\
-aders\x07\0\x08\x04\0\x12on-gateway-request\x01\x09\x04\x01\"component:grafbase/\
-gateway-request\x05\x04\x04\x01\x18component:grafbase/hooks\x04\0\x0b\x0b\x01\0\x05\
-hooks\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\x070.208.\
-1\x10wit-bindgen-rust\x060.25.0";
+o\x02ss\x01p\x09\x01r\x02\x0aextensions\x0a\x07messages\x04\0\x05error\x03\0\x0b\
+\x01h\x02\x01ks\x01@\x02\x04self\x0d\x04names\0\x0e\x04\0\x13[method]context.get\
+\x01\x0f\x01@\x03\x04self\x0d\x04names\x05values\x01\0\x04\0\x13[method]context.\
+set\x01\x10\x04\0\x16[method]context.delete\x01\x0f\x01h\x03\x01@\x02\x04self\x11\
+\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01j\x01\x0e\
+\x01\x01\x01@\x02\x04self\x13\x04names\0\x14\x04\0\x13[method]headers.get\x01\x15\
+\x01j\0\x01\x01\x01@\x03\x04self\x13\x04names\x05values\0\x16\x04\0\x13[method]h\
+eaders.set\x01\x17\x04\0\x16[method]headers.delete\x01\x15\x03\x01\x18component:\
+grafbase/types\x05\0\x02\x03\0\0\x07headers\x02\x03\0\0\x05error\x02\x03\0\0\x07\
+context\x01B\x0b\x02\x03\x02\x01\x01\x04\0\x07headers\x03\0\0\x02\x03\x02\x01\x02\
+\x04\0\x05error\x03\0\x02\x02\x03\x02\x01\x03\x04\0\x07context\x03\0\x04\x01i\x05\
+\x01i\x01\x01j\0\x01\x03\x01@\x02\x07context\x06\x07headers\x07\0\x08\x04\0\x12o\
+n-gateway-request\x01\x09\x04\x01\"component:grafbase/gateway-request\x05\x04\x04\
+\x01\x18component:grafbase/hooks\x04\0\x0b\x0b\x01\0\x05hooks\x03\0\0\0G\x09prod\
+ucers\x01\x0cprocessed-by\x02\x0dwit-component\x070.208.1\x10wit-bindgen-rust\x06\
+0.25.0";
 
 #[inline(never)]
 #[doc(hidden)]

--- a/engine/crates/wasi-component-loader/examples/crates/error/src/lib.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/error/src/lib.rs
@@ -2,15 +2,15 @@
 mod bindings;
 
 use bindings::{
-    component::grafbase::types::{Context, ErrorResponse, Headers},
+    component::grafbase::types::{Context, Error, Headers},
     exports::component::grafbase::gateway_request,
 };
 
 struct Component;
 
 impl gateway_request::Guest for Component {
-    fn on_gateway_request(_: Context, _: Headers) -> Result<(), ErrorResponse> {
-        Err(ErrorResponse {
+    fn on_gateway_request(_: Context, _: Headers) -> Result<(), Error> {
+        Err(Error {
             message: String::from("not found"),
             extensions: vec![(String::from("my"), String::from("extension"))],
         })

--- a/engine/crates/wasi-component-loader/examples/crates/missing_hook/src/bindings.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/missing_hook/src/bindings.rs
@@ -221,24 +221,24 @@ pub mod component {
                 }
             }
             #[derive(Clone)]
-            pub struct ErrorResponse {
+            pub struct Error {
                 pub message: _rt::String,
                 pub extensions: _rt::Vec<(_rt::String, _rt::String)>,
             }
-            impl ::core::fmt::Debug for ErrorResponse {
+            impl ::core::fmt::Debug for Error {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                    f.debug_struct("ErrorResponse")
+                    f.debug_struct("Error")
                         .field("message", &self.message)
                         .field("extensions", &self.extensions)
                         .finish()
                 }
             }
-            impl ::core::fmt::Display for ErrorResponse {
+            impl ::core::fmt::Display for Error {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                     write!(f, "{:?}", self)
                 }
             }
-            impl std::error::Error for ErrorResponse {}
+            impl std::error::Error for Error {}
             impl Context {
                 #[allow(unused_unsafe, clippy::all)]
                 pub fn get(&self, name: &str) -> Option<_rt::String> {
@@ -579,7 +579,7 @@ pub mod exports {
                 #[cfg(target_arch = "wasm32")]
                 static __FORCE_SECTION_REF: fn() = super::super::super::super::__link_custom_section_describing_imports;
                 use super::super::super::super::_rt;
-                pub type ErrorResponse = super::super::super::super::component::grafbase::types::ErrorResponse;
+                pub type Error = super::super::super::super::component::grafbase::types::Error;
                 pub type SharedContext = super::super::super::super::component::grafbase::types::SharedContext;
                 pub type EdgeDefinition = super::super::super::super::component::grafbase::types::EdgeDefinition;
                 pub type NodeDefinition = super::super::super::super::component::grafbase::types::NodeDefinition;
@@ -622,7 +622,7 @@ pub mod exports {
                         }
                         Err(e) => {
                             *ptr5.add(0).cast::<u8>() = (1i32) as u8;
-                            let super::super::super::super::component::grafbase::types::ErrorResponse {
+                            let super::super::super::super::component::grafbase::types::Error {
                                 message: message6,
                                 extensions: extensions6,
                             } = e;
@@ -728,7 +728,7 @@ pub mod exports {
                         }
                         Err(e) => {
                             *ptr3.add(0).cast::<u8>() = (1i32) as u8;
-                            let super::super::super::super::component::grafbase::types::ErrorResponse {
+                            let super::super::super::super::component::grafbase::types::Error {
                                 message: message4,
                                 extensions: extensions4,
                             } = e;
@@ -811,12 +811,12 @@ pub mod exports {
                         definition: EdgeDefinition,
                         arguments: _rt::String,
                         metadata: _rt::String,
-                    ) -> Result<(), ErrorResponse>;
+                    ) -> Result<(), Error>;
                     fn authorize_node_pre_execution(
                         context: SharedContext,
                         definition: NodeDefinition,
                         metadata: _rt::String,
-                    ) -> Result<(), ErrorResponse>;
+                    ) -> Result<(), Error>;
                 }
                 #[doc(hidden)]
 
@@ -1007,31 +1007,31 @@ pub(crate) use __export_hooks_impl as export;
 #[cfg(target_arch = "wasm32")]
 #[link_section = "component-type:wit-bindgen:0.25.0:hooks:encoded world"]
 #[doc(hidden)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 1117] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xe1\x07\x01A\x02\x01\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 1090] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xc6\x07\x01A\x02\x01\
 A\x08\x01B\x1f\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
 header-error\x03\0\0\x04\0\x07context\x03\x01\x04\0\x0eshared-context\x03\x01\x04\
 \0\x07headers\x03\x01\x01r\x02\x10parent-type-names\x0afield-names\x04\0\x0fedge\
 -definition\x03\0\x05\x01r\x01\x09type-names\x04\0\x0fnode-definition\x03\0\x07\x01\
-o\x02ss\x01p\x09\x01r\x02\x07messages\x0aextensions\x0a\x04\0\x0eerror-response\x03\
-\0\x0b\x01h\x02\x01ks\x01@\x02\x04self\x0d\x04names\0\x0e\x04\0\x13[method]conte\
-xt.get\x01\x0f\x01@\x03\x04self\x0d\x04names\x05values\x01\0\x04\0\x13[method]co\
-ntext.set\x01\x10\x04\0\x16[method]context.delete\x01\x0f\x01h\x03\x01@\x02\x04s\
-elf\x11\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01j\
-\x01\x0e\x01\x01\x01@\x02\x04self\x13\x04names\0\x14\x04\0\x13[method]headers.ge\
-t\x01\x15\x01j\0\x01\x01\x01@\x03\x04self\x13\x04names\x05values\0\x16\x04\0\x13\
-[method]headers.set\x01\x17\x04\0\x16[method]headers.delete\x01\x15\x03\x01\x18c\
-omponent:grafbase/types\x05\0\x02\x03\0\0\x0eerror-response\x02\x03\0\0\x0eshare\
-d-context\x02\x03\0\0\x0fedge-definition\x02\x03\0\0\x0fnode-definition\x01B\x0e\
-\x02\x03\x02\x01\x01\x04\0\x0eerror-response\x03\0\0\x02\x03\x02\x01\x02\x04\0\x0e\
-shared-context\x03\0\x02\x02\x03\x02\x01\x03\x04\0\x0fedge-definition\x03\0\x04\x02\
-\x03\x02\x01\x04\x04\0\x0fnode-definition\x03\0\x06\x01i\x03\x01j\0\x01\x01\x01@\
-\x04\x07context\x08\x0adefinition\x05\x09argumentss\x08metadatas\0\x09\x04\0\x1c\
-authorize-edge-pre-execution\x01\x0a\x01@\x03\x07context\x08\x0adefinition\x07\x08\
-metadatas\0\x09\x04\0\x1cauthorize-node-pre-execution\x01\x0b\x04\x01\x20compone\
-nt:grafbase/authorization\x05\x05\x04\x01\x18component:grafbase/hooks\x04\0\x0b\x0b\
-\x01\0\x05hooks\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\
-\x070.208.1\x10wit-bindgen-rust\x060.25.0";
+o\x02ss\x01p\x09\x01r\x02\x07messages\x0aextensions\x0a\x04\0\x05error\x03\0\x0b\
+\x01h\x02\x01ks\x01@\x02\x04self\x0d\x04names\0\x0e\x04\0\x13[method]context.get\
+\x01\x0f\x01@\x03\x04self\x0d\x04names\x05values\x01\0\x04\0\x13[method]context.\
+set\x01\x10\x04\0\x16[method]context.delete\x01\x0f\x01h\x03\x01@\x02\x04self\x11\
+\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01j\x01\x0e\
+\x01\x01\x01@\x02\x04self\x13\x04names\0\x14\x04\0\x13[method]headers.get\x01\x15\
+\x01j\0\x01\x01\x01@\x03\x04self\x13\x04names\x05values\0\x16\x04\0\x13[method]h\
+eaders.set\x01\x17\x04\0\x16[method]headers.delete\x01\x15\x03\x01\x18component:\
+grafbase/types\x05\0\x02\x03\0\0\x05error\x02\x03\0\0\x0eshared-context\x02\x03\0\
+\0\x0fedge-definition\x02\x03\0\0\x0fnode-definition\x01B\x0e\x02\x03\x02\x01\x01\
+\x04\0\x05error\x03\0\0\x02\x03\x02\x01\x02\x04\0\x0eshared-context\x03\0\x02\x02\
+\x03\x02\x01\x03\x04\0\x0fedge-definition\x03\0\x04\x02\x03\x02\x01\x04\x04\0\x0f\
+node-definition\x03\0\x06\x01i\x03\x01j\0\x01\x01\x01@\x04\x07context\x08\x0adef\
+inition\x05\x09argumentss\x08metadatas\0\x09\x04\0\x1cauthorize-edge-pre-executi\
+on\x01\x0a\x01@\x03\x07context\x08\x0adefinition\x07\x08metadatas\0\x09\x04\0\x1c\
+authorize-node-pre-execution\x01\x0b\x04\x01\x20component:grafbase/authorization\
+\x05\x05\x04\x01\x18component:grafbase/hooks\x04\0\x0b\x0b\x01\0\x05hooks\x03\0\0\
+\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\x070.208.1\x10wit-bind\
+gen-rust\x060.25.0";
 
 #[inline(never)]
 #[doc(hidden)]

--- a/engine/crates/wasi-component-loader/examples/crates/missing_hook/src/lib.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/missing_hook/src/lib.rs
@@ -2,23 +2,18 @@
 mod bindings;
 
 use bindings::{
-    component::grafbase::types::{EdgeDefinition, ErrorResponse, NodeDefinition, SharedContext},
+    component::grafbase::types::{EdgeDefinition, Error, NodeDefinition, SharedContext},
     exports::component::grafbase::authorization,
 };
 
 struct Component;
 
 impl authorization::Guest for Component {
-    fn authorize_edge_pre_execution(
-        _: SharedContext,
-        _: EdgeDefinition,
-        _: String,
-        _: String,
-    ) -> Result<(), ErrorResponse> {
+    fn authorize_edge_pre_execution(_: SharedContext, _: EdgeDefinition, _: String, _: String) -> Result<(), Error> {
         Ok(())
     }
 
-    fn authorize_node_pre_execution(_: SharedContext, _: NodeDefinition, _: String) -> Result<(), ErrorResponse> {
+    fn authorize_node_pre_execution(_: SharedContext, _: NodeDefinition, _: String) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/engine/crates/wasi-component-loader/examples/crates/missing_hook/wit/world.wit
+++ b/engine/crates/wasi-component-loader/examples/crates/missing_hook/wit/world.wit
@@ -31,33 +31,33 @@ interface types {
         type-name: string,
     }
 
-    record error-response {
+    record error {
         message: string,
         extensions: list<tuple<string,string>>,
     }
 }
 
 interface gateway-request {
-    use types.{headers, error-response, context};
+    use types.{headers, error, context};
 
-    on-gateway-request: func(context: context, headers: headers) -> result<_, error-response>;
+    on-gateway-request: func(context: context, headers: headers) -> result<_, error>;
 }
 
 interface authorization {
-    use types.{error-response, shared-context, edge-definition, node-definition};
+    use types.{error, shared-context, edge-definition, node-definition};
 
     authorize-edge-pre-execution: func(
         context: shared-context,
         definition: edge-definition,
         arguments: string,
         metadata: string
-    ) -> result<_, error-response>;
+    ) -> result<_, error>;
 
     authorize-node-pre-execution: func(
         context: shared-context,
         definition: node-definition,
         metadata: string
-    ) -> result<_, error-response>;
+    ) -> result<_, error>;
 }
 
 world hooks {

--- a/engine/crates/wasi-component-loader/examples/crates/networking/src/bindings.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/networking/src/bindings.rs
@@ -197,24 +197,24 @@ pub mod component {
             }
 
             #[derive(Clone)]
-            pub struct ErrorResponse {
+            pub struct Error {
                 pub extensions: _rt::Vec<(_rt::String, _rt::String)>,
                 pub message: _rt::String,
             }
-            impl ::core::fmt::Debug for ErrorResponse {
+            impl ::core::fmt::Debug for Error {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                    f.debug_struct("ErrorResponse")
+                    f.debug_struct("Error")
                         .field("extensions", &self.extensions)
                         .field("message", &self.message)
                         .finish()
                 }
             }
-            impl ::core::fmt::Display for ErrorResponse {
+            impl ::core::fmt::Display for Error {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                     write!(f, "{:?}", self)
                 }
             }
-            impl std::error::Error for ErrorResponse {}
+            impl std::error::Error for Error {}
             impl Context {
                 #[allow(unused_unsafe, clippy::all)]
                 pub fn get(&self, name: &str) -> Option<_rt::String> {
@@ -556,7 +556,7 @@ pub mod exports {
                 static __FORCE_SECTION_REF: fn() = super::super::super::super::__link_custom_section_describing_imports;
                 use super::super::super::super::_rt;
                 pub type Headers = super::super::super::super::component::grafbase::types::Headers;
-                pub type ErrorResponse = super::super::super::super::component::grafbase::types::ErrorResponse;
+                pub type Error = super::super::super::super::component::grafbase::types::Error;
                 pub type Context = super::super::super::super::component::grafbase::types::Context;
                 #[doc(hidden)]
                 #[allow(non_snake_case)]
@@ -574,7 +574,7 @@ pub mod exports {
                         }
                         Err(e) => {
                             *ptr1.add(0).cast::<u8>() = (1i32) as u8;
-                            let super::super::super::super::component::grafbase::types::ErrorResponse {
+                            let super::super::super::super::component::grafbase::types::Error {
                                 extensions: extensions2,
                                 message: message2,
                             } = e;
@@ -652,7 +652,7 @@ pub mod exports {
                     }
                 }
                 pub trait Guest {
-                    fn on_gateway_request(context: Context, headers: Headers) -> Result<(), ErrorResponse>;
+                    fn on_gateway_request(context: Context, headers: Headers) -> Result<(), Error>;
                 }
                 #[doc(hidden)]
 
@@ -835,28 +835,28 @@ pub(crate) use __export_hooks_impl as export;
 #[cfg(target_arch = "wasm32")]
 #[link_section = "component-type:wit-bindgen:0.25.0:hooks:encoded world"]
 #[doc(hidden)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 943] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xb3\x06\x01A\x02\x01\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 916] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\x98\x06\x01A\x02\x01\
 A\x07\x01B\x1f\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
 header-error\x03\0\0\x04\0\x07context\x03\x01\x04\0\x0eshared-context\x03\x01\x04\
 \0\x07headers\x03\x01\x01r\x02\x10parent-type-names\x0afield-names\x04\0\x0fedge\
 -definition\x03\0\x05\x01r\x01\x09type-names\x04\0\x0fnode-definition\x03\0\x07\x01\
-o\x02ss\x01p\x09\x01r\x02\x0aextensions\x0a\x07messages\x04\0\x0eerror-response\x03\
-\0\x0b\x01h\x02\x01ks\x01@\x02\x04self\x0d\x04names\0\x0e\x04\0\x13[method]conte\
-xt.get\x01\x0f\x01@\x03\x04self\x0d\x04names\x05values\x01\0\x04\0\x13[method]co\
-ntext.set\x01\x10\x04\0\x16[method]context.delete\x01\x0f\x01h\x03\x01@\x02\x04s\
-elf\x11\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01j\
-\x01\x0e\x01\x01\x01@\x02\x04self\x13\x04names\0\x14\x04\0\x13[method]headers.ge\
-t\x01\x15\x01j\0\x01\x01\x01@\x03\x04self\x13\x04names\x05values\0\x16\x04\0\x13\
-[method]headers.set\x01\x17\x04\0\x16[method]headers.delete\x01\x15\x03\x01\x18c\
-omponent:grafbase/types\x05\0\x02\x03\0\0\x07headers\x02\x03\0\0\x0eerror-respon\
-se\x02\x03\0\0\x07context\x01B\x0b\x02\x03\x02\x01\x01\x04\0\x07headers\x03\0\0\x02\
-\x03\x02\x01\x02\x04\0\x0eerror-response\x03\0\x02\x02\x03\x02\x01\x03\x04\0\x07\
-context\x03\0\x04\x01i\x05\x01i\x01\x01j\0\x01\x03\x01@\x02\x07context\x06\x07he\
-aders\x07\0\x08\x04\0\x12on-gateway-request\x01\x09\x04\x01\"component:grafbase/\
-gateway-request\x05\x04\x04\x01\x18component:grafbase/hooks\x04\0\x0b\x0b\x01\0\x05\
-hooks\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\x070.208.\
-1\x10wit-bindgen-rust\x060.25.0";
+o\x02ss\x01p\x09\x01r\x02\x0aextensions\x0a\x07messages\x04\0\x05error\x03\0\x0b\
+\x01h\x02\x01ks\x01@\x02\x04self\x0d\x04names\0\x0e\x04\0\x13[method]context.get\
+\x01\x0f\x01@\x03\x04self\x0d\x04names\x05values\x01\0\x04\0\x13[method]context.\
+set\x01\x10\x04\0\x16[method]context.delete\x01\x0f\x01h\x03\x01@\x02\x04self\x11\
+\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01j\x01\x0e\
+\x01\x01\x01@\x02\x04self\x13\x04names\0\x14\x04\0\x13[method]headers.get\x01\x15\
+\x01j\0\x01\x01\x01@\x03\x04self\x13\x04names\x05values\0\x16\x04\0\x13[method]h\
+eaders.set\x01\x17\x04\0\x16[method]headers.delete\x01\x15\x03\x01\x18component:\
+grafbase/types\x05\0\x02\x03\0\0\x07headers\x02\x03\0\0\x05error\x02\x03\0\0\x07\
+context\x01B\x0b\x02\x03\x02\x01\x01\x04\0\x07headers\x03\0\0\x02\x03\x02\x01\x02\
+\x04\0\x05error\x03\0\x02\x02\x03\x02\x01\x03\x04\0\x07context\x03\0\x04\x01i\x05\
+\x01i\x01\x01j\0\x01\x03\x01@\x02\x07context\x06\x07headers\x07\0\x08\x04\0\x12o\
+n-gateway-request\x01\x09\x04\x01\"component:grafbase/gateway-request\x05\x04\x04\
+\x01\x18component:grafbase/hooks\x04\0\x0b\x0b\x01\0\x05hooks\x03\0\0\0G\x09prod\
+ucers\x01\x0cprocessed-by\x02\x0dwit-component\x070.208.1\x10wit-bindgen-rust\x06\
+0.25.0";
 
 #[inline(never)]
 #[doc(hidden)]

--- a/engine/crates/wasi-component-loader/examples/crates/networking/src/lib.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/networking/src/lib.rs
@@ -2,14 +2,14 @@
 mod bindings;
 
 use bindings::{
-    component::grafbase::types::{Context, ErrorResponse, Headers},
+    component::grafbase::types::{Context, Error, Headers},
     exports::component::grafbase::gateway_request,
 };
 
 struct Component;
 
 impl gateway_request::Guest for Component {
-    fn on_gateway_request(context: Context, _: Headers) -> Result<(), ErrorResponse> {
+    fn on_gateway_request(context: Context, _: Headers) -> Result<(), Error> {
         let address = std::env::var("MOCK_SERVER_ADDRESS").unwrap();
         let response = waki::Client::new().get(&address).send().unwrap().body().unwrap();
         let body = String::from_utf8(response).unwrap();

--- a/engine/crates/wasi-component-loader/examples/crates/simple/src/bindings.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/simple/src/bindings.rs
@@ -197,24 +197,24 @@ pub mod component {
             }
 
             #[derive(Clone)]
-            pub struct ErrorResponse {
+            pub struct Error {
                 pub extensions: _rt::Vec<(_rt::String, _rt::String)>,
                 pub message: _rt::String,
             }
-            impl ::core::fmt::Debug for ErrorResponse {
+            impl ::core::fmt::Debug for Error {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                    f.debug_struct("ErrorResponse")
+                    f.debug_struct("Error")
                         .field("extensions", &self.extensions)
                         .field("message", &self.message)
                         .finish()
                 }
             }
-            impl ::core::fmt::Display for ErrorResponse {
+            impl ::core::fmt::Display for Error {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                     write!(f, "{:?}", self)
                 }
             }
-            impl std::error::Error for ErrorResponse {}
+            impl std::error::Error for Error {}
             impl Context {
                 #[allow(unused_unsafe, clippy::all)]
                 pub fn get(&self, name: &str) -> Option<_rt::String> {
@@ -556,7 +556,7 @@ pub mod exports {
                 static __FORCE_SECTION_REF: fn() = super::super::super::super::__link_custom_section_describing_imports;
                 use super::super::super::super::_rt;
                 pub type Headers = super::super::super::super::component::grafbase::types::Headers;
-                pub type ErrorResponse = super::super::super::super::component::grafbase::types::ErrorResponse;
+                pub type Error = super::super::super::super::component::grafbase::types::Error;
                 pub type Context = super::super::super::super::component::grafbase::types::Context;
                 #[doc(hidden)]
                 #[allow(non_snake_case)]
@@ -574,7 +574,7 @@ pub mod exports {
                         }
                         Err(e) => {
                             *ptr1.add(0).cast::<u8>() = (1i32) as u8;
-                            let super::super::super::super::component::grafbase::types::ErrorResponse {
+                            let super::super::super::super::component::grafbase::types::Error {
                                 extensions: extensions2,
                                 message: message2,
                             } = e;
@@ -652,7 +652,7 @@ pub mod exports {
                     }
                 }
                 pub trait Guest {
-                    fn on_gateway_request(context: Context, headers: Headers) -> Result<(), ErrorResponse>;
+                    fn on_gateway_request(context: Context, headers: Headers) -> Result<(), Error>;
                 }
                 #[doc(hidden)]
 
@@ -835,28 +835,28 @@ pub(crate) use __export_hooks_impl as export;
 #[cfg(target_arch = "wasm32")]
 #[link_section = "component-type:wit-bindgen:0.25.0:hooks:encoded world"]
 #[doc(hidden)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 943] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xb3\x06\x01A\x02\x01\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 916] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\x98\x06\x01A\x02\x01\
 A\x07\x01B\x1f\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
 header-error\x03\0\0\x04\0\x07context\x03\x01\x04\0\x0eshared-context\x03\x01\x04\
 \0\x07headers\x03\x01\x01r\x02\x10parent-type-names\x0afield-names\x04\0\x0fedge\
 -definition\x03\0\x05\x01r\x01\x09type-names\x04\0\x0fnode-definition\x03\0\x07\x01\
-o\x02ss\x01p\x09\x01r\x02\x0aextensions\x0a\x07messages\x04\0\x0eerror-response\x03\
-\0\x0b\x01h\x02\x01ks\x01@\x02\x04self\x0d\x04names\0\x0e\x04\0\x13[method]conte\
-xt.get\x01\x0f\x01@\x03\x04self\x0d\x04names\x05values\x01\0\x04\0\x13[method]co\
-ntext.set\x01\x10\x04\0\x16[method]context.delete\x01\x0f\x01h\x03\x01@\x02\x04s\
-elf\x11\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01j\
-\x01\x0e\x01\x01\x01@\x02\x04self\x13\x04names\0\x14\x04\0\x13[method]headers.ge\
-t\x01\x15\x01j\0\x01\x01\x01@\x03\x04self\x13\x04names\x05values\0\x16\x04\0\x13\
-[method]headers.set\x01\x17\x04\0\x16[method]headers.delete\x01\x15\x03\x01\x18c\
-omponent:grafbase/types\x05\0\x02\x03\0\0\x07headers\x02\x03\0\0\x0eerror-respon\
-se\x02\x03\0\0\x07context\x01B\x0b\x02\x03\x02\x01\x01\x04\0\x07headers\x03\0\0\x02\
-\x03\x02\x01\x02\x04\0\x0eerror-response\x03\0\x02\x02\x03\x02\x01\x03\x04\0\x07\
-context\x03\0\x04\x01i\x05\x01i\x01\x01j\0\x01\x03\x01@\x02\x07context\x06\x07he\
-aders\x07\0\x08\x04\0\x12on-gateway-request\x01\x09\x04\x01\"component:grafbase/\
-gateway-request\x05\x04\x04\x01\x18component:grafbase/hooks\x04\0\x0b\x0b\x01\0\x05\
-hooks\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\x070.208.\
-1\x10wit-bindgen-rust\x060.25.0";
+o\x02ss\x01p\x09\x01r\x02\x0aextensions\x0a\x07messages\x04\0\x05error\x03\0\x0b\
+\x01h\x02\x01ks\x01@\x02\x04self\x0d\x04names\0\x0e\x04\0\x13[method]context.get\
+\x01\x0f\x01@\x03\x04self\x0d\x04names\x05values\x01\0\x04\0\x13[method]context.\
+set\x01\x10\x04\0\x16[method]context.delete\x01\x0f\x01h\x03\x01@\x02\x04self\x11\
+\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01j\x01\x0e\
+\x01\x01\x01@\x02\x04self\x13\x04names\0\x14\x04\0\x13[method]headers.get\x01\x15\
+\x01j\0\x01\x01\x01@\x03\x04self\x13\x04names\x05values\0\x16\x04\0\x13[method]h\
+eaders.set\x01\x17\x04\0\x16[method]headers.delete\x01\x15\x03\x01\x18component:\
+grafbase/types\x05\0\x02\x03\0\0\x07headers\x02\x03\0\0\x05error\x02\x03\0\0\x07\
+context\x01B\x0b\x02\x03\x02\x01\x01\x04\0\x07headers\x03\0\0\x02\x03\x02\x01\x02\
+\x04\0\x05error\x03\0\x02\x02\x03\x02\x01\x03\x04\0\x07context\x03\0\x04\x01i\x05\
+\x01i\x01\x01j\0\x01\x03\x01@\x02\x07context\x06\x07headers\x07\0\x08\x04\0\x12o\
+n-gateway-request\x01\x09\x04\x01\"component:grafbase/gateway-request\x05\x04\x04\
+\x01\x18component:grafbase/hooks\x04\0\x0b\x0b\x01\0\x05hooks\x03\0\0\0G\x09prod\
+ucers\x01\x0cprocessed-by\x02\x0dwit-component\x070.208.1\x10wit-bindgen-rust\x06\
+0.25.0";
 
 #[inline(never)]
 #[doc(hidden)]

--- a/engine/crates/wasi-component-loader/examples/crates/simple/src/lib.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/simple/src/lib.rs
@@ -2,14 +2,14 @@
 mod bindings;
 
 use bindings::{
-    component::grafbase::types::{Context, ErrorResponse, Headers},
+    component::grafbase::types::{Context, Error, Headers},
     exports::component::grafbase::gateway_request,
 };
 
 struct Component;
 
 impl gateway_request::Guest for Component {
-    fn on_gateway_request(context: Context, headers: Headers) -> Result<(), ErrorResponse> {
+    fn on_gateway_request(context: Context, headers: Headers) -> Result<(), Error> {
         headers.set("direct", "call").unwrap();
 
         assert_eq!(Ok(Some("call".to_string())), headers.get("direct"));

--- a/engine/crates/wasi-component-loader/examples/wit/world.wit
+++ b/engine/crates/wasi-component-loader/examples/wit/world.wit
@@ -31,33 +31,33 @@ interface types {
         type-name: string,
     }
 
-    record error-response {
+    record error {
         extensions: list<tuple<string, string>>,
         message: string,
     }
 }
 
 interface gateway-request {
-    use types.{headers, error-response, context};
+    use types.{headers, error, context};
 
-    on-gateway-request: func(context: context, headers: headers) -> result<_, error-response>;
+    on-gateway-request: func(context: context, headers: headers) -> result<_, error>;
 }
 
 interface authorization {
-    use types.{error-response, shared-context, edge-definition, node-definition};
+    use types.{error, shared-context, edge-definition, node-definition};
 
     authorize-edge-pre-execution: func(
         context: shared-context,
         definition: edge-definition,
         arguments: string,
         metadata: string
-    ) -> result<_, error-response>;
+    ) -> result<_, error>;
 
     authorize-node-pre-execution: func(
         context: shared-context,
         definition: node-definition,
         metadata: string
-    ) -> result<_, error-response>;
+    ) -> result<_, error>;
 }
 
 world hooks {

--- a/engine/crates/wasi-component-loader/gateway-hooks.wit
+++ b/engine/crates/wasi-component-loader/gateway-hooks.wit
@@ -61,7 +61,7 @@ interface types {
     }
 
     // An error response can be used to inject an error to the GraphQL response.
-    record error-response {
+    record error {
         // Adds the given extensions to the response extensions. The first item in
         // the tuple is the extension key, and the second item is the extension value.
         // The extension value can be string-encoded JSON, which will be converted as
@@ -74,7 +74,7 @@ interface types {
 }
 
 interface gateway-request {
-    use types.{headers, error-response, context};
+    use types.{headers, error, context};
 
     // The hook is called in the federated gateway just before authentication. It can be used
     // to read and modify the request headers. The context object is provided in a mutable form,
@@ -82,11 +82,11 @@ interface gateway-request {
     //
     // If returning an error from the hook, the request processing is stopped and the given error
     // returned to the client.
-    on-gateway-request: func(context: context, headers: headers) -> result<_, error-response>;
+    on-gateway-request: func(context: context, headers: headers) -> result<_, error>;
 }
 
 interface authorization {
-    use types.{error-response, shared-context, edge-definition, node-definition};
+    use types.{error, shared-context, edge-definition, node-definition};
 
     // The hook is called in the request cycle if the schema defines an authorization directive on
     // an edge, providing the arguments of the edge selected in the directive, the definition of the esge
@@ -101,7 +101,7 @@ interface authorization {
         definition: edge-definition,
         arguments: string,
         metadata: string
-    ) -> result<_, error-response>;
+    ) -> result<_, error>;
 
     // The hook is called in the request cycle if the schema defines an authorization directive to
     // a node, providing the definition of the node and the metadata of the directive to the hook.
@@ -114,7 +114,7 @@ interface authorization {
         context: shared-context,
         definition: node-definition,
         metadata: string
-    ) -> result<_, error-response>;
+    ) -> result<_, error>;
 }
 
 // Export here all the hooks the guest wants to implement. If a hook interface is not exported in the world,

--- a/engine/crates/wasi-component-loader/src/error.rs
+++ b/engine/crates/wasi-component-loader/src/error.rs
@@ -1,6 +1,4 @@
-use core::fmt;
-
-use wasmtime::component::{ComponentType, Lift};
+pub mod guest;
 
 /// The error type from a WASI call
 #[derive(Debug, thiserror::Error)]
@@ -10,31 +8,15 @@ pub enum Error {
     Internal(#[from] anyhow::Error),
     /// User-thrown error of the WASI guest
     #[error("{0}")]
-    User(#[from] ErrorResponse),
+    User(#[from] guest::Error),
 }
 
 impl Error {
     /// Converts into user error response, if one.
-    pub fn into_user_error(self) -> Option<ErrorResponse> {
+    pub fn into_user_error(self) -> Option<guest::Error> {
         match self {
             Error::Internal(_) => None,
             Error::User(error) => Some(error),
         }
-    }
-}
-
-/// An error type available for the user to throw from the guest.
-#[derive(Clone, ComponentType, Lift, Debug, thiserror::Error, PartialEq)]
-#[component(record)]
-pub struct ErrorResponse {
-    /// Additional extensions added to the GraphQL response
-    pub extensions: Vec<(String, String)>,
-    /// The error message
-    pub message: String,
-}
-
-impl fmt::Display for ErrorResponse {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.message.fmt(f)
     }
 }

--- a/engine/crates/wasi-component-loader/src/error/guest.rs
+++ b/engine/crates/wasi-component-loader/src/error/guest.rs
@@ -1,0 +1,19 @@
+use core::fmt;
+
+use wasmtime::component::{ComponentType, Lift};
+
+/// An error type available for the user to throw from the guest.
+#[derive(Clone, ComponentType, Lift, Debug, thiserror::Error, PartialEq)]
+#[component(record)]
+pub struct Error {
+    /// Additional extensions added to the GraphQL response
+    pub extensions: Vec<(String, String)>,
+    /// The error message
+    pub message: String,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.message.fmt(f)
+    }
+}

--- a/engine/crates/wasi-component-loader/src/lib.rs
+++ b/engine/crates/wasi-component-loader/src/lib.rs
@@ -21,7 +21,7 @@ mod tests;
 
 pub use config::Config;
 pub use context::{ContextMap, SharedContextMap};
-pub use error::{Error, ErrorResponse};
+pub use error::{guest::Error as ErrorResponse, Error};
 pub use hooks::{
     authorization::{AuthorizationHookInstance, EdgeDefinition, NodeDefinition},
     gateway::GatewayHookInstance,

--- a/engine/crates/wasi-component-loader/src/tests.rs
+++ b/engine/crates/wasi-component-loader/src/tests.rs
@@ -266,16 +266,12 @@ async fn authorize_edge_pre_execution_error() {
         .await
         .unwrap_err();
 
-    let expected = expect![[r#"
-        User(
-            ErrorResponse {
-                extensions: [],
-                message: "not authorized",
-            },
-        )
-    "#]];
+    let expected = ErrorResponse {
+        message: String::from("not authorized"),
+        extensions: vec![],
+    };
 
-    expected.assert_debug_eq(&error);
+    assert_eq!(Some(expected), error.into_user_error());
 }
 
 #[tokio::test]
@@ -339,16 +335,12 @@ async fn authorize_node_pre_execution_error() {
         .await
         .unwrap_err();
 
-    let expected = expect![[r#"
-        User(
-            ErrorResponse {
-                extensions: [],
-                message: "not authorized",
-            },
-        )
-    "#]];
+    let expected = ErrorResponse {
+        message: String::from("not authorized"),
+        extensions: vec![],
+    };
 
-    expected.assert_debug_eq(&error);
+    assert_eq!(Some(expected), error.into_user_error());
 }
 
 #[tokio::test]


### PR DESCRIPTION
A small rename, the error-response type should be just error for the user-facing parts of the hooks.
