### PR TITLE
Add licenses used by wasmtime to allowed licenses

### DIFF
--- a/cli/about.toml
+++ b/cli/about.toml
@@ -1,5 +1,6 @@
 accepted = [
     "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
     "BSL-1.0",
@@ -9,6 +10,7 @@ accepted = [
     "MPL-2.0",
     "NOASSERTION",
     "OpenSSL",
+    "Unicode-3.0",
     "Unicode-DFS-2016",
     "Unlicense",
     "Zlib",


### PR DESCRIPTION
That currently is blocking the release on `cargo about` because they aren't in our allowlist (see https://github.com/grafbase/grafbase/actions/runs/9765727643).

Both permissive open source, so that shouldn't be a problem.