### PR TITLE
chore: bump gateway to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2791,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -3485,7 +3485,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.0] - 2024-07-03
+
+[CHANGELOG](changelog/0.4.0.md)
+
 ## [0.3.2] - 2024-06-19
 
 [CHANGELOG](changelog/0.3.2.md)

--- a/gateway/changelog/0.4.0.md
+++ b/gateway/changelog/0.4.0.md
@@ -1,0 +1,9 @@
+### Features
+
+- Custom hooks with WebAssembly components ([docs](https://grafbase.com/docs/self-hosted-gateway/hooks))
+- Support for `@authorized` directive ([docs](https://grafbase.com/docs/federation/federation-directives#authorized))
+- Automatically generate an operation name from the first query field in OTEL traces & metrics if none was provided
+
+### Bug Fixes
+
+- Proper error propagation of authenticated & requiresScopes (#1813)

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.3.2"
+version = "0.4.0"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.3.2"
+version = "0.4.0"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true


### PR DESCRIPTION
### Features

- Custom hooks with WebAssembly components ([docs](https://grafbase.com/docs/self-hosted-gateway/hooks))
- Support for `@authorized` directive ([docs](https://grafbase.com/docs/federation/federation-directives#authorized))
- Automatically generate an operation name from the first query field in OTEL traces & metrics if none was provided

### Bug Fixes

- Proper error propagation of authenticated & requiresScopes (#1813)