### PR TITLE
fix(gateway): Add two OSI licenses to gateway

### DIFF
--- a/gateway/about.toml
+++ b/gateway/about.toml
@@ -1,5 +1,6 @@
 accepted = [
     "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
     "BSL-1.0",
@@ -9,6 +10,7 @@ accepted = [
     "MPL-2.0",
     "NOASSERTION",
     "OpenSSL",
+    "Unicode-3.0",
     "Unicode-DFS-2016",
     "Unlicense",
     "Zlib",


### PR DESCRIPTION
We need this for the gateway too to make a successful release.
