### PR TITLE
chore: add supertype info to partial caching registry

### DIFF
--- a/engine/crates/engine/registry-for-cache/src/ids.rs
+++ b/engine/crates/engine/registry-for-cache/src/ids.rs
@@ -13,4 +13,6 @@ make_id!(InterfaceTypeId, InterfaceTypeRecord, interfaces, PartialCacheRegistry)
 
 make_id!(OtherTypeId, OtherTypeRecord, others, PartialCacheRegistry);
 
+make_id!(SubtypeTargetId, StringId, subtype_targets, PartialCacheRegistry);
+
 make_id!(StringId, str, strings, PartialCacheRegistry);

--- a/engine/crates/engine/registry-for-cache/src/ids.rs
+++ b/engine/crates/engine/registry-for-cache/src/ids.rs
@@ -13,6 +13,7 @@ make_id!(InterfaceTypeId, InterfaceTypeRecord, interfaces, PartialCacheRegistry)
 
 make_id!(OtherTypeId, OtherTypeRecord, others, PartialCacheRegistry);
 
-make_id!(SubtypeTargetId, StringId, subtype_targets, PartialCacheRegistry);
+make_id!(SupertypeId, StringId, supertypes, PartialCacheRegistry);
+impl_id_range!(SupertypeId);
 
 make_id!(StringId, str, strings, PartialCacheRegistry);

--- a/engine/crates/engine/registry-for-cache/src/lib.rs
+++ b/engine/crates/engine/registry-for-cache/src/lib.rs
@@ -3,9 +3,9 @@
 //! We don't use the full registry for this because it's large and caching
 //! needs to be fast.
 
-use std::{cmp::Ordering, fmt};
+use std::{cmp::Ordering, collections::BTreeMap, fmt};
 
-use ids::{MetaTypeId, StringId};
+use ids::{MetaTypeId, StringId, SubtypeTargetId};
 use indexmap::IndexSet;
 
 mod common;
@@ -41,6 +41,14 @@ pub struct PartialCacheRegistry {
     query_type: MetaTypeId,
     mutation_type: Option<MetaTypeId>,
     subscription_type: Option<MetaTypeId>,
+
+    /// HashMap from the name of a type to the interfaces that it implements
+    /// & unions it is a member of
+    #[serde(default)]
+    subtype_types: BTreeMap<StringId, IdRange<SubtypeTargetId>>,
+    #[serde(default)]
+    // TODO: Better names for these, these names are a load of shit
+    subtype_targets: Vec<StringId>,
 
     pub enable_caching: bool,
     #[serde(default)]
@@ -102,6 +110,8 @@ impl PartialCacheRegistry {
             query_type: MetaTypeId::new(0),
             mutation_type: Default::default(),
             subscription_type: Default::default(),
+            subtype_types: Default::default(),
+            subtype_targets: Default::default(),
             enable_caching: Default::default(),
             enable_partial_caching: false,
         }

--- a/engine/crates/engine/registry-for-cache/src/lib.rs
+++ b/engine/crates/engine/registry-for-cache/src/lib.rs
@@ -5,7 +5,7 @@
 
 use std::{cmp::Ordering, collections::BTreeMap, fmt};
 
-use ids::{MetaTypeId, StringId, SubtypeTargetId};
+use ids::{MetaTypeId, StringId, SupertypeId};
 use indexmap::IndexSet;
 
 mod common;
@@ -14,6 +14,7 @@ mod generated;
 
 mod extensions;
 pub mod ids;
+mod type_relations;
 pub mod writer;
 
 pub use self::{
@@ -42,13 +43,17 @@ pub struct PartialCacheRegistry {
     mutation_type: Option<MetaTypeId>,
     subscription_type: Option<MetaTypeId>,
 
-    /// HashMap from the name of a type to the interfaces that it implements
-    /// & unions it is a member of
+    /// Map from the name of a type to the interfaces that it
+    /// implements & unions it is a member of
     #[serde(default)]
-    subtype_types: BTreeMap<StringId, IdRange<SubtypeTargetId>>,
+    type_relations: BTreeMap<StringId, IdRange<SupertypeId>>,
+
+    /// The supertypes for type_relations.
+    ///
+    /// Each distinct IdRange<SupertypeId> within this vec should be sorted by
+    /// StringId, allowing for binary searches on those subslices
     #[serde(default)]
-    // TODO: Better names for these, these names are a load of shit
-    subtype_targets: Vec<StringId>,
+    supertypes: Vec<StringId>,
 
     pub enable_caching: bool,
     #[serde(default)]
@@ -110,8 +115,8 @@ impl PartialCacheRegistry {
             query_type: MetaTypeId::new(0),
             mutation_type: Default::default(),
             subscription_type: Default::default(),
-            subtype_types: Default::default(),
-            subtype_targets: Default::default(),
+            type_relations: Default::default(),
+            supertypes: Default::default(),
             enable_caching: Default::default(),
             enable_partial_caching: false,
         }

--- a/engine/crates/engine/registry-for-cache/src/lib.rs
+++ b/engine/crates/engine/registry-for-cache/src/lib.rs
@@ -45,13 +45,16 @@ pub struct PartialCacheRegistry {
 
     /// Map from the name of a type to the interfaces that it
     /// implements & unions it is a member of
-    #[serde(default)]
-    type_relations: BTreeMap<StringId, IdRange<SupertypeId>>,
-
-    /// The supertypes for type_relations.
     ///
-    /// Each distinct IdRange<SupertypeId> within this vec should be sorted by
+    /// The IdRange<SupertypeId> within supertypes should be sorted by
     /// StringId, allowing for binary searches on those subslices
+    #[serde(default)]
+    typename_to_supertypes: BTreeMap<StringId, IdRange<SupertypeId>>,
+
+    /// The names of supertypes
+    ///
+    /// Subslices of this that correspond to an IdRange in typename_to_supertypes
+    /// should be sorted by StringId
     #[serde(default)]
     supertypes: Vec<StringId>,
 
@@ -115,7 +118,7 @@ impl PartialCacheRegistry {
             query_type: MetaTypeId::new(0),
             mutation_type: Default::default(),
             subscription_type: Default::default(),
-            type_relations: Default::default(),
+            typename_to_supertypes: Default::default(),
             supertypes: Default::default(),
             enable_caching: Default::default(),
             enable_partial_caching: false,

--- a/engine/crates/engine/registry-for-cache/src/type_relations.rs
+++ b/engine/crates/engine/registry-for-cache/src/type_relations.rs
@@ -1,0 +1,63 @@
+use std::fmt;
+
+use registry_v2::IdRange;
+
+use crate::{
+    ids::{StringId, SupertypeId},
+    IdReader, Iter, ReadContext, RecordLookup, RegistryId,
+};
+
+impl super::PartialCacheRegistry {
+    pub fn supertypes<'a>(&'a self, typename: &str) -> Iter<'a, Supertype<'a>> {
+        Iter::new(self.supertype_range(typename), self)
+    }
+
+    pub fn is_supertype(&self, possible_supertype: &str, subtype: &str) -> bool {
+        let Some(possible_supertype_id) = self.strings.get_index_of(possible_supertype).map(StringId::new) else {
+            return false;
+        };
+        let supertype_range = self.supertype_range(subtype);
+
+        self.supertypes[supertype_range.start.to_index()..supertype_range.end.to_index()]
+            .binary_search(&possible_supertype_id)
+            .is_ok()
+    }
+
+    fn supertype_range(&self, typename: &str) -> IdRange<SupertypeId> {
+        self.strings
+            .get_index_of(typename)
+            .map(StringId::new)
+            .and_then(|string_id| self.type_relations.get(&string_id))
+            .copied()
+            .unwrap_or_default()
+    }
+}
+
+pub struct Supertype<'a>(pub(crate) ReadContext<'a, SupertypeId>);
+
+impl<'a> Supertype<'a> {
+    pub fn typename(&self) -> &'a str {
+        let registry = self.0.registry;
+        registry.lookup(*registry.lookup(self.0.id))
+    }
+}
+
+impl fmt::Debug for Supertype<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Supertype").field("typename", &self.typename()).finish()
+    }
+}
+
+impl RegistryId for SupertypeId {
+    type Reader<'a> = Supertype<'a>;
+}
+
+impl IdReader for Supertype<'_> {
+    type Id = SupertypeId;
+}
+
+impl<'a> From<ReadContext<'a, SupertypeId>> for Supertype<'a> {
+    fn from(value: ReadContext<'a, SupertypeId>) -> Self {
+        Self(value)
+    }
+}

--- a/engine/crates/engine/registry-for-cache/src/type_relations.rs
+++ b/engine/crates/engine/registry-for-cache/src/type_relations.rs
@@ -27,7 +27,7 @@ impl super::PartialCacheRegistry {
         self.strings
             .get_index_of(typename)
             .map(StringId::new)
-            .and_then(|string_id| self.type_relations.get(&string_id))
+            .and_then(|string_id| self.typename_to_supertypes.get(&string_id))
             .copied()
             .unwrap_or_default()
     }

--- a/engine/crates/engine/registry-for-cache/src/writer.rs
+++ b/engine/crates/engine/registry-for-cache/src/writer.rs
@@ -91,17 +91,17 @@ impl RegistryWriter {
         MetaTypeRecord::Other(id)
     }
 
-    pub fn insert_subtypes(&mut self, typename: String, subtypes: IdRange<SupertypeId>) {
+    pub fn insert_supertypes_for_type(&mut self, typename: String, subtypes: IdRange<SupertypeId>) {
         let typename = self.intern_string(typename);
         self.typename_to_supertypes.insert(typename, subtypes);
     }
 
     #[must_use]
-    pub fn insert_subtype_targets(&mut self, targets: Vec<String>) -> IdRange<SupertypeId> {
+    pub fn insert_supertypes(&mut self, supertype_names: Vec<String>) -> IdRange<SupertypeId> {
         let starting_index = self.supertypes.len();
 
-        self.supertypes.reserve(targets.len());
-        for target in targets {
+        self.supertypes.reserve(supertype_names.len());
+        for target in supertype_names {
             let id = self.intern_string(target);
             self.supertypes.push(id);
         }

--- a/engine/crates/engine/registry-upgrade/src/partial_cache_registry.rs
+++ b/engine/crates/engine/registry-upgrade/src/partial_cache_registry.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use indexmap::IndexMap;
 use registry_for_cache::{ids::*, storage::*, writer::RegistryWriter, IdRange};
@@ -12,7 +12,7 @@ pub fn convert_v1_to_partial_cache_registry(
     let registry_v1::Registry {
         types,
         directives: _,
-        implements: _,
+        mut implements,
         query_type,
         mutation_type,
         subscription_type,
@@ -44,6 +44,9 @@ pub fn convert_v1_to_partial_cache_registry(
         types.sort_by(|lhs, rhs| lhs.name().cmp(rhs.name()));
         types
     };
+
+    add_unions_to_implements(&types, &mut implements);
+    insert_subtype_info(&mut writer, implements);
 
     // Build a map of type name -> the ID it'll have when we insert it.
     let preallocated_ids = writer.preallocate_type_ids(types.len()).collect::<Vec<_>>();
@@ -243,6 +246,35 @@ fn wrappers_from_string(str: &str) -> Wrapping {
     }
 
     rv
+}
+
+fn insert_subtype_info(writer: &mut RegistryWriter, implements: HashMap<String, HashSet<String>>) {
+    let mut groups = HashMap::<Vec<String>, Vec<String>>::with_capacity(implements.len());
+    for (implementer, implemented) in implements {
+        let mut implemented = implemented.into_iter().collect::<Vec<_>>();
+        implemented.sort();
+        groups.entry(implemented).or_default().push(implementer)
+    }
+
+    for (targets, parents) in groups {
+        let target_ids = writer.insert_subtype_targets(targets);
+        for ty in parents {
+            writer.insert_subtypes(ty, target_ids)
+        }
+    }
+}
+
+/// Implements in the v1 registry doesn't contain any union membership details
+///
+/// This adds that in, ready for conversion to subtype info in the caching registry
+fn add_unions_to_implements(types: &[registry_v1::MetaType], implements: &mut HashMap<String, HashSet<String>>) {
+    for ty in types {
+        if let registry_v1::MetaType::Union(union) = ty {
+            for member in &union.possible_types {
+                implements.entry(member.clone()).or_default().insert(union.name.clone());
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/engine/crates/engine/registry-upgrade/src/partial_cache_registry.rs
+++ b/engine/crates/engine/registry-upgrade/src/partial_cache_registry.rs
@@ -46,7 +46,7 @@ pub fn convert_v1_to_partial_cache_registry(
     };
 
     add_unions_to_implements(&types, &mut implements);
-    insert_subtype_info(&mut writer, implements);
+    insert_supertype_info(&mut writer, implements);
 
     // Build a map of type name -> the ID it'll have when we insert it.
     let preallocated_ids = writer.preallocate_type_ids(types.len()).collect::<Vec<_>>();
@@ -248,7 +248,7 @@ fn wrappers_from_string(str: &str) -> Wrapping {
     rv
 }
 
-fn insert_subtype_info(writer: &mut RegistryWriter, implements: HashMap<String, HashSet<String>>) {
+fn insert_supertype_info(writer: &mut RegistryWriter, implements: HashMap<String, HashSet<String>>) {
     let mut groups = HashMap::<Vec<String>, Vec<String>>::with_capacity(implements.len());
     for (implementer, implemented) in implements {
         let mut implemented = implemented.into_iter().collect::<Vec<_>>();
@@ -256,10 +256,10 @@ fn insert_subtype_info(writer: &mut RegistryWriter, implements: HashMap<String, 
         groups.entry(implemented).or_default().push(implementer)
     }
 
-    for (targets, parents) in groups {
-        let target_ids = writer.insert_subtype_targets(targets);
-        for ty in parents {
-            writer.insert_subtypes(ty, target_ids)
+    for (supertypes, subtypes) in groups {
+        let target_ids = writer.insert_supertypes(supertypes);
+        for ty in subtypes {
+            writer.insert_supertypes_for_type(ty, target_ids)
         }
     }
 }

--- a/engine/crates/parser-sdl/src/rules/interface.rs
+++ b/engine/crates/parser-sdl/src/rules/interface.rs
@@ -25,13 +25,13 @@ impl<'a> Visitor<'a> for Interface {
         ctx: &mut VisitorContext<'a>,
         type_definition: &'a engine::Positioned<engine_parser::types::TypeDefinition>,
     ) {
-        let TypeKind::Interface(object) = &type_definition.node.kind else {
+        let TypeKind::Interface(interface) = &type_definition.node.kind else {
             return;
         };
 
         let type_name = type_definition.node.name.node.to_string();
 
-        let fields = object
+        let fields = interface
             .fields
             .iter()
             .map(|field| {
@@ -92,7 +92,7 @@ impl<'a> Visitor<'a> for Interface {
             .implements
             .entry(type_name)
             .or_default()
-            .extend(object.implements.iter().map(|name| name.to_string()));
+            .extend(interface.implements.iter().map(|name| name.to_string()));
     }
 }
 


### PR DESCRIPTION
Partial caching needs to know the relationships between types in order to handle type conditions correctly.  This is essential for us to support APIs that use unions or interfaces.

This PR is pretty simple: it just adds those details into the PartialCacheRegistry (which I have realised is named somewhat ambiguously - it's a partial registry for caching, not a registry for partial caching.  May need to fix that sometime).

I am very aware that this could bump up the size of the caching registry a bit, and therefore slow down cache responses.  I have tried to minimise that as much as possible though.  It's structured as a map of `StringId -> IdRange<SupertypeId>`, where `SupertypeId` is an index into a separate Vec.  Using this separate Vec allows us to deduplicate things a bit - if we have an interface like `Node` that has 1000s of subtypes we don't necessarily need to store `Node` 1000s of times.

Fixes GB-6942