### PR TITLE
fix: use timestamp for cache identifier if git hash is not available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,6 +914,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6a6c0b39c38fd754ac338b00a88066436389c0f029da5d37d1e01091d9b7c17"
 dependencies = [
+ "chrono",
  "git2",
 ]
 

--- a/engine/crates/engine-v2/schema/Cargo.toml
+++ b/engine/crates/engine-v2/schema/Cargo.toml
@@ -12,7 +12,7 @@ version = "3.0.31"
 build = "build.rs"
 
 [build-dependencies]
-built = {version = "0.7", features = ["git2"]}
+built = {version = "0.7", features = ["git2", "chrono"]}
 
 [dependencies]
 fnv = "1.0.7"

--- a/engine/crates/engine-v2/schema/src/lib.rs
+++ b/engine/crates/engine-v2/schema/src/lib.rs
@@ -30,10 +30,15 @@ mod built_info {
 }
 
 impl Schema {
-    pub fn commit_sha() -> &'static [u8] {
+    /// A unique identifier of this build of the engine to version cache keys.
+    /// If built in a git repository, the cache version is taken from the git commit id.
+    /// For builds outside of a git repository, the build time is used.
+    pub fn build_identifier() -> &'static [u8] {
         static SHA: OnceLock<Vec<u8>> = OnceLock::new();
-        SHA.get_or_init(|| {
-            hex::decode(built_info::GIT_COMMIT_HASH.expect("No git commit hash found")).expect("Expect hex format")
+
+        SHA.get_or_init(|| match built_info::GIT_COMMIT_HASH {
+            Some(hash) => hex::decode(hash).expect("Expect hex format"),
+            None => built_info::BUILT_TIME_UTC.as_bytes().to_vec(),
         })
     }
 }

--- a/engine/crates/engine-v2/schema/tests/conversion.rs
+++ b/engine/crates/engine-v2/schema/tests/conversion.rs
@@ -318,5 +318,5 @@ fn serde_roundtrip(#[case] sdl: &str) {
 
 #[test]
 fn non_empty_version() {
-    assert!(!Schema::commit_sha().is_empty());
+    assert!(!Schema::build_identifier().is_empty());
 }

--- a/engine/crates/engine-v2/src/engine/cache.rs
+++ b/engine/crates/engine-v2/src/engine/cache.rs
@@ -44,8 +44,8 @@ impl std::fmt::Display for Key<'_> {
                 document,
             } => {
                 let mut hasher = blake3::Hasher::new();
-                hasher.update(&Schema::commit_sha().len().to_ne_bytes());
-                hasher.update(Schema::commit_sha());
+                hasher.update(&Schema::build_identifier().len().to_ne_bytes());
+                hasher.update(Schema::build_identifier());
                 hasher.update(&schema_version.len().to_ne_bytes());
                 hasher.update(schema_version);
 

--- a/examples/gateway-hooks/flake.lock
+++ b/examples/gateway-hooks/flake.lock
@@ -121,16 +121,16 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1720006459,
-        "narHash": "sha256-p9qbziUiCpAr9+lSsKeKJsQWdlsv7MgtC9JDCn2DjHg=",
+        "lastModified": 1720107011,
+        "narHash": "sha256-5NSoOzDv0Cw2q+FzkuSR6paQQ8v/mFdMQ2I4rtOq03o=",
         "owner": "grafbase",
         "repo": "grafbase",
-        "rev": "35e169729577136aebfff07664797205cb7627d3",
+        "rev": "54a215bf2b9acfcb60ffa312411134436cf5c489",
         "type": "github"
       },
       "original": {
         "owner": "grafbase",
-        "ref": "gateway-0.4.0",
+        "ref": "gateway-0.4.1",
         "repo": "grafbase",
         "type": "github"
       }


### PR DESCRIPTION
The engine caches will panic if engine is not compiled from a git environment. E.g. if using nix, which does not want any git files in its build environment. This patch uses the build timestamp as an identifier if git hash is not available.
