### PR TITLE
fix: write typename to partial caches

### DIFF
--- a/engine/crates/partial-caching/src/execution/defer.rs
+++ b/engine/crates/partial-caching/src/execution/defer.rs
@@ -94,7 +94,7 @@ impl StreamingExecutionPhase {
 
         let return_value = store
             .reader(&self.shapes)
-            .map(|object| object.into_query_response())
+            .map(|object| object.into_query_response(false))
             .unwrap_or_default();
 
         self.output = Some(store);
@@ -158,7 +158,7 @@ impl StreamingExecutionPhase {
 
         output
             .read_object(&self.shapes, destination_object_id)
-            .into_query_response()
+            .into_query_response(false)
     }
 
     pub fn finish(mut self) -> Option<CacheUpdatePhase> {
@@ -175,7 +175,7 @@ impl StreamingExecutionPhase {
                         self.execution_phase.plan.document,
                         self.execution_phase.plan.cache_partitions,
                         self.keys_to_write,
-                        root.into_query_response(),
+                        root.into_query_response(true),
                     ));
                 }
             }


### PR DESCRIPTION
When partial caching encounters a type condition, it will add a `__typename` field into the query if one is not already present.  These `__typenames` are not written into the `OutputStore` as actual `__typename` fields, so don't currently get written to the cache.  But this means when we read from the cache we don't know which type that object is meant to be.

This commit fixes that by storing the typename in a new `typename` field on the `Object`.  We intern these to save on space, and only write them if the query doesn't have a user provided `__typename` on it.

Now that this is in place I've updated the associated tests to hit the cache and make sure that works.

Fixes GB-7037