### PR TITLE
chore(engine-v2): Early validation of parsed operation

### DIFF
--- a/engine/crates/engine-v2/src/operation/bind/validation.rs
+++ b/engine/crates/engine-v2/src/operation/bind/validation.rs
@@ -1,0 +1,130 @@
+use config::latest::OperationLimits;
+use engine::Positioned;
+
+use crate::operation::parse::ParsedOperation;
+
+use super::{BindError, BindResult};
+
+pub(super) fn validate_parsed_operation(operation: &ParsedOperation, limits: &OperationLimits) -> BindResult<()> {
+    Visitor {
+        operation,
+        current_fragments_stack: Vec::new(),
+        root_fields: 0,
+        max_root_fields: limits.root_fields.map(Into::into).unwrap_or(usize::MAX),
+        current_depth: 0,
+        max_depth: limits.depth.map(Into::into).unwrap_or(usize::MAX),
+        aliases_count: 0,
+        max_aliases_count: limits.aliases.map(Into::into).unwrap_or(usize::MAX),
+        complexity: 0,
+        max_complexity: limits.complexity.map(Into::into).unwrap_or(usize::MAX),
+    }
+    .visit_selection_set(&operation.definition.selection_set)
+}
+
+struct Visitor<'p> {
+    operation: &'p ParsedOperation,
+    current_fragments_stack: Vec<&'p str>,
+    root_fields: usize,
+    max_root_fields: usize,
+    current_depth: usize,
+    max_depth: usize,
+    aliases_count: usize,
+    max_aliases_count: usize,
+    complexity: usize,
+    max_complexity: usize,
+}
+
+impl<'p> Visitor<'p> {
+    fn visit_selection_set(
+        &mut self,
+        selection_set: &'p Positioned<engine_parser::types::SelectionSet>,
+    ) -> BindResult<()> {
+        for item in &selection_set.items {
+            match &item.node {
+                engine_parser::types::Selection::Field(field) => {
+                    self.root_fields += (self.current_depth == 0) as usize;
+                    if self.root_fields > self.max_root_fields {
+                        return Err(BindError::QueryContainsTooManyRootFields {
+                            count: self.root_fields,
+                            location: selection_set.pos.try_into()?,
+                        });
+                    }
+                    self.complexity += 1;
+                    if self.complexity > self.max_complexity {
+                        return Err(BindError::QueryTooComplex {
+                            complexity: self.complexity,
+                            location: selection_set.pos.try_into()?,
+                        });
+                    }
+                    self.visit_field(field)?;
+                }
+                engine_parser::types::Selection::FragmentSpread(fragment_spread) => {
+                    self.visit_fragment_spread(fragment_spread)?;
+                }
+                engine_parser::types::Selection::InlineFragment(inline_fragment) => {
+                    self.visit_inline_fragment(inline_fragment)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn visit_field(&mut self, field: &'p Positioned<engine_parser::types::Field>) -> BindResult<()> {
+        self.aliases_count += field.alias.is_some() as usize;
+        if self.aliases_count > self.max_aliases_count {
+            return Err(BindError::QueryContainsTooManyAliases {
+                count: self.aliases_count,
+                location: field.pos.try_into()?,
+            });
+        }
+        self.current_depth += 1;
+        if self.current_depth > self.max_depth {
+            return Err(BindError::QueryTooDeep {
+                depth: self.current_depth,
+                location: field.selection_set.pos.try_into()?,
+            });
+        }
+
+        self.visit_selection_set(&field.selection_set)?;
+        self.current_depth -= 1;
+
+        Ok(())
+    }
+
+    fn visit_fragment_spread(
+        &mut self,
+        fragment_spread: &'p Positioned<engine_parser::types::FragmentSpread>,
+    ) -> BindResult<()> {
+        let fragment_name = &fragment_spread.fragment_name.node;
+        if self.current_fragments_stack.contains(&fragment_name.as_str()) {
+            self.current_fragments_stack.push(fragment_name.as_str());
+            return Err(BindError::FragmentCycle {
+                cycle: std::mem::take(&mut self.current_fragments_stack)
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect(),
+                location: fragment_spread.pos.try_into()?,
+            });
+        }
+        let Some(fragment) = self.operation.fragments.get(fragment_name) else {
+            return Err(BindError::UnknownFragment {
+                name: fragment_name.to_string(),
+                location: fragment_spread.pos.try_into()?,
+            });
+        };
+
+        self.current_fragments_stack.push(fragment_name.as_str());
+        self.visit_selection_set(&fragment.selection_set)?;
+        self.current_fragments_stack.pop();
+
+        Ok(())
+    }
+
+    fn visit_inline_fragment(
+        &mut self,
+        inline_fragment: &'p Positioned<engine_parser::types::InlineFragment>,
+    ) -> BindResult<()> {
+        self.visit_selection_set(&inline_fragment.selection_set)
+    }
+}

--- a/engine/crates/engine-v2/src/operation/validation/operation_limits.rs
+++ b/engine/crates/engine-v2/src/operation/validation/operation_limits.rs
@@ -7,16 +7,8 @@ use crate::operation::{OperationWalker, SelectionSetWalker};
 #[allow(clippy::enum_variant_names)]
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum OperationLimitExceededError {
-    #[error("Query is too complex.")]
-    QueryTooComplex,
-    #[error("Query is nested too deep.")]
-    QueryTooDeep,
     #[error("Query is too high.")]
     QueryTooHigh,
-    #[error("Query contains too many root fields.")]
-    QueryContainsTooManyRootFields,
-    #[error("Query contains too many aliases.")]
-    QueryContainsTooManyAliases,
 }
 
 pub(super) fn enforce_operation_limits(
@@ -31,27 +23,7 @@ pub(super) fn enforce_operation_limits(
     let operation_limits = &schema.settings.operation_limits;
     let selection_set = operation.selection_set();
 
-    if let Some(depth_limit) = operation_limits.depth {
-        let max_depth = selection_set.max_depth();
-        if max_depth > depth_limit {
-            return Err(OperationLimitExceededError::QueryTooDeep);
-        }
-    }
-
-    if let Some(max_alias_count) = operation_limits.aliases {
-        let alias_count = selection_set.alias_count();
-        if alias_count > max_alias_count {
-            return Err(OperationLimitExceededError::QueryContainsTooManyAliases);
-        }
-    }
-
-    if let Some(max_root_field_count) = operation_limits.root_fields {
-        let root_field_count = selection_set.root_field_count();
-        if root_field_count > max_root_field_count {
-            return Err(OperationLimitExceededError::QueryContainsTooManyRootFields);
-        }
-    }
-
+    // All other limits are verified before the binding step.
     if let Some(max_height) = operation_limits.height {
         let height = selection_set.height(&mut Default::default());
         if height > max_height {
@@ -59,58 +31,10 @@ pub(super) fn enforce_operation_limits(
         }
     }
 
-    if let Some(max_complexity) = operation_limits.complexity {
-        let complexity = selection_set.complexity();
-        if complexity > max_complexity {
-            return Err(OperationLimitExceededError::QueryTooComplex);
-        }
-    }
-
     Ok(())
 }
 
 impl SelectionSetWalker<'_> {
-    fn max_depth(&self) -> u16 {
-        self.fields()
-            .map(|field| {
-                field
-                    .selection_set()
-                    .map(|selection_set| selection_set.max_depth())
-                    .unwrap_or_default()
-                    + 1
-            })
-            .max()
-            .expect("must be defined")
-    }
-
-    fn alias_count(&self) -> u16 {
-        self.fields()
-            .map(|field| {
-                field.alias().is_some() as u16
-                    + field
-                        .selection_set()
-                        .map(|selection_set| selection_set.alias_count())
-                        .unwrap_or_default()
-            })
-            .sum()
-    }
-
-    fn root_field_count(&self) -> u16 {
-        self.fields().count() as u16
-    }
-
-    fn complexity(&self) -> u16 {
-        self.fields()
-            .map(|field| {
-                field
-                    .selection_set()
-                    .map(|selection_set| selection_set.complexity())
-                    .unwrap_or_default()
-                    + 1
-            })
-            .sum()
-    }
-
     // `None` stored in the set means `__typename`.
     fn height(&self, fields_seen: &mut HashSet<Option<schema::FieldDefinitionId>>) -> u16 {
         self.fields()

--- a/engine/crates/engine-v2/src/operation/walkers/field.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/field.rs
@@ -36,10 +36,6 @@ impl<'a> FieldWalker<'a> {
         self.as_ref().location()
     }
 
-    pub fn alias(&self) -> Option<&'a str> {
-        Some(self.response_key_str()).filter(|key| key != &self.name())
-    }
-
     pub fn selection_set(&self) -> Option<SelectionSetWalker<'a>> {
         self.as_ref().selection_set_id().map(|id| self.walk_with(id, ()))
     }


### PR DESCRIPTION
In a further commit checking for fragment cycles is pretty hard, so
doing it just after parsing in a separate step now. I've also moved
all operation limits check that could be verified at this step (all but
height).