### PR TITLE
chore(engine-v2): Move "logical planning" to operation module.

### DIFF
--- a/engine/crates/engine-v2/src/lib.rs
+++ b/engine/crates/engine-v2/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(clippy::future_not_send)]
-#![allow(dead_code)]
 
 mod engine;
 mod execution;

--- a/engine/crates/engine-v2/src/operation/bind/mod.rs
+++ b/engine/crates/engine-v2/src/operation/bind/mod.rs
@@ -156,7 +156,7 @@ id_newtypes::index! {
     Binder<'s, 'p>.selection_sets[SelectionSetId] => SelectionSet,
 }
 
-pub fn bind(schema: &Schema, mut parsed_operation: ParsedOperation) -> BindResult<Operation> {
+pub fn bind_operation(schema: &Schema, mut parsed_operation: ParsedOperation) -> BindResult<Operation> {
     validate_parsed_operation(&parsed_operation, &schema.settings.operation_limits)?;
 
     let root_object_id = match parsed_operation.definition.ty {
@@ -220,8 +220,8 @@ pub fn bind(schema: &Schema, mut parsed_operation: ParsedOperation) -> BindResul
             cond.sort_unstable_by_key(|(_, id)| usize::from(*id));
             cond.into_iter().map(|(cond, _)| cond).collect()
         },
-        plans: Vec::new(),
-        field_to_plan_id: Vec::new(),
+        logical_plans: Vec::new(),
+        field_to_logical_plan_id: Vec::new(),
         plan_edges: Vec::new(),
         solved_requirements: Vec::new(),
     })

--- a/engine/crates/engine-v2/src/operation/ids.rs
+++ b/engine/crates/engine-v2/src/operation/ids.rs
@@ -1,4 +1,4 @@
-use super::{Condition, Field, FieldArgument, Operation, Plan, SelectionSet, VariableDefinition};
+use super::{Condition, Field, FieldArgument, LogicalPlan, Operation, SelectionSet, VariableDefinition};
 
 id_newtypes::NonZeroU16! {
     Operation.fields[FieldId] => Field,
@@ -6,5 +6,5 @@ id_newtypes::NonZeroU16! {
     Operation.variable_definitions[VariableDefinitionId] => VariableDefinition,
     Operation.field_arguments[FieldArgumentId] => FieldArgument,
     Operation.conditions[ConditionId] => Condition,
-    Operation.plans[PlanId] => Plan,
+    Operation.logical_plans[LogicalPlanId] => LogicalPlan,
 }

--- a/engine/crates/engine-v2/src/operation/logical_planner/mod.rs
+++ b/engine/crates/engine-v2/src/operation/logical_planner/mod.rs
@@ -1,83 +1,88 @@
+mod logic;
+mod selection_set;
+
 use engine_parser::types::OperationType;
-use im::HashSet;
 use itertools::Itertools;
 use schema::{ResolverId, Schema};
 
-use super::{boundary::SelectionSetSolver, logic::PlanningLogic, PlanningError, PlanningResult};
-use crate::operation::{
-    FieldId, Operation, OperationWalker, ParentToChildEdge, Plan, PlanId, QueryPath, SelectionSetId,
-    SolvedRequiredFieldSet, Variables,
+use crate::{
+    operation::{
+        FieldId, LogicalPlan, LogicalPlanId, Operation, OperationWalker, QueryPath, SelectionSetId,
+        SolvedRequiredFieldSet, Variables,
+    },
+    response::{ErrorCode, GraphqlError},
 };
+use logic::*;
+use selection_set::*;
 
-/// The planner is responsible to attribute a plan id for every field & selection set in the
-/// operation and ensuring that all requirements from resolvers and fields are satisfied.
-///
-/// The planning works in three steps:
-///
-/// 1. Attribute the fields and adding any extra ones:
-///     - We have unplanned (missing) fields
-///     - Flatten the selection set, removing fragments & inline fragments, for easier
-///       manipulation.
-///     - Detect which part is providable by the current plan if any and which aren't.
-///     - Attribute relevant fields & selection sets to the current plan.
-///     - If there are missing fields, create a new plan boundary. This allows us to know that we
-///       should keep a reference to response objects for that selection sets so that children plan
-///       don't need to search for for them. We plan any missing fields with the same logic.
-/// 2. Collect attributed fields to know what to expect from the response. This follows the field
-///    collection logic from GraphQL. If the selection set is simple enough (no type conditions
-///    typically), we can do it in advance and store it. Otherwise we generate what we can for
-///    later.
-/// 3. Generate the actual plans for each resolver, allowing them to cache what they can for later.
-///    During execution, those Plans create Executors with the actual response objects that do the
-///    real work.
-///
-pub(super) struct OperationSolver<'a> {
-    pub(super) schema: &'a Schema,
-    pub(super) variables: &'a Variables,
-    pub(super) operation: &'a mut Operation,
-    plan_edges: HashSet<ParentToChildEdge>,
-    plans: Vec<Plan>,
-    pub(super) field_to_plan_id: Vec<Option<PlanId>>,
-    pub(super) solved_requirements: Vec<(SelectionSetId, SolvedRequiredFieldSet)>,
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum LogicalPlanningError {
+    #[error("Could not plan fields: {}", .missing.join(", "))]
+    CouldNotPlanAnyField {
+        missing: Vec<String>,
+        query_path: Vec<String>,
+    },
+}
+
+impl From<LogicalPlanningError> for GraphqlError {
+    fn from(error: LogicalPlanningError) -> Self {
+        let message = error.to_string();
+        let query_path = match error {
+            LogicalPlanningError::CouldNotPlanAnyField { query_path, .. } => query_path
+                .into_iter()
+                .map(serde_json::Value::String)
+                .collect::<Vec<_>>(),
+        };
+
+        GraphqlError::new(message, ErrorCode::OperationPlanningError).with_extension("queryPath", query_path)
+    }
+}
+
+pub(super) type LogicalPlanningResult<T> = Result<T, LogicalPlanningError>;
+
+pub(super) struct LogicalPlanner<'a> {
+    schema: &'a Schema,
+    variables: &'a Variables,
+    operation: &'a mut Operation,
+    field_to_logical_plan_id: Vec<Option<LogicalPlanId>>,
+    logical_plans: Vec<LogicalPlan>,
+    solved_requirements: Vec<(SelectionSetId, SolvedRequiredFieldSet)>,
 }
 
 id_newtypes::index! {
-    OperationSolver<'a>.plans[PlanId] => Plan,
-    OperationSolver<'a>.field_to_plan_id[FieldId] => Option<PlanId>,
+    LogicalPlanner<'a>.logical_plans[LogicalPlanId] => LogicalPlan,
+    LogicalPlanner<'a>.field_to_logical_plan_id[FieldId] => Option<LogicalPlanId>,
 }
 
-impl<'a> OperationSolver<'a> {
+impl<'a> LogicalPlanner<'a> {
     pub(super) fn new(schema: &'a Schema, variables: &'a Variables, operation: &'a mut Operation) -> Self {
         Self {
             schema,
             variables,
-            field_to_plan_id: vec![None; operation.fields.len()],
+            field_to_logical_plan_id: vec![None; operation.fields.len()],
             operation,
-            plans: Vec::new(),
-            plan_edges: HashSet::new(),
+            logical_plans: Vec::new(),
             solved_requirements: Vec::new(),
         }
     }
 
-    pub(super) fn solve(mut self) -> PlanningResult<()> {
+    pub(super) fn run(mut self) -> LogicalPlanningResult<()> {
         self.plan_all_fields()?;
         let Self {
             operation,
-            plan_edges,
-            plans,
-            field_to_plan_id,
+            logical_plans,
+            field_to_logical_plan_id,
             solved_requirements,
             ..
         } = self;
 
-        operation.plans = plans;
-        operation.plan_edges = plan_edges.into_iter().collect();
+        operation.logical_plans = logical_plans;
         operation.solved_requirements = solved_requirements;
-        operation.field_to_plan_id = field_to_plan_id
+        operation.field_to_logical_plan_id = field_to_logical_plan_id
             .into_iter()
             .enumerate()
-            .map(|(i, maybe_plan_id)| match maybe_plan_id {
-                Some(plan_id) => plan_id,
+            .map(|(i, maybe_logical_plan_id)| match maybe_logical_plan_id {
+                Some(logical_plan_id) => logical_plan_id,
                 None => {
                     let name = &operation.response_keys[operation.fields[i].response_key()];
                     unreachable!("No plan was associated with field:\n{name}");
@@ -86,12 +91,11 @@ impl<'a> OperationSolver<'a> {
             .collect();
 
         operation.solved_requirements.sort_unstable_by_key(|(id, _)| *id);
-        operation.plan_edges.sort_unstable();
         Ok(())
     }
 
     /// Step 1 of the planning, attributed all fields to a plan and satisfying their requirements.
-    fn plan_all_fields(&mut self) -> PlanningResult<()> {
+    fn plan_all_fields(&mut self) -> LogicalPlanningResult<()> {
         // The root plan is always introspection which also lets us handle operations like:
         // query { __typename }
         let introspection = self.schema.walker().introspection_metadata();
@@ -126,15 +130,15 @@ impl<'a> OperationSolver<'a> {
     }
 
     /// A query is simply treated as a plan boundary with no parent.
-    fn plan_query(&mut self, field_ids: Vec<FieldId>) -> PlanningResult<()> {
+    fn plan_query(&mut self, field_ids: Vec<FieldId>) -> LogicalPlanningResult<()> {
         let id = self.operation.root_selection_set_id;
-        SelectionSetSolver::new(self, &QueryPath::default(), None).solve(id, Vec::new(), field_ids)
+        SelectionSetLogicalPlanner::new(self, &QueryPath::default(), None).solve(id, Vec::new(), field_ids)
     }
 
     /// Mutation is a special case because root fields need to execute in order. So planning each
     /// field individually and setting up plan dependencies between them to ensures proper
     /// execution order.
-    fn plan_mutation(&mut self, field_ids: Vec<FieldId>) -> PlanningResult<()> {
+    fn plan_mutation(&mut self, field_ids: Vec<FieldId>) -> LogicalPlanningResult<()> {
         let mut groups = self
             .walker()
             .group_by_response_key_sorted_by_query_position(field_ids)
@@ -142,8 +146,6 @@ impl<'a> OperationSolver<'a> {
             .collect::<Vec<_>>();
         // Ordering groups by their position in the query, ensuring proper ordering of plans.
         groups.sort_unstable_by_key(|field_ids| self.operation[field_ids[0]].query_position());
-
-        let mut maybe_previous_plan_id: Option<PlanId> = None;
 
         // FIXME: generates one plan per field, should be aggregated if consecutive fields can be
         // planned by a single resolver.
@@ -159,31 +161,25 @@ impl<'a> OperationSolver<'a> {
                 .walk(definition_id)
                 .resolvers()
                 .next()
-                .ok_or_else(|| PlanningError::CouldNotPlanAnyField {
+                .ok_or_else(|| LogicalPlanningError::CouldNotPlanAnyField {
                     missing: vec![self.operation.response_keys[field.response_key()].to_string()],
                     query_path: vec![],
                 })?;
 
-            let plan_id = self.push_plan(QueryPath::default(), resolver.id(), &field_ids)?;
-
-            if let Some(parent) = maybe_previous_plan_id {
-                self.push_plan_dependency(ParentToChildEdge { parent, child: plan_id });
-            }
-            maybe_previous_plan_id = Some(plan_id);
+            self.push_plan(QueryPath::default(), resolver.id(), &field_ids)?;
         }
         Ok(())
     }
 
     /// Obviously providable fields have no requirements and can be provided by the current
     /// resolver.
-    pub(super) fn plan_obviously_providable_subselections(
+    fn grow_with_obviously_providable_subselections(
         &mut self,
         path: &QueryPath,
         logic: &PlanningLogic<'a>,
         field_ids: &[FieldId],
-    ) -> PlanningResult<()> {
-        let plan_id = logic.plan_id();
-        self.attribute_fields(field_ids, plan_id);
+    ) -> LogicalPlanningResult<()> {
+        self.attribute_fields(field_ids, logic.id());
         for id in field_ids {
             if let Some(selection_set_id) = self.operation[*id].selection_set_id() {
                 let field = self.walker().walk(*id);
@@ -208,7 +204,7 @@ impl<'a> OperationSolver<'a> {
         path: &QueryPath,
         logic: &PlanningLogic<'a>,
         id: SelectionSetId,
-    ) -> PlanningResult<()> {
+    ) -> LogicalPlanningResult<()> {
         let walker = self.walker();
         let (obviously_plannable_field_ids, unplanned_field_ids): (Vec<_>, Vec<_>) =
             self.operation[id].field_ids.iter().copied().partition(|field_id| {
@@ -220,10 +216,10 @@ impl<'a> OperationSolver<'a> {
                 }
             });
 
-        self.plan_obviously_providable_subselections(path, logic, &obviously_plannable_field_ids)?;
+        self.grow_with_obviously_providable_subselections(path, logic, &obviously_plannable_field_ids)?;
 
         if !unplanned_field_ids.is_empty() {
-            SelectionSetSolver::new(self, path, Some(logic)).solve(
+            SelectionSetLogicalPlanner::new(self, path, Some(logic)).solve(
                 id,
                 obviously_plannable_field_ids,
                 unplanned_field_ids,
@@ -241,31 +237,25 @@ impl<'a> OperationSolver<'a> {
         query_path: QueryPath,
         resolver_id: ResolverId,
         field_ids: &[FieldId],
-    ) -> PlanningResult<PlanId> {
-        let plan_id = PlanId::from(self.plans.len());
+    ) -> LogicalPlanningResult<LogicalPlanId> {
+        let id = LogicalPlanId::from(self.logical_plans.len());
         tracing::trace!(
-            "Creating {plan_id} ({}): {}",
+            "Creating {id} ({}): {}",
             self.schema.walk(resolver_id).name(),
             field_ids.iter().format_with(", ", |id, f| f(&format_args!(
                 "{}",
                 self.walker().walk(*id).response_key_str()
             )))
         );
-        self.plans.push(Plan { resolver_id });
-        let logic = PlanningLogic::new(plan_id, self.schema.walk(resolver_id));
-        self.plan_obviously_providable_subselections(&query_path, &logic, field_ids)?;
-        Ok(plan_id)
+        self.logical_plans.push(LogicalPlan { resolver_id });
+        let logic = PlanningLogic::new(id, self.schema.walk(resolver_id));
+        self.grow_with_obviously_providable_subselections(&query_path, &logic, field_ids)?;
+        Ok(id)
     }
 
-    pub fn push_plan_dependency(&mut self, edge: ParentToChildEdge) {
-        if edge.parent != edge.child {
-            self.plan_edges.insert(edge);
-        }
-    }
-
-    pub fn attribute_fields(&mut self, fields: &[FieldId], plan_id: PlanId) {
-        for id in fields {
-            self[*id] = Some(plan_id);
+    pub fn attribute_fields(&mut self, fields: &[FieldId], id: LogicalPlanId) {
+        for field_id in fields {
+            self[*field_id] = Some(id);
         }
     }
 }

--- a/engine/crates/engine-v2/src/operation/logical_planner/selection_set.rs
+++ b/engine/crates/engine-v2/src/operation/logical_planner/selection_set.rs
@@ -10,11 +10,11 @@ use schema::{
 };
 use tracing::{instrument, Level};
 
-use super::{logic::PlanningLogic, planner::OperationSolver, PlanningError, PlanningResult};
+use super::{logic::PlanningLogic, LogicalPlanner, LogicalPlanningError, LogicalPlanningResult};
 use crate::{
     operation::{
-        ExtraField, Field, FieldArgument, FieldArgumentId, FieldId, ParentToChildEdge, PlanId, QueryInputValue,
-        QueryPath, SelectionSet, SelectionSetId, SolvedRequiredField, SolvedRequiredFieldSet,
+        ExtraField, Field, FieldArgument, FieldArgumentId, FieldId, LogicalPlanId, QueryInputValue, QueryPath,
+        SelectionSet, SelectionSetId, SolvedRequiredField, SolvedRequiredFieldSet,
     },
     response::{SafeResponseKey, UnpackedResponseEdge},
 };
@@ -22,22 +22,22 @@ use crate::{
 /// The Planner traverses the selection sets to plan all the fields, but it doesn't define the
 /// plans directly. That's the job of the BoundaryPlanner which will attribute a plan for each
 /// field for a given selection set and satisfy any requirements.
-pub(super) struct SelectionSetSolver<'schema, 'a> {
-    solver: &'a mut OperationSolver<'schema>,
+pub(super) struct SelectionSetLogicalPlanner<'schema, 'a> {
+    planner: &'a mut LogicalPlanner<'schema>,
     query_path: &'a QueryPath,
     maybe_parent: Option<&'a PlanningLogic<'schema>>,
-    children: Vec<PlanId>,
+    children: Vec<LogicalPlanId>,
     extra_response_key_suffix: usize,
 }
 
-impl<'schema, 'a> SelectionSetSolver<'schema, 'a> {
+impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
     pub(super) fn new(
-        solver: &'a mut OperationSolver<'schema>,
+        planner: &'a mut LogicalPlanner<'schema>,
         query_path: &'a QueryPath,
         maybe_parent: Option<&'a PlanningLogic<'schema>>,
     ) -> Self {
         Self {
-            solver,
+            planner,
             query_path,
             maybe_parent,
             children: Vec::new(),
@@ -49,19 +49,19 @@ impl<'schema, 'a> SelectionSetSolver<'schema, 'a> {
         level = Level::DEBUG,
         skip_all,
         fields(parent = %self.maybe_parent.as_ref().map(|p| p.to_string()).unwrap_or_default(),
-               path = %self.solver.walker().walk(self.query_path))
+               path = %self.planner.walker().walk(self.query_path))
     )]
     pub(super) fn solve(
         &mut self,
         selection_set_id: SelectionSetId,
         planned_field_ids: Vec<FieldId>,
         unplanned_field_ids: Vec<FieldId>,
-    ) -> PlanningResult<()> {
+    ) -> LogicalPlanningResult<()> {
         let mut planned_selection_set = self.build_planned_selection_set(selection_set_id, &planned_field_ids);
         let missing = self.build_unplanned_fields(unplanned_field_ids);
-        self.solve_selection_set(&mut planned_selection_set, missing)?;
+        self.plan_selection_set(&mut planned_selection_set, missing)?;
 
-        self.solver
+        self.planner
             .solved_requirements
             .push((selection_set_id, Self::build_solved_requirements(planned_selection_set)));
 
@@ -110,7 +110,7 @@ impl<'schema, 'a> SelectionSetSolver<'schema, 'a> {
                 // was already planned. By construction, as soon as we create a new plan with
                 // push_plan() it plans all of the nested selection sets.
                 // And for extra fields we add during planning, those are attributed immediately.
-                let plan_id = self.solver[field_id].expect("field should be planned");
+                let plan_id = self.planner[field_id].expect("field should be planned");
 
                 fields.entry(definition_id).or_default().push(PlannedField::Query {
                     field_id,
@@ -139,16 +139,16 @@ impl<'schema, 'a> SelectionSetSolver<'schema, 'a> {
     }
 }
 
-impl<'schema, 'a> std::ops::Deref for SelectionSetSolver<'schema, 'a> {
-    type Target = OperationSolver<'schema>;
+impl<'schema, 'a> std::ops::Deref for SelectionSetLogicalPlanner<'schema, 'a> {
+    type Target = LogicalPlanner<'schema>;
     fn deref(&self) -> &Self::Target {
-        self.solver
+        self.planner
     }
 }
 
-impl<'schema, 'a> std::ops::DerefMut for SelectionSetSolver<'schema, 'a> {
+impl<'schema, 'a> std::ops::DerefMut for SelectionSetLogicalPlanner<'schema, 'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.solver
+        self.planner
     }
 }
 
@@ -163,14 +163,14 @@ enum PlannedField {
     Query {
         field_id: FieldId,
         required_field_id: Option<RequiredFieldId>,
-        plan_id: PlanId,
+        plan_id: LogicalPlanId,
         lazy_subselection: Option<PlannedSelectionSet>,
     },
     Extra {
         field_id: Option<FieldId>,
         petitioner_field_id: FieldId,
         required_field_id: RequiredFieldId,
-        plan_id: PlanId,
+        logical_plan_id: LogicalPlanId,
         subselection: PlannedSelectionSet,
     },
 }
@@ -191,17 +191,17 @@ struct ChildPlanCandidate<'schema> {
     providable_fields: Vec<(FieldId, &'schema RequiredFieldSet)>,
 }
 
-impl<'schema, 'a> SelectionSetSolver<'schema, 'a> {
+impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
     /// Iteratively plan fields.
     /// 1. Generate all potential plan candidates satisfying their requirements if possible.
     /// 2. Select the best candidate, generate its input and remove its output fields from the
     ///    unplanned ones.
     /// 3. Continue until there are no more unplanned fields.
-    fn solve_selection_set(
+    fn plan_selection_set(
         &mut self,
         planned_selection_set: &mut PlannedSelectionSet,
         mut unplanned_fields: HashMap<FieldId, FieldDefinitionWalker<'schema>>,
-    ) -> PlanningResult<()> {
+    ) -> LogicalPlanningResult<()> {
         // unplanned_field may be still be provided by the parent plan, but at this stage it
         // means they had requirements.
         if let Some(parent_logic) = self.maybe_parent {
@@ -228,9 +228,9 @@ impl<'schema, 'a> SelectionSetSolver<'schema, 'a> {
                 field_ids.push(id);
             }
 
-            self.solver
-                .plan_obviously_providable_subselections(self.query_path, parent_logic, &field_ids)?;
-            self.push_plan_requires_dependencies(planned_selection_set, parent_logic.plan_id(), &requires);
+            self.planner
+                .grow_with_obviously_providable_subselections(self.query_path, parent_logic, &field_ids)?;
+            self.register_necessary_extra_fields(planned_selection_set, &requires);
         }
 
         if unplanned_fields.is_empty() {
@@ -258,7 +258,7 @@ impl<'schema, 'a> SelectionSetSolver<'schema, 'a> {
                         .map(|id| walker.walk(*id).definition().unwrap())
                         .format_with("\n", |field, f| f(&format_args!("{field:#?}")))
                 );
-                return Err(PlanningError::CouldNotPlanAnyField {
+                return Err(LogicalPlanningError::CouldNotPlanAnyField {
                     missing: unplanned_fields
                         .into_keys()
                         .map(|id| walker.walk(id).response_key_str().to_string())
@@ -288,10 +288,10 @@ impl<'schema, 'a> SelectionSetSolver<'schema, 'a> {
         resolver_id: ResolverId,
         requires: Cow<'_, RequiredFieldSet>,
         root_field_ids: Vec<FieldId>,
-    ) -> PlanningResult<()> {
+    ) -> LogicalPlanningResult<()> {
         let path = self.query_path.clone();
-        let plan_id = self.solver.push_plan(path, resolver_id, &root_field_ids)?;
-        self.push_plan_requires_dependencies(planned_selection_set, plan_id, &requires);
+        let plan_id = self.planner.push_plan(path, resolver_id, &root_field_ids)?;
+        self.register_necessary_extra_fields(planned_selection_set, &requires);
         for field_id in root_field_ids {
             let definition_id = self.operation[field_id]
                 .definition_id()
@@ -316,10 +316,9 @@ impl<'schema, 'a> SelectionSetSolver<'schema, 'a> {
     /// We iterate over the requirements and find the matching fields inside the boundary fields,
     /// which contains all providable & extra fields. During the iteration we track all the dependency
     /// plans.
-    fn push_plan_requires_dependencies(
+    fn register_necessary_extra_fields(
         &mut self,
         planned_selection_set: &mut PlannedSelectionSet,
-        plan_id: PlanId,
         requires: &RequiredFieldSet,
     ) {
         for required_field in requires {
@@ -332,28 +331,16 @@ impl<'schema, 'a> SelectionSetSolver<'schema, 'a> {
                 .find(|field| field.required_field_id() == Some(required_field.id))
                 .expect("We depend on it, so it must have been planned");
             match planned_field {
-                PlannedField::Query {
-                    plan_id: parent_plan_id,
-                    lazy_subselection,
-                    ..
-                } => {
-                    self.solver.push_plan_dependency(ParentToChildEdge {
-                        parent: *parent_plan_id,
-                        child: plan_id,
-                    });
+                PlannedField::Query { lazy_subselection, .. } => {
                     if let Some(planned_subselection) = lazy_subselection {
-                        self.push_plan_requires_dependencies(
-                            planned_subselection,
-                            plan_id,
-                            &required_field.subselection,
-                        )
+                        self.register_necessary_extra_fields(planned_subselection, &required_field.subselection)
                     }
                 }
                 PlannedField::Extra {
                     field_id,
                     petitioner_field_id,
                     required_field_id,
-                    plan_id: parent_plan_id,
+                    logical_plan_id: parent_plan_id,
                     subselection,
                 } => {
                     // Now we're sure this filed is needed by plan, so it has to be in the
@@ -372,23 +359,18 @@ impl<'schema, 'a> SelectionSetSolver<'schema, 'a> {
                             parent_selection_set_id,
                         });
                         self.operation.fields.push(field);
-                        self.field_to_plan_id.push(Some(*parent_plan_id));
+                        self.field_to_logical_plan_id.push(Some(*parent_plan_id));
                         let id = (self.operation.fields.len() - 1).into();
                         *field_id = Some(id);
                         self.operation[parent_selection_set_id].field_ids.push(id);
                     }
-
-                    self.solver.push_plan_dependency(ParentToChildEdge {
-                        parent: *parent_plan_id,
-                        child: plan_id,
-                    });
 
                     if !required_field.subselection.is_empty() {
                         if subselection.id.is_none() {
                             self.operation.selection_sets.push(SelectionSet::default());
                             subselection.id = Some((self.operation.selection_sets.len() - 1).into());
                         }
-                        self.push_plan_requires_dependencies(subselection, plan_id, &required_field.subselection)
+                        self.register_necessary_extra_fields(subselection, &required_field.subselection)
                     }
                 }
             }
@@ -400,7 +382,7 @@ impl<'schema, 'a> SelectionSetSolver<'schema, 'a> {
         unplanned_fields: &HashMap<FieldId, FieldDefinitionWalker<'schema>>,
         planned_selection_set: &mut PlannedSelectionSet,
         candidates: &mut HashMap<ResolverId, ChildPlanCandidate<'schema>>,
-    ) -> PlanningResult<()>
+    ) -> LogicalPlanningResult<()>
     where
         'schema: 'field,
     {
@@ -438,29 +420,20 @@ impl<'schema, 'a> SelectionSetSolver<'schema, 'a> {
         planned_selection_set: &mut PlannedSelectionSet,
         petitioner_field_id: FieldId,
         requires: &'schema RequiredFieldSet,
-    ) -> PlanningResult<bool> {
+    ) -> LogicalPlanningResult<bool> {
         if requires.is_empty() {
             return Ok(true);
         }
-        let parent_field_plan_id = self
-            .maybe_parent
-            .expect("Cannot have requirements without a parent plan")
-            .plan_id();
-        self.could_plan_requirements_on_previous_plans(
-            parent_field_plan_id,
-            planned_selection_set,
-            petitioner_field_id,
-            requires,
-        )
+        self.could_plan_requirements_on_previous_plans(None, planned_selection_set, petitioner_field_id, requires)
     }
 
     fn could_plan_requirements_on_previous_plans(
         &mut self,
-        parent_field_plan_id: PlanId,
+        parent_resolved_query_part_id: Option<LogicalPlanId>,
         planned_selection_set: &mut PlannedSelectionSet,
         petitioner_field_id: FieldId,
         requires: &'schema RequiredFieldSet,
-    ) -> PlanningResult<bool> {
+    ) -> LogicalPlanningResult<bool> {
         if requires.is_empty() {
             return Ok(true);
         }
@@ -501,7 +474,7 @@ impl<'schema, 'a> SelectionSetSolver<'schema, 'a> {
                             // So either we can plan the necessary requirements with this group or we
                             // don't.
                             if self.could_plan_requirements_on_previous_plans(
-                                *plan_id,
+                                Some(*plan_id),
                                 lazy_subselection.as_mut().unwrap(),
                                 petitioner_field_id,
                                 &required.subselection,
@@ -513,7 +486,7 @@ impl<'schema, 'a> SelectionSetSolver<'schema, 'a> {
                         }
                         PlannedField::Extra {
                             required_field_id,
-                            plan_id,
+                            logical_plan_id: plan_id,
                             subselection,
                             ..
                         } => {
@@ -532,7 +505,7 @@ impl<'schema, 'a> SelectionSetSolver<'schema, 'a> {
                             // So either we can plan the necessary requirements with this group or we
                             // don't.
                             if self.could_plan_requirements_on_previous_plans(
-                                *plan_id,
+                                Some(*plan_id),
                                 subselection,
                                 petitioner_field_id,
                                 &required.subselection,
@@ -548,29 +521,34 @@ impl<'schema, 'a> SelectionSetSolver<'schema, 'a> {
 
             let required = self.schema.walk(required);
 
+            // if we're within a nested selection set, we only handle the case where the parent
+            // resolver can provide this field.
+            if let Some(parent_resolved_query_part_id) = parent_resolved_query_part_id {
+                return Ok(self.could_plan_exra_field(
+                    planned_selection_set,
+                    petitioner_field_id,
+                    &PlanningLogic::new(
+                        parent_resolved_query_part_id,
+                        self.schema.walk(self[parent_resolved_query_part_id].resolver_id),
+                    ),
+                    required,
+                ));
+            }
+
             // -- Plannable by the parent --
-            let parent_logic = self
-                .maybe_parent
-                .expect("Cannot have requirements without a parent plan");
-            // the parent field does come from the parent plan
-            if parent_logic.plan_id() == parent_field_plan_id
-                && self.could_plan_exra_field(planned_selection_set, petitioner_field_id, parent_logic, required)
-            {
-                continue;
+            if let Some(parent_logic) = self.maybe_parent {
+                if self.could_plan_exra_field(planned_selection_set, petitioner_field_id, parent_logic, required) {
+                    continue;
+                }
             }
 
             // -- Plannable by existing children --
             for i in 0..self.children.len() {
-                let plan_id = self.children[i];
-                // ensures we don't have cycles between plans ensuring they can only depend on
-                // plan_ids lower than theirs. Could be better.
-                if plan_id < parent_field_plan_id {
-                    continue;
-                }
+                let logical_plan_id = self.children[i];
                 if self.could_plan_exra_field(
                     planned_selection_set,
                     petitioner_field_id,
-                    &PlanningLogic::new(plan_id, self.schema.walk(self[plan_id].resolver_id)),
+                    &PlanningLogic::new(logical_plan_id, self.schema.walk(self[logical_plan_id].resolver_id)),
                     required,
                 ) {
                     continue 'requires;
@@ -611,14 +589,14 @@ impl<'schema, 'a> SelectionSetSolver<'schema, 'a> {
                 field_id: None,
                 petitioner_field_id,
                 required_field_id: required.required_field_id(),
-                plan_id: logic.plan_id(),
+                logical_plan_id: logic.id(),
                 subselection,
             });
 
         tracing::trace!(
             "Added extra field '{}' provided by {} required by '{}'",
             self.schema.walker().walk(required.definition().id()).name(),
-            logic.plan_id(),
+            logic.id(),
             self.walker().walk(petitioner_field_id).response_key_str()
         );
 

--- a/engine/crates/engine-v2/src/operation/logical_planner/selection_set.rs
+++ b/engine/crates/engine-v2/src/operation/logical_planner/selection_set.rs
@@ -19,9 +19,6 @@ use crate::{
     response::{SafeResponseKey, UnpackedResponseEdge},
 };
 
-/// The Planner traverses the selection sets to plan all the fields, but it doesn't define the
-/// plans directly. That's the job of the BoundaryPlanner which will attribute a plan for each
-/// field for a given selection set and satisfy any requirements.
 pub(super) struct SelectionSetLogicalPlanner<'schema, 'a> {
     planner: &'a mut LogicalPlanner<'schema>,
     query_path: &'a QueryPath,

--- a/engine/crates/engine-v2/src/operation/mod.rs
+++ b/engine/crates/engine-v2/src/operation/mod.rs
@@ -4,6 +4,7 @@ mod condition;
 pub mod ids;
 mod input_value;
 mod location;
+mod logical_planner;
 mod parse;
 mod path;
 mod selection_set;
@@ -24,7 +25,7 @@ pub(crate) use variables::*;
 pub(crate) use walkers::*;
 
 #[derive(serde::Serialize, serde::Deserialize)]
-pub(crate) struct Plan {
+pub(crate) struct LogicalPlan {
     pub resolver_id: ResolverId,
 }
 
@@ -53,9 +54,9 @@ pub(crate) struct Operation {
     pub query_input_values: QueryInputValues,
     // deduplicated
     pub conditions: Vec<Condition>,
-    // -- Added during planning --
-    pub plans: Vec<Plan>,
-    pub field_to_plan_id: Vec<PlanId>,
+    // -- Added during the solving step --
+    pub logical_plans: Vec<LogicalPlan>,
+    pub field_to_logical_plan_id: Vec<LogicalPlanId>,
     // Sorted
     pub plan_edges: Vec<ParentToChildEdge>,
     pub solved_requirements: Vec<(SelectionSetId, SolvedRequiredFieldSet)>,
@@ -63,8 +64,8 @@ pub(crate) struct Operation {
 
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
 pub(crate) struct ParentToChildEdge {
-    pub parent: PlanId,
-    pub child: PlanId,
+    pub parent: LogicalPlanId,
+    pub child: LogicalPlanId,
 }
 
 pub(crate) type SolvedRequiredFieldSet = Vec<SolvedRequiredField>;
@@ -77,8 +78,8 @@ pub(crate) struct SolvedRequiredField {
 }
 
 impl Operation {
-    pub fn plan_id_for(&self, id: FieldId) -> PlanId {
-        self.field_to_plan_id[usize::from(id)]
+    pub fn plan_id_for(&self, id: FieldId) -> LogicalPlanId {
+        self.field_to_logical_plan_id[usize::from(id)]
     }
 
     pub fn solved_requirements_for(&self, id: SelectionSetId) -> Option<&SolvedRequiredFieldSet> {

--- a/engine/crates/engine-v2/src/operation/walkers/field.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/field.rs
@@ -57,10 +57,6 @@ impl<'a> FieldWalker<'a> {
     pub fn selection_set(&self) -> Option<SelectionSetWalker<'a>> {
         self.as_ref().selection_set_id().map(|id| self.walk_with(id, ()))
     }
-
-    pub fn parent_selection_set(&self) -> SelectionSetWalker<'a> {
-        self.walk_with(self.as_ref().parent_selection_set_id(), ())
-    }
 }
 
 impl PartialEq<RequiredField> for FieldWalker<'_> {

--- a/engine/crates/engine-v2/src/plan/mod.rs
+++ b/engine/crates/engine-v2/src/plan/mod.rs
@@ -4,7 +4,7 @@ use schema::{EntityId, ResolverId, Schema};
 
 use crate::{
     execution::ExecutionContext,
-    operation::{Operation, PlanId, Variables},
+    operation::{LogicalPlanId, Operation, Variables},
     response::{GraphqlError, ReadSelectionSet},
     sources::PreparedExecutor,
     Runtime,
@@ -64,7 +64,7 @@ pub(crate) struct OperationPlan {
 }
 
 pub(crate) struct ExecutionPlan {
-    pub plan_id: PlanId,
+    pub plan_id: LogicalPlanId,
     pub resolver_id: ResolverId,
     pub input: PlanInput,
     pub output: PlanOutput,

--- a/engine/crates/engine-v2/src/plan/walkers/field.rs
+++ b/engine/crates/engine-v2/src/plan/walkers/field.rs
@@ -1,7 +1,7 @@
 use schema::{FieldDefinitionId, FieldDefinitionWalker};
 
 use crate::{
-    operation::{FieldArgumentsWalker, FieldId, LogicalPlanId, QueryInputValueWalker},
+    operation::{FieldArgumentsWalker, FieldId, QueryInputValueWalker},
     response::ResponseKey,
 };
 
@@ -14,10 +14,6 @@ impl<'a> PlanField<'a> {
         self.as_ref()
             .selection_set_id()
             .map(|id| PlanSelectionSet::SelectionSet(self.walk_with(id, ())))
-    }
-
-    pub fn plan_id(&self) -> LogicalPlanId {
-        self.operation_plan.plan_id_for(self.item)
     }
 
     pub fn response_key(&self) -> ResponseKey {

--- a/engine/crates/engine-v2/src/plan/walkers/field.rs
+++ b/engine/crates/engine-v2/src/plan/walkers/field.rs
@@ -1,7 +1,7 @@
 use schema::{FieldDefinitionId, FieldDefinitionWalker};
 
 use crate::{
-    operation::{FieldArgumentsWalker, FieldId, PlanId, QueryInputValueWalker},
+    operation::{FieldArgumentsWalker, FieldId, LogicalPlanId, QueryInputValueWalker},
     response::ResponseKey,
 };
 
@@ -16,7 +16,7 @@ impl<'a> PlanField<'a> {
             .map(|id| PlanSelectionSet::SelectionSet(self.walk_with(id, ())))
     }
 
-    pub fn plan_id(&self) -> PlanId {
+    pub fn plan_id(&self) -> LogicalPlanId {
         self.operation_plan.plan_id_for(self.item)
     }
 


### PR DESCRIPTION
I'm not super happy with the name, but I find `Plan` and
`ExecutionPlan` is too ambiguous in some places. Couldn't find
a better name than that.
