### PR TITLE
feat(engine-v2): Add error code for all GraphQL errors

### DIFF
--- a/engine/crates/engine-v2/src/operation/bind/mod.rs
+++ b/engine/crates/engine-v2/src/operation/bind/mod.rs
@@ -19,7 +19,7 @@ use crate::{
         InlineFragment, InlineFragmentId, Location, Operation, Selection, SelectionSet, SelectionSetId,
         SelectionSetType, TypeCondition, VariableDefinition,
     },
-    response::{GraphqlError, ResponseKeys},
+    response::{ErrorCode, GraphqlError, ResponseKeys},
 };
 pub use variables::*;
 
@@ -119,11 +119,7 @@ impl From<BindError> for GraphqlError {
                 vec![]
             }
         };
-        GraphqlError {
-            message: err.to_string(),
-            locations,
-            ..Default::default()
-        }
+        GraphqlError::new(err.to_string(), ErrorCode::OperationValidationError).with_locations(locations)
     }
 }
 

--- a/engine/crates/engine-v2/src/operation/bind/variables.rs
+++ b/engine/crates/engine-v2/src/operation/bind/variables.rs
@@ -4,7 +4,7 @@ use schema::Schema;
 
 use crate::{
     operation::{Location, Operation, VariableValue, Variables},
-    response::GraphqlError,
+    response::{ErrorCode, GraphqlError},
 };
 
 use super::coercion::{coerce_variable, InputValueError};
@@ -23,11 +23,7 @@ impl From<VariableError> for GraphqlError {
             VariableError::MissingVariable { location, .. } => vec![location],
             VariableError::InvalidValue { ref err, .. } => vec![err.location()],
         };
-        GraphqlError {
-            message: err.to_string(),
-            locations,
-            ..Default::default()
-        }
+        GraphqlError::new(err.to_string(), ErrorCode::OperationValidationError).with_locations(locations)
     }
 }
 

--- a/engine/crates/engine-v2/src/operation/build.rs
+++ b/engine/crates/engine-v2/src/operation/build.rs
@@ -1,6 +1,6 @@
 use schema::Schema;
 
-use crate::response::GraphqlError;
+use crate::response::{ErrorCode, GraphqlError};
 
 use super::{parse::ParsedOperation, Operation, OperationMetadata, Variables};
 
@@ -34,10 +34,7 @@ impl From<OperationError> for GraphqlError {
             OperationError::Validation { err, .. } => err.into(),
             OperationError::Parse(err) => err.into(),
             OperationError::Solve { err, .. } => err.into(),
-            OperationError::NormalizationError => GraphqlError {
-                message: err.to_string(),
-                ..Default::default()
-            },
+            OperationError::NormalizationError => GraphqlError::new(err.to_string(), ErrorCode::InternalServerError),
         }
     }
 }

--- a/engine/crates/engine-v2/src/operation/parse.rs
+++ b/engine/crates/engine-v2/src/operation/parse.rs
@@ -5,7 +5,7 @@ use engine_parser::{
     Positioned,
 };
 
-use crate::response::GraphqlError;
+use crate::response::{ErrorCode, GraphqlError};
 
 #[derive(thiserror::Error, Debug)]
 pub enum ParseError {
@@ -22,15 +22,9 @@ pub type ParseResult<T> = Result<T, ParseError>;
 impl From<ParseError> for GraphqlError {
     fn from(err: ParseError) -> Self {
         match err {
-            ParseError::ParserError(err) => GraphqlError {
-                message: err.to_string(),
-                locations: err.positions().filter_map(|pos| pos.try_into().ok()).collect(),
-                ..Default::default()
-            },
-            err => GraphqlError {
-                message: err.to_string(),
-                ..Default::default()
-            },
+            ParseError::ParserError(err) => GraphqlError::new(err.to_string(), ErrorCode::OperationParsingError)
+                .with_locations(err.positions().filter_map(|pos| pos.try_into().ok())),
+            err => GraphqlError::new(err.to_string(), ErrorCode::OperationParsingError),
         }
     }
 }

--- a/engine/crates/engine-v2/src/operation/validation/mod.rs
+++ b/engine/crates/engine-v2/src/operation/validation/mod.rs
@@ -3,7 +3,7 @@ mod operation_limits;
 
 use crate::{
     operation::{Location, OperationWalker},
-    response::GraphqlError,
+    response::{ErrorCode, GraphqlError},
 };
 use introspection::*;
 use operation_limits::*;
@@ -23,11 +23,7 @@ impl From<ValidationError> for GraphqlError {
             ValidationError::IntrospectionWhenDisabled { location } => vec![*location],
             ValidationError::OperationLimitExceeded { .. } => Vec::new(),
         };
-        GraphqlError {
-            message: err.to_string(),
-            locations,
-            ..Default::default()
-        }
+        GraphqlError::new(err.to_string(), ErrorCode::OperationValidationError).with_locations(locations)
     }
 }
 

--- a/engine/crates/engine-v2/src/plan/planning/collect.rs
+++ b/engine/crates/engine-v2/src/plan/planning/collect.rs
@@ -19,7 +19,7 @@ use crate::{
         ConditionalSelectionSetId, EntityId, ExecutionPlan, ExecutionPlanId, FieldError, FieldType, FlatField,
         OperationPlan, ParentToChildEdge, PlanInput, PlanOutput,
     },
-    response::{GraphqlError, ReadField, ReadSelectionSet},
+    response::{ErrorCode, GraphqlError, ReadField, ReadSelectionSet},
     sources::PreparedExecutor,
     Runtime,
 };
@@ -98,7 +98,7 @@ impl<'a, R: Runtime> OperationPlanBuilder<'a, R> {
                     .fold(ConditionResult::Include, |current, cond| current & cond),
                 Condition::Authenticated => {
                     if is_anonymous {
-                        ConditionResult::Errors(vec![GraphqlError::new("Unauthenticated")])
+                        ConditionResult::Errors(vec![GraphqlError::new("Unauthenticated", ErrorCode::Unauthenticated)])
                     } else {
                         ConditionResult::Include
                     }
@@ -116,7 +116,10 @@ impl<'a, R: Runtime> OperationPlanBuilder<'a, R> {
                     if self.ctx.schema.walk(*id).matches(scopes) {
                         ConditionResult::Include
                     } else {
-                        ConditionResult::Errors(vec![GraphqlError::new("Not allowed: insufficient scopes")])
+                        ConditionResult::Errors(vec![GraphqlError::new(
+                            "Not allowed: insufficient scopes",
+                            ErrorCode::Unauthenticated,
+                        )])
                     }
                 }
                 Condition::AuthorizedEdge { directive_id, field_id } => {

--- a/engine/crates/engine-v2/src/plan/planning/mod.rs
+++ b/engine/crates/engine-v2/src/plan/planning/mod.rs
@@ -1,10 +1,8 @@
-use std::collections::BTreeMap;
-
 use schema::Schema;
 
 use crate::{
     operation::{Operation, Variables},
-    response::GraphqlError,
+    response::{ErrorCode, GraphqlError},
 };
 
 mod boundary;
@@ -37,12 +35,8 @@ impl From<PlanningError> for GraphqlError {
             PlanningError::InternalError { .. } => vec![],
         };
 
-        GraphqlError {
-            message,
-            locations: vec![],
-            path: None,
-            extensions: BTreeMap::from([("queryPath".into(), serde_json::Value::Array(query_path))]),
-        }
+        GraphqlError::new(message, ErrorCode::OperationPlanningError)
+            .with_extension("queryPath", serde_json::Value::Array(query_path))
     }
 }
 

--- a/engine/crates/engine-v2/src/response/error.rs
+++ b/engine/crates/engine-v2/src/response/error.rs
@@ -1,44 +1,103 @@
-use std::collections::BTreeMap;
+use std::borrow::Cow;
 
-use engine::ErrorCode;
+use runtime::error::PartialErrorCode;
+
+use crate::operation::Location;
 
 use super::ResponsePath;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize, strum::Display)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+pub(crate) enum ErrorCode {
+    BadRequest,
+    InternalServerError,
+    TrustedDocumentError,
+    // Used for APQ
+    PersistedQueryError,
+    PersistedQueryNotFound,
+    // Subgraph errors
+    SubgraphError,
+    SubgraphInvalidResponseError,
+    SubgraphRequestError,
+    // Auth
+    Unauthenticated,
+    Unauthorized,
+    // Operation preparation phases
+    OperationParsingError,
+    OperationValidationError,
+    OperationPlanningError,
+    // Runtime
+    HookError,
+}
+
+impl From<PartialErrorCode> for ErrorCode {
+    fn from(code: PartialErrorCode) -> Self {
+        match code {
+            PartialErrorCode::InternalServerError => Self::InternalServerError,
+            PartialErrorCode::HookError => Self::HookError,
+            PartialErrorCode::Unauthorized => Self::Unauthorized,
+            PartialErrorCode::BadRequest => Self::BadRequest,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct GraphqlError {
-    pub message: String,
-    pub locations: Vec<crate::operation::Location>,
+    pub message: Cow<'static, str>,
+    pub code: ErrorCode,
+    pub locations: Vec<Location>,
     pub path: Option<ResponsePath>,
-    // ensures consistent ordering for tests
-    pub extensions: BTreeMap<String, serde_json::Value>,
+    // Serialized as a map, but kept as a Vec for efficiency.
+    pub extensions: Vec<(Cow<'static, str>, serde_json::Value)>,
 }
 
 impl GraphqlError {
-    pub fn new(message: impl Into<String>) -> Self {
+    pub fn new(message: impl Into<Cow<'static, str>>, code: ErrorCode) -> Self {
         GraphqlError {
             message: message.into(),
-            ..Default::default()
+            code,
+            locations: Vec::new(),
+            path: None,
+            extensions: Vec::new(),
         }
     }
 
-    pub fn with_error_code(mut self, code: ErrorCode) -> Self {
-        self.extensions
-            .insert("code".to_string(), serde_json::Value::String(code.to_string()));
+    #[must_use]
+    pub fn with_location(mut self, location: Location) -> Self {
+        self.locations.push(location);
         self
     }
 
-    #[allow(dead_code)]
-    pub fn internal_server_error() -> Self {
-        GraphqlError::new("Internal server error").with_error_code(ErrorCode::InternalServerError)
+    #[must_use]
+    pub fn with_locations(mut self, locations: impl IntoIterator<Item = Location>) -> Self {
+        self.locations.extend(locations);
+        self
+    }
+
+    #[must_use]
+    pub fn with_path(mut self, path: ResponsePath) -> Self {
+        self.path = Some(path);
+        self
+    }
+
+    #[must_use]
+    pub fn with_extension(mut self, key: impl Into<Cow<'static, str>>, value: impl Into<serde_json::Value>) -> Self {
+        let key = key.into();
+        debug_assert!(key != "code");
+        self.extensions.push((key, value.into()));
+        self
     }
 }
 
-impl From<runtime::error::GraphqlError> for GraphqlError {
-    fn from(err: runtime::error::GraphqlError) -> Self {
+impl From<runtime::error::PartialGraphqlError> for GraphqlError {
+    fn from(err: runtime::error::PartialGraphqlError) -> Self {
         GraphqlError {
-            message: err.message.into_owned(),
-            extensions: err.extensions.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
-            ..Default::default()
+            message: err.message,
+            code: err.code.into(),
+            extensions: err.extensions,
+            locations: Vec::new(),
+            path: None,
         }
     }
 }

--- a/engine/crates/engine-v2/src/response/write/deserialize/field.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/field.rs
@@ -4,7 +4,7 @@ use serde::de::DeserializeSeed;
 use super::{ListSeed, NullableSeed, ScalarTypeSeed, SeedContext, SelectionSetSeed};
 use crate::{
     plan::{CollectedField, FieldType},
-    response::{GraphqlError, ResponseValue},
+    response::{ErrorCode, GraphqlError, ResponseValue},
 };
 
 #[derive(Clone)]
@@ -66,12 +66,11 @@ impl<'de, 'ctx, 'parent> DeserializeSeed<'de> for FieldSeed<'ctx, 'parent> {
 
         result.map_err(move |err| {
             if self.ctx.should_create_new_graphql_error() {
-                self.ctx.writer.push_error(GraphqlError {
-                    message: err.to_string(),
-                    locations: vec![self.ctx.plan[self.field.id].location()],
-                    path: Some(self.ctx.response_path()),
-                    ..Default::default()
-                });
+                self.ctx.writer.push_error(
+                    GraphqlError::new(err.to_string(), ErrorCode::SubgraphInvalidResponseError)
+                        .with_location(self.ctx.plan[self.field.id].location())
+                        .with_path(self.ctx.response_path()),
+                );
             }
             err
         })

--- a/engine/crates/engine-v2/src/response/write/deserialize/mod.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/mod.rs
@@ -10,7 +10,7 @@ use serde::{
 
 use crate::{
     plan::{CollectedField, PlanWalker},
-    response::{GraphqlError, ResponseEdge, ResponsePath, ResponseWriter},
+    response::{ErrorCode, GraphqlError, ResponseEdge, ResponsePath, ResponseWriter},
 };
 
 mod field;
@@ -127,11 +127,10 @@ impl<'de, 'ctx> DeserializeSeed<'de> for UpdateSeed<'ctx> {
             Ok(None) => {}
             Err(err) => {
                 if ctx.should_create_new_graphql_error() {
-                    ctx.writer.propagate_error(GraphqlError {
-                        message: err.to_string(),
-                        path: Some(ctx.response_path()),
-                        ..Default::default()
-                    });
+                    ctx.writer.propagate_error(
+                        GraphqlError::new(err.to_string(), ErrorCode::SubgraphInvalidResponseError)
+                            .with_path(ctx.response_path()),
+                    );
                 } else {
                     ctx.writer.continue_error_propagation();
                 }

--- a/engine/crates/engine-v2/src/sources/graphql/deserialize/entities.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/deserialize/entities.rs
@@ -7,8 +7,7 @@ use serde::{
 
 use crate::{
     plan::PlanWalker,
-    response::{ResponseKeys, ResponsePartMut, ResponsePath, UnpackedResponseEdge},
-    sources::ExecutionError,
+    response::{ErrorCode, GraphqlError, ResponseKeys, ResponsePartMut, ResponsePath, UnpackedResponseEdge},
 };
 
 use super::errors::GraphqlErrorsSeed;
@@ -104,8 +103,9 @@ impl<'de, 'a> Visitor<'de> for EntitiesSeed<'a> {
             }
         }
         if seq.next_element::<IgnoredAny>()?.is_some() {
-            self.response_part.push_error(ExecutionError::Internal(
-                "Received more entities than expected".to_string(),
+            self.response_part.push_error(GraphqlError::new(
+                "Received more entities than expected",
+                ErrorCode::SubgraphInvalidResponseError,
             ));
             while seq.next_element::<IgnoredAny>()?.is_some() {}
         }

--- a/engine/crates/engine-v2/src/sources/graphql/subscription.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/subscription.rs
@@ -12,7 +12,7 @@ use super::{
 use crate::{
     execution::OperationRootPlanExecution,
     plan::PlanWalker,
-    sources::{ExecutionError, ExecutionResult, SubscriptionExecutor, SubscriptionInput},
+    sources::{ExecutionResult, SubscriptionExecutor, SubscriptionInput},
     Runtime,
 };
 
@@ -75,7 +75,7 @@ impl<'ctx, R: Runtime> GraphqlSubscriptionExecutor<'ctx, R> {
                     variables: &operation.variables,
                     inputs: Vec::new(),
                 })
-                .map_err(|error| ExecutionError::Internal(error.to_string()))?,
+                .map_err(|error| error.to_string())?,
                 headers: subgraph
                     .headers()
                     .filter_map(|header| {

--- a/engine/crates/integration-tests/tests/federation/apq.rs
+++ b/engine/crates/integration-tests/tests/federation/apq.rs
@@ -68,7 +68,10 @@ fn single_field_from_single_server() {
         {
           "errors": [
             {
-              "message": "Invalid persisted query sha256Hash"
+              "message": "Invalid persisted query sha256Hash",
+              "extensions": {
+                "code": "PERSISTED_QUERY_ERROR"
+              }
             }
           ]
         }
@@ -85,7 +88,10 @@ fn single_field_from_single_server() {
         {
           "errors": [
             {
-              "message": "Persisted query version not supported"
+              "message": "Persisted query version not supported",
+              "extensions": {
+                "code": "PERSISTED_QUERY_ERROR"
+              }
             }
           ]
         }

--- a/engine/crates/integration-tests/tests/federation/auth/authenticated.rs
+++ b/engine/crates/integration-tests/tests/federation/auth/authenticated.rs
@@ -93,7 +93,10 @@ fn not_authenticated() {
               "path": [
                 "check",
                 "mustBeAuthenticated"
-              ]
+              ],
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }
@@ -121,7 +124,10 @@ fn faillible_authenticated() {
               "path": [
                 "check",
                 "faillibleMustBeAuthenticated"
-              ]
+              ],
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }
@@ -144,7 +150,10 @@ fn authenticated_on_nullable_field() {
               "path": [
                 "nullableCheck",
                 "mustBeAuthenticated"
-              ]
+              ],
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }
@@ -180,7 +189,10 @@ fn authenticated_on_union() {
               "path": [
                 "entity",
                 "mustBeAuthenticated"
-              ]
+              ],
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }
@@ -203,7 +215,10 @@ fn authenticated_on_union() {
               "path": [
                 "entity",
                 "faillibleMustBeAuthenticated"
-              ]
+              ],
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }
@@ -271,7 +286,10 @@ fn authenticated_on_list_with_nullable_items() {
                 "entitiesNullable",
                 1,
                 "mustBeAuthenticated"
-              ]
+              ],
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }
@@ -311,7 +329,10 @@ fn authenticated_on_list_with_nullable_items() {
                 "entitiesNullable",
                 1,
                 "faillibleMustBeAuthenticated"
-              ]
+              ],
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }
@@ -371,7 +392,10 @@ fn authenticated_on_list_with_required_items() {
                 "entities",
                 1,
                 "mustBeAuthenticated"
-              ]
+              ],
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }
@@ -411,7 +435,10 @@ fn authenticated_on_list_with_required_items() {
                 "entities",
                 1,
                 "faillibleMustBeAuthenticated"
-              ]
+              ],
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }

--- a/engine/crates/integration-tests/tests/federation/auth/requires_scopes.rs
+++ b/engine/crates/integration-tests/tests/federation/auth/requires_scopes.rs
@@ -14,7 +14,10 @@ fn anonymous_does_not_any_scope() {
               "path": [
                 "check",
                 "mustHaveReadScope"
-              ]
+              ],
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }
@@ -44,7 +47,10 @@ fn no_scope() {
               "path": [
                 "check",
                 "mustHaveReadScope"
-              ]
+              ],
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }
@@ -88,7 +94,10 @@ fn has_read_scope() {
               "path": [
                 "check",
                 "mustHaveWriteScope"
-              ]
+              ],
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }
@@ -121,7 +130,10 @@ fn has_read_scope() {
               "path": [
                 "check",
                 "mustHaveReadAndWriteScope"
-              ]
+              ],
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }
@@ -151,7 +163,10 @@ fn has_write_scope() {
               "path": [
                 "check",
                 "mustHaveReadScope"
-              ]
+              ],
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }
@@ -198,7 +213,10 @@ fn has_write_scope() {
               "path": [
                 "check",
                 "mustHaveReadAndWriteScope"
-              ]
+              ],
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }

--- a/engine/crates/integration-tests/tests/federation/basic/errors.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/errors.rs
@@ -26,10 +26,13 @@ fn subgraph_no_response() {
       "data": null,
       "errors": [
         {
-          "message": "Deserialization error: invalid type: null, expected a valid GraphQL response at line 1 column 4",
+          "message": "invalid type: null, expected a valid GraphQL response at line 1 column 4",
           "path": [
             "me"
-          ]
+          ],
+          "extensions": {
+            "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+          }
         }
       ]
     }
@@ -59,7 +62,10 @@ fn subgraph_no_response() {
           "message": "Missing data from subgraph",
           "path": [
             "me"
-          ]
+          ],
+          "extensions": {
+            "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+          }
         }
       ]
     }
@@ -92,7 +98,10 @@ fn request_error() {
               "line": 3,
               "column": 13
             }
-          ]
+          ],
+          "extensions": {
+            "code": "OPERATION_VALIDATION_ERROR"
+          }
         }
       ]
     }
@@ -122,7 +131,10 @@ fn sugraph_request_error() {
       "data": null,
       "errors": [
         {
-          "message": "Upstream error: failed!"
+          "message": "failed!",
+          "extensions": {
+            "code": "SUBGRAPH_ERROR"
+          }
         }
       ]
     }
@@ -155,7 +167,10 @@ fn invalid_response_for_nullable_field() {
           "message": "Missing data from subgraph",
           "path": [
             "name"
-          ]
+          ],
+          "extensions": {
+            "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+          }
         }
       ]
     }
@@ -185,11 +200,14 @@ fn subgraph_field_error() {
       "data": null,
       "errors": [
         {
-          "message": "Upstream error: failed!",
+          "message": "failed!",
           "path": [
             "me",
             "id"
-          ]
+          ],
+          "extensions": {
+            "code": "SUBGRAPH_ERROR"
+          }
         }
       ]
     }
@@ -285,7 +303,10 @@ fn simple_error() {
             "reviews",
             0,
             "author"
-          ]
+          ],
+          "extensions": {
+            "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+          }
         }
       ]
     }
@@ -318,13 +339,16 @@ fn null_entity_with_error() {
       "data": null,
       "errors": [
         {
-          "message": "Upstream error: I'm broken!",
+          "message": "I'm broken!",
           "path": [
             "me",
             "reviews",
             0,
             "body"
-          ]
+          ],
+          "extensions": {
+            "code": "SUBGRAPH_ERROR"
+          }
         }
       ]
     }

--- a/engine/crates/integration-tests/tests/federation/basic/fragments.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/fragments.rs
@@ -113,7 +113,10 @@ fn named_fragment_cycle() {
               "line": 19,
               "column": 29
             }
-          ]
+          ],
+          "extensions": {
+            "code": "OPERATION_VALIDATION_ERROR"
+          }
         }
       ]
     }

--- a/engine/crates/integration-tests/tests/federation/basic/mutation.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/mutation.rs
@@ -100,10 +100,13 @@ fn mutation_failure_should_stop_later_executions_if_required() {
           },
           "errors": [
             {
-              "message": "Upstream error: This mutation always fails",
+              "message": "This mutation always fails",
               "path": [
                 "faillible"
-              ]
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_ERROR"
+              }
             }
           ]
         }
@@ -137,10 +140,13 @@ fn mutation_failure_should_stop_later_executions_if_required() {
           "data": null,
           "errors": [
             {
-              "message": "Upstream error: This mutation always fails",
+              "message": "This mutation always fails",
               "path": [
                 "fail"
-              ]
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_ERROR"
+              }
             }
           ]
         }

--- a/engine/crates/integration-tests/tests/federation/basic/scalars.rs
+++ b/engine/crates/integration-tests/tests/federation/basic/scalars.rs
@@ -55,7 +55,10 @@ fn supports_unused_builtin_scalars() {
               "line": 1,
               "column": 38
             }
-          ]
+          ],
+          "extensions": {
+            "code": "OPERATION_VALIDATION_ERROR"
+          }
         }
       ]
     }

--- a/engine/crates/integration-tests/tests/federation/hooks/on_gateway_request.rs
+++ b/engine/crates/integration-tests/tests/federation/hooks/on_gateway_request.rs
@@ -3,7 +3,7 @@ use graphql_mocks::{EchoSchema, MockGraphQlServer};
 use http::HeaderMap;
 use integration_tests::{federation::GatewayV2Ext, runtime};
 use runtime::{
-    error::GraphqlError,
+    error::{PartialErrorCode, PartialGraphqlError},
     hooks::{DynHookContext, DynHooks},
 };
 
@@ -17,7 +17,7 @@ fn can_modify_headers() {
             &self,
             _context: &mut DynHookContext,
             mut headers: HeaderMap,
-        ) -> Result<HeaderMap, GraphqlError> {
+        ) -> Result<HeaderMap, PartialGraphqlError> {
             headers.insert("b", "22".parse().unwrap());
             headers.remove("c");
             Ok(headers)
@@ -85,8 +85,8 @@ fn error_is_propagated_back_to_the_user() {
             &self,
             _context: &mut DynHookContext,
             _headers: HeaderMap,
-        ) -> Result<HeaderMap, GraphqlError> {
-            Err(GraphqlError::new("impossible error").with_extension("foo", "bar"))
+        ) -> Result<HeaderMap, PartialGraphqlError> {
+            Err(PartialGraphqlError::new("impossible error", PartialErrorCode::BadRequest).with_extension("foo", "bar"))
         }
     }
 
@@ -105,12 +105,57 @@ fn error_is_propagated_back_to_the_user() {
 
     insta::assert_json_snapshot!(response, @r###"
     {
-      "data": null,
       "errors": [
         {
           "message": "impossible error",
           "extensions": {
-            "foo": "bar"
+            "foo": "bar",
+            "code": "BAD_REQUEST"
+          }
+        }
+      ]
+    }
+    "###);
+}
+
+#[test]
+fn error_code_is_propagated_back_to_the_user() {
+    struct TestHooks;
+
+    #[async_trait::async_trait]
+    impl DynHooks for TestHooks {
+        async fn on_gateway_request(
+            &self,
+            _context: &mut DynHookContext,
+            _headers: HeaderMap,
+        ) -> Result<HeaderMap, PartialGraphqlError> {
+            Err(
+                PartialGraphqlError::new("impossible error", PartialErrorCode::BadRequest)
+                    .with_extension("code", "IMPOSSIBLE"),
+            )
+        }
+    }
+
+    let response = runtime().block_on(async move {
+        let github_mock = MockGraphQlServer::new(EchoSchema).await;
+
+        let engine = Engine::builder()
+            .with_hooks(TestHooks)
+            .with_schema("schema", &github_mock)
+            .await
+            .finish()
+            .await;
+
+        engine.execute("query { serverVersion }").await
+    });
+
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "errors": [
+        {
+          "message": "impossible error",
+          "extensions": {
+            "code": "IMPOSSIBLE"
           }
         }
       ]

--- a/engine/crates/integration-tests/tests/federation/introspection.rs
+++ b/engine/crates/integration-tests/tests/federation/introspection.rs
@@ -839,7 +839,10 @@ fn rejects_bogus_introspection_queries() {
               "line": 5,
               "column": 33
             }
-          ]
+          ],
+          "extensions": {
+            "code": "OPERATION_VALIDATION_ERROR"
+          }
         }
       ]
     }

--- a/engine/crates/integration-tests/tests/federation/trusted_documents.rs
+++ b/engine/crates/integration-tests/tests/federation/trusted_documents.rs
@@ -110,7 +110,10 @@ fn regular_non_persisted_queries_are_rejected() {
         {
           "errors": [
             {
-              "message": "Cannot execute a trusted document query: missing documentId, doc_id or the persistedQuery extension."
+              "message": "Cannot execute a trusted document query: missing documentId, doc_id or the persistedQuery extension.",
+              "extensions": {
+                "code": "TRUSTED_DOCUMENT_ERROR"
+              }
             }
           ]
         }
@@ -130,7 +133,10 @@ fn trusted_document_queries_without_client_name_header_are_rejected() {
         {
           "errors": [
             {
-              "message": "Trusted document queries must include the x-grafbase-client-name header"
+              "message": "Trusted document queries must include the x-grafbase-client-name header",
+              "extensions": {
+                "code": "TRUSTED_DOCUMENT_ERROR"
+              }
             }
           ]
         }
@@ -151,7 +157,10 @@ fn wrong_client_name() {
         {
           "errors": [
             {
-              "message": "Unknown document id: 'df40d7fae090cfec1c7e96d78ffb4087f0421798d96c4c90df3556c7de585dc9'"
+              "message": "Unknown document id: 'df40d7fae090cfec1c7e96d78ffb4087f0421798d96c4c90df3556c7de585dc9'",
+              "extensions": {
+                "code": "TRUSTED_DOCUMENT_ERROR"
+              }
             }
           ]
         }
@@ -194,7 +203,10 @@ fn bypass_header() {
         {
           "errors": [
             {
-              "message": "Cannot execute a trusted document query: missing documentId, doc_id or the persistedQuery extension."
+              "message": "Cannot execute a trusted document query: missing documentId, doc_id or the persistedQuery extension.",
+              "extensions": {
+                "code": "TRUSTED_DOCUMENT_ERROR"
+              }
             }
           ]
         }

--- a/engine/crates/runtime/src/error.rs
+++ b/engine/crates/runtime/src/error.rs
@@ -1,19 +1,32 @@
 use std::{borrow::Cow, fmt};
 
+/// Some of the error codes that the engine supports
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, strum::Display)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+pub enum PartialErrorCode {
+    InternalServerError,
+    BadRequest,
+    Unauthorized,
+    HookError,
+}
+
 /// User facing GraphQL error that will be extended with the right path & location if relevant by
 /// the engine.
 #[derive(Clone, Debug, PartialEq)]
-pub struct GraphqlError {
+pub struct PartialGraphqlError {
     pub message: Cow<'static, str>,
+    pub code: PartialErrorCode,
     /// Optional extensions added to the response
     /// Will be serialized as a map, but we store it as a Vec for efficiency
     pub extensions: Vec<(Cow<'static, str>, serde_json::Value)>,
 }
 
-impl GraphqlError {
-    pub fn new(message: impl Into<String>) -> Self {
-        GraphqlError {
-            message: Cow::Owned(message.into()),
+impl PartialGraphqlError {
+    pub fn new(message: impl Into<Cow<'static, str>>, code: PartialErrorCode) -> Self {
+        PartialGraphqlError {
+            message: message.into(),
+            code,
             extensions: Vec::new(),
         }
     }
@@ -25,32 +38,23 @@ impl GraphqlError {
     }
 
     pub fn internal_server_error() -> Self {
-        GraphqlError {
+        PartialGraphqlError {
             message: Cow::Borrowed("Internal server error"),
+            code: PartialErrorCode::InternalServerError,
+            extensions: Vec::new(),
+        }
+    }
+
+    pub fn internal_hook_error() -> Self {
+        PartialGraphqlError {
+            message: Cow::Borrowed("Internal hook error"),
+            code: PartialErrorCode::HookError,
             extensions: Vec::new(),
         }
     }
 }
 
-impl From<String> for GraphqlError {
-    fn from(message: String) -> Self {
-        GraphqlError {
-            message: Cow::Owned(message),
-            extensions: Vec::new(),
-        }
-    }
-}
-
-impl From<&'static str> for GraphqlError {
-    fn from(message: &'static str) -> Self {
-        GraphqlError {
-            message: Cow::Borrowed(message),
-            extensions: Vec::new(),
-        }
-    }
-}
-
-impl fmt::Display for GraphqlError {
+impl fmt::Display for PartialGraphqlError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.message.fmt(f)
     }

--- a/engine/crates/runtime/src/hooks.rs
+++ b/engine/crates/runtime/src/hooks.rs
@@ -8,7 +8,7 @@ use std::future::Future;
 
 pub use http::HeaderMap;
 
-use crate::error::GraphqlError;
+use crate::error::{PartialErrorCode, PartialGraphqlError};
 
 pub struct NodeDefinition<'a> {
     pub type_name: &'a str,
@@ -37,7 +37,7 @@ pub trait Hooks: Send + Sync + 'static {
     fn on_gateway_request(
         &self,
         headers: HeaderMap,
-    ) -> impl Future<Output = Result<(Self::Context, HeaderMap), GraphqlError>> + Send;
+    ) -> impl Future<Output = Result<(Self::Context, HeaderMap), PartialGraphqlError>> + Send;
 
     fn authorize_edge_pre_execution<'a>(
         &self,
@@ -45,14 +45,14 @@ pub trait Hooks: Send + Sync + 'static {
         definition: EdgeDefinition<'a>,
         arguments: impl serde::Serialize + serde::de::Deserializer<'a> + Send,
         metadata: Option<impl serde::Serialize + serde::de::Deserializer<'a> + Send>,
-    ) -> impl Future<Output = Result<(), GraphqlError>> + Send;
+    ) -> impl Future<Output = Result<(), PartialGraphqlError>> + Send;
 
     fn authorize_node_pre_execution<'a>(
         &self,
         context: &Self::Context,
         definition: NodeDefinition<'a>,
         metadata: Option<impl serde::Serialize + serde::de::Deserializer<'a> + Send>,
-    ) -> impl Future<Output = Result<(), GraphqlError>> + Send;
+    ) -> impl Future<Output = Result<(), PartialGraphqlError>> + Send;
 
     fn authorize_parent_edge_post_execution<'a>(
         &self,
@@ -60,7 +60,7 @@ pub trait Hooks: Send + Sync + 'static {
         definition: EdgeDefinition<'a>,
         parents: Vec<String>,
         metadata: Option<impl serde::Serialize + serde::de::Deserializer<'a> + Send>,
-    ) -> impl Future<Output = Result<Vec<Result<(), GraphqlError>>, GraphqlError>> + Send;
+    ) -> impl Future<Output = Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError>> + Send;
 
     fn authorize_edge_node_post_execution<'a>(
         &self,
@@ -68,7 +68,7 @@ pub trait Hooks: Send + Sync + 'static {
         definition: EdgeDefinition<'a>,
         nodes: Vec<String>,
         metadata: Option<impl serde::Serialize + serde::de::Deserializer<'a> + Send>,
-    ) -> impl Future<Output = Result<Vec<Result<(), GraphqlError>>, GraphqlError>> + Send;
+    ) -> impl Future<Output = Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError>> + Send;
 
     fn authorize_edge_post_execution<'a>(
         &self,
@@ -76,7 +76,7 @@ pub trait Hooks: Send + Sync + 'static {
         definition: EdgeDefinition<'a>,
         edges: Vec<(String, Vec<String>)>,
         metadata: Option<impl serde::Serialize + serde::de::Deserializer<'a> + Send>,
-    ) -> impl Future<Output = Result<Vec<Result<(), GraphqlError>>, GraphqlError>> + Send;
+    ) -> impl Future<Output = Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError>> + Send;
 }
 
 // ---------------------------//
@@ -85,7 +85,7 @@ pub trait Hooks: Send + Sync + 'static {
 impl Hooks for () {
     type Context = ();
 
-    async fn on_gateway_request(&self, headers: HeaderMap) -> Result<(Self::Context, HeaderMap), GraphqlError> {
+    async fn on_gateway_request(&self, headers: HeaderMap) -> Result<(Self::Context, HeaderMap), PartialGraphqlError> {
         Ok(((), headers))
     }
 
@@ -95,9 +95,10 @@ impl Hooks for () {
         _: EdgeDefinition<'a>,
         _: impl serde::Serialize + serde::de::Deserializer<'a> + Send,
         _: Option<impl serde::Serialize + serde::de::Deserializer<'a> + Send>,
-    ) -> Result<(), GraphqlError> {
-        Err(GraphqlError::new(
+    ) -> Result<(), PartialGraphqlError> {
+        Err(PartialGraphqlError::new(
             "@authorized directive cannot be used, so access was denied",
+            PartialErrorCode::Unauthorized,
         ))
     }
 
@@ -106,9 +107,10 @@ impl Hooks for () {
         _: &Self::Context,
         _: NodeDefinition<'a>,
         _: Option<impl serde::Serialize + serde::de::Deserializer<'a> + Send>,
-    ) -> Result<(), GraphqlError> {
-        Err(GraphqlError::new(
+    ) -> Result<(), PartialGraphqlError> {
+        Err(PartialGraphqlError::new(
             "@authorized directive cannot be used, so access was denied",
+            PartialErrorCode::Unauthorized,
         ))
     }
 
@@ -118,9 +120,10 @@ impl Hooks for () {
         _: EdgeDefinition<'a>,
         _: Vec<String>,
         _: Option<impl serde::Serialize + serde::de::Deserializer<'a> + Send>,
-    ) -> Result<Vec<Result<(), GraphqlError>>, GraphqlError> {
-        Err(GraphqlError::new(
+    ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
+        Err(PartialGraphqlError::new(
             "@authorized directive cannot be used, so access was denied",
+            PartialErrorCode::Unauthorized,
         ))
     }
 
@@ -130,9 +133,10 @@ impl Hooks for () {
         _: EdgeDefinition<'a>,
         _: Vec<String>,
         _: Option<impl serde::Serialize + serde::de::Deserializer<'a> + Send>,
-    ) -> Result<Vec<Result<(), GraphqlError>>, GraphqlError> {
-        Err(GraphqlError::new(
+    ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
+        Err(PartialGraphqlError::new(
             "@authorized directive cannot be used, so access was denied",
+            PartialErrorCode::Unauthorized,
         ))
     }
 
@@ -142,9 +146,10 @@ impl Hooks for () {
         _: EdgeDefinition<'a>,
         _: Vec<(String, Vec<String>)>,
         _: Option<impl serde::Serialize + serde::de::Deserializer<'a> + Send>,
-    ) -> Result<Vec<Result<(), GraphqlError>>, GraphqlError> {
-        Err(GraphqlError::new(
+    ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
+        Err(PartialGraphqlError::new(
             "@authorized directive cannot be used, so access was denied",
+            PartialErrorCode::Unauthorized,
         ))
     }
 }

--- a/engine/crates/runtime/src/hooks/test_utils.rs
+++ b/engine/crates/runtime/src/hooks/test_utils.rs
@@ -17,7 +17,7 @@ pub trait DynHooks: Send + Sync + 'static {
         &self,
         context: &mut DynHookContext,
         headers: HeaderMap,
-    ) -> Result<HeaderMap, GraphqlError> {
+    ) -> Result<HeaderMap, PartialGraphqlError> {
         Ok(headers)
     }
 
@@ -27,8 +27,11 @@ pub trait DynHooks: Send + Sync + 'static {
         definition: EdgeDefinition<'_>,
         arguments: serde_json::Value,
         metadata: Option<serde_json::Value>,
-    ) -> Result<(), GraphqlError> {
-        Err("authorize_edge_pre_execution is not implemented".into())
+    ) -> Result<(), PartialGraphqlError> {
+        Err(PartialGraphqlError::new(
+            "authorize_edge_pre_execution is not implemented",
+            PartialErrorCode::Unauthorized,
+        ))
     }
 
     async fn authorize_node_pre_execution(
@@ -36,8 +39,11 @@ pub trait DynHooks: Send + Sync + 'static {
         context: &DynHookContext,
         definition: NodeDefinition<'_>,
         metadata: Option<serde_json::Value>,
-    ) -> Result<(), GraphqlError> {
-        Err("authorize_node_pre_execution is not implemented".into())
+    ) -> Result<(), PartialGraphqlError> {
+        Err(PartialGraphqlError::new(
+            "authorize_node_pre_execution is not implemented",
+            PartialErrorCode::Unauthorized,
+        ))
     }
 
     async fn authorize_parent_edge_post_execution<'a>(
@@ -46,8 +52,11 @@ pub trait DynHooks: Send + Sync + 'static {
         definition: EdgeDefinition<'a>,
         parents: Vec<String>,
         metadata: Option<serde_json::Value>,
-    ) -> Result<Vec<Result<(), GraphqlError>>, GraphqlError> {
-        Err("authorize_parent_edge_post_execution is not implemented".into())
+    ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
+        Err(PartialGraphqlError::new(
+            "authorize_parent_edge_post_execution is not implemented",
+            PartialErrorCode::Unauthorized,
+        ))
     }
 
     async fn authorize_edge_node_post_execution<'a>(
@@ -56,8 +65,11 @@ pub trait DynHooks: Send + Sync + 'static {
         definition: EdgeDefinition<'a>,
         nodes: Vec<String>,
         metadata: Option<serde_json::Value>,
-    ) -> Result<Vec<Result<(), GraphqlError>>, GraphqlError> {
-        Err("authorize_edge_node_post_execution is not implemented".into())
+    ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
+        Err(PartialGraphqlError::new(
+            "authorize_edge_node_post_execution is not implemented",
+            PartialErrorCode::Unauthorized,
+        ))
     }
 
     async fn authorize_edge_post_execution<'a>(
@@ -66,8 +78,11 @@ pub trait DynHooks: Send + Sync + 'static {
         definition: EdgeDefinition<'a>,
         edges: Vec<(String, Vec<String>)>,
         metadata: Option<serde_json::Value>,
-    ) -> Result<Vec<Result<(), GraphqlError>>, GraphqlError> {
-        Err("authorize_edge_post_execution is not implemented".into())
+    ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
+        Err(PartialGraphqlError::new(
+            "authorize_edge_post_execution is not implemented",
+            PartialErrorCode::Unauthorized,
+        ))
     }
 }
 
@@ -128,7 +143,7 @@ impl DynamicHooks {
 impl Hooks for DynamicHooks {
     type Context = DynHookContext;
 
-    async fn on_gateway_request(&self, headers: HeaderMap) -> Result<(Self::Context, HeaderMap), GraphqlError> {
+    async fn on_gateway_request(&self, headers: HeaderMap) -> Result<(Self::Context, HeaderMap), PartialGraphqlError> {
         let mut context = DynHookContext::default();
         let headers = self.0.on_gateway_request(&mut context, headers).await?;
         Ok((context, headers))
@@ -140,7 +155,7 @@ impl Hooks for DynamicHooks {
         definition: EdgeDefinition<'a>,
         arguments: impl serde::Serialize + serde::de::Deserializer<'a> + Send,
         metadata: Option<impl serde::Serialize + serde::de::Deserializer<'a> + Send>,
-    ) -> Result<(), GraphqlError> {
+    ) -> Result<(), PartialGraphqlError> {
         self.0
             .authorize_edge_pre_execution(
                 context,
@@ -156,7 +171,7 @@ impl Hooks for DynamicHooks {
         context: &Self::Context,
         definition: NodeDefinition<'a>,
         metadata: Option<impl serde::Serialize + serde::de::Deserializer<'a> + Send>,
-    ) -> Result<(), GraphqlError> {
+    ) -> Result<(), PartialGraphqlError> {
         self.0
             .authorize_node_pre_execution(context, definition, metadata.map(|m| serde_json::to_value(&m).unwrap()))
             .await
@@ -168,7 +183,7 @@ impl Hooks for DynamicHooks {
         definition: EdgeDefinition<'a>,
         parents: Vec<String>,
         metadata: Option<impl serde::Serialize + serde::de::Deserializer<'a> + Send>,
-    ) -> Result<Vec<Result<(), GraphqlError>>, GraphqlError> {
+    ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
         self.0
             .authorize_parent_edge_post_execution(
                 context,
@@ -185,7 +200,7 @@ impl Hooks for DynamicHooks {
         definition: EdgeDefinition<'a>,
         nodes: Vec<String>,
         metadata: Option<impl serde::Serialize + serde::de::Deserializer<'a> + Send>,
-    ) -> Result<Vec<Result<(), GraphqlError>>, GraphqlError> {
+    ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
         self.0
             .authorize_parent_edge_post_execution(
                 context,
@@ -202,7 +217,7 @@ impl Hooks for DynamicHooks {
         definition: EdgeDefinition<'a>,
         edges: Vec<(String, Vec<String>)>,
         metadata: Option<impl serde::Serialize + serde::de::Deserializer<'a> + Send>,
-    ) -> Result<Vec<Result<(), GraphqlError>>, GraphqlError> {
+    ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
         self.0
             .authorize_edge_post_execution(
                 context,

--- a/gateway/crates/gateway-binary/tests/integration_tests.rs
+++ b/gateway/crates/gateway-binary/tests/integration_tests.rs
@@ -434,7 +434,10 @@ fn static_schema() {
               "message": "error sending request for url (http://127.0.0.1:46697/)",
               "path": [
                 "me"
-              ]
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_REQUEST_ERROR"
+              }
             }
           ]
         }
@@ -553,7 +556,10 @@ fn custom_path() {
               "message": "error sending request for url (http://127.0.0.1:46697/)",
               "path": [
                 "me"
-              ]
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_REQUEST_ERROR"
+              }
             }
           ]
         }
@@ -615,7 +621,10 @@ fn csrf_with_header() {
               "message": "error sending request for url (http://127.0.0.1:46697/)",
               "path": [
                 "me"
-              ]
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_REQUEST_ERROR"
+              }
             }
           ]
         }
@@ -647,7 +656,10 @@ fn hybrid_graph() {
               "message": "error sending request for url (http://127.0.0.1:46697/)",
               "path": [
                 "me"
-              ]
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_REQUEST_ERROR"
+              }
             }
           ]
         }

--- a/gateway/crates/gateway-binary/tests/telemetry/metrics/operation.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/metrics/operation.rs
@@ -64,7 +64,10 @@ fn generate_operation_name() {
                   "line": 1,
                   "column": 9
                 }
-              ]
+              ],
+              "extensions": {
+                "code": "OPERATION_VALIDATION_ERROR"
+              }
             }
           ]
         }
@@ -118,7 +121,10 @@ fn request_error() {
                   "line": 1,
                   "column": 16
                 }
-              ]
+              ],
+              "extensions": {
+                "code": "OPERATION_VALIDATION_ERROR"
+              }
             }
           ]
         }
@@ -170,7 +176,10 @@ fn field_error() {
               "message": "error sending request for url (http://127.0.0.1:46697/)",
               "path": [
                 "me"
-              ]
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_REQUEST_ERROR"
+              }
             }
           ]
         }
@@ -222,7 +231,10 @@ fn field_error_data_null() {
               "message": "error sending request for url (http://127.0.0.1:46697/)",
               "path": [
                 "me"
-              ]
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_REQUEST_ERROR"
+              }
             }
           ]
         }

--- a/gateway/crates/gateway-binary/tests/telemetry/metrics/request.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/metrics/request.rs
@@ -56,7 +56,10 @@ fn request_error() {
                   "line": 1,
                   "column": 2
                 }
-              ]
+              ],
+              "extensions": {
+                "code": "OPERATION_PARSING_ERROR"
+              }
             }
           ]
         }
@@ -105,7 +108,10 @@ fn field_error() {
               "message": "error sending request for url (http://127.0.0.1:46697/)",
               "path": [
                 "me"
-              ]
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_REQUEST_ERROR"
+              }
             }
           ]
         }
@@ -151,7 +157,10 @@ fn field_error_data_null() {
               "message": "error sending request for url (http://127.0.0.1:46697/)",
               "path": [
                 "me"
-              ]
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_REQUEST_ERROR"
+              }
             }
           ]
         }


### PR DESCRIPTION
Adding a mandatory error code in engine-v2 errors.
I'm not sure how we should handle custom error codes from hooks though if we want to support that later.

I have renamed the `runtime::error:{GraphqlError, ErrorCode}` to `runtime::error::{PartialGraphqlError, PartialErrorCode}` as they're extended by the engine on top. Not a great name, but avoids having identical names at least.