### PR TITLE
fix(engine-v2): Add missing (sanitized) query in traces

### DIFF
--- a/engine/crates/gateway-core/src/lib.rs
+++ b/engine/crates/gateway-core/src/lib.rs
@@ -161,7 +161,7 @@ where
             unreachable!("auth must be AccessToken::V1 at this point");
         };
 
-        let gql_span = GqlRequestSpan::new().into_span();
+        let gql_span = GqlRequestSpan::create();
         let start = web_time::Instant::now();
 
         async {
@@ -192,7 +192,8 @@ where
                         common_types::OperationType::Mutation => "mutation",
                         common_types::OperationType::Subscription => "subscription",
                     },
-                    operation_name: operation.name.clone(),
+                    operation_name: operation.name.as_deref(),
+                    sanitized_query: normalized_query.as_deref(),
                 });
                 gql_span.record_gql_status(status);
             }

--- a/engine/crates/integration-tests/tests/tracing/v2.rs
+++ b/engine/crates/integration-tests/tests/tracing/v2.rs
@@ -2,8 +2,8 @@ use tracing::Level;
 use tracing_mock::{expect, subscriber};
 
 use engine_v2::Engine;
-use grafbase_tracing::span::{gql::GRAPHQL_SPAN_NAME, subgraph::SUBGRAPH_SPAN_NAME};
-use graphql_mocks::{FakeFederationProductsSchema, FakeGithubSchema, MockGraphQlServer};
+use grafbase_tracing::span::gql::GRAPHQL_SPAN_NAME;
+use graphql_mocks::{FakeGithubSchema, MockGraphQlServer};
 use integration_tests::{federation::GatewayV2Ext, runtime};
 
 #[test]
@@ -18,6 +18,11 @@ fn query_bad_request() {
             .record(
                 span.clone(),
                 expect::field("gql.operation.name").with_value(&"__type_name"),
+            )
+            .record(span.clone(), expect::field("otel.name").with_value(&"__type_name"))
+            .record(
+                span.clone(),
+                expect::field("gql.operation.query").with_value(&"{\n  __type_name\n}\n"),
             )
             .record(span.clone(), expect::field("gql.operation.type").with_value(&"query"))
             .record(
@@ -38,106 +43,6 @@ fn query_bad_request() {
 
         // act
         let _ = engine.execute("{ __type_name }").await;
-
-        // assert
-        handle.assert_finished();
-    })
-}
-
-#[test]
-#[ignore]
-fn query_named() {
-    runtime().block_on(async {
-        // prepare
-        let query = "query Named { __typename }";
-        let graphql_span = expect::span().at_level(Level::INFO).named(GRAPHQL_SPAN_NAME);
-        let subgraphql_span = expect::span().at_level(Level::INFO).named(SUBGRAPH_SPAN_NAME);
-
-        let (subscriber, handle) = subscriber::mock()
-            .with_filter(|meta| meta.is_span() && meta.target() == "grafbase" && *meta.level() >= Level::INFO)
-            .enter(graphql_span.clone())
-            .new_span(
-                subgraphql_span
-                    .clone()
-                    .with_field(expect::field("subgraph.name").with_value(&"github"))
-                    .with_field(expect::field("subgraph.gql.document").with_value(&"query {\n  serverVersion\n}"))
-                    .with_field(expect::field("subgraph.gql.operation.type").with_value(&"query")),
-            )
-            .enter(subgraphql_span.clone())
-            .exit(subgraphql_span.clone())
-            .record(
-                graphql_span.clone(),
-                expect::field("gql.operation.name").with_value(&"Named"),
-            )
-            .record(
-                graphql_span.clone(),
-                expect::field("gql.operation.type").with_value(&"query"),
-            )
-            .exit(graphql_span.clone())
-            .run_with_handle();
-
-        let _default = tracing::subscriber::set_default(subscriber);
-
-        let github_mock = MockGraphQlServer::new(FakeGithubSchema).await;
-
-        let engine = Engine::builder()
-            .with_schema("github", &github_mock)
-            .await
-            .finish()
-            .await;
-
-        // act
-        let _ = engine.execute(query).await;
-
-        // assert
-        handle.assert_finished();
-    })
-}
-
-#[test]
-#[ignore]
-fn subscription() {
-    runtime().block_on(async {
-        // prepare
-        let query = r"
-                subscription Sub {
-                    newProducts {
-                        upc
-                        name
-                        price
-                    }
-                }
-                ";
-        let span = expect::span().at_level(Level::INFO).named(GRAPHQL_SPAN_NAME);
-
-        let (subscriber, handle) = subscriber::mock()
-            .with_filter(|meta| meta.is_span() && meta.target() == "grafbase" && *meta.level() >= Level::INFO)
-            .enter(span.clone())
-            .record(span.clone(), expect::field("gql.operation.name").with_value(&"Sub"))
-            .record(
-                span.clone(),
-                expect::field("gql.operation.type").with_value(&"subscription"),
-            )
-            .run_with_handle();
-
-        let _default = tracing::subscriber::set_default(subscriber);
-
-        // engine
-        let products = MockGraphQlServer::new(FakeFederationProductsSchema).await;
-        let engine = Engine::builder()
-            .with_schema("products", &products)
-            .await
-            .with_supergraph_config(indoc::formatdoc!(
-                r#"
-                    extend schema
-                      @subgraph(name: "products", websocketUrl: "{}")
-                "#,
-                products.websocket_url(),
-            ))
-            .finish()
-            .await;
-
-        let _ = engine.execute(query).into_multipart_stream().collect::<Vec<_>>().await;
 
         // assert
         handle.assert_finished();

--- a/engine/crates/tracing/src/span.rs
+++ b/engine/crates/tracing/src/span.rs
@@ -32,7 +32,7 @@ pub trait HttpRecorderSpanExt {
 /// Extension trait to record gql request attributes
 pub trait GqlRecorderSpanExt {
     /// Record GraphQL request attributes in the span
-    fn record_gql_request(&self, attributes: GqlRequestAttributes);
+    fn record_gql_request(&self, attributes: GqlRequestAttributes<'_>);
     /// Record GraphQL response attributes in the span
     fn record_gql_response(&self, attributes: GqlResponseAttributes);
 
@@ -43,11 +43,13 @@ pub trait GqlRecorderSpanExt {
 
 /// Wraps attributes of a graphql request intended to be recorded
 #[derive(Debug)]
-pub struct GqlRequestAttributes {
+pub struct GqlRequestAttributes<'a> {
     /// GraphQL operation type
     pub operation_type: &'static str,
     /// GraphQL operation name
-    pub operation_name: Option<String>,
+    pub operation_name: Option<&'a str>,
+    /// Must NOT contain any sensitive data
+    pub sanitized_query: Option<&'a str>,
 }
 
 /// Wraps attributes of a graphql response intended to be recorded

--- a/engine/crates/tracing/src/span/subgraph.rs
+++ b/engine/crates/tracing/src/span/subgraph.rs
@@ -9,58 +9,20 @@ pub const SUBGRAPH_NAME_ATTRIBUTE: &str = "subgraph.name";
 
 /// A span for a subgraph request
 pub struct SubgraphRequestSpan<'a> {
-    name: &'a str,
-    operation_name: Option<&'a str>,
-    operation_type: Option<&'a str>,
-    document: Option<&'a str>,
-    url: Option<&'a Url>,
+    pub name: &'a str,
+    pub operation_type: &'a str,
+    pub sanitized_query: &'a str,
+    pub url: &'a Url,
 }
 impl<'a> SubgraphRequestSpan<'a> {
-    /// Create a new instance
-    pub fn new(name: &'a str) -> Self {
-        SubgraphRequestSpan {
-            name,
-            operation_name: None,
-            operation_type: None,
-            document: None,
-            url: None,
-        }
-    }
-
-    /// Set the subgraph GraphQL document as an attribute of the span
-    pub fn with_document(mut self, document: &'a str) -> Self {
-        self.document = Some(document);
-        self
-    }
-
-    /// Set the subgraph operation name as an attribute of the span
-    pub fn with_operation_name(mut self, operation_name: impl Into<Option<&'a str>>) -> Self {
-        self.operation_name = operation_name.into();
-        self
-    }
-
-    /// Set the subgraph operation type as an attribute of the span
-    pub fn with_operation_type(mut self, operation_type: &'a str) -> Self {
-        self.operation_type = Some(operation_type);
-        self
-    }
-
-    /// Set the subgraph url as an attribute of the span
-    pub fn with_url(mut self, url: &'a Url) -> Self {
-        self.url = Some(url);
-        self
-    }
-
-    /// Consume self and turn into a [Span]
     pub fn into_span(self) -> Span {
         info_span!(
             target: crate::span::GRAFBASE_TARGET,
             SUBGRAPH_SPAN_NAME,
             "subgraph.name" = self.name,
-            "subgraph.url" = self.url.map(|url| url.as_str()).unwrap_or_default(),
-            "subgraph.gql.operation.name" = self.operation_name.as_ref(),
-            "subgraph.gql.operation.type" = self.operation_type,
-            "subgraph.gql.document" = self.document,
+            "subgraph.url" = self.url.as_str(),
+            "gql.operation.type" = self.operation_type,
+            "gql.operation.query" = self.sanitized_query,
             "otel.name" = format!("{SUBGRAPH_SPAN_NAME}:{}", self.name),
         )
     }


### PR DESCRIPTION
Adding missing (sanitized) GraphQL query in traces and cleaning up a few things. Renamed `gql.document` to `gql.operation.query` as it's more accurate. Removed some of the tracing v2 tests, the tracing mock ones are super hard to get right and understand. We should just test against the output in ClickHouse as we do for metrics.