### PR TITLE
fix: defer served entirely from partial cache

### DIFF
--- a/engine/crates/partial-caching/src/lib.rs
+++ b/engine/crates/partial-caching/src/lib.rs
@@ -18,6 +18,7 @@ use cynic_parser::{
     executable::{ids::OperationDefinitionId, OperationDefinition},
     ExecutableDocument,
 };
+use planning::defers::DeferStore;
 use registry_for_cache::CacheControl;
 
 mod execution;
@@ -47,7 +48,7 @@ pub struct CachingPlan {
     pub cache_partitions: Vec<(CacheControl, QuerySubset)>,
     pub nocache_partition: QuerySubset,
     operation_id: OperationDefinitionId,
-    defers: Vec<planning::defers::DeferRecord>,
+    defers: DeferStore,
 }
 
 impl CachingPlan {

--- a/engine/crates/partial-caching/src/planning/mod.rs
+++ b/engine/crates/partial-caching/src/planning/mod.rs
@@ -60,6 +60,8 @@ pub fn build_plan(
     let (cache_groups, uncached_group) =
         visit_fragments(&document, registry, fragment_tracker, partitioner, &mut defer_visitor)?;
 
+    let defers = defer_visitor.defers;
+
     let nocache_variables = variables_required(&uncached_group, &document, operation);
 
     Ok(Some(CachingPlan {
@@ -73,7 +75,7 @@ pub fn build_plan(
         nocache_partition: QuerySubset::new(operation.id(), uncached_group, nocache_variables),
         operation_id: operation.id(),
         document,
-        defers: defer_visitor.defers,
+        defers,
     }))
 }
 

--- a/engine/crates/partial-caching/src/query_subset/mod.rs
+++ b/engine/crates/partial-caching/src/query_subset/mod.rs
@@ -59,6 +59,10 @@ impl QuerySubset {
         self.variables.extend(other.variables.iter().cloned());
     }
 
+    pub fn contains_selection(&self, selection: SelectionId) -> bool {
+        self.partition.selections.contains(&selection)
+    }
+
     pub fn as_display<'a>(&'a self, document: &'a ExecutableDocument) -> QuerySubsetDisplay<'a> {
         QuerySubsetDisplay {
             subset: self,


### PR DESCRIPTION
When testing defer on production, I saw some weird behaviour: sometimes a cached defer would not return some of the fields.

This turned out to be because I'd forgotten to account for the case where a defer is served entirely from the cache and doesn't make it as far as the query we send to the executor.

Easy to fix though: just need to check which defers aren't in the executor partition and then count those amongst the active defers when doing the initial cache merge.