### PR TITLE
fix: use `CompactValue` directly inside `StreamingPayload`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4593,6 +4593,7 @@ dependencies = [
  "bitmaps",
  "rand_core 0.6.4",
  "rand_xoshiro",
+ "serde",
  "sized-chunks",
  "typenum",
  "version_check",

--- a/engine/crates/engine/query-path/Cargo.toml
+++ b/engine/crates/engine/query-path/Cargo.toml
@@ -13,6 +13,6 @@ publish = false
 [features]
 
 [dependencies]
-im = "15"
+im = { version = "15", features = ["serde"] }
 internment.workspace = true
 serde.workspace = true

--- a/engine/crates/engine/query-path/src/lib.rs
+++ b/engine/crates/engine/query-path/src/lib.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 /// At one point this was just a reverse linked-list of references, but that was a
 /// real pain to integrate with defer & stream as the lifetimes wouldn't last long
 /// enough.
-#[derive(Default, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct QueryPath(im::Vector<QueryPathSegment>);
 
 impl QueryPath {
@@ -35,6 +35,14 @@ impl QueryPath {
 
     pub fn iter(&self) -> impl DoubleEndedIterator<Item = &QueryPathSegment> {
         self.0.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 }
 

--- a/engine/crates/engine/src/schema.rs
+++ b/engine/crates/engine/src/schema.rs
@@ -668,7 +668,9 @@ async fn process_deferred_workload(
 
     IncrementalPayload {
         label: workload.label,
-        data,
+        data: data
+            .into_compact_value()
+            .expect("handle this, also possibly use CompactValue"),
         path: workload.path,
         has_next: false, // We hardcode this to false here, the function calling us should override
         errors,

--- a/engine/crates/engine/src/schema.rs
+++ b/engine/crates/engine/src/schema.rs
@@ -668,9 +668,7 @@ async fn process_deferred_workload(
 
     IncrementalPayload {
         label: workload.label,
-        data: data
-            .into_compact_value()
-            .expect("handle this, also possibly use CompactValue"),
+        data: data.into_compact_value().unwrap_or_default(),
         path: workload.path,
         has_next: false, // We hardcode this to false here, the function calling us should override
         errors,

--- a/engine/crates/gateway-core/src/cache/partial.rs
+++ b/engine/crates/gateway-core/src/cache/partial.rs
@@ -122,7 +122,7 @@ where
 
             Ok(stream::once(async move {
                 engine::StreamingPayload::InitialResponse(InitialResponse {
-                    data: response.data.into_compact_value().expect("TODO: handle me"),
+                    data: response.data.into_compact_value(),
                     errors: response.errors,
                     has_next: false,
                 })
@@ -132,7 +132,6 @@ where
     }
 }
 
-#[allow(clippy::diverging_sub_expression)] // TODO: Remove me
 async fn run_execution_phase_stream(
     mut execution_phase: StreamingExecutionPhase,
     mut engine_stream: BoxStream<'static, engine::StreamingPayload>,
@@ -143,9 +142,9 @@ async fn run_execution_phase_stream(
         todo!("GB-6966");
     };
 
-    payload.data = todo!("execution_phase.record_initial_response(payload.data, !payload.errors.is_empty());");
-
-    // payload.response = response;
+    if let Some(data) = payload.data {
+        payload.data = Some(execution_phase.record_initial_response(data, !payload.errors.is_empty()));
+    }
 
     if response_sender
         .send(StreamingPayload::InitialResponse(payload))
@@ -162,13 +161,11 @@ async fn run_execution_phase_stream(
 
         let path = payload.path.iter().collect::<Vec<_>>();
 
-        payload.data = todo!(
-            "execution_phase.record_incremental_response(
+        payload.data = execution_phase.record_incremental_response(
             payload.label.as_deref(),
             &path,
             payload.data,
             !payload.errors.is_empty(),
-        )"
         );
 
         if response_sender

--- a/engine/crates/gateway-core/src/cache/partial.rs
+++ b/engine/crates/gateway-core/src/cache/partial.rs
@@ -122,7 +122,8 @@ where
 
             Ok(stream::once(async move {
                 engine::StreamingPayload::InitialResponse(InitialResponse {
-                    response,
+                    data: response.data.into_compact_value().expect("TODO: handle me"),
+                    errors: response.errors,
                     has_next: false,
                 })
             })
@@ -131,6 +132,7 @@ where
     }
 }
 
+#[allow(clippy::diverging_sub_expression)] // TODO: Remove me
 async fn run_execution_phase_stream(
     mut execution_phase: StreamingExecutionPhase,
     mut engine_stream: BoxStream<'static, engine::StreamingPayload>,
@@ -141,11 +143,9 @@ async fn run_execution_phase_stream(
         todo!("GB-6966");
     };
 
-    let mut response = payload.response;
+    payload.data = todo!("execution_phase.record_initial_response(payload.data, !payload.errors.is_empty());");
 
-    response.data = execution_phase.record_initial_response(response.data, !response.errors.is_empty());
-
-    payload.response = response;
+    // payload.response = response;
 
     if response_sender
         .send(StreamingPayload::InitialResponse(payload))
@@ -162,11 +162,13 @@ async fn run_execution_phase_stream(
 
         let path = payload.path.iter().collect::<Vec<_>>();
 
-        payload.data = execution_phase.record_incremental_response(
+        payload.data = todo!(
+            "execution_phase.record_incremental_response(
             payload.label.as_deref(),
             &path,
             payload.data,
             !payload.errors.is_empty(),
+        )"
         );
 
         if response_sender

--- a/engine/crates/graph-entities/src/value/mod.rs
+++ b/engine/crates/graph-entities/src/value/mod.rs
@@ -50,6 +50,17 @@ impl CompactValue {
     pub fn is_array(&self) -> bool {
         matches!(self, CompactValue::List(_))
     }
+
+    pub fn is_null(&self) -> bool {
+        matches!(self, CompactValue::Null)
+    }
+
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            CompactValue::String(s) => Some(s.as_str()),
+            _ => None,
+        }
+    }
 }
 
 impl From<ConstValue> for CompactValue {

--- a/engine/crates/integration-tests/src/helpers.rs
+++ b/engine/crates/integration-tests/src/helpers.rs
@@ -105,9 +105,9 @@ impl ResponseExt for Response {
 impl ResponseExt for StreamingPayload {
     fn assert_success(self) -> Self {
         match self {
-            StreamingPayload::InitialResponse(InitialResponse { response, has_next }) => {
-                let response = response.assert_success();
-                StreamingPayload::InitialResponse(InitialResponse { response, has_next })
+            StreamingPayload::InitialResponse(InitialResponse { data, has_next, errors }) => {
+                assert_eq!(errors, vec![]);
+                StreamingPayload::InitialResponse(InitialResponse { data, has_next, errors })
             }
             StreamingPayload::Incremental(incremental) => {
                 assert_eq!(incremental.errors, vec![]);

--- a/engine/crates/integration-tests/tests/defer/mod.rs
+++ b/engine/crates/integration-tests/tests/defer/mod.rs
@@ -498,6 +498,7 @@ fn test_defer_with_labels() {
             "hasNext": true
           },
           {
+            "label": "outer",
             "data": {
               "firstPet": {
                 "id": 123,
@@ -507,10 +508,10 @@ fn test_defer_with_labels() {
             "path": [
               "petstore"
             ],
-            "hasNext": true,
-            "label": "outer"
+            "hasNext": true
           },
           {
+            "label": "inner",
             "data": {
               "secondPet": {
                 "id": 456,
@@ -520,8 +521,7 @@ fn test_defer_with_labels() {
             "path": [
               "petstore"
             ],
-            "hasNext": false,
-            "label": "inner"
+            "hasNext": false
           }
         ]
         "###

--- a/engine/crates/integration-tests/tests/partial_caching/defer.rs
+++ b/engine/crates/integration-tests/tests/partial_caching/defer.rs
@@ -55,6 +55,7 @@ fn smoke_test() {
             "hasNext": true
           },
           {
+            "label": "woo",
             "data": {
               "name": "Jo 1",
               "email": "1@example.com",
@@ -63,8 +64,7 @@ fn smoke_test() {
             "path": [
               "user"
             ],
-            "hasNext": false,
-            "label": "woo"
+            "hasNext": false
           }
         ]
         "###);
@@ -124,6 +124,7 @@ fn test_defer_with_uncached_field() {
             "hasNext": true
           },
           {
+            "label": "woo",
             "data": {
               "name": "Jo 1",
               "email": "1@example.com",
@@ -133,8 +134,7 @@ fn test_defer_with_uncached_field() {
             "path": [
               "user"
             ],
-            "hasNext": false,
-            "label": "woo"
+            "hasNext": false
           }
         ]
         "###);
@@ -154,6 +154,7 @@ fn test_defer_with_uncached_field() {
             "hasNext": true
           },
           {
+            "label": "woo",
             "data": {
               "name": "Jo 1",
               "email": "1@example.com",
@@ -163,8 +164,7 @@ fn test_defer_with_uncached_field() {
             "path": [
               "user"
             ],
-            "hasNext": false,
-            "label": "woo"
+            "hasNext": false
           }
         ]
         "###);
@@ -440,14 +440,14 @@ fn test_when_defer_served_entirely_from_cache() {
             "hasNext": true
           },
           {
+            "label": "hello",
             "data": {
               "reallyExpensiveField": "hello"
             },
             "path": [
               "user"
             ],
-            "hasNext": false,
-            "label": "hello"
+            "hasNext": false
           }
         ]
         "###);

--- a/engine/crates/partial-caching/src/output/response_merging.rs
+++ b/engine/crates/partial-caching/src/output/response_merging.rs
@@ -2,7 +2,8 @@
 
 use std::collections::HashSet;
 
-use graph_entities::{CompactValue, QueryResponse, QueryResponseNode, ResponseNodeId};
+use engine_value::Name;
+use graph_entities::CompactValue;
 
 use crate::{planning::defers::DeferId, TypeRelationships};
 
@@ -14,28 +15,27 @@ use super::{
 
 /// Handles the initial response from the engine
 pub fn handle_initial_response(
-    mut response: QueryResponse,
+    response: CompactValue,
     shapes: &OutputShapes,
     root_object: ConcreteShape<'_>,
     type_relationships: &dyn TypeRelationships,
 ) -> (OutputStore, HashSet<DeferId>) {
     let mut output = OutputStore::default();
 
-    let Some(src_root) = response.root else {
+    let CompactValue::Object(fields) = response else {
         todo!("GB-6966");
     };
 
     let dest_root = output.new_value();
 
     let mut context = MergeContext {
-        source: &mut response,
         output: &mut output,
         active_defers: HashSet::new(),
         type_relationships,
         shapes,
     };
 
-    merge_container_into_value(src_root, dest_root, &mut context, ObjectShape::Concrete(root_object));
+    merge_fields_into_value(fields, dest_root, &mut context, ObjectShape::Concrete(root_object));
 
     let active_defers = context.active_defers;
 
@@ -46,59 +46,53 @@ impl OutputStore {
     pub fn merge_incremental_payload(
         &mut self,
         defer_root_object: ObjectId,
-        mut source: QueryResponse,
+        source: CompactValue,
         shapes: &OutputShapes,
         type_relationships: &dyn TypeRelationships,
     ) -> HashSet<DeferId> {
-        let Some(root_container_id) = source.root else {
+        let CompactValue::Object(fields) = source else {
             todo!("GB-6966");
         };
         let defer_root_shape = shapes.concrete_object(self.read_object(shapes, defer_root_object).shape_id());
 
         let mut context = MergeContext {
-            source: &mut source,
             output: self,
             active_defers: HashSet::new(),
             type_relationships,
             shapes,
         };
 
-        merge_container_into_object(root_container_id, defer_root_object, &mut context, defer_root_shape);
+        merge_fields_into_object(fields, defer_root_object, &mut context, defer_root_shape);
 
         context.active_defers
     }
 }
 
 struct MergeContext<'a> {
-    source: &'a mut QueryResponse,
     output: &'a mut OutputStore,
     active_defers: HashSet<DeferId>,
     type_relationships: &'a dyn TypeRelationships,
     shapes: &'a OutputShapes,
 }
 
-fn merge_container_into_object(
-    container_id: ResponseNodeId,
+fn merge_fields_into_object(
+    fields: Vec<(Name, CompactValue)>,
     dest_object_id: ObjectId,
     context: &mut MergeContext<'_>,
     shape: ConcreteShape<'_>,
 ) {
-    let Some(QueryResponseNode::Container(container)) = context.source.get_node(container_id) else {
-        todo!("GB-6966");
-    };
-
-    let fields = container
-        .iter()
-        .filter_map(|(name, src_id)| {
+    let fields = fields
+        .into_iter()
+        .filter_map(|(name, value)| {
             // If the field is missing from the shape we ignore it.
             // This _could_ be a bug, but it also could just be an implied __typename
             let field_shape = shape.field(name.as_str())?;
 
-            Some((field_shape, *src_id))
+            Some((field_shape, value))
         })
         .collect::<Vec<_>>();
 
-    for (field_shape, src_id) in fields {
+    for (field_shape, value) in fields {
         if let Some(defer) = field_shape.defer_id() {
             context.active_defers.insert(defer);
         }
@@ -106,44 +100,43 @@ fn merge_container_into_object(
         let Some(subselection_shape) = field_shape.subselection_shape() else {
             // This must be a leaf field, process it as such
             let field_dest_id = context.output.field_value_id(dest_object_id, field_shape.index());
-            take_leaf_value(context, src_id, field_dest_id);
+            take_leaf_value(context, value, field_dest_id);
             continue;
         };
 
         let dest_id = context.output.field_value_id(dest_object_id, field_shape.index());
 
-        merge_node(src_id, dest_id, context, subselection_shape);
+        merge_value(value, dest_id, context, subselection_shape);
     }
 }
 
-fn merge_container_into_value(
-    container_id: ResponseNodeId,
+fn merge_fields_into_value(
+    fields: Vec<(Name, CompactValue)>,
     dest_value_id: ValueId,
     context: &mut MergeContext<'_>,
     object_shape: ObjectShape<'_>,
 ) {
     let (object_id, concrete_shape) = match context.output.value(dest_value_id) {
         ValueRecord::Unset => {
-            let (concrete_shape, object_id) = match object_shape {
+            let (object_id, concrete_shape) = match object_shape {
                 ObjectShape::Concrete(concrete_shape) => {
                     let object_id = context.output.insert_object(concrete_shape);
 
-                    (concrete_shape, object_id)
+                    (object_id, concrete_shape)
                 }
                 ObjectShape::Polymorphic(shape) => {
-                    let typename = context.source.get_node(container_id).and_then(|node| {
-                        context
-                            .source
-                            .get_node(node.as_container()?.child("__typename")?)?
-                            .as_str()
-                    });
+                    let typename = fields
+                        .iter()
+                        .find(|(name, _)| name == "__typename")
+                        .and_then(|(_, value)| value.as_str());
 
                     let Some(typename) = typename else { todo!("GB-6966") };
+
                     let concrete_shape = shape.concrete_shape_for_typename(typename, context.type_relationships);
 
                     let object_id = context.output.insert_polymorphic_object(concrete_shape, typename);
 
-                    (concrete_shape, object_id)
+                    (object_id, concrete_shape)
                 }
             };
 
@@ -160,40 +153,37 @@ fn merge_container_into_value(
         _ => todo!("GB-6966"),
     };
 
-    merge_container_into_object(container_id, object_id, context, concrete_shape)
+    merge_fields_into_object(fields, object_id, context, concrete_shape)
 }
 
-fn merge_node(
-    src_id: ResponseNodeId,
+fn merge_value(
+    value: CompactValue,
     dest_id: ValueId,
     context: &mut MergeContext<'_>,
     subselection_shape: ObjectShape<'_>,
 ) {
-    match context.source.get_node(src_id) {
-        Some(QueryResponseNode::Container(_)) => {
-            merge_container_into_value(src_id, dest_id, context, subselection_shape);
+    match value {
+        CompactValue::Object(fields) => {
+            merge_fields_into_value(fields, dest_id, context, subselection_shape);
         }
-        Some(QueryResponseNode::List(list)) => merge_list(list.iter().collect(), dest_id, context, subselection_shape),
-        Some(QueryResponseNode::Primitive(_)) => {
-            todo!("GB-6966")
-        }
-        None => todo!("GB-6966"),
+        CompactValue::List(items) => merge_list(items, dest_id, context, subselection_shape),
+        _ => todo!("GB-6966"),
     }
 }
 
 fn merge_list(
-    entry_src_ids: Vec<ResponseNodeId>,
+    items: Vec<CompactValue>,
     dest_value_id: ValueId,
     context: &mut MergeContext<'_>,
     subselection_shape: ObjectShape<'_>,
 ) {
     let dest_ids = match context.output.value(dest_value_id) {
-        ValueRecord::List(dest_ids) if dest_ids.len() == entry_src_ids.len() => *dest_ids,
+        ValueRecord::List(dest_ids) if dest_ids.len() == items.len() => *dest_ids,
         ValueRecord::List(_) => {
             todo!("GB-6966")
         }
         ValueRecord::Unset => {
-            let ids = context.output.new_list(entry_src_ids.len());
+            let ids = context.output.new_list(items.len());
             context.output.write_value(dest_value_id, ValueRecord::List(ids));
             ids
         }
@@ -202,27 +192,21 @@ fn merge_list(
         }
     };
 
-    for (src_id, dest_id) in entry_src_ids.iter().zip(dest_ids) {
-        merge_node(*src_id, dest_id, context, subselection_shape)
+    for (value, dest_id) in items.into_iter().zip(dest_ids) {
+        merge_value(value, dest_id, context, subselection_shape)
     }
 }
 
-fn take_leaf_value(context: &mut MergeContext<'_>, src_id: ResponseNodeId, dest_id: ValueId) {
-    match context.source.get_node_mut(src_id) {
-        Some(QueryResponseNode::Primitive(primitive)) => {
-            let value = match std::mem::take(&mut primitive.0) {
-                CompactValue::Null => ValueRecord::Null,
-                CompactValue::Number(inner) => ValueRecord::Number(inner.clone()),
-                CompactValue::String(inner) => ValueRecord::String(inner.into_boxed_str()),
-                CompactValue::Boolean(inner) => ValueRecord::Boolean(inner),
-                CompactValue::Binary(_) => todo!("do we even use binaries?  not sure we do"),
-                CompactValue::Enum(inner) => ValueRecord::String(inner.as_str().into()),
-                value @ (CompactValue::List(_) | CompactValue::Object(_)) => ValueRecord::InlineValue(Box::new(value)),
-            };
-            context.output.write_value(dest_id, value);
-        }
-        _ => {
-            todo!("GB-6966");
-        }
-    }
+fn take_leaf_value(context: &mut MergeContext<'_>, value: CompactValue, dest_id: ValueId) {
+    let new_value = match value {
+        CompactValue::Null => ValueRecord::Null,
+        CompactValue::Number(inner) => ValueRecord::Number(inner.clone()),
+        CompactValue::String(inner) => ValueRecord::String(inner.into_boxed_str()),
+        CompactValue::Boolean(inner) => ValueRecord::Boolean(inner),
+        CompactValue::Binary(_) => todo!("do we even use binaries?  not sure we do"),
+        CompactValue::Enum(inner) => ValueRecord::String(inner.as_str().into()),
+        value @ (CompactValue::List(_) | CompactValue::Object(_)) => ValueRecord::InlineValue(Box::new(value)),
+    };
+
+    context.output.write_value(dest_id, new_value);
 }

--- a/engine/crates/partial-caching/src/output/ser.rs
+++ b/engine/crates/partial-caching/src/output/ser.rs
@@ -72,6 +72,12 @@ impl Object<'_> {
         response.set_root_unchecked(root);
         response
     }
+
+    pub fn into_compact_value(self, include_synthetic_typenames: bool) -> CompactValue {
+        let mut response = QueryResponse::default();
+        let root = write_value(Value::Object(self), &mut response, include_synthetic_typenames);
+        response.take_node_into_compact_value(root).expect("node to exist")
+    }
 }
 
 fn write_value(value: Value<'_>, response: &mut QueryResponse, include_synthetic_typenames: bool) -> ResponseNodeId {

--- a/engine/crates/partial-caching/src/output/tests.rs
+++ b/engine/crates/partial-caching/src/output/tests.rs
@@ -5,16 +5,16 @@
 
 use std::collections::HashSet;
 
-use graph_entities::QueryResponse;
+use graph_entities::CompactValue;
 use serde_json::json;
 
 use crate::{build_plan, output::handle_initial_response, type_relationships::NoSubtypes};
 
 use super::shapes::build_output_shapes;
 
-macro_rules! query_response {
+macro_rules! compact_value {
     ($($json:tt)+) => {
-        self::query_response(serde_json::json!($($json)+))
+        self::compact_value(serde_json::json!($($json)+))
     }
 }
 
@@ -27,7 +27,7 @@ fn test_initial_response_handling() {
     let shapes = build_output_shapes(&plan, &NoSubtypes);
     let root_shape = shapes.root();
 
-    let query_response = query_response!({
+    let compact_value = compact_value!({
         "user": {
             "name": "G",
             "email": "whatever",
@@ -36,7 +36,7 @@ fn test_initial_response_handling() {
         }
     });
 
-    let (store, _) = handle_initial_response(query_response, &shapes, root_shape, &NoSubtypes);
+    let (store, _) = handle_initial_response(compact_value, &shapes, root_shape, &NoSubtypes);
 
     insta::assert_json_snapshot!(store.serialize_all(&shapes, serde_json::value::Serializer).unwrap(), @r###"
     {
@@ -73,7 +73,7 @@ fn test_cache_merging() {
     let shapes = build_output_shapes(&plan, &NoSubtypes);
     let root_shape = shapes.root();
 
-    let query_response = query_response!({
+    let compact_value = compact_value!({
         "user": {
             "name": "G",
             "email": "whatever",
@@ -81,7 +81,7 @@ fn test_cache_merging() {
         }
     });
 
-    let (mut store, active_defers) = handle_initial_response(query_response, &shapes, root_shape, &NoSubtypes);
+    let (mut store, active_defers) = handle_initial_response(compact_value, &shapes, root_shape, &NoSubtypes);
 
     store.merge_cache_entry(
         &mut json!({
@@ -139,14 +139,14 @@ fn test_cache_merging_with_defer() {
     let shapes = build_output_shapes(&plan, &NoSubtypes);
     let root_shape = shapes.root();
 
-    let query_response = query_response!({
+    let compact_value = compact_value!({
         "user": {
             "name": "G",
             "email": "whatever",
         }
     });
 
-    let (mut store, active_defers) = handle_initial_response(query_response, &shapes, root_shape, &NoSubtypes);
+    let (mut store, active_defers) = handle_initial_response(compact_value, &shapes, root_shape, &NoSubtypes);
 
     store.merge_cache_entry(
         &mut json!({
@@ -197,14 +197,14 @@ fn test_cache_merging_when_defer_ignored() {
     let shapes = build_output_shapes(&plan, &NoSubtypes);
     let root_shape = shapes.root();
 
-    let query_response = query_response!({
+    let compact_value = compact_value!({
         "user": {
             "name": "G",
             "email": "whatever",
         }
     });
 
-    let (mut store, active_defers) = handle_initial_response(query_response, &shapes, root_shape, &NoSubtypes);
+    let (mut store, active_defers) = handle_initial_response(compact_value, &shapes, root_shape, &NoSubtypes);
 
     assert!(active_defers.contains(&defer_id));
 
@@ -265,14 +265,14 @@ fn test_incremental_response_merging() {
     let shapes = build_output_shapes(&plan, &NoSubtypes);
     let root_shape = shapes.root();
 
-    let query_response = query_response!({
+    let compact_value = compact_value!({
         "user": {
             "name": "G",
             "email": "whatever",
         }
     });
 
-    let (mut store, active_defers) = handle_initial_response(query_response, &shapes, root_shape, &NoSubtypes);
+    let (mut store, active_defers) = handle_initial_response(compact_value, &shapes, root_shape, &NoSubtypes);
 
     let mut cache_entry = json!({
         "user": {
@@ -295,7 +295,7 @@ fn test_incremental_response_merging() {
 
     store.merge_incremental_payload(
         user_object_id,
-        query_response!({
+        compact_value!({
             "nonCached": "I was not cached",
             "nested": [
                 {"nonCached": "nor was I"},
@@ -355,14 +355,14 @@ fn test_nested_defers() {
     let shapes = build_output_shapes(&plan, &NoSubtypes);
     let root_shape = shapes.root();
 
-    let query_response = query_response!({
+    let compact_value = compact_value!({
         "user": {
             "name": "G",
             "email": "whatever",
         }
     });
 
-    let (mut store, active_defers) = handle_initial_response(query_response, &shapes, root_shape, &NoSubtypes);
+    let (mut store, active_defers) = handle_initial_response(compact_value, &shapes, root_shape, &NoSubtypes);
 
     let mut cache_entry = json!({
         "user": {
@@ -383,7 +383,7 @@ fn test_nested_defers() {
 
     let active_defers = store.merge_incremental_payload(
         user_object_id,
-        query_response!({"nonCached": "I was not cached"}),
+        compact_value!({"nonCached": "I was not cached"}),
         &shapes,
         &NoSubtypes,
     );
@@ -402,7 +402,7 @@ fn test_nested_defers() {
 
     let active_defers = store.merge_incremental_payload(
         user_object_id,
-        query_response!({
+        compact_value!({
             "nested": [
                 {"nonCached": "nor was I"},
                 {"nonCached": "nor I"},
@@ -468,14 +468,14 @@ fn test_nested_defers_when_defer_ignored() {
     let shapes = build_output_shapes(&plan, &NoSubtypes);
     let root_shape = shapes.root();
 
-    let query_response = query_response!({
+    let compact_value = compact_value!({
         "user": {
             "name": "G",
             "email": "whatever",
         }
     });
 
-    let (mut store, active_defers) = handle_initial_response(query_response, &shapes, root_shape, &NoSubtypes);
+    let (mut store, active_defers) = handle_initial_response(compact_value, &shapes, root_shape, &NoSubtypes);
 
     let mut cache_entry = json!({
         "user": {
@@ -496,7 +496,7 @@ fn test_nested_defers_when_defer_ignored() {
 
     let active_defers = store.merge_incremental_payload(
         user_object_id,
-        query_response!({
+        compact_value!({
             "nonCached": "I was not cached",
             "nested": [
                 {"nonCached": "nor was I"},
@@ -530,9 +530,6 @@ fn test_nested_defers_when_defer_ignored() {
     "###);
 }
 
-fn query_response(json: serde_json::Value) -> QueryResponse {
-    let mut query_response = QueryResponse::default();
-    let root_node = query_response.from_serde_value(json);
-    query_response.set_root_unchecked(root_node);
-    query_response
+fn compact_value(json: serde_json::Value) -> CompactValue {
+    json.into()
 }


### PR DESCRIPTION
I've been updating the `api` repo to use `execute_stream_v2` instead of `execute_stream`.  The main difference between these two is that `v2` returns a `Stream<StreamingPayload>`, where as the original returned an `http::Response.

In the API these functions need to make an HTTP call to another worker, so I needed to serialise & deserialise the `StreamingPayload` on either side of this HTTP call.  This turned out to be quite hard, because `StreamingPayload` didn't implement `Deserialize`.  Implementing `Deserialize` was also tricky, because it contained an `engine::Response`, but didn't make use of the `engine::Response` impl of `Serialize` but instead serialized to response format JSON.  There's no existing deserialize impl from response format JSON into an engine::Response, and we also lose a bunch of info in the process so it'd be hard to even write one.  It's a big mess.

I tried 2 or 3 things to fix this, but the easiest one turned out to be just removing `engine::Response` from `StremaingPayload` and having a `CompactValue` instead.  Which is what this commit does.  

This might not be perfect - we normally ferry some things between the gateway & the executor inside `engine::Response`, which will be completely missing here.  But I'll deal with the individual issues as I discover them, want to get this out first and this was the easiest way without refactoring all the things.