### PR TITLE
chore(engine-v2): order selection set fields

### DIFF
--- a/engine/crates/engine-v2/src/operation/bind/field.rs
+++ b/engine/crates/engine-v2/src/operation/bind/field.rs
@@ -67,7 +67,7 @@ impl<'schema, 'p> Binder<'schema, 'p> {
         self.fields.push(Field::Query(QueryField {
             bound_response_key,
             location,
-            field_definition_id: definition.id(),
+            definition_id: definition.id(),
             argument_ids,
             selection_set_id,
             condition,

--- a/engine/crates/engine-v2/src/operation/bind/selection_set.rs
+++ b/engine/crates/engine-v2/src/operation/bind/selection_set.rs
@@ -70,8 +70,15 @@ impl<'schema, 'p, 'binder> SelectionSetBinder<'schema, 'p, 'binder> {
         }
         let id = SelectionSetId::from(self.selection_sets.len());
         self.selection_sets.push(SelectionSet::default());
-        let field_ids = self.generate_fields(ty, id)?;
-        self.binder[id].field_ids = field_ids;
+        let mut field_ids = self.generate_fields(ty, id)?;
+        field_ids.sort_unstable_by_key(|id| {
+            let field = &self[*id];
+            (
+                field.definition_id().map(|id| self.schema[id].parent_entity),
+                field.query_position(),
+            )
+        });
+        self.binder[id].field_ids_ordered_by_parent_entity_id_then_position = field_ids;
 
         Ok(id)
     }

--- a/engine/crates/engine-v2/src/operation/build.rs
+++ b/engine/crates/engine-v2/src/operation/build.rs
@@ -1,4 +1,5 @@
 use schema::Schema;
+use tracing::instrument;
 
 use crate::response::{ErrorCode, GraphqlError};
 
@@ -62,6 +63,7 @@ impl Operation {
     ///
     /// All field names are mapped to their actual field id in the schema and respective configuration.
     /// At this stage the operation might not be resolvable but it should make sense given the schema types.
+    #[instrument(skip_all)]
     pub fn build(schema: &Schema, request: &engine::Request) -> Result<Operation, OperationError> {
         let parsed_operation = parse_operation(request)?;
         let operation_metadata = prepare_metadata(&parsed_operation, request);
@@ -85,7 +87,7 @@ impl Operation {
             });
         }
 
-        if let Err(err) = LogicalPlanner::new(schema, &variables, &mut operation).run() {
+        if let Err(err) = LogicalPlanner::new(schema, &variables, &mut operation).plan() {
             return Err(OperationError::LogicalPlanning {
                 operation_metadata: Box::new(operation_metadata),
                 err,

--- a/engine/crates/engine-v2/src/operation/variables.rs
+++ b/engine/crates/engine-v2/src/operation/variables.rs
@@ -1,4 +1,5 @@
 use schema::Schema;
+use tracing::instrument;
 
 use super::{
     bind::{bind_variables, VariableError},
@@ -49,6 +50,7 @@ where
 }
 
 impl Variables {
+    #[instrument(skip_all)]
     pub(crate) fn build(
         schema: &Schema,
         operation: &Operation,

--- a/engine/crates/engine-v2/src/operation/walkers/field.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/field.rs
@@ -19,18 +19,8 @@ impl<'a> FieldWalker<'a> {
     pub fn type_condition(&self) -> SelectionSetType {
         match self.as_ref() {
             Field::TypeName(f) => f.type_condition,
-            Field::Query(f) => self
-                .schema_walker
-                .walk(f.field_definition_id)
-                .parent_entity()
-                .id()
-                .into(),
-            Field::Extra(f) => self
-                .schema_walker
-                .walk(f.field_definition_id)
-                .parent_entity()
-                .id()
-                .into(),
+            Field::Query(f) => self.schema_walker.walk(f.definition_id).parent_entity().id().into(),
+            Field::Extra(f) => self.schema_walker.walk(f.definition_id).parent_entity().id().into(),
         }
     }
 
@@ -95,13 +85,10 @@ impl<'a> std::fmt::Debug for FieldWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.as_ref() {
             Field::TypeName { .. } => "__typename".fmt(f),
-            Field::Query(QueryField {
-                field_definition_id: field_id,
-                ..
-            }) => {
+            Field::Query(QueryField { definition_id, .. }) => {
                 let mut fmt = f.debug_struct("Field");
                 fmt.field("id", &self.item);
-                let name = self.schema_walker.walk(*field_id).name();
+                let name = self.schema_walker.walk(*definition_id).name();
                 if self.response_key_str() != name {
                     fmt.field("key", &self.response_key_str());
                 }
@@ -109,13 +96,10 @@ impl<'a> std::fmt::Debug for FieldWalker<'a> {
                     .field("selection_set", &self.selection_set())
                     .finish()
             }
-            Field::Extra(ExtraField {
-                field_definition_id: field_id,
-                ..
-            }) => {
+            Field::Extra(ExtraField { definition_id, .. }) => {
                 let mut fmt = f.debug_struct("ExtraField");
                 fmt.field("id", &self.item);
-                let name = self.schema_walker.walk(*field_id).name();
+                let name = self.schema_walker.walk(*definition_id).name();
                 if self.response_key_str() != name {
                     fmt.field("key", &self.response_key_str());
                 }

--- a/engine/crates/engine-v2/src/operation/walkers/mod.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/mod.rs
@@ -7,7 +7,7 @@ mod variable;
 pub use argument::*;
 use engine_parser::types::OperationType;
 pub use field::*;
-use schema::{ObjectWalker, SchemaWalker};
+use schema::SchemaWalker;
 pub use selection_set::*;
 #[allow(unused_imports)]
 pub use variable::*;
@@ -56,11 +56,6 @@ impl<'a> OperationWalker<'a, (), ()> {
 
     pub(crate) fn selection_set(&self) -> SelectionSetWalker<'a> {
         self.walk(self.operation.root_selection_set_id)
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn root_object(&self) -> ObjectWalker<'a> {
-        self.schema_walker.walk(self.as_ref().root_object_id)
     }
 }
 

--- a/engine/crates/engine-v2/src/operation/walkers/selection_set.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/selection_set.rs
@@ -6,7 +6,10 @@ pub type SelectionSetWalker<'a> = OperationWalker<'a, SelectionSetId, ()>;
 impl<'a> SelectionSetWalker<'a> {
     pub fn fields(self) -> impl Iterator<Item = FieldWalker<'a>> + 'a {
         let walker = self.walk_with((), ());
-        self.as_ref().field_ids.iter().map(move |id| walker.walk(*id))
+        self.as_ref()
+            .field_ids_ordered_by_parent_entity_id_then_position
+            .iter()
+            .map(move |id| walker.walk(*id))
     }
 }
 

--- a/engine/crates/engine-v2/src/response/key/mod.rs
+++ b/engine/crates/engine-v2/src/response/key/mod.rs
@@ -73,6 +73,12 @@ use crate::operation::QueryPosition;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
 pub struct ResponseEdge(u32);
 
+impl From<ResponseEdge> for usize {
+    fn from(edge: ResponseEdge) -> usize {
+        edge.0 as usize
+    }
+}
+
 /// A ResponseKey associated with a position within the query, guaranteeing the right order of
 /// fields in the output as we BTreeMaps to store them in the response.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
When generating the GraphQL query for subgraph we aggregate the field per parent object and order by query position. I was doing it with a hashmap, but I can just keep the array sorted instead.
