### PR TITLE
chore(hooks): add missing node_post_execution method, more generics and split trait

### DIFF
--- a/engine/crates/engine-v2/src/execution/hooks/authorized.rs
+++ b/engine/crates/engine-v2/src/execution/hooks/authorized.rs
@@ -1,5 +1,5 @@
 use futures::FutureExt;
-use runtime::hooks::{EdgeDefinition, Hooks, NodeDefinition};
+use runtime::hooks::{AuthorizedHooks, EdgeDefinition, Hooks, NodeDefinition};
 use schema::{EntityWalker, FieldDefinitionWalker, SchemaInputValueWalker};
 use tracing::{instrument, Level};
 
@@ -14,6 +14,7 @@ impl<'ctx, H: Hooks> super::RequestHooks<'ctx, H> {
         metadata: Option<SchemaInputValueWalker<'_>>,
     ) -> Result<(), GraphqlError> {
         self.hooks
+            .authorized()
             .authorize_edge_pre_execution(
                 self.context,
                 EdgeDefinition {
@@ -38,6 +39,7 @@ impl<'ctx, H: Hooks> super::RequestHooks<'ctx, H> {
         metadata: Option<SchemaInputValueWalker<'_>>,
     ) -> Result<(), GraphqlError> {
         self.hooks
+            .authorized()
             .authorize_node_pre_execution(
                 self.context,
                 NodeDefinition {

--- a/engine/crates/runtime-local/src/hooks.rs
+++ b/engine/crates/runtime-local/src/hooks.rs
@@ -1,3 +1,4 @@
+mod authorized;
 mod pool;
 
 use std::{collections::HashMap, sync::Arc};
@@ -5,7 +6,7 @@ use std::{collections::HashMap, sync::Arc};
 use deadpool::managed::Pool;
 use runtime::{
     error::{PartialErrorCode, PartialGraphqlError},
-    hooks::{EdgeDefinition, HeaderMap, Hooks, NodeDefinition},
+    hooks::{AuthorizedHooks, HeaderMap, Hooks},
 };
 use tracing::instrument;
 pub use wasi_component_loader::{ComponentLoader, Config as HooksConfig};
@@ -13,6 +14,7 @@ pub use wasi_component_loader::{ComponentLoader, Config as HooksConfig};
 use self::pool::{AuthorizationHookManager, GatewayHookManager};
 
 pub struct HooksWasi(Option<HooksWasiInner>);
+type Context = Arc<HashMap<String, String>>;
 
 struct HooksWasiInner {
     gateway_hooks: Pool<GatewayHookManager>,
@@ -45,7 +47,7 @@ impl HooksWasi {
 }
 
 impl Hooks for HooksWasi {
-    type Context = Arc<HashMap<String, String>>;
+    type Context = Context;
 
     #[instrument(skip_all)]
     async fn on_gateway_request(&self, headers: HeaderMap) -> Result<(Self::Context, HeaderMap), PartialGraphqlError> {
@@ -69,245 +71,8 @@ impl Hooks for HooksWasi {
             })
     }
 
-    #[instrument(skip_all)]
-    async fn authorize_edge_pre_execution<'a>(
-        &self,
-        context: &Self::Context,
-        definition: EdgeDefinition<'a>,
-        arguments: impl serde::Serialize + serde::de::Deserializer<'a> + Send,
-        metadata: Option<impl serde::Serialize + serde::de::Deserializer<'a> + Send>,
-    ) -> Result<(), PartialGraphqlError> {
-        let Some(ref inner) = self.0 else {
-            return Err(PartialGraphqlError::new(
-                "@authorized directive cannot be used, so access was denied",
-                PartialErrorCode::Unauthorized,
-            ));
-        };
-
-        let Ok(arguments) = serde_json::to_string(&arguments) else {
-            tracing::error!("authorize_edge_pre_execution error at {definition}: failed to serialize arguments");
-            return Err(PartialGraphqlError::internal_server_error());
-        };
-
-        let Ok(metadata) = metadata.as_ref().map(serde_json::to_string).transpose() else {
-            tracing::error!("authorize_edge_pre_execution error at {definition}: failed to serialize metadata");
-            return Err(PartialGraphqlError::internal_server_error());
-        };
-
-        let mut instance = inner.authorization_hooks.get().await.expect("no io, should not fail");
-
-        let definition = wasi_component_loader::EdgeDefinition {
-            parent_type_name: definition.parent_type_name.to_string(),
-            field_name: definition.field_name.to_string(),
-        };
-
-        instance
-            .authorize_edge_pre_execution(Arc::clone(context), definition, arguments, metadata.unwrap_or_default())
-            .await
-            .map_err(|err| match err {
-                wasi_component_loader::Error::Internal(error) => {
-                    tracing::error!("authorize_edge_pre_execution error at: {error}");
-                    PartialGraphqlError::internal_hook_error()
-                }
-                wasi_component_loader::Error::User(error) => {
-                    error_response_to_user_error(error, PartialErrorCode::Unauthorized)
-                }
-            })?;
-
-        Ok(())
-    }
-
-    #[instrument(skip_all)]
-    async fn authorize_node_pre_execution<'a>(
-        &self,
-        context: &Self::Context,
-        definition: NodeDefinition<'a>,
-        metadata: Option<impl serde::Serialize + serde::de::Deserializer<'a> + Send>,
-    ) -> Result<(), PartialGraphqlError> {
-        let Some(ref inner) = self.0 else {
-            return Err(PartialGraphqlError::new(
-                "@authorized directive cannot be used, so access was denied",
-                PartialErrorCode::Unauthorized,
-            ));
-        };
-
-        let Ok(metadata) = metadata.as_ref().map(serde_json::to_string).transpose() else {
-            tracing::error!("authorize_edge_pre_execution error at {definition}: failed to serialize metadata");
-            return Err(PartialGraphqlError::internal_server_error());
-        };
-
-        let definition = wasi_component_loader::NodeDefinition {
-            type_name: definition.type_name.to_string(),
-        };
-
-        let mut instance = inner.authorization_hooks.get().await.expect("no io, should not fail");
-
-        instance
-            .authorize_node_pre_execution(Arc::clone(context), definition, metadata.unwrap_or_default())
-            .await
-            .map_err(|err| match err {
-                wasi_component_loader::Error::Internal(error) => {
-                    tracing::error!("authorize_node_pre_execution error at: {error}");
-                    PartialGraphqlError::internal_hook_error()
-                }
-                wasi_component_loader::Error::User(error) => {
-                    error_response_to_user_error(error, PartialErrorCode::Unauthorized)
-                }
-            })?;
-
-        Ok(())
-    }
-
-    #[instrument(skip_all)]
-    async fn authorize_parent_edge_post_execution<'a>(
-        &self,
-        context: &Self::Context,
-        definition: EdgeDefinition<'a>,
-        parents: Vec<String>,
-        metadata: Option<impl serde::Serialize + serde::de::Deserializer<'a> + Send>,
-    ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
-        let Some(ref inner) = self.0 else {
-            return Err(PartialGraphqlError::new(
-                "@authorized directive cannot be used, so access was denied",
-                PartialErrorCode::Unauthorized,
-            ));
-        };
-
-        let Ok(metadata) = metadata.as_ref().map(serde_json::to_string).transpose() else {
-            tracing::error!("authorize_edge_pre_execution error at {definition}: failed to serialize metadata");
-            return Err(PartialGraphqlError::internal_server_error());
-        };
-
-        let definition = wasi_component_loader::EdgeDefinition {
-            parent_type_name: definition.parent_type_name.to_string(),
-            field_name: definition.field_name.to_string(),
-        };
-
-        let mut instance = inner.authorization_hooks.get().await.expect("no io, should not fail");
-
-        let results = instance
-            .authorize_parent_edge_post_execution(
-                Arc::clone(context),
-                definition,
-                parents,
-                metadata.unwrap_or_default(),
-            )
-            .await
-            .map_err(|err| match err {
-                wasi_component_loader::Error::Internal(error) => {
-                    tracing::error!("authorize_node_pre_execution error at: {error}");
-                    PartialGraphqlError::internal_server_error()
-                }
-                wasi_component_loader::Error::User(error) => {
-                    error_response_to_user_error(error, PartialErrorCode::Unauthorized)
-                }
-            })?
-            .into_iter()
-            .map(|result| match result {
-                Ok(()) => Ok(()),
-                Err(error) => Err(error_response_to_user_error(error, PartialErrorCode::Unauthorized)),
-            })
-            .collect();
-
-        Ok(results)
-    }
-
-    #[instrument(skip_all)]
-    async fn authorize_edge_node_post_execution<'a>(
-        &self,
-        context: &Self::Context,
-        definition: EdgeDefinition<'a>,
-        nodes: Vec<String>,
-        metadata: Option<impl serde::Serialize + serde::de::Deserializer<'a> + Send>,
-    ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
-        let Some(ref inner) = self.0 else {
-            return Err(PartialGraphqlError::new(
-                "@authorized directive cannot be used, so access was denied",
-                PartialErrorCode::Unauthorized,
-            ));
-        };
-
-        let Ok(metadata) = metadata.as_ref().map(serde_json::to_string).transpose() else {
-            tracing::error!("authorize_edge_pre_execution error at {definition}: failed to serialize metadata");
-            return Err(PartialGraphqlError::internal_server_error());
-        };
-
-        let definition = wasi_component_loader::EdgeDefinition {
-            parent_type_name: definition.parent_type_name.to_string(),
-            field_name: definition.field_name.to_string(),
-        };
-
-        let mut instance = inner.authorization_hooks.get().await.expect("no io, should not fail");
-
-        let result = instance
-            .authorize_edge_node_post_execution(Arc::clone(context), definition, nodes, metadata.unwrap_or_default())
-            .await
-            .map_err(|err| match err {
-                wasi_component_loader::Error::Internal(error) => {
-                    tracing::error!("authorize_node_pre_execution error at: {error}");
-                    PartialGraphqlError::internal_server_error()
-                }
-                wasi_component_loader::Error::User(error) => {
-                    error_response_to_user_error(error, PartialErrorCode::Unauthorized)
-                }
-            })?
-            .into_iter()
-            .map(|result| match result {
-                Ok(()) => Ok(()),
-                Err(error) => Err(error_response_to_user_error(error, PartialErrorCode::Unauthorized)),
-            })
-            .collect();
-
-        Ok(result)
-    }
-
-    #[instrument(skip_all)]
-    async fn authorize_edge_post_execution<'a>(
-        &self,
-        context: &Self::Context,
-        definition: EdgeDefinition<'a>,
-        edges: Vec<(String, Vec<String>)>,
-        metadata: Option<impl serde::Serialize + serde::de::Deserializer<'a> + Send>,
-    ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
-        let Some(ref inner) = self.0 else {
-            return Err(PartialGraphqlError::new(
-                "@authorized directive cannot be used, so access was denied",
-                PartialErrorCode::Unauthorized,
-            ));
-        };
-
-        let Ok(metadata) = metadata.as_ref().map(serde_json::to_string).transpose() else {
-            tracing::error!("authorize_edge_pre_execution error at {definition}: failed to serialize metadata");
-            return Err(PartialGraphqlError::internal_server_error());
-        };
-
-        let definition = wasi_component_loader::EdgeDefinition {
-            parent_type_name: definition.parent_type_name.to_string(),
-            field_name: definition.field_name.to_string(),
-        };
-
-        let mut instance = inner.authorization_hooks.get().await.expect("no io, should not fail");
-
-        let result = instance
-            .authorize_edge_post_execution(Arc::clone(context), definition, edges, metadata.unwrap_or_default())
-            .await
-            .map_err(|err| match err {
-                wasi_component_loader::Error::Internal(error) => {
-                    tracing::error!("authorize_node_pre_execution error at: {error}");
-                    PartialGraphqlError::internal_server_error()
-                }
-                wasi_component_loader::Error::User(error) => {
-                    error_response_to_user_error(error, PartialErrorCode::Unauthorized)
-                }
-            })?
-            .into_iter()
-            .map(|result| match result {
-                Ok(()) => Ok(()),
-                Err(error) => Err(error_response_to_user_error(error, PartialErrorCode::Unauthorized)),
-            })
-            .collect();
-
-        Ok(result)
+    fn authorized(&self) -> &impl AuthorizedHooks<Self::Context> {
+        self
     }
 }
 

--- a/engine/crates/runtime-local/src/hooks/authorized.rs
+++ b/engine/crates/runtime-local/src/hooks/authorized.rs
@@ -1,0 +1,277 @@
+use std::sync::Arc;
+
+use runtime::{
+    error::{PartialErrorCode, PartialGraphqlError},
+    hooks::{Anything, AuthorizationVerdict, AuthorizationVerdicts, AuthorizedHooks, EdgeDefinition, NodeDefinition},
+};
+use tracing::instrument;
+
+use super::{error_response_to_user_error, Context, HooksWasi};
+
+macro_rules! prepare_authorized {
+    ($self:ident named $func_name:literal at $definition:expr; [$(($name:literal, $input:expr),)+]) => {{
+        let Some(ref inner) = $self.0 else {
+            return Err(PartialGraphqlError::new(
+                "@authorized directive cannot be used, so access was denied",
+                PartialErrorCode::Unauthorized,
+            ));
+        };
+        let instance = inner.authorization_hooks.get().await.expect("no io, should not fail");
+        let inputs = [$(
+            encode($func_name, $definition, $name, $input)?,
+        )+];
+        (instance, inputs)
+    }};
+}
+
+fn encode<'a>(
+    func_name: &str,
+    definition: impl std::fmt::Display,
+    name: &str,
+    values: impl IntoIterator<Item: Anything<'a>>,
+) -> Result<Vec<String>, PartialGraphqlError> {
+    values
+        .into_iter()
+        .map(|value| {
+            serde_json::to_string(&value).map_err(|_| {
+                tracing::error!("{func_name} error at {definition}: failed to serialize {name}");
+                PartialGraphqlError::internal_server_error()
+            })
+        })
+        .collect()
+}
+
+impl AuthorizedHooks<Context> for HooksWasi {
+    #[instrument(skip_all)]
+    async fn authorize_edge_pre_execution<'a>(
+        &self,
+        context: &Context,
+        definition: EdgeDefinition<'a>,
+        arguments: impl Anything<'a>,
+        metadata: Option<impl Anything<'a>>,
+    ) -> AuthorizationVerdict {
+        let (mut instance, [arguments, metadata]) = prepare_authorized!(
+            self named "authorize_edge_pre_execution" at &definition;
+            [("arguments", [arguments]), ("metadata", metadata),]
+        );
+        let arguments = arguments.into_iter().next().unwrap();
+        let metadata = metadata.into_iter().next().unwrap_or_default();
+        let definition = wasi_component_loader::EdgeDefinition {
+            parent_type_name: definition.parent_type_name.to_string(),
+            field_name: definition.field_name.to_string(),
+        };
+
+        instance
+            .authorize_edge_pre_execution(Arc::clone(context), definition, arguments, metadata)
+            .await
+            .map_err(|err| match err {
+                wasi_component_loader::Error::Internal(error) => {
+                    tracing::error!("authorize_edge_pre_execution error at: {error}");
+                    PartialGraphqlError::internal_hook_error()
+                }
+                wasi_component_loader::Error::User(error) => {
+                    error_response_to_user_error(error, PartialErrorCode::Unauthorized)
+                }
+            })?;
+
+        Ok(())
+    }
+
+    #[instrument(skip_all)]
+    async fn authorize_node_pre_execution<'a>(
+        &self,
+        context: &Context,
+        definition: NodeDefinition<'a>,
+        metadata: Option<impl Anything<'a>>,
+    ) -> AuthorizationVerdict {
+        let (mut instance, [metadata]) = prepare_authorized!(
+            self named "authorize_node_pre_execution" at &definition;
+            [ ("metadata", metadata),]
+        );
+        let metadata = metadata.into_iter().next().unwrap_or_default();
+        let definition = wasi_component_loader::NodeDefinition {
+            type_name: definition.type_name.to_string(),
+        };
+
+        instance
+            .authorize_node_pre_execution(Arc::clone(context), definition, metadata)
+            .await
+            .map_err(|err| match err {
+                wasi_component_loader::Error::Internal(error) => {
+                    tracing::error!("authorize_node_pre_execution error at: {error}");
+                    PartialGraphqlError::internal_hook_error()
+                }
+                wasi_component_loader::Error::User(error) => {
+                    error_response_to_user_error(error, PartialErrorCode::Unauthorized)
+                }
+            })?;
+
+        Ok(())
+    }
+
+    #[instrument(skip_all)]
+    async fn authorize_node_post_execution<'a>(
+        &self,
+        _context: &Context,
+        definition: NodeDefinition<'a>,
+        nodes: impl IntoIterator<Item: Anything<'a>> + Send,
+        metadata: Option<impl Anything<'a>>,
+    ) -> AuthorizationVerdicts {
+        let (mut _instance, [_nodes, metadata]) = prepare_authorized!(
+            self named "authorize_node_post_execution" at &definition;
+            [("nodes", nodes), ("metadata", metadata),]
+        );
+        let _metadata = metadata.into_iter().next().unwrap_or_default();
+        let _definition = wasi_component_loader::NodeDefinition {
+            type_name: definition.type_name.to_string(),
+        };
+
+        todo!()
+    }
+
+    #[instrument(skip_all)]
+    async fn authorize_parent_edge_post_execution<'a>(
+        &self,
+        context: &Context,
+        definition: EdgeDefinition<'a>,
+        parents: impl IntoIterator<Item: Anything<'a>> + Send,
+        metadata: Option<impl Anything<'a>>,
+    ) -> AuthorizationVerdicts {
+        let (mut instance, [parents, metadata]) = prepare_authorized!(
+            self named "authorize_parent_edge_post_execution" at &definition;
+            [("parents", parents), ("metadata", metadata),]
+        );
+        let metadata = metadata.into_iter().next().unwrap_or_default();
+        let definition = wasi_component_loader::EdgeDefinition {
+            parent_type_name: definition.parent_type_name.to_string(),
+            field_name: definition.field_name.to_string(),
+        };
+
+        let results = instance
+            .authorize_parent_edge_post_execution(Arc::clone(context), definition, parents, metadata)
+            .await
+            .map_err(|err| match err {
+                wasi_component_loader::Error::Internal(error) => {
+                    tracing::error!("authorize_parent_edge_post_execution error at: {error}");
+                    PartialGraphqlError::internal_server_error()
+                }
+                wasi_component_loader::Error::User(error) => {
+                    error_response_to_user_error(error, PartialErrorCode::Unauthorized)
+                }
+            })?
+            .into_iter()
+            .map(|result| match result {
+                Ok(()) => Ok(()),
+                Err(error) => Err(error_response_to_user_error(error, PartialErrorCode::Unauthorized)),
+            })
+            .collect();
+
+        Ok(results)
+    }
+
+    #[instrument(skip_all)]
+    async fn authorize_edge_node_post_execution<'a>(
+        &self,
+        context: &Context,
+        definition: EdgeDefinition<'a>,
+        nodes: impl IntoIterator<Item: Anything<'a>> + Send,
+        metadata: Option<impl Anything<'a>>,
+    ) -> AuthorizationVerdicts {
+        let (mut instance, [nodes, metadata]) = prepare_authorized!(
+            self named "authorize_edge_node_post_execution" at &definition;
+            [("nodes", nodes), ("metadata", metadata),]
+        );
+        let metadata = metadata.into_iter().next().unwrap_or_default();
+        let definition = wasi_component_loader::EdgeDefinition {
+            parent_type_name: definition.parent_type_name.to_string(),
+            field_name: definition.field_name.to_string(),
+        };
+
+        let result = instance
+            .authorize_edge_node_post_execution(Arc::clone(context), definition, nodes, metadata)
+            .await
+            .map_err(|err| match err {
+                wasi_component_loader::Error::Internal(error) => {
+                    tracing::error!("authorize_edge_node_post_execution error at: {error}");
+                    PartialGraphqlError::internal_server_error()
+                }
+                wasi_component_loader::Error::User(error) => {
+                    error_response_to_user_error(error, PartialErrorCode::Unauthorized)
+                }
+            })?
+            .into_iter()
+            .map(|result| match result {
+                Ok(()) => Ok(()),
+                Err(error) => Err(error_response_to_user_error(error, PartialErrorCode::Unauthorized)),
+            })
+            .collect();
+
+        Ok(result)
+    }
+
+    #[instrument(skip_all)]
+    async fn authorize_edge_post_execution<'a, Parent, Nodes>(
+        &self,
+        context: &Context,
+        definition: EdgeDefinition<'a>,
+        edges: impl IntoIterator<Item = (Parent, Nodes)> + Send,
+        metadata: Option<impl Anything<'a>>,
+    ) -> AuthorizationVerdicts
+    where
+        Parent: Anything<'a>,
+        Nodes: IntoIterator<Item: Anything<'a>> + Send,
+    {
+        let (mut instance, [metadata]) = prepare_authorized!(
+            self named "authorize_edge_post_execution" at &definition;
+            [("metadata", metadata),]
+        );
+        let metadata: String = metadata.into_iter().next().unwrap_or_default();
+        let edges: Vec<(String, Vec<String>)> = edges
+            .into_iter()
+            .map(|(parent, nodes): (Parent, Nodes)| {
+                let parent = serde_json::to_string(&parent).map_err(|_| {
+                    tracing::error!("authorize_edge_post_execution error at {definition}: failed to serialize edge");
+                    PartialGraphqlError::internal_server_error()
+                })?;
+                let nodes = nodes
+                    .into_iter()
+                    .map(|node| {
+                        serde_json::to_string(&node).map_err(|_| {
+                            tracing::error!(
+                                "authorize_edge_post_execution error at {definition}: failed to serialize edge"
+                            );
+                            PartialGraphqlError::internal_server_error()
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                Ok((parent, nodes))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let definition = wasi_component_loader::EdgeDefinition {
+            parent_type_name: definition.parent_type_name.to_string(),
+            field_name: definition.field_name.to_string(),
+        };
+
+        let result = instance
+            .authorize_edge_post_execution(Arc::clone(context), definition, edges, metadata)
+            .await
+            .map_err(|err| match err {
+                wasi_component_loader::Error::Internal(error) => {
+                    tracing::error!("authorize_edge_post_execution error at: {error}");
+                    PartialGraphqlError::internal_server_error()
+                }
+                wasi_component_loader::Error::User(error) => {
+                    error_response_to_user_error(error, PartialErrorCode::Unauthorized)
+                }
+            })?
+            .into_iter()
+            .map(|result| match result {
+                Ok(()) => Ok(()),
+                Err(error) => Err(error_response_to_user_error(error, PartialErrorCode::Unauthorized)),
+            })
+            .collect();
+
+        Ok(result)
+    }
+}


### PR DESCRIPTION
Add the missing method and split the authorization part of the `Hooks` into a different one. It started to be overcrowded.
Using generics for all inputs for more flexibility.
