### PR TITLE
chore(gateway): bump to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2839,7 +2839,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.5.0] - 2024-07-12
+
+[CHANGELOG](changelog/0.5.0.md)
+
 ## [0.4.1] - 2024-07-04
 
 [CHANGELOG](changelog/0.4.1.md)

--- a/gateway/changelog/0.5.0.md
+++ b/gateway/changelog/0.5.0.md
@@ -1,0 +1,8 @@
+### Features
+
+- Add error codes for all GraphQL errors ([docs](https://grafbase.com/docs/federation/error-codes)) (#1871)
+- Health checks endpoint ([docs](https://grafbase.com/docs/self-hosted-gateway#health-checks)) (#1870)
+
+### Breaking
+
+- Rule-based header handling ([docs](https://grafbase.com/docs/self-hosted-gateway#global-header-configuration)) (#1872)

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.4.1"
+version = "0.5.0"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.4.1"
+version = "0.5.0"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true


### PR DESCRIPTION
### Features

- Add error code for all GraphQL errors (#1871)
- Health checks endpoint (#1870)

### Breaking

- Rule-based header handling (#1872)

This can be merged when we have docs for the graphql errors.