### PR TITLE
chore(engine-v2): Add missing error codes & better request context initialization

### DIFF
--- a/cli/crates/cli/tests/federation.rs
+++ b/cli/crates/cli/tests/federation.rs
@@ -47,7 +47,10 @@ async fn federation_start() {
     {
       "errors": [
         {
-          "message": "there are no subgraphs registered currently"
+          "message": "there are no subgraphs registered currently",
+          "extensions": {
+            "code": "INTERNAL_SERVER_ERROR"
+          }
         }
       ]
     }
@@ -262,7 +265,10 @@ async fn test_sse_transport_with_failed_auth() {
       {
         "errors": [
           {
-            "message": "Unauthorized"
+            "message": "Unauthenticated",
+            "extensions": {
+              "code": "UNAUTHENTICATED"
+            }
           }
         ]
       }
@@ -481,7 +487,10 @@ async fn test_multipart_transport_with_bad_auth() {
       {
         "errors": [
           {
-            "message": "Unauthorized"
+            "message": "Unauthenticated",
+            "extensions": {
+              "code": "UNAUTHENTICATED"
+            }
           }
         ]
       }

--- a/cli/crates/federated-dev/src/dev.rs
+++ b/cli/crates/federated-dev/src/dev.rs
@@ -171,7 +171,7 @@ async fn handle_engine_request(
 ) -> impl IntoResponse {
     log::debug!("engine request received");
     let Some(engine) = engine.borrow().clone() else {
-        return engine_v2_axum::error("there are no subgraphs registered currently");
+        return engine_v2_axum::internal_server_error("there are no subgraphs registered currently");
     };
     engine_v2_axum::into_response(engine.execute(headers, request).await)
 }

--- a/engine/crates/engine-v2/axum/src/lib.rs
+++ b/engine/crates/engine-v2/axum/src/lib.rs
@@ -4,8 +4,12 @@ use runtime::bytes::OwnedOrSharedBytes;
 
 pub mod websocket;
 
-pub fn error(message: &str) -> axum::response::Response {
-    into_response(HttpGraphqlResponse::request_error(message))
+pub fn internal_server_error(message: &str) -> axum::response::Response {
+    into_response(HttpGraphqlResponse::internal_server_error(message))
+}
+
+pub fn bad_request_error(message: &str) -> axum::response::Response {
+    into_response(HttpGraphqlResponse::bad_request_error(message))
 }
 
 pub fn into_response(response: HttpGraphqlResponse) -> axum::response::Response {

--- a/engine/crates/engine-v2/schema/src/builder/external_sources.rs
+++ b/engine/crates/engine-v2/schema/src/builder/external_sources.rs
@@ -29,7 +29,7 @@ impl ExternalDataSources {
                             url,
                             websocket_url: websocket_url
                                 .map(|url| ctx.urls.insert(url::Url::parse(&config[url]).expect("valid url"))),
-                            headers: headers.into_iter().map(Into::into).collect(),
+                            header_rules: headers.into_iter().map(Into::into).collect(),
                         }
                     }
 
@@ -38,7 +38,7 @@ impl ExternalDataSources {
                         subgraph_id,
                         url,
                         websocket_url: None,
-                        headers: Vec::new(),
+                        header_rules: Vec::new(),
                     },
                 }
             })

--- a/engine/crates/engine-v2/schema/src/sources/graphql.rs
+++ b/engine/crates/engine-v2/schema/src/sources/graphql.rs
@@ -15,7 +15,7 @@ pub struct GraphqlEndpoint {
     pub(crate) name: StringId,
     pub(crate) url: UrlId,
     pub(crate) websocket_url: Option<UrlId>,
-    pub(crate) headers: Vec<HeaderRuleId>,
+    pub(crate) header_rules: Vec<HeaderRuleId>,
 }
 
 id_newtypes::U8! {
@@ -139,12 +139,12 @@ impl<'a> GraphqlEndpointWalker<'a> {
         }
     }
 
-    pub fn headers(self) -> impl Iterator<Item = HeaderRuleWalker<'a>> {
+    pub fn header_rules(self) -> impl Iterator<Item = HeaderRuleWalker<'a>> {
         self.schema
             .settings
             .default_header_rules
             .iter()
-            .chain(self.as_ref().headers.iter())
+            .chain(self.as_ref().header_rules.iter())
             .map(move |id| self.walk(*id))
     }
 }

--- a/engine/crates/engine-v2/schema/src/walkers/mod.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/mod.rs
@@ -115,6 +115,14 @@ impl<'a> SchemaWalker<'a, ()> {
     pub fn as_ref(&self) -> &'a Schema {
         self.schema
     }
+
+    pub fn default_header_rules(self) -> impl ExactSizeIterator<Item = HeaderRuleWalker<'a>> {
+        self.as_ref()
+            .settings
+            .default_header_rules
+            .iter()
+            .map(move |id| self.walk(*id))
+    }
 }
 
 impl<'a> std::ops::Deref for SchemaWalker<'a, ()> {

--- a/engine/crates/engine-v2/src/sources/graphql/federation.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/federation.rs
@@ -117,7 +117,7 @@ impl<'ctx, R: Runtime> FederationEntityExecutor<'ctx, R> {
                 .post(FetchRequest {
                     url: self.subgraph.url(),
                     json_body: self.json_body,
-                    headers: self.ctx.headers_with_rules(self.subgraph.headers()),
+                    headers: self.ctx.headers_with_rules(self.subgraph.header_rules()),
                 })
                 .await?
                 .bytes;

--- a/engine/crates/engine-v2/src/sources/graphql/mod.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/mod.rs
@@ -111,7 +111,7 @@ impl<'ctx, R: Runtime> GraphqlExecutor<'ctx, R> {
                 .post(FetchRequest {
                     url: self.subgraph.url(),
                     json_body: self.json_body,
-                    headers: self.ctx.headers_with_rules(self.subgraph.headers()),
+                    headers: self.ctx.headers_with_rules(self.subgraph.header_rules()),
                 })
                 .await?
                 .bytes;

--- a/engine/crates/engine-v2/src/sources/graphql/subscription.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/subscription.rs
@@ -75,7 +75,7 @@ impl<'ctx, R: Runtime> GraphqlSubscriptionExecutor<'ctx, R> {
                     inputs: Vec::new(),
                 })
                 .map_err(|error| error.to_string())?,
-                headers: self.ctx.headers_with_rules(subgraph.headers()),
+                headers: self.ctx.headers_with_rules(subgraph.header_rules()),
             })
             .await?;
 

--- a/engine/crates/gateway-core/src/lib.rs
+++ b/engine/crates/gateway-core/src/lib.rs
@@ -136,7 +136,7 @@ where
     {
         let auth = match self
             .auth
-            .authorize(ctx.headers())
+            .authenticate(ctx.headers())
             .instrument(info_span!("authorize_request"))
             .await
         {
@@ -256,7 +256,7 @@ where
 
         let auth = match self
             .auth
-            .authorize(ctx.headers())
+            .authenticate(ctx.headers())
             .instrument(info_span!("authorize_request"))
             .await
         {
@@ -315,7 +315,7 @@ where
 
         let auth = match self
             .auth
-            .authorize(ctx.headers())
+            .authenticate(ctx.headers())
             .instrument(info_span!("authorize_request"))
             .await
         {

--- a/engine/crates/gateway-v2/auth/src/lib.rs
+++ b/engine/crates/gateway-v2/auth/src/lib.rs
@@ -49,7 +49,7 @@ impl AuthService {
     }
 
     #[instrument(skip_all)]
-    pub async fn authorize(&self, headers: &http::HeaderMap) -> Option<AccessToken> {
+    pub async fn authenticate(&self, headers: &http::HeaderMap) -> Option<AccessToken> {
         let fut = self
             .authorizers
             .iter()

--- a/engine/crates/integration-tests/tests/federation/auth/jwt.rs
+++ b/engine/crates/integration-tests/tests/federation/auth/jwt.rs
@@ -106,7 +106,10 @@ fn test_unauthorized() {
         {
           "errors": [
             {
-              "message": "Unauthorized"
+              "message": "Unauthenticated",
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }
@@ -121,7 +124,10 @@ fn test_unauthorized() {
         {
           "errors": [
             {
-              "message": "Unauthorized"
+              "message": "Unauthenticated",
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }
@@ -136,7 +142,10 @@ fn test_unauthorized() {
         {
           "errors": [
             {
-              "message": "Unauthorized"
+              "message": "Unauthenticated",
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }
@@ -172,7 +181,10 @@ fn test_tampered_jwt() {
         {
           "errors": [
             {
-              "message": "Unauthorized"
+              "message": "Unauthenticated",
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }
@@ -226,7 +238,10 @@ fn test_wrong_provider() {
         {
           "errors": [
             {
-              "message": "Unauthorized"
+              "message": "Unauthenticated",
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }
@@ -284,7 +299,10 @@ fn test_audience() {
         {
           "errors": [
             {
-              "message": "Unauthorized"
+              "message": "Unauthenticated",
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }
@@ -305,7 +323,10 @@ fn test_audience() {
         {
           "errors": [
             {
-              "message": "Unauthorized"
+              "message": "Unauthenticated",
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }

--- a/engine/crates/integration-tests/tests/federation/auth/multiple.rs
+++ b/engine/crates/integration-tests/tests/federation/auth/multiple.rs
@@ -69,7 +69,10 @@ fn test_provider() {
         {
           "errors": [
             {
-              "message": "Unauthorized"
+              "message": "Unauthenticated",
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
             }
           ]
         }

--- a/gateway/crates/federated-server/src/server/engine.rs
+++ b/gateway/crates/federated-server/src/server/engine.rs
@@ -62,7 +62,7 @@ async fn traced(
 
 async fn handle(headers: HeaderMap, request: BatchRequest, engine: EngineWatcher) -> impl IntoResponse {
     let Some(engine) = engine.borrow().clone() else {
-        return engine_v2_axum::error("there are no subgraphs registered currently");
+        return engine_v2_axum::internal_server_error("there are no subgraphs registered currently");
     };
     engine_v2_axum::into_response(engine.execute(headers, request).await)
 }


### PR DESCRIPTION
Initially wanted to apply default headers rules once before hooks and
authorization, but realized:
1. Their purpose is to define what we send to subgraphs, so applying
   them before auth/hook doesn't make sense
2. Would need to rework the apply_header_rules function which I wanted
   to avoid.

So just ended up with better request context initialization and
added some missing error code in some errors.