### PR TITLE
fix: remove musl constraint from linux-x86_64 `package.json`

### DIFF
--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -25,8 +25,5 @@
     "executableFiles": [
       "grafbase"
     ]
-  },
-  "libc": [
-    "musl"
-  ]
+  }
 }


### PR DESCRIPTION
If you try to `npx grafbase` on certain linux installs (WSL, apparently also NixOS) it'll silently do nothing.  Digging in some more the error apppears to be:

> Unsupported platform for @grafbase/cli-x86_64-unknown-linux-musl@0.77.0: wanted {"os":"linux","cpu":"x64","libc":"musl"} (current: {"os":"linux","cpu":"x64","libc":"glibc"})

The platform has `glibc` installed (pretty normal in linux) but our package.json is saying it needs musl.  This isn't technically correct - we _use_ musl, but we don't need it installed.  A musl binary should work fine on a system with glibc.

This PR removes the constraint from the package.json, hopefully fixing the issue.  