### PR TITLE
feat: cache directive on query extension fields in sdk

### DIFF
--- a/packages/grafbase-sdk/src/define.ts
+++ b/packages/grafbase-sdk/src/define.ts
@@ -56,7 +56,8 @@ export default {
       name,
       definition.returns,
       definition.resolver,
-      false
+      false,
+      definition.cache
     )
 
     if (definition.args != null) {
@@ -79,7 +80,9 @@ export default {
       name,
       definition.returns,
       definition.resolver,
-      true
+      true,
+      // Mutations shouldn't be cached, so passing undefined here explicitly
+      undefined
     )
 
     if (definition.args != null) {

--- a/packages/grafbase-sdk/src/query.ts
+++ b/packages/grafbase-sdk/src/query.ts
@@ -1,3 +1,4 @@
+import { FieldCacheParams, FieldLevelCache } from './typedefs/cache'
 import {
   DefaultDefinition,
   DefaultFieldShape,
@@ -47,6 +48,7 @@ export interface QueryInput {
   args?: Record<string, InputType>
   returns: OutputType
   resolver: string
+  cache?: FieldCacheParams
 }
 
 /**
@@ -82,12 +84,14 @@ export class Query {
   private arguments: FieldArgument[]
   private returns: OutputType
   private resolver: string
+  private _cache?: FieldLevelCache
 
   constructor(
     name: string,
     returnType: OutputType,
     resolverName: string,
-    mutation: boolean
+    mutation: boolean,
+    cache?: FieldCacheParams
   ) {
     validateIdentifier(name)
 
@@ -96,6 +100,9 @@ export class Query {
     this.returns = returnType
     this.resolver = resolverName
     this._kind = mutation ? 'mutation' : 'query'
+    if (cache) {
+      this.cache(cache)
+    }
   }
 
   public get kind(): 'mutation' | 'query' {
@@ -114,10 +121,21 @@ export class Query {
     return this
   }
 
+  /**
+   * Set the cache settiings for this field
+   *
+   * @param params - The cache definition parameters.
+   */
+  public cache(params: FieldCacheParams): Query {
+    this._cache = new FieldLevelCache(params)
+    return this
+  }
+
   public toString(): string {
     const args = this.arguments.map(String).join(', ')
     const argsStr = args ? `(${args})` : ''
+    const cacheStr = this._cache ? `${this._cache.toString()} ` : ''
 
-    return `${this.name}${argsStr}: ${this.returns} @resolver(name: "${this.resolver}")`
+    return `${this.name}${argsStr}: ${this.returns} ${cacheStr}@resolver(name: "${this.resolver}")`
   }
 }

--- a/packages/grafbase-sdk/tests/unit/cache.test.ts
+++ b/packages/grafbase-sdk/tests/unit/cache.test.ts
@@ -291,4 +291,32 @@ describe('Cache generator', () => {
       }"
     `)
   })
+
+  it('renders query cache rule', async () => {
+    g.query('cached', {
+      resolver: 'blah',
+      returns: g.string(),
+      cache: {
+        maxAge: 100
+      }
+    })
+
+    g.query('alsoCached', {
+      resolver: 'blah2',
+      returns: g.string()
+    }).cache({
+      maxAge: 200
+    })
+
+    const cfg = config({
+      schema: g
+    })
+
+    expect(renderGraphQL(cfg)).toMatchInlineSnapshot(`
+      "extend type Query {
+        cached: String! @cache(maxAge: 100) @resolver(name: "blah")
+        alsoCached: String! @cache(maxAge: 200) @resolver(name: "blah2")
+      }"
+    `)
+  })
 })


### PR DESCRIPTION
I'm writing up docs & changelog for partial caching, and I was trying to convert the following SDL into TS:

```graphql
type Query {
  field: String @cache(maxAge: 120)
}
```

Seems like this isn't something the SDK supports right now.  I could probably write an equivalent using the `extend schema @cache` syntax, but I'd rather just fix it.