### PR TITLE
graphql-schema-diff: release 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-schema-diff"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "cynic-parser 0.4.5",
  "datatest-stable",

--- a/engine/crates/graphql-schema-diff/CHANGELOG.md
+++ b/engine/crates/graphql-schema-diff/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.2.0 - 2024-07-16
+
 ### Changed
 
 - The library no longer produces changes for fields of newly added types, variants of newly added unions, values of enums, etc. This turned out to be too verbose. This could be made configurable if there is interest. (https://github.com/grafbase/grafbase/pull/1421)

--- a/engine/crates/graphql-schema-diff/Cargo.toml
+++ b/engine/crates/graphql-schema-diff/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graphql-schema-diff"
 description = "Semantic diffing for GraphQL schemas"
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 license = "Apache-2.0"
 homepage.workspace = true


### PR DESCRIPTION
Changed

- The library no longer produces changes for fields of newly added types, variants of newly added unions, values of enums, etc. This turned out to be too verbose. This could be made configurable if there is interest. (https://github.com/grafbase/grafbase/pull/1421)

Fixed

- Handle empty schema strings gracefully
