### PR TITLE
chore(engine-v2/id-newtypes): few improvements, bitset and idtomany

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,7 @@ checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
+ "serde",
  "tap",
  "wyz",
 ]
@@ -2563,6 +2564,7 @@ dependencies = [
 name = "engine-v2-id-newtypes"
 version = "0.0.0"
 dependencies = [
+ "bitvec",
  "serde",
 ]
 

--- a/engine/crates/engine-v2/id-newtypes/Cargo.toml
+++ b/engine/crates/engine-v2/id-newtypes/Cargo.toml
@@ -13,3 +13,5 @@ workspace = true
 
 [dependencies]
 serde.workspace = true
+bitvec = { version = "1", features = ["serde"]}
+

--- a/engine/crates/engine-v2/id-newtypes/src/bitset.rs
+++ b/engine/crates/engine-v2/id-newtypes/src/bitset.rs
@@ -1,0 +1,65 @@
+use bitvec::{bitvec, vec::BitVec};
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct BitSet<Id> {
+    inner: BitVec,
+    _phantom: std::marker::PhantomData<Id>,
+}
+
+impl<Id> Default for BitSet<Id> {
+    fn default() -> Self {
+        Self {
+            inner: BitVec::new(),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<Id> BitSet<Id>
+where
+    usize: From<Id>,
+{
+    pub fn init_with(value: bool, n: usize) -> Self {
+        Self {
+            inner: bitvec![value as usize; n],
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    pub fn set(&mut self, id: Id, value: bool) {
+        self.inner.set(usize::from(id), value)
+    }
+}
+
+impl<Id> std::ops::Index<Id> for BitSet<Id>
+where
+    usize: From<Id>,
+{
+    type Output = bool;
+    fn index(&self, index: Id) -> &Self::Output {
+        &self.inner[usize::from(index)]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bitset() {
+        let bitset = BitSet::<usize>::init_with(true, 129);
+        for i in 0..129 {
+            assert!(bitset[i]);
+        }
+
+        let mut bitset = BitSet::<usize>::init_with(false, 129);
+        for i in 0..129 {
+            assert!(!bitset[i]);
+        }
+
+        bitset.set(100, true);
+        assert!(!bitset[99]);
+        assert!(bitset[100]);
+        assert!(!bitset[101]);
+    }
+}

--- a/engine/crates/engine-v2/id-newtypes/src/lib.rs
+++ b/engine/crates/engine-v2/id-newtypes/src/lib.rs
@@ -1,5 +1,9 @@
+mod bitset;
+mod many;
 mod range;
-pub use range::IdRange;
+pub use bitset::*;
+pub use many::*;
+pub use range::*;
 
 #[macro_export]
 macro_rules! debug_display {
@@ -88,10 +92,10 @@ macro_rules! index {
 
 #[macro_export]
 macro_rules! NonZeroU32 {
-    ($($ty:ident$(<$( $lt:lifetime ),+>)?.$field:ident[$name:ident] => $output:ty $(|max($max:expr))? $(|proxy($ty2:ident$(.$field2:ident)+))* ,)*) => {
+    ($($ty:ident$(<$( $lt:lifetime ),+>)?$(.$field:ident)+[$name:ident] => $output:ty $(|max($max:expr))? $(|proxy($ty2:ident$(.$field2:ident)+))* ,)*) => {
         $(
             $crate::NonZeroU32! { $name $(|max($max))?, }
-            $crate::index!{ $ty$(<$($lt),+>)?.$field[$name] => $output $(|proxy($ty2$(.$field2)+))*, }
+            $crate::index!{ $ty$(<$($lt),+>)?$(.$field)+[$name] => $output $(|proxy($ty2$(.$field2)+))*, }
         )*
     };
     ($($name:ident $(|max($max:expr))?,)*) => {
@@ -130,10 +134,10 @@ macro_rules! NonZeroU32 {
 
 #[macro_export]
 macro_rules! NonZeroU16 {
-    ($($ty:ident$(<$( $lt:lifetime ),+>)?.$field:ident[$name:ident] => $output:ty $(| $(max($max:expr))?)? $(|proxy($ty2:ident$(.$field2:ident)+))*,)*) => {
+    ($($ty:ident$(<$( $lt:lifetime ),+>)?$(.$field:ident)+[$name:ident] => $output:ty $(| $(max($max:expr))?)? $(|proxy($ty2:ident$(.$field2:ident)+))*,)*) => {
         $(
             $crate::NonZeroU16! { $name $(|max($max))?, }
-            $crate::index!{ $ty$(<$($lt),+>)?.$field[$name] => $output $(|proxy($ty2$(.$field2)+))*, }
+            $crate::index!{ $ty$(<$($lt),+>)?$(.$field)+[$name] => $output $(|proxy($ty2$(.$field2)+))*, }
         )*
     };
     ($($name:ident $(|max($max:expr))?,)*) => {
@@ -172,10 +176,10 @@ macro_rules! NonZeroU16 {
 
 #[macro_export]
 macro_rules! U8 {
-    ($($ty:ident$(<$( $lt:lifetime ),+>)?.$field:ident[$name:ident] => $output:ty $(| $(max($max:expr))?)? $(|proxy($ty2:ident$(.$field2:ident)+))*,)*) => {
+    ($($ty:ident$(<$( $lt:lifetime ),+>)?$(.$field:ident)+[$name:ident] => $output:ty $(| $(max($max:expr))?)? $(|proxy($ty2:ident$(.$field2:ident)+))*,)*) => {
         $(
             $crate::NonZeroU16! { $name $(|max($max))?, }
-            $crate::index!{ $ty$(<$($lt),+>)?.$field[$name] => $output $(|proxy($ty2$(.$field2)+))*, }
+            $crate::index!{ $ty$(<$($lt),+>)?$(.$field)+[$name] => $output $(|proxy($ty2$(.$field2)+))*, }
         )*
     };
     ($($name:ident $(|max($max:expr))?,)*) => {

--- a/engine/crates/engine-v2/id-newtypes/src/many.rs
+++ b/engine/crates/engine-v2/id-newtypes/src/many.rs
@@ -1,0 +1,71 @@
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct IdToMany<Id, V>(Vec<(Id, V)>);
+
+impl<Id, V> Default for IdToMany<Id, V> {
+    fn default() -> Self {
+        Self(Vec::new())
+    }
+}
+
+impl<Id: Ord + Copy, V> FromIterator<(Id, V)> for IdToMany<Id, V> {
+    fn from_iter<T: IntoIterator<Item = (Id, V)>>(iter: T) -> Self {
+        iter.into_iter().collect::<Vec<_>>().into()
+    }
+}
+
+impl<Id: Ord + Copy, V> From<Vec<(Id, V)>> for IdToMany<Id, V> {
+    fn from(mut relations: Vec<(Id, V)>) -> Self {
+        relations.sort_unstable_by_key(|(id, _)| *id);
+        Self(relations)
+    }
+}
+
+impl<Id, V> AsRef<[(Id, V)]> for IdToMany<Id, V> {
+    fn as_ref(&self) -> &[(Id, V)] {
+        &self.0
+    }
+}
+
+impl<Id, V> IdToMany<Id, V> {
+    pub fn from_sorted_vec(relations: Vec<(Id, V)>) -> Self {
+        Self(relations)
+    }
+
+    pub fn ids(&self) -> impl ExactSizeIterator<Item = Id> + '_
+    where
+        Id: Copy,
+    {
+        self.0.iter().map(|(id, _)| *id)
+    }
+
+    pub fn find_all(&self, id: Id) -> impl Iterator<Item = &V> + '_
+    where
+        Id: Copy + Ord,
+    {
+        ValueIterator {
+            relations: self,
+            id,
+            idx: self.0.partition_point(|probe| probe.0 < id),
+        }
+    }
+}
+
+struct ValueIterator<'a, Id, V> {
+    relations: &'a IdToMany<Id, V>,
+    id: Id,
+    idx: usize,
+}
+
+impl<'a, Id: Eq, V> Iterator for ValueIterator<'a, Id, V> {
+    type Item = &'a V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (key, value) = self.relations.0.get(self.idx)?;
+        if key == &self.id {
+            self.idx += 1;
+            Some(value)
+        } else {
+            None
+        }
+    }
+}

--- a/engine/crates/engine-v2/schema/src/walkers/enum.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/enum.rs
@@ -10,7 +10,7 @@ impl<'a> EnumWalker<'a> {
     }
 
     pub fn values(self) -> impl ExactSizeIterator<Item = EnumValueWalker<'a>> + 'a {
-        self.as_ref().value_ids.map(move |id| self.walk(id))
+        self.as_ref().value_ids.into_iter().map(move |id| self.walk(id))
     }
 
     pub fn find_value_by_name(&self, name: &str) -> Option<EnumValueId> {

--- a/engine/crates/engine-v2/schema/src/walkers/field.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/field.rs
@@ -53,7 +53,10 @@ impl<'a> FieldDefinitionWalker<'a> {
     }
 
     pub fn arguments(self) -> impl ExactSizeIterator<Item = InputValueDefinitionWalker<'a>> + 'a {
-        self.schema[self.item].argument_ids.map(move |id| self.walk(id))
+        self.schema[self.item]
+            .argument_ids
+            .into_iter()
+            .map(move |id| self.walk(id))
     }
 
     pub fn ty(self) -> TypeWalker<'a> {

--- a/engine/crates/engine-v2/schema/src/walkers/input_object.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/input_object.rs
@@ -9,7 +9,10 @@ impl<'a> InputObjectWalker<'a> {
     }
 
     pub fn input_fields(self) -> impl ExactSizeIterator<Item = InputValueDefinitionWalker<'a>> + 'a {
-        self.schema[self.item].input_field_ids.map(move |id| self.walk(id))
+        self.schema[self.item]
+            .input_field_ids
+            .into_iter()
+            .map(move |id| self.walk(id))
     }
 
     pub fn directives(&self) -> TypeSystemDirectivesWalker<'a> {

--- a/engine/crates/engine-v2/schema/src/walkers/interface.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/interface.rs
@@ -10,7 +10,7 @@ impl<'a> InterfaceWalker<'a> {
 
     pub fn fields(self) -> impl Iterator<Item = FieldDefinitionWalker<'a>> + 'a {
         let fields = self.schema[self.item].fields;
-        fields.map(move |field_id| self.walk(field_id))
+        fields.into_iter().map(move |field_id| self.walk(field_id))
     }
 
     pub fn interfaces(self) -> impl ExactSizeIterator<Item = InterfaceWalker<'a>> + 'a {

--- a/engine/crates/engine-v2/schema/src/walkers/object.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/object.rs
@@ -10,7 +10,7 @@ impl<'a> ObjectWalker<'a> {
 
     pub fn fields(self) -> impl Iterator<Item = FieldDefinitionWalker<'a>> + 'a {
         let fields = self.schema[self.item].fields;
-        fields.map(move |field_id| self.walk(field_id))
+        fields.into_iter().map(move |field_id| self.walk(field_id))
     }
 
     pub fn interfaces(self) -> impl ExactSizeIterator<Item = InterfaceWalker<'a>> + 'a {

--- a/engine/crates/engine-v2/src/execution/coordinator.rs
+++ b/engine/crates/engine-v2/src/execution/coordinator.rs
@@ -342,7 +342,7 @@ impl<'ctx, R: Runtime> OperationExecution<'ctx, R> {
             .iter()
             .map(|field| field.edge)
             .min()
-            .or_else(|| shape.field_error_ids.map(|id| shapes[id].edge).min())
+            .or_else(|| shape.field_error_ids.into_iter().map(|id| shapes[id].edge).min())
             .or_else(|| shape.typename_response_edges.iter().min().copied())
             .expect("Selection set without any fields?");
 

--- a/engine/crates/engine-v2/src/operation/walkers/argument.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/argument.rs
@@ -1,4 +1,4 @@
-use id_newtypes::IdRange;
+use id_newtypes::{IdRange, IdRangeIterator};
 use schema::{InputValueDefinitionId, InputValueDefinitionWalker, InputValueSerdeError, InputValueSet};
 use serde::{de::value::MapDeserializer, forward_to_deserialize_any};
 
@@ -40,7 +40,7 @@ impl std::fmt::Debug for FieldArgumentWalker<'_> {
     }
 }
 
-pub type FieldArgumentsWalker<'a> = OperationWalker<'a, IdRange<FieldArgumentId>>;
+pub type FieldArgumentsWalker<'a> = OperationWalker<'a, IdRange<FieldArgumentId>, ()>;
 
 impl<'a> FieldArgumentsWalker<'a> {
     pub fn is_empty(&self) -> bool {
@@ -61,11 +61,11 @@ impl<'a> IntoIterator for FieldArgumentsWalker<'a> {
     type IntoIter = FieldArgumentsIterator<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
-        FieldArgumentsIterator(self)
+        FieldArgumentsIterator(self.walk(self.item.into_iter()))
     }
 }
 
-pub(crate) struct FieldArgumentsIterator<'a>(FieldArgumentsWalker<'a>);
+pub(crate) struct FieldArgumentsIterator<'a>(OperationWalker<'a, IdRangeIterator<FieldArgumentId>, ()>);
 
 impl<'a> Iterator for FieldArgumentsIterator<'a> {
     type Item = FieldArgumentWalker<'a>;

--- a/engine/crates/engine-v2/src/response/write/mod.rs
+++ b/engine/crates/engine-v2/src/response/write/mod.rs
@@ -211,7 +211,7 @@ impl ResponseBuilder {
                 })
                 .collect();
         }
-        part.response_object_set_ids.zip(boundaries).collect()
+        part.response_object_set_ids.into_iter().zip(boundaries).collect()
     }
 
     pub fn build(self, schema: Arc<Schema>, operation: Arc<Operation>) -> Response {
@@ -357,7 +357,7 @@ impl ResponsePart {
             errors: Vec::new(),
             updates: Vec::new(),
             response_object_set_ids,
-            response_object_sets: response_object_set_ids.map(|_| (Vec::new())).collect(),
+            response_object_sets: response_object_set_ids.into_iter().map(|_| (Vec::new())).collect(),
         }
     }
 


### PR DESCRIPTION
Adding two new structs: BitSet and IdToMany. The first is obvious, the second is used to store a list of `(Id, Value)` to provide all `Value` associated with an `Id`. It's not great yet, might never be. It's an attempt to avoid using `usize::from(id)` too much to access data for an id, as we lose type safety, and have one correct implementation. I made the mistake initially of using `binary_search` rather than `partition_point` here for exampe.