### PR TITLE
chore(engine-v2): executor simplification

### DIFF
--- a/engine/crates/engine-v2/src/response/read/mod.rs
+++ b/engine/crates/engine-v2/src/response/read/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::{FilteredResponseObjectSet, ResponseBuilder};
 mod selection_set;
 mod ser;
@@ -11,7 +13,7 @@ impl ResponseBuilder {
     pub fn read<'a>(
         &'a self,
         schema: &'a Schema,
-        response_object_set: &'a FilteredResponseObjectSet,
+        response_object_set: Arc<FilteredResponseObjectSet>,
         selection_set: &'a ReadSelectionSet,
     ) -> ResponseObjectsView<'a> {
         ResponseObjectsView {

--- a/engine/crates/engine-v2/src/response/read/view/mod.rs
+++ b/engine/crates/engine-v2/src/response/read/view/mod.rs
@@ -1,6 +1,8 @@
 mod de;
 mod ser;
 
+use std::sync::Arc;
+
 use schema::Schema;
 
 use super::ReadSelectionSet;
@@ -10,7 +12,7 @@ use crate::response::{FilteredResponseObjectSet, ResponseBuilder, ResponseObject
 pub(crate) struct ResponseObjectsView<'a> {
     pub(super) schema: &'a Schema,
     pub(super) response: &'a ResponseBuilder,
-    pub(super) response_object_set: &'a FilteredResponseObjectSet,
+    pub(super) response_object_set: Arc<FilteredResponseObjectSet>,
     pub(super) selection_set: &'a ReadSelectionSet,
 }
 
@@ -18,7 +20,7 @@ pub(crate) struct ResponseObjectsView<'a> {
 pub(crate) struct ResponseObjectsViewWithExtraFields<'a> {
     schema: &'a Schema,
     response: &'a ResponseBuilder,
-    response_object_set: &'a FilteredResponseObjectSet,
+    response_object_set: Arc<FilteredResponseObjectSet>,
     selection_set: &'a ReadSelectionSet,
     extra_constant_fields: Vec<(String, serde_json::Value)>,
 }

--- a/engine/crates/engine-v2/src/sources/graphql/deserialize/entities.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/deserialize/entities.rs
@@ -7,13 +7,13 @@ use serde::{
 
 use crate::{
     execution::PlanWalker,
-    response::{ErrorCode, GraphqlError, ResponseKeys, ResponsePath, SharedSubgraphResponse, UnpackedResponseEdge},
+    response::{ErrorCode, GraphqlError, ResponseKeys, ResponsePath, SubgraphResponseRefMut, UnpackedResponseEdge},
 };
 
 use super::errors::GraphqlErrorsSeed;
 
 pub(in crate::sources::graphql) struct EntitiesDataSeed<'resp> {
-    pub response: SharedSubgraphResponse<'resp>,
+    pub response: SubgraphResponseRefMut<'resp>,
     pub plan: PlanWalker<'resp>,
 }
 
@@ -71,7 +71,7 @@ enum EntitiesKey {
 }
 
 struct EntitiesSeed<'resp, 'parent> {
-    response_part: &'parent SharedSubgraphResponse<'resp>,
+    response_part: &'parent SubgraphResponseRefMut<'resp>,
     plan: PlanWalker<'resp>,
 }
 
@@ -126,12 +126,12 @@ where
 }
 
 pub(in crate::sources::graphql) struct EntitiesErrorsSeed<'resp> {
-    pub response: SharedSubgraphResponse<'resp>,
+    pub response: SubgraphResponseRefMut<'resp>,
     pub response_keys: &'resp ResponseKeys,
 }
 
 impl<'resp> GraphqlErrorsSeed<'resp> for EntitiesErrorsSeed<'resp> {
-    fn response(&self) -> &SharedSubgraphResponse<'resp> {
+    fn response(&self) -> &SubgraphResponseRefMut<'resp> {
         &self.response
     }
 

--- a/engine/crates/engine-v2/src/sources/graphql/deserialize/errors.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/deserialize/errors.rs
@@ -1,21 +1,21 @@
 use serde::{de::DeserializeSeed, Deserializer};
 
 use crate::response::{
-    ErrorCode, GraphqlError, ResponseKeys, ResponsePath, SharedSubgraphResponse, UnpackedResponseEdge,
+    ErrorCode, GraphqlError, ResponseKeys, ResponsePath, SubgraphResponseRefMut, UnpackedResponseEdge,
 };
 
 pub(super) trait GraphqlErrorsSeed<'resp> {
-    fn response(&self) -> &SharedSubgraphResponse<'resp>;
+    fn response(&self) -> &SubgraphResponseRefMut<'resp>;
     fn convert_path(&self, path: &serde_json::Value) -> Option<ResponsePath>;
 }
 
 pub(in crate::sources::graphql) struct RootGraphqlErrors<'resp> {
-    pub response: SharedSubgraphResponse<'resp>,
+    pub response: SubgraphResponseRefMut<'resp>,
     pub response_keys: &'resp ResponseKeys,
 }
 
 impl<'resp> GraphqlErrorsSeed<'resp> for RootGraphqlErrors<'resp> {
-    fn response(&self) -> &SharedSubgraphResponse<'resp> {
+    fn response(&self) -> &SubgraphResponseRefMut<'resp> {
         &self.response
     }
 

--- a/engine/crates/engine-v2/src/sources/graphql/federation.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/federation.rs
@@ -1,16 +1,17 @@
 use grafbase_tracing::span::{subgraph::SubgraphRequestSpan, GqlRecorderSpanExt};
 use runtime::fetch::FetchRequest;
-use schema::sources::graphql::{FederationEntityResolverWalker, GraphqlEndpointId, GraphqlEndpointWalker};
+use schema::sources::graphql::{FederationEntityResolverWalker, GraphqlEndpointId};
 use serde::de::DeserializeSeed;
+use std::future::Future;
 use tracing::Instrument;
 
 use crate::{
     execution::{ExecutionContext, PlanWalker, PlanningResult},
     operation::OperationType,
-    response::SubgraphResponseMutRef,
+    response::{ResponseObjectsView, SubgraphResponse},
     sources::{
         graphql::deserialize::{EntitiesErrorsSeed, GraphqlResponseSeed},
-        ExecutionResult, Executor, ExecutorInput, PreparedExecutor,
+        ExecutionResult, PreparedExecutor,
     },
     Runtime,
 };
@@ -36,16 +37,16 @@ impl FederationEntityPreparedExecutor {
         }))
     }
 
-    pub fn new_executor<'ctx, R: Runtime>(
+    pub fn execute<'ctx, 'fut, R: Runtime>(
         &'ctx self,
-        input: ExecutorInput<'ctx, '_, R>,
-    ) -> ExecutionResult<Executor<'ctx, R>> {
-        let ExecutorInput {
-            ctx,
-            plan,
-            root_response_objects,
-        } = input;
-
+        ctx: ExecutionContext<'ctx, R>,
+        plan: PlanWalker<'ctx, (), ()>,
+        root_response_objects: ResponseObjectsView<'_>,
+        mut subgraph_response: SubgraphResponse,
+    ) -> ExecutionResult<impl Future<Output = ExecutionResult<SubgraphResponse>> + Send + 'fut>
+    where
+        'ctx: 'fut,
+    {
         let root_response_objects = root_response_objects.with_extra_constant_fields(vec![(
             "__typename".to_string(),
             serde_json::Value::String(
@@ -76,73 +77,48 @@ impl FederationEntityPreparedExecutor {
         }))
         .map_err(|err| format!("Failed to serialize query: {err}"))?;
 
-        Ok(Executor::FederationEntity(FederationEntityExecutor {
-            ctx,
-            subgraph,
-            operation: &self.operation,
-            json_body,
-            plan,
-        }))
-    }
-}
-
-pub(crate) struct FederationEntityExecutor<'ctx, R: Runtime> {
-    ctx: ExecutionContext<'ctx, R>,
-    subgraph: GraphqlEndpointWalker<'ctx>,
-    operation: &'ctx PreparedFederationEntityOperation,
-    json_body: String,
-    plan: PlanWalker<'ctx>,
-}
-
-impl<'ctx, R: Runtime> FederationEntityExecutor<'ctx, R> {
-    #[tracing::instrument(skip_all)]
-    pub async fn execute<'resp>(self, subgraph_response: SubgraphResponseMutRef<'resp>) -> ExecutionResult<()>
-    where
-        'ctx: 'resp,
-    {
         let span = SubgraphRequestSpan {
-            name: self.subgraph.name(),
+            name: subgraph.name(),
             operation_type: OperationType::Query.as_str(),
             // The generated query does not contain any data, everything are in the variables, so
             // it's safe to use.
             sanitized_query: &self.operation.query,
-            url: self.subgraph.url(),
+            url: subgraph.url(),
         }
         .into_span();
+        let span_clone = span.clone();
 
-        async {
-            let bytes = self
-                .ctx
+        Ok(async move {
+            let bytes = ctx
                 .engine
                 .runtime
                 .fetcher()
                 .post(FetchRequest {
-                    url: self.subgraph.url(),
-                    json_body: self.json_body,
-                    headers: self.ctx.headers_with_rules(self.subgraph.header_rules()),
+                    url: subgraph.url(),
+                    json_body,
+                    headers: ctx.headers_with_rules(subgraph.header_rules()),
                 })
                 .await?
                 .bytes;
             tracing::debug!("{}", String::from_utf8_lossy(&bytes));
 
-            let response = subgraph_response.into_shared();
+            let response = subgraph_response.as_mut();
             let status = GraphqlResponseSeed::new(
                 EntitiesDataSeed {
                     response: response.clone(),
-                    plan: self.plan,
+                    plan,
                 },
                 EntitiesErrorsSeed {
                     response,
-                    response_keys: self.plan.response_keys(),
+                    response_keys: plan.response_keys(),
                 },
             )
             .deserialize(&mut serde_json::Deserializer::from_slice(&bytes))?;
 
             span.record_gql_status(status);
 
-            Ok(())
+            Ok(subgraph_response)
         }
-        .instrument(span.clone())
-        .await
+        .instrument(span_clone))
     }
 }

--- a/engine/crates/engine-v2/src/sources/graphql/subscription.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/subscription.rs
@@ -1,54 +1,26 @@
 use futures_util::{stream::BoxStream, StreamExt};
 use runtime::fetch::GraphqlRequest;
-use schema::sources::graphql::GraphqlEndpointWalker;
 use serde::de::DeserializeSeed;
 
 use super::{
     deserialize::{GraphqlResponseSeed, RootGraphqlErrors},
-    query::PreparedGraphqlOperation,
     variables::SubgraphVariables,
     ExecutionContext, GraphqlPreparedExecutor,
 };
 use crate::{
     execution::{PlanWalker, SubscriptionResponse},
-    sources::{ExecutionResult, SubscriptionExecutor, SubscriptionInput},
+    sources::ExecutionResult,
     Runtime,
 };
 
-pub(crate) struct GraphqlSubscriptionExecutor<'ctx, R: Runtime> {
-    ctx: ExecutionContext<'ctx, R>,
-    subgraph: GraphqlEndpointWalker<'ctx>,
-    operation: &'ctx PreparedGraphqlOperation,
-    plan: PlanWalker<'ctx>,
-}
-
 impl GraphqlPreparedExecutor {
-    pub fn new_subscription_executor<'ctx, R: Runtime>(
+    pub async fn execute_subscription<'ctx, R: Runtime>(
         &'ctx self,
-        input: SubscriptionInput<'ctx, R>,
-    ) -> ExecutionResult<SubscriptionExecutor<'ctx, R>> {
-        let SubscriptionInput { ctx, plan } = input;
-        let subgraph = ctx.schema().walk(self.subgraph_id);
-        Ok(SubscriptionExecutor::Graphql(GraphqlSubscriptionExecutor {
-            ctx,
-            subgraph,
-            operation: &self.operation,
-            plan,
-        }))
-    }
-}
-
-impl<'ctx, R: Runtime> GraphqlSubscriptionExecutor<'ctx, R> {
-    pub async fn execute(
-        self,
+        ctx: ExecutionContext<'ctx, R>,
+        plan: PlanWalker<'ctx>,
         new_response: impl Fn() -> SubscriptionResponse + Send + 'ctx,
     ) -> ExecutionResult<BoxStream<'ctx, ExecutionResult<SubscriptionResponse>>> {
-        let Self {
-            ctx,
-            subgraph,
-            operation,
-            plan,
-        } = self;
+        let subgraph = ctx.schema().walk(self.subgraph_id);
 
         let url = {
             let mut url = subgraph.websocket_url().clone();
@@ -68,17 +40,16 @@ impl<'ctx, R: Runtime> GraphqlSubscriptionExecutor<'ctx, R> {
             .fetcher()
             .stream(GraphqlRequest {
                 url: &url,
-                query: &operation.query,
+                query: &self.operation.query,
                 variables: serde_json::to_value(&SubgraphVariables {
                     plan,
-                    variables: &operation.variables,
+                    variables: &self.operation.variables,
                     inputs: Vec::new(),
                 })
                 .map_err(|error| error.to_string())?,
-                headers: self.ctx.headers_with_rules(subgraph.header_rules()),
+                headers: ctx.headers_with_rules(subgraph.header_rules()),
             })
             .await?;
-
         Ok(Box::pin(stream.map(move |subgraph_response| {
             let mut subscription_response = new_response();
             ingest_response(&mut subscription_response, plan, subgraph_response?)?;
@@ -92,7 +63,7 @@ fn ingest_response(
     plan: PlanWalker<'_>,
     subgraph_response: serde_json::Value,
 ) -> ExecutionResult<()> {
-    let response = subscription_response.root_response().into_shared();
+    let response = subscription_response.root_response();
     GraphqlResponseSeed::new(
         response.next_seed(plan).expect("Must have a root object to update"),
         RootGraphqlErrors {

--- a/engine/crates/engine-v2/src/sources/mod.rs
+++ b/engine/crates/engine-v2/src/sources/mod.rs
@@ -42,22 +42,21 @@
 //!
 //! The executor for the catalog plan would have a single response object root and the price plan
 //! executor will have a root for each product in the response.
+use futures::{future::BoxFuture, FutureExt};
 use futures_util::stream::BoxStream;
 use schema::{Resolver, ResolverWalker};
+use std::future::Future;
 
 use crate::{
     execution::{ExecutionContext, ExecutionError, ExecutionResult, PlanWalker, PlanningResult, SubscriptionResponse},
     operation::OperationType,
-    response::{ResponseObjectsView, SubgraphResponseMutRef},
+    response::{ResponseObjectsView, SubgraphResponse},
     Runtime,
 };
 
 use self::{
-    graphql::{
-        FederationEntityExecutor, FederationEntityPreparedExecutor, GraphqlExecutor, GraphqlPreparedExecutor,
-        GraphqlSubscriptionExecutor,
-    },
-    introspection::{IntrospectionExecutor, IntrospectionPreparedExecutor},
+    graphql::{FederationEntityPreparedExecutor, GraphqlPreparedExecutor},
+    introspection::IntrospectionPreparedExecutor,
 };
 
 mod graphql;
@@ -91,75 +90,50 @@ impl PreparedExecutor {
     }
 }
 
-pub(crate) struct ExecutorInput<'ctx, 'input, R: Runtime> {
-    pub ctx: ExecutionContext<'ctx, R>,
-    pub plan: PlanWalker<'ctx, (), ()>,
-    pub root_response_objects: ResponseObjectsView<'input>,
-}
-
-pub(crate) struct SubscriptionInput<'ctx, R: Runtime> {
-    pub ctx: ExecutionContext<'ctx, R>,
-    pub plan: PlanWalker<'ctx>,
-}
-
 impl PreparedExecutor {
-    pub fn new_executor<'ctx, R: Runtime>(
+    pub fn execute<'ctx, 'fut, R: Runtime>(
         &'ctx self,
-        input: ExecutorInput<'ctx, '_, R>,
-    ) -> Result<Executor<'ctx, R>, ExecutionError> {
-        match self {
-            PreparedExecutor::Introspection(prepared) => prepared.new_executor(input),
-            PreparedExecutor::GraphQL(prepared) => prepared.new_executor(input),
-            PreparedExecutor::FederationEntity(prepared) => prepared.new_executor(input),
+        ctx: ExecutionContext<'ctx, R>,
+        plan: PlanWalker<'ctx, (), ()>,
+        // This cannot be kept in the future, it locks the whole the response to have this view.
+        // So an executor is expected to prepare whatever it required from the response before
+        // awaiting anything.
+        root_response_objects: ResponseObjectsView<'_>,
+        subgraph_response: SubgraphResponse,
+    ) -> impl Future<Output = ExecutionResult<SubgraphResponse>> + Send + 'fut
+    where
+        'ctx: 'fut,
+    {
+        let result: ExecutionResult<BoxFuture<'fut, _>> = match self {
+            PreparedExecutor::GraphQL(prepared) => Ok(prepared.execute(ctx, plan, subgraph_response).boxed()),
+            PreparedExecutor::FederationEntity(prepared) => prepared
+                .execute(ctx, plan, root_response_objects, subgraph_response)
+                .map(FutureExt::boxed),
+            PreparedExecutor::Introspection(prepared) => Ok(prepared.execute(ctx, plan, subgraph_response).boxed()),
+        };
+
+        async {
+            match result {
+                Ok(future) => future.await,
+                Err(err) => Err(err),
+            }
         }
     }
 
-    pub fn new_subscription_executor<'ctx, R: Runtime>(
+    pub async fn execute_subscription<'ctx, R: Runtime>(
         &'ctx self,
-        input: SubscriptionInput<'ctx, R>,
-    ) -> Result<SubscriptionExecutor<'ctx, R>, ExecutionError> {
+        ctx: ExecutionContext<'ctx, R>,
+        plan: PlanWalker<'ctx>,
+        new_response: impl Fn() -> SubscriptionResponse + Send + 'ctx,
+    ) -> ExecutionResult<BoxStream<'ctx, ExecutionResult<SubscriptionResponse>>> {
         match self {
-            PreparedExecutor::GraphQL(prepared) => prepared.new_subscription_executor(input),
+            PreparedExecutor::GraphQL(prepared) => prepared.execute_subscription(ctx, plan, new_response).await,
             PreparedExecutor::Introspection(_) => Err(ExecutionError::Internal(
                 "Subscriptions can't contain introspection".into(),
             )),
             PreparedExecutor::FederationEntity(_) => Err(ExecutionError::Internal(
                 "Subscriptions can only be at the root of a query so can't contain federated entitites".into(),
             )),
-        }
-    }
-}
-
-pub(crate) enum Executor<'ctx, R: Runtime> {
-    GraphQL(GraphqlExecutor<'ctx, R>),
-    Introspection(IntrospectionExecutor<'ctx, R>),
-    FederationEntity(FederationEntityExecutor<'ctx, R>),
-}
-
-impl<'ctx, R: Runtime> Executor<'ctx, R> {
-    pub async fn execute<'resp>(self, subgraph_response: SubgraphResponseMutRef<'resp>) -> ExecutionResult<()>
-    where
-        'ctx: 'resp,
-    {
-        match self {
-            Executor::GraphQL(executor) => executor.execute(subgraph_response).await,
-            Executor::Introspection(executor) => executor.execute(subgraph_response).await,
-            Executor::FederationEntity(executor) => executor.execute(subgraph_response).await,
-        }
-    }
-}
-
-pub(crate) enum SubscriptionExecutor<'ctx, R: Runtime> {
-    Graphql(GraphqlSubscriptionExecutor<'ctx, R>),
-}
-
-impl<'ctx, R: Runtime> SubscriptionExecutor<'ctx, R> {
-    pub async fn execute(
-        self,
-        new_response: impl Fn() -> SubscriptionResponse + Send + 'ctx,
-    ) -> ExecutionResult<BoxStream<'ctx, ExecutionResult<SubscriptionResponse>>> {
-        match self {
-            SubscriptionExecutor::Graphql(executor) => executor.execute(new_response).await,
         }
     }
 }


### PR DESCRIPTION
I realized what I was doing all along with executor is just a
hand-written future. So removing it entirely. Now there are only two
steps, instead of three:
- prepare
- execute

The reason for the intermediate step was that the response object view
which provides any required fields locks the response, and thus must be
used before awaiting anything. But that can be done just as well by
returning a future.

# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
