### PR TITLE
feat(wasm hooks): Add on_subgraph_request hook definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9705,10 +9705,12 @@ name = "wasi-component-loader"
 version = "0.77.1"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "expect-test",
  "grafbase-tracing",
  "http 1.1.0",
  "indoc",
+ "insta",
  "serde",
  "serde_json",
  "tempdir",
@@ -9716,6 +9718,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "url",
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",

--- a/engine/crates/runtime-local/src/hooks.rs
+++ b/engine/crates/runtime-local/src/hooks.rs
@@ -65,7 +65,7 @@ impl Hooks for HooksWasi {
                     tracing::error!("on_gateway_request error: {err}");
                     PartialGraphqlError::internal_hook_error()
                 }
-                wasi_component_loader::Error::User(err) => {
+                wasi_component_loader::Error::Guest(err) => {
                     error_response_to_user_error(err, PartialErrorCode::BadRequest)
                 }
             })
@@ -77,7 +77,7 @@ impl Hooks for HooksWasi {
 }
 
 fn error_response_to_user_error(
-    error: wasi_component_loader::ErrorResponse,
+    error: wasi_component_loader::GuestError,
     code: PartialErrorCode,
 ) -> PartialGraphqlError {
     let extensions = error

--- a/engine/crates/runtime-local/src/hooks/authorized.rs
+++ b/engine/crates/runtime-local/src/hooks/authorized.rs
@@ -69,7 +69,7 @@ impl AuthorizedHooks<Context> for HooksWasi {
                     tracing::error!("authorize_edge_pre_execution error at: {error}");
                     PartialGraphqlError::internal_hook_error()
                 }
-                wasi_component_loader::Error::User(error) => {
+                wasi_component_loader::Error::Guest(error) => {
                     error_response_to_user_error(error, PartialErrorCode::Unauthorized)
                 }
             })?;
@@ -101,7 +101,7 @@ impl AuthorizedHooks<Context> for HooksWasi {
                     tracing::error!("authorize_node_pre_execution error at: {error}");
                     PartialGraphqlError::internal_hook_error()
                 }
-                wasi_component_loader::Error::User(error) => {
+                wasi_component_loader::Error::Guest(error) => {
                     error_response_to_user_error(error, PartialErrorCode::Unauthorized)
                 }
             })?;
@@ -155,7 +155,7 @@ impl AuthorizedHooks<Context> for HooksWasi {
                     tracing::error!("authorize_parent_edge_post_execution error at: {error}");
                     PartialGraphqlError::internal_server_error()
                 }
-                wasi_component_loader::Error::User(error) => {
+                wasi_component_loader::Error::Guest(error) => {
                     error_response_to_user_error(error, PartialErrorCode::Unauthorized)
                 }
             })?
@@ -195,7 +195,7 @@ impl AuthorizedHooks<Context> for HooksWasi {
                     tracing::error!("authorize_edge_node_post_execution error at: {error}");
                     PartialGraphqlError::internal_server_error()
                 }
-                wasi_component_loader::Error::User(error) => {
+                wasi_component_loader::Error::Guest(error) => {
                     error_response_to_user_error(error, PartialErrorCode::Unauthorized)
                 }
             })?
@@ -261,7 +261,7 @@ impl AuthorizedHooks<Context> for HooksWasi {
                     tracing::error!("authorize_edge_post_execution error at: {error}");
                     PartialGraphqlError::internal_server_error()
                 }
-                wasi_component_loader::Error::User(error) => {
+                wasi_component_loader::Error::Guest(error) => {
                     error_response_to_user_error(error, PartialErrorCode::Unauthorized)
                 }
             })?

--- a/engine/crates/wasi-component-loader/Cargo.toml
+++ b/engine/crates/wasi-component-loader/Cargo.toml
@@ -14,6 +14,7 @@ http.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+url.workspace = true
 
 [dependencies.wasmtime]
 git = "https://github.com/grafbase/wasmtime"
@@ -35,6 +36,8 @@ workspace = true
 expect-test = "1.5.0"
 indoc = "2.0.5"
 serde_json.workspace = true
+base64.workspace = true
+insta.workspace = true
 tempdir = "0.3.7"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 toml = "0.8.14"

--- a/engine/crates/wasi-component-loader/examples/Cargo.lock
+++ b/engine/crates/wasi-component-loader/examples/Cargo.lock
@@ -262,7 +262,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
- "wit-bindgen-rt 0.27.0",
+ "wit-bindgen-rt 0.28.0",
 ]
 
 [[package]]
@@ -291,6 +291,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -423,7 +429,7 @@ dependencies = [
 name = "dir_access"
 version = "0.1.0"
 dependencies = [
- "wit-bindgen-rt 0.27.0",
+ "wit-bindgen-rt 0.28.0",
 ]
 
 [[package]]
@@ -476,7 +482,7 @@ dependencies = [
 name = "error"
 version = "0.1.0"
 dependencies = [
- "wit-bindgen-rt 0.27.0",
+ "wit-bindgen-rt 0.28.0",
 ]
 
 [[package]]
@@ -1004,7 +1010,7 @@ dependencies = [
 name = "missing_hook"
 version = "0.1.0"
 dependencies = [
- "wit-bindgen-rt 0.27.0",
+ "wit-bindgen-rt 0.28.0",
 ]
 
 [[package]]
@@ -1012,7 +1018,7 @@ name = "networking"
 version = "0.1.0"
 dependencies = [
  "waki",
- "wit-bindgen-rt 0.27.0",
+ "wit-bindgen-rt 0.28.0",
 ]
 
 [[package]]
@@ -1185,7 +1191,7 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1288,7 +1294,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -1399,7 +1405,7 @@ dependencies = [
 name = "simple"
 version = "0.1.0"
 dependencies = [
- "wit-bindgen-rt 0.27.0",
+ "wit-bindgen-rt 0.28.0",
 ]
 
 [[package]]
@@ -1451,6 +1457,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "subgraph_request"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "serde_json",
+ "wit-bindgen-rt 0.28.0",
+]
 
 [[package]]
 name = "syn"
@@ -2110,9 +2125,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75956ff0a04a87ca0526b07199ce3b9baee899f2e4723b5b63aa296ab172ec52"
+checksum = "d7a37bd9274cb2d4754b915d624447ec0dce9105d174361841c0826efc79ceb9"
 dependencies = [
  "bitflags 2.5.0",
 ]

--- a/engine/crates/wasi-component-loader/examples/Cargo.toml
+++ b/engine/crates/wasi-component-loader/examples/Cargo.toml
@@ -20,3 +20,7 @@ strip = true
 lto = true
 
 [workspace.dependencies]
+serde_json = "1"
+base64 = "0.22"
+wit-bindgen-rt = { version = "0.28.0", features = ["bitflags"] }
+

--- a/engine/crates/wasi-component-loader/examples/crates/authorization/Cargo.toml
+++ b/engine/crates/wasi-component-loader/examples/crates/authorization/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 [dependencies]
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.120"
-wit-bindgen-rt = { version = "0.27.0", features = ["bitflags"] }
+wit-bindgen-rt.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/engine/crates/wasi-component-loader/examples/crates/authorization/src/bindings.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/authorization/src/bindings.rs
@@ -393,11 +393,11 @@ pub mod component {
             }
             impl Headers {
                 #[allow(unused_unsafe, clippy::all)]
-                pub fn get(&self, name: &str) -> Result<Option<_rt::String>, HeaderError> {
+                pub fn get(&self, name: &str) -> Option<_rt::String> {
                     unsafe {
                         #[repr(align(4))]
-                        struct RetArea([::core::mem::MaybeUninit<u8>; 16]);
-                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 16]);
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 12]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 12]);
                         let vec0 = name;
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
@@ -416,35 +416,17 @@ pub mod component {
                         wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
                         let l2 = i32::from(*ptr1.add(0).cast::<u8>());
                         match l2 {
-                            0 => {
-                                let e = {
-                                    let l3 = i32::from(*ptr1.add(4).cast::<u8>());
-
-                                    match l3 {
-                                        0 => None,
-                                        1 => {
-                                            let e = {
-                                                let l4 = *ptr1.add(8).cast::<*mut u8>();
-                                                let l5 = *ptr1.add(12).cast::<usize>();
-                                                let len6 = l5;
-                                                let bytes6 = _rt::Vec::from_raw_parts(l4.cast(), len6, len6);
-
-                                                _rt::string_lift(bytes6)
-                                            };
-                                            Some(e)
-                                        }
-                                        _ => _rt::invalid_enum_discriminant(),
-                                    }
-                                };
-                                Ok(e)
-                            }
+                            0 => None,
                             1 => {
                                 let e = {
-                                    let l7 = i32::from(*ptr1.add(4).cast::<u8>());
+                                    let l3 = *ptr1.add(4).cast::<*mut u8>();
+                                    let l4 = *ptr1.add(8).cast::<usize>();
+                                    let len5 = l4;
+                                    let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
 
-                                    HeaderError::_lift(l7 as u8)
+                                    _rt::string_lift(bytes5)
                                 };
-                                Err(e)
+                                Some(e)
                             }
                             _ => _rt::invalid_enum_discriminant(),
                         }
@@ -505,11 +487,11 @@ pub mod component {
             }
             impl Headers {
                 #[allow(unused_unsafe, clippy::all)]
-                pub fn delete(&self, name: &str) -> Result<Option<_rt::String>, HeaderError> {
+                pub fn delete(&self, name: &str) -> Option<_rt::String> {
                     unsafe {
                         #[repr(align(4))]
-                        struct RetArea([::core::mem::MaybeUninit<u8>; 16]);
-                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 16]);
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 12]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 12]);
                         let vec0 = name;
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
@@ -528,35 +510,17 @@ pub mod component {
                         wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
                         let l2 = i32::from(*ptr1.add(0).cast::<u8>());
                         match l2 {
-                            0 => {
-                                let e = {
-                                    let l3 = i32::from(*ptr1.add(4).cast::<u8>());
-
-                                    match l3 {
-                                        0 => None,
-                                        1 => {
-                                            let e = {
-                                                let l4 = *ptr1.add(8).cast::<*mut u8>();
-                                                let l5 = *ptr1.add(12).cast::<usize>();
-                                                let len6 = l5;
-                                                let bytes6 = _rt::Vec::from_raw_parts(l4.cast(), len6, len6);
-
-                                                _rt::string_lift(bytes6)
-                                            };
-                                            Some(e)
-                                        }
-                                        _ => _rt::invalid_enum_discriminant(),
-                                    }
-                                };
-                                Ok(e)
-                            }
+                            0 => None,
                             1 => {
                                 let e = {
-                                    let l7 = i32::from(*ptr1.add(4).cast::<u8>());
+                                    let l3 = *ptr1.add(4).cast::<*mut u8>();
+                                    let l4 = *ptr1.add(8).cast::<usize>();
+                                    let len5 = l4;
+                                    let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
 
-                                    HeaderError::_lift(l7 as u8)
+                                    _rt::string_lift(bytes5)
                                 };
-                                Err(e)
+                                Some(e)
                             }
                             _ => _rt::invalid_enum_discriminant(),
                         }
@@ -1679,9 +1643,9 @@ pub(crate) use __export_hooks_impl as export;
 #[cfg(target_arch = "wasm32")]
 #[link_section = "component-type:wit-bindgen:0.25.0:hooks:encoded world"]
 #[doc(hidden)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 1524] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xf8\x0a\x01A\x02\x01\
-A\x0c\x01B\x1f\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 1518] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xf2\x0a\x01A\x02\x01\
+A\x0c\x01B\x1e\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
 header-error\x03\0\0\x04\0\x07context\x03\x01\x04\0\x0eshared-context\x03\x01\x04\
 \0\x07headers\x03\x01\x01r\x02\x10parent-type-names\x0afield-names\x04\0\x0fedge\
 -definition\x03\0\x05\x01r\x01\x09type-names\x04\0\x0fnode-definition\x03\0\x07\x01\
@@ -1689,30 +1653,30 @@ o\x02ss\x01p\x09\x01r\x02\x0aextensions\x0a\x07messages\x04\0\x05error\x03\0\x0b
 \x01h\x02\x01ks\x01@\x02\x04self\x0d\x04names\0\x0e\x04\0\x13[method]context.get\
 \x01\x0f\x01@\x03\x04self\x0d\x04names\x05values\x01\0\x04\0\x13[method]context.\
 set\x01\x10\x04\0\x16[method]context.delete\x01\x0f\x01h\x03\x01@\x02\x04self\x11\
-\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01j\x01\x0e\
-\x01\x01\x01@\x02\x04self\x13\x04names\0\x14\x04\0\x13[method]headers.get\x01\x15\
-\x01j\0\x01\x01\x01@\x03\x04self\x13\x04names\x05values\0\x16\x04\0\x13[method]h\
-eaders.set\x01\x17\x04\0\x16[method]headers.delete\x01\x15\x03\x01\x18component:\
-grafbase/types\x05\0\x02\x03\0\0\x07headers\x02\x03\0\0\x05error\x02\x03\0\0\x07\
-context\x01B\x0b\x02\x03\x02\x01\x01\x04\0\x07headers\x03\0\0\x02\x03\x02\x01\x02\
-\x04\0\x05error\x03\0\x02\x02\x03\x02\x01\x03\x04\0\x07context\x03\0\x04\x01i\x05\
-\x01i\x01\x01j\0\x01\x03\x01@\x02\x07context\x06\x07headers\x07\0\x08\x04\0\x12o\
-n-gateway-request\x01\x09\x04\x01\"component:grafbase/gateway-request\x05\x04\x02\
-\x03\0\0\x0eshared-context\x02\x03\0\0\x0fedge-definition\x02\x03\0\0\x0fnode-de\
-finition\x01B\x18\x02\x03\x02\x01\x02\x04\0\x05error\x03\0\0\x02\x03\x02\x01\x05\
-\x04\0\x0eshared-context\x03\0\x02\x02\x03\x02\x01\x06\x04\0\x0fedge-definition\x03\
-\0\x04\x02\x03\x02\x01\x07\x04\0\x0fnode-definition\x03\0\x06\x01i\x03\x01j\0\x01\
-\x01\x01@\x04\x07context\x08\x0adefinition\x05\x09argumentss\x08metadatas\0\x09\x04\
-\0\x1cauthorize-edge-pre-execution\x01\x0a\x01@\x03\x07context\x08\x0adefinition\
-\x07\x08metadatas\0\x09\x04\0\x1cauthorize-node-pre-execution\x01\x0b\x01ps\x01p\
-\x09\x01@\x04\x07context\x08\x0adefinition\x05\x07parents\x0c\x08metadatas\0\x0d\
-\x04\0$authorize-parent-edge-post-execution\x01\x0e\x01@\x04\x07context\x08\x0ad\
-efinition\x05\x05nodes\x0c\x08metadatas\0\x0d\x04\0\"authorize-edge-node-post-ex\
-ecution\x01\x0f\x01o\x02s\x0c\x01p\x10\x01@\x04\x07context\x08\x0adefinition\x05\
-\x05edges\x11\x08metadatas\0\x0d\x04\0\x1dauthorize-edge-post-execution\x01\x12\x04\
-\x01\x20component:grafbase/authorization\x05\x08\x04\x01\x18component:grafbase/h\
-ooks\x04\0\x0b\x0b\x01\0\x05hooks\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\
-\x0dwit-component\x070.208.1\x10wit-bindgen-rust\x060.25.0";
+\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01@\x02\x04\
+self\x13\x04names\0\x0e\x04\0\x13[method]headers.get\x01\x14\x01j\0\x01\x01\x01@\
+\x03\x04self\x13\x04names\x05values\0\x15\x04\0\x13[method]headers.set\x01\x16\x04\
+\0\x16[method]headers.delete\x01\x14\x03\x01\x18component:grafbase/types\x05\0\x02\
+\x03\0\0\x07headers\x02\x03\0\0\x05error\x02\x03\0\0\x07context\x01B\x0b\x02\x03\
+\x02\x01\x01\x04\0\x07headers\x03\0\0\x02\x03\x02\x01\x02\x04\0\x05error\x03\0\x02\
+\x02\x03\x02\x01\x03\x04\0\x07context\x03\0\x04\x01i\x05\x01i\x01\x01j\0\x01\x03\
+\x01@\x02\x07context\x06\x07headers\x07\0\x08\x04\0\x12on-gateway-request\x01\x09\
+\x04\x01\"component:grafbase/gateway-request\x05\x04\x02\x03\0\0\x0eshared-conte\
+xt\x02\x03\0\0\x0fedge-definition\x02\x03\0\0\x0fnode-definition\x01B\x18\x02\x03\
+\x02\x01\x02\x04\0\x05error\x03\0\0\x02\x03\x02\x01\x05\x04\0\x0eshared-context\x03\
+\0\x02\x02\x03\x02\x01\x06\x04\0\x0fedge-definition\x03\0\x04\x02\x03\x02\x01\x07\
+\x04\0\x0fnode-definition\x03\0\x06\x01i\x03\x01j\0\x01\x01\x01@\x04\x07context\x08\
+\x0adefinition\x05\x09argumentss\x08metadatas\0\x09\x04\0\x1cauthorize-edge-pre-\
+execution\x01\x0a\x01@\x03\x07context\x08\x0adefinition\x07\x08metadatas\0\x09\x04\
+\0\x1cauthorize-node-pre-execution\x01\x0b\x01ps\x01p\x09\x01@\x04\x07context\x08\
+\x0adefinition\x05\x07parents\x0c\x08metadatas\0\x0d\x04\0$authorize-parent-edge\
+-post-execution\x01\x0e\x01@\x04\x07context\x08\x0adefinition\x05\x05nodes\x0c\x08\
+metadatas\0\x0d\x04\0\"authorize-edge-node-post-execution\x01\x0f\x01o\x02s\x0c\x01\
+p\x10\x01@\x04\x07context\x08\x0adefinition\x05\x05edges\x11\x08metadatas\0\x0d\x04\
+\0\x1dauthorize-edge-post-execution\x01\x12\x04\x01\x20component:grafbase/author\
+ization\x05\x08\x04\x01\x18component:grafbase/hooks\x04\0\x0b\x0b\x01\0\x05hooks\
+\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\x070.208.1\x10\
+wit-bindgen-rust\x060.25.0";
 
 #[inline(never)]
 #[doc(hidden)]

--- a/engine/crates/wasi-component-loader/examples/crates/authorization/src/lib.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/authorization/src/lib.rs
@@ -15,7 +15,7 @@ struct Edge {
 
 impl gateway_request::Guest for Component {
     fn on_gateway_request(context: Context, headers: Headers) -> Result<(), Error> {
-        if let Ok(Some(auth_header)) = headers.get("Authorization") {
+        if let Some(auth_header) = headers.get("Authorization") {
             context.set("entitlement", &auth_header);
         }
 

--- a/engine/crates/wasi-component-loader/examples/crates/dir_access/src/lib.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/dir_access/src/lib.rs
@@ -12,11 +12,11 @@ impl gateway_request::Guest for Component {
     fn on_gateway_request(_: Context, headers: Headers) -> Result<(), Error> {
         match std::fs::read_to_string("./contents.txt") {
             Ok(contents) => headers.set("READ_CONTENTS", &contents).unwrap(),
-            Err(e) => eprintln!("error reading file contents: {}", e.to_string()),
+            Err(e) => eprintln!("error reading file contents: {e}"),
         }
 
         if let Err(e) = std::fs::write("./guest_write.txt", "answer") {
-            eprintln!("error writing file contents: {}", e.to_string());
+            eprintln!("error writing file contents: {e}");
         }
 
         Ok(())

--- a/engine/crates/wasi-component-loader/examples/crates/error/Cargo.toml
+++ b/engine/crates/wasi-component-loader/examples/crates/error/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace = true
 repository.workspace = true
 
 [dependencies]
-wit-bindgen-rt = { version = "0.27.0", features = ["bitflags"] }
+wit-bindgen-rt.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/engine/crates/wasi-component-loader/examples/crates/error/src/bindings.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/error/src/bindings.rs
@@ -369,11 +369,11 @@ pub mod component {
             }
             impl Headers {
                 #[allow(unused_unsafe, clippy::all)]
-                pub fn get(&self, name: &str) -> Result<Option<_rt::String>, HeaderError> {
+                pub fn get(&self, name: &str) -> Option<_rt::String> {
                     unsafe {
                         #[repr(align(4))]
-                        struct RetArea([::core::mem::MaybeUninit<u8>; 16]);
-                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 16]);
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 12]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 12]);
                         let vec0 = name;
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
@@ -392,35 +392,17 @@ pub mod component {
                         wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
                         let l2 = i32::from(*ptr1.add(0).cast::<u8>());
                         match l2 {
-                            0 => {
-                                let e = {
-                                    let l3 = i32::from(*ptr1.add(4).cast::<u8>());
-
-                                    match l3 {
-                                        0 => None,
-                                        1 => {
-                                            let e = {
-                                                let l4 = *ptr1.add(8).cast::<*mut u8>();
-                                                let l5 = *ptr1.add(12).cast::<usize>();
-                                                let len6 = l5;
-                                                let bytes6 = _rt::Vec::from_raw_parts(l4.cast(), len6, len6);
-
-                                                _rt::string_lift(bytes6)
-                                            };
-                                            Some(e)
-                                        }
-                                        _ => _rt::invalid_enum_discriminant(),
-                                    }
-                                };
-                                Ok(e)
-                            }
+                            0 => None,
                             1 => {
                                 let e = {
-                                    let l7 = i32::from(*ptr1.add(4).cast::<u8>());
+                                    let l3 = *ptr1.add(4).cast::<*mut u8>();
+                                    let l4 = *ptr1.add(8).cast::<usize>();
+                                    let len5 = l4;
+                                    let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
 
-                                    HeaderError::_lift(l7 as u8)
+                                    _rt::string_lift(bytes5)
                                 };
-                                Err(e)
+                                Some(e)
                             }
                             _ => _rt::invalid_enum_discriminant(),
                         }
@@ -481,11 +463,11 @@ pub mod component {
             }
             impl Headers {
                 #[allow(unused_unsafe, clippy::all)]
-                pub fn delete(&self, name: &str) -> Result<Option<_rt::String>, HeaderError> {
+                pub fn delete(&self, name: &str) -> Option<_rt::String> {
                     unsafe {
                         #[repr(align(4))]
-                        struct RetArea([::core::mem::MaybeUninit<u8>; 16]);
-                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 16]);
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 12]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 12]);
                         let vec0 = name;
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
@@ -504,38 +486,66 @@ pub mod component {
                         wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
                         let l2 = i32::from(*ptr1.add(0).cast::<u8>());
                         match l2 {
-                            0 => {
-                                let e = {
-                                    let l3 = i32::from(*ptr1.add(4).cast::<u8>());
-
-                                    match l3 {
-                                        0 => None,
-                                        1 => {
-                                            let e = {
-                                                let l4 = *ptr1.add(8).cast::<*mut u8>();
-                                                let l5 = *ptr1.add(12).cast::<usize>();
-                                                let len6 = l5;
-                                                let bytes6 = _rt::Vec::from_raw_parts(l4.cast(), len6, len6);
-
-                                                _rt::string_lift(bytes6)
-                                            };
-                                            Some(e)
-                                        }
-                                        _ => _rt::invalid_enum_discriminant(),
-                                    }
-                                };
-                                Ok(e)
-                            }
+                            0 => None,
                             1 => {
                                 let e = {
-                                    let l7 = i32::from(*ptr1.add(4).cast::<u8>());
+                                    let l3 = *ptr1.add(4).cast::<*mut u8>();
+                                    let l4 = *ptr1.add(8).cast::<usize>();
+                                    let len5 = l4;
+                                    let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
 
-                                    HeaderError::_lift(l7 as u8)
+                                    _rt::string_lift(bytes5)
                                 };
-                                Err(e)
+                                Some(e)
                             }
                             _ => _rt::invalid_enum_discriminant(),
                         }
+                    }
+                }
+            }
+            impl Headers {
+                #[allow(unused_unsafe, clippy::all)]
+                pub fn entries(&self) -> _rt::Vec<(_rt::String, _rt::String)> {
+                    unsafe {
+                        #[repr(align(4))]
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 8]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 8]);
+                        let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[method]headers.entries"]
+                            fn wit_import(_: i32, _: *mut u8);
+                        }
+
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0);
+                        let l1 = *ptr0.add(0).cast::<*mut u8>();
+                        let l2 = *ptr0.add(4).cast::<usize>();
+                        let base9 = l1;
+                        let len9 = l2;
+                        let mut result9 = _rt::Vec::with_capacity(len9);
+                        for i in 0..len9 {
+                            let base = base9.add(i * 16);
+                            let e9 = {
+                                let l3 = *base.add(0).cast::<*mut u8>();
+                                let l4 = *base.add(4).cast::<usize>();
+                                let len5 = l4;
+                                let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
+                                let l6 = *base.add(8).cast::<*mut u8>();
+                                let l7 = *base.add(12).cast::<usize>();
+                                let len8 = l7;
+                                let bytes8 = _rt::Vec::from_raw_parts(l6.cast(), len8, len8);
+
+                                (_rt::string_lift(bytes5), _rt::string_lift(bytes8))
+                            };
+                            result9.push(e9);
+                        }
+                        _rt::cabi_dealloc(base9, len9 * 16, 4);
+                        result9
                     }
                 }
             }
@@ -788,12 +798,6 @@ mod _rt {
             core::hint::unreachable_unchecked()
         }
     }
-
-    #[cfg(target_arch = "wasm32")]
-    pub fn run_ctors_once() {
-        wit_bindgen_rt::run_ctors_once();
-    }
-    pub use alloc_crate::alloc;
     pub unsafe fn cabi_dealloc(ptr: *mut u8, size: usize, align: usize) {
         if size == 0 {
             return;
@@ -801,6 +805,12 @@ mod _rt {
         let layout = alloc::Layout::from_size_align_unchecked(size, align);
         alloc::dealloc(ptr as *mut u8, layout);
     }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn run_ctors_once() {
+        wit_bindgen_rt::run_ctors_once();
+    }
+    pub use alloc_crate::alloc;
     extern crate alloc as alloc_crate;
 }
 
@@ -835,9 +845,9 @@ pub(crate) use __export_hooks_impl as export;
 #[cfg(target_arch = "wasm32")]
 #[link_section = "component-type:wit-bindgen:0.25.0:hooks:encoded world"]
 #[doc(hidden)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 916] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\x98\x06\x01A\x02\x01\
-A\x07\x01B\x1f\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 949] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xb9\x06\x01A\x02\x01\
+A\x07\x01B\x20\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
 header-error\x03\0\0\x04\0\x07context\x03\x01\x04\0\x0eshared-context\x03\x01\x04\
 \0\x07headers\x03\x01\x01r\x02\x10parent-type-names\x0afield-names\x04\0\x0fedge\
 -definition\x03\0\x05\x01r\x01\x09type-names\x04\0\x0fnode-definition\x03\0\x07\x01\
@@ -845,18 +855,18 @@ o\x02ss\x01p\x09\x01r\x02\x0aextensions\x0a\x07messages\x04\0\x05error\x03\0\x0b
 \x01h\x02\x01ks\x01@\x02\x04self\x0d\x04names\0\x0e\x04\0\x13[method]context.get\
 \x01\x0f\x01@\x03\x04self\x0d\x04names\x05values\x01\0\x04\0\x13[method]context.\
 set\x01\x10\x04\0\x16[method]context.delete\x01\x0f\x01h\x03\x01@\x02\x04self\x11\
-\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01j\x01\x0e\
-\x01\x01\x01@\x02\x04self\x13\x04names\0\x14\x04\0\x13[method]headers.get\x01\x15\
-\x01j\0\x01\x01\x01@\x03\x04self\x13\x04names\x05values\0\x16\x04\0\x13[method]h\
-eaders.set\x01\x17\x04\0\x16[method]headers.delete\x01\x15\x03\x01\x18component:\
-grafbase/types\x05\0\x02\x03\0\0\x07headers\x02\x03\0\0\x05error\x02\x03\0\0\x07\
-context\x01B\x0b\x02\x03\x02\x01\x01\x04\0\x07headers\x03\0\0\x02\x03\x02\x01\x02\
-\x04\0\x05error\x03\0\x02\x02\x03\x02\x01\x03\x04\0\x07context\x03\0\x04\x01i\x05\
-\x01i\x01\x01j\0\x01\x03\x01@\x02\x07context\x06\x07headers\x07\0\x08\x04\0\x12o\
-n-gateway-request\x01\x09\x04\x01\"component:grafbase/gateway-request\x05\x04\x04\
-\x01\x18component:grafbase/hooks\x04\0\x0b\x0b\x01\0\x05hooks\x03\0\0\0G\x09prod\
-ucers\x01\x0cprocessed-by\x02\x0dwit-component\x070.208.1\x10wit-bindgen-rust\x06\
-0.25.0";
+\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01@\x02\x04\
+self\x13\x04names\0\x0e\x04\0\x13[method]headers.get\x01\x14\x01j\0\x01\x01\x01@\
+\x03\x04self\x13\x04names\x05values\0\x15\x04\0\x13[method]headers.set\x01\x16\x04\
+\0\x16[method]headers.delete\x01\x14\x01@\x01\x04self\x13\0\x0a\x04\0\x17[method\
+]headers.entries\x01\x17\x03\x01\x18component:grafbase/types\x05\0\x02\x03\0\0\x07\
+headers\x02\x03\0\0\x05error\x02\x03\0\0\x07context\x01B\x0b\x02\x03\x02\x01\x01\
+\x04\0\x07headers\x03\0\0\x02\x03\x02\x01\x02\x04\0\x05error\x03\0\x02\x02\x03\x02\
+\x01\x03\x04\0\x07context\x03\0\x04\x01i\x05\x01i\x01\x01j\0\x01\x03\x01@\x02\x07\
+context\x06\x07headers\x07\0\x08\x04\0\x12on-gateway-request\x01\x09\x04\x01\"co\
+mponent:grafbase/gateway-request\x05\x04\x04\x01\x18component:grafbase/hooks\x04\
+\0\x0b\x0b\x01\0\x05hooks\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit\
+-component\x070.208.1\x10wit-bindgen-rust\x060.25.0";
 
 #[inline(never)]
 #[doc(hidden)]

--- a/engine/crates/wasi-component-loader/examples/crates/missing_hook/Cargo.toml
+++ b/engine/crates/wasi-component-loader/examples/crates/missing_hook/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace = true
 repository.workspace = true
 
 [dependencies]
-wit-bindgen-rt = { version = "0.27.0", features = ["bitflags"] }
+wit-bindgen-rt.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/engine/crates/wasi-component-loader/examples/crates/missing_hook/src/bindings.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/missing_hook/src/bindings.rs
@@ -393,11 +393,11 @@ pub mod component {
             }
             impl Headers {
                 #[allow(unused_unsafe, clippy::all)]
-                pub fn get(&self, name: &str) -> Result<Option<_rt::String>, HeaderError> {
+                pub fn get(&self, name: &str) -> Option<_rt::String> {
                     unsafe {
                         #[repr(align(4))]
-                        struct RetArea([::core::mem::MaybeUninit<u8>; 16]);
-                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 16]);
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 12]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 12]);
                         let vec0 = name;
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
@@ -416,35 +416,17 @@ pub mod component {
                         wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
                         let l2 = i32::from(*ptr1.add(0).cast::<u8>());
                         match l2 {
-                            0 => {
-                                let e = {
-                                    let l3 = i32::from(*ptr1.add(4).cast::<u8>());
-
-                                    match l3 {
-                                        0 => None,
-                                        1 => {
-                                            let e = {
-                                                let l4 = *ptr1.add(8).cast::<*mut u8>();
-                                                let l5 = *ptr1.add(12).cast::<usize>();
-                                                let len6 = l5;
-                                                let bytes6 = _rt::Vec::from_raw_parts(l4.cast(), len6, len6);
-
-                                                _rt::string_lift(bytes6)
-                                            };
-                                            Some(e)
-                                        }
-                                        _ => _rt::invalid_enum_discriminant(),
-                                    }
-                                };
-                                Ok(e)
-                            }
+                            0 => None,
                             1 => {
                                 let e = {
-                                    let l7 = i32::from(*ptr1.add(4).cast::<u8>());
+                                    let l3 = *ptr1.add(4).cast::<*mut u8>();
+                                    let l4 = *ptr1.add(8).cast::<usize>();
+                                    let len5 = l4;
+                                    let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
 
-                                    HeaderError::_lift(l7 as u8)
+                                    _rt::string_lift(bytes5)
                                 };
-                                Err(e)
+                                Some(e)
                             }
                             _ => _rt::invalid_enum_discriminant(),
                         }
@@ -505,11 +487,11 @@ pub mod component {
             }
             impl Headers {
                 #[allow(unused_unsafe, clippy::all)]
-                pub fn delete(&self, name: &str) -> Result<Option<_rt::String>, HeaderError> {
+                pub fn delete(&self, name: &str) -> Option<_rt::String> {
                     unsafe {
                         #[repr(align(4))]
-                        struct RetArea([::core::mem::MaybeUninit<u8>; 16]);
-                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 16]);
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 12]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 12]);
                         let vec0 = name;
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
@@ -528,35 +510,17 @@ pub mod component {
                         wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
                         let l2 = i32::from(*ptr1.add(0).cast::<u8>());
                         match l2 {
-                            0 => {
-                                let e = {
-                                    let l3 = i32::from(*ptr1.add(4).cast::<u8>());
-
-                                    match l3 {
-                                        0 => None,
-                                        1 => {
-                                            let e = {
-                                                let l4 = *ptr1.add(8).cast::<*mut u8>();
-                                                let l5 = *ptr1.add(12).cast::<usize>();
-                                                let len6 = l5;
-                                                let bytes6 = _rt::Vec::from_raw_parts(l4.cast(), len6, len6);
-
-                                                _rt::string_lift(bytes6)
-                                            };
-                                            Some(e)
-                                        }
-                                        _ => _rt::invalid_enum_discriminant(),
-                                    }
-                                };
-                                Ok(e)
-                            }
+                            0 => None,
                             1 => {
                                 let e = {
-                                    let l7 = i32::from(*ptr1.add(4).cast::<u8>());
+                                    let l3 = *ptr1.add(4).cast::<*mut u8>();
+                                    let l4 = *ptr1.add(8).cast::<usize>();
+                                    let len5 = l4;
+                                    let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
 
-                                    HeaderError::_lift(l7 as u8)
+                                    _rt::string_lift(bytes5)
                                 };
-                                Err(e)
+                                Some(e)
                             }
                             _ => _rt::invalid_enum_discriminant(),
                         }
@@ -1550,9 +1514,9 @@ pub(crate) use __export_hooks_impl as export;
 #[cfg(target_arch = "wasm32")]
 #[link_section = "component-type:wit-bindgen:0.25.0:hooks:encoded world"]
 #[doc(hidden)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 1349] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xc9\x09\x01A\x02\x01\
-A\x08\x01B\x1f\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 1343] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xc3\x09\x01A\x02\x01\
+A\x08\x01B\x1e\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
 header-error\x03\0\0\x04\0\x07context\x03\x01\x04\0\x0eshared-context\x03\x01\x04\
 \0\x07headers\x03\x01\x01r\x02\x10parent-type-names\x0afield-names\x04\0\x0fedge\
 -definition\x03\0\x05\x01r\x01\x09type-names\x04\0\x0fnode-definition\x03\0\x07\x01\
@@ -1560,26 +1524,25 @@ o\x02ss\x01p\x09\x01r\x02\x07messages\x0aextensions\x0a\x04\0\x05error\x03\0\x0b
 \x01h\x02\x01ks\x01@\x02\x04self\x0d\x04names\0\x0e\x04\0\x13[method]context.get\
 \x01\x0f\x01@\x03\x04self\x0d\x04names\x05values\x01\0\x04\0\x13[method]context.\
 set\x01\x10\x04\0\x16[method]context.delete\x01\x0f\x01h\x03\x01@\x02\x04self\x11\
-\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01j\x01\x0e\
-\x01\x01\x01@\x02\x04self\x13\x04names\0\x14\x04\0\x13[method]headers.get\x01\x15\
-\x01j\0\x01\x01\x01@\x03\x04self\x13\x04names\x05values\0\x16\x04\0\x13[method]h\
-eaders.set\x01\x17\x04\0\x16[method]headers.delete\x01\x15\x03\x01\x18component:\
-grafbase/types\x05\0\x02\x03\0\0\x05error\x02\x03\0\0\x0eshared-context\x02\x03\0\
-\0\x0fedge-definition\x02\x03\0\0\x0fnode-definition\x01B\x18\x02\x03\x02\x01\x01\
-\x04\0\x05error\x03\0\0\x02\x03\x02\x01\x02\x04\0\x0eshared-context\x03\0\x02\x02\
-\x03\x02\x01\x03\x04\0\x0fedge-definition\x03\0\x04\x02\x03\x02\x01\x04\x04\0\x0f\
-node-definition\x03\0\x06\x01i\x03\x01j\0\x01\x01\x01@\x04\x07context\x08\x0adef\
-inition\x05\x09argumentss\x08metadatas\0\x09\x04\0\x1cauthorize-edge-pre-executi\
-on\x01\x0a\x01@\x03\x07context\x08\x0adefinition\x07\x08metadatas\0\x09\x04\0\x1c\
-authorize-node-pre-execution\x01\x0b\x01ps\x01p\x09\x01@\x04\x07context\x08\x0ad\
-efinition\x05\x07parents\x0c\x08metadatas\0\x0d\x04\0$authorize-parent-edge-post\
--execution\x01\x0e\x01@\x04\x07context\x08\x0adefinition\x05\x05nodes\x0c\x08met\
-adatas\0\x0d\x04\0\"authorize-edge-node-post-execution\x01\x0f\x01o\x02s\x0c\x01\
-p\x10\x01@\x04\x07context\x08\x0adefinition\x05\x05edges\x11\x08metadatas\0\x0d\x04\
-\0\x1dauthorize-edge-post-execution\x01\x12\x04\x01\x20component:grafbase/author\
-ization\x05\x05\x04\x01\x18component:grafbase/hooks\x04\0\x0b\x0b\x01\0\x05hooks\
-\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\x070.208.1\x10\
-wit-bindgen-rust\x060.25.0";
+\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01@\x02\x04\
+self\x13\x04names\0\x0e\x04\0\x13[method]headers.get\x01\x14\x01j\0\x01\x01\x01@\
+\x03\x04self\x13\x04names\x05values\0\x15\x04\0\x13[method]headers.set\x01\x16\x04\
+\0\x16[method]headers.delete\x01\x14\x03\x01\x18component:grafbase/types\x05\0\x02\
+\x03\0\0\x05error\x02\x03\0\0\x0eshared-context\x02\x03\0\0\x0fedge-definition\x02\
+\x03\0\0\x0fnode-definition\x01B\x18\x02\x03\x02\x01\x01\x04\0\x05error\x03\0\0\x02\
+\x03\x02\x01\x02\x04\0\x0eshared-context\x03\0\x02\x02\x03\x02\x01\x03\x04\0\x0f\
+edge-definition\x03\0\x04\x02\x03\x02\x01\x04\x04\0\x0fnode-definition\x03\0\x06\
+\x01i\x03\x01j\0\x01\x01\x01@\x04\x07context\x08\x0adefinition\x05\x09argumentss\
+\x08metadatas\0\x09\x04\0\x1cauthorize-edge-pre-execution\x01\x0a\x01@\x03\x07co\
+ntext\x08\x0adefinition\x07\x08metadatas\0\x09\x04\0\x1cauthorize-node-pre-execu\
+tion\x01\x0b\x01ps\x01p\x09\x01@\x04\x07context\x08\x0adefinition\x05\x07parents\
+\x0c\x08metadatas\0\x0d\x04\0$authorize-parent-edge-post-execution\x01\x0e\x01@\x04\
+\x07context\x08\x0adefinition\x05\x05nodes\x0c\x08metadatas\0\x0d\x04\0\"authori\
+ze-edge-node-post-execution\x01\x0f\x01o\x02s\x0c\x01p\x10\x01@\x04\x07context\x08\
+\x0adefinition\x05\x05edges\x11\x08metadatas\0\x0d\x04\0\x1dauthorize-edge-post-\
+execution\x01\x12\x04\x01\x20component:grafbase/authorization\x05\x05\x04\x01\x18\
+component:grafbase/hooks\x04\0\x0b\x0b\x01\0\x05hooks\x03\0\0\0G\x09producers\x01\
+\x0cprocessed-by\x02\x0dwit-component\x070.208.1\x10wit-bindgen-rust\x060.25.0";
 
 #[inline(never)]
 #[doc(hidden)]

--- a/engine/crates/wasi-component-loader/examples/crates/missing_hook/wit/world.wit
+++ b/engine/crates/wasi-component-loader/examples/crates/missing_hook/wit/world.wit
@@ -17,9 +17,9 @@ interface types {
     }
 
     resource headers {
-        get: func(name: string) -> result<option<string>, header-error>;
+        get: func(name: string) -> option<string>;
         set: func(name: string, value: string) -> result<_, header-error>;
-        delete: func(name: string) -> result<option<string>, header-error>;
+        delete: func(name: string) -> option<string>;
     }
 
     record edge-definition {

--- a/engine/crates/wasi-component-loader/examples/crates/networking/Cargo.toml
+++ b/engine/crates/wasi-component-loader/examples/crates/networking/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 
 [dependencies]
 waki = "0.3.0"
-wit-bindgen-rt = { version = "0.27.0", features = ["bitflags"] }
+wit-bindgen-rt.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/engine/crates/wasi-component-loader/examples/crates/networking/src/bindings.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/networking/src/bindings.rs
@@ -369,11 +369,11 @@ pub mod component {
             }
             impl Headers {
                 #[allow(unused_unsafe, clippy::all)]
-                pub fn get(&self, name: &str) -> Result<Option<_rt::String>, HeaderError> {
+                pub fn get(&self, name: &str) -> Option<_rt::String> {
                     unsafe {
                         #[repr(align(4))]
-                        struct RetArea([::core::mem::MaybeUninit<u8>; 16]);
-                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 16]);
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 12]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 12]);
                         let vec0 = name;
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
@@ -392,35 +392,17 @@ pub mod component {
                         wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
                         let l2 = i32::from(*ptr1.add(0).cast::<u8>());
                         match l2 {
-                            0 => {
-                                let e = {
-                                    let l3 = i32::from(*ptr1.add(4).cast::<u8>());
-
-                                    match l3 {
-                                        0 => None,
-                                        1 => {
-                                            let e = {
-                                                let l4 = *ptr1.add(8).cast::<*mut u8>();
-                                                let l5 = *ptr1.add(12).cast::<usize>();
-                                                let len6 = l5;
-                                                let bytes6 = _rt::Vec::from_raw_parts(l4.cast(), len6, len6);
-
-                                                _rt::string_lift(bytes6)
-                                            };
-                                            Some(e)
-                                        }
-                                        _ => _rt::invalid_enum_discriminant(),
-                                    }
-                                };
-                                Ok(e)
-                            }
+                            0 => None,
                             1 => {
                                 let e = {
-                                    let l7 = i32::from(*ptr1.add(4).cast::<u8>());
+                                    let l3 = *ptr1.add(4).cast::<*mut u8>();
+                                    let l4 = *ptr1.add(8).cast::<usize>();
+                                    let len5 = l4;
+                                    let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
 
-                                    HeaderError::_lift(l7 as u8)
+                                    _rt::string_lift(bytes5)
                                 };
-                                Err(e)
+                                Some(e)
                             }
                             _ => _rt::invalid_enum_discriminant(),
                         }
@@ -481,11 +463,11 @@ pub mod component {
             }
             impl Headers {
                 #[allow(unused_unsafe, clippy::all)]
-                pub fn delete(&self, name: &str) -> Result<Option<_rt::String>, HeaderError> {
+                pub fn delete(&self, name: &str) -> Option<_rt::String> {
                     unsafe {
                         #[repr(align(4))]
-                        struct RetArea([::core::mem::MaybeUninit<u8>; 16]);
-                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 16]);
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 12]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 12]);
                         let vec0 = name;
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
@@ -504,38 +486,66 @@ pub mod component {
                         wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
                         let l2 = i32::from(*ptr1.add(0).cast::<u8>());
                         match l2 {
-                            0 => {
-                                let e = {
-                                    let l3 = i32::from(*ptr1.add(4).cast::<u8>());
-
-                                    match l3 {
-                                        0 => None,
-                                        1 => {
-                                            let e = {
-                                                let l4 = *ptr1.add(8).cast::<*mut u8>();
-                                                let l5 = *ptr1.add(12).cast::<usize>();
-                                                let len6 = l5;
-                                                let bytes6 = _rt::Vec::from_raw_parts(l4.cast(), len6, len6);
-
-                                                _rt::string_lift(bytes6)
-                                            };
-                                            Some(e)
-                                        }
-                                        _ => _rt::invalid_enum_discriminant(),
-                                    }
-                                };
-                                Ok(e)
-                            }
+                            0 => None,
                             1 => {
                                 let e = {
-                                    let l7 = i32::from(*ptr1.add(4).cast::<u8>());
+                                    let l3 = *ptr1.add(4).cast::<*mut u8>();
+                                    let l4 = *ptr1.add(8).cast::<usize>();
+                                    let len5 = l4;
+                                    let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
 
-                                    HeaderError::_lift(l7 as u8)
+                                    _rt::string_lift(bytes5)
                                 };
-                                Err(e)
+                                Some(e)
                             }
                             _ => _rt::invalid_enum_discriminant(),
                         }
+                    }
+                }
+            }
+            impl Headers {
+                #[allow(unused_unsafe, clippy::all)]
+                pub fn entries(&self) -> _rt::Vec<(_rt::String, _rt::String)> {
+                    unsafe {
+                        #[repr(align(4))]
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 8]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 8]);
+                        let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[method]headers.entries"]
+                            fn wit_import(_: i32, _: *mut u8);
+                        }
+
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0);
+                        let l1 = *ptr0.add(0).cast::<*mut u8>();
+                        let l2 = *ptr0.add(4).cast::<usize>();
+                        let base9 = l1;
+                        let len9 = l2;
+                        let mut result9 = _rt::Vec::with_capacity(len9);
+                        for i in 0..len9 {
+                            let base = base9.add(i * 16);
+                            let e9 = {
+                                let l3 = *base.add(0).cast::<*mut u8>();
+                                let l4 = *base.add(4).cast::<usize>();
+                                let len5 = l4;
+                                let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
+                                let l6 = *base.add(8).cast::<*mut u8>();
+                                let l7 = *base.add(12).cast::<usize>();
+                                let len8 = l7;
+                                let bytes8 = _rt::Vec::from_raw_parts(l6.cast(), len8, len8);
+
+                                (_rt::string_lift(bytes5), _rt::string_lift(bytes8))
+                            };
+                            result9.push(e9);
+                        }
+                        _rt::cabi_dealloc(base9, len9 * 16, 4);
+                        result9
                     }
                 }
             }
@@ -788,12 +798,6 @@ mod _rt {
             core::hint::unreachable_unchecked()
         }
     }
-
-    #[cfg(target_arch = "wasm32")]
-    pub fn run_ctors_once() {
-        wit_bindgen_rt::run_ctors_once();
-    }
-    pub use alloc_crate::alloc;
     pub unsafe fn cabi_dealloc(ptr: *mut u8, size: usize, align: usize) {
         if size == 0 {
             return;
@@ -801,6 +805,12 @@ mod _rt {
         let layout = alloc::Layout::from_size_align_unchecked(size, align);
         alloc::dealloc(ptr as *mut u8, layout);
     }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn run_ctors_once() {
+        wit_bindgen_rt::run_ctors_once();
+    }
+    pub use alloc_crate::alloc;
     extern crate alloc as alloc_crate;
 }
 
@@ -835,9 +845,9 @@ pub(crate) use __export_hooks_impl as export;
 #[cfg(target_arch = "wasm32")]
 #[link_section = "component-type:wit-bindgen:0.25.0:hooks:encoded world"]
 #[doc(hidden)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 916] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\x98\x06\x01A\x02\x01\
-A\x07\x01B\x1f\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 949] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xb9\x06\x01A\x02\x01\
+A\x07\x01B\x20\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
 header-error\x03\0\0\x04\0\x07context\x03\x01\x04\0\x0eshared-context\x03\x01\x04\
 \0\x07headers\x03\x01\x01r\x02\x10parent-type-names\x0afield-names\x04\0\x0fedge\
 -definition\x03\0\x05\x01r\x01\x09type-names\x04\0\x0fnode-definition\x03\0\x07\x01\
@@ -845,18 +855,18 @@ o\x02ss\x01p\x09\x01r\x02\x0aextensions\x0a\x07messages\x04\0\x05error\x03\0\x0b
 \x01h\x02\x01ks\x01@\x02\x04self\x0d\x04names\0\x0e\x04\0\x13[method]context.get\
 \x01\x0f\x01@\x03\x04self\x0d\x04names\x05values\x01\0\x04\0\x13[method]context.\
 set\x01\x10\x04\0\x16[method]context.delete\x01\x0f\x01h\x03\x01@\x02\x04self\x11\
-\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01j\x01\x0e\
-\x01\x01\x01@\x02\x04self\x13\x04names\0\x14\x04\0\x13[method]headers.get\x01\x15\
-\x01j\0\x01\x01\x01@\x03\x04self\x13\x04names\x05values\0\x16\x04\0\x13[method]h\
-eaders.set\x01\x17\x04\0\x16[method]headers.delete\x01\x15\x03\x01\x18component:\
-grafbase/types\x05\0\x02\x03\0\0\x07headers\x02\x03\0\0\x05error\x02\x03\0\0\x07\
-context\x01B\x0b\x02\x03\x02\x01\x01\x04\0\x07headers\x03\0\0\x02\x03\x02\x01\x02\
-\x04\0\x05error\x03\0\x02\x02\x03\x02\x01\x03\x04\0\x07context\x03\0\x04\x01i\x05\
-\x01i\x01\x01j\0\x01\x03\x01@\x02\x07context\x06\x07headers\x07\0\x08\x04\0\x12o\
-n-gateway-request\x01\x09\x04\x01\"component:grafbase/gateway-request\x05\x04\x04\
-\x01\x18component:grafbase/hooks\x04\0\x0b\x0b\x01\0\x05hooks\x03\0\0\0G\x09prod\
-ucers\x01\x0cprocessed-by\x02\x0dwit-component\x070.208.1\x10wit-bindgen-rust\x06\
-0.25.0";
+\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01@\x02\x04\
+self\x13\x04names\0\x0e\x04\0\x13[method]headers.get\x01\x14\x01j\0\x01\x01\x01@\
+\x03\x04self\x13\x04names\x05values\0\x15\x04\0\x13[method]headers.set\x01\x16\x04\
+\0\x16[method]headers.delete\x01\x14\x01@\x01\x04self\x13\0\x0a\x04\0\x17[method\
+]headers.entries\x01\x17\x03\x01\x18component:grafbase/types\x05\0\x02\x03\0\0\x07\
+headers\x02\x03\0\0\x05error\x02\x03\0\0\x07context\x01B\x0b\x02\x03\x02\x01\x01\
+\x04\0\x07headers\x03\0\0\x02\x03\x02\x01\x02\x04\0\x05error\x03\0\x02\x02\x03\x02\
+\x01\x03\x04\0\x07context\x03\0\x04\x01i\x05\x01i\x01\x01j\0\x01\x03\x01@\x02\x07\
+context\x06\x07headers\x07\0\x08\x04\0\x12on-gateway-request\x01\x09\x04\x01\"co\
+mponent:grafbase/gateway-request\x05\x04\x04\x01\x18component:grafbase/hooks\x04\
+\0\x0b\x0b\x01\0\x05hooks\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit\
+-component\x070.208.1\x10wit-bindgen-rust\x060.25.0";
 
 #[inline(never)]
 #[doc(hidden)]

--- a/engine/crates/wasi-component-loader/examples/crates/simple/Cargo.toml
+++ b/engine/crates/wasi-component-loader/examples/crates/simple/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace = true
 repository.workspace = true
 
 [dependencies]
-wit-bindgen-rt = { version = "0.27.0", features = ["bitflags"] }
+wit-bindgen-rt.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/engine/crates/wasi-component-loader/examples/crates/simple/src/bindings.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/simple/src/bindings.rs
@@ -369,11 +369,11 @@ pub mod component {
             }
             impl Headers {
                 #[allow(unused_unsafe, clippy::all)]
-                pub fn get(&self, name: &str) -> Result<Option<_rt::String>, HeaderError> {
+                pub fn get(&self, name: &str) -> Option<_rt::String> {
                     unsafe {
                         #[repr(align(4))]
-                        struct RetArea([::core::mem::MaybeUninit<u8>; 16]);
-                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 16]);
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 12]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 12]);
                         let vec0 = name;
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
@@ -392,35 +392,17 @@ pub mod component {
                         wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
                         let l2 = i32::from(*ptr1.add(0).cast::<u8>());
                         match l2 {
-                            0 => {
-                                let e = {
-                                    let l3 = i32::from(*ptr1.add(4).cast::<u8>());
-
-                                    match l3 {
-                                        0 => None,
-                                        1 => {
-                                            let e = {
-                                                let l4 = *ptr1.add(8).cast::<*mut u8>();
-                                                let l5 = *ptr1.add(12).cast::<usize>();
-                                                let len6 = l5;
-                                                let bytes6 = _rt::Vec::from_raw_parts(l4.cast(), len6, len6);
-
-                                                _rt::string_lift(bytes6)
-                                            };
-                                            Some(e)
-                                        }
-                                        _ => _rt::invalid_enum_discriminant(),
-                                    }
-                                };
-                                Ok(e)
-                            }
+                            0 => None,
                             1 => {
                                 let e = {
-                                    let l7 = i32::from(*ptr1.add(4).cast::<u8>());
+                                    let l3 = *ptr1.add(4).cast::<*mut u8>();
+                                    let l4 = *ptr1.add(8).cast::<usize>();
+                                    let len5 = l4;
+                                    let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
 
-                                    HeaderError::_lift(l7 as u8)
+                                    _rt::string_lift(bytes5)
                                 };
-                                Err(e)
+                                Some(e)
                             }
                             _ => _rt::invalid_enum_discriminant(),
                         }
@@ -481,11 +463,11 @@ pub mod component {
             }
             impl Headers {
                 #[allow(unused_unsafe, clippy::all)]
-                pub fn delete(&self, name: &str) -> Result<Option<_rt::String>, HeaderError> {
+                pub fn delete(&self, name: &str) -> Option<_rt::String> {
                     unsafe {
                         #[repr(align(4))]
-                        struct RetArea([::core::mem::MaybeUninit<u8>; 16]);
-                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 16]);
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 12]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 12]);
                         let vec0 = name;
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
@@ -504,38 +486,66 @@ pub mod component {
                         wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
                         let l2 = i32::from(*ptr1.add(0).cast::<u8>());
                         match l2 {
-                            0 => {
-                                let e = {
-                                    let l3 = i32::from(*ptr1.add(4).cast::<u8>());
-
-                                    match l3 {
-                                        0 => None,
-                                        1 => {
-                                            let e = {
-                                                let l4 = *ptr1.add(8).cast::<*mut u8>();
-                                                let l5 = *ptr1.add(12).cast::<usize>();
-                                                let len6 = l5;
-                                                let bytes6 = _rt::Vec::from_raw_parts(l4.cast(), len6, len6);
-
-                                                _rt::string_lift(bytes6)
-                                            };
-                                            Some(e)
-                                        }
-                                        _ => _rt::invalid_enum_discriminant(),
-                                    }
-                                };
-                                Ok(e)
-                            }
+                            0 => None,
                             1 => {
                                 let e = {
-                                    let l7 = i32::from(*ptr1.add(4).cast::<u8>());
+                                    let l3 = *ptr1.add(4).cast::<*mut u8>();
+                                    let l4 = *ptr1.add(8).cast::<usize>();
+                                    let len5 = l4;
+                                    let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
 
-                                    HeaderError::_lift(l7 as u8)
+                                    _rt::string_lift(bytes5)
                                 };
-                                Err(e)
+                                Some(e)
                             }
                             _ => _rt::invalid_enum_discriminant(),
                         }
+                    }
+                }
+            }
+            impl Headers {
+                #[allow(unused_unsafe, clippy::all)]
+                pub fn entries(&self) -> _rt::Vec<(_rt::String, _rt::String)> {
+                    unsafe {
+                        #[repr(align(4))]
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 8]);
+                        let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 8]);
+                        let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "component:grafbase/types")]
+                        extern "C" {
+                            #[link_name = "[method]headers.entries"]
+                            fn wit_import(_: i32, _: *mut u8);
+                        }
+
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0);
+                        let l1 = *ptr0.add(0).cast::<*mut u8>();
+                        let l2 = *ptr0.add(4).cast::<usize>();
+                        let base9 = l1;
+                        let len9 = l2;
+                        let mut result9 = _rt::Vec::with_capacity(len9);
+                        for i in 0..len9 {
+                            let base = base9.add(i * 16);
+                            let e9 = {
+                                let l3 = *base.add(0).cast::<*mut u8>();
+                                let l4 = *base.add(4).cast::<usize>();
+                                let len5 = l4;
+                                let bytes5 = _rt::Vec::from_raw_parts(l3.cast(), len5, len5);
+                                let l6 = *base.add(8).cast::<*mut u8>();
+                                let l7 = *base.add(12).cast::<usize>();
+                                let len8 = l7;
+                                let bytes8 = _rt::Vec::from_raw_parts(l6.cast(), len8, len8);
+
+                                (_rt::string_lift(bytes5), _rt::string_lift(bytes8))
+                            };
+                            result9.push(e9);
+                        }
+                        _rt::cabi_dealloc(base9, len9 * 16, 4);
+                        result9
                     }
                 }
             }
@@ -788,12 +798,6 @@ mod _rt {
             core::hint::unreachable_unchecked()
         }
     }
-
-    #[cfg(target_arch = "wasm32")]
-    pub fn run_ctors_once() {
-        wit_bindgen_rt::run_ctors_once();
-    }
-    pub use alloc_crate::alloc;
     pub unsafe fn cabi_dealloc(ptr: *mut u8, size: usize, align: usize) {
         if size == 0 {
             return;
@@ -801,6 +805,12 @@ mod _rt {
         let layout = alloc::Layout::from_size_align_unchecked(size, align);
         alloc::dealloc(ptr as *mut u8, layout);
     }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn run_ctors_once() {
+        wit_bindgen_rt::run_ctors_once();
+    }
+    pub use alloc_crate::alloc;
     extern crate alloc as alloc_crate;
 }
 
@@ -835,9 +845,9 @@ pub(crate) use __export_hooks_impl as export;
 #[cfg(target_arch = "wasm32")]
 #[link_section = "component-type:wit-bindgen:0.25.0:hooks:encoded world"]
 #[doc(hidden)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 916] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\x98\x06\x01A\x02\x01\
-A\x07\x01B\x1f\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 949] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xb9\x06\x01A\x02\x01\
+A\x07\x01B\x20\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
 header-error\x03\0\0\x04\0\x07context\x03\x01\x04\0\x0eshared-context\x03\x01\x04\
 \0\x07headers\x03\x01\x01r\x02\x10parent-type-names\x0afield-names\x04\0\x0fedge\
 -definition\x03\0\x05\x01r\x01\x09type-names\x04\0\x0fnode-definition\x03\0\x07\x01\
@@ -845,18 +855,18 @@ o\x02ss\x01p\x09\x01r\x02\x0aextensions\x0a\x07messages\x04\0\x05error\x03\0\x0b
 \x01h\x02\x01ks\x01@\x02\x04self\x0d\x04names\0\x0e\x04\0\x13[method]context.get\
 \x01\x0f\x01@\x03\x04self\x0d\x04names\x05values\x01\0\x04\0\x13[method]context.\
 set\x01\x10\x04\0\x16[method]context.delete\x01\x0f\x01h\x03\x01@\x02\x04self\x11\
-\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01j\x01\x0e\
-\x01\x01\x01@\x02\x04self\x13\x04names\0\x14\x04\0\x13[method]headers.get\x01\x15\
-\x01j\0\x01\x01\x01@\x03\x04self\x13\x04names\x05values\0\x16\x04\0\x13[method]h\
-eaders.set\x01\x17\x04\0\x16[method]headers.delete\x01\x15\x03\x01\x18component:\
-grafbase/types\x05\0\x02\x03\0\0\x07headers\x02\x03\0\0\x05error\x02\x03\0\0\x07\
-context\x01B\x0b\x02\x03\x02\x01\x01\x04\0\x07headers\x03\0\0\x02\x03\x02\x01\x02\
-\x04\0\x05error\x03\0\x02\x02\x03\x02\x01\x03\x04\0\x07context\x03\0\x04\x01i\x05\
-\x01i\x01\x01j\0\x01\x03\x01@\x02\x07context\x06\x07headers\x07\0\x08\x04\0\x12o\
-n-gateway-request\x01\x09\x04\x01\"component:grafbase/gateway-request\x05\x04\x04\
-\x01\x18component:grafbase/hooks\x04\0\x0b\x0b\x01\0\x05hooks\x03\0\0\0G\x09prod\
-ucers\x01\x0cprocessed-by\x02\x0dwit-component\x070.208.1\x10wit-bindgen-rust\x06\
-0.25.0";
+\x04names\0\x0e\x04\0\x1a[method]shared-context.get\x01\x12\x01h\x04\x01@\x02\x04\
+self\x13\x04names\0\x0e\x04\0\x13[method]headers.get\x01\x14\x01j\0\x01\x01\x01@\
+\x03\x04self\x13\x04names\x05values\0\x15\x04\0\x13[method]headers.set\x01\x16\x04\
+\0\x16[method]headers.delete\x01\x14\x01@\x01\x04self\x13\0\x0a\x04\0\x17[method\
+]headers.entries\x01\x17\x03\x01\x18component:grafbase/types\x05\0\x02\x03\0\0\x07\
+headers\x02\x03\0\0\x05error\x02\x03\0\0\x07context\x01B\x0b\x02\x03\x02\x01\x01\
+\x04\0\x07headers\x03\0\0\x02\x03\x02\x01\x02\x04\0\x05error\x03\0\x02\x02\x03\x02\
+\x01\x03\x04\0\x07context\x03\0\x04\x01i\x05\x01i\x01\x01j\0\x01\x03\x01@\x02\x07\
+context\x06\x07headers\x07\0\x08\x04\0\x12on-gateway-request\x01\x09\x04\x01\"co\
+mponent:grafbase/gateway-request\x05\x04\x04\x01\x18component:grafbase/hooks\x04\
+\0\x0b\x0b\x01\0\x05hooks\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit\
+-component\x070.208.1\x10wit-bindgen-rust\x060.25.0";
 
 #[inline(never)]
 #[doc(hidden)]

--- a/engine/crates/wasi-component-loader/examples/crates/simple/src/lib.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/simple/src/lib.rs
@@ -12,7 +12,7 @@ impl gateway_request::Guest for Component {
     fn on_gateway_request(context: Context, headers: Headers) -> Result<(), Error> {
         headers.set("direct", "call").unwrap();
 
-        assert_eq!(Ok(Some("call".to_string())), headers.get("direct"));
+        assert_eq!(Some("call".to_string()), headers.get("direct"));
 
         if let Ok(var) = std::env::var("GRAFBASE_WASI_TEST") {
             headers.set("fromEnv", &var).unwrap();

--- a/engine/crates/wasi-component-loader/examples/crates/subgraph_request/Cargo.toml
+++ b/engine/crates/wasi-component-loader/examples/crates/subgraph_request/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "dir_access"
+name = "subgraph_request"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -8,10 +8,12 @@ keywords.workspace = true
 repository.workspace = true
 
 [dependencies]
+serde_json.workspace = true
+base64.workspace = true
 wit-bindgen-rt.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
 
 [package.metadata.component]
-package = "component:dir-access"
+package = "component:subgraph-request"

--- a/engine/crates/wasi-component-loader/examples/crates/subgraph_request/src/bindings.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/subgraph_request/src/bindings.rs
@@ -559,42 +559,55 @@ pub mod exports {
         #[allow(dead_code)]
         pub mod grafbase {
             #[allow(dead_code, clippy::all)]
-            pub mod gateway_request {
+            pub mod subgraph_request {
                 #[used]
                 #[doc(hidden)]
                 #[cfg(target_arch = "wasm32")]
                 static __FORCE_SECTION_REF: fn() = super::super::super::super::__link_custom_section_describing_imports;
                 use super::super::super::super::_rt;
+                pub type SharedContext = super::super::super::super::component::grafbase::types::SharedContext;
                 pub type Headers = super::super::super::super::component::grafbase::types::Headers;
                 pub type Error = super::super::super::super::component::grafbase::types::Error;
-                pub type Context = super::super::super::super::component::grafbase::types::Context;
                 #[doc(hidden)]
                 #[allow(non_snake_case)]
-                pub unsafe fn _export_on_gateway_request_cabi<T: Guest>(arg0: i32, arg1: i32) -> *mut u8 {
+                pub unsafe fn _export_on_subgraph_request_cabi<T: Guest>(
+                    arg0: i32,
+                    arg1: *mut u8,
+                    arg2: usize,
+                    arg3: *mut u8,
+                    arg4: usize,
+                    arg5: i32,
+                ) -> *mut u8 {
                     #[cfg(target_arch = "wasm32")]
                     _rt::run_ctors_once();
-                    let result0 = T::on_gateway_request(
-                        super::super::super::super::component::grafbase::types::Context::from_handle(arg0 as u32),
-                        super::super::super::super::component::grafbase::types::Headers::from_handle(arg1 as u32),
+                    let len0 = arg2;
+                    let bytes0 = _rt::Vec::from_raw_parts(arg1.cast(), len0, len0);
+                    let len1 = arg4;
+                    let bytes1 = _rt::Vec::from_raw_parts(arg3.cast(), len1, len1);
+                    let result2 = T::on_subgraph_request(
+                        super::super::super::super::component::grafbase::types::SharedContext::from_handle(arg0 as u32),
+                        _rt::string_lift(bytes0),
+                        _rt::string_lift(bytes1),
+                        super::super::super::super::component::grafbase::types::Headers::from_handle(arg5 as u32),
                     );
-                    let ptr1 = _RET_AREA.0.as_mut_ptr().cast::<u8>();
-                    match result0 {
+                    let ptr3 = _RET_AREA.0.as_mut_ptr().cast::<u8>();
+                    match result2 {
                         Ok(_) => {
-                            *ptr1.add(0).cast::<u8>() = (0i32) as u8;
+                            *ptr3.add(0).cast::<u8>() = (0i32) as u8;
                         }
                         Err(e) => {
-                            *ptr1.add(0).cast::<u8>() = (1i32) as u8;
+                            *ptr3.add(0).cast::<u8>() = (1i32) as u8;
                             let super::super::super::super::component::grafbase::types::Error {
-                                extensions: extensions2,
-                                message: message2,
+                                extensions: extensions4,
+                                message: message4,
                             } = e;
-                            let vec6 = extensions2;
-                            let len6 = vec6.len();
-                            let layout6 = _rt::alloc::Layout::from_size_align_unchecked(vec6.len() * 16, 4);
-                            let result6 = if layout6.size() != 0 {
-                                let ptr = _rt::alloc::alloc(layout6).cast::<u8>();
+                            let vec8 = extensions4;
+                            let len8 = vec8.len();
+                            let layout8 = _rt::alloc::Layout::from_size_align_unchecked(vec8.len() * 16, 4);
+                            let result8 = if layout8.size() != 0 {
+                                let ptr = _rt::alloc::alloc(layout8).cast::<u8>();
                                 if ptr.is_null() {
-                                    _rt::alloc::handle_alloc_error(layout6);
+                                    _rt::alloc::handle_alloc_error(layout8);
                                 }
                                 ptr
                             } else {
@@ -602,39 +615,39 @@ pub mod exports {
                                     ::core::ptr::null_mut()
                                 }
                             };
-                            for (i, e) in vec6.into_iter().enumerate() {
-                                let base = result6.add(i * 16);
+                            for (i, e) in vec8.into_iter().enumerate() {
+                                let base = result8.add(i * 16);
                                 {
-                                    let (t3_0, t3_1) = e;
-                                    let vec4 = (t3_0.into_bytes()).into_boxed_slice();
-                                    let ptr4 = vec4.as_ptr().cast::<u8>();
-                                    let len4 = vec4.len();
-                                    ::core::mem::forget(vec4);
-                                    *base.add(4).cast::<usize>() = len4;
-                                    *base.add(0).cast::<*mut u8>() = ptr4.cast_mut();
-                                    let vec5 = (t3_1.into_bytes()).into_boxed_slice();
-                                    let ptr5 = vec5.as_ptr().cast::<u8>();
-                                    let len5 = vec5.len();
-                                    ::core::mem::forget(vec5);
-                                    *base.add(12).cast::<usize>() = len5;
-                                    *base.add(8).cast::<*mut u8>() = ptr5.cast_mut();
+                                    let (t5_0, t5_1) = e;
+                                    let vec6 = (t5_0.into_bytes()).into_boxed_slice();
+                                    let ptr6 = vec6.as_ptr().cast::<u8>();
+                                    let len6 = vec6.len();
+                                    ::core::mem::forget(vec6);
+                                    *base.add(4).cast::<usize>() = len6;
+                                    *base.add(0).cast::<*mut u8>() = ptr6.cast_mut();
+                                    let vec7 = (t5_1.into_bytes()).into_boxed_slice();
+                                    let ptr7 = vec7.as_ptr().cast::<u8>();
+                                    let len7 = vec7.len();
+                                    ::core::mem::forget(vec7);
+                                    *base.add(12).cast::<usize>() = len7;
+                                    *base.add(8).cast::<*mut u8>() = ptr7.cast_mut();
                                 }
                             }
-                            *ptr1.add(8).cast::<usize>() = len6;
-                            *ptr1.add(4).cast::<*mut u8>() = result6;
-                            let vec7 = (message2.into_bytes()).into_boxed_slice();
-                            let ptr7 = vec7.as_ptr().cast::<u8>();
-                            let len7 = vec7.len();
-                            ::core::mem::forget(vec7);
-                            *ptr1.add(16).cast::<usize>() = len7;
-                            *ptr1.add(12).cast::<*mut u8>() = ptr7.cast_mut();
+                            *ptr3.add(8).cast::<usize>() = len8;
+                            *ptr3.add(4).cast::<*mut u8>() = result8;
+                            let vec9 = (message4.into_bytes()).into_boxed_slice();
+                            let ptr9 = vec9.as_ptr().cast::<u8>();
+                            let len9 = vec9.len();
+                            ::core::mem::forget(vec9);
+                            *ptr3.add(16).cast::<usize>() = len9;
+                            *ptr3.add(12).cast::<*mut u8>() = ptr9.cast_mut();
                         }
                     };
-                    ptr1
+                    ptr3
                 }
                 #[doc(hidden)]
                 #[allow(non_snake_case)]
-                pub unsafe fn __post_return_on_gateway_request<T: Guest>(arg0: *mut u8) {
+                pub unsafe fn __post_return_on_subgraph_request<T: Guest>(arg0: *mut u8) {
                     let l0 = i32::from(*arg0.add(0).cast::<u8>());
                     match l0 {
                         0 => (),
@@ -662,25 +675,30 @@ pub mod exports {
                     }
                 }
                 pub trait Guest {
-                    fn on_gateway_request(context: Context, headers: Headers) -> Result<(), Error>;
+                    fn on_subgraph_request(
+                        context: SharedContext,
+                        method: _rt::String,
+                        url: _rt::String,
+                        headers: Headers,
+                    ) -> Result<(), Error>;
                 }
                 #[doc(hidden)]
 
-                macro_rules! __export_component_grafbase_gateway_request_cabi{
+                macro_rules! __export_component_grafbase_subgraph_request_cabi{
         ($ty:ident with_types_in $($path_to_types:tt)*) => (const _: () = {
 
-          #[export_name = "component:grafbase/gateway-request#on-gateway-request"]
-          unsafe extern "C" fn export_on_gateway_request(arg0: i32,arg1: i32,) -> *mut u8 {
-            $($path_to_types)*::_export_on_gateway_request_cabi::<$ty>(arg0, arg1)
+          #[export_name = "component:grafbase/subgraph-request#on-subgraph-request"]
+          unsafe extern "C" fn export_on_subgraph_request(arg0: i32,arg1: *mut u8,arg2: usize,arg3: *mut u8,arg4: usize,arg5: i32,) -> *mut u8 {
+            $($path_to_types)*::_export_on_subgraph_request_cabi::<$ty>(arg0, arg1, arg2, arg3, arg4, arg5)
           }
-          #[export_name = "cabi_post_component:grafbase/gateway-request#on-gateway-request"]
-          unsafe extern "C" fn _post_return_on_gateway_request(arg0: *mut u8,) {
-            $($path_to_types)*::__post_return_on_gateway_request::<$ty>(arg0)
+          #[export_name = "cabi_post_component:grafbase/subgraph-request#on-subgraph-request"]
+          unsafe extern "C" fn _post_return_on_subgraph_request(arg0: *mut u8,) {
+            $($path_to_types)*::__post_return_on_subgraph_request::<$ty>(arg0)
           }
         };);
       }
                 #[doc(hidden)]
-                pub(crate) use __export_component_grafbase_gateway_request_cabi;
+                pub(crate) use __export_component_grafbase_subgraph_request_cabi;
                 #[repr(align(4))]
                 struct _RetArea([::core::mem::MaybeUninit<u8>; 20]);
                 static mut _RET_AREA: _RetArea = _RetArea([::core::mem::MaybeUninit::uninit(); 20]);
@@ -836,7 +854,7 @@ mod _rt {
 macro_rules! __export_hooks_impl {
   ($ty:ident) => (self::export!($ty with_types_in self););
   ($ty:ident with_types_in $($path_to_types_root:tt)*) => (
-  $($path_to_types_root)*::exports::component::grafbase::gateway_request::__export_component_grafbase_gateway_request_cabi!($ty with_types_in $($path_to_types_root)*::exports::component::grafbase::gateway_request);
+  $($path_to_types_root)*::exports::component::grafbase::subgraph_request::__export_component_grafbase_subgraph_request_cabi!($ty with_types_in $($path_to_types_root)*::exports::component::grafbase::subgraph_request);
   )
 }
 #[doc(inline)]
@@ -845,8 +863,8 @@ pub(crate) use __export_hooks_impl as export;
 #[cfg(target_arch = "wasm32")]
 #[link_section = "component-type:wit-bindgen:0.25.0:hooks:encoded world"]
 #[doc(hidden)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 949] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xb9\x06\x01A\x02\x01\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 978] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xd6\x06\x01A\x02\x01\
 A\x07\x01B\x20\x01m\x02\x14invalid-header-value\x13invalid-header-name\x04\0\x0c\
 header-error\x03\0\0\x04\0\x07context\x03\x01\x04\0\x0eshared-context\x03\x01\x04\
 \0\x07headers\x03\x01\x01r\x02\x10parent-type-names\x0afield-names\x04\0\x0fedge\
@@ -859,14 +877,14 @@ set\x01\x10\x04\0\x16[method]context.delete\x01\x0f\x01h\x03\x01@\x02\x04self\x1
 self\x13\x04names\0\x0e\x04\0\x13[method]headers.get\x01\x14\x01j\0\x01\x01\x01@\
 \x03\x04self\x13\x04names\x05values\0\x15\x04\0\x13[method]headers.set\x01\x16\x04\
 \0\x16[method]headers.delete\x01\x14\x01@\x01\x04self\x13\0\x0a\x04\0\x17[method\
-]headers.entries\x01\x17\x03\x01\x18component:grafbase/types\x05\0\x02\x03\0\0\x07\
-headers\x02\x03\0\0\x05error\x02\x03\0\0\x07context\x01B\x0b\x02\x03\x02\x01\x01\
-\x04\0\x07headers\x03\0\0\x02\x03\x02\x01\x02\x04\0\x05error\x03\0\x02\x02\x03\x02\
-\x01\x03\x04\0\x07context\x03\0\x04\x01i\x05\x01i\x01\x01j\0\x01\x03\x01@\x02\x07\
-context\x06\x07headers\x07\0\x08\x04\0\x12on-gateway-request\x01\x09\x04\x01\"co\
-mponent:grafbase/gateway-request\x05\x04\x04\x01\x18component:grafbase/hooks\x04\
-\0\x0b\x0b\x01\0\x05hooks\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit\
--component\x070.208.1\x10wit-bindgen-rust\x060.25.0";
+]headers.entries\x01\x17\x03\x01\x18component:grafbase/types\x05\0\x02\x03\0\0\x0e\
+shared-context\x02\x03\0\0\x07headers\x02\x03\0\0\x05error\x01B\x0b\x02\x03\x02\x01\
+\x01\x04\0\x0eshared-context\x03\0\0\x02\x03\x02\x01\x02\x04\0\x07headers\x03\0\x02\
+\x02\x03\x02\x01\x03\x04\0\x05error\x03\0\x04\x01i\x01\x01i\x03\x01j\0\x01\x05\x01\
+@\x04\x07context\x06\x06methods\x03urls\x07headers\x07\0\x08\x04\0\x13on-subgrap\
+h-request\x01\x09\x04\x01#component:grafbase/subgraph-request\x05\x04\x04\x01\x18\
+component:grafbase/hooks\x04\0\x0b\x0b\x01\0\x05hooks\x03\0\0\0G\x09producers\x01\
+\x0cprocessed-by\x02\x0dwit-component\x070.208.1\x10wit-bindgen-rust\x060.25.0";
 
 #[inline(never)]
 #[doc(hidden)]

--- a/engine/crates/wasi-component-loader/examples/crates/subgraph_request/src/lib.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/subgraph_request/src/lib.rs
@@ -1,0 +1,39 @@
+#[allow(warnings)]
+mod bindings;
+
+use bindings::{component::grafbase::types::Error, exports::component::grafbase::subgraph_request};
+
+struct Component;
+
+impl subgraph_request::Guest for Component {
+    fn on_subgraph_request(
+        context: subgraph_request::SharedContext,
+        method: String,
+        url: String,
+        headers: subgraph_request::Headers,
+    ) -> Result<(), subgraph_request::Error> {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+
+        if context.get("should-fail").is_some() {
+            return Err(Error {
+                message: "failure".to_string(),
+                extensions: Vec::new(),
+            });
+        }
+
+        let everything = serde_json::to_vec(&serde_json::json!({
+            "method": method,
+            "url": url,
+            "headers": headers.entries()
+        }))
+        .unwrap();
+
+        let encoded = URL_SAFE_NO_PAD.encode(everything);
+
+        headers.set("everything", &encoded).unwrap();
+
+        Ok(())
+    }
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/engine/crates/wasi-component-loader/examples/crates/subgraph_request/wit/world.wit
+++ b/engine/crates/wasi-component-loader/examples/crates/subgraph_request/wit/world.wit
@@ -20,6 +20,7 @@ interface types {
         get: func(name: string) -> option<string>;
         set: func(name: string, value: string) -> result<_, header-error>;
         delete: func(name: string) -> option<string>;
+        entries: func() -> list<tuple<string, string>>;
     }
 
     record edge-definition {
@@ -41,6 +42,12 @@ interface gateway-request {
     use types.{headers, error, context};
 
     on-gateway-request: func(context: context, headers: headers) -> result<_, error>;
+}
+
+interface subgraph-request {
+    use types.{shared-context, headers, error};
+
+    on-subgraph-request: func(context: shared-context, method: string, url: string, headers: headers) -> result<_, error>;
 }
 
 interface authorization {
@@ -80,8 +87,7 @@ interface authorization {
         metadata: string
     ) -> list<result<_, error>>;
 }
- 
+
 world hooks {
-    export gateway-request;
-    export authorization;
+    export subgraph-request;
 }

--- a/engine/crates/wasi-component-loader/examples/wit/world.wit
+++ b/engine/crates/wasi-component-loader/examples/wit/world.wit
@@ -17,9 +17,10 @@ interface types {
     }
 
     resource headers {
-        get: func(name: string) -> result<option<string>, header-error>;
+        get: func(name: string) -> option<string>;
         set: func(name: string, value: string) -> result<_, header-error>;
-        delete: func(name: string) -> result<option<string>, header-error>;
+        delete: func(name: string) -> option<string>;
+        entries: func() -> list<tuple<string, string>>;
     }
 
     record edge-definition {
@@ -41,6 +42,12 @@ interface gateway-request {
     use types.{headers, error, context};
 
     on-gateway-request: func(context: context, headers: headers) -> result<_, error>;
+}
+
+interface subgraph-request {
+    use types.{shared-context, headers, error};
+
+    on-subgraph-request: func(context: shared-context, method: string, url: string, headers: headers) -> result<_, error>;
 }
 
 interface authorization {

--- a/engine/crates/wasi-component-loader/src/error.rs
+++ b/engine/crates/wasi-component-loader/src/error.rs
@@ -8,15 +8,21 @@ pub enum Error {
     Internal(#[from] anyhow::Error),
     /// User-thrown error of the WASI guest
     #[error("{0}")]
-    User(#[from] guest::Error),
+    Guest(#[from] guest::GuestError),
 }
 
 impl Error {
     /// Converts into user error response, if one.
-    pub fn into_user_error(self) -> Option<guest::Error> {
+    pub fn into_guest_error(self) -> Option<guest::GuestError> {
         match self {
             Error::Internal(_) => None,
-            Error::User(error) => Some(error),
+            Error::Guest(error) => Some(error),
         }
+    }
+}
+
+impl From<String> for Error {
+    fn from(error: String) -> Self {
+        Error::Internal(anyhow::anyhow!(error))
     }
 }

--- a/engine/crates/wasi-component-loader/src/error/guest.rs
+++ b/engine/crates/wasi-component-loader/src/error/guest.rs
@@ -5,14 +5,14 @@ use wasmtime::component::{ComponentType, Lift};
 /// An error type available for the user to throw from the guest.
 #[derive(Clone, ComponentType, Lift, Debug, thiserror::Error, PartialEq)]
 #[component(record)]
-pub struct Error {
+pub struct GuestError {
     /// Additional extensions added to the GraphQL response
     pub extensions: Vec<(String, String)>,
     /// The error message
     pub message: String,
 }
 
-impl fmt::Display for Error {
+impl fmt::Display for GuestError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.message.fmt(f)
     }

--- a/engine/crates/wasi-component-loader/src/hooks.rs
+++ b/engine/crates/wasi-component-loader/src/hooks.rs
@@ -165,7 +165,6 @@ impl ComponentInstance {
                 Some(hook)
             }
             Err(e) => {
-                dbg!(&e);
                 tracing::debug!(target: GRAFBASE_TARGET, "error instantizing the authorization hook WASM function: {e}");
                 None
             }

--- a/engine/crates/wasi-component-loader/src/hooks.rs
+++ b/engine/crates/wasi-component-loader/src/hooks.rs
@@ -1,9 +1,17 @@
-use wasmtime::{Engine, Store};
+use std::sync::RwLock;
 
-use crate::{state::WasiState, Config};
+use anyhow::anyhow;
+use grafbase_tracing::span::GRAFBASE_TARGET;
+use wasmtime::{
+    component::{ComponentNamedList, Instance, Lift, Lower, Resource, TypedFunc},
+    Engine, Store,
+};
+
+use crate::{state::WasiState, ComponentLoader, Config, SharedContextMap};
 
 pub(crate) mod authorization;
 pub(crate) mod gateway;
+pub(crate) mod subgraph;
 
 /// Generic initialization of WASI components for all hooks.
 fn initialize_store(config: &Config, engine: &Engine) -> crate::Result<Store<WasiState>> {
@@ -16,4 +24,164 @@ fn initialize_store(config: &Config, engine: &Engine) -> crate::Result<Store<Was
     store.fuel_async_yield_interval(Some(10000))?;
 
     Ok(store)
+}
+
+type FunctionCache = RwLock<Vec<(&'static str, Box<dyn std::any::Any + Send + Sync>)>>;
+
+pub struct ComponentInstance {
+    store: Store<WasiState>,
+    instance: Instance,
+    export_name: &'static str,
+    function_cache: FunctionCache,
+    poisoned: bool,
+}
+
+impl ComponentInstance {
+    /// Creates a new instance of the authorization hook
+    async fn new(loader: &ComponentLoader, export_name: &'static str) -> crate::Result<Self> {
+        let mut store = initialize_store(loader.config(), loader.engine())?;
+
+        let instance = loader
+            .linker()
+            .instantiate_async(&mut store, loader.component())
+            .await?;
+
+        Ok(Self {
+            store,
+            instance,
+            export_name,
+            function_cache: Default::default(),
+            poisoned: false,
+        })
+    }
+
+    async fn call2<A1, A2, R>(
+        &mut self,
+        name: &'static str,
+        context: SharedContextMap,
+        args: (A1, A2),
+    ) -> crate::Result<Option<R>>
+    where
+        (Resource<SharedContextMap>, A1, A2): ComponentNamedList + Lower + Send + Sync + 'static,
+        (R,): ComponentNamedList + Lift + Send + Sync + 'static,
+    {
+        let Some(hook) = self.get_hook::<(Resource<SharedContextMap>, A1, A2), (R,)>(name) else {
+            return Ok(None);
+        };
+
+        let context = self.store.data_mut().push_resource(context)?;
+        let context_rep = context.rep();
+
+        let result = hook.call_async(&mut self.store, (context, args.0, args.1)).await;
+
+        // We check if the hook call trapped, and if so we mark the instance poisoned.
+        //
+        // If no traps, we mark this hook so it can be called again.
+        if result.is_err() {
+            self.poisoned = true;
+        } else {
+            hook.post_return_async(&mut self.store).await?;
+        }
+
+        let result = result?.0;
+
+        // This is a bit ugly because we don't need it, but we need to clean the shared
+        // resources before exiting or this will leak RAM.
+        let _: SharedContextMap = self.store.data_mut().take_resource(context_rep)?;
+
+        Ok(Some(result))
+    }
+
+    async fn call3<A1, A2, A3, R>(
+        &mut self,
+        name: &'static str,
+        context: SharedContextMap,
+        args: (A1, A2, A3),
+    ) -> crate::Result<Option<R>>
+    where
+        (Resource<SharedContextMap>, A1, A2, A3): ComponentNamedList + Lower + Send + Sync + 'static,
+        (R,): ComponentNamedList + Lift + Send + Sync + 'static,
+    {
+        let Some(hook) = self.get_hook::<(Resource<SharedContextMap>, A1, A2, A3), (R,)>(name) else {
+            return Ok(None);
+        };
+
+        let context = self.store.data_mut().push_resource(context)?;
+        let context_rep = context.rep();
+
+        let result = hook
+            .call_async(&mut self.store, (context, args.0, args.1, args.2))
+            .await;
+
+        // We check if the hook call trapped, and if so we mark the instance poisoned.
+        //
+        // If no traps, we mark this hook so it can be called again.
+        if result.is_err() {
+            self.poisoned = true;
+        } else {
+            hook.post_return_async(&mut self.store).await?;
+        }
+
+        let result = result?.0;
+
+        // This is a bit ugly because we don't need it, but we need to clean the shared
+        // resources before exiting or this will leak RAM.
+        let _: SharedContextMap = self.store.data_mut().take_resource(context_rep)?;
+
+        Ok(Some(result))
+    }
+
+    /// A generic get hook we can use to find a different function from the interface.
+    fn get_hook<I, O>(&mut self, function_name: &'static str) -> Option<TypedFunc<I, O>>
+    where
+        I: ComponentNamedList + Lower + Send + Sync + 'static,
+        O: ComponentNamedList + Lift + Send + Sync + 'static,
+    {
+        if let Some(func) = self
+            .function_cache
+            .read()
+            .unwrap()
+            .iter()
+            .filter(|(name, _)| *name == function_name)
+            .find_map(|(_, cached)| cached.downcast_ref::<TypedFunc<I, O>>())
+        {
+            return Some(*func);
+        }
+        let mut exports = self.instance.exports(&mut self.store);
+        let mut root = exports.root();
+
+        let Some(mut interface) = root.instance(self.export_name) else {
+            tracing::debug!(target: GRAFBASE_TARGET, "could not find export for authorization interface");
+            return None;
+        };
+
+        match interface.typed_func(function_name) {
+            Ok(hook) => {
+                tracing::debug!(target: GRAFBASE_TARGET, "instantized the authorization hook WASM function");
+                self.function_cache
+                    .write()
+                    .unwrap()
+                    .push((function_name, Box::new(hook)));
+                Some(hook)
+            }
+            Err(e) => {
+                dbg!(&e);
+                tracing::debug!(target: GRAFBASE_TARGET, "error instantizing the authorization hook WASM function: {e}");
+                None
+            }
+        }
+    }
+
+    /// Resets the store to the original state. This must be called if wanting to reuse this instance.
+    ///
+    /// If the cleanup fails, the instance is gone and must be dropped.
+    pub fn cleanup(&mut self) -> crate::Result<()> {
+        if self.poisoned {
+            return Err(anyhow!("this instance is poisoned").into());
+        }
+
+        self.store.set_fuel(u64::MAX)?;
+
+        Ok(())
+    }
 }

--- a/engine/crates/wasi-component-loader/src/hooks/gateway.rs
+++ b/engine/crates/wasi-component-loader/src/hooks/gateway.rs
@@ -1,38 +1,32 @@
 use core::fmt;
 
-use anyhow::anyhow;
-use grafbase_tracing::span::GRAFBASE_TARGET;
 use http::HeaderMap;
-use wasmtime::{
-    component::{Instance, Resource, TypedFunc},
-    Store,
-};
 
 use crate::{
     names::{COMPONENT_GATEWAY_REQUEST, GATEWAY_HOOK_FUNCTION},
-    state::WasiState,
-    ComponentLoader, ContextMap, ErrorResponse,
+    ComponentLoader, ContextMap, GuestResult,
 };
 
-/// The hook function takes two parameters: the context and the headers.
-/// They are wrapped as resources, meaning they are in a shared memory space
-/// accessible from the host and from the guest.
-pub(crate) type Parameters = (Resource<ContextMap>, Resource<HeaderMap>);
-
-/// The guest can read and modify the input headers and request as it wishes. A successful
-/// call returns unit. The user can return an error response, which should be mapped to a
-/// corresponding HTTP status code.
-pub(crate) type Response = (Result<(), ErrorResponse>,);
+use super::ComponentInstance;
 
 /// The gateway hook is called right after authentication.
 ///
 /// An instance of a function to be called from the Gateway level for the request.
 /// The instance is meant to be separate for every request. The instance shares a memory space
 /// with the guest, and cannot be shared with multiple requests.
-pub struct GatewayHookInstance {
-    store: Store<WasiState>,
-    hook: Option<TypedFunc<Parameters, Response>>,
-    poisoned: bool,
+pub struct GatewayHookInstance(ComponentInstance);
+
+impl std::ops::Deref for GatewayHookInstance {
+    type Target = ComponentInstance;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for GatewayHookInstance {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
 }
 
 impl fmt::Debug for GatewayHookInstance {
@@ -44,87 +38,40 @@ impl fmt::Debug for GatewayHookInstance {
 impl GatewayHookInstance {
     /// Creates a new instance for the gateway hook.
     pub async fn new(loader: &ComponentLoader) -> crate::Result<Self> {
-        let mut store = super::initialize_store(loader.config(), loader.engine())?;
-
-        let instance = loader
-            .linker()
-            .instantiate_async(&mut store, loader.component())
-            .await?;
-
-        let hook = get_hook(&mut store, &instance);
-
-        Ok(Self {
-            store,
-            hook,
-            poisoned: false,
-        })
+        ComponentInstance::new(loader, COMPONENT_GATEWAY_REQUEST)
+            .await
+            .map(Self)
     }
 
     /// Calls the hook with the given parameters.
     pub async fn call(&mut self, context: ContextMap, headers: HeaderMap) -> crate::Result<(ContextMap, HeaderMap)> {
-        match self.hook {
-            Some(ref hook) => {
-                // adds the data to the shared memory
-                let context = self.store.data_mut().push_resource(context)?;
-                let headers = self.store.data_mut().push_resource(headers)?;
+        let Some(hook) = self.get_hook::<_, (GuestResult<()>,)>(GATEWAY_HOOK_FUNCTION) else {
+            return Ok((context, headers));
+        };
 
-                // we need to take the pointers now, because a resource is not Copy and we need
-                // the pointers to get the data back from the shared memory.
-                let headers_rep = headers.rep();
-                let context_rep = context.rep();
+        // adds the data to the shared memory
+        let context = self.store.data_mut().push_resource(context)?;
+        let headers = self.store.data_mut().push_resource(headers)?;
 
-                let result = hook.call_async(&mut self.store, (context, headers)).await;
+        // we need to take the pointers now, because a resource is not Copy and we need
+        // the pointers to get the data back from the shared memory.
+        let headers_rep = headers.rep();
+        let context_rep = context.rep();
 
-                if result.is_err() {
-                    self.poisoned = true;
-                } else {
-                    hook.post_return_async(&mut self.store).await?;
-                }
+        let result = hook.call_async(&mut self.store, (context, headers)).await;
 
-                result?.0?;
-
-                // take the data back from the shared memory
-                let context = self.store.data_mut().take_resource(context_rep)?;
-                let headers = self.store.data_mut().take_resource(headers_rep)?;
-
-                Ok((context, headers))
-            }
-            None => Ok((context, headers)),
-        }
-    }
-
-    /// Resets the store to the original state. This must be called if wanting to reuse this instance.
-    ///
-    /// If the cleanup fails, the instance is gone and must be dropped.
-    pub fn cleanup(&mut self) -> crate::Result<()> {
-        if self.poisoned {
-            return Err(anyhow!("this instance is poisoned").into());
+        if result.is_err() {
+            self.poisoned = true;
+        } else {
+            hook.post_return_async(&mut self.store).await?;
         }
 
-        self.store.set_fuel(u64::MAX)?;
+        result?.0?;
 
-        Ok(())
-    }
-}
+        // take the data back from the shared memory
+        let context = self.store.data_mut().take_resource(context_rep)?;
+        let headers = self.store.data_mut().take_resource(headers_rep)?;
 
-fn get_hook(store: &mut Store<WasiState>, instance: &Instance) -> Option<TypedFunc<Parameters, Response>> {
-    let mut exports = instance.exports(store);
-    let mut root = exports.root();
-
-    let Some(mut interface) = root.instance(COMPONENT_GATEWAY_REQUEST) else {
-        tracing::debug!(target: GRAFBASE_TARGET, "could not find export for gateway-request interface");
-        return None;
-    };
-
-    match interface.typed_func(GATEWAY_HOOK_FUNCTION) {
-        Ok(hook) => {
-            tracing::debug!(target: GRAFBASE_TARGET, "instantized the gateway hook WASM function");
-            Some(hook)
-        }
-        // the user has not defined the hook function, so we return none and do not try to call this function.
-        Err(e) => {
-            tracing::debug!(target: GRAFBASE_TARGET, "error instantizing the gateway hook WASM function: {e}");
-            None
-        }
+        Ok((context, headers))
     }
 }

--- a/engine/crates/wasi-component-loader/src/hooks/subgraph.rs
+++ b/engine/crates/wasi-component-loader/src/hooks/subgraph.rs
@@ -1,0 +1,74 @@
+use url::Url;
+
+use crate::{
+    context::SharedContextMap,
+    names::{COMPONENT_SUBGRAPH_REQUEST, ON_SUBGRAGH_REQUEST_HOOK_FUNCTION},
+    ComponentLoader, GuestResult,
+};
+
+use super::ComponentInstance;
+
+/// Subgraph related hooks
+pub struct SubgraphHookInstance(ComponentInstance);
+
+impl std::ops::Deref for SubgraphHookInstance {
+    type Target = ComponentInstance;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for SubgraphHookInstance {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl SubgraphHookInstance {
+    /// Creates a new instance for the subgraph hooks.
+    pub async fn new(loader: &ComponentLoader) -> crate::Result<Self> {
+        ComponentInstance::new(loader, COMPONENT_SUBGRAPH_REQUEST)
+            .await
+            .map(Self)
+    }
+
+    /// Called just before sending a HTTP request to a subgraph
+    pub async fn on_subgraph_request(
+        &mut self,
+        context: SharedContextMap,
+        method: http::Method,
+        url: &Url,
+        headers: http::HeaderMap,
+    ) -> crate::Result<http::HeaderMap> {
+        let Some(hook) = self.get_hook::<_, (GuestResult<()>,)>(ON_SUBGRAGH_REQUEST_HOOK_FUNCTION) else {
+            return Ok(headers);
+        };
+
+        let url = url.to_string();
+        let method = method.to_string();
+        // adds the data to the shared memory
+        let context = self.store.data_mut().push_resource(context)?;
+        let headers = self.store.data_mut().push_resource(headers)?;
+
+        // we need to take the pointers now, because a resource is not Copy and we need
+        // the pointers to get the data back from the shared memory.
+        let headers_rep = headers.rep();
+        let context_rep = context.rep();
+
+        let result = hook.call_async(&mut self.store, (context, method, url, headers)).await;
+
+        if result.is_err() {
+            self.poisoned = true;
+        } else {
+            hook.post_return_async(&mut self.store).await?;
+        }
+
+        result?.0?;
+
+        // take the data back from the shared memory
+        self.store.data_mut().take_resource::<SharedContextMap>(context_rep)?;
+        let headers = self.store.data_mut().take_resource(headers_rep)?;
+
+        Ok(headers)
+    }
+}

--- a/engine/crates/wasi-component-loader/src/lib.rs
+++ b/engine/crates/wasi-component-loader/src/lib.rs
@@ -21,14 +21,17 @@ mod tests;
 
 pub use config::Config;
 pub use context::{ContextMap, SharedContextMap};
-pub use error::{guest::Error as ErrorResponse, Error};
+pub use error::{guest::GuestError, Error};
 pub use hooks::{
     authorization::{AuthorizationHookInstance, EdgeDefinition, NodeDefinition},
     gateway::GatewayHookInstance,
+    subgraph::*,
 };
 
 /// The crate result type
 pub type Result<T> = std::result::Result<T, Error>;
+/// The guest result type
+pub type GuestResult<T> = std::result::Result<T, GuestError>;
 
 use grafbase_tracing::span::GRAFBASE_TARGET;
 use state::WasiState;

--- a/engine/crates/wasi-component-loader/src/names.rs
+++ b/engine/crates/wasi-component-loader/src/names.rs
@@ -1,6 +1,7 @@
 pub(crate) static COMPONENT_TYPES: &str = "component:grafbase/types";
 pub(crate) static COMPONENT_GATEWAY_REQUEST: &str = "component:grafbase/gateway-request";
 pub(crate) static COMPONENT_AUTHORIZATION: &str = "component:grafbase/authorization";
+pub(crate) static COMPONENT_SUBGRAPH_REQUEST: &str = "component:grafbase/subgraph-request";
 
 pub(crate) static GATEWAY_HOOK_FUNCTION: &str = "on-gateway-request";
 pub(crate) static AUTHORIZE_EDGE_PRE_EXECUTION_HOOK_FUNCTION: &str = "authorize-edge-pre-execution";
@@ -8,11 +9,13 @@ pub(crate) static AUTHORIZE_NODE_PRE_EXECUTION_HOOK_FUNCTION: &str = "authorize-
 pub(crate) static AUTHORIZE_PARENT_EDGE_POST_EXECUTION_HOOK_FUNCTION: &str = "authorize-parent-edge-post-execution";
 pub(crate) static AUTHORIZE_EDGE_NODE_POST_EXECUTION_HOOK_FUNCTION: &str = "authorize-edge-node-post-execution";
 pub(crate) static AUTHORIZE_EDGE_POST_EXECUTION_HOOK_FUNCTION: &str = "authorize-edge-post-execution";
+pub(crate) static ON_SUBGRAGH_REQUEST_HOOK_FUNCTION: &str = "on-subgraph-request";
 
 pub(crate) static HEADERS_RESOURCE: &str = "headers";
 pub(crate) static HEADERS_SET_METHOD: &str = "[method]headers.set";
 pub(crate) static HEADERS_GET_METHOD: &str = "[method]headers.get";
 pub(crate) static HEADERS_DELETE_METHOD: &str = "[method]headers.delete";
+pub(crate) static HEADERS_ENTRIES_METHOD: &str = "[method]headers.entries";
 
 pub(crate) static CONTEXT_RESOURCE: &str = "context";
 pub(crate) static CONTEXT_SET_METHOD: &str = "[method]context.set";


### PR DESCRIPTION
Also simplifying the headers interface to not return errors for `get`
and `delete`, there is nothing the user guest can do with those.

Created a common `ComponentInstance` to put in common a bunch of stuff
between wasm module instances.
