### PR TITLE
feat(engine-v2): duplicating header rename

### DIFF
--- a/cli/crates/federated-dev/src/dev/subgraph_config_watcher.rs
+++ b/cli/crates/federated-dev/src/dev/subgraph_config_watcher.rs
@@ -65,6 +65,7 @@ impl SubgraphConfigWatcher {
                         }),
                         SubgraphHeaderRule::Forward(_) => None,
                         SubgraphHeaderRule::Remove(_) => None,
+                        SubgraphHeaderRule::RenameDuplicate(_) => None,
                     })
                     .collect::<Vec<_>>();
 

--- a/engine/crates/engine-config-builder/src/lib.rs
+++ b/engine/crates/engine-config-builder/src/lib.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use engine_v2_config::latest::{
     AuthConfig, AuthProviderConfig, CacheConfig, CacheConfigTarget, CacheConfigs, HeaderForward, HeaderInsert,
-    HeaderRemove, HeaderRule, HeaderRuleId, NameOrPattern, OperationLimits,
+    HeaderRemove, HeaderRenameDuplicate, HeaderRule, HeaderRuleId, NameOrPattern, OperationLimits,
 };
 use engine_v2_config::{
     latest::{self as config},
@@ -179,6 +179,11 @@ impl<'a> BuildContext<'a> {
             }),
             SubgraphHeaderRule::Remove(ref rule) => HeaderRule::Remove(HeaderRemove {
                 name: self.intern_header_name(&rule.name),
+            }),
+            SubgraphHeaderRule::RenameDuplicate(ref rule) => HeaderRule::RenameDuplicate(HeaderRenameDuplicate {
+                name: self.strings.intern(&rule.name),
+                default: rule.default.as_ref().map(|default| self.strings.intern(default)),
+                rename: self.strings.intern(&rule.rename),
             }),
         };
 

--- a/engine/crates/engine-v2/config/src/v5.rs
+++ b/engine/crates/engine-v2/config/src/v5.rs
@@ -108,6 +108,9 @@ pub enum HeaderRule {
     /// Remove the header.
     #[serde(rename = "remove")]
     Remove(HeaderRemove),
+    /// Duplicate the header with a new name.
+    #[serde(rename = "rename_duplicate")]
+    RenameDuplicate(HeaderRenameDuplicate),
 }
 
 /// Header forwarding rules.
@@ -137,6 +140,17 @@ pub struct HeaderRemove {
     /// Removes the header with a static name or matching a regex pattern.
     #[serde(flatten)]
     pub name: NameOrPattern,
+}
+
+/// Header forwarding rules.
+#[derive(serde::Deserialize, serde::Serialize, Debug)]
+pub struct HeaderRenameDuplicate {
+    /// Name or pattern of the header to be duplicated.
+    pub name: StringId,
+    /// If header is not present, insert this value.
+    pub default: Option<StringId>,
+    /// Use this name for the copy.
+    pub rename: StringId,
 }
 
 impl std::ops::Index<StringId> for Config {

--- a/engine/crates/engine-v2/schema/src/builder/mod.rs
+++ b/engine/crates/engine-v2/schema/src/builder/mod.rs
@@ -201,6 +201,11 @@ impl BuildContext {
 
                         HeaderRule::Remove { name }
                     }
+                    config::latest::HeaderRule::RenameDuplicate(rule) => HeaderRule::RenameDuplicate {
+                        name: self.strings.get_or_new(&config[rule.name]),
+                        default: rule.default.map(|id| self.strings.get_or_new(&config[id])),
+                        rename: self.strings.get_or_new(&config[rule.rename]),
+                    },
                 }
             })
             .collect();

--- a/engine/crates/engine-v2/schema/src/lib.rs
+++ b/engine/crates/engine-v2/schema/src/lib.rs
@@ -441,4 +441,9 @@ pub enum HeaderRule {
     Remove {
         name: NameOrPattern,
     },
+    RenameDuplicate {
+        name: StringId,
+        default: Option<StringId>,
+        rename: StringId,
+    },
 }

--- a/engine/crates/engine-v2/schema/src/walkers/header.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/header.rs
@@ -19,6 +19,11 @@ impl<'a> HeaderRuleWalker<'a> {
             HeaderRule::Remove { name } => HeaderRuleRef::Remove {
                 name: self.name_or_pattern_ref(name),
             },
+            HeaderRule::RenameDuplicate { name, default, rename } => HeaderRuleRef::RenameDuplicate {
+                name: self.schema[*name].as_str(),
+                default: default.map(|id| self.schema[id].as_str()),
+                rename: self.schema[*rename].as_str(),
+            },
         }
     }
 
@@ -49,6 +54,11 @@ pub enum HeaderRuleRef<'a> {
     },
     Remove {
         name: NameOrPatternRef<'a>,
+    },
+    RenameDuplicate {
+        name: &'a str,
+        default: Option<&'a str>,
+        rename: &'a str,
     },
 }
 

--- a/engine/crates/parser-sdl/src/federation/header.rs
+++ b/engine/crates/parser-sdl/src/federation/header.rs
@@ -52,6 +52,8 @@ pub enum SubgraphHeaderRule {
     Insert(SubgraphHeaderInsert),
     /// Remove the header.
     Remove(SubgraphHeaderRemove),
+    /// Duplicate the header with a new name.
+    RenameDuplicate(SubgraphRenameDuplicate),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -76,4 +78,14 @@ pub struct SubgraphHeaderInsert {
 pub struct SubgraphHeaderRemove {
     /// Removes the header with a static name or matching a regex pattern.
     pub name: NameOrPattern,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SubgraphRenameDuplicate {
+    /// Name or pattern of the header to be forwarded.
+    pub name: String,
+    /// If header is not present, insert this value.
+    pub default: Option<String>,
+    /// Use this name instead of the original when forwarding.
+    pub rename: String,
 }

--- a/gateway/crates/federated-server/src/config.rs
+++ b/gateway/crates/federated-server/src/config.rs
@@ -838,6 +838,39 @@ mod tests {
     }
 
     #[test]
+    fn header_rename_duplicate() {
+        let input = indoc! {r#"
+            [[headers]]     
+            rule = "rename_duplicate"
+            name = "content-type"
+            default = "foo"
+            rename = "something"
+        "#};
+
+        let result: Config = toml::from_str(input).unwrap();
+
+        insta::assert_debug_snapshot!(&result.headers, @r###"
+        [
+            RenameDuplicate(
+                RenameDuplicate {
+                    name: DynamicString(
+                        "content-type",
+                    ),
+                    default: Some(
+                        DynamicString(
+                            "foo",
+                        ),
+                    ),
+                    rename: DynamicString(
+                        "something",
+                    ),
+                },
+            ),
+        ]
+        "###);
+    }
+
+    #[test]
     fn header_forward_static() {
         let input = indoc! {r#"
             [[headers]]     

--- a/gateway/crates/federated-server/src/config/header.rs
+++ b/gateway/crates/federated-server/src/config/header.rs
@@ -38,6 +38,9 @@ pub enum HeaderRule {
     /// Remove the header.
     #[serde(rename = "remove")]
     Remove(HeaderRemove),
+    /// Forward the header to the subgraphs together with a renamed copy.
+    #[serde(rename = "rename_duplicate")]
+    RenameDuplicate(RenameDuplicate),
 }
 
 impl From<HeaderRule> for header::SubgraphHeaderRule {
@@ -46,6 +49,29 @@ impl From<HeaderRule> for header::SubgraphHeaderRule {
             HeaderRule::Forward(fwd) => Self::Forward(fwd.into()),
             HeaderRule::Insert(insert) => Self::Insert(insert.into()),
             HeaderRule::Remove(remove) => Self::Remove(remove.into()),
+            HeaderRule::RenameDuplicate(rename) => Self::RenameDuplicate(rename.into()),
+        }
+    }
+}
+
+/// Header forwarding rules.
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct RenameDuplicate {
+    /// Name or pattern of the header to be forwarded.
+    pub name: DynamicString<AsciiString>,
+    /// If header is not present, insert this value.
+    pub default: Option<DynamicString<AsciiString>>,
+    /// Use this name instead of the original when forwarding.
+    pub rename: DynamicString<AsciiString>,
+}
+
+impl From<RenameDuplicate> for header::SubgraphRenameDuplicate {
+    fn from(value: RenameDuplicate) -> Self {
+        Self {
+            name: value.name.to_string(),
+            default: value.default.as_ref().map(ToString::to_string),
+            rename: value.rename.to_string(),
         }
     }
 }


### PR DESCRIPTION
Adds a rule for headers that forwards a header and duplicates it with a different name.
