### PR TITLE
gateway: nest gateway timeout config under `[gateway]`

### DIFF
--- a/gateway/crates/federated-server/src/server.rs
+++ b/gateway/crates/federated-server/src/server.rs
@@ -71,7 +71,8 @@ pub async fn serve(
                 trusted_documents: config.trusted_documents,
                 wasi: config.hooks,
                 header_rules: config.headers,
-                rate_limit: config.rate_limit,
+                rate_limit: config.gateway.rate_limit,
+                timeout: config.gateway.timeout,
             },
             otel_reload,
             sender,
@@ -102,7 +103,7 @@ pub async fn serve(
             grafbase_telemetry::metrics::meter_from_global_provider(),
         ))
         .layer(tower_http::timeout::RequestBodyTimeoutLayer::new(
-            config.timeout.unwrap_or(DEFAULT_GATEWAY_TIMEOUT),
+            config.gateway.timeout.unwrap_or(DEFAULT_GATEWAY_TIMEOUT),
         ))
         .layer(axum::middleware::map_response(
             |mut response: axum::response::Response<_>| async {

--- a/gateway/crates/federated-server/src/server/gateway.rs
+++ b/gateway/crates/federated-server/src/server/gateway.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::time::Duration;
 use std::{collections::BTreeMap, sync::Arc};
 
 use tokio::sync::watch;
@@ -36,6 +37,7 @@ pub(crate) struct GatewayConfig {
     pub trusted_documents: TrustedDocumentsConfig,
     pub wasi: Option<HooksWasiConfig>,
     pub rate_limit: Option<RateLimitConfig>,
+    pub timeout: Option<Duration>,
 }
 
 /// Creates a new gateway from federated schema.
@@ -53,6 +55,7 @@ pub(super) async fn generate(
         trusted_documents,
         wasi,
         rate_limit,
+        timeout,
     } = config;
 
     let schema_version = blake3::hash(federated_schema.as_bytes());
@@ -68,6 +71,8 @@ pub(super) async fn generate(
     if let Some(auth_config) = authentication {
         graph_config.auth = Some(auth_config.into());
     }
+
+    graph_config.timeout = timeout;
 
     graph_config.disable_introspection = !enable_introspection;
 

--- a/gateway/crates/gateway-binary/tests/integration_tests.rs
+++ b/gateway/crates/gateway-binary/tests/integration_tests.rs
@@ -795,7 +795,7 @@ fn health_custom_listener() {
 #[test]
 fn global_rate_limiting() {
     let config = indoc! {r#"
-        [rate_limit]
+        [gateway.rate_limit]
         limit = 1
         duration = "1s"
     "#};


### PR DESCRIPTION
Having that value as the only top-level, non-nested setting feels weird
