### PR TITLE
chore(engine-v2): Identify requirements by their id rather than response key in the response

### DIFF
--- a/engine/crates/engine-v2/src/execution/mod.rs
+++ b/engine/crates/engine-v2/src/execution/mod.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use crate::{
     operation::{FieldId, LogicalPlanId, PreparedOperation, Variables},
-    response::{ConcreteObjectShapeId, FieldShapeId, GraphqlError, ReadSelectionSet},
+    response::{ConcreteObjectShapeId, FieldShapeId, GraphqlError, ResponseViewSelectionSet, ResponseViews},
     sources::PreparedExecutor,
     Runtime,
 };
@@ -44,6 +44,7 @@ pub(crate) struct ExecutableOperation {
     pub(crate) subgraph_default_headers: http::HeaderMap,
     pub(crate) query_modifications: QueryModifications,
     pub(crate) execution_plans: Vec<ExecutionPlan>,
+    pub(crate) response_views: ResponseViews,
 }
 
 impl std::ops::Deref for ExecutableOperation {
@@ -68,7 +69,7 @@ pub(crate) struct ExecutionPlan {
     pub logical_plan_id: LogicalPlanId,
     pub parent_count: usize,
     pub children: Vec<ExecutionPlanId>,
-    pub requires: ReadSelectionSet,
+    pub requires: ResponseViewSelectionSet,
     pub prepared_executor: PreparedExecutor,
 }
 

--- a/engine/crates/engine-v2/src/execution/state.rs
+++ b/engine/crates/engine-v2/src/execution/state.rs
@@ -63,7 +63,7 @@ impl<'ctx> OperationExecutionState<'ctx> {
     }
 
     pub fn push_response_objects(&mut self, set_id: ResponseObjectSetId, response_object_refs: ResponseObjectSet) {
-        tracing::trace!("Pushing response objects for {set_id}");
+        tracing::trace!("Pushing response objects for {set_id}: {}", response_object_refs.len());
         self[set_id] = Some(Arc::new(response_object_refs));
     }
 

--- a/engine/crates/engine-v2/src/operation/bind/mod.rs
+++ b/engine/crates/engine-v2/src/operation/bind/mod.rs
@@ -232,7 +232,7 @@ pub fn bind_operation(schema: &Schema, mut parsed_operation: ParsedOperation) ->
 
 /// A helper struct for optionally including operation names in error messages
 #[derive(Debug, Clone)]
-pub struct ErrorOperationName(Option<String>);
+pub(crate) struct ErrorOperationName(Option<String>);
 
 impl std::fmt::Display for ErrorOperationName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/engine/crates/engine-v2/src/operation/blueprint/plan.rs
+++ b/engine/crates/engine-v2/src/operation/blueprint/plan.rs
@@ -349,6 +349,9 @@ where
             expected_key: self.operation.response_keys.ensure_safety(response_key),
             edge: field.response_edge(),
             id: field.id(),
+            required_field_id: fields
+                .iter()
+                .find_map(|field| self.plan.field_to_solved_requirement[usize::from(field.id())]),
             definition_id: definition.id(),
             shape: match ty.inner().scalar_type() {
                 Some(scalar) => Shape::Scalar(scalar),

--- a/engine/crates/engine-v2/src/operation/input_value/query/mod.rs
+++ b/engine/crates/engine-v2/src/operation/input_value/query/mod.rs
@@ -10,7 +10,7 @@ use crate::operation::{Operation, OperationWalker, VariableDefinitionId, Variabl
 pub(crate) use view::*;
 
 #[derive(Default, Clone, serde::Serialize, serde::Deserialize)]
-pub struct QueryInputValues {
+pub(crate) struct QueryInputValues {
     /// Individual input values and list values
     values: Vec<QueryInputValue>,
     /// InputObject's fields
@@ -26,7 +26,7 @@ id_newtypes::NonZeroU32! {
 }
 
 #[derive(Default, Clone, serde::Serialize, serde::Deserialize)]
-pub enum QueryInputValue {
+pub(crate) enum QueryInputValue {
     #[default]
     Null,
     String(String),
@@ -84,7 +84,7 @@ impl QueryInputValues {
     }
 }
 
-pub type QueryInputValueWalker<'a> = OperationWalker<'a, &'a QueryInputValue, ()>;
+pub(crate) type QueryInputValueWalker<'a> = OperationWalker<'a, &'a QueryInputValue, ()>;
 
 impl<'a> QueryInputValueWalker<'a> {
     pub fn is_undefined(&self) -> bool {

--- a/engine/crates/engine-v2/src/operation/input_value/query/view.rs
+++ b/engine/crates/engine-v2/src/operation/input_value/query/view.rs
@@ -7,7 +7,7 @@ use serde::{
 
 use super::{QueryInputValue, QueryInputValueWalker};
 
-pub struct QueryInputValueView<'a> {
+pub(crate) struct QueryInputValueView<'a> {
     pub(super) inner: QueryInputValueWalker<'a>,
     pub(super) selection_set: &'a InputValueSet,
 }

--- a/engine/crates/engine-v2/src/operation/location.rs
+++ b/engine/crates/engine-v2/src/operation/location.rs
@@ -5,7 +5,7 @@ use super::bind::BindError;
 // 65 KB for query without any new lines is pretty huge. If a user ever has a QueryTooBig error
 // we'll increase it to u32. But for now it's just wasted memory.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, serde::Serialize, serde::Deserialize)]
-pub struct Location {
+pub(crate) struct Location {
     /// One-based line number.
     line: u16,
     /// One-based column number.

--- a/engine/crates/engine-v2/src/operation/mod.rs
+++ b/engine/crates/engine-v2/src/operation/mod.rs
@@ -85,6 +85,7 @@ pub struct OperationMetadata {
 #[derive(serde::Serialize, serde::Deserialize)]
 pub(crate) struct OperationPlan {
     pub field_to_logical_plan_id: Vec<LogicalPlanId>,
+    pub field_to_solved_requirement: Vec<Option<RequiredFieldId>>,
     pub logical_plans: Vec<LogicalPlan>,
     pub mutation_fields_plan_order: Vec<LogicalPlanId>,
     pub children: IdToMany<LogicalPlanId, LogicalPlanId>,

--- a/engine/crates/engine-v2/src/response/mod.rs
+++ b/engine/crates/engine-v2/src/response/mod.rs
@@ -8,7 +8,7 @@ pub(crate) use path::*;
 pub(crate) use read::*;
 use schema::Schema;
 pub(crate) use shape::*;
-pub(crate) use value::{ResponseObject, ResponseValue};
+pub(crate) use value::*;
 pub(crate) use write::*;
 
 use crate::operation::PreparedOperation;

--- a/engine/crates/engine-v2/src/response/object_set.rs
+++ b/engine/crates/engine-v2/src/response/object_set.rs
@@ -46,9 +46,9 @@ impl OutputResponseObjectSets {
     }
 }
 
-const SET_INDEX_OFFSET: u32 = 24;
-const MAX_SET_INDEX: usize = (1 << (u32::BITS - SET_INDEX_OFFSET)) as usize;
-const OBJECT_INDEX_MASK: u32 = (1 << SET_INDEX_OFFSET) - 1;
+const SET_INDEX_SHIFT: u32 = 24;
+const MAX_SET_INDEX: usize = (1 << (u32::BITS - SET_INDEX_SHIFT)) as usize;
+const OBJECT_INDEX_MASK: u32 = (1 << SET_INDEX_SHIFT) - 1;
 
 /// An individual ResponseObjectSet may contain more objects than what a ResponseModifier or Plan
 /// requires. ResponseObjectSet are built by accumulating all the response object references for a
@@ -77,7 +77,7 @@ impl InputdResponseObjectSet {
         let set_idx = self.sets.len() - 1;
         assert!(set_idx < MAX_SET_INDEX, "Too many sets");
         for i in 0..self.sets[set_idx].len() {
-            self.indices.push((set_idx << SET_INDEX_OFFSET) as u32 | i as u32);
+            self.indices.push((set_idx << SET_INDEX_SHIFT) as u32 | i as u32);
         }
         assert!(
             self.indices.len() - n < (OBJECT_INDEX_MASK as usize),
@@ -104,14 +104,14 @@ impl InputdResponseObjectSet {
                 let possible_types = &schema[id].possible_types;
                 for (i, item) in self.sets[set_idx].iter().enumerate() {
                     if possible_types.binary_search(&item.definition_id).is_ok() {
-                        self.indices.push((set_idx << SET_INDEX_OFFSET) as u32 | i as u32);
+                        self.indices.push((set_idx << SET_INDEX_SHIFT) as u32 | i as u32);
                     }
                 }
             }
             EntityId::Object(id) => {
                 for (i, item) in self.sets[set_idx].iter().enumerate() {
                     if item.definition_id == id {
-                        self.indices.push((set_idx << SET_INDEX_OFFSET) as u32 | i as u32);
+                        self.indices.push((set_idx << SET_INDEX_SHIFT) as u32 | i as u32);
                     }
                 }
             }
@@ -139,7 +139,7 @@ impl InputdResponseObjectSet {
     pub(crate) fn get(&self, i: usize) -> Option<&ResponseObjectRef> {
         self.indices
             .get(i)
-            .map(|index| &self.sets[(index >> SET_INDEX_OFFSET) as usize][(index & OBJECT_INDEX_MASK) as usize])
+            .map(|index| &self.sets[(index >> SET_INDEX_SHIFT) as usize][(index & OBJECT_INDEX_MASK) as usize])
     }
 }
 

--- a/engine/crates/engine-v2/src/response/read/mod.rs
+++ b/engine/crates/engine-v2/src/response/read/mod.rs
@@ -13,12 +13,16 @@ impl ResponseBuilder {
     pub fn read<'a>(
         &'a self,
         schema: &'a Schema,
+        response_views: &'a ResponseViews,
         response_object_set: Arc<InputdResponseObjectSet>,
-        selection_set: &'a ReadSelectionSet,
+        selection_set: ResponseViewSelectionSet,
     ) -> ResponseObjectsView<'a> {
         ResponseObjectsView {
-            schema,
-            response: self,
+            ctx: ViewContext {
+                schema,
+                response_views,
+                response: self,
+            },
             response_object_set,
             selection_set,
         }

--- a/engine/crates/engine-v2/src/response/read/selection_set.rs
+++ b/engine/crates/engine-v2/src/response/read/selection_set.rs
@@ -1,87 +1,20 @@
-use schema::StringId;
+use id_newtypes::IdRange;
+use schema::{RequiredFieldId, StringId};
 
-use crate::response::ResponseEdge;
-
-/// Selection set used to read data from the response.
-/// Used for plan inputs.
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
-pub struct ReadSelectionSet {
-    items: Vec<ReadField>,
+#[derive(Default)]
+pub(crate) struct ResponseViews {
+    pub selections: Vec<ResponseViewSelection>,
 }
+
+id_newtypes::NonZeroU16! {
+    ResponseViews.selections[ResponseViewSelectionId] => ResponseViewSelection,
+}
+
+pub(crate) type ResponseViewSelectionSet = IdRange<ResponseViewSelectionId>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ReadField {
-    pub edge: ResponseEdge,
+pub(crate) struct ResponseViewSelection {
     pub name: StringId,
-    pub subselection: ReadSelectionSet,
-}
-
-impl ReadSelectionSet {
-    pub fn len(&self) -> usize {
-        self.items.len()
-    }
-
-    pub fn extend_disjoint(&mut self, other: Self) {
-        self.items.extend(other.items);
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.items.is_empty()
-    }
-
-    pub fn union(self, other: ReadSelectionSet) -> ReadSelectionSet {
-        let mut left = self.items;
-        let mut right = other.items;
-
-        // We're reading fields from a single entity, so names will unique.
-        left.sort_unstable_by(|a, b| a.name.cmp(&b.name));
-        right.sort_unstable_by(|a, b| a.name.cmp(&b.name));
-
-        let mut items = Vec::with_capacity(left.len() + right.len());
-        let mut left = left.into_iter().peekable();
-        let mut right = right.into_iter().peekable();
-
-        while let (Some(l), Some(r)) = (left.peek(), right.peek()) {
-            match l.name.cmp(&r.name) {
-                std::cmp::Ordering::Less => {
-                    items.push(left.next().unwrap());
-                }
-                std::cmp::Ordering::Equal => {
-                    let left_field = left.next().unwrap();
-                    let right_field = right.next().unwrap();
-                    items.push(ReadField {
-                        edge: std::cmp::min(right_field.edge, left_field.edge),
-                        name: left_field.name,
-                        subselection: left_field.subselection.union(right_field.subselection),
-                    });
-                }
-                std::cmp::Ordering::Greater => {
-                    items.push(right.next().unwrap());
-                }
-            }
-        }
-
-        items.extend(left);
-        items.extend(right);
-
-        ReadSelectionSet { items }
-    }
-}
-
-impl<'a> IntoIterator for &'a ReadSelectionSet {
-    type Item = &'a ReadField;
-
-    type IntoIter = <&'a Vec<ReadField> as IntoIterator>::IntoIter;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.items.iter()
-    }
-}
-
-impl FromIterator<ReadField> for ReadSelectionSet {
-    fn from_iter<T: IntoIterator<Item = ReadField>>(iter: T) -> Self {
-        Self {
-            items: iter.into_iter().collect::<Vec<_>>(),
-        }
-    }
+    pub id: RequiredFieldId,
+    pub subselection: ResponseViewSelectionSet,
 }

--- a/engine/crates/engine-v2/src/response/read/ser.rs
+++ b/engine/crates/engine-v2/src/response/read/ser.rs
@@ -3,9 +3,9 @@ use std::borrow::Cow;
 use serde::ser::{SerializeMap, SerializeSeq};
 
 use crate::response::{
-    ErrorCode, ExecutionFailureResponse, GraphqlError, InitialResponse, PreExecutionErrorResponse, Response,
-    ResponseData, ResponseKeys, ResponseListId, ResponseObject, ResponseObjectId, ResponsePath, ResponseValue,
-    UnpackedResponseEdge,
+    value::ResponseObjectField, ErrorCode, ExecutionFailureResponse, GraphqlError, InitialResponse,
+    PreExecutionErrorResponse, Response, ResponseData, ResponseKeys, ResponseListId, ResponseObject, ResponseObjectId,
+    ResponsePath, ResponseValue, UnpackedResponseEdge,
 };
 
 impl serde::Serialize for Response {
@@ -204,8 +204,8 @@ impl<'a> serde::Serialize for SerializableResponseObject<'a> {
         let keys = &self.data.operation.response_keys;
         // Thanks to the BoundResponseKey starting with the position and the fields being a BTreeMap
         // we're ensuring the fields are serialized in the order they appear in the query.
-        for (key, value) in self.object.fields() {
-            let UnpackedResponseEdge::BoundResponseKey(key) = key.unpack() else {
+        for ResponseObjectField { edge, value, .. } in self.object.fields() {
+            let UnpackedResponseEdge::BoundResponseKey(key) = edge.unpack() else {
                 // Bound response keys are always first, anything after are extra fields which
                 // don't need to be serialized.
                 break;

--- a/engine/crates/engine-v2/src/response/shape.rs
+++ b/engine/crates/engine-v2/src/response/shape.rs
@@ -1,5 +1,5 @@
 use id_newtypes::IdRange;
-use schema::{FieldDefinitionId, InterfaceId, ObjectId, ScalarType, UnionId, Wrapping};
+use schema::{FieldDefinitionId, InterfaceId, ObjectId, RequiredFieldId, ScalarType, UnionId, Wrapping};
 
 use crate::operation::FieldId;
 
@@ -23,6 +23,7 @@ pub(crate) struct FieldShape {
     pub expected_key: SafeResponseKey,
     pub edge: ResponseEdge,
     pub id: FieldId,
+    pub required_field_id: Option<RequiredFieldId>,
     pub definition_id: FieldDefinitionId,
     pub shape: Shape,
     pub wrapping: Wrapping,

--- a/engine/crates/engine-v2/src/response/write/deserialize/scalar.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/scalar.rs
@@ -3,7 +3,7 @@ use serde::{de::DeserializeSeed, Deserialize};
 
 use crate::response::ResponseValue;
 
-pub struct ScalarTypeSeed(pub ScalarType);
+pub(crate) struct ScalarTypeSeed(pub ScalarType);
 
 impl<'de> DeserializeSeed<'de> for ScalarTypeSeed {
     type Value = ResponseValue;

--- a/engine/crates/engine-v2/src/response/write/mod.rs
+++ b/engine/crates/engine-v2/src/response/write/mod.rs
@@ -15,9 +15,9 @@ use schema::{ObjectId, Schema};
 use self::deserialize::UpdateSeed;
 
 use super::{
-    ErrorCode, GraphqlError, InitialResponse, InputdResponseObjectSet, OutputResponseObjectSets, Response,
-    ResponseData, ResponseEdge, ResponseObject, ResponseObjectRef, ResponseObjectSet, ResponseObjectSetId,
-    ResponsePath, ResponseValue, UnpackedResponseEdge,
+    value::ResponseObjectField, ErrorCode, GraphqlError, InitialResponse, InputdResponseObjectSet,
+    OutputResponseObjectSets, Response, ResponseData, ResponseEdge, ResponseObject, ResponseObjectRef,
+    ResponseObjectSet, ResponseObjectSetId, ResponsePath, ResponseValue, UnpackedResponseEdge,
 };
 use crate::{
     execution::{ExecutionError, PlanWalker},
@@ -106,7 +106,7 @@ impl ResponseBuilder {
         root_response_object_set: Arc<InputdResponseObjectSet>,
         error: ExecutionError,
         any_edge: ResponseEdge,
-        default_fields: Option<Vec<(ResponseEdge, ResponseValue)>>,
+        default_fields: Option<Vec<ResponseObjectField>>,
     ) {
         let error = GraphqlError::from(error);
         if let Some(fields) = default_fields {
@@ -133,7 +133,7 @@ impl ResponseBuilder {
         &mut self,
         subgraph_response: SubgraphResponse,
         any_edge: ResponseEdge,
-        default_fields: Option<Vec<(ResponseEdge, ResponseValue)>>,
+        default_fields: Option<Vec<ResponseObjectField>>,
     ) -> OutputResponseObjectSets {
         let reservation = &mut self.parts[usize::from(subgraph_response.data.id)];
         assert!(reservation.is_empty(), "Part already has data");
@@ -450,7 +450,7 @@ impl<'resp> ResponseWriter<'resp> {
         self.part().data.push_list(value)
     }
 
-    pub fn update_root_object_with(&self, fields: Vec<(ResponseEdge, ResponseValue)>) {
+    pub fn update_root_object_with(&self, fields: Vec<ResponseObjectField>) {
         self.part().updates[self.index] = UpdateSlot::Fields(fields);
     }
 
@@ -477,6 +477,6 @@ impl<'resp> ResponseWriter<'resp> {
 
 enum UpdateSlot {
     Reserved,
-    Fields(Vec<(ResponseEdge, ResponseValue)>),
+    Fields(Vec<ResponseObjectField>),
     Error,
 }

--- a/engine/crates/engine-v2/src/sources/graphql/request.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/request.rs
@@ -51,7 +51,7 @@ pub(super) async fn execute_subgraph_request<'ctx, 'a, R: Runtime>(
         tracing::error!(target: GRAFBASE_TARGET, "{err}");
     })?;
 
-    tracing::trace!("{}", String::from_utf8_lossy(&fetch_response.bytes));
+    tracing::debug!("{}", String::from_utf8_lossy(&fetch_response.bytes));
 
     let (status, response) = ingest(fetch_response.bytes).inspect_err(|err| {
         let status = SubgraphResponseStatus::InvalidResponseError;

--- a/engine/crates/graphql-mocks/src/slow.rs
+++ b/engine/crates/graphql-mocks/src/slow.rs
@@ -15,18 +15,14 @@ struct Query;
 
 #[Object]
 impl Query {
-    async fn fast_field(&self) -> i64 {
-        100
+    async fn delay(&self, ms: u32) -> u32 {
+        tokio::time::sleep(tokio::time::Duration::from_millis(ms.into())).await;
+        ms
     }
 
-    async fn one_second_field(&self) -> i64 {
-        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-        200
-    }
-
-    async fn five_second_field(&self) -> i64 {
-        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
-        300
+    async fn nullable_delay(&self, ms: u32) -> Option<u32> {
+        tokio::time::sleep(tokio::time::Duration::from_millis(ms.into())).await;
+        Some(ms)
     }
 }
 


### PR DESCRIPTION
Response objects are just a sorted list of `(ResponseEdge, ResponseValue)` with `ResponseEdge = QueryPosition + ResponseKey` to have the right ordering.

When reading the required inputs for a plan I used to create a `ReadSelectionSet` which reads fields from a list of `ResponseObject` through `ResponseEdge` (best-effort guess) and falls back to finding the one with the right `ResponseKey` if I made a mistake. This kind of worked for plans, but wasn't great and not that easy to build.

So instead of relying of trying to determine the right `ResponseEdge` / `ResponseKey`, I associated a `FieldId`s with their `RequiredFieldId` (deduplicated), so now when building their field shapes I can keep track of whether it matches a specific requirements. When writing into the response we copy that id into the response object fields so that we can identify the right field when reading the response.

I hoped to keep this information in field shapes, but required too much work for now

I also adjusted the timeout tests, they were too long for my taste