### PR TITLE
Fix auto-detection of JWKS urls for issuers with subpaths

### DIFF
--- a/engine/crates/parser-sdl/src/rules/auth_directive/providers.rs
+++ b/engine/crates/parser-sdl/src/rules/auth_directive/providers.rs
@@ -77,9 +77,18 @@ impl AuthProvider {
                     )),
                     (Some(issuer), None) => {
                         // issuer must be a URL in this case so that jwks_endpoint can be constructed.
-                        let url = Self::validate_url(issuer, "JWKS provider")?;
-                        const JWKS_PATH: &str = "/.well-known/jwks.json";
-                        let url = url.join(JWKS_PATH).expect("cannot fail");
+                        let mut url = Self::validate_url(issuer, "JWKS provider")?;
+                        const JWKS_PATH_SEGMENTS: [&str; 2] = [".well-known", "jwks.json"];
+
+                        url.path_segments_mut()
+                            .map_err(|_| {
+                                ServerError::new(
+                                    String::from("JWKS provider: encountered a cannot-be-a-base issuer url"),
+                                    None,
+                                )
+                            })?
+                            .extend(JWKS_PATH_SEGMENTS);
+
                         *jwks_endpoint = Some(url.to_string());
                         Ok(())
                     }


### PR DESCRIPTION
# Description

## Fixes

- Fixes the detection of JWKS endpoints for issuers that contain a subpath (https://example.com/issuer)

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
