### PR TITLE
chore(engine-v2): Create response modifier executor with proper dependencies

### DIFF
--- a/engine/crates/engine-v2/id-newtypes/src/lib.rs
+++ b/engine/crates/engine-v2/id-newtypes/src/lib.rs
@@ -35,9 +35,10 @@ macro_rules! debug_display {
 
 #[macro_export]
 macro_rules! index {
-    ($($ty:ident$(<$( $lt:lifetime ),+>)?$(.$field:ident)+[$name:ident] => $output:ty $(|proxy($ty2:ident$(.$field2:ident)+))*,)*) => {
+    // Type<generic/lifetimes>.field[Id] => Output
+    ($($ty:ident $(< $( $ltOrGeneric:tt $( : $bound:tt $(+ $bounds:tt )* )? ),+ >)? $(.$field:ident)+[$name:ident] => $output:ty $(|proxy($ty2:ident$(.$field2:ident)+))*,)*) => {
         $(
-            impl$(<$($lt),+>)? std::ops::Index<$name> for $ty$(<$($lt),+>)? {
+            impl$(< $( $ltOrGeneric $( : $bound $(+ $bounds )* )? ),+ >)? std::ops::Index<$name> for $ty$(< $( $ltOrGeneric  ),+ >)? {
                 type Output = $output;
 
                 fn index(&self, index: $name) -> &Self::Output {
@@ -45,13 +46,13 @@ macro_rules! index {
                 }
             }
 
-            impl$(<$($lt),+>)? std::ops::IndexMut<$name> for $ty$(<$($lt),+>)? {
+            impl$(< $( $ltOrGeneric $( : $bound $(+ $bounds )* )? ),+ >)? std::ops::IndexMut<$name> for $ty$(< $( $ltOrGeneric  ),+ >)? {
                 fn index_mut(&mut self, index: $name) -> &mut Self::Output {
                     &mut self$(.$field)+[usize::from(index)]
                 }
             }
 
-            impl$(<$($lt),+>)? std::ops::Index<$crate::IdRange<$name>> for $ty$(<$($lt),+>)? {
+            impl$(< $( $ltOrGeneric $( : $bound $(+ $bounds )* )? ),+ >)? std::ops::Index<$crate::IdRange<$name>> for $ty$(< $( $ltOrGeneric  ),+ >)? {
                 type Output = [$output];
 
                 fn index(&self, range: $crate::IdRange<$name>) -> &Self::Output {
@@ -62,7 +63,7 @@ macro_rules! index {
                 }
             }
 
-            impl$(<$($lt),+>)? std::ops::IndexMut<$crate::IdRange<$name>> for $ty$(<$($lt),+>)? {
+            impl$(< $( $ltOrGeneric $( : $bound $(+ $bounds )* )? ),+ >)? std::ops::IndexMut<$crate::IdRange<$name>> for $ty$(< $( $ltOrGeneric  ),+ >)? {
                 fn index_mut(&mut self, range: $crate::IdRange<$name>) -> &mut Self::Output {
                     let $crate::IdRange { start, end } = range;
                     let start = usize::from(start);
@@ -92,10 +93,10 @@ macro_rules! index {
 
 #[macro_export]
 macro_rules! NonZeroU32 {
-    ($($ty:ident$(<$( $lt:lifetime ),+>)?$(.$field:ident)+[$name:ident] => $output:ty $(|max($max:expr))? $(|proxy($ty2:ident$(.$field2:ident)+))* ,)*) => {
+    ($($ty:ident$(< $( $ltOrGeneric:tt $( : $bound:tt $(+ $bounds:tt )* )? ),+ >)?$(.$field:ident)+[$name:ident] => $output:ty $(|max($max:expr))? $(|proxy($ty2:ident$(.$field2:ident)+))* ,)*) => {
         $(
             $crate::NonZeroU32! { $name $(|max($max))?, }
-            $crate::index!{ $ty$(<$($lt),+>)?$(.$field)+[$name] => $output $(|proxy($ty2$(.$field2)+))*, }
+            $crate::index!{ $ty$(< $( $ltOrGeneric $( : $bound $(+ $bounds )* )? ),+ >)?$(.$field)+[$name] => $output $(|proxy($ty2$(.$field2)+))*, }
         )*
     };
     ($($name:ident $(|max($max:expr))?,)*) => {
@@ -134,10 +135,10 @@ macro_rules! NonZeroU32 {
 
 #[macro_export]
 macro_rules! NonZeroU16 {
-    ($($ty:ident$(<$( $lt:lifetime ),+>)?$(.$field:ident)+[$name:ident] => $output:ty $(| $(max($max:expr))?)? $(|proxy($ty2:ident$(.$field2:ident)+))*,)*) => {
+    ($($ty:ident$(< $( $ltOrGeneric:tt $( : $bound:tt $(+ $bounds:tt )* )? ),+ >)?$(.$field:ident)+[$name:ident] => $output:ty $(| $(max($max:expr))?)? $(|proxy($ty2:ident$(.$field2:ident)+))*,)*) => {
         $(
             $crate::NonZeroU16! { $name $(|max($max))?, }
-            $crate::index!{ $ty$(<$($lt),+>)?$(.$field)+[$name] => $output $(|proxy($ty2$(.$field2)+))*, }
+            $crate::index!{ $ty$(< $( $ltOrGeneric $( : $bound $(+ $bounds )* )? ),+ >)?$(.$field)+[$name] => $output $(|proxy($ty2$(.$field2)+))*, }
         )*
     };
     ($($name:ident $(|max($max:expr))?,)*) => {
@@ -176,10 +177,10 @@ macro_rules! NonZeroU16 {
 
 #[macro_export]
 macro_rules! U8 {
-    ($($ty:ident$(<$( $lt:lifetime ),+>)?$(.$field:ident)+[$name:ident] => $output:ty $(| $(max($max:expr))?)? $(|proxy($ty2:ident$(.$field2:ident)+))*,)*) => {
+    ($($ty:ident$(< $( $ltOrGeneric:tt $( : $bound:tt $(+ $bounds:tt )* )? ),+ >)?$(.$field:ident)+[$name:ident] => $output:ty $(| $(max($max:expr))?)? $(|proxy($ty2:ident$(.$field2:ident)+))*,)*) => {
         $(
             $crate::NonZeroU16! { $name $(|max($max))?, }
-            $crate::index!{ $ty$(<$($lt),+>)?$(.$field)+[$name] => $output $(|proxy($ty2$(.$field2)+))*, }
+            $crate::index!{ $ty$(< $( $ltOrGeneric $( : $bound $(+ $bounds )* )? ),+ >)?$(.$field)+[$name] => $output $(|proxy($ty2$(.$field2)+))*, }
         )*
     };
     ($($name:ident $(|max($max:expr))?,)*) => {

--- a/engine/crates/engine-v2/src/execution/ids.rs
+++ b/engine/crates/engine-v2/src/execution/ids.rs
@@ -1,8 +1,9 @@
 use crate::response::GraphqlError;
 
-use super::{ExecutableOperation, ExecutionPlan};
+use super::{ExecutableOperation, ExecutionPlan, ResponseModifierExecutor};
 
 id_newtypes::NonZeroU16! {
     ExecutableOperation.execution_plans[ExecutionPlanId] => ExecutionPlan,
     ExecutableOperation.query_modifications.errors[ErrorId] => GraphqlError,
+    ExecutableOperation.response_modifier_executors[ResponseModifierExecutorId] => ResponseModifierExecutor,
 }

--- a/engine/crates/engine-v2/src/execution/planner/query_modifier.rs
+++ b/engine/crates/engine-v2/src/execution/planner/query_modifier.rs
@@ -3,7 +3,9 @@ use schema::Schema;
 
 use crate::{
     execution::{ErrorId, PlanningResult, PreExecutionContext, QueryModifications},
-    operation::{ImpactedFieldId, OperationWalker, PreparedOperation, QueryModifierId, QueryModifierRule, Variables},
+    operation::{
+        OperationWalker, PreparedOperation, QueryModifierId, QueryModifierImpactedFieldId, QueryModifierRule, Variables,
+    },
     response::{ConcreteObjectShapeId, ErrorCode, FieldShapeId, GraphqlError},
     Runtime,
 };
@@ -157,7 +159,7 @@ where
     fn handle_modifier_resulted_in_error(
         &mut self,
         id: QueryModifierId,
-        impacted_fields: IdRange<ImpactedFieldId>,
+        impacted_fields: IdRange<QueryModifierImpactedFieldId>,
         error: GraphqlError,
     ) {
         let error_id = self.push_error(error);

--- a/engine/crates/engine-v2/src/execution/state.rs
+++ b/engine/crates/engine-v2/src/execution/state.rs
@@ -34,7 +34,7 @@ impl<'ctx> OperationExecutionState<'ctx> {
         Self {
             schema,
             operation,
-            response_object_sets: vec![None; operation.response_blueprint.response_object_set_count],
+            response_object_sets: vec![None; operation.response_blueprint.response_object_sets_to_type.len()],
             plan_dependencies_count: operation.execution_plans.iter().map(|plan| plan.parent_count).collect(),
         }
     }

--- a/engine/crates/engine-v2/src/execution/walkers/mod.rs
+++ b/engine/crates/engine-v2/src/execution/walkers/mod.rs
@@ -3,7 +3,7 @@ use schema::SchemaWalker;
 use crate::{
     operation::{
         LogicalPlanId, LogicalPlanResponseBlueprint, OperationWalker, PreparedOperation, QueryInputValueId,
-        QueryInputValueWalker, ResponseBlueprint, ResponseModifier,
+        QueryInputValueWalker, ResponseBlueprint,
     },
     response::ResponseKeys,
 };
@@ -106,10 +106,5 @@ type LogicalPlanWalker<'a> = PlanWalker<'a, LogicalPlanId, ()>;
 impl<'a> LogicalPlanWalker<'a> {
     pub fn response_blueprint(&self) -> &LogicalPlanResponseBlueprint {
         &self.operation.response_blueprint[self.item]
-    }
-
-    #[allow(unused)]
-    pub fn response_modifiers(&self) -> impl Iterator<Item = &'a ResponseModifier> + 'a {
-        self.operation[self.response_blueprint().response_modifiers_ids].iter()
     }
 }

--- a/engine/crates/engine-v2/src/operation/bind/field.rs
+++ b/engine/crates/engine-v2/src/operation/bind/field.rs
@@ -62,7 +62,6 @@ impl<'schema, 'p> Binder<'schema, 'p> {
 
         let field_id = FieldId::from(self.fields.len());
         let argument_ids = self.bind_field_arguments(definition, field_id, location, &field.arguments)?;
-        let subject_to_response_modifier_rules = self.generate_field_modifiers(field_id, argument_ids, definition);
         self.fields.push(Field::Query(QueryField {
             bound_response_key,
             location,
@@ -70,9 +69,9 @@ impl<'schema, 'p> Binder<'schema, 'p> {
             argument_ids,
             selection_set_id,
             parent_selection_set_id,
-            subject_to_response_modifier_rules,
         }));
 
+        self.generate_field_modifiers(field_id, argument_ids, definition);
         Ok(field_id)
     }
 

--- a/engine/crates/engine-v2/src/operation/ids.rs
+++ b/engine/crates/engine-v2/src/operation/ids.rs
@@ -1,6 +1,6 @@
 use super::{
     Field, FieldArgument, LogicalPlan, LogicalPlanResponseBlueprint, Operation, OperationPlan, PreparedOperation,
-    QueryModifier, ResponseBlueprint, ResponseModifier, ResponseModifierRule, SelectionSet, VariableDefinition,
+    QueryModifier, ResponseBlueprint, ResponseModifier, SelectionSet, VariableDefinition,
 };
 
 id_newtypes::NonZeroU16! {
@@ -8,14 +8,14 @@ id_newtypes::NonZeroU16! {
     Operation.variable_definitions[VariableDefinitionId] => VariableDefinition,
     Operation.fields[FieldId] => Field,
     Operation.field_arguments[FieldArgumentId] => FieldArgument,
-    Operation.fields_subject_to_response_modifier_rules[SubjectToResponseModifierRuleId] => ResponseModifierRuleId,
-    Operation.response_modifier_rules[ResponseModifierRuleId] => ResponseModifierRule,
+    Operation.response_modifiers[ResponseModifierId] => ResponseModifier,
+    Operation.response_modifier_impacted_fields[ResponseModifierImpactedFieldId] => FieldId,
     Operation.query_modifiers[QueryModifierId] => QueryModifier,
-    Operation.query_modifiers_impacted_fields[ImpactedFieldId] => FieldId,
+    Operation.query_modifier_impacted_fields[QueryModifierImpactedFieldId] => FieldId,
     OperationPlan.logical_plans[LogicalPlanId] => LogicalPlan | proxy(PreparedOperation.plan),
-    ResponseBlueprint.logical_plan_response_modifiers[ResponseModifierId] => ResponseModifier | proxy(PreparedOperation.response_blueprint),
 }
 
 id_newtypes::index! {
+    OperationPlan.field_to_logical_plan_id[FieldId] => LogicalPlanId,
     ResponseBlueprint.logical_plan_to_blueprint[LogicalPlanId] => LogicalPlanResponseBlueprint,
 }

--- a/engine/crates/engine-v2/src/operation/logical_planner/selection_set.rs
+++ b/engine/crates/engine-v2/src/operation/logical_planner/selection_set.rs
@@ -83,6 +83,9 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
 
         let solved_requirements = self.build_solved_requirements(planned_selection_set);
         if !solved_requirements.is_empty() {
+            // At least one child or response modifier will read something from this selection set
+            self.selection_set_to_objects_must_be_tracked
+                .set(selection_set_id, true);
             self.planner
                 .solved_requirements
                 .push((selection_set_id, solved_requirements));

--- a/engine/crates/engine-v2/src/operation/modifier.rs
+++ b/engine/crates/engine-v2/src/operation/modifier.rs
@@ -1,14 +1,12 @@
 use id_newtypes::IdRange;
-use schema::{AuthorizedDirectiveId, Definition, EntityId, FieldDefinitionId, RequiredScopesId};
+use schema::{AuthorizedDirectiveId, Definition, FieldDefinitionId, RequiredScopesId};
 
-use crate::response::ResponseObjectSetId;
-
-use super::{FieldArgumentId, ImpactedFieldId, ResponseModifierRuleId};
+use super::{FieldArgumentId, QueryModifierImpactedFieldId, ResponseModifierImpactedFieldId};
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct QueryModifier {
     pub rule: QueryModifierRule,
-    pub impacted_fields: IdRange<ImpactedFieldId>,
+    pub impacted_fields: IdRange<QueryModifierImpactedFieldId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -26,14 +24,13 @@ pub(crate) enum QueryModifierRule {
     },
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct ResponseModifier {
-    pub rule_id: ResponseModifierRuleId,
-    pub response_object_set_id: ResponseObjectSetId,
-    pub type_condition: EntityId,
+    pub rule: ResponseModifierRule,
+    pub impacted_fields: IdRange<ResponseModifierImpactedFieldId>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) enum ResponseModifierRule {
     AuthorizedField {
         directive_id: AuthorizedDirectiveId,

--- a/engine/crates/engine-v2/src/operation/selection_set.rs
+++ b/engine/crates/engine-v2/src/operation/selection_set.rs
@@ -3,7 +3,7 @@ use schema::{Definition, EntityId, FieldDefinitionId, InputValueDefinitionId, In
 
 use crate::response::{BoundResponseKey, ResponseEdge, ResponseKey};
 
-use super::{FieldArgumentId, FieldId, Location, QueryInputValueId, SelectionSetId, SubjectToResponseModifierRuleId};
+use super::{FieldArgumentId, FieldId, Location, QueryInputValueId, SelectionSetId};
 
 #[derive(Default, serde::Serialize, serde::Deserialize)]
 pub(crate) struct SelectionSet {
@@ -104,7 +104,6 @@ pub struct QueryField {
     pub argument_ids: IdRange<FieldArgumentId>,
     pub selection_set_id: Option<SelectionSetId>,
     pub parent_selection_set_id: SelectionSetId,
-    pub subject_to_response_modifier_rules: IdRange<SubjectToResponseModifierRuleId>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -189,17 +188,6 @@ impl Field {
                 parent_selection_set_id,
                 ..
             }) => *parent_selection_set_id,
-        }
-    }
-
-    pub fn subject_to_response_modifier_rules(&self) -> IdRange<SubjectToResponseModifierRuleId> {
-        match self {
-            Field::TypeName(_) => IdRange::empty(),
-            Field::Query(QueryField {
-                subject_to_response_modifier_rules,
-                ..
-            }) => *subject_to_response_modifier_rules,
-            Field::Extra(_) => IdRange::empty(),
         }
     }
 }

--- a/engine/crates/engine-v2/src/operation/walkers/field.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/field.rs
@@ -2,7 +2,7 @@ use schema::{FieldDefinitionWalker, RequiredField};
 
 use super::{FieldArgumentsWalker, OperationWalker, SelectionSetWalker};
 use crate::{
-    operation::{ExtraField, Field, FieldId, Location, QueryField, ResponseModifierRuleId},
+    operation::{ExtraField, Field, FieldId, Location, QueryField},
     response::{ResponseEdge, ResponseKey},
 };
 
@@ -26,12 +26,6 @@ impl<'a> FieldWalker<'a> {
 
     pub fn response_key(&self) -> ResponseKey {
         self.as_ref().response_key()
-    }
-
-    pub fn subject_to_response_modifier_rules(&self) -> impl Iterator<Item = ResponseModifierRuleId> + 'a {
-        self.operation[self.as_ref().subject_to_response_modifier_rules()]
-            .iter()
-            .copied()
     }
 
     pub fn response_key_str(&self) -> &'a str {


### PR DESCRIPTION
So adjusting the `ResponseModifier` creation to be the same as the `QueryModiifer`, used a different data layout initially, but was a mistake. So a modifier is roughly just a rule (which `@authorized` directive basically) and a list of impacted fields.

Now I'm defining whenever a SelectionSet object needs to be tracked in the "logical planning" phase, the "shape" phase then create an appropriate `ResponseObjectSetId` whenever necessary. Had to do this because now a ResponseModifier points to its impacted fields (where we need to track objects), rather than the opposite.

In the execution planning phase, I'm building `ResponseModifierExecutor` which will do the actual modification if the field is still queried after the query modifications. This is also where I define all the dependencies between execution plans and response modifiers. I define all of those by relying on the input & output fields of each of them.
