### PR TITLE
feat: entity caching for top level fields

### DIFF
--- a/engine/crates/engine-config-builder/src/lib.rs
+++ b/engine/crates/engine-config-builder/src/lib.rs
@@ -45,6 +45,7 @@ pub fn build_config(config: &FederatedGraphConfig, graph: FederatedGraph) -> Ver
         disable_introspection: config.disable_introspection,
         rate_limit: context.rate_limit,
         timeout: config.timeout,
+        enable_entity_caching: config.enable_entity_caching,
     })
 }
 
@@ -175,6 +176,7 @@ impl<'a> BuildContext<'a> {
                 header_rules,
                 rate_limit,
                 timeout,
+                entity_cache_ttl,
                 ..
             } = config;
 
@@ -197,6 +199,7 @@ impl<'a> BuildContext<'a> {
                     websocket_url,
                     rate_limit,
                     timeout: *timeout,
+                    entity_cache_ttl: *entity_cache_ttl,
                 },
             );
         }

--- a/engine/crates/engine-v2/config/src/lib.rs
+++ b/engine/crates/engine-v2/config/src/lib.rs
@@ -142,6 +142,7 @@ impl VersionedConfig {
                     disable_introspection,
                     rate_limit: Default::default(),
                     timeout: None,
+                    enable_entity_caching: false,
                 }
             }
             VersionedConfig::V5(latest) => latest,

--- a/engine/crates/engine-v2/config/src/v2/mod.rs
+++ b/engine/crates/engine-v2/config/src/v2/mod.rs
@@ -52,6 +52,9 @@ pub struct SubgraphConfig {
     pub rate_limit: Option<GraphRateLimit>,
     #[serde(default)]
     pub timeout: Option<Duration>,
+
+    #[serde(default)]
+    pub entity_cache_ttl: Option<Duration>,
 }
 
 /// A header that should be sent to a subgraph

--- a/engine/crates/engine-v2/config/src/v5.rs
+++ b/engine/crates/engine-v2/config/src/v5.rs
@@ -53,6 +53,9 @@ pub struct Config {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout: Option<Duration>,
+
+    #[serde(default)]
+    pub enable_entity_caching: bool,
 }
 
 impl Config {
@@ -70,6 +73,7 @@ impl Config {
             disable_introspection: Default::default(),
             rate_limit: Default::default(),
             timeout: None,
+            enable_entity_caching: false,
         }
     }
 
@@ -178,6 +182,7 @@ mod tests {
             disable_introspection: Default::default(),
             rate_limit: Default::default(),
             timeout: None,
+            enable_entity_caching: false,
         };
 
         insta::with_settings!({sort_maps => true}, {
@@ -200,6 +205,7 @@ mod tests {
               },
               "default_header_rules": [],
               "disable_introspection": false,
+              "enable_entity_caching": false,
               "graph": {
                 "authorized_directives": [],
                 "directives": [],

--- a/engine/crates/engine-v2/schema/src/builder/external_sources.rs
+++ b/engine/crates/engine-v2/schema/src/builder/external_sources.rs
@@ -26,6 +26,7 @@ impl ExternalDataSources {
                         websocket_url,
                         headers,
                         timeout,
+                        entity_cache_ttl,
                         ..
                     }) => sources::graphql::GraphqlEndpoint {
                         name,
@@ -35,6 +36,7 @@ impl ExternalDataSources {
                             .map(|url| ctx.urls.insert(url::Url::parse(&config[url]).expect("valid url"))),
                         header_rules: headers.into_iter().map(Into::into).collect(),
                         timeout: timeout.unwrap_or(DEFAULT_SUBGRAPH_TIMEOUT),
+                        entity_cache_ttl: entity_cache_ttl.unwrap_or(DEFAULT_ENTITY_CACHE_TTL),
                     },
 
                     None => sources::graphql::GraphqlEndpoint {
@@ -44,6 +46,7 @@ impl ExternalDataSources {
                         websocket_url: None,
                         header_rules: Vec::new(),
                         timeout: DEFAULT_SUBGRAPH_TIMEOUT,
+                        entity_cache_ttl: DEFAULT_ENTITY_CACHE_TTL,
                     },
                 }
             })
@@ -55,3 +58,4 @@ impl ExternalDataSources {
 }
 
 const DEFAULT_SUBGRAPH_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_ENTITY_CACHE_TTL: Duration = Duration::from_secs(60);

--- a/engine/crates/engine-v2/schema/src/builder/mod.rs
+++ b/engine/crates/engine-v2/schema/src/builder/mod.rs
@@ -229,6 +229,7 @@ impl BuildContext {
                 auth_config: take(&mut config.auth),
                 operation_limits: take(&mut config.operation_limits),
                 disable_introspection: config.disable_introspection,
+                enable_entity_caching: config.enable_entity_caching,
             },
         })
     }

--- a/engine/crates/engine-v2/schema/src/lib.rs
+++ b/engine/crates/engine-v2/schema/src/lib.rs
@@ -71,6 +71,8 @@ pub struct Settings {
     pub auth_config: Option<config::latest::AuthConfig>,
     pub operation_limits: config::latest::OperationLimits,
     pub disable_introspection: bool,
+
+    pub enable_entity_caching: bool,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/engine/crates/engine-v2/schema/src/sources/graphql.rs
+++ b/engine/crates/engine-v2/schema/src/sources/graphql.rs
@@ -18,6 +18,7 @@ pub struct GraphqlEndpoint {
     pub(crate) websocket_url: Option<UrlId>,
     pub(crate) header_rules: Vec<HeaderRuleId>,
     pub(crate) timeout: Duration,
+    pub(crate) entity_cache_ttl: Duration,
 }
 
 id_newtypes::U8! {
@@ -147,6 +148,10 @@ impl<'a> GraphqlEndpointWalker<'a> {
 
     pub fn header_rules(self) -> impl Iterator<Item = HeaderRuleWalker<'a>> {
         self.as_ref().header_rules.iter().map(move |id| self.walk(*id))
+    }
+
+    pub fn entity_cache_ttl(self) -> Duration {
+        self.as_ref().entity_cache_ttl
     }
 }
 

--- a/engine/crates/engine-v2/src/sources/graphql/federation.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/federation.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use grafbase_telemetry::span::subgraph::SubgraphRequestSpan;
 use runtime::fetch::FetchRequest;
 use schema::sources::graphql::{FederationEntityResolverWalker, GraphqlEndpointId};
@@ -101,7 +102,7 @@ impl FederationEntityPreparedExecutor {
                 subgraph_name: subgraph.name(),
                 timeout: subgraph.timeout(),
             },
-            move |bytes| {
+            move |bytes: Bytes| {
                 let response = subgraph_response.as_mut();
                 let status = GraphqlResponseSeed::new(
                     EntitiesDataSeed {

--- a/engine/crates/gateway-v2/auth/src/jwt.rs
+++ b/engine/crates/gateway-v2/auth/src/jwt.rs
@@ -100,7 +100,11 @@ impl JwtProvider {
 
                 let bytes = Vec::from(bytes);
                 self.kv
-                    .put(&self.key, bytes.clone(), Some(self.config.jwks.poll_interval))
+                    .put(
+                        &self.key,
+                        Cow::Borrowed(bytes.as_ref()),
+                        Some(self.config.jwks.poll_interval),
+                    )
                     .await
                     .inspect_err(|err| {
                         tracing::error!("Could not store JWKS metadata in KV: {err}");

--- a/engine/crates/integration-tests/src/federation/builder.rs
+++ b/engine/crates/integration-tests/src/federation/builder.rs
@@ -24,6 +24,7 @@ pub struct EngineV2Builder {
     runtime: TestRuntime,
     header_rules: Vec<SubgraphHeaderRule>,
     timeout: Option<Duration>,
+    enable_entity_caching: bool,
 }
 
 struct TestSubgraph {
@@ -41,6 +42,7 @@ pub trait EngineV2Ext {
             header_rules: Vec::new(),
             timeout: None,
             runtime: TestRuntime::default(),
+            enable_entity_caching: false,
         }
     }
 }
@@ -106,6 +108,11 @@ impl EngineV2Builder {
 
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = Some(timeout);
+        self
+    }
+
+    pub fn with_entity_caching(mut self) -> Self {
+        self.enable_entity_caching = true;
         self
     }
 
@@ -183,6 +190,7 @@ impl EngineV2Builder {
 
         federated_graph_config.timeout = self.timeout;
         federated_graph_config.header_rules.extend(self.header_rules);
+        federated_graph_config.enable_entity_caching = self.enable_entity_caching;
 
         (
             engine_config_builder::build_config(&federated_graph_config, graph).into_latest(),

--- a/engine/crates/integration-tests/tests/federation/entity_caching.rs
+++ b/engine/crates/integration-tests/tests/federation/entity_caching.rs
@@ -1,0 +1,141 @@
+use std::time::Duration;
+
+use engine_v2::Engine;
+use graphql_mocks::{FakeFederationProductsSchema, MockGraphQlServer};
+use integration_tests::{federation::EngineV2Ext, runtime};
+
+#[test]
+fn root_level_entity_caching() {
+    let response = runtime().block_on(async move {
+        let mut products = MockGraphQlServer::new(FakeFederationProductsSchema).await;
+
+        let engine = Engine::builder()
+            .with_subgraph("products", &products)
+            .with_entity_caching()
+            .build()
+            .await;
+
+        const QUERY: &str = r"query { topProducts { upc name price } }";
+
+        let first_response = engine.execute(QUERY).await.into_data();
+        let second_response = engine.execute(QUERY).await.into_data();
+
+        assert_eq!(first_response, second_response);
+
+        assert_eq!(products.drain_requests().await.count(), 1);
+
+        first_response
+    });
+
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "topProducts": [
+        {
+          "upc": "top-1",
+          "name": "Trilby",
+          "price": 11
+        },
+        {
+          "upc": "top-2",
+          "name": "Fedora",
+          "price": 22
+        },
+        {
+          "upc": "top-3",
+          "name": "Boater",
+          "price": 33
+        },
+        {
+          "upc": "top-4",
+          "name": "Jeans",
+          "price": 44
+        },
+        {
+          "upc": "top-5",
+          "name": "Pink Jeans",
+          "price": 55
+        }
+      ]
+    }
+    "###);
+}
+
+#[test]
+fn different_queries_dont_share_cache() {
+    runtime().block_on(async move {
+        let mut products = MockGraphQlServer::new(FakeFederationProductsSchema).await;
+
+        let engine = Engine::builder()
+            .with_subgraph("products", &products)
+            .with_entity_caching()
+            .build()
+            .await;
+
+        let first_response = engine.execute("query { topProducts { upc } }").await.into_data();
+        let second_response = engine.execute("query { topProducts { name } }").await.into_data();
+
+        assert!(first_response != second_response);
+
+        assert_eq!(products.drain_requests().await.count(), 2);
+    });
+}
+
+#[test]
+fn test_cache_expiry() {
+    let response = runtime().block_on(async move {
+        let mut products = MockGraphQlServer::new(FakeFederationProductsSchema).await;
+
+        let engine = Engine::builder()
+            .with_subgraph("products", &products)
+            .with_supergraph_config(r#"extend schema @subgraph(name: "products", entityCacheTtl: "1s")"#)
+            .with_entity_caching()
+            .build()
+            .await;
+
+        const QUERY: &str = r"query { topProducts { upc name price } }";
+
+        let first_response = engine.execute(QUERY).await.into_data();
+
+        tokio::time::sleep(Duration::from_millis(1100)).await;
+
+        let second_response = engine.execute(QUERY).await.into_data();
+
+        assert_eq!(first_response, second_response);
+
+        assert_eq!(products.drain_requests().await.count(), 2);
+
+        first_response
+    });
+
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "topProducts": [
+        {
+          "upc": "top-1",
+          "name": "Trilby",
+          "price": 11
+        },
+        {
+          "upc": "top-2",
+          "name": "Fedora",
+          "price": 22
+        },
+        {
+          "upc": "top-3",
+          "name": "Boater",
+          "price": 33
+        },
+        {
+          "upc": "top-4",
+          "name": "Jeans",
+          "price": 44
+        },
+        {
+          "upc": "top-5",
+          "name": "Pink Jeans",
+          "price": 55
+        }
+      ]
+    }
+    "###);
+}

--- a/engine/crates/integration-tests/tests/federation/mod.rs
+++ b/engine/crates/integration-tests/tests/federation/mod.rs
@@ -1,6 +1,7 @@
 mod apq;
 mod auth;
 mod basic;
+mod entity_caching;
 mod hooks;
 mod introspection;
 mod issues;

--- a/engine/crates/jwt-verifier/src/lib.rs
+++ b/engine/crates/jwt-verifier/src/lib.rs
@@ -475,7 +475,7 @@ impl<'a> Client<'a> {
             cache
                 .put(
                     &key,
-                    serde_json::to_vec(&jwk).expect("serializable"),
+                    Cow::Owned(serde_json::to_vec(&jwk).expect("serializable")),
                     Some(Duration::from_secs(JWKS_CACHE_TTL)),
                 )
                 .await

--- a/engine/crates/parser-sdl/src/federation.rs
+++ b/engine/crates/parser-sdl/src/federation.rs
@@ -19,6 +19,7 @@ pub struct FederatedGraphConfig {
     pub disable_introspection: bool,
     pub rate_limit: Option<RateLimitConfig>,
     pub timeout: Option<Duration>,
+    pub enable_entity_caching: bool,
 }
 
 /// Configuration for a subgraph of the current federated graph
@@ -46,6 +47,9 @@ pub struct SubgraphConfig {
 
     /// Timeouts to apply to subgraph requests
     pub timeout: Option<Duration>,
+
+    /// The ttl of entity cache entries for this subgraph
+    pub entity_cache_ttl: Option<Duration>,
 }
 
 impl From<(String, ConnectorHeaderValue)> for SubgraphHeaderRule {

--- a/engine/crates/parser-sdl/src/rules/all_subgraphs_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/all_subgraphs_directive.rs
@@ -126,6 +126,7 @@ mod tests {
                         ],
                         rate_limit: None,
                         timeout: None,
+                        entity_cache_ttl: None,
                     },
                 },
                 header_rules: [
@@ -171,6 +172,7 @@ mod tests {
                 disable_introspection: false,
                 rate_limit: None,
                 timeout: None,
+                enable_entity_caching: false,
             },
         )
         "###);

--- a/engine/crates/parser-sdl/src/rules/subgraph_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/subgraph_directive.rs
@@ -34,6 +34,10 @@ pub struct SubgraphDirective {
     /// Timeout for requests to that subgraph
     #[serde(default, deserialize_with = "duration_str::deserialize_option_duration")]
     timeout: Option<std::time::Duration>,
+
+    /// Timeout for requests to that subgraph
+    #[serde(default, deserialize_with = "duration_str::deserialize_option_duration")]
+    entity_cache_ttl: Option<std::time::Duration>,
 }
 
 impl Directive for SubgraphDirective {
@@ -64,6 +68,11 @@ impl Directive for SubgraphDirective {
           Timeout for requests to that subgraph
           """
           timeout: String
+
+          """
+          Timeout for requests to that subgraph
+          """
+          entityCacheTtl: String
         ) on SCHEMA
 
         input SubgraphHeader {
@@ -129,6 +138,10 @@ impl Visitor<'_> for SubgraphDirectiveVisitor {
 
             if let Some(url) = directive.development_url {
                 subgraph.development_url = Some(url.to_string())
+            }
+
+            if let Some(ttl) = directive.entity_cache_ttl {
+                subgraph.entity_cache_ttl = Some(ttl)
             }
 
             subgraph.header_rules.extend(
@@ -200,6 +213,7 @@ mod tests {
                         ],
                         rate_limit: None,
                         timeout: None,
+                        entity_cache_ttl: None,
                     },
                     "Reviews": SubgraphConfig {
                         name: "Reviews",
@@ -215,6 +229,7 @@ mod tests {
                         ],
                         rate_limit: None,
                         timeout: None,
+                        entity_cache_ttl: None,
                     },
                 },
                 header_rules: [],
@@ -232,6 +247,7 @@ mod tests {
                 disable_introspection: false,
                 rate_limit: None,
                 timeout: None,
+                enable_entity_caching: false,
             },
         )
         "###);

--- a/engine/crates/runtime-local/src/kv.rs
+++ b/engine/crates/runtime-local/src/kv.rs
@@ -1,5 +1,6 @@
 use runtime::kv::{KvResult, KvStore, KvStoreInner};
 use std::{
+    borrow::Cow,
     collections::{hash_map::Entry, HashMap},
     sync::Mutex,
     time::{Duration, Instant},
@@ -48,12 +49,12 @@ impl KvStoreInner for InMemoryKvStore {
     }
 
     #[allow(clippy::panic)]
-    async fn put(&self, name: &str, bytes: Vec<u8>, expiration_ttl: Option<Duration>) -> KvResult<()> {
+    async fn put(&self, name: &str, bytes: Cow<'_, [u8]>, expiration_ttl: Option<Duration>) -> KvResult<()> {
         let mut inner = self.inner.lock().unwrap();
         inner.insert(
             name.to_string(),
             CacheValue {
-                data: bytes,
+                data: bytes.into_owned(),
                 expires_at: expiration_ttl.map(|ttl| Instant::now() + ttl),
             },
         );

--- a/engine/crates/runtime-noop/src/kv.rs
+++ b/engine/crates/runtime-noop/src/kv.rs
@@ -1,5 +1,5 @@
 /// FIXME: Only here because of jwt-verifier, to be refactored with auth
-use std::time::Duration;
+use std::{borrow::Cow, time::Duration};
 
 use runtime::kv::{KvError, KvResult, KvStoreInner};
 
@@ -17,7 +17,7 @@ impl KvStoreInner for NoopKvStore {
         Err(KvError::Kv("Not available".into()))
     }
 
-    async fn put(&self, _name: &str, _bytes: Vec<u8>, _expiration_ttl: Option<Duration>) -> KvResult<()> {
+    async fn put(&self, _name: &str, _bytes: Cow<'_, [u8]>, _expiration_ttl: Option<Duration>) -> KvResult<()> {
         Ok(())
     }
 }

--- a/engine/crates/runtime/src/kv.rs
+++ b/engine/crates/runtime/src/kv.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{borrow::Cow, sync::Arc, time::Duration};
 
 #[derive(Debug, thiserror::Error)]
 pub enum KvError {
@@ -46,7 +46,7 @@ impl KvStore {
         expiration_ttl: Option<Duration>,
     ) -> KvResult<()> {
         let bytes = serde_json::to_vec(value)?;
-        self.put(name, bytes, expiration_ttl).await
+        self.put(name, Cow::Owned(bytes), expiration_ttl).await
     }
 }
 
@@ -70,5 +70,5 @@ pub trait KvStoreInner: Send + Sync {
     async fn get(&self, name: &str, cache_ttl: Option<Duration>) -> KvResult<Option<Vec<u8>>>;
 
     /// Put an entry into the TTL store, with an optional expiry.
-    async fn put(&self, name: &str, bytes: Vec<u8>, expiration_ttl: Option<Duration>) -> KvResult<()>;
+    async fn put(&self, name: &str, bytes: Cow<'_, [u8]>, expiration_ttl: Option<Duration>) -> KvResult<()>;
 }

--- a/gateway/crates/federated-server/src/config.rs
+++ b/gateway/crates/federated-server/src/config.rs
@@ -848,7 +848,7 @@ mod tests {
     #[test]
     fn header_rename_duplicate() {
         let input = indoc! {r#"
-            [[headers]]     
+            [[headers]]
             rule = "rename_duplicate"
             name = "content-type"
             default = "foo"
@@ -881,7 +881,7 @@ mod tests {
     #[test]
     fn header_forward_static() {
         let input = indoc! {r#"
-            [[headers]]     
+            [[headers]]
             rule = "forward"
             name = "content-type"
         "#};
@@ -908,7 +908,7 @@ mod tests {
     #[test]
     fn header_forward_invalid_name() {
         let input = indoc! {r#"
-            [[headers]]     
+            [[headers]]
             rule = "forward"
             name = "Authoriz🎠"
         "#};
@@ -918,8 +918,8 @@ mod tests {
         insta::assert_snapshot!(&error.to_string(), @r###"
         TOML parse error at line 1, column 1
           |
-        1 | [[headers]]     
-          | ^^^^^^^^^^^^^^^^
+        1 | [[headers]]
+          | ^^^^^^^^^^^
         the byte at index 8 is not ASCII
         "###);
     }
@@ -927,11 +927,11 @@ mod tests {
     #[test]
     fn header_forward_two_headers_in_written_order() {
         let input = indoc! {r#"
-            [[headers]]     
+            [[headers]]
             rule = "forward"
             name = "content-type"
 
-            [[headers]]     
+            [[headers]]
             rule = "forward"
             name = "accept"
         "#};
@@ -969,7 +969,7 @@ mod tests {
     #[test]
     fn header_forward_pattern() {
         let input = indoc! {r#"
-            [[headers]]     
+            [[headers]]
             rule = "forward"
             pattern = "^content-type-*"
         "#};
@@ -996,7 +996,7 @@ mod tests {
     #[test]
     fn header_forward_invalid_pattern() {
         let input = indoc! {r#"
-            [[headers]]     
+            [[headers]]
             rule = "forward"
             pattern = "foo(bar"
         "#};
@@ -1006,8 +1006,8 @@ mod tests {
         insta::assert_snapshot!(&error.to_string(), @r###"
         TOML parse error at line 1, column 1
           |
-        1 | [[headers]]     
-          | ^^^^^^^^^^^^^^^^
+        1 | [[headers]]
+          | ^^^^^^^^^^^
         regex parse error:
             foo(bar
                ^
@@ -1018,7 +1018,7 @@ mod tests {
     #[test]
     fn header_forward_default() {
         let input = indoc! {r#"
-            [[headers]]     
+            [[headers]]
             rule = "forward"
             name = "content-type"
             default = "application/json"
@@ -1050,7 +1050,7 @@ mod tests {
     #[test]
     fn header_forward_invalid_default() {
         let input = indoc! {r#"
-            [[headers]]     
+            [[headers]]
             rule = "forward"
             name = "content-type"
             default = "application/json🎠"
@@ -1061,8 +1061,8 @@ mod tests {
         insta::assert_snapshot!(&error.to_string(), @r###"
         TOML parse error at line 1, column 1
           |
-        1 | [[headers]]     
-          | ^^^^^^^^^^^^^^^^
+        1 | [[headers]]
+          | ^^^^^^^^^^^
         the byte at index 16 is not ASCII
         "###);
     }
@@ -1070,7 +1070,7 @@ mod tests {
     #[test]
     fn header_forward_rename() {
         let input = indoc! {r#"
-            [[headers]]     
+            [[headers]]
             rule = "forward"
             name = "content-type"
             rename = "kekw-type"
@@ -1102,7 +1102,7 @@ mod tests {
     #[test]
     fn header_forward_invalid_rename() {
         let input = indoc! {r#"
-            [[headers]]     
+            [[headers]]
             rule = "forward"
             name = "content-type"
             rename = "🎠"
@@ -1113,8 +1113,8 @@ mod tests {
         insta::assert_snapshot!(&error.to_string(), @r###"
         TOML parse error at line 1, column 1
           |
-        1 | [[headers]]     
-          | ^^^^^^^^^^^^^^^^
+        1 | [[headers]]
+          | ^^^^^^^^^^^
         the byte at index 0 is not ASCII
         "###);
     }
@@ -1122,7 +1122,7 @@ mod tests {
     #[test]
     fn header_insert() {
         let input = indoc! {r#"
-            [[headers]]     
+            [[headers]]
             rule = "insert"
             name = "content-type"
             value = "application/json"
@@ -1150,7 +1150,7 @@ mod tests {
     fn header_insert_env() {
         temp_env::with_var("CONTENT_TYPE", Some("application/json"), || {
             let input = indoc! {r#"
-                [[headers]]     
+                [[headers]]
                 rule = "insert"
                 name = "content-type"
                 value = "{{ env.CONTENT_TYPE }}"
@@ -1218,7 +1218,7 @@ mod tests {
     #[test]
     fn header_remove() {
         let input = indoc! {r#"
-            [[headers]]     
+            [[headers]]
             rule = "remove"
             name = "content-type"
         "#};
@@ -1262,7 +1262,7 @@ mod tests {
     #[test]
     fn subgraph_header_forward_static() {
         let input = indoc! {r#"
-            [[subgraphs.products.headers]]     
+            [[subgraphs.products.headers]]
             rule = "forward"
             name = "content-type"
         "#};

--- a/gateway/crates/federated-server/src/server/gateway.rs
+++ b/gateway/crates/federated-server/src/server/gateway.rs
@@ -92,6 +92,7 @@ pub(super) async fn generate(
                 development_url: None,
                 rate_limit: value.rate_limit.map(Into::into),
                 timeout: value.timeout,
+                entity_cache_ttl: None,
             };
 
             (name, config)


### PR DESCRIPTION
This adds entity caching for requests to top level fields.  The name entity caching isn't _really_ accurate for these, since they're not neccesarily entities, but whatever.

The implementation is very barebones at the moment: we just hash the query, and look that up in the cache.  We don't yet bother with auth scopes, cache invalidation, or even much of the configuration concerns for this feature (beyond what I needed for tests).

Fixes GB-7148