### PR TITLE
fix: expose otlp config structs regardless of otlp feature

### DIFF
--- a/engine/crates/telemetry/src/config.rs
+++ b/engine/crates/telemetry/src/config.rs
@@ -2,7 +2,7 @@ mod exporters;
 
 use std::collections::HashMap;
 
-#[cfg(feature = "otlp")]
+// #[cfg(feature = "otlp")]
 pub use exporters::{
     Headers, OtlpExporterConfig, OtlpExporterGrpcConfig, OtlpExporterHttpConfig, OtlpExporterProtocol,
     OtlpExporterTlsConfig,
@@ -34,7 +34,6 @@ pub struct TelemetryConfig {
     pub metrics: Option<MetricsConfig>,
     /// Grafbase OTEL exporter configuration when an access token is used.
     #[serde(skip)]
-    #[cfg(feature = "otlp")]
     pub grafbase: Option<OtlpExporterConfig>,
 }
 
@@ -382,7 +381,7 @@ pub mod tests {
 
         let input = indoc! {r#"
             service_name = "kekw"
-                
+
             [exporters.stdout]
             enabled = true
             timeout = 10
@@ -407,7 +406,7 @@ pub mod tests {
 
         let input = indoc! {r#"
             service_name = "kekw"
-                
+
             [exporters.stdout]
             enabled = true
             timeout = 10
@@ -440,7 +439,7 @@ pub mod tests {
 
         let input = indoc! {r#"
             service_name = "kekw"
-                
+
             [exporters.stdout]
             enabled = true
             timeout = 10
@@ -476,7 +475,7 @@ pub mod tests {
 
         let input = indoc! {r#"
             service_name = "kekw"
-                
+
             [exporters.otlp]
             enabled = true
             endpoint = "http://localhost:1234"
@@ -516,7 +515,7 @@ pub mod tests {
 
         let input = indoc! {r#"
             service_name = "kekw"
-                
+
             [exporters.otlp]
             enabled = true
             endpoint = "http://localhost:1234"
@@ -578,7 +577,7 @@ pub mod tests {
 
         let input = indoc! {r#"
             service_name = "kekw"
-                
+
             [exporters.otlp]
             enabled = true
             endpoint = "http://localhost:1234"
@@ -641,7 +640,7 @@ pub mod tests {
 
         let input = indoc! {r#"
             service_name = "kekw"
-                
+
             [exporters.stdout]
             enabled = true
             timeout = 10
@@ -666,7 +665,7 @@ pub mod tests {
 
         let input = indoc! {r#"
             service_name = "kekw"
-                
+
             [exporters.stdout]
             enabled = true
             timeout = 10
@@ -698,7 +697,7 @@ pub mod tests {
 
         let input = indoc! {r#"
             service_name = "kekw"
-                
+
             [exporters.stdout]
             enabled = true
             timeout = 10
@@ -734,7 +733,7 @@ pub mod tests {
 
         let input = indoc! {r#"
             service_name = "kekw"
-                
+
             [exporters.otlp]
             enabled = true
             endpoint = "http://localhost:1234"
@@ -774,7 +773,7 @@ pub mod tests {
 
         let input = indoc! {r#"
             service_name = "kekw"
-                
+
             [exporters.otlp]
             enabled = true
             endpoint = "http://localhost:1234"
@@ -836,7 +835,7 @@ pub mod tests {
 
         let input = indoc! {r#"
             service_name = "kekw"
-                
+
             [exporters.otlp]
             enabled = true
             endpoint = "http://localhost:1234"
@@ -899,7 +898,7 @@ pub mod tests {
 
         let input = indoc! {r#"
             service_name = "kekw"
-                
+
             [exporters.stdout]
             enabled = true
             timeout = 10
@@ -924,7 +923,7 @@ pub mod tests {
 
         let input = indoc! {r#"
             service_name = "kekw"
-                
+
             [exporters.stdout]
             enabled = true
             timeout = 10
@@ -957,7 +956,7 @@ pub mod tests {
 
         let input = indoc! {r#"
             service_name = "kekw"
-                
+
             [exporters.stdout]
             enabled = true
             timeout = 10
@@ -993,7 +992,7 @@ pub mod tests {
 
         let input = indoc! {r#"
             service_name = "kekw"
-                
+
             [exporters.otlp]
             enabled = true
             endpoint = "http://localhost:1234"
@@ -1033,7 +1032,7 @@ pub mod tests {
 
         let input = indoc! {r#"
             service_name = "kekw"
-                
+
             [exporters.otlp]
             enabled = true
             endpoint = "http://localhost:1234"
@@ -1094,7 +1093,7 @@ pub mod tests {
 
         let input = indoc! {r#"
             service_name = "kekw"
-                
+
             [exporters.otlp]
             enabled = true
             endpoint = "http://localhost:1234"

--- a/engine/crates/telemetry/src/config/exporters.rs
+++ b/engine/crates/telemetry/src/config/exporters.rs
@@ -1,13 +1,13 @@
 mod logs;
 mod metrics;
-#[cfg(feature = "otlp")]
+// #[cfg(feature = "otlp")]
 mod otlp;
 mod stdout;
 mod tracing;
 
 pub use logs::LogsConfig;
 pub use metrics::MetricsConfig;
-#[cfg(feature = "otlp")]
+// #[cfg(feature = "otlp")]
 pub use otlp::{
     Headers, OtlpExporterConfig, OtlpExporterGrpcConfig, OtlpExporterHttpConfig, OtlpExporterProtocol,
     OtlpExporterTlsConfig,
@@ -23,7 +23,6 @@ pub struct ExportersConfig {
     #[serde(default)]
     pub stdout: Option<StdoutExporterConfig>,
     #[serde(default)]
-    #[cfg(feature = "otlp")]
     pub otlp: Option<OtlpExporterConfig>,
 }
 

--- a/engine/crates/telemetry/src/config/exporters/otlp.rs
+++ b/engine/crates/telemetry/src/config/exporters/otlp.rs
@@ -5,7 +5,6 @@ pub use headers::Headers;
 use super::{default_export_timeout, deserialize_duration, BatchExportConfig};
 use crate::error::TracingError;
 use std::{path::PathBuf, str::FromStr};
-use tonic::transport::{Certificate, ClientTlsConfig, Identity};
 use url::Url;
 
 /// Otlp exporter configuration
@@ -95,11 +94,12 @@ pub struct OtlpExporterTlsConfig {
 }
 
 #[cfg(feature = "otlp")]
-impl TryFrom<OtlpExporterTlsConfig> for ClientTlsConfig {
+impl TryFrom<OtlpExporterTlsConfig> for tonic::transport::ClientTlsConfig {
     type Error = TracingError;
 
-    fn try_from(value: OtlpExporterTlsConfig) -> Result<ClientTlsConfig, Self::Error> {
+    fn try_from(value: OtlpExporterTlsConfig) -> Result<tonic::transport::ClientTlsConfig, Self::Error> {
         use std::fs;
+        use tonic::transport::{Certificate, ClientTlsConfig, Identity};
 
         let mut tls = ClientTlsConfig::new();
 


### PR DESCRIPTION
There's been problems pulling this repo into our `api` repo in the past couple of days.  This seems to be because the clickhouse tests require in a bunch of structs that are hidden behind the `oltp` feature flag in the `grafbase_telemetry` crate, and as soon as you enable that flag you pull in a bunch of additional crates, that don't play well with the set of dependencies we have in `api`, and unpicking that is nightmarish.

Prior to https://github.com/grafbase/grafbase/commit/0f4cdd3bc2cfe92feeb77cb81bf548cddb35d87d these structs were all exposed even when the `oltp` feature was turned off, which allowed the clickhouse tests to compile without introducing this dependency hell situation.

This commit removes the oltp feature flag from these structs so that the clickhouse tests compile, while still keeping the oltp functionality behind the feature flag.  I'm not entirely sure if the clickhouse tests _work_ with this setup, but they do seem to compile.