### PR TITLE
feat(engine-v2): authorized parent edge post execution

### DIFF
--- a/engine/crates/engine-v2/schema/src/walkers/directives.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/directives.rs
@@ -1,8 +1,8 @@
 use id_newtypes::IdRange;
 
 use crate::{
-    CacheControl, Deprecated, RequiredFieldSet, RequiredScopesWalker, SchemaWalker, TypeSystemDirective,
-    TypeSystemDirectiveId,
+    AuthorizedDirectiveId, CacheControl, Deprecated, InputValueSet, RequiredFieldSet, RequiredScopesWalker,
+    SchemaInputValueWalker, SchemaWalker, TypeSystemDirective, TypeSystemDirectiveId,
 };
 
 pub type TypeSystemDirectivesWalker<'a> = SchemaWalker<'a, IdRange<TypeSystemDirectiveId>>;
@@ -60,5 +60,17 @@ impl<'a> TypeSystemDirectivesWalker<'a> {
             }
             _ => false,
         })
+    }
+}
+
+pub type AuthorizedDirectiveWalker<'a> = SchemaWalker<'a, AuthorizedDirectiveId>;
+
+impl<'a> AuthorizedDirectiveWalker<'a> {
+    pub fn arguments(&self) -> &'a InputValueSet {
+        &self.as_ref().arguments
+    }
+
+    pub fn metadata(&self) -> Option<SchemaInputValueWalker<'a>> {
+        self.as_ref().metadata.map(|id| self.walk(&self.schema[id]))
     }
 }

--- a/engine/crates/engine-v2/src/execution/mod.rs
+++ b/engine/crates/engine-v2/src/execution/mod.rs
@@ -5,6 +5,7 @@ mod header_rule;
 pub(crate) mod hooks;
 mod ids;
 mod planner;
+mod response_modifier;
 mod state;
 mod walkers;
 
@@ -89,10 +90,10 @@ pub(crate) struct QueryModifications {
 }
 
 // Modifies the response based on a given rule
-#[allow(unused)]
 pub(crate) struct ResponseModifierExecutor {
     pub rule: ResponseModifierRule,
     /// Which object & fields are impacted
+    /// ordered
     pub on: Vec<(ResponseObjectSetId, Option<EntityId>, ResponseKey)>,
     /// What fields the hook requires
     pub requires: ResponseViewSelectionSet,

--- a/engine/crates/engine-v2/src/execution/planner/mod.rs
+++ b/engine/crates/engine-v2/src/execution/planner/mod.rs
@@ -163,12 +163,14 @@ where
         {
             let parent_id = ResponseModifierExecutorId::from(i);
             for &field_id in &self.build_context[output_fields] {
-                let child_logical_plan_id = self.operation.plan.field_to_logical_plan_id[usize::from(field_id)];
-                let child_id = self.logical_plan_to_execution_plan_id[usize::from(child_logical_plan_id)]
-                    .expect("Depend on unfinished plan");
-                if !self.operation[parent_id].children.contains(&child_id) {
-                    self.operation[parent_id].children.push(child_id);
-                    self.operation[child_id].parent_count += 1;
+                for (i, input_fields) in self.build_context.execution_plans_input_fields.iter().enumerate() {
+                    let child_id = ExecutionPlanId::from(i);
+                    if self.build_context[*input_fields].contains(&field_id)
+                        && !self.operation[parent_id].children.contains(&child_id)
+                    {
+                        self.operation[parent_id].children.push(child_id);
+                        self.operation[child_id].parent_count += 1;
+                    }
                 }
             }
         }

--- a/engine/crates/engine-v2/src/execution/planner/query_modifier.rs
+++ b/engine/crates/engine-v2/src/execution/planner/query_modifier.rs
@@ -81,7 +81,7 @@ where
                     definition_id,
                     argument_ids,
                 } => {
-                    let directive = &self.schema()[directive_id];
+                    let directive = &self.schema().walk(directive_id);
                     let verdict = self
                         .ctx
                         .hooks()
@@ -89,8 +89,8 @@ where
                             self.schema().walk(definition_id),
                             self.walker()
                                 .walk(argument_ids)
-                                .with_selection_set(&directive.arguments),
-                            directive.metadata.map(|id| self.ctx.schema.walk(&self.ctx.schema[id])),
+                                .with_selection_set(directive.arguments()),
+                            directive.metadata(),
                         )
                         .await;
                     if let Err(err) = verdict {
@@ -101,14 +101,11 @@ where
                     directive_id,
                     definition,
                 } => {
-                    let directive = &self.ctx.schema[directive_id];
+                    let directive = &self.schema().walk(directive_id);
                     let result = self
                         .ctx
                         .hooks()
-                        .authorize_node_pre_execution(
-                            self.ctx.schema.walk(definition),
-                            directive.metadata.map(|id| self.ctx.schema.walk(&self.ctx.schema[id])),
-                        )
+                        .authorize_node_pre_execution(self.ctx.schema.walk(definition), directive.metadata())
                         .await;
 
                     if let Err(err) = result {

--- a/engine/crates/engine-v2/src/execution/response_modifier.rs
+++ b/engine/crates/engine-v2/src/execution/response_modifier.rs
@@ -1,0 +1,109 @@
+use std::sync::Arc;
+
+use itertools::Itertools;
+
+use crate::{
+    operation::ResponseModifierRule,
+    response::{ErrorCode, GraphqlError, InputdResponseObjectSet, ResponseBuilder, UnpackedResponseEdge},
+    Runtime,
+};
+
+use super::{state::OperationExecutionState, ExecutionContext, ResponseModifierExecutorId};
+
+impl<'ctx, R: Runtime> ExecutionContext<'ctx, R> {
+    pub(super) async fn execute_response_modifier(
+        &self,
+        state: &mut OperationExecutionState<'ctx>,
+        response: &mut ResponseBuilder,
+        response_modifier_executor_id: ResponseModifierExecutorId,
+    ) {
+        let executor = &self.operation[response_modifier_executor_id];
+        // First step is aggregating all the object refs we must read into a single
+        // InputdResponseObjectSet.
+        // As the AuthorizedField resolver applies on a specific field, we have to keep track of
+        // which ResponseKeys (~field in the output) would be impacted if unauthorized. As multiple
+        // fields might be impacted in a given object set (because of aliases), we keep a range of
+        // of those keys for each ResponseObjectSet we add to the input.
+        let mut input = InputdResponseObjectSet::default();
+        let mut input_associated_key_range = Vec::new();
+        for (set_id, chunk) in executor
+            .on
+            .iter()
+            .enumerate()
+            .chunk_by(|(_, (set_id, _, _))| *set_id)
+            .into_iter()
+        {
+            let refs = state[set_id]
+                .as_ref()
+                .expect("Response Modifier is ready but response object set doesn't exist");
+
+            for (entity_id, mut chunk) in chunk.into_iter().chunk_by(|(_, (_, entity, _))| *entity).into_iter() {
+                let start = chunk.next().unwrap().0;
+                let end = chunk.last().map(|(ix, _)| ix).unwrap_or(start) + 1;
+                input_associated_key_range.push(start..end);
+
+                if let Some(entity_id) = entity_id {
+                    input = input.with_filtered_response_objects(self.schema(), entity_id, refs.clone());
+                } else {
+                    input = input.with_response_objects(refs.clone());
+                }
+            }
+        }
+
+        // Now we can execute the hook and propagate any errors.
+        match executor.rule {
+            ResponseModifierRule::AuthorizedField {
+                directive_id,
+                definition_id,
+            } => {
+                let definition = self.schema().walk(definition_id);
+                let directive = self.schema().walk(directive_id);
+                let input = Arc::new(input);
+                let parents = response.read(
+                    self.schema(),
+                    &self.operation.response_views,
+                    input.clone(),
+                    executor.requires,
+                );
+                let result = self
+                    .hooks()
+                    .authorize_parent_edge_post_execution(definition, parents, directive.metadata())
+                    .await;
+                // FIXME: make this efficient
+                let result = match result {
+                    Ok(result) => {
+                        if result.len() == input.len() {
+                            result
+                                .into_iter()
+                                .map(|res| res.map_err(GraphqlError::from))
+                                .collect::<Vec<_>>()
+                        } else {
+                            // TODO: should be an error log instead not add any GraphQL error I
+                            // guess
+                            (0..input.len())
+                                .map(|_| {
+                                    Err(GraphqlError::new(
+                                        "Incorrect number of authorization replies",
+                                        ErrorCode::HookError,
+                                    ))
+                                })
+                                .collect()
+                        }
+                    }
+                    Err(err) => (0..input.len()).map(|_| Err(err.clone())).collect(),
+                };
+
+                for ((i, obj_ref), result) in input.iter_with_set_index().zip_eq(result) {
+                    if let Err(err) = result {
+                        for (_, _, key) in &executor.on[input_associated_key_range[i].clone()] {
+                            let path = obj_ref
+                                .path
+                                .child(UnpackedResponseEdge::ExtraFieldResponseKey(*key).pack());
+                            response.push_error(err.clone().with_path(path));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/engine/crates/engine-v2/src/operation/blueprint/plan.rs
+++ b/engine/crates/engine-v2/src/operation/blueprint/plan.rs
@@ -22,7 +22,6 @@ use super::{
 pub(super) struct LogicalPlanResponseBlueprintBuilder<'schema, 'op, 'builder> {
     builder: &'builder mut ResponseBlueprintBuilder<'schema, 'op>,
     logical_plan_id: LogicalPlanId,
-    output_response_object_set_ids: Vec<ResponseObjectSetId>,
 }
 
 impl<'schema, 'op, 'builder> std::ops::Deref for LogicalPlanResponseBlueprintBuilder<'schema, 'op, 'builder> {
@@ -50,15 +49,15 @@ where
             root_field_ids,
         }: &ToBuild,
     ) -> LogicalPlanResponseBlueprint {
+        let start = builder.blueprint.response_object_sets_to_type.len();
         let mut builder = LogicalPlanResponseBlueprintBuilder {
             builder,
             logical_plan_id: *logical_plan_id,
-            output_response_object_set_ids: Vec::new(),
         };
         let concrete_shape_id = builder.create_root_shape_for(builder.plan[*logical_plan_id].entity_id, root_field_ids);
         LogicalPlanResponseBlueprint {
             input_id: *input_id,
-            output_ids: IdRange::from_slice(&builder.output_response_object_set_ids).unwrap(),
+            output_ids: IdRange::from(start..builder.blueprint.response_object_sets_to_type.len()),
             concrete_shape_id,
         }
     }
@@ -95,7 +94,6 @@ where
         }
         let maybe_response_object_set_id = if !children_plan.is_empty() {
             let id = self.next_response_object_set_id(ty);
-            self.output_response_object_set_ids.push(id);
             self.to_build_stack
                 .extend(children_plan.into_iter().map(|(plan_id, root_fields)| ToBuild {
                     input_id: id,

--- a/engine/crates/engine-v2/src/operation/logical_planner/mod.rs
+++ b/engine/crates/engine-v2/src/operation/logical_planner/mod.rs
@@ -118,7 +118,7 @@ impl<'a> LogicalPlanner<'a> {
             "Solved requirements: {:?}",
             solved_requirements.iter().map(|(id, _)| id).collect::<Vec<_>>()
         );
-        tracing::debug!("{:?}", field_to_solved_requirement);
+        tracing::trace!("Field to solved requirements: {:?}", field_to_solved_requirement);
 
         dependents_builder.sort_unstable();
         let children = IdToMany::from_sorted_vec(dependents_builder.into_iter().dedup().collect());
@@ -335,7 +335,11 @@ impl<'a> LogicalPlanner<'a> {
     }
 
     pub fn register_plan_child(&mut self, edge: ParentToChildEdge) {
-        self.dependents_builder.push((edge.parent, edge.child));
+        // A parent and child may be the same if the requirements is coming from a ResponseModifier
+        // like @authorized
+        if edge.parent != edge.child {
+            self.dependents_builder.push((edge.parent, edge.child));
+        }
     }
 
     pub fn attribute_fields(&mut self, fields: &[FieldId], id: LogicalPlanId) {

--- a/engine/crates/engine-v2/src/response/error.rs
+++ b/engine/crates/engine-v2/src/response/error.rs
@@ -38,10 +38,10 @@ pub(crate) enum ErrorCode {
 impl From<PartialErrorCode> for ErrorCode {
     fn from(code: PartialErrorCode) -> Self {
         match code {
-            PartialErrorCode::InternalServerError => Self::InternalServerError,
             PartialErrorCode::HookError => Self::HookError,
             PartialErrorCode::Unauthorized => Self::Unauthorized,
             PartialErrorCode::BadRequest => Self::BadRequest,
+            _ => Self::InternalServerError,
         }
     }
 }

--- a/engine/crates/engine-v2/src/response/object_set.rs
+++ b/engine/crates/engine-v2/src/response/object_set.rs
@@ -128,6 +128,10 @@ impl InputdResponseObjectSet {
         ResponseObjectIterator { parent: self, idx: 0 }
     }
 
+    pub(crate) fn iter_with_set_index(&self) -> ResponseObjectIteratorWithSetIndex<'_> {
+        ResponseObjectIteratorWithSetIndex { parent: self, idx: 0 }
+    }
+
     pub(crate) fn len(&self) -> usize {
         self.indices.len()
     }
@@ -162,5 +166,24 @@ impl<'set> Iterator for ResponseObjectIterator<'set> {
         let item = self.parent.get(self.idx)?;
         self.idx += 1;
         Some(item)
+    }
+}
+
+pub(crate) struct ResponseObjectIteratorWithSetIndex<'set> {
+    parent: &'set InputdResponseObjectSet,
+    idx: usize,
+}
+
+impl<'set> Iterator for ResponseObjectIteratorWithSetIndex<'set> {
+    type Item = (usize, &'set ResponseObjectRef);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let index = self.parent.indices.get(self.idx)?;
+        self.idx += 1;
+
+        let set_idex = (index >> SET_INDEX_SHIFT) as usize;
+        let object_index = (index & OBJECT_INDEX_MASK) as usize;
+        let item = &self.parent.sets[set_idex][object_index];
+        Some((set_idex, item))
     }
 }

--- a/engine/crates/engine-v2/src/response/value.rs
+++ b/engine/crates/engine-v2/src/response/value.rs
@@ -39,8 +39,20 @@ impl ResponseObject {
         self.fields.iter()
     }
 
+    // FIXME: Shouldn't store by edge nor should the response path...
     pub(super) fn field_position(&self, edge: ResponseEdge) -> Option<usize> {
-        self.fields.binary_search_by(|field| field.edge.cmp(&edge)).ok()
+        self.fields
+            .binary_search_by(|field| field.edge.cmp(&edge))
+            .ok()
+            .or_else(|| match edge.as_response_key() {
+                Some(key) => {
+                    return self
+                        .fields
+                        .iter()
+                        .position(|field| field.edge.as_response_key() == Some(key));
+                }
+                None => None,
+            })
     }
 
     pub(super) fn find_required_field(&self, id: RequiredFieldId) -> Option<&ResponseValue> {

--- a/engine/crates/integration-tests/tests/federation/hooks/authorize_parent_edge_post_execution.rs
+++ b/engine/crates/integration-tests/tests/federation/hooks/authorize_parent_edge_post_execution.rs
@@ -1,0 +1,394 @@
+use http::HeaderMap;
+use runtime::{
+    error::{PartialErrorCode, PartialGraphqlError},
+    hooks::{DynHookContext, DynHooks, EdgeDefinition},
+};
+
+use super::with_engine_for_auth;
+
+#[test]
+fn parents_are_provided() {
+    struct TestHooks;
+
+    #[async_trait::async_trait]
+    impl DynHooks for TestHooks {
+        async fn authorize_parent_edge_post_execution(
+            &self,
+            _context: &DynHookContext,
+            _definition: EdgeDefinition<'_>,
+            parents: Vec<serde_json::Value>,
+            _metadata: Option<serde_json::Value>,
+        ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
+            Ok(parents
+                .into_iter()
+                .map(|value| {
+                    if value["id"] == "edge#1" {
+                        Ok(())
+                    } else {
+                        Err(PartialGraphqlError::new(
+                            "Unauthorized role",
+                            PartialErrorCode::Unauthorized,
+                        ))
+                    }
+                })
+                .collect())
+        }
+    }
+
+    with_engine_for_auth(TestHooks, |engine| async move {
+        let response = engine
+            .execute(
+                r#"
+                query {
+                    yes: nullableCheck {
+                       authorizedEdgeWithFields(prefix: "edge#", id: "1") {
+                           withId
+                       }
+                    }
+                    no: nullableCheck {
+                       authorizedEdgeWithFields(prefix: "edge#", id: "2") {
+                           withId
+                       }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "yes": {
+              "authorizedEdgeWithFields": {
+                "withId": "You have access"
+              }
+            },
+            "no": null
+          },
+          "errors": [
+            {
+              "message": "Unauthorized role",
+              "path": [
+                "no",
+                "authorizedEdgeWithFields",
+                "withId"
+              ],
+              "extensions": {
+                "code": "UNAUTHORIZED"
+              }
+            }
+          ]
+        }
+        "###);
+    });
+}
+
+#[test]
+fn metadata_is_provided() {
+    struct TestHooks;
+
+    const NULL: serde_json::Value = serde_json::Value::Null;
+
+    fn extract_role(metadata: Option<&serde_json::Value>) -> Option<&str> {
+        metadata
+            .unwrap_or(&NULL)
+            .as_array()?
+            .first()?
+            .as_array()?
+            .first()?
+            .as_str()
+    }
+
+    #[async_trait::async_trait]
+    impl DynHooks for TestHooks {
+        async fn authorize_parent_edge_post_execution(
+            &self,
+            _context: &DynHookContext,
+            _definition: EdgeDefinition<'_>,
+            parents: Vec<serde_json::Value>,
+            metadata: Option<serde_json::Value>,
+        ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
+            let Some(role) = extract_role(metadata.as_ref()) else {
+                return Err(PartialGraphqlError::new(
+                    "Unauthorized role",
+                    PartialErrorCode::Unauthorized,
+                ));
+            };
+            Ok(parents
+                .into_iter()
+                .map(|value| {
+                    if value["id"].as_str().unwrap().starts_with(role) {
+                        Ok(())
+                    } else {
+                        Err(PartialGraphqlError::new(
+                            "Unauthorized role",
+                            PartialErrorCode::Unauthorized,
+                        ))
+                    }
+                })
+                .collect())
+        }
+    }
+
+    with_engine_for_auth(TestHooks, |engine| async move {
+        let response = engine
+            .execute(
+                r#"
+                query {
+                    ok: nullableCheck {
+                       authorizedEdgeWithFields(prefix: "rusty#", id: "1") {
+                           withIdAndMetadata
+                       }
+                    }
+                    wrongPrefix: nullableCheck {
+                       authorizedEdgeWithFields(prefix: "edge#", id: "1") {
+                            withIdAndMetadata
+                       }
+                    }
+                    noMetadata: nullableCheck {
+                       authorizedEdgeWithFields(prefix: "rusty#", id: "1") {
+                            withId
+                       }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "ok": {
+              "authorizedEdgeWithFields": {
+                "withIdAndMetadata": "You have access"
+              }
+            },
+            "wrongPrefix": null,
+            "noMetadata": null
+          },
+          "errors": [
+            {
+              "message": "Unauthorized role",
+              "path": [
+                "noMetadata",
+                "authorizedEdgeWithFields",
+                "withId"
+              ],
+              "extensions": {
+                "code": "UNAUTHORIZED"
+              }
+            },
+            {
+              "message": "Unauthorized role",
+              "path": [
+                "wrongPrefix",
+                "authorizedEdgeWithFields",
+                "withIdAndMetadata"
+              ],
+              "extensions": {
+                "code": "UNAUTHORIZED"
+              }
+            }
+          ]
+        }
+        "###);
+    });
+}
+
+#[test]
+fn definition_is_provided() {
+    struct TestHooks;
+
+    #[async_trait::async_trait]
+    impl DynHooks for TestHooks {
+        async fn authorize_parent_edge_post_execution(
+            &self,
+            _context: &DynHookContext,
+            definition: EdgeDefinition<'_>,
+            parents: Vec<serde_json::Value>,
+            _metadata: Option<serde_json::Value>,
+        ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
+            if definition.parent_type_name == "AuthorizedEdgeWithFields" && definition.field_name == "withId" {
+                Ok(vec![Ok(()); parents.len()])
+            } else {
+                Err(PartialGraphqlError::new(
+                    "Wrong definition",
+                    PartialErrorCode::Unauthorized,
+                ))
+            }
+        }
+    }
+
+    with_engine_for_auth(TestHooks, |engine| async move {
+        let response = engine
+            .execute(
+                r#"
+                query {
+                    ok: nullableCheck {
+                       authorizedEdgeWithFields(prefix: "edge#", id: "1") {
+                           withId
+                       }
+                    }
+                    wrongField: nullableCheck {
+                       authorizedEdgeWithFields(prefix: "edge#", id: "1") {
+                           withIdAndMetadata
+                       }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "ok": {
+              "authorizedEdgeWithFields": {
+                "withId": "You have access"
+              }
+            },
+            "wrongField": null
+          },
+          "errors": [
+            {
+              "message": "Wrong definition",
+              "path": [
+                "wrongField",
+                "authorizedEdgeWithFields",
+                "withIdAndMetadata"
+              ],
+              "extensions": {
+                "code": "UNAUTHORIZED"
+              }
+            }
+          ]
+        }
+        "###);
+    });
+}
+
+#[test]
+fn context_is_propagated() {
+    struct TestHooks;
+
+    #[async_trait::async_trait]
+    impl DynHooks for TestHooks {
+        async fn on_gateway_request(
+            &self,
+            context: &mut DynHookContext,
+            headers: HeaderMap,
+        ) -> Result<HeaderMap, PartialGraphqlError> {
+            if let Some(client) = headers
+                .get("x-grafbase-client-name")
+                .and_then(|value| value.to_str().ok())
+            {
+                context.insert("client", client);
+            }
+            Ok(headers)
+        }
+
+        async fn authorize_parent_edge_post_execution(
+            &self,
+            context: &DynHookContext,
+            _definition: EdgeDefinition<'_>,
+            parents: Vec<serde_json::Value>,
+            _metadata: Option<serde_json::Value>,
+        ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
+            if context.get("client").is_some() {
+                Ok(vec![Ok(()); parents.len()])
+            } else {
+                Err(PartialGraphqlError::new(
+                    "Missing client",
+                    PartialErrorCode::Unauthorized,
+                ))
+            }
+        }
+    }
+
+    with_engine_for_auth(TestHooks, |engine| async move {
+        let response = engine
+            .execute(r###"query { check { authorizedEdgeWithFields(prefix: "edge#", id: "1") { withId } } }"###)
+            .by_client("hi", "")
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "check": {
+              "authorizedEdgeWithFields": {
+                "withId": "You have access"
+              }
+            }
+          }
+        }
+        "###);
+
+        let response = engine
+            .execute(r###"query { check { authorizedEdgeWithFields(prefix: "edge#", id: "1") { withId } } }"###)
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "Missing client",
+              "path": [
+                "check",
+                "authorizedEdgeWithFields",
+                "withId"
+              ],
+              "extensions": {
+                "code": "UNAUTHORIZED"
+              }
+            }
+          ]
+        }
+        "###);
+    });
+}
+
+#[test]
+fn error_propagation() {
+    struct TestHooks;
+
+    #[async_trait::async_trait]
+    impl DynHooks for TestHooks {
+        async fn authorize_parent_edge_post_execution(
+            &self,
+            _context: &DynHookContext,
+            _definition: EdgeDefinition<'_>,
+            _parents: Vec<serde_json::Value>,
+            _metadata: Option<serde_json::Value>,
+        ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
+            Err(PartialGraphqlError::new("Broken", PartialErrorCode::HookError))
+        }
+    }
+
+    with_engine_for_auth(TestHooks, |engine| async move {
+        let response = engine
+            .execute(
+                r#"
+                query {
+                    check {
+                        authorizedEdgeWithFields(prefix: "edge#", id: "1") { withId }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "Broken",
+              "path": [
+                "check",
+                "authorizedEdgeWithFields",
+                "withId"
+              ],
+              "extensions": {
+                "code": "HOOK_ERROR"
+              }
+            }
+          ]
+        }
+        "###);
+    });
+}

--- a/engine/crates/integration-tests/tests/federation/hooks/mod.rs
+++ b/engine/crates/integration-tests/tests/federation/hooks/mod.rs
@@ -1,5 +1,6 @@
 mod authorize_edge_pre_execution;
 mod authorize_node_pre_execution;
+mod authorize_parent_edge_post_execution;
 mod on_gateway_request;
 mod on_subgraph_request;
 

--- a/engine/crates/runtime/src/error.rs
+++ b/engine/crates/runtime/src/error.rs
@@ -1,9 +1,12 @@
 use std::{borrow::Cow, fmt};
 
 /// Some of the error codes that the engine supports
+/// These are not exhaustive and can be extended as needed by adding a `code` inside the
+/// extensions.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, strum::Display)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+#[non_exhaustive]
 pub enum PartialErrorCode {
     InternalServerError,
     BadRequest,
@@ -16,6 +19,8 @@ pub enum PartialErrorCode {
 #[derive(Clone, Debug, PartialEq)]
 pub struct PartialGraphqlError {
     pub message: Cow<'static, str>,
+    /// An error MUST have an error code, but it can be overridden by adding a custom string inside
+    /// extensions for the `code` key.
     pub code: PartialErrorCode,
     /// Optional extensions added to the response
     /// Will be serialized as a map, but we store it as a Vec for efficiency


### PR DESCRIPTION
So this applies the response modifiers, once all the requirements are present, and adds some basic tests for them for the case:
```graphql
type User {
   name @authorized(fields: "id")
}
```
