### PR TITLE
fix: feature flag redis in runtime-local

### DIFF
--- a/cli/crates/federated-dev/Cargo.toml
+++ b/cli/crates/federated-dev/Cargo.toml
@@ -22,7 +22,7 @@ indoc = "2.0.5"
 log = "0.4.21"
 reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 runtime.workspace = true
-runtime-local = { workspace = true, features = ["wasi"] }
+runtime-local = { workspace = true, features = ["wasi", "redis"] }
 runtime-noop.workspace = true
 serde = "1.0.199"
 serde_json.workspace = true
@@ -37,7 +37,7 @@ common = { package = "grafbase-local-common", path = "../common", version = "0.7
 engine = { path = "../../../engine/crates/engine" }
 engine-config-builder = { path = "../../../engine/crates/engine-config-builder" }
 engine-v2.workspace = true
-engine-v2-axum.workspace = true 
+engine-v2-axum.workspace = true
 grafbase-graphql-introspection.workspace = true
 grafbase-telemetry = { workspace = true , features = ["tower"] }
 parser-sdl = { path = "../../../engine/crates/parser-sdl" }

--- a/cli/crates/gateway/Cargo.toml
+++ b/cli/crates/gateway/Cargo.toml
@@ -32,7 +32,7 @@ registry-v2.workspace = true
 registry-for-cache.workspace = true
 runtime = { path = "../../../engine/crates/runtime" }
 runtime-noop = { path = "../../../engine/crates/runtime-noop" }
-runtime-local = { path = "../../../engine/crates/runtime-local", features = ["wasi"] }
+runtime-local = { path = "../../../engine/crates/runtime-local", features = ["wasi", "redis"] }
 common-types = { path = "../../../engine/crates/common-types" }
 postgres-connector-types = { path = "../../../engine/crates/postgres-connector-types", features = ["pooling"] }
 gateway-v2-auth.workspace = true

--- a/engine/crates/integration-tests/Cargo.toml
+++ b/engine/crates/integration-tests/Cargo.toml
@@ -42,7 +42,7 @@ ulid.workspace = true
 url.workspace = true
 wiremock.workspace = true
 registry-upgrade.workspace = true
-runtime-local = { workspace = true, features = ["wasi"] }
+runtime-local = { workspace = true, features = ["wasi", "redis"] }
 runtime-noop.workspace = true
 ory-client = "1.9.0"
 tracing-subscriber = { version = "0.3.18", default-features = false, features = [

--- a/engine/crates/runtime-local/Cargo.toml
+++ b/engine/crates/runtime-local/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [features]
 wasi = ["wasi-component-loader", "url"]
+redis = ["dep:redis"]
 
 [dependencies]
 async-runtime.workspace = true
@@ -34,7 +35,7 @@ runtime.workspace = true
 url = { workspace = true, optional = true }
 postgres-connector-types = { path = "../postgres-connector-types" }
 mini-moka = "0.10"
-redis = { version = "0.25.4", features = ["tokio-rustls-comp", "connection-manager"] }
+redis = { version = "0.25.4", features = ["tokio-rustls-comp", "connection-manager"], optional = true }
 
 reqwest = { workspace = true, features = [
   "json",

--- a/engine/crates/runtime-local/src/rate_limiting.rs
+++ b/engine/crates/runtime-local/src/rate_limiting.rs
@@ -1,2 +1,3 @@
 pub mod in_memory;
+#[cfg(feature = "redis")]
 pub mod redis;

--- a/engine/crates/telemetry/src/config/exporters/otlp.rs
+++ b/engine/crates/telemetry/src/config/exporters/otlp.rs
@@ -3,7 +3,6 @@ mod headers;
 pub use headers::Headers;
 
 use super::{default_export_timeout, deserialize_duration, BatchExportConfig};
-use crate::error::TracingError;
 use std::{path::PathBuf, str::FromStr};
 use url::Url;
 
@@ -95,9 +94,10 @@ pub struct OtlpExporterTlsConfig {
 
 #[cfg(feature = "otlp")]
 impl TryFrom<OtlpExporterTlsConfig> for tonic::transport::ClientTlsConfig {
-    type Error = TracingError;
+    type Error = crate::error::TracingError;
 
     fn try_from(value: OtlpExporterTlsConfig) -> Result<tonic::transport::ClientTlsConfig, Self::Error> {
+        use crate::error::TracingError;
         use std::fs;
         use tonic::transport::{Certificate, ClientTlsConfig, Identity};
 

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -37,7 +37,7 @@ http.workspace = true
 parser-sdl = { version = "0.1.0", path = "../../../engine/crates/parser-sdl" }
 reqwest = { workspace = true, features = ["http2", "json", "rustls-tls"] }
 runtime.workspace = true
-runtime-local = { workspace = true, features = ["wasi"] }
+runtime-local = { workspace = true, features = ["wasi", "redis"] }
 runtime-noop.workspace = true
 serde.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
I'm trying to pull the latest grafbase into api and getting some mismatch in rustls versions in the redis crate.  Don't think we actually need redis in `api` right now, so putting it behind a feature flag that `api` can opt out of.