### PR TITLE
fix: the runtime-local implementation of KvStoreInner

### DIFF
--- a/engine/crates/runtime/src/kv.rs
+++ b/engine/crates/runtime/src/kv.rs
@@ -59,6 +59,16 @@ impl std::ops::Deref for KvStore {
 
 #[async_trait::async_trait]
 pub trait KvStoreInner: Send + Sync {
+    /// Get an entry from the KV store.
+    ///
+    /// If cache_ttl is provided and the local cache has a sufficiently fresh entry, we'll read it
+    /// from there.  Otherwise we will fetch from a central location.
+    ///
+    /// See https://developers.cloudflare.com/kv/reference/how-kv-works/#performance for more details.
+    ///
+    /// Non-cloudflare implementations of this trait may have different behaviour.
     async fn get(&self, name: &str, cache_ttl: Option<Duration>) -> KvResult<Option<Vec<u8>>>;
+
+    /// Put an entry into the TTL store, with an optional expiry.
     async fn put(&self, name: &str, bytes: Vec<u8>, expiration_ttl: Option<Duration>) -> KvResult<()>;
 }


### PR DESCRIPTION
In #1931 it was pointed out that I was passing a None ttl to KvStoreInner::get, which on CF will cause the KV store to always look up in a central location instead of in a local datastore cache.

I did not realise that this was what the `cache_ttl` function was for, because I based my understanding on the runtime-local implementation, which used this parameter to decide whether an entry had expired.  although even that was a bit weird - it added the cache_ttl to the orignially requested expiry time, and ignored the original expiry time if you didn't provide a cache_ttl

This PR fixes the KV impl to be closer to what the parameters actually mean, and adds some docstrings.  So nobody else falls into this trap in the future.