### PR TITLE
feat(engine-v2): authorize_edge_node_post_execution hook

### DIFF
--- a/engine/crates/composition/src/ingest_subgraph/directives/authorized.rs
+++ b/engine/crates/composition/src/ingest_subgraph/directives/authorized.rs
@@ -23,6 +23,15 @@ pub(super) fn ingest(
         .map(|fields| subgraphs.selection_set_from_str(fields))
         .transpose()?;
 
+    let node = directive
+        .get_argument("node")
+        .and_then(|arg| match &arg.node {
+            ConstValue::String(requires) => Some(requires),
+            _ => None,
+        })
+        .map(|fields| subgraphs.selection_set_from_str(fields))
+        .transpose()?;
+
     let metadata = directive
         .get_argument("metadata")
         .map(|value| ast_value_to_subgraph_value(&value.node, subgraphs));
@@ -31,6 +40,7 @@ pub(super) fn ingest(
         directive_site_id,
         subgraphs::AuthorizedDirective {
             arguments,
+            node,
             fields,
             metadata,
         },

--- a/engine/crates/composition/src/subgraphs/directives.rs
+++ b/engine/crates/composition/src/subgraphs/directives.rs
@@ -261,6 +261,7 @@ pub(crate) struct OverrideDirective {
 pub(crate) struct AuthorizedDirective {
     pub(crate) arguments: Option<Vec<Selection>>,
     pub(crate) fields: Option<Vec<Selection>>,
+    pub(crate) node: Option<Vec<Selection>>,
     pub(crate) metadata: Option<Value>,
 }
 

--- a/engine/crates/composition/tests/composition/authorized_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/authorized_basic/federated.graphql
@@ -36,10 +36,10 @@ type Account @authorized(fields: "user { userId }") {
 }
 
 type Query {
-    account(id: ID!): Account @join__field(graph: BANK_ACCOUNT)
+    account(id: ID!): Account @join__field(graph: BANK_ACCOUNT) @authorized(node: "id")
     accounts: [Account!]! @join__field(graph: BANK_ACCOUNT)
     transaction(id: ID!): Transaction @join__field(graph: BANK_ACCOUNT)
-    transactions: [Transaction!]! @join__field(graph: BANK_ACCOUNT)
+    transactions: [Transaction!]! @join__field(graph: BANK_ACCOUNT) @authorized(node: "account { id }")
     user(id: ID!): User @join__field(graph: BANK_ACCOUNT)
     users: [User!]! @join__field(graph: BANK_ACCOUNT)
 }

--- a/engine/crates/composition/tests/composition/authorized_basic/subgraphs/bank_account.graphql
+++ b/engine/crates/composition/tests/composition/authorized_basic/subgraphs/bank_account.graphql
@@ -31,13 +31,13 @@ type Query {
   users: [User!]!
   user(id: ID!): User
   accounts: [Account!]!
-  account(id: ID!): Account
-  transactions: [Transaction!]!
+  account(id: ID!): Account @authorized(node: "id")
+  transactions: [Transaction!]! @authorized(node: "account { id }")
   transaction(id: ID!): Transaction
 }
 
 type Mutation {
-  createUser( name: String!, email: String!): User!
+  createUser(name: String!, email: String!): User!
   createAccount(userId: ID!, type: AccountType!, initialBalance: Float!): Account!
   createTransaction(accountId: ID!, amount: Float!, description: String): Transaction!
   updateUser(id: ID!, name: String, email: String): User!
@@ -45,7 +45,8 @@ type Mutation {
   deleteUser(id: ID!, soft: Boolean): User! @authorized(arguments: "id")
   deleteAccount(id: ID!): Account!
   deleteTransaction(id: ID!): Transaction!
-  createAccount(input: CreateAccountInput, included: Boolean, notIncluded: String): Account @authorized(arguments: "input { userId nested { name } } included", metadata: ["a", "b", "c"])
+  createAccount(input: CreateAccountInput, included: Boolean, notIncluded: String): Account
+    @authorized(arguments: "input { userId nested { name } } included", metadata: ["a", "b", "c"])
 }
 
 input CreateAccountInput {

--- a/engine/crates/composition/tests/composition/authorized_validation/subgraphs/bank_account.graphql
+++ b/engine/crates/composition/tests/composition/authorized_validation/subgraphs/bank_account.graphql
@@ -32,13 +32,13 @@ type Query {
   user(id: ID!): User
   accounts: [Account!]!
   account(id: ID!): Account
-  transactions: [Transaction!]!
+  transactions: [Transaction!]! @authorized(node: "doesNotExist")
   transaction(id: ID!): Transaction
 }
 
 # Define the Mutation type
 type Mutation {
-  createUser( name: String!, email: String!): User! @authorized(arguments: "not-a-selection")
+  createUser(name: String!, email: String!): User! @authorized(arguments: "not-a-selection")
   createAccount(userId: ID!, type: AccountType!, initialBalance: Float!): Account!
   createTransaction(accountId: ID!, amount: Float!, description: String): Transaction!
   updateUser(id: ID!, name: String, email: String): User!
@@ -47,4 +47,3 @@ type Mutation {
   deleteAccount(id: ID!): Account!
   deleteTransaction(id: ID!): Transaction!
 }
-

--- a/engine/crates/engine-v2/schema/src/builder/graph.rs
+++ b/engine/crates/engine-v2/schema/src/builder/graph.rs
@@ -686,6 +686,7 @@ impl<'a> GraphBuilder<'a> {
                     fields,
                     arguments,
                     metadata,
+                    node,
                 } = &config.graph[id];
 
                 self.graph.authorized_directives.push(AuthorizedDirective {
@@ -695,7 +696,10 @@ impl<'a> GraphBuilder<'a> {
                         .unwrap_or_default(),
                     fields: fields
                         .as_ref()
-                        .map(|fields| self.required_field_sets_buffer.push(schema_location, fields.clone())),
+                        .map(|field_set| self.required_field_sets_buffer.push(schema_location, field_set.clone())),
+                    node: node
+                        .as_ref()
+                        .map(|field_set| self.required_field_sets_buffer.push(schema_location, field_set.clone())),
                     metadata: metadata.clone().map(|value| {
                         let value = self
                             .graph

--- a/engine/crates/engine-v2/schema/src/directives/authorized.rs
+++ b/engine/crates/engine-v2/schema/src/directives/authorized.rs
@@ -4,5 +4,6 @@ use crate::{InputValueSet, RequiredFieldSetId, SchemaInputValueId};
 pub struct AuthorizedDirective {
     pub arguments: InputValueSet,
     pub fields: Option<RequiredFieldSetId>,
+    pub node: Option<RequiredFieldSetId>,
     pub metadata: Option<SchemaInputValueId>,
 }

--- a/engine/crates/engine-v2/schema/src/walkers/directives.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/directives.rs
@@ -61,6 +61,14 @@ impl<'a> TypeSystemDirectivesWalker<'a> {
             _ => false,
         })
     }
+
+    pub fn authorized(&self) -> impl Iterator<Item = AuthorizedDirectiveWalker<'a>> + 'a {
+        let schema = self.schema;
+        self.as_ref().iter().filter_map(move |d| match d {
+            TypeSystemDirective::Authorized(id) => Some(schema.walk(*id)),
+            _ => None,
+        })
+    }
 }
 
 pub type AuthorizedDirectiveWalker<'a> = SchemaWalker<'a, AuthorizedDirectiveId>;
@@ -68,6 +76,13 @@ pub type AuthorizedDirectiveWalker<'a> = SchemaWalker<'a, AuthorizedDirectiveId>
 impl<'a> AuthorizedDirectiveWalker<'a> {
     pub fn arguments(&self) -> &'a InputValueSet {
         &self.as_ref().arguments
+    }
+
+    pub fn node(&self) -> &'a RequiredFieldSet {
+        self.as_ref()
+            .node
+            .map(|id| &self.schema[id])
+            .unwrap_or(&crate::requires::EMPTY)
     }
 
     pub fn metadata(&self) -> Option<SchemaInputValueWalker<'a>> {

--- a/engine/crates/engine-v2/src/execution/hooks/authorized.rs
+++ b/engine/crates/engine-v2/src/execution/hooks/authorized.rs
@@ -65,6 +65,32 @@ impl<'ctx, H: Hooks> super::RequestHooks<'ctx, H> {
     }
 
     #[instrument(skip_all, ret(level = Level::DEBUG))]
+    pub async fn authorize_edge_node_post_execution(
+        &self,
+        definition: FieldDefinitionWalker<'_>,
+        nodes: ResponseObjectsView<'_>,
+        metadata: Option<SchemaInputValueWalker<'_>>,
+    ) -> Result<Vec<Result<(), PartialGraphqlError>>, GraphqlError> {
+        self.hooks
+            .authorized()
+            .authorize_edge_node_post_execution(
+                self.context,
+                EdgeDefinition {
+                    parent_type_name: definition.parent_entity().name(),
+                    field_name: definition.name(),
+                },
+                nodes,
+                metadata,
+            )
+            // FIXME: Unfortunately, boxing seems to be the only solution for the bug explained here:
+            //        https://github.com/rust-lang/rust/issues/110338#issuecomment-1513761297
+            //        Otherwise is not correctly evaluated to be Send due to the impl IntoIterator
+            .boxed()
+            .await
+            .map_err(Into::into)
+    }
+
+    #[instrument(skip_all, ret(level = Level::DEBUG))]
     pub async fn authorize_node_pre_execution(
         &self,
         definition: DefinitionWalker<'_>,

--- a/engine/crates/engine-v2/src/execution/mod.rs
+++ b/engine/crates/engine-v2/src/execution/mod.rs
@@ -93,7 +93,7 @@ pub(crate) struct QueryModifications {
 pub(crate) struct ResponseModifierExecutor {
     pub rule: ResponseModifierRule,
     /// Which object & fields are impacted
-    /// ordered
+    /// sorted by natural order
     pub on: Vec<(ResponseObjectSetId, Option<EntityId>, ResponseKey)>,
     /// What fields the hook requires
     pub requires: ResponseViewSelectionSet,

--- a/engine/crates/engine-v2/src/operation/bind/modifier.rs
+++ b/engine/crates/engine-v2/src/operation/bind/modifier.rs
@@ -25,23 +25,38 @@ impl<'schema, 'p> super::Binder<'schema, 'p> {
                 }
                 TypeSystemDirective::Authorized(id) => {
                     let directive = &self.schema[*id];
-                    if directive.fields.is_some() {
-                        self.register_field_impacted_by_response_modifier(
-                            ResponseModifierRule::AuthorizedField {
-                                directive_id: *id,
-                                definition_id: definition.id(),
-                            },
-                            field_id,
-                        );
-                    } else {
-                        self.register_field_impacted_by_query_modifier(
-                            QueryModifierRule::AuthorizedField {
-                                directive_id: *id,
-                                definition_id: definition.id(),
-                                argument_ids,
-                            },
-                            field_id,
-                        );
+                    match (directive.fields.is_some(), directive.node.is_some()) {
+                        (true, true) => {
+                            unreachable!("Authorized directive with both fields and node isn't supported yet");
+                        }
+                        (true, false) => {
+                            self.register_field_impacted_by_response_modifier(
+                                ResponseModifierRule::AuthorizedParentEdge {
+                                    directive_id: *id,
+                                    definition_id: definition.id(),
+                                },
+                                field_id,
+                            );
+                        }
+                        (false, true) => {
+                            self.register_field_impacted_by_response_modifier(
+                                ResponseModifierRule::AuthorizedEdgeChild {
+                                    directive_id: *id,
+                                    definition_id: definition.id(),
+                                },
+                                field_id,
+                            );
+                        }
+                        (false, false) => {
+                            self.register_field_impacted_by_query_modifier(
+                                QueryModifierRule::AuthorizedField {
+                                    directive_id: *id,
+                                    definition_id: definition.id(),
+                                    argument_ids,
+                                },
+                                field_id,
+                            );
+                        }
                     }
                 }
                 _ => {}

--- a/engine/crates/engine-v2/src/operation/modifier.rs
+++ b/engine/crates/engine-v2/src/operation/modifier.rs
@@ -32,7 +32,11 @@ pub(crate) struct ResponseModifier {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) enum ResponseModifierRule {
-    AuthorizedField {
+    AuthorizedParentEdge {
+        directive_id: AuthorizedDirectiveId,
+        definition_id: FieldDefinitionId,
+    },
+    AuthorizedEdgeChild {
         directive_id: AuthorizedDirectiveId,
         definition_id: FieldDefinitionId,
     },

--- a/engine/crates/federated-graph/src/federated_graph/v3.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v3.rs
@@ -119,6 +119,7 @@ pub enum Directive {
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, PartialOrd)]
 pub struct AuthorizedDirective {
     pub fields: Option<FieldSet>,
+    pub node: Option<FieldSet>,
     pub arguments: Option<InputValueDefinitionSet>,
     pub metadata: Option<Value>,
 }

--- a/engine/crates/federated-graph/src/render_sdl/display_utils.rs
+++ b/engine/crates/federated-graph/src/render_sdl/display_utils.rs
@@ -318,6 +318,11 @@ impl Display for AuthorizedDirectiveDisplay<'_> {
             .as_ref()
             .map(|fields| ("fields", DisplayableArgument::from(FieldSetDisplay(fields, graph))));
 
+        let node = directive
+            .node
+            .as_ref()
+            .map(|fields| ("node", DisplayableArgument::from(FieldSetDisplay(fields, graph))));
+
         let arguments = directive.arguments.as_ref().map(|arguments| {
             (
                 "arguments",
@@ -330,7 +335,7 @@ impl Display for AuthorizedDirectiveDisplay<'_> {
             .as_ref()
             .map(|metadata| ("metadata", DisplayableArgument::Value(metadata.clone())));
 
-        let arguments = [fields, arguments, metadata];
+        let arguments = [fields, node, arguments, metadata];
 
         write_directive(f, "authorized", arguments.into_iter().flatten(), graph)
     }

--- a/engine/crates/integration-tests/tests/federation/hooks/authorize_edge_node_post_execution.rs
+++ b/engine/crates/integration-tests/tests/federation/hooks/authorize_edge_node_post_execution.rs
@@ -1,0 +1,766 @@
+use http::HeaderMap;
+use runtime::{
+    error::{PartialErrorCode, PartialGraphqlError},
+    hooks::{DynHookContext, DynHooks, EdgeDefinition},
+};
+
+use super::with_engine_for_auth;
+
+#[test]
+fn nodes_are_provided() {
+    struct TestHooks;
+
+    #[async_trait::async_trait]
+    impl DynHooks for TestHooks {
+        async fn authorize_edge_node_post_execution(
+            &self,
+            _context: &DynHookContext,
+            _definition: EdgeDefinition<'_>,
+            nodes: Vec<serde_json::Value>,
+            _metadata: Option<serde_json::Value>,
+        ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
+            Ok(nodes
+                .into_iter()
+                .map(|value| {
+                    if value["id"] == "1" {
+                        Ok(())
+                    } else {
+                        Err(PartialGraphqlError::new(
+                            "Unauthorized id",
+                            PartialErrorCode::Unauthorized,
+                        ))
+                    }
+                })
+                .collect())
+        }
+    }
+
+    with_engine_for_auth(TestHooks, |engine| async move {
+        let response = engine
+            .execute(
+                r#"
+                query {
+                    yes: nullableCheck {
+                       authorizedEdgeWithNode(ids: ["1"]) {
+                           withId { id }
+                       }
+                    }
+                    no: nullableCheck {
+                       authorizedEdgeWithNode(ids: ["2"]) {
+                           withId { id }
+                       }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "yes": {
+              "authorizedEdgeWithNode": {
+                "withId": {
+                  "id": "1"
+                }
+              }
+            },
+            "no": null
+          },
+          "errors": [
+            {
+              "message": "Unauthorized id",
+              "path": [
+                "no",
+                "authorizedEdgeWithNode",
+                "withId"
+              ],
+              "extensions": {
+                "code": "UNAUTHORIZED"
+              }
+            }
+          ]
+        }
+        "###);
+    });
+}
+
+#[test]
+fn metadata_is_provided() {
+    struct TestHooks;
+
+    const NULL: serde_json::Value = serde_json::Value::Null;
+
+    fn extract_role(metadata: Option<&serde_json::Value>) -> Option<&str> {
+        metadata
+            .unwrap_or(&NULL)
+            .as_array()?
+            .first()?
+            .as_array()?
+            .first()?
+            .as_str()
+    }
+
+    #[async_trait::async_trait]
+    impl DynHooks for TestHooks {
+        async fn authorize_edge_node_post_execution(
+            &self,
+            _context: &DynHookContext,
+            _definition: EdgeDefinition<'_>,
+            nodes: Vec<serde_json::Value>,
+            metadata: Option<serde_json::Value>,
+        ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
+            let Some(role) = extract_role(metadata.as_ref()) else {
+                return Err(PartialGraphqlError::new(
+                    "Unauthorized role",
+                    PartialErrorCode::Unauthorized,
+                ));
+            };
+            Ok(nodes
+                .into_iter()
+                .map(|value| {
+                    if value["id"].as_str().unwrap().starts_with(role) {
+                        Ok(())
+                    } else {
+                        Err(PartialGraphqlError::new(
+                            "Unauthorized role",
+                            PartialErrorCode::Unauthorized,
+                        ))
+                    }
+                })
+                .collect())
+        }
+    }
+
+    with_engine_for_auth(TestHooks, |engine| async move {
+        let response = engine
+            .execute(
+                r#"
+                query {
+                    ok: nullableCheck {
+                       authorizedEdgeWithNode(ids: ["rusty"]) {
+                           withIdAndMetadata { id }
+                       }
+                    }
+                    wrongId: nullableCheck {
+                       authorizedEdgeWithNode(ids: ["anonymous"]) {
+                            withIdAndMetadata { id }
+                       }
+                    }
+                    noMetadata: nullableCheck {
+                       authorizedEdgeWithNode(ids: ["rusty"]) {
+                            withId { id }
+                       }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "ok": {
+              "authorizedEdgeWithNode": {
+                "withIdAndMetadata": {
+                  "id": "rusty"
+                }
+              }
+            },
+            "wrongId": null,
+            "noMetadata": null
+          },
+          "errors": [
+            {
+              "message": "Unauthorized role",
+              "path": [
+                "noMetadata",
+                "authorizedEdgeWithNode",
+                "withId"
+              ],
+              "extensions": {
+                "code": "UNAUTHORIZED"
+              }
+            },
+            {
+              "message": "Unauthorized role",
+              "path": [
+                "wrongId",
+                "authorizedEdgeWithNode",
+                "withIdAndMetadata"
+              ],
+              "extensions": {
+                "code": "UNAUTHORIZED"
+              }
+            }
+          ]
+        }
+        "###);
+    });
+}
+
+#[test]
+fn definition_is_provided() {
+    struct TestHooks;
+
+    #[async_trait::async_trait]
+    impl DynHooks for TestHooks {
+        async fn authorize_edge_node_post_execution(
+            &self,
+            _context: &DynHookContext,
+            definition: EdgeDefinition<'_>,
+            nodes: Vec<serde_json::Value>,
+            _metadata: Option<serde_json::Value>,
+        ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
+            if definition.parent_type_name == "AuthorizedEdgeWithNode" && definition.field_name == "withId" {
+                Ok(vec![Ok(()); nodes.len()])
+            } else {
+                Err(PartialGraphqlError::new(
+                    "Wrong definition",
+                    PartialErrorCode::Unauthorized,
+                ))
+            }
+        }
+    }
+
+    with_engine_for_auth(TestHooks, |engine| async move {
+        let response = engine
+            .execute(
+                r#"
+                query {
+                    ok: nullableCheck {
+                       authorizedEdgeWithNode(ids: ["1"]) {
+                           withId { id }
+                       }
+                    }
+                    wrongField: nullableCheck {
+                       authorizedEdgeWithNode(ids: ["1"]) {
+                           withIdAndMetadata { id }
+                       }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "ok": {
+              "authorizedEdgeWithNode": {
+                "withId": {
+                  "id": "1"
+                }
+              }
+            },
+            "wrongField": null
+          },
+          "errors": [
+            {
+              "message": "Wrong definition",
+              "path": [
+                "wrongField",
+                "authorizedEdgeWithNode",
+                "withIdAndMetadata"
+              ],
+              "extensions": {
+                "code": "UNAUTHORIZED"
+              }
+            }
+          ]
+        }
+        "###);
+    });
+}
+
+#[test]
+fn context_is_propagated() {
+    struct TestHooks;
+
+    #[async_trait::async_trait]
+    impl DynHooks for TestHooks {
+        async fn on_gateway_request(
+            &self,
+            context: &mut DynHookContext,
+            headers: HeaderMap,
+        ) -> Result<HeaderMap, PartialGraphqlError> {
+            if let Some(client) = headers
+                .get("x-grafbase-client-name")
+                .and_then(|value| value.to_str().ok())
+            {
+                context.insert("client", client);
+            }
+            Ok(headers)
+        }
+
+        async fn authorize_edge_node_post_execution(
+            &self,
+            context: &DynHookContext,
+            _definition: EdgeDefinition<'_>,
+            nodes: Vec<serde_json::Value>,
+            _metadata: Option<serde_json::Value>,
+        ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
+            if context.get("client").is_some() {
+                Ok(vec![Ok(()); nodes.len()])
+            } else {
+                Err(PartialGraphqlError::new(
+                    "Missing client",
+                    PartialErrorCode::Unauthorized,
+                ))
+            }
+        }
+    }
+
+    with_engine_for_auth(TestHooks, |engine| async move {
+        let response = engine
+            .execute(r###"query { check { authorizedEdgeWithNode(ids: ["1"]) { withId { id } } } }"###)
+            .by_client("hi", "")
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "check": {
+              "authorizedEdgeWithNode": {
+                "withId": {
+                  "id": "1"
+                }
+              }
+            }
+          }
+        }
+        "###);
+
+        let response = engine
+            .execute(r###"query { check { authorizedEdgeWithNode(ids: ["1"]) { withId { id } } } }"###)
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "Missing client",
+              "path": [
+                "check",
+                "authorizedEdgeWithNode",
+                "withId"
+              ],
+              "extensions": {
+                "code": "UNAUTHORIZED"
+              }
+            }
+          ]
+        }
+        "###);
+    });
+}
+
+#[test]
+fn error_propagation() {
+    struct TestHooks;
+
+    #[async_trait::async_trait]
+    impl DynHooks for TestHooks {
+        async fn authorize_edge_node_post_execution(
+            &self,
+            _context: &DynHookContext,
+            _definition: EdgeDefinition<'_>,
+            _nodes: Vec<serde_json::Value>,
+            _metadata: Option<serde_json::Value>,
+        ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
+            Err(PartialGraphqlError::new("Broken", PartialErrorCode::HookError))
+        }
+    }
+
+    with_engine_for_auth(TestHooks, |engine| async move {
+        let response = engine
+            .execute(
+                r#"
+                query {
+                    check {
+                        authorizedEdgeWithNode(ids: ["1"]) { withId { id } }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "Broken",
+              "path": [
+                "check",
+                "authorizedEdgeWithNode",
+                "withId"
+              ],
+              "extensions": {
+                "code": "HOOK_ERROR"
+              }
+            }
+          ]
+        }
+        "###);
+
+        let response = engine
+            .execute(
+                r#"
+                query {
+                    check {
+                        authorizedEdgeWithNode(ids: ["1"]) { nullableWithId { id } }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "check": {
+              "authorizedEdgeWithNode": {
+                "nullableWithId": null
+              }
+            }
+          },
+          "errors": [
+            {
+              "message": "Broken",
+              "path": [
+                "check",
+                "authorizedEdgeWithNode",
+                "nullableWithId"
+              ],
+              "extensions": {
+                "code": "HOOK_ERROR"
+              }
+            }
+          ]
+        }
+        "###);
+    });
+}
+
+#[test]
+fn lists() {
+    struct TestHooks;
+
+    #[async_trait::async_trait]
+    impl DynHooks for TestHooks {
+        async fn authorize_edge_node_post_execution(
+            &self,
+            _context: &DynHookContext,
+            _definition: EdgeDefinition<'_>,
+            nodes: Vec<serde_json::Value>,
+            _metadata: Option<serde_json::Value>,
+        ) -> Result<Vec<Result<(), PartialGraphqlError>>, PartialGraphqlError> {
+            Ok(nodes
+                .into_iter()
+                .map(|value| {
+                    if value["id"].as_str().unwrap().len() <= 1 {
+                        Ok(())
+                    } else {
+                        Err(PartialGraphqlError::new("Id too long!", PartialErrorCode::Unauthorized))
+                    }
+                })
+                .collect())
+        }
+    }
+
+    with_engine_for_auth(TestHooks, |engine| async move {
+        let response = engine
+            .execute(
+                r#"
+                query {
+                    goodIds: check {
+                       authorizedEdgeWithNode(ids: ["1", "7"]) {
+                           listWithId { id }
+                           listNullableWithId { id }
+                           listListWithId { id }
+                           listNullableListWithId { id }
+                           listListNullableWithId { id }
+                       }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "goodIds": {
+              "authorizedEdgeWithNode": {
+                "listWithId": [
+                  {
+                    "id": "1"
+                  },
+                  {
+                    "id": "7"
+                  }
+                ],
+                "listNullableWithId": [
+                  {
+                    "id": "1"
+                  },
+                  {
+                    "id": "7"
+                  }
+                ],
+                "listListWithId": [
+                  [
+                    {
+                      "id": "1"
+                    }
+                  ],
+                  [
+                    {
+                      "id": "7"
+                    }
+                  ]
+                ],
+                "listNullableListWithId": [
+                  [
+                    {
+                      "id": "1"
+                    }
+                  ],
+                  [
+                    {
+                      "id": "7"
+                    }
+                  ]
+                ],
+                "listListNullableWithId": [
+                  [
+                    {
+                      "id": "1"
+                    }
+                  ],
+                  [
+                    {
+                      "id": "7"
+                    }
+                  ]
+                ]
+              }
+            }
+          }
+        }
+        "###);
+
+        let response = engine
+            .execute(
+                r#"
+                query {
+                    check {
+                       authorizedEdgeWithNode(ids: ["1", "10", "7"]) {
+                           listWithId { id }
+                       }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "Id too long!",
+              "path": [
+                "check",
+                "authorizedEdgeWithNode",
+                "listWithId",
+                1
+              ],
+              "extensions": {
+                "code": "UNAUTHORIZED"
+              }
+            }
+          ]
+        }
+        "###);
+
+        let response = engine
+            .execute(
+                r#"
+                query {
+                    check {
+                       authorizedEdgeWithNode(ids: ["1", "10", "7"]) {
+                           listListWithId { id }
+                       }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "Id too long!",
+              "path": [
+                "check",
+                "authorizedEdgeWithNode",
+                "listListWithId",
+                1,
+                0
+              ],
+              "extensions": {
+                "code": "UNAUTHORIZED"
+              }
+            }
+          ]
+        }
+        "###);
+
+        let response = engine
+            .execute(
+                r#"
+                query {
+                    check {
+                       authorizedEdgeWithNode(ids: ["1", "10", "7"]) {
+                           listNullableWithId { id }
+                       }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "check": {
+              "authorizedEdgeWithNode": {
+                "listNullableWithId": [
+                  {
+                    "id": "1"
+                  },
+                  null,
+                  {
+                    "id": "7"
+                  }
+                ]
+              }
+            }
+          },
+          "errors": [
+            {
+              "message": "Id too long!",
+              "path": [
+                "check",
+                "authorizedEdgeWithNode",
+                "listNullableWithId",
+                1
+              ],
+              "extensions": {
+                "code": "UNAUTHORIZED"
+              }
+            }
+          ]
+        }
+        "###);
+
+        let response = engine
+            .execute(
+                r#"
+                query {
+                    check {
+                       authorizedEdgeWithNode(ids: ["1", "10", "7"]) {
+                           listNullableListWithId { id }
+                       }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "check": {
+              "authorizedEdgeWithNode": {
+                "listNullableListWithId": [
+                  [
+                    {
+                      "id": "1"
+                    }
+                  ],
+                  null,
+                  [
+                    {
+                      "id": "7"
+                    }
+                  ]
+                ]
+              }
+            }
+          },
+          "errors": [
+            {
+              "message": "Id too long!",
+              "path": [
+                "check",
+                "authorizedEdgeWithNode",
+                "listNullableListWithId",
+                1,
+                0
+              ],
+              "extensions": {
+                "code": "UNAUTHORIZED"
+              }
+            }
+          ]
+        }
+        "###);
+        let response = engine
+            .execute(
+                r#"
+                query {
+                    check {
+                       authorizedEdgeWithNode(ids: ["1", "10", "7"]) {
+                           listListNullableWithId { id }
+                       }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "check": {
+              "authorizedEdgeWithNode": {
+                "listListNullableWithId": [
+                  [
+                    {
+                      "id": "1"
+                    }
+                  ],
+                  [
+                    null
+                  ],
+                  [
+                    {
+                      "id": "7"
+                    }
+                  ]
+                ]
+              }
+            }
+          },
+          "errors": [
+            {
+              "message": "Id too long!",
+              "path": [
+                "check",
+                "authorizedEdgeWithNode",
+                "listListNullableWithId",
+                1,
+                0
+              ],
+              "extensions": {
+                "code": "UNAUTHORIZED"
+              }
+            }
+          ]
+        }
+        "###);
+    });
+}

--- a/engine/crates/integration-tests/tests/federation/hooks/mod.rs
+++ b/engine/crates/integration-tests/tests/federation/hooks/mod.rs
@@ -1,3 +1,4 @@
+mod authorize_edge_node_post_execution;
 mod authorize_edge_pre_execution;
 mod authorize_node_pre_execution;
 mod authorize_parent_edge_post_execution;


### PR DESCRIPTION
I added this hook which filters the _output_ of a field

```graphql
type Account {
  transactions: [Transaction!] @authorized(node: "kind")
}

type Transaction {
  kind: String
}
```

Here individual `Transaction` objects would be authorized or not, not the
`transactions` field. I'm re-using the structure I made for
`@authorized(fields: "...")` but reversing the SelectionSetId everywhere
basically, using the output instead of the parent one. It's pretty much
a hack. I'll separate a lot of that code in the next week.

Had to add the necessary code in composition also. We didn't parse `node` before.