### PR TITLE
chore: refine redis keys a bit nicer

### DIFF
--- a/engine/crates/engine-v2/src/engine/rate_limiting.rs
+++ b/engine/crates/engine-v2/src/engine/rate_limiting.rs
@@ -33,4 +33,8 @@ impl RateLimiterContext for RateLimitContext<'_> {
             RateLimitContext::Subgraph(name) => name,
         })
     }
+
+    fn is_global(&self) -> bool {
+        matches!(self, Self::Global)
+    }
 }

--- a/engine/crates/runtime/src/rate_limiting.rs
+++ b/engine/crates/runtime/src/rate_limiting.rs
@@ -21,6 +21,10 @@ pub trait RateLimiterContext: Send + Sync {
     fn key(&self) -> Option<&str> {
         None
     }
+
+    fn is_global(&self) -> bool {
+        true
+    }
 }
 
 pub trait RateLimiterInner: Send + Sync {


### PR DESCRIPTION
If subgraph has a name "global" we would be in trouble.
