### PR TITLE
feat: cache entity requests in engine-v2

### DIFF
--- a/engine/crates/engine-v2/src/response/read/view/mod.rs
+++ b/engine/crates/engine-v2/src/response/read/view/mod.rs
@@ -45,7 +45,7 @@ impl<'a> ResponseObjectsView<'a> {
 }
 
 impl<'a> ResponseObjectsViewWithExtraFields<'a> {
-    fn iter(&self) -> impl Iterator<Item = ResponseObjectWithExtraFieldsWalker<'_>> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = ResponseObjectWithExtraFieldsWalker<'_>> + '_ {
         self.response_object_set
             .iter()
             .map(|item| ResponseObjectWithExtraFieldsWalker {
@@ -92,7 +92,7 @@ pub(crate) struct ResponseObjectView<'a> {
     selection_set: ResponseViewSelectionSet,
 }
 
-struct ResponseObjectWithExtraFieldsWalker<'a> {
+pub(crate) struct ResponseObjectWithExtraFieldsWalker<'a> {
     ctx: ViewContext<'a>,
     response_object: &'a ResponseObject,
     selection_set: ResponseViewSelectionSet,

--- a/engine/crates/engine-v2/src/sources/graphql/deserialize/entities.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/deserialize/entities.rs
@@ -1,13 +1,14 @@
 use std::fmt;
 
 use serde::{
-    de::{DeserializeSeed, IgnoredAny, MapAccess, SeqAccess, Visitor},
+    de::{DeserializeSeed, Error, IgnoredAny, MapAccess, SeqAccess, Visitor},
     Deserializer,
 };
 
 use crate::{
     execution::PlanWalker,
     response::{ErrorCode, GraphqlError, ResponseKeys, ResponsePath, SubgraphResponseRefMut, UnpackedResponseEdge},
+    sources::graphql::CachedEntity,
 };
 
 use super::errors::GraphqlErrorsSeed;
@@ -15,6 +16,7 @@ use super::errors::GraphqlErrorsSeed;
 pub(in crate::sources::graphql) struct EntitiesDataSeed<'resp> {
     pub response: SubgraphResponseRefMut<'resp>,
     pub plan: PlanWalker<'resp>,
+    pub cache_entries: Option<&'resp [CachedEntity]>,
 }
 
 impl<'resp, 'de> DeserializeSeed<'de> for EntitiesDataSeed<'resp>
@@ -51,6 +53,7 @@ where
                     map.next_value_seed(EntitiesSeed {
                         response_part: &self.response,
                         plan: self.plan,
+                        cache_entries: self.cache_entries.map(|slice| slice.iter()),
                     })?;
                 }
                 EntitiesKey::Unknown => {
@@ -73,6 +76,7 @@ enum EntitiesKey {
 struct EntitiesSeed<'resp, 'parent> {
     response_part: &'parent SubgraphResponseRefMut<'resp>,
     plan: PlanWalker<'resp>,
+    cache_entries: Option<std::slice::Iter<'parent, CachedEntity>>,
 }
 
 impl<'resp, 'de, 'parent> DeserializeSeed<'de> for EntitiesSeed<'resp, 'parent>
@@ -99,12 +103,23 @@ where
         formatter.write_str("a non null entities list")
     }
 
-    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    fn visit_seq<A>(mut self, mut seq: A) -> Result<Self::Value, A::Error>
     where
         A: SeqAccess<'de>,
     {
         while let Some(seed) = self.response_part.next_seed(self.plan) {
-            match seq.next_element_seed(seed) {
+            let next_cache_entry = self.cache_entries.as_mut().and_then(Iterator::next);
+            let result = match next_cache_entry {
+                Some(entry) if entry.data.is_some() => seed
+                    .deserialize(&mut serde_json::Deserializer::from_slice(
+                        entry.data.as_deref().unwrap(),
+                    ))
+                    .map(Some)
+                    .map_err(A::Error::custom),
+                _ => seq.next_element_seed(seed),
+            };
+
+            match result {
                 Ok(Some(_)) => continue,
                 Ok(None) => break,
                 Err(err) => {

--- a/engine/crates/engine-v2/src/sources/graphql/federation.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/federation.rs
@@ -1,13 +1,17 @@
 use bytes::Bytes;
-use grafbase_telemetry::span::subgraph::SubgraphRequestSpan;
+use futures::future::join_all;
+use grafbase_telemetry::{gql_response_status::GraphqlResponseStatus, span::subgraph::SubgraphRequestSpan};
+use hex::ToHex;
 use runtime::fetch::FetchRequest;
 use schema::sources::graphql::{FederationEntityResolverWalker, GraphqlEndpointId};
-use serde::de::DeserializeSeed;
-use std::future::Future;
+use serde::{de::DeserializeSeed, Deserialize};
+use serde_json::value::RawValue;
+use sha2::Digest;
+use std::{borrow::Cow, future::Future, time::Duration};
 use tracing::Instrument;
 
 use crate::{
-    execution::{ExecutionContext, PlanWalker, PlanningResult},
+    execution::{ExecutionContext, ExecutionError, PlanWalker, PlanningResult},
     operation::OperationType,
     response::{ResponseObjectsView, SubgraphResponse},
     sources::{
@@ -18,7 +22,9 @@ use crate::{
 };
 
 use super::{
-    deserialize::EntitiesDataSeed, query::PreparedFederationEntityOperation, request::execute_subgraph_request,
+    deserialize::EntitiesDataSeed,
+    query::PreparedFederationEntityOperation,
+    request::{execute_subgraph_request, ResponseIngester},
     variables::SubgraphVariables,
 };
 
@@ -46,41 +52,21 @@ impl FederationEntityPreparedExecutor {
         ctx: ExecutionContext<'ctx, R>,
         plan: PlanWalker<'ctx, (), ()>,
         root_response_objects: ResponseObjectsView<'_>,
-        mut subgraph_response: SubgraphResponse,
+        subgraph_response: SubgraphResponse,
     ) -> ExecutionResult<impl Future<Output = ExecutionResult<SubgraphResponse>> + Send + 'fut>
     where
         'ctx: 'fut,
     {
         let root_response_objects = root_response_objects.with_extra_constant_fields(vec![(
             "__typename".to_string(),
-            serde_json::Value::String(
-                ctx.engine
-                    .schema
-                    .walker()
-                    .walk(schema::Definition::from(plan.logical_plan().as_ref().entity_id))
-                    .name()
-                    .to_string(),
-            ),
+            serde_json::Value::String(entity_name(ctx, plan)),
         )]);
-        let variables = SubgraphVariables {
-            plan,
-            variables: &self.operation.variables,
-            inputs: vec![(&self.operation.entities_variable_name, root_response_objects)],
-        };
+        let mut representations = root_response_objects
+            .iter()
+            .map(|object| serde_json::to_string(&object).and_then(RawValue::from_string))
+            .collect::<Result<Vec<_>, _>>()?;
 
         let subgraph = ctx.engine.schema.walk(self.subgraph_id);
-        tracing::debug!(
-            "Query {}\n{}\n{}",
-            subgraph.name(),
-            self.operation.query,
-            serde_json::to_string_pretty(&variables).unwrap_or_default()
-        );
-        let json_body = serde_json::to_string(&serde_json::json!({
-            "query": self.operation.query,
-            "variables": variables
-        }))
-        .map_err(|err| format!("Failed to serialize query: {err}"))?;
-
         let span = SubgraphRequestSpan {
             name: subgraph.name(),
             operation_type: OperationType::Query.as_str(),
@@ -91,34 +77,214 @@ impl FederationEntityPreparedExecutor {
         }
         .into_span();
 
-        let fut = execute_subgraph_request(
-            ctx,
-            span.clone(),
-            subgraph.name(),
-            move || FetchRequest {
-                url: subgraph.url(),
-                headers: ctx.subgraph_headers_with_rules(subgraph.header_rules()),
-                json_body,
-                subgraph_name: subgraph.name(),
-                timeout: subgraph.timeout(),
-            },
-            move |bytes: Bytes| {
-                let response = subgraph_response.as_mut();
-                let status = GraphqlResponseSeed::new(
-                    EntitiesDataSeed {
-                        response: response.clone(),
-                        plan,
+        let cache_ttl = subgraph.entity_cache_ttl();
+
+        let fut = {
+            let span = span.clone();
+            async move {
+                let mut ingester = EntityIngester {
+                    ctx,
+                    plan,
+                    cache_entries: None,
+                    subgraph_response,
+                    cache_ttl,
+                };
+
+                if ctx.engine.schema.settings.enable_entity_caching {
+                    let fetches = representations
+                        .iter()
+                        .map(|repr| cache_fetch(ctx, subgraph.name(), repr));
+
+                    let cache_entries = join_all(fetches).await;
+                    let fully_cached = !cache_entries.iter().any(|entry| entry.data.is_none());
+                    ingester.cache_entries = Some(cache_entries);
+                    if fully_cached {
+                        let (_, response) = ingester
+                            .ingest(Bytes::from_static(br#"{"data": {"_entities": []}}"#))
+                            .await?;
+
+                        return Ok(response);
+                    }
+                    representations = representations
+                        .into_iter()
+                        .zip(ingester.cache_entries.as_ref().unwrap())
+                        .filter(|(_, cache_entry)| cache_entry.data.is_none())
+                        .map(|(repr, _)| repr)
+                        .collect();
+                }
+                let variables = SubgraphVariables {
+                    plan,
+                    variables: &self.operation.variables,
+                    inputs: vec![(&self.operation.entities_variable_name, representations)],
+                };
+
+                tracing::debug!(
+                    "Query {}\n{}\n{}",
+                    subgraph.name(),
+                    self.operation.query,
+                    serde_json::to_string_pretty(&variables).unwrap_or_default()
+                );
+                let json_body = serde_json::to_string(&serde_json::json!({
+                    "query": self.operation.query,
+                    "variables": variables
+                }))
+                .map_err(|err| format!("Failed to serialize query: {err}"))?;
+
+                execute_subgraph_request(
+                    ctx,
+                    span.clone(),
+                    subgraph.name(),
+                    move || FetchRequest {
+                        url: subgraph.url(),
+                        headers: ctx.subgraph_headers_with_rules(subgraph.header_rules()),
+                        json_body,
+                        subgraph_name: subgraph.name(),
+                        timeout: subgraph.timeout(),
                     },
-                    EntitiesErrorsSeed {
-                        response,
-                        response_keys: plan.response_keys(),
-                    },
+                    ingester,
                 )
-                .deserialize(&mut serde_json::Deserializer::from_slice(&bytes))?;
-                Ok((status, subgraph_response))
-            },
-        )
+                .await
+            }
+        }
         .instrument(span);
+
         Ok(fut)
     }
+}
+
+struct EntityIngester<'ctx, R: Runtime> {
+    ctx: ExecutionContext<'ctx, R>,
+    plan: PlanWalker<'ctx, (), ()>,
+    cache_entries: Option<Vec<CachedEntity>>,
+    subgraph_response: SubgraphResponse,
+    cache_ttl: Duration,
+}
+
+pub struct CachedEntity {
+    pub key: String,
+    pub data: Option<Vec<u8>>,
+}
+
+impl<'ctx, R> ResponseIngester for EntityIngester<'ctx, R>
+where
+    R: Runtime,
+{
+    async fn ingest(self, bytes: Bytes) -> Result<(GraphqlResponseStatus, SubgraphResponse), ExecutionError> {
+        let Self {
+            ctx,
+            plan,
+            cache_entries,
+            mut subgraph_response,
+            cache_ttl,
+        } = self;
+
+        let status = {
+            let response = subgraph_response.as_mut();
+            GraphqlResponseSeed::new(
+                EntitiesDataSeed {
+                    response: response.clone(),
+                    cache_entries: cache_entries.as_deref(),
+                    plan,
+                },
+                EntitiesErrorsSeed {
+                    response,
+                    response_keys: plan.response_keys(),
+                },
+            )
+            .deserialize(&mut serde_json::Deserializer::from_slice(&bytes))?
+        };
+
+        if let Some(cache_entries) = cache_entries.filter(|_| status.is_success()) {
+            update_cache(ctx, cache_ttl, bytes, cache_entries).await
+        }
+
+        Ok((status, subgraph_response))
+    }
+}
+
+async fn update_cache<R: Runtime>(
+    ctx: ExecutionContext<'_, R>,
+    cache_ttl: Duration,
+    bytes: Bytes,
+    cache_entries: Vec<CachedEntity>,
+) {
+    let mut entities = match Response::deserialize(&mut serde_json::Deserializer::from_slice(&bytes)) {
+        Ok(response) => response.data.entities.into_iter(),
+        Err(err) => {
+            tracing::warn!("Couldn't deserialize response for cache update: {err}");
+            // This shouldn't really happen but if it does lets ignore it
+            // Don't want cache stuff to break the actual request
+            return;
+        }
+    };
+
+    let mut update_futures = vec![];
+    for entry in cache_entries {
+        if entry.data.is_some() {
+            continue;
+        }
+        let Some(data) = entities.next() else {
+            // This shouldn't really happen but if it does lets ignore it
+            // Don't want cache stuff to break the actual request
+            return;
+        };
+        let bytes = data.get().as_bytes();
+        let cache_key = entry.key;
+        update_futures.push(async move {
+            ctx.engine
+                .runtime
+                .kv()
+                .put(&cache_key, Cow::Borrowed(bytes), Some(cache_ttl))
+                .await
+                .inspect_err(|err| tracing::warn!("Failed to write the cache key {cache_key}: {err}"))
+                .ok();
+        })
+    }
+
+    join_all(update_futures).await;
+}
+
+#[derive(serde::Deserialize)]
+struct Response<'a> {
+    #[serde(borrow)]
+    data: Data<'a>,
+}
+
+#[derive(serde::Deserialize)]
+struct Data<'a> {
+    #[serde(borrow, rename = "_entities")]
+    entities: Vec<&'a serde_json::value::RawValue>,
+}
+
+async fn cache_fetch<R: Runtime>(ctx: ExecutionContext<'_, R>, subgraph_name: &str, repr: &RawValue) -> CachedEntity {
+    let key = build_cache_key(subgraph_name, repr);
+
+    let data = ctx
+        .engine
+        .runtime
+        .kv()
+        .get(&key, Some(Duration::ZERO))
+        .await
+        .inspect_err(|err| tracing::warn!("Failed to read the cache key {key}: {err}"))
+        .ok()
+        .flatten();
+
+    CachedEntity { key, data }
+}
+
+fn build_cache_key(subgraph_name: &str, repr: &RawValue) -> String {
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(subgraph_name);
+    hasher.update(repr.get());
+    let output = hasher.finalize();
+    output.encode_hex()
+}
+
+fn entity_name<R: Runtime>(ctx: ExecutionContext<'_, R>, plan: PlanWalker<'_, (), ()>) -> String {
+    ctx.engine
+        .schema
+        .walker()
+        .walk(schema::Definition::from(plan.logical_plan().as_ref().entity_id))
+        .name()
+        .to_string()
 }

--- a/engine/crates/engine-v2/src/sources/graphql/mod.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/mod.rs
@@ -59,7 +59,7 @@ impl GraphqlPreparedExecutor {
         mut subgraph_response: SubgraphResponse,
     ) -> ExecutionResult<SubgraphResponse> {
         let subgraph = plan.schema().walk(self.subgraph_id);
-        let variables = SubgraphVariables {
+        let variables = SubgraphVariables::<()> {
             plan,
             variables: &self.operation.variables,
             inputs: Vec::new(),

--- a/engine/crates/engine-v2/src/sources/graphql/mod.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/mod.rs
@@ -2,12 +2,10 @@ use std::{borrow::Cow, time::Duration};
 
 use bytes::Bytes;
 use grafbase_telemetry::{gql_response_status::GraphqlResponseStatus, span::subgraph::SubgraphRequestSpan};
-use hex::ToHex;
 use request::{execute_subgraph_request, ResponseIngester};
 use runtime::fetch::FetchRequest;
 use schema::sources::graphql::{GraphqlEndpointId, RootFieldResolverWalker};
 use serde::de::DeserializeSeed;
-use sha2::Digest;
 use tracing::Instrument;
 
 use self::query::PreparedGraphqlOperation;
@@ -147,10 +145,9 @@ impl GraphqlPreparedExecutor {
 }
 
 fn build_cache_key(json_body: &str) -> String {
-    let mut hasher = sha2::Sha256::new();
-    hasher.update(json_body);
-    let output = hasher.finalize();
-    output.encode_hex()
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(json_body.as_bytes());
+    hasher.finalize().to_string()
 }
 
 struct GraphqlIngester<'ctx, R: Runtime> {

--- a/engine/crates/engine-v2/src/sources/graphql/subscription.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/subscription.rs
@@ -47,7 +47,7 @@ impl GraphqlPreparedExecutor {
             .stream(GraphqlRequest {
                 url: &url,
                 query: &self.operation.query,
-                variables: serde_json::to_value(&SubgraphVariables {
+                variables: serde_json::to_value(&SubgraphVariables::<()> {
                     plan,
                     variables: &self.operation.variables,
                     inputs: Vec::new(),

--- a/engine/crates/engine-v2/src/sources/graphql/variables.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/variables.rs
@@ -1,16 +1,19 @@
 use serde::ser::SerializeMap;
 
-use crate::{execution::PlanWalker, response::ResponseObjectsViewWithExtraFields};
+use crate::execution::PlanWalker;
 
 use super::query::QueryVariables;
 
-pub(super) struct SubgraphVariables<'a> {
+pub(super) struct SubgraphVariables<'a, Input> {
     pub plan: PlanWalker<'a>,
     pub variables: &'a QueryVariables,
-    pub inputs: Vec<(&'a str, ResponseObjectsViewWithExtraFields<'a>)>,
+    pub inputs: Vec<(&'a str, Input)>,
 }
 
-impl<'a> serde::Serialize for SubgraphVariables<'a> {
+impl<'a, Input> serde::Serialize for SubgraphVariables<'a, Input>
+where
+    Input: serde::Serialize,
+{
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/engine/crates/graphql-mocks/src/federation/products.rs
+++ b/engine/crates/graphql-mocks/src/federation/products.rs
@@ -112,6 +112,11 @@ impl Query {
         ctx.data_unchecked::<Vec<Product>>()
     }
 
+    async fn product<'a>(&self, ctx: &'a Context<'_>, upc: String) -> Option<&'a Product> {
+        let products = ctx.data_unchecked::<Vec<Product>>();
+        products.iter().find(|product| product.upc == upc)
+    }
+
     #[graphql(entity)]
     async fn find_product_by_upc<'a>(&self, ctx: &'a Context<'_>, upc: String) -> Option<&'a Product> {
         let products = ctx.data_unchecked::<Vec<Product>>();

--- a/engine/crates/integration-tests/tests/federation/introspection.rs
+++ b/engine/crates/integration-tests/tests/federation/introspection.rs
@@ -817,6 +817,7 @@ fn introspection_on_multiple_federation_subgraphs() {
 
     type Query {
       me: User!
+      product(upc: String!): Product
       topProducts: [Product!]!
     }
 


### PR DESCRIPTION
Following on from #1931 - this adds caching on the entity requests to subgraphs.  These are a bit more complicated because one request will usually map to more than one cache entry.  We need to filter out any representations that have a cache hit from the request to the subgraph, and then make sure we use the cache entry for those during deserialisation rather than trying to read them from the response.

I've made use of `serde_json::RawValue` in quite a few places to try to make things more efficient - so we don't have to go through a bunch of extra serde roundtrips.

Fixes GB-7159