### PR TITLE
chore: update dependencies and hooks configuration

### DIFF
--- a/examples/gateway-hooks/Cargo.lock
+++ b/examples/gateway-hooks/Cargo.lock
@@ -1122,7 +1122,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 [[package]]
 name = "reqwest"
 version = "0.12.4"
-source = "git+https://github.com/pimeys/reqwest/?branch=feat/wasi-p2-component-support#7e26f0f13a7f51ca1f79a12a110fdd0b7aaf45d9"
+source = "git+https://github.com/pimeys/reqwest/?branch=feat/wasi-p2-component-support#6b23d746e95aa900630cfe82c5ed81bb9aeea5e3"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/examples/gateway-hooks/grafbase.toml
+++ b/examples/gateway-hooks/grafbase.toml
@@ -2,7 +2,7 @@
 introspection = true
 
 [hooks]
-location = "target/wasm32-wasip1/release/demo_hooks.wasm"
+location = "target/wasm32-wasip1/release/hooks.wasm"
 stdout = true
 stderr = true
 environment_variables = true


### PR DESCRIPTION
- Updated reqwest package in Cargo.lock from commit 7e26f0f to 6b23d746
- Changed hooks location in grafbase.toml to target/wasm32-wasip1/release/hooks.wasm
