### PR TITLE
feat(engine): Expose used fields in OTEL metrics

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .gitignore
 .github
 .git
+.cargo/bin
 Dockerfile
 node_modules
 templates

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2448,6 +2448,7 @@ name = "engine-parser"
 version = "3.0.31"
 dependencies = [
  "engine-value",
+ "grafbase-telemetry",
  "pest",
  "pest_derive",
  "serde",
@@ -6943,7 +6944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18bec9b0adc4eba778b33684b7ba3e7137789434769ee3ce3930463ef904cfca"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.66",

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,4 +53,4 @@ WORKDIR /data
 ENTRYPOINT ["/bin/grafbase-gateway"]
 CMD ["--config", "/etc/grafbase.toml", "--listen-address", "0.0.0.0:5000"]
 
-EXPOSE 4000
+EXPOSE 5000

--- a/engine/crates/engine-v2/Cargo.toml
+++ b/engine/crates/engine-v2/Cargo.toml
@@ -34,7 +34,7 @@ itertools.workspace = true
 lasso2 = { version = "0.8.2", features = ["serialize"] }
 serde = { workspace = true, features = ["rc"] }
 serde-value = "0.7"
-serde_json.workspace = true
+serde_json = { workspace = true, features = ["raw_value"] }
 sha2.workspace = true
 strum.workspace = true
 thiserror.workspace = true

--- a/engine/crates/engine-v2/src/operation/build.rs
+++ b/engine/crates/engine-v2/src/operation/build.rs
@@ -7,9 +7,10 @@ use super::{
     bind::{bind_operation, BindError},
     blueprint::ResponseBlueprintBuilder,
     logical_planner::{LogicalPlanner, LogicalPlanningError},
-    parse::{parse_operation, ParseError, ParsedOperation},
+    metrics::{generate_used_fields, prepare_metrics_attributes},
+    parse::{parse_operation, ParseError},
     validation::{validate_operation, ValidationError},
-    Operation, OperationMetadata, PreparedOperation, Variables,
+    Operation, OperationMetricsAttributes, PreparedOperation, Variables,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -18,17 +19,17 @@ pub(crate) enum OperationError {
     Parse(#[from] ParseError),
     #[error("{err}")]
     Bind {
-        operation_metadata: Box<Option<OperationMetadata>>,
+        metrics_attributes: Box<Option<OperationMetricsAttributes>>,
         err: BindError,
     },
     #[error("{err}")]
     Validation {
-        operation_metadata: Box<Option<OperationMetadata>>,
+        metrics_attributes: Box<Option<OperationMetricsAttributes>>,
         err: ValidationError,
     },
     #[error("{err}")]
     LogicalPlanning {
-        operation_metadata: Box<Option<OperationMetadata>>,
+        metrics_attributes: Box<Option<OperationMetricsAttributes>>,
         err: LogicalPlanningError,
     },
     #[error("Failed to normalize query")]
@@ -48,11 +49,11 @@ impl From<OperationError> for GraphqlError {
 }
 
 impl OperationError {
-    pub fn take_operation_metadata(&mut self) -> Option<OperationMetadata> {
+    pub fn take_metrics_attributes(&mut self) -> Option<OperationMetricsAttributes> {
         match self {
-            OperationError::Bind { operation_metadata, .. } => std::mem::take(operation_metadata),
-            OperationError::Validation { operation_metadata, .. } => std::mem::take(operation_metadata),
-            OperationError::LogicalPlanning { operation_metadata, .. } => std::mem::take(operation_metadata),
+            OperationError::Bind { metrics_attributes, .. } => std::mem::take(metrics_attributes),
+            OperationError::Validation { metrics_attributes, .. } => std::mem::take(metrics_attributes),
+            OperationError::LogicalPlanning { metrics_attributes, .. } => std::mem::take(metrics_attributes),
             _ => None,
         }
     }
@@ -67,13 +68,13 @@ impl Operation {
     #[instrument(skip_all)]
     pub fn build(schema: &Schema, request: &engine::Request) -> Result<PreparedOperation, OperationError> {
         let parsed_operation = parse_operation(request)?;
-        let operation_metadata = prepare_metadata(&parsed_operation, request);
+        let metrics_attributes = prepare_metrics_attributes(&parsed_operation, request);
 
         let mut operation = match bind_operation(schema, parsed_operation) {
             Ok(operation) => operation,
             Err(err) => {
                 return Err(OperationError::Bind {
-                    operation_metadata: Box::new(operation_metadata),
+                    metrics_attributes: Box::new(metrics_attributes),
                     err,
                 })
             }
@@ -83,7 +84,7 @@ impl Operation {
         let variables = Variables::create_unavailable_for(&operation);
         if let Err(err) = validate_operation(schema, operation.walker_with(schema.walker(), &variables), request) {
             return Err(OperationError::Validation {
-                operation_metadata: Box::new(operation_metadata),
+                metrics_attributes: Box::new(metrics_attributes),
                 err,
             });
         }
@@ -92,7 +93,7 @@ impl Operation {
             Ok(plan) => plan,
             Err(err) => {
                 return Err(OperationError::LogicalPlanning {
-                    operation_metadata: Box::new(operation_metadata),
+                    metrics_attributes: Box::new(metrics_attributes),
                     err,
                 });
             }
@@ -100,24 +101,14 @@ impl Operation {
 
         let response_blueprint = ResponseBlueprintBuilder::new(schema, &variables, &operation, &plan).build();
 
+        let mut metrics_attributes = metrics_attributes.ok_or(OperationError::NormalizationError)?;
+        metrics_attributes.used_fields = generate_used_fields(schema, &operation);
+
         Ok(PreparedOperation {
             operation,
-            metadata: operation_metadata.ok_or(OperationError::NormalizationError)?,
+            metrics_attributes,
             plan,
             response_blueprint,
         })
     }
-}
-
-fn prepare_metadata(operation: &ParsedOperation, request: &engine::Request) -> Option<OperationMetadata> {
-    operation_normalizer::normalize(request.query(), request.operation_name())
-        .ok()
-        .map(|normalized_query| OperationMetadata {
-            ty: operation.definition.ty,
-            name: operation.name.clone().or_else(|| {
-                engine_parser::find_first_field_name(&operation.fragments, &operation.definition.selection_set)
-            }),
-            normalized_query_hash: blake3::hash(normalized_query.as_bytes()).into(),
-            normalized_query,
-        })
 }

--- a/engine/crates/engine-v2/src/operation/metrics.rs
+++ b/engine/crates/engine-v2/src/operation/metrics.rs
@@ -1,0 +1,62 @@
+use grafbase_telemetry::metrics::OperationMetricsAttributes;
+use itertools::Itertools;
+use schema::Schema;
+
+use super::{parse::ParsedOperation, Operation};
+
+pub(super) fn prepare_metrics_attributes(
+    operation: &ParsedOperation,
+    request: &engine::Request,
+) -> Option<OperationMetricsAttributes> {
+    operation_normalizer::normalize(request.query(), request.operation_name())
+        .ok()
+        .map(|sanitized_query| OperationMetricsAttributes {
+            ty: operation.definition.ty.into(),
+            name: operation.name.clone().or_else(|| {
+                engine_parser::find_first_field_name(&operation.fragments, &operation.definition.selection_set)
+            }),
+            sanitized_query_hash: blake3::hash(sanitized_query.as_bytes()).into(),
+            sanitized_query,
+            used_fields: String::new(),
+        })
+}
+
+pub(super) fn generate_used_fields(schema: &Schema, operation: &Operation) -> String {
+    let mut used_field_definitions = Vec::with_capacity(operation.fields.len());
+    for field in &operation.fields {
+        let Some(definition_id) = field.definition_id() else {
+            continue;
+        };
+
+        let field = schema.walk(definition_id);
+        let entity = field.parent_entity();
+        // Skipping introspection related fields
+        if !entity.name().starts_with("__") && !field.name().starts_with("__") {
+            used_field_definitions.push((entity.id(), definition_id))
+        }
+    }
+    used_field_definitions.sort_unstable();
+
+    // Kind of arbitrary, we may have duplicated fields but each field & type name will take
+    // several bytes.
+    let mut out = String::with_capacity(used_field_definitions.len() * 4);
+    for (entity_id, field_definitions) in used_field_definitions
+        .into_iter()
+        .dedup()
+        .chunk_by(|(entity_id, _)| *entity_id)
+        .into_iter()
+    {
+        out.push_str(schema.walk(entity_id).name());
+        out.push('.');
+        for s in Itertools::intersperse(
+            field_definitions.map(|(_, definition_id)| schema.walk(definition_id).name()),
+            "+",
+        ) {
+            out.push_str(s);
+        }
+        out.push(',')
+    }
+    out.pop();
+
+    out
+}

--- a/engine/crates/engine-v2/src/operation/mod.rs
+++ b/engine/crates/engine-v2/src/operation/mod.rs
@@ -5,6 +5,7 @@ pub mod ids;
 mod input_value;
 mod location;
 mod logical_planner;
+mod metrics;
 mod modifier;
 mod parse;
 mod path;
@@ -15,6 +16,7 @@ mod walkers;
 
 use crate::response::{ConcreteObjectShapeId, FieldShapeId, ResponseKeys, ResponseObjectSetId, Shapes};
 pub(crate) use engine_parser::types::OperationType;
+use grafbase_telemetry::metrics::OperationMetricsAttributes;
 use id_newtypes::{BitSet, IdRange, IdToMany};
 pub(crate) use ids::*;
 pub(crate) use input_value::*;
@@ -29,7 +31,7 @@ pub(crate) use walkers::*;
 #[derive(serde::Serialize, serde::Deserialize)]
 pub(crate) struct PreparedOperation {
     pub operation: Operation,
-    pub metadata: OperationMetadata,
+    pub metrics_attributes: OperationMetricsAttributes,
     pub plan: OperationPlan,
     pub response_blueprint: ResponseBlueprint,
 }
@@ -70,17 +72,6 @@ pub(crate) struct Operation {
     // deduplicated by rule
     pub response_modifiers: Vec<ResponseModifier>,
     pub response_modifier_impacted_fields: Vec<FieldId>,
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct OperationMetadata {
-    pub ty: OperationType,
-    /// This is a *processed* operation name, it does not strictly reflect the GraphQL operation
-    /// name. Currently, if the latter doesn't exist we take the first field's name as the
-    /// operation name.
-    pub name: Option<String>,
-    pub normalized_query: String,
-    pub normalized_query_hash: [u8; 32],
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/engine/crates/engine/parser/Cargo.toml
+++ b/engine/crates/engine/parser/Cargo.toml
@@ -13,4 +13,5 @@ keywords = ["graphql", "query", "parser", "grafbase"]
 engine-value = { path = "../value", version = "3" }
 pest = "2.7.9"
 pest_derive = "2.7.9"
+grafbase-telemetry.workspace = true
 serde.workspace = true

--- a/engine/crates/engine/parser/src/types/mod.rs
+++ b/engine/crates/engine/parser/src/types/mod.rs
@@ -43,6 +43,16 @@ pub enum OperationType {
     Subscription,
 }
 
+impl From<OperationType> for grafbase_telemetry::metrics::OperationType {
+    fn from(value: OperationType) -> Self {
+        match value {
+            OperationType::Query => Self::Query,
+            OperationType::Mutation => Self::Mutation,
+            OperationType::Subscription => Self::Subscription,
+        }
+    }
+}
+
 impl OperationType {
     /// Operation type as str
     pub fn as_str(&self) -> &'static str {

--- a/engine/crates/engine/validation/src/visitor.rs
+++ b/engine/crates/engine/validation/src/visitor.rs
@@ -246,27 +246,29 @@ impl<A, B> VisitorCons<A, B> {
 
 impl<'a, Registry: AnyRegistry> Visitor<'a, Registry> for VisitorNil {}
 
-impl<'a, A, B, Registry> Visitor<'a, Registry> for VisitorCons<A, B>
+impl<'ctx, 'a, 'b, A, B, Registry> Visitor<'ctx, Registry> for VisitorCons<A, B>
 where
     Registry: AnyRegistry,
-    A: Visitor<'a, Registry> + 'a,
-    B: Visitor<'a, Registry> + 'a,
+    A: Visitor<'ctx, Registry> + 'a,
+    B: Visitor<'ctx, Registry> + 'b,
+    'ctx: 'a,
+    'ctx: 'b,
 {
-    fn enter_document(&mut self, ctx: &mut VisitorContext<'a, Registry>, doc: &'a ExecutableDocument) {
+    fn enter_document(&mut self, ctx: &mut VisitorContext<'ctx, Registry>, doc: &'ctx ExecutableDocument) {
         self.0.enter_document(ctx, doc);
         self.1.enter_document(ctx, doc);
     }
 
-    fn exit_document(&mut self, ctx: &mut VisitorContext<'a, Registry>, doc: &'a ExecutableDocument) {
+    fn exit_document(&mut self, ctx: &mut VisitorContext<'ctx, Registry>, doc: &'ctx ExecutableDocument) {
         self.0.exit_document(ctx, doc);
         self.1.exit_document(ctx, doc);
     }
 
     fn enter_operation_definition(
         &mut self,
-        ctx: &mut VisitorContext<'a, Registry>,
-        name: Option<&'a Name>,
-        operation_definition: &'a Positioned<OperationDefinition>,
+        ctx: &mut VisitorContext<'ctx, Registry>,
+        name: Option<&'ctx Name>,
+        operation_definition: &'ctx Positioned<OperationDefinition>,
     ) {
         self.0.enter_operation_definition(ctx, name, operation_definition);
         self.1.enter_operation_definition(ctx, name, operation_definition);
@@ -274,9 +276,9 @@ where
 
     fn exit_operation_definition(
         &mut self,
-        ctx: &mut VisitorContext<'a, Registry>,
-        name: Option<&'a Name>,
-        operation_definition: &'a Positioned<OperationDefinition>,
+        ctx: &mut VisitorContext<'ctx, Registry>,
+        name: Option<&'ctx Name>,
+        operation_definition: &'ctx Positioned<OperationDefinition>,
     ) {
         self.0.exit_operation_definition(ctx, name, operation_definition);
         self.1.exit_operation_definition(ctx, name, operation_definition);
@@ -284,9 +286,9 @@ where
 
     fn enter_fragment_definition(
         &mut self,
-        ctx: &mut VisitorContext<'a, Registry>,
-        name: &'a Name,
-        fragment_definition: &'a Positioned<FragmentDefinition>,
+        ctx: &mut VisitorContext<'ctx, Registry>,
+        name: &'ctx Name,
+        fragment_definition: &'ctx Positioned<FragmentDefinition>,
     ) {
         self.0.enter_fragment_definition(ctx, name, fragment_definition);
         self.1.enter_fragment_definition(ctx, name, fragment_definition);
@@ -294,9 +296,9 @@ where
 
     fn exit_fragment_definition(
         &mut self,
-        ctx: &mut VisitorContext<'a, Registry>,
-        name: &'a Name,
-        fragment_definition: &'a Positioned<FragmentDefinition>,
+        ctx: &mut VisitorContext<'ctx, Registry>,
+        name: &'ctx Name,
+        fragment_definition: &'ctx Positioned<FragmentDefinition>,
     ) {
         self.0.exit_fragment_definition(ctx, name, fragment_definition);
         self.1.exit_fragment_definition(ctx, name, fragment_definition);
@@ -304,8 +306,8 @@ where
 
     fn enter_variable_definition(
         &mut self,
-        ctx: &mut VisitorContext<'a, Registry>,
-        variable_definition: &'a Positioned<VariableDefinition>,
+        ctx: &mut VisitorContext<'ctx, Registry>,
+        variable_definition: &'ctx Positioned<VariableDefinition>,
     ) {
         self.0.enter_variable_definition(ctx, variable_definition);
         self.1.enter_variable_definition(ctx, variable_definition);
@@ -313,28 +315,28 @@ where
 
     fn exit_variable_definition(
         &mut self,
-        ctx: &mut VisitorContext<'a, Registry>,
-        variable_definition: &'a Positioned<VariableDefinition>,
+        ctx: &mut VisitorContext<'ctx, Registry>,
+        variable_definition: &'ctx Positioned<VariableDefinition>,
     ) {
         self.0.exit_variable_definition(ctx, variable_definition);
         self.1.exit_variable_definition(ctx, variable_definition);
     }
 
-    fn enter_directive(&mut self, ctx: &mut VisitorContext<'a, Registry>, directive: &'a Positioned<Directive>) {
+    fn enter_directive(&mut self, ctx: &mut VisitorContext<'ctx, Registry>, directive: &'ctx Positioned<Directive>) {
         self.0.enter_directive(ctx, directive);
         self.1.enter_directive(ctx, directive);
     }
 
-    fn exit_directive(&mut self, ctx: &mut VisitorContext<'a, Registry>, directive: &'a Positioned<Directive>) {
+    fn exit_directive(&mut self, ctx: &mut VisitorContext<'ctx, Registry>, directive: &'ctx Positioned<Directive>) {
         self.0.exit_directive(ctx, directive);
         self.1.exit_directive(ctx, directive);
     }
 
     fn enter_argument(
         &mut self,
-        ctx: &mut VisitorContext<'a, Registry>,
-        name: &'a Positioned<Name>,
-        value: &'a Positioned<Value>,
+        ctx: &mut VisitorContext<'ctx, Registry>,
+        name: &'ctx Positioned<Name>,
+        value: &'ctx Positioned<Value>,
     ) {
         self.0.enter_argument(ctx, name, value);
         self.1.enter_argument(ctx, name, value);
@@ -342,9 +344,9 @@ where
 
     fn exit_argument(
         &mut self,
-        ctx: &mut VisitorContext<'a, Registry>,
-        name: &'a Positioned<Name>,
-        value: &'a Positioned<Value>,
+        ctx: &mut VisitorContext<'ctx, Registry>,
+        name: &'ctx Positioned<Name>,
+        value: &'ctx Positioned<Value>,
     ) {
         self.0.exit_argument(ctx, name, value);
         self.1.exit_argument(ctx, name, value);
@@ -352,8 +354,8 @@ where
 
     fn enter_selection_set(
         &mut self,
-        ctx: &mut VisitorContext<'a, Registry>,
-        selection_set: &'a Positioned<SelectionSet>,
+        ctx: &mut VisitorContext<'ctx, Registry>,
+        selection_set: &'ctx Positioned<SelectionSet>,
     ) {
         self.0.enter_selection_set(ctx, selection_set);
         self.1.enter_selection_set(ctx, selection_set);
@@ -361,37 +363,37 @@ where
 
     fn exit_selection_set(
         &mut self,
-        ctx: &mut VisitorContext<'a, Registry>,
-        selection_set: &'a Positioned<SelectionSet>,
+        ctx: &mut VisitorContext<'ctx, Registry>,
+        selection_set: &'ctx Positioned<SelectionSet>,
     ) {
         self.0.exit_selection_set(ctx, selection_set);
         self.1.exit_selection_set(ctx, selection_set);
     }
 
-    fn enter_selection(&mut self, ctx: &mut VisitorContext<'a, Registry>, selection: &'a Positioned<Selection>) {
+    fn enter_selection(&mut self, ctx: &mut VisitorContext<'ctx, Registry>, selection: &'ctx Positioned<Selection>) {
         self.0.enter_selection(ctx, selection);
         self.1.enter_selection(ctx, selection);
     }
 
-    fn exit_selection(&mut self, ctx: &mut VisitorContext<'a, Registry>, selection: &'a Positioned<Selection>) {
+    fn exit_selection(&mut self, ctx: &mut VisitorContext<'ctx, Registry>, selection: &'ctx Positioned<Selection>) {
         self.0.exit_selection(ctx, selection);
         self.1.exit_selection(ctx, selection);
     }
 
-    fn enter_field(&mut self, ctx: &mut VisitorContext<'a, Registry>, field: &'a Positioned<Field>) {
+    fn enter_field(&mut self, ctx: &mut VisitorContext<'ctx, Registry>, field: &'ctx Positioned<Field>) {
         self.0.enter_field(ctx, field);
         self.1.enter_field(ctx, field);
     }
 
-    fn exit_field(&mut self, ctx: &mut VisitorContext<'a, Registry>, field: &'a Positioned<Field>) {
+    fn exit_field(&mut self, ctx: &mut VisitorContext<'ctx, Registry>, field: &'ctx Positioned<Field>) {
         self.0.exit_field(ctx, field);
         self.1.exit_field(ctx, field);
     }
 
     fn enter_fragment_spread(
         &mut self,
-        ctx: &mut VisitorContext<'a, Registry>,
-        fragment_spread: &'a Positioned<FragmentSpread>,
+        ctx: &mut VisitorContext<'ctx, Registry>,
+        fragment_spread: &'ctx Positioned<FragmentSpread>,
     ) {
         self.0.enter_fragment_spread(ctx, fragment_spread);
         self.1.enter_fragment_spread(ctx, fragment_spread);
@@ -399,8 +401,8 @@ where
 
     fn exit_fragment_spread(
         &mut self,
-        ctx: &mut VisitorContext<'a, Registry>,
-        fragment_spread: &'a Positioned<FragmentSpread>,
+        ctx: &mut VisitorContext<'ctx, Registry>,
+        fragment_spread: &'ctx Positioned<FragmentSpread>,
     ) {
         self.0.exit_fragment_spread(ctx, fragment_spread);
         self.1.exit_fragment_spread(ctx, fragment_spread);
@@ -408,8 +410,8 @@ where
 
     fn enter_inline_fragment(
         &mut self,
-        ctx: &mut VisitorContext<'a, Registry>,
-        inline_fragment: &'a Positioned<InlineFragment>,
+        ctx: &mut VisitorContext<'ctx, Registry>,
+        inline_fragment: &'ctx Positioned<InlineFragment>,
     ) {
         self.0.enter_inline_fragment(ctx, inline_fragment);
         self.1.enter_inline_fragment(ctx, inline_fragment);
@@ -417,8 +419,8 @@ where
 
     fn exit_inline_fragment(
         &mut self,
-        ctx: &mut VisitorContext<'a, Registry>,
-        inline_fragment: &'a Positioned<InlineFragment>,
+        ctx: &mut VisitorContext<'ctx, Registry>,
+        inline_fragment: &'ctx Positioned<InlineFragment>,
     ) {
         self.0.exit_inline_fragment(ctx, inline_fragment);
         self.1.exit_inline_fragment(ctx, inline_fragment);
@@ -426,11 +428,11 @@ where
 
     fn enter_input_value(
         &mut self,
-        ctx: &mut VisitorContext<'a, Registry>,
+        ctx: &mut VisitorContext<'ctx, Registry>,
         pos: Pos,
         expected_type: &Option<MetaTypeName<'_>>,
-        value: &'a Value,
-        meta: Option<Registry::MetaInputValue<'a>>,
+        value: &'ctx Value,
+        meta: Option<Registry::MetaInputValue<'ctx>>,
     ) {
         self.0.enter_input_value(ctx, pos, expected_type, value, meta);
         self.1.enter_input_value(ctx, pos, expected_type, value, meta);
@@ -438,11 +440,11 @@ where
 
     fn exit_input_value(
         &mut self,
-        ctx: &mut VisitorContext<'a, Registry>,
+        ctx: &mut VisitorContext<'ctx, Registry>,
         pos: Pos,
         expected_type: &Option<MetaTypeName<'_>>,
         value: &Value,
-        meta: Option<Registry::MetaInputValue<'a>>,
+        meta: Option<Registry::MetaInputValue<'ctx>>,
     ) {
         self.0.exit_input_value(ctx, pos, expected_type, value, meta);
         self.1.exit_input_value(ctx, pos, expected_type, value, meta);

--- a/engine/crates/engine/validation/src/visitors/mod.rs
+++ b/engine/crates/engine/validation/src/visitors/mod.rs
@@ -4,6 +4,7 @@ mod depth;
 mod height;
 mod input_validations;
 mod root_field_count;
+mod used_fields;
 
 pub use alias_count::AliasCountCalculate;
 pub use cache_control::CacheControlCalculate;
@@ -11,3 +12,4 @@ pub use depth::DepthCalculate;
 pub use height::HeightCalculate;
 pub use input_validations::InputValidationVisitor;
 pub use root_field_count::RootFieldCountCalculate;
+pub use used_fields::UsedFieldsAggregator;

--- a/engine/crates/engine/validation/src/visitors/used_fields.rs
+++ b/engine/crates/engine/validation/src/visitors/used_fields.rs
@@ -1,0 +1,42 @@
+use std::collections::{HashMap, HashSet};
+
+use engine_parser::{types::Field, Positioned};
+
+use crate::{visitor::Visitor, VisitorContext};
+
+pub struct UsedFieldsAggregator<'ctx, 'a>(pub &'a mut HashMap<&'ctx str, HashSet<&'ctx str>>);
+
+impl UsedFieldsAggregator<'_, '_> {
+    pub fn finalize(&self) -> String {
+        let mut out = String::new();
+        for (type_name, fields) in self.0.iter() {
+            out.push_str(type_name);
+            out.push('.');
+            for (i, field) in fields.iter().enumerate() {
+                if i > 0 {
+                    out.push('+');
+                }
+                out.push_str(field);
+            }
+            out.push(',');
+        }
+        out.pop();
+        out
+    }
+}
+
+impl<'ctx, 'a> Visitor<'ctx, registry_v2::Registry> for UsedFieldsAggregator<'ctx, 'a> {
+    fn enter_field(&mut self, ctx: &mut VisitorContext<'ctx, registry_v2::Registry>, field: &'ctx Positioned<Field>) {
+        if field.node.name.node.starts_with("__") {
+            return;
+        }
+
+        // Skip introspection fields
+        if let Some(parent_type) = ctx.parent_type().filter(|parent| !parent.name().starts_with("__")) {
+            self.0
+                .entry(parent_type.name())
+                .or_default()
+                .insert(field.node.name.node.as_str());
+        }
+    }
+}

--- a/engine/crates/telemetry/src/span.rs
+++ b/engine/crates/telemetry/src/span.rs
@@ -1,7 +1,10 @@
 use http::Response;
 use http_body::Body;
 
-use crate::gql_response_status::{GraphqlResponseStatus, SubgraphResponseStatus};
+use crate::{
+    gql_response_status::{GraphqlResponseStatus, SubgraphResponseStatus},
+    metrics::OperationMetricsAttributes,
+};
 
 /// Tracing target for logging
 pub const GRAFBASE_TARGET: &str = "grafbase";
@@ -54,6 +57,16 @@ pub struct GqlRequestAttributes<'a> {
     pub operation_name: Option<&'a str>,
     /// Must NOT contain any sensitive data
     pub sanitized_query: Option<&'a str>,
+}
+
+impl<'a> From<&'a OperationMetricsAttributes> for GqlRequestAttributes<'a> {
+    fn from(metrics_attributes: &'a OperationMetricsAttributes) -> Self {
+        Self {
+            operation_type: metrics_attributes.ty.as_str(),
+            operation_name: metrics_attributes.name.as_deref(),
+            sanitized_query: Some(&metrics_attributes.sanitized_query),
+        }
+    }
 }
 
 /// Wraps attributes of a graphql response intended to be recorded

--- a/gateway/crates/gateway-binary/tests/telemetry/metrics.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/metrics.rs
@@ -13,6 +13,8 @@ use crate::{clickhouse_client, load_schema, with_static_server, Client};
 mod operation;
 mod request;
 
+const METRICS_DELAY: Duration = Duration::from_secs(2);
+
 #[serde_with::serde_as]
 #[derive(Debug, clickhouse::Row, Deserialize, Serialize, PartialEq)]
 struct SumMetricCountRow {
@@ -40,6 +42,9 @@ where
 {
     let service_name = format!("service_{}", ulid::Ulid::new());
     let config = &formatdoc! {r#"
+        [graph]
+        introspection = true
+
         [telemetry]
         service_name = "{service_name}"
 

--- a/gateway/crates/gateway-binary/tests/telemetry/metrics/operation.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/metrics/operation.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use crate::telemetry::metrics::METRICS_DELAY;
 
 use super::{with_gateway, ExponentialHistogramRow};
 
@@ -15,7 +15,7 @@ fn basic() {
             "__typename": "Query"
           }
         }"###);
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(METRICS_DELAY).await;
 
         let row = clickhouse
             .query(
@@ -37,10 +37,133 @@ fn basic() {
           "Count": 1,
           "Attributes": {
             "gql.operation.name": "Simple",
-            "gql.operation.normalized_query": "query Simple {\n  __typename\n}\n",
-            "gql.operation.normalized_query_hash": "cAe1+tBRHQLrF/EO1ul4CTx+q5SB9YD+YtG3VDU6VCM=",
+            "gql.operation.query": "query Simple {\n  __typename\n}\n",
+            "gql.operation.query_hash": "cAe1+tBRHQLrF/EO1ul4CTx+q5SB9YD+YtG3VDU6VCM=",
             "gql.operation.type": "query",
+            "gql.operation.used_fields": "",
             "gql.response.status": "SUCCESS"
+          }
+        }
+        "###);
+    });
+}
+
+#[test]
+fn introspection_should_not_appear_in_used_fields() {
+    with_gateway(|service_name, start_time_unix, gateway, clickhouse| async move {
+        let response = gateway
+            .gql::<serde_json::Value>("query { __schema { description } }")
+            .send()
+            .await;
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "__schema": {
+              "description": null
+            }
+          }
+        }
+        "###);
+        tokio::time::sleep(METRICS_DELAY).await;
+
+        let row = clickhouse
+            .query(
+                r#"
+                SELECT Count, Attributes
+                FROM otel_metrics_exponential_histogram
+                WHERE ServiceName = ? AND StartTimeUnix >= ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'gql_operation_latency'
+                "#,
+            )
+            .bind(&service_name)
+            .bind(start_time_unix)
+            .fetch_one::<ExponentialHistogramRow>()
+            .await
+            .unwrap();
+        insta::assert_json_snapshot!(row, @r###"
+        {
+          "Count": 1,
+          "Attributes": {
+            "gql.operation.name": "__schema",
+            "gql.operation.query": "query {\n  __schema {\n    description\n  }\n}\n",
+            "gql.operation.query_hash": "0AmmdiLirkkd0r11qjmdCjpV7OGLe0J5c4yugMq1oeQ=",
+            "gql.operation.type": "query",
+            "gql.operation.used_fields": "",
+            "gql.response.status": "SUCCESS"
+          }
+        }
+        "###);
+    });
+}
+
+#[test]
+fn used_fields_should_be_unique() {
+    with_gateway(|service_name, start_time_unix, gateway, clickhouse| async move {
+        let resp = gateway
+            .gql::<serde_json::Value>(
+                r###"
+                query Faulty {
+                    me {
+                        id
+                        username
+                        reviews {
+                            body
+                            alias: body
+                            author {
+                                id
+                                username
+                            }
+                        }
+                    }
+                }
+                "###,
+            )
+            .send()
+            .await;
+        insta::assert_json_snapshot!(resp, @r###"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "error sending request for url (http://127.0.0.1:46697/)",
+              "path": [
+                "me"
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_REQUEST_ERROR"
+              }
+            }
+          ]
+        }
+        "###);
+        tokio::time::sleep(METRICS_DELAY).await;
+
+        let row = clickhouse
+            .query(
+                r#"
+                SELECT Count, Attributes
+                FROM otel_metrics_exponential_histogram
+                WHERE ServiceName = ? AND StartTimeUnix >= ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'gql_operation_latency'
+                "#,
+            )
+            .bind(&service_name)
+            .bind(start_time_unix)
+            .fetch_one::<ExponentialHistogramRow>()
+            .await
+            .unwrap();
+        insta::assert_json_snapshot!(row, @r###"
+        {
+          "Count": 1,
+          "Attributes": {
+            "gql.operation.name": "Faulty",
+            "gql.operation.query": "query Faulty {\n  me {\n    id\n    reviews {\n      author {\n        id\n        username\n      }\n      body\n      body\n    }\n    username\n  }\n}\n",
+            "gql.operation.query_hash": "4iL1kpGebrS0NAZQbUo76cwD4SUC5jxtUlCdc2149fg=",
+            "gql.operation.type": "query",
+            "gql.operation.used_fields": "User.id+username+reviews,Review.body+author,Query.me",
+            "gql.response.status": "FIELD_ERROR_NULL_DATA"
           }
         }
         "###);
@@ -72,7 +195,7 @@ fn generate_operation_name() {
           ]
         }
         "###);
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(METRICS_DELAY).await;
 
         let row = clickhouse
             .query(
@@ -94,9 +217,10 @@ fn generate_operation_name() {
           "Count": 1,
           "Attributes": {
             "gql.operation.name": "myFavoriteField",
-            "gql.operation.normalized_query": "query {\n  ignoreMe\n  myFavoriteField\n}\n",
-            "gql.operation.normalized_query_hash": "WDOyTh2uUUEIkab8iqn+MGWh5J3MntAvRkUy3yEpJS8=",
+            "gql.operation.query": "query {\n  ignoreMe\n  myFavoriteField\n}\n",
+            "gql.operation.query_hash": "WDOyTh2uUUEIkab8iqn+MGWh5J3MntAvRkUy3yEpJS8=",
             "gql.operation.type": "query",
+            "gql.operation.used_fields": "",
             "gql.response.status": "REQUEST_ERROR"
           }
         }
@@ -129,7 +253,7 @@ fn request_error() {
           ]
         }
         "###);
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(METRICS_DELAY).await;
 
         let row = clickhouse
             .query(
@@ -151,9 +275,10 @@ fn request_error() {
           "Count": 1,
           "Attributes": {
             "gql.operation.name": "Faulty",
-            "gql.operation.normalized_query": "query Faulty {\n  __typ__ename\n}\n",
-            "gql.operation.normalized_query_hash": "er/VMZUszb2iQhlPMx46c+flOdO8hXv8PjV1Pk/6u2A=",
+            "gql.operation.query": "query Faulty {\n  __typ__ename\n}\n",
+            "gql.operation.query_hash": "er/VMZUszb2iQhlPMx46c+flOdO8hXv8PjV1Pk/6u2A=",
             "gql.operation.type": "query",
+            "gql.operation.used_fields": "",
             "gql.response.status": "REQUEST_ERROR"
           }
         }
@@ -184,7 +309,7 @@ fn field_error() {
           ]
         }
         "###);
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(METRICS_DELAY).await;
 
         let row = clickhouse
             .query(
@@ -206,9 +331,10 @@ fn field_error() {
           "Count": 1,
           "Attributes": {
             "gql.operation.name": "Faulty",
-            "gql.operation.normalized_query": "query Faulty {\n  __typename\n  me {\n    id\n  }\n}\n",
-            "gql.operation.normalized_query_hash": "M4bDtLPhj8uQPEFBdDWqalBphwVy7V5WPXOPHrzyikE=",
+            "gql.operation.query": "query Faulty {\n  __typename\n  me {\n    id\n  }\n}\n",
+            "gql.operation.query_hash": "M4bDtLPhj8uQPEFBdDWqalBphwVy7V5WPXOPHrzyikE=",
             "gql.operation.type": "query",
+            "gql.operation.used_fields": "User.id,Query.me",
             "gql.response.status": "FIELD_ERROR_NULL_DATA"
           }
         }
@@ -239,7 +365,7 @@ fn field_error_data_null() {
           ]
         }
         "###);
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(METRICS_DELAY).await;
 
         let row = clickhouse
             .query(
@@ -261,9 +387,10 @@ fn field_error_data_null() {
           "Count": 1,
           "Attributes": {
             "gql.operation.name": "Faulty",
-            "gql.operation.normalized_query": "query Faulty {\n  me {\n    id\n  }\n}\n",
-            "gql.operation.normalized_query_hash": "Txoer8zp21WTkEG253qN503QOPQP7Pb9utIDx55IVD8=",
+            "gql.operation.query": "query Faulty {\n  me {\n    id\n  }\n}\n",
+            "gql.operation.query_hash": "Txoer8zp21WTkEG253qN503QOPQP7Pb9utIDx55IVD8=",
             "gql.operation.type": "query",
+            "gql.operation.used_fields": "User.id,Query.me",
             "gql.response.status": "FIELD_ERROR_NULL_DATA"
           }
         }
@@ -288,7 +415,7 @@ fn client() {
         }
         "###);
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(METRICS_DELAY).await;
 
         let row = clickhouse
             .query(
@@ -310,9 +437,10 @@ fn client() {
           "Count": 1,
           "Attributes": {
             "gql.operation.name": "SimpleQuery",
-            "gql.operation.normalized_query": "query SimpleQuery {\n  __typename\n}\n",
-            "gql.operation.normalized_query_hash": "qIzPxtWwHz0t+aJjvOljljbR3aGLQAA0LI5VXjW/FwQ=",
+            "gql.operation.query": "query SimpleQuery {\n  __typename\n}\n",
+            "gql.operation.query_hash": "qIzPxtWwHz0t+aJjvOljljbR3aGLQAA0LI5VXjW/FwQ=",
             "gql.operation.type": "query",
+            "gql.operation.used_fields": "",
             "gql.response.status": "SUCCESS",
             "http.headers.x-grafbase-client-name": "test",
             "http.headers.x-grafbase-client-version": "1.0.0"

--- a/gateway/crates/gateway-binary/tests/telemetry/metrics/request.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/metrics/request.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use crate::telemetry::metrics::METRICS_DELAY;
 
 use super::{with_gateway, ExponentialHistogramRow};
 
@@ -13,7 +13,7 @@ fn basic() {
           }
         }
         "###);
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(METRICS_DELAY).await;
 
         let row = clickhouse
             .query(
@@ -64,7 +64,7 @@ fn request_error() {
           ]
         }
         "###);
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(METRICS_DELAY).await;
 
         let row = clickhouse
             .query(
@@ -116,7 +116,7 @@ fn field_error() {
           ]
         }
         "###);
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(METRICS_DELAY).await;
 
         let row = clickhouse
             .query(
@@ -165,7 +165,7 @@ fn field_error_data_null() {
           ]
         }
         "###);
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(METRICS_DELAY).await;
 
         let row = clickhouse
             .query(
@@ -210,7 +210,7 @@ fn client() {
           }
         }
         "###);
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(METRICS_DELAY).await;
 
         let row = clickhouse
             .query(


### PR DESCRIPTION
For a schema:
```graphql
type Query {
   user(id: ID!): User
}

type User {
  id: ID!
  name: String
}
```
and query:
```graphql
query {
  user(id: "0x1") {
    id
    name
  }
}
```
We produce the following string
```
"Query.user,User.id+name"
```

I'm also renaming `gql.operation.normalized_query` to `gql.operation.query` in metrics for consistency with tracing. That's the only `query` we're sending and likely will ever send anyway.