### PR TITLE
feat: gateway config for entity caching

### DIFF
--- a/engine/crates/engine-config-builder/src/lib.rs
+++ b/engine/crates/engine-config-builder/src/lib.rs
@@ -4,8 +4,9 @@ use std::collections::BTreeMap;
 use std::time::Duration;
 
 use engine_v2_config::latest::{
-    AuthConfig, AuthProviderConfig, CacheConfig, CacheConfigTarget, CacheConfigs, HeaderForward, HeaderInsert,
-    HeaderRemove, HeaderRenameDuplicate, HeaderRule, HeaderRuleId, NameOrPattern, OperationLimits, SubgraphConfig,
+    AuthConfig, AuthProviderConfig, CacheConfig, CacheConfigTarget, CacheConfigs, EntityCaching,
+    HeaderForward, HeaderInsert, HeaderRemove, HeaderRenameDuplicate, HeaderRule, HeaderRuleId,
+    NameOrPattern, OperationLimits, SubgraphConfig,
 };
 use engine_v2_config::{
     latest::{self as config},
@@ -13,7 +14,7 @@ use engine_v2_config::{
 };
 use federated_graph::{FederatedGraph, FederatedGraphV3, FieldId, ObjectId, SubgraphId};
 use parser_sdl::federation::header::SubgraphHeaderRule;
-use parser_sdl::federation::FederatedGraphConfig;
+use parser_sdl::federation::{EntityCachingConfig, FederatedGraphConfig};
 use parser_sdl::{AuthV2Provider, GlobalCacheTarget};
 
 mod paths;
@@ -45,7 +46,10 @@ pub fn build_config(config: &FederatedGraphConfig, graph: FederatedGraph) -> Ver
         disable_introspection: config.disable_introspection,
         rate_limit: context.rate_limit,
         timeout: config.timeout,
-        enable_entity_caching: config.enable_entity_caching,
+        entity_caching: match config.entity_caching {
+            EntityCachingConfig::Enabled { ttl } => EntityCaching::Enabled { ttl },
+            _ => EntityCaching::Disabled,
+        },
     })
 }
 
@@ -67,17 +71,19 @@ fn build_auth_config(config: &FederatedGraphConfig) -> Option<AuthConfig> {
             .providers
             .iter()
             .map(|provider| match provider {
-                AuthV2Provider::JWT { name, jwks, header } => AuthProviderConfig::Jwt(config::JwtConfig {
-                    name: name.clone(),
-                    jwks: config::JwksConfig {
-                        issuer: jwks.issuer.clone(),
-                        audience: jwks.audience.clone(),
-                        url: jwks.url.clone(),
-                        poll_interval: jwks.poll_interval,
-                    },
-                    header_name: header.name.clone(),
-                    header_value_prefix: header.value_prefix.clone(),
-                }),
+                AuthV2Provider::JWT { name, jwks, header } => {
+                    AuthProviderConfig::Jwt(config::JwtConfig {
+                        name: name.clone(),
+                        jwks: config::JwksConfig {
+                            issuer: jwks.issuer.clone(),
+                            audience: jwks.audience.clone(),
+                            url: jwks.url.clone(),
+                            poll_interval: jwks.poll_interval,
+                        },
+                        header_name: header.name.clone(),
+                        header_value_prefix: header.value_prefix.clone(),
+                    })
+                }
                 AuthV2Provider::Anonymous => AuthProviderConfig::Anonymous,
             })
             .collect();
@@ -96,7 +102,11 @@ struct BuildContext<'a> {
 }
 
 impl<'a> BuildContext<'a> {
-    pub fn insert_cache_config(&mut self, graph: &FederatedGraphV3, rules: &parser_sdl::GlobalCacheRules<'static>) {
+    pub fn insert_cache_config(
+        &mut self,
+        graph: &FederatedGraphV3,
+        rules: &parser_sdl::GlobalCacheRules<'static>,
+    ) {
         let mut cache_config = BTreeMap::new();
 
         for (target, cache_control) in rules.iter() {
@@ -130,31 +140,37 @@ impl<'a> BuildContext<'a> {
             }
         }
 
-        self.cache = CacheConfigs { rules: cache_config }
+        self.cache = CacheConfigs {
+            rules: cache_config,
+        }
     }
 
     pub fn insert_rate_limit(&mut self, config: &'a parser_sdl::federation::RateLimitConfig) {
         let rate_limit = engine_v2_config::latest::RateLimitConfig {
-            global: config.global.map(|config| engine_v2_config::latest::GraphRateLimit {
-                limit: config.limit,
-                duration: config.duration,
-            }),
+            global: config
+                .global
+                .map(|config| engine_v2_config::latest::GraphRateLimit {
+                    limit: config.limit,
+                    duration: config.duration,
+                }),
             storage: match config.storage {
-                parser_sdl::federation::RateLimitStorage::Memory => engine_v2_config::latest::RateLimitStorage::Memory,
-                parser_sdl::federation::RateLimitStorage::Redis => engine_v2_config::latest::RateLimitStorage::Redis,
+                parser_sdl::federation::RateLimitStorage::Memory => {
+                    engine_v2_config::latest::RateLimitStorage::Memory
+                }
+                parser_sdl::federation::RateLimitStorage::Redis => {
+                    engine_v2_config::latest::RateLimitStorage::Redis
+                }
             },
             redis: engine_v2_config::latest::RateLimitRedisConfig {
                 url: self.strings.intern(config.redis.url.as_str()),
                 key_prefix: self.strings.intern(&config.redis.key_prefix),
-                tls: config
-                    .redis
-                    .tls
-                    .as_ref()
-                    .map(|config| engine_v2_config::latest::RateLimitRedisTlsConfig {
+                tls: config.redis.tls.as_ref().map(|config| {
+                    engine_v2_config::latest::RateLimitRedisTlsConfig {
                         cert: config.cert.as_ref().map(|cert| self.paths.intern(cert)),
                         key: config.key.as_ref().map(|key| self.paths.intern(key)),
                         ca: config.ca.as_ref().map(|ca| self.paths.intern(ca)),
-                    }),
+                    }
+                }),
             },
         };
 
@@ -176,7 +192,7 @@ impl<'a> BuildContext<'a> {
                 header_rules,
                 rate_limit,
                 timeout,
-                entity_cache_ttl,
+                entity_caching,
                 ..
             } = config;
 
@@ -184,12 +200,13 @@ impl<'a> BuildContext<'a> {
             let websocket_url = websocket_url.as_ref().map(|url| self.strings.intern(url));
             let subgraph_name = self.strings.intern(name);
 
-            let rate_limit = rate_limit
-                .as_ref()
-                .map(|config| engine_v2_config::latest::GraphRateLimit {
-                    limit: config.limit,
-                    duration: config.duration,
-                });
+            let rate_limit =
+                rate_limit
+                    .as_ref()
+                    .map(|config| engine_v2_config::latest::GraphRateLimit {
+                        limit: config.limit,
+                        duration: config.duration,
+                    });
 
             let retry = config.retry.as_ref().map(
                 |parser_sdl::federation::RetryConfig {
@@ -213,8 +230,13 @@ impl<'a> BuildContext<'a> {
                     websocket_url,
                     rate_limit,
                     timeout: *timeout,
-                    entity_cache_ttl: *entity_cache_ttl,
                     retry,
+                    entity_caching: entity_caching.as_ref().map(|config| match config {
+                        EntityCachingConfig::Disabled => EntityCaching::Disabled,
+                        EntityCachingConfig::Enabled { ttl } => {
+                            EntityCaching::Enabled { ttl: *ttl }
+                        }
+                    }),
                 },
             );
         }
@@ -224,17 +246,30 @@ impl<'a> BuildContext<'a> {
         &mut self,
         header_rules: impl IntoIterator<Item = &'a SubgraphHeaderRule>,
     ) -> Vec<HeaderRuleId> {
-        header_rules.into_iter().map(|rule| self.insert_header(rule)).collect()
+        header_rules
+            .into_iter()
+            .map(|rule| self.insert_header(rule))
+            .collect()
     }
 
     pub fn insert_header(&mut self, rule: &'a SubgraphHeaderRule) -> HeaderRuleId {
         let rule = match rule {
             SubgraphHeaderRule::Forward(ref rule) => {
                 let name = self.intern_header_name(&rule.name);
-                let default = rule.default.as_ref().map(|default| self.strings.intern(default));
-                let rename = rule.rename.as_ref().map(|rename| self.strings.intern(rename));
+                let default = rule
+                    .default
+                    .as_ref()
+                    .map(|default| self.strings.intern(default));
+                let rename = rule
+                    .rename
+                    .as_ref()
+                    .map(|rename| self.strings.intern(rename));
 
-                HeaderRule::Forward(HeaderForward { name, default, rename })
+                HeaderRule::Forward(HeaderForward {
+                    name,
+                    default,
+                    rename,
+                })
             }
             SubgraphHeaderRule::Insert(ref rule) => HeaderRule::Insert(HeaderInsert {
                 name: self.strings.intern(&rule.name),
@@ -243,11 +278,16 @@ impl<'a> BuildContext<'a> {
             SubgraphHeaderRule::Remove(ref rule) => HeaderRule::Remove(HeaderRemove {
                 name: self.intern_header_name(&rule.name),
             }),
-            SubgraphHeaderRule::RenameDuplicate(ref rule) => HeaderRule::RenameDuplicate(HeaderRenameDuplicate {
-                name: self.strings.intern(&rule.name),
-                default: rule.default.as_ref().map(|default| self.strings.intern(default)),
-                rename: self.strings.intern(&rule.rename),
-            }),
+            SubgraphHeaderRule::RenameDuplicate(ref rule) => {
+                HeaderRule::RenameDuplicate(HeaderRenameDuplicate {
+                    name: self.strings.intern(&rule.name),
+                    default: rule
+                        .default
+                        .as_ref()
+                        .map(|default| self.strings.intern(default)),
+                    rename: self.strings.intern(&rule.rename),
+                })
+            }
         };
 
         let id = config::HeaderRuleId(self.header_rules.len());
@@ -256,7 +296,10 @@ impl<'a> BuildContext<'a> {
         id
     }
 
-    fn intern_header_name(&mut self, name: &'a parser_sdl::federation::header::NameOrPattern) -> NameOrPattern {
+    fn intern_header_name(
+        &mut self,
+        name: &'a parser_sdl::federation::header::NameOrPattern,
+    ) -> NameOrPattern {
         match name {
             parser_sdl::federation::header::NameOrPattern::Pattern(ref pattern) => {
                 NameOrPattern::Pattern(pattern.clone())

--- a/engine/crates/engine-v2/config/src/lib.rs
+++ b/engine/crates/engine-v2/config/src/lib.rs
@@ -142,7 +142,7 @@ impl VersionedConfig {
                     disable_introspection,
                     rate_limit: Default::default(),
                     timeout: None,
-                    enable_entity_caching: false,
+                    entity_caching: Default::default(),
                 }
             }
             VersionedConfig::V5(latest) => latest,

--- a/engine/crates/engine-v2/config/src/v2/mod.rs
+++ b/engine/crates/engine-v2/config/src/v2/mod.rs
@@ -107,9 +107,7 @@ pub enum HeaderValue {
     Static(StringId),
 }
 
-#[derive(
-    Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd, serde::Serialize, serde::Deserialize, Debug,
-)]
+#[derive(Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd, serde::Serialize, serde::Deserialize, Debug)]
 pub struct StringId(pub usize);
 
 impl std::ops::Index<StringId> for Config {
@@ -173,9 +171,7 @@ mod tests {
             headers: vec![],
             default_headers: vec![],
             subgraph_configs: Default::default(),
-            cache: CacheConfigs {
-                rules: cache_config,
-            },
+            cache: CacheConfigs { rules: cache_config },
             auth: None,
             operation_limits: Default::default(),
         };

--- a/engine/crates/engine-v2/config/src/v5.rs
+++ b/engine/crates/engine-v2/config/src/v5.rs
@@ -12,6 +12,7 @@ use federated_graph::{FederatedGraphV3, SubgraphId};
 
 use self::rate_limit::{RateLimitConfigRef, RateLimitRedisConfigRef, RateLimitRedisTlsConfigRef};
 
+pub use super::v2::EntityCaching;
 pub use super::v4::{
     AuthConfig, AuthProviderConfig, CacheConfig, CacheConfigTarget, CacheConfigs, Header, HeaderId, HeaderValue,
     JwksConfig, JwtConfig, OperationLimits, RetryConfig, StringId, SubgraphConfig,
@@ -55,7 +56,7 @@ pub struct Config {
     pub timeout: Option<Duration>,
 
     #[serde(default)]
-    pub enable_entity_caching: bool,
+    pub entity_caching: EntityCaching,
 }
 
 impl Config {
@@ -73,7 +74,7 @@ impl Config {
             disable_introspection: Default::default(),
             rate_limit: Default::default(),
             timeout: None,
-            enable_entity_caching: false,
+            entity_caching: EntityCaching::Disabled,
         }
     }
 
@@ -182,7 +183,7 @@ mod tests {
             disable_introspection: Default::default(),
             rate_limit: Default::default(),
             timeout: None,
-            enable_entity_caching: false,
+            entity_caching: Default::default(),
         };
 
         insta::with_settings!({sort_maps => true}, {
@@ -205,7 +206,7 @@ mod tests {
               },
               "default_header_rules": [],
               "disable_introspection": false,
-              "enable_entity_caching": false,
+              "entity_caching": "Disabled",
               "graph": {
                 "authorized_directives": [],
                 "directives": [],

--- a/engine/crates/engine-v2/schema/src/builder/external_sources.rs
+++ b/engine/crates/engine-v2/schema/src/builder/external_sources.rs
@@ -21,10 +21,7 @@ impl ExternalDataSources {
                 let url = ctx
                     .urls
                     .insert(url::Url::parse(&ctx.strings[subgraph.url.into()]).expect("valid url"));
-                match config
-                    .subgraph_configs
-                    .remove(&federated_graph::SubgraphId(index))
-                {
+                match config.subgraph_configs.remove(&federated_graph::SubgraphId(index)) {
                     Some(config::latest::SubgraphConfig {
                         websocket_url,
                         headers,
@@ -36,10 +33,8 @@ impl ExternalDataSources {
                         name,
                         subgraph_id,
                         url,
-                        websocket_url: websocket_url.map(|url| {
-                            ctx.urls
-                                .insert(url::Url::parse(&config[url]).expect("valid url"))
-                        }),
+                        websocket_url: websocket_url
+                            .map(|url| ctx.urls.insert(url::Url::parse(&config[url]).expect("valid url"))),
                         header_rules: headers.into_iter().map(Into::into).collect(),
                         timeout: timeout.unwrap_or(DEFAULT_SUBGRAPH_TIMEOUT),
                         retry: retry.map(
@@ -55,10 +50,7 @@ impl ExternalDataSources {
                                 retry_mutations,
                             },
                         ),
-                        entity_cache_ttl: entity_caching
-                            .as_ref()
-                            .unwrap_or(&config.entity_caching)
-                            .ttl(),
+                        entity_cache_ttl: entity_caching.as_ref().unwrap_or(&config.entity_caching).ttl(),
                     },
 
                     None => sources::graphql::GraphqlEndpoint {

--- a/engine/crates/engine-v2/schema/src/builder/mod.rs
+++ b/engine/crates/engine-v2/schema/src/builder/mod.rs
@@ -229,7 +229,6 @@ impl BuildContext {
                 auth_config: take(&mut config.auth),
                 operation_limits: take(&mut config.operation_limits),
                 disable_introspection: config.disable_introspection,
-                enable_entity_caching: config.enable_entity_caching,
             },
         })
     }

--- a/engine/crates/engine-v2/schema/src/lib.rs
+++ b/engine/crates/engine-v2/schema/src/lib.rs
@@ -71,8 +71,6 @@ pub struct Settings {
     pub auth_config: Option<config::latest::AuthConfig>,
     pub operation_limits: config::latest::OperationLimits,
     pub disable_introspection: bool,
-
-    pub enable_entity_caching: bool,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/engine/crates/engine-v2/schema/src/sources/graphql.rs
+++ b/engine/crates/engine-v2/schema/src/sources/graphql.rs
@@ -2,8 +2,7 @@ use std::time::Duration;
 use url::Url;
 
 use crate::{
-    HeaderRuleId, HeaderRuleWalker, RequiredFieldSet, RequiredFieldSetId, SchemaWalker, StringId,
-    SubgraphId, UrlId,
+    HeaderRuleId, HeaderRuleWalker, RequiredFieldSet, RequiredFieldSetId, SchemaWalker, StringId, SubgraphId, UrlId,
 };
 
 #[derive(Default, serde::Serialize, serde::Deserialize)]
@@ -58,10 +57,7 @@ impl<'a> std::ops::Deref for RootFieldResolverWalker<'a> {
 
 impl<'a> RootFieldResolverWalker<'a> {
     pub fn name(&self) -> String {
-        format!(
-            "Graphql root field resolver for subgraph '{}'",
-            self.endpoint().name()
-        )
+        format!("Graphql root field resolver for subgraph '{}'", self.endpoint().name())
     }
 
     pub fn subgraph_id(&self) -> SubgraphId {
@@ -166,10 +162,7 @@ impl<'a> GraphqlEndpointWalker<'a> {
     }
 
     pub fn header_rules(self) -> impl Iterator<Item = HeaderRuleWalker<'a>> {
-        self.as_ref()
-            .header_rules
-            .iter()
-            .map(move |id| self.walk(*id))
+        self.as_ref().header_rules.iter().map(move |id| self.walk(*id))
     }
 
     pub fn entity_cache_ttl(self) -> Option<Duration> {

--- a/engine/crates/engine-v2/src/sources/graphql/federation.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/federation.rs
@@ -88,7 +88,7 @@ impl FederationEntityPreparedExecutor {
                     cache_ttl,
                 };
 
-                if ctx.engine.schema.settings.enable_entity_caching {
+                if cache_ttl.is_some() {
                     let fetches = representations
                         .iter()
                         .map(|repr| cache_fetch(ctx, subgraph.name(), repr));
@@ -158,7 +158,7 @@ struct EntityIngester<'ctx, R: Runtime> {
     plan: PlanWalker<'ctx, (), ()>,
     cache_entries: Option<Vec<CacheEntry>>,
     subgraph_response: SubgraphResponse,
-    cache_ttl: Duration,
+    cache_ttl: Option<Duration>,
 }
 
 pub enum CacheEntry {
@@ -208,8 +208,10 @@ where
             .deserialize(&mut serde_json::Deserializer::from_slice(&bytes))?
         };
 
-        if let Some(cache_entries) = cache_entries.filter(|_| status.is_success()) {
-            update_cache(ctx, cache_ttl, bytes, cache_entries).await
+        if let Some(cache_ttl) = cache_ttl {
+            if let Some(cache_entries) = cache_entries.filter(|_| status.is_success()) {
+                update_cache(ctx, cache_ttl, bytes, cache_entries).await
+            }
         }
 
         Ok((status, subgraph_response))

--- a/engine/crates/engine-v2/src/sources/graphql/mod.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/mod.rs
@@ -89,15 +89,11 @@ impl GraphqlPreparedExecutor {
         }
         .into_span();
 
-        let cache_key = ctx
-            .engine
-            .schema
-            .settings
-            .enable_entity_caching
-            .then(|| build_cache_key(&json_body));
-        let cache_ttl = subgraph.entity_cache_ttl();
+        let cache_ttl_and_key = subgraph
+            .entity_cache_ttl()
+            .map(|ttl| (ttl, build_cache_key(&json_body)));
 
-        if let Some(cache_key) = &cache_key {
+        if let Some((_, cache_key)) = &cache_ttl_and_key {
             let cache_entry = ctx
                 .engine
                 .runtime
@@ -147,9 +143,8 @@ impl GraphqlPreparedExecutor {
             GraphqlIngester {
                 ctx,
                 plan,
-                cache_key,
+                cache_ttl_and_key,
                 subgraph_response,
-                cache_ttl,
             },
         )
         .instrument(span)
@@ -166,9 +161,8 @@ fn build_cache_key(json_body: &str) -> String {
 struct GraphqlIngester<'ctx, R: Runtime> {
     ctx: ExecutionContext<'ctx, R>,
     plan: PlanWalker<'ctx, (), ()>,
-    cache_key: Option<String>,
     subgraph_response: SubgraphResponse,
-    cache_ttl: Duration,
+    cache_ttl_and_key: Option<(Duration, String)>,
 }
 
 impl<'ctx, R> ResponseIngester for GraphqlIngester<'ctx, R>
@@ -191,14 +185,14 @@ where
             .deserialize(&mut serde_json::Deserializer::from_slice(&bytes))?
         };
 
-        if let Some(cache_key) = self.cache_key.filter(|_| status.is_success()) {
+        if let Some((cache_ttl, cache_key)) = self.cache_ttl_and_key.filter(|_| status.is_success()) {
             // We could probably put this call into the background at some point, but for
             // simplicities sake I am not going to do that just now.
             self.ctx
                 .engine
                 .runtime
                 .kv()
-                .put(&cache_key, Cow::Borrowed(bytes.as_ref()), Some(self.cache_ttl))
+                .put(&cache_key, Cow::Borrowed(bytes.as_ref()), Some(cache_ttl))
                 .await
                 .inspect_err(|err| tracing::warn!("Failed to write the cache key {cache_key}: {err}"))
                 .ok();

--- a/engine/crates/integration-tests/tests/federation/entity_caching.rs
+++ b/engine/crates/integration-tests/tests/federation/entity_caching.rs
@@ -88,7 +88,7 @@ fn test_cache_expiry() {
     let response = runtime().block_on(async move {
         let engine = Engine::builder()
             .with_subgraph(FederatedProductsSchema)
-            .with_sdl_config(r#"extend schema @subgraph(name: "products", entityCacheTtl: "1s")"#)
+            .with_sdl_config(r#"extend schema @subgraph(name: "products", entityCachingTtl: "1s")"#)
             .with_entity_caching()
             .build()
             .await;

--- a/engine/crates/parser-sdl/src/federation.rs
+++ b/engine/crates/parser-sdl/src/federation.rs
@@ -6,9 +6,7 @@ use std::{collections::BTreeMap, path::PathBuf};
 use crate::{rules::auth_directive::v2::AuthV2Directive, GlobalCacheRules};
 use registry_v2::{ConnectorHeaderValue, OperationLimits};
 
-use self::header::{
-    NameOrPattern, SubgraphHeaderForward, SubgraphHeaderInsert, SubgraphHeaderRule,
-};
+use self::header::{NameOrPattern, SubgraphHeaderForward, SubgraphHeaderInsert, SubgraphHeaderRule};
 
 /// Configuration for a federated graph
 #[derive(Clone, Debug, Default)]
@@ -69,16 +67,12 @@ pub enum EntityCachingConfig {
 impl From<(String, ConnectorHeaderValue)> for SubgraphHeaderRule {
     fn from((name, value): (String, ConnectorHeaderValue)) -> Self {
         match value {
-            ConnectorHeaderValue::Static(value) => {
-                SubgraphHeaderRule::Insert(SubgraphHeaderInsert { name, value })
-            }
-            ConnectorHeaderValue::Forward(value) => {
-                SubgraphHeaderRule::Forward(SubgraphHeaderForward {
-                    name: NameOrPattern::Name(value),
-                    default: None,
-                    rename: Some(name),
-                })
-            }
+            ConnectorHeaderValue::Static(value) => SubgraphHeaderRule::Insert(SubgraphHeaderInsert { name, value }),
+            ConnectorHeaderValue::Forward(value) => SubgraphHeaderRule::Forward(SubgraphHeaderForward {
+                name: NameOrPattern::Name(value),
+                default: None,
+                rename: Some(name),
+            }),
         }
     }
 }

--- a/engine/crates/parser-sdl/src/rules/all_subgraphs_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/all_subgraphs_directive.rs
@@ -33,11 +33,7 @@ impl Directive for AllSubgraphsDirective {
 pub struct AllSubgraphsDirectiveVisitor;
 
 impl Visitor<'_> for AllSubgraphsDirectiveVisitor {
-    fn enter_schema(
-        &mut self,
-        ctx: &mut VisitorContext<'_>,
-        doc: &engine::Positioned<SchemaDefinition>,
-    ) {
+    fn enter_schema(&mut self, ctx: &mut VisitorContext<'_>, doc: &engine::Positioned<SchemaDefinition>) {
         let directives = doc
             .node
             .directives
@@ -48,10 +44,7 @@ impl Visitor<'_> for AllSubgraphsDirectiveVisitor {
         if !ctx.registry.borrow().is_federated {
             if !directives.is_empty() {
                 ctx.report_error(
-                    directives
-                        .into_iter()
-                        .map(|directive| directive.pos)
-                        .collect(),
+                    directives.into_iter().map(|directive| directive.pos).collect(),
                     "The @allSubgraphs directive is only valid in federated graphs",
                 );
             }
@@ -59,8 +52,7 @@ impl Visitor<'_> for AllSubgraphsDirectiveVisitor {
         }
 
         for directive in directives {
-            let directive = match parse_directive::<AllSubgraphsDirective>(directive, ctx.variables)
-            {
+            let directive = match parse_directive::<AllSubgraphsDirective>(directive, ctx.variables) {
                 Ok(directive) => directive,
                 Err(error) => {
                     ctx.append_errors(vec![error]);

--- a/engine/crates/parser-sdl/src/rules/all_subgraphs_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/all_subgraphs_directive.rs
@@ -33,7 +33,11 @@ impl Directive for AllSubgraphsDirective {
 pub struct AllSubgraphsDirectiveVisitor;
 
 impl Visitor<'_> for AllSubgraphsDirectiveVisitor {
-    fn enter_schema(&mut self, ctx: &mut VisitorContext<'_>, doc: &engine::Positioned<SchemaDefinition>) {
+    fn enter_schema(
+        &mut self,
+        ctx: &mut VisitorContext<'_>,
+        doc: &engine::Positioned<SchemaDefinition>,
+    ) {
         let directives = doc
             .node
             .directives
@@ -44,7 +48,10 @@ impl Visitor<'_> for AllSubgraphsDirectiveVisitor {
         if !ctx.registry.borrow().is_federated {
             if !directives.is_empty() {
                 ctx.report_error(
-                    directives.into_iter().map(|directive| directive.pos).collect(),
+                    directives
+                        .into_iter()
+                        .map(|directive| directive.pos)
+                        .collect(),
                     "The @allSubgraphs directive is only valid in federated graphs",
                 );
             }
@@ -52,7 +59,8 @@ impl Visitor<'_> for AllSubgraphsDirectiveVisitor {
         }
 
         for directive in directives {
-            let directive = match parse_directive::<AllSubgraphsDirective>(directive, ctx.variables) {
+            let directive = match parse_directive::<AllSubgraphsDirective>(directive, ctx.variables)
+            {
                 Ok(directive) => directive,
                 Err(error) => {
                     ctx.append_errors(vec![error]);
@@ -126,8 +134,8 @@ mod tests {
                         ],
                         rate_limit: None,
                         timeout: None,
-                        entity_cache_ttl: None,
                         retry: None,
+                        entity_caching: None,
                     },
                 },
                 header_rules: [
@@ -173,7 +181,7 @@ mod tests {
                 disable_introspection: false,
                 rate_limit: None,
                 timeout: None,
-                enable_entity_caching: false,
+                entity_caching: Disabled,
             },
         )
         "###);

--- a/gateway/crates/federated-server/config/grafbase.toml
+++ b/gateway/crates/federated-server/config/grafbase.toml
@@ -5,7 +5,7 @@ listen_address = "127.0.0.1:4000"
 
 [graph]
 # The path endpoint for the GraphQL gateway
-path = "/graphql"    
+path = "/graphql"
 # Set to true to enable GraphQL introspection
 introspection = false
 
@@ -73,6 +73,10 @@ enabled = false
 # [headers.Authentication]
 # value = "Bearer {{ env.ACCESS_TOKEN }}"
 
+# [entity_caching]
+# enabled = true
+# ttl = "60s"
+
 ## Subgraph level configuration
 # [subgraphs.products]
 ## Custom websocket URL to be used for subscription requests. If not set, the default is the subgraph URL.
@@ -87,3 +91,7 @@ enabled = false
 ## when starting the gateway.
 # [subgraphs.products.headers.Authentication]
 # value = "Bearer {{ env.SUBGRAPH_ACCESS_TOKEN }}"
+## Entity caching can be configured on a per-subgraph basis
+# [subgraphs.products.entity_caching]
+# enabled = true
+# ttl = "30s"

--- a/gateway/crates/federated-server/src/config/entity_caching.rs
+++ b/gateway/crates/federated-server/src/config/entity_caching.rs
@@ -2,19 +2,20 @@ use std::time::Duration;
 
 #[derive(Debug, Default, serde::Deserialize, Clone, PartialEq)]
 pub struct EntityCachingConfig {
-    pub enabled: bool,
+    pub enabled: Option<bool>,
 
     /// The ttl to store cache entries with.  Defaults to 60s
-    #[serde(deserialize_with = "duration_str::deserialize_option_duration")]
+    #[serde(deserialize_with = "duration_str::deserialize_option_duration", default)]
     pub ttl: Option<Duration>,
 }
 
 impl From<EntityCachingConfig> for parser_sdl::federation::EntityCachingConfig {
     fn from(config: EntityCachingConfig) -> Self {
-        if config.enabled {
-            parser_sdl::federation::EntityCachingConfig::Enabled { ttl: config.ttl }
-        } else {
-            parser_sdl::federation::EntityCachingConfig::Disabled
+        match (config.enabled, config.ttl) {
+            (Some(false), _) => parser_sdl::federation::EntityCachingConfig::Disabled,
+            (Some(true), ttl) => parser_sdl::federation::EntityCachingConfig::Enabled { ttl },
+            (_, Some(ttl)) => parser_sdl::federation::EntityCachingConfig::Enabled { ttl: Some(ttl) },
+            _ => parser_sdl::federation::EntityCachingConfig::Disabled,
         }
     }
 }

--- a/gateway/crates/federated-server/src/config/entity_caching.rs
+++ b/gateway/crates/federated-server/src/config/entity_caching.rs
@@ -1,0 +1,20 @@
+use std::time::Duration;
+
+#[derive(Debug, Default, serde::Deserialize, Clone, PartialEq)]
+pub struct EntityCachingConfig {
+    pub enabled: bool,
+
+    /// The ttl to store cache entries with.  Defaults to 60s
+    #[serde(deserialize_with = "duration_str::deserialize_option_duration")]
+    pub ttl: Option<Duration>,
+}
+
+impl From<EntityCachingConfig> for parser_sdl::federation::EntityCachingConfig {
+    fn from(config: EntityCachingConfig) -> Self {
+        if config.enabled {
+            parser_sdl::federation::EntityCachingConfig::Enabled { ttl: config.ttl }
+        } else {
+            parser_sdl::federation::EntityCachingConfig::Disabled
+        }
+    }
+}

--- a/gateway/crates/federated-server/src/server.rs
+++ b/gateway/crates/federated-server/src/server.rs
@@ -73,6 +73,7 @@ pub async fn serve(
                 header_rules: config.headers,
                 rate_limit: config.gateway.rate_limit,
                 timeout: config.gateway.timeout,
+                entity_caching: config.entity_caching,
             },
             otel_reload,
             sender,


### PR DESCRIPTION
Adds entity caching config to the gateway toml.  Allowing users to set defaults and also enable/disable and set the TTL per subgraph.

Config should look something like:

```toml
[entity_caching]
enabled = true
ttl = "60s"

[subgraphs.products.entity_caching]
ttl = "30s"

[subgraphs.reviews.entity_caching]
enabled = false
```

This PR is just the config for enabling & setting the TTL: configuring redis etc. will come when I get to adding redis support.

Fixes GB-7160
Fixes GB-7051