### PR TITLE
feat: redis config for entity caching

### DIFF
--- a/engine/crates/engine-config-builder/src/from_sdl_config.rs
+++ b/engine/crates/engine-config-builder/src/from_sdl_config.rs
@@ -44,7 +44,7 @@ pub fn build_with_sdl_config(config: &FederatedGraphConfig, graph: FederatedGrap
         rate_limit: context.rate_limit,
         timeout: config.timeout,
         entity_caching: match config.entity_caching {
-            EntityCachingConfig::Enabled { ttl } => EntityCaching::Enabled { ttl },
+            EntityCachingConfig::Enabled { ttl, .. } => EntityCaching::Enabled { ttl },
             _ => EntityCaching::Disabled,
         },
     })
@@ -211,7 +211,7 @@ impl<'a> BuildContext<'a> {
                     retry,
                     entity_caching: entity_caching.as_ref().map(|config| match config {
                         EntityCachingConfig::Disabled => EntityCaching::Disabled,
-                        EntityCachingConfig::Enabled { ttl } => EntityCaching::Enabled { ttl: *ttl },
+                        EntityCachingConfig::Enabled { ttl, .. } => EntityCaching::Enabled { ttl: *ttl },
                     }),
                 },
             );

--- a/engine/crates/parser-sdl/src/rules/subgraph_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/subgraph_directive.rs
@@ -190,18 +190,18 @@ impl Visitor<'_> for SubgraphDirectiveVisitor {
                 subgraph.development_url = Some(url.to_string())
             }
 
-            if let Some(enabled) = directive.entity_caching_enabled {
-                if enabled {
-                    subgraph.entity_caching = Some(EntityCachingConfig::Enabled { ttl: None });
-                } else {
-                    subgraph.entity_caching = Some(EntityCachingConfig::Disabled);
-                }
-            }
-
-            if let Some(ttl) = directive.entity_caching_ttl {
-                // If there's a ttl we always enable
-                subgraph.entity_caching = Some(EntityCachingConfig::Enabled { ttl: Some(ttl) });
-            }
+            subgraph.entity_caching = match (directive.entity_caching_enabled, directive.entity_caching_ttl) {
+                (Some(false), _) => Some(EntityCachingConfig::Disabled),
+                (Some(true), ttl) => Some(EntityCachingConfig::Enabled {
+                    ttl,
+                    storage: Default::default(),
+                }),
+                (_, Some(ttl)) => Some(EntityCachingConfig::Enabled {
+                    ttl: Some(ttl),
+                    storage: Default::default(),
+                }),
+                _ => None,
+            };
 
             subgraph.header_rules.extend(
                 directive

--- a/gateway/crates/config/src/entity_caching.rs
+++ b/gateway/crates/config/src/entity_caching.rs
@@ -1,10 +1,62 @@
-use std::time::Duration;
+use std::{path::PathBuf, time::Duration};
 
 #[derive(Debug, Default, serde::Deserialize, Clone, PartialEq)]
 pub struct EntityCachingConfig {
     pub enabled: Option<bool>,
 
+    #[serde(default)]
+    pub storage: EntityCachingStorage,
+
+    #[serde(default)]
+    pub redis: Option<EntityCachingRedisConfig>,
+
     /// The ttl to store cache entries with.  Defaults to 60s
     #[serde(deserialize_with = "duration_str::deserialize_option_duration", default)]
     pub ttl: Option<Duration>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EntityCachingStorage {
+    #[default]
+    Memory,
+    Redis,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EntityCachingRedisConfig {
+    #[serde(default = "EntityCachingRedisConfig::default_url")]
+    pub url: url::Url,
+    #[serde(default = "EntityCachingRedisConfig::default_key_prefix")]
+    pub key_prefix: String,
+    pub tls: Option<EntityCachingRedisTlsConfig>,
+}
+
+impl Default for EntityCachingRedisConfig {
+    fn default() -> Self {
+        Self {
+            url: Self::default_url(),
+            key_prefix: Self::default_key_prefix(),
+            tls: None,
+        }
+    }
+}
+
+impl EntityCachingRedisConfig {
+    fn default_url() -> url::Url {
+        url::Url::parse("redis://localhost:6379").expect("must be correct")
+    }
+
+    fn default_key_prefix() -> String {
+        String::from("grafbase-cache")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EntityCachingRedisTlsConfig {
+    pub cert: Option<PathBuf>,
+    pub key: Option<PathBuf>,
+    pub ca: Option<PathBuf>,
 }


### PR DESCRIPTION
This adds redis config for entity caching into the gateway toml structs. Doesn't actually do anything yet, that'll be my next PR.

Part of GB-6894