### PR TITLE
fix: put my new redis stuff behind the redis flag

### DIFF
--- a/engine/crates/runtime-local/src/lib.rs
+++ b/engine/crates/runtime-local/src/lib.rs
@@ -8,6 +8,7 @@ mod kv;
 mod log;
 mod pg;
 pub mod rate_limiting;
+#[cfg(feature = "redis")]
 pub mod redis;
 mod ufd_invoker;
 


### PR DESCRIPTION
I didn't notice redis was feature flagged.