### PR TITLE
feat: implement and hook up RedisEntityCache

### DIFF
--- a/engine/crates/integration-tests/tests/federation/trusted_documents.rs
+++ b/engine/crates/integration-tests/tests/federation/trusted_documents.rs
@@ -77,7 +77,7 @@ fn apollo_client_style_happy_path() {
             engine
                 .execute("")
                 .extensions(
-                    &json!({"persistedQuery": { "version": 1, "sha256Hash": &TRUSTED_DOCUMENTS[0].document_id }}),
+                    json!({"persistedQuery": { "version": 1, "sha256Hash": &TRUSTED_DOCUMENTS[0].document_id }}),
                 )
                 .header("x-grafbase-client-name", "ios-app")
         };
@@ -123,7 +123,7 @@ fn trusted_document_queries_without_client_name_header_are_rejected() {
     test(|engine| async move {
         let response = engine
             .execute("")
-            .extensions(&json!({"persistedQuery": { "version": 1, "sha256Hash": &TRUSTED_DOCUMENTS[0].document_id }}))
+            .extensions(json!({"persistedQuery": { "version": 1, "sha256Hash": &TRUSTED_DOCUMENTS[0].document_id }}))
             .await;
 
         insta::assert_json_snapshot!(response, @r###"
@@ -146,7 +146,7 @@ fn wrong_client_name() {
     test(|engine| async move {
         let response = engine
             .execute("")
-            .extensions(&json!({"persistedQuery": { "version": 1, "sha256Hash": &TRUSTED_DOCUMENTS[0].document_id }}))
+            .extensions(json!({"persistedQuery": { "version": 1, "sha256Hash": &TRUSTED_DOCUMENTS[0].document_id }}))
             .header("x-grafbase-client-name", "android-app")
             .await;
 

--- a/engine/crates/parser-sdl/src/federation.rs
+++ b/engine/crates/parser-sdl/src/federation.rs
@@ -91,11 +91,11 @@ impl From<gateway_config::EntityCachingConfig> for EntityCachingConfig {
 
 fn entity_cache_storage(
     storage: gateway_config::EntityCachingStorage,
-    redis: Option<gateway_config::EntityCachingRedisConfig>,
+    redis: gateway_config::EntityCachingRedisConfig,
 ) -> EntityCacheStorage {
     match storage {
         gateway_config::EntityCachingStorage::Memory => EntityCacheStorage::Memory,
-        gateway_config::EntityCachingStorage::Redis => EntityCacheStorage::Redis(redis.unwrap_or_default().into()),
+        gateway_config::EntityCachingStorage::Redis => EntityCacheStorage::Redis(redis.into()),
     }
 }
 

--- a/engine/crates/runtime-local/src/entity_cache.rs
+++ b/engine/crates/runtime-local/src/entity_cache.rs
@@ -1,2 +1,3 @@
 pub(crate) mod memory;
+#[cfg(feature = "redis")]
 pub(crate) mod redis;

--- a/engine/crates/runtime-local/src/entity_cache/redis.rs
+++ b/engine/crates/runtime-local/src/entity_cache/redis.rs
@@ -1,1 +1,73 @@
+use deadpool::managed::Object;
+use futures_util::future::BoxFuture;
+use grafbase_telemetry::span::GRAFBASE_TARGET;
+use redis::{AsyncCommands, SetOptions};
 
+use crate::redis::{Manager, Pool};
+
+pub struct RedisEntityCache {
+    pool: Pool,
+    key_prefix: String,
+}
+
+impl RedisEntityCache {
+    pub fn new(pool: Pool, key_prefix: &str) -> Self {
+        RedisEntityCache {
+            pool,
+            key_prefix: key_prefix.to_string(),
+        }
+    }
+
+    async fn get(&self, name: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        let mut connection = self.connection().await?;
+        Ok(connection.get(self.key(name)).await?)
+    }
+
+    async fn put(
+        &self,
+        name: &str,
+        bytes: std::borrow::Cow<'_, [u8]>,
+        expiration_ttl: std::time::Duration,
+    ) -> anyhow::Result<()> {
+        let mut connection = self.connection().await?;
+        let options = SetOptions::default().with_expiration(self.expiry_time(expiration_ttl));
+        Ok(connection.set_options(self.key(name), bytes.as_ref(), options).await?)
+    }
+
+    fn key(&self, name: &str) -> String {
+        format!("{}-{name}", self.key_prefix)
+    }
+
+    fn expiry_time(&self, duration: std::time::Duration) -> redis::SetExpiry {
+        if duration.as_secs() > 60 {
+            redis::SetExpiry::PX(duration.as_millis() as usize)
+        } else {
+            redis::SetExpiry::EX(duration.as_secs() as usize)
+        }
+    }
+
+    async fn connection(&self) -> Result<Object<Manager>, anyhow::Error> {
+        match self.pool.get().await {
+            Ok(conn) => Ok(conn),
+            Err(error) => {
+                tracing::error!(target: GRAFBASE_TARGET, "error fetching a Redis connection: {error}");
+                anyhow::bail!("error fetching a redis connection: {error}");
+            }
+        }
+    }
+}
+
+impl runtime::entity_cache::EntityCache for RedisEntityCache {
+    fn get<'a>(&'a self, name: &'a str) -> BoxFuture<'a, anyhow::Result<Option<Vec<u8>>>> {
+        Box::pin(self.get(name))
+    }
+
+    fn put<'a>(
+        &'a self,
+        name: &'a str,
+        bytes: std::borrow::Cow<'a, [u8]>,
+        expiration_ttl: std::time::Duration,
+    ) -> BoxFuture<'a, anyhow::Result<()>> {
+        Box::pin(self.put(name, bytes, expiration_ttl))
+    }
+}

--- a/engine/crates/runtime-local/src/lib.rs
+++ b/engine/crates/runtime-local/src/lib.rs
@@ -16,6 +16,8 @@ mod ufd_invoker;
 pub use bridge::Bridge;
 pub use cache::InMemoryCache;
 pub use entity_cache::memory::InMemoryEntityCache;
+#[cfg(feature = "redis")]
+pub use entity_cache::redis::RedisEntityCache;
 pub use fetch::NativeFetcher;
 pub use hot_cache::{InMemoryHotCache, InMemoryHotCacheFactory};
 pub use kv::*;

--- a/engine/crates/runtime-local/src/redis.rs
+++ b/engine/crates/runtime-local/src/redis.rs
@@ -14,6 +14,8 @@ use redis::ClientTlsConfig;
 
 pub type Pool = deadpool::managed::Pool<pool::Manager>;
 
+pub use pool::Manager;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RedisTlsConfig<'a> {
     pub cert: Option<&'a Path>,

--- a/gateway/crates/config/src/entity_caching.rs
+++ b/gateway/crates/config/src/entity_caching.rs
@@ -8,7 +8,7 @@ pub struct EntityCachingConfig {
     pub storage: EntityCachingStorage,
 
     #[serde(default)]
-    pub redis: Option<EntityCachingRedisConfig>,
+    pub redis: EntityCachingRedisConfig,
 
     /// The ttl to store cache entries with.  Defaults to 60s
     #[serde(deserialize_with = "duration_str::deserialize_option_duration", default)]


### PR DESCRIPTION
As per the title this finishes adding redis entity caching support.  

I haven't written any tests of this yet because the existing tests of the gateway binary don't seem to call subgraphs, so there's a bit of setup I'd need to do for that.  Have added GB-7210 to handle that.

Fixes GB-6894