### PR TITLE
feat(config): Add subgraph_timeout configuration option

### DIFF
--- a/engine/crates/engine-config-builder/src/from_toml_config.rs
+++ b/engine/crates/engine-config-builder/src/from_toml_config.rs
@@ -45,7 +45,7 @@ pub fn build_with_toml_config(config: &Config, graph: FederatedGraph) -> Version
                 header_rules,
                 development_url: None,
                 rate_limit: subgraph_config.rate_limit.map(Into::into),
-                timeout: subgraph_config.timeout,
+                timeout: subgraph_config.timeout.or(config.gateway.subgraph_timeout),
                 entity_caching: subgraph_config.entity_caching.map(Into::into),
                 retry: subgraph_config
                     .retry

--- a/gateway/crates/config/src/lib.rs
+++ b/gateway/crates/config/src/lib.rs
@@ -91,9 +91,12 @@ impl Config {
 #[derive(Clone, Debug, Default, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct GatewayConfig {
-    /// Time out for gateway requests.
+    /// Timeout for gateway requests.
     #[serde(deserialize_with = "duration_str::deserialize_option_duration", default)]
     pub timeout: Option<Duration>,
+    /// Default timeout for subgraph requests.
+    #[serde(deserialize_with = "duration_str::deserialize_option_duration", default)]
+    pub subgraph_timeout: Option<Duration>,
     /// Global rate limiting configuration
     #[serde(default)]
     pub rate_limit: Option<RateLimitConfig>,
@@ -1365,6 +1368,29 @@ mod tests {
         2 | websocket_url = "WRONG"
           |                 ^^^^^^^
         invalid value: string "WRONG", expected relative URL without a base
+        "###);
+    }
+
+    #[test]
+    fn timeouts() {
+        let input = indoc! {r#"
+            [gateway]
+            timeout = "1s"
+            subgraph_timeout = "2s"
+        "#};
+
+        let config: Config = toml::from_str(input).unwrap();
+
+        insta::assert_debug_snapshot!(&config.gateway, @r###"
+        GatewayConfig {
+            timeout: Some(
+                1s,
+            ),
+            subgraph_timeout: Some(
+                2s,
+            ),
+            rate_limit: None,
+        }
         "###);
     }
 


### PR DESCRIPTION
It acts as a default subgraph timeout, which can be overriden per subgraph if needed.
