### PR TITLE
feat(config): Global retry settings

### DIFF
--- a/engine/crates/engine-config-builder/src/from_toml_config.rs
+++ b/engine/crates/engine-config-builder/src/from_toml_config.rs
@@ -1,6 +1,6 @@
 use engine_v2_config::VersionedConfig;
 use federated_graph::FederatedGraph;
-use gateway_config::Config;
+use gateway_config::{Config, RetryConfig};
 use parser_sdl::federation::{header::SubgraphHeaderRule, FederatedGraphConfig};
 
 use crate::build_with_sdl_config;
@@ -18,14 +18,15 @@ pub fn build_with_toml_config(config: &Config, graph: FederatedGraph) -> Version
 
     graph_config.timeout = config.gateway.timeout;
     graph_config.disable_introspection = !config.graph.introspection;
+
     graph_config.header_rules = config
         .headers
         .clone()
         .into_iter()
         .map(SubgraphHeaderRule::from)
         .collect();
-    graph_config.rate_limit = config.gateway.rate_limit.clone().map(Into::into);
 
+    graph_config.rate_limit = config.gateway.rate_limit.clone().map(Into::into);
     graph_config.entity_caching = config.entity_caching.clone().into();
 
     graph_config.subgraphs = config
@@ -47,15 +48,7 @@ pub fn build_with_toml_config(config: &Config, graph: FederatedGraph) -> Version
                 rate_limit: subgraph_config.rate_limit.map(Into::into),
                 timeout: subgraph_config.timeout,
                 entity_caching: subgraph_config.entity_caching.map(Into::into),
-                retry: subgraph_config
-                    .retry
-                    .enabled
-                    .then_some(parser_sdl::federation::RetryConfig {
-                        min_per_second: subgraph_config.retry.min_per_second,
-                        ttl: subgraph_config.retry.ttl,
-                        retry_percent: subgraph_config.retry.retry_percent,
-                        retry_mutations: subgraph_config.retry.retry_mutations,
-                    }),
+                retry: retry_config(subgraph_config.retry, config.gateway.retry),
             };
 
             (name, config)
@@ -63,4 +56,109 @@ pub fn build_with_toml_config(config: &Config, graph: FederatedGraph) -> Version
         .collect();
 
     build_with_sdl_config(&graph_config, graph)
+}
+
+fn retry_config(
+    subgraph_retry: Option<RetryConfig>,
+    global_retry: RetryConfig,
+) -> Option<parser_sdl::federation::RetryConfig> {
+    let retry = match subgraph_retry {
+        Some(retry) if retry.enabled => Some(retry),
+        None if global_retry.enabled => Some(global_retry),
+        _ => None,
+    };
+
+    retry.map(|retry| parser_sdl::federation::RetryConfig {
+        min_per_second: retry.min_per_second,
+        ttl: retry.ttl,
+        retry_percent: retry.retry_percent,
+        retry_mutations: retry.retry_mutations,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use gateway_config::RetryConfig;
+
+    #[test]
+    fn no_retry_enabled() {
+        let result = super::retry_config(None, RetryConfig::default());
+        assert_eq!(None, result);
+    }
+
+    #[test]
+    fn global_retry_enabled() {
+        let result = super::retry_config(
+            None,
+            RetryConfig {
+                enabled: true,
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(Some(parser_sdl::federation::RetryConfig::default()), result);
+    }
+
+    #[test]
+    fn global_retry_enabled_subgraph_retry_disabled() {
+        let global = RetryConfig {
+            enabled: true,
+            ..Default::default()
+        };
+
+        let subgraph = RetryConfig {
+            enabled: false,
+            ..Default::default()
+        };
+
+        let result = super::retry_config(Some(subgraph), global);
+
+        assert_eq!(None, result);
+    }
+
+    #[test]
+    fn global_retry_enabled_subgraph_retry_enabled() {
+        let global = RetryConfig {
+            enabled: true,
+            ..Default::default()
+        };
+
+        let subgraph = RetryConfig {
+            enabled: true,
+            min_per_second: Some(10),
+            ..Default::default()
+        };
+
+        let result = super::retry_config(Some(subgraph), global);
+
+        let expected = parser_sdl::federation::RetryConfig {
+            min_per_second: Some(10),
+            ..Default::default()
+        };
+
+        assert_eq!(Some(expected), result);
+    }
+
+    #[test]
+    fn global_retry_disabled_subgraph_retry_enabled() {
+        let global = RetryConfig {
+            enabled: false,
+            ..Default::default()
+        };
+
+        let subgraph = RetryConfig {
+            enabled: true,
+            min_per_second: Some(10),
+            ..Default::default()
+        };
+
+        let result = super::retry_config(Some(subgraph), global);
+
+        let expected = parser_sdl::federation::RetryConfig {
+            min_per_second: Some(10),
+            ..Default::default()
+        };
+
+        assert_eq!(Some(expected), result);
+    }
 }

--- a/engine/crates/engine-v2/config/src/v2/mod.rs
+++ b/engine/crates/engine-v2/config/src/v2/mod.rs
@@ -87,6 +87,7 @@ pub struct RetryConfig {
     /// The fraction of the successful requests budget that can be used for retries.
     pub retry_percent: Option<f32>,
     /// Whether mutations should be retried at all. False by default.
+    #[serde(default)]
     pub retry_mutations: bool,
 }
 

--- a/engine/crates/engine-v2/config/src/v2/mod.rs
+++ b/engine/crates/engine-v2/config/src/v2/mod.rs
@@ -87,7 +87,7 @@ pub struct RetryConfig {
     /// The fraction of the successful requests budget that can be used for retries.
     pub retry_percent: Option<f32>,
     /// Whether mutations should be retried at all. False by default.
-    pub retry_mutations: Option<bool>,
+    pub retry_mutations: bool,
 }
 
 /// A header that should be sent to a subgraph

--- a/engine/crates/engine-v2/schema/src/sources/graphql.rs
+++ b/engine/crates/engine-v2/schema/src/sources/graphql.rs
@@ -33,7 +33,7 @@ pub struct RetryConfig {
     /// The fraction of the successful requests budget that can be used for retries.
     pub retry_percent: Option<f32>,
     /// Whether mutations should be retried at all. False by default.
-    pub retry_mutations: Option<bool>,
+    pub retry_mutations: bool,
 }
 
 id_newtypes::U8! {

--- a/engine/crates/engine-v2/src/sources/graphql/mod.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/mod.rs
@@ -123,7 +123,10 @@ impl GraphqlPreparedExecutor {
         let mut retry_budget = ctx.engine.retry_budget_for_subgraph(self.subgraph_id);
 
         if self.operation.ty.is_mutation()
-            && subgraph.retry_config().and_then(|config| config.retry_mutations) != Some(true)
+            && !subgraph
+                .retry_config()
+                .map(|config| config.retry_mutations)
+                .unwrap_or(false)
         {
             retry_budget = None;
         }

--- a/engine/crates/parser-sdl/src/federation.rs
+++ b/engine/crates/parser-sdl/src/federation.rs
@@ -222,7 +222,7 @@ pub struct RetryConfig {
     /// The fraction of the successful requests budget that can be used for retries.
     pub retry_percent: Option<f32>,
     /// Whether mutations should be retried at all. False by default.
-    pub retry_mutations: Option<bool>,
+    pub retry_mutations: bool,
 }
 
 #[cfg(test)]

--- a/engine/crates/parser-sdl/src/rules/subgraph_directive.rs
+++ b/engine/crates/parser-sdl/src/rules/subgraph_directive.rs
@@ -223,7 +223,7 @@ impl Visitor<'_> for SubgraphDirectiveVisitor {
                     min_per_second,
                     ttl,
                     retry_percent,
-                    retry_mutations,
+                    retry_mutations: retry_mutations.unwrap_or_default(),
                 },
             );
         }


### PR DESCRIPTION
A global setting to define retries for all subgraphs.