### PR TITLE
chore: unflag partial-caching feature in gateway-core

### DIFF
--- a/cli/crates/gateway/Cargo.toml
+++ b/cli/crates/gateway/Cargo.toml
@@ -26,7 +26,7 @@ engine = { path = "../../../engine/crates/engine" }
 graphql-extensions = { path = "../../../engine/crates/graphql-extensions", features = [
   "local",
 ] }
-gateway-core = { path = "../../../engine/crates/gateway-core", features = ["partial-caching"] }
+gateway-core.workspace = true
 grafbase-telemetry = { workspace = true , features = ["tower"] }
 registry-v2.workspace = true
 registry-for-cache.workspace = true

--- a/engine/crates/engine-v2/Cargo.toml
+++ b/engine/crates/engine-v2/Cargo.toml
@@ -42,7 +42,7 @@ tower = { workspace = true, features = ["retry"] }
 tracing.workspace = true
 http.workspace = true
 headers.workspace = true
-gateway-core = { path = "../gateway-core" }
+gateway-core.workspace = true
 web-time.workspace = true
 
 gateway-v2-auth = { path = "../gateway-v2/auth" }

--- a/engine/crates/gateway-core/Cargo.toml
+++ b/engine/crates/gateway-core/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["graphql", "gateway", "grafbase"]
 
 [features]
 default = []
-partial-caching = ["dep:partial-caching", "dep:cynic-parser", "dep:futures-channel"]
 
 [lints]
 workspace = true
@@ -25,12 +24,12 @@ async-trait = "0.1.80"
 blake3.workspace = true
 bytes.workspace = true
 common-types.workspace = true
-cynic-parser = { workspace = true, optional = true }
+cynic-parser.workspace = true
 engine-parser.workspace = true
 engine-validation.workspace = true
 engine-value.workspace = true
 engine.workspace = true
-futures-channel = { workspace = true, optional = true }
+futures-channel.workspace = true
 futures-util.workspace = true
 grafbase-telemetry.workspace = true
 headers.workspace = true
@@ -39,7 +38,7 @@ mediatype = "0.19.18"
 mime = "0.3.17"
 multipart-stream = "0.1.2"
 operation-normalizer = { path = "../operation-normalizer" }
-partial-caching = { workspace = true, optional = true }
+partial-caching.workspace = true
 registry-for-cache.workspace = true
 runtime = { workspace = true, features = ["test-utils"] }
 serde.workspace = true

--- a/engine/crates/gateway-core/src/cache/mod.rs
+++ b/engine/crates/gateway-core/src/cache/mod.rs
@@ -8,7 +8,6 @@ use runtime::cache::{Cache, Cacheable, CachedExecutionResponse};
 mod build_key;
 mod key;
 
-#[cfg(feature = "partial-caching")]
 pub mod partial;
 
 #[derive(Clone)]

--- a/engine/crates/gateway-core/src/lib.rs
+++ b/engine/crates/gateway-core/src/lib.rs
@@ -15,9 +15,7 @@ use runtime::{
 use std::sync::Arc;
 use tracing::{info_span, Instrument};
 
-#[cfg(feature = "partial-caching")]
 use engine::{InitialResponse, StreamingPayload};
-#[cfg(feature = "partial-caching")]
 use futures_util::stream::{self, BoxStream, StreamExt};
 
 mod admin;
@@ -299,7 +297,6 @@ where
             .await
     }
 
-    #[cfg(feature = "partial-caching")]
     pub async fn execute_stream_v2(
         &self,
         ctx: &Arc<Executor::Context>,
@@ -407,7 +404,6 @@ where
             return Ok((Arc::new(response), Default::default()));
         }
 
-        #[cfg(feature = "partial-caching")]
         if self.cache_config.partial_registry.enable_partial_caching {
             let cache_plan = partial_caching::build_plan(
                 request.query(),
@@ -472,7 +468,6 @@ where
     }
 }
 
-#[cfg(feature = "partial-caching")]
 fn error_stream(response: engine::Response) -> BoxStream<'static, engine::StreamingPayload> {
     stream::once(async move { StreamingPayload::InitialResponse(InitialResponse::error(response)) }).boxed()
 }

--- a/engine/crates/integration-tests/Cargo.toml
+++ b/engine/crates/integration-tests/Cargo.toml
@@ -22,7 +22,7 @@ graphql-mocks.workspace = true
 engine-config-builder = { path = "../engine-config-builder" }
 expect-test = "1.5"
 futures = "0.3.30"
-gateway-core = { workspace = true, features = ["partial-caching"] }
+gateway-core.workspace = true
 gateway-config.workspace = true
 grafbase-graphql-introspection.workspace = true
 graphql-composition.workspace = true


### PR DESCRIPTION
I had the partial-caching code in gateway-core behind a feature flag while I was developing it.  Now that it's out this flag is not worth keeping around.

Fixes GB-7072