### PR TITLE
chore(engine-v2): Improve benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,6 +947,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
+name = "bytemuck"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,7 +999,7 @@ dependencies = [
  "futures",
  "hex",
  "libc",
- "memmap2",
+ "memmap2 0.5.10",
  "miette 5.10.0",
  "reflink-copy",
  "serde",
@@ -1748,7 +1754,7 @@ version = "3.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "672465ae37dc1bc6380a6547a8883d5dd397b0f1faaad4f265726cc7042a5345"
 dependencies = [
- "nix",
+ "nix 0.28.0",
  "windows-sys 0.52.0",
 ]
 
@@ -2907,6 +2913,18 @@ dependencies = [
  "libc",
  "redox_syscall 0.4.1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -4491,6 +4509,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
+name = "inferno"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9"
+dependencies = [
+ "ahash 0.8.11",
+ "indexmap 2.2.6",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml 0.26.0",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "inotify"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4578,6 +4614,7 @@ dependencies = [
  "ctor",
  "cynic",
  "cynic-introspection",
+ "cynic-parser 0.4.5",
  "engine",
  "engine-config-builder",
  "engine-parser",
@@ -4598,6 +4635,7 @@ dependencies = [
  "http",
  "indoc",
  "insta",
+ "itertools 0.13.0",
  "multipart-stream",
  "names",
  "openidconnect",
@@ -4607,6 +4645,7 @@ dependencies = [
  "parser-postgres",
  "parser-sdl",
  "postgres-connector-types",
+ "pprof",
  "regex",
  "registry-for-cache",
  "registry-upgrade",
@@ -5267,6 +5306,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5479,6 +5527,17 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
@@ -5592,6 +5651,16 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec 0.7.4",
+ "itoa",
+]
 
 [[package]]
 name = "num-integer"
@@ -6471,7 +6540,7 @@ dependencies = [
  "base64 0.21.7",
  "indexmap 2.2.6",
  "line-wrap",
- "quick-xml",
+ "quick-xml 0.31.0",
  "serde",
  "time",
 ]
@@ -6582,6 +6651,28 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "pprof"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "criterion",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix 0.26.4",
+ "once_cell",
+ "parking_lot",
+ "smallvec",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -6796,6 +6887,15 @@ dependencies = [
  "form_urlencoded",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -7345,6 +7445,15 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -8327,6 +8436,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7beae5182595e9a8b683fa98c4317f956c9a2dec3b9716990d20023cc60c766"
 
 [[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
 name = "string_enum"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8529,6 +8644,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e194d14f94121fd08b823d3379eedb3ce455785d9e0c3d2742c59377e283207"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "symbolic-common"
+version = "12.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16629323a4ec5268ad23a575110a724ad4544aae623451de600c747bf87b36cf"
+dependencies = [
+ "debugid",
+ "memmap2 0.9.4",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c043a45f08f41187414592b3ceb53fb0687da57209cc77401767fb69d5b596"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,6 +216,7 @@ worker-env = { path = "engine/crates/worker-env" }
 wrapping = { path = "engine/crates/wrapping", package = "graphql-wrapping-types" }
 
 [profile.bench]
+strip = "none"
 debug = true
 
 [profile.release]

--- a/engine/crates/engine-v2/src/engine.rs
+++ b/engine/crates/engine-v2/src/engine.rs
@@ -105,7 +105,7 @@ impl<R: Runtime> Engine<R> {
             auth,
             retry_budgets,
             operation_metrics: GraphqlOperationMetrics::build(runtime.meter()),
-            trusted_documents_cache: runtime.cache_factory().create(CachedDataKind::PersistedQuery).await,
+            trusted_documents_cache: runtime.cache_factory().create(CachedDataKind::TrustedDocument).await,
             operation_cache: runtime.cache_factory().create(CachedDataKind::Operation).await,
             runtime,
         }

--- a/engine/crates/engine-v2/src/response/shape.rs
+++ b/engine/crates/engine-v2/src/response/shape.rs
@@ -12,7 +12,7 @@ pub(crate) struct Shapes {
     pub fields: Vec<FieldShape>,
 }
 
-id_newtypes::NonZeroU16! {
+id_newtypes::NonZeroU32! {
     Shapes.concrete[ConcreteObjectShapeId] => ConcreteObjectShape,
     Shapes.polymorphic[PolymorphicObjectShapeId] => PolymorphicObjectShape,
     Shapes.fields[FieldShapeId] => FieldShape,

--- a/engine/crates/integration-tests/Cargo.toml
+++ b/engine/crates/integration-tests/Cargo.toml
@@ -94,16 +94,19 @@ features = ["tower"]
 
 [dev-dependencies]
 similar-asserts = "1.5"
+cynic-parser = "0.4"
 base64.workspace = true
 rstest.workspace = true
 const_format = "0.2.32"
 headers.workspace = true
 criterion = { version = "0.5.1", features = ["async_tokio"] }
+pprof = { version = "0.13", features = ["criterion", "flamegraph"] }
 sha2.workspace = true
 hex.workspace = true
 secrecy.workspace = true
 gateway-v2-auth.workspace = true
 common-types.workspace = true
+itertools.workspace = true
 
 [[bench]]
 name = "federation"

--- a/engine/crates/integration-tests/benches/federation.rs
+++ b/engine/crates/integration-tests/benches/federation.rs
@@ -1,7 +1,12 @@
 #![allow(unused_crate_dependencies)]
+use std::{fmt::Write, sync::OnceLock};
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use futures::{stream::FuturesUnordered, StreamExt};
+use indoc::{indoc, writedoc};
 use integration_tests::{federation::DeterministicEngine, runtime};
+use itertools::Itertools;
+use pprof::criterion::{Output, PProfProfiler};
 use serde_json::json;
 
 const SCHEMA: &str = include_str!("../data/federated-graph-schema.graphql");
@@ -27,39 +32,39 @@ pub fn introspection(c: &mut Criterion) {
                 .build()
                 .unwrap(),
         )
-        .iter(|| bench.execute());
+        .iter(|| bench.raw_execute());
     });
 }
 
 pub fn basic_federation(c: &mut Criterion) {
     let bench = runtime().block_on(DeterministicEngine::new(
-        SCHEMA,
-        r#"
-        query ExampleQuery {
-            me {
-                id
-                username
-                reviews {
-                    body
-                    product {
-                        reviews {
-                            author {
-                                id
-                                username
+            SCHEMA,
+            r#"
+            query ExampleQuery {
+                me {
+                    id
+                    username
+                    reviews {
+                        body
+                        product {
+                            reviews {
+                                author {
+                                    id
+                                    username
+                                }
+                                body
                             }
-                            body
                         }
                     }
                 }
             }
-        }
-        "#,
-        &[
-            json!({"data":{"me":{"id":"1234","username":"Me"}}}),
-            json!({"data":{"_entities":[{"__typename":"User","reviews":[{"body":"A highly effective form of birth control.","product":{"reviews":[{"author":{"id":"1234"},"body":"A highly effective form of birth control."}]}},{"body":"Fedoras are one of the most fashionable hats around and can look great with a variety of outfits.","product":{"reviews":[{"author":{"id":"1234"},"body":"Fedoras are one of the most fashionable hats around and can look great with a variety of outfits."}]}}]}]}}),
-            json!({"data":{"_entities":[{"__typename":"User","username":"Me"},{"__typename":"User","username":"Me"}]}}),
-        ],
-    ));
+            "#,
+            &[
+                json!({"data":{"me":{"id":"1234","username":"Me"}}}),
+                json!({"data":{"_entities":[{"__typename":"User","reviews":[{"body":"A highly effective form of birth control.","product":{"reviews":[{"author":{"id":"1234"},"body":"A highly effective form of birth control."}]}},{"body":"Fedoras are one of the most fashionable hats around and can look great with a variety of outfits.","product":{"reviews":[{"author":{"id":"1234"},"body":"Fedoras are one of the most fashionable hats around and can look great with a variety of outfits."}]}}]}]}}),
+                json!({"data":{"_entities":[{"__typename":"User","username":"Me"},{"__typename":"User","username":"Me"}]}}),
+            ],
+        ));
     let response = runtime().block_on(bench.execute());
 
     // Sanity check it works.
@@ -74,9 +79,223 @@ pub fn basic_federation(c: &mut Criterion) {
                 .build()
                 .unwrap(),
         )
-        .iter(|| bench.execute());
+        .iter(|| bench.raw_execute());
     });
 }
 
-criterion_group!(benches, introspection, basic_federation);
+pub fn complex_schema(c: &mut Criterion) {
+    let mut group = c.benchmark_group("complex_schema");
+
+    for (size, case) in ComplexSchemaAndQuery::cases() {
+        group.throughput(Throughput::Bytes(case.schema.len() as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, _| {
+            b.to_async(
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap(),
+            )
+            .iter(|| case.to_engine())
+        });
+    }
+    group.finish();
+}
+
+pub fn cynic_complex_schema(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cynic_complex_schema");
+
+    for (size, case) in ComplexSchemaAndQuery::cases() {
+        group.throughput(Throughput::Bytes(case.schema.len() as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, _| {
+            b.iter(|| cynic_parser::parse_type_system_document(&case.schema).unwrap())
+        });
+    }
+    group.finish();
+}
+
+pub fn complex_query(c: &mut Criterion) {
+    let mut group = c.benchmark_group("complex_query");
+
+    let cases = runtime().block_on(
+        ComplexSchemaAndQuery::cases()
+            .iter()
+            .map(|(size, case)| async { (*size, case.query.len(), case.to_engine().await) })
+            .collect::<FuturesUnordered<_>>()
+            .collect::<Vec<_>>(),
+    );
+
+    // Sanity check it works.
+    let response = runtime().block_on(async { cases.first().unwrap().2.execute().await });
+    insta::assert_json_snapshot!(response);
+
+    for (size, query_len, engine) in cases {
+        group.throughput(Throughput::Bytes(query_len as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _| {
+            b.to_async(
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap(),
+            )
+            .iter(|| engine.raw_execute());
+        });
+    }
+    group.finish();
+}
+
+struct ComplexSchemaAndQuery {
+    schema: String,
+    query: String,
+}
+
+impl ComplexSchemaAndQuery {
+    fn cases() -> &'static [(usize, ComplexSchemaAndQuery)] {
+        static CACHE: OnceLock<Vec<(usize, ComplexSchemaAndQuery)>> = OnceLock::new();
+        CACHE.get_or_init(|| {
+            [8, 16, 32, 48]
+                .into_iter()
+                .map(|size| {
+                    let case = ComplexSchemaAndQuery::build(size, 2, size * size);
+                    println!(
+                        "Case {size}: schema: {} KB / query: {} KB",
+                        case.schema.len() >> 10,
+                        case.query.len() >> 10
+                    );
+                    (size, case)
+                })
+                .collect::<Vec<_>>()
+        })
+    }
+
+    fn build(n: usize, k: usize, extras: usize) -> ComplexSchemaAndQuery {
+        let mut schema = indoc!(
+            r###"
+            enum join__Graph {
+              SUB @join__graph(name: "sub", url: "http://127.0.0.1:46697")
+            }
+
+            type Query {
+                node: Node @join__field(graph: SUB)
+            }
+
+            interface Node {
+                id: ID!
+                node: Node!
+            }
+
+            type Nothing implements Node {
+                id: ID!
+                node: Node!
+            }
+            "###
+        )
+        .to_string();
+
+        let mut query = indoc!(
+            r###"
+            query {
+              node {
+                __typename
+                id
+                ...Complex
+                node {
+                  __typename
+                  id
+                  ...Complex
+                }
+              }
+            }
+
+            fragment Complex on Node {
+            "###
+        )
+        .to_string();
+
+        let mut interface_to_fields = (0..n).map(|i| vec![i]).collect::<Vec<_>>();
+        for (j, (i1, i2)) in (0..n).tuple_combinations().enumerate() {
+            interface_to_fields[i1].push(n + j);
+            interface_to_fields[i2].push(n + j);
+        }
+
+        for (i, fields) in interface_to_fields.iter().enumerate() {
+            writedoc!(
+                schema,
+                r###"
+                interface I{i} implements Node {{
+                    id: ID! @join__field(graph: SUB)
+                    node: Node! @join__field(graph: SUB)
+                {}
+                }}
+                "###,
+                fields.iter().format_with("\n", |j, f| {
+                    f(&format_args!("    f{}: String! @join_field(graph: SUB)", j))
+                })
+            )
+            .unwrap();
+            writedoc!(
+                query,
+                "  ... on I{} {{ {} }}\n",
+                i,
+                fields.iter().format_with(" ", |j, f| { f(&format_args!("f{}", j)) })
+            )
+            .unwrap();
+        }
+
+        let mut buffer: Vec<usize> = Vec::new();
+        for c in 1..=n.min(k).min(2) {
+            for (j, interfaces) in (0..n).combinations(c).enumerate() {
+                for i in &interfaces {
+                    buffer.extend_from_slice(&interface_to_fields[*i])
+                }
+                buffer.sort_unstable();
+                writedoc!(
+                    schema,
+                    r###"
+                    type T{c}x{j} implements Node & {} {{
+                        id: ID! @join__field(graph: SUB)
+                        node: Node!
+                    {}
+                    }}
+                    "###,
+                    interfaces.iter().format_with(" & ", |i, f| f(&format_args!("I{}", i))),
+                    buffer.drain(..).dedup().format_with("\n", |i, f| f(&format_args!(
+                        "    f{i}: String! @join_field(graph: SUB)"
+                    )))
+                )
+                .unwrap();
+            }
+        }
+
+        for i in 0..extras {
+            writedoc!(
+                schema,
+                r###"
+                type E{i} implements Node {{
+                    id: ID! @join__field(graph: SUB)
+                    node: Node!
+                }}
+                "###,
+            )
+            .unwrap();
+        }
+        query.push('}');
+
+        ComplexSchemaAndQuery { schema, query }
+    }
+
+    async fn to_engine(&self) -> DeterministicEngine {
+        DeterministicEngine::builder(&self.schema, self.query.clone())
+            .without_hot_cache()
+            .with_subgraph_response(json!({"data":{"node":{"id":"1234", "__typename": "Nothing"}}}))
+            .build()
+            .await
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(1000, Output::Flamegraph(None)));
+    targets = introspection, basic_federation, complex_schema, complex_query, cynic_complex_schema
+}
+
 criterion_main!(benches);

--- a/engine/crates/integration-tests/benches/snapshots/federation__complex_query.snap
+++ b/engine/crates/integration-tests/benches/snapshots/federation__complex_query.snap
@@ -1,0 +1,12 @@
+---
+source: engine/crates/integration-tests/benches/federation.rs
+expression: response
+---
+{
+  "data": {
+    "node": {
+      "__typename": "Nothing",
+      "id": "1234"
+    }
+  }
+}

--- a/engine/crates/integration-tests/benches/snapshots/federation__complex_shapes.snap
+++ b/engine/crates/integration-tests/benches/snapshots/federation__complex_shapes.snap
@@ -1,0 +1,12 @@
+---
+source: engine/crates/integration-tests/benches/federation.rs
+expression: response
+---
+{
+  "data": {
+    "node": {
+      "__typename": "Nothing",
+      "id": "1234"
+    }
+  }
+}

--- a/engine/crates/integration-tests/src/federation/builder/bench.rs
+++ b/engine/crates/integration-tests/src/federation/builder/bench.rs
@@ -1,6 +1,9 @@
-use std::sync::{
-    atomic::{AtomicUsize, Ordering},
-    Arc,
+use std::{
+    borrow::Cow,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
 };
 
 use engine::BatchRequest;
@@ -13,22 +16,23 @@ use runtime::{
     fetch::{FetchError, FetchRequest, FetchResponse, FetchResult, GraphqlRequest},
     hooks::DynamicHooks,
 };
+use runtime_local::InMemoryHotCacheFactory;
 
 use crate::federation::{GraphqlResponse, GraphqlStreamingResponse};
 
 use super::TestRuntime;
 
 #[derive(Clone)]
-pub struct DeterministicEngine<'a> {
+pub struct DeterministicEngine {
     engine: Arc<engine_v2::Engine<TestRuntime>>,
-    query: &'a str,
+    query: String,
     dummy_responses_index: Arc<AtomicUsize>,
 }
 
 pub struct DeterministicEngineBuilder<'a> {
-    hooks: DynamicHooks,
+    runtime: TestRuntime,
     schema: &'a str,
-    query: &'a str,
+    query: String,
     subgraphs_json_responses: Vec<String>,
 }
 
@@ -42,11 +46,16 @@ impl<'a> DeterministicEngineBuilder<'a> {
 
     #[must_use]
     pub fn with_hooks(mut self, hooks: impl Into<DynamicHooks>) -> Self {
-        self.hooks = hooks.into();
+        self.runtime.hooks = hooks.into();
         self
     }
 
-    pub async fn build(self) -> DeterministicEngine<'a> {
+    pub fn without_hot_cache(mut self) -> Self {
+        self.runtime.hot_cache_factory = InMemoryHotCacheFactory::inactive();
+        self
+    }
+
+    pub async fn build(self) -> DeterministicEngine {
         let dummy_responses_index = Arc::new(AtomicUsize::new(0));
         let fetcher = DummyFetcher::create(
             self.subgraphs_json_responses
@@ -66,13 +75,7 @@ impl<'a> DeterministicEngineBuilder<'a> {
             None,
             TestRuntime {
                 fetcher,
-                trusted_documents: runtime::trusted_documents_client::Client::new(
-                    runtime_noop::trusted_documents::NoopTrustedDocuments,
-                ),
-                kv: runtime_local::InMemoryKvStore::runtime(),
-                meter: grafbase_telemetry::metrics::meter_from_global_provider(),
-                hooks: self.hooks,
-                rate_limiter: runtime_noop::rate_limiting::NoopRateLimiter::runtime(),
+                ..self.runtime
             },
         )
         .await;
@@ -84,17 +87,21 @@ impl<'a> DeterministicEngineBuilder<'a> {
     }
 }
 
-impl<'a> DeterministicEngine<'a> {
-    pub fn builder(schema: &'a str, query: &'a str) -> DeterministicEngineBuilder<'a> {
+impl DeterministicEngine {
+    pub fn builder(schema: &str, query: impl Into<Cow<'static, str>>) -> DeterministicEngineBuilder<'_> {
         DeterministicEngineBuilder {
-            hooks: DynamicHooks::default(),
+            runtime: TestRuntime::default(),
             schema,
-            query,
+            query: query.into().into_owned(),
             subgraphs_json_responses: Vec::new(),
         }
     }
 
-    pub async fn new<T: serde::Serialize, I>(schema: &'a str, query: &'a str, subgraphs_responses: I) -> Self
+    pub async fn new<T: serde::Serialize, I>(
+        schema: &str,
+        query: impl Into<Cow<'static, str>>,
+        subgraphs_responses: I,
+    ) -> Self
     where
         I: IntoIterator<Item = T>,
     {
@@ -110,7 +117,7 @@ impl<'a> DeterministicEngine<'a> {
         self.engine
             .execute(
                 http::HeaderMap::new(),
-                BatchRequest::Single(engine::Request::new(self.query)),
+                BatchRequest::Single(engine::Request::new(&self.query)),
             )
             .await
     }
@@ -125,7 +132,7 @@ impl<'a> DeterministicEngine<'a> {
         headers.typed_insert(StreamingFormat::IncrementalDelivery);
         let response = self
             .engine
-            .execute(headers, BatchRequest::Single(engine::Request::new(self.query)))
+            .execute(headers, BatchRequest::Single(engine::Request::new(&self.query)))
             .await;
         let stream = multipart_stream::parse(response.body.into_stream().map_ok(Into::into), "-")
             .map(|result| serde_json::from_slice(&result.unwrap().body).unwrap());

--- a/engine/crates/integration-tests/src/federation/builder/test_runtime.rs
+++ b/engine/crates/integration-tests/src/federation/builder/test_runtime.rs
@@ -10,6 +10,7 @@ pub struct TestRuntime {
     pub fetcher: runtime::fetch::Fetcher,
     pub trusted_documents: trusted_documents_client::Client,
     pub kv: runtime::kv::KvStore,
+    pub hot_cache_factory: InMemoryHotCacheFactory,
     pub meter: opentelemetry::metrics::Meter,
     pub hooks: DynamicHooks,
     pub rate_limiter: runtime::rate_limiting::RateLimiter,
@@ -26,6 +27,7 @@ impl Default for TestRuntime {
             meter: metrics::meter_from_global_provider(),
             hooks: Default::default(),
             rate_limiter: InMemoryRateLimiter::runtime_with_watcher(rx),
+            hot_cache_factory: Default::default(),
         }
     }
 }
@@ -55,7 +57,7 @@ impl engine_v2::Runtime for TestRuntime {
     }
 
     fn cache_factory(&self) -> &Self::CacheFactory {
-        &InMemoryHotCacheFactory
+        &self.hot_cache_factory
     }
 
     fn rate_limiter(&self) -> &runtime::rate_limiting::RateLimiter {

--- a/engine/crates/runtime/src/hot_cache.rs
+++ b/engine/crates/runtime/src/hot_cache.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 
 #[derive(strum::Display)]
 pub enum CachedDataKind {
-    PersistedQuery,
+    TrustedDocument,
     Operation,
 }
 


### PR DESCRIPTION
Currently there are edge cases in engine-v2 where we end up doing a lot
of work to prepare the operation. So made the worst possible case I
could think of. There are certainly complex planning case that could be
time consuming, but I can't think of any obvious one.

I'm roughly generated N interfaces each with a unique field. Two by two,
they all also have a common field. In addition to this I'm generating a
bunch of types that implement one & two interfaces. Lastly, I'm adding
some extra types who do no implement any of the interfaces.

For N=2 I generate the following schema:

```graphql
enum join__Graph {
  SUB @join__graph(name: "sub", url: "http://127.0.0.1:46697")
}

type Query {
    node: Node @join__field(graph: SUB)
}

interface Node {
    id: ID!
    node: Node!
}

type Nothing implements Node {
    id: ID!
    node: Node!
}
interface I0 implements Node {
    id: ID! @join__field(graph: SUB)
    node: Node! @join__field(graph: SUB)
    f0: String! @join_field(graph: SUB)
    f2: String! @join_field(graph: SUB)
}
interface I1 implements Node {
    id: ID! @join__field(graph: SUB)
    node: Node! @join__field(graph: SUB)
    f1: String! @join_field(graph: SUB)
    f2: String! @join_field(graph: SUB)
}
type T1x0 implements Node & I0 {
    id: ID! @join__field(graph: SUB)
    node: Node!
    f0: String! @join_field(graph: SUB)
    f2: String! @join_field(graph: SUB)
}
type T1x1 implements Node & I1 {
    id: ID! @join__field(graph: SUB)
    node: Node!
    f1: String! @join_field(graph: SUB)
    f2: String! @join_field(graph: SUB)
}
type T2x0 implements Node & I0 & I1 {
    id: ID! @join__field(graph: SUB)
    node: Node!
    f0: String! @join_field(graph: SUB)
    f1: String! @join_field(graph: SUB)
    f2: String! @join_field(graph: SUB)
}
type E0 implements Node {
    id: ID! @join__field(graph: SUB)
    node: Node!
}
type E1 implements Node {
    id: ID! @join__field(graph: SUB)
    node: Node!
}
type E2 implements Node {
    id: ID! @join__field(graph: SUB)
    node: Node!
}
type E3 implements Node {
    id: ID! @join__field(graph: SUB)
    node: Node!
}
```

And the following query:
```graphql
query {
  node {
    __typename
    id
    ...Complex
    node {
      __typename
      id
      ...Complex
    }
  }
}

fragment Complex on Node {
  ... on I0 { f0 f2 }
  ... on I1 { f1 f2 }
}
```

By doing that I've noticed that the `FederatedGraph::from_sdl` is
slower than I expected, for N=48 (~5MB) schema, it takes 344ms on my
machine. With async-graphql-parser being responsible for more than half
of it. Cynic-parser in comparison takes 60ms.

For the query itself it roughly takes as much time as parsing the schema
currently roughly, but I know what to fix.

# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
