### PR TITLE
chore(engine-v2): Use Definition suffix in schema structs

### DIFF
--- a/engine/crates/engine-v2/schema/src/builder/coerce/mod.rs
+++ b/engine/crates/engine-v2/schema/src/builder/coerce/mod.rs
@@ -2,8 +2,8 @@ mod error;
 mod path;
 
 use crate::{
-    Definition, EnumId, Graph, InputObjectId, InputValueDefinitionId, ScalarId, ScalarType, SchemaInputValue,
-    SchemaInputValueId, SchemaInputValues, StringId, Type,
+    Definition, EnumDefinitionId, Graph, InputObjectDefinitionId, InputValueDefinitionId, ScalarDefinitionId,
+    ScalarType, SchemaInputValue, SchemaInputValueId, SchemaInputValues, StringId, Type,
 };
 pub use error::*;
 use federated_graph::Value;
@@ -98,7 +98,7 @@ impl<'a> InputValueCoercer<'a> {
 
     fn coerce_input_objet(
         &mut self,
-        input_object_id: InputObjectId,
+        input_object_id: InputObjectDefinitionId,
         value: Value,
     ) -> Result<SchemaInputValue, InputValueError> {
         let input_object = &self.graph[input_object_id];
@@ -158,7 +158,7 @@ impl<'a> InputValueCoercer<'a> {
         Ok(SchemaInputValue::InputObject(ids))
     }
 
-    fn coerce_enum(&mut self, enum_id: EnumId, value: Value) -> Result<SchemaInputValue, InputValueError> {
+    fn coerce_enum(&mut self, enum_id: EnumDefinitionId, value: Value) -> Result<SchemaInputValue, InputValueError> {
         let r#enum = &self.graph[enum_id];
         let name = match &value {
             Value::EnumValue(id) => &self.ctx.strings[StringId::from(*id)],
@@ -183,7 +183,11 @@ impl<'a> InputValueCoercer<'a> {
         }
     }
 
-    fn coerce_scalar(&mut self, scalar_id: ScalarId, value: Value) -> Result<SchemaInputValue, InputValueError> {
+    fn coerce_scalar(
+        &mut self,
+        scalar_id: ScalarDefinitionId,
+        value: Value,
+    ) -> Result<SchemaInputValue, InputValueError> {
         match self.graph[scalar_id].ty {
             ScalarType::String => match value {
                 Value::String(id) => Some(id.into()),

--- a/engine/crates/engine-v2/schema/src/builder/external_sources.rs
+++ b/engine/crates/engine-v2/schema/src/builder/external_sources.rs
@@ -2,12 +2,16 @@ use std::{mem::take, time::Duration};
 
 use config::latest::Config;
 
-use crate::sources;
-
-use super::BuildContext;
+use super::{
+    sources::{
+        graphql::{GraphqlEndpoint, RetryConfig},
+        GraphqlEndpoints,
+    },
+    BuildContext,
+};
 
 pub struct ExternalDataSources {
-    pub graphql: sources::graphql::GraphqlEndpoints,
+    pub graphql: GraphqlEndpoints,
 }
 
 impl ExternalDataSources {
@@ -29,7 +33,7 @@ impl ExternalDataSources {
                         retry,
                         entity_caching,
                         ..
-                    }) => sources::graphql::GraphqlEndpoint {
+                    }) => GraphqlEndpoint {
                         subgraph_name: name,
                         subgraph_id,
                         url,
@@ -43,7 +47,7 @@ impl ExternalDataSources {
                                  ttl,
                                  retry_percent,
                                  retry_mutations,
-                             }| sources::graphql::RetryConfig {
+                             }| RetryConfig {
                                 min_per_second,
                                 ttl,
                                 retry_percent,
@@ -53,7 +57,7 @@ impl ExternalDataSources {
                         entity_cache_ttl: entity_caching.as_ref().unwrap_or(&config.entity_caching).ttl(),
                     },
 
-                    None => sources::graphql::GraphqlEndpoint {
+                    None => GraphqlEndpoint {
                         subgraph_name: name,
                         subgraph_id,
                         url,
@@ -67,7 +71,7 @@ impl ExternalDataSources {
             })
             .collect();
         ExternalDataSources {
-            graphql: sources::GraphqlEndpoints { endpoints },
+            graphql: GraphqlEndpoints { endpoints },
         }
     }
 }

--- a/engine/crates/engine-v2/schema/src/builder/mod.rs
+++ b/engine/crates/engine-v2/schema/src/builder/mod.rs
@@ -11,15 +11,15 @@ use std::mem::take;
 use std::time::Duration;
 
 use config::latest::Config;
+use sources::graphql::GraphqlEndpointId;
 use url::Url;
 
 use self::external_sources::ExternalDataSources;
 use self::graph::GraphBuilder;
 use self::ids::IdMaps;
 use self::interner::ProxyKeyInterner;
-use self::sources::graphql::GraphqlEndpointId;
 
-use super::*;
+use crate::*;
 use error::*;
 use interner::Interner;
 use requires::*;
@@ -50,9 +50,9 @@ pub(crate) struct BuildContext {
 impl BuildContext {
     #[cfg(test)]
     pub fn build_with<T>(build: impl FnOnce(&mut Self, &mut Graph) -> T) -> (Schema, T) {
-        use crate::builder::interner::ProxyKeyInterner;
+        use sources::introspection::IntrospectionBuilder;
 
-        use self::sources::introspection::IntrospectionBuilder;
+        use crate::builder::interner::ProxyKeyInterner;
 
         let mut ctx = Self {
             strings: Interner::from_vec(Vec::new()),
@@ -65,12 +65,12 @@ impl BuildContext {
         let mut graph = Graph {
             description: None,
             root_operation_types: RootOperationTypes {
-                query: ObjectId::from(0),
+                query: ObjectDefinitionId::from(0),
                 mutation: None,
                 subscription: None,
             },
             type_definitions: Vec::new(),
-            object_definitions: vec![Object {
+            object_definitions: vec![ObjectDefinition {
                 name: ctx.strings.get_or_new("Query"),
                 description: None,
                 interfaces: Default::default(),
@@ -85,7 +85,7 @@ impl BuildContext {
                     description: None,
                     // will be replaced by introspection, doesn't matter.
                     ty: Type {
-                        inner: Definition::Object(ObjectId::from(0)),
+                        inner: Definition::Object(ObjectDefinitionId::from(0)),
                         wrapping: Default::default(),
                     },
                     resolvers: Default::default(),
@@ -101,7 +101,7 @@ impl BuildContext {
                     description: None,
                     // will be replaced by introspection, doesn't matter.
                     ty: Type {
-                        inner: Definition::Object(ObjectId::from(0)),
+                        inner: Definition::Object(ObjectDefinitionId::from(0)),
                         wrapping: Default::default(),
                     },
                     resolvers: Default::default(),
@@ -119,7 +119,7 @@ impl BuildContext {
             input_value_definitions: Vec::new(),
             type_system_directives: Vec::new(),
             enum_value_definitions: Vec::new(),
-            resolvers: Vec::new(),
+            resolver_definitions: Vec::new(),
             required_field_sets: Vec::new(),
             required_fields: Vec::new(),
             cache_control: Vec::new(),
@@ -249,14 +249,14 @@ macro_rules! from_id_newtypes {
 // EnumValueId from federated_graph can't be directly
 // converted, we sort them by their name.
 from_id_newtypes! {
-    federated_graph::EnumId => EnumId,
-    federated_graph::InputObjectId => InputObjectId,
-    federated_graph::InterfaceId => InterfaceId,
-    federated_graph::ObjectId => ObjectId,
-    federated_graph::ScalarId => ScalarId,
+    federated_graph::EnumId => EnumDefinitionId,
+    federated_graph::InputObjectId => InputObjectDefinitionId,
+    federated_graph::InterfaceId => InterfaceDefinitionId,
+    federated_graph::ObjectId => ObjectDefinitionId,
+    federated_graph::ScalarId => ScalarDefinitionId,
     federated_graph::StringId => StringId,
     federated_graph::SubgraphId => GraphqlEndpointId,
-    federated_graph::UnionId => UnionId,
+    federated_graph::UnionId => UnionDefinitionId,
     config::latest::HeaderRuleId => HeaderRuleId,
 }
 

--- a/engine/crates/engine-v2/schema/src/ids.rs
+++ b/engine/crates/engine-v2/schema/src/ids.rs
@@ -1,9 +1,10 @@
 /// Isolating ids from the rest to prevent misuse of the NonZeroU32.
 /// They can only be created by From<usize>
 use crate::{
-    AuthorizedDirective, CacheControl, Definition, Enum, EnumValue, FieldDefinition, Graph, HeaderRule, InputObject,
-    InputValueDefinition, Interface, Object, RequiredField, RequiredFieldSet, RequiredScopes, Resolver, Scalar, Schema,
-    TypeSystemDirective, Union,
+    AuthorizedDirective, CacheControl, Definition, EnumDefinition, EnumValue, FieldDefinition, Graph, HeaderRule,
+    InputObjectDefinition, InputValueDefinition, InterfaceDefinition, ObjectDefinition, RequiredField,
+    RequiredFieldSet, RequiredScopes, ResolverDefinition, ScalarDefinition, Schema, TypeSystemDirective,
+    UnionDefinition,
 };
 use regex::Regex;
 use url::Url;
@@ -17,15 +18,15 @@ id_newtypes::NonZeroU32! {
     Graph.type_definitions[DefinitionId] => Definition | max(MAX_ID) | proxy(Schema.graph),
     Graph.type_system_directives[TypeSystemDirectiveId] => TypeSystemDirective | max(MAX_ID) | proxy(Schema.graph),
     Graph.enum_value_definitions[EnumValueId] => EnumValue | max(MAX_ID) | proxy(Schema.graph),
-    Graph.enum_definitions[EnumId] => Enum | max(MAX_ID) | proxy(Schema.graph),
+    Graph.enum_definitions[EnumDefinitionId] => EnumDefinition | max(MAX_ID) | proxy(Schema.graph),
     Graph.field_definitions[FieldDefinitionId] => FieldDefinition | max(MAX_ID) | proxy(Schema.graph),
-    Graph.input_object_definitions[InputObjectId] => InputObject | max(MAX_ID) | proxy(Schema.graph),
+    Graph.input_object_definitions[InputObjectDefinitionId] => InputObjectDefinition | max(MAX_ID) | proxy(Schema.graph),
     Graph.input_value_definitions[InputValueDefinitionId] => InputValueDefinition | max(MAX_ID) | proxy(Schema.graph),
-    Graph.interface_definitions[InterfaceId] => Interface | max(MAX_ID) | proxy(Schema.graph),
-    Graph.object_definitions[ObjectId] => Object | max(MAX_ID) | proxy(Schema.graph),
-    Graph.scalar_definitions[ScalarId] => Scalar | max(MAX_ID) | proxy(Schema.graph),
-    Graph.union_definitions[UnionId] => Union | max(MAX_ID) | proxy(Schema.graph),
-    Graph.resolvers[ResolverId] => Resolver | max(MAX_ID) | proxy(Schema.graph),
+    Graph.interface_definitions[InterfaceDefinitionId] => InterfaceDefinition | max(MAX_ID) | proxy(Schema.graph),
+    Graph.object_definitions[ObjectDefinitionId] => ObjectDefinition | max(MAX_ID) | proxy(Schema.graph),
+    Graph.scalar_definitions[ScalarDefinitionId] => ScalarDefinition | max(MAX_ID) | proxy(Schema.graph),
+    Graph.union_definitions[UnionDefinitionId] => UnionDefinition | max(MAX_ID) | proxy(Schema.graph),
+    Graph.resolver_definitions[ResolverDefinitionId] => ResolverDefinition | max(MAX_ID) | proxy(Schema.graph),
     Graph.required_field_sets[RequiredFieldSetId] => RequiredFieldSet | max(MAX_ID) | proxy(Schema.graph),
     Graph.required_fields[RequiredFieldId] => RequiredField | max(MAX_ID) | proxy(Schema.graph),
     Graph.cache_control[CacheControlId] => CacheControl | max(MAX_ID) | proxy(Schema.graph),

--- a/engine/crates/engine-v2/schema/src/names.rs
+++ b/engine/crates/engine-v2/schema/src/names.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Definition, EnumId, EnumValueId, FieldDefinitionId, InputObjectId, InputValueDefinitionId, InterfaceId, ObjectId,
-    ScalarId, Schema, UnionId,
+    Definition, EnumDefinitionId, EnumValueId, FieldDefinitionId, InputObjectDefinitionId, InputValueDefinitionId,
+    InterfaceDefinitionId, ObjectDefinitionId, ScalarDefinitionId, Schema, UnionDefinitionId,
 };
 
 /// Small abstraction over the actual names to make easier to deal with
@@ -11,15 +11,15 @@ pub trait Names: Send + Sync {
         &schema[schema[field_id].name]
     }
 
-    fn object<'s>(&self, schema: &'s Schema, object_id: ObjectId) -> &'s str {
+    fn object<'s>(&self, schema: &'s Schema, object_id: ObjectDefinitionId) -> &'s str {
         &schema[schema[object_id].name]
     }
 
-    fn union<'s>(&self, schema: &'s Schema, union_id: UnionId) -> &'s str {
+    fn union<'s>(&self, schema: &'s Schema, union_id: UnionDefinitionId) -> &'s str {
         &schema[schema[union_id].name]
     }
 
-    fn interface<'s>(&self, schema: &'s Schema, interface_id: InterfaceId) -> &'s str {
+    fn interface<'s>(&self, schema: &'s Schema, interface_id: InterfaceDefinitionId) -> &'s str {
         &schema[schema[interface_id].name]
     }
 
@@ -27,15 +27,15 @@ pub trait Names: Send + Sync {
         &schema[schema[input_value_id].name]
     }
 
-    fn input_object<'s>(&self, schema: &'s Schema, input_object_id: InputObjectId) -> &'s str {
+    fn input_object<'s>(&self, schema: &'s Schema, input_object_id: InputObjectDefinitionId) -> &'s str {
         &schema[schema[input_object_id].name]
     }
 
-    fn scalar<'s>(&self, schema: &'s Schema, scalar_id: ScalarId) -> &'s str {
+    fn scalar<'s>(&self, schema: &'s Schema, scalar_id: ScalarDefinitionId) -> &'s str {
         &schema[schema[scalar_id].name]
     }
 
-    fn r#enum<'s>(&self, schema: &'s Schema, enum_id: EnumId) -> &'s str {
+    fn r#enum<'s>(&self, schema: &'s Schema, enum_id: EnumDefinitionId) -> &'s str {
         &schema[schema[enum_id].name]
     }
 
@@ -46,20 +46,20 @@ pub trait Names: Send + Sync {
     ////////////////////////////////////////////////////////////////////////////////
     // Used when writing data into the response to determine the actual object id //
 
-    fn union_discriminant_key<'s>(&self, _schema: &'s Schema, _union_id: UnionId) -> &'s str {
+    fn union_discriminant_key<'s>(&self, _schema: &'s Schema, _union_id: UnionDefinitionId) -> &'s str {
         "__typename"
     }
 
-    fn interface_discriminant_key<'s>(&self, _schema: &'s Schema, _interface_id: InterfaceId) -> &'s str {
+    fn interface_discriminant_key<'s>(&self, _schema: &'s Schema, _interface_id: InterfaceDefinitionId) -> &'s str {
         "__typename"
     }
 
     fn concrete_object_id_from_union_discriminant(
         &self,
         schema: &Schema,
-        union_id: UnionId,
+        union_id: UnionDefinitionId,
         discriminant: &str,
-    ) -> Option<ObjectId> {
+    ) -> Option<ObjectDefinitionId> {
         schema.definition_by_name(discriminant).and_then(|definition| {
             if let Definition::Object(object_id) = definition {
                 if schema[union_id].possible_types.contains(&object_id) {
@@ -76,9 +76,9 @@ pub trait Names: Send + Sync {
     fn concrete_object_id_from_interface_discriminant(
         &self,
         schema: &Schema,
-        interface_id: InterfaceId,
+        interface_id: InterfaceDefinitionId,
         discriminant: &str,
-    ) -> Option<ObjectId> {
+    ) -> Option<ObjectDefinitionId> {
         schema.definition_by_name(discriminant).and_then(|definition| {
             if let Definition::Object(object_id) = definition {
                 if schema[interface_id].possible_types.contains(&object_id) {

--- a/engine/crates/engine-v2/schema/src/resolver.rs
+++ b/engine/crates/engine-v2/schema/src/resolver.rs
@@ -8,8 +8,8 @@ use crate::sources::*;
 /// as they can't be mixed together in a single operation. So a resolver id can be used
 /// on both Query and Mutation fields.
 #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub enum Resolver {
-    Introspection(introspection::Resolver),
-    GraphqlRootField(graphql::RootFieldResolver),
-    GraphqlFederationEntity(graphql::FederationEntityResolver),
+pub enum ResolverDefinition {
+    Introspection(introspection::IntrospectionResolverDefinition),
+    GraphqlRootField(graphql::RootFieldResolverDefinition),
+    GraphqlFederationEntity(graphql::FederationEntityResolverDefinition),
 }

--- a/engine/crates/engine-v2/schema/src/sources/graphql.rs
+++ b/engine/crates/engine-v2/schema/src/sources/graphql.rs
@@ -41,21 +41,21 @@ id_newtypes::U8! {
 }
 
 #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct RootFieldResolver {
+pub struct RootFieldResolverDefinition {
     pub(crate) endpoint_id: GraphqlEndpointId,
 }
 
-pub type RootFieldResolverWalker<'a> = SchemaWalker<'a, &'a RootFieldResolver>;
+pub type RootFieldResolverDefinitionWalker<'a> = SchemaWalker<'a, &'a RootFieldResolverDefinition>;
 
-impl<'a> std::ops::Deref for RootFieldResolverWalker<'a> {
-    type Target = RootFieldResolver;
+impl<'a> std::ops::Deref for RootFieldResolverDefinitionWalker<'a> {
+    type Target = RootFieldResolverDefinition;
 
     fn deref(&self) -> &'a Self::Target {
         self.item
     }
 }
 
-impl<'a> RootFieldResolverWalker<'a> {
+impl<'a> RootFieldResolverDefinitionWalker<'a> {
     pub fn name(&self) -> String {
         format!(
             "Graphql root field resolver for subgraph '{}'",
@@ -72,7 +72,7 @@ impl<'a> RootFieldResolverWalker<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for RootFieldResolverWalker<'a> {
+impl<'a> std::fmt::Debug for RootFieldResolverDefinitionWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GraphqlRootField")
             .field("subgraph", &self.endpoint().subgraph_name())
@@ -82,7 +82,7 @@ impl<'a> std::fmt::Debug for RootFieldResolverWalker<'a> {
 }
 
 #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct FederationEntityResolver {
+pub struct FederationEntityResolverDefinition {
     pub(crate) endpoint_id: GraphqlEndpointId,
     pub(crate) key: FederationKey,
 }
@@ -92,17 +92,17 @@ pub struct FederationKey {
     pub(crate) fields: RequiredFieldSetId,
 }
 
-pub type FederationEntityResolverWalker<'a> = SchemaWalker<'a, &'a FederationEntityResolver>;
+pub type FederationEntityResolveDefinitionrWalker<'a> = SchemaWalker<'a, &'a FederationEntityResolverDefinition>;
 
-impl<'a> std::ops::Deref for FederationEntityResolverWalker<'a> {
-    type Target = FederationEntityResolver;
+impl<'a> std::ops::Deref for FederationEntityResolveDefinitionrWalker<'a> {
+    type Target = FederationEntityResolverDefinition;
 
     fn deref(&self) -> &'a Self::Target {
         self.item
     }
 }
 
-impl<'a> FederationEntityResolverWalker<'a> {
+impl<'a> FederationEntityResolveDefinitionrWalker<'a> {
     pub fn name(&self) -> String {
         format!(
             "Graphql federation entity resolver for subgraph '{}'",
@@ -123,7 +123,7 @@ impl<'a> FederationEntityResolverWalker<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for FederationEntityResolverWalker<'a> {
+impl<'a> std::fmt::Debug for FederationEntityResolveDefinitionrWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GraphqlFederationEntityResolver")
             .field("subgraph", &self.endpoint().subgraph_name())

--- a/engine/crates/engine-v2/schema/src/sources/mod.rs
+++ b/engine/crates/engine-v2/schema/src/sources/mod.rs
@@ -3,3 +3,17 @@ pub mod introspection;
 
 pub use graphql::GraphqlEndpoints;
 pub use introspection::IntrospectionMetadata;
+
+/// A resolver is assumed to be specific to an object or an interface.
+/// So multiple fields within an interface/object can share a resolver (like federation `@key`)
+/// but different objects/interfaces MUST NOT share resolvers. To be more precise, they MUST NOT
+/// share resolver *ids*. Resolvers are grouped and planned together by their id.
+/// The only exception to this rule are resolvers on Mutation, Query and Subscription root types
+/// as they can't be mixed together in a single operation. So a resolver id can be used
+/// on both Query and Mutation fields.
+#[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum ResolverDefinition {
+    Introspection(introspection::IntrospectionResolverDefinition),
+    GraphqlRootField(graphql::RootFieldResolverDefinition),
+    GraphqlFederationEntity(graphql::FederationEntityResolverDefinition),
+}

--- a/engine/crates/engine-v2/schema/src/walkers/definition.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/definition.rs
@@ -1,7 +1,7 @@
 use super::{field::FieldDefinitionWalker, SchemaWalker};
 use crate::{
-    Definition, EntityId, EntityWalker, EnumWalker, InputObjectWalker, InterfaceWalker, ObjectWalker, ScalarType,
-    ScalarWalker, StringId, TypeSystemDirectivesWalker,
+    Definition, EntityId, EntityWalker, EnumDefinitionWalker, InputObjectDefinitionWalker, InterfaceDefinitionWalker,
+    ObjectDefinitionWalker, ScalarDefinitionWalker, ScalarType, StringId, TypeSystemDirectivesWalker,
 };
 
 pub type DefinitionWalker<'a> = SchemaWalker<'a, Definition>;
@@ -52,7 +52,7 @@ impl<'a> DefinitionWalker<'a> {
         }
     }
 
-    pub fn interfaces(&self) -> Option<Box<dyn ExactSizeIterator<Item = InterfaceWalker<'a>> + 'a>> {
+    pub fn interfaces(&self) -> Option<Box<dyn ExactSizeIterator<Item = InterfaceDefinitionWalker<'a>> + 'a>> {
         match self.item {
             Definition::Object(o) => Some(Box::new(self.walk(o).interfaces())),
             Definition::Interface(i) => Some(Box::new(self.walk(i).interfaces())),
@@ -60,7 +60,7 @@ impl<'a> DefinitionWalker<'a> {
         }
     }
 
-    pub fn possible_types(&self) -> Option<Box<dyn ExactSizeIterator<Item = ObjectWalker<'a>> + 'a>> {
+    pub fn possible_types(&self) -> Option<Box<dyn ExactSizeIterator<Item = ObjectDefinitionWalker<'a>> + 'a>> {
         match self.item {
             Definition::Interface(i) => Some(Box::new(self.walk(i).possible_types())),
             Definition::Union(u) => Some(Box::new(self.walk(u).possible_types())),
@@ -68,28 +68,28 @@ impl<'a> DefinitionWalker<'a> {
         }
     }
 
-    pub fn as_enum(&self) -> Option<EnumWalker<'a>> {
+    pub fn as_enum(&self) -> Option<EnumDefinitionWalker<'a>> {
         match self.item {
             Definition::Enum(e) => Some(self.walk(e)),
             _ => None,
         }
     }
 
-    pub fn as_input_object(&self) -> Option<InputObjectWalker<'a>> {
+    pub fn as_input_object(&self) -> Option<InputObjectDefinitionWalker<'a>> {
         match self.item {
             Definition::InputObject(io) => Some(self.walk(io)),
             _ => None,
         }
     }
 
-    pub fn as_scalar(&self) -> Option<ScalarWalker<'a>> {
+    pub fn as_scalar(&self) -> Option<ScalarDefinitionWalker<'a>> {
         match self.item {
             Definition::Scalar(s) => Some(self.walk(s)),
             _ => None,
         }
     }
 
-    pub fn as_object(&self) -> Option<ObjectWalker<'a>> {
+    pub fn as_object(&self) -> Option<ObjectDefinitionWalker<'a>> {
         match self.item {
             Definition::Object(s) => Some(self.walk(s)),
             _ => None,
@@ -128,14 +128,14 @@ impl<'a> DefinitionWalker<'a> {
     }
 }
 
-impl<'a> From<ObjectWalker<'a>> for DefinitionWalker<'a> {
-    fn from(value: ObjectWalker<'a>) -> Self {
+impl<'a> From<ObjectDefinitionWalker<'a>> for DefinitionWalker<'a> {
+    fn from(value: ObjectDefinitionWalker<'a>) -> Self {
         value.walk(value.item.into())
     }
 }
 
-impl<'a> From<InterfaceWalker<'a>> for DefinitionWalker<'a> {
-    fn from(value: InterfaceWalker<'a>) -> Self {
+impl<'a> From<InterfaceDefinitionWalker<'a>> for DefinitionWalker<'a> {
+    fn from(value: InterfaceDefinitionWalker<'a>) -> Self {
         value.walk(value.item.into())
     }
 }

--- a/engine/crates/engine-v2/schema/src/walkers/enum.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/enum.rs
@@ -1,10 +1,10 @@
 use super::SchemaWalker;
-use crate::{EnumId, EnumValueId, TypeSystemDirectivesWalker};
+use crate::{EnumDefinitionId, EnumValueId, TypeSystemDirectivesWalker};
 
-pub type EnumWalker<'a> = SchemaWalker<'a, EnumId>;
+pub type EnumDefinitionWalker<'a> = SchemaWalker<'a, EnumDefinitionId>;
 pub type EnumValueWalker<'a> = SchemaWalker<'a, EnumValueId>;
 
-impl<'a> EnumWalker<'a> {
+impl<'a> EnumDefinitionWalker<'a> {
     pub fn name(&self) -> &'a str {
         self.names.r#enum(self.schema, self.item)
     }
@@ -36,7 +36,7 @@ impl<'a> EnumValueWalker<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for EnumWalker<'a> {
+impl<'a> std::fmt::Debug for EnumDefinitionWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Enum")
             .field("id", &usize::from(self.item))

--- a/engine/crates/engine-v2/schema/src/walkers/field.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/field.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use super::{resolver::ResolverWalker, SchemaWalker};
+use super::{resolver::ResolverDefinitionWalker, SchemaWalker};
 use crate::{
     EntityWalker, FieldDefinitionId, InputValueDefinitionWalker, ProvidableFieldSet, RequiredFieldSet, SubgraphId,
     TypeSystemDirectivesWalker, TypeWalker,
@@ -13,7 +13,7 @@ impl<'a> FieldDefinitionWalker<'a> {
         self.names.field(self.schema, self.item)
     }
 
-    pub fn resolvers(self) -> impl ExactSizeIterator<Item = ResolverWalker<'a>> {
+    pub fn resolvers(self) -> impl ExactSizeIterator<Item = ResolverDefinitionWalker<'a>> {
         self.schema[self.item].resolvers.iter().map(move |id| self.walk(*id))
     }
 
@@ -84,7 +84,7 @@ impl<'a> FieldDefinitionWalker<'a> {
 }
 
 pub struct FieldResolverWalker<'a> {
-    pub resolver: ResolverWalker<'a>,
+    pub resolver: ResolverDefinitionWalker<'a>,
     pub field_requires: &'a RequiredFieldSet,
 }
 

--- a/engine/crates/engine-v2/schema/src/walkers/input_object.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/input_object.rs
@@ -1,9 +1,9 @@
 use super::SchemaWalker;
-use crate::{InputObjectId, InputValueDefinitionWalker, TypeSystemDirectivesWalker};
+use crate::{InputObjectDefinitionId, InputValueDefinitionWalker, TypeSystemDirectivesWalker};
 
-pub type InputObjectWalker<'a> = SchemaWalker<'a, InputObjectId>;
+pub type InputObjectDefinitionWalker<'a> = SchemaWalker<'a, InputObjectDefinitionId>;
 
-impl<'a> InputObjectWalker<'a> {
+impl<'a> InputObjectDefinitionWalker<'a> {
     pub fn name(&self) -> &'a str {
         self.names.input_object(self.schema, self.item)
     }
@@ -20,7 +20,7 @@ impl<'a> InputObjectWalker<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for InputObjectWalker<'a> {
+impl<'a> std::fmt::Debug for InputObjectDefinitionWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("InputObject")
             .field("id", &usize::from(self.item))

--- a/engine/crates/engine-v2/schema/src/walkers/interface.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/interface.rs
@@ -1,9 +1,9 @@
 use super::{FieldDefinitionWalker, SchemaWalker};
-use crate::{InterfaceId, ObjectWalker, TypeSystemDirectivesWalker};
+use crate::{InterfaceDefinitionId, ObjectDefinitionWalker, TypeSystemDirectivesWalker};
 
-pub type InterfaceWalker<'a> = SchemaWalker<'a, InterfaceId>;
+pub type InterfaceDefinitionWalker<'a> = SchemaWalker<'a, InterfaceDefinitionId>;
 
-impl<'a> InterfaceWalker<'a> {
+impl<'a> InterfaceDefinitionWalker<'a> {
     pub fn name(&self) -> &'a str {
         self.names.interface(self.schema, self.item)
     }
@@ -13,7 +13,7 @@ impl<'a> InterfaceWalker<'a> {
         fields.into_iter().map(move |field_id| self.walk(field_id))
     }
 
-    pub fn interfaces(self) -> impl ExactSizeIterator<Item = InterfaceWalker<'a>> + 'a {
+    pub fn interfaces(self) -> impl ExactSizeIterator<Item = InterfaceDefinitionWalker<'a>> + 'a {
         self.as_ref()
             .interfaces
             .clone()
@@ -21,7 +21,7 @@ impl<'a> InterfaceWalker<'a> {
             .map(move |id| self.walk(id))
     }
 
-    pub fn possible_types(self) -> impl ExactSizeIterator<Item = ObjectWalker<'a>> + 'a {
+    pub fn possible_types(self) -> impl ExactSizeIterator<Item = ObjectDefinitionWalker<'a>> + 'a {
         self.as_ref()
             .possible_types
             .clone()
@@ -34,7 +34,7 @@ impl<'a> InterfaceWalker<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for InterfaceWalker<'a> {
+impl<'a> std::fmt::Debug for InterfaceDefinitionWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Interface")
             .field("id", &usize::from(self.item))

--- a/engine/crates/engine-v2/schema/src/walkers/mod.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/mod.rs
@@ -93,15 +93,15 @@ impl<'a> SchemaWalker<'a, ()> {
         &self.schema.data_sources.introspection
     }
 
-    pub fn query(&self) -> ObjectWalker<'a> {
+    pub fn query(&self) -> ObjectDefinitionWalker<'a> {
         self.walk(self.schema.graph.root_operation_types.query)
     }
 
-    pub fn mutation(&self) -> Option<ObjectWalker<'a>> {
+    pub fn mutation(&self) -> Option<ObjectDefinitionWalker<'a>> {
         self.schema.graph.root_operation_types.mutation.map(|id| self.walk(id))
     }
 
-    pub fn subscription(&self) -> Option<ObjectWalker<'a>> {
+    pub fn subscription(&self) -> Option<ObjectDefinitionWalker<'a>> {
         self.schema
             .graph
             .root_operation_types

--- a/engine/crates/engine-v2/schema/src/walkers/object.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/object.rs
@@ -1,9 +1,9 @@
 use super::{FieldDefinitionWalker, SchemaWalker};
-use crate::{InterfaceWalker, ObjectId, TypeSystemDirectivesWalker};
+use crate::{InterfaceDefinitionWalker, ObjectDefinitionId, TypeSystemDirectivesWalker};
 
-pub type ObjectWalker<'a> = SchemaWalker<'a, ObjectId>;
+pub type ObjectDefinitionWalker<'a> = SchemaWalker<'a, ObjectDefinitionId>;
 
-impl<'a> ObjectWalker<'a> {
+impl<'a> ObjectDefinitionWalker<'a> {
     pub fn name(&self) -> &'a str {
         self.names.object(self.schema, self.item)
     }
@@ -13,7 +13,7 @@ impl<'a> ObjectWalker<'a> {
         fields.into_iter().map(move |field_id| self.walk(field_id))
     }
 
-    pub fn interfaces(self) -> impl ExactSizeIterator<Item = InterfaceWalker<'a>> + 'a {
+    pub fn interfaces(self) -> impl ExactSizeIterator<Item = InterfaceDefinitionWalker<'a>> + 'a {
         self.as_ref()
             .interfaces
             .clone()
@@ -26,7 +26,7 @@ impl<'a> ObjectWalker<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for ObjectWalker<'a> {
+impl<'a> std::fmt::Debug for ObjectDefinitionWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Object")
             .field("id", &usize::from(self.item))

--- a/engine/crates/engine-v2/schema/src/walkers/resolver.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/resolver.rs
@@ -1,19 +1,23 @@
-use crate::{FieldDefinitionId, Names, RequiredFieldSet, Resolver, ResolverId, SchemaWalker, SubgraphId};
+use crate::{
+    FieldDefinitionId, Names, RequiredFieldSet, ResolverDefinition, ResolverDefinitionId, SchemaWalker, SubgraphId,
+};
 
-pub type ResolverWalker<'a> = SchemaWalker<'a, ResolverId>;
+pub type ResolverDefinitionWalker<'a> = SchemaWalker<'a, ResolverDefinitionId>;
 
-impl<'a> ResolverWalker<'a> {
+impl<'a> ResolverDefinitionWalker<'a> {
     pub fn name(&self) -> String {
         match self.as_ref() {
-            Resolver::Introspection(_) => "Introspection resolver".to_string(),
-            Resolver::GraphqlRootField(resolver) => self.walk(resolver).name(),
-            Resolver::GraphqlFederationEntity(resolver) => self.walk(resolver).name(),
+            ResolverDefinition::Introspection(_) => "Introspection resolver".to_string(),
+            ResolverDefinition::GraphqlRootField(resolver) => self.walk(resolver).name(),
+            ResolverDefinition::GraphqlFederationEntity(resolver) => self.walk(resolver).name(),
         }
     }
 
     pub fn supports_aliases(&self) -> bool {
         match self.as_ref() {
-            Resolver::GraphqlRootField(_) | Resolver::Introspection(_) | Resolver::GraphqlFederationEntity(_) => true,
+            ResolverDefinition::GraphqlRootField(_)
+            | ResolverDefinition::Introspection(_)
+            | ResolverDefinition::GraphqlFederationEntity(_) => true,
         }
     }
 
@@ -27,16 +31,16 @@ impl<'a> ResolverWalker<'a> {
 
     pub fn requires(&self) -> &'a RequiredFieldSet {
         match self.as_ref() {
-            Resolver::GraphqlFederationEntity(resolver) => self.walk(resolver).requires(),
-            Resolver::Introspection(_) | Resolver::GraphqlRootField(_) => &crate::requires::EMPTY,
+            ResolverDefinition::GraphqlFederationEntity(resolver) => self.walk(resolver).requires(),
+            ResolverDefinition::Introspection(_) | ResolverDefinition::GraphqlRootField(_) => &crate::requires::EMPTY,
         }
     }
 
     pub fn subgraph_id(&self) -> SubgraphId {
         match self.as_ref() {
-            Resolver::Introspection(resolver) => self.walk(resolver).subgraph_id(),
-            Resolver::GraphqlRootField(resolver) => self.walk(resolver).subgraph_id(),
-            Resolver::GraphqlFederationEntity(resolver) => self.walk(resolver).subgraph_id(),
+            ResolverDefinition::Introspection(resolver) => self.walk(resolver).subgraph_id(),
+            ResolverDefinition::GraphqlRootField(resolver) => self.walk(resolver).subgraph_id(),
+            ResolverDefinition::GraphqlFederationEntity(resolver) => self.walk(resolver).subgraph_id(),
         }
     }
 
@@ -45,12 +49,12 @@ impl<'a> ResolverWalker<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for ResolverWalker<'a> {
+impl<'a> std::fmt::Debug for ResolverDefinitionWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.as_ref() {
-            Resolver::Introspection(_) => f.debug_struct("Introspection").finish(),
-            Resolver::GraphqlRootField(resolver) => self.walk(resolver).fmt(f),
-            Resolver::GraphqlFederationEntity(resolver) => self.walk(resolver).fmt(f),
+            ResolverDefinition::Introspection(_) => f.debug_struct("Introspection").finish(),
+            ResolverDefinition::GraphqlRootField(resolver) => self.walk(resolver).fmt(f),
+            ResolverDefinition::GraphqlFederationEntity(resolver) => self.walk(resolver).fmt(f),
         }
     }
 }

--- a/engine/crates/engine-v2/schema/src/walkers/scalar.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/scalar.rs
@@ -1,9 +1,9 @@
 use super::SchemaWalker;
-use crate::{ScalarId, TypeSystemDirectivesWalker};
+use crate::{ScalarDefinitionId, TypeSystemDirectivesWalker};
 
-pub type ScalarWalker<'a> = SchemaWalker<'a, ScalarId>;
+pub type ScalarDefinitionWalker<'a> = SchemaWalker<'a, ScalarDefinitionId>;
 
-impl<'a> ScalarWalker<'a> {
+impl<'a> ScalarDefinitionWalker<'a> {
     pub fn name(&self) -> &'a str {
         self.names.scalar(self.schema, self.item)
     }
@@ -13,7 +13,7 @@ impl<'a> ScalarWalker<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for ScalarWalker<'a> {
+impl<'a> std::fmt::Debug for ScalarDefinitionWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Scalar")
             .field("id", &usize::from(self.item))

--- a/engine/crates/engine-v2/schema/src/walkers/union.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/union.rs
@@ -1,14 +1,14 @@
 use super::SchemaWalker;
-use crate::{ObjectWalker, TypeSystemDirectivesWalker, UnionId};
+use crate::{ObjectDefinitionWalker, TypeSystemDirectivesWalker, UnionDefinitionId};
 
-pub type UnionWalker<'a> = SchemaWalker<'a, UnionId>;
+pub type UnionDefinitionWalker<'a> = SchemaWalker<'a, UnionDefinitionId>;
 
-impl<'a> UnionWalker<'a> {
+impl<'a> UnionDefinitionWalker<'a> {
     pub fn name(&self) -> &'a str {
         self.names.union(self.schema, self.item)
     }
 
-    pub fn possible_types(self) -> impl ExactSizeIterator<Item = ObjectWalker<'a>> + 'a {
+    pub fn possible_types(self) -> impl ExactSizeIterator<Item = ObjectDefinitionWalker<'a>> + 'a {
         self.as_ref()
             .possible_types
             .clone()
@@ -21,7 +21,7 @@ impl<'a> UnionWalker<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for UnionWalker<'a> {
+impl<'a> std::fmt::Debug for UnionDefinitionWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Union")
             .field("id", &usize::from(self.item))

--- a/engine/crates/engine-v2/src/execution/coordinator.rs
+++ b/engine/crates/engine-v2/src/execution/coordinator.rs
@@ -90,7 +90,7 @@ impl<'ctx, R: Runtime> ExecutionContext<'ctx, R> {
         }
 
         OperationExecution {
-            futures: ExecutorFutureSet::new(),
+            futures: ResolverFutureSet::new(),
             state: self.new_execution_state(),
             response: ResponseBuilder::new(self.operation.root_object_id),
             ctx: self,
@@ -137,7 +137,7 @@ impl<'ctx, R: Runtime> ExecutionContext<'ctx, R> {
     {
         let plan = self.plan_walker(subscription_plan_id);
         self.operation[subscription_plan_id]
-            .executor
+            .resolver
             .execute_subscription(self, plan, move || self.new_subscription_response(subscription_plan_id))
             .await
     }
@@ -237,13 +237,13 @@ where
                             root_subgraph_response,
                         }) => {
                             let mut operation_execution = OperationExecution {
-                                futures: ExecutorFutureSet::new(),
+                                futures: ResolverFutureSet::new(),
                                 state: self.initial_state.clone(),
                                 ctx: self.ctx,
                                 response,
                             };
 
-                            operation_execution.futures.push_result(ExecutorFutureResult {
+                            operation_execution.futures.push_result(ResolverFutureResult {
                                 plan_id: self.subscription_plan_id,
                                 result: Ok(root_subgraph_response),
                             });
@@ -281,7 +281,7 @@ impl SubscriptionResponse {
 
 struct OperationExecution<'ctx, 'exec, R: Runtime> {
     ctx: ExecutionContext<'ctx, R>,
-    futures: ExecutorFutureSet<'exec>,
+    futures: ResolverFutureSet<'exec>,
     state: OperationExecutionState<'ctx>,
     response: ResponseBuilder,
 }
@@ -300,10 +300,10 @@ where
     /// Runs a single execution to completion, returning its response
     async fn run(mut self) -> Response {
         for plan_id in self.state.get_executable_plans() {
-            self.spawn_executor(plan_id);
+            self.spawn_resolver(plan_id);
         }
 
-        while let Some(ExecutorFutureResult { plan_id, result }) = self.futures.next().await {
+        while let Some(ResolverFutureResult { plan_id, result }) = self.futures.next().await {
             // Retrieving the first edge (response key) appearing in the query to provide a better
             // error path if necessary.
             let (any_edge, default_fields) = self.get_first_edge_and_default_object(plan_id);
@@ -327,7 +327,7 @@ where
                         .state
                         .get_next_executable_plans(plan_id, response_modifier_executor_ids)
                     {
-                        self.spawn_executor(plan_id);
+                        self.spawn_resolver(plan_id);
                     }
                 }
                 Err((root_response_object_set, error)) => {
@@ -389,7 +389,7 @@ where
         (first_edge, Some(fields))
     }
 
-    fn spawn_executor(&mut self, plan_id: ExecutionPlanId) {
+    fn spawn_resolver(&mut self, plan_id: ExecutionPlanId) {
         tracing::trace!(%plan_id, "Starting plan");
         let root_response_object_set = Arc::new(self.state.get_input(&self.response, plan_id));
 
@@ -413,9 +413,9 @@ where
             );
             let fut =
                 self.operation[plan_id]
-                    .executor
+                    .resolver
                     .execute(self.ctx, plan, root_response_objects, subgraph_response);
-            make_send_on_wasm(fut.map(move |result| ExecutorFutureResult {
+            make_send_on_wasm(fut.map(move |result| ResolverFutureResult {
                 plan_id,
                 result: result.map_err(|err| (root_response_object_set, err)),
             }))
@@ -424,31 +424,31 @@ where
     }
 }
 
-struct ExecutorFutureSet<'exec> {
-    futures: FuturesUnordered<BoxFuture<'exec, ExecutorFutureResult>>,
+struct ResolverFutureSet<'exec> {
+    futures: FuturesUnordered<BoxFuture<'exec, ResolverFutureResult>>,
 }
 
-impl<'exec> ExecutorFutureSet<'exec> {
+impl<'exec> ResolverFutureSet<'exec> {
     fn new() -> Self {
         Self {
             futures: FuturesUnordered::new(),
         }
     }
 
-    fn push_fut(&mut self, fut: BoxFuture<'exec, ExecutorFutureResult>) {
+    fn push_fut(&mut self, fut: BoxFuture<'exec, ResolverFutureResult>) {
         self.futures.push(fut);
     }
 
-    fn push_result(&mut self, result: ExecutorFutureResult) {
+    fn push_result(&mut self, result: ResolverFutureResult) {
         self.futures.push(Box::pin(async move { result }));
     }
 
-    async fn next(&mut self) -> Option<ExecutorFutureResult> {
+    async fn next(&mut self) -> Option<ResolverFutureResult> {
         self.futures.next().await
     }
 }
 
-struct ExecutorFutureResult {
+struct ResolverFutureResult {
     plan_id: ExecutionPlanId,
     result: Result<SubgraphResponse, (Arc<InputdResponseObjectSet>, ExecutionError)>,
 }

--- a/engine/crates/engine-v2/src/execution/mod.rs
+++ b/engine/crates/engine-v2/src/execution/mod.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use crate::{
     operation::{LogicalPlanId, PreparedOperation, QueryModifications, ResponseModifierRule, Variables},
     response::{ResponseKey, ResponseObjectSetId, ResponseViewSelectionSet, ResponseViews},
-    sources::Executor,
+    sources::Resolver,
     Runtime,
 };
 pub(crate) use context::*;
@@ -71,7 +71,7 @@ pub(crate) struct ExecutionPlan {
     pub children: Vec<ExecutionPlanId>,
     pub dependent_response_modifiers: Vec<ResponseModifierExecutorId>,
     pub requires: ResponseViewSelectionSet,
-    pub executor: Executor,
+    pub resolver: Resolver,
 }
 
 // Modifies the response based on a given rule

--- a/engine/crates/engine-v2/src/execution/planner/builder.rs
+++ b/engine/crates/engine-v2/src/execution/planner/builder.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use itertools::Itertools;
-use schema::{RequiredFieldSet, ResolverWalker};
+use schema::{RequiredFieldSet, ResolverDefinitionWalker};
 
 use crate::{
     execution::{ExecutableOperation, ExecutionPlan, ExecutionPlanId, PreExecutionContext, ResponseModifierExecutor},
@@ -12,7 +12,7 @@ use crate::{
         FieldId, LogicalPlanId, OperationWalker, PlanWalker, ResponseModifierRule, SelectionSetId, SelectionSetType,
     },
     response::{ResponseObjectSetId, ResponseViewSelection, ResponseViewSelectionSet},
-    sources::Executor,
+    sources::Resolver,
     Runtime,
 };
 
@@ -53,7 +53,7 @@ where
             resolver,
             &logical_plan.root_field_ids_ordered_by_parent_entity_id_then_position,
         );
-        let prepared_executor = Executor::prepare(
+        let resolver = Resolver::prepare(
             resolver,
             self.operation.borrow().ty(),
             PlanWalker {
@@ -71,7 +71,7 @@ where
             parent_count: 0,
             children: Vec::new(),
             requires,
-            executor: prepared_executor,
+            resolver,
             logical_plan_id,
             dependent_response_modifiers: Vec::new(),
         };
@@ -194,7 +194,7 @@ where
 
     fn create_plan_view_and_list_dependencies(
         &mut self,
-        resolver: ResolverWalker<'_>,
+        resolver: ResolverDefinitionWalker<'_>,
         field_ids: &Vec<FieldId>,
     ) -> (ResponseViewSelectionSet, Vec<FieldId>) {
         let mut required_fields = Cow::Borrowed(resolver.requires());

--- a/engine/crates/engine-v2/src/operation/bind/coercion/query.rs
+++ b/engine/crates/engine-v2/src/operation/bind/coercion/query.rs
@@ -1,8 +1,8 @@
 use engine_value::{ConstValue, Name, Value};
 use id_newtypes::IdRange;
 use schema::{
-    Definition, EnumWalker, InputObjectWalker, InputValueDefinitionId, ListWrapping, ScalarType, ScalarWalker, Type,
-    Wrapping,
+    Definition, EnumDefinitionWalker, InputObjectDefinitionWalker, InputValueDefinitionId, ListWrapping,
+    ScalarDefinitionWalker, ScalarType, Type, Wrapping,
 };
 
 use super::super::Binder;
@@ -185,7 +185,7 @@ impl<'binder, 'schema, 'parsed> QueryValueCoercionContext<'binder, 'schema, 'par
 
     fn coerce_input_objet(
         &mut self,
-        input_object: InputObjectWalker<'_>,
+        input_object: InputObjectDefinitionWalker<'_>,
         value: Value,
     ) -> Result<QueryInputValue, InputValueError> {
         let Value::Object(mut fields) = value else {
@@ -232,7 +232,11 @@ impl<'binder, 'schema, 'parsed> QueryValueCoercionContext<'binder, 'schema, 'par
         Ok(QueryInputValue::InputObject(ids))
     }
 
-    fn coerce_enum(&mut self, r#enum: EnumWalker<'_>, value: Value) -> Result<QueryInputValue, InputValueError> {
+    fn coerce_enum(
+        &mut self,
+        r#enum: EnumDefinitionWalker<'_>,
+        value: Value,
+    ) -> Result<QueryInputValue, InputValueError> {
         let name = match &value {
             Value::Enum(value) => value.as_str(),
             value => {
@@ -257,7 +261,11 @@ impl<'binder, 'schema, 'parsed> QueryValueCoercionContext<'binder, 'schema, 'par
         Ok(QueryInputValue::EnumValue(id))
     }
 
-    fn coerce_scalar(&mut self, scalar: ScalarWalker<'_>, value: Value) -> Result<QueryInputValue, InputValueError> {
+    fn coerce_scalar(
+        &mut self,
+        scalar: ScalarDefinitionWalker<'_>,
+        value: Value,
+    ) -> Result<QueryInputValue, InputValueError> {
         match (value, scalar.as_ref().ty) {
             (value, ScalarType::JSON) => Ok(match value {
                 Value::Null => QueryInputValue::Null,

--- a/engine/crates/engine-v2/src/operation/bind/coercion/variable.rs
+++ b/engine/crates/engine-v2/src/operation/bind/coercion/variable.rs
@@ -1,8 +1,8 @@
 use engine_value::ConstValue;
 use id_newtypes::IdRange;
 use schema::{
-    Definition, EnumWalker, InputObjectWalker, InputValueDefinitionId, ListWrapping, ScalarType, ScalarWalker, Schema,
-    Type,
+    Definition, EnumDefinitionWalker, InputObjectDefinitionWalker, InputValueDefinitionId, ListWrapping,
+    ScalarDefinitionWalker, ScalarType, Schema, Type,
 };
 
 use crate::operation::{Location, VariableDefinition, VariableInputValue, VariableInputValueId, VariableInputValues};
@@ -102,7 +102,7 @@ impl<'a> VariableCoercionContext<'a> {
 
     fn coerce_input_objet(
         &mut self,
-        input_object: InputObjectWalker<'_>,
+        input_object: InputObjectDefinitionWalker<'_>,
         value: ConstValue,
     ) -> Result<VariableInputValue, InputValueError> {
         let ConstValue::Object(mut fields) = value else {
@@ -151,7 +151,7 @@ impl<'a> VariableCoercionContext<'a> {
 
     fn coerce_enum(
         &mut self,
-        r#enum: EnumWalker<'_>,
+        r#enum: EnumDefinitionWalker<'_>,
         value: ConstValue,
     ) -> Result<VariableInputValue, InputValueError> {
         let name = match &value {
@@ -181,7 +181,7 @@ impl<'a> VariableCoercionContext<'a> {
 
     fn coerce_scalar(
         &mut self,
-        scalar: ScalarWalker<'_>,
+        scalar: ScalarDefinitionWalker<'_>,
         value: ConstValue,
     ) -> Result<VariableInputValue, InputValueError> {
         match (value, scalar.as_ref().ty) {

--- a/engine/crates/engine-v2/src/operation/bind/modifier.rs
+++ b/engine/crates/engine-v2/src/operation/bind/modifier.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, ops::Range};
 
 use id_newtypes::IdRange;
-use schema::{Definition, FieldDefinitionWalker, ObjectId, TypeSystemDirective};
+use schema::{Definition, FieldDefinitionWalker, ObjectDefinitionId, TypeSystemDirective};
 
 use crate::operation::{
     FieldArgumentId, FieldId, QueryModifier, QueryModifierId, QueryModifierRule, ResponseModifier, ResponseModifierId,
@@ -86,7 +86,10 @@ impl<'schema, 'p> super::Binder<'schema, 'p> {
         }
     }
 
-    pub(super) fn generate_modifiers_for_root_object(&mut self, root_object_id: ObjectId) -> Vec<QueryModifierId> {
+    pub(super) fn generate_modifiers_for_root_object(
+        &mut self,
+        root_object_id: ObjectDefinitionId,
+    ) -> Vec<QueryModifierId> {
         let mut modifiers = Vec::new();
         for directive in self.schema.walk(root_object_id).directives().as_ref() {
             match directive {

--- a/engine/crates/engine-v2/src/operation/bind/selection_set.rs
+++ b/engine/crates/engine-v2/src/operation/bind/selection_set.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use engine_parser::Positioned;
 use im::HashMap;
-use schema::{Definition, FieldDefinitionId, ObjectId};
+use schema::{Definition, FieldDefinitionId, ObjectDefinitionId};
 
 use crate::{
     operation::{FieldId, Location, QueryPosition, SelectionSet, SelectionSetId, SelectionSetType},
@@ -304,7 +304,7 @@ impl<'schema, 'p, 'binder> SelectionSetBinder<'schema, 'p, 'binder> {
         })
     }
 
-    fn get_possible_types(&self, ty: SelectionSetType) -> Cow<'schema, [ObjectId]> {
+    fn get_possible_types(&self, ty: SelectionSetType) -> Cow<'schema, [ObjectDefinitionId]> {
         match ty {
             SelectionSetType::Object(id) => Cow::Owned(vec![id]),
             SelectionSetType::Interface(id) => Cow::Borrowed(&self.schema[id].possible_types),

--- a/engine/crates/engine-v2/src/operation/blueprint/plan.rs
+++ b/engine/crates/engine-v2/src/operation/blueprint/plan.rs
@@ -1,7 +1,7 @@
 use id_newtypes::IdRange;
 use im::HashMap;
 use itertools::Itertools;
-use schema::{EntityId, FieldDefinitionWalker, ObjectId, Schema};
+use schema::{EntityId, FieldDefinitionWalker, ObjectDefinitionId, Schema};
 
 use crate::{
     operation::{
@@ -144,7 +144,7 @@ where
         maybe_response_object_set_id: Option<ResponseObjectSetId>,
         field_ids: Vec<FieldId>,
     ) -> Shape {
-        let output: &[ObjectId] = match &ty {
+        let output: &[ObjectDefinitionId] = match &ty {
             SelectionSetType::Object(id) => std::array::from_ref(id),
             SelectionSetType::Interface(id) => &self.schema[*id].possible_types,
             SelectionSetType::Union(id) => &self.schema[*id].possible_types,
@@ -207,7 +207,11 @@ where
         }
     }
 
-    fn compute_shape_partitions(&self, output: &[ObjectId], field_ids: &[FieldId]) -> Option<Vec<Partition<ObjectId>>> {
+    fn compute_shape_partitions(
+        &self,
+        output: &[ObjectDefinitionId],
+        field_ids: &[FieldId],
+    ) -> Option<Vec<Partition<ObjectDefinitionId>>> {
         let mut type_conditions = Vec::new();
         for field_id in field_ids {
             match &self.operation[*field_id] {
@@ -235,7 +239,7 @@ where
 
     fn create_shape_for<'a>(
         &mut self,
-        exemplar_object_id: ObjectId,
+        exemplar_object_id: ObjectDefinitionId,
         maybe_response_object_set_id: Option<ResponseObjectSetId>,
         fields_sorted_by_response_key_then_position: &'a [FieldWalker<'op>],
         fields_buffer: &mut Vec<&'a FieldWalker<'op>>,
@@ -359,7 +363,7 @@ where
     }
 }
 
-fn is_field_of(schema: &Schema, field: &FieldWalker<'_>, object_id: ObjectId) -> bool {
+fn is_field_of(schema: &Schema, field: &FieldWalker<'_>, object_id: ObjectDefinitionId) -> bool {
     match field.as_ref() {
         Field::TypeName(TypeNameField { type_condition, .. }) => match type_condition {
             SelectionSetType::Object(id) => *id == object_id,

--- a/engine/crates/engine-v2/src/operation/logical_planner/logic.rs
+++ b/engine/crates/engine-v2/src/operation/logical_planner/logic.rs
@@ -1,4 +1,4 @@
-use schema::{FieldDefinitionId, ProvidableFieldSet, ResolverWalker};
+use schema::{FieldDefinitionId, ProvidableFieldSet, ResolverDefinitionWalker};
 
 use crate::operation::LogicalPlanId;
 
@@ -9,13 +9,13 @@ pub(super) enum PlanningLogic<'schema> {
     /// Having a resolver in the same group or having no resolver at all.
     SameSubgrah {
         id: LogicalPlanId,
-        resolver: ResolverWalker<'schema>,
+        resolver: ResolverDefinitionWalker<'schema>,
         providable: ProvidableFieldSet,
     },
     /// Only an explicitly providable (@provide) field can be provided.
     OnlyProvidable {
         id: LogicalPlanId,
-        resolver: ResolverWalker<'schema>,
+        resolver: ResolverDefinitionWalker<'schema>,
         providable: ProvidableFieldSet,
     },
 }
@@ -27,7 +27,7 @@ impl std::fmt::Display for PlanningLogic<'_> {
 }
 
 impl<'schema> PlanningLogic<'schema> {
-    pub(super) fn new(id: LogicalPlanId, resolver: ResolverWalker<'schema>) -> Self {
+    pub(super) fn new(id: LogicalPlanId, resolver: ResolverDefinitionWalker<'schema>) -> Self {
         PlanningLogic::SameSubgrah {
             id,
             resolver,
@@ -85,7 +85,7 @@ impl<'schema> PlanningLogic<'schema> {
         }
     }
 
-    pub(super) fn resolver(&self) -> &ResolverWalker<'schema> {
+    pub(super) fn resolver(&self) -> &ResolverDefinitionWalker<'schema> {
         match self {
             PlanningLogic::SameSubgrah { resolver, .. } => resolver,
             PlanningLogic::OnlyProvidable { resolver, .. } => resolver,

--- a/engine/crates/engine-v2/src/operation/logical_planner/mod.rs
+++ b/engine/crates/engine-v2/src/operation/logical_planner/mod.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 use engine_parser::types::OperationType;
 use id_newtypes::{BitSet, IdToMany};
 use itertools::Itertools;
-use schema::{EntityId, FieldDefinitionId, RequiredFieldId, RequiredFieldSet, ResolverId, Schema};
+use schema::{EntityId, FieldDefinitionId, RequiredFieldId, RequiredFieldSet, ResolverDefinitionId, Schema};
 use tracing::instrument;
 
 use crate::{
@@ -339,7 +339,7 @@ impl<'a> LogicalPlanner<'a> {
     pub fn push_plan(
         &mut self,
         query_path: QueryPath,
-        resolver_id: ResolverId,
+        resolver_id: ResolverDefinitionId,
         entity_id: EntityId,
         root_field_ids: &[FieldId],
     ) -> LogicalPlanningResult<LogicalPlanId> {

--- a/engine/crates/engine-v2/src/operation/logical_planner/selection_set.rs
+++ b/engine/crates/engine-v2/src/operation/logical_planner/selection_set.rs
@@ -7,7 +7,7 @@ use id_newtypes::IdRange;
 use itertools::Itertools;
 use schema::{
     EntityId, FieldDefinitionId, FieldDefinitionWalker, RequiredFieldId, RequiredFieldSet, RequiredFieldSetItemWalker,
-    ResolverId,
+    ResolverDefinitionId,
 };
 use tracing::{instrument, Level};
 
@@ -223,7 +223,7 @@ impl PlannedField {
 /// Potential child plan, but might not be the best one.
 struct ChildPlanCandidate<'schema> {
     entity_id: EntityId,
-    resolver_id: ResolverId,
+    resolver_id: ResolverDefinitionId,
     /// Providable fields by the resolvers with their requirements
     providable_fields: Vec<(FieldId, Cow<'schema, RequiredFieldSet>)>,
 }
@@ -287,7 +287,7 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
         }
 
         // Actual planning, we plan one child plan at a time.
-        let mut candidates: HashMap<ResolverId, ChildPlanCandidate<'schema>> = HashMap::default();
+        let mut candidates: HashMap<ResolverDefinitionId, ChildPlanCandidate<'schema>> = HashMap::default();
         while !unplanned_fields.is_empty() {
             candidates.clear();
             self.generate_all_candidates(&unplanned_fields, planned_selection_set, &mut candidates)?;
@@ -370,7 +370,7 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
     fn push_child(
         &mut self,
         planned_selection_set: &mut PlannedSelectionSet,
-        resolver_id: ResolverId,
+        resolver_id: ResolverDefinitionId,
         requires: Cow<'_, RequiredFieldSet>,
         entity_id: EntityId,
         root_field_ids: Vec<FieldId>,
@@ -517,7 +517,7 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
         &mut self,
         unplanned_fields: &HashMap<FieldId, FieldDefinitionWalker<'schema>>,
         planned_selection_set: &mut PlannedSelectionSet,
-        candidates: &mut HashMap<ResolverId, ChildPlanCandidate<'schema>>,
+        candidates: &mut HashMap<ResolverDefinitionId, ChildPlanCandidate<'schema>>,
     ) -> LogicalPlanningResult<()>
     where
         'schema: 'field,
@@ -791,7 +791,7 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
 }
 
 fn select_best_child_plan<'c, 'op>(
-    candidates: &'c mut HashMap<ResolverId, ChildPlanCandidate<'op>>,
+    candidates: &'c mut HashMap<ResolverDefinitionId, ChildPlanCandidate<'op>>,
 ) -> Option<&'c mut ChildPlanCandidate<'op>> {
     // We could be smarter, but we need to be sure there is no intersection between
     // candidates (which impacts ordering among other things) and some fields may now be

--- a/engine/crates/engine-v2/src/operation/mod.rs
+++ b/engine/crates/engine-v2/src/operation/mod.rs
@@ -23,7 +23,7 @@ pub(crate) use input_value::*;
 pub(crate) use location::Location;
 pub(crate) use modifier::*;
 pub(crate) use path::QueryPath;
-use schema::{EntityId, ObjectId, RequiredFieldId, ResolverId, SchemaWalker};
+use schema::{EntityId, ObjectDefinitionId, RequiredFieldId, ResolverDefinitionId, SchemaWalker};
 pub(crate) use selection_set::*;
 pub(crate) use variables::*;
 pub(crate) use walkers::*;
@@ -56,7 +56,7 @@ where
 #[derive(serde::Serialize, serde::Deserialize)]
 pub(crate) struct Operation {
     pub ty: OperationType,
-    pub root_object_id: ObjectId,
+    pub root_object_id: ObjectDefinitionId,
     pub root_selection_set_id: SelectionSetId,
     // sorted
     pub root_query_modifier_ids: Vec<QueryModifierId>,
@@ -92,7 +92,7 @@ pub(crate) struct OperationPlan {
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub(crate) struct LogicalPlan {
-    pub resolver_id: ResolverId,
+    pub resolver_id: ResolverDefinitionId,
     pub entity_id: EntityId,
     pub root_field_ids_ordered_by_parent_entity_id_then_position: Vec<FieldId>,
 }

--- a/engine/crates/engine-v2/src/operation/selection_set.rs
+++ b/engine/crates/engine-v2/src/operation/selection_set.rs
@@ -1,5 +1,8 @@
 use id_newtypes::IdRange;
-use schema::{Definition, EntityId, FieldDefinitionId, InputValueDefinitionId, InterfaceId, ObjectId, UnionId};
+use schema::{
+    Definition, EntityId, FieldDefinitionId, InputValueDefinitionId, InterfaceDefinitionId, ObjectDefinitionId,
+    UnionDefinitionId,
+};
 
 use crate::response::{BoundResponseKey, ResponseEdge, ResponseKey};
 
@@ -14,9 +17,9 @@ pub(crate) struct SelectionSet {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
 pub enum SelectionSetType {
-    Object(ObjectId),
-    Interface(InterfaceId),
-    Union(UnionId),
+    Object(ObjectDefinitionId),
+    Interface(InterfaceDefinitionId),
+    Union(UnionDefinitionId),
 }
 
 impl SelectionSetType {
@@ -54,7 +57,7 @@ impl SelectionSetType {
         }
     }
 
-    pub fn as_object_id(&self) -> Option<ObjectId> {
+    pub fn as_object_id(&self) -> Option<ObjectDefinitionId> {
         match self {
             SelectionSetType::Object(id) => Some(*id),
             _ => None,

--- a/engine/crates/engine-v2/src/response/object_set.rs
+++ b/engine/crates/engine-v2/src/response/object_set.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use id_newtypes::IdRange;
-use schema::{EntityId, ObjectId, Schema};
+use schema::{EntityId, ObjectDefinitionId, Schema};
 
 use super::{ResponseObjectId, ResponsePath};
 
@@ -15,7 +15,7 @@ id_newtypes::NonZeroU16! {
 pub struct ResponseObjectRef {
     pub id: ResponseObjectId,
     pub path: ResponsePath,
-    pub definition_id: ObjectId,
+    pub definition_id: ObjectDefinitionId,
 }
 
 /// A ResponseObjectSet hols all the response object references for a given selection sets,

--- a/engine/crates/engine-v2/src/response/shape.rs
+++ b/engine/crates/engine-v2/src/response/shape.rs
@@ -1,5 +1,8 @@
 use id_newtypes::IdRange;
-use schema::{FieldDefinitionId, InterfaceId, ObjectId, RequiredFieldId, ScalarType, UnionId, Wrapping};
+use schema::{
+    FieldDefinitionId, InterfaceDefinitionId, ObjectDefinitionId, RequiredFieldId, ScalarType, UnionDefinitionId,
+    Wrapping,
+};
 
 use crate::operation::FieldId;
 
@@ -48,7 +51,7 @@ impl Shape {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct PolymorphicObjectShape {
     // Sorted by Object typename
-    pub possibilities: Vec<(ObjectId, ConcreteObjectShapeId)>,
+    pub possibilities: Vec<(ObjectDefinitionId, ConcreteObjectShapeId)>,
 }
 
 /// Being concrete does not mean it's only associated with a single object definition id
@@ -64,8 +67,8 @@ pub(crate) struct ConcreteObjectShape {
 
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub enum ObjectIdentifier {
-    Known(ObjectId),
-    UnionTypename(UnionId),
-    InterfaceTypename(InterfaceId),
+    Known(ObjectDefinitionId),
+    UnionTypename(UnionDefinitionId),
+    InterfaceTypename(InterfaceDefinitionId),
     Anonymous,
 }

--- a/engine/crates/engine-v2/src/response/write/deserialize/object/concrete.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/object/concrete.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use id_newtypes::IdRange;
-use schema::ObjectId;
+use schema::ObjectDefinitionId;
 use serde::de::{DeserializeSeed, IgnoredAny, MapAccess, Visitor};
 
 use crate::response::{
@@ -36,7 +36,7 @@ impl<'ctx, 'seed> ConcreteObjectSeed<'ctx, 'seed> {
     pub fn new_with_object_id(
         ctx: &'seed SeedContext<'ctx>,
         shape_id: ConcreteObjectShapeId,
-        object_id: ObjectId,
+        object_id: ObjectDefinitionId,
     ) -> Self {
         let shape = &ctx.operation.response_blueprint[shape_id];
         Self {
@@ -107,7 +107,7 @@ impl<'de, 'ctx, 'parent> Visitor<'de> for ConcreteObjectSeed<'ctx, 'parent> {
 }
 
 impl<'de, 'ctx, 'seed> DeserializeSeed<'de> for ConcreteObjectFieldsSeed<'ctx, 'seed> {
-    type Value = (Option<ObjectId>, Vec<ResponseObjectField>);
+    type Value = (Option<ObjectDefinitionId>, Vec<ResponseObjectField>);
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
     where
@@ -118,7 +118,7 @@ impl<'de, 'ctx, 'seed> DeserializeSeed<'de> for ConcreteObjectFieldsSeed<'ctx, '
 }
 
 impl<'de, 'ctx, 'seed> Visitor<'de> for ConcreteObjectFieldsSeed<'ctx, 'seed> {
-    type Value = (Option<ObjectId>, Vec<ResponseObjectField>);
+    type Value = (Option<ObjectDefinitionId>, Vec<ResponseObjectField>);
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("an object")
@@ -246,9 +246,9 @@ impl<'de, 'ctx, 'seed> ConcreteObjectFieldsSeed<'ctx, 'seed> {
     fn visit_fields_with_typename_detection<A: MapAccess<'de>>(
         &self,
         map: &mut A,
-        possible_types_ordered_by_typename: &[ObjectId],
+        possible_types_ordered_by_typename: &[ObjectDefinitionId],
         response_fields: &mut Vec<ResponseObjectField>,
-    ) -> Result<ObjectId, A::Error> {
+    ) -> Result<ObjectDefinitionId, A::Error> {
         let schema = self.ctx.schema;
         let keys = &self.ctx.operation.response_keys;
         let fields = &self.ctx.operation.response_blueprint[self.field_shape_ids];

--- a/engine/crates/engine-v2/src/response/write/deserialize/object/polymorphic.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/object/polymorphic.rs
@@ -1,6 +1,6 @@
 use std::{collections::VecDeque, fmt};
 
-use schema::ObjectId;
+use schema::ObjectDefinitionId;
 use serde::de::{DeserializeSeed, IgnoredAny, MapAccess, Visitor};
 
 use crate::response::{
@@ -12,7 +12,7 @@ use super::concrete::ConcreteObjectSeed;
 
 pub(crate) struct PolymorphicObjectSeed<'ctx, 'seed> {
     ctx: &'seed SeedContext<'ctx>,
-    possibilities: &'ctx [(ObjectId, ConcreteObjectShapeId)],
+    possibilities: &'ctx [(ObjectDefinitionId, ConcreteObjectShapeId)],
 }
 
 impl<'ctx, 'seed> PolymorphicObjectSeed<'ctx, 'seed> {

--- a/engine/crates/engine-v2/src/response/write/mod.rs
+++ b/engine/crates/engine-v2/src/response/write/mod.rs
@@ -10,7 +10,7 @@ use std::{
 use id_newtypes::IdRange;
 pub use ids::*;
 use itertools::Either;
-use schema::{ObjectId, Schema};
+use schema::{ObjectDefinitionId, Schema};
 
 use self::deserialize::UpdateSeed;
 
@@ -47,7 +47,7 @@ impl ResponseDataPart {
 
 pub(crate) struct ResponseBuilder {
     // will be None if an error propagated up to the root.
-    pub(super) root: Option<(ResponseObjectId, ObjectId)>,
+    pub(super) root: Option<(ResponseObjectId, ObjectDefinitionId)>,
     parts: Vec<ResponseDataPart>,
     errors: Vec<GraphqlError>,
 }
@@ -58,7 +58,7 @@ pub(crate) struct ResponseBuilder {
 // least wait until we face actual problems. We're focused on OLTP workloads, so might never
 // happen.
 impl ResponseBuilder {
-    pub fn new(root_object_id: ObjectId) -> Self {
+    pub fn new(root_object_id: ObjectDefinitionId) -> Self {
         let mut initial_part = ResponseDataPart {
             id: ResponseDataPartId::from(0),
             objects: Vec::new(),

--- a/engine/crates/engine-v2/src/sources/graphql/federation.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/federation.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use futures::future::join_all;
 use grafbase_telemetry::{gql_response_status::GraphqlResponseStatus, span::subgraph::SubgraphRequestSpan};
 use runtime::fetch::FetchRequest;
-use schema::sources::graphql::{FederationEntityResolverWalker, GraphqlEndpointId};
+use schema::sources::graphql::{FederationEntityResolveDefinitionrWalker, GraphqlEndpointId};
 use serde::{de::DeserializeSeed, Deserialize};
 use serde_json::value::RawValue;
 use std::{borrow::Cow, future::Future, time::Duration};
@@ -17,7 +17,7 @@ use crate::{
             deserialize::{EntitiesErrorsSeed, GraphqlResponseSeed},
             request::{SubgraphGraphqlRequest, SubgraphVariables},
         },
-        ExecutionResult, Executor,
+        ExecutionResult, Resolver,
     },
     Runtime,
 };
@@ -27,17 +27,20 @@ use super::{
     request::{execute_subgraph_request, PreparedFederationEntityOperation, ResponseIngester},
 };
 
-pub(crate) struct FederationEntityExecutor {
+pub(crate) struct FederationEntityResolver {
     endpoint_id: GraphqlEndpointId,
     operation: PreparedFederationEntityOperation,
 }
 
-impl FederationEntityExecutor {
-    pub fn prepare(resolver: FederationEntityResolverWalker<'_>, plan: PlanWalker<'_>) -> PlanningResult<Executor> {
+impl FederationEntityResolver {
+    pub fn prepare(
+        definition: FederationEntityResolveDefinitionrWalker<'_>,
+        plan: PlanWalker<'_>,
+    ) -> PlanningResult<Resolver> {
         let operation =
             PreparedFederationEntityOperation::build(plan).map_err(|err| format!("Failed to build query: {err}"))?;
-        Ok(Executor::FederationEntity(Self {
-            endpoint_id: resolver.endpoint().id(),
+        Ok(Resolver::FederationEntity(Self {
+            endpoint_id: definition.endpoint().id(),
             operation,
         }))
     }

--- a/engine/crates/engine-v2/src/sources/graphql/mod.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/mod.rs
@@ -1,8 +1,8 @@
 mod deserialize;
-mod executor;
 mod federation;
 mod request;
+mod root_fields;
 mod subscription;
 
-pub(crate) use executor::*;
 pub(crate) use federation::*;
+pub(crate) use root_fields::*;

--- a/engine/crates/engine-v2/src/sources/graphql/root_fields.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/root_fields.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, time::Duration};
 use bytes::Bytes;
 use grafbase_telemetry::{gql_response_status::GraphqlResponseStatus, span::subgraph::SubgraphRequestSpan};
 use runtime::fetch::FetchRequest;
-use schema::sources::graphql::{GraphqlEndpointId, RootFieldResolverWalker};
+use schema::sources::graphql::{GraphqlEndpointId, RootFieldResolverDefinitionWalker};
 use serde::de::DeserializeSeed;
 use tracing::Instrument;
 
@@ -15,26 +15,26 @@ use crate::{
     execution::PlanningResult,
     operation::{OperationType, PlanWalker},
     response::SubgraphResponse,
-    sources::{graphql::request::SubgraphGraphqlRequest, ExecutionContext, ExecutionResult, Executor},
+    sources::{graphql::request::SubgraphGraphqlRequest, ExecutionContext, ExecutionResult, Resolver},
     Runtime,
 };
 
-pub(crate) struct GraphqlExecutor {
+pub(crate) struct GraphqlResolver {
     pub(super) endpoint_id: GraphqlEndpointId,
     pub(super) operation: PreparedGraphqlOperation,
 }
 
-impl GraphqlExecutor {
+impl GraphqlResolver {
     pub fn prepare(
-        resolver: RootFieldResolverWalker<'_>,
+        definition: RootFieldResolverDefinitionWalker<'_>,
         operation_type: OperationType,
         plan: PlanWalker<'_>,
-    ) -> PlanningResult<Executor> {
+    ) -> PlanningResult<Resolver> {
         let operation = PreparedGraphqlOperation::build(operation_type, plan)
             .map_err(|err| format!("Failed to build query: {err}"))?;
 
-        Ok(Executor::GraphQL(Self {
-            endpoint_id: resolver.endpoint().id(),
+        Ok(Resolver::GraphQL(Self {
+            endpoint_id: definition.endpoint().id(),
             operation,
         }))
     }

--- a/engine/crates/engine-v2/src/sources/graphql/subscription.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/subscription.rs
@@ -5,7 +5,7 @@ use serde::de::DeserializeSeed;
 use super::{
     deserialize::{GraphqlResponseSeed, RootGraphqlErrors},
     request::SubgraphVariables,
-    GraphqlExecutor,
+    GraphqlResolver,
 };
 use crate::{
     execution::{ExecutionContext, ExecutionError, SubscriptionResponse},
@@ -14,7 +14,7 @@ use crate::{
     Runtime,
 };
 
-impl GraphqlExecutor {
+impl GraphqlResolver {
     pub async fn execute_subscription<'ctx, R: Runtime>(
         &'ctx self,
         ctx: ExecutionContext<'ctx, R>,

--- a/engine/crates/engine-v2/src/sources/introspection/mod.rs
+++ b/engine/crates/engine-v2/src/sources/introspection/mod.rs
@@ -7,9 +7,9 @@ use crate::{
 
 mod writer;
 
-pub(crate) struct IntrospectionExecutor;
+pub(crate) struct IntrospectionResolver;
 
-impl IntrospectionExecutor {
+impl IntrospectionResolver {
     #[allow(clippy::unnecessary_wraps)]
     pub async fn execute<'ctx, R: Runtime>(
         &'ctx self,


### PR DESCRIPTION
Not having this suffix makes a lot of things more confusing than
necessary. I've also renamed `Executor` to simply `Resolver` now with
this change.