### PR TITLE
chore: switch to mainline otel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5892,8 +5892,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.22.0"
-source = "git+https://github.com/grafbase/opentelemetry-rust?rev=f215fe9a391d7d159b9c8a6f8c303d143ba2910f#f215fe9a391d7d159b9c8a6f8c303d143ba2910f"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -5901,17 +5902,15 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "thiserror",
- "urlencoding",
 ]
 
 [[package]]
 name = "opentelemetry-appender-tracing"
-version = "0.3.0"
-source = "git+https://github.com/grafbase/opentelemetry-rust?rev=f215fe9a391d7d159b9c8a6f8c303d143ba2910f#f215fe9a391d7d159b9c8a6f8c303d143ba2910f"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84de945cb3a6f1e0d6317cbd998bbd0519ab00f4b790db67e0ff4fdcf7cedb6"
 dependencies = [
- "once_cell",
  "opentelemetry",
- "opentelemetry_sdk",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -5920,9 +5919,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-aws"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42c915961c059be65af3be9aeaedb3f8930e1e9590e26e5f23b1919e90d1ed7d"
+checksum = "4f2e5bd1a2e1d14877086a2defe4ac968f42a6a15cfc5862a0f0ecd0f3530135"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5931,8 +5930,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.11.0"
-source = "git+https://github.com/grafbase/opentelemetry-rust?rev=f215fe9a391d7d159b9c8a6f8c303d143ba2910f#f215fe9a391d7d159b9c8a6f8c303d143ba2910f"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad31e9de44ee3538fb9d64fe3376c1362f406162434609e79aea2a41a0af78ab"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5942,8 +5942,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.15.0"
-source = "git+https://github.com/grafbase/opentelemetry-rust?rev=f215fe9a391d7d159b9c8a6f8c303d143ba2910f#f215fe9a391d7d159b9c8a6f8c303d143ba2910f"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b925a602ffb916fb7421276b86756027b37ee708f9dce2dbdcc51739f07e727"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -5951,7 +5952,6 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "prost",
  "thiserror",
@@ -5961,8 +5961,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.5.0"
-source = "git+https://github.com/grafbase/opentelemetry-rust?rev=f215fe9a391d7d159b9c8a6f8c303d143ba2910f#f215fe9a391d7d159b9c8a6f8c303d143ba2910f"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ee9f20bff9c984511a02f082dc8ede839e4a9bf15cc2487c8d6fea5ad850d9"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -5971,14 +5972,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.14.0"
-source = "git+https://github.com/grafbase/opentelemetry-rust?rev=f215fe9a391d7d159b9c8a6f8c303d143ba2910f#f215fe9a391d7d159b9c8a6f8c303d143ba2910f"
-
-[[package]]
 name = "opentelemetry-stdout"
-version = "0.3.0"
-source = "git+https://github.com/grafbase/opentelemetry-rust?rev=f215fe9a391d7d159b9c8a6f8c303d143ba2910f#f215fe9a391d7d159b9c8a6f8c303d143ba2910f"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d408d4345b8be6129a77c46c3bfc75f0d3476f3091909c7dd99c1f3d78582287"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5993,20 +5990,17 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.22.1"
-source = "git+https://github.com/grafbase/opentelemetry-rust?rev=f215fe9a391d7d159b9c8a6f8c303d143ba2910f#f215fe9a391d7d159b9c8a6f8c303d143ba2910f"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692eac490ec80f24a17828d49b40b60f5aeaccdfe6a503f939713afd22bc28df"
 dependencies = [
  "async-trait",
- "crossbeam-channel",
  "futures-channel",
  "futures-executor",
  "futures-util",
- "getrandom 0.2.15",
  "glob",
- "js-sys",
  "once_cell",
  "opentelemetry",
- "ordered-float 4.2.0",
  "percent-encoding",
  "rand 0.8.5",
  "serde_json",
@@ -9343,9 +9337,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
+checksum = "a9784ed4da7d921bc8df6963f8c80a0e4ce34ba6ba76668acadd3edbd985ff3b"
 dependencies = [
  "js-sys",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,14 +36,6 @@ names = { git = "https://github.com/grafbase/names", rev = "443800fbb7bc2936c1f2
 # FIXME: Drop when a new version is released.
 openidconnect = { git = "https://github.com/ramosbugs/openidconnect-rs", rev = "7efc8943a8f699aff2db742827fc3d0fc2b3f34d" } # main
 
-opentelemetry = { git = "https://github.com/grafbase/opentelemetry-rust", rev = "f215fe9a391d7d159b9c8a6f8c303d143ba2910f" }                    # http-v1
-opentelemetry-otlp = { git = "https://github.com/grafbase/opentelemetry-rust", rev = "f215fe9a391d7d159b9c8a6f8c303d143ba2910f" }               # http-v1
-opentelemetry-stdout = { git = "https://github.com/grafbase/opentelemetry-rust", rev = "f215fe9a391d7d159b9c8a6f8c303d143ba2910f" }             # http-v1
-opentelemetry_sdk = { git = "https://github.com/grafbase/opentelemetry-rust", rev = "f215fe9a391d7d159b9c8a6f8c303d143ba2910f" }                # http-v1
-opentelemetry-appender-tracing = { git = "https://github.com/grafbase/opentelemetry-rust", rev = "f215fe9a391d7d159b9c8a6f8c303d143ba2910f" }
-
-# FIXME: Uncomment when we upgrade opentelemetry to 0.23.
-# opentelemetry-aws = { git = "https://github.com/open-telemetry/opentelemetry-rust-contrib", rev = "086961e18437743c5ea43c9474cc1a7b13a49c6b" } # main
 ory-client = { git = "https://github.com/ory/client-rust", rev = "v1.14.3" }
 reqwest = { git = "https://github.com/grafbase/reqwest", rev = "874a6b3c522de296629d4542943934fa20d7ab4d" } # 0.12.5-with-patches-wasm-timeout
 rudderanalytics =  { git = "https://github.com/grafbase/rudder-sdk-rust", rev = "3e994eb4dcc9c580be311ef9eab6e96dd264293b" } # async
@@ -51,8 +43,6 @@ serde_with = { git = "https://github.com/grafbase/serde_with", rev = "06ad277a0e
 # Temporary change till https://github.com/alexcrichton/tar-rs/pull/319 is merged and released.
 tar = { git = "https://github.com/grafbase/tar-rs.git", rev = "a889df5bd9fec44faf081f7fade5ec81935c2418" } # overwrite-hard-links
 tokio-postgres = { git = "https://github.com/grafbase/rust-postgres/", branch = "grafbase-rebased" }
-# FIXME: Uncomment when we upgrade opentelemetry to 0.23.
-# tracing-opentelemetry = { git = "https://github.com/tokio-rs/tracing-opentelemetry", rev = "2539f4f7bde3dc3f320e5fb935d2c13a69a540dd" } # main
 tracing = { git = "https://github.com/tokio-rs/tracing", rev = "6d00d7d9f72dc6797138a1062bc33073afbad5a1" } # v0.1.x
 tracing-core = { git = "https://github.com/tokio-rs/tracing", rev = "6d00d7d9f72dc6797138a1062bc33073afbad5a1" } # v0.1.x
 tracing-mock = { git = "https://github.com/tokio-rs/tracing", rev = "6d00d7d9f72dc6797138a1062bc33073afbad5a1" } # v0.1.x
@@ -153,12 +143,12 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 tracing-futures = "0.2.5"
 tracing-mock = "0.1"
-tracing-opentelemetry = "0.23"
-opentelemetry = "0.22"
-opentelemetry_sdk = "0.22.0"
-opentelemetry-stdout = "0.3"
-opentelemetry-otlp = "0.15"
-opentelemetry-appender-tracing = "0.3.0"
+tracing-opentelemetry = "0.25"
+opentelemetry = "0.24"
+opentelemetry_sdk = "0.24.1"
+opentelemetry-stdout = "0.5"
+opentelemetry-otlp = "0.17"
+opentelemetry-appender-tracing = "0.5.0"
 
 # Common
 graph-ref = { path = "graph-ref" }

--- a/engine/crates/telemetry/src/otel/layer.rs
+++ b/engine/crates/telemetry/src/otel/layer.rs
@@ -1,9 +1,8 @@
-use std::borrow::Cow;
-
 use opentelemetry::trace::noop::NoopTracer;
 use opentelemetry::trace::TracerProvider;
 use opentelemetry::KeyValue;
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
+use opentelemetry_sdk::logs::{Logger, LoggerProvider};
 use opentelemetry_sdk::runtime::RuntimeChannel;
 use opentelemetry_sdk::trace::IdGenerator;
 use opentelemetry_sdk::Resource;
@@ -30,7 +29,7 @@ pub struct ReloadableOtelLayers<S> {
     /// A reloadable metrics layer
     pub meter_provider: Option<opentelemetry_sdk::metrics::SdkMeterProvider>,
     /// A reloadable logging layer
-    pub logger: Option<LoggerLayer>,
+    pub logger: Option<OpenTelemetryTracingBridge<LoggerProvider, Logger>>,
 }
 
 /// Holds tracing reloadable layer components
@@ -41,11 +40,6 @@ pub struct ReloadableOtelLayer<Subscriber, Provider> {
     pub layer_reload_handle: reload::Handle<BoxedLayer<Subscriber>, Subscriber>,
     /// The tracer provider used for tracers attached to the layer
     pub provider: Provider,
-}
-
-pub struct LoggerLayer {
-    pub layer: OpenTelemetryTracingBridge<opentelemetry_sdk::logs::LoggerProvider, opentelemetry_sdk::logs::Logger>,
-    pub provider: opentelemetry_sdk::logs::LoggerProvider,
 }
 
 /// Creates a new OTEL tracing layer that doesn't collect or export any tracing data.
@@ -99,22 +93,17 @@ where
     };
 
     let logger = match super::logs::build_logs_provider(runtime.clone(), &config, resource.clone())? {
-        Some(provider) if config.logs_exporters_enabled() => Some(LoggerLayer {
-            layer: OpenTelemetryTracingBridge::new(&provider),
-            provider,
-        }),
+        Some(provider) if config.logs_exporters_enabled() => Some(OpenTelemetryTracingBridge::new(&provider)),
         _ => None,
     };
 
     let tracing_layer = if config.tracing_exporters_enabled() {
         let tracer_provider = super::traces::build_trace_provider(runtime, id_generator, &config, resource.clone())?;
 
-        let tracer = tracer_provider.versioned_tracer(
-            crate::SCOPE,
-            Some(crate::SCOPE_VERSION),
-            None::<Cow<'static, str>>,
-            None,
-        );
+        let tracer = tracer_provider
+            .tracer_builder(crate::SCOPE)
+            .with_version(crate::SCOPE_VERSION)
+            .build();
 
         let tracer_layer = tracing_opentelemetry::layer().with_tracer(tracer);
         let tracer_layer = tracer_layer.boxed();

--- a/engine/crates/telemetry/src/otel/logs.rs
+++ b/engine/crates/telemetry/src/otel/logs.rs
@@ -12,10 +12,10 @@ where
 {
     cfg_if::cfg_if! {
         if #[cfg(feature = "otlp")] {
-            use opentelemetry_sdk::logs::{BatchConfigBuilder, BatchLogProcessor, Config};
+            use opentelemetry_sdk::logs::{BatchConfigBuilder, BatchLogProcessor};
             use std::time::Duration;
 
-            let mut builder = LoggerProvider::builder().with_config(Config::default().with_resource(resource));
+            let mut builder = LoggerProvider::builder().with_resource(resource);
 
             if let Some(config) = config.logs_otlp_config() {
                 use opentelemetry_otlp::LogExporterBuilder;

--- a/engine/crates/telemetry/src/otel/traces.rs
+++ b/engine/crates/telemetry/src/otel/traces.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use opentelemetry_sdk::{
     export::trace::SpanExporter,
     runtime::RuntimeChannel,
-    trace::{BatchConfigBuilder, BatchSpanProcessor, Builder, IdGenerator, Sampler, TracerProvider},
+    trace::{BatchConfigBuilder, BatchSpanProcessor, Builder, Config, IdGenerator, Sampler, TracerProvider},
     Resource,
 };
 
@@ -23,7 +23,7 @@ where
     I: IdGenerator + 'static,
 {
     let builder = TracerProvider::builder().with_config(
-        opentelemetry_sdk::trace::config()
+        Config::default()
             .with_id_generator(id_generator)
             .with_sampler(Sampler::TraceIdRatioBased(config.tracing.sampling))
             .with_max_events_per_span(config.tracing.collect.max_events_per_span as u32)

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -25,7 +25,7 @@ gateway-config.workspace = true
 grafbase-telemetry = { workspace = true, features = ["otlp"] }
 graph-ref.workspace = true
 mimalloc = "0.1.41"
-opentelemetry-aws = { version = "0.10.0", optional = true }
+opentelemetry-aws = { version = "0.12.0", optional = true }
 rustls = { workspace = true, features = ["ring"] }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 toml = "0.8.12"

--- a/gateway/crates/gateway-binary/src/main.rs
+++ b/gateway/crates/gateway-binary/src/main.rs
@@ -137,12 +137,10 @@ fn init_global_tracing(args: &impl Args, config: Option<TelemetryConfig>) -> any
         Some(logger) => {
             tracing_subscriber::registry()
                 .with(tracer.layer.boxed())
-                .with(logger.layer.boxed())
+                .with(logger.boxed())
                 .with(args.log_format())
                 .with(env_filter)
                 .init();
-
-            grafbase_telemetry::otel::opentelemetry::global::set_logger_provider(logger.provider.clone());
         }
         None => {
             tracing_subscriber::registry()
@@ -181,7 +179,7 @@ fn otel_layer_reload<S>(
         let ReloadableOtelLayers {
             tracer,
             meter_provider,
-            logger,
+            logger: _logger,
         } = match build_otel_layers(config, Some(reload_data), false) {
             Ok(value) => value,
             Err(err) => {
@@ -211,10 +209,6 @@ fn otel_layer_reload<S>(
 
         grafbase_telemetry::otel::opentelemetry::global::set_meter_provider(meter_provider);
         grafbase_telemetry::otel::opentelemetry::global::set_tracer_provider(tracer.provider.clone());
-
-        if let Some(logger) = logger {
-            grafbase_telemetry::otel::opentelemetry::global::set_logger_provider(logger.provider.clone());
-        }
 
         reload_ack_sender.send(()).ok();
 


### PR DESCRIPTION
Let's got some of the forks we need. The otel setup is now in http 1.0 and all that. Seems like we even get otel logs even when removing that provider set methods. Looks good.