### PR TITLE
fix: include headers in entity caching keys

### DIFF
--- a/engine/crates/engine-v2/src/sources/graphql/federation.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/federation.rs
@@ -331,11 +331,11 @@ async fn cache_fetch<R: Runtime>(
 fn build_cache_key(subgraph_name: &str, headers: &HeaderMap, repr: &RawValue) -> String {
     let mut hasher = blake3::Hasher::new();
     hasher.update(subgraph_name.as_bytes());
-    hasher.update(&headers.len().to_ne_bytes());
+    hasher.update(&headers.len().to_le_bytes());
     for (name, value) in headers {
-        hasher.update(&name.as_str().len().to_ne_bytes());
+        hasher.update(&name.as_str().len().to_le_bytes());
         hasher.update(name.as_str().as_bytes());
-        hasher.update(&value.len().to_ne_bytes());
+        hasher.update(&value.len().to_le_bytes());
         hasher.update(value.as_bytes());
     }
     hasher.update(repr.get().as_bytes());

--- a/engine/crates/engine-v2/src/sources/graphql/root_fields.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/root_fields.rs
@@ -137,11 +137,11 @@ impl GraphqlResolver {
 fn build_cache_key(subgraph_name: &str, subgraph_request_body: &[u8], headers: &http::HeaderMap) -> Option<String> {
     let mut hasher = blake3::Hasher::new();
     hasher.update(subgraph_name.as_bytes());
-    hasher.update(&headers.len().to_ne_bytes());
+    hasher.update(&headers.len().to_le_bytes());
     for (name, value) in headers {
-        hasher.update(&name.as_str().len().to_ne_bytes());
+        hasher.update(&name.as_str().len().to_le_bytes());
         hasher.update(name.as_str().as_bytes());
-        hasher.update(&value.len().to_ne_bytes());
+        hasher.update(&value.len().to_le_bytes());
         hasher.update(value.as_bytes());
     }
     hasher.update(subgraph_request_body);

--- a/engine/crates/engine-v2/src/sources/graphql/root_fields.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/root_fields.rs
@@ -66,7 +66,12 @@ impl GraphqlResolver {
         })
         .map_err(|err| format!("Failed to serialize query: {err}"))?;
 
-        let cache_ttl_and_key = endpoint.entity_cache_ttl().map(|ttl| (ttl, build_cache_key(&body)));
+        let headers = ctx.subgraph_headers_with_rules(endpoint.header_rules());
+
+        let cache_ttl_and_key = endpoint
+            .entity_cache_ttl()
+            .and_then(|ttl| Some((ttl, build_cache_key(endpoint.subgraph_name(), &body, &headers)?)));
+
         if let Some((_, cache_key)) = &cache_ttl_and_key {
             let cache_entry = ctx
                 .engine
@@ -114,7 +119,7 @@ impl GraphqlResolver {
             retry_budget,
             || FetchRequest {
                 url: endpoint.url(),
-                headers: ctx.subgraph_headers_with_rules(endpoint.header_rules()),
+                headers,
                 json_body: Bytes::from(body),
                 timeout: endpoint.timeout(),
             },
@@ -129,10 +134,21 @@ impl GraphqlResolver {
     }
 }
 
-fn build_cache_key(subgraph_request_body: &[u8]) -> String {
+fn build_cache_key(subgraph_name: &str, subgraph_request_body: &[u8], headers: &http::HeaderMap) -> Option<String> {
+    let header_json = serde_json::to_vec(
+        &headers
+            .iter()
+            .map(|(name, value)| (name.as_str(), value.as_bytes()))
+            .collect::<Vec<_>>(),
+    )
+    .inspect_err(|err| tracing::warn!("Couldn't encode headers as JSON for cache key: {err}"))
+    .ok()?;
+
     let mut hasher = blake3::Hasher::new();
+    hasher.update(subgraph_name.as_bytes());
+    hasher.update(&header_json);
     hasher.update(subgraph_request_body);
-    hasher.finalize().to_string()
+    Some(hasher.finalize().to_string())
 }
 
 struct GraphqlIngester<'ctx, R: Runtime> {


### PR DESCRIPTION
One of the things we want to avoid in entity caching is sharing cache entries that shouldn't be shared: one way that could happen is if some kind of authentication header was included in a subgraph request.  This handles that case by adding subgraph headers into the entity caching key.

We probably still need to handle adding auth scopes and such into the caching key, but that's a bigger job - this should handle a lot of the obvious cases.