### PR TITLE
Remove frontend team from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,8 @@
 cli/ @grafbase/backend
 engine/ @grafbase/backend
 .github/actions/ @grafbase/infrastructure
-examples/ @grafbase/frontend
-packages/ @grafbase/frontend
+examples/ @grafbase/backend
+packages/ @grafbase/backend
 packages/grafbase-sdk @grafbase/backend
-templates/ @grafbase/frontend
+templates/ @grafbase/backend
 


### PR DESCRIPTION
# Description

The frontend team is not active in this repo, yet we get tagged for review in a lot of pull requests. I think it's better to manually tag us if needed.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [x] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
