### PR TITLE
Use correct version of wasi-component-loader in runtime-local

### DIFF
--- a/engine/crates/runtime-local/Cargo.toml
+++ b/engine/crates/runtime-local/Cargo.toml
@@ -42,7 +42,7 @@ reqwest = { workspace = true, features = [
   "json",
   "rustls-tls",
 ] }
-wasi-component-loader = { version = "0.77.1", path = "../wasi-component-loader", optional = true }
+wasi-component-loader = { version = "0.78.0", path = "../wasi-component-loader", optional = true }
 deadpool = { version = "0.12.1", features = ["rt_tokio_1"] }
 grafbase-telemetry.workspace = true
 anyhow.workspace = true


### PR DESCRIPTION
The versions don't match. This is making builds fail on main.
