### PR TITLE
cli: add CDDL-1.0 to accepted licenses

### DIFF
--- a/cli/about.toml
+++ b/cli/about.toml
@@ -5,6 +5,7 @@ accepted = [
     "BSD-3-Clause",
     "BSL-1.0",
     "CC0-1.0",
+    "CDDL-1.0",
     "ISC",
     "MIT",
     "MPL-2.0",


### PR DESCRIPTION
This is currently blocking release. It's a weak copyleft license derived from MPL, so that should be fine.

Reference: https://en.wikipedia.org/wiki/Common_Development_and_Distribution_License

# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
