### PR TITLE
chore(metrics): Separate our internal operation metrics attributes

### DIFF
--- a/engine/crates/engine-v2/src/operation/build.rs
+++ b/engine/crates/engine-v2/src/operation/build.rs
@@ -100,7 +100,7 @@ impl Operation {
         let response_blueprint = ResponseBlueprintBuilder::new(schema, &operation, &plan).build();
 
         let mut metrics_attributes = metrics_attributes.ok_or(OperationError::NormalizationError)?;
-        metrics_attributes.used_fields = generate_used_fields(schema, &operation);
+        metrics_attributes.internal.used_fields = generate_used_fields(schema, &operation);
 
         Ok(PreparedOperation {
             operation,

--- a/engine/crates/engine/response/src/lib.rs
+++ b/engine/crates/engine/response/src/lib.rs
@@ -23,6 +23,7 @@ mod streaming;
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct GraphqlOperationAnalyticsAttributes {
     pub name: Option<String>,
+    pub name_or_generated_one: String,
     pub r#type: common_types::OperationType,
     #[serde(default)]
     pub used_fields: String,
@@ -102,6 +103,7 @@ impl Response {
             errors,
             graphql_operation: Some(GraphqlOperationAnalyticsAttributes {
                 name: None,
+                name_or_generated_one: String::new(),
                 r#type: match operation_type {
                     OperationType::Query => common_types::OperationType::Query {
                         is_introspection: false,

--- a/engine/crates/gateway-core/src/cache/partial.rs
+++ b/engine/crates/gateway-core/src/cache/partial.rs
@@ -72,6 +72,7 @@ where
                     body,
                     engine::GraphqlOperationAnalyticsAttributes {
                         name: request.operation_name().map(str::to_string),
+                        name_or_generated_one: request.operation_name().map(str::to_string).unwrap_or_default(),
                         r#type: operation_type,
                         used_fields: String::new(),
                     },
@@ -130,6 +131,7 @@ where
                 body,
                 engine::GraphqlOperationAnalyticsAttributes {
                     name: request.operation_name().map(str::to_string),
+                    name_or_generated_one: request.operation_name().map(str::to_string).unwrap_or_default(),
                     r#type: operation_type,
                     used_fields: String::new(),
                 },

--- a/engine/crates/gateway-core/src/lib.rs
+++ b/engine/crates/gateway-core/src/lib.rs
@@ -194,6 +194,7 @@ where
                         common_types::OperationType::Subscription => "subscription",
                     },
                     operation_name: operation.name.as_deref(),
+                    otel_name: &operation.name_or_generated_one,
                     sanitized_query: normalized_query.as_deref(),
                 });
 
@@ -216,9 +217,12 @@ where
                                 }
                             },
                             name: operation.name.clone(),
-                            sanitized_query_hash: blake3::hash(normalized_query.as_bytes()).into(),
+                            internal: grafbase_telemetry::metrics::InternalOperationMetricsAttributes {
+                                sanitized_query_hash: blake3::hash(normalized_query.as_bytes()).into(),
+                                operation_name_or_generated_one: operation.name_or_generated_one.clone(),
+                                used_fields: operation.used_fields.clone(),
+                            },
                             sanitized_query: normalized_query,
-                            used_fields: operation.used_fields.clone(),
                         },
                         status,
                         cache_status: headers

--- a/engine/crates/integration-tests/tests/tracing/v1.rs
+++ b/engine/crates/integration-tests/tests/tracing/v1.rs
@@ -26,10 +26,6 @@ async fn query_bad_request() {
         })
         .new_span(span.clone())
         .enter(span.clone())
-        .record(
-            span.clone(),
-            expect::field("gql.operation.name").with_value(&"__type_name"),
-        )
         .record(span.clone(), expect::field("otel.name").with_value(&"__type_name"))
         .record(
             span.clone(),
@@ -84,7 +80,6 @@ async fn query() {
         .exit(resolver_span.clone())
         .enter(resolver_span.clone())
         .exit(resolver_span.clone())
-        .record(span.clone(), expect::field("gql.operation.name").with_value(&"test"))
         .record(span.clone(), expect::field("otel.name").with_value(&"test"))
         .record(
             span.clone(),
@@ -223,7 +218,6 @@ async fn resolvers_with_error() {
             resolver_span_error.clone(),
             expect::field("resolver.invocation.is_error").with_value(&true),
         )
-        .record(span.clone(), expect::field("gql.operation.name").with_value(&"nope"))
         .record(span.clone(), expect::field("otel.name").with_value(&"nope"))
         .record(
             span.clone(),

--- a/engine/crates/integration-tests/tests/tracing/v2.rs
+++ b/engine/crates/integration-tests/tests/tracing/v2.rs
@@ -15,10 +15,6 @@ fn query_bad_request() {
         let (subscriber, handle) = subscriber::mock()
             .with_filter(|meta| meta.is_span() && meta.target() == "grafbase" && *meta.level() >= Level::INFO)
             .enter(span.clone())
-            .record(
-                span.clone(),
-                expect::field("gql.operation.name").with_value(&"__type_name"),
-            )
             .record(span.clone(), expect::field("otel.name").with_value(&"__type_name"))
             .record(
                 span.clone(),

--- a/engine/crates/telemetry/src/span.rs
+++ b/engine/crates/telemetry/src/span.rs
@@ -55,6 +55,8 @@ pub struct GqlRequestAttributes<'a> {
     pub operation_type: &'static str,
     /// GraphQL operation name
     pub operation_name: Option<&'a str>,
+    /// OTEL name of the span
+    pub otel_name: &'a str,
     /// Must NOT contain any sensitive data
     pub sanitized_query: Option<&'a str>,
 }
@@ -64,6 +66,7 @@ impl<'a> From<&'a OperationMetricsAttributes> for GqlRequestAttributes<'a> {
         Self {
             operation_type: metrics_attributes.ty.as_str(),
             operation_name: metrics_attributes.name.as_deref(),
+            otel_name: &metrics_attributes.internal.operation_name_or_generated_one,
             sanitized_query: Some(&metrics_attributes.sanitized_query),
         }
     }

--- a/engine/crates/telemetry/src/span/gql.rs
+++ b/engine/crates/telemetry/src/span/gql.rs
@@ -41,8 +41,8 @@ impl GqlRecorderSpanExt for Span {
     fn record_gql_request(&self, attributes: GqlRequestAttributes<'_>) {
         if let Some(name) = attributes.operation_name {
             self.record("gql.operation.name", name);
-            self.record("otel.name", name);
         }
+        self.record("otel.name", attributes.otel_name);
         if let Some(query) = attributes.sanitized_query {
             self.record("gql.operation.query", query);
         }

--- a/gateway/crates/gateway-binary/tests/telemetry/metrics/operation.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/metrics/operation.rs
@@ -36,11 +36,12 @@ fn basic() {
         {
           "Count": 1,
           "Attributes": {
+            "__grafbase.gql.operation.inferred_name": "Simple",
+            "__grafbase.gql.operation.query_hash": "cAe1+tBRHQLrF/EO1ul4CTx+q5SB9YD+YtG3VDU6VCM=",
+            "__grafbase.gql.operation.used_fields": "",
             "gql.operation.name": "Simple",
             "gql.operation.query": "query Simple {\n  __typename\n}\n",
-            "gql.operation.query_hash": "cAe1+tBRHQLrF/EO1ul4CTx+q5SB9YD+YtG3VDU6VCM=",
             "gql.operation.type": "query",
-            "gql.operation.used_fields": "",
             "gql.response.status": "SUCCESS"
           }
         }
@@ -85,11 +86,11 @@ fn introspection_should_not_appear_in_used_fields() {
         {
           "Count": 1,
           "Attributes": {
-            "gql.operation.name": "__schema",
+            "__grafbase.gql.operation.inferred_name": "__schema",
+            "__grafbase.gql.operation.query_hash": "0AmmdiLirkkd0r11qjmdCjpV7OGLe0J5c4yugMq1oeQ=",
+            "__grafbase.gql.operation.used_fields": "",
             "gql.operation.query": "query {\n  __schema {\n    description\n  }\n}\n",
-            "gql.operation.query_hash": "0AmmdiLirkkd0r11qjmdCjpV7OGLe0J5c4yugMq1oeQ=",
             "gql.operation.type": "query",
-            "gql.operation.used_fields": "",
             "gql.response.status": "SUCCESS"
           }
         }
@@ -158,11 +159,12 @@ fn used_fields_should_be_unique() {
         {
           "Count": 1,
           "Attributes": {
+            "__grafbase.gql.operation.inferred_name": "Faulty",
+            "__grafbase.gql.operation.query_hash": "4iL1kpGebrS0NAZQbUo76cwD4SUC5jxtUlCdc2149fg=",
+            "__grafbase.gql.operation.used_fields": "User.id+username+reviews,Review.body+author,Query.me",
             "gql.operation.name": "Faulty",
             "gql.operation.query": "query Faulty {\n  me {\n    id\n    reviews {\n      author {\n        id\n        username\n      }\n      body\n      body\n    }\n    username\n  }\n}\n",
-            "gql.operation.query_hash": "4iL1kpGebrS0NAZQbUo76cwD4SUC5jxtUlCdc2149fg=",
             "gql.operation.type": "query",
-            "gql.operation.used_fields": "User.id+username+reviews,Review.body+author,Query.me",
             "gql.response.status": "FIELD_ERROR_NULL_DATA"
           }
         }
@@ -216,11 +218,11 @@ fn generate_operation_name() {
         {
           "Count": 1,
           "Attributes": {
-            "gql.operation.name": "myFavoriteField",
+            "__grafbase.gql.operation.inferred_name": "myFavoriteField",
+            "__grafbase.gql.operation.query_hash": "WDOyTh2uUUEIkab8iqn+MGWh5J3MntAvRkUy3yEpJS8=",
+            "__grafbase.gql.operation.used_fields": "",
             "gql.operation.query": "query {\n  ignoreMe\n  myFavoriteField\n}\n",
-            "gql.operation.query_hash": "WDOyTh2uUUEIkab8iqn+MGWh5J3MntAvRkUy3yEpJS8=",
             "gql.operation.type": "query",
-            "gql.operation.used_fields": "",
             "gql.response.status": "REQUEST_ERROR"
           }
         }
@@ -274,11 +276,12 @@ fn request_error() {
         {
           "Count": 1,
           "Attributes": {
+            "__grafbase.gql.operation.inferred_name": "Faulty",
+            "__grafbase.gql.operation.query_hash": "er/VMZUszb2iQhlPMx46c+flOdO8hXv8PjV1Pk/6u2A=",
+            "__grafbase.gql.operation.used_fields": "",
             "gql.operation.name": "Faulty",
             "gql.operation.query": "query Faulty {\n  __typ__ename\n}\n",
-            "gql.operation.query_hash": "er/VMZUszb2iQhlPMx46c+flOdO8hXv8PjV1Pk/6u2A=",
             "gql.operation.type": "query",
-            "gql.operation.used_fields": "",
             "gql.response.status": "REQUEST_ERROR"
           }
         }
@@ -330,11 +333,12 @@ fn field_error() {
         {
           "Count": 1,
           "Attributes": {
+            "__grafbase.gql.operation.inferred_name": "Faulty",
+            "__grafbase.gql.operation.query_hash": "M4bDtLPhj8uQPEFBdDWqalBphwVy7V5WPXOPHrzyikE=",
+            "__grafbase.gql.operation.used_fields": "User.id,Query.me",
             "gql.operation.name": "Faulty",
             "gql.operation.query": "query Faulty {\n  __typename\n  me {\n    id\n  }\n}\n",
-            "gql.operation.query_hash": "M4bDtLPhj8uQPEFBdDWqalBphwVy7V5WPXOPHrzyikE=",
             "gql.operation.type": "query",
-            "gql.operation.used_fields": "User.id,Query.me",
             "gql.response.status": "FIELD_ERROR_NULL_DATA"
           }
         }
@@ -386,11 +390,12 @@ fn field_error_data_null() {
         {
           "Count": 1,
           "Attributes": {
+            "__grafbase.gql.operation.inferred_name": "Faulty",
+            "__grafbase.gql.operation.query_hash": "Txoer8zp21WTkEG253qN503QOPQP7Pb9utIDx55IVD8=",
+            "__grafbase.gql.operation.used_fields": "User.id,Query.me",
             "gql.operation.name": "Faulty",
             "gql.operation.query": "query Faulty {\n  me {\n    id\n  }\n}\n",
-            "gql.operation.query_hash": "Txoer8zp21WTkEG253qN503QOPQP7Pb9utIDx55IVD8=",
             "gql.operation.type": "query",
-            "gql.operation.used_fields": "User.id,Query.me",
             "gql.response.status": "FIELD_ERROR_NULL_DATA"
           }
         }
@@ -436,11 +441,12 @@ fn client() {
         {
           "Count": 1,
           "Attributes": {
+            "__grafbase.gql.operation.inferred_name": "SimpleQuery",
+            "__grafbase.gql.operation.query_hash": "qIzPxtWwHz0t+aJjvOljljbR3aGLQAA0LI5VXjW/FwQ=",
+            "__grafbase.gql.operation.used_fields": "",
             "gql.operation.name": "SimpleQuery",
             "gql.operation.query": "query SimpleQuery {\n  __typename\n}\n",
-            "gql.operation.query_hash": "qIzPxtWwHz0t+aJjvOljljbR3aGLQAA0LI5VXjW/FwQ=",
             "gql.operation.type": "query",
-            "gql.operation.used_fields": "",
             "gql.response.status": "SUCCESS",
             "http.headers.x-grafbase-client-name": "test",
             "http.headers.x-grafbase-client-version": "1.0.0"


### PR DESCRIPTION
Prefixing a few custom metrics attributes to `__grafbase` and separating our custom operation name from the real one.

I've also fixed the operation name handling. We're generating a custom one if there isn't one already but we were sending it as `gql.operation.name` directly as if it was the real one which is too ambiguous for "public" use. So separated it into `__grafbase.gql.operation.inferred.name`
