### PR TITLE
graphql-schema-diff: add spans to diff changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,11 +1804,10 @@ dependencies = [
 [[package]]
 name = "cynic-codegen"
 version = "3.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0ec86f960a00ce087e96ff6f073f6ff28b6876d69ce8caa06c03fb4143981c"
+source = "git+https://github.com/grafbase/cynic?branch=more-spans#05d60a06ea41c810dcc3023e73147ada38545908"
 dependencies = [
  "counter",
- "cynic-parser 0.4.5",
+ "cynic-parser",
  "darling",
  "once_cell",
  "ouroboros",
@@ -1834,25 +1833,13 @@ dependencies = [
 
 [[package]]
 name = "cynic-parser"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411ab40d3f72ca1442d50a60e572838e5a2f0719b93a77a29647117ffdf67687"
-dependencies = [
- "indexmap 2.2.6",
- "lalrpop-util",
- "logos 0.13.0",
-]
-
-[[package]]
-name = "cynic-parser"
 version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718f6cd8c54ae5249fd42b0c86639df0100b8a86eea2e5f1b915cde2e1481453"
+source = "git+https://github.com/grafbase/cynic?branch=more-spans#05d60a06ea41c810dcc3023e73147ada38545908"
 dependencies = [
  "ariadne",
  "indexmap 2.2.6",
  "lalrpop-util",
- "logos 0.14.0",
+ "logos",
  "pretty",
 ]
 
@@ -3271,7 +3258,7 @@ dependencies = [
  "blake3",
  "bytes",
  "common-types",
- "cynic-parser 0.4.5",
+ "cynic-parser",
  "engine",
  "engine-parser",
  "engine-validation",
@@ -3456,7 +3443,7 @@ version = "0.1.1"
 dependencies = [
  "clap",
  "colored",
- "graphql-lint 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "graphql-lint",
  "thiserror",
 ]
 
@@ -3492,7 +3479,7 @@ dependencies = [
  "grafbase-local-common",
  "grafbase-local-server",
  "graph-ref",
- "graphql-lint 0.1.3",
+ "graphql-lint",
  "graphql-mocks",
  "graphql-ws-client",
  "headers",
@@ -3605,7 +3592,7 @@ version = "0.78.0"
 dependencies = [
  "cynic",
  "cynic-introspection",
- "cynic-parser 0.4.5",
+ "cynic-parser",
  "indoc",
  "reqwest",
  "serde",
@@ -3671,7 +3658,7 @@ dependencies = [
  "common-types",
  "const_format",
  "criterion",
- "cynic-parser 0.4.5",
+ "cynic-parser",
  "dotenv",
  "engine",
  "federated-dev",
@@ -3833,18 +3820,7 @@ name = "graphql-lint"
 version = "0.1.3"
 dependencies = [
  "criterion",
- "cynic-parser 0.4.5",
- "heck 0.5.0",
- "thiserror",
-]
-
-[[package]]
-name = "graphql-lint"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f471b7a105553bc432d405b90ea7737b1a611de7d3741718daffa5f62ac4ddde"
-dependencies = [
- "cynic-parser 0.2.6",
+ "cynic-parser",
  "heck 0.5.0",
  "thiserror",
 ]
@@ -3889,7 +3865,7 @@ dependencies = [
 name = "graphql-schema-diff"
 version = "0.2.0"
 dependencies = [
- "cynic-parser 0.4.5",
+ "cynic-parser",
  "datatest-stable",
  "miette 7.2.0",
  "serde",
@@ -4616,7 +4592,7 @@ dependencies = [
  "ctor",
  "cynic",
  "cynic-introspection",
- "cynic-parser 0.4.5",
+ "cynic-parser",
  "engine",
  "engine-config-builder",
  "engine-parser",
@@ -5136,34 +5112,11 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "logos"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c000ca4d908ff18ac99b93a062cb8958d331c3220719c52e77cb19cc6ac5d2c1"
-dependencies = [
- "logos-derive 0.13.0",
-]
-
-[[package]]
-name = "logos"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161971eb88a0da7ae0c333e1063467c5b5727e7fb6b710b8db4814eade3a42e8"
 dependencies = [
- "logos-derive 0.14.0",
-]
-
-[[package]]
-name = "logos-codegen"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc487311295e0002e452025d6b580b77bb17286de87b57138f3b5db711cded68"
-dependencies = [
- "beef",
- "fnv",
- "proc-macro2",
- "quote",
- "regex-syntax 0.6.29",
- "syn 2.0.72",
+ "logos-derive",
 ]
 
 [[package]]
@@ -5183,20 +5136,11 @@ dependencies = [
 
 [[package]]
 name = "logos-derive"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfc0d229f1f42d790440136d941afd806bc9e949e2bcb8faa813b0f00d1267e"
-dependencies = [
- "logos-codegen 0.13.0",
-]
-
-[[package]]
-name = "logos-derive"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c2a69b3eb68d5bd595107c9ee58d7e07fe2bb5e360cc85b0f084dedac80de0a"
 dependencies = [
- "logos-codegen 0.14.0",
+ "logos-codegen",
 ]
 
 [[package]]
@@ -6307,7 +6251,7 @@ dependencies = [
  "anyhow",
  "blake3",
  "common-types",
- "cynic-parser 0.4.5",
+ "cynic-parser",
  "engine-value",
  "graph-entities",
  "headers",
@@ -7331,7 +7275,7 @@ name = "registry-v2-generator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cynic-parser 0.4.5",
+ "cynic-parser",
  "indexmap 2.2.6",
  "indoc",
  "itertools 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ exclude = ["engine/crates/gateway-v2", "engine/crates/wasi-component-loader/exam
 axum = { git = "https://github.com/grafbase/axum", rev = "c3146f9ca921907d9884fbf7549a1520e9e72eac" } # axum-tungstenite-upgrade
 # Drop when https://github.com/programatik29/axum-server/pull/112 is merged.
 axum-server = { git = "https://github.com/grafbase/axum-server", rev = "bc0c489c82e6fa76648f0d47191330ef4e125347" } # rustls-0.23-tokio-rustls-0.26
+cynic-parser = { git = "https://github.com/grafbase/cynic", branch = "more-spans" }
+cynic-codegen = { git = "https://github.com/grafbase/cynic", branch = "more-spans" }
 multipart-stream = { git = "https://github.com/grafbase/multipart-stream-rs-fork", rev = "06ff198e4041c8a8c1c93e580c260d597727c193" } # http-1.0-fix-multipart-mixed
 names = { git = "https://github.com/grafbase/names", rev = "443800fbb7bc2936c1f2c16f3a5e116698b1454a" } # main
 # FIXME: Drop when a new version is released.

--- a/engine/crates/engine/registry-v2-generator/src/union.rs
+++ b/engine/crates/engine/registry-v2-generator/src/union.rs
@@ -25,8 +25,8 @@ pub fn union_output(
         .enumerate()
         .map(|(variant_index, ty)| -> anyhow::Result<TypeEdge> {
             let target = *model_index
-                .get(ty)
-                .ok_or_else(|| anyhow::anyhow!("Could not find type {ty}"))?;
+                .get(ty.name())
+                .ok_or_else(|| anyhow::anyhow!("Could not find type {ty}", ty = ty.name()))?;
 
             Ok(TypeEdge {
                 index: variant_index,

--- a/engine/crates/graphql-schema-diff/CHANGELOG.md
+++ b/engine/crates/graphql-schema-diff/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Enrich `Change` with spans pointing to the added / changed / removed parts of schemas (https://github.com/grafbase/grafbase/pull/2014)
+
 ## 0.2.0 - 2024-07-16
 
 ### Changed

--- a/engine/crates/graphql-schema-diff/README.md
+++ b/engine/crates/graphql-schema-diff/README.md
@@ -8,7 +8,7 @@ This crate implements diffing of two GraphQL schemas, returning a list of change
 ## Example
 
 ```rust
-use graphql_schema_diff::{diff, Change, ChangeKind};
+use graphql_schema_diff::{diff, Change, ChangeKind, Span};
 
 let source = r#"
   type Pizza {
@@ -49,19 +49,23 @@ assert_eq!(changes,
    &[
         Change {
             path: String::from("Pizza.name"),
-            kind: ChangeKind::ChangeFieldType
+            kind: ChangeKind::ChangeFieldType,
+            span: Span::new(38, 47),
         },
         Change {
             path: String::from("PizzaName"),
-            kind: ChangeKind::AddObjectType
+            kind: ChangeKind::AddObjectType,
+            span: Span::new(81, 142),
         },
         Change {
             path: String::from("Topping.PINEAPPLE"),
-            kind: ChangeKind::RemoveEnumValue
+            kind: ChangeKind::RemoveEnumValue,
+            span: Span::new(0, 0),
         },
         Change {
             path: String::from("Topping.POTATO"),
-            kind: ChangeKind::AddEnumValue
+            kind: ChangeKind::AddEnumValue,
+            span: Span::new(190, 199),
         }
 ]);
 

--- a/engine/crates/graphql-schema-diff/src/lib.rs
+++ b/engine/crates/graphql-schema-diff/src/lib.rs
@@ -6,7 +6,7 @@ mod change;
 mod state;
 mod traverse_schemas;
 
-pub use change::{Change, ChangeKind};
+pub use change::{Change, ChangeKind, Span};
 
 use self::state::*;
 use cynic_parser::type_system as ast;

--- a/engine/crates/graphql-schema-diff/src/state.rs
+++ b/engine/crates/graphql-schema-diff/src/state.rs
@@ -1,3 +1,5 @@
+use change::Span;
+
 use crate::*;
 
 pub(crate) type DiffMap<K, V> = HashMap<K, (Option<V>, Option<V>)>;
@@ -5,10 +7,10 @@ pub(crate) type DiffMap<K, V> = HashMap<K, (Option<V>, Option<V>)>;
 #[derive(Default)]
 pub(crate) struct DiffState<'a> {
     pub(crate) schema_definition_map: [Option<ast::SchemaDefinition<'a>>; 2],
-    pub(crate) types_map: DiffMap<&'a str, DefinitionKind>,
-    pub(crate) fields_map: DiffMap<[&'a str; 2], Option<ast::Type<'a>>>,
+    pub(crate) types_map: DiffMap<&'a str, ast::Definition<'a>>,
+    pub(crate) fields_map: DiffMap<[&'a str; 2], (Option<ast::Type<'a>>, Span)>,
     pub(crate) interface_impls: DiffMap<&'a str, Vec<&'a str>>,
-    pub(crate) arguments_map: DiffMap<[&'a str; 3], (ast::Type<'a>, Option<ast::Value<'a>>)>,
+    pub(crate) arguments_map: DiffMap<[&'a str; 3], ast::InputValueDefinition<'a>>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -21,6 +23,23 @@ pub(crate) enum DefinitionKind {
     Object,
     Scalar,
     Union,
+}
+
+impl DefinitionKind {
+    pub(crate) fn new(definition: &ast::Definition<'_>) -> Option<Self> {
+        match definition {
+            ast::Definition::Schema(_) | ast::Definition::SchemaExtension(_) => None,
+            ast::Definition::Type(ty) | ast::Definition::TypeExtension(ty) => match ty {
+                ast::TypeDefinition::Scalar(_) => Some(DefinitionKind::Scalar),
+                ast::TypeDefinition::Object(_) => Some(DefinitionKind::Object),
+                ast::TypeDefinition::Interface(_) => Some(DefinitionKind::Interface),
+                ast::TypeDefinition::Union(_) => Some(DefinitionKind::Union),
+                ast::TypeDefinition::Enum(_) => Some(DefinitionKind::Enum),
+                ast::TypeDefinition::InputObject(_) => Some(DefinitionKind::InputObject),
+            },
+            ast::Definition::Directive(_) => Some(DefinitionKind::Directive),
+        }
+    }
 }
 
 impl DiffState<'_> {
@@ -59,6 +78,7 @@ fn push_interface_implementer_changes(interface_impls: DiffMap<&str, Vec<&str>>,
                 changes.push(Change {
                     path: format!("{}.{}", src_impl, implementer),
                     kind: ChangeKind::RemoveInterfaceImplementation,
+                    span: Span::empty(),
                 });
             }
         }
@@ -68,6 +88,7 @@ fn push_interface_implementer_changes(interface_impls: DiffMap<&str, Vec<&str>>,
                 changes.push(Change {
                     path: format!("{}.{}", target_impl, implementer),
                     kind: ChangeKind::AddInterfaceImplementation,
+                    span: Span::empty(),
                 });
             }
         }
@@ -75,48 +96,66 @@ fn push_interface_implementer_changes(interface_impls: DiffMap<&str, Vec<&str>>,
 }
 
 fn push_argument_changes(
-    fields_map: &DiffMap<[&str; 2], Option<ast::Type<'_>>>,
-    arguments_map: &DiffMap<[&str; 3], (ast::Type<'_>, Option<ast::Value<'_>>)>,
+    fields_map: &DiffMap<[&str; 2], (Option<ast::Type<'_>>, Span)>,
+    arguments_map: &DiffMap<[&str; 3], ast::InputValueDefinition<'_>>,
     changes: &mut Vec<Change>,
 ) {
     for (path @ [type_name, field_name, _arg_name], (src, target)) in arguments_map {
         let path = *path;
         let parent_is_gone = || matches!(&fields_map[&[*type_name, *field_name]], (Some(_), None));
 
-        let kind = match (src, target) {
+        match (src, target) {
             (None, None) => unreachable!(),
-            (None, Some(_)) => Some(ChangeKind::AddFieldArgument),
-            (Some(_), None) if !parent_is_gone() => Some(ChangeKind::RemoveFieldArgument),
-            (Some(_), None) => None,
-            (Some((src_type, src_default)), Some((target_type, target_default))) => {
-                if src_type != target_type {
+            (None, Some(target)) => {
+                changes.push(Change {
+                    path: path.join("."),
+                    kind: ChangeKind::AddFieldArgument,
+                    span: target.span().into(),
+                });
+            }
+            (Some(_), None) if !parent_is_gone() => {
+                changes.push(Change {
+                    path: path.join("."),
+                    kind: ChangeKind::RemoveFieldArgument,
+                    span: Span::empty(),
+                });
+            }
+            (Some(_), None) => (),
+            (Some(src_arg), Some(target_arg)) => {
+                if src_arg.ty() != target_arg.ty() {
                     changes.push(Change {
                         path: path.join("."),
                         kind: ChangeKind::ChangeFieldArgumentType,
+                        span: target_arg.ty().span().into(),
                     });
                 }
 
-                match (src_default, target_default) {
-                    (None, Some(_)) => Some(ChangeKind::AddFieldArgumentDefault),
-                    (Some(_), None) => Some(ChangeKind::RemoveFieldArgumentDefault),
-                    (Some(a), Some(b)) if a != b => Some(ChangeKind::ChangeFieldArgumentDefault),
-                    _ => None,
+                match (src_arg.default_value(), target_arg.default_value()) {
+                    (None, Some(_)) => changes.push(Change {
+                        path: path.join("."),
+                        kind: ChangeKind::AddFieldArgumentDefault,
+                        span: target_arg.default_value_span().into(),
+                    }),
+                    (Some(_), None) => changes.push(Change {
+                        path: path.join("."),
+                        kind: ChangeKind::RemoveFieldArgumentDefault,
+                        span: Span::empty(),
+                    }),
+                    (Some(a), Some(b)) if a != b => changes.push(Change {
+                        path: path.join("."),
+                        kind: ChangeKind::ChangeFieldArgumentDefault,
+                        span: target_arg.default_value_span().into(),
+                    }),
+                    _ => (),
                 }
             }
         };
-
-        if let Some(kind) = kind {
-            changes.push(Change {
-                path: path.join("."),
-                kind,
-            });
-        }
     }
 }
 
 fn push_field_changes(
-    fields_map: &DiffMap<[&str; 2], Option<ast::Type<'_>>>,
-    types_map: &DiffMap<&str, DefinitionKind>,
+    fields_map: &DiffMap<[&str; 2], (Option<ast::Type<'_>>, Span)>,
+    types_map: &DiffMap<&str, ast::Definition<'_>>,
     changes: &mut Vec<Change>,
 ) {
     for (path @ [type_name, _field_name], (src, target)) in fields_map {
@@ -125,49 +164,56 @@ fn push_field_changes(
 
         let definition = match parent {
             (None, None) => unreachable!(),
-            (Some(a), Some(b)) if a != b => {
+            (Some(a), Some(b)) if DefinitionKind::new(a) != DefinitionKind::new(b) => {
                 continue; // so we don't falsely interpret same name as field type change
             }
             (Some(_), None) | (None, Some(_)) => continue,
             (Some(kind), Some(_)) => *kind,
         };
 
-        let change_kind = match (src, target, definition) {
+        let change_kind = match (src, target, DefinitionKind::new(&definition).unwrap()) {
             (None, None, _) | (_, _, DefinitionKind::Scalar | DefinitionKind::Directive) => {
                 unreachable!()
             }
-            (None, Some(_), DefinitionKind::Object | DefinitionKind::Interface | DefinitionKind::InputObject) => {
-                Some(ChangeKind::AddField)
+            (
+                None,
+                Some((_, span)),
+                DefinitionKind::Object | DefinitionKind::Interface | DefinitionKind::InputObject,
+            ) => Some((ChangeKind::AddField, *span)),
+            (None, Some((_, span)), DefinitionKind::Enum) => Some((ChangeKind::AddEnumValue, *span)),
+            (Some(_), None, DefinitionKind::Enum) if !parent_is_gone() => {
+                Some((ChangeKind::RemoveEnumValue, Span::empty()))
             }
-            (None, Some(_), DefinitionKind::Enum) => Some(ChangeKind::AddEnumValue),
-            (Some(_), None, DefinitionKind::Enum) if !parent_is_gone() => Some(ChangeKind::RemoveEnumValue),
-            (None, Some(_), DefinitionKind::Union) => Some(ChangeKind::AddUnionMember),
-            (Some(_), None, DefinitionKind::Union) if !parent_is_gone() => Some(ChangeKind::RemoveUnionMember),
+            (None, Some((_, span)), DefinitionKind::Union) => Some((ChangeKind::AddUnionMember, *span)),
+            (Some(_), None, DefinitionKind::Union) if !parent_is_gone() => {
+                Some((ChangeKind::RemoveUnionMember, Span::empty()))
+            }
             (Some(_), None, DefinitionKind::Object | DefinitionKind::Interface | DefinitionKind::InputObject)
                 if !parent_is_gone() =>
             {
-                Some(ChangeKind::RemoveField)
+                Some((ChangeKind::RemoveField, Span::empty()))
             }
             (
-                Some(ty_a),
-                Some(ty_b),
+                Some((ty_a, _)),
+                Some((ty_b, _)),
                 DefinitionKind::Object | DefinitionKind::InputObject | DefinitionKind::Interface,
-            ) if ty_a.as_ref() != ty_b.as_ref() => Some(ChangeKind::ChangeFieldType),
+            ) if ty_a.as_ref() != ty_b.as_ref() => Some((ChangeKind::ChangeFieldType, ty_b.unwrap().span().into())),
             (Some(_), None, _) => None,
             (Some(_), Some(_), _) => None,
         };
 
-        if let Some(kind) = change_kind {
+        if let Some((kind, span)) = change_kind {
             changes.push(Change {
                 path: path.join("."),
                 kind,
+                span,
             });
         }
     }
 }
 
 fn push_definition_changes(
-    types_map: &HashMap<&str, (Option<DefinitionKind>, Option<DefinitionKind>)>,
+    types_map: &HashMap<&str, (Option<ast::Definition<'_>>, Option<ast::Definition<'_>>)>,
     changes: &mut Vec<Change>,
 ) {
     for (name, entries) in types_map {
@@ -175,7 +221,7 @@ fn push_definition_changes(
             (None, None) => unreachable!(),
             (None, Some(definition)) => push_added_type(name, *definition, changes),
             (Some(definition), None) => push_removed_type(name, *definition, changes),
-            (Some(a), Some(b)) if a != b => {
+            (Some(a), Some(b)) if DefinitionKind::new(a) != DefinitionKind::new(b) => {
                 push_removed_type(name, *a, changes);
                 push_added_type(name, *b, changes);
             }
@@ -184,7 +230,11 @@ fn push_definition_changes(
     }
 }
 
-fn push_added_type(name: &str, kind: DefinitionKind, changes: &mut Vec<Change>) {
+fn push_added_type(name: &str, definition: ast::Definition<'_>, changes: &mut Vec<Change>) {
+    let Some(kind) = DefinitionKind::new(&definition) else {
+        return;
+    };
+
     let change_kind = match kind {
         DefinitionKind::Directive => ChangeKind::AddDirectiveDefinition,
         DefinitionKind::Enum => ChangeKind::AddEnum,
@@ -198,11 +248,12 @@ fn push_added_type(name: &str, kind: DefinitionKind, changes: &mut Vec<Change>) 
     changes.push(Change {
         path: name.to_owned(),
         kind: change_kind,
+        span: definition.span().into(),
     });
 }
 
-fn push_removed_type(name: &str, kind: DefinitionKind, changes: &mut Vec<Change>) {
-    let change_kind = match kind {
+fn push_removed_type(name: &str, definition: ast::Definition<'_>, changes: &mut Vec<Change>) {
+    let change_kind = match DefinitionKind::new(&definition).unwrap() {
         DefinitionKind::Directive => ChangeKind::RemoveDirectiveDefinition,
         DefinitionKind::Enum => ChangeKind::RemoveEnum,
         DefinitionKind::InputObject => ChangeKind::RemoveInputObject,
@@ -215,6 +266,7 @@ fn push_removed_type(name: &str, kind: DefinitionKind, changes: &mut Vec<Change>
     changes.push(Change {
         path: name.to_owned(),
         kind: change_kind,
+        span: definition.span().into(),
     });
 }
 
@@ -231,34 +283,41 @@ fn push_schema_definition_changes(
             let [target_query, target_mutation, target_subscription] =
                 [target.query_type(), target.mutation_type(), target.subscription_type()];
 
-            if src_query != target_query {
+            if src_query.map(|ty| ty.named_type()) != target_query.map(|ty| ty.named_type()) {
                 changes.push(Change {
                     path: String::new(),
                     kind: ChangeKind::ChangeQueryType,
+                    span: target_query.map(|ty| ty.span().into()).unwrap_or_else(Span::empty),
                 });
             }
 
-            if src_mutation != target_mutation {
+            if src_mutation.map(|ty| ty.named_type()) != target_mutation.map(|ty| ty.named_type()) {
                 changes.push(Change {
                     path: String::new(),
                     kind: ChangeKind::ChangeMutationType,
+                    span: target_mutation.map(|ty| ty.span().into()).unwrap_or_else(Span::empty),
                 });
             }
 
-            if src_subscription != target_subscription {
+            if src_subscription.map(|ty| ty.named_type()) != target_subscription.map(|ty| ty.named_type()) {
                 changes.push(Change {
                     path: String::new(),
                     kind: ChangeKind::ChangeSubscriptionType,
+                    span: target_subscription
+                        .map(|ty| ty.span().into())
+                        .unwrap_or_else(Span::empty),
                 });
             }
         }
-        [None, Some(_)] => changes.push(Change {
+        [None, Some(definition)] => changes.push(Change {
             path: String::new(),
             kind: ChangeKind::AddSchemaDefinition,
+            span: definition.span().into(),
         }),
         [Some(_), None] => changes.push(Change {
             path: String::new(),
             kind: ChangeKind::RemoveSchemaDefinition,
+            span: Span::empty(),
         }),
     }
 }

--- a/engine/crates/graphql-schema-diff/src/traverse_schemas.rs
+++ b/engine/crates/graphql-schema-diff/src/traverse_schemas.rs
@@ -1,4 +1,4 @@
-use crate::{ast, DefinitionKind, DiffMap, DiffState};
+use crate::{ast, DiffMap, DiffState};
 use std::{collections::hash_map::Entry, hash::Hash};
 
 /// Traverse the source and target schemas, populating the `DiffState`.
@@ -22,23 +22,23 @@ pub(crate) fn traverse_schemas<'a>(
 }
 
 fn traverse_source<'a>(source: &'a ast::TypeSystemDocument, state: &mut DiffState<'a>) {
-    for tpe in source.definitions() {
-        match tpe {
+    for definition in source.definitions() {
+        match definition {
             ast::Definition::Schema(def) | ast::Definition::SchemaExtension(def) => {
                 state.schema_definition_map[0] = Some(def);
             }
             ast::Definition::Directive(directive_def) => {
-                insert_source(&mut state.types_map, directive_def.name(), DefinitionKind::Directive);
+                insert_source(&mut state.types_map, directive_def.name(), definition);
             }
             ast::Definition::Type(tpe) | ast::Definition::TypeExtension(tpe) => {
                 let type_name = tpe.name();
 
                 match &tpe {
                     ast::TypeDefinition::Scalar(_) => {
-                        state.types_map.insert(type_name, (Some(DefinitionKind::Scalar), None));
+                        state.types_map.insert(type_name, (Some(definition), None));
                     }
                     ast::TypeDefinition::Object(obj) => {
-                        state.types_map.insert(type_name, (Some(DefinitionKind::Object), None));
+                        state.types_map.insert(type_name, (Some(definition), None));
                         insert_source(
                             &mut state.interface_impls,
                             type_name,
@@ -48,16 +48,18 @@ fn traverse_source<'a>(source: &'a ast::TypeSystemDocument, state: &mut DiffStat
                         for field in obj.fields() {
                             let field_name = field.name();
 
-                            insert_source(&mut state.fields_map, [type_name, field_name], Some(field.ty()));
+                            insert_source(
+                                &mut state.fields_map,
+                                [type_name, field_name],
+                                (Some(field.ty()), field.span().into()),
+                            );
 
                             let mut args = field.arguments();
                             fill_args_src(&mut state.arguments_map, type_name, field_name, &mut args);
                         }
                     }
                     ast::TypeDefinition::Interface(iface) => {
-                        state
-                            .types_map
-                            .insert(type_name, (Some(DefinitionKind::Interface), None));
+                        state.types_map.insert(type_name, (Some(definition), None));
                         insert_source(
                             &mut state.interface_impls,
                             type_name,
@@ -67,32 +69,46 @@ fn traverse_source<'a>(source: &'a ast::TypeSystemDocument, state: &mut DiffStat
                         for field in iface.fields() {
                             let field_name = field.name();
 
-                            insert_source(&mut state.fields_map, [type_name, field_name], Some(field.ty()));
+                            insert_source(
+                                &mut state.fields_map,
+                                [type_name, field_name],
+                                (Some(field.ty()), field.span().into()),
+                            );
 
                             fill_args_src(&mut state.arguments_map, type_name, field_name, &mut field.arguments());
                         }
                     }
                     ast::TypeDefinition::Union(union) => {
-                        state.types_map.insert(type_name, (Some(DefinitionKind::Union), None));
+                        state.types_map.insert(type_name, (Some(definition), None));
 
                         for member in union.members() {
-                            insert_source(&mut state.fields_map, [type_name, member], None);
+                            insert_source(
+                                &mut state.fields_map,
+                                [type_name, member.name()],
+                                (None, member.span().into()),
+                            );
                         }
                     }
                     ast::TypeDefinition::Enum(enm) => {
-                        state.types_map.insert(type_name, (Some(DefinitionKind::Enum), None));
+                        state.types_map.insert(type_name, (Some(definition), None));
 
                         for value in enm.values() {
-                            insert_source(&mut state.fields_map, [type_name, value.value()], None);
+                            insert_source(
+                                &mut state.fields_map,
+                                [type_name, value.value()],
+                                (None, value.span().into()),
+                            );
                         }
                     }
                     ast::TypeDefinition::InputObject(input) => {
-                        state
-                            .types_map
-                            .insert(type_name, (Some(DefinitionKind::InputObject), None));
+                        state.types_map.insert(type_name, (Some(definition), None));
 
                         for field in input.fields() {
-                            insert_source(&mut state.fields_map, [type_name, field.name()], Some(field.ty()));
+                            insert_source(
+                                &mut state.fields_map,
+                                [type_name, field.name()],
+                                (Some(field.ty()), field.span().into()),
+                            );
                         }
                     }
                 }
@@ -102,36 +118,39 @@ fn traverse_source<'a>(source: &'a ast::TypeSystemDocument, state: &mut DiffStat
 }
 
 fn traverse_target<'a>(target: &'a ast::TypeSystemDocument, state: &mut DiffState<'a>) {
-    for tpe in target.definitions() {
-        match tpe {
+    for definition in target.definitions() {
+        match definition {
             ast::Definition::Schema(def) | ast::Definition::SchemaExtension(def) => {
                 state.schema_definition_map[1] = Some(def);
             }
             ast::Definition::Directive(directive_def) => {
-                merge_target(state.types_map.entry(directive_def.name()), DefinitionKind::Directive);
+                merge_target(state.types_map.entry(directive_def.name()), definition);
             }
             ast::Definition::Type(tpe) | ast::Definition::TypeExtension(tpe) => {
                 let type_name = tpe.name();
 
                 match tpe {
                     ast::TypeDefinition::Scalar(_) => {
-                        state.types_map.entry(type_name).or_default().1 = Some(DefinitionKind::Scalar);
+                        state.types_map.entry(type_name).or_default().1 = Some(definition);
                     }
                     ast::TypeDefinition::Object(obj) => {
-                        state.types_map.entry(type_name).or_default().1 = Some(DefinitionKind::Object);
+                        state.types_map.entry(type_name).or_default().1 = Some(definition);
                         merge_target(
                             state.interface_impls.entry(type_name),
                             obj.implements_interfaces().collect(),
                         );
 
                         for field in obj.fields() {
-                            merge_target(state.fields_map.entry([type_name, field.name()]), Some(field.ty()));
+                            merge_target(
+                                state.fields_map.entry([type_name, field.name()]),
+                                (Some(field.ty()), field.span().into()),
+                            );
                             let mut args = field.arguments();
                             args_target(&mut state.arguments_map, type_name, field.name(), &mut args);
                         }
                     }
                     ast::TypeDefinition::Interface(iface) => {
-                        state.types_map.entry(type_name).or_default().1 = Some(DefinitionKind::Interface);
+                        state.types_map.entry(type_name).or_default().1 = Some(definition);
                         merge_target(
                             state.interface_impls.entry(type_name),
                             iface.implements_interfaces().collect(),
@@ -140,29 +159,41 @@ fn traverse_target<'a>(target: &'a ast::TypeSystemDocument, state: &mut DiffStat
                         for field in iface.fields() {
                             let field_name = field.name();
 
-                            merge_target(state.fields_map.entry([type_name, field_name]), Some(field.ty()));
+                            merge_target(
+                                state.fields_map.entry([type_name, field_name]),
+                                (Some(field.ty()), field.span().into()),
+                            );
                             args_target(&mut state.arguments_map, type_name, field_name, &mut field.arguments());
                         }
                     }
                     ast::TypeDefinition::Union(union) => {
-                        state.types_map.entry(type_name).or_default().1 = Some(DefinitionKind::Union);
+                        state.types_map.entry(type_name).or_default().1 = Some(definition);
 
                         for member in union.members() {
-                            merge_target(state.fields_map.entry([type_name, member]), None);
+                            merge_target(
+                                state.fields_map.entry([type_name, member.name()]),
+                                (None, member.span().into()),
+                            );
                         }
                     }
                     ast::TypeDefinition::Enum(enm) => {
-                        state.types_map.entry(type_name).or_default().1 = Some(DefinitionKind::Enum);
+                        state.types_map.entry(type_name).or_default().1 = Some(definition);
 
                         for value in enm.values() {
-                            merge_target(state.fields_map.entry([type_name, value.value()]), None);
+                            merge_target(
+                                state.fields_map.entry([type_name, value.value()]),
+                                (None, value.span().into()),
+                            );
                         }
                     }
                     ast::TypeDefinition::InputObject(input) => {
-                        state.types_map.entry(type_name).or_default().1 = Some(DefinitionKind::InputObject);
+                        state.types_map.entry(type_name).or_default().1 = Some(definition);
 
                         for field in input.fields() {
-                            merge_target(state.fields_map.entry([type_name, field.name()]), Some(field.ty()));
+                            merge_target(
+                                state.fields_map.entry([type_name, field.name()]),
+                                (Some(field.ty()), field.span().into()),
+                            );
                         }
                     }
                 }
@@ -173,32 +204,25 @@ fn traverse_target<'a>(target: &'a ast::TypeSystemDocument, state: &mut DiffStat
 
 // Insert the arguments of a field into the DiffState.
 fn fill_args_src<'a>(
-    arguments_map: &mut DiffMap<[&'a str; 3], (ast::Type<'a>, Option<ast::Value<'a>>)>,
+    arguments_map: &mut DiffMap<[&'a str; 3], ast::InputValueDefinition<'a>>,
     parent: &'a str,
     field: &'a str,
     args: &mut (dyn Iterator<Item = ast::InputValueDefinition<'a>> + 'a),
 ) {
     for arg in args {
-        insert_source(
-            arguments_map,
-            [parent, field, (arg.name())],
-            (arg.ty(), arg.default_value()),
-        )
+        insert_source(arguments_map, [parent, field, (arg.name())], arg)
     }
 }
 
 // Merge the arguments of a field in the target schema into the DiffState.
 fn args_target<'a>(
-    arguments_map: &mut DiffMap<[&'a str; 3], (ast::Type<'a>, Option<ast::Value<'a>>)>,
+    arguments_map: &mut DiffMap<[&'a str; 3], ast::InputValueDefinition<'a>>,
     parent: &'a str,
     field: &'a str,
     args: &mut (dyn Iterator<Item = ast::InputValueDefinition<'a>> + 'a),
 ) {
     for arg in args {
-        merge_target(
-            arguments_map.entry([parent, field, arg.name()]),
-            (arg.ty(), arg.default_value()),
-        )
+        merge_target(arguments_map.entry([parent, field, arg.name()]), arg)
     }
 }
 

--- a/engine/crates/graphql-schema-diff/tests/diff/add_fields.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/add_fields.snapshot.json
@@ -2,29 +2,53 @@
   "src → target": [
     {
       "path": "CatInHat.whimsicalQuote",
-      "kind": "AddField"
+      "kind": "AddField",
+      "span": {
+        "start": 154,
+        "end": 180
+      }
     },
     {
       "path": "CreateSeussCharacterInput.favoriteRhyme",
-      "kind": "AddField"
+      "kind": "AddField",
+      "span": {
+        "start": 252,
+        "end": 275
+      }
     },
     {
       "path": "SeussCharacter.whimsicalQuote",
-      "kind": "AddField"
+      "kind": "AddField",
+      "span": {
+        "start": 57,
+        "end": 81
+      }
     }
   ],
   "target → src": [
     {
       "path": "CatInHat.whimsicalQuote",
-      "kind": "RemoveField"
+      "kind": "RemoveField",
+      "span": {
+        "start": 0,
+        "end": 0
+      }
     },
     {
       "path": "CreateSeussCharacterInput.favoriteRhyme",
-      "kind": "RemoveField"
+      "kind": "RemoveField",
+      "span": {
+        "start": 0,
+        "end": 0
+      }
     },
     {
       "path": "SeussCharacter.whimsicalQuote",
-      "kind": "RemoveField"
+      "kind": "RemoveField",
+      "span": {
+        "start": 0,
+        "end": 0
+      }
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/add_one_object.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/add_one_object.snapshot.json
@@ -2,13 +2,21 @@
   "src → target": [
     {
       "path": "Locust",
-      "kind": "AddObjectType"
+      "kind": "AddObjectType",
+      "span": {
+        "start": 16,
+        "end": 41
+      }
     }
   ],
   "target → src": [
     {
       "path": "Locust",
-      "kind": "RemoveObjectType"
+      "kind": "RemoveObjectType",
+      "span": {
+        "start": 16,
+        "end": 41
+      }
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/directive_basic.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/directive_basic.snapshot.json
@@ -2,13 +2,21 @@
   "src → target": [
     {
       "path": "auth",
-      "kind": "RemoveDirectiveDefinition"
+      "kind": "RemoveDirectiveDefinition",
+      "span": {
+        "start": 12,
+        "end": 80
+      }
     }
   ],
   "target → src": [
     {
       "path": "auth",
-      "kind": "AddDirectiveDefinition"
+      "kind": "AddDirectiveDefinition",
+      "span": {
+        "start": 12,
+        "end": 80
+      }
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/empty_source.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/empty_source.snapshot.json
@@ -2,13 +2,21 @@
   "src → target": [
     {
       "path": "Cat",
-      "kind": "AddObjectType"
+      "kind": "AddObjectType",
+      "span": {
+        "start": 2,
+        "end": 10
+      }
     }
   ],
   "target → src": [
     {
       "path": "Cat",
-      "kind": "RemoveObjectType"
+      "kind": "RemoveObjectType",
+      "span": {
+        "start": 2,
+        "end": 10
+      }
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/enum_basic.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/enum_basic.snapshot.json
@@ -2,21 +2,37 @@
   "src → target": [
     {
       "path": "Color.ALPHA",
-      "kind": "AddEnumValue"
+      "kind": "AddEnumValue",
+      "span": {
+        "start": 50,
+        "end": 56
+      }
     },
     {
       "path": "People",
-      "kind": "RemoveEnum"
+      "kind": "RemoveEnum",
+      "span": {
+        "start": 49,
+        "end": 76
+      }
     }
   ],
   "target → src": [
     {
       "path": "Color.ALPHA",
-      "kind": "RemoveEnumValue"
+      "kind": "RemoveEnumValue",
+      "span": {
+        "start": 0,
+        "end": 0
+      }
     },
     {
       "path": "People",
-      "kind": "AddEnum"
+      "kind": "AddEnum",
+      "span": {
+        "start": 49,
+        "end": 76
+      }
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/field_argument_default.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/field_argument_default.snapshot.json
@@ -2,13 +2,21 @@
   "src → target": [
     {
       "path": "Query.doMop.useMop",
-      "kind": "AddFieldArgumentDefault"
+      "kind": "AddFieldArgumentDefault",
+      "span": {
+        "start": 35,
+        "end": 42
+      }
     }
   ],
   "target → src": [
     {
       "path": "Query.doMop.useMop",
-      "kind": "RemoveFieldArgumentDefault"
+      "kind": "RemoveFieldArgumentDefault",
+      "span": {
+        "start": 0,
+        "end": 0
+      }
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/field_argument_default_value.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/field_argument_default_value.snapshot.json
@@ -2,13 +2,21 @@
   "src → target": [
     {
       "path": "Query.doMop.useMop",
-      "kind": "ChangeFieldArgumentDefault"
+      "kind": "ChangeFieldArgumentDefault",
+      "span": {
+        "start": 35,
+        "end": 42
+      }
     }
   ],
   "target → src": [
     {
       "path": "Query.doMop.useMop",
-      "kind": "ChangeFieldArgumentDefault"
+      "kind": "ChangeFieldArgumentDefault",
+      "span": {
+        "start": 33,
+        "end": 40
+      }
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/field_arguments_basic.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/field_arguments_basic.snapshot.json
@@ -2,21 +2,37 @@
   "src → target": [
     {
       "path": "MapleSyrup.pricePerLiter.currency",
-      "kind": "RemoveFieldArgument"
+      "kind": "RemoveFieldArgument",
+      "span": {
+        "start": 0,
+        "end": 0
+      }
     },
     {
       "path": "PriceArgs.currency",
-      "kind": "AddField"
+      "kind": "AddField",
+      "span": {
+        "start": 299,
+        "end": 317
+      }
     }
   ],
   "target → src": [
     {
       "path": "MapleSyrup.pricePerLiter.currency",
-      "kind": "AddFieldArgument"
+      "kind": "AddFieldArgument",
+      "span": {
+        "start": 228,
+        "end": 245
+      }
     },
     {
       "path": "PriceArgs.currency",
-      "kind": "RemoveField"
+      "kind": "RemoveField",
+      "span": {
+        "start": 0,
+        "end": 0
+      }
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/field_type_change.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/field_type_change.snapshot.json
@@ -2,21 +2,37 @@
   "src → target": [
     {
       "path": "Mutation.drop",
-      "kind": "ChangeFieldType"
+      "kind": "ChangeFieldType",
+      "span": {
+        "start": 40,
+        "end": 44
+      }
     },
     {
       "path": "Mutation.drop.coin",
-      "kind": "ChangeFieldArgumentType"
+      "kind": "ChangeFieldArgumentType",
+      "span": {
+        "start": 31,
+        "end": 37
+      }
     }
   ],
   "target → src": [
     {
       "path": "Mutation.drop",
-      "kind": "ChangeFieldType"
+      "kind": "ChangeFieldType",
+      "span": {
+        "start": 36,
+        "end": 43
+      }
     },
     {
       "path": "Mutation.drop.coin",
-      "kind": "ChangeFieldArgumentType"
+      "kind": "ChangeFieldArgumentType",
+      "span": {
+        "start": 29,
+        "end": 33
+      }
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/field_wrapping_type_changes.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/field_wrapping_type_changes.snapshot.json
@@ -2,37 +2,69 @@
   "src → target": [
     {
       "path": "Mutation.isTuesday",
-      "kind": "ChangeFieldType"
+      "kind": "ChangeFieldType",
+      "span": {
+        "start": 92,
+        "end": 100
+      }
     },
     {
       "path": "Mutation.isTuesday.exceptions",
-      "kind": "ChangeFieldArgumentType"
+      "kind": "ChangeFieldArgumentType",
+      "span": {
+        "start": 81,
+        "end": 89
+      }
     },
     {
       "path": "Mutation.isTuesday.lat",
-      "kind": "ChangeFieldArgumentType"
+      "kind": "ChangeFieldArgumentType",
+      "span": {
+        "start": 48,
+        "end": 54
+      }
     },
     {
       "path": "Mutation.isTuesday.lon",
-      "kind": "ChangeFieldArgumentType"
+      "kind": "ChangeFieldArgumentType",
+      "span": {
+        "start": 61,
+        "end": 67
+      }
     }
   ],
   "target → src": [
     {
       "path": "Mutation.isTuesday",
-      "kind": "ChangeFieldType"
+      "kind": "ChangeFieldType",
+      "span": {
+        "start": 86,
+        "end": 93
+      }
     },
     {
       "path": "Mutation.isTuesday.exceptions",
-      "kind": "ChangeFieldArgumentType"
+      "kind": "ChangeFieldArgumentType",
+      "span": {
+        "start": 77,
+        "end": 83
+      }
     },
     {
       "path": "Mutation.isTuesday.lat",
-      "kind": "ChangeFieldArgumentType"
+      "kind": "ChangeFieldArgumentType",
+      "span": {
+        "start": 46,
+        "end": 51
+      }
     },
     {
       "path": "Mutation.isTuesday.lon",
-      "kind": "ChangeFieldArgumentType"
+      "kind": "ChangeFieldArgumentType",
+      "span": {
+        "start": 58,
+        "end": 63
+      }
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/interface_implements_interface.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/interface_implements_interface.snapshot.json
@@ -2,13 +2,21 @@
   "src → target": [
     {
       "path": "Candy.Cookie",
-      "kind": "AddInterfaceImplementation"
+      "kind": "AddInterfaceImplementation",
+      "span": {
+        "start": 0,
+        "end": 0
+      }
     }
   ],
   "target → src": [
     {
       "path": "Candy.Cookie",
-      "kind": "RemoveInterfaceImplementation"
+      "kind": "RemoveInterfaceImplementation",
+      "span": {
+        "start": 0,
+        "end": 0
+      }
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/mutation_type_changed.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/mutation_type_changed.snapshot.json
@@ -2,13 +2,21 @@
   "src → target": [
     {
       "path": "",
-      "kind": "ChangeMutationType"
+      "kind": "ChangeMutationType",
+      "span": {
+        "start": 45,
+        "end": 46
+      }
     }
   ],
   "target → src": [
     {
       "path": "",
-      "kind": "ChangeMutationType"
+      "kind": "ChangeMutationType",
+      "span": {
+        "start": 45,
+        "end": 46
+      }
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/object_becomes_enum.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/object_becomes_enum.snapshot.json
@@ -2,21 +2,37 @@
   "src → target": [
     {
       "path": "Color",
-      "kind": "RemoveObjectType"
+      "kind": "RemoveObjectType",
+      "span": {
+        "start": 0,
+        "end": 56
+      }
     },
     {
       "path": "Color",
-      "kind": "AddEnum"
+      "kind": "AddEnum",
+      "span": {
+        "start": 2,
+        "end": 43
+      }
     }
   ],
   "target → src": [
     {
       "path": "Color",
-      "kind": "AddObjectType"
+      "kind": "AddObjectType",
+      "span": {
+        "start": 0,
+        "end": 56
+      }
     },
     {
       "path": "Color",
-      "kind": "RemoveEnum"
+      "kind": "RemoveEnum",
+      "span": {
+        "start": 2,
+        "end": 43
+      }
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/object_interface.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/object_interface.snapshot.json
@@ -2,13 +2,21 @@
   "src → target": [
     {
       "path": "Candy.Cookie",
-      "kind": "AddInterfaceImplementation"
+      "kind": "AddInterfaceImplementation",
+      "span": {
+        "start": 0,
+        "end": 0
+      }
     }
   ],
   "target → src": [
     {
       "path": "Candy.Cookie",
-      "kind": "RemoveInterfaceImplementation"
+      "kind": "RemoveInterfaceImplementation",
+      "span": {
+        "start": 0,
+        "end": 0
+      }
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/query_type_changed.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/query_type_changed.snapshot.json
@@ -2,13 +2,21 @@
   "src → target": [
     {
       "path": "",
-      "kind": "ChangeQueryType"
+      "kind": "ChangeQueryType",
+      "span": {
+        "start": 52,
+        "end": 53
+      }
     }
   ],
   "target → src": [
     {
       "path": "",
-      "kind": "ChangeQueryType"
+      "kind": "ChangeQueryType",
+      "span": {
+        "start": 32,
+        "end": 33
+      }
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/schema_definition_basic.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/schema_definition_basic.snapshot.json
@@ -2,13 +2,21 @@
   "src → target": [
     {
       "path": "",
-      "kind": "RemoveSchemaDefinition"
+      "kind": "RemoveSchemaDefinition",
+      "span": {
+        "start": 0,
+        "end": 0
+      }
     }
   ],
   "target → src": [
     {
       "path": "",
-      "kind": "AddSchemaDefinition"
+      "kind": "AddSchemaDefinition",
+      "span": {
+        "start": 7,
+        "end": 18
+      }
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/subscription_type_changed.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/subscription_type_changed.snapshot.json
@@ -2,21 +2,37 @@
   "src → target": [
     {
       "path": "",
-      "kind": "ChangeMutationType"
+      "kind": "ChangeMutationType",
+      "span": {
+        "start": 63,
+        "end": 64
+      }
     },
     {
       "path": "",
-      "kind": "ChangeSubscriptionType"
+      "kind": "ChangeSubscriptionType",
+      "span": {
+        "start": 80,
+        "end": 81
+      }
     }
   ],
   "target → src": [
     {
       "path": "",
-      "kind": "ChangeMutationType"
+      "kind": "ChangeMutationType",
+      "span": {
+        "start": 49,
+        "end": 50
+      }
     },
     {
       "path": "",
-      "kind": "ChangeSubscriptionType"
+      "kind": "ChangeSubscriptionType",
+      "span": {
+        "start": 66,
+        "end": 67
+      }
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/union_basic.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/union_basic.snapshot.json
@@ -2,13 +2,21 @@
   "src → target": [
     {
       "path": "Color",
-      "kind": "RemoveUnion"
+      "kind": "RemoveUnion",
+      "span": {
+        "start": 45,
+        "end": 77
+      }
     }
   ],
   "target → src": [
     {
       "path": "Color",
-      "kind": "AddUnion"
+      "kind": "AddUnion",
+      "span": {
+        "start": 45,
+        "end": 77
+      }
     }
   ]
 }

--- a/engine/crates/graphql-schema-diff/tests/diff/union_members.snapshot.json
+++ b/engine/crates/graphql-schema-diff/tests/diff/union_members.snapshot.json
@@ -2,13 +2,21 @@
   "src → target": [
     {
       "path": "FloralProduct.FloralArrangement",
-      "kind": "RemoveUnionMember"
+      "kind": "RemoveUnionMember",
+      "span": {
+        "start": 0,
+        "end": 0
+      }
     }
   ],
   "target → src": [
     {
       "path": "FloralProduct.FloralArrangement",
-      "kind": "AddUnionMember"
+      "kind": "AddUnionMember",
+      "span": {
+        "start": 123,
+        "end": 140
+      }
     }
   ]
 }

--- a/engine/crates/integration-tests/Cargo.toml
+++ b/engine/crates/integration-tests/Cargo.toml
@@ -97,7 +97,7 @@ features = ["tower"]
 
 [dev-dependencies]
 similar-asserts = "1.5"
-cynic-parser = "0.4"
+cynic-parser.workspace = true
 base64.workspace = true
 rstest.workspace = true
 const_format = "0.2.32"

--- a/engine/crates/partial-caching/Cargo.toml
+++ b/engine/crates/partial-caching/Cargo.toml
@@ -11,8 +11,7 @@ repository.workspace = true
 anyhow.workspace = true
 blake3.workspace = true
 common-types.workspace = true
-cynic-parser.features = ["print"]
-cynic-parser.workspace = true
+cynic-parser = { workspace = true, features = ["print"] }
 engine-value.workspace = true
 graph-entities.workspace = true
 headers.workspace = true

--- a/gqlint/Cargo.toml
+++ b/gqlint/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 [dependencies]
 clap = {version = "4.5.4", features = ["derive"] }
 colored = "2.1.0"
-graphql-lint = "0.1.3"
+graphql-lint = { path = "../graphql-lint", version = "0.1.3" }
 thiserror.workspace = true
 
 [lints]

--- a/graphql-introspection/Cargo.toml
+++ b/graphql-introspection/Cargo.toml
@@ -15,6 +15,5 @@ indoc = "2.0.5"
 reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 cynic = { workspace = true, features = ["http-reqwest"] }
 cynic-introspection.workspace = true
-cynic-parser.workspace = true
-cynic-parser.features = ["pretty"]
+cynic-parser = { workspace = true,  features = ["pretty"] }
 serde = "1.0.199"

--- a/graphql-lint/Cargo.toml
+++ b/graphql-lint/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-cynic-parser = "0.4.0"
+cynic-parser.workspace = true
 heck = "0.5.0"
 thiserror.workspace = true
 


### PR DESCRIPTION
The goal is to enable, in a follow-up PR, taking a base schema and a diff, and applying the diff to the base schema to obtain a patched schema.

closes GB-7272