### PR TITLE
feat: implement caching metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3593,6 +3593,7 @@ dependencies = [
  "grafbase-graphql-introspection",
  "grafbase-telemetry",
  "graph-ref",
+ "handlebars",
  "http",
  "indoc",
  "insta",

--- a/engine/crates/engine-v2/src/sources/graphql/mod.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/mod.rs
@@ -1,5 +1,6 @@
 mod deserialize;
 mod federation;
+mod record;
 mod request;
 mod root_fields;
 mod subscription;

--- a/engine/crates/engine-v2/src/sources/graphql/record.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/record.rs
@@ -1,8 +1,9 @@
 use grafbase_telemetry::{
     gql_response_status::SubgraphResponseStatus,
     metrics::{
-        SubgraphInFlightRequestAttributes, SubgraphRequestBodySizeAttributes, SubgraphRequestDurationAttributes,
-        SubgraphRequestRetryAttributes, SubgraphResponseBodySizeAttributes,
+        SubgraphCacheHitAttributes, SubgraphCacheMissAttributes, SubgraphInFlightRequestAttributes,
+        SubgraphRequestBodySizeAttributes, SubgraphRequestDurationAttributes, SubgraphRequestRetryAttributes,
+        SubgraphResponseBodySizeAttributes,
     },
 };
 use schema::sources::graphql::GraphqlEndpointWalker;
@@ -82,6 +83,25 @@ pub(super) fn decrement_inflight_requests<R: Runtime>(
     ctx.engine
         .operation_metrics
         .decrement_subgraph_inflight_requests(SubgraphInFlightRequestAttributes {
+            name: endpoint.subgraph_name().to_string(),
+        });
+}
+
+pub(super) fn record_subgraph_cache_hit<R: Runtime>(ctx: ExecutionContext<'_, R>, endpoint: GraphqlEndpointWalker<'_>) {
+    ctx.engine
+        .operation_metrics
+        .record_subgraph_cache_hit(SubgraphCacheHitAttributes {
+            name: endpoint.subgraph_name().to_string(),
+        });
+}
+
+pub(super) fn record_subgraph_cache_miss<R: Runtime>(
+    ctx: ExecutionContext<'_, R>,
+    endpoint: GraphqlEndpointWalker<'_>,
+) {
+    ctx.engine
+        .operation_metrics
+        .record_subgraph_cache_miss(SubgraphCacheMissAttributes {
             name: endpoint.subgraph_name().to_string(),
         });
 }

--- a/engine/crates/engine-v2/src/sources/graphql/request/execute.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/request/execute.rs
@@ -1,5 +1,3 @@
-mod record;
-
 use std::borrow::Cow;
 
 use bytes::Bytes;
@@ -22,6 +20,7 @@ use web_time::{Duration, SystemTime};
 use crate::{
     execution::{ExecutionContext, ExecutionError, ExecutionResult},
     response::SubgraphResponse,
+    sources::graphql::record,
     Runtime,
 };
 

--- a/engine/crates/runtime-local/src/operation_cache.rs
+++ b/engine/crates/runtime-local/src/operation_cache.rs
@@ -1,3 +1,4 @@
+use mini_moka::sync::ConcurrentCacheExt;
 use runtime::operation_cache::{OperationCache, OperationCacheFactory};
 
 pub struct InMemoryOperationCacheConfig {
@@ -49,8 +50,10 @@ impl<V> OperationCache<V> for InMemoryOperationCache<V>
 where
     V: Clone + Send + Sync + 'static + serde::Serialize + serde::de::DeserializeOwned,
 {
-    async fn insert(&self, key: String, value: V) {
+    async fn insert(&self, key: String, value: V) -> u64 {
         self.inner.insert(key, value);
+        self.inner.sync();
+        self.inner.entry_count()
     }
 
     async fn get(&self, key: &String) -> Option<V> {

--- a/engine/crates/runtime/src/operation_cache.rs
+++ b/engine/crates/runtime/src/operation_cache.rs
@@ -25,7 +25,8 @@ pub trait OperationCache<V>: Send + Sync + 'static
 where
     V: Clone + Send + Sync + 'static + serde::Serialize + serde::de::DeserializeOwned,
 {
-    fn insert(&self, key: String, value: V) -> impl Future<Output = ()> + Send;
+    // insert a new cache item, return the current cache size
+    fn insert(&self, key: String, value: V) -> impl Future<Output = u64> + Send;
     // moka-cache does require a &String rather than a &str
     #[allow(clippy::ptr_arg)]
     fn get(&self, key: &String) -> impl Future<Output = Option<V>> + Send;
@@ -50,7 +51,9 @@ impl<V> OperationCache<V> for ()
 where
     V: Clone + Send + Sync + 'static + serde::Serialize + serde::de::DeserializeOwned,
 {
-    async fn insert(&self, _: String, _: V) {}
+    async fn insert(&self, _: String, _: V) -> u64 {
+        0
+    }
 
     async fn get(&self, _: &String) -> Option<V> {
         None

--- a/engine/crates/telemetry/Cargo.toml
+++ b/engine/crates/telemetry/Cargo.toml
@@ -33,7 +33,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing-opentelemetry.workspace = true
 opentelemetry-appender-tracing = { workspace = true, features = ["experimental_metadata_attributes"] }
-opentelemetry.workspace = true
+opentelemetry = { workspace = true, features = ["otel_unstable"] }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio", "logs"] }
 opentelemetry-stdout = { workspace = true, features = ["trace", "metrics", "logs"] }
 opentelemetry-otlp = { workspace = true, features = ["grpc-tonic", "tls", "tonic", "http-proto", "logs"], optional = true }

--- a/engine/crates/telemetry/src/metrics/operation.rs
+++ b/engine/crates/telemetry/src/metrics/operation.rs
@@ -1,5 +1,5 @@
 use opentelemetry::{
-    metrics::{Counter, Histogram, Meter, UpDownCounter},
+    metrics::{Counter, Gauge, Histogram, Meter, UpDownCounter},
     KeyValue,
 };
 
@@ -18,6 +18,9 @@ pub struct GraphqlOperationMetrics {
     subgraph_requests_inflight: UpDownCounter<i64>,
     subgraph_cache_hits: Counter<u64>,
     subgraph_cache_misses: Counter<u64>,
+    operation_cache_hits: Counter<u64>,
+    operation_cache_misses: Counter<u64>,
+    operation_cache_size: Gauge<u64>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -126,6 +129,9 @@ impl GraphqlOperationMetrics {
             subgraph_requests_inflight: meter.i64_up_down_counter("graphql.subgraph.request.inflight").init(),
             subgraph_cache_hits: meter.u64_counter("graphql.subgraph.request.cache.hit").init(),
             subgraph_cache_misses: meter.u64_counter("graphql.subgraph.request.cache.miss").init(),
+            operation_cache_hits: meter.u64_counter("graphql.operation.cache.hit").init(),
+            operation_cache_misses: meter.u64_counter("graphql.operation.cache.miss").init(),
+            operation_cache_size: meter.u64_gauge("graphql.operation.cache.in_memory.size").init(),
         }
     }
 
@@ -243,5 +249,17 @@ impl GraphqlOperationMetrics {
     pub fn record_subgraph_cache_miss(&self, SubgraphCacheMissAttributes { name }: SubgraphCacheMissAttributes) {
         let attributes = vec![KeyValue::new("graphql.subgraph.name", name)];
         self.subgraph_cache_misses.add(1, &attributes);
+    }
+
+    pub fn record_operation_cache_hit(&self) {
+        self.operation_cache_hits.add(1, &[]);
+    }
+
+    pub fn record_operation_cache_miss(&self) {
+        self.operation_cache_misses.add(1, &[]);
+    }
+
+    pub fn operation_cache_size_gauge(&self) -> Gauge<u64> {
+        self.operation_cache_size.clone()
     }
 }

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -54,3 +54,4 @@ serde_json.workspace = true
 tempfile = "3.10.1"
 wiremock.workspace = true
 ulid.workspace = true
+handlebars.workspace = true

--- a/gateway/crates/gateway-binary/tests/schemas/small.graphql
+++ b/gateway/crates/gateway-binary/tests/schemas/small.graphql
@@ -1,0 +1,18 @@
+directive @core(feature: String!) repeatable on SCHEMA
+directive @join__owner(graph: join__Graph!) on OBJECT
+directive @join__type(graph: join__Graph!, key: String!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @join__field(graph: join__Graph, requires: String, provides: String) on FIELD_DEFINITION
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+enum join__Graph {
+  ACCOUNTS @join__graph(name: "accounts", url: "{{ subgraph_endpoint }}")
+}
+
+type User @join__type(graph: ACCOUNTS, key: "id") {
+  id: ID!
+  username: String! @join__field(graph: ACCOUNTS)
+}
+
+type Query {
+  me: User! @join__field(graph: ACCOUNTS)
+}

--- a/gateway/crates/gateway-binary/tests/schemas/small.graphql
+++ b/gateway/crates/gateway-binary/tests/schemas/small.graphql
@@ -1,7 +1,11 @@
 directive @core(feature: String!) repeatable on SCHEMA
+
 directive @join__owner(graph: join__Graph!) on OBJECT
+
 directive @join__type(graph: join__Graph!, key: String!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
 directive @join__field(graph: join__Graph, requires: String, provides: String) on FIELD_DEFINITION
+
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
 enum join__Graph {

--- a/gateway/crates/gateway-binary/tests/telemetry/metrics.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/metrics.rs
@@ -5,10 +5,12 @@ use std::{
 };
 
 use futures_util::Future;
+use handlebars::Handlebars;
 use indoc::formatdoc;
 use serde::{Deserialize, Serialize};
+use wiremock::{matchers::method, Mock, ResponseTemplate};
 
-use crate::{clickhouse_client, load_schema, with_static_server, Client};
+use crate::{clickhouse_client, load_schema, runtime, with_static_server, Client};
 
 mod operation;
 mod request;
@@ -124,6 +126,80 @@ where
 
     println!("service_name: {service_name}");
     println!("{config}");
+    with_static_server(config, &schema, None, None, |client| async move {
+        const WAIT_SECONDS: u64 = 2;
+        let start = std::time::SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + WAIT_SECONDS;
+
+        // wait for initial polling to be pushed to OTEL tables so we can ignore it with the
+        // appropriate start time filter.
+        tokio::time::sleep(Duration::from_secs(WAIT_SECONDS)).await;
+
+        test(service_name, start, client, clickhouse).await
+    })
+}
+
+fn with_small_subgraph<T, F>(config: &str, test: T)
+where
+    T: FnOnce(String, u64, Arc<Client>, &'static clickhouse::Client) -> F,
+    F: Future<Output = ()>,
+{
+    let service_name = format!("service_{}", ulid::Ulid::new());
+    let config = &formatdoc! {r#"
+        [graph]
+        introspection = true
+
+        [telemetry]
+        service_name = "{service_name}"
+
+        [telemetry.tracing]
+        sampling = 1
+
+        [telemetry.exporters.otlp]
+        enabled = true
+        endpoint = "http://localhost:4318"
+        protocol = "grpc"
+
+        [telemetry.exporters.otlp.batch_export]
+        scheduled_delay = 1
+        max_export_batch_size = 1
+
+        {config}
+    "#};
+
+    let server = runtime().block_on(async move {
+        let server = wiremock::MockServer::start().await;
+
+        let response = ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": {
+                "me": {
+                    "id": "1",
+                    "username": "Alice",
+                }
+            }
+        }));
+
+        Mock::given(method("POST")).respond_with(response).mount(&server).await;
+
+        server
+    });
+
+    let mut hb = Handlebars::new();
+    hb.register_template_string("t1", load_schema("small")).unwrap();
+
+    let mut data = BTreeMap::new();
+    data.insert("subgraph_endpoint", format!("http://{}", server.address()));
+
+    let schema = hb.render("t1", &data).unwrap();
+
+    let clickhouse = clickhouse_client();
+
+    println!("service_name: {service_name}");
+    println!("{config}");
+    println!("{schema}");
     with_static_server(config, &schema, None, None, |client| async move {
         const WAIT_SECONDS: u64 = 2;
         let start = std::time::SystemTime::now()

--- a/gateway/crates/gateway-binary/tests/telemetry/metrics.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/metrics.rs
@@ -15,7 +15,7 @@ use crate::{clickhouse_client, load_schema, runtime, with_static_server, Client}
 mod operation;
 mod request;
 
-const METRICS_DELAY: Duration = Duration::from_secs(3);
+const METRICS_DELAY: Duration = Duration::from_secs(2);
 
 #[serde_with::serde_as]
 #[derive(Debug, clickhouse::Row, Deserialize, Serialize, PartialEq)]

--- a/gateway/crates/gateway-binary/tests/telemetry/metrics/operation/subgraph.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/metrics/operation/subgraph.rs
@@ -58,8 +58,8 @@ fn request_duration() {
 }
 
 #[test]
-fn request_body_size() {
-    with_gateway(|service_name, start_time_unix, gateway, clickhouse| async move {
+fn body_size() {
+    with_small_subgraph("", |service_name, start_time_unix, gateway, clickhouse| async move {
         let response = gateway
             .gql::<serde_json::Value>("query Simple { me { id } }")
             .send()
@@ -67,18 +67,11 @@ fn request_body_size() {
 
         insta::assert_json_snapshot!(response, @r###"
         {
-          "data": null,
-          "errors": [
-            {
-              "message": "Request to subgraph 'accounts' failed with: error sending request for url (http://127.0.0.1:46697/)",
-              "path": [
-                "me"
-              ],
-              "extensions": {
-                "code": "SUBGRAPH_REQUEST_ERROR"
-              }
+          "data": {
+            "me": {
+              "id": "1"
             }
-          ]
+          }
         }
         "###);
 
@@ -92,6 +85,31 @@ fn request_body_size() {
                 WHERE ServiceName = ? AND StartTimeUnix >= ?
                     AND ScopeName = 'grafbase'
                     AND MetricName = 'graphql.subgraph.request.body.size'
+                "#,
+            )
+            .bind(&service_name)
+            .bind(start_time_unix)
+            .fetch_one::<ExponentialHistogramRow>()
+            .await
+            .unwrap();
+
+        insta::assert_json_snapshot!(row, @r###"
+        {
+          "Count": 1,
+          "Attributes": {
+            "graphql.subgraph.name": "accounts"
+          }
+        }
+        "###);
+
+        let row = clickhouse
+            .query(
+                r#"
+                SELECT Count, Attributes
+                FROM otel_metrics_exponential_histogram
+                WHERE ServiceName = ? AND StartTimeUnix >= ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'graphql.subgraph.response.body.size'
                 "#,
             )
             .bind(&service_name)


### PR DESCRIPTION
### subgraph entity cache
- hits
- misses
### operation cache:
- hits
- misses
- size

Also enables in-memory operation cache for gateway.