### PR TITLE
graphql-schema-diff: skip tests on windows

### DIFF
--- a/engine/crates/graphql-schema-diff/tests/diff_tests.rs
+++ b/engine/crates/graphql-schema-diff/tests/diff_tests.rs
@@ -8,6 +8,10 @@ fn update_expect() -> bool {
 }
 
 fn run_test(case: &Path) -> datatest_stable::Result<()> {
+    if cfg!(windows) {
+        return Ok(()); // windows line endings make the spans in the snapshots different
+    }
+
     let schemas = fs::read_to_string(case)?;
     let mut schemas = schemas.split("# --- #");
     let source = schemas.next().expect("Can't find first schema in test case.");


### PR DESCRIPTION
We can't reuse the spans across unices and windows, because of the different line endings. This is making CI fail as of right now.
