### PR TITLE
cli: make creating federated graphs possible in grafbase create

### DIFF
--- a/cli/crates/backend/src/api/graphql/types/mutations.rs
+++ b/cli/crates/backend/src/api/graphql/types/mutations.rs
@@ -10,6 +10,13 @@ pub struct GraphCreateInput<'a> {
     pub graph_slug: &'a str,
     pub repo_root_path: &'a str,
     pub environment_variables: Vec<EnvironmentVariableSpecification<'a>>,
+    pub graph_mode: GraphMode,
+}
+
+#[derive(cynic::Enum, Clone, Debug, Copy)]
+pub enum GraphMode {
+    Managed,
+    SelfHosted,
 }
 
 #[derive(cynic::InputObject, Clone, Debug)]

--- a/cli/crates/cli/src/cli_input/create.rs
+++ b/cli/crates/cli/src/cli_input/create.rs
@@ -11,6 +11,9 @@ pub struct CreateCommand {
     /// The slug of the account in which the new graph should be created
     #[arg(short, long, value_name = "SLUG")]
     pub account: Option<String>,
+    /// Whether the graph is self-hosted or managed. Possible values: self-hosted or managed (default).
+    #[arg(short, long)]
+    pub mode: Option<crate::create::GraphMode>,
     /// Adds an environment variable to the graph
     #[clap(short = 'e', long = "env", value_parser, num_args = 0..)]
     environment_variables: Vec<String>,
@@ -25,6 +28,7 @@ impl CreateCommand {
                 account_slug,
                 name,
                 env_vars: self.environment_variables().collect(),
+                graph_mode: self.mode.unwrap_or_default(),
             })
     }
 
@@ -37,7 +41,7 @@ impl CreateCommand {
 
 impl ArgumentNames for CreateCommand {
     fn argument_names(&self) -> Option<Vec<&'static str>> {
-        let arguments = [(self.name.is_some(), vec!["name", "account"])]
+        let arguments = [(self.name.is_some(), vec!["name", "account", "self-hosted"])]
             .iter()
             .filter(|arguments| arguments.0)
             .flat_map(|arguments| arguments.1.clone())


### PR DESCRIPTION
Both interactively (we prompt the user) and through CLI args with the `--mode` argument. In both cases, we default to managed graphs.

```
  Set up and deploy a new graph

Usage: grafbase create [OPTIONS]

Options:
  -n, --name <NAME>
          The name to use for the new graph
  -a, --account <SLUG>
          The slug of the account in which the new graph should be created
  -m,  --mode <MODE>
          Whether the graph is self-hosted or managed. Possible values: self-hosted or managed
          (default)
  -e, --env [<ENVIRONMENT_VARIABLES>...]
          Adds an environment variable to the graph
  -h, --help
          Print help

```

closes GB-7297