### PR TITLE
gateway: release 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2865,7 +2865,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -3576,7 +3576,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.9.0] - 2024-08-15
+
+[CHANGELOG](changelog/0.9.1.md)
+
 ## [0.9.0] - 2024-08-14
 
 [CHANGELOG](changelog/0.9.0.md)

--- a/gateway/changelog/0.9.1.md
+++ b/gateway/changelog/0.9.1.md
@@ -1,0 +1,4 @@
+### Fixes
+
+- Fix rendering of multiline strings in federated graph SDL (https://github.com/grafbase/grafbase/pull/2021)
+- Fix excessive strictness in the Content-Type headers we accepted following the strict implementation of Graphql-over-HTTP. Content-Type headers with parameters (for example "application/json;charset=utf-8") are now accepted again. (https://github.com/grafbase/grafbase/pull/2023)

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true


### PR DESCRIPTION
Fixes

- Fix rendering of multiline strings in federated graph SDL (https://github.com/grafbase/grafbase/pull/2021)
- Fix excessive strictness in the Content-Type headers we accepted following the strict implementation of Graphql-over-HTTP. Content-Type headers with parameters (for example "application/json;charset=utf-8") are now accepted again. (https://github.com/grafbase/grafbase/pull/2023)

