### PR TITLE
gateway: set a 3 second grace period for graceful shutdowns

### DIFF
--- a/gateway/crates/federated-server/src/server.rs
+++ b/gateway/crates/federated-server/src/server.rs
@@ -224,7 +224,7 @@ async fn graceful_shutdown(handle: axum_server::Handle) {
     }
 
     tracing::info!(target: GRAFBASE_TARGET, "Shutting down gracefully...");
-    handle.graceful_shutdown(None);
+    handle.graceful_shutdown(Some(std::time::Duration::from_secs(3)));
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
Sometimes, tasks cannot be terminated gracefully, and that results in the gateway not being responsive, not responding to CTRL+C anymore, and just hanging. I haven't been able to reproduce this, but this commit at least limits that time to three seconds.