### PR TITLE
gateway: release 0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2865,7 +2865,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -3576,7 +3576,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [0.9.0] - 2024-08-15
+## [0.9.2] - 2024-08-16
+
+[CHANGELOG](changelog/0.9.2.md)
+
+## [0.9.1] - 2024-08-15
 
 [CHANGELOG](changelog/0.9.1.md)
 

--- a/gateway/changelog/0.9.2.md
+++ b/gateway/changelog/0.9.2.md
@@ -1,0 +1,3 @@
+### Fixes
+
+- Limit the grace period to 3 seconds for graceful shutdowns (https://github.com/grafbase/grafbase/pull/2026)

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.9.1"
+version = "0.9.2"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.9.1"
+version = "0.9.2"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true


### PR DESCRIPTION
Fixes

- Limit the grace period to 3 seconds for graceful shutdowns (https://github.com/grafbase/grafbase/pull/2026)