### PR TITLE
gateway: release 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/engine/crates/federated-graph/src/render_sdl/display_utils.rs
+++ b/engine/crates/federated-graph/src/render_sdl/display_utils.rs
@@ -7,15 +7,15 @@ use std::{
 pub(super) const BUILTIN_SCALARS: &[&str] = &["ID", "String", "Int", "Float", "Boolean"];
 pub(super) const INDENT: &str = "    ";
 
-// Copy-pasted from async-graphql-value
 pub(super) fn write_quoted(sdl: &mut impl Write, s: &str) -> fmt::Result {
     sdl.write_char('"')?;
     for c in s.chars() {
         match c {
-            c @ ('\r' | '\n' | '\t' | '"' | '\\') => {
-                sdl.write_char('\\')?;
-                sdl.write_char(c)
-            }
+            '\r' => sdl.write_str("\\r"),
+            '\n' => sdl.write_str("\\n"),
+            '\t' => sdl.write_str("\\t"),
+            '\\' => sdl.write_str("\\\\"),
+            '"' => sdl.write_str("\\\""),
             c if c.is_control() => write!(sdl, "\\u{:04}", c as u32),
             c => sdl.write_char(c),
         }?

--- a/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
@@ -563,4 +563,52 @@ mod tests {
 
         expected.assert_eq(&actual);
     }
+
+    #[test]
+    fn multiline_strings() {
+        use expect_test::expect;
+
+        let empty = from_sdl(
+            r###"
+            directive @dummy(test: String!) on FIELD
+
+            type Query {
+                field: String @deprecated(reason: """This is a "deprecated" reason
+
+                on multiple lines.
+
+                yes, way
+                
+                """) @dummy(test: "a \"test\"")
+            }
+            "###,
+        )
+        .unwrap();
+        let actual = render_federated_sdl(&empty.into_latest()).expect("valid");
+        let expected = expect![[r#"
+            directive @core(feature: String!) repeatable on SCHEMA
+
+            directive @join__owner(graph: join__Graph!) on OBJECT
+
+            directive @join__type(
+                graph: join__Graph!
+                key: String!
+                resolvable: Boolean = true
+            ) repeatable on OBJECT | INTERFACE
+
+            directive @join__field(
+                graph: join__Graph
+                requires: String
+                provides: String
+            ) on FIELD_DEFINITION
+
+            directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+            type Query {
+                field: String @deprecated(reason: "This is a \"deprecated\" reason\n\non multiple lines.\n\nyes, way") @dummy(test: "a \"test\"")
+            }
+        "#]];
+
+        expected.assert_eq(&actual);
+    }
 }

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [0.9.0] - 2024-08-15
+## [0.9.2] - 2024-08-16
+
+[CHANGELOG](changelog/0.9.2.md)
+
+## [0.9.1] - 2024-08-15
 
 [CHANGELOG](changelog/0.9.1.md)
 

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.9.0] - 2024-08-15
+
+[CHANGELOG](changelog/0.9.1.md)
+
 ## [0.9.0] - 2024-08-14
 
 [CHANGELOG](changelog/0.9.0.md)

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.9.3] - 2024-08-16
+
+[CHANGELOG](changelog/0.9.3.md)
+
 ## [0.9.2] - 2024-08-16
 
 [CHANGELOG](changelog/0.9.2.md)

--- a/gateway/changelog/0.9.1.md
+++ b/gateway/changelog/0.9.1.md
@@ -1,0 +1,4 @@
+### Fixes
+
+- Fix rendering of multiline strings in federated graph SDL (https://github.com/grafbase/grafbase/pull/2021)
+- Fix excessive strictness in the Content-Type headers we accepted following the strict implementation of Graphql-over-HTTP. Content-Type headers with parameters (for example "application/json;charset=utf-8") are now accepted again. (https://github.com/grafbase/grafbase/pull/2023)

--- a/gateway/changelog/0.9.2.md
+++ b/gateway/changelog/0.9.2.md
@@ -1,0 +1,3 @@
+### Fixes
+
+- Limit the grace period to 3 seconds for graceful shutdowns (https://github.com/grafbase/grafbase/pull/2026)

--- a/gateway/changelog/0.9.3.md
+++ b/gateway/changelog/0.9.3.md
@@ -1,0 +1,3 @@
+### Fixes
+
+- The 0.9.2 release of the gateway accidentally included changes that will be released with 0.10.0. This version only includes the fixes present in the changelogs of versions 0.9.1 and 0.9.2.

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.9.1"
+version = "0.9.2"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.9.2"
+version = "0.9.3"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/crates/federated-server/src/server.rs
+++ b/gateway/crates/federated-server/src/server.rs
@@ -224,7 +224,7 @@ async fn graceful_shutdown(handle: axum_server::Handle) {
     }
 
     tracing::info!(target: GRAFBASE_TARGET, "Shutting down gracefully...");
-    handle.graceful_shutdown(None);
+    handle.graceful_shutdown(Some(std::time::Duration::from_secs(3)));
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.9.1"
+version = "0.9.2"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.9.2"
+version = "0.9.3"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true


### PR DESCRIPTION
The 0.9.2 release of the gateway accidentally included changes that will be released with 0.10.0. This version only includes the fixes present in the changelogs of versions 0.9.1 and 0.9.2.