### PR TITLE
gateway: release 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2865,7 +2865,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -3576,7 +3576,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.9.3] - 2024-08-16
+
+[CHANGELOG](changelog/0.9.3.md)
+
 ## [0.9.2] - 2024-08-16
 
 [CHANGELOG](changelog/0.9.2.md)

--- a/gateway/changelog/0.9.3.md
+++ b/gateway/changelog/0.9.3.md
@@ -1,0 +1,3 @@
+### Fixes
+
+- The 0.9.2 release of the gateway accidentally included changes that will be released with 0.10.0. This version only includes the fixes present in the changelogs of versions 0.9.1 and 0.9.2.

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.9.2"
+version = "0.9.3"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.9.2"
+version = "0.9.3"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true


### PR DESCRIPTION
The 0.9.2 release of the gateway accidentally included changes that will be released with 0.10.0. This version only includes the fixes present in the changelogs of versions 0.9.1 and 0.9.2.
