### PR TITLE
gateway: shut down tracer and logger providers in graceful shutdown

### DIFF
--- a/engine/crates/telemetry/src/graceful_shutdown.rs
+++ b/engine/crates/telemetry/src/graceful_shutdown.rs
@@ -1,0 +1,4 @@
+pub fn graceful_shutdown() {
+    opentelemetry::global::shutdown_tracer_provider();
+    opentelemetry::global::shutdown_logger_provider();
+}

--- a/engine/crates/telemetry/src/lib.rs
+++ b/engine/crates/telemetry/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(unused_crate_dependencies)]
 //! Grafbase [tracing](https://docs.rs/tracing/latest/tracing/) integration
 
+pub use self::graceful_shutdown::graceful_shutdown;
 pub use gateway_config::telemetry as config;
 /// Potential errors from this crate
 pub mod error;
@@ -14,6 +15,8 @@ pub mod span;
 /// [Tower](https://docs.rs/tower/latest/tower/) integration
 #[cfg(feature = "tower")]
 pub mod tower;
+
+mod graceful_shutdown;
 
 pub(crate) const SCOPE: &str = "grafbase";
 pub(crate) const SCOPE_VERSION: &str = "1.0";

--- a/gateway/crates/federated-server/src/server.rs
+++ b/gateway/crates/federated-server/src/server.rs
@@ -224,6 +224,7 @@ async fn graceful_shutdown(handle: axum_server::Handle) {
     }
 
     tracing::info!(target: GRAFBASE_TARGET, "Shutting down gracefully...");
+    grafbase_telemetry::graceful_shutdown();
     handle.graceful_shutdown(Some(std::time::Duration::from_secs(3)));
 }
 


### PR DESCRIPTION
So the exporters have time to flush during the grace period.