### PR TITLE
fix(gateway): Fix inconsistent defaults in the Gateway configuration

### DIFF
--- a/gateway/crates/config/src/cors.rs
+++ b/gateway/crates/config/src/cors.rs
@@ -5,16 +5,15 @@ use std::time::Duration;
 use tower_http::cors::{AllowHeaders, AllowMethods, AllowOrigin, ExposeHeaders};
 use url::Url;
 
-#[derive(Clone, Debug, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Default, Debug, serde::Deserialize)]
+#[serde(default, deny_unknown_fields)]
 pub struct CorsConfig {
     /// If false (or not defined), credentials are not allowed in requests
-    #[serde(default)]
     pub allow_credentials: bool,
     /// Origins from which we allow requests
     pub allow_origins: Option<AnyOrUrlArray>,
     /// Maximum time between OPTIONS and the next request
-    #[serde(default, deserialize_with = "deserialize_option_duration")]
+    #[serde(deserialize_with = "deserialize_option_duration")]
     pub max_age: Option<Duration>,
     /// HTTP methods allowed to the endpoint.
     pub allow_methods: Option<AnyOrHttpMethodArray>,
@@ -23,7 +22,6 @@ pub struct CorsConfig {
     /// Headers exposed from the OPTIONS request
     pub expose_headers: Option<AnyOrAsciiStringArray>,
     /// If set, allows browsers from private network to connect
-    #[serde(default)]
     pub allow_private_network: bool,
 }
 

--- a/gateway/crates/config/src/entity_caching.rs
+++ b/gateway/crates/config/src/entity_caching.rs
@@ -1,17 +1,14 @@
 use std::{path::PathBuf, time::Duration};
 
 #[derive(Debug, Default, serde::Deserialize, Clone, PartialEq)]
+#[serde(default, deny_unknown_fields)]
 pub struct EntityCachingConfig {
     pub enabled: Option<bool>,
-
-    #[serde(default)]
     pub storage: EntityCachingStorage,
-
-    #[serde(default)]
     pub redis: EntityCachingRedisConfig,
 
     /// The ttl to store cache entries with.  Defaults to 60s
-    #[serde(deserialize_with = "duration_str::deserialize_option_duration", default)]
+    #[serde(deserialize_with = "duration_str::deserialize_option_duration")]
     pub ttl: Option<Duration>,
 }
 
@@ -24,11 +21,9 @@ pub enum EntityCachingStorage {
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 pub struct EntityCachingRedisConfig {
-    #[serde(default = "EntityCachingRedisConfig::default_url")]
     pub url: url::Url,
-    #[serde(default = "EntityCachingRedisConfig::default_key_prefix")]
     pub key_prefix: String,
     pub tls: Option<EntityCachingRedisTlsConfig>,
 }
@@ -36,20 +31,10 @@ pub struct EntityCachingRedisConfig {
 impl Default for EntityCachingRedisConfig {
     fn default() -> Self {
         Self {
-            url: Self::default_url(),
-            key_prefix: Self::default_key_prefix(),
+            url: url::Url::parse("redis://localhost:6379").expect("must be correct"),
+            key_prefix: String::from("grafbase-cache"),
             tls: None,
         }
-    }
-}
-
-impl EntityCachingRedisConfig {
-    fn default_url() -> url::Url {
-        url::Url::parse("redis://localhost:6379").expect("must be correct")
-    }
-
-    fn default_key_prefix() -> String {
-        String::from("grafbase-cache")
     }
 }
 

--- a/gateway/crates/config/src/health.rs
+++ b/gateway/crates/config/src/health.rs
@@ -2,22 +2,11 @@ use std::{borrow::Cow, net::SocketAddr};
 
 /// Health endpoint configuration.
 #[derive(Clone, Debug, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 pub struct HealthConfig {
-    #[serde(default = "default_true")]
     pub enabled: bool,
-    #[serde(default)]
     pub listen: Option<SocketAddr>,
-    #[serde(default = "default_path")]
     pub path: Cow<'static, str>,
-}
-
-fn default_path() -> Cow<'static, str> {
-    Cow::Borrowed("/health")
-}
-
-fn default_true() -> bool {
-    true
 }
 
 impl Default for HealthConfig {
@@ -25,7 +14,7 @@ impl Default for HealthConfig {
         HealthConfig {
             enabled: true,
             listen: None,
-            path: default_path(),
+            path: Cow::Borrowed("/health"),
         }
     }
 }

--- a/gateway/crates/config/src/hooks.rs
+++ b/gateway/crates/config/src/hooks.rs
@@ -2,17 +2,13 @@ use std::path::PathBuf;
 
 /// GraphQL WASI component configuration.
 #[derive(Clone, Default, Debug, serde::Deserialize)]
+#[serde(default, deny_unknown_fields)]
 pub struct HooksWasiConfig {
     pub location: PathBuf,
-    #[serde(default)]
     pub networking: bool,
-    #[serde(default)]
     pub environment_variables: bool,
-    #[serde(default)]
     pub stdout: bool,
-    #[serde(default)]
     pub stderr: bool,
-    #[serde(default)]
     pub preopened_directories: Vec<PreopenedDirectory>,
 }
 

--- a/gateway/crates/config/src/lib.rs
+++ b/gateway/crates/config/src/lib.rs
@@ -24,26 +24,21 @@ pub use telemetry::*;
 use url::Url;
 
 #[serde_with::serde_as]
-#[derive(Clone, Debug, Default, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, serde::Deserialize)]
+#[serde(default, deny_unknown_fields)]
 /// Configuration struct to define settings for self-hosted
 /// Grafbase gateway.
 pub struct Config {
     /// Graph location and features, such as introspection
-    #[serde(default)]
     pub graph: GraphConfig,
     /// Server bind settings
-    #[serde(default)]
     pub network: NetworkConfig,
     /// General settings for the gateway server
-    #[serde(default)]
     pub gateway: GatewayConfig,
     /// Maximum size of the request body in bytes
     #[serde_as(as = "DisplayFromStr")]
-    #[serde(default = "default_request_body_limit")]
     pub request_body_limit: Size,
     /// Cross-site request forgery settings
-    #[serde(default)]
     pub csrf: CsrfConfig,
     /// Cross-origin resource sharing settings
     pub cors: Option<CorsConfig>,
@@ -54,63 +49,71 @@ pub struct Config {
     /// Telemetry settings
     pub telemetry: Option<TelemetryConfig>,
     /// Configuration for Trusted Documents.
-    #[serde(default)]
     pub trusted_documents: TrustedDocumentsConfig,
     /// Authentication configuration
     pub authentication: Option<AuthenticationConfig>,
     /// Header bypass configuration
-    #[serde(default)]
     pub headers: Vec<HeaderRule>,
     /// Subgraph configuration
-    #[serde(default)]
     pub subgraphs: BTreeMap<String, SubgraphConfig>,
     /// Hooks configuration
-    #[serde(default)]
     pub hooks: Option<HooksWasiConfig>,
     /// Health check endpoint configuration
-    #[serde(default)]
     pub health: HealthConfig,
     /// Global configuration for entity caching
-    #[serde(default)]
     pub entity_caching: EntityCachingConfig,
 }
 
-fn default_request_body_limit() -> Size {
-    // 2 MiB
-    Size::from_mebibytes(2)
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            graph: Default::default(),
+            network: Default::default(),
+            gateway: Default::default(),
+            request_body_limit: Size::from_mebibytes(2),
+            csrf: Default::default(),
+            cors: Default::default(),
+            tls: Default::default(),
+            operation_limits: Default::default(),
+            telemetry: Default::default(),
+            trusted_documents: Default::default(),
+            authentication: Default::default(),
+            headers: Default::default(),
+            subgraphs: Default::default(),
+            hooks: Default::default(),
+            health: Default::default(),
+            entity_caching: Default::default(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 pub struct GatewayConfig {
     /// Timeout for gateway requests.
-    #[serde(deserialize_with = "duration_str::deserialize_option_duration", default)]
+    #[serde(deserialize_with = "duration_str::deserialize_option_duration")]
     pub timeout: Option<Duration>,
     /// Default timeout for subgraph requests.
-    #[serde(deserialize_with = "duration_str::deserialize_option_duration", default)]
+    #[serde(deserialize_with = "duration_str::deserialize_option_duration")]
     pub subgraph_timeout: Option<Duration>,
     /// Global rate limiting configuration
-    #[serde(default)]
     pub rate_limit: Option<RateLimitConfig>,
     /// Global retry configuration
-    #[serde(default)]
     pub retry: RetryConfig,
 }
 
-#[derive(Debug, serde::Deserialize, Clone)]
+#[derive(Debug, Default, serde::Deserialize, Clone)]
+#[serde(default, deny_unknown_fields)]
 pub struct SubgraphConfig {
     /// Header bypass configuration
-    #[serde(default)]
     pub headers: Vec<HeaderRule>,
     /// The URL to use for GraphQL websocket calls.
     pub websocket_url: Option<Url>,
     /// Rate limiting configuration specifically for this Subgraph
-    #[serde(default)]
     pub rate_limit: Option<GraphRateLimit>,
     /// Timeout for subgraph requests in seconds. Default: 30 seconds.
-    #[serde(deserialize_with = "duration_str::deserialize_option_duration", default)]
+    #[serde(deserialize_with = "duration_str::deserialize_option_duration")]
     pub timeout: Option<Duration>,
-    #[serde(default)]
     pub retry: Option<RetryConfig>,
 
     /// Subgraph specific entity caching config  this overrides the global config if there
@@ -119,40 +122,36 @@ pub struct SubgraphConfig {
 }
 
 #[derive(Debug, serde::Deserialize, Clone, Copy, Default, PartialEq)]
+#[serde(default, deny_unknown_fields)]
 pub struct RetryConfig {
     /// Should we retry or not.
     pub enabled: bool,
     /// How many retries are available per second, at a minimum.
-    #[serde(default)]
     pub min_per_second: Option<u32>,
     /// Each successful request to the subgraph adds to the retry budget. This setting controls for how long the budget remembers successful requests.
-    #[serde(default, deserialize_with = "duration_str::deserialize_option_duration")]
+    #[serde(deserialize_with = "duration_str::deserialize_option_duration")]
     pub ttl: Option<Duration>,
     /// The fraction of the successful requests budget that can be used for retries.
-    #[serde(default)]
     pub retry_percent: Option<f32>,
     /// Whether mutations should be retried at all. False by default.
-    #[serde(default)]
     pub retry_mutations: bool,
 }
 
 #[derive(Clone, Debug, Default, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 pub struct GraphConfig {
     pub path: Option<String>,
-    #[serde(default)]
     pub introspection: bool,
 }
 
 #[derive(Clone, Debug, Default, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 pub struct CsrfConfig {
-    #[serde(default)]
     pub enabled: bool,
 }
 
 #[derive(Clone, Debug, Default, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 pub struct NetworkConfig {
     pub listen_address: Option<SocketAddr>,
 }
@@ -165,10 +164,9 @@ pub struct TlsConfig {
 }
 
 #[derive(Debug, serde::Deserialize, Default, Clone)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 pub struct TrustedDocumentsConfig {
     /// If true, the engine will only accept trusted document queries. Default: false.
-    #[serde(default)]
     pub enabled: bool,
     /// See [BypassHeader]
     #[serde(flatten)]
@@ -177,17 +175,16 @@ pub struct TrustedDocumentsConfig {
 
 /// An optional header that can be passed by clients to bypass trusted documents enforcement, allowing arbitrary queries.
 #[derive(Debug, serde::Deserialize, Clone, Default)]
+#[serde(default, deny_unknown_fields)]
 pub struct BypassHeader {
     /// Name of the optional header that can be set to bypass trusted documents enforcement, when `enabled = true`. Only meaningful in combination with `bypass_header_value`.
-    #[serde(default)]
     pub bypass_header_name: Option<AsciiString>,
     /// Value of the optional header that can be set to bypass trusted documents enforcement, when `enabled = true`. Only meaningful in combination with `bypass_header_value`.
-    #[serde(default)]
     pub bypass_header_value: Option<DynamicString<String>>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, serde::Deserialize)]
+#[serde(default, deny_unknown_fields)]
 pub struct OperationLimitsConfig {
     /// Limits the deepest nesting of selection sets in an operation,
     /// including fields in fragments.

--- a/gateway/crates/config/src/telemetry/exporters.rs
+++ b/gateway/crates/config/src/telemetry/exporters.rs
@@ -18,37 +18,30 @@ use serde::{Deserialize, Deserializer};
 pub use stdout::StdoutExporterConfig;
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 pub struct ExportersConfig {
-    #[serde(default)]
     pub stdout: Option<StdoutExporterConfig>,
-    #[serde(default)]
     pub otlp: Option<OtlpExporterConfig>,
 }
 
 /// Configuration for batched exports
 #[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 pub struct BatchExportConfig {
     /// The delay, in seconds, between two consecutive processing of batches.
     /// The default value is 5 seconds.
-    #[serde(
-        deserialize_with = "deserialize_duration",
-        default = "BatchExportConfig::default_scheduled_delay"
-    )]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub scheduled_delay: chrono::Duration,
 
     /// The maximum queue size to buffer spans for delayed processing. If the
     /// queue gets full it drops the spans.
     /// The default value of is 2048.
-    #[serde(default = "BatchExportConfig::default_max_queue_size")]
     pub max_queue_size: usize,
 
     /// The maximum number of spans to process in a single batch. If there are
     /// more than one batch worth of spans then it processes multiple batches
     /// of spans one batch after the other without any delay.
     /// The default value is 512.
-    #[serde(default = "BatchExportConfig::default_max_export_batch_size")]
     pub max_export_batch_size: usize,
 
     /// Maximum number of concurrent exports
@@ -57,7 +50,6 @@ pub struct BatchExportConfig {
     /// by an exporter. A value of 1 will cause exports to be performed
     /// synchronously on the [`BatchSpanProcessor`] task.
     /// The default is 1.
-    #[serde(default = "BatchExportConfig::default_max_concurrent_exports")]
     pub max_concurrent_exports: usize,
 }
 

--- a/gateway/crates/config/src/telemetry/exporters/logs.rs
+++ b/gateway/crates/config/src/telemetry/exporters/logs.rs
@@ -1,10 +1,9 @@
 use super::ExportersConfig;
 
 /// Logs configuration
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Default, Clone, PartialEq, serde::Deserialize)]
+#[serde(default, deny_unknown_fields)]
 pub struct LogsConfig {
     /// Exporters configurations
-    #[serde(default)]
     pub exporters: ExportersConfig,
 }

--- a/gateway/crates/config/src/telemetry/exporters/metrics.rs
+++ b/gateway/crates/config/src/telemetry/exporters/metrics.rs
@@ -1,10 +1,9 @@
 use super::ExportersConfig;
 
 /// Logs configuration
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Default, Clone, PartialEq, serde::Deserialize)]
+#[serde(default, deny_unknown_fields)]
 pub struct MetricsConfig {
     /// Exporters configurations
-    #[serde(default)]
     pub exporters: ExportersConfig,
 }

--- a/gateway/crates/config/src/telemetry/exporters/otlp.rs
+++ b/gateway/crates/config/src/telemetry/exporters/otlp.rs
@@ -8,18 +8,15 @@ use url::Url;
 
 /// Otlp exporter configuration
 #[derive(Debug, Clone, PartialEq, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 pub struct OtlpExporterConfig {
     /// Enable or disable the exporter
-    #[serde(default)]
     pub enabled: bool,
     /// Endpoint of the otlp collector
     pub endpoint: Url,
     /// Batch export configuration
-    #[serde(default)]
     pub batch_export: BatchExportConfig,
     /// Protocol to use when exporting
-    #[serde(default)]
     pub protocol: OtlpExporterProtocol,
     /// GRPC exporting configuration
     pub grpc: Option<OtlpExporterGrpcConfig>,
@@ -27,7 +24,7 @@ pub struct OtlpExporterConfig {
     pub http: Option<OtlpExporterHttpConfig>,
     /// The maximum duration to export data.
     /// The default value is 60 seconds.
-    #[serde(deserialize_with = "deserialize_duration", default = "default_export_timeout")]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub timeout: chrono::Duration,
 }
 
@@ -58,27 +55,25 @@ pub enum OtlpExporterProtocol {
 
 /// GRPC exporting configuration
 #[derive(Debug, Clone, PartialEq, Default, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 pub struct OtlpExporterGrpcConfig {
     /// Tls configuration to use on export requests
     pub tls: Option<OtlpExporterTlsConfig>,
     /// Headers to send on export requests
-    #[serde(default)]
     pub headers: Headers,
 }
 
 /// OTLP HTTP exporting configuration
 #[derive(Debug, Clone, PartialEq, Default, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 pub struct OtlpExporterHttpConfig {
     /// Http headers to send on export requests
-    #[serde(default)]
     pub headers: Headers,
 }
 
 /// OTLP GRPC TLS export configuration
 #[derive(Debug, Clone, PartialEq, Default, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 /// Wraps tls configuration used when exporting data.
 /// Any files referenced are read in *sync* fashion using `[std::fs::read]`.
 pub struct OtlpExporterTlsConfig {

--- a/gateway/crates/config/src/telemetry/exporters/stdout.rs
+++ b/gateway/crates/config/src/telemetry/exporters/stdout.rs
@@ -1,17 +1,25 @@
 use super::{default_export_timeout, deserialize_duration, BatchExportConfig};
 
 /// Stdout exporter configuration
-#[derive(Debug, Clone, PartialEq, Default, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[serde(default, deny_unknown_fields)]
 pub struct StdoutExporterConfig {
     /// Enable or disable the exporter
-    #[serde(default)]
     pub enabled: bool,
     /// Batch export configuration
-    #[serde(default)]
     pub batch_export: Option<BatchExportConfig>,
     /// The maximum duration to export data.
     /// The default value is 60 seconds.
-    #[serde(deserialize_with = "deserialize_duration", default = "default_export_timeout")]
+    #[serde(deserialize_with = "deserialize_duration")]
     pub timeout: chrono::Duration,
+}
+
+impl Default for StdoutExporterConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            batch_export: None,
+            timeout: default_export_timeout(),
+        }
+    }
 }

--- a/gateway/crates/config/src/telemetry/exporters/tracing.rs
+++ b/gateway/crates/config/src/telemetry/exporters/tracing.rs
@@ -8,17 +8,15 @@ pub const DEFAULT_COLLECT_VALUE: usize = 128;
 
 /// Tracing configuration
 #[derive(Debug, Clone, PartialEq, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 pub struct TracingConfig {
     /// The sampler between 0.0 and 1.0.
     /// Default is 0.15.
-    #[serde(default = "default_sampling", deserialize_with = "deserialize_sampling")]
+    #[serde(deserialize_with = "deserialize_sampling")]
     pub sampling: f64,
     /// Collection configuration
-    #[serde(default)]
     pub collect: TracingCollectConfig,
     /// Exporters configurations
-    #[serde(default)]
     pub exporters: ExportersConfig,
 }
 
@@ -34,48 +32,35 @@ impl Default for TracingConfig {
 
 /// Tracing collection configuration
 #[derive(Debug, Clone, PartialEq, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 pub struct TracingCollectConfig {
     /// The maximum events per span before discarding.
     /// The default is 128.
-    #[serde(default = "default_collect")]
     pub max_events_per_span: usize,
     /// The maximum attributes per span before discarding.
     /// The default is 128.
-    #[serde(default = "default_collect")]
     pub max_attributes_per_span: usize,
     /// The maximum links per span before discarding.
     /// The default is 128.
-    #[serde(default = "default_collect")]
     pub max_links_per_span: usize,
     /// The maximum attributes per event before discarding.
     /// The default is 128.
-    #[serde(default = "default_collect")]
     pub max_attributes_per_event: usize,
     /// The maximum attributes per link before discarding.
     /// The default is 128.
-    #[serde(default = "default_collect")]
     pub max_attributes_per_link: usize,
 }
 
 impl Default for TracingCollectConfig {
     fn default() -> Self {
         Self {
-            max_events_per_span: 128,
-            max_attributes_per_span: 128,
-            max_links_per_span: 128,
-            max_attributes_per_event: 128,
-            max_attributes_per_link: 128,
+            max_events_per_span: DEFAULT_COLLECT_VALUE,
+            max_attributes_per_span: DEFAULT_COLLECT_VALUE,
+            max_links_per_span: DEFAULT_COLLECT_VALUE,
+            max_attributes_per_event: DEFAULT_COLLECT_VALUE,
+            max_attributes_per_link: DEFAULT_COLLECT_VALUE,
         }
     }
-}
-
-fn default_sampling() -> f64 {
-    DEFAULT_SAMPLING
-}
-
-fn default_collect() -> usize {
-    DEFAULT_COLLECT_VALUE
 }
 
 fn deserialize_sampling<'de, D>(deserializer: D) -> Result<f64, D::Error>

--- a/gateway/crates/config/src/telemetry/mod.rs
+++ b/gateway/crates/config/src/telemetry/mod.rs
@@ -15,20 +15,17 @@ pub use exporters::{BatchExportConfig, ExportersConfig, StdoutExporterConfig};
 
 /// Holds telemetry configuration
 #[derive(Default, Debug, Clone, PartialEq, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 pub struct TelemetryConfig {
     /// The name of the service
     pub service_name: String,
     /// Additional resource attributes
-    #[serde(default)]
     pub resource_attributes: HashMap<String, String>,
     /// Global exporters config
-    #[serde(default)]
     pub exporters: ExportersConfig,
     /// Separate configuration for logs exports. If set, overrides the global values.
     pub logs: Option<LogsConfig>,
     /// Separate configuration for traces exports. If set, overrides the global values.
-    #[serde(default)]
     pub tracing: TracingConfig,
     /// Separate configuration for metrics exports. If set, overrides the global values.
     pub metrics: Option<MetricsConfig>,


### PR DESCRIPTION
We weren't applying the same defaults everywhere for `Config::default()` and through deserialization. 