### PR TITLE
fix(gateway): Panic with `--log=trace`

### DIFF
--- a/engine/crates/engine-v2/src/execution/planner/mod.rs
+++ b/engine/crates/engine-v2/src/execution/planner/mod.rs
@@ -112,7 +112,10 @@ pub(super) async fn plan<'ctx, R: Runtime>(
                 "**{id}**\n  input <- {}\n  ouput -> {}",
                 plan.parent_count,
                 plan.children.iter().join(",")
-            ))),
+            )))
+            // with opentelemetry this string might be formatted more than once... Leading to a
+            // panic with .format_with()
+            .to_string()
     );
 
     Ok(operation)

--- a/engine/crates/engine-v2/src/operation/logical_planner/mod.rs
+++ b/engine/crates/engine-v2/src/operation/logical_planner/mod.rs
@@ -347,10 +347,15 @@ impl<'a> LogicalPlanner<'a> {
         tracing::trace!(
             "Creating {id} ({}): {}",
             self.schema.walk(resolver_id).name(),
-            root_field_ids.iter().format_with(", ", |id, f| f(&format_args!(
-                "{}",
-                self.walker().walk(*id).response_key_str()
-            )))
+            root_field_ids
+                .iter()
+                .format_with(", ", |id, f| f(&format_args!(
+                    "{}",
+                    self.walker().walk(*id).response_key_str()
+                )))
+                // with opentelemetry this string might be formatted more than once... Leading to a
+                // panic with .format_with()
+                .to_string()
         );
         self.logical_plans.push(LogicalPlan {
             resolver_id,

--- a/engine/crates/engine-v2/src/operation/logical_planner/selection_set.rs
+++ b/engine/crates/engine-v2/src/operation/logical_planner/selection_set.rs
@@ -302,7 +302,10 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
                         .fields
                         .keys()
                         .map(|id| self.schema.walk(*id))
-                        .format_with("\n", |field, f| f(&format_args!("{field:#?}"))),
+                        .format_with("\n", |field, f| f(&format_args!("{field:#?}")))
+                        // with opentelemetry this string might be formatted more than once... Leading to a
+                        // panic with .format_with()
+                        .to_string(),
                     unplanned_fields
                         .keys()
                         .map(|id| walker.walk(*id).definition().unwrap())
@@ -310,6 +313,9 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
                             "{field:#?}\n{:#?}",
                             parent_subgraph_id.map(|id| field.required_fields(id))
                         )))
+                        // with opentelemetry this string might be formatted more than once... Leading to a
+                        // panic with .format_with()
+                        .to_string()
                 );
                 return Err(LogicalPlanningError::CouldNotPlanAnyField {
                     missing: unplanned_fields
@@ -350,7 +356,10 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
                         .fields
                         .keys()
                         .map(|id| self.schema.walk(*id))
-                        .format_with("\n", |field, f| f(&format_args!("{field:#?}"))),
+                        .format_with("\n", |field, f| f(&format_args!("{field:#?}")))
+                        // with opentelemetry this string might be formatted more than once... Leading to a
+                        // panic with .format_with()
+                        .to_string(),
                     walker.walk(parent_field_id).response_key_str(),
                     self.schema.walk(parent_extra_requirements.as_ref())
                 );


### PR DESCRIPTION
I use at various places `itertools.format_with` with `tracing::trace!` which works without a problem a
simple subscriber but panics with opentelemetry as it somehow gets
called multiple times.
