### PR TITLE
fix(federated-graph): `@join__field` may not be present

### DIFF
--- a/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
@@ -71,17 +71,19 @@ pub fn render_federated_sdl(graph: &FederatedGraphV3) -> Result<String, fmt::Err
         if !object.keys.is_empty() {
             sdl.push('\n');
             for key in &object.keys {
-                let selection_set = FieldSetDisplay(&key.fields, graph);
                 let subgraph_name = GraphEnumVariantName(&graph[graph[key.subgraph_id].name]);
-                if key.resolvable {
+                if key.fields.is_empty() {
                     writeln!(
                         sdl,
-                        r#"{INDENT}@join__type(graph: {subgraph_name}, key: {selection_set})"#
+                        r#"{INDENT}@join__type(graph: {subgraph_name}{resolvable})"#,
+                        resolvable = if key.resolvable { "" } else { ", resolvable: false" }
                     )?;
                 } else {
                     writeln!(
                         sdl,
-                        r#"{INDENT}@join__type(graph: {subgraph_name}, key: {selection_set}, resolvable: false)"#
+                        r#"{INDENT}@join__type(graph: {subgraph_name}, key: {selection_set}{resolvable})"#,
+                        selection_set = FieldSetDisplay(&key.fields, graph),
+                        resolvable = if key.resolvable { "" } else { ", resolvable: false" }
                     )?;
                 }
             }

--- a/engine/crates/integration-tests/data/federated-graph-schema.graphql
+++ b/engine/crates/integration-tests/data/federated-graph-schema.graphql
@@ -44,7 +44,7 @@ type User @join__type(graph: ACCOUNTS, key: "id") @join__type(graph: REVIEWS, ke
   This used to be part of this subgraph, but is now being overridden from
   `reviews`
   """
-  reviewCount: Int! @join__field(graph: reviews, overrides: "accounts")
+  reviewCount: Int! @join__field(graph: REVIEWS, overrides: "accounts")
   joinedTimestamp: Int! @join__field(graph: ACCOUNTS)
   cart: Cart! @join__field(graph: ACCOUNTS)
   reviews: [Review!]! @join__field(graph: REVIEWS)

--- a/engine/crates/integration-tests/src/federation/builder.rs
+++ b/engine/crates/integration-tests/src/federation/builder.rs
@@ -142,6 +142,7 @@ impl EngineV2Builder {
         // Ensure SDL/JSON serialization work as a expected
         let graph = {
             let sdl = graph.into_sdl().unwrap();
+            println!("{sdl}");
             let mut graph = FederatedGraph::from_sdl(&sdl).unwrap();
             let json = serde_json::to_value(&graph).unwrap();
             graph = serde_json::from_value(json).unwrap();

--- a/engine/crates/integration-tests/tests/federation/issues.rs
+++ b/engine/crates/integration-tests/tests/federation/issues.rs
@@ -107,3 +107,82 @@ fn gb6873_wrong_enum_sent_to_subgraph() {
         });
     });
 }
+
+#[test]
+fn gb7323_join_field_may_not_be_present() {
+    const SDL: &str = r###"
+    schema
+      @link(url: "https://specs.apollo.dev/link/v1.0")
+      @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+    {
+      query: Query
+    }
+
+    directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+    directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+    directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+    directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+    directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+    directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+    directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+    scalar join__FieldSet
+
+    enum join__Graph {
+      NAME @join__graph(name: "name", url: "http://localhost:4200/name")
+    }
+
+    scalar link__Import
+
+    enum link__Purpose {
+      SECURITY
+      EXECUTION
+    }
+    type Product
+      @join__type(graph: NAME)
+    {
+      id: ID!
+      name: String
+    }
+
+    type Query
+      @join__type(graph: NAME)
+    {
+      product: Product
+      products: [Product]
+    }
+    "###;
+
+    runtime().block_on(async move {
+        let fetcher = MockFetch::default().with_responses("localhost", vec![json!({"data": {"product": {"id": "1"}}})]);
+        let engine = Engine::builder()
+            .with_federated_sdl(SDL)
+            .with_mock_fetcher(fetcher.clone())
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query { product { id } }
+                "#,
+            )
+            .await;
+
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "product": {
+              "id": "1"
+            }
+          }
+        }
+        "###);
+    });
+}

--- a/gateway/changelog/0.10.0.md
+++ b/gateway/changelog/0.10.0.md
@@ -6,3 +6,4 @@
 
 - Using `--log=trace` would panic.
 - Gateway configuration defaults were not consistently applied. When not providing any TOML configuration path, it led `request_body_limit` to have a default value of `0` refusing all requests.
+- `@join__field` is now optional for non-federated types: no `@join__type` directive with a `key` argument.


### PR DESCRIPTION
@join__field is only needed when a type (exception is the root type) belongs to more than one subgraph