### PR TITLE
feat: respect subgraph CacheControl headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3863,6 +3863,7 @@ dependencies = [
  "axum",
  "crossbeam-queue",
  "futures",
+ "headers",
  "http",
  "serde",
  "serde_json",

--- a/engine/crates/engine-v2/src/sources/graphql/mod.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/mod.rs
@@ -5,25 +5,17 @@ mod request;
 mod root_fields;
 mod subscription;
 
-use std::time::Duration;
-
 pub(crate) use federation::*;
-use headers::HeaderMapExt;
 pub(crate) use root_fields::*;
 
 use grafbase_telemetry::gql_response_status::GraphqlResponseStatus;
-use runtime::bytes::OwnedOrSharedBytes;
-
-fn should_update_cache(status: GraphqlResponseStatus, cache_control: Option<&headers::CacheControl>) -> bool {
-    status.is_success()
-        && cache_control
-            .map(|cache_control| !(cache_control.private() || cache_control.no_store()))
-            .unwrap_or(true)
-}
+use headers::HeaderMapExt;
+use http::HeaderMap;
+use std::time::Duration;
 
 fn calculate_cache_ttl(
-    http_response: &http::Response<OwnedOrSharedBytes>,
-    cache_control: Option<&headers::CacheControl>,
+    status: GraphqlResponseStatus,
+    headers: &HeaderMap,
     subgraph_default_ttl: Option<Duration>,
 ) -> Option<Duration> {
     let Some(subgraph_default_ttl) = subgraph_default_ttl else {
@@ -32,17 +24,23 @@ fn calculate_cache_ttl(
         return None;
     };
 
-    let age = http_response
-        .headers()
-        .typed_get::<headers::Age>()
-        .map(|age| age.as_secs());
+    if !status.is_success() {
+        return None;
+    }
+
+    let Some(cache_control) = headers.typed_get::<headers::CacheControl>() else {
+        return Some(subgraph_default_ttl);
+    };
+
+    if cache_control.private() || cache_control.no_store() {
+        return None;
+    }
+
+    let age = headers.typed_get::<headers::Age>().map(|age| age.as_secs());
 
     let cache_ttl = cache_control
-        .and_then(|cache_control| {
-            cache_control
-                .max_age()
-                .map(|max_age| max_age - Duration::from_secs(age.unwrap_or_default()))
-        })
+        .max_age()
+        .map(|max_age| max_age - Duration::from_secs(age.unwrap_or_default()))
         .unwrap_or(subgraph_default_ttl);
 
     Some(cache_ttl)

--- a/engine/crates/engine-v2/src/sources/graphql/mod.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/mod.rs
@@ -5,5 +5,45 @@ mod request;
 mod root_fields;
 mod subscription;
 
+use std::time::Duration;
+
 pub(crate) use federation::*;
+use headers::HeaderMapExt;
 pub(crate) use root_fields::*;
+
+use grafbase_telemetry::gql_response_status::GraphqlResponseStatus;
+use runtime::bytes::OwnedOrSharedBytes;
+
+fn should_update_cache(status: GraphqlResponseStatus, cache_control: Option<&headers::CacheControl>) -> bool {
+    status.is_success()
+        && cache_control
+            .map(|cache_control| !(cache_control.private() || cache_control.no_store()))
+            .unwrap_or(true)
+}
+
+fn calculate_cache_ttl(
+    http_response: &http::Response<OwnedOrSharedBytes>,
+    cache_control: Option<&headers::CacheControl>,
+    subgraph_default_ttl: Option<Duration>,
+) -> Option<Duration> {
+    let Some(subgraph_default_ttl) = subgraph_default_ttl else {
+        // The subgraph_default_ttl is set to None if entity caching is disabled for a subgraph, so
+        // we always return None here in that case.
+        return None;
+    };
+
+    let age = http_response
+        .headers()
+        .typed_get::<headers::Age>()
+        .map(|age| age.as_secs());
+
+    let cache_ttl = cache_control
+        .and_then(|cache_control| {
+            cache_control
+                .max_age()
+                .map(|max_age| max_age - Duration::from_secs(age.unwrap_or_default()))
+        })
+        .unwrap_or(subgraph_default_ttl);
+
+    Some(cache_ttl)
+}

--- a/engine/crates/graphql-mocks/Cargo.toml
+++ b/engine/crates/graphql-mocks/Cargo.toml
@@ -15,6 +15,7 @@ async-graphql.workspace = true
 async-trait = "0.1.80"
 axum.workspace = true
 futures.workspace = true
+headers.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/engine/crates/integration-tests/tests/federation/entity_caching.rs
+++ b/engine/crates/integration-tests/tests/federation/entity_caching.rs
@@ -5,6 +5,8 @@ use graphql_mocks::{ErrorSchema, FederatedInventorySchema, FederatedProductsSche
 use integration_tests::{federation::EngineV2Ext, runtime};
 use serde_json::json;
 
+mod subgraph_cache_control;
+
 #[test]
 fn root_level_entity_caching() {
     let response = runtime().block_on(async move {

--- a/engine/crates/integration-tests/tests/federation/entity_caching/subgraph_cache_control.rs
+++ b/engine/crates/integration-tests/tests/federation/entity_caching/subgraph_cache_control.rs
@@ -1,0 +1,363 @@
+use std::time::Duration;
+
+use engine_v2::Engine;
+use graphql_mocks::{FederatedInventorySchema, FederatedProductsSchema, FederatedReviewsSchema};
+use headers::{Age, CacheControl};
+use integration_tests::{federation::EngineV2Ext, runtime};
+
+struct CacheControlReviewSubgraph {
+    header: CacheControl,
+    age: Option<Age>,
+}
+
+impl graphql_mocks::Subgraph for CacheControlReviewSubgraph {
+    fn name(&self) -> String {
+        "reviews".into()
+    }
+
+    async fn start(self) -> graphql_mocks::MockGraphQlServer {
+        let mut server = FederatedReviewsSchema.start().await.with_additional_header(self.header);
+
+        if let Some(age) = self.age {
+            server = server.with_additional_header(age);
+        }
+
+        server
+    }
+}
+
+struct CacheControlProductSubgraph {
+    header: CacheControl,
+    age: Option<Age>,
+}
+
+impl graphql_mocks::Subgraph for CacheControlProductSubgraph {
+    fn name(&self) -> String {
+        "products".into()
+    }
+
+    async fn start(self) -> graphql_mocks::MockGraphQlServer {
+        let mut server = FederatedProductsSchema
+            .start()
+            .await
+            .with_additional_header(self.header);
+
+        if let Some(age) = self.age {
+            server = server.with_additional_header(age);
+        }
+
+        server
+    }
+}
+
+#[test]
+fn test_private_cache_control_entity_request() {
+    runtime().block_on(async move {
+        let engine = Engine::builder()
+            .with_subgraph(FederatedProductsSchema)
+            .with_subgraph(CacheControlReviewSubgraph {
+                header: CacheControl::new().with_private(),
+                age: None,
+            })
+            .with_subgraph(FederatedInventorySchema)
+            .with_toml_config(
+                r#"
+                [entity_caching]
+                enabled = true
+                "#,
+            )
+            .build()
+            .await;
+
+        const QUERY: &str = "{ topProducts { upc reviews { id body } } }";
+
+        engine.post(QUERY).await.into_data();
+        engine.post(QUERY).await.into_data();
+
+        assert_eq!(
+            engine.drain_graphql_requests_sent_to::<FederatedProductsSchema>().len(),
+            1
+        );
+        assert_eq!(
+            engine
+                .drain_graphql_requests_sent_to::<CacheControlReviewSubgraph>()
+                .len(),
+            2
+        );
+    })
+}
+
+#[test]
+fn test_nostore_cache_control_entity_request() {
+    runtime().block_on(async move {
+        let engine = Engine::builder()
+            .with_subgraph(FederatedProductsSchema)
+            .with_subgraph(CacheControlReviewSubgraph {
+                header: CacheControl::new().with_no_store(),
+                age: None,
+            })
+            .with_subgraph(FederatedInventorySchema)
+            .with_toml_config(
+                r#"
+                [entity_caching]
+                enabled = true
+                "#,
+            )
+            .build()
+            .await;
+
+        const QUERY: &str = "{ topProducts { upc reviews { id body } } }";
+
+        engine.post(QUERY).await.into_data();
+        engine.post(QUERY).await.into_data();
+
+        assert_eq!(
+            engine.drain_graphql_requests_sent_to::<FederatedProductsSchema>().len(),
+            1
+        );
+        assert_eq!(
+            engine
+                .drain_graphql_requests_sent_to::<CacheControlReviewSubgraph>()
+                .len(),
+            2
+        );
+    })
+}
+
+#[test]
+fn test_max_age_without_age_entity_request() {
+    runtime().block_on(async move {
+        let engine = Engine::builder()
+            .with_subgraph(FederatedProductsSchema)
+            .with_subgraph(CacheControlReviewSubgraph {
+                header: CacheControl::new().with_max_age(Duration::from_secs(1)),
+                age: None,
+            })
+            .with_subgraph(FederatedInventorySchema)
+            .with_toml_config(
+                r#"
+                [entity_caching]
+                enabled = true
+                "#,
+            )
+            .build()
+            .await;
+
+        const QUERY: &str = "{ topProducts { upc reviews { id body } } }";
+
+        engine.post(QUERY).await.into_data();
+        engine.post(QUERY).await.into_data();
+
+        tokio::time::sleep(Duration::from_millis(1200)).await;
+
+        engine.post(QUERY).await.into_data();
+
+        assert_eq!(
+            engine.drain_graphql_requests_sent_to::<FederatedProductsSchema>().len(),
+            1
+        );
+        assert_eq!(
+            engine
+                .drain_graphql_requests_sent_to::<CacheControlReviewSubgraph>()
+                .len(),
+            2
+        );
+    })
+}
+
+#[test]
+fn test_max_age_with_age_entity_request() {
+    runtime().block_on(async move {
+        let engine = Engine::builder()
+            .with_subgraph(FederatedProductsSchema)
+            .with_subgraph(CacheControlReviewSubgraph {
+                header: CacheControl::new().with_max_age(Duration::from_secs(2)),
+                age: Some(Age::from_secs(1)),
+            })
+            .with_subgraph(FederatedInventorySchema)
+            .with_toml_config(
+                r#"
+                [entity_caching]
+                enabled = true
+                "#,
+            )
+            .build()
+            .await;
+
+        const QUERY: &str = "{ topProducts { upc reviews { id body } } }";
+
+        engine.post(QUERY).await.into_data();
+        engine.post(QUERY).await.into_data();
+
+        tokio::time::sleep(Duration::from_millis(1200)).await;
+
+        engine.post(QUERY).await.into_data();
+
+        assert_eq!(
+            engine.drain_graphql_requests_sent_to::<FederatedProductsSchema>().len(),
+            1
+        );
+        assert_eq!(
+            engine
+                .drain_graphql_requests_sent_to::<CacheControlReviewSubgraph>()
+                .len(),
+            2
+        );
+    })
+}
+
+#[test]
+fn test_private_cache_control_root_request() {
+    runtime().block_on(async move {
+        let engine = Engine::builder()
+            .with_subgraph(CacheControlProductSubgraph {
+                header: CacheControl::new().with_private(),
+                age: None,
+            })
+            .with_subgraph(FederatedReviewsSchema)
+            .with_subgraph(FederatedInventorySchema)
+            .with_toml_config(
+                r#"
+                [entity_caching]
+                enabled = true
+                "#,
+            )
+            .build()
+            .await;
+
+        const QUERY: &str = "{ topProducts { upc reviews { id body } } }";
+
+        engine.post(QUERY).await.into_data();
+        engine.post(QUERY).await.into_data();
+
+        assert_eq!(
+            engine
+                .drain_graphql_requests_sent_to::<CacheControlProductSubgraph>()
+                .len(),
+            2
+        );
+        assert_eq!(
+            engine.drain_graphql_requests_sent_to::<FederatedReviewsSchema>().len(),
+            1
+        );
+    })
+}
+
+#[test]
+fn test_nostore_cache_control_root_request() {
+    runtime().block_on(async move {
+        let engine = Engine::builder()
+            .with_subgraph(CacheControlProductSubgraph {
+                header: CacheControl::new().with_no_store(),
+                age: None,
+            })
+            .with_subgraph(FederatedReviewsSchema)
+            .with_subgraph(FederatedInventorySchema)
+            .with_toml_config(
+                r#"
+                [entity_caching]
+                enabled = true
+                "#,
+            )
+            .build()
+            .await;
+
+        const QUERY: &str = "{ topProducts { upc reviews { id body } } }";
+
+        engine.post(QUERY).await.into_data();
+        engine.post(QUERY).await.into_data();
+
+        assert_eq!(
+            engine
+                .drain_graphql_requests_sent_to::<CacheControlProductSubgraph>()
+                .len(),
+            2
+        );
+        assert_eq!(
+            engine.drain_graphql_requests_sent_to::<FederatedReviewsSchema>().len(),
+            1
+        );
+    })
+}
+
+#[test]
+fn test_max_age_without_age_root_request() {
+    runtime().block_on(async move {
+        let engine = Engine::builder()
+            .with_subgraph(CacheControlProductSubgraph {
+                header: CacheControl::new().with_max_age(Duration::from_secs(1)),
+                age: None,
+            })
+            .with_subgraph(FederatedReviewsSchema)
+            .with_subgraph(FederatedInventorySchema)
+            .with_toml_config(
+                r#"
+                [entity_caching]
+                enabled = true
+                "#,
+            )
+            .build()
+            .await;
+
+        const QUERY: &str = "{ topProducts { upc reviews { id body } } }";
+
+        engine.post(QUERY).await.into_data();
+        engine.post(QUERY).await.into_data();
+
+        tokio::time::sleep(Duration::from_millis(1200)).await;
+
+        engine.post(QUERY).await.into_data();
+
+        assert_eq!(
+            engine
+                .drain_graphql_requests_sent_to::<CacheControlProductSubgraph>()
+                .len(),
+            2
+        );
+        assert_eq!(
+            engine.drain_graphql_requests_sent_to::<FederatedReviewsSchema>().len(),
+            1
+        );
+    })
+}
+
+#[test]
+fn test_max_age_with_age_root_request() {
+    runtime().block_on(async move {
+        let engine = Engine::builder()
+            .with_subgraph(CacheControlProductSubgraph {
+                header: CacheControl::new().with_max_age(Duration::from_secs(2)),
+                age: Some(Age::from_secs(1)),
+            })
+            .with_subgraph(FederatedReviewsSchema)
+            .with_subgraph(FederatedInventorySchema)
+            .with_toml_config(
+                r#"
+                [entity_caching]
+                enabled = true
+                "#,
+            )
+            .build()
+            .await;
+
+        const QUERY: &str = "{ topProducts { upc reviews { id body } } }";
+
+        engine.post(QUERY).await.into_data();
+        engine.post(QUERY).await.into_data();
+
+        tokio::time::sleep(Duration::from_millis(1200)).await;
+
+        engine.post(QUERY).await.into_data();
+
+        assert_eq!(
+            engine
+                .drain_graphql_requests_sent_to::<CacheControlProductSubgraph>()
+                .len(),
+            2
+        );
+        assert_eq!(
+            engine.drain_graphql_requests_sent_to::<FederatedReviewsSchema>().len(),
+            1
+        );
+    })
+}


### PR DESCRIPTION
Prior to this PR we'd always use the default cache TTL for a subgraph as provided in the configuration.  However, we want subgraphs to be able to override that on a per-response basis by returning a CacheControl header.

This PR implements that:

1. If a subgraph returns `no-store` or `private` directives we avoid writing to the entity cache.
2. If the `Age` header and the `max-age` directive are present we set the TTL to `age - max_age`
3. If the `max-age` directive is present with no `Age` header we take the `max-age` as the TTL

Fixes GB-7164