### PR TITLE
gateway: tracing context propagation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3593,6 +3593,7 @@ version = "0.10.0"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",
+ "async-graphql-parser",
  "atty",
  "cfg-if",
  "clap",
@@ -3606,6 +3607,8 @@ dependencies = [
  "grafbase-graphql-introspection",
  "grafbase-telemetry",
  "graph-ref",
+ "graphql-composition",
+ "graphql-mocks",
  "handlebars",
  "http",
  "indoc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,7 +1804,7 @@ dependencies = [
 [[package]]
 name = "cynic-codegen"
 version = "3.7.3"
-source = "git+https://github.com/grafbase/cynic?branch=more-spans#05d60a06ea41c810dcc3023e73147ada38545908"
+source = "git+https://github.com/grafbase/cynic?branch=more-spans#1c94229efa280a1bc2c77a71bdb7fbf863475bde"
 dependencies = [
  "counter",
  "cynic-parser",
@@ -1834,7 +1834,7 @@ dependencies = [
 [[package]]
 name = "cynic-parser"
 version = "0.4.5"
-source = "git+https://github.com/grafbase/cynic?branch=more-spans#05d60a06ea41c810dcc3023e73147ada38545908"
+source = "git+https://github.com/grafbase/cynic?branch=more-spans#1c94229efa280a1bc2c77a71bdb7fbf863475bde"
 dependencies = [
  "ariadne",
  "indexmap 2.2.6",

--- a/engine/crates/telemetry/Cargo.toml
+++ b/engine/crates/telemetry/Cargo.toml
@@ -33,7 +33,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing-opentelemetry.workspace = true
 opentelemetry-appender-tracing = { workspace = true, features = ["experimental_metadata_attributes"] }
-opentelemetry = { workspace = true, features = ["otel_unstable"] }
+opentelemetry = { workspace = true, features = ["otel_unstable", "trace"] }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio", "logs"] }
 opentelemetry-stdout = { workspace = true, features = ["trace", "metrics", "logs"] }
 opentelemetry-otlp = { workspace = true, features = ["grpc-tonic", "tls", "tonic", "http-proto", "logs"], optional = true }

--- a/engine/crates/telemetry/src/http.rs
+++ b/engine/crates/telemetry/src/http.rs
@@ -1,0 +1,12 @@
+/// FIXME: Can be replaced with tracing-http once we are back to upstream opentelemetry.
+pub struct HeaderInjector<'a>(pub &'a mut http::HeaderMap);
+
+impl<'a> opentelemetry::propagation::Injector for HeaderInjector<'a> {
+    fn set(&mut self, key: &str, value: String) {
+        if let Ok(name) = http::header::HeaderName::from_bytes(key.as_bytes()) {
+            if let Ok(val) = http::header::HeaderValue::from_str(&value) {
+                self.0.insert(name, val);
+            }
+        }
+    }
+}

--- a/engine/crates/telemetry/src/lib.rs
+++ b/engine/crates/telemetry/src/lib.rs
@@ -6,6 +6,7 @@ pub use gateway_config::telemetry as config;
 pub mod error;
 pub mod gql_response_status;
 pub mod grafbase_client;
+pub mod http;
 pub mod metrics;
 /// Otel integration
 pub mod otel;

--- a/engine/crates/telemetry/src/span/request.rs
+++ b/engine/crates/telemetry/src/span/request.rs
@@ -46,13 +46,6 @@ pub struct HttpRequestSpan<'a> {
 }
 
 impl<'a> HttpRequestSpan<'a> {
-    /// Sets the span ray_id
-    pub fn with_ray_id(mut self, ray_id: impl Into<Option<Cow<'a, http::HeaderValue>>>) -> Self {
-        self.header_ray_id = ray_id.into();
-
-        self
-    }
-
     /// Sets the span git_branch
     pub fn with_git_branch(mut self, git_branch: impl Into<Option<Cow<'a, http::HeaderValue>>>) -> Self {
         self.git_branch = git_branch.into();

--- a/engine/crates/telemetry/src/tower.rs
+++ b/engine/crates/telemetry/src/tower.rs
@@ -56,18 +56,11 @@ pub struct TelemetryService<S> {
 }
 
 impl<S> TelemetryService<S> {
-    #[cfg(not(feature = "lambda"))]
-    fn make_span<B: Body>(&mut self, request: &Request<B>) -> Span {
-        HttpRequestSpan::from_http(request).into_span()
-    }
-
-    #[cfg(feature = "lambda")]
     fn make_span<B: Body>(&self, request: &Request<B>) -> Span {
-        use opentelemetry::Context;
         use tracing_opentelemetry::OpenTelemetrySpanExt;
 
         let parent_ctx = opentelemetry::global::get_text_map_propagator(|propagator| {
-            propagator.extract_with_context(&Context::current(), &HeaderExtractor(request.headers()))
+            propagator.extract(&HeaderExtractor(request.headers()))
         });
 
         let span = HttpRequestSpan::from_http(request).into_span();

--- a/gateway/changelog/0.11.0.md
+++ b/gateway/changelog/0.11.0.md
@@ -1,3 +1,29 @@
+### Features
+
+- The gateway now implements tracing propagation: it can receive tracing context (trace id, parent span id, additional context) from headers in the requests it receives, and pass that context on to subgraphs when it makes requests to them. That enables correlation of requests across network boundaries.
+
+  There are different standards for propagation. In this release, we implement [Trace Context](https://www.w3.org/TR/trace-context/) and [Baggage](https://opentelemetry.io/docs/concepts/signals/baggage/) — the standard OpenTelemetry mechanisms for trace parent and trace context propagation respectively —, and AWS X-Ray. Multiple mechanisms can be combined.
+
+  This is configurable through the `telemetry.tracing.propagation` key in the configuration. For example:
+
+  ```toml
+  [telemetry.tracing.propagation]
+  trace_context = true
+  baggage = true
+  ```
+
+  In addition, a new option named `parent_based_sampler` appears in `telemetry.tracing`:
+
+  ```toml
+  [telemetry.tracing]
+  sampling = 0.2
+  parent_based_sampler = true
+  ```
+
+  When enabled, the gateway will honor sampling configuration passed in through the `sampled` header (W3C spec), then fall back to its own configuration. This option is disabled by default and should not be enabled if the gateway is exposed directly to the internet, since malicious clients could increase load on the gateway by forcing traces to be recorded.
+
+  See also the [documentation](https://github.com/grafbase/website/pull/2782)
+
 ### Fixes
 
 - Correct handling of `operationName`.

--- a/gateway/crates/config/src/telemetry/exporters.rs
+++ b/gateway/crates/config/src/telemetry/exporters.rs
@@ -12,7 +12,7 @@ pub use otlp::{
     Headers, OtlpExporterConfig, OtlpExporterGrpcConfig, OtlpExporterHttpConfig, OtlpExporterProtocol,
     OtlpExporterTlsConfig,
 };
-pub use tracing::{TracingCollectConfig, TracingConfig, DEFAULT_SAMPLING};
+pub use tracing::{PropagationConfig, TracingCollectConfig, TracingConfig, DEFAULT_SAMPLING};
 
 use serde::{Deserialize, Deserializer};
 pub use stdout::StdoutExporterConfig;

--- a/gateway/crates/config/src/telemetry/exporters/tracing.rs
+++ b/gateway/crates/config/src/telemetry/exporters/tracing.rs
@@ -14,10 +14,14 @@ pub struct TracingConfig {
     /// Default is 0.15.
     #[serde(deserialize_with = "deserialize_sampling")]
     pub sampling: f64,
+    /// Allow clients to specify sampling rate. Enable only if you are not exposing the gateway directly to clients. Default: false.
+    pub parent_based_sampler: bool,
     /// Collection configuration
     pub collect: TracingCollectConfig,
     /// Exporters configurations
     pub exporters: ExportersConfig,
+    /// Trace parent and context propagation configuration
+    pub propagation: PropagationConfig,
 }
 
 impl Default for TracingConfig {
@@ -26,6 +30,8 @@ impl Default for TracingConfig {
             sampling: DEFAULT_SAMPLING,
             collect: Default::default(),
             exporters: Default::default(),
+            propagation: Default::default(),
+            parent_based_sampler: false,
         }
     }
 }
@@ -61,6 +67,22 @@ impl Default for TracingCollectConfig {
             max_attributes_per_link: DEFAULT_COLLECT_VALUE,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Deserialize, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct PropagationConfig {
+    /// Enable [TraceContext](https://www.w3.org/TR/trace-context/) propagation through the `traceparent` header. This is the standard trace parent propagation mechanism in OpenTelemetry.
+    pub trace_context: bool,
+    /// Enable Baggage context propagation through the `baggage` header. This is the standard context propagation mechanism in OpenTelemetry.
+    ///
+    /// Resources:
+    ///
+    /// - https://www.w3.org/TR/baggage/
+    /// - https://opentelemetry.io/docs/concepts/signals/baggage/
+    pub baggage: bool,
+    /// Enable AWS X-Ray propagation through the `x-amzn-trace-id` header. This is the standard trace parent propagation mechanism for AWS X-Ray. https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader
+    pub aws_xray: bool,
 }
 
 fn deserialize_sampling<'de, D>(deserializer: D) -> Result<f64, D::Error>

--- a/gateway/crates/config/src/telemetry/mod.rs
+++ b/gateway/crates/config/src/telemetry/mod.rs
@@ -8,7 +8,7 @@ pub use exporters::{
     OtlpExporterTlsConfig,
 };
 pub use exporters::{
-    LogsConfig, MetricsConfig, {TracingCollectConfig, TracingConfig, DEFAULT_SAMPLING},
+    LogsConfig, MetricsConfig, PropagationConfig, {TracingCollectConfig, TracingConfig, DEFAULT_SAMPLING},
 };
 
 pub use exporters::{BatchExportConfig, ExportersConfig, StdoutExporterConfig};
@@ -1201,5 +1201,42 @@ mod tests {
         };
         let result = ClientTlsConfig::try_from(tls_config);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn tracing_with_parent_based_sampling_and_propagation() {
+        let input = indoc! {r#"
+            [tracing]
+            parent_based_sampler = true
+
+            [tracing.propagation]
+            trace_context = true
+            baggage = true
+        "#};
+
+        let config: TelemetryConfig = toml::from_str(input).unwrap();
+
+        assert_eq!(
+            TelemetryConfig {
+                service_name: String::from(""),
+                resource_attributes: Default::default(),
+                exporters: Default::default(),
+                logs: Default::default(),
+                metrics: Default::default(),
+                grafbase: None,
+                tracing: TracingConfig {
+                    sampling: 0.15,
+                    parent_based_sampler: true,
+                    collect: Default::default(),
+                    exporters: Default::default(),
+                    propagation: exporters::PropagationConfig {
+                        trace_context: true,
+                        baggage: true,
+                        aws_xray: false
+                    },
+                },
+            },
+            config
+        );
     }
 }

--- a/gateway/crates/federated-server/src/server/graph_fetch_method.rs
+++ b/gateway/crates/federated-server/src/server/graph_fetch_method.rs
@@ -62,6 +62,8 @@ impl GraphFetchMethod {
                 let gateway = gateway::generate(&federated_schema, None, config, hot_reload_config_path).await?;
 
                 sender.send(Some(Arc::new(gateway)))?;
+
+                std::mem::forget(otel_reload);
             }
         }
 

--- a/gateway/crates/federated-server/src/server/graph_fetch_method.rs
+++ b/gateway/crates/federated-server/src/server/graph_fetch_method.rs
@@ -62,8 +62,6 @@ impl GraphFetchMethod {
                 let gateway = gateway::generate(&federated_schema, None, config, hot_reload_config_path).await?;
 
                 sender.send(Some(Arc::new(gateway)))?;
-
-                std::mem::forget(otel_reload);
             }
         }
 

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -12,7 +12,6 @@ lambda = [
   "federated-server/lambda",
   "tracing-subscriber/json",
   "grafbase-telemetry/lambda",
-  "dep:opentelemetry-aws"
 ]
 
 [dependencies]
@@ -25,7 +24,7 @@ gateway-config.workspace = true
 grafbase-telemetry = { workspace = true, features = ["otlp"] }
 graph-ref.workspace = true
 mimalloc = "0.1.41"
-opentelemetry-aws = { version = "0.10.0", optional = true }
+opentelemetry-aws = { version = "0.10.0" }
 rustls = { workspace = true, features = ["ring"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
 toml = "0.8.12"

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -37,12 +37,15 @@ cfg-if = "1.0.0"
 workspace = true
 
 [dev-dependencies]
+async-graphql-parser.workspace = true
 clickhouse = { version = "0.12" }
 ctor.workspace = true
 duct = "0.13.7"
 fslock = "0.2.1"
 futures-util.workspace = true
+graphql-composition.workspace = true
 grafbase-graphql-introspection.workspace = true
+graphql-mocks.workspace = true
 http.workspace = true
 indoc = "2.0.5"
 insta = { workspace = true, features = ["json", "redactions", "yaml"] }

--- a/gateway/crates/gateway-binary/src/telemetry.rs
+++ b/gateway/crates/gateway-binary/src/telemetry.rs
@@ -15,25 +15,56 @@ pub(crate) struct OpenTelemetryProviders {
 }
 
 pub(crate) fn init(args: &impl Args, config: TelemetryConfig) -> anyhow::Result<OpenTelemetryProviders> {
+    use grafbase_telemetry::otel::opentelemetry::propagation::TextMapPropagator;
+    use grafbase_telemetry::otel::opentelemetry_sdk::trace::RandomIdGenerator;
+    use opentelemetry_aws::trace::XrayPropagator;
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
 
     let filter = args.log_level().map(|l| l.as_filter_str()).unwrap_or("info");
     let env_filter = EnvFilter::new(filter);
-    let id_generator = {
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "lambda")] {
-                use opentelemetry_aws::trace::{XrayIdGenerator, XrayPropagator};
-                grafbase_telemetry::otel::opentelemetry::global::set_text_map_propagator(XrayPropagator::default());
 
-                XrayIdGenerator::default()
-            } else {
-                use grafbase_telemetry::otel::opentelemetry_sdk::trace::RandomIdGenerator;
+    {
+        let mut propagators: Vec<Box<dyn TextMapPropagator + Send + Sync>> = Vec::new();
 
-                RandomIdGenerator::default()
-            }
+        let mut xray_propagator_added = false;
+
+        let tracing_config = &config.tracing;
+        if tracing_config.propagation.trace_context {
+            propagators.push(Box::new(
+                grafbase_telemetry::otel::opentelemetry_sdk::propagation::TraceContextPropagator::new(),
+            ));
         }
-    };
+
+        if tracing_config.propagation.baggage {
+            propagators.push(Box::new(
+                grafbase_telemetry::otel::opentelemetry_sdk::propagation::BaggagePropagator::new(),
+            ))
+        }
+
+        if tracing_config.propagation.aws_xray {
+            propagators.push(Box::new(XrayPropagator::default()));
+            xray_propagator_added = true;
+        }
+
+        if cfg!(feature = "lambda") && !xray_propagator_added {
+            propagators.push(Box::new(XrayPropagator::default()))
+        }
+
+        if !propagators.is_empty() {
+            let propagator =
+                grafbase_telemetry::otel::opentelemetry::propagation::TextMapCompositePropagator::new(propagators);
+            grafbase_telemetry::otel::opentelemetry::global::set_text_map_propagator(propagator);
+        }
+    }
+
+    cfg_if::cfg_if! {
+      if #[cfg(feature = "lambda")] {
+            let id_generator = opentelemetry_aws::trace::XrayIdGenerator::default();
+        } else {
+            let id_generator = RandomIdGenerator::default();
+        }
+    }
 
     let OtelTelemetry {
         tracer,

--- a/gateway/crates/gateway-binary/tests/integration_tests.rs
+++ b/gateway/crates/gateway-binary/tests/integration_tests.rs
@@ -356,7 +356,7 @@ impl From<String> for ConfigContent<'static> {
 struct GatewayBuilder<'a> {
     toml_config: ConfigContent<'a>,
     schema: &'a str,
-    log_evel: Option<String>,
+    log_level: Option<String>,
     client_url_path: Option<&'a str>,
     client_headers: Option<&'static [(&'static str, &'static str)]>,
 }
@@ -366,14 +366,14 @@ impl<'a> GatewayBuilder<'a> {
         Self {
             toml_config: ConfigContent(None),
             schema,
-            log_evel: None,
+            log_level: None,
             client_url_path: None,
             client_headers: None,
         }
     }
 
     fn with_log_level(mut self, level: &str) -> Self {
-        self.log_evel = Some(level.to_string());
+        self.log_level = Some(level.to_string());
         self
     }
 
@@ -401,12 +401,14 @@ impl<'a> GatewayBuilder<'a> {
             args.push(config_path.to_str().unwrap().to_string());
         }
 
-        if let Some(level) = self.log_evel {
+        if let Some(level) = self.log_level {
             args.push("--log".to_string());
             args.push(level);
         }
 
-        let command = cmd(cargo_bin("grafbase-gateway"), &args).stdout_null().stderr_null();
+        let command = cmd(cargo_bin("grafbase-gateway"), &args)
+            .stdout_null()
+            .stderr_path("/home/tom/stderr.txt");
 
         let endpoint = match self.client_url_path {
             Some(path) => format!("http://{addr}/{path}"),
@@ -454,7 +456,7 @@ fn with_static_server<'a, F, T>(
     GatewayBuilder {
         toml_config: config.into(),
         schema,
-        log_evel: None,
+        log_level: None,
         client_url_path: path,
         client_headers: headers,
     }

--- a/gateway/crates/gateway-binary/tests/integration_tests.rs
+++ b/gateway/crates/gateway-binary/tests/integration_tests.rs
@@ -406,9 +406,7 @@ impl<'a> GatewayBuilder<'a> {
             args.push(level);
         }
 
-        let command = cmd(cargo_bin("grafbase-gateway"), &args)
-            .stdout_null()
-            .stderr_path("/home/tom/stderr.txt");
+        let command = cmd(cargo_bin("grafbase-gateway"), &args).stdout_null().stderr_null();
 
         let endpoint = match self.client_url_path {
             Some(path) => format!("http://{addr}/{path}"),

--- a/gateway/crates/gateway-binary/tests/telemetry/mod.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/mod.rs
@@ -7,6 +7,7 @@ use crate::{load_schema, with_static_server};
 
 mod logs;
 mod metrics;
+mod tracing;
 
 #[test]
 fn with_stdout_telemetry() {

--- a/gateway/crates/gateway-binary/tests/telemetry/tracing.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/tracing.rs
@@ -8,12 +8,17 @@ use indoc::formatdoc;
 
 use crate::{clickhouse_client, runtime, Client};
 
+const TRACE_INGESTION_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
+
 #[test]
-fn propagation() {
+fn no_traceparent_no_propagation() {
     with_mock_subgraph(
-        "",
+        "
+            [telemetry.tracing.propagation]
+            trace_context = false
+        ",
         graphql_mocks::EchoSchema,
-        |service_name, start, gateway, clickhouse| async move {
+        |_service_name, _start, gateway, _clickhouse| async move {
             let request = r#"
                 query {
                     headers {
@@ -23,15 +28,325 @@ fn propagation() {
                 }
             "#;
 
-            let response: serde_json::Value = gateway
+            let response: HeadersResponse = gateway
                 .gql(request)
-                .header("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+                .header("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01") // should not be included
+                .header("baggage", "userId=Am%C3%A9lie,serverNode=DF%2028,isProduction=false") // should not be included
+                .header("x-amzn-trace-id", "Root=1-5759e988-bd862e3fe1be46a994272793;Sampled=1") // should not be included
                 .send()
                 .await;
 
-            panic!("response: {:#?}", response);
+            response.assert_header_names(&["accept", "content-length", "content-type"]);
         },
     );
+}
+
+#[test]
+fn tracecontext_traceparent_propagation() {
+    with_mock_subgraph(
+        "
+            [telemetry.tracing.propagation]
+            trace_context = true
+        ",
+        graphql_mocks::EchoSchema,
+        |service_name, start_time_unix, gateway, clickhouse| async move {
+            let request = r#"
+                query {
+                    headers {
+                        name
+                        value
+                    }
+                }
+            "#;
+
+            let response: HeadersResponse = gateway
+                .gql(request)
+                .header("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+                .header("baggage", "userId=Am%C3%A9lie,serverNode=DF%2028,isProduction=false") // should not be included
+                .header("x-amzn-trace-id", "Root=1-5759e988-bd862e3fe1be46a994272793;Sampled=1") // should not be included
+                .send()
+                .await;
+
+            response.assert_header_names(&["accept", "content-length", "content-type", "traceparent", "tracestate"]);
+            response.assert_header_content("tracestate", "");
+
+            let trace_parent = response.assert_header("traceparent");
+
+            assert_eq!(
+                traceparent_deterministic_part(trace_parent),
+                "00-0af7651916cd43dd8448eb211c80319c-xxxxxxxxxxxxxxxx-01"
+            );
+
+            tokio::time::sleep(TRACE_INGESTION_DELAY).await;
+
+            let row = clickhouse
+                .query(
+                    r#"
+                SELECT count()
+                FROM otel_traces
+                WHERE ServiceName = ?
+                    AND Timestamp >= ?
+                    AND SpanName = 'gateway'
+                    AND TraceId = '0af7651916cd43dd8448eb211c80319c'
+                "#,
+                )
+                .bind(&service_name)
+                .bind(start_time_unix)
+                .fetch_one::<TracesRow>()
+                .await
+                .unwrap();
+
+            insta::assert_json_snapshot!(row, @r###"
+            {
+              "count": 1
+            }
+            "###);
+        },
+    );
+}
+
+#[test]
+fn tracecontext_and_baggage_propagation() {
+    with_mock_subgraph(
+        "
+            [telemetry.tracing.propagation]
+            trace_context = true
+            baggage = true
+        ",
+        graphql_mocks::EchoSchema,
+        |service_name, start_time_unix, gateway, clickhouse| async move {
+            let request = r#"
+                query {
+                    headers {
+                        name
+                        value
+                    }
+                }
+            "#;
+
+            let response: HeadersResponse = gateway
+                .gql(request)
+                .header("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+                .header("baggage", "userId=Am%C3%A9lie,serverNode=DF%2028,isProduction=false")
+                .header("x-amzn-trace-id", "Root=1-5759e988-bd862e3fe1be46a994272793;Sampled=1") // should not be included
+                .send()
+                .await;
+
+            response.assert_header_names(&[
+                "accept",
+                "baggage",
+                "content-length",
+                "content-type",
+                "traceparent",
+                "tracestate",
+            ]);
+            response.assert_header_content("tracestate", "");
+
+            let trace_parent = response.assert_header("traceparent");
+
+            let to_deterministic_part = |traceparent: &str| {
+                // https://www.w3.org/TR/trace-context/
+                let mut segments = traceparent.split('-');
+                let mut out = String::with_capacity(traceparent.len());
+
+                out.push_str(segments.next().unwrap());
+                out.push('-');
+
+                out.push_str(segments.next().unwrap());
+                out.push('-');
+
+                segments.next().unwrap();
+                out.push_str("xxxxxxxxxxxxxxxx");
+                out.push('-');
+
+                out.push_str(segments.next().unwrap());
+
+                out
+            };
+
+            assert_eq!(
+                to_deterministic_part(trace_parent),
+                "00-0af7651916cd43dd8448eb211c80319c-xxxxxxxxxxxxxxxx-01"
+            );
+
+            let baggage = response.assert_header("baggage");
+            let mut baggage_values: Vec<_> = baggage.split(',').collect();
+            baggage_values.sort();
+            assert_eq!(
+                baggage_values,
+                &["isProduction=false", "serverNode=DF%2028", "userId=Am%C3%A9lie"]
+            );
+
+            tokio::time::sleep(TRACE_INGESTION_DELAY).await;
+
+            let row = clickhouse
+                .query(
+                    r#"
+                SELECT count()
+                FROM otel_traces
+                WHERE ServiceName = ?
+                    AND Timestamp >= ?
+                    AND SpanName = 'gateway'
+                    AND TraceId = '0af7651916cd43dd8448eb211c80319c'
+                "#,
+                )
+                .bind(&service_name)
+                .bind(start_time_unix)
+                .fetch_one::<TracesRow>()
+                .await
+                .unwrap();
+
+            insta::assert_json_snapshot!(row, @r###"
+            {
+              "count": 1
+            }
+            "###);
+        },
+    );
+}
+
+#[test]
+fn baggage_propagation() {
+    with_mock_subgraph(
+        "
+            [telemetry.tracing.propagation]
+            baggage = true
+        ",
+        graphql_mocks::EchoSchema,
+        |_service_name, _start, gateway, _clickhouse| async move {
+            let request = r#"
+                query {
+                    headers {
+                        name
+                        value
+                    }
+                }
+            "#;
+
+            let response: HeadersResponse = gateway
+                .gql(request)
+                .header("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01") // should not be included
+                .header("baggage", "userId=Am%C3%A9lie,serverNode=DF%2028,isProduction=false")
+                .header("baggage", "userName=alice") // FIXME: this should also be included (https://www.w3.org/TR/baggage/#examples-of-http-headers)
+                .send()
+                .await;
+
+            response.assert_header_names(&["accept", "baggage", "content-length", "content-type"]);
+            let values = response.assert_header("baggage");
+            let mut values: Vec<_> = values.split(',').collect();
+            values.sort();
+            assert_eq!(
+                values,
+                &["isProduction=false", "serverNode=DF%2028", "userId=Am%C3%A9lie"]
+            );
+        },
+    );
+}
+
+#[test]
+fn aws_xray_propagation() {
+    with_mock_subgraph(
+        "
+            [telemetry.tracing.propagation]
+            trace_context = true
+        ",
+        graphql_mocks::EchoSchema,
+        |_service_name, _start, gateway, _clickhouse| async move {
+            let request = r#"
+                query {
+                    headers {
+                        name
+                        value
+                    }
+                }
+            "#;
+
+            let response: HeadersResponse = gateway
+                .gql(request)
+                .header("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+                .header("baggage", "userId=Am%C3%A9lie,serverNode=DF%2028,isProduction=false") // should not be included
+                .header("x-amzn-trace-id", "Root=1-5759e988-bd862e3fe1be46a994272793;Sampled=1") // should not be included
+                .send()
+                .await;
+
+            response.assert_header_names(&["accept", "content-length", "content-type", "traceparent", "tracestate"]);
+            response.assert_header_content("tracestate", "");
+
+            let trace_parent = response.assert_header("traceparent");
+
+            assert_eq!(
+                traceparent_deterministic_part(trace_parent),
+                "00-0af7651916cd43dd8448eb211c80319c-xxxxxxxxxxxxxxxx-01"
+            );
+        },
+    );
+}
+
+/// https://www.w3.org/TR/trace-context/
+fn traceparent_deterministic_part(traceparent: &str) -> String {
+    let mut segments = traceparent.split('-');
+    let mut out = String::with_capacity(traceparent.len());
+
+    out.push_str(segments.next().unwrap());
+    out.push('-');
+
+    out.push_str(segments.next().unwrap());
+    out.push('-');
+
+    segments.next().unwrap();
+    out.push_str("xxxxxxxxxxxxxxxx");
+    out.push('-');
+
+    out.push_str(segments.next().unwrap());
+
+    out
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct HeadersResponse {
+    data: HeadersResponseData,
+}
+
+impl HeadersResponse {
+    #[track_caller]
+    fn assert_header_names(&self, expected: &[&str]) {
+        let actual: Vec<_> = self.data.headers.iter().map(|h| h.name.as_str()).collect();
+        assert_eq!(actual, expected);
+    }
+
+    #[track_caller]
+    fn assert_header_content(&self, header_name: &str, expected_value: &str) {
+        let value = self.assert_header(header_name);
+        assert_eq!(value, expected_value);
+    }
+
+    #[track_caller]
+    fn assert_header<'a>(&'a self, header_name: &str) -> &'a str {
+        let header = self
+            .data
+            .headers
+            .iter()
+            .find(|h| h.name == header_name)
+            .expect("header not found");
+
+        &header.value
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct HeadersResponseData {
+    headers: Vec<Header>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct Header {
+    name: String,
+    value: String,
+}
+
+#[derive(Debug, clickhouse::Row, serde::Deserialize, serde::Serialize, PartialEq)]
+struct TracesRow {
+    count: u64,
 }
 
 fn with_mock_subgraph<T, F>(config: &str, subgraph_schema: impl graphql_mocks::Schema + 'static, test: T)
@@ -82,7 +397,14 @@ where
             .unwrap()
     };
 
-    super::with_static_server(config, &federated_schema, None, None, |client| async move {
+    crate::GatewayBuilder {
+        toml_config: config.into(),
+        schema: &federated_schema,
+        log_level: None,
+        client_url_path: None,
+        client_headers: None,
+    }
+    .run(|client| async move {
         const WAIT_SECONDS: u64 = 2;
         let start = std::time::SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/gateway/crates/gateway-binary/tests/telemetry/tracing.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/tracing.rs
@@ -393,8 +393,7 @@ where
         graphql_composition::compose(&subgraphs)
             .into_result()
             .unwrap()
-            .into_sdl()
-            .unwrap()
+            .into_federated_sdl()
     };
 
     crate::GatewayBuilder {

--- a/gateway/crates/gateway-binary/tests/telemetry/tracing.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/tracing.rs
@@ -1,0 +1,99 @@
+use std::{
+    sync::Arc,
+    time::{Duration, UNIX_EPOCH},
+};
+
+use futures_util::Future;
+use indoc::formatdoc;
+
+use crate::{clickhouse_client, runtime, Client};
+
+#[test]
+fn propagation() {
+    with_mock_subgraph(
+        "",
+        graphql_mocks::EchoSchema,
+        |service_name, start, gateway, clickhouse| async move {
+            let request = r#"
+                query {
+                    headers {
+                        name
+                        value
+                    }
+                }
+            "#;
+
+            let response: serde_json::Value = gateway
+                .gql(request)
+                .header("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+                .send()
+                .await;
+
+            panic!("response: {:#?}", response);
+        },
+    );
+}
+
+fn with_mock_subgraph<T, F>(config: &str, subgraph_schema: impl graphql_mocks::Schema + 'static, test: T)
+where
+    T: FnOnce(String, u64, Arc<Client>, &'static clickhouse::Client) -> F,
+    F: Future<Output = ()>,
+{
+    let service_name = format!("service_{}", ulid::Ulid::new());
+    let config = &formatdoc! {r#"
+        [graph]
+        introspection = true
+
+        [telemetry]
+        service_name = "{service_name}"
+
+        [telemetry.tracing]
+        sampling = 1
+
+        [telemetry.exporters.otlp]
+        enabled = true
+        endpoint = "http://localhost:4318"
+        protocol = "grpc"
+
+        [telemetry.exporters.otlp.batch_export]
+        scheduled_delay = 1
+        max_export_batch_size = 1
+
+        {config}
+    "#};
+
+    let clickhouse = clickhouse_client();
+
+    println!("service_name: {service_name}");
+    println!("{config}");
+
+    let subgraph_sdl = subgraph_schema.sdl();
+
+    let subgraph_server = runtime().block_on(async { graphql_mocks::MockGraphQlServer::new(subgraph_schema).await });
+
+    let federated_schema = {
+        let parsed = async_graphql_parser::parse_schema(&subgraph_sdl).unwrap();
+        let mut subgraphs = graphql_composition::Subgraphs::default();
+        subgraphs.ingest(&parsed, "the-subgraph", subgraph_server.url().as_str());
+        graphql_composition::compose(&subgraphs)
+            .into_result()
+            .unwrap()
+            .into_sdl()
+            .unwrap()
+    };
+
+    super::with_static_server(config, &federated_schema, None, None, |client| async move {
+        const WAIT_SECONDS: u64 = 2;
+        let start = std::time::SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + WAIT_SECONDS;
+
+        // wait for initial polling to be pushed to OTEL tables so we can ignore it with the
+        // appropriate start time filter.
+        tokio::time::sleep(Duration::from_secs(WAIT_SECONDS)).await;
+
+        test(service_name, start, client, clickhouse).await
+    })
+}


### PR DESCRIPTION
The gateway now implements tracing propagation: it can receive tracing context (trace id, parent span id, additional context) from headers in the requests it receives, and pass that context on to subgraphs when it makes requests to them. That enables correlation of requests across network boundaries.

There are different standards for propagation. In this release, we implement [Trace Context](https://www.w3.org/TR/trace-context/) and [Baggage](https://opentelemetry.io/docs/concepts/signals/baggage/) — the standard OpenTelemetry mechanisms for trace parent and trace context propagation respectively —, and AWS X-Ray. Multiple mechanisms can be combined.

This is configurable through the `telemetry.tracing.propagation` key in the configuration. For example:

```toml
[telemetry.tracing.propagation]
trace_context = true
baggage = true
```

In addition, a new option named `parent_based_sampler` appears in `telemetry.tracing`:

```toml
[telemetry.tracing]
sampling = 0.2
parent_based_sampler = true
```

When enabled, the gateway will honor sampling configuration passed in through the `sampled` header (W3C spec), then fall back to its own configuration. This option is disabled by default and should not be enabled if the gateway is exposed directly to the internet, since malicious clients could increase load on the gateway by forcing traces to be recorded.