### PR TITLE
cli: release 0.79.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,7 +2394,7 @@ dependencies = [
 
 [[package]]
 name = "engine-config-builder"
-version = "0.79.0"
+version = "0.79.1"
 dependencies = [
  "engine-v2-config",
  "gateway-config",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "federated-dev"
-version = "0.79.0"
+version = "0.79.1"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "0.79.0"
+version = "0.79.1"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -3476,7 +3476,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.79.0"
+version = "0.79.1"
 dependencies = [
  "assert_matches",
  "async-graphql",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-docker-tests"
-version = "0.79.0"
+version = "0.79.1"
 dependencies = [
  "anyhow",
  "bollard",
@@ -3616,7 +3616,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-graphql-introspection"
-version = "0.79.0"
+version = "0.79.1"
 dependencies = [
  "cynic",
  "cynic-introspection",
@@ -3628,7 +3628,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.79.0"
+version = "0.79.1"
 dependencies = [
  "async-compression",
  "axum",
@@ -3658,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.79.0"
+version = "0.79.1"
 dependencies = [
  "chrono",
  "common-types",
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-server"
-version = "0.79.0"
+version = "0.79.1"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -3791,7 +3791,7 @@ dependencies = [
 
 [[package]]
 name = "graph-ref"
-version = "0.79.0"
+version = "0.79.1"
 
 [[package]]
 name = "graphql-composition"
@@ -3809,7 +3809,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-cursor"
-version = "0.79.0"
+version = "0.79.1"
 dependencies = [
  "serde",
  "serde_with",
@@ -5994,7 +5994,7 @@ dependencies = [
 
 [[package]]
 name = "operation-checks"
-version = "0.79.0"
+version = "0.79.1"
 dependencies = [
  "async-graphql-parser",
  "async-graphql-value",
@@ -6007,7 +6007,7 @@ dependencies = [
 
 [[package]]
 name = "operation-normalizer"
-version = "0.79.0"
+version = "0.79.1"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -6276,7 +6276,7 @@ dependencies = [
 
 [[package]]
 name = "partial-caching"
-version = "0.79.0"
+version = "0.79.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -7911,7 +7911,7 @@ dependencies = [
 
 [[package]]
 name = "serde-dynamic-string"
-version = "0.79.0"
+version = "0.79.1"
 dependencies = [
  "ascii 1.1.0",
  "insta",
@@ -9430,7 +9430,7 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typed-resolvers"
-version = "0.79.0"
+version = "0.79.1"
 dependencies = [
  "datatest-stable",
  "engine-parser",
@@ -9664,7 +9664,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-component-loader"
-version = "0.79.0"
+version = "0.79.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ tracing-core = { git = "https://github.com/tokio-rs/tracing", rev = "6d00d7d9f72
 tracing-mock = { git = "https://github.com/tokio-rs/tracing", rev = "6d00d7d9f72dc6797138a1062bc33073afbad5a1" } # v0.1.x
 
 [workspace.package]
-version = "0.79.0"
+version = "0.79.1"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://grafbase.com"

--- a/cli/changelog/0.79.1.md
+++ b/cli/changelog/0.79.1.md
@@ -1,0 +1,3 @@
+## Fixes
+
+- cli: make grafbase.config.ts optional for gb create --mode=self-hosted. The configuration is not relevant in fully self-hosted deployments. (#2045)

--- a/cli/crates/backend/Cargo.toml
+++ b/cli/crates/backend/Cargo.toml
@@ -36,8 +36,8 @@ ulid = "1.1.2"
 url = "2.5.0"
 urlencoding = "2.1.3"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.79.0" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.79.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.79.1" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.79.1" }
 
 [build-dependencies]
 cynic-codegen = { version = "3.7.0", features = ["rkyv"] }

--- a/cli/crates/cli/Cargo.toml
+++ b/cli/crates/cli/Cargo.toml
@@ -52,13 +52,13 @@ url = "2.5.0"
 uuid = { version = "1.8.0", features = ["v4"] }
 webbrowser = "1.0"
 
-backend = { package = "grafbase-local-backend", path = "../backend", version = "0.79.0" }
-common = { package = "grafbase-local-common", path = "../common", version = "0.79.0" }
+backend = { package = "grafbase-local-backend", path = "../backend", version = "0.79.1" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.79.1" }
 federated-dev = { path = "../federated-dev" }
 grafbase-graphql-introspection.workspace = true
 graphql-lint.workspace = true
 graph-ref = { path = "../../../graph-ref" }
-server = { package = "grafbase-local-server", path = "../server", version = "0.79.0" }
+server = { package = "grafbase-local-server", path = "../server", version = "0.79.1" }
 prettytable = { version = "0.10.0", default-features = false, features = ["win_crlf"] }
 
 [dev-dependencies]

--- a/cli/crates/federated-dev/Cargo.toml
+++ b/cli/crates/federated-dev/Cargo.toml
@@ -34,7 +34,7 @@ tokio-stream = { version = "0.1.15", features = ["sync"] }
 tower-http = { workspace = true, features = ["cors", "fs", "trace"] }
 url = "2.5.0"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.79.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.79.1" }
 engine-config-builder = { path = "../../../engine/crates/engine-config-builder" }
 engine-v2.workspace = true
 engine-v2-axum.workspace = true

--- a/cli/crates/server/Cargo.toml
+++ b/cli/crates/server/Cargo.toml
@@ -62,7 +62,7 @@ tracing = "0.1.40"
 which.workspace = true
 zip = "2.0.0"
 
-common = { package = "grafbase-local-common", path = "../common", version = "0.79.0" }
+common = { package = "grafbase-local-common", path = "../common", version = "0.79.1" }
 gateway = { path = "../gateway" }
 typed-resolvers = { path = "../typed-resolvers" }
 federated-dev = { path = "../federated-dev" }

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.79.0",
+  "version": "0.79.1",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.79.0",
+  "version": "0.79.1",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.79.0",
+  "version": "0.79.1",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.79.0",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.79.0",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.79.0",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.79.0",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.79.0"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.79.1",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.79.1",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.79.1",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.79.1",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.79.1"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.79.0",
+  "version": "0.79.1",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.79.0",
+  "version": "0.79.1",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.79.0",
+  "version": "0.79.1",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/engine/crates/runtime-local/Cargo.toml
+++ b/engine/crates/runtime-local/Cargo.toml
@@ -44,7 +44,7 @@ reqwest = { workspace = true, features = [
   "json",
   "rustls-tls",
 ] }
-wasi-component-loader = { version = "0.79.0", path = "../wasi-component-loader", optional = true }
+wasi-component-loader = { version = "0.79.1", path = "../wasi-component-loader", optional = true }
 deadpool = { version = "0.12.1", features = ["rt_tokio_1"] }
 grafbase-telemetry.workspace = true
 anyhow.workspace = true


### PR DESCRIPTION
__Fixes__

- cli: make grafbase.config.ts optional for gb create --mode=self-hosted. The configuration is not relevant in fully self-hosted deployments. (#2045)