### PR TITLE
cli: fix grafbase create --mode=self-hosted outside of project context

### DIFF
--- a/cli/crates/backend/src/api/graphql/types/mutations.rs
+++ b/cli/crates/backend/src/api/graphql/types/mutations.rs
@@ -8,7 +8,7 @@ use super::schema;
 pub struct GraphCreateInput<'a> {
     pub account_id: cynic::Id,
     pub graph_slug: &'a str,
-    pub repo_root_path: &'a str,
+    pub repo_root_path: Option<&'a str>,
     pub environment_variables: Vec<EnvironmentVariableSpecification<'a>>,
     pub graph_mode: GraphMode,
 }


### PR DESCRIPTION
We do rely on some globals lower down the call stack, that was not identified and addressed in https://github.com/grafbase/grafbase/pull/2045