### PR TITLE
graphql-federated-graph: decouple FederatedGraph from serialized format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2856,6 +2856,7 @@ dependencies = [
  "grafbase-local-common",
  "grafbase-telemetry",
  "graphql-composition",
+ "graphql-federated-graph",
  "handlebars",
  "indoc",
  "log",

--- a/cli/crates/federated-dev/Cargo.toml
+++ b/cli/crates/federated-dev/Cargo.toml
@@ -18,6 +18,7 @@ futures-concurrency = "7.6.0"
 futures-util = "0.3.30"
 gateway-config.workspace = true
 graphql-composition.workspace = true
+graphql-federated-graph.path = "../../../engine/crates/federated-graph"
 handlebars.workspace = true
 indoc = "2.0.5"
 log = "0.4.21"

--- a/cli/crates/federated-dev/src/dev.rs
+++ b/cli/crates/federated-dev/src/dev.rs
@@ -11,7 +11,7 @@ use axum::{
 };
 use common::environment::Environment;
 use engine_v2_axum::websocket::{WebsocketAccepter, WebsocketService};
-use graphql_federated_graph::FederatedGraphV4;
+use graphql_federated_graph::FederatedGraph;
 use handlebars::Handlebars;
 use serde_json::json;
 use std::{net::SocketAddr, time::Duration};
@@ -44,7 +44,7 @@ struct ProxyState {
 pub(super) async fn run(
     listen_address: SocketAddr,
     config: ConfigWatcher,
-    graph: Option<FederatedGraphV4>,
+    graph: Option<FederatedGraph>,
 ) -> Result<(), crate::Error> {
     log::trace!("starting the federated dev server");
 

--- a/cli/crates/federated-dev/src/dev.rs
+++ b/cli/crates/federated-dev/src/dev.rs
@@ -11,7 +11,7 @@ use axum::{
 };
 use common::environment::Environment;
 use engine_v2_axum::websocket::{WebsocketAccepter, WebsocketService};
-use graphql_composition::FederatedGraph;
+use graphql_federated_graph::FederatedGraphV4;
 use handlebars::Handlebars;
 use serde_json::json;
 use std::{net::SocketAddr, time::Duration};
@@ -44,7 +44,7 @@ struct ProxyState {
 pub(super) async fn run(
     listen_address: SocketAddr,
     config: ConfigWatcher,
-    graph: Option<FederatedGraph>,
+    graph: Option<FederatedGraphV4>,
 ) -> Result<(), crate::Error> {
     log::trace!("starting the federated dev server");
 

--- a/cli/crates/federated-dev/src/dev/bus.rs
+++ b/cli/crates/federated-dev/src/dev/bus.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 pub(crate) use admin::AdminBus;
 pub(crate) use compose::ComposeBus;
 use engine_v2::Engine;
-use graphql_federated_graph::FederatedGraphV4;
+use graphql_federated_graph::FederatedGraph;
 pub(crate) use message::*;
 pub(crate) use refresh::RefreshBus;
 pub(crate) use subgraph_config_watcher::SubgraphConfigWatcherBus;
@@ -22,10 +22,10 @@ use url::Url;
 use super::{admin::Header, gateway_nanny::CliRuntime, refresher::RefreshMessage};
 
 /// A channel to send composed federated graph, typically to a router.
-pub(crate) type GraphSender = watch::Sender<Option<FederatedGraphV4>>;
+pub(crate) type GraphSender = watch::Sender<Option<FederatedGraph>>;
 
 /// A channel to receive a composed federated graph, typically for a router.
-pub(crate) type GraphWatcher = watch::Receiver<Option<FederatedGraphV4>>;
+pub(crate) type GraphWatcher = watch::Receiver<Option<FederatedGraph>>;
 
 /// A channel to send a refresh message with a collection of graphs.
 pub(crate) type RefreshSender = mpsc::Sender<Vec<RefreshMessage>>;

--- a/cli/crates/federated-dev/src/dev/bus.rs
+++ b/cli/crates/federated-dev/src/dev/bus.rs
@@ -9,23 +9,23 @@ use std::sync::Arc;
 pub(crate) use admin::AdminBus;
 pub(crate) use compose::ComposeBus;
 use engine_v2::Engine;
+use graphql_federated_graph::FederatedGraphV4;
 pub(crate) use message::*;
 pub(crate) use refresh::RefreshBus;
 pub(crate) use subgraph_config_watcher::SubgraphConfigWatcherBus;
 
 use crate::{dev::composer::Subgraph, error::Error};
 use async_graphql_parser::types::ServiceDocument;
-use graphql_composition::FederatedGraph;
 use tokio::sync::{mpsc, oneshot, watch};
 use url::Url;
 
 use super::{admin::Header, gateway_nanny::CliRuntime, refresher::RefreshMessage};
 
 /// A channel to send composed federated graph, typically to a router.
-pub(crate) type GraphSender = watch::Sender<Option<FederatedGraph>>;
+pub(crate) type GraphSender = watch::Sender<Option<FederatedGraphV4>>;
 
 /// A channel to receive a composed federated graph, typically for a router.
-pub(crate) type GraphWatcher = watch::Receiver<Option<FederatedGraph>>;
+pub(crate) type GraphWatcher = watch::Receiver<Option<FederatedGraphV4>>;
 
 /// A channel to send a refresh message with a collection of graphs.
 pub(crate) type RefreshSender = mpsc::Sender<Vec<RefreshMessage>>;

--- a/cli/crates/federated-dev/src/dev/bus/compose.rs
+++ b/cli/crates/federated-dev/src/dev/bus/compose.rs
@@ -1,6 +1,6 @@
 use super::{ComposeMessage, ComposeReceiver, ComposeSender, GraphSender, RefreshMessage, RefreshSender};
 use crate::error::Error;
-use graphql_composition::FederatedGraph;
+use graphql_federated_graph::FederatedGraphV4;
 
 pub(crate) struct ComposeBus {
     graph_sender: GraphSender,
@@ -32,7 +32,7 @@ impl ComposeBus {
         Ok(self.compose_sender.send(message.into()).await?)
     }
 
-    pub async fn send_graph(&self, message: FederatedGraph) -> Result<(), Error> {
+    pub async fn send_graph(&self, message: FederatedGraphV4) -> Result<(), Error> {
         Ok(self.graph_sender.send(Some(message))?)
     }
 

--- a/cli/crates/federated-dev/src/dev/bus/compose.rs
+++ b/cli/crates/federated-dev/src/dev/bus/compose.rs
@@ -1,6 +1,6 @@
 use super::{ComposeMessage, ComposeReceiver, ComposeSender, GraphSender, RefreshMessage, RefreshSender};
 use crate::error::Error;
-use graphql_federated_graph::FederatedGraphV4;
+use graphql_federated_graph::FederatedGraph;
 
 pub(crate) struct ComposeBus {
     graph_sender: GraphSender,
@@ -32,7 +32,7 @@ impl ComposeBus {
         Ok(self.compose_sender.send(message.into()).await?)
     }
 
-    pub async fn send_graph(&self, message: FederatedGraphV4) -> Result<(), Error> {
+    pub async fn send_graph(&self, message: FederatedGraph) -> Result<(), Error> {
         Ok(self.graph_sender.send(Some(message))?)
     }
 

--- a/cli/crates/federated-dev/src/dev/composer.rs
+++ b/cli/crates/federated-dev/src/dev/composer.rs
@@ -118,7 +118,7 @@ impl Composer {
                 emit_event(crate::FederatedDevEvent::ComposeAfterAdditionSuccess {
                     subgraph_name: name.clone(),
                 });
-                graph
+                graph.into_latest()
             }
             Err(error) => {
                 emit_event(crate::FederatedDevEvent::ComposeAfterAdditionFailure {
@@ -174,7 +174,7 @@ impl Composer {
                 emit_event(crate::FederatedDevEvent::ComposeAfterRemovalSuccess {
                     subgraph_name: subgraph_name.clone(),
                 });
-                self.bus.send_graph(graph).await?
+                self.bus.send_graph(graph.into_latest()).await?
             }
             Err(error) => {
                 log::warn!("Recomposition failed: {error:?}");

--- a/cli/crates/federated-dev/src/dev/gateway_nanny.rs
+++ b/cli/crates/federated-dev/src/dev/gateway_nanny.rs
@@ -51,7 +51,7 @@ impl EngineNanny {
 
 pub(super) async fn new_gateway(config: Option<engine_v2::VersionedConfig>) -> Option<Arc<Engine<CliRuntime>>> {
     let config = config?.into_latest();
-    let graph = graphql_federated_graph::from_sdl(&config.graph).ok()?;
+    let graph = graphql_federated_graph::from_sdl(&config.federated_sdl).ok()?;
 
     let runtime = CliRuntime {
         fetcher: NativeFetcher::default(),
@@ -92,7 +92,7 @@ pub(super) async fn new_gateway(config: Option<engine_v2::VersionedConfig>) -> O
         entity_cache: InMemoryEntityCache::default(),
     };
 
-    let schema = (config, graph).try_into().ok()?;
+    let schema = config.try_into().ok()?;
     let engine = Engine::new(Arc::new(schema), None, runtime).await;
 
     Some(Arc::new(engine))

--- a/cli/crates/federated-dev/src/dev/gateway_nanny.rs
+++ b/cli/crates/federated-dev/src/dev/gateway_nanny.rs
@@ -51,6 +51,7 @@ impl EngineNanny {
 
 pub(super) async fn new_gateway(config: Option<engine_v2::VersionedConfig>) -> Option<Arc<Engine<CliRuntime>>> {
     let config = config?.into_latest();
+    let graph = graphql_federated_graph::from_sdl(&config.graph).ok()?;
 
     let runtime = CliRuntime {
         fetcher: NativeFetcher::default(),
@@ -75,7 +76,7 @@ pub(super) async fn new_gateway(config: Option<engine_v2::VersionedConfig>) -> O
 
             for (subgraph_name, subgraph) in config.subgraph_configs.iter() {
                 if let Some(limit) = subgraph.rate_limit {
-                    let name = &config.graph[config.graph[*subgraph_name].name];
+                    let name = &graph[graph[*subgraph_name].name];
                     key_based_config.insert(
                         RateLimitKey::Subgraph(name.clone().into()),
                         GraphRateLimit {
@@ -91,7 +92,7 @@ pub(super) async fn new_gateway(config: Option<engine_v2::VersionedConfig>) -> O
         entity_cache: InMemoryEntityCache::default(),
     };
 
-    let schema = config.try_into().ok()?;
+    let schema = (config, graph).try_into().ok()?;
     let engine = Engine::new(Arc::new(schema), None, runtime).await;
 
     Some(Arc::new(engine))

--- a/cli/crates/federated-dev/src/lib.rs
+++ b/cli/crates/federated-dev/src/lib.rs
@@ -59,7 +59,7 @@ pub use self::{
     events::{subscribe, FederatedDevEvent},
 };
 
-use graphql_composition::FederatedGraph;
+use graphql_federated_graph::FederatedGraphV4;
 use parser_sdl::federation::FederatedGraphConfig;
 use tokio::runtime::Builder;
 use url::Url;
@@ -81,7 +81,7 @@ pub fn add_subgraph(name: &str, url: &Url, dev_api_port: u16, headers: Vec<(&str
 pub async fn run(
     listen_address: SocketAddr,
     config: ConfigWatcher,
-    graph: Option<FederatedGraph>,
+    graph: Option<FederatedGraphV4>,
 ) -> Result<(), Error> {
     dev::run(listen_address, config, graph).await
 }

--- a/cli/crates/federated-dev/src/lib.rs
+++ b/cli/crates/federated-dev/src/lib.rs
@@ -59,7 +59,7 @@ pub use self::{
     events::{subscribe, FederatedDevEvent},
 };
 
-use graphql_federated_graph::FederatedGraphV4;
+use graphql_federated_graph::FederatedGraph;
 use parser_sdl::federation::FederatedGraphConfig;
 use tokio::runtime::Builder;
 use url::Url;
@@ -81,7 +81,7 @@ pub fn add_subgraph(name: &str, url: &Url, dev_api_port: u16, headers: Vec<(&str
 pub async fn run(
     listen_address: SocketAddr,
     config: ConfigWatcher,
-    graph: Option<FederatedGraphV4>,
+    graph: Option<FederatedGraph>,
 ) -> Result<(), Error> {
     dev::run(listen_address, config, graph).await
 }

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -11,7 +11,7 @@ use common::channels::constant_watch_receiver;
 use common::consts::MAX_PORT;
 use common::consts::{GRAFBASE_SCHEMA_FILE_NAME, GRAFBASE_TS_CONFIG_FILE_NAME};
 use common::environment::{Environment, Project};
-use federated_graph::FederatedGraphV4;
+use federated_graph::FederatedGraph;
 use flate2::read::GzDecoder;
 use futures_util::StreamExt;
 use std::collections::HashMap;
@@ -44,7 +44,7 @@ pub enum ProductionServer {
     Federated {
         message_sender: MessageSender,
         config: parser_sdl::federation::FederatedGraphConfig,
-        graph: Option<FederatedGraphV4>,
+        graph: Option<FederatedGraph>,
     },
 }
 

--- a/cli/crates/server/src/servers.rs
+++ b/cli/crates/server/src/servers.rs
@@ -11,7 +11,7 @@ use common::channels::constant_watch_receiver;
 use common::consts::MAX_PORT;
 use common::consts::{GRAFBASE_SCHEMA_FILE_NAME, GRAFBASE_TS_CONFIG_FILE_NAME};
 use common::environment::{Environment, Project};
-use federated_graph::FederatedGraph;
+use federated_graph::FederatedGraphV4;
 use flate2::read::GzDecoder;
 use futures_util::StreamExt;
 use std::collections::HashMap;
@@ -44,7 +44,7 @@ pub enum ProductionServer {
     Federated {
         message_sender: MessageSender,
         config: parser_sdl::federation::FederatedGraphConfig,
-        graph: Option<FederatedGraph>,
+        graph: Option<FederatedGraphV4>,
     },
 }
 

--- a/engine/crates/composition/src/emit_federated_graph.rs
+++ b/engine/crates/composition/src/emit_federated_graph.rs
@@ -14,11 +14,11 @@ use itertools::Itertools;
 use std::{collections::BTreeSet, mem};
 
 /// This can't fail. All the relevant, correct information should already be in the CompositionIr.
-pub(crate) fn emit_federated_graph(mut ir: CompositionIr, subgraphs: &Subgraphs) -> federated::FederatedGraph {
+pub(crate) fn emit_federated_graph(mut ir: CompositionIr, subgraphs: &Subgraphs) -> federated::VersionedFederatedGraph {
     let __schema = ir.strings.insert("__schema");
     let __type = ir.strings.insert("__type");
 
-    let mut out = federated::FederatedGraphV4 {
+    let mut out = federated::FederatedGraph {
         enums: mem::take(&mut ir.enums),
         enum_values: mem::take(&mut ir.enum_values),
         objects: mem::take(&mut ir.objects),
@@ -61,7 +61,7 @@ pub(crate) fn emit_federated_graph(mut ir: CompositionIr, subgraphs: &Subgraphs)
 
     drop(ctx);
 
-    federated::FederatedGraph::Sdl(graphql_federated_graph::render_federated_sdl(&out).unwrap())
+    federated::VersionedFederatedGraph::Sdl(graphql_federated_graph::render_federated_sdl(&out).unwrap())
 }
 
 fn emit_authorized_directives(ir: &CompositionIr, ctx: &mut Context<'_>) {

--- a/engine/crates/composition/src/emit_federated_graph.rs
+++ b/engine/crates/composition/src/emit_federated_graph.rs
@@ -18,7 +18,7 @@ pub(crate) fn emit_federated_graph(mut ir: CompositionIr, subgraphs: &Subgraphs)
     let __schema = ir.strings.insert("__schema");
     let __type = ir.strings.insert("__type");
 
-    let mut out = federated::FederatedGraphV3 {
+    let mut out = federated::FederatedGraphV4 {
         enums: mem::take(&mut ir.enums),
         enum_values: mem::take(&mut ir.enum_values),
         objects: mem::take(&mut ir.objects),
@@ -61,7 +61,7 @@ pub(crate) fn emit_federated_graph(mut ir: CompositionIr, subgraphs: &Subgraphs)
 
     drop(ctx);
 
-    federated::FederatedGraph::V3(out)
+    federated::FederatedGraph::Sdl(graphql_federated_graph::render_federated_sdl(&out).unwrap())
 }
 
 fn emit_authorized_directives(ir: &CompositionIr, ctx: &mut Context<'_>) {

--- a/engine/crates/composition/src/emit_federated_graph/context.rs
+++ b/engine/crates/composition/src/emit_federated_graph/context.rs
@@ -4,7 +4,7 @@ use graphql_federated_graph as federated;
 use std::collections::HashMap;
 
 pub(super) struct Context<'a> {
-    pub(super) out: &'a mut federated::FederatedGraphV4,
+    pub(super) out: &'a mut federated::FederatedGraph,
     pub(super) subgraphs: &'a subgraphs::Subgraphs,
     pub(super) field_types_map: FieldTypesMap,
     pub(super) selection_map: HashMap<(federated::Definition, federated::StringId), federated::FieldId>,
@@ -17,7 +17,7 @@ impl<'a> Context<'a> {
     pub(crate) fn new(
         ir: &mut ir::CompositionIr,
         subgraphs: &'a subgraphs::Subgraphs,
-        out: &'a mut federated::FederatedGraphV4,
+        out: &'a mut federated::FederatedGraph,
     ) -> Self {
         Context {
             out,

--- a/engine/crates/composition/src/emit_federated_graph/context.rs
+++ b/engine/crates/composition/src/emit_federated_graph/context.rs
@@ -4,7 +4,7 @@ use graphql_federated_graph as federated;
 use std::collections::HashMap;
 
 pub(super) struct Context<'a> {
-    pub(super) out: &'a mut federated::FederatedGraphV3,
+    pub(super) out: &'a mut federated::FederatedGraphV4,
     pub(super) subgraphs: &'a subgraphs::Subgraphs,
     pub(super) field_types_map: FieldTypesMap,
     pub(super) selection_map: HashMap<(federated::Definition, federated::StringId), federated::FieldId>,
@@ -17,7 +17,7 @@ impl<'a> Context<'a> {
     pub(crate) fn new(
         ir: &mut ir::CompositionIr,
         subgraphs: &'a subgraphs::Subgraphs,
-        out: &'a mut federated::FederatedGraphV3,
+        out: &'a mut federated::FederatedGraphV4,
     ) -> Self {
         Context {
             out,

--- a/engine/crates/composition/src/lib.rs
+++ b/engine/crates/composition/src/lib.rs
@@ -12,7 +12,7 @@ mod subgraphs;
 mod validate;
 
 pub use self::{diagnostics::Diagnostics, result::CompositionResult, subgraphs::Subgraphs};
-pub use graphql_federated_graph::{render_api_sdl, render_federated_sdl, render_sdl, FederatedGraph};
+pub use graphql_federated_graph::{render_api_sdl, render_federated_sdl, FederatedGraph};
 
 use self::{
     compose::{compose_subgraphs, ComposeContext},

--- a/engine/crates/composition/src/lib.rs
+++ b/engine/crates/composition/src/lib.rs
@@ -12,7 +12,7 @@ mod subgraphs;
 mod validate;
 
 pub use self::{diagnostics::Diagnostics, result::CompositionResult, subgraphs::Subgraphs};
-pub use graphql_federated_graph::{render_api_sdl, render_federated_sdl, FederatedGraph};
+pub use graphql_federated_graph::{render_api_sdl, render_federated_sdl, VersionedFederatedGraph};
 
 use self::{
     compose::{compose_subgraphs, ComposeContext},

--- a/engine/crates/composition/src/result.rs
+++ b/engine/crates/composition/src/result.rs
@@ -1,10 +1,10 @@
-use graphql_federated_graph::FederatedGraph;
+use graphql_federated_graph::VersionedFederatedGraph;
 
 use crate::Diagnostics;
 
 /// The result of a [`compose()`](crate::compose()) invocation.
 pub struct CompositionResult {
-    pub(crate) federated_graph: Option<FederatedGraph>,
+    pub(crate) federated_graph: Option<VersionedFederatedGraph>,
     pub(crate) diagnostics: Diagnostics,
 }
 
@@ -13,7 +13,7 @@ impl CompositionResult {
     ///
     /// `Ok()` contains the [FederatedGraph].
     /// `Err()` contains all [Diagnostics].
-    pub fn into_result(self) -> Result<FederatedGraph, Diagnostics> {
+    pub fn into_result(self) -> Result<VersionedFederatedGraph, Diagnostics> {
         if let Some(federated_graph) = self.federated_graph {
             Ok(federated_graph)
         } else {

--- a/engine/crates/composition/tests/composition_tests.rs
+++ b/engine/crates/composition/tests/composition_tests.rs
@@ -117,8 +117,7 @@ fn test_sdl_roundtrip(federated_graph_path: &Path) -> datatest_stable::Result<()
 
     let roundtripped = graphql_federated_graph::render_federated_sdl(
         &graphql_federated_graph::from_sdl(&sdl)
-            .map_err(|err| miette::miette!("Error ingesting SDL: {err}\n\nSDL:\n{sdl}"))?
-            .into_latest(),
+            .map_err(|err| miette::miette!("Error ingesting SDL: {err}\n\nSDL:\n{sdl}"))?,
     )?;
 
     if roundtripped == sdl {

--- a/engine/crates/engine-config-builder/src/from_sdl_config.rs
+++ b/engine/crates/engine-config-builder/src/from_sdl_config.rs
@@ -12,12 +12,12 @@ use engine_v2_config::{
     latest::{self as config},
     VersionedConfig,
 };
-use federated_graph::{FederatedGraphV4, FieldId, ObjectId, SubgraphId};
+use federated_graph::{FederatedGraph, FieldId, ObjectId, SubgraphId};
 use parser_sdl::federation::header::SubgraphHeaderRule;
 use parser_sdl::federation::{EntityCachingConfig, FederatedGraphConfig};
 use parser_sdl::{AuthV2Provider, GlobalCacheTarget};
 
-pub fn build_with_sdl_config(config: &FederatedGraphConfig, federated_graph: FederatedGraphV4) -> VersionedConfig {
+pub fn build_with_sdl_config(config: &FederatedGraphConfig, federated_graph: FederatedGraph) -> VersionedConfig {
     let mut context = BuildContext::default();
     let default_header_rules = context.insert_headers(&config.header_rules);
 
@@ -29,7 +29,7 @@ pub fn build_with_sdl_config(config: &FederatedGraphConfig, federated_graph: Fed
     }
 
     VersionedConfig::V6(config::Config {
-        graph: federated_graph::render_federated_sdl(&federated_graph).unwrap(),
+        federated_sdl: federated_graph::render_federated_sdl(&federated_graph).unwrap(),
         strings: context.strings.into_vec(),
         paths: context.paths.into_vec(),
         header_rules: context.header_rules,
@@ -101,7 +101,7 @@ struct BuildContext<'a> {
 }
 
 impl<'a> BuildContext<'a> {
-    fn insert_cache_config(&mut self, graph: &FederatedGraphV4, rules: &parser_sdl::GlobalCacheRules<'static>) {
+    fn insert_cache_config(&mut self, graph: &FederatedGraph, rules: &parser_sdl::GlobalCacheRules<'static>) {
         let mut cache_config = BTreeMap::new();
 
         for (target, cache_control) in rules.iter() {
@@ -164,7 +164,7 @@ impl<'a> BuildContext<'a> {
 
     fn insert_subgraph_configs(
         &mut self,
-        graph: &FederatedGraphV4,
+        graph: &FederatedGraph,
         configs: impl IntoIterator<Item = (&'a String, &'a parser_sdl::federation::SubgraphConfig)>,
     ) {
         for (name, config) in configs {
@@ -273,7 +273,7 @@ trait FederatedGraphExt {
     fn find_object_field(&self, object_name: &str, field_name: &str) -> Option<FieldId>;
 }
 
-impl FederatedGraphExt for FederatedGraphV4 {
+impl FederatedGraphExt for FederatedGraph {
     fn find_subgraph(&self, name: &str) -> Option<SubgraphId> {
         self.subgraphs
             .iter()

--- a/engine/crates/engine-config-builder/src/from_toml_config.rs
+++ b/engine/crates/engine-config-builder/src/from_toml_config.rs
@@ -1,11 +1,11 @@
 use engine_v2_config::VersionedConfig;
-use federated_graph::FederatedGraph;
+use federated_graph::FederatedGraphV4;
 use gateway_config::{Config, RetryConfig};
 use parser_sdl::federation::{header::SubgraphHeaderRule, FederatedGraphConfig};
 
 use crate::build_with_sdl_config;
 
-pub fn build_with_toml_config(config: &Config, graph: FederatedGraph) -> VersionedConfig {
+pub fn build_with_toml_config(config: &Config, graph: FederatedGraphV4) -> VersionedConfig {
     let mut graph_config = FederatedGraphConfig::default();
 
     if let Some(limits_config) = config.operation_limits {

--- a/engine/crates/engine-config-builder/src/from_toml_config.rs
+++ b/engine/crates/engine-config-builder/src/from_toml_config.rs
@@ -1,11 +1,11 @@
 use engine_v2_config::VersionedConfig;
-use federated_graph::FederatedGraphV4;
+use federated_graph::FederatedGraph;
 use gateway_config::{Config, RetryConfig};
 use parser_sdl::federation::{header::SubgraphHeaderRule, FederatedGraphConfig};
 
 use crate::build_with_sdl_config;
 
-pub fn build_with_toml_config(config: &Config, graph: FederatedGraphV4) -> VersionedConfig {
+pub fn build_with_toml_config(config: &Config, graph: FederatedGraph) -> VersionedConfig {
     let mut graph_config = FederatedGraphConfig::default();
 
     if let Some(limits_config) = config.operation_limits {

--- a/engine/crates/engine-v2/config/src/lib.rs
+++ b/engine/crates/engine-v2/config/src/lib.rs
@@ -164,7 +164,7 @@ impl VersionedConfig {
                 entity_caching,
                 retry,
             }) => v6::Config {
-                graph: federated_graph::FederatedGraph::V3(graph).into_federated_sdl(),
+                federated_sdl: federated_graph::VersionedFederatedGraph::V3(graph).into_federated_sdl(),
                 strings,
                 paths,
                 header_rules,

--- a/engine/crates/engine-v2/config/src/v5.rs
+++ b/engine/crates/engine-v2/config/src/v5.rs
@@ -9,7 +9,7 @@ use std::{
 
 use federated_graph::{FederatedGraphV3, SubgraphId};
 
-use self::rate_limit::{RateLimitConfigRef, RateLimitRedisConfigRef, RateLimitRedisTlsConfigRef};
+pub(crate) use self::rate_limit::{RateLimitConfigRef, RateLimitRedisConfigRef, RateLimitRedisTlsConfigRef};
 
 pub use super::v2::EntityCaching;
 pub use super::v4::{

--- a/engine/crates/engine-v2/config/src/v6.rs
+++ b/engine/crates/engine-v2/config/src/v6.rs
@@ -1,0 +1,123 @@
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use federated_graph::SubgraphId;
+
+use crate::v5::{RateLimitConfigRef, RateLimitRedisConfigRef, RateLimitRedisTlsConfigRef};
+
+pub use super::v5::{
+    AuthConfig, AuthProviderConfig, CacheConfig, CacheConfigTarget, CacheConfigs, EntityCaching, GraphRateLimit,
+    Header, HeaderForward, HeaderInsert, HeaderRemove, HeaderRenameDuplicate, HeaderRule, HeaderRuleId, HeaderValue,
+    JwksConfig, JwtConfig, NameOrPattern, OperationLimits, PathId, RateLimitConfig, RateLimitKey, RateLimitRedisConfig,
+    RateLimitRedisTlsConfig, RateLimitStorage, RetryConfig, StringId, SubgraphConfig,
+};
+
+/// Configuration for a federated graph
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub struct Config {
+    pub graph: String,
+    pub strings: Vec<String>,
+    #[serde(default)]
+    pub paths: Vec<PathBuf>,
+    pub header_rules: Vec<HeaderRule>,
+    pub default_header_rules: Vec<HeaderRuleId>,
+
+    /// Additional configuration for our subgraphs
+    pub subgraph_configs: BTreeMap<SubgraphId, SubgraphConfig>,
+
+    /// Caching configuration
+    #[serde(default)]
+    pub cache: CacheConfigs,
+
+    pub auth: Option<AuthConfig>,
+
+    #[serde(default)]
+    pub operation_limits: OperationLimits,
+
+    #[serde(default)]
+    pub disable_introspection: bool,
+
+    #[serde(default)]
+    pub rate_limit: Option<RateLimitConfig>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<Duration>,
+
+    #[serde(default)]
+    pub entity_caching: EntityCaching,
+
+    #[serde(default)]
+    pub retry: Option<RetryConfig>,
+}
+
+impl Config {
+    pub fn from_federated_sdl(graph: String) -> Self {
+        Config {
+            graph,
+            strings: Vec::new(),
+            paths: Vec::new(),
+            header_rules: Vec::new(),
+            default_header_rules: Default::default(),
+            subgraph_configs: Default::default(),
+            cache: Default::default(),
+            auth: Default::default(),
+            operation_limits: Default::default(),
+            disable_introspection: Default::default(),
+            rate_limit: Default::default(),
+            timeout: None,
+            entity_caching: EntityCaching::Disabled,
+            retry: None,
+        }
+    }
+
+    pub fn rate_limit_config(&self) -> Option<RateLimitConfigRef<'_>> {
+        self.rate_limit.map(|config| RateLimitConfigRef {
+            storage: config.storage,
+            redis: RateLimitRedisConfigRef {
+                url: &self[config.redis.url],
+                key_prefix: &self[config.redis.key_prefix],
+                tls: config.redis.tls.map(|config| RateLimitRedisTlsConfigRef {
+                    cert: config.cert.map(|cert| &self[cert]),
+                    key: config.key.map(|key| &self[key]),
+                    ca: config.ca.map(|ca| &self[ca]),
+                }),
+            },
+        })
+    }
+
+    pub fn as_keyed_rate_limit_config(&self) -> Vec<(RateLimitKey<'_>, GraphRateLimit)> {
+        let mut key_based_config = Vec::new();
+
+        if let Some(global_config) = self.rate_limit.as_ref().and_then(|c| c.global) {
+            key_based_config.push((RateLimitKey::Global, global_config));
+        }
+
+        for subgraph in self.subgraph_configs.values() {
+            if let Some(subgraph_rate_limit) = subgraph.rate_limit {
+                let key = RateLimitKey::Subgraph(&self.strings[subgraph.name.0]);
+                key_based_config.push((key, subgraph_rate_limit));
+            }
+        }
+
+        key_based_config
+    }
+}
+
+impl std::ops::Index<StringId> for Config {
+    type Output = String;
+
+    fn index(&self, index: StringId) -> &String {
+        &self.strings[index.0]
+    }
+}
+
+impl std::ops::Index<PathId> for Config {
+    type Output = Path;
+
+    fn index(&self, index: PathId) -> &Path {
+        &self.paths[index.0]
+    }
+}

--- a/engine/crates/engine-v2/config/src/v6.rs
+++ b/engine/crates/engine-v2/config/src/v6.rs
@@ -18,7 +18,7 @@ pub use super::v5::{
 /// Configuration for a federated graph
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct Config {
-    pub graph: String,
+    pub federated_sdl: String,
     pub strings: Vec<String>,
     #[serde(default)]
     pub paths: Vec<PathBuf>,
@@ -56,7 +56,7 @@ pub struct Config {
 impl Config {
     pub fn from_federated_sdl(graph: String) -> Self {
         Config {
-            graph,
+            federated_sdl: graph,
             strings: Vec::new(),
             paths: Vec::new(),
             header_rules: Vec::new(),

--- a/engine/crates/engine-v2/schema/src/builder/error.rs
+++ b/engine/crates/engine-v2/schema/src/builder/error.rs
@@ -21,4 +21,6 @@ impl SchemaLocation {
 pub enum BuildError {
     #[error("At {location}, a required field argument is invalid: {err}")]
     RequiredFieldArgumentCoercionError { location: String, err: InputValueError },
+    #[error(transparent)]
+    GraphFromSdlError(#[from] federated_graph::DomainError),
 }

--- a/engine/crates/engine-v2/schema/src/builder/external_sources.rs
+++ b/engine/crates/engine-v2/schema/src/builder/external_sources.rs
@@ -1,7 +1,7 @@
 use std::{mem::take, time::Duration};
 
 use config::latest::Config;
-use federated_graph::FederatedGraphV4;
+use federated_graph::FederatedGraph;
 
 use super::{
     sources::{
@@ -16,7 +16,7 @@ pub struct ExternalDataSources {
 }
 
 impl ExternalDataSources {
-    pub(super) fn build(ctx: &mut BuildContext, config: &mut Config, graph: &mut FederatedGraphV4) -> Self {
+    pub(super) fn build(ctx: &mut BuildContext, config: &mut Config, graph: &mut FederatedGraph) -> Self {
         let endpoints = take(&mut graph.subgraphs)
             .into_iter()
             .enumerate()

--- a/engine/crates/engine-v2/schema/src/builder/external_sources.rs
+++ b/engine/crates/engine-v2/schema/src/builder/external_sources.rs
@@ -1,6 +1,7 @@
 use std::{mem::take, time::Duration};
 
 use config::latest::Config;
+use federated_graph::FederatedGraphV4;
 
 use super::{
     sources::{
@@ -15,8 +16,8 @@ pub struct ExternalDataSources {
 }
 
 impl ExternalDataSources {
-    pub(super) fn build(ctx: &mut BuildContext, config: &mut Config) -> Self {
-        let endpoints = take(&mut config.graph.subgraphs)
+    pub(super) fn build(ctx: &mut BuildContext, config: &mut Config, graph: &mut FederatedGraphV4) -> Self {
+        let endpoints = take(&mut graph.subgraphs)
             .into_iter()
             .enumerate()
             .map(|(index, subgraph)| {

--- a/engine/crates/engine-v2/schema/src/builder/graph.rs
+++ b/engine/crates/engine-v2/schema/src/builder/graph.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use config::latest::{CacheConfigTarget, Config};
-use federated_graph::FederatedGraphV4;
+use federated_graph::FederatedGraph;
 use id_newtypes::IdRange;
 use sources::{
     graphql::{FederationEntityResolverDefinition, FederationKey, GraphqlEndpointId, RootFieldResolverDefinition},
@@ -34,7 +34,7 @@ impl<'a> GraphBuilder<'a> {
         ctx: &'a mut BuildContext,
         sources: &ExternalDataSources,
         config: &mut Config,
-        graph: &mut FederatedGraphV4,
+        graph: &mut FederatedGraph,
     ) -> Result<(Graph, IntrospectionMetadata), BuildError> {
         let mut builder = GraphBuilder {
             ctx,
@@ -73,7 +73,7 @@ impl<'a> GraphBuilder<'a> {
         builder.finalize()
     }
 
-    fn ingest_config(&mut self, config: &mut Config, graph: &mut FederatedGraphV4) {
+    fn ingest_config(&mut self, config: &mut Config, graph: &mut FederatedGraph) {
         self.ingest_input_values(config, graph);
         self.ingest_input_objects(config, graph);
         self.ingest_unions(config, graph);
@@ -90,7 +90,7 @@ impl<'a> GraphBuilder<'a> {
         self.ingest_fields_after_input_values(config, object_metadata, interface_metadata, graph);
     }
 
-    fn ingest_input_values(&mut self, config: &mut Config, graph: &mut FederatedGraphV4) {
+    fn ingest_input_values(&mut self, config: &mut Config, graph: &mut FederatedGraph) {
         self.graph.input_value_definitions = take(&mut graph.input_value_definitions)
             .into_iter()
             .enumerate()
@@ -123,7 +123,7 @@ impl<'a> GraphBuilder<'a> {
             .collect();
     }
 
-    fn ingest_input_objects(&mut self, config: &mut Config, graph: &mut FederatedGraphV4) {
+    fn ingest_input_objects(&mut self, config: &mut Config, graph: &mut FederatedGraph) {
         self.graph.input_object_definitions = take(&mut graph.input_objects)
             .into_iter()
             .enumerate()
@@ -149,7 +149,7 @@ impl<'a> GraphBuilder<'a> {
             .collect();
     }
 
-    fn ingest_unions(&mut self, config: &mut Config, graph: &mut FederatedGraphV4) {
+    fn ingest_unions(&mut self, config: &mut Config, graph: &mut FederatedGraph) {
         self.graph.union_definitions = take(&mut graph.unions)
             .into_iter()
             .map(|union| UnionDefinition {
@@ -175,7 +175,7 @@ impl<'a> GraphBuilder<'a> {
             .collect();
     }
 
-    fn ingest_enums(&mut self, config: &mut Config, graph: &mut FederatedGraphV4) {
+    fn ingest_enums(&mut self, config: &mut Config, graph: &mut FederatedGraph) {
         let mut idmap = IdMap::<federated_graph::EnumValueId, EnumValueId>::default();
         self.graph.enum_value_definitions = take(&mut graph.enum_values)
             .into_iter()
@@ -225,7 +225,7 @@ impl<'a> GraphBuilder<'a> {
             .collect();
     }
 
-    fn ingest_scalars(&mut self, config: &mut Config, graph: &mut FederatedGraphV4) {
+    fn ingest_scalars(&mut self, config: &mut Config, graph: &mut FederatedGraph) {
         self.graph.scalar_definitions = take(&mut graph.scalars)
             .into_iter()
             .map(|scalar| {
@@ -248,7 +248,7 @@ impl<'a> GraphBuilder<'a> {
             .collect();
     }
 
-    fn ingest_objects(&mut self, config: &mut Config, graph: &mut FederatedGraphV4) -> ObjectMetadata {
+    fn ingest_objects(&mut self, config: &mut Config, graph: &mut FederatedGraph) -> ObjectMetadata {
         let mut entities_metadata = ObjectMetadata {
             entities: Default::default(),
             // At most we have as many field as the FederatedGraph
@@ -310,7 +310,7 @@ impl<'a> GraphBuilder<'a> {
     fn ingest_interfaces_after_objects(
         &mut self,
         config: &mut Config,
-        graph: &mut FederatedGraphV4,
+        graph: &mut FederatedGraph,
     ) -> InterfaceMetadata {
         let mut entities_metadata = InterfaceMetadata {
             entities: Default::default(),
@@ -372,7 +372,7 @@ impl<'a> GraphBuilder<'a> {
         config: &mut Config,
         object_metadata: ObjectMetadata,
         interface_metadata: InterfaceMetadata,
-        graph: &mut FederatedGraphV4,
+        graph: &mut FederatedGraph,
     ) {
         let root_fields = {
             let mut root_fields = vec![];
@@ -662,7 +662,7 @@ impl<'a> GraphBuilder<'a> {
         &mut self,
         config: &Config,
         directives: Directives,
-        graph: &mut FederatedGraphV4,
+        graph: &FederatedGraph,
     ) -> IdRange<TypeSystemDirectiveId> {
         let start = self.graph.type_system_directives.len();
 
@@ -805,7 +805,7 @@ struct FederationEntity {
 }
 
 pub(super) fn is_inaccessible(
-    graph: &federated_graph::FederatedGraphV4,
+    graph: &federated_graph::FederatedGraph,
     directives: federated_graph::Directives,
 ) -> bool {
     graph[directives]

--- a/engine/crates/engine-v2/schema/src/builder/graph.rs
+++ b/engine/crates/engine-v2/schema/src/builder/graph.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use config::latest::{CacheConfigTarget, Config};
+use federated_graph::FederatedGraphV4;
 use id_newtypes::IdRange;
 use sources::{
     graphql::{FederationEntityResolverDefinition, FederationKey, GraphqlEndpointId, RootFieldResolverDefinition},
@@ -33,6 +34,7 @@ impl<'a> GraphBuilder<'a> {
         ctx: &'a mut BuildContext,
         sources: &ExternalDataSources,
         config: &mut Config,
+        graph: &mut FederatedGraphV4,
     ) -> Result<(Graph, IntrospectionMetadata), BuildError> {
         let mut builder = GraphBuilder {
             ctx,
@@ -43,9 +45,9 @@ impl<'a> GraphBuilder<'a> {
             graph: Graph {
                 description: None,
                 root_operation_types: RootOperationTypes {
-                    query: config.graph.root_operation_types.query.into(),
-                    mutation: config.graph.root_operation_types.mutation.map(Into::into),
-                    subscription: config.graph.root_operation_types.subscription.map(Into::into),
+                    query: graph.root_operation_types.query.into(),
+                    mutation: graph.root_operation_types.mutation.map(Into::into),
+                    subscription: graph.root_operation_types.subscription.map(Into::into),
                 },
                 object_definitions: Vec::new(),
                 interface_definitions: Vec::new(),
@@ -67,35 +69,29 @@ impl<'a> GraphBuilder<'a> {
                 authorized_directives: Vec::new(),
             },
         };
-        builder.ingest_config(config);
+        builder.ingest_config(config, graph);
         builder.finalize()
     }
 
-    fn ingest_config(&mut self, config: &mut Config) {
-        self.ingest_input_values(config);
-        self.ingest_input_objects(config);
-        self.ingest_unions(config);
-        self.ingest_enums(config);
-        self.ingest_scalars(config);
+    fn ingest_config(&mut self, config: &mut Config, graph: &mut FederatedGraphV4) {
+        self.ingest_input_values(config, graph);
+        self.ingest_input_objects(config, graph);
+        self.ingest_unions(config, graph);
+        self.ingest_enums(config, graph);
+        self.ingest_scalars(config, graph);
         // Not guaranteed to be sorted and rely on binary search to find the directives for a
         // field.
-        config
-            .graph
-            .object_authorized_directives
-            .sort_unstable_by_key(|(id, _)| *id);
-        let object_metadata = self.ingest_objects(config);
-        let interface_metadata = self.ingest_interfaces_after_objects(config);
+        graph.object_authorized_directives.sort_unstable_by_key(|(id, _)| *id);
+        let object_metadata = self.ingest_objects(config, graph);
+        let interface_metadata = self.ingest_interfaces_after_objects(config, graph);
         // Not guaranteed to be sorted and rely on binary search to find the directives for a
         // field.
-        config
-            .graph
-            .field_authorized_directives
-            .sort_unstable_by_key(|(id, _)| *id);
-        self.ingest_fields_after_input_values(config, object_metadata, interface_metadata);
+        graph.field_authorized_directives.sort_unstable_by_key(|(id, _)| *id);
+        self.ingest_fields_after_input_values(config, object_metadata, interface_metadata, graph);
     }
 
-    fn ingest_input_values(&mut self, config: &mut Config) {
-        self.graph.input_value_definitions = take(&mut config.graph.input_value_definitions)
+    fn ingest_input_values(&mut self, config: &mut Config, graph: &mut FederatedGraphV4) {
+        self.graph.input_value_definitions = take(&mut graph.input_value_definitions)
             .into_iter()
             .enumerate()
             .filter_map(|(idx, definition)| {
@@ -117,6 +113,7 @@ impl<'a> GraphBuilder<'a> {
                                 federated: definition.directives,
                                 ..Default::default()
                             },
+                            graph,
                         ),
                     })
                 } else {
@@ -126,8 +123,8 @@ impl<'a> GraphBuilder<'a> {
             .collect();
     }
 
-    fn ingest_input_objects(&mut self, config: &mut Config) {
-        self.graph.input_object_definitions = take(&mut config.graph.input_objects)
+    fn ingest_input_objects(&mut self, config: &mut Config, graph: &mut FederatedGraphV4) {
+        self.graph.input_object_definitions = take(&mut graph.input_objects)
             .into_iter()
             .enumerate()
             .filter_map(|(idx, definition)| {
@@ -142,6 +139,7 @@ impl<'a> GraphBuilder<'a> {
                                 federated: definition.composed_directives,
                                 ..Default::default()
                             },
+                            graph,
                         ),
                     })
                 } else {
@@ -151,8 +149,8 @@ impl<'a> GraphBuilder<'a> {
             .collect();
     }
 
-    fn ingest_unions(&mut self, config: &mut Config) {
-        self.graph.union_definitions = take(&mut config.graph.unions)
+    fn ingest_unions(&mut self, config: &mut Config, graph: &mut FederatedGraphV4) {
+        self.graph.union_definitions = take(&mut graph.unions)
             .into_iter()
             .map(|union| UnionDefinition {
                 name: union.name.into(),
@@ -160,7 +158,7 @@ impl<'a> GraphBuilder<'a> {
                 possible_types: union
                     .members
                     .into_iter()
-                    .filter(|object_id| !is_inaccessible(&config.graph, config.graph[*object_id].composed_directives))
+                    .filter(|object_id| !is_inaccessible(graph, graph[*object_id].composed_directives))
                     .map(Into::into)
                     .collect(),
                 // Added at the end.
@@ -171,18 +169,19 @@ impl<'a> GraphBuilder<'a> {
                         federated: union.composed_directives,
                         ..Default::default()
                     },
+                    graph,
                 ),
             })
             .collect();
     }
 
-    fn ingest_enums(&mut self, config: &mut Config) {
+    fn ingest_enums(&mut self, config: &mut Config, graph: &mut FederatedGraphV4) {
         let mut idmap = IdMap::<federated_graph::EnumValueId, EnumValueId>::default();
-        self.graph.enum_value_definitions = take(&mut config.graph.enum_values)
+        self.graph.enum_value_definitions = take(&mut graph.enum_values)
             .into_iter()
             .enumerate()
             .filter_map(|(idx, enum_value)| {
-                if is_inaccessible(&config.graph, enum_value.composed_directives) {
+                if is_inaccessible(graph, enum_value.composed_directives) {
                     idmap.skip(federated_graph::EnumValueId(idx));
                     None
                 } else {
@@ -195,13 +194,14 @@ impl<'a> GraphBuilder<'a> {
                                 federated: enum_value.composed_directives,
                                 ..Default::default()
                             },
+                            graph,
                         ),
                     })
                 }
             })
             .collect();
 
-        self.graph.enum_definitions = take(&mut config.graph.enums)
+        self.graph.enum_definitions = take(&mut graph.enums)
             .into_iter()
             .map(|federated_enum| EnumDefinition {
                 name: federated_enum.name.into(),
@@ -219,13 +219,14 @@ impl<'a> GraphBuilder<'a> {
                         federated: federated_enum.composed_directives,
                         ..Default::default()
                     },
+                    graph,
                 ),
             })
             .collect();
     }
 
-    fn ingest_scalars(&mut self, config: &mut Config) {
-        self.graph.scalar_definitions = take(&mut config.graph.scalars)
+    fn ingest_scalars(&mut self, config: &mut Config, graph: &mut FederatedGraphV4) {
+        self.graph.scalar_definitions = take(&mut graph.scalars)
             .into_iter()
             .map(|scalar| {
                 let name = StringId::from(scalar.name);
@@ -240,21 +241,22 @@ impl<'a> GraphBuilder<'a> {
                             federated: scalar.composed_directives,
                             ..Default::default()
                         },
+                        graph,
                     ),
                 }
             })
             .collect();
     }
 
-    fn ingest_objects(&mut self, config: &mut Config) -> ObjectMetadata {
+    fn ingest_objects(&mut self, config: &mut Config, graph: &mut FederatedGraphV4) -> ObjectMetadata {
         let mut entities_metadata = ObjectMetadata {
             entities: Default::default(),
             // At most we have as many field as the FederatedGraph
-            field_id_to_maybe_object_id: vec![None; config.graph.fields.len()],
+            field_id_to_maybe_object_id: vec![None; graph.fields.len()],
         };
 
-        self.graph.object_definitions = Vec::with_capacity(config.graph.objects.len());
-        for (federated_id, object) in take(&mut config.graph.objects).into_iter().enumerate() {
+        self.graph.object_definitions = Vec::with_capacity(graph.objects.len());
+        for (federated_id, object) in take(&mut graph.objects).into_iter().enumerate() {
             let federated_id = federated_graph::ObjectId(federated_id);
             let object_id = ObjectDefinitionId::from(self.graph.object_definitions.len());
 
@@ -277,7 +279,7 @@ impl<'a> GraphBuilder<'a> {
                     federated: object.composed_directives,
                     cache_config_target: Some(CacheConfigTarget::Object(federated_id)),
                     authorized_directives: {
-                        let mapping = &config.graph.object_authorized_directives;
+                        let mapping = &graph.object_authorized_directives;
                         let mut i = mapping.partition_point(|(id, _)| *id < federated_id);
                         let mut ids = Vec::new();
                         while i < mapping.len() && mapping[i].0 == federated_id {
@@ -287,6 +289,7 @@ impl<'a> GraphBuilder<'a> {
                         Some((schema_location, ids))
                     },
                 },
+                graph,
             );
             self.graph.object_definitions.push(ObjectDefinition {
                 name: object.name.into(),
@@ -304,15 +307,19 @@ impl<'a> GraphBuilder<'a> {
         entities_metadata
     }
 
-    fn ingest_interfaces_after_objects(&mut self, config: &mut Config) -> InterfaceMetadata {
+    fn ingest_interfaces_after_objects(
+        &mut self,
+        config: &mut Config,
+        graph: &mut FederatedGraphV4,
+    ) -> InterfaceMetadata {
         let mut entities_metadata = InterfaceMetadata {
             entities: Default::default(),
             // At most we have as many field as the FederatedGraph
-            field_id_to_maybe_interface_id: vec![None; config.graph.fields.len()],
+            field_id_to_maybe_interface_id: vec![None; graph.fields.len()],
         };
 
-        self.graph.interface_definitions = Vec::with_capacity(config.graph.interfaces.len());
-        for interface in take(&mut config.graph.interfaces) {
+        self.graph.interface_definitions = Vec::with_capacity(graph.interfaces.len());
+        for interface in take(&mut graph.interfaces) {
             let interface_id = InterfaceDefinitionId::from(self.graph.interface_definitions.len());
             let fields = self.ctx.idmaps.field.get_range((
                 interface.fields.start,
@@ -327,6 +334,7 @@ impl<'a> GraphBuilder<'a> {
                     federated: interface.composed_directives,
                     ..Default::default()
                 },
+                graph,
             );
             self.graph.interface_definitions.push(InterfaceDefinition {
                 name: interface.name.into(),
@@ -364,6 +372,7 @@ impl<'a> GraphBuilder<'a> {
         config: &mut Config,
         object_metadata: ObjectMetadata,
         interface_metadata: InterfaceMetadata,
+        graph: &mut FederatedGraphV4,
     ) {
         let root_fields = {
             let mut root_fields = vec![];
@@ -380,7 +389,7 @@ impl<'a> GraphBuilder<'a> {
         };
 
         let mut root_field_resolvers = HashMap::<GraphqlEndpointId, ResolverDefinitionId>::new();
-        for (federated_id, field) in take(&mut config.graph.fields).into_iter().enumerate() {
+        for (federated_id, field) in take(&mut graph.fields).into_iter().enumerate() {
             let federated_id = federated_graph::FieldId(federated_id);
             let Some(field_id) = self.ctx.idmaps.field.get(federated_id) else {
                 continue;
@@ -468,7 +477,7 @@ impl<'a> GraphBuilder<'a> {
                     federated: field.composed_directives,
                     cache_config_target: Some(CacheConfigTarget::Field(federated_id)),
                     authorized_directives: {
-                        let mapping = &config.graph.field_authorized_directives;
+                        let mapping = &graph.field_authorized_directives;
                         let mut i = mapping.partition_point(|(id, _)| *id < federated_id);
                         let mut ids = Vec::new();
                         while i < mapping.len() && mapping[i].0 == federated_id {
@@ -478,6 +487,7 @@ impl<'a> GraphBuilder<'a> {
                         Some((schema_location, ids))
                     },
                 },
+                graph,
             );
 
             self.graph.field_definitions.push(FieldDefinition {
@@ -648,10 +658,15 @@ impl<'a> GraphBuilder<'a> {
         resolver_id
     }
 
-    fn push_directives(&mut self, config: &Config, directives: Directives) -> IdRange<TypeSystemDirectiveId> {
+    fn push_directives(
+        &mut self,
+        config: &Config,
+        directives: Directives,
+        graph: &mut FederatedGraphV4,
+    ) -> IdRange<TypeSystemDirectiveId> {
         let start = self.graph.type_system_directives.len();
 
-        for directive in &config.graph[directives.federated] {
+        for directive in &graph[directives.federated] {
             let directive = match directive {
                 federated_graph::Directive::Authenticated => TypeSystemDirective::Authenticated,
                 federated_graph::Directive::RequiresScopes(federated_scopes) => {
@@ -695,7 +710,7 @@ impl<'a> GraphBuilder<'a> {
                     arguments,
                     metadata,
                     node,
-                } = &config.graph[id];
+                } = &graph[id];
 
                 self.graph.authorized_directives.push(AuthorizedDirective {
                     arguments: arguments
@@ -790,7 +805,7 @@ struct FederationEntity {
 }
 
 pub(super) fn is_inaccessible(
-    graph: &federated_graph::FederatedGraphV3,
+    graph: &federated_graph::FederatedGraphV4,
     directives: federated_graph::Directives,
 ) -> bool {
     graph[directives]

--- a/engine/crates/engine-v2/schema/src/builder/ids.rs
+++ b/engine/crates/engine-v2/schema/src/builder/ids.rs
@@ -6,7 +6,7 @@
 
 use std::marker::PhantomData;
 
-use config::latest::Config;
+use federated_graph::FederatedGraphV4;
 use id_newtypes::IdRange;
 
 use crate::{FieldDefinitionId, InputValueDefinitionId};
@@ -47,19 +47,19 @@ impl IdMaps {
         }
     }
 
-    pub fn new(config: &Config) -> Self {
+    pub fn new(graph: &FederatedGraphV4) -> Self {
         let mut idmaps = IdMaps {
             field: Default::default(),
             input_value: Default::default(),
         };
 
-        for (i, field) in config.graph.fields.iter().enumerate() {
-            if is_inaccessible(&config.graph, field.composed_directives) {
+        for (i, field) in graph.fields.iter().enumerate() {
+            if is_inaccessible(graph, field.composed_directives) {
                 idmaps.field.skip(federated_graph::FieldId(i))
             }
         }
-        for (i, input_value) in config.graph.input_value_definitions.iter().enumerate() {
-            if is_inaccessible(&config.graph, input_value.directives) {
+        for (i, input_value) in graph.input_value_definitions.iter().enumerate() {
+            if is_inaccessible(graph, input_value.directives) {
                 idmaps.input_value.skip(federated_graph::InputValueDefinitionId(i))
             }
         }

--- a/engine/crates/engine-v2/schema/src/builder/ids.rs
+++ b/engine/crates/engine-v2/schema/src/builder/ids.rs
@@ -6,7 +6,7 @@
 
 use std::marker::PhantomData;
 
-use federated_graph::FederatedGraphV4;
+use federated_graph::FederatedGraph;
 use id_newtypes::IdRange;
 
 use crate::{FieldDefinitionId, InputValueDefinitionId};
@@ -47,7 +47,7 @@ impl IdMaps {
         }
     }
 
-    pub fn new(graph: &FederatedGraphV4) -> Self {
+    pub fn new(graph: &FederatedGraph) -> Self {
         let mut idmaps = IdMaps {
             field: Default::default(),
             input_value: Default::default(),

--- a/engine/crates/engine-v2/schema/tests/conversion.rs
+++ b/engine/crates/engine-v2/schema/tests/conversion.rs
@@ -1,6 +1,5 @@
 use config::latest::{HeaderRemove, HeaderRule, NameOrPattern};
 use engine_v2_schema::{Definition, Schema};
-use federated_graph::FederatedGraph;
 use pretty_assertions::assert_eq;
 use regex::Regex;
 
@@ -98,8 +97,8 @@ type User
 
 #[test]
 fn should_not_fail() {
-    let graph = FederatedGraph::from_sdl(SCHEMA).unwrap().into_latest();
-    let config = config::VersionedConfig::V5(config::latest::Config::from_graph(graph)).into_latest();
+    let config =
+        config::VersionedConfig::V6(config::latest::Config::from_federated_sdl(SCHEMA.to_owned())).into_latest();
     let _schema = Schema::try_from(config).unwrap();
 }
 
@@ -231,10 +230,10 @@ input BookInput2 {
 
 #[test]
 fn should_remove_all_inaccessible_items() {
-    let graph = FederatedGraph::from_sdl(SCHEMA_WITH_INACCESSIBLES)
-        .unwrap()
-        .into_latest();
-    let config = config::VersionedConfig::V5(config::latest::Config::from_graph(graph)).into_latest();
+    let config = config::VersionedConfig::V6(config::latest::Config::from_federated_sdl(
+        SCHEMA_WITH_INACCESSIBLES.to_owned(),
+    ))
+    .into_latest();
     let schema = Schema::try_from(config).unwrap();
 
     // Inaccessible types are still in the schema, they're just not reachable through input and output fields.
@@ -310,8 +309,8 @@ fn should_remove_all_inaccessible_items() {
 #[case(SCHEMA)]
 #[case(SCHEMA_WITH_INACCESSIBLES)]
 fn serde_roundtrip(#[case] sdl: &str) {
-    let graph = FederatedGraph::from_sdl(sdl).unwrap().into_latest();
-    let mut config = config::VersionedConfig::V5(config::latest::Config::from_graph(graph)).into_latest();
+    let mut config =
+        config::VersionedConfig::V6(config::latest::Config::from_federated_sdl(sdl.to_owned())).into_latest();
 
     config.header_rules.push(HeaderRule::Remove(HeaderRemove {
         name: NameOrPattern::Pattern(Regex::new("^foo*").unwrap()),

--- a/engine/crates/federated-graph/src/federated_graph.rs
+++ b/engine/crates/federated-graph/src/federated_graph.rs
@@ -1,5 +1,6 @@
 mod v1;
 mod v2;
 mod v3;
+mod v4;
 
-pub use self::{v1::FederatedGraphV1, v2::FederatedGraphV2, v3::*};
+pub use self::{v1::FederatedGraphV1, v2::FederatedGraphV2, v3::FederatedGraphV3, v4::*};

--- a/engine/crates/federated-graph/src/federated_graph/v1.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v1.rs
@@ -100,7 +100,7 @@ pub type FieldSet = Vec<FieldSetItem>;
 pub struct FieldSetItem {
     pub field: FieldId,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub arguments: Vec<(super::v3::InputValueDefinitionId, super::v3::Value)>,
+    pub arguments: Vec<(super::v4::InputValueDefinitionId, super::v4::Value)>,
     pub subselection: FieldSet,
 }
 

--- a/engine/crates/federated-graph/src/federated_graph/v1.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v1.rs
@@ -459,11 +459,11 @@ id_newtypes! {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::FederatedGraph;
+    use crate::VersionedFederatedGraph;
 
     #[test]
     fn serde_json_backwards_compatibility() {
-        let schema = serde_json::from_str::<FederatedGraph>(
+        let schema = serde_json::from_str::<VersionedFederatedGraph>(
             r#"
             {
               "V1": {

--- a/engine/crates/federated-graph/src/federated_graph/v2.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v2.rs
@@ -62,6 +62,7 @@ pub struct InputValueDefinition {
 }
 
 #[derive(Default, serde::Serialize, serde::Deserialize, Clone, PartialEq, PartialOrd, Debug)]
+#[allow(clippy::enum_variant_names)]
 pub enum Value {
     #[default]
     Null,

--- a/engine/crates/federated-graph/src/federated_graph/v4.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v4.rs
@@ -1,0 +1,402 @@
+use std::ops::Range;
+
+pub use super::v3::{
+    AuthorizedDirectiveId, Definition, DirectiveId, Directives, Enum, EnumId, EnumValue, EnumValueId, EnumValues,
+    Field, FieldId, FieldProvides, FieldRequires, FieldSet, FieldSetItem, Fields, InputObject, InputObjectId,
+    InputValueDefinitionId, InputValueDefinitionSet, InputValueDefinitionSetItem, InputValueDefinitions, Interface,
+    InterfaceId, Key, Object, ObjectId, Override, OverrideLabel, OverrideSource, RootOperationTypes, Scalar, ScalarId,
+    StringId, Subgraph, SubgraphId, Type, Union, UnionId, Wrapping, NO_DIRECTIVES, NO_ENUM_VALUE, NO_FIELDS,
+    NO_INPUT_VALUE_DEFINITION,
+};
+
+#[derive(Clone)]
+pub struct FederatedGraphV4 {
+    pub subgraphs: Vec<Subgraph>,
+    pub root_operation_types: RootOperationTypes,
+    pub objects: Vec<Object>,
+    pub interfaces: Vec<Interface>,
+    pub fields: Vec<Field>,
+
+    pub enums: Vec<Enum>,
+    pub unions: Vec<Union>,
+    pub scalars: Vec<Scalar>,
+    pub input_objects: Vec<InputObject>,
+    pub enum_values: Vec<EnumValue>,
+
+    /// All [input value definitions](http://spec.graphql.org/October2021/#InputValueDefinition) in the federated graph. Concretely, these are arguments of output fields, and input object fields.
+    pub input_value_definitions: Vec<InputValueDefinition>,
+
+    /// All the strings in the federated graph, deduplicated.
+    pub strings: Vec<String>,
+
+    /// All composed directive instances (not definitions) in a federated graph.
+    pub directives: Vec<Directive>,
+
+    /// All @authorized directives
+    pub authorized_directives: Vec<AuthorizedDirective>,
+    pub field_authorized_directives: Vec<(FieldId, AuthorizedDirectiveId)>,
+    pub object_authorized_directives: Vec<(ObjectId, AuthorizedDirectiveId)>,
+    pub interface_authorized_directives: Vec<(InterfaceId, AuthorizedDirectiveId)>,
+}
+
+impl std::fmt::Debug for FederatedGraphV4 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct(std::any::type_name::<Self>()).finish_non_exhaustive()
+    }
+}
+
+impl FederatedGraphV4 {
+    pub fn iter_interfaces(&self) -> impl ExactSizeIterator<Item = (InterfaceId, &Interface)> {
+        self.interfaces
+            .iter()
+            .enumerate()
+            .map(|(idx, interface)| (InterfaceId(idx), interface))
+    }
+
+    pub fn iter_objects(&self) -> impl ExactSizeIterator<Item = (ObjectId, &Object)> {
+        self.objects
+            .iter()
+            .enumerate()
+            .map(|(idx, object)| (ObjectId(idx), object))
+    }
+
+    pub fn object_authorized_directives(&self, object_id: ObjectId) -> impl Iterator<Item = &AuthorizedDirective> {
+        let start = self
+            .object_authorized_directives
+            .partition_point(|(needle, _)| *needle < object_id);
+
+        self.object_authorized_directives[start..]
+            .iter()
+            .take_while(move |(needle, _)| *needle == object_id)
+            .map(move |(_, authorized_directive_id)| &self[*authorized_directive_id])
+    }
+
+    pub fn interface_authorized_directives(
+        &self,
+        interface_id: InterfaceId,
+    ) -> impl Iterator<Item = &AuthorizedDirective> {
+        let start = self
+            .interface_authorized_directives
+            .partition_point(|(needle, _)| *needle < interface_id);
+
+        self.interface_authorized_directives[start..]
+            .iter()
+            .take_while(move |(needle, _)| *needle == interface_id)
+            .map(move |(_, authorized_directive_id)| &self[*authorized_directive_id])
+    }
+}
+
+#[derive(PartialEq, PartialOrd, Clone)]
+pub enum Directive {
+    Authenticated,
+    Deprecated {
+        reason: Option<StringId>,
+    },
+    Inaccessible,
+    Policy(Vec<Vec<StringId>>),
+    RequiresScopes(Vec<Vec<StringId>>),
+
+    Other {
+        name: StringId,
+        arguments: Vec<(StringId, Value)>,
+    },
+}
+
+#[derive(Default, serde::Serialize, serde::Deserialize, Clone, PartialEq, PartialOrd, Debug)]
+#[allow(clippy::enum_variant_names)]
+pub enum Value {
+    #[default]
+    Null,
+    String(StringId),
+    Int(i64),
+    Float(f64),
+    Boolean(bool),
+    /// Different from `String`.
+    ///
+    /// `@tag(name: "SOMETHING")` vs `@tag(name: SOMETHING)`
+    EnumValue(StringId),
+    Object(Box<[(StringId, Value)]>),
+    List(Box<[Value]>),
+}
+
+impl Value {
+    pub fn is_list(&self) -> bool {
+        matches!(self, Value::List(_))
+    }
+
+    pub fn is_null(&self) -> bool {
+        matches!(self, Value::Null)
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, PartialOrd)]
+pub struct AuthorizedDirective {
+    pub fields: Option<FieldSet>,
+    pub node: Option<FieldSet>,
+    pub arguments: Option<InputValueDefinitionSet>,
+    pub metadata: Option<Value>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq)]
+pub struct InputValueDefinition {
+    pub name: StringId,
+    pub r#type: Type,
+    pub directives: Directives,
+    pub description: Option<StringId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<Value>,
+}
+
+impl Default for FederatedGraphV4 {
+    fn default() -> Self {
+        FederatedGraphV4 {
+            subgraphs: Vec::new(),
+            root_operation_types: RootOperationTypes {
+                query: ObjectId(0),
+                mutation: None,
+                subscription: None,
+            },
+            objects: vec![Object {
+                name: StringId(0),
+                implements_interfaces: Vec::new(),
+                keys: Vec::new(),
+                composed_directives: NO_DIRECTIVES,
+                fields: FieldId(0)..FieldId(2),
+                description: None,
+            }],
+            interfaces: Vec::new(),
+            fields: vec![
+                Field {
+                    name: StringId(1),
+                    r#type: Type {
+                        wrapping: Default::default(),
+                        definition: Definition::Scalar(ScalarId(0)),
+                    },
+                    arguments: NO_INPUT_VALUE_DEFINITION,
+                    resolvable_in: Vec::new(),
+                    provides: Vec::new(),
+                    requires: Vec::new(),
+                    overrides: Vec::new(),
+                    composed_directives: NO_DIRECTIVES,
+                    description: None,
+                },
+                Field {
+                    name: StringId(2),
+                    r#type: Type {
+                        wrapping: Default::default(),
+                        definition: Definition::Scalar(ScalarId(0)),
+                    },
+                    arguments: NO_INPUT_VALUE_DEFINITION,
+                    resolvable_in: Vec::new(),
+                    provides: Vec::new(),
+                    requires: Vec::new(),
+                    overrides: Vec::new(),
+                    composed_directives: NO_DIRECTIVES,
+                    description: None,
+                },
+            ],
+            enums: Vec::new(),
+            unions: Vec::new(),
+            scalars: Vec::new(),
+            input_objects: Vec::new(),
+            enum_values: Vec::new(),
+            input_value_definitions: Vec::new(),
+            strings: ["Query", "__type", "__schema"]
+                .into_iter()
+                .map(|string| string.to_owned())
+                .collect(),
+            directives: Vec::new(),
+            authorized_directives: Vec::new(),
+            field_authorized_directives: Vec::new(),
+            object_authorized_directives: Vec::new(),
+            interface_authorized_directives: Vec::new(),
+        }
+    }
+}
+
+macro_rules! id_newtypes {
+    ($($name:ident + $storage:ident + $out:ident,)*) => {
+        $(
+            impl std::ops::Index<$name> for FederatedGraphV4 {
+                type Output = $out;
+
+                fn index(&self, index: $name) -> &$out {
+                    &self.$storage[index.0]
+                }
+            }
+
+            impl std::ops::IndexMut<$name> for FederatedGraphV4 {
+                fn index_mut(&mut self, index: $name) -> &mut $out {
+                    &mut self.$storage[index.0]
+                }
+            }
+        )*
+    }
+}
+
+id_newtypes! {
+    AuthorizedDirectiveId + authorized_directives + AuthorizedDirective,
+    EnumId + enums + Enum,
+    FieldId + fields + Field,
+    InputValueDefinitionId + input_value_definitions + InputValueDefinition,
+    InputObjectId + input_objects + InputObject,
+    InterfaceId + interfaces + Interface,
+    ObjectId + objects + Object,
+    ScalarId + scalars + Scalar,
+    StringId + strings + String,
+    SubgraphId + subgraphs + Subgraph,
+    UnionId + unions + Union,
+}
+
+impl From<super::FederatedGraphV3> for FederatedGraphV4 {
+    fn from(
+        crate::FederatedGraphV3 {
+            subgraphs,
+            root_operation_types,
+            objects,
+            interfaces,
+            fields,
+            enums,
+            unions,
+            scalars,
+            input_objects,
+            enum_values,
+            input_value_definitions,
+            strings,
+            directives,
+            authorized_directives,
+            field_authorized_directives,
+            object_authorized_directives,
+            interface_authorized_directives,
+        }: super::FederatedGraphV3,
+    ) -> Self {
+        FederatedGraphV4 {
+            subgraphs,
+            root_operation_types,
+            objects,
+            interfaces,
+            fields,
+            enums,
+            unions,
+            scalars,
+            input_objects,
+            enum_values,
+            input_value_definitions: input_value_definitions
+                .into_iter()
+                .map(
+                    |super::v3::InputValueDefinition {
+                         name,
+                         r#type,
+                         directives,
+                         description,
+                         default,
+                     }: super::v3::InputValueDefinition| InputValueDefinition {
+                        name,
+                        r#type,
+                        directives,
+                        description,
+                        default: default.map(From::from),
+                    },
+                )
+                .collect(),
+            strings,
+            directives: directives
+                .into_iter()
+                .map(|directive| match directive {
+                    super::v3::Directive::Authenticated => Directive::Authenticated,
+                    super::v3::Directive::Deprecated { reason } => Directive::Deprecated { reason },
+                    super::v3::Directive::Inaccessible => Directive::Inaccessible,
+                    super::v3::Directive::Policy(policy) => Directive::Policy(policy),
+                    super::v3::Directive::RequiresScopes(scopes) => Directive::RequiresScopes(scopes),
+                    super::v3::Directive::Other { name, arguments } => Directive::Other {
+                        name,
+                        arguments: arguments.into_iter().map(|(key, value)| (key, value.into())).collect(),
+                    },
+                })
+                .collect(),
+            authorized_directives: authorized_directives
+                .into_iter()
+                .map(
+                    |super::v3::AuthorizedDirective {
+                         fields,
+                         node,
+                         arguments,
+                         metadata,
+                     }| AuthorizedDirective {
+                        fields,
+                        node,
+                        arguments,
+                        metadata: metadata.map(From::from),
+                    },
+                )
+                .collect(),
+            field_authorized_directives,
+            object_authorized_directives,
+            interface_authorized_directives,
+        }
+    }
+}
+
+impl From<super::v3::Value> for Value {
+    fn from(value: super::v3::Value) -> Self {
+        match value {
+            super::v3::Value::Null => Value::Null,
+            super::v3::Value::String(s) => Value::String(s),
+            super::v3::Value::Int(i) => Value::Int(i),
+            super::v3::Value::Float(i) => Value::Float(i),
+            super::v3::Value::Boolean(b) => Value::Boolean(b),
+            super::v3::Value::EnumValue(i) => Value::EnumValue(i),
+            super::v3::Value::Object(obj) => Value::Object(
+                obj.iter()
+                    .map(|(k, v)| (*k, v.clone().into()))
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice(),
+            ),
+            super::v3::Value::List(list) => Value::List(
+                list.iter()
+                    .map(|inner| inner.clone().into())
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice(),
+            ),
+        }
+    }
+}
+
+impl std::ops::Index<Directives> for FederatedGraphV4 {
+    type Output = [Directive];
+
+    fn index(&self, index: Directives) -> &Self::Output {
+        let (DirectiveId(start), len) = index;
+        &self.directives[start..(start + len)]
+    }
+}
+
+impl std::ops::Index<InputValueDefinitions> for FederatedGraphV4 {
+    type Output = [InputValueDefinition];
+
+    fn index(&self, index: InputValueDefinitions) -> &Self::Output {
+        let (InputValueDefinitionId(start), len) = index;
+        &self.input_value_definitions[start..(start + len)]
+    }
+}
+
+impl std::ops::Index<EnumValues> for FederatedGraphV4 {
+    type Output = [EnumValue];
+
+    fn index(&self, index: EnumValues) -> &Self::Output {
+        let (EnumValueId(start), len) = index;
+        &self.enum_values[start..(start + len)]
+    }
+}
+
+impl std::ops::Index<Fields> for FederatedGraphV4 {
+    type Output = [Field];
+
+    fn index(&self, index: Fields) -> &Self::Output {
+        let Range {
+            start: FieldId(start),
+            end: FieldId(end),
+        } = index;
+        &self.fields[start..end]
+    }
+}

--- a/engine/crates/federated-graph/src/federated_graph/v4.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v4.rs
@@ -10,7 +10,7 @@ pub use super::v3::{
 };
 
 #[derive(Clone)]
-pub struct FederatedGraphV4 {
+pub struct FederatedGraph {
     pub subgraphs: Vec<Subgraph>,
     pub root_operation_types: RootOperationTypes,
     pub objects: Vec<Object>,
@@ -39,13 +39,13 @@ pub struct FederatedGraphV4 {
     pub interface_authorized_directives: Vec<(InterfaceId, AuthorizedDirectiveId)>,
 }
 
-impl std::fmt::Debug for FederatedGraphV4 {
+impl std::fmt::Debug for FederatedGraph {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct(std::any::type_name::<Self>()).finish_non_exhaustive()
     }
 }
 
-impl FederatedGraphV4 {
+impl FederatedGraph {
     pub fn iter_interfaces(&self) -> impl ExactSizeIterator<Item = (InterfaceId, &Interface)> {
         self.interfaces
             .iter()
@@ -147,9 +147,9 @@ pub struct InputValueDefinition {
     pub default: Option<Value>,
 }
 
-impl Default for FederatedGraphV4 {
+impl Default for FederatedGraph {
     fn default() -> Self {
-        FederatedGraphV4 {
+        FederatedGraph {
             subgraphs: Vec::new(),
             root_operation_types: RootOperationTypes {
                 query: ObjectId(0),
@@ -217,7 +217,7 @@ impl Default for FederatedGraphV4 {
 macro_rules! id_newtypes {
     ($($name:ident + $storage:ident + $out:ident,)*) => {
         $(
-            impl std::ops::Index<$name> for FederatedGraphV4 {
+            impl std::ops::Index<$name> for FederatedGraph {
                 type Output = $out;
 
                 fn index(&self, index: $name) -> &$out {
@@ -225,7 +225,7 @@ macro_rules! id_newtypes {
                 }
             }
 
-            impl std::ops::IndexMut<$name> for FederatedGraphV4 {
+            impl std::ops::IndexMut<$name> for FederatedGraph {
                 fn index_mut(&mut self, index: $name) -> &mut $out {
                     &mut self.$storage[index.0]
                 }
@@ -248,7 +248,7 @@ id_newtypes! {
     UnionId + unions + Union,
 }
 
-impl From<super::FederatedGraphV3> for FederatedGraphV4 {
+impl From<super::FederatedGraphV3> for FederatedGraph {
     fn from(
         crate::FederatedGraphV3 {
             subgraphs,
@@ -270,7 +270,7 @@ impl From<super::FederatedGraphV3> for FederatedGraphV4 {
             interface_authorized_directives,
         }: super::FederatedGraphV3,
     ) -> Self {
-        FederatedGraphV4 {
+        FederatedGraph {
             subgraphs,
             root_operation_types,
             objects,
@@ -362,7 +362,7 @@ impl From<super::v3::Value> for Value {
     }
 }
 
-impl std::ops::Index<Directives> for FederatedGraphV4 {
+impl std::ops::Index<Directives> for FederatedGraph {
     type Output = [Directive];
 
     fn index(&self, index: Directives) -> &Self::Output {
@@ -371,7 +371,7 @@ impl std::ops::Index<Directives> for FederatedGraphV4 {
     }
 }
 
-impl std::ops::Index<InputValueDefinitions> for FederatedGraphV4 {
+impl std::ops::Index<InputValueDefinitions> for FederatedGraph {
     type Output = [InputValueDefinition];
 
     fn index(&self, index: InputValueDefinitions) -> &Self::Output {
@@ -380,7 +380,7 @@ impl std::ops::Index<InputValueDefinitions> for FederatedGraphV4 {
     }
 }
 
-impl std::ops::Index<EnumValues> for FederatedGraphV4 {
+impl std::ops::Index<EnumValues> for FederatedGraph {
     type Output = [EnumValue];
 
     fn index(&self, index: EnumValues) -> &Self::Output {
@@ -389,7 +389,7 @@ impl std::ops::Index<EnumValues> for FederatedGraphV4 {
     }
 }
 
-impl std::ops::Index<Fields> for FederatedGraphV4 {
+impl std::ops::Index<Fields> for FederatedGraph {
     type Output = [Field];
 
     fn index(&self, index: Fields) -> &Self::Output {

--- a/engine/crates/federated-graph/src/from_sdl.rs
+++ b/engine/crates/federated-graph/src/from_sdl.rs
@@ -157,7 +157,7 @@ impl<'a> State<'a> {
     }
 }
 
-pub fn from_sdl(sdl: &str) -> Result<FederatedGraphV4, DomainError> {
+pub fn from_sdl(sdl: &str) -> Result<FederatedGraph, DomainError> {
     let mut state = State::default();
     let parsed = async_graphql_parser::parse_schema(sdl).map_err(|err| DomainError(err.to_string()))?;
 
@@ -196,7 +196,7 @@ pub fn from_sdl(sdl: &str) -> Result<FederatedGraphV4, DomainError> {
     // This needs to happen after all fields have been ingested, in order to attach selection sets.
     ingest_selection_sets(&parsed, &mut state)?;
 
-    Ok(FederatedGraphV4 {
+    Ok(FederatedGraph {
         root_operation_types: state.root_operation_types()?,
         subgraphs: state.subgraphs,
         objects: state.objects,

--- a/engine/crates/federated-graph/src/lib.rs
+++ b/engine/crates/federated-graph/src/lib.rs
@@ -6,7 +6,7 @@ pub use self::federated_graph::*;
 mod render_sdl;
 
 #[cfg(feature = "render_sdl")]
-pub use render_sdl::{render_api_sdl, render_federated_sdl, render_sdl};
+pub use render_sdl::{render_api_sdl, render_federated_sdl};
 
 #[cfg(feature = "from_sdl")]
 mod from_sdl;
@@ -19,27 +19,27 @@ pub enum FederatedGraph {
     V1(FederatedGraphV1),
     V2(FederatedGraphV2),
     V3(FederatedGraphV3),
+    Sdl(String),
 }
 
 impl FederatedGraph {
-    pub fn into_sdl(self) -> Result<String, std::fmt::Error> {
-        render_sdl(self)
-    }
-
-    #[deprecated(note = "Use into_sdl() instead")]
-    pub fn to_sdl(&self) -> Result<String, std::fmt::Error> {
-        self.clone().into_sdl()
-    }
-
     pub fn from_sdl(sdl: &str) -> Result<FederatedGraph, DomainError> {
-        from_sdl(sdl)
+        Ok(FederatedGraph::Sdl(sdl.to_owned()))
     }
 
-    pub fn into_latest(self) -> FederatedGraphV3 {
+    pub fn into_federated_sdl(self) -> String {
+        match self {
+            FederatedGraph::Sdl(sdl) => sdl,
+            other => render_federated_sdl(&other.into_latest()).unwrap(),
+        }
+    }
+
+    pub fn into_latest(self) -> FederatedGraphV4 {
         match self {
             FederatedGraph::V1(v1) => FederatedGraph::V2(FederatedGraphV2::from(v1)).into_latest(),
-            FederatedGraph::V2(v2) => v2.into(),
-            FederatedGraph::V3(v3) => v3,
+            FederatedGraph::V2(v2) => FederatedGraph::V3(FederatedGraphV3::from(v2)).into_latest(),
+            FederatedGraph::V3(v3) => v3.into(),
+            FederatedGraph::Sdl(sdl) => from_sdl(&sdl).unwrap(),
         }
     }
 }

--- a/engine/crates/federated-graph/src/lib.rs
+++ b/engine/crates/federated-graph/src/lib.rs
@@ -15,31 +15,31 @@ mod from_sdl;
 pub use from_sdl::{from_sdl, DomainError};
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
-pub enum FederatedGraph {
+pub enum VersionedFederatedGraph {
     V1(FederatedGraphV1),
     V2(FederatedGraphV2),
     V3(FederatedGraphV3),
     Sdl(String),
 }
 
-impl FederatedGraph {
-    pub fn from_sdl(sdl: &str) -> Result<FederatedGraph, DomainError> {
-        Ok(FederatedGraph::Sdl(sdl.to_owned()))
+impl VersionedFederatedGraph {
+    pub fn from_sdl(sdl: &str) -> Result<VersionedFederatedGraph, DomainError> {
+        Ok(VersionedFederatedGraph::Sdl(sdl.to_owned()))
     }
 
     pub fn into_federated_sdl(self) -> String {
         match self {
-            FederatedGraph::Sdl(sdl) => sdl,
+            VersionedFederatedGraph::Sdl(sdl) => sdl,
             other => render_federated_sdl(&other.into_latest()).unwrap(),
         }
     }
 
-    pub fn into_latest(self) -> FederatedGraphV4 {
+    pub fn into_latest(self) -> FederatedGraph {
         match self {
-            FederatedGraph::V1(v1) => FederatedGraph::V2(FederatedGraphV2::from(v1)).into_latest(),
-            FederatedGraph::V2(v2) => FederatedGraph::V3(FederatedGraphV3::from(v2)).into_latest(),
-            FederatedGraph::V3(v3) => v3.into(),
-            FederatedGraph::Sdl(sdl) => from_sdl(&sdl).unwrap(),
+            VersionedFederatedGraph::V1(v1) => VersionedFederatedGraph::V2(FederatedGraphV2::from(v1)).into_latest(),
+            VersionedFederatedGraph::V2(v2) => VersionedFederatedGraph::V3(FederatedGraphV3::from(v2)).into_latest(),
+            VersionedFederatedGraph::V3(v3) => v3.into(),
+            VersionedFederatedGraph::Sdl(sdl) => from_sdl(&sdl).unwrap(),
         }
     }
 }

--- a/engine/crates/federated-graph/src/render_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl.rs
@@ -3,7 +3,3 @@ mod render_api_sdl;
 mod render_federated_sdl;
 
 pub use self::{render_api_sdl::render_api_sdl, render_federated_sdl::render_federated_sdl};
-
-pub fn render_sdl(graph: crate::FederatedGraph) -> Result<String, std::fmt::Error> {
-    render_federated_sdl(&graph.into_latest())
-}

--- a/engine/crates/federated-graph/src/render_sdl/display_utils.rs
+++ b/engine/crates/federated-graph/src/render_sdl/display_utils.rs
@@ -57,7 +57,7 @@ impl fmt::Display for Description<'_> {
     }
 }
 
-pub(super) struct ValueDisplay<'a>(pub &'a crate::Value, pub &'a FederatedGraphV3);
+pub(super) struct ValueDisplay<'a>(pub &'a crate::Value, pub &'a FederatedGraphV4);
 
 impl fmt::Display for ValueDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -99,7 +99,7 @@ impl fmt::Display for ValueDisplay<'_> {
     }
 }
 
-pub(super) struct DirectiveArguments<'a>(pub &'a [(StringId, Value)], pub &'a FederatedGraphV3);
+pub(super) struct DirectiveArguments<'a>(pub &'a [(StringId, Value)], pub &'a FederatedGraphV4);
 
 impl Display for DirectiveArguments<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -140,7 +140,7 @@ impl<T: Display> Display for MaybeDisplay<T> {
 }
 
 /// Displays a field set inside quotes
-pub(super) struct FieldSetDisplay<'a>(pub &'a crate::FieldSet, pub &'a FederatedGraphV3);
+pub(super) struct FieldSetDisplay<'a>(pub &'a crate::FieldSet, pub &'a FederatedGraphV4);
 
 impl Display for FieldSetDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -149,7 +149,7 @@ impl Display for FieldSetDisplay<'_> {
     }
 }
 
-pub(super) struct BareFieldSetDisplay<'a>(pub &'a crate::FieldSet, pub &'a FederatedGraphV3);
+pub(super) struct BareFieldSetDisplay<'a>(pub &'a crate::FieldSet, pub &'a FederatedGraphV4);
 
 impl Display for BareFieldSetDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -185,7 +185,7 @@ impl Display for BareFieldSetDisplay<'_> {
 }
 
 /// Displays a input value definition set inside quotes
-pub(super) struct InputValueDefinitionSetDisplay<'a>(pub &'a crate::InputValueDefinitionSet, pub &'a FederatedGraphV3);
+pub(super) struct InputValueDefinitionSetDisplay<'a>(pub &'a crate::InputValueDefinitionSet, pub &'a FederatedGraphV4);
 
 impl Display for InputValueDefinitionSetDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -196,7 +196,7 @@ impl Display for InputValueDefinitionSetDisplay<'_> {
 
 pub(super) struct BareInputValueDefinitionSetDisplay<'a>(
     pub &'a crate::InputValueDefinitionSet,
-    pub &'a FederatedGraphV3,
+    pub &'a FederatedGraphV4,
 );
 
 impl Display for BareInputValueDefinitionSetDisplay<'_> {
@@ -228,13 +228,13 @@ pub(super) fn write_description(
     f: &mut fmt::Formatter<'_>,
     description: Option<StringId>,
     indent: &str,
-    graph: &FederatedGraphV3,
+    graph: &FederatedGraphV4,
 ) -> fmt::Result {
     let Some(description) = description else { return Ok(()) };
     Display::fmt(&Description(&graph[description], indent), f)
 }
 
-pub(crate) struct DirectiveDisplay<'a>(pub &'a Directive, pub &'a FederatedGraphV3);
+pub(crate) struct DirectiveDisplay<'a>(pub &'a Directive, pub &'a FederatedGraphV4);
 
 impl Display for DirectiveDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -246,7 +246,7 @@ impl Display for DirectiveDisplay<'_> {
 pub(crate) fn write_composed_directive(
     f: &mut fmt::Formatter<'_>,
     directive: &Directive,
-    graph: &FederatedGraphV3,
+    graph: &FederatedGraphV4,
 ) -> fmt::Result {
     match directive {
         Directive::Authenticated => write_directive(f, "authenticated", iter::empty::<(&str, Value)>(), graph),
@@ -320,7 +320,7 @@ impl<'a> From<InputValueDefinitionSetDisplay<'a>> for DisplayableArgument<'a> {
     }
 }
 
-pub(super) struct AuthorizedDirectiveDisplay<'a>(pub &'a AuthorizedDirective, pub &'a FederatedGraphV3);
+pub(super) struct AuthorizedDirectiveDisplay<'a>(pub &'a AuthorizedDirective, pub &'a FederatedGraphV4);
 
 impl Display for AuthorizedDirectiveDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -358,7 +358,7 @@ fn write_directive<'a, A>(
     f: &mut fmt::Formatter<'_>,
     directive_name: &str,
     arguments: impl Iterator<Item = (&'a str, A)>,
-    graph: &FederatedGraphV3,
+    graph: &FederatedGraphV4,
 ) -> fmt::Result
 where
     A: Into<DisplayableArgument<'a>>,
@@ -371,7 +371,7 @@ where
 fn write_directive_arguments<'a>(
     f: &mut fmt::Formatter<'_>,
     arguments: impl Iterator<Item = (&'a str, DisplayableArgument<'a>)>,
-    graph: &FederatedGraphV3,
+    graph: &FederatedGraphV4,
 ) -> fmt::Result {
     let mut arguments = arguments.peekable();
 
@@ -405,7 +405,7 @@ fn write_directive_arguments<'a>(
     f.write_str(")")
 }
 
-pub(super) fn render_field_type(field_type: &Type, graph: &FederatedGraphV3) -> String {
+pub(super) fn render_field_type(field_type: &Type, graph: &FederatedGraphV4) -> String {
     let name_id = match field_type.definition {
         Definition::Scalar(scalar_id) => graph[scalar_id].name,
         Definition::Object(object_id) => graph[object_id].name,

--- a/engine/crates/federated-graph/src/render_sdl/display_utils.rs
+++ b/engine/crates/federated-graph/src/render_sdl/display_utils.rs
@@ -57,7 +57,7 @@ impl fmt::Display for Description<'_> {
     }
 }
 
-pub(super) struct ValueDisplay<'a>(pub &'a crate::Value, pub &'a FederatedGraphV4);
+pub(super) struct ValueDisplay<'a>(pub &'a crate::Value, pub &'a FederatedGraph);
 
 impl fmt::Display for ValueDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -99,7 +99,7 @@ impl fmt::Display for ValueDisplay<'_> {
     }
 }
 
-pub(super) struct DirectiveArguments<'a>(pub &'a [(StringId, Value)], pub &'a FederatedGraphV4);
+pub(super) struct DirectiveArguments<'a>(pub &'a [(StringId, Value)], pub &'a FederatedGraph);
 
 impl Display for DirectiveArguments<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -140,7 +140,7 @@ impl<T: Display> Display for MaybeDisplay<T> {
 }
 
 /// Displays a field set inside quotes
-pub(super) struct FieldSetDisplay<'a>(pub &'a crate::FieldSet, pub &'a FederatedGraphV4);
+pub(super) struct FieldSetDisplay<'a>(pub &'a crate::FieldSet, pub &'a FederatedGraph);
 
 impl Display for FieldSetDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -149,7 +149,7 @@ impl Display for FieldSetDisplay<'_> {
     }
 }
 
-pub(super) struct BareFieldSetDisplay<'a>(pub &'a crate::FieldSet, pub &'a FederatedGraphV4);
+pub(super) struct BareFieldSetDisplay<'a>(pub &'a crate::FieldSet, pub &'a FederatedGraph);
 
 impl Display for BareFieldSetDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -185,7 +185,7 @@ impl Display for BareFieldSetDisplay<'_> {
 }
 
 /// Displays a input value definition set inside quotes
-pub(super) struct InputValueDefinitionSetDisplay<'a>(pub &'a crate::InputValueDefinitionSet, pub &'a FederatedGraphV4);
+pub(super) struct InputValueDefinitionSetDisplay<'a>(pub &'a crate::InputValueDefinitionSet, pub &'a FederatedGraph);
 
 impl Display for InputValueDefinitionSetDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -196,7 +196,7 @@ impl Display for InputValueDefinitionSetDisplay<'_> {
 
 pub(super) struct BareInputValueDefinitionSetDisplay<'a>(
     pub &'a crate::InputValueDefinitionSet,
-    pub &'a FederatedGraphV4,
+    pub &'a FederatedGraph,
 );
 
 impl Display for BareInputValueDefinitionSetDisplay<'_> {
@@ -228,13 +228,13 @@ pub(super) fn write_description(
     f: &mut fmt::Formatter<'_>,
     description: Option<StringId>,
     indent: &str,
-    graph: &FederatedGraphV4,
+    graph: &FederatedGraph,
 ) -> fmt::Result {
     let Some(description) = description else { return Ok(()) };
     Display::fmt(&Description(&graph[description], indent), f)
 }
 
-pub(crate) struct DirectiveDisplay<'a>(pub &'a Directive, pub &'a FederatedGraphV4);
+pub(crate) struct DirectiveDisplay<'a>(pub &'a Directive, pub &'a FederatedGraph);
 
 impl Display for DirectiveDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -246,7 +246,7 @@ impl Display for DirectiveDisplay<'_> {
 pub(crate) fn write_composed_directive(
     f: &mut fmt::Formatter<'_>,
     directive: &Directive,
-    graph: &FederatedGraphV4,
+    graph: &FederatedGraph,
 ) -> fmt::Result {
     match directive {
         Directive::Authenticated => write_directive(f, "authenticated", iter::empty::<(&str, Value)>(), graph),
@@ -320,7 +320,7 @@ impl<'a> From<InputValueDefinitionSetDisplay<'a>> for DisplayableArgument<'a> {
     }
 }
 
-pub(super) struct AuthorizedDirectiveDisplay<'a>(pub &'a AuthorizedDirective, pub &'a FederatedGraphV4);
+pub(super) struct AuthorizedDirectiveDisplay<'a>(pub &'a AuthorizedDirective, pub &'a FederatedGraph);
 
 impl Display for AuthorizedDirectiveDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -358,7 +358,7 @@ fn write_directive<'a, A>(
     f: &mut fmt::Formatter<'_>,
     directive_name: &str,
     arguments: impl Iterator<Item = (&'a str, A)>,
-    graph: &FederatedGraphV4,
+    graph: &FederatedGraph,
 ) -> fmt::Result
 where
     A: Into<DisplayableArgument<'a>>,
@@ -371,7 +371,7 @@ where
 fn write_directive_arguments<'a>(
     f: &mut fmt::Formatter<'_>,
     arguments: impl Iterator<Item = (&'a str, DisplayableArgument<'a>)>,
-    graph: &FederatedGraphV4,
+    graph: &FederatedGraph,
 ) -> fmt::Result {
     let mut arguments = arguments.peekable();
 
@@ -405,7 +405,7 @@ fn write_directive_arguments<'a>(
     f.write_str(")")
 }
 
-pub(super) fn render_field_type(field_type: &Type, graph: &FederatedGraphV4) -> String {
+pub(super) fn render_field_type(field_type: &Type, graph: &FederatedGraph) -> String {
     let name_id = match field_type.definition {
         Definition::Scalar(scalar_id) => graph[scalar_id].name,
         Definition::Object(object_id) => graph[object_id].name,

--- a/engine/crates/federated-graph/src/render_sdl/render_api_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl/render_api_sdl.rs
@@ -1,16 +1,16 @@
 use super::display_utils::*;
-use crate::{federated_graph::*, FederatedGraphV3};
+use crate::{federated_graph::*, FederatedGraphV4};
 use std::fmt::{self, Write as _};
 
 /// Render a GraphQL SDL string for a federated graph. It does not include any
 /// federation-specific directives, it only reflects the final API schema as visible
 /// for consumers.
-pub fn render_api_sdl(graph: &FederatedGraphV3) -> String {
+pub fn render_api_sdl(graph: &FederatedGraphV4) -> String {
     Renderer { graph }.to_string()
 }
 
 struct Renderer<'a> {
-    graph: &'a FederatedGraphV3,
+    graph: &'a FederatedGraphV4,
 }
 
 impl fmt::Display for Renderer<'_> {
@@ -227,7 +227,7 @@ impl fmt::Display for Renderer<'_> {
     }
 }
 
-fn has_inaccessible(directives: &Directives, graph: &FederatedGraphV3) -> bool {
+fn has_inaccessible(directives: &Directives, graph: &FederatedGraphV4) -> bool {
     graph[*directives]
         .iter()
         .any(|directive| matches!(directive, Directive::Inaccessible))
@@ -236,7 +236,7 @@ fn has_inaccessible(directives: &Directives, graph: &FederatedGraphV3) -> bool {
 fn write_public_directives(
     f: &mut fmt::Formatter<'_>,
     directives: Directives,
-    graph: &FederatedGraphV3,
+    graph: &FederatedGraphV4,
 ) -> fmt::Result {
     for directive in graph[directives].iter().filter(|directive| match directive {
         Directive::Inaccessible | Directive::Policy(_) => false,
@@ -253,7 +253,7 @@ fn write_public_directives(
     Ok(())
 }
 
-fn write_enum_variant(f: &mut fmt::Formatter<'_>, enum_variant: &EnumValue, graph: &FederatedGraphV3) -> fmt::Result {
+fn write_enum_variant(f: &mut fmt::Formatter<'_>, enum_variant: &EnumValue, graph: &FederatedGraphV4) -> fmt::Result {
     f.write_str(INDENT)?;
     write_description(f, enum_variant.description, INDENT, graph)?;
     f.write_str(&graph[enum_variant.value])?;
@@ -264,7 +264,7 @@ fn write_enum_variant(f: &mut fmt::Formatter<'_>, enum_variant: &EnumValue, grap
 fn write_field_arguments(
     f: &mut fmt::Formatter<'_>,
     args: &[InputValueDefinition],
-    graph: &FederatedGraphV3,
+    graph: &FederatedGraphV4,
 ) -> fmt::Result {
     if args.is_empty() {
         return Ok(());
@@ -308,7 +308,7 @@ mod tests {
 
     #[test]
     fn test_empty() {
-        let empty = FederatedGraphV3::default();
+        let empty = FederatedGraphV4::default();
         let sdl = render_api_sdl(&empty);
         assert!(sdl.is_empty());
     }

--- a/engine/crates/federated-graph/src/render_sdl/render_api_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl/render_api_sdl.rs
@@ -1,16 +1,16 @@
 use super::display_utils::*;
-use crate::{federated_graph::*, FederatedGraphV4};
+use crate::{federated_graph::*, FederatedGraph};
 use std::fmt::{self, Write as _};
 
 /// Render a GraphQL SDL string for a federated graph. It does not include any
 /// federation-specific directives, it only reflects the final API schema as visible
 /// for consumers.
-pub fn render_api_sdl(graph: &FederatedGraphV4) -> String {
+pub fn render_api_sdl(graph: &FederatedGraph) -> String {
     Renderer { graph }.to_string()
 }
 
 struct Renderer<'a> {
-    graph: &'a FederatedGraphV4,
+    graph: &'a FederatedGraph,
 }
 
 impl fmt::Display for Renderer<'_> {
@@ -227,17 +227,13 @@ impl fmt::Display for Renderer<'_> {
     }
 }
 
-fn has_inaccessible(directives: &Directives, graph: &FederatedGraphV4) -> bool {
+fn has_inaccessible(directives: &Directives, graph: &FederatedGraph) -> bool {
     graph[*directives]
         .iter()
         .any(|directive| matches!(directive, Directive::Inaccessible))
 }
 
-fn write_public_directives(
-    f: &mut fmt::Formatter<'_>,
-    directives: Directives,
-    graph: &FederatedGraphV4,
-) -> fmt::Result {
+fn write_public_directives(f: &mut fmt::Formatter<'_>, directives: Directives, graph: &FederatedGraph) -> fmt::Result {
     for directive in graph[directives].iter().filter(|directive| match directive {
         Directive::Inaccessible | Directive::Policy(_) => false,
 
@@ -253,7 +249,7 @@ fn write_public_directives(
     Ok(())
 }
 
-fn write_enum_variant(f: &mut fmt::Formatter<'_>, enum_variant: &EnumValue, graph: &FederatedGraphV4) -> fmt::Result {
+fn write_enum_variant(f: &mut fmt::Formatter<'_>, enum_variant: &EnumValue, graph: &FederatedGraph) -> fmt::Result {
     f.write_str(INDENT)?;
     write_description(f, enum_variant.description, INDENT, graph)?;
     f.write_str(&graph[enum_variant.value])?;
@@ -264,7 +260,7 @@ fn write_enum_variant(f: &mut fmt::Formatter<'_>, enum_variant: &EnumValue, grap
 fn write_field_arguments(
     f: &mut fmt::Formatter<'_>,
     args: &[InputValueDefinition],
-    graph: &FederatedGraphV4,
+    graph: &FederatedGraph,
 ) -> fmt::Result {
     if args.is_empty() {
         return Ok(());
@@ -308,7 +304,7 @@ mod tests {
 
     #[test]
     fn test_empty() {
-        let empty = FederatedGraphV4::default();
+        let empty = FederatedGraph::default();
         let sdl = render_api_sdl(&empty);
         assert!(sdl.is_empty());
     }

--- a/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
@@ -4,7 +4,7 @@ use std::fmt::{self, Display, Write};
 
 /// Render a GraphQL SDL string for a federated graph. It includes [join spec
 /// directives](https://specs.apollo.dev/join/v0.3/) about subgraphs and entities.
-pub fn render_federated_sdl(graph: &FederatedGraphV4) -> Result<String, fmt::Error> {
+pub fn render_federated_sdl(graph: &FederatedGraph) -> Result<String, fmt::Error> {
     let mut sdl = String::new();
 
     write_prelude(&mut sdl)?;
@@ -263,7 +263,7 @@ fn write_prelude(sdl: &mut String) -> fmt::Result {
     Ok(())
 }
 
-fn write_subgraphs_enum(graph: &FederatedGraphV4, sdl: &mut String) -> fmt::Result {
+fn write_subgraphs_enum(graph: &FederatedGraph, sdl: &mut String) -> fmt::Result {
     if graph.subgraphs.is_empty() {
         return Ok(());
     }
@@ -287,7 +287,7 @@ fn write_subgraphs_enum(graph: &FederatedGraphV4, sdl: &mut String) -> fmt::Resu
     Ok(())
 }
 
-fn write_input_field(field: &InputValueDefinition, graph: &FederatedGraphV4, sdl: &mut String) -> fmt::Result {
+fn write_input_field(field: &InputValueDefinition, graph: &FederatedGraph, sdl: &mut String) -> fmt::Result {
     let field_name = &graph[field.name];
     let field_type = render_field_type(&field.r#type, graph);
 
@@ -307,7 +307,7 @@ fn write_input_field(field: &InputValueDefinition, graph: &FederatedGraphV4, sdl
     Ok(())
 }
 
-fn write_field(field_id: FieldId, field: &Field, graph: &FederatedGraphV4, sdl: &mut String) -> fmt::Result {
+fn write_field(field_id: FieldId, field: &Field, graph: &FederatedGraph, sdl: &mut String) -> fmt::Result {
     let field_name = &graph[field.name];
     let field_type = render_field_type(&field.r#type, graph);
     let args = render_field_arguments(&graph[field.arguments], graph);
@@ -332,7 +332,7 @@ fn write_field(field_id: FieldId, field: &Field, graph: &FederatedGraphV4, sdl: 
     Ok(())
 }
 
-fn write_composed_directives(directives: Directives, graph: &FederatedGraphV4, sdl: &mut String) -> fmt::Result {
+fn write_composed_directives(directives: Directives, graph: &FederatedGraph, sdl: &mut String) -> fmt::Result {
     for directive in &graph[directives] {
         write!(sdl, "{}", DirectiveDisplay(directive, graph))?;
     }
@@ -340,7 +340,7 @@ fn write_composed_directives(directives: Directives, graph: &FederatedGraphV4, s
     Ok(())
 }
 
-fn write_resolvable_in(subgraph: SubgraphId, field: &Field, graph: &FederatedGraphV4, sdl: &mut String) -> fmt::Result {
+fn write_resolvable_in(subgraph: SubgraphId, field: &Field, graph: &FederatedGraph, sdl: &mut String) -> fmt::Result {
     let subgraph_name = GraphEnumVariantName(&graph[graph[subgraph].name]);
     let provides = MaybeDisplay(
         field
@@ -361,7 +361,7 @@ fn write_resolvable_in(subgraph: SubgraphId, field: &Field, graph: &FederatedGra
     Ok(())
 }
 
-fn write_overrides(field: &Field, graph: &FederatedGraphV4, sdl: &mut String) -> fmt::Result {
+fn write_overrides(field: &Field, graph: &FederatedGraph, sdl: &mut String) -> fmt::Result {
     for Override {
         graph: overriding_graph,
         label,
@@ -388,7 +388,7 @@ fn write_overrides(field: &Field, graph: &FederatedGraphV4, sdl: &mut String) ->
     Ok(())
 }
 
-fn write_provides(field: &Field, graph: &FederatedGraphV4, sdl: &mut String) -> fmt::Result {
+fn write_provides(field: &Field, graph: &FederatedGraph, sdl: &mut String) -> fmt::Result {
     for provides in field
         .provides
         .iter()
@@ -402,7 +402,7 @@ fn write_provides(field: &Field, graph: &FederatedGraphV4, sdl: &mut String) -> 
     Ok(())
 }
 
-fn write_requires(field: &Field, graph: &FederatedGraphV4, sdl: &mut String) -> fmt::Result {
+fn write_requires(field: &Field, graph: &FederatedGraph, sdl: &mut String) -> fmt::Result {
     for requires in field
         .requires
         .iter()
@@ -416,7 +416,7 @@ fn write_requires(field: &Field, graph: &FederatedGraphV4, sdl: &mut String) -> 
     Ok(())
 }
 
-fn write_authorized(field_id: FieldId, graph: &FederatedGraphV4, sdl: &mut String) -> fmt::Result {
+fn write_authorized(field_id: FieldId, graph: &FederatedGraph, sdl: &mut String) -> fmt::Result {
     let start = graph
         .field_authorized_directives
         .partition_point(|(other_field_id, _)| *other_field_id < field_id);
@@ -433,7 +433,7 @@ fn write_authorized(field_id: FieldId, graph: &FederatedGraphV4, sdl: &mut Strin
     Ok(())
 }
 
-fn render_field_arguments(args: &[InputValueDefinition], graph: &FederatedGraphV4) -> String {
+fn render_field_arguments(args: &[InputValueDefinition], graph: &FederatedGraph) -> String {
     if args.is_empty() {
         String::new()
     } else {
@@ -499,8 +499,9 @@ mod tests {
     fn test_render_empty() {
         use expect_test::expect;
 
-        let empty =
-            crate::FederatedGraph::Sdl(crate::render_sdl::render_federated_sdl(&FederatedGraphV4::default()).unwrap());
+        let empty = crate::VersionedFederatedGraph::Sdl(
+            crate::render_sdl::render_federated_sdl(&FederatedGraph::default()).unwrap(),
+        );
         let actual = render_federated_sdl(&empty.into_latest()).expect("valid");
         let expected = expect![[r#"
             directive @core(feature: String!) repeatable on SCHEMA

--- a/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
@@ -1,10 +1,10 @@
 use super::display_utils::*;
-use crate::{federated_graph::*, FederatedGraphV3};
+use crate::federated_graph::*;
 use std::fmt::{self, Display, Write};
 
 /// Render a GraphQL SDL string for a federated graph. It includes [join spec
 /// directives](https://specs.apollo.dev/join/v0.3/) about subgraphs and entities.
-pub fn render_federated_sdl(graph: &FederatedGraphV3) -> Result<String, fmt::Error> {
+pub fn render_federated_sdl(graph: &FederatedGraphV4) -> Result<String, fmt::Error> {
     let mut sdl = String::new();
 
     write_prelude(&mut sdl)?;
@@ -263,7 +263,7 @@ fn write_prelude(sdl: &mut String) -> fmt::Result {
     Ok(())
 }
 
-fn write_subgraphs_enum(graph: &FederatedGraphV3, sdl: &mut String) -> fmt::Result {
+fn write_subgraphs_enum(graph: &FederatedGraphV4, sdl: &mut String) -> fmt::Result {
     if graph.subgraphs.is_empty() {
         return Ok(());
     }
@@ -287,7 +287,7 @@ fn write_subgraphs_enum(graph: &FederatedGraphV3, sdl: &mut String) -> fmt::Resu
     Ok(())
 }
 
-fn write_input_field(field: &InputValueDefinition, graph: &FederatedGraphV3, sdl: &mut String) -> fmt::Result {
+fn write_input_field(field: &InputValueDefinition, graph: &FederatedGraphV4, sdl: &mut String) -> fmt::Result {
     let field_name = &graph[field.name];
     let field_type = render_field_type(&field.r#type, graph);
 
@@ -307,7 +307,7 @@ fn write_input_field(field: &InputValueDefinition, graph: &FederatedGraphV3, sdl
     Ok(())
 }
 
-fn write_field(field_id: FieldId, field: &Field, graph: &FederatedGraphV3, sdl: &mut String) -> fmt::Result {
+fn write_field(field_id: FieldId, field: &Field, graph: &FederatedGraphV4, sdl: &mut String) -> fmt::Result {
     let field_name = &graph[field.name];
     let field_type = render_field_type(&field.r#type, graph);
     let args = render_field_arguments(&graph[field.arguments], graph);
@@ -332,7 +332,7 @@ fn write_field(field_id: FieldId, field: &Field, graph: &FederatedGraphV3, sdl: 
     Ok(())
 }
 
-fn write_composed_directives(directives: Directives, graph: &FederatedGraphV3, sdl: &mut String) -> fmt::Result {
+fn write_composed_directives(directives: Directives, graph: &FederatedGraphV4, sdl: &mut String) -> fmt::Result {
     for directive in &graph[directives] {
         write!(sdl, "{}", DirectiveDisplay(directive, graph))?;
     }
@@ -340,7 +340,7 @@ fn write_composed_directives(directives: Directives, graph: &FederatedGraphV3, s
     Ok(())
 }
 
-fn write_resolvable_in(subgraph: SubgraphId, field: &Field, graph: &FederatedGraphV3, sdl: &mut String) -> fmt::Result {
+fn write_resolvable_in(subgraph: SubgraphId, field: &Field, graph: &FederatedGraphV4, sdl: &mut String) -> fmt::Result {
     let subgraph_name = GraphEnumVariantName(&graph[graph[subgraph].name]);
     let provides = MaybeDisplay(
         field
@@ -361,7 +361,7 @@ fn write_resolvable_in(subgraph: SubgraphId, field: &Field, graph: &FederatedGra
     Ok(())
 }
 
-fn write_overrides(field: &Field, graph: &FederatedGraphV3, sdl: &mut String) -> fmt::Result {
+fn write_overrides(field: &Field, graph: &FederatedGraphV4, sdl: &mut String) -> fmt::Result {
     for Override {
         graph: overriding_graph,
         label,
@@ -388,7 +388,7 @@ fn write_overrides(field: &Field, graph: &FederatedGraphV3, sdl: &mut String) ->
     Ok(())
 }
 
-fn write_provides(field: &Field, graph: &FederatedGraphV3, sdl: &mut String) -> fmt::Result {
+fn write_provides(field: &Field, graph: &FederatedGraphV4, sdl: &mut String) -> fmt::Result {
     for provides in field
         .provides
         .iter()
@@ -402,7 +402,7 @@ fn write_provides(field: &Field, graph: &FederatedGraphV3, sdl: &mut String) -> 
     Ok(())
 }
 
-fn write_requires(field: &Field, graph: &FederatedGraphV3, sdl: &mut String) -> fmt::Result {
+fn write_requires(field: &Field, graph: &FederatedGraphV4, sdl: &mut String) -> fmt::Result {
     for requires in field
         .requires
         .iter()
@@ -416,7 +416,7 @@ fn write_requires(field: &Field, graph: &FederatedGraphV3, sdl: &mut String) -> 
     Ok(())
 }
 
-fn write_authorized(field_id: FieldId, graph: &FederatedGraphV3, sdl: &mut String) -> fmt::Result {
+fn write_authorized(field_id: FieldId, graph: &FederatedGraphV4, sdl: &mut String) -> fmt::Result {
     let start = graph
         .field_authorized_directives
         .partition_point(|(other_field_id, _)| *other_field_id < field_id);
@@ -433,7 +433,7 @@ fn write_authorized(field_id: FieldId, graph: &FederatedGraphV3, sdl: &mut Strin
     Ok(())
 }
 
-fn render_field_arguments(args: &[InputValueDefinition], graph: &FederatedGraphV3) -> String {
+fn render_field_arguments(args: &[InputValueDefinition], graph: &FederatedGraphV4) -> String {
     if args.is_empty() {
         String::new()
     } else {
@@ -499,7 +499,8 @@ mod tests {
     fn test_render_empty() {
         use expect_test::expect;
 
-        let empty = crate::FederatedGraph::V3(FederatedGraphV3::default());
+        let empty =
+            crate::FederatedGraph::Sdl(crate::render_sdl::render_federated_sdl(&FederatedGraphV4::default()).unwrap());
         let actual = render_federated_sdl(&empty.into_latest()).expect("valid");
         let expected = expect![[r#"
             directive @core(feature: String!) repeatable on SCHEMA
@@ -538,7 +539,7 @@ mod tests {
             "###,
         )
         .unwrap();
-        let actual = render_federated_sdl(&empty.into_latest()).expect("valid");
+        let actual = render_federated_sdl(&empty).expect("valid");
         let expected = expect![[r#"
             directive @core(feature: String!) repeatable on SCHEMA
 
@@ -586,7 +587,7 @@ mod tests {
             "###,
         )
         .unwrap();
-        let actual = render_federated_sdl(&empty.into_latest()).expect("valid");
+        let actual = render_federated_sdl(&empty).expect("valid");
         let expected = expect![[r#"
             directive @core(feature: String!) repeatable on SCHEMA
 

--- a/engine/crates/integration-tests/src/federation/builder.rs
+++ b/engine/crates/integration-tests/src/federation/builder.rs
@@ -15,7 +15,7 @@ use engine_config_builder::{build_with_sdl_config, build_with_toml_config};
 use federated_graph::FederatedGraphV3;
 use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, StreamExt};
 use grafbase_telemetry::metrics::meter_from_global_provider;
-use graphql_composition::FederatedGraph;
+use graphql_composition::VersionedFederatedGraph;
 use graphql_mocks::MockGraphQlServer;
 use itertools::Itertools;
 use parser_sdl::{connector_parsers::MockConnectorParsers, federation::FederatedGraphConfig};
@@ -120,7 +120,7 @@ impl EngineV2Builder {
 
         let graph = self
             .federated_sdl
-            .map(|sdl| FederatedGraph::from_sdl(&sdl).unwrap())
+            .map(|sdl| VersionedFederatedGraph::from_sdl(&sdl).unwrap())
             .unwrap_or_else(|| {
                 if !subgraphs.is_empty() {
                     graphql_composition::compose(&subgraphs.iter().fold(
@@ -135,7 +135,7 @@ impl EngineV2Builder {
                     .into_result()
                     .expect("schemas to compose succesfully")
                 } else {
-                    FederatedGraph::V3(FederatedGraphV3::default())
+                    VersionedFederatedGraph::V3(FederatedGraphV3::default())
                 }
             });
 
@@ -143,7 +143,7 @@ impl EngineV2Builder {
         let graph = {
             let sdl = graph.into_federated_sdl();
             println!("{sdl}");
-            let mut graph = FederatedGraph::from_sdl(&sdl).unwrap();
+            let mut graph = VersionedFederatedGraph::from_sdl(&sdl).unwrap();
             let json = serde_json::to_value(&graph).unwrap();
             graph = serde_json::from_value(json).unwrap();
             graph

--- a/engine/crates/integration-tests/src/federation/builder.rs
+++ b/engine/crates/integration-tests/src/federation/builder.rs
@@ -141,7 +141,7 @@ impl EngineV2Builder {
 
         // Ensure SDL/JSON serialization work as a expected
         let graph = {
-            let sdl = graph.into_sdl().unwrap();
+            let sdl = graph.into_federated_sdl();
             println!("{sdl}");
             let mut graph = FederatedGraph::from_sdl(&sdl).unwrap();
             let json = serde_json::to_value(&graph).unwrap();
@@ -153,12 +153,12 @@ impl EngineV2Builder {
             Some(ConfigSource::Toml(toml)) => {
                 let config: gateway_config::Config = toml::from_str(&toml).unwrap();
                 update_runtime_with_toml_config(&mut self.runtime, &config);
-                build_with_toml_config(&config, graph)
+                build_with_toml_config(&config, graph.into_latest())
             }
             Some(ConfigSource::Sdl(mut sdl)) => {
                 sdl.push_str("\nextend schema @graph(type: federated)");
                 let config = parse_sdl_config(&sdl).await;
-                build_with_sdl_config(&config, graph)
+                build_with_sdl_config(&config, graph.into_latest())
             }
             Some(ConfigSource::SdlWebsocket) => {
                 let mut sdl = String::new();
@@ -172,9 +172,9 @@ impl EngineV2Builder {
                 }
 
                 let config = parse_sdl_config(&sdl).await;
-                build_with_sdl_config(&config, graph)
+                build_with_sdl_config(&config, graph.into_latest())
             }
-            None => build_with_sdl_config(&Default::default(), graph),
+            None => build_with_sdl_config(&Default::default(), graph.into_latest()),
         }
         .into_latest();
 

--- a/engine/crates/integration-tests/src/federation/builder/bench.rs
+++ b/engine/crates/integration-tests/src/federation/builder/bench.rs
@@ -6,7 +6,6 @@ use std::sync::{
 use bytes::Bytes;
 use engine_v2::Body;
 use futures::{StreamExt, TryStreamExt};
-use graphql_composition::FederatedGraph;
 use runtime::{
     bytes::OwnedOrSharedBytes,
     fetch::{dynamic::DynFetcher, FetchRequest, FetchResult},
@@ -61,9 +60,9 @@ impl<'a> DeterministicEngineBuilder<'a> {
                 .collect(),
             dummy_responses_index.clone(),
         );
-        let federated_graph = FederatedGraph::from_sdl(self.schema).unwrap().into_latest();
         let config =
-            engine_v2::VersionedConfig::V5(engine_v2::config::Config::from_graph(federated_graph)).into_latest();
+            engine_v2::VersionedConfig::V6(engine_v2::config::Config::from_federated_sdl(self.schema.to_owned()))
+                .into_latest();
 
         let engine = engine_v2::Engine::new(
             Arc::new(config.try_into().unwrap()),

--- a/gateway/crates/federated-server/src/server/gateway.rs
+++ b/gateway/crates/federated-server/src/server/gateway.rs
@@ -38,7 +38,7 @@ pub(super) async fn generate(
     let schema_version = blake3::hash(federated_schema.as_bytes());
     let graph =
         FederatedGraph::from_sdl(federated_schema).map_err(|e| crate::Error::SchemaValidationError(e.to_string()))?;
-    let config = engine_config_builder::build_with_toml_config(gateway_config, graph).into_latest();
+    let config = engine_config_builder::build_with_toml_config(gateway_config, graph.into_latest()).into_latest();
 
     // TODO: https://linear.app/grafbase/issue/GB-6168/support-trusted-documents-in-air-gapped-mode
     let trusted_documents = if gateway_config.trusted_documents.enabled {

--- a/gateway/crates/federated-server/src/server/gateway.rs
+++ b/gateway/crates/federated-server/src/server/gateway.rs
@@ -8,7 +8,7 @@ use runtime_local::redis::{RedisPoolFactory, RedisTlsConfig};
 use tokio::sync::watch;
 
 use engine_v2::Engine;
-use graphql_composition::FederatedGraph;
+use graphql_composition::VersionedFederatedGraph;
 use runtime_local::{
     ComponentLoader, HooksWasi, InMemoryEntityCache, InMemoryKvStore, InMemoryOperationCacheFactory, NativeFetcher,
     RedisEntityCache,
@@ -36,8 +36,8 @@ pub(super) async fn generate(
     hot_reload_config_path: Option<PathBuf>,
 ) -> crate::Result<Engine<GatewayRuntime>> {
     let schema_version = blake3::hash(federated_schema.as_bytes());
-    let graph =
-        FederatedGraph::from_sdl(federated_schema).map_err(|e| crate::Error::SchemaValidationError(e.to_string()))?;
+    let graph = VersionedFederatedGraph::from_sdl(federated_schema)
+        .map_err(|e| crate::Error::SchemaValidationError(e.to_string()))?;
     let config = engine_config_builder::build_with_toml_config(gateway_config, graph.into_latest()).into_latest();
 
     // TODO: https://linear.app/grafbase/issue/GB-6168/support-trusted-documents-in-air-gapped-mode


### PR DESCRIPTION
The original rationale for this data structure being serializable was twofold:

1. Easier to deserialize than parse from sdl. Convenience for us.
2. Faster to deserialize than parse from sdl. Performance on engine start up.

Both reasons do not apply anymore.

1. We had to implement from_sdl anyway, so now there are three ways to construct a FederatedGraph (from composition, from sdl and deserialization)
2. In managed contexts, the executor stores engine_v2::Schema in its cache, not the config, so startup times are unaffected.

This change will let us iterate on FederatedGraph without having to provide an upgrade path for the data structure, without fear of breaking changes.

closes GB-7359