### PR TITLE
composition/engine-v2: fix introspection of defaults of enum type

### DIFF
--- a/engine/crates/composition/src/compose/context.rs
+++ b/engine/crates/composition/src/compose/context.rs
@@ -35,7 +35,7 @@ impl<'a> Context<'a> {
         self.ir
     }
 
-    pub(crate) fn insert_directive(&mut self, directive: federated::Directive) -> federated::DirectiveId {
+    pub(crate) fn insert_directive(&mut self, directive: ir::Directive) -> federated::DirectiveId {
         federated::DirectiveId(self.ir.directives.push_return_idx(directive))
     }
 

--- a/engine/crates/composition/src/compose/directives.rs
+++ b/engine/crates/composition/src/compose/directives.rs
@@ -109,26 +109,3 @@ pub(super) fn collect_composed_directives<'a>(
 
     ids.unwrap_or((federated::DirectiveId(0), 0))
 }
-
-// fn subgraphs_value_to_federated_value(value: &subgraphs::Value, ctx: &mut ComposeContext<'_>) -> federated::Value {
-//     match value {
-//         subgraphs::Value::String(value) => federated::Value::String(ctx.insert_string(*value)),
-//         subgraphs::Value::Int(value) => federated::Value::Int(*value),
-//         subgraphs::Value::Float(value) => federated::Value::Float(*value),
-//         subgraphs::Value::Boolean(value) => federated::Value::Boolean(*value),
-//         subgraphs::Value::UnboundEnum(value) => federated::Value::UnboundEnumValue(ctx.insert_string(*value)),
-//         subgraphs::Value::Enum(value) => federated::Value::EnumValue(ctx.insert_string(*value)),
-//         subgraphs::Value::Object(value) => federated::Value::Object(
-//             value
-//                 .iter()
-//                 .map(|(k, v)| (ctx.insert_string(*k), subgraphs_value_to_federated_value(v, ctx)))
-//                 .collect(),
-//         ),
-//         subgraphs::Value::List(value) => federated::Value::List(
-//             value
-//                 .iter()
-//                 .map(|v| subgraphs_value_to_federated_value(v, ctx))
-//                 .collect(),
-//         ),
-//     }
-// }

--- a/engine/crates/composition/src/composition_ir.rs
+++ b/engine/crates/composition/src/composition_ir.rs
@@ -1,3 +1,6 @@
+mod directive;
+
+pub(crate) use self::directive::Directive;
 use crate::subgraphs;
 use graphql_federated_graph as federated;
 use std::collections::{BTreeSet, HashMap};
@@ -21,7 +24,7 @@ pub(crate) struct CompositionIr {
     pub(crate) enum_values: Vec<federated::EnumValue>,
     pub(crate) scalars: Vec<federated::Scalar>,
     pub(crate) input_objects: Vec<federated::InputObject>,
-    pub(crate) directives: Vec<federated::Directive>,
+    pub(crate) directives: Vec<Directive>,
     pub(crate) input_value_definitions: Vec<InputValueDefinitionIr>,
 
     /// The root `Query` type

--- a/engine/crates/composition/src/composition_ir/directive.rs
+++ b/engine/crates/composition/src/composition_ir/directive.rs
@@ -1,0 +1,18 @@
+use crate::subgraphs;
+use graphql_federated_graph as federated;
+
+#[derive(PartialEq, PartialOrd, Clone)]
+pub enum Directive {
+    Authenticated,
+    Deprecated {
+        reason: Option<federated::StringId>,
+    },
+    Inaccessible,
+    Policy(Vec<Vec<federated::StringId>>),
+    RequiresScopes(Vec<Vec<federated::StringId>>),
+
+    Other {
+        name: federated::StringId,
+        arguments: Vec<(federated::StringId, subgraphs::Value)>,
+    },
+}

--- a/engine/crates/composition/src/emit_federated_graph.rs
+++ b/engine/crates/composition/src/emit_federated_graph.rs
@@ -79,7 +79,7 @@ fn emit_directives(ir: &mut Vec<ir::Directive>, ctx: &mut Context<'_>) {
                 name,
                 arguments: arguments
                     .into_iter()
-                    .map(|(name, value)| (name, ctx.insert_value(&value, None)))
+                    .map(|(name, value)| (name, ctx.insert_value(&value)))
                     .collect(),
             },
         };
@@ -91,10 +91,7 @@ fn emit_directives(ir: &mut Vec<ir::Directive>, ctx: &mut Context<'_>) {
 fn emit_authorized_directives(ir: &CompositionIr, ctx: &mut Context<'_>) {
     for (object_id, authorized) in &ir.object_authorized_directives {
         let authorized = ctx.subgraphs.walk(*authorized).authorized().unwrap();
-        let metadata = authorized
-            .metadata
-            .as_ref()
-            .map(|metadata| ctx.insert_value(metadata, None));
+        let metadata = authorized.metadata.as_ref().map(|metadata| ctx.insert_value(metadata));
         let fields = authorized
             .fields
             .as_ref()
@@ -119,10 +116,7 @@ fn emit_authorized_directives(ir: &CompositionIr, ctx: &mut Context<'_>) {
 
     for (interface_id, authorized) in &ir.interface_authorized_directives {
         let authorized = ctx.subgraphs.walk(*authorized).authorized().unwrap();
-        let metadata = authorized
-            .metadata
-            .as_ref()
-            .map(|metadata| ctx.insert_value(metadata, None));
+        let metadata = authorized.metadata.as_ref().map(|metadata| ctx.insert_value(metadata));
         let fields = authorized
             .fields
             .as_ref()
@@ -160,7 +154,7 @@ fn emit_input_value_definitions(input_value_definitions: &[InputValueDefinitionI
                 let r#type = ctx.insert_field_type(ctx.subgraphs.walk(*r#type));
                 let default = default
                     .as_ref()
-                    .map(|default| ctx.insert_value(default, r#type.definition.as_enum().copied()));
+                    .map(|default| ctx.insert_value_with_type(default, r#type.definition.as_enum().copied()));
 
                 federated::InputValueDefinition {
                     name: *name,
@@ -399,10 +393,7 @@ fn emit_fields<'a>(
             .node
             .as_ref()
             .map(|field_set| attach_selection(field_set, output, ctx));
-        let metadata = directive
-            .metadata
-            .as_ref()
-            .map(|metadata| ctx.insert_value(metadata, None));
+        let metadata = directive.metadata.as_ref().map(|metadata| ctx.insert_value(metadata));
 
         let arguments = directive
             .arguments
@@ -498,7 +489,7 @@ fn attach_selection(
                         .unwrap();
 
                     let argument_enum_type = ctx.out[argument].r#type.definition.as_enum().copied();
-                    let value = ctx.insert_value(value, argument_enum_type);
+                    let value = ctx.insert_value_with_type(value, argument_enum_type);
 
                     (argument, value)
                 })

--- a/engine/crates/composition/src/emit_federated_graph/context.rs
+++ b/engine/crates/composition/src/emit_federated_graph/context.rs
@@ -34,7 +34,11 @@ impl<'a> Context<'a> {
         self.strings_ir.insert(string.as_str())
     }
 
-    pub(crate) fn insert_value(
+    pub(crate) fn insert_value(&mut self, value: &subgraphs::Value) -> federated::Value {
+        self.insert_value_with_type(value, None)
+    }
+
+    pub(crate) fn insert_value_with_type(
         &mut self,
         value: &subgraphs::Value,
         enum_type: Option<federated::EnumId>,
@@ -68,14 +72,17 @@ impl<'a> Context<'a> {
                     .map(|(k, v)| {
                         (
                             self.insert_string(self.subgraphs.walk(*k)),
-                            self.insert_value(v, enum_type),
+                            self.insert_value_with_type(v, enum_type),
                         )
                     })
                     .collect(),
             ),
-            subgraphs::Value::List(value) => {
-                federated::Value::List(value.iter().map(|v| self.insert_value(v, enum_type)).collect())
-            }
+            subgraphs::Value::List(value) => federated::Value::List(
+                value
+                    .iter()
+                    .map(|v| self.insert_value_with_type(v, enum_type))
+                    .collect(),
+            ),
         }
     }
 }

--- a/engine/crates/engine-v2/schema/src/builder/coerce/error.rs
+++ b/engine/crates/engine-v2/schema/src/builder/coerce/error.rs
@@ -42,6 +42,8 @@ pub enum InputValueError {
     },
     #[error("Missing required argument named '{0}'")]
     MissingRequiredArgument(String),
+    #[error("Used an inaccessible enum value{path}")]
+    InaccessibleEnumValue { path: String },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display)]

--- a/engine/crates/engine-v2/schema/src/builder/coerce/error.rs
+++ b/engine/crates/engine-v2/schema/src/builder/coerce/error.rs
@@ -34,12 +34,6 @@ pub enum InputValueError {
         actual: ValueKind,
         path: String,
     },
-    #[error("Unknown enum value '{value}' for enum {r#enum}{path}")]
-    UnknownEnumValue {
-        r#enum: String,
-        value: String,
-        path: String,
-    },
     #[error("Input object {input_object} does not have a field named '{name}'{path}")]
     UnknownInputField {
         input_object: String,
@@ -78,7 +72,7 @@ impl From<&Value> for ValueKind {
             Value::Null => ValueKind::Null,
             Value::List(_) => ValueKind::List,
             Value::Object(_) => ValueKind::Object,
-            Value::EnumValue(_) => ValueKind::Enum,
+            Value::UnboundEnumValue(_) | Value::EnumValue(_) => ValueKind::Enum,
         }
     }
 }

--- a/engine/crates/engine-v2/schema/src/builder/coerce/mod.rs
+++ b/engine/crates/engine-v2/schema/src/builder/coerce/mod.rs
@@ -209,7 +209,14 @@ impl<'a> InputValueCoercer<'a> {
                 _ => None,
             }
             .map(SchemaInputValue::Boolean),
-            ScalarType::JSON => return Ok(self.input_values.ingest_arbitrary_federated_value(self.ctx, value)),
+            ScalarType::JSON => {
+                return Ok(self
+                    .input_values
+                    .ingest_arbitrary_federated_value(self.ctx, value)
+                    .map_err(|_: super::input_values::InaccessibleEnumValue| {
+                        InputValueError::InaccessibleEnumValue { path: self.path() }
+                    }))?
+            }
         }
         .ok_or_else(|| InputValueError::IncorrectScalarType {
             actual: value.into(),

--- a/engine/crates/engine-v2/schema/src/builder/coerce/mod.rs
+++ b/engine/crates/engine-v2/schema/src/builder/coerce/mod.rs
@@ -160,24 +160,11 @@ impl<'a> InputValueCoercer<'a> {
 
     fn coerce_enum(&mut self, enum_id: EnumDefinitionId, value: Value) -> Result<SchemaInputValue, InputValueError> {
         let r#enum = &self.graph[enum_id];
-        let name = match &value {
-            Value::EnumValue(id) => &self.ctx.strings[StringId::from(*id)],
-            value => {
-                return Err(InputValueError::IncorrectEnumValueType {
-                    r#enum: self.ctx.strings[r#enum.name].to_string(),
-                    actual: value.into(),
-                    path: self.path(),
-                })
-            }
-        };
-
-        let value_ids = r#enum.value_ids;
-        match self.graph[value_ids].binary_search_by(|enum_value| self.ctx.strings[enum_value.name].as_str().cmp(name))
-        {
-            Ok(id) => Ok(SchemaInputValue::EnumValue(r#enum.value_ids.get(id).unwrap())),
-            Err(_) => Err(InputValueError::UnknownEnumValue {
+        match &value {
+            Value::EnumValue(id) => Ok(SchemaInputValue::EnumValue(crate::EnumValueId::from(id.0))),
+            value => Err(InputValueError::IncorrectEnumValueType {
                 r#enum: self.ctx.strings[r#enum.name].to_string(),
-                value: name.to_string(),
+                actual: value.into(),
                 path: self.path(),
             }),
         }

--- a/engine/crates/engine-v2/schema/src/builder/graph.rs
+++ b/engine/crates/engine-v2/schema/src/builder/graph.rs
@@ -100,13 +100,14 @@ impl<'a> GraphBuilder<'a> {
                         name: definition.name.into(),
                         description: definition.description.map(Into::into),
                         ty: definition.r#type.into(),
-                        default_value: definition.default.map(|default| {
+                        default_value: definition.default.and_then(|default| {
                             let value = self
                                 .graph
                                 .input_values
-                                .ingest_arbitrary_federated_value(self.ctx, default);
+                                .ingest_arbitrary_federated_value(self.ctx, default)
+                                .ok()?;
 
-                            self.graph.input_values.push_value(value)
+                            Some(self.graph.input_values.push_value(value))
                         }),
                         directives: self.push_directives(
                             config,
@@ -717,12 +718,14 @@ impl<'a> GraphBuilder<'a> {
                     node: node
                         .as_ref()
                         .map(|field_set| self.required_field_sets_buffer.push(schema_location, field_set.clone())),
-                    metadata: metadata.clone().map(|value| {
+                    metadata: metadata.clone().and_then(|value| {
                         let value = self
                             .graph
                             .input_values
-                            .ingest_arbitrary_federated_value(self.ctx, value);
-                        self.graph.input_values.push_value(value)
+                            .ingest_arbitrary_federated_value(self.ctx, value)
+                            .ok()?;
+
+                        Some(self.graph.input_values.push_value(value))
                     }),
                 });
 

--- a/engine/crates/engine-v2/schema/src/builder/graph.rs
+++ b/engine/crates/engine-v2/schema/src/builder/graph.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
     mem::take,
-    ops::Range,
 };
 
 use config::latest::{CacheConfigTarget, Config};
@@ -74,10 +73,10 @@ impl<'a> GraphBuilder<'a> {
     }
 
     fn ingest_config(&mut self, config: &mut Config, graph: &mut FederatedGraph) {
+        self.ingest_enums(config, graph);
         self.ingest_input_values(config, graph);
         self.ingest_input_objects(config, graph);
         self.ingest_unions(config, graph);
-        self.ingest_enums(config, graph);
         self.ingest_scalars(config, graph);
         // Not guaranteed to be sorted and rely on binary search to find the directives for a
         // field.
@@ -105,6 +104,7 @@ impl<'a> GraphBuilder<'a> {
                                 .graph
                                 .input_values
                                 .ingest_arbitrary_federated_value(self.ctx, default);
+
                             self.graph.input_values.push_value(value)
                         }),
                         directives: self.push_directives(
@@ -176,13 +176,12 @@ impl<'a> GraphBuilder<'a> {
     }
 
     fn ingest_enums(&mut self, config: &mut Config, graph: &mut FederatedGraph) {
-        let mut idmap = IdMap::<federated_graph::EnumValueId, EnumValueId>::default();
         self.graph.enum_value_definitions = take(&mut graph.enum_values)
             .into_iter()
             .enumerate()
             .filter_map(|(idx, enum_value)| {
                 if is_inaccessible(graph, enum_value.composed_directives) {
-                    idmap.skip(federated_graph::EnumValueId(idx));
+                    self.ctx.idmaps.enum_values.skip(federated_graph::EnumValueId(idx));
                     None
                 } else {
                     Some(EnumValue {
@@ -206,13 +205,7 @@ impl<'a> GraphBuilder<'a> {
             .map(|federated_enum| EnumDefinition {
                 name: federated_enum.name.into(),
                 description: None,
-                value_ids: {
-                    let range = idmap.get_range(federated_enum.values);
-                    self.graph.enum_value_definitions[Range::<usize>::from(range)]
-                        .sort_unstable_by(|a, b| self.ctx.strings[a.name].cmp(&self.ctx.strings[b.name]));
-                    // The range is still valid even if individual ids don't match anymore.
-                    range
-                },
+                value_ids: self.ctx.idmaps.enum_values.get_range(federated_enum.values),
                 directives: self.push_directives(
                     config,
                     Directives {

--- a/engine/crates/engine-v2/schema/src/builder/graph.rs
+++ b/engine/crates/engine-v2/schema/src/builder/graph.rs
@@ -73,7 +73,8 @@ impl<'a> GraphBuilder<'a> {
     }
 
     fn ingest_config(&mut self, config: &mut Config, graph: &mut FederatedGraph) {
-        self.ingest_enums(config, graph);
+        self.ingest_enums_before_input_values(config, graph);
+
         self.ingest_input_values(config, graph);
         self.ingest_input_objects(config, graph);
         self.ingest_unions(config, graph);
@@ -175,7 +176,7 @@ impl<'a> GraphBuilder<'a> {
             .collect();
     }
 
-    fn ingest_enums(&mut self, config: &mut Config, graph: &mut FederatedGraph) {
+    fn ingest_enums_before_input_values(&mut self, config: &mut Config, graph: &mut FederatedGraph) {
         self.graph.enum_value_definitions = take(&mut graph.enum_values)
             .into_iter()
             .enumerate()

--- a/engine/crates/engine-v2/schema/src/builder/ids.rs
+++ b/engine/crates/engine-v2/schema/src/builder/ids.rs
@@ -9,7 +9,7 @@ use std::marker::PhantomData;
 use federated_graph::FederatedGraph;
 use id_newtypes::IdRange;
 
-use crate::{FieldDefinitionId, InputValueDefinitionId};
+use crate::{EnumValueId, FieldDefinitionId, InputValueDefinitionId};
 
 use super::graph::is_inaccessible;
 
@@ -36,6 +36,7 @@ where
 pub(super) struct IdMaps {
     pub field: IdMap<federated_graph::FieldId, FieldDefinitionId>,
     pub input_value: IdMap<federated_graph::InputValueDefinitionId, InputValueDefinitionId>,
+    pub enum_values: IdMap<federated_graph::EnumValueId, EnumValueId>,
 }
 
 impl IdMaps {
@@ -44,6 +45,7 @@ impl IdMaps {
         IdMaps {
             field: IdMap::default(),
             input_value: IdMap::default(),
+            enum_values: IdMap::default(),
         }
     }
 
@@ -51,6 +53,7 @@ impl IdMaps {
         let mut idmaps = IdMaps {
             field: Default::default(),
             input_value: Default::default(),
+            enum_values: IdMap::default(),
         };
 
         for (i, field) in graph.fields.iter().enumerate() {

--- a/engine/crates/engine-v2/schema/src/builder/input_values.rs
+++ b/engine/crates/engine-v2/schema/src/builder/input_values.rs
@@ -8,11 +8,14 @@ impl SchemaInputValues {
     pub(crate) fn ingest_arbitrary_federated_value(&mut self, ctx: &BuildContext, value: Value) -> SchemaInputValue {
         match value {
             Value::Null => SchemaInputValue::Null,
-            Value::String(id) => SchemaInputValue::String(id.into()),
+            Value::String(id) | Value::UnboundEnumValue(id) => SchemaInputValue::String(id.into()),
             Value::Int(n) => SchemaInputValue::BigInt(n),
             Value::Float(f) => SchemaInputValue::Float(f),
             Value::Boolean(b) => SchemaInputValue::Boolean(b),
-            Value::EnumValue(id) => SchemaInputValue::String(id.into()),
+            Value::EnumValue(id) => {
+                let id = ctx.idmaps.enum_values.get(id).expect("enum ids to be valid");
+                SchemaInputValue::EnumValue(id)
+            }
             Value::Object(fields) => {
                 let ids = self.reserve_map(fields.len());
                 for ((name, value), id) in fields.into_vec().into_iter().zip(ids) {

--- a/engine/crates/engine-v2/schema/src/builder/input_values.rs
+++ b/engine/crates/engine-v2/schema/src/builder/input_values.rs
@@ -4,22 +4,32 @@ use crate::{SchemaInputValue, SchemaInputValues};
 
 use super::BuildContext;
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct InaccessibleEnumValue;
+
 impl SchemaInputValues {
-    pub(crate) fn ingest_arbitrary_federated_value(&mut self, ctx: &BuildContext, value: Value) -> SchemaInputValue {
-        match value {
+    pub(crate) fn ingest_arbitrary_federated_value(
+        &mut self,
+        ctx: &BuildContext,
+        value: Value,
+    ) -> Result<SchemaInputValue, InaccessibleEnumValue> {
+        Ok(match value {
             Value::Null => SchemaInputValue::Null,
             Value::String(id) | Value::UnboundEnumValue(id) => SchemaInputValue::String(id.into()),
             Value::Int(n) => SchemaInputValue::BigInt(n),
             Value::Float(f) => SchemaInputValue::Float(f),
             Value::Boolean(b) => SchemaInputValue::Boolean(b),
             Value::EnumValue(id) => {
-                let id = ctx.idmaps.enum_values.get(id).expect("enum ids to be valid");
+                let Some(id) = ctx.idmaps.enum_values.get(id) else {
+                    return Err(InaccessibleEnumValue);
+                };
+
                 SchemaInputValue::EnumValue(id)
             }
             Value::Object(fields) => {
                 let ids = self.reserve_map(fields.len());
                 for ((name, value), id) in fields.into_vec().into_iter().zip(ids) {
-                    self[id] = (name.into(), self.ingest_arbitrary_federated_value(ctx, value));
+                    self[id] = (name.into(), self.ingest_arbitrary_federated_value(ctx, value)?);
                 }
                 self[ids].sort_unstable_by(|(left_key, _), (right_key, _)| {
                     ctx.strings.get_by_id(*left_key).cmp(&ctx.strings.get_by_id(*right_key))
@@ -29,11 +39,11 @@ impl SchemaInputValues {
             Value::List(list) => {
                 let ids = self.reserve_list(list.len());
                 for (value, id) in list.into_vec().into_iter().zip(ids) {
-                    let value = self.ingest_arbitrary_federated_value(ctx, value);
+                    let value = self.ingest_arbitrary_federated_value(ctx, value)?;
                     self[id] = value;
                 }
                 SchemaInputValue::List(ids)
             }
-        }
+        })
     }
 }

--- a/engine/crates/engine-v2/schema/src/builder/interner.rs
+++ b/engine/crates/engine-v2/schema/src/builder/interner.rs
@@ -4,6 +4,7 @@ pub use non_ord::ProxyKeyInterner;
 
 use std::{borrow::Borrow, marker::PhantomData};
 
+#[derive(Debug)]
 pub struct Interner<T, Id>(indexmap::IndexSet<T, fnv::FnvBuildHasher>, PhantomData<Id>);
 
 impl<T, Id> Default for Interner<T, Id> {

--- a/engine/crates/engine-v2/schema/src/lib.rs
+++ b/engine/crates/engine-v2/schema/src/lib.rs
@@ -166,7 +166,7 @@ pub struct Graph {
     #[indexed_by(RequiredFieldId)]
     required_fields: Vec<RequiredField>,
     /// Default input values & directive arguments
-    input_values: SchemaInputValues,
+    pub input_values: SchemaInputValues,
 
     #[indexed_by(TypeSystemDirectiveId)]
     type_system_directives: Vec<TypeSystemDirective>,

--- a/engine/crates/engine-v2/schema/src/walkers/enum.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/enum.rs
@@ -16,9 +16,9 @@ impl<'a> EnumDefinitionWalker<'a> {
     pub fn find_value_by_name(&self, name: &str) -> Option<EnumValueId> {
         let ids = self.as_ref().value_ids;
         self.schema[ids]
-            .binary_search_by(|enum_value| self.schema[enum_value.name].as_str().cmp(name))
-            .ok()
-            .and_then(|i| ids.get(i))
+            .iter()
+            .position(|enum_value| self.schema[enum_value.name].as_str() == name)
+            .and_then(|idx| ids.get(idx))
     }
 
     pub fn directives(&self) -> TypeSystemDirectivesWalker<'a> {

--- a/engine/crates/federated-graph/src/federated_graph/v1.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v1.rs
@@ -183,6 +183,14 @@ impl Definition {
             None
         }
     }
+
+    pub fn as_enum(&self) -> Option<&EnumId> {
+        if let Self::Enum(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Hash, PartialEq, Eq, Clone)]

--- a/engine/crates/federated-graph/src/federated_graph/v2.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v2.rs
@@ -128,7 +128,7 @@ pub struct Enum {
     pub description: Option<StringId>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct EnumValue {
     pub value: StringId,
 
@@ -243,7 +243,7 @@ pub struct InputObject {
 /// A (start, len) range in FederatedSchema.
 pub type Directives = (DirectiveId, usize);
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct DirectiveId(pub usize);
 
 impl From<DirectiveId> for usize {
@@ -273,7 +273,7 @@ impl From<usize> for InputValueDefinitionId {
 
 pub const NO_INPUT_VALUE_DEFINITION: InputValueDefinitions = (InputValueDefinitionId(0), 0);
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct EnumValueId(pub usize);
 
 impl From<EnumValueId> for usize {

--- a/engine/crates/federated-graph/src/federated_graph/v4.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v4.rs
@@ -114,7 +114,10 @@ pub enum Value {
     /// Different from `String`.
     ///
     /// `@tag(name: "SOMETHING")` vs `@tag(name: SOMETHING)`
-    EnumValue(StringId),
+    ///
+    /// FIXME: This is currently required because we do not keep accurate track of the directives in use in the schema, but we should strive towards removing UnboundEnumValue in favour of EnumValue.
+    UnboundEnumValue(StringId),
+    EnumValue(EnumValueId),
     Object(Box<[(StringId, Value)]>),
     List(Box<[Value]>),
 }
@@ -237,6 +240,7 @@ macro_rules! id_newtypes {
 id_newtypes! {
     AuthorizedDirectiveId + authorized_directives + AuthorizedDirective,
     EnumId + enums + Enum,
+    EnumValueId + enum_values + EnumValue,
     FieldId + fields + Field,
     InputValueDefinitionId + input_value_definitions + InputValueDefinition,
     InputObjectId + input_objects + InputObject,
@@ -345,7 +349,7 @@ impl From<super::v3::Value> for Value {
             super::v3::Value::Int(i) => Value::Int(i),
             super::v3::Value::Float(i) => Value::Float(i),
             super::v3::Value::Boolean(b) => Value::Boolean(b),
-            super::v3::Value::EnumValue(i) => Value::EnumValue(i),
+            super::v3::Value::EnumValue(i) => Value::String(i),
             super::v3::Value::Object(obj) => Value::Object(
                 obj.iter()
                     .map(|(k, v)| (*k, v.clone().into()))

--- a/engine/crates/federated-graph/src/render_sdl/display_utils.rs
+++ b/engine/crates/federated-graph/src/render_sdl/display_utils.rs
@@ -68,7 +68,8 @@ impl fmt::Display for ValueDisplay<'_> {
             crate::Value::String(s) => write_quoted(f, &graph[*s]),
             crate::Value::Int(i) => Display::fmt(i, f),
             crate::Value::Float(val) => Display::fmt(val, f),
-            crate::Value::EnumValue(val) => f.write_str(&graph[*val]),
+            crate::Value::UnboundEnumValue(val) => f.write_str(&graph[*val]),
+            crate::Value::EnumValue(val) => f.write_str(&graph[graph[*val].value]),
             crate::Value::Boolean(true) => f.write_str("true"),
             crate::Value::Boolean(false) => f.write_str("false"),
             crate::Value::Object(key_values) => {

--- a/engine/crates/integration-tests/tests/federation/introspection.rs
+++ b/engine/crates/integration-tests/tests/federation/introspection.rs
@@ -61,13 +61,13 @@ fn can_run_pathfinder_introspection_query() {
       pullRequestOrIssue(id: ID!): PullRequestOrIssue
       pullRequestsAndIssues(filter: PullRequestsAndIssuesFilters!): [PullRequestOrIssue!]!
       serverVersion: String!
-      sillyDefaultValue(status: Status! = "OPEN"): String!
+      sillyDefaultValue(status: Status! = OPEN): String!
       statusString(status: Status!): String!
     }
 
     enum Status {
-      CLOSED
       OPEN
+      CLOSED
     }
 
     type User {
@@ -137,13 +137,13 @@ fn can_run_2018_introspection_query() {
       pullRequestOrIssue(id: ID!): PullRequestOrIssue
       pullRequestsAndIssues(filter: PullRequestsAndIssuesFilters!): [PullRequestOrIssue!]!
       serverVersion: String!
-      sillyDefaultValue(status: Status! = "OPEN"): String!
+      sillyDefaultValue(status: Status! = OPEN): String!
       statusString(status: Status!): String!
     }
 
     enum Status {
-      CLOSED
       OPEN
+      CLOSED
     }
 
     type User {
@@ -213,13 +213,13 @@ fn can_run_2021_introspection_query() {
       pullRequestOrIssue(id: ID!): PullRequestOrIssue
       pullRequestsAndIssues(filter: PullRequestsAndIssuesFilters!): [PullRequestOrIssue!]!
       serverVersion: String!
-      sillyDefaultValue(status: Status! = "OPEN"): String!
+      sillyDefaultValue(status: Status! = OPEN): String!
       statusString(status: Status!): String!
     }
 
     enum Status {
-      CLOSED
       OPEN
+      CLOSED
     }
 
     type User {
@@ -248,8 +248,8 @@ fn echo_subgraph_introspection() {
 
     insta::assert_snapshot!(introspection_to_sdl(response.into_data()), @r###"
     enum FancyBool {
-      NO
       YES
+      NO
     }
 
     type Header {
@@ -377,8 +377,8 @@ fn can_introsect_when_multiple_subgraphs() {
     scalar CustomRepoId
 
     enum FancyBool {
-      NO
       YES
+      NO
     }
 
     type Header {
@@ -441,14 +441,14 @@ fn can_introsect_when_multiple_subgraphs() {
       pullRequestOrIssue(id: ID!): PullRequestOrIssue
       pullRequestsAndIssues(filter: PullRequestsAndIssuesFilters!): [PullRequestOrIssue!]!
       serverVersion: String!
-      sillyDefaultValue(status: Status! = "OPEN"): String!
+      sillyDefaultValue(status: Status! = OPEN): String!
       statusString(status: Status!): String!
       string(input: String!): String!
     }
 
     enum Status {
-      CLOSED
       OPEN
+      CLOSED
     }
 
     type User {
@@ -856,9 +856,9 @@ fn introspection_on_multiple_federation_subgraphs() {
     }
 
     enum Trustworthiness {
+      REALLY_TRUSTED
       KINDA_TRUSTED
       NOT_TRUSTED
-      REALLY_TRUSTED
     }
 
     type User {
@@ -873,8 +873,8 @@ fn introspection_on_multiple_federation_subgraphs() {
     }
 
     enum WeightUnit {
-      GRAM
       KILOGRAM
+      GRAM
     }
 
     "###)
@@ -1011,7 +1011,7 @@ fn default_values() {
               "args": [
                 {
                   "name": "status",
-                  "defaultValue": "\"OPEN\""
+                  "defaultValue": "OPEN"
                 }
               ]
             },

--- a/engine/crates/integration-tests/tests/federation/snapshots/integration_tests__federation__introspection__introspecting_with_grafbase_openapi_subgraph.snap
+++ b/engine/crates/integration-tests/tests/federation/snapshots/integration_tests__federation__introspection__introspecting_with_grafbase_openapi_subgraph.snap
@@ -83,7 +83,7 @@ enum PetStatus {
 }
 
 type Query {
-  findPetsByStatus(status: FindPetsByStatusStatus = "AVAILABLE"): [Pet!]
+  findPetsByStatus(status: FindPetsByStatusStatus = AVAILABLE): [Pet!]
   findPetsByTags(tags: [String!]): [Pet!]
   inventory: JSON
   loginUser(password: String, username: String): String

--- a/engine/crates/integration-tests/tests/federation/snapshots/integration_tests__federation__introspection__raw_introspetion_output.snap
+++ b/engine/crates/integration-tests/tests/federation/snapshots/integration_tests__federation__introspection__raw_introspetion_output.snap
@@ -106,13 +106,13 @@ expression: response
           "interfaces": null,
           "enumValues": [
             {
-              "name": "NO",
+              "name": "YES",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "YES",
+              "name": "NO",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -1150,7 +1150,7 @@ expression: response
                       "ofType": null
                     }
                   },
-                  "defaultValue": "\"OPEN\""
+                  "defaultValue": "OPEN"
                 }
               ],
               "type": {
@@ -1242,13 +1242,13 @@ expression: response
           "interfaces": null,
           "enumValues": [
             {
-              "name": "CLOSED",
+              "name": "OPEN",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "OPEN",
+              "name": "CLOSED",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/gateway/crates/gateway-binary/tests/integration_tests.rs
+++ b/gateway/crates/gateway-binary/tests/integration_tests.rs
@@ -702,9 +702,9 @@ fn introspect_enabled() {
         }
 
         enum Trustworthiness {
+          REALLY_TRUSTED
           KINDA_TRUSTED
           NOT_TRUSTED
-          REALLY_TRUSTED
         }
 
         type User {


### PR DESCRIPTION
The internal value type in engine-v2 has a variant for enum values that contains an enum id. Since composition produced Value::Enum(id) where id is a StringId, those were converted and rendered as strings.

There are two potential ways out of this situation: make engine-v2's value type less precise, or make federated-graph's value type more precise. The path taken in this PR is the second one. We introduce a Value::EnumValue() variant that takes an EnumId, but retain the variant with a StringId inside as Value::UnboundEnumValue. That is necessary because we don't have enum values in the schema for enums that are used in directives. We don't do enough analysis on directive definitions, but we still need to represent these values.

What we want to fix, and what is fixed in this PR, are enum values as defaults in output field arguments and fields of input objects (collectively: input value definitions). They now use the stricter Value::Enum variant in compositionn and from_sdl().

One side effect of this change is that within a given enum, values cannot be alphabetically sorted anymore in engine_v2::Schema, because that sorting step would break the referencing ids in Values.

closes GB-7375