### PR TITLE
feat: scope entity cache entries by auth directives

### DIFF
--- a/engine/crates/engine-v2/schema/src/directives/requires_scopes.rs
+++ b/engine/crates/engine-v2/schema/src/directives/requires_scopes.rs
@@ -3,6 +3,12 @@ use crate::{RequiredScopesId, SchemaWalker, StringId};
 #[derive(Debug, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct RequiredScopes(Vec<Vec<StringId>>);
 
+/// An index into the outer vector of an instance of RequiredScopes
+///
+/// Used to record which of the sets of scopes matched in a given requests
+#[derive(Clone, Copy, Debug)]
+pub struct RequiredScopeSetIndex(u16);
+
 impl RequiredScopes {
     pub fn new(mut scopes: Vec<Vec<StringId>>) -> Self {
         for scopes in &mut scopes {
@@ -15,11 +21,19 @@ impl RequiredScopes {
 
 pub type RequiredScopesWalker<'a> = SchemaWalker<'a, RequiredScopesId>;
 
-impl RequiredScopesWalker<'_> {
-    pub fn matches(&self, scopes: &[&str]) -> bool {
+impl<'a> RequiredScopesWalker<'a> {
+    pub fn scopes(&self, index: RequiredScopeSetIndex) -> impl ExactSizeIterator<Item = &'a str> {
+        self.as_ref().0[index.0 as usize]
+            .iter()
+            .map(|id| self.schema[*id].as_ref())
+    }
+
+    pub fn matches(&self, scopes: &[&str]) -> Option<RequiredScopeSetIndex> {
         self.as_ref()
             .0
             .iter()
-            .any(|any_of| any_of.iter().all(|id| scopes.contains(&self.schema[*id].as_str())))
+            .enumerate()
+            .find(|(_, any_of)| any_of.iter().all(|id| scopes.contains(&self.schema[*id].as_str())))
+            .map(|(index, _)| RequiredScopeSetIndex(index as u16))
     }
 }

--- a/engine/crates/engine-v2/schema/src/walkers/field.rs
+++ b/engine/crates/engine-v2/schema/src/walkers/field.rs
@@ -103,6 +103,7 @@ impl<'a> std::fmt::Debug for FieldDefinitionWalker<'a> {
                     .map(|arg| (arg.name(), arg.ty().to_string()))
                     .collect::<Vec<_>>(),
             )
+            .field("directiives", &self.directives().as_ref().iter().collect::<Vec<_>>())
             .finish()
     }
 }

--- a/engine/crates/engine-v2/src/operation/build.rs
+++ b/engine/crates/engine-v2/src/operation/build.rs
@@ -9,6 +9,7 @@ use crate::{
 use super::{
     bind::{bind_operation, BindError},
     blueprint::ResponseBlueprintBuilder,
+    cache_scopes::calculate_cache_scopes,
     logical_planner::{LogicalPlanner, LogicalPlanningError},
     metrics::{generate_used_fields, prepare_metrics_attributes},
     parse::{parse_operation, ParseError},
@@ -100,6 +101,9 @@ impl Operation {
             }
         };
 
+        let (logical_plan_cache_scopes, cache_scopes) =
+            calculate_cache_scopes(operation.walker_with(schema.walker()), &plan);
+
         let response_blueprint = ResponseBlueprintBuilder::new(schema, &operation, &plan).build();
 
         let mut metrics_attributes = metrics_attributes.ok_or(OperationError::NormalizationError)?;
@@ -110,6 +114,8 @@ impl Operation {
             metrics_attributes,
             plan,
             response_blueprint,
+            logical_plan_cache_scopes,
+            cache_scopes,
         })
     }
 }

--- a/engine/crates/engine-v2/src/operation/cache_scopes.rs
+++ b/engine/crates/engine-v2/src/operation/cache_scopes.rs
@@ -1,0 +1,192 @@
+use std::collections::HashSet;
+
+use schema::{RequiredScopeSetIndex, RequiredScopesId, RequiredScopesWalker, TypeSystemDirectivesWalker};
+
+use super::{LogicalPlanId, OperationPlan, OperationWalker, PlanWalker, SelectionSetWalker};
+
+#[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize)]
+pub struct CacheScopeId(u16);
+
+impl<'a, Item, SchemaItem> PlanWalker<'a, Item, SchemaItem> {
+    /// The cache scopes that should be applied to the current plans cache
+    pub fn cache_scopes(self) -> CacheScopes<'a> {
+        CacheScopes {
+            walker: self.walk_with((), ()),
+            current_index: self
+                .operation
+                .logical_plan_cache_scopes
+                .binary_search_by(|(plan_id, _)| plan_id.cmp(&self.logical_plan_id))
+                .unwrap_or(self.operation.logical_plan_cache_scopes.len()),
+        }
+    }
+}
+
+pub struct CacheScopes<'a> {
+    walker: PlanWalker<'a>,
+    current_index: usize,
+}
+
+impl<'a> Iterator for CacheScopes<'a> {
+    type Item = CacheScope<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let current = self
+            .walker
+            .operation
+            .logical_plan_cache_scopes
+            .get(self.current_index)?;
+
+        if current.0 != self.walker.logical_plan_id {
+            return None;
+        }
+
+        self.current_index += 1;
+
+        Some(match self.walker.operation.cache_scopes[current.1 .0 as usize] {
+            CacheScopeRecord::Authenticated => CacheScope::Authenticated,
+            CacheScopeRecord::RequiresScopes(required_scopes_id) => CacheScope::RequiresScopes(RequiredScopeSet {
+                walker: self.walker.schema_walker.walk(required_scopes_id),
+                scope_set: self
+                    .walker
+                    .query_modifications
+                    .selected_scope_set(required_scopes_id)
+                    .expect("a scope set to be selected"),
+            }),
+        })
+    }
+}
+
+pub enum CacheScope<'a> {
+    Authenticated,
+    RequiresScopes(RequiredScopeSet<'a>),
+}
+
+pub struct RequiredScopeSet<'a> {
+    walker: RequiredScopesWalker<'a>,
+    scope_set: RequiredScopeSetIndex,
+}
+
+impl<'a> RequiredScopeSet<'a> {
+    pub fn scopes(&self) -> impl ExactSizeIterator<Item = &'a str> {
+        self.walker.scopes(self.scope_set)
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub(super) enum CacheScopeRecord {
+    Authenticated,
+    RequiresScopes(RequiredScopesId),
+}
+
+pub(super) fn calculate_cache_scopes(
+    operation: OperationWalker<'_>,
+    operation_plan: &OperationPlan,
+) -> (Vec<(LogicalPlanId, CacheScopeId)>, Vec<CacheScopeRecord>) {
+    let mut builder = CacheScopeBuilder::default();
+
+    calculate_cache_scopes_for_selection_set(operation.selection_set(), None, operation_plan, &mut builder);
+
+    let CacheScopeBuilder {
+        mut plan_id_to_cache_scope_id,
+        cache_scopes,
+        plans_handled: _,
+        scope_stack: _,
+    } = builder;
+
+    plan_id_to_cache_scope_id.sort_by_key(|(plan_id, _)| *plan_id);
+
+    (plan_id_to_cache_scope_id, cache_scopes)
+}
+
+fn calculate_cache_scopes_for_selection_set(
+    selection_set: SelectionSetWalker<'_>,
+    parent_plan_id: Option<LogicalPlanId>,
+    operation_plan: &OperationPlan,
+    builder: &mut CacheScopeBuilder,
+) {
+    let mut last_parent_entity_id = None;
+    let mut parent_entity_scopes_added = 0;
+
+    for field in selection_set.fields() {
+        let Some(definition) = field.definition() else { continue };
+
+        // This takes advantage of fields being ordered by parent entity Id
+        let parent_entity_id = definition.parent_entity().id();
+        if Some(parent_entity_id) != last_parent_entity_id {
+            last_parent_entity_id = Some(parent_entity_id);
+            builder.pop_scopes(parent_entity_scopes_added);
+            parent_entity_scopes_added = add_directive_scopes(definition.parent_entity().directives(), builder)
+        }
+
+        let scopes_added = add_directive_scopes(definition.directives(), builder);
+
+        let current_plan_id = operation_plan.plan_id_for_field(field.item);
+        if parent_plan_id != Some(current_plan_id) {
+            builder.link_scopes_to_plan(current_plan_id)
+        }
+
+        if let Some(nested_selection_set) = field.selection_set() {
+            calculate_cache_scopes_for_selection_set(
+                nested_selection_set,
+                Some(current_plan_id),
+                operation_plan,
+                builder,
+            );
+        }
+
+        builder.pop_scopes(scopes_added);
+    }
+
+    builder.pop_scopes(parent_entity_scopes_added);
+}
+
+fn add_directive_scopes(directives: TypeSystemDirectivesWalker<'_>, builder: &mut CacheScopeBuilder) -> usize {
+    let mut scopes_added = 0;
+    for directive in directives.as_ref().iter() {
+        match directive {
+            schema::TypeSystemDirective::Deprecated(_)
+            | schema::TypeSystemDirective::CacheControl(_)
+            | schema::TypeSystemDirective::Authorized(_) => {}
+
+            schema::TypeSystemDirective::Authenticated => {
+                scopes_added += 1;
+                builder.insert_scope(CacheScopeRecord::Authenticated);
+            }
+            schema::TypeSystemDirective::RequiresScopes(requires_scope_id) => {
+                scopes_added += 1;
+                builder.insert_scope(CacheScopeRecord::RequiresScopes(*requires_scope_id));
+            }
+        }
+    }
+    scopes_added
+}
+
+#[derive(Default)]
+struct CacheScopeBuilder {
+    plan_id_to_cache_scope_id: Vec<(LogicalPlanId, CacheScopeId)>,
+    cache_scopes: Vec<CacheScopeRecord>,
+
+    scope_stack: Vec<CacheScopeId>,
+    plans_handled: HashSet<LogicalPlanId>,
+}
+
+impl CacheScopeBuilder {
+    fn pop_scopes(&mut self, count: usize) {
+        self.scope_stack.truncate(self.scope_stack.len() - count);
+    }
+
+    fn insert_scope(&mut self, record: CacheScopeRecord) {
+        let id = CacheScopeId(self.cache_scopes.len() as u16);
+        self.cache_scopes.push(record);
+        self.scope_stack.push(id);
+    }
+
+    fn link_scopes_to_plan(&mut self, plan: LogicalPlanId) {
+        if self.plans_handled.contains(&plan) {
+            return;
+        }
+        self.plans_handled.insert(plan);
+        self.plan_id_to_cache_scope_id
+            .extend(self.scope_stack.iter().map(|scope_id| (plan, *scope_id)))
+    }
+}

--- a/engine/crates/engine-v2/src/operation/mod.rs
+++ b/engine/crates/engine-v2/src/operation/mod.rs
@@ -38,8 +38,7 @@ pub(crate) struct PreparedOperation {
     pub plan: OperationPlan,
     pub response_blueprint: ResponseBlueprint,
 
-    // Should be sorted by LogicalPlanId
-    logical_plan_cache_scopes: Vec<(LogicalPlanId, cache_scopes::CacheScopeId)>,
+    logical_plan_cache_scopes: id_newtypes::IdToMany<LogicalPlanId, cache_scopes::CacheScopeId>,
     cache_scopes: Vec<cache_scopes::CacheScopeRecord>,
 }
 

--- a/engine/crates/engine-v2/src/operation/mod.rs
+++ b/engine/crates/engine-v2/src/operation/mod.rs
@@ -1,6 +1,7 @@
 mod bind;
 mod blueprint;
 mod build;
+mod cache_scopes;
 pub mod ids;
 mod input_value;
 mod location;
@@ -15,6 +16,7 @@ mod variables;
 mod walkers;
 
 use crate::response::{ConcreteObjectShapeId, FieldShapeId, ResponseKeys, ResponseObjectSetId, Shapes};
+pub(crate) use cache_scopes::*;
 pub(crate) use engine_parser::types::OperationType;
 use grafbase_telemetry::metrics::OperationMetricsAttributes;
 use id_derives::IndexedFields;
@@ -35,6 +37,10 @@ pub(crate) struct PreparedOperation {
     pub metrics_attributes: OperationMetricsAttributes,
     pub plan: OperationPlan,
     pub response_blueprint: ResponseBlueprint,
+
+    // Should be sorted by LogicalPlanId
+    logical_plan_cache_scopes: Vec<(LogicalPlanId, cache_scopes::CacheScopeId)>,
+    cache_scopes: Vec<cache_scopes::CacheScopeRecord>,
 }
 
 impl std::ops::Deref for PreparedOperation {
@@ -107,6 +113,12 @@ pub(crate) struct OperationPlan {
     pub in_topological_order: Vec<LogicalPlanId>,
     // Sorted
     pub solved_requirements: Vec<(SelectionSetId, SolvedRequiredFieldSet)>,
+}
+
+impl OperationPlan {
+    pub fn plan_id_for_field(&self, field_id: FieldId) -> LogicalPlanId {
+        self.field_to_logical_plan_id[usize::from(field_id)]
+    }
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/engine/crates/engine-v2/src/operation/modifier/query.rs
+++ b/engine/crates/engine-v2/src/operation/modifier/query.rs
@@ -20,7 +20,7 @@ pub(crate) struct QueryModifications {
     pub concrete_shape_has_error: BitSet<ConcreteObjectShapeId>,
     pub field_shape_id_to_error_ids: IdToMany<FieldShapeId, ErrorId>,
     pub root_error_ids: Vec<ErrorId>,
-    selected_scope_sets: Vec<(RequiredScopesId, RequiredScopeSetIndex)>,
+    matched_scopes: Vec<(RequiredScopesId, RequiredScopeSetIndex)>,
 }
 
 impl QueryModifications {
@@ -48,20 +48,20 @@ impl QueryModifications {
             errors: Vec::new(),
             field_shape_id_to_error_ids: Default::default(),
             root_error_ids: Vec::new(),
-            selected_scope_sets: vec![],
+            matched_scopes: vec![],
         }
     }
 
-    pub(in crate::operation) fn selected_scope_set(
+    pub(in crate::operation) fn matched_scope_set(
         &self,
         required_scope: RequiredScopesId,
     ) -> Option<RequiredScopeSetIndex> {
         let index = self
-            .selected_scope_sets
+            .matched_scopes
             .binary_search_by_key(&required_scope, |(id, _)| *id)
             .ok()?;
 
-        Some(self.selected_scope_sets[index].1)
+        Some(self.matched_scopes[index].1)
     }
 }
 
@@ -190,7 +190,7 @@ where
         drop(field_shape_ids_with_errors);
 
         self.modifications
-            .selected_scope_sets
+            .matched_scopes
             .sort_unstable_by_key(|(scope_id, _)| *scope_id);
 
         self.modifications
@@ -236,6 +236,6 @@ where
     }
 
     fn record_selected_scope_set(&mut self, id: RequiredScopesId, selected_scope_set: schema::RequiredScopeSetIndex) {
-        self.modifications.selected_scope_sets.push((id, selected_scope_set));
+        self.modifications.matched_scopes.push((id, selected_scope_set));
     }
 }

--- a/engine/crates/engine-v2/src/operation/modifier/query.rs
+++ b/engine/crates/engine-v2/src/operation/modifier/query.rs
@@ -1,5 +1,5 @@
 use id_newtypes::{BitSet, IdRange, IdToMany};
-use schema::Schema;
+use schema::{RequiredScopeSetIndex, RequiredScopesId, Schema};
 
 use crate::{
     execution::{ErrorId, PlanningResult, PreExecutionContext},
@@ -20,6 +20,7 @@ pub(crate) struct QueryModifications {
     pub concrete_shape_has_error: BitSet<ConcreteObjectShapeId>,
     pub field_shape_id_to_error_ids: IdToMany<FieldShapeId, ErrorId>,
     pub root_error_ids: Vec<ErrorId>,
+    selected_scope_sets: Vec<(RequiredScopesId, RequiredScopeSetIndex)>,
 }
 
 impl QueryModifications {
@@ -47,7 +48,20 @@ impl QueryModifications {
             errors: Vec::new(),
             field_shape_id_to_error_ids: Default::default(),
             root_error_ids: Vec::new(),
+            selected_scope_sets: vec![],
         }
+    }
+
+    pub(in crate::operation) fn selected_scope_set(
+        &self,
+        required_scope: RequiredScopesId,
+    ) -> Option<RequiredScopeSetIndex> {
+        let index = self
+            .selected_scope_sets
+            .binary_search_by_key(&required_scope, |(id, _)| *id)
+            .ok()?;
+
+        Some(self.selected_scope_sets[index].1)
     }
 }
 
@@ -89,13 +103,16 @@ where
                             .unwrap_or_default()
                     });
 
-                    if !self.schema().walk(id).matches(scopes) {
+                    let Some(selected_scope_set) = self.schema().walk(id).matches(scopes) else {
                         self.handle_modifier_resulted_in_error(
                             modifier_id,
                             modifier.impacted_fields,
                             GraphqlError::new("Insufficient scopes", ErrorCode::Unauthorized),
-                        )
-                    }
+                        );
+                        continue;
+                    };
+
+                    self.record_selected_scope_set(id, selected_scope_set);
                 }
                 QueryModifierRule::AuthorizedField {
                     directive_id,
@@ -171,6 +188,11 @@ where
             }
         }
         drop(field_shape_ids_with_errors);
+
+        self.modifications
+            .selected_scope_sets
+            .sort_unstable_by_key(|(scope_id, _)| *scope_id);
+
         self.modifications
     }
 
@@ -211,5 +233,9 @@ where
 
     fn schema(&self) -> &'ctx Schema {
         &self.ctx.engine.schema
+    }
+
+    fn record_selected_scope_set(&mut self, id: RequiredScopesId, selected_scope_set: schema::RequiredScopeSetIndex) {
+        self.modifications.selected_scope_sets.push((id, selected_scope_set));
     }
 }

--- a/engine/crates/engine-v2/src/operation/walkers/selection_set.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/selection_set.rs
@@ -5,6 +5,10 @@ pub type SelectionSetWalker<'a> = OperationWalker<'a, SelectionSetId, ()>;
 
 impl<'a> SelectionSetWalker<'a> {
     pub fn fields(self) -> impl Iterator<Item = FieldWalker<'a>> + 'a {
+        self.fields_ordered_by_parent_entity_id()
+    }
+
+    pub fn fields_ordered_by_parent_entity_id(self) -> impl Iterator<Item = FieldWalker<'a>> + 'a {
         let walker = self.walk_with((), ());
         self.as_ref()
             .field_ids_ordered_by_parent_entity_id_then_position

--- a/engine/crates/engine-v2/src/sources/graphql/federation.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/federation.rs
@@ -52,6 +52,7 @@ impl FederationEntityResolver {
                     CacheScope::Authenticated => "authenticated".into(),
                     CacheScope::RequiresScopes(scopes) => {
                         let mut hasher = blake3::Hasher::new();
+                        hasher.update(b"requiresScopes");
                         hasher.update(&scopes.scopes().len().to_le_bytes());
                         for scope in scopes.scopes() {
                             hasher.update(&scope.len().to_le_bytes());
@@ -357,6 +358,7 @@ async fn cache_fetch<R: Runtime>(
 
 fn build_cache_key(subgraph_name: &str, headers: &HeaderMap, repr: &RawValue, additional_scopes: &[String]) -> String {
     let mut hasher = blake3::Hasher::new();
+    hasher.update(b"v1");
     hasher.update(subgraph_name.as_bytes());
     hasher.update(&headers.len().to_le_bytes());
     for (name, value) in headers {

--- a/engine/crates/engine-v2/src/sources/graphql/root_fields.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/root_fields.rs
@@ -140,6 +140,7 @@ impl GraphqlResolver {
 
 fn build_cache_key(subgraph_name: &str, subgraph_request_body: &[u8], headers: &http::HeaderMap) -> Option<String> {
     let mut hasher = blake3::Hasher::new();
+    hasher.update(b"v1");
     hasher.update(subgraph_name.as_bytes());
     hasher.update(&headers.len().to_le_bytes());
     for (name, value) in headers {

--- a/engine/crates/federated-graph/src/federated_graph/v3.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v3.rs
@@ -100,7 +100,7 @@ impl std::fmt::Debug for FederatedGraphV3 {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, PartialOrd)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, PartialOrd, Debug)]
 pub enum Directive {
     Authenticated,
     Deprecated {

--- a/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
@@ -582,7 +582,7 @@ mod tests {
                 on multiple lines.
 
                 yes, way
-                
+
                 """) @dummy(test: "a \"test\"")
             }
             "###,

--- a/engine/crates/graphql-mocks/src/federation/mod.rs
+++ b/engine/crates/graphql-mocks/src/federation/mod.rs
@@ -4,8 +4,10 @@ mod accounts;
 mod inventory;
 mod products;
 mod reviews;
+mod secure;
 
 pub use accounts::FederatedAccountsSchema;
 pub use inventory::FederatedInventorySchema;
 pub use products::FederatedProductsSchema;
 pub use reviews::FederatedReviewsSchema;
+pub use secure::SecureFederatedSchema;

--- a/engine/crates/graphql-mocks/src/federation/secure.rs
+++ b/engine/crates/graphql-mocks/src/federation/secure.rs
@@ -1,0 +1,92 @@
+//! A mock GraphQL server that exposes authenticated & requiresScope directives
+//! for testing their interaction with cache (and possibly other things)
+
+use async_graphql::{EmptyMutation, EmptySubscription, Object, SimpleObject, TypeDirective};
+
+pub struct SecureFederatedSchema;
+
+impl crate::Subgraph for SecureFederatedSchema {
+    fn name(&self) -> String {
+        "secure".to_string()
+    }
+
+    async fn start(self) -> crate::MockGraphQlServer {
+        crate::MockGraphQlServer::new(
+            async_graphql::Schema::build(Query, EmptyMutation, EmptySubscription)
+                .enable_federation()
+                .finish(),
+        )
+        .await
+    }
+}
+
+struct Query;
+
+#[Object]
+impl Query {
+    #[graphql(
+        directive = authenticated::apply()
+    )]
+    async fn authenticated_products(&self) -> Vec<Product> {
+        vec![Product { upc: "top-1".into() }]
+    }
+
+    #[graphql(
+        directive = requires_scopes::apply(vec![vec!["read".into()], vec!["write".into()]])
+    )]
+    async fn scoped_products(&self) -> Vec<Product> {
+        vec![Product { upc: "top-1".into() }]
+    }
+
+    async fn authenticated(&self) -> AuthenticatedType {
+        AuthenticatedType
+    }
+
+    async fn scoped(&self) -> ScopedType {
+        ScopedType
+    }
+}
+
+struct AuthenticatedType;
+
+#[Object(
+    directive = authenticated::apply()
+)]
+impl AuthenticatedType {
+    async fn products(&self) -> Vec<Product> {
+        vec![Product { upc: "top-1".into() }]
+    }
+}
+
+struct ScopedType;
+
+#[Object(
+    directive = requires_scopes::apply(vec![vec!["read".into()], vec!["write".into()]])
+)]
+impl ScopedType {
+    async fn products(&self) -> Vec<Product> {
+        vec![Product { upc: "top-1".into() }]
+    }
+}
+
+#[derive(Clone, SimpleObject)]
+#[graphql(unresolvable = "upc")]
+struct Product {
+    upc: String,
+}
+
+#[TypeDirective(
+    name = "federation__authenticated",
+    location = "FieldDefinition",
+    location = "Object",
+    composable = "https://custom.spec.dev/extension/v1.0"
+)]
+fn authenticated() {}
+
+#[TypeDirective(
+    name = "federation__requiresScopes",
+    location = "FieldDefinition",
+    location = "Object",
+    composable = "https://custom.spec.dev/extension/v1.0"
+)]
+fn requires_scopes(scopes: Vec<Vec<String>>) {}

--- a/engine/crates/graphql-mocks/src/lib.rs
+++ b/engine/crates/graphql-mocks/src/lib.rs
@@ -275,7 +275,16 @@ where
     }
 
     fn sdl(&self) -> String {
-        self.sdl_with_options(async_graphql::SDLExportOptions::new())
+        let options = {
+            let names = self.names();
+            if names.iter().any(|name| name == "_Any") && names.iter().any(|name| name == "_service") {
+                async_graphql::SDLExportOptions::new().federation()
+            } else {
+                async_graphql::SDLExportOptions::new()
+            }
+        };
+
+        self.sdl_with_options(options)
     }
 }
 

--- a/engine/crates/graphql-mocks/src/secure.rs
+++ b/engine/crates/graphql-mocks/src/secure.rs
@@ -1,8 +1,5 @@
 use async_graphql::{EmptyMutation, EmptySubscription, Object, SimpleObject, TypeDirective, Union};
 
-/// A schema that only uses String types.
-///
-/// This is used to make sure that we're not pruning built in scalars that aren't used
 #[derive(Default)]
 pub struct SecureSchema;
 

--- a/engine/crates/integration-tests/tests/federation/entity_caching.rs
+++ b/engine/crates/integration-tests/tests/federation/entity_caching.rs
@@ -5,6 +5,7 @@ use graphql_mocks::{ErrorSchema, FederatedInventorySchema, FederatedProductsSche
 use integration_tests::{federation::EngineV2Ext, runtime};
 use serde_json::json;
 
+mod directive_scopes;
 mod subgraph_cache_control;
 
 #[test]

--- a/engine/crates/integration-tests/tests/federation/entity_caching/directive_scopes.rs
+++ b/engine/crates/integration-tests/tests/federation/entity_caching/directive_scopes.rs
@@ -1,0 +1,187 @@
+//! Tests that we handle `@authenticated` & `@requiresScopes` directives on parent fields/types
+//! correctly when doing entity caching
+
+use engine_v2::Engine;
+use graphql_mocks::{FederatedInventorySchema, FederatedProductsSchema, FederatedReviewsSchema, SecureFederatedSchema};
+use integration_tests::{
+    federation::{EngineV2Ext, TestEngineV2},
+    openid::{CoreClientExt, OryHydraOpenIDProvider, JWKS_URI},
+    runtime,
+};
+
+#[test]
+fn test_authenticated_field_does_not_share_cache_with_unauthenticated() {
+    runtime().block_on(async move {
+        let token = jwt_token("read").await;
+
+        let engine = engine().await;
+
+        const AUTHENTICATED_QUERY: &str = "{ authenticatedProducts { upc reviews { id body } } }";
+        const UNAUTHENTICATED_QUERY: &str = "{ topProducts { upc reviews { id body } } }";
+
+        engine
+            .post(AUTHENTICATED_QUERY)
+            .header("Authorization", format!("Bearer {token}"))
+            .await
+            .into_data();
+        engine
+            .post(UNAUTHENTICATED_QUERY)
+            .header("Authorization", format!("Bearer {token}"))
+            .await
+            .into_data();
+        engine
+            .post(AUTHENTICATED_QUERY)
+            .header("Authorization", format!("Bearer {token}"))
+            .await
+            .into_data();
+
+        assert_eq!(
+            engine.drain_graphql_requests_sent_to::<FederatedReviewsSchema>().len(),
+            2
+        );
+    })
+}
+
+#[test]
+fn test_authenticated_type_does_not_share_cache_with_unauthenticated() {
+    runtime().block_on(async move {
+        let token = jwt_token("read").await;
+
+        let engine = engine().await;
+
+        const AUTHENTICATED_QUERY: &str = "{ authenticated { products { upc reviews { id body } } } }";
+        const UNAUTHENTICATED_QUERY: &str = "{ topProducts { upc reviews { id body } } }";
+
+        engine
+            .post(AUTHENTICATED_QUERY)
+            .header("Authorization", format!("Bearer {token}"))
+            .await
+            .into_data();
+        engine
+            .post(UNAUTHENTICATED_QUERY)
+            .header("Authorization", format!("Bearer {token}"))
+            .await
+            .into_data();
+        engine
+            .post(AUTHENTICATED_QUERY)
+            .header("Authorization", format!("Bearer {token}"))
+            .await
+            .into_data();
+
+        assert_eq!(
+            engine.drain_graphql_requests_sent_to::<FederatedReviewsSchema>().len(),
+            2
+        );
+    })
+}
+
+#[test]
+fn test_requires_scope_on_field() {
+    runtime().block_on(async move {
+        let read_token = jwt_token("read").await;
+        let write_token = jwt_token("write").await;
+
+        let engine = engine().await;
+
+        const QUERY: &str = "{ scopedProducts { upc reviews { id body } } }";
+
+        engine
+            .post(QUERY)
+            .header("Authorization", format!("Bearer {read_token}"))
+            .await
+            .into_data();
+        engine
+            .post(QUERY)
+            .header("Authorization", format!("Bearer {read_token}"))
+            .await
+            .into_data();
+
+        // The two above share scopes
+        assert_eq!(
+            engine.drain_graphql_requests_sent_to::<FederatedReviewsSchema>().len(),
+            1
+        );
+
+        engine
+            .post(QUERY)
+            .header("Authorization", format!("Bearer {write_token}"))
+            .await
+            .into_data();
+
+        assert_eq!(
+            engine.drain_graphql_requests_sent_to::<FederatedReviewsSchema>().len(),
+            1
+        );
+    })
+}
+
+#[test]
+fn test_requires_scope_on_type() {
+    runtime().block_on(async move {
+        let read_token = jwt_token("read").await;
+        let write_token = jwt_token("write").await;
+
+        let engine = engine().await;
+
+        const QUERY: &str = "{ scoped { products { upc reviews { id body } } } }";
+
+        engine
+            .post(QUERY)
+            .header("Authorization", format!("Bearer {read_token}"))
+            .await
+            .into_data();
+        engine
+            .post(QUERY)
+            .header("Authorization", format!("Bearer {read_token}"))
+            .await
+            .into_data();
+
+        // The two above share scopes
+        assert_eq!(
+            engine.drain_graphql_requests_sent_to::<FederatedReviewsSchema>().len(),
+            1
+        );
+
+        engine
+            .post(QUERY)
+            .header("Authorization", format!("Bearer {write_token}"))
+            .await
+            .into_data();
+
+        assert_eq!(
+            engine.drain_graphql_requests_sent_to::<FederatedReviewsSchema>().len(),
+            1
+        );
+    })
+}
+
+async fn jwt_token(scope: &str) -> String {
+    OryHydraOpenIDProvider::default()
+        .create_client()
+        .await
+        .get_access_token_with_client_credentials(&[("scope", scope)])
+        .await
+}
+
+async fn engine() -> TestEngineV2 {
+    Engine::builder()
+        .with_subgraph(FederatedProductsSchema)
+        .with_subgraph(FederatedReviewsSchema)
+        .with_subgraph(SecureFederatedSchema)
+        .with_subgraph(FederatedInventorySchema)
+        .with_toml_config(format!(
+            r#"
+                [entity_caching]
+                enabled = true
+
+                [[authentication.providers]]
+                [authentication.providers.jwt]
+                name = "my-authenticator"
+
+                [authentication.providers.jwt.jwks]
+                url = "{JWKS_URI}"
+                "#,
+        ))
+        .build()
+        .await
+}


### PR DESCRIPTION
When we're doing entity caching we need to consider whether the entity that we are caching was contained inside a type or field with `@authenticated` or `@requiresScopes`.  If it was we should include that fact in the cache key, so that we don't share a cache entry from an authenticated user with that of an unauthed user etc.

Fixes GB-7179