### PR TITLE
chore: bump gateway to 0.11.0

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -78,9 +78,9 @@ runs:
       if: ${{ inputs.with-integration-tests == 'true' }}
       shell: bash
       run: |
-        docker-compose -f engine/crates/integration-tests/docker-compose.yml up -d
+        docker compose -f engine/crates/integration-tests/docker-compose.yml up -d
         RUST_BACKTRACE=1 cargo nextest run --workspace --profile ci --exclude grafbase-gateway --exclude grafbase-docker-tests
-        docker-compose -f engine/crates/integration-tests/docker-compose.yml stop -t 3
+        docker compose -f engine/crates/integration-tests/docker-compose.yml stop -t 3
 
     - name: Upload the JUnit files
       if: ${{ inputs.with-integration-tests == 'true' && ( success() || failure() ) && !contains(steps.all_tests.outputs.exitcode, '101') }}
@@ -95,7 +95,7 @@ runs:
       if: ${{ inputs.with-integration-tests == 'true' }}
       shell: bash
       run: |
-        docker-compose -f gateway/crates/gateway-binary/docker-compose.yml up -d
+        docker compose -f gateway/crates/gateway-binary/docker-compose.yml up -d
         RUST_BACKTRACE=1 cargo nextest run -p grafbase-gateway --profile ci
 
     - name: Upload the gateway junit files

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2877,7 +2877,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.11.0] - 2024-08-28
+
+[CHANGELOG](changelog/0.11.0.md)
+
 ## [0.10.0] - 2024-08-20
 
 [CHANGELOG](changelog/0.10.0.md)

--- a/gateway/changelog/0.11.0.md
+++ b/gateway/changelog/0.11.0.md
@@ -22,10 +22,11 @@
 
   When enabled, the gateway will honor sampling configuration passed in through the `sampled` header (W3C spec), then fall back to its own configuration. This option is disabled by default and should not be enabled if the gateway is exposed directly to the internet, since malicious clients could increase load on the gateway by forcing traces to be recorded.
 
-  See also the [documentation](https://github.com/grafbase/website/pull/2782)
+  See also the [documentation](https://grafbase.com/docs/self-hosted-gateway/telemetry#traces)
 
 ### Fixes
 
 - Correct handling of `operationName`.
 - `nbf` claim was required in JWT auth. Now it is only validated if present.
 - Gateway does not require the `Accept` header anymore and will default to `application/json` if absent.
+- Fix deadlock case with OpenTelemetry

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true


### PR DESCRIPTION
Bump gateway to 0.11.0

**Description:**

This change updates the `federated-server` and `grafbase-gateway` crates to their latest version, 0.11.0.

**Changes:**

* Updated Cargo.toml files in `gateway` crate to reflect new versions.
* Updated CHANGELOG.md file in `gateway` crate with a note about the release.
* Updated changelog document for gateway version 0.11.0 with details about the changes.
