### PR TITLE
test: redis entity caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4670,6 +4670,7 @@ dependencies = [
  "postgres-connector-types",
  "pprof",
  "pretty_assertions",
+ "rand 0.8.5",
  "regex",
  "registry-for-cache",
  "registry-upgrade",

--- a/engine/crates/integration-tests/Cargo.toml
+++ b/engine/crates/integration-tests/Cargo.toml
@@ -97,20 +97,21 @@ workspace = true
 features = ["tower"]
 
 [dev-dependencies]
-similar-asserts = "1.5"
-cynic-parser.workspace = true
 base64.workspace = true
-rstest.workspace = true
-const_format = "0.2.32"
-headers.workspace = true
-criterion = { version = "0.5.1", features = ["async_tokio"] }
-pprof = { version = "0.13", features = ["criterion", "flamegraph"] }
-sha2.workspace = true
-hex.workspace = true
-secrecy.workspace = true
-gateway-v2-auth.workspace = true
 common-types.workspace = true
+const_format = "0.2.32"
+criterion = { version = "0.5.1", features = ["async_tokio"] }
+cynic-parser.workspace = true
+gateway-v2-auth.workspace = true
+headers.workspace = true
+hex.workspace = true
+pprof = { version = "0.13", features = ["criterion", "flamegraph"] }
 pretty_assertions = "1"
+rand = "0.8"
+rstest.workspace = true
+secrecy.workspace = true
+sha2.workspace = true
+similar-asserts = "1.5"
 
 
 [[bench]]

--- a/engine/crates/integration-tests/tests/federation/entity_caching.rs
+++ b/engine/crates/integration-tests/tests/federation/entity_caching.rs
@@ -5,6 +5,7 @@ use graphql_mocks::{ErrorSchema, FederatedInventorySchema, FederatedProductsSche
 use integration_tests::{federation::EngineV2Ext, runtime};
 use serde_json::json;
 
+mod redis;
 mod subgraph_cache_control;
 
 #[test]

--- a/engine/crates/integration-tests/tests/federation/entity_caching/redis.rs
+++ b/engine/crates/integration-tests/tests/federation/entity_caching/redis.rs
@@ -1,0 +1,75 @@
+use engine_v2::Engine;
+use graphql_mocks::FederatedProductsSchema;
+use integration_tests::{federation::EngineV2Ext, runtime};
+use rand::Rng;
+
+#[test]
+fn entity_caching_via_redis() {
+    // Create a random key prefix so we don't clash with other tests
+    let key_prefix = rand::thread_rng()
+        .sample_iter(&rand::distributions::Alphanumeric)
+        .take(6)
+        .map(char::from)
+        .collect::<String>();
+
+    let response = runtime().block_on(async move {
+        let engine = Engine::builder()
+            .with_subgraph(FederatedProductsSchema)
+            .with_toml_config(format!(
+                r#"
+                [entity_caching]
+                enabled = true
+                redis.url = "redis://localhost:6379"
+                redis.key_prefix = "test-{key_prefix}-"
+                "#,
+            ))
+            .build()
+            .await;
+
+        const QUERY: &str = r"query { topProducts { upc name price } }";
+
+        let first_response = engine.post(QUERY).await.into_data();
+        let second_response = engine.post(QUERY).await.into_data();
+
+        assert_eq!(first_response, second_response);
+
+        assert_eq!(
+            engine.drain_graphql_requests_sent_to::<FederatedProductsSchema>().len(),
+            1
+        );
+
+        first_response
+    });
+
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "topProducts": [
+        {
+          "upc": "top-1",
+          "name": "Trilby",
+          "price": 11
+        },
+        {
+          "upc": "top-2",
+          "name": "Fedora",
+          "price": 22
+        },
+        {
+          "upc": "top-3",
+          "name": "Boater",
+          "price": 33
+        },
+        {
+          "upc": "top-4",
+          "name": "Jeans",
+          "price": 44
+        },
+        {
+          "upc": "top-5",
+          "name": "Pink Jeans",
+          "price": 55
+        }
+      ]
+    }
+    "###);
+}

--- a/gateway/crates/gateway-binary/tests/entity_caching/mod.rs
+++ b/gateway/crates/gateway-binary/tests/entity_caching/mod.rs
@@ -1,0 +1,79 @@
+use std::{future::Future, sync::Arc};
+
+use graphql_mocks::Schema;
+use indoc::formatdoc;
+use rand::Rng;
+
+use crate::{runtime, Client};
+
+#[test]
+fn entity_caching_via_redis() {
+    // Create a random key prefix so we don't clash with other tests
+    let key_prefix = rand::thread_rng()
+        .sample_iter(&rand::distributions::Alphanumeric)
+        .take(6)
+        .map(char::from)
+        .collect::<String>();
+
+    let config = formatdoc!(
+        r#"
+        [entity_caching]
+        enabled = true
+        redis.url = "redis://localhost:6379"
+        redis.key_prefix = "test-{key_prefix}-"
+        "#,
+    );
+
+    let subgraph_schema = graphql_mocks::EchoSchema;
+    let subgraph_sdl = subgraph_schema.sdl();
+    let subgraph_server = runtime().block_on(async { graphql_mocks::MockGraphQlServer::new(subgraph_schema).await });
+
+    with_mock_subgraph(
+        &config,
+        &subgraph_sdl,
+        subgraph_server.url().as_str(),
+        |client| async move {
+            const QUERY: &str = r#"query { id(input: "hello") }"#;
+
+            let first_response = client.gql::<serde_json::Value>(QUERY).send().await;
+            let second_response = client.gql::<serde_json::Value>(QUERY).send().await;
+
+            assert_eq!(first_response, second_response);
+
+            assert_eq!(subgraph_server.drain_received_requests().count(), 1);
+
+            insta::assert_json_snapshot!(first_response, @r###"
+            {
+              "data": {
+                "id": "hello"
+              }
+            }
+            "###);
+        },
+    );
+}
+
+fn with_mock_subgraph<T, F>(config: &str, subgraph_schema: &str, subgraph_url: &str, test: T)
+where
+    T: FnOnce(Arc<Client>) -> F,
+    F: Future<Output = ()>,
+{
+    let federated_schema = {
+        let parsed = async_graphql_parser::parse_schema(subgraph_schema).unwrap();
+        let mut subgraphs = graphql_composition::Subgraphs::default();
+        subgraphs.ingest(&parsed, "the-subgraph", subgraph_url);
+        graphql_composition::compose(&subgraphs)
+            .into_result()
+            .unwrap()
+            .into_federated_sdl()
+    };
+
+    crate::GatewayBuilder {
+        toml_config: config.into(),
+        schema: &federated_schema,
+        log_level: None,
+        client_url_path: None,
+        client_headers: None,
+    }
+    .run(test)
+}

--- a/gateway/crates/gateway-binary/tests/integration_tests.rs
+++ b/gateway/crates/gateway-binary/tests/integration_tests.rs
@@ -1,5 +1,6 @@
 #![allow(unused_crate_dependencies, clippy::panic)]
 
+mod entity_caching;
 mod mocks;
 mod telemetry;
 


### PR DESCRIPTION
A very simple test of the gateways redis entity caching functionality, just to make sure we don't regress.  Didn't have time to add this earlier.

Fixes GB-7179