### PR TITLE
graphql-federated-graph: fix rendering of @join__type on interfaces without keys

### DIFF
--- a/cli/crates/federated-dev/src/dev.rs
+++ b/cli/crates/federated-dev/src/dev.rs
@@ -49,9 +49,10 @@ pub(super) async fn run(
     log::trace!("starting the federated dev server");
 
     let (gateway_sender, gateway) = watch::channel(
-        gateway_nanny::new_gateway(
-            graph.map(|graph| engine_config_builder::build_with_sdl_config(&config.borrow(), graph)),
-        )
+        gateway_nanny::new_gateway(graph.map(|graph| {
+            let federated_sdl = graphql_federated_graph::render_federated_sdl(&graph).unwrap();
+            engine_config_builder::build_with_sdl_config(&config.borrow(), graph, federated_sdl)
+        }))
         .await,
     );
     let (websocket_sender, websocket_receiver) = mpsc::channel(16);

--- a/cli/crates/federated-dev/src/dev/gateway_nanny.rs
+++ b/cli/crates/federated-dev/src/dev/gateway_nanny.rs
@@ -36,11 +36,10 @@ impl EngineNanny {
 
         while let Some(message) = stream.next().await {
             log::trace!("nanny received a {message:?}");
-            let config = self
-                .graph
-                .borrow()
-                .clone()
-                .map(|graph| engine_config_builder::build_with_sdl_config(&self.config.borrow(), graph));
+            let config = self.graph.borrow().clone().map(|graph| {
+                let federated_sdl = graphql_federated_graph::render_federated_sdl(&graph).unwrap();
+                engine_config_builder::build_with_sdl_config(&self.config.borrow(), graph, federated_sdl)
+            });
             let gateway = new_gateway(config).await;
             if let Err(error) = self.sender.send(gateway) {
                 log::error!("Couldn't publish new gateway: {error:?}");

--- a/engine/crates/composition/CHANGELOG.md
+++ b/engine/crates/composition/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## Unreleased
 
+### Features
+
 - Added composition for default values of output field arguments and input fields. They are now reflected in the federated graph.
 - Support the experimental @authorized directive
+
+### Fixes
+
 - Fixed the ingestion of numeric literals when creating a federated graph from a string.
+- In federated_graph, when parsing a schema with `@join__type` and no key argument, then rendering it with `render_federated_sdl()` would produce a `@join__type` directive
 
 ## 0.4.0 - 2024-06-11
 

--- a/engine/crates/engine-config-builder/src/from_sdl_config.rs
+++ b/engine/crates/engine-config-builder/src/from_sdl_config.rs
@@ -17,7 +17,11 @@ use parser_sdl::federation::header::SubgraphHeaderRule;
 use parser_sdl::federation::{EntityCachingConfig, FederatedGraphConfig};
 use parser_sdl::{AuthV2Provider, GlobalCacheTarget};
 
-pub fn build_with_sdl_config(config: &FederatedGraphConfig, federated_graph: FederatedGraph) -> VersionedConfig {
+pub fn build_with_sdl_config(
+    config: &FederatedGraphConfig,
+    federated_graph: FederatedGraph,
+    federated_sdl: String,
+) -> VersionedConfig {
     let mut context = BuildContext::default();
     let default_header_rules = context.insert_headers(&config.header_rules);
 
@@ -29,7 +33,7 @@ pub fn build_with_sdl_config(config: &FederatedGraphConfig, federated_graph: Fed
     }
 
     VersionedConfig::V6(config::Config {
-        federated_sdl: federated_graph::render_federated_sdl(&federated_graph).unwrap(),
+        federated_sdl,
         strings: context.strings.into_vec(),
         paths: context.paths.into_vec(),
         header_rules: context.header_rules,

--- a/engine/crates/engine-config-builder/src/from_toml_config.rs
+++ b/engine/crates/engine-config-builder/src/from_toml_config.rs
@@ -5,7 +5,7 @@ use parser_sdl::federation::{header::SubgraphHeaderRule, FederatedGraphConfig};
 
 use crate::build_with_sdl_config;
 
-pub fn build_with_toml_config(config: &Config, graph: FederatedGraph) -> VersionedConfig {
+pub fn build_with_toml_config(config: &Config, graph: FederatedGraph, federated_sdl: String) -> VersionedConfig {
     let mut graph_config = FederatedGraphConfig::default();
 
     if let Some(limits_config) = config.operation_limits {
@@ -56,7 +56,7 @@ pub fn build_with_toml_config(config: &Config, graph: FederatedGraph) -> Version
         })
         .collect();
 
-    build_with_sdl_config(&graph_config, graph)
+    build_with_sdl_config(&graph_config, graph, federated_sdl)
 }
 
 fn retry_config(retry_config: Option<RetryConfig>) -> Option<parser_sdl::federation::RetryConfig> {

--- a/engine/crates/engine-v2/schema/src/builder/mod.rs
+++ b/engine/crates/engine-v2/schema/src/builder/mod.rs
@@ -15,13 +15,15 @@ use federated_graph::FederatedGraph;
 use sources::graphql::GraphqlEndpointId;
 use url::Url;
 
+use self::error::*;
 use self::external_sources::ExternalDataSources;
 use self::graph::GraphBuilder;
 use self::ids::IdMaps;
 use self::interner::ProxyKeyInterner;
 
+pub use self::error::BuildError;
+
 use crate::*;
-use error::*;
 use interner::Interner;
 use requires::*;
 

--- a/engine/crates/engine-v2/schema/src/lib.rs
+++ b/engine/crates/engine-v2/schema/src/lib.rs
@@ -11,6 +11,7 @@ mod resolver;
 pub mod sources;
 mod walkers;
 
+pub use self::builder::BuildError;
 pub use directives::*;
 use id_newtypes::IdRange;
 pub use ids::*;

--- a/engine/crates/engine-v2/src/lib.rs
+++ b/engine/crates/engine-v2/src/lib.rs
@@ -13,6 +13,6 @@ pub mod websocket;
 pub use engine::{Engine, Runtime, WebsocketSession};
 pub use graphql_over_http::Body;
 pub use response::error::ErrorCode;
-pub use schema::Schema;
+pub use schema::{BuildError, Schema};
 
 pub use ::config::{latest as config, VersionedConfig};

--- a/engine/crates/federated-graph/src/from_sdl.rs
+++ b/engine/crates/federated-graph/src/from_sdl.rs
@@ -1089,7 +1089,7 @@ fn parse_selection_set(fields: &str) -> Result<Vec<Positioned<ast::Selection>>, 
     // Cheating for now, we should port the parser from engines instead.
     let fields = format!("{{ {fields} }}");
     let parsed = async_graphql_parser::parse_query(fields)
-        .map_err(|err| err.to_string())
+        .map_err(|err| format!("Error parsing a selection from a federated directive: {err}"))
         .map_err(DomainError)?;
 
     let ast::ExecutableDocument {

--- a/engine/crates/integration-tests/src/federation/builder.rs
+++ b/engine/crates/integration-tests/src/federation/builder.rs
@@ -139,11 +139,13 @@ impl EngineV2Builder {
                 }
             });
 
+        let federated_sdl = graph.into_federated_sdl();
+
         // Ensure SDL/JSON serialization work as a expected
         let graph = {
-            let sdl = graph.into_federated_sdl();
+            let sdl = &federated_sdl;
             println!("{sdl}");
-            let mut graph = VersionedFederatedGraph::from_sdl(&sdl).unwrap();
+            let mut graph = VersionedFederatedGraph::from_sdl(sdl).unwrap();
             let json = serde_json::to_value(&graph).unwrap();
             graph = serde_json::from_value(json).unwrap();
             graph
@@ -153,12 +155,12 @@ impl EngineV2Builder {
             Some(ConfigSource::Toml(toml)) => {
                 let config: gateway_config::Config = toml::from_str(&toml).unwrap();
                 update_runtime_with_toml_config(&mut self.runtime, &config);
-                build_with_toml_config(&config, graph.into_latest())
+                build_with_toml_config(&config, graph.into_latest(), federated_sdl)
             }
             Some(ConfigSource::Sdl(mut sdl)) => {
                 sdl.push_str("\nextend schema @graph(type: federated)");
                 let config = parse_sdl_config(&sdl).await;
-                build_with_sdl_config(&config, graph.into_latest())
+                build_with_sdl_config(&config, graph.into_latest(), federated_sdl)
             }
             Some(ConfigSource::SdlWebsocket) => {
                 let mut sdl = String::new();
@@ -172,9 +174,9 @@ impl EngineV2Builder {
                 }
 
                 let config = parse_sdl_config(&sdl).await;
-                build_with_sdl_config(&config, graph.into_latest())
+                build_with_sdl_config(&config, graph.into_latest(), federated_sdl)
             }
-            None => build_with_sdl_config(&Default::default(), graph.into_latest()),
+            None => build_with_sdl_config(&Default::default(), graph.into_latest(), federated_sdl),
         }
         .into_latest();
 

--- a/gateway/crates/federated-server/src/error.rs
+++ b/gateway/crates/federated-server/src/error.rs
@@ -3,7 +3,7 @@ use tokio::sync::{mpsc, watch};
 /// The Grafbase gateway error type
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("{0}")]
+    #[error("Error validating federated SDL: {0}")]
     /// The GraphQL schema validation
     SchemaValidationError(String),
     /// Internal error

--- a/gateway/crates/federated-server/src/server/gateway.rs
+++ b/gateway/crates/federated-server/src/server/gateway.rs
@@ -29,15 +29,16 @@ pub(crate) type EngineWatcher = watch::Receiver<Option<Arc<Engine<GatewayRuntime
 
 /// Creates a new gateway from federated schema.
 pub(super) async fn generate(
-    federated_schema: &str,
+    federated_schema: String,
     branch_id: Option<ulid::Ulid>,
     gateway_config: &Config,
     hot_reload_config_path: Option<PathBuf>,
 ) -> crate::Result<Engine<GatewayRuntime>> {
     let schema_version = blake3::hash(federated_schema.as_bytes());
-    let graph = VersionedFederatedGraph::from_sdl(federated_schema)
+    let graph = VersionedFederatedGraph::from_sdl(&federated_schema)
         .map_err(|e| crate::Error::SchemaValidationError(e.to_string()))?;
-    let config = engine_config_builder::build_with_toml_config(gateway_config, graph.into_latest()).into_latest();
+    let config = engine_config_builder::build_with_toml_config(gateway_config, graph.into_latest(), federated_schema)
+        .into_latest();
 
     // TODO: https://linear.app/grafbase/issue/GB-6168/support-trusted-documents-in-air-gapped-mode
     let trusted_documents = if gateway_config.trusted_documents.enabled {

--- a/gateway/crates/federated-server/src/server/graph_fetch_method.rs
+++ b/gateway/crates/federated-server/src/server/graph_fetch_method.rs
@@ -59,7 +59,7 @@ impl GraphFetchMethod {
                 });
             }
             GraphFetchMethod::FromLocal { federated_schema } => {
-                let gateway = gateway::generate(&federated_schema, None, config, hot_reload_config_path).await?;
+                let gateway = gateway::generate(federated_schema, None, config, hot_reload_config_path).await?;
 
                 sender.send(Some(Arc::new(gateway)))?;
             }

--- a/gateway/crates/federated-server/src/server/graph_updater.rs
+++ b/gateway/crates/federated-server/src/server/graph_updater.rs
@@ -225,7 +225,7 @@ impl GraphUpdater {
             );
 
             let gateway = match super::gateway::generate(
-                &response.sdl,
+                response.sdl,
                 Some(response.branch_id),
                 &self.gateway_config,
                 None,


### PR DESCRIPTION
When you start the gateway with `--schema` and federated SDL that contains an interface with an `@join__type` directive _without keys argument_, the gateway fails to start with the following error:

```
Error: internal error: Failed to generate engine Schema:  --> 1:4
  |
1 | {  }
  |    ^---
  |
  = expected selection
```

This error comes from `graphql_federated_graph::from_sdl()`, because we try to parse an empty string as a selection set.

The SDL that triggers the error when generating the engine Schema contains something like:

```
@join__type(graph: MY_GRAPH, key: "")
```

which is not valid. But the original SDL passed to the engine contains something like:

```
@join__type(graph: MY_GRAPH)
```

which is valid.

**How does that happen?**

The root cause is the following: `graphql_federated_graph::from_sdl()` will populate a `Key` in the `FederatedGraph` for each `@join__type` directive. The key has a selection, but in the absence of a `key` argument on the directive, that selection is empty. When we re-render that graph to SDL with
`graphql_federated_graph::render_federated_sdl()`, the rendered SDL a key argument with an empty string as a selection. When that is passed again to `from_sdl()`, we run into the error that ends up being displayed.

This error on startup is a combination of a recent change and a bug fix that missed a scenario.

The recent change is #2055. The relevant part is that we now store SDL in the `engine_v2::Config` struct instead of a structured representation of the FederatedGraph. This change should not be relevant to the gateway, but it introduced the conditions for the bug to manifest: we parse the SDL to a `FederatedGraph` to construct `Config`, then render that same `FederatedGraph` to federated SDL to store in that same `Config`. When we later instantiate the `engine_v2::Schema` from that config, we call `from_sdl()` on that SDL, completing the `from_sdl() -> render federated_sdl() -> from_sdl()` sequence that triggers the error. Ideally in the future, for the gateway, we would keep the same FederatedGraph and avoid re-instantiating.

The bug fix is f34d0bd. That fixed the empty `key` on `@join__type` on objects, but not interfaces.

**The fix**

The changes in this pull request are three fold:

1. The error message for this kind of errors will be slightly more helpful. It now looks like this:
```
      Error: Error validating federated SDL: Error parsing a selection from a federated directive:  --> 1:4
     |
   1 | {  }
     |    ^---
     |
     = expected selection
```

2. In `render_federated_sdl()`, we no longer render empty strings in `key` on `@join__type` on interfaces. That completes the bug fix in f34d0bd.
3. In the gateway, we stop rendering and re-parsing the rendered SDL. Instead, we pass the original SDL into the `engine_v2::Config`.

Any of the last two changes on their own fixes the observed bug, but combining both introduces some defense in depth. If there is another bug in `render_federated_sdl()`, 3. will prevent it from affecting gateway start up.

closes GB-7322