### PR TITLE
federated-graph: start decluttering render_federated_sdl()

### DIFF
--- a/engine/crates/composition/README.md
+++ b/engine/crates/composition/README.md
@@ -48,7 +48,7 @@ let mut subgraphs = Subgraphs::default();
 subgraphs.ingest(&user_subgraph, "users-service", "http://users.example.com");
 subgraphs.ingest(&cart_subgraph, "carts-service", "http://carts.example.com");
 
-let composed = compose(&subgraphs).into_result().unwrap().to_sdl().unwrap();
+let composed = compose(&subgraphs).into_result().unwrap().into_federated_sdl();
 
 let expected = r#"
 directive @core(feature: String!) repeatable on SCHEMA

--- a/engine/crates/federated-graph/src/render_sdl/render_api_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl/render_api_sdl.rs
@@ -233,7 +233,11 @@ fn has_inaccessible(directives: &Directives, graph: &FederatedGraph) -> bool {
         .any(|directive| matches!(directive, Directive::Inaccessible))
 }
 
-fn write_public_directives(f: &mut fmt::Formatter<'_>, directives: Directives, graph: &FederatedGraph) -> fmt::Result {
+fn write_public_directives<'a, 'b: 'a>(
+    f: &'a mut fmt::Formatter<'b>,
+    directives: Directives,
+    graph: &'a FederatedGraph,
+) -> fmt::Result {
     for directive in graph[directives].iter().filter(|directive| match directive {
         Directive::Inaccessible | Directive::Policy(_) => false,
 
@@ -243,13 +247,18 @@ fn write_public_directives(f: &mut fmt::Formatter<'_>, directives: Directives, g
         | Directive::Deprecated { .. }
         | Directive::Other { .. } => true,
     }) {
+        f.write_str(" ")?;
         write_composed_directive(f, directive, graph)?;
     }
 
     Ok(())
 }
 
-fn write_enum_variant(f: &mut fmt::Formatter<'_>, enum_variant: &EnumValue, graph: &FederatedGraph) -> fmt::Result {
+fn write_enum_variant<'a, 'b: 'a>(
+    f: &'a mut fmt::Formatter<'b>,
+    enum_variant: &EnumValue,
+    graph: &'a FederatedGraph,
+) -> fmt::Result {
     f.write_str(INDENT)?;
     write_description(f, enum_variant.description, INDENT, graph)?;
     f.write_str(&graph[enum_variant.value])?;
@@ -257,10 +266,10 @@ fn write_enum_variant(f: &mut fmt::Formatter<'_>, enum_variant: &EnumValue, grap
     f.write_char('\n')
 }
 
-fn write_field_arguments(
-    f: &mut fmt::Formatter<'_>,
+fn write_field_arguments<'a, 'b: 'a>(
+    f: &'a mut fmt::Formatter<'b>,
     args: &[InputValueDefinition],
-    graph: &FederatedGraph,
+    graph: &'a FederatedGraph,
 ) -> fmt::Result {
     if args.is_empty() {
         return Ok(());


### PR DESCRIPTION
While working on this morning's fix, I noticed this module could really do with some love. Here's what this PR starts to address:

- Align render_federated_sdl() and render_api sdl() on `fmt::Formatter` based APIs instead of writing directly to a `String`.
- Reduce the number of different ways we render directives. This PR introduces a `DirectiveWriter` abstraction that should work in the whole crate.
- Avoid the proliferation of types that only hold FederatedGraph, an item and implement Display. Functions are more concise and easy to follow.

These changes should not affect the output in any way. We have pretty extensive tests in the graphql-federated-graph and graphql-composition crates so I am fairly confident that this is the case.