### PR TITLE
engine-v2: avoid re-parsing of federated SDL

### DIFF
--- a/cli/crates/federated-dev/src/dev.rs
+++ b/cli/crates/federated-dev/src/dev.rs
@@ -49,10 +49,9 @@ pub(super) async fn run(
     log::trace!("starting the federated dev server");
 
     let (gateway_sender, gateway) = watch::channel(
-        gateway_nanny::new_gateway(graph.map(|graph| {
-            let federated_sdl = graphql_federated_graph::render_federated_sdl(&graph).unwrap();
-            engine_config_builder::build_with_sdl_config(&config.borrow(), graph, federated_sdl)
-        }))
+        gateway_nanny::new_gateway(
+            graph.map(|graph| engine_config_builder::build_with_sdl_config(&config.borrow(), graph)),
+        )
         .await,
     );
     let (websocket_sender, websocket_receiver) = mpsc::channel(16);

--- a/engine/crates/engine-config-builder/src/from_sdl_config.rs
+++ b/engine/crates/engine-config-builder/src/from_sdl_config.rs
@@ -17,11 +17,7 @@ use parser_sdl::federation::header::SubgraphHeaderRule;
 use parser_sdl::federation::{EntityCachingConfig, FederatedGraphConfig};
 use parser_sdl::{AuthV2Provider, GlobalCacheTarget};
 
-pub fn build_with_sdl_config(
-    config: &FederatedGraphConfig,
-    federated_graph: FederatedGraph,
-    federated_sdl: String,
-) -> VersionedConfig {
+pub fn build_with_sdl_config(config: &FederatedGraphConfig, federated_graph: FederatedGraph) -> VersionedConfig {
     let mut context = BuildContext::default();
     let default_header_rules = context.insert_headers(&config.header_rules);
 
@@ -33,7 +29,7 @@ pub fn build_with_sdl_config(
     }
 
     VersionedConfig::V6(config::Config {
-        federated_sdl,
+        graph: federated_graph,
         strings: context.strings.into_vec(),
         paths: context.paths.into_vec(),
         header_rules: context.header_rules,

--- a/engine/crates/engine-config-builder/src/from_toml_config.rs
+++ b/engine/crates/engine-config-builder/src/from_toml_config.rs
@@ -5,7 +5,7 @@ use parser_sdl::federation::{header::SubgraphHeaderRule, FederatedGraphConfig};
 
 use crate::build_with_sdl_config;
 
-pub fn build_with_toml_config(config: &Config, graph: FederatedGraph, federated_sdl: String) -> VersionedConfig {
+pub fn build_with_toml_config(config: &Config, graph: FederatedGraph) -> VersionedConfig {
     let mut graph_config = FederatedGraphConfig::default();
 
     if let Some(limits_config) = config.operation_limits {
@@ -56,7 +56,7 @@ pub fn build_with_toml_config(config: &Config, graph: FederatedGraph, federated_
         })
         .collect();
 
-    build_with_sdl_config(&graph_config, graph, federated_sdl)
+    build_with_sdl_config(&graph_config, graph)
 }
 
 fn retry_config(retry_config: Option<RetryConfig>) -> Option<parser_sdl::federation::RetryConfig> {

--- a/engine/crates/engine-v2/config/src/lib.rs
+++ b/engine/crates/engine-v2/config/src/lib.rs
@@ -164,7 +164,7 @@ impl VersionedConfig {
                 entity_caching,
                 retry,
             }) => v6::Config {
-                federated_sdl: federated_graph::VersionedFederatedGraph::V3(graph).into_federated_sdl(),
+                graph: federated_graph::VersionedFederatedGraph::V3(graph).into_latest(),
                 strings,
                 paths,
                 header_rules,

--- a/engine/crates/engine-v2/schema/src/builder/external_sources.rs
+++ b/engine/crates/engine-v2/schema/src/builder/external_sources.rs
@@ -1,7 +1,6 @@
 use std::{mem::take, time::Duration};
 
 use config::latest::Config;
-use federated_graph::FederatedGraph;
 
 use super::{
     sources::{
@@ -16,8 +15,8 @@ pub struct ExternalDataSources {
 }
 
 impl ExternalDataSources {
-    pub(super) fn build(ctx: &mut BuildContext, config: &mut Config, graph: &mut FederatedGraph) -> Self {
-        let endpoints = take(&mut graph.subgraphs)
+    pub(super) fn build(ctx: &mut BuildContext, config: &mut Config) -> Self {
+        let endpoints = take(&mut config.graph.subgraphs)
             .into_iter()
             .enumerate()
             .map(|(index, subgraph)| {

--- a/engine/crates/engine-v2/schema/src/builder/graph.rs
+++ b/engine/crates/engine-v2/schema/src/builder/graph.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use config::latest::{CacheConfigTarget, Config};
-use federated_graph::FederatedGraph;
 use id_newtypes::IdRange;
 use sources::{
     graphql::{FederationEntityResolverDefinition, FederationKey, GraphqlEndpointId, RootFieldResolverDefinition},
@@ -33,7 +32,6 @@ impl<'a> GraphBuilder<'a> {
         ctx: &'a mut BuildContext,
         sources: &ExternalDataSources,
         config: &mut Config,
-        graph: &mut FederatedGraph,
     ) -> Result<(Graph, IntrospectionMetadata), BuildError> {
         let mut builder = GraphBuilder {
             ctx,
@@ -44,9 +42,9 @@ impl<'a> GraphBuilder<'a> {
             graph: Graph {
                 description: None,
                 root_operation_types: RootOperationTypes {
-                    query: graph.root_operation_types.query.into(),
-                    mutation: graph.root_operation_types.mutation.map(Into::into),
-                    subscription: graph.root_operation_types.subscription.map(Into::into),
+                    query: config.graph.root_operation_types.query.into(),
+                    mutation: config.graph.root_operation_types.mutation.map(Into::into),
+                    subscription: config.graph.root_operation_types.subscription.map(Into::into),
                 },
                 object_definitions: Vec::new(),
                 interface_definitions: Vec::new(),
@@ -68,30 +66,40 @@ impl<'a> GraphBuilder<'a> {
                 authorized_directives: Vec::new(),
             },
         };
-        builder.ingest_config(config, graph);
+        builder.ingest_config(config);
         builder.finalize()
     }
 
-    fn ingest_config(&mut self, config: &mut Config, graph: &mut FederatedGraph) {
-        self.ingest_enums_before_input_values(config, graph);
+    fn ingest_config(&mut self, config: &mut Config) {
+        self.ingest_enums_before_input_values(config);
 
-        self.ingest_input_values(config, graph);
-        self.ingest_input_objects(config, graph);
-        self.ingest_unions(config, graph);
-        self.ingest_scalars(config, graph);
+        self.ingest_input_values(config);
+        self.ingest_input_objects(config);
+        self.ingest_unions(config);
+        self.ingest_scalars(config);
+
         // Not guaranteed to be sorted and rely on binary search to find the directives for a
         // field.
-        graph.object_authorized_directives.sort_unstable_by_key(|(id, _)| *id);
-        let object_metadata = self.ingest_objects(config, graph);
-        let interface_metadata = self.ingest_interfaces_after_objects(config, graph);
+        config
+            .graph
+            .object_authorized_directives
+            .sort_unstable_by_key(|(id, _)| *id);
+
+        let object_metadata = self.ingest_objects(config);
+        let interface_metadata = self.ingest_interfaces_after_objects(config);
+
         // Not guaranteed to be sorted and rely on binary search to find the directives for a
         // field.
-        graph.field_authorized_directives.sort_unstable_by_key(|(id, _)| *id);
-        self.ingest_fields_after_input_values(config, object_metadata, interface_metadata, graph);
+        config
+            .graph
+            .field_authorized_directives
+            .sort_unstable_by_key(|(id, _)| *id);
+
+        self.ingest_fields_after_input_values(config, object_metadata, interface_metadata);
     }
 
-    fn ingest_input_values(&mut self, config: &mut Config, graph: &mut FederatedGraph) {
-        self.graph.input_value_definitions = take(&mut graph.input_value_definitions)
+    fn ingest_input_values(&mut self, config: &mut Config) {
+        self.graph.input_value_definitions = take(&mut config.graph.input_value_definitions)
             .into_iter()
             .enumerate()
             .filter_map(|(idx, definition)| {
@@ -115,7 +123,6 @@ impl<'a> GraphBuilder<'a> {
                                 federated: definition.directives,
                                 ..Default::default()
                             },
-                            graph,
                         ),
                     })
                 } else {
@@ -125,8 +132,8 @@ impl<'a> GraphBuilder<'a> {
             .collect();
     }
 
-    fn ingest_input_objects(&mut self, config: &mut Config, graph: &mut FederatedGraph) {
-        self.graph.input_object_definitions = take(&mut graph.input_objects)
+    fn ingest_input_objects(&mut self, config: &mut Config) {
+        self.graph.input_object_definitions = take(&mut config.graph.input_objects)
             .into_iter()
             .enumerate()
             .filter_map(|(idx, definition)| {
@@ -141,7 +148,6 @@ impl<'a> GraphBuilder<'a> {
                                 federated: definition.composed_directives,
                                 ..Default::default()
                             },
-                            graph,
                         ),
                     })
                 } else {
@@ -151,8 +157,8 @@ impl<'a> GraphBuilder<'a> {
             .collect();
     }
 
-    fn ingest_unions(&mut self, config: &mut Config, graph: &mut FederatedGraph) {
-        self.graph.union_definitions = take(&mut graph.unions)
+    fn ingest_unions(&mut self, config: &mut Config) {
+        self.graph.union_definitions = take(&mut config.graph.unions)
             .into_iter()
             .map(|union| UnionDefinition {
                 name: union.name.into(),
@@ -160,7 +166,7 @@ impl<'a> GraphBuilder<'a> {
                 possible_types: union
                     .members
                     .into_iter()
-                    .filter(|object_id| !is_inaccessible(graph, graph[*object_id].composed_directives))
+                    .filter(|object_id| !is_inaccessible(&config.graph, config.graph[*object_id].composed_directives))
                     .map(Into::into)
                     .collect(),
                 // Added at the end.
@@ -171,18 +177,17 @@ impl<'a> GraphBuilder<'a> {
                         federated: union.composed_directives,
                         ..Default::default()
                     },
-                    graph,
                 ),
             })
             .collect();
     }
 
-    fn ingest_enums_before_input_values(&mut self, config: &mut Config, graph: &mut FederatedGraph) {
-        self.graph.enum_value_definitions = take(&mut graph.enum_values)
+    fn ingest_enums_before_input_values(&mut self, config: &mut Config) {
+        self.graph.enum_value_definitions = take(&mut config.graph.enum_values)
             .into_iter()
             .enumerate()
             .filter_map(|(idx, enum_value)| {
-                if is_inaccessible(graph, enum_value.composed_directives) {
+                if is_inaccessible(&config.graph, enum_value.composed_directives) {
                     self.ctx.idmaps.enum_values.skip(federated_graph::EnumValueId(idx));
                     None
                 } else {
@@ -195,14 +200,13 @@ impl<'a> GraphBuilder<'a> {
                                 federated: enum_value.composed_directives,
                                 ..Default::default()
                             },
-                            graph,
                         ),
                     })
                 }
             })
             .collect();
 
-        self.graph.enum_definitions = take(&mut graph.enums)
+        self.graph.enum_definitions = take(&mut config.graph.enums)
             .into_iter()
             .map(|federated_enum| EnumDefinition {
                 name: federated_enum.name.into(),
@@ -214,14 +218,13 @@ impl<'a> GraphBuilder<'a> {
                         federated: federated_enum.composed_directives,
                         ..Default::default()
                     },
-                    graph,
                 ),
             })
             .collect();
     }
 
-    fn ingest_scalars(&mut self, config: &mut Config, graph: &mut FederatedGraph) {
-        self.graph.scalar_definitions = take(&mut graph.scalars)
+    fn ingest_scalars(&mut self, config: &mut Config) {
+        self.graph.scalar_definitions = take(&mut config.graph.scalars)
             .into_iter()
             .map(|scalar| {
                 let name = StringId::from(scalar.name);
@@ -236,22 +239,21 @@ impl<'a> GraphBuilder<'a> {
                             federated: scalar.composed_directives,
                             ..Default::default()
                         },
-                        graph,
                     ),
                 }
             })
             .collect();
     }
 
-    fn ingest_objects(&mut self, config: &mut Config, graph: &mut FederatedGraph) -> ObjectMetadata {
+    fn ingest_objects(&mut self, config: &mut Config) -> ObjectMetadata {
         let mut entities_metadata = ObjectMetadata {
             entities: Default::default(),
             // At most we have as many field as the FederatedGraph
-            field_id_to_maybe_object_id: vec![None; graph.fields.len()],
+            field_id_to_maybe_object_id: vec![None; config.graph.fields.len()],
         };
 
-        self.graph.object_definitions = Vec::with_capacity(graph.objects.len());
-        for (federated_id, object) in take(&mut graph.objects).into_iter().enumerate() {
+        self.graph.object_definitions = Vec::with_capacity(config.graph.objects.len());
+        for (federated_id, object) in take(&mut config.graph.objects).into_iter().enumerate() {
             let federated_id = federated_graph::ObjectId(federated_id);
             let object_id = ObjectDefinitionId::from(self.graph.object_definitions.len());
 
@@ -274,7 +276,7 @@ impl<'a> GraphBuilder<'a> {
                     federated: object.composed_directives,
                     cache_config_target: Some(CacheConfigTarget::Object(federated_id)),
                     authorized_directives: {
-                        let mapping = &graph.object_authorized_directives;
+                        let mapping = &config.graph.object_authorized_directives;
                         let mut i = mapping.partition_point(|(id, _)| *id < federated_id);
                         let mut ids = Vec::new();
                         while i < mapping.len() && mapping[i].0 == federated_id {
@@ -284,7 +286,6 @@ impl<'a> GraphBuilder<'a> {
                         Some((schema_location, ids))
                     },
                 },
-                graph,
             );
             self.graph.object_definitions.push(ObjectDefinition {
                 name: object.name.into(),
@@ -302,19 +303,15 @@ impl<'a> GraphBuilder<'a> {
         entities_metadata
     }
 
-    fn ingest_interfaces_after_objects(
-        &mut self,
-        config: &mut Config,
-        graph: &mut FederatedGraph,
-    ) -> InterfaceMetadata {
+    fn ingest_interfaces_after_objects(&mut self, config: &mut Config) -> InterfaceMetadata {
         let mut entities_metadata = InterfaceMetadata {
             entities: Default::default(),
             // At most we have as many field as the FederatedGraph
-            field_id_to_maybe_interface_id: vec![None; graph.fields.len()],
+            field_id_to_maybe_interface_id: vec![None; config.graph.fields.len()],
         };
 
-        self.graph.interface_definitions = Vec::with_capacity(graph.interfaces.len());
-        for interface in take(&mut graph.interfaces) {
+        self.graph.interface_definitions = Vec::with_capacity(config.graph.interfaces.len());
+        for interface in take(&mut config.graph.interfaces) {
             let interface_id = InterfaceDefinitionId::from(self.graph.interface_definitions.len());
             let fields = self.ctx.idmaps.field.get_range((
                 interface.fields.start,
@@ -329,7 +326,6 @@ impl<'a> GraphBuilder<'a> {
                     federated: interface.composed_directives,
                     ..Default::default()
                 },
-                graph,
             );
             self.graph.interface_definitions.push(InterfaceDefinition {
                 name: interface.name.into(),
@@ -367,7 +363,6 @@ impl<'a> GraphBuilder<'a> {
         config: &mut Config,
         object_metadata: ObjectMetadata,
         interface_metadata: InterfaceMetadata,
-        graph: &mut FederatedGraph,
     ) {
         let root_fields = {
             let mut root_fields = vec![];
@@ -384,7 +379,7 @@ impl<'a> GraphBuilder<'a> {
         };
 
         let mut root_field_resolvers = HashMap::<GraphqlEndpointId, ResolverDefinitionId>::new();
-        for (federated_id, field) in take(&mut graph.fields).into_iter().enumerate() {
+        for (federated_id, field) in take(&mut config.graph.fields).into_iter().enumerate() {
             let federated_id = federated_graph::FieldId(federated_id);
             let Some(field_id) = self.ctx.idmaps.field.get(federated_id) else {
                 continue;
@@ -472,7 +467,7 @@ impl<'a> GraphBuilder<'a> {
                     federated: field.composed_directives,
                     cache_config_target: Some(CacheConfigTarget::Field(federated_id)),
                     authorized_directives: {
-                        let mapping = &graph.field_authorized_directives;
+                        let mapping = &config.graph.field_authorized_directives;
                         let mut i = mapping.partition_point(|(id, _)| *id < federated_id);
                         let mut ids = Vec::new();
                         while i < mapping.len() && mapping[i].0 == federated_id {
@@ -482,7 +477,6 @@ impl<'a> GraphBuilder<'a> {
                         Some((schema_location, ids))
                     },
                 },
-                graph,
             );
 
             self.graph.field_definitions.push(FieldDefinition {
@@ -653,15 +647,10 @@ impl<'a> GraphBuilder<'a> {
         resolver_id
     }
 
-    fn push_directives(
-        &mut self,
-        config: &Config,
-        directives: Directives,
-        graph: &FederatedGraph,
-    ) -> IdRange<TypeSystemDirectiveId> {
+    fn push_directives(&mut self, config: &Config, directives: Directives) -> IdRange<TypeSystemDirectiveId> {
         let start = self.graph.type_system_directives.len();
 
-        for directive in &graph[directives.federated] {
+        for directive in &config.graph[directives.federated] {
             let directive = match directive {
                 federated_graph::Directive::Authenticated => TypeSystemDirective::Authenticated,
                 federated_graph::Directive::RequiresScopes(federated_scopes) => {
@@ -705,7 +694,7 @@ impl<'a> GraphBuilder<'a> {
                     arguments,
                     metadata,
                     node,
-                } = &graph[id];
+                } = &config.graph[id];
 
                 self.graph.authorized_directives.push(AuthorizedDirective {
                     arguments: arguments

--- a/engine/crates/integration-tests/src/federation/builder.rs
+++ b/engine/crates/integration-tests/src/federation/builder.rs
@@ -139,13 +139,11 @@ impl EngineV2Builder {
                 }
             });
 
-        let federated_sdl = graph.into_federated_sdl();
-
         // Ensure SDL/JSON serialization work as a expected
         let graph = {
-            let sdl = &federated_sdl;
+            let sdl = graph.into_federated_sdl();
             println!("{sdl}");
-            let mut graph = VersionedFederatedGraph::from_sdl(sdl).unwrap();
+            let mut graph = VersionedFederatedGraph::from_sdl(&sdl).unwrap();
             let json = serde_json::to_value(&graph).unwrap();
             graph = serde_json::from_value(json).unwrap();
             graph
@@ -155,12 +153,12 @@ impl EngineV2Builder {
             Some(ConfigSource::Toml(toml)) => {
                 let config: gateway_config::Config = toml::from_str(&toml).unwrap();
                 update_runtime_with_toml_config(&mut self.runtime, &config);
-                build_with_toml_config(&config, graph.into_latest(), federated_sdl)
+                build_with_toml_config(&config, graph.into_latest())
             }
             Some(ConfigSource::Sdl(mut sdl)) => {
                 sdl.push_str("\nextend schema @graph(type: federated)");
                 let config = parse_sdl_config(&sdl).await;
-                build_with_sdl_config(&config, graph.into_latest(), federated_sdl)
+                build_with_sdl_config(&config, graph.into_latest())
             }
             Some(ConfigSource::SdlWebsocket) => {
                 let mut sdl = String::new();
@@ -174,9 +172,9 @@ impl EngineV2Builder {
                 }
 
                 let config = parse_sdl_config(&sdl).await;
-                build_with_sdl_config(&config, graph.into_latest(), federated_sdl)
+                build_with_sdl_config(&config, graph.into_latest())
             }
-            None => build_with_sdl_config(&Default::default(), graph.into_latest(), federated_sdl),
+            None => build_with_sdl_config(&Default::default(), graph.into_latest()),
         }
         .into_latest();
 

--- a/engine/crates/integration-tests/src/federation/builder/bench.rs
+++ b/engine/crates/integration-tests/src/federation/builder/bench.rs
@@ -60,9 +60,8 @@ impl<'a> DeterministicEngineBuilder<'a> {
                 .collect(),
             dummy_responses_index.clone(),
         );
-        let config =
-            engine_v2::VersionedConfig::V6(engine_v2::config::Config::from_federated_sdl(self.schema.to_owned()))
-                .into_latest();
+        let graph = federated_graph::from_sdl(self.schema).unwrap();
+        let config = engine_v2::VersionedConfig::V6(engine_v2::config::Config::from_graph(graph)).into_latest();
 
         let engine = engine_v2::Engine::new(
             Arc::new(config.try_into().unwrap()),

--- a/gateway/crates/federated-server/src/server/gateway.rs
+++ b/gateway/crates/federated-server/src/server/gateway.rs
@@ -37,8 +37,7 @@ pub(super) async fn generate(
     let schema_version = blake3::hash(federated_schema.as_bytes());
     let graph = VersionedFederatedGraph::from_sdl(&federated_schema)
         .map_err(|e| crate::Error::SchemaValidationError(e.to_string()))?;
-    let config = engine_config_builder::build_with_toml_config(gateway_config, graph.into_latest(), federated_schema)
-        .into_latest();
+    let config = engine_config_builder::build_with_toml_config(gateway_config, graph.into_latest()).into_latest();
 
     // TODO: https://linear.app/grafbase/issue/GB-6168/support-trusted-documents-in-air-gapped-mode
     let trusted_documents = if gateway_config.trusted_documents.enabled {


### PR DESCRIPTION
This is a follow up to https://github.com/grafbase/grafbase/pull/2064.

We went into cycles of rendering and parsing federated SDL, creating the conditions for the bug in render_federated_sdl() to manifest on engine start up.

This change makes sure we parse only once, _either_ when constructing it when instantiating Config directly, _or_ during deserialization.

closes GB-7388