### PR TITLE
feat: plug new hook to the runtime with the channel logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2899,7 +2899,6 @@ dependencies = [
  "axum-server",
  "blake3",
  "cfg-if",
- "crossbeam",
  "engine-config-builder",
  "engine-v2",
  "engine-v2-axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2899,6 +2899,7 @@ dependencies = [
  "axum-server",
  "blake3",
  "cfg-if",
+ "crossbeam",
  "engine-config-builder",
  "engine-v2",
  "engine-v2-axum",
@@ -2919,6 +2920,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-appender",
  "ulid",
  "url",
 ]
@@ -9305,6 +9307,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "parking_lot",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/engine/crates/engine-v2/src/execution/hooks/mod.rs
+++ b/engine/crates/engine-v2/src/execution/hooks/mod.rs
@@ -5,6 +5,7 @@ use crate::Runtime;
 use super::{ExecutionContext, PreExecutionContext};
 
 mod authorized;
+mod responses;
 mod subgraph;
 
 pub(crate) struct RequestHooks<'ctx, H: Hooks> {

--- a/engine/crates/engine-v2/src/execution/hooks/responses.rs
+++ b/engine/crates/engine-v2/src/execution/hooks/responses.rs
@@ -1,0 +1,39 @@
+use runtime::hooks::{
+    ExecutedGatewayRequest, ExecutedHttpRequest, ExecutedSubgraphRequest, Hooks, Operation, ResponseHooks,
+};
+use tracing::{instrument, Level};
+
+use crate::response::GraphqlError;
+
+impl<'ctx, H: Hooks> super::RequestHooks<'ctx, H> {
+    #[instrument(skip_all, ret(level = Level::DEBUG))]
+    pub async fn on_subgraph_response(&self, request: ExecutedSubgraphRequest<'_>) -> Result<Vec<u8>, GraphqlError> {
+        self.hooks
+            .responses()
+            .on_subgraph_response(self.context, request)
+            .await
+            .map_err(Into::into)
+    }
+
+    #[instrument(skip_all, ret(level = Level::DEBUG))]
+    pub async fn on_gateway_response(
+        &self,
+        operation: Operation<'_>,
+        request: ExecutedGatewayRequest,
+    ) -> Result<Vec<u8>, GraphqlError> {
+        self.hooks
+            .responses()
+            .on_gateway_response(self.context, operation, request)
+            .await
+            .map_err(Into::into)
+    }
+
+    #[instrument(skip_all, ret(level = Level::DEBUG))]
+    pub async fn on_http_response(&self, request: ExecutedHttpRequest<'_>) -> Result<(), GraphqlError> {
+        self.hooks
+            .responses()
+            .on_http_response(self.context, request)
+            .await
+            .map_err(Into::into)
+    }
+}

--- a/engine/crates/engine-v2/src/response/mod.rs
+++ b/engine/crates/engine-v2/src/response/mod.rs
@@ -42,6 +42,9 @@ pub(crate) enum Response {
 pub(crate) struct ExecutedResponse {
     data: Option<ResponseData>,
     errors: Vec<GraphqlError>,
+    // TODO: next PR
+    #[allow(dead_code)]
+    on_subgraph_response_hook_results: Vec<Vec<u8>>,
 }
 
 impl ExecutedResponse {
@@ -93,6 +96,7 @@ impl Response {
         Self::Executed(ExecutedResponse {
             data: None,
             errors: errors.into_iter().map(Into::into).collect(),
+            on_subgraph_response_hook_results: Vec::new(),
         })
     }
 
@@ -130,6 +134,16 @@ impl Response {
                 set |= error.code;
                 set
             })
+    }
+
+    /// TODO: This one might be the way of getting the response data for the next hook. We need a mutable response
+    /// at this point.
+    pub(crate) fn _take_subgraph_response_hook_results(&mut self) -> Vec<Vec<u8>> {
+        match self {
+            Response::RefusedRequest(_) => Vec::new(),
+            Response::RequestError(_) => Vec::new(),
+            Response::Executed(response) => std::mem::take(&mut response.on_subgraph_response_hook_results),
+        }
     }
 }
 

--- a/engine/crates/engine-v2/src/sources/graphql/federation.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/federation.rs
@@ -117,9 +117,7 @@ impl<'ctx> FederationEntityRequest<'ctx> {
                 cache_ttl,
             };
 
-            let headers = ctx
-                .execution_context()
-                .subgraph_headers_with_rules(ctx.endpoint().header_rules());
+            let headers = ctx.subgraph_headers_with_rules(ctx.endpoint().header_rules());
 
             if cache_ttl.is_some() {
                 match cache_fetches(

--- a/engine/crates/engine-v2/src/sources/graphql/federation.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/federation.rs
@@ -2,23 +2,23 @@ use bytes::Bytes;
 use futures::future::join_all;
 use grafbase_telemetry::{gql_response_status::GraphqlResponseStatus, span::subgraph::SubgraphRequestSpan};
 use http::HeaderMap;
-use runtime::bytes::OwnedOrSharedBytes;
+use runtime::{bytes::OwnedOrSharedBytes, hooks::CacheStatus};
 use schema::sources::graphql::{FederationEntityResolveDefinitionrWalker, GraphqlEndpointId, GraphqlEndpointWalker};
 use serde::{de::DeserializeSeed, Deserialize};
 use serde_json::value::RawValue;
-use std::{borrow::Cow, future::Future, time::Duration};
+use std::{borrow::Cow, time::Duration};
 use tracing::Instrument;
 
 use crate::{
     execution::{ExecutionContext, ExecutionError, PlanningResult},
-    operation::{CacheScope, OperationType, PlanWalker},
+    operation::{OperationType, PlanWalker},
     response::{ResponseObjectsView, SubgraphResponse},
     sources::{
         graphql::{
             deserialize::{EntitiesErrorsSeed, GraphqlResponseSeed},
             request::{SubgraphGraphqlRequest, SubgraphVariables},
         },
-        ExecutionResult, Resolver,
+        ExecutionResult, Resolver, SubgraphRequestContext,
     },
     Runtime,
 };
@@ -33,7 +33,6 @@ use super::{
 pub(crate) struct FederationEntityResolver {
     endpoint_id: GraphqlEndpointId,
     operation: PreparedFederationEntityOperation,
-    cache_scopes: Vec<String>,
 }
 
 impl FederationEntityResolver {
@@ -43,130 +42,149 @@ impl FederationEntityResolver {
     ) -> PlanningResult<Resolver> {
         let operation =
             PreparedFederationEntityOperation::build(plan).map_err(|err| format!("Failed to build query: {err}"))?;
+
         Ok(Resolver::FederationEntity(Self {
             endpoint_id: definition.endpoint().id(),
             operation,
-            cache_scopes: plan
-                .cache_scopes()
-                .map(|scope| match scope {
-                    CacheScope::Authenticated => "authenticated".into(),
-                    CacheScope::RequiresScopes(scopes) => {
-                        let mut hasher = blake3::Hasher::new();
-                        hasher.update(b"requiresScopes");
-                        hasher.update(&scopes.scopes().len().to_le_bytes());
-                        for scope in scopes.scopes() {
-                            hasher.update(&scope.len().to_le_bytes());
-                            hasher.update(scope.as_bytes());
-                        }
-                        hasher.finalize().to_hex().to_string()
-                    }
-                })
-                .collect(),
         }))
     }
 
-    pub fn execute<'ctx, 'fut, R: Runtime>(
+    #[tracing::instrument(skip_all)]
+    pub fn prepare_request<'ctx, R: Runtime>(
         &'ctx self,
         ctx: ExecutionContext<'ctx, R>,
         plan: PlanWalker<'ctx, (), ()>,
         root_response_objects: ResponseObjectsView<'_>,
         subgraph_response: SubgraphResponse,
-    ) -> ExecutionResult<impl Future<Output = ExecutionResult<SubgraphResponse>> + Send + 'fut>
-    where
-        'ctx: 'fut,
-    {
+    ) -> ExecutionResult<FederationEntityRequest<'ctx>> {
         let root_response_objects = root_response_objects.with_extra_constant_fields(vec![(
             "__typename".to_string(),
             serde_json::Value::String(entity_name(ctx, plan)),
         )]);
-        let mut representations = root_response_objects
+
+        let representations = root_response_objects
             .iter()
             .map(|object| serde_json::value::to_raw_value(&object))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let endpoint = ctx.engine.schema.walk(self.endpoint_id);
+        Ok(FederationEntityRequest {
+            resolver: self,
+            subgraph_response,
+            representations,
+        })
+    }
+
+    pub(crate) fn endpoint<'ctx, R: Runtime>(&self, ctx: ExecutionContext<'ctx, R>) -> GraphqlEndpointWalker<'ctx> {
+        ctx.engine.schema.walk(self.endpoint_id)
+    }
+}
+
+pub(crate) struct FederationEntityRequest<'ctx> {
+    resolver: &'ctx FederationEntityResolver,
+    subgraph_response: SubgraphResponse,
+    representations: Vec<Box<RawValue>>,
+}
+
+impl<'ctx> FederationEntityRequest<'ctx> {
+    pub async fn execute<R: Runtime>(
+        self,
+        ctx: &mut SubgraphRequestContext<'ctx, R>,
+    ) -> ExecutionResult<SubgraphResponse> {
+        let Self {
+            resolver: FederationEntityResolver { operation, .. },
+            subgraph_response,
+            mut representations,
+        } = self;
+
         let span = SubgraphRequestSpan {
-            name: endpoint.subgraph_name(),
+            name: ctx.endpoint().subgraph_name(),
             operation_type: OperationType::Query.as_str(),
             // The generated query does not contain any data, everything are in the variables, so
             // it's safe to use.
-            sanitized_query: &self.operation.query,
-            url: endpoint.url(),
+            sanitized_query: &operation.query,
+            url: ctx.endpoint().url(),
         }
         .into_span();
 
-        let cache_ttl = endpoint.entity_cache_ttl();
+        let cache_ttl = ctx.endpoint().entity_cache_ttl();
+        let span_clone = span.clone();
 
-        let fut = {
-            let span = span.clone();
-            async move {
-                let mut ingester = EntityIngester {
-                    ctx,
-                    cache_entries: None,
-                    subgraph_response,
-                    cache_ttl,
-                };
+        async move {
+            let mut ingester = EntityIngester {
+                ctx: ctx.execution_context(),
+                cache_entries: None,
+                subgraph_response,
+                cache_ttl,
+            };
 
-                let headers = ctx.subgraph_headers_with_rules(endpoint.header_rules());
+            let headers = ctx
+                .execution_context()
+                .subgraph_headers_with_rules(ctx.endpoint().header_rules());
 
-                if cache_ttl.is_some() {
-                    match cache_fetches(ctx, endpoint, &headers, representations, &self.cache_scopes).await {
-                        CacheFetchOutcome::FullyCached { cache_entries } => {
-                            ingester.cache_entries = Some(cache_entries);
-
-                            let (_, response) = ingester
-                                .ingest(http::Response::new(
-                                    Bytes::from_static(br#"{"data": {"_entities": []}}"#).into(),
-                                ))
-                                .await?;
-
-                            return Ok(response);
-                        }
-                        CacheFetchOutcome::Other {
-                            cache_entries,
-                            filtered_representations,
-                        } => {
-                            ingester.cache_entries = cache_entries;
-                            representations = filtered_representations;
-                        }
-                    }
-                }
-                let variables = SubgraphVariables {
-                    plan,
-                    variables: &self.operation.variables,
-                    extra_variables: vec![(&self.operation.entities_variable_name, representations)],
-                };
-
-                tracing::debug!(
-                    "Executing request to subgraph named '{}' with query and variables:\n{}\n{}",
-                    endpoint.subgraph_name(),
-                    self.operation.query,
-                    serde_json::to_string_pretty(&variables).unwrap_or_default()
-                );
-
-                let body = serde_json::to_vec(&SubgraphGraphqlRequest {
-                    query: &self.operation.query,
-                    variables,
-                })
-                .map_err(|err| format!("Failed to serialize query: {err}"))?;
-
-                let retry_budget = ctx.engine.get_retry_budget_for_non_mutation(self.endpoint_id);
-
-                execute_subgraph_request(
-                    ctx,
-                    span.clone(),
-                    self.endpoint_id,
-                    retry_budget,
-                    headers,
-                    Bytes::from(body),
-                    ingester,
+            if cache_ttl.is_some() {
+                match cache_fetches(
+                    ctx.execution_context(),
+                    ctx.endpoint(),
+                    &headers,
+                    representations,
+                    &ctx.cache_scopes(),
                 )
                 .await
-            }
-        }
-        .instrument(span);
+                {
+                    CacheFetchOutcome::FullyCached { cache_entries } => {
+                        ingester.cache_entries = Some(cache_entries);
 
-        Ok(fut)
+                        let (_, response) = ingester
+                            .ingest(http::Response::new(
+                                Bytes::from_static(br#"{"data": {"_entities": []}}"#).into(),
+                            ))
+                            .await?;
+
+                        return Ok(response);
+                    }
+                    CacheFetchOutcome::Other {
+                        cache_entries,
+                        filtered_representations,
+                    } => {
+                        if cache_entries
+                            .as_ref()
+                            .map(|entries| entries.iter().any(|e| e.is_hit()))
+                            .unwrap_or(true)
+                        {
+                            ctx.request_info().set_cache_status(CacheStatus::PartialHit);
+                        } else {
+                            ctx.request_info().set_cache_status(CacheStatus::Miss);
+                        }
+
+                        ingester.cache_entries = cache_entries;
+                        representations = filtered_representations;
+                    }
+                }
+            }
+
+            let variables = SubgraphVariables {
+                plan: ctx.plan(),
+                variables: &operation.variables,
+                extra_variables: vec![(&operation.entities_variable_name, representations)],
+            };
+
+            tracing::debug!(
+                "Executing request to subgraph named '{}' with query and variables:\n{}\n{}",
+                ctx.endpoint().subgraph_name(),
+                self.resolver.operation.query,
+                serde_json::to_string_pretty(&variables).unwrap_or_default()
+            );
+
+            let body = serde_json::to_vec(&SubgraphGraphqlRequest {
+                query: &operation.query,
+                variables,
+            })
+            .map_err(|err| format!("Failed to serialize query: {err}"))?;
+
+            execute_subgraph_request(ctx, span, headers, Bytes::from(body), ingester).await
+        }
+        .instrument(span_clone)
+        .await
     }
 }
 
@@ -226,6 +244,10 @@ pub enum CacheEntry {
 impl CacheEntry {
     pub fn is_miss(&self) -> bool {
         matches!(self, CacheEntry::Miss { .. })
+    }
+
+    pub fn is_hit(&self) -> bool {
+        matches!(self, CacheEntry::Hit { .. })
     }
 
     pub fn as_data(&self) -> Option<&[u8]> {
@@ -326,9 +348,9 @@ struct Data<'a> {
     entities: Vec<&'a serde_json::value::RawValue>,
 }
 
-async fn cache_fetch<R: Runtime>(
-    ctx: ExecutionContext<'_, R>,
-    endpoint: GraphqlEndpointWalker<'_>,
+async fn cache_fetch<'ctx, R: Runtime>(
+    ctx: ExecutionContext<'ctx, R>,
+    endpoint: GraphqlEndpointWalker<'ctx>,
     headers: &HeaderMap,
     repr: &RawValue,
     additional_scopes: &[String],

--- a/engine/crates/engine-v2/src/sources/graphql/request/execute.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/request/execute.rs
@@ -11,17 +11,16 @@ use headers::HeaderMapExt;
 use runtime::{
     bytes::OwnedOrSharedBytes,
     fetch::{FetchRequest, FetchResult, Fetcher},
+    hooks::{ResponseInfo, ResponseKind},
     rate_limiting::RateLimitKey,
 };
-use schema::sources::graphql::{GraphqlEndpointId, GraphqlEndpointWalker};
-use tower::retry::budget::Budget;
 use tracing::Span;
 use web_time::{Duration, SystemTime};
 
 use crate::{
-    execution::{ExecutionContext, ExecutionError, ExecutionResult},
+    execution::{ExecutionError, ExecutionResult},
     response::SubgraphResponse,
-    sources::graphql::record,
+    sources::{graphql::record, SubgraphRequestContext},
     Runtime,
 };
 
@@ -33,21 +32,23 @@ pub trait ResponseIngester: Send {
 }
 
 pub(crate) async fn execute_subgraph_request<'ctx, 'a, R: Runtime>(
-    ctx: ExecutionContext<'ctx, R>,
+    ctx: &mut SubgraphRequestContext<'ctx, R>,
     span: Span,
-    endpoint_id: GraphqlEndpointId,
-    retry_budget: Option<&Budget>,
     headers: http::HeaderMap,
     body: Bytes,
     ingester: impl ResponseIngester,
 ) -> ExecutionResult<SubgraphResponse> {
-    let endpoint = ctx.schema().walk(endpoint_id);
+    let endpoint = ctx.endpoint();
 
     let request = {
         let mut headers = ctx
             .hooks()
             .on_subgraph_request(endpoint.subgraph_name(), http::Method::POST, endpoint.url(), headers)
-            .await?;
+            .await
+            .map_err(|error| {
+                ctx.request_info().push_response(ResponseKind::HookError);
+                error
+            })?;
 
         headers.typed_insert(headers::ContentType::json());
         headers.typed_insert(headers::ContentLength(body.len() as u64));
@@ -69,10 +70,11 @@ pub(crate) async fn execute_subgraph_request<'ctx, 'a, R: Runtime>(
     };
 
     let start = SystemTime::now();
+    let execution_context = ctx.execution_context();
 
-    let response = retrying_fetch(ctx, endpoint, retry_budget, move || {
-        record::subgraph_request_size(ctx, endpoint, request.body.len());
-        ctx.engine.runtime.fetcher().fetch(request.clone())
+    let response = retrying_fetch(ctx, move || {
+        record::subgraph_request_size(execution_context, endpoint, request.body.len());
+        execution_context.engine.runtime.fetcher().fetch(request.clone())
     })
     .await;
 
@@ -84,47 +86,63 @@ pub(crate) async fn execute_subgraph_request<'ctx, 'a, R: Runtime>(
         Ok(response) => response,
         Err(e) => {
             let status = SubgraphResponseStatus::HttpError;
-            record::subgraph_duration(ctx, endpoint, status, None, duration);
+
+            ctx.request_info().set_graphql_status(status);
+            record::subgraph_duration(execution_context, endpoint, status, None, duration);
 
             return Err(e);
         }
     };
 
     tracing::debug!("Received response:\n{}", String::from_utf8_lossy(response.body()));
-    record::subgraph_response_size(ctx, endpoint, response.body().len());
+    record::subgraph_response_size(execution_context, endpoint, response.body().len());
 
     let status_code = response.status();
 
     let (status, response) = ingester.ingest(response).await.inspect_err(|err| {
         let subgraph_status = SubgraphResponseStatus::InvalidResponseError;
 
+        ctx.request_info().set_graphql_status(subgraph_status);
         span.record_subgraph_status(subgraph_status);
-        record::subgraph_duration(ctx, endpoint, subgraph_status, Some(status_code), duration);
+
+        record::subgraph_duration(
+            execution_context,
+            endpoint,
+            subgraph_status,
+            Some(status_code),
+            duration,
+        );
 
         tracing::debug!("invalid subgraph response: {err}");
     })?;
 
     let subgraph_status = SubgraphResponseStatus::GraphqlResponse(status);
+    ctx.request_info().set_graphql_status(subgraph_status);
 
     span.record_subgraph_status(subgraph_status);
-    record::subgraph_duration(ctx, endpoint, subgraph_status, Some(status_code), duration);
+
+    record::subgraph_duration(
+        execution_context,
+        endpoint,
+        subgraph_status,
+        Some(status_code),
+        duration,
+    );
 
     Ok(response)
 }
 
-pub(crate) async fn retrying_fetch<'ctx, R: Runtime, F, T>(
-    ctx: ExecutionContext<'ctx, R>,
-    endpoint: GraphqlEndpointWalker<'_>,
-    retry_budget: Option<&Budget>,
+async fn retrying_fetch<'ctx, R: Runtime, F, T>(
+    ctx: &mut SubgraphRequestContext<'ctx, R>,
     fetch: impl Fn() -> F + Send + Sync,
-) -> ExecutionResult<T>
+) -> ExecutionResult<http::Response<T>>
 where
-    F: Future<Output = FetchResult<T>> + Send,
+    F: Future<Output = FetchResult<http::Response<T>>> + Send,
     T: Send,
 {
-    let mut result = rate_limited_fetch(ctx, endpoint, &fetch).await;
+    let mut result = rate_limited_fetch(ctx, &fetch).await;
 
-    let Some(retry_budget) = retry_budget else {
+    if ctx.retry_budget().is_none() {
         return result;
     };
 
@@ -133,23 +151,28 @@ where
     loop {
         match result {
             Ok(bytes) => {
-                retry_budget.deposit();
+                if let Some(b) = ctx.retry_budget() {
+                    b.deposit()
+                }
                 return Ok(bytes);
             }
             Err(err) => {
-                if retry_budget.withdraw().is_ok() {
+                let withdraw = ctx.retry_budget().and_then(|b| b.withdraw().ok());
+
+                if withdraw.is_some() {
                     let jitter = rand::random::<f64>() * 2.0;
                     let exp_backoff = (100 * 2u64.pow(counter)) as f64;
                     let backoff_ms = (exp_backoff * jitter).round() as u64;
 
-                    ctx.engine.runtime.sleep(Duration::from_millis(backoff_ms)).await;
-                    record::subgraph_retry(ctx, endpoint, false);
+                    ctx.engine().runtime.sleep(Duration::from_millis(backoff_ms)).await;
+                    record::subgraph_retry(ctx.execution_context(), ctx.endpoint(), false);
 
                     counter += 1;
 
-                    result = rate_limited_fetch(ctx, endpoint, &fetch).await;
+                    result = rate_limited_fetch(ctx, &fetch).await;
                 } else {
-                    record::subgraph_retry(ctx, endpoint, true);
+                    record::subgraph_retry(ctx.execution_context(), ctx.endpoint(), true);
+
                     return Err(err);
                 }
             }
@@ -158,26 +181,40 @@ where
 }
 
 async fn rate_limited_fetch<'ctx, R: Runtime, F, T>(
-    ctx: ExecutionContext<'ctx, R>,
-    endpoint: GraphqlEndpointWalker<'ctx>,
+    ctx: &mut SubgraphRequestContext<'ctx, R>,
     fetch: impl Fn() -> F + Send,
-) -> ExecutionResult<T>
+) -> ExecutionResult<http::Response<T>>
 where
-    F: Future<Output = FetchResult<T>> + Send,
+    F: Future<Output = FetchResult<http::Response<T>>> + Send,
     T: Send,
 {
-    ctx.engine
+    ctx.engine()
         .runtime
         .rate_limiter()
-        .limit(&RateLimitKey::Subgraph(endpoint.subgraph_name().into()))
-        .await?;
+        .limit(&RateLimitKey::Subgraph(ctx.endpoint().subgraph_name().into()))
+        .await
+        .map_err(|e| {
+            ctx.request_info().push_response(ResponseKind::RateLimited);
+            e
+        })?;
 
-    record::increment_inflight_requests(ctx, endpoint);
-    let result = fetch().await;
-    record::decrement_inflight_requests(ctx, endpoint);
+    record::increment_inflight_requests(ctx.execution_context(), ctx.endpoint());
+    let mut result = fetch().await;
+    record::decrement_inflight_requests(ctx.execution_context(), ctx.endpoint());
+
+    match result {
+        Ok(ref mut response) => {
+            if let Some(info) = response.extensions_mut().remove::<ResponseInfo>() {
+                ctx.request_info().push_response(ResponseKind::Responsed(info));
+            }
+        }
+        Err(_) => {
+            ctx.request_info().push_response(ResponseKind::RequestError);
+        }
+    }
 
     result.map_err(|error| ExecutionError::Fetch {
-        subgraph_name: endpoint.subgraph_name().to_string(),
+        subgraph_name: ctx.endpoint().subgraph_name().to_string(),
         error,
     })
 }

--- a/engine/crates/engine-v2/src/sources/graphql/root_fields.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/root_fields.rs
@@ -2,8 +2,8 @@ use std::{borrow::Cow, time::Duration};
 
 use bytes::Bytes;
 use grafbase_telemetry::{gql_response_status::GraphqlResponseStatus, span::subgraph::SubgraphRequestSpan};
-use runtime::bytes::OwnedOrSharedBytes;
-use schema::sources::graphql::{GraphqlEndpointId, RootFieldResolverDefinitionWalker};
+use runtime::{bytes::OwnedOrSharedBytes, hooks::CacheStatus};
+use schema::sources::graphql::{GraphqlEndpointId, GraphqlEndpointWalker, RootFieldResolverDefinitionWalker};
 use serde::de::DeserializeSeed;
 use tracing::Instrument;
 
@@ -18,7 +18,7 @@ use crate::{
     response::SubgraphResponse,
     sources::{
         graphql::{record, request::SubgraphGraphqlRequest},
-        ExecutionContext, ExecutionResult, Resolver,
+        ExecutionContext, ExecutionResult, Resolver, SubgraphRequestContext,
     },
     Runtime,
 };
@@ -45,20 +45,18 @@ impl GraphqlResolver {
 
     pub async fn execute<'ctx, R: Runtime>(
         &'ctx self,
-        ctx: ExecutionContext<'ctx, R>,
-        plan: PlanWalker<'ctx, (), ()>,
+        ctx: &mut SubgraphRequestContext<'ctx, R>,
         mut subgraph_response: SubgraphResponse,
     ) -> ExecutionResult<SubgraphResponse> {
-        let endpoint = plan.schema().walk(self.endpoint_id);
         let variables = SubgraphVariables::<()> {
-            plan,
+            plan: ctx.plan(),
             variables: &self.operation.variables,
             extra_variables: Vec::new(),
         };
 
         tracing::debug!(
             "Executing request to subgraph named '{}' with query and variables:\n{}\n{}",
-            endpoint.subgraph_name(),
+            ctx.endpoint().subgraph_name(),
             self.operation.query,
             serde_json::to_string_pretty(&variables).unwrap_or_default()
         );
@@ -69,14 +67,16 @@ impl GraphqlResolver {
         })
         .map_err(|err| format!("Failed to serialize query: {err}"))?;
 
-        let headers = ctx.subgraph_headers_with_rules(endpoint.header_rules());
+        let headers = ctx
+            .execution_context()
+            .subgraph_headers_with_rules(ctx.endpoint().header_rules());
 
-        let subgraph_cache_ttl = endpoint.entity_cache_ttl();
-        let cache_key = build_cache_key(endpoint.subgraph_name(), &body, &headers);
+        let subgraph_cache_ttl = ctx.endpoint().entity_cache_ttl();
+        let cache_key = build_cache_key(ctx.endpoint().subgraph_name(), &body, &headers);
 
         if let Some((_, cache_key)) = subgraph_cache_ttl.zip(cache_key.as_ref()) {
             let cache_entry = ctx
-                .engine
+                .engine()
                 .runtime
                 .entity_cache()
                 .get(cache_key)
@@ -86,54 +86,54 @@ impl GraphqlResolver {
                 .flatten();
 
             if let Some(bytes) = cache_entry {
-                record::record_subgraph_cache_hit(ctx, endpoint);
+                ctx.request_info().set_cache_status(CacheStatus::Hit);
+                record::record_subgraph_cache_hit(ctx.execution_context(), ctx.endpoint());
 
                 let response = subgraph_response.as_mut();
 
                 GraphqlResponseSeed::new(
-                    response.next_seed(ctx).ok_or("No object to update")?,
-                    RootGraphqlErrors::new(ctx, response),
+                    response
+                        .next_seed(ctx.execution_context())
+                        .ok_or("No object to update")?,
+                    RootGraphqlErrors::new(ctx.execution_context(), response),
                 )
                 .deserialize(&mut serde_json::Deserializer::from_slice(&bytes))?;
 
                 return Ok(subgraph_response);
             } else {
-                record::record_subgraph_cache_miss(ctx, endpoint);
+                ctx.request_info().set_cache_status(CacheStatus::Miss);
+                record::record_subgraph_cache_miss(ctx.execution_context(), ctx.endpoint());
             }
         };
 
-        let retry_budget = if self.operation.ty.is_mutation() {
-            ctx.engine.get_retry_budget_for_mutation(self.endpoint_id)
-        } else {
-            ctx.engine.get_retry_budget_for_non_mutation(self.endpoint_id)
-        };
-
         let span = SubgraphRequestSpan {
-            name: endpoint.subgraph_name(),
+            name: ctx.endpoint().subgraph_name(),
             operation_type: self.operation.ty.as_str(),
             // The generated query does not contain any data, everything are in the variables, so
             // it's safe to use.
             sanitized_query: &self.operation.query,
-            url: endpoint.url(),
+            url: ctx.endpoint().url(),
         }
         .into_span();
 
-        execute_subgraph_request(
-            ctx,
-            span.clone(),
-            self.endpoint_id,
-            retry_budget,
-            headers,
-            Bytes::from(body),
-            GraphqlIngester {
-                ctx,
-                subgraph_cache_ttl,
-                cache_key,
-                subgraph_response,
-            },
-        )
-        .instrument(span)
-        .await
+        let ingester = GraphqlIngester {
+            ctx: ctx.execution_context(),
+            subgraph_cache_ttl,
+            cache_key,
+            subgraph_response,
+        };
+
+        execute_subgraph_request(ctx, span.clone(), headers, Bytes::from(body), ingester)
+            .instrument(span)
+            .await
+    }
+
+    pub fn endpoint<'ctx, R: Runtime>(&self, ctx: ExecutionContext<'ctx, R>) -> GraphqlEndpointWalker<'ctx> {
+        ctx.schema().walk(self.endpoint_id)
+    }
+
+    pub fn operation_type(&self) -> OperationType {
+        self.operation.ty
     }
 }
 

--- a/engine/crates/engine-v2/src/sources/graphql/subscription.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/subscription.rs
@@ -1,56 +1,46 @@
 use std::borrow::Cow;
 
 use bytes::Bytes;
-use futures::{Future, TryStreamExt};
+use futures::{FutureExt, TryStreamExt};
 use futures_util::{stream::BoxStream, StreamExt};
 use headers::HeaderMapExt;
-use runtime::{
-    fetch::{FetchRequest, FetchResult, Fetcher},
-    rate_limiting::RateLimitKey,
-};
-use schema::sources::graphql::GraphqlEndpointWalker;
+use runtime::fetch::{FetchRequest, Fetcher};
 use serde::de::DeserializeSeed;
-use tower::retry::budget::Budget;
 use url::Url;
-use web_time::Duration;
 
 use super::{
     deserialize::{GraphqlResponseSeed, RootGraphqlErrors},
-    record,
-    request::{SubgraphGraphqlRequest, SubgraphVariables},
+    request::{retrying_fetch, SubgraphGraphqlRequest, SubgraphVariables},
     GraphqlResolver,
 };
 use crate::{
-    execution::{ExecutionContext, ExecutionError, SubscriptionResponse},
-    operation::PlanWalker,
-    sources::ExecutionResult,
+    execution::{ExecutionError, SubscriptionResponse},
+    sources::{ExecutionResult, SubgraphRequestContext},
     Runtime,
 };
 
 impl GraphqlResolver {
     pub async fn execute_subscription<'ctx, R: Runtime>(
         &'ctx self,
-        ctx: ExecutionContext<'ctx, R>,
-        plan: PlanWalker<'ctx>,
+        ctx: &mut SubgraphRequestContext<'ctx, R>,
         new_response: impl Fn() -> SubscriptionResponse + Send + 'ctx,
     ) -> ExecutionResult<BoxStream<'ctx, ExecutionResult<SubscriptionResponse>>> {
-        let endpoint = ctx.schema().walk(self.endpoint_id);
-        if let Some(websocket_url) = endpoint.websocket_url() {
-            self.execute_websocket_subscription(ctx, plan, new_response, endpoint, websocket_url)
+        if let Some(websocket_url) = ctx.endpoint().websocket_url() {
+            self.execute_websocket_subscription(ctx, new_response, websocket_url)
                 .await
         } else {
-            self.execute_sse_subscription(ctx, plan, new_response, endpoint).await
+            self.execute_sse_subscription(ctx, new_response).await
         }
     }
 
     async fn execute_websocket_subscription<'ctx, R: Runtime>(
         &'ctx self,
-        ctx: ExecutionContext<'ctx, R>,
-        plan: PlanWalker<'ctx>,
+        ctx: &mut SubgraphRequestContext<'ctx, R>,
         new_response: impl Fn() -> SubscriptionResponse + Send + 'ctx,
-        endpoint: GraphqlEndpointWalker<'ctx>,
         websocket_url: &'ctx Url,
     ) -> ExecutionResult<BoxStream<'ctx, ExecutionResult<SubscriptionResponse>>> {
+        let endpoint = ctx.endpoint();
+
         // If the user doesn't provide an explicit websocket URL we use the normal URL,
         // so make sure to convert the scheme to something appropriate
         let url = match websocket_url.scheme() {
@@ -67,14 +57,13 @@ impl GraphqlResolver {
             _ => Cow::Borrowed(websocket_url),
         };
 
+        let header_rules = ctx
+            .execution_context()
+            .subgraph_headers_with_rules(endpoint.header_rules());
+
         let headers = ctx
             .hooks()
-            .on_subgraph_request(
-                endpoint.subgraph_name(),
-                http::Method::POST,
-                &url,
-                ctx.subgraph_headers_with_rules(endpoint.header_rules()),
-            )
+            .on_subgraph_request(endpoint.subgraph_name(), http::Method::POST, &url, header_rules)
             .await?;
 
         let request = FetchRequest {
@@ -84,62 +73,69 @@ impl GraphqlResolver {
             body: &SubgraphGraphqlRequest {
                 query: &self.operation.query,
                 variables: SubgraphVariables::<()> {
-                    plan,
+                    plan: ctx.plan(),
                     variables: &self.operation.variables,
                     extra_variables: Vec::new(),
                 },
             },
             timeout: endpoint.timeout(),
         };
-        let stream = retrying_fetch(
-            ctx,
-            endpoint,
-            ctx.engine.get_retry_budget_for_non_mutation(endpoint.id()),
-            move || {
-                ctx.engine
-                    .runtime
-                    .fetcher()
-                    .graphql_over_websocket_stream(request.clone())
-            },
-        )
-        .await?
-        .map_err(move |error| ExecutionError::Fetch {
-            subgraph_name: endpoint.subgraph_name().to_string(),
-            error,
-        })
-        .map(move |subgraph_response| {
-            let mut subscription_response = new_response();
 
-            let resp = subscription_response.as_mut();
-            GraphqlResponseSeed::new(
-                resp.next_seed(ctx).expect("Must have a root object to update"),
-                RootGraphqlErrors::new(ctx, resp),
-            )
-            .deserialize(subgraph_response?)?;
+        let execution_ctx = ctx.execution_context();
+        let fetch = move || {
+            let result = execution_ctx
+                .engine
+                .runtime
+                .fetcher()
+                .graphql_over_websocket_stream(request.clone());
 
-            Ok(subscription_response)
-        });
+            result.then(|res| async { (res, None) })
+        };
+
+        let stream = retrying_fetch(ctx, fetch)
+            .await?
+            .map_err(move |error| ExecutionError::Fetch {
+                subgraph_name: endpoint.subgraph_name().to_string(),
+                error,
+            })
+            .map(move |subgraph_response| {
+                let mut subscription_response = new_response();
+
+                let resp = subscription_response.as_mut();
+                GraphqlResponseSeed::new(
+                    resp.next_seed(execution_ctx)
+                        .expect("Must have a root object to update"),
+                    RootGraphqlErrors::new(execution_ctx, resp),
+                )
+                .deserialize(subgraph_response?)?;
+
+                Ok(subscription_response)
+            });
 
         Ok(Box::pin(stream))
     }
 
     async fn execute_sse_subscription<'ctx, R: Runtime>(
         &'ctx self,
-        ctx: ExecutionContext<'ctx, R>,
-        plan: PlanWalker<'ctx>,
+        ctx: &mut SubgraphRequestContext<'ctx, R>,
         new_response: impl Fn() -> SubscriptionResponse + Send + 'ctx,
-        endpoint: GraphqlEndpointWalker<'ctx>,
     ) -> ExecutionResult<BoxStream<'ctx, ExecutionResult<SubscriptionResponse>>> {
+        let endpoint = ctx.endpoint();
+
         let request = {
             let body = serde_json::to_vec(&SubgraphGraphqlRequest {
                 query: &self.operation.query,
                 variables: SubgraphVariables::<()> {
-                    plan,
+                    plan: ctx.plan(),
                     variables: &self.operation.variables,
                     extra_variables: Vec::new(),
                 },
             })
             .map_err(|err| format!("Failed to serialize query: {err}"))?;
+
+            let header_rules = ctx
+                .execution_context()
+                .subgraph_headers_with_rules(endpoint.header_rules());
 
             let mut headers = ctx
                 .hooks()
@@ -147,9 +143,10 @@ impl GraphqlResolver {
                     endpoint.subgraph_name(),
                     http::Method::POST,
                     endpoint.url(),
-                    ctx.subgraph_headers_with_rules(endpoint.header_rules()),
+                    header_rules,
                 )
                 .await?;
+
             headers.typed_insert(headers::ContentType::json());
             headers.typed_insert(headers::ContentLength(body.len() as u64));
             headers.insert(
@@ -165,100 +162,37 @@ impl GraphqlResolver {
             }
         };
 
-        let stream = retrying_fetch(
-            ctx,
-            endpoint,
-            ctx.engine.get_retry_budget_for_non_mutation(endpoint.id()),
-            move || ctx.engine.runtime.fetcher().graphql_over_sse_stream(request.clone()),
-        )
-        .await?
-        .map_err(move |error| ExecutionError::Fetch {
-            subgraph_name: endpoint.subgraph_name().to_string(),
-            error,
-        })
-        .map(move |subgraph_response| {
-            let mut subscription_response = new_response();
+        let execution_ctx = ctx.execution_context();
+        let fetch = move || {
+            let result = execution_ctx
+                .engine
+                .runtime
+                .fetcher()
+                .graphql_over_sse_stream(request.clone());
 
-            let resp = subscription_response.as_mut();
-            GraphqlResponseSeed::new(
-                resp.next_seed(ctx).expect("Must have a root object to update"),
-                RootGraphqlErrors::new(ctx, resp),
-            )
-            .deserialize(&mut serde_json::Deserializer::from_slice(&subgraph_response?))?;
+            result.then(|result| async { (result, None) })
+        };
 
-            Ok(subscription_response)
-        });
+        let stream = retrying_fetch(ctx, fetch)
+            .await?
+            .map_err(move |error| ExecutionError::Fetch {
+                subgraph_name: endpoint.subgraph_name().to_string(),
+                error,
+            })
+            .map(move |subgraph_response| {
+                let mut subscription_response = new_response();
+                let resp = subscription_response.as_mut();
+
+                GraphqlResponseSeed::new(
+                    resp.next_seed(execution_ctx)
+                        .expect("Must have a root object to update"),
+                    RootGraphqlErrors::new(execution_ctx, resp),
+                )
+                .deserialize(&mut serde_json::Deserializer::from_slice(&subgraph_response?))?;
+
+                Ok(subscription_response)
+            });
 
         Ok(Box::pin(stream))
     }
-}
-
-async fn retrying_fetch<'ctx, R: Runtime, F, T>(
-    ctx: ExecutionContext<'ctx, R>,
-    endpoint: GraphqlEndpointWalker<'_>,
-    retry_budget: Option<&Budget>,
-    fetch: impl Fn() -> F + Send + Sync,
-) -> ExecutionResult<T>
-where
-    F: Future<Output = FetchResult<T>> + Send,
-    T: Send,
-{
-    let mut result = rate_limited_fetch(ctx, endpoint, &fetch).await;
-
-    let Some(retry_budget) = retry_budget else {
-        return result;
-    };
-
-    let mut counter = 0;
-
-    loop {
-        match result {
-            Ok(bytes) => {
-                retry_budget.deposit();
-                return Ok(bytes);
-            }
-            Err(err) => {
-                if retry_budget.withdraw().is_ok() {
-                    let jitter = rand::random::<f64>() * 2.0;
-                    let exp_backoff = (100 * 2u64.pow(counter)) as f64;
-                    let backoff_ms = (exp_backoff * jitter).round() as u64;
-
-                    ctx.engine.runtime.sleep(Duration::from_millis(backoff_ms)).await;
-                    record::subgraph_retry(ctx, endpoint, false);
-
-                    counter += 1;
-
-                    result = rate_limited_fetch(ctx, endpoint, &fetch).await;
-                } else {
-                    record::subgraph_retry(ctx, endpoint, true);
-                    return Err(err);
-                }
-            }
-        }
-    }
-}
-
-async fn rate_limited_fetch<'ctx, R: Runtime, F, T>(
-    ctx: ExecutionContext<'ctx, R>,
-    endpoint: GraphqlEndpointWalker<'ctx>,
-    fetch: impl Fn() -> F + Send,
-) -> ExecutionResult<T>
-where
-    F: Future<Output = FetchResult<T>> + Send,
-    T: Send,
-{
-    ctx.engine
-        .runtime
-        .rate_limiter()
-        .limit(&RateLimitKey::Subgraph(endpoint.subgraph_name().into()))
-        .await?;
-
-    record::increment_inflight_requests(ctx, endpoint);
-    let result = fetch().await;
-    record::decrement_inflight_requests(ctx, endpoint);
-
-    result.map_err(|error| ExecutionError::Fetch {
-        subgraph_name: endpoint.subgraph_name().to_string(),
-        error,
-    })
 }

--- a/engine/crates/integration-tests/src/federation/builder/bench.rs
+++ b/engine/crates/integration-tests/src/federation/builder/bench.rs
@@ -9,7 +9,7 @@ use futures::{StreamExt, TryStreamExt};
 use runtime::{
     bytes::OwnedOrSharedBytes,
     fetch::{dynamic::DynFetcher, FetchRequest, FetchResult},
-    hooks::DynamicHooks,
+    hooks::{DynamicHooks, ResponseInfo},
 };
 use runtime_local::InMemoryOperationCacheFactory;
 
@@ -164,11 +164,16 @@ impl DummyFetcher {
 
 #[async_trait::async_trait]
 impl DynFetcher for DummyFetcher {
-    async fn fetch(&self, _request: FetchRequest<'_, Bytes>) -> FetchResult<http::Response<OwnedOrSharedBytes>> {
-        Ok(self
+    async fn fetch(
+        &self,
+        _request: FetchRequest<'_, Bytes>,
+    ) -> (FetchResult<http::Response<OwnedOrSharedBytes>>, Option<ResponseInfo>) {
+        let result = Ok(self
             .responses
             .get(self.index.fetch_add(1, Ordering::Relaxed))
             .cloned()
-            .expect("No more responses"))
+            .expect("No more responses"));
+
+        (result, None)
     }
 }

--- a/engine/crates/runtime-local/src/fetch.rs
+++ b/engine/crates/runtime-local/src/fetch.rs
@@ -7,6 +7,7 @@ use reqwest::RequestBuilder;
 use reqwest_eventsource::RequestBuilderExt;
 use runtime::bytes::OwnedOrSharedBytes;
 use runtime::fetch::{FetchError, FetchRequest, FetchResult, Fetcher};
+use runtime::hooks::ResponseInfo;
 
 #[derive(Default, Clone)]
 pub struct NativeFetcher {
@@ -15,19 +16,29 @@ pub struct NativeFetcher {
 
 impl Fetcher for NativeFetcher {
     async fn fetch(&self, request: FetchRequest<'_, Bytes>) -> FetchResult<http::Response<OwnedOrSharedBytes>> {
-        let mut resp = self.client.execute(into_reqwest(request)).await.map_err(|e| {
+        let mut info = ResponseInfo::builder();
+
+        let result = self.client.execute(into_reqwest(request)).await.map_err(|e| {
             if e.is_timeout() {
                 FetchError::Timeout
             } else {
                 reqwest_error_to_fetch_error(e)
             }
-        })?;
+        });
+
+        info.track_connection();
+
+        let mut resp = result?;
 
         let status = resp.status();
         let headers = std::mem::take(resp.headers_mut());
         let extensions = std::mem::take(resp.extensions_mut());
         let version = resp.version();
-        let bytes = resp.bytes().await.map_err(reqwest_error_to_fetch_error)?;
+        let result = resp.bytes().await.map_err(reqwest_error_to_fetch_error);
+
+        info.track_response();
+
+        let bytes = result?;
 
         // reqwest transforms the body into a stream with Into
         let mut response = http::Response::new(OwnedOrSharedBytes::Shared(bytes));
@@ -35,6 +46,8 @@ impl Fetcher for NativeFetcher {
         *response.version_mut() = version;
         *response.extensions_mut() = extensions;
         *response.headers_mut() = headers;
+
+        response.extensions_mut().insert(info.finalize(status.as_u16()));
 
         Ok(response)
     }

--- a/engine/crates/runtime-local/src/hooks/responses.rs
+++ b/engine/crates/runtime-local/src/hooks/responses.rs
@@ -1,0 +1,171 @@
+use runtime::{error::PartialGraphqlError, hooks::ResponseHooks};
+use wasi_component_loader::{
+    CacheStatus, ExecutedGatewayRequest, ExecutedHttpRequest, ExecutedSubgraphRequest, FieldError,
+    GraphqlResponseStatus, Operation, RequestError, ResponseInfo, ResponseKind,
+};
+
+use crate::HooksWasi;
+
+use super::Context;
+
+impl ResponseHooks<Context> for HooksWasi {
+    async fn on_subgraph_response(
+        &self,
+        context: &Context,
+        request: runtime::hooks::ExecutedSubgraphRequest<'_>,
+    ) -> Result<Vec<u8>, PartialGraphqlError> {
+        let Some(ref inner) = self.0 else {
+            return Ok(Vec::new());
+        };
+
+        let mut hook = inner.responses.get().await;
+
+        let runtime::hooks::ExecutedSubgraphRequest {
+            subgraph_name,
+            method,
+            url,
+            responses,
+            cache_status,
+            total_duration,
+            has_errors,
+        } = request;
+
+        let request = ExecutedSubgraphRequest {
+            subgraph_name: subgraph_name.to_string(),
+            method: method.to_string(),
+            url: url.to_string(),
+            responses: responses
+                .into_iter()
+                .map(|response| match response {
+                    runtime::hooks::ResponseKind::SerializationError => ResponseKind::SerializationError,
+                    runtime::hooks::ResponseKind::HookError => ResponseKind::HookError,
+                    runtime::hooks::ResponseKind::RequestError => ResponseKind::RequestError,
+                    runtime::hooks::ResponseKind::RateLimited => ResponseKind::RateLimited,
+                    runtime::hooks::ResponseKind::Responsed(info) => ResponseKind::Responsed(ResponseInfo {
+                        connection_time: info.connection_time,
+                        response_time: info.response_time,
+                        status_code: info.status_code,
+                    }),
+                })
+                .collect(),
+            cache_status: match cache_status {
+                runtime::hooks::CacheStatus::Hit => CacheStatus::Hit,
+                runtime::hooks::CacheStatus::PartialHit => CacheStatus::PartialHit,
+                runtime::hooks::CacheStatus::Miss => CacheStatus::Miss,
+            },
+            total_duration,
+            has_errors,
+        };
+
+        inner
+            .run_and_measure(
+                "on-subgraph-response",
+                hook.on_subgraph_response(inner.shared_context(context), request),
+            )
+            .await
+            .map_err(|err| {
+                tracing::error!("on_subgraph_response error: {err}");
+                PartialGraphqlError::internal_hook_error()
+            })
+    }
+
+    async fn on_gateway_response(
+        &self,
+        context: &Context,
+        operation: runtime::hooks::Operation<'_>,
+        request: runtime::hooks::ExecutedGatewayRequest,
+    ) -> Result<Vec<u8>, PartialGraphqlError> {
+        let Some(ref inner) = self.0 else {
+            return Ok(Vec::new());
+        };
+
+        let mut hook = inner.responses.get().await;
+
+        let runtime::hooks::Operation {
+            name,
+            document,
+            prepare_duration,
+            cached,
+        } = operation;
+
+        let runtime::hooks::ExecutedGatewayRequest {
+            duration,
+            status,
+            on_subgraph_request_outputs,
+        } = request;
+
+        let operation = Operation {
+            name: name.map(ToString::to_string),
+            document: document.to_string(),
+            prepare_duration,
+            cached,
+        };
+
+        let request = ExecutedGatewayRequest {
+            duration,
+            status: match status {
+                grafbase_telemetry::gql_response_status::GraphqlResponseStatus::Success => {
+                    GraphqlResponseStatus::Success
+                }
+                grafbase_telemetry::gql_response_status::GraphqlResponseStatus::FieldError { count, data_is_null } => {
+                    GraphqlResponseStatus::FieldError(FieldError { count, data_is_null })
+                }
+                grafbase_telemetry::gql_response_status::GraphqlResponseStatus::RequestError { count } => {
+                    GraphqlResponseStatus::RequestError(RequestError { count })
+                }
+                grafbase_telemetry::gql_response_status::GraphqlResponseStatus::RefusedRequest => {
+                    GraphqlResponseStatus::RefusedRequest
+                }
+            },
+            on_subgraph_request_outputs,
+        };
+
+        inner
+            .run_and_measure(
+                "on-gateway-response",
+                hook.on_gateway_response(inner.shared_context(context), operation, request),
+            )
+            .await
+            .map_err(|err| {
+                tracing::error!("on_gateway_response error: {err}");
+                PartialGraphqlError::internal_hook_error()
+            })
+    }
+
+    async fn on_http_response(
+        &self,
+        context: &Context,
+        request: runtime::hooks::ExecutedHttpRequest<'_>,
+    ) -> Result<(), PartialGraphqlError> {
+        let Some(ref inner) = self.0 else {
+            return Ok(());
+        };
+
+        let mut hook = inner.responses.get().await;
+
+        let runtime::hooks::ExecutedHttpRequest {
+            method,
+            url,
+            status_code,
+            on_gateway_response_outputs,
+        } = request;
+
+        let request = ExecutedHttpRequest {
+            method: method.to_string(),
+            url: url.to_string(),
+            status_code: status_code.as_u16(),
+            on_gateway_response_outputs,
+        };
+
+        inner
+            .run_and_measure(
+                "on-http-response",
+                hook.on_http_response(inner.shared_context(context), request),
+            )
+            .await
+            .map_err(|err| {
+                tracing::error!("on_http_response error: {err}");
+                PartialGraphqlError::internal_hook_error()
+            })
+    }
+}

--- a/engine/crates/runtime/src/hooks.rs
+++ b/engine/crates/runtime/src/hooks.rs
@@ -1,11 +1,12 @@
 #[cfg(feature = "test-utils")]
 mod test_utils;
 
+use grafbase_telemetry::gql_response_status::{GraphqlResponseStatus, SubgraphResponseStatus};
 #[cfg(feature = "test-utils")]
 pub use test_utils::*;
 use url::Url;
 
-use std::future::Future;
+use std::{future::Future, time::SystemTime};
 
 pub use http::HeaderMap;
 
@@ -39,6 +40,11 @@ impl<'a, T> Anything<'a> for T where T: serde::Serialize + serde::de::Deserializ
 pub type AuthorizationVerdict = Result<(), PartialGraphqlError>;
 pub type AuthorizationVerdicts = Result<Vec<AuthorizationVerdict>, PartialGraphqlError>;
 
+pub struct ChannelBuilder<'a, Sender: Clone> {
+    pub sender: &'a Sender,
+    pub lossy_log: bool,
+}
+
 pub trait Hooks: Send + Sync + 'static {
     type Context: Send + Sync + 'static;
 
@@ -50,6 +56,8 @@ pub trait Hooks: Send + Sync + 'static {
     fn authorized(&self) -> &impl AuthorizedHooks<Self::Context>;
 
     fn subgraph(&self) -> &impl SubgraphHooks<Self::Context>;
+
+    fn responses(&self) -> &impl ResponseHooks<Self::Context>;
 }
 
 pub trait AuthorizedHooks<Context>: Send + Sync + 'static {
@@ -115,6 +123,191 @@ pub trait SubgraphHooks<Context>: Send + Sync + 'static {
     ) -> impl Future<Output = Result<HeaderMap, PartialGraphqlError>> + Send;
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct ResponseInfo {
+    pub connection_time: u64,
+    pub response_time: u64,
+    pub status_code: u16,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ResponseKind {
+    SerializationError,
+    HookError,
+    RequestError,
+    RateLimited,
+    Responsed(ResponseInfo),
+}
+
+impl ResponseInfo {
+    pub fn builder() -> ResponseInfoBuilder {
+        ResponseInfoBuilder {
+            start: SystemTime::now(),
+            connection_time: None,
+            response_time: None,
+        }
+    }
+}
+
+pub struct ResponseInfoBuilder {
+    start: SystemTime,
+    connection_time: Option<u64>,
+    response_time: Option<u64>,
+}
+
+impl ResponseInfoBuilder {
+    /// Stops the clock for connection time. This is typically the time the request gets
+    /// sent, but no data is fetched back.
+    pub fn track_connection(&mut self) {
+        self.connection_time = Some(
+            SystemTime::now()
+                .duration_since(self.start)
+                .unwrap_or_default()
+                .as_millis() as u64,
+        );
+    }
+
+    /// Stops the clock for response time. This time is the time it takes to initialize
+    /// a connection and waiting to get all the data back.
+    pub fn track_response(&mut self) {
+        self.response_time = Some(
+            SystemTime::now()
+                .duration_since(self.start)
+                .unwrap_or_default()
+                .as_millis() as u64,
+        );
+    }
+
+    pub fn finalize(self, status_code: u16) -> ResponseInfo {
+        ResponseInfo {
+            connection_time: self.connection_time.unwrap_or_default(),
+            response_time: self.response_time.unwrap_or_default(),
+            status_code,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum CacheStatus {
+    Hit,
+    PartialHit,
+    Miss,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExecutedSubgraphRequest<'a> {
+    pub subgraph_name: &'a str,
+    pub method: &'a str,
+    pub url: &'a str,
+    pub responses: Vec<ResponseKind>,
+    pub cache_status: CacheStatus,
+    pub total_duration: u64,
+    pub has_errors: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExecutedSubgraphRequestBuilder<'a> {
+    subgraph_name: &'a str,
+    method: &'a str,
+    url: &'a str,
+    responses: Vec<ResponseKind>,
+    cache_status: CacheStatus,
+    start_time: SystemTime,
+    status: SubgraphResponseStatus,
+}
+
+impl<'a> ExecutedSubgraphRequestBuilder<'a> {
+    pub fn push_response(&mut self, kind: ResponseKind) {
+        self.responses.push(kind);
+    }
+
+    pub fn set_cache_status(&mut self, status: CacheStatus) {
+        self.cache_status = status;
+    }
+
+    pub fn set_graphql_status(&mut self, status: SubgraphResponseStatus) {
+        self.status = status;
+    }
+
+    pub fn build(self) -> ExecutedSubgraphRequest<'a> {
+        let is_success = matches!(
+            self.status,
+            SubgraphResponseStatus::GraphqlResponse(GraphqlResponseStatus::Success)
+        );
+
+        ExecutedSubgraphRequest {
+            subgraph_name: self.subgraph_name,
+            method: self.method,
+            url: self.url,
+            responses: self.responses,
+            cache_status: self.cache_status,
+            total_duration: SystemTime::now()
+                .duration_since(self.start_time)
+                .unwrap_or_default()
+                .as_millis() as u64,
+            has_errors: !is_success,
+        }
+    }
+}
+
+impl<'a> ExecutedSubgraphRequest<'a> {
+    pub fn builder(subgraph_name: &'a str, method: &'a str, url: &'a str) -> ExecutedSubgraphRequestBuilder<'a> {
+        ExecutedSubgraphRequestBuilder {
+            subgraph_name,
+            method,
+            url,
+            responses: Vec::new(),
+            cache_status: CacheStatus::Miss,
+            start_time: SystemTime::now(),
+            status: SubgraphResponseStatus::GraphqlResponse(GraphqlResponseStatus::Success),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Operation<'a> {
+    pub name: Option<&'a str>,
+    pub document: &'a str,
+    pub prepare_duration: u64,
+    pub cached: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExecutedGatewayRequest {
+    pub duration: u64,
+    pub status: GraphqlResponseStatus,
+    pub on_subgraph_request_outputs: Vec<Vec<u8>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExecutedHttpRequest<'a> {
+    pub method: &'a str,
+    pub url: &'a str,
+    pub status_code: http::StatusCode,
+    pub on_gateway_response_outputs: Vec<Vec<u8>>,
+}
+
+pub trait ResponseHooks<Context>: Send + Sync + 'static {
+    fn on_subgraph_response(
+        &self,
+        context: &Context,
+        request: ExecutedSubgraphRequest<'_>,
+    ) -> impl Future<Output = Result<Vec<u8>, PartialGraphqlError>> + Send;
+
+    fn on_gateway_response(
+        &self,
+        context: &Context,
+        operation: Operation<'_>,
+        request: ExecutedGatewayRequest,
+    ) -> impl Future<Output = Result<Vec<u8>, PartialGraphqlError>> + Send;
+
+    fn on_http_response(
+        &self,
+        context: &Context,
+        request: ExecutedHttpRequest<'_>,
+    ) -> impl Future<Output = Result<(), PartialGraphqlError>> + Send;
+}
+
 // ---------------------------//
 // -- No-op implementation -- //
 // ---------------------------//
@@ -130,6 +323,10 @@ impl Hooks for () {
     }
 
     fn subgraph(&self) -> &impl SubgraphHooks<()> {
+        self
+    }
+
+    fn responses(&self) -> &impl ResponseHooks<Self::Context> {
         self
     }
 }
@@ -227,5 +424,28 @@ impl SubgraphHooks<()> for () {
         headers: HeaderMap,
     ) -> Result<HeaderMap, PartialGraphqlError> {
         Ok(headers)
+    }
+}
+
+impl ResponseHooks<()> for () {
+    async fn on_subgraph_response(
+        &self,
+        _: &(),
+        _: ExecutedSubgraphRequest<'_>,
+    ) -> Result<Vec<u8>, PartialGraphqlError> {
+        Ok(Vec::new())
+    }
+
+    async fn on_gateway_response(
+        &self,
+        _: &(),
+        _: Operation<'_>,
+        _: ExecutedGatewayRequest,
+    ) -> Result<Vec<u8>, PartialGraphqlError> {
+        Ok(Vec::new())
+    }
+
+    async fn on_http_response(&self, _: &(), _: ExecutedHttpRequest<'_>) -> Result<(), PartialGraphqlError> {
+        Ok(())
     }
 }

--- a/engine/crates/wasi-component-loader/Cargo.toml
+++ b/engine/crates/wasi-component-loader/Cargo.toml
@@ -15,6 +15,7 @@ tracing.workspace = true
 url.workspace = true
 gateway-config.workspace = true
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
+tokio = { workspace = true, features = ["time", "rt"] }
 
 [dependencies.wasmtime]
 git = "https://github.com/grafbase/wasmtime"

--- a/engine/crates/wasi-component-loader/examples/crates/response-hooks/src/lib.rs
+++ b/engine/crates/wasi-component-loader/examples/crates/response-hooks/src/lib.rs
@@ -1,9 +1,8 @@
-use bindings::{
-    component::grafbase::types::{
-        CacheStatus, ExecutedGatewayRequest, ExecutedHttpRequest, ExecutedSubgraphRequest, Operation, SharedContext,
-    },
-    exports::component::grafbase::responses::Guest,
+use bindings::component::grafbase::types::{
+    CacheStatus, ExecutedGatewayRequest, ExecutedHttpRequest, ExecutedSubgraphRequest, Operation, ResponseKind,
+    SharedContext,
 };
+use bindings::exports::component::grafbase::responses::Guest;
 
 #[allow(warnings)]
 mod bindings;
@@ -67,15 +66,35 @@ impl Guest for Component {
             subgraph_name,
             method,
             url,
-            response_infos,
+            responses,
             cache_status,
             total_duration,
             has_errors,
         } = request;
 
-        let connection_times = response_infos.iter().map(|r| r.connection_time).collect();
-        let response_times = response_infos.iter().map(|r| r.response_time).collect();
-        let status_codes = response_infos.iter().map(|r| r.status_code).collect();
+        let connection_times = responses
+            .iter()
+            .map(|r| match r {
+                ResponseKind::Responded(info) => info.connection_time,
+                _ => unreachable!(),
+            })
+            .collect();
+
+        let response_times = responses
+            .iter()
+            .map(|r| match r {
+                ResponseKind::Responded(info) => info.response_time,
+                _ => unreachable!(),
+            })
+            .collect();
+
+        let status_codes = responses
+            .iter()
+            .map(|r| match r {
+                ResponseKind::Responded(info) => info.status_code,
+                _ => unreachable!(),
+            })
+            .collect();
 
         let info = SubgraphInfo {
             subgraph_name,

--- a/engine/crates/wasi-component-loader/examples/crates/response-hooks/wit/world.wit
+++ b/engine/crates/wasi-component-loader/examples/crates/response-hooks/wit/world.wit
@@ -137,10 +137,28 @@ interface types {
         status-code: u16
     }
 
+    // Cache status of a subgraph call.
     enum cache-status {
+        // All data fetched from cache.
         hit,
+        // Some data fetched from cache.
         partial-hit,
+        // Cache miss
         miss,
+    }
+
+    // Subgraph response variant.
+    variant response-kind {
+        // Error in response serialization.
+        serialization-error,
+        // Response prevented by subgraph request hook.
+        hook-error,
+        // HTTP request failed.
+        request-error,
+        // Request was rate-limited.
+        rate-limited,
+        // A response was received.
+        responded(response-info),
     }
 
     // Info about an executed subgraph request.
@@ -154,9 +172,10 @@ interface types {
         // The subgraph URL.
         url: string,
        
-        // The subgraph response info
-        response-infos: list<response-info>,
+        // The subgraph responses
+        responses: list<response-kind>,
 
+        // The cache status of the subgraph call.
         cache-status: cache-status,
 
         // The time in milliseconds taken for the whole operation.

--- a/engine/crates/wasi-component-loader/src/context.rs
+++ b/engine/crates/wasi-component-loader/src/context.rs
@@ -123,7 +123,8 @@ pub(crate) fn map(types: &mut LinkerInstance<'_, WasiState>) -> crate::Result<()
 /// interface types {
 ///     resource shared-context {
 ///         get: func(key: string) -> option<string>;
-///     }    
+///         access-log: func(data: list<u8>) -> result<_, log-error>;
+///     }
 /// }
 /// ```
 pub(crate) fn map_shared(types: &mut LinkerInstance<'_, WasiState>) -> crate::Result<()> {

--- a/engine/crates/wasi-component-loader/src/context.rs
+++ b/engine/crates/wasi-component-loader/src/context.rs
@@ -37,6 +37,17 @@ impl ChannelLogSender {
 
         Ok(())
     }
+
+    /// Wait until all access logs are written to the file.
+    pub async fn graceful_shutdown(&self) {
+        let wg = WaitGroup::new();
+
+        if self.sender.send(AccessLogMessage::Shutdown(wg.clone())).is_err() {
+            tracing::debug!("access log receiver is already dead, cannot empty log channel");
+        }
+
+        tokio::task::spawn_blocking(|| wg.wait()).await.unwrap();
+    }
 }
 
 /// A receiver for the logger to receive messages and write them somewhere.

--- a/engine/crates/wasi-component-loader/src/hooks.rs
+++ b/engine/crates/wasi-component-loader/src/hooks.rs
@@ -263,6 +263,7 @@ impl ComponentInstance {
         {
             return cached.as_ref().and_then(|func| func.downcast_ref().copied());
         }
+
         let mut exports = self.instance.exports(&mut self.store);
         let mut root = exports.root();
 

--- a/engine/crates/wasi-component-loader/src/hooks/response.rs
+++ b/engine/crates/wasi-component-loader/src/hooks/response.rs
@@ -104,7 +104,7 @@ pub struct ExecutedGatewayRequest {
 /// A response info from an executed subgraph request.
 #[derive(Debug, Clone, Copy, Lower, ComponentType)]
 #[component(record)]
-pub struct SubgraphResponseInfo {
+pub struct ResponseInfo {
     /// Time it took to connect to the subgraph endpoint, in milliseconds.
     #[component(name = "connection-time")]
     pub connection_time: u64,
@@ -131,6 +131,27 @@ pub enum CacheStatus {
     Miss,
 }
 
+/// Response data from a subgraph request.
+#[derive(Debug, Clone, Copy, Lower, ComponentType)]
+#[component(variant)]
+pub enum ResponseKind {
+    /// Error in response serialization.
+    #[component(name = "serialization-error")]
+    SerializationError,
+    /// Response prevented by a hook.
+    #[component(name = "hook-error")]
+    HookError,
+    /// Request failed.
+    #[component(name = "request-error")]
+    RequestError,
+    /// Request was rate-limited.
+    #[component(name = "rate-limited")]
+    RateLimited,
+    /// A response was received.
+    #[component(name = "responded")]
+    Responsed(ResponseInfo),
+}
+
 /// A response info from subgraph fetch.
 #[derive(Debug, Clone, Lower, ComponentType)]
 #[component(record)]
@@ -145,8 +166,8 @@ pub struct ExecutedSubgraphRequest {
     #[component(name = "url")]
     pub url: String,
     /// The subgraph response(s).
-    #[component(name = "response-infos")]
-    pub response_infos: Vec<SubgraphResponseInfo>,
+    #[component(name = "responses")]
+    pub responses: Vec<ResponseKind>,
     /// If anything in the request was cached.
     #[component(name = "cache-status")]
     pub cache_status: CacheStatus,

--- a/engine/crates/wasi-component-loader/src/lib.rs
+++ b/engine/crates/wasi-component-loader/src/lib.rs
@@ -24,13 +24,14 @@ pub use context::{
     create_log_channel, AccessLogMessage, ChannelLogReceiver, ChannelLogSender, ContextMap, SharedContext,
 };
 pub use crossbeam::channel::Sender;
+pub use crossbeam::sync::WaitGroup;
 pub use error::{guest::GuestError, Error};
 pub use hooks::{
     authorization::{AuthorizationComponentInstance, EdgeDefinition, NodeDefinition},
     gateway::GatewayComponentInstance,
     response::{
-        ExecutedGatewayRequest, ExecutedHttpRequest, ExecutedSubgraphRequest, FieldError, GraphqlResponseStatus,
-        Operation, RequestError, ResponsesComponentInstance, SubgraphResponseInfo,
+        CacheStatus, ExecutedGatewayRequest, ExecutedHttpRequest, ExecutedSubgraphRequest, FieldError,
+        GraphqlResponseStatus, Operation, RequestError, ResponseInfo, ResponseKind, ResponsesComponentInstance,
     },
     subgraph::*,
     RecycleableComponentInstance,

--- a/engine/crates/wasi-component-loader/src/tests.rs
+++ b/engine/crates/wasi-component-loader/src/tests.rs
@@ -1,14 +1,10 @@
 use std::{collections::HashMap, sync::Arc};
 
 use crate::{
-    create_log_channel,
-    hooks::{
-        response::{CacheStatus, SubgraphResponseInfo},
-        subgraph::SubgraphComponentInstance,
-    },
-    AuthorizationComponentInstance, ComponentLoader, Config, EdgeDefinition, ExecutedGatewayRequest,
-    ExecutedHttpRequest, ExecutedSubgraphRequest, GatewayComponentInstance, GuestError, NodeDefinition, Operation,
-    RecycleableComponentInstance, ResponsesComponentInstance, SharedContext,
+    create_log_channel, hooks::subgraph::SubgraphComponentInstance, AuthorizationComponentInstance, CacheStatus,
+    ComponentLoader, Config, EdgeDefinition, ExecutedGatewayRequest, ExecutedHttpRequest, ExecutedSubgraphRequest,
+    GatewayComponentInstance, GuestError, NodeDefinition, Operation, RecycleableComponentInstance, ResponseInfo,
+    ResponsesComponentInstance, SharedContext,
 };
 use expect_test::expect;
 use http::{HeaderMap, HeaderValue};
@@ -686,11 +682,11 @@ async fn response_hooks() {
         url: String::from("https://example.com"),
         total_duration: 10,
         has_errors: false,
-        response_infos: vec![SubgraphResponseInfo {
+        responses: vec![crate::ResponseKind::Responsed(ResponseInfo {
             connection_time: 10,
             response_time: 4,
             status_code: 200,
-        }],
+        })],
         cache_status: CacheStatus::Miss,
     };
 

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -52,4 +52,3 @@ notify = "6.1.1"
 axum-aws-lambda = { version = "0.7.0", optional = true }
 tower = { workspace = true, optional = true }
 lambda_http = { version = "0.11.1", optional = true }
-crossbeam = "0.8.4"

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -43,6 +43,7 @@ toml.workspace = true
 tokio = { workspace = true, features = ["signal", "time", "net"] }
 tower-http = { version = "0.5.2", features = ["cors", "timeout"] }
 tracing.workspace = true
+tracing-appender = { version = "0.2.3", features = ["parking_lot"] }
 ulid = { workspace = true, features = ["serde"] }
 url = { workspace = true, features = ["serde"] }
 notify = "6.1.1"
@@ -51,3 +52,4 @@ notify = "6.1.1"
 axum-aws-lambda = { version = "0.7.0", optional = true }
 tower = { workspace = true, optional = true }
 lambda_http = { version = "0.11.1", optional = true }
+crossbeam = "0.8.4"

--- a/gateway/crates/federated-server/src/server/access_logs.rs
+++ b/gateway/crates/federated-server/src/server/access_logs.rs
@@ -1,0 +1,43 @@
+use std::io::Write;
+
+use gateway_config::{AccessLogsConfig, RotateMode};
+use grafbase_telemetry::span::GRAFBASE_TARGET;
+use runtime_local::hooks::{AccessLogMessage, ChannelLogReceiver};
+use tracing_appender::rolling::{RollingFileAppender, Rotation};
+
+pub(crate) fn start(config: &AccessLogsConfig, access_log_receiver: ChannelLogReceiver) -> crate::Result<()> {
+    let rotation = match config.rotate {
+        RotateMode::Never => Rotation::NEVER,
+        RotateMode::Minutely => Rotation::MINUTELY,
+        RotateMode::Hourly => Rotation::HOURLY,
+        RotateMode::Daily => Rotation::DAILY,
+    };
+
+    let mut log = RollingFileAppender::builder()
+        .rotation(rotation)
+        .filename_prefix("access")
+        .filename_suffix("log")
+        .build(&config.path)
+        .map_err(|e| crate::Error::InternalError(e.to_string()))?;
+
+    tokio::task::spawn_blocking(move || {
+        while let Ok(msg) = access_log_receiver.recv() {
+            match msg {
+                AccessLogMessage::Data(data) => {
+                    if let Err(e) = log.write_all(&data) {
+                        tracing::error!(target: GRAFBASE_TARGET, "error writing to access log: {e}");
+                    }
+                }
+                AccessLogMessage::Shutdown(guard) => {
+                    if let Err(e) = log.flush() {
+                        tracing::error!(target: GRAFBASE_TARGET, "error flushing access log: {e}");
+                    }
+
+                    drop(guard);
+                }
+            }
+        }
+    });
+
+    Ok(())
+}


### PR DESCRIPTION
This is going to plug in the subgraph hook to the access logs. Now it's time to say a word about the wit, but only for subgraphs. This also implements a "kind of I think this is how it should look like version" of the access log writer.
