### PR TITLE
feat(gateway): better logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9701,7 +9701,6 @@ dependencies = [
  "crossbeam",
  "expect-test",
  "gateway-config",
- "grafbase-telemetry",
  "http",
  "indoc",
  "insta",

--- a/engine/crates/engine-v2/src/engine/execute/stream.rs
+++ b/engine/crates/engine-v2/src/engine/execute/stream.rs
@@ -9,7 +9,7 @@ use grafbase_telemetry::{
     gql_response_status::GraphqlResponseStatus,
     grafbase_client::Client,
     metrics::{EngineMetrics, GraphqlErrorAttributes, GraphqlRequestMetricsAttributes, OperationMetricsAttributes},
-    span::{gql::GqlRequestSpan, GqlRecorderSpanExt, GRAFBASE_TARGET},
+    span::{gql::GqlRequestSpan, GqlRecorderSpanExt},
 };
 use tracing::Instrument;
 use web_time::Instant;
@@ -42,7 +42,7 @@ impl<R: Runtime> Engine<R> {
                 let elapsed = start.elapsed();
 
                 if let Some(operation_metrics_attributes) = operation_metrics_attributes {
-                    tracing::Span::current().record_gql_request((&operation_metrics_attributes).into());
+                    span.record_gql_request((&operation_metrics_attributes).into());
 
                     engine.metrics.record_operation_duration(
                         GraphqlRequestMetricsAttributes {
@@ -56,12 +56,8 @@ impl<R: Runtime> Engine<R> {
                 }
 
                 span.record_gql_status(status);
-
-                if status.is_success() {
-                    tracing::debug!(target: GRAFBASE_TARGET, "gateway request")
-                } else {
-                    tracing::debug!(target: GRAFBASE_TARGET, "gateway error")
-                }
+                // After recording all operation metadata
+                tracing::debug!("Executed operation in stream.")
             }
             .instrument(span_clone),
         )

--- a/engine/crates/engine-v2/src/execution/mod.rs
+++ b/engine/crates/engine-v2/src/execution/mod.rs
@@ -22,10 +22,8 @@ pub(crate) use error::*;
 pub(crate) use hooks::RequestHooks;
 pub(crate) use ids::*;
 use schema::EntityId;
-use tracing::instrument;
 
 impl<'ctx, R: Runtime> PreExecutionContext<'ctx, R> {
-    #[instrument(skip_all)]
     pub(crate) async fn finalize_operation(
         &self,
         operation: Arc<PreparedOperation>,

--- a/engine/crates/engine-v2/src/operation/build.rs
+++ b/engine/crates/engine-v2/src/operation/build.rs
@@ -1,5 +1,4 @@
 use schema::Schema;
-use tracing::instrument;
 
 use crate::{
     request::Request,
@@ -68,7 +67,6 @@ impl Operation {
     ///
     /// All field names are mapped to their actual field id in the schema and respective configuration.
     /// At this stage the operation might not be resolvable but it should make sense given the schema types.
-    #[instrument(skip_all)]
     pub fn build(schema: &Schema, request: &Request, document: &str) -> Result<PreparedOperation, OperationError> {
         let parsed_operation = parse_operation(request.operation_name.as_deref(), document)?;
         let metrics_attributes = prepare_metrics_attributes(&parsed_operation, document);

--- a/engine/crates/engine-v2/src/operation/logical_planner/mod.rs
+++ b/engine/crates/engine-v2/src/operation/logical_planner/mod.rs
@@ -8,7 +8,6 @@ use id_derives::IndexedFields;
 use id_newtypes::{BitSet, IdToMany};
 use itertools::Itertools;
 use schema::{EntityId, FieldDefinitionId, RequiredFieldId, RequiredFieldSet, ResolverDefinitionId, Schema};
-use tracing::instrument;
 
 use crate::{
     operation::{
@@ -85,7 +84,6 @@ impl<'a> LogicalPlanner<'a> {
         }
     }
 
-    #[instrument(skip_all)]
     pub(super) fn plan(mut self) -> LogicalPlanningResult<OperationPlan> {
         tracing::trace!("Logical Planning");
         self.plan_all_fields()?;

--- a/engine/crates/engine-v2/src/operation/logical_planner/selection_set.rs
+++ b/engine/crates/engine-v2/src/operation/logical_planner/selection_set.rs
@@ -295,7 +295,7 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
             let Some(candidate) = select_best_child_plan(&mut candidates) else {
                 let walker = self.walker();
                 let parent_subgraph_id = self.maybe_parent.map(|parent| parent.resolver().subgraph_id());
-                tracing::debug!(
+                tracing::error!(
                     "Could not plan fields:\n=== PARENT ===\n{:#?}\n=== CURRENT ===\n{}\n=== MISSING ===\n{}",
                     self.maybe_parent.map(|parent| parent.resolver()),
                     planned_selection_set
@@ -349,7 +349,7 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
                 self.register_necessary_extra_fields(None, planned_selection_set, &parent_extra_requirements);
             } else {
                 let walker = self.walker();
-                tracing::debug!(
+                tracing::error!(
                     "Could not plan extra requirements:\n=== PARENT ===\n{:#?}\n=== CURRENT ===\n{}\n=== MISSING ===\nFor {}\n{:#?}",
                     self.maybe_parent.map(|parent| parent.resolver()),
                     planned_selection_set

--- a/engine/crates/engine-v2/src/operation/variables.rs
+++ b/engine/crates/engine-v2/src/operation/variables.rs
@@ -1,5 +1,4 @@
 use schema::Schema;
-use tracing::instrument;
 
 use super::{
     bind::{bind_variables, VariableError},
@@ -49,7 +48,6 @@ where
 }
 
 impl Variables {
-    #[instrument(skip_all)]
     pub(crate) fn build(
         schema: &Schema,
         operation: &Operation,

--- a/engine/crates/engine-v2/src/operation/walkers/plan/mod.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/plan/mod.rs
@@ -99,6 +99,10 @@ impl<'a> PlanWalker<'a, (), ()> {
 type LogicalPlanWalker<'a> = PlanWalker<'a, LogicalPlanId, ()>;
 
 impl<'a> LogicalPlanWalker<'a> {
+    pub fn id(&self) -> LogicalPlanId {
+        self.item
+    }
+
     pub fn response_blueprint(&self) -> &LogicalPlanResponseBlueprint {
         &self.operation.response_blueprint[self.item]
     }

--- a/engine/crates/engine-v2/src/response/write/mod.rs
+++ b/engine/crates/engine-v2/src/response/write/mod.rs
@@ -384,15 +384,6 @@ impl SubgraphResponse {
             inner: Rc::new(RefCell::new(self)),
         }
     }
-
-    pub fn subgraph_errors(&self) -> impl Iterator<Item = &GraphqlError> + '_ {
-        self.errors.iter().filter(|e| {
-            matches!(
-                e.code,
-                ErrorCode::SubgraphError | ErrorCode::SubgraphInvalidResponseError | ErrorCode::SubgraphRequestError
-            )
-        })
-    }
 }
 
 #[derive(Clone)]

--- a/engine/crates/engine-v2/src/sources/graphql/federation.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/federation.rs
@@ -121,11 +121,12 @@ impl FederationEntityResolver {
                 };
 
                 tracing::debug!(
-                    "Query {}\n{}\n{}",
+                    "Executing request to subgraph named '{}' with query and variables:\n{}\n{}",
                     endpoint.subgraph_name(),
                     self.operation.query,
                     serde_json::to_string_pretty(&variables).unwrap_or_default()
                 );
+
                 let body = serde_json::to_vec(&SubgraphGraphqlRequest {
                     query: &self.operation.query,
                     variables,

--- a/engine/crates/engine-v2/src/sources/graphql/root_fields.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/root_fields.rs
@@ -43,7 +43,6 @@ impl GraphqlResolver {
         }))
     }
 
-    #[tracing::instrument(skip_all)]
     pub async fn execute<'ctx, R: Runtime>(
         &'ctx self,
         ctx: ExecutionContext<'ctx, R>,
@@ -58,7 +57,7 @@ impl GraphqlResolver {
         };
 
         tracing::debug!(
-            "Query {}\n{}\n{}",
+            "Executing request to subgraph named '{}' with query and variables:\n{}\n{}",
             endpoint.subgraph_name(),
             self.operation.query,
             serde_json::to_string_pretty(&variables).unwrap_or_default()

--- a/engine/crates/runtime-local/src/entity_cache/redis.rs
+++ b/engine/crates/runtime-local/src/entity_cache/redis.rs
@@ -1,6 +1,5 @@
 use deadpool::managed::Object;
 use futures_util::future::BoxFuture;
-use grafbase_telemetry::span::GRAFBASE_TARGET;
 use redis::{AsyncCommands, SetOptions};
 
 use crate::redis::{Manager, Pool};
@@ -50,7 +49,7 @@ impl RedisEntityCache {
         match self.pool.get().await {
             Ok(conn) => Ok(conn),
             Err(error) => {
-                tracing::error!(target: GRAFBASE_TARGET, "error fetching a Redis connection: {error}");
+                tracing::error!("error fetching a Redis connection: {error}");
                 anyhow::bail!("error fetching a redis connection: {error}");
             }
         }

--- a/engine/crates/runtime-local/src/rate_limiting/in_memory/key_based.rs
+++ b/engine/crates/runtime-local/src/rate_limiting/in_memory/key_based.rs
@@ -6,7 +6,6 @@ use futures_util::future::BoxFuture;
 use futures_util::FutureExt;
 use gateway_config::{Config, GraphRateLimit};
 use governor::Quota;
-use grafbase_telemetry::span::GRAFBASE_TARGET;
 
 use runtime::rate_limiting::{Error, RateLimitKey, RateLimiter, RateLimiterContext};
 use tokio::sync::watch;
@@ -93,12 +92,12 @@ impl InMemoryRateLimiter {
 
 fn create_limiter(rate_limit_config: GraphRateLimit) -> Option<governor::DefaultKeyedRateLimiter<usize>> {
     let Some(quota) = (rate_limit_config.limit as u64).checked_div(rate_limit_config.duration.as_secs()) else {
-        tracing::error!(target: GRAFBASE_TARGET, "the duration for rate limit cannot be zero");
+        tracing::error!("the duration for rate limit cannot be zero");
         return None;
     };
 
     let Some(quota) = NonZeroU32::new(quota as u32) else {
-        tracing::error!(target: GRAFBASE_TARGET, "the limit is too low per defined duration");
+        tracing::error!("the limit is too low per defined duration");
         return None;
     };
 

--- a/engine/crates/runtime-local/src/redis.rs
+++ b/engine/crates/runtime-local/src/redis.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 use anyhow::Context;
-use grafbase_telemetry::span::GRAFBASE_TARGET;
 use redis::ClientTlsConfig;
 
 pub type Pool = deadpool::managed::Pool<pool::Manager>;
@@ -114,7 +113,7 @@ fn new_pool(url: &str, tls_config: Option<RedisTlsConfig<'_>>) -> anyhow::Result
     let manager = match pool::Manager::new(url, tls_config) {
         Ok(manager) => manager,
         Err(e) => {
-            tracing::error!(target: GRAFBASE_TARGET, "error creating a Redis pool: {e}");
+            tracing::error!("error creating a Redis pool: {e}");
             return Err(e.into());
         }
     };
@@ -127,7 +126,7 @@ fn new_pool(url: &str, tls_config: Option<RedisTlsConfig<'_>>) -> anyhow::Result
     {
         Ok(pool) => Ok(pool),
         Err(e) => {
-            tracing::error!(target: GRAFBASE_TARGET, "error creating a Redis pool: {e}");
+            tracing::error!("error creating a Redis pool: {e}");
             Err(e.into())
         }
     }

--- a/engine/crates/telemetry/src/span/gql.rs
+++ b/engine/crates/telemetry/src/span/gql.rs
@@ -25,7 +25,7 @@ impl GqlRequestSpan {
         info_span!(
             target: crate::span::GRAFBASE_TARGET,
             GRAPHQL_SPAN_NAME,
-            "otel.name"  = GRAPHQL_SPAN_NAME,
+            "otel.name"  = Empty,
             "gql.operation.name"  = Empty,
             "gql.operation.type"  = Empty,
             "gql.operation.query"  = Empty,

--- a/engine/crates/telemetry/src/tower.rs
+++ b/engine/crates/telemetry/src/tower.rs
@@ -194,17 +194,13 @@ where
                 match gql_status {
                     Some(status) if status.is_success() => {
                         Span::current().record_gql_status(status);
-                        tracing::debug!(target: GRAFBASE_TARGET, "gateway response");
                     }
                     Some(status) => {
                         Span::current().record_gql_status(status);
-                        tracing::debug!(target: GRAFBASE_TARGET, "responding a GraphQL error");
                     }
                     None => {
                         let status = GraphqlResponseStatus::RequestError { count: 1 };
                         Span::current().record_gql_status(status);
-
-                        tracing::debug!(target: GRAFBASE_TARGET, "responding a GraphQL error");
                     }
                 }
 
@@ -233,7 +229,7 @@ where
                 );
 
                 Span::current().record_failure(err.to_string());
-                tracing::error!(target: GRAFBASE_TARGET, "{err}");
+                tracing::error!(target: GRAFBASE_TARGET, "Internal server error: {err}");
             }
         }
 

--- a/engine/crates/wasi-component-loader/Cargo.toml
+++ b/engine/crates/wasi-component-loader/Cargo.toml
@@ -9,7 +9,6 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-grafbase-telemetry.workspace = true
 http.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/engine/crates/wasi-component-loader/src/context.rs
+++ b/engine/crates/wasi-component-loader/src/context.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
 use crossbeam::{channel::TrySendError, sync::WaitGroup};
-use grafbase_telemetry::span::GRAFBASE_TARGET;
 use wasmtime::{
     component::{ComponentType, LinkerInstance, Lower, Resource, ResourceType},
     StoreContextMut,
@@ -192,10 +191,10 @@ fn log_access(
         Err(e) => {
             match e {
                 LogError::ChannelFull(_) => {
-                    tracing::error!(target: GRAFBASE_TARGET, "access log channel is over capacity");
+                    tracing::error!("access log channel is over capacity");
                 }
                 LogError::ChannelClosed => {
-                    tracing::error!(target: GRAFBASE_TARGET, "access log channel closed");
+                    tracing::error!("access log channel closed");
                 }
             }
 

--- a/engine/crates/wasi-component-loader/src/hooks.rs
+++ b/engine/crates/wasi-component-loader/src/hooks.rs
@@ -3,7 +3,6 @@ use std::future::Future;
 use std::sync::RwLock;
 
 use anyhow::anyhow;
-use grafbase_telemetry::span::GRAFBASE_TARGET;
 use wasmtime::{
     component::{ComponentNamedList, Instance, Lift, Lower, Resource, TypedFunc},
     Engine, Store,
@@ -268,14 +267,14 @@ impl ComponentInstance {
         let mut root = exports.root();
 
         let Some(mut interface) = root.instance(self.interface_name) else {
-            tracing::debug!(target: GRAFBASE_TARGET, "could not find export for {} interface", self.interface_name);
+            tracing::debug!("could not find export for {} interface", self.interface_name);
             self.function_cache.write().unwrap().push((function_name, None));
             return None;
         };
 
         match interface.typed_func(function_name) {
             Ok(hook) => {
-                tracing::debug!(target: GRAFBASE_TARGET, "instantized the {function_name} hook Wasm function");
+                tracing::debug!("instantized the {function_name} hook Wasm function");
                 self.function_cache
                     .write()
                     .unwrap()
@@ -284,7 +283,7 @@ impl ComponentInstance {
             }
             Err(e) => {
                 // Shouldn't happen, so we keep spamming errors to be sure it's seen.
-                tracing::error!(target: GRAFBASE_TARGET, "error instantizing the {function_name} hook Wasm function: {e}");
+                tracing::error!("error instantizing the {function_name} hook Wasm function: {e}");
                 None
             }
         }

--- a/engine/crates/wasi-component-loader/src/lib.rs
+++ b/engine/crates/wasi-component-loader/src/lib.rs
@@ -41,7 +41,6 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// The guest result type
 pub type GuestResult<T> = std::result::Result<T, GuestError>;
 
-use grafbase_telemetry::span::GRAFBASE_TARGET;
 use state::WasiState;
 use wasmtime::{
     component::{Component, Linker},
@@ -81,9 +80,8 @@ impl ComponentLoader {
         let this = match Component::from_file(&engine, &config.location) {
             Ok(component) => {
                 tracing::debug!(
-                    target: GRAFBASE_TARGET,
-                    message = "loaded the provided web assembly component successfully",
                     location = config.location.to_str(),
+                    "loaded the provided web assembly component successfully",
                 );
 
                 let mut linker = Linker::<WasiState>::new(&engine);
@@ -111,10 +109,8 @@ impl ComponentLoader {
             }
             Err(e) => {
                 tracing::error!(
-                    target: GRAFBASE_TARGET,
-                    message = "error loading web assembly component",
                     location = config.location.to_str(),
-                    error = e.to_string(),
+                    "error loading web assembly component: {e}",
                 );
 
                 None

--- a/gateway/changelog/0.12.0.md
+++ b/gateway/changelog/0.12.0.md
@@ -1,0 +1,3 @@
+## Features
+
+- Better logs with pretty formatting by default in the terminal. It can be forced with `--log-style pretty`, the previous format is available with `--log-style text`. Now when using `--log debug`, the executed subgraph query with variables and the response are shown.

--- a/gateway/crates/federated-server/src/hot_reload.rs
+++ b/gateway/crates/federated-server/src/hot_reload.rs
@@ -1,7 +1,6 @@
 use std::{fs, path::PathBuf, sync::OnceLock, time::Duration};
 
 use gateway_config::Config;
-use grafbase_telemetry::span::GRAFBASE_TARGET;
 use notify::{EventHandler, EventKind, PollWatcher, Watcher};
 use tokio::sync::watch;
 
@@ -41,7 +40,7 @@ impl ConfigWatcher {
         let config = match fs::read_to_string(&self.path) {
             Ok(config) => config,
             Err(e) => {
-                tracing::error!(target: GRAFBASE_TARGET, "error reading gateway config: {e}");
+                tracing::error!("error reading gateway config: {e}");
 
                 return Ok(());
             }
@@ -50,7 +49,7 @@ impl ConfigWatcher {
         let config: Config = match toml::from_str(&config) {
             Ok(config) => config,
             Err(e) => {
-                tracing::error!(target: GRAFBASE_TARGET, "error parsing gateway config: {e}");
+                tracing::error!("error parsing gateway config: {e}");
 
                 return Ok(());
             }
@@ -66,15 +65,15 @@ impl EventHandler for ConfigWatcher {
     fn handle_event(&mut self, event: notify::Result<notify::Event>) {
         match event.map(|e| e.kind) {
             Ok(EventKind::Any | EventKind::Create(_) | EventKind::Modify(_) | EventKind::Other) => {
-                tracing::debug!(target: GRAFBASE_TARGET, "reloading configuration file");
+                tracing::debug!("reloading configuration file");
 
                 if let Err(e) = self.reload_config() {
-                    tracing::error!(target: GRAFBASE_TARGET, "error reloading gateway config: {e}");
+                    tracing::error!("error reloading gateway config: {e}");
                 };
             }
             Ok(_) => (),
             Err(e) => {
-                tracing::error!(target: GRAFBASE_TARGET, "error reading gateway config: {e}");
+                tracing::error!("error reading gateway config: {e}");
             }
         }
     }

--- a/gateway/crates/federated-server/src/server/health.rs
+++ b/gateway/crates/federated-server/src/server/health.rs
@@ -4,7 +4,6 @@ use gateway_config::{HealthConfig, TlsConfig};
 
 use super::{state::ServerState, ServerRuntime};
 use axum::{extract::State, routing::get, Json, Router};
-use grafbase_telemetry::span::GRAFBASE_TARGET;
 use http::StatusCode;
 
 #[derive(Debug, serde::Serialize)]
@@ -35,7 +34,7 @@ pub(super) async fn bind_health_endpoint<SR: ServerRuntime>(
         .with_state(state)
         .into_make_service();
 
-    tracing::info!(target: GRAFBASE_TARGET, "Health check endpoint exposed at {scheme}://{addr}{path}");
+    tracing::info!("Health check endpoint exposed at {scheme}://{addr}{path}");
 
     match tls_config {
         Some(tls) => {

--- a/gateway/crates/gateway-binary/src/args.rs
+++ b/gateway/crates/gateway-binary/src/args.rs
@@ -7,15 +7,12 @@ use ::std::{net::SocketAddr, path::Path};
 use clap::Parser;
 use federated_server::GraphFetchMethod;
 use gateway_config::Config;
-use grafbase_telemetry::otel::layer::BoxedLayer;
-pub(crate) use log::LogLevel;
-use tracing::Subscriber;
-use tracing_subscriber::registry::LookupSpan;
+pub(crate) use log::*;
 
 pub(crate) trait Args {
     fn listen_address(&self) -> Option<SocketAddr>;
 
-    fn log_level(&self) -> Option<LogLevel>;
+    fn log_level(&self) -> LogLevel;
 
     fn fetch_method(&self) -> anyhow::Result<GraphFetchMethod>;
 
@@ -25,9 +22,7 @@ pub(crate) trait Args {
 
     fn hot_reload(&self) -> bool;
 
-    fn log_format<S>(&self) -> BoxedLayer<S>
-    where
-        S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync;
+    fn log_style(&self) -> LogStyle;
 }
 
 pub(crate) fn parse() -> impl Args {

--- a/gateway/crates/gateway-binary/src/args/log.rs
+++ b/gateway/crates/gateway-binary/src/args/log.rs
@@ -2,39 +2,23 @@ use std::fmt;
 
 use clap::ValueEnum;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub(crate) enum LogLevel {
-    /// Completely disables logging
+    /// Completely disables logging.
     Off,
-    /// Only errors from Grafbase libraries
+    /// Only errors.
     Error,
-    /// Warnings and errors from Grafbase libraries
+    /// Warnings and errors.
     Warn,
-    /// Info, warning and error messages from Grafbase libraries
+    /// Info, warning and error messages.
+    #[default]
     Info,
-    /// Debug, info, warning and error messages from Grafbase libraries
+    /// Debug, info, warning and error messages. Beware that debug messages will include sensitive
+    /// information like request variables, responses, etc. Do not use it in production.
     Debug,
-    /// Trace, debug, info, warning and error messages from all dependencies
+    /// Trace, debug, info, warning and error messages. Similar to debug, this will include
+    /// sensitive information and should not be used in production.
     Trace,
-}
-
-impl Default for LogLevel {
-    fn default() -> Self {
-        Self::Info
-    }
-}
-
-impl LogLevel {
-    pub(crate) fn as_filter_str(&self) -> &'static str {
-        match self {
-            LogLevel::Off => "off",
-            LogLevel::Error => "grafbase=error,off",
-            LogLevel::Warn => "grafbase=warn,off",
-            LogLevel::Info => "grafbase=info,off",
-            LogLevel::Debug => "grafbase=debug,off",
-            LogLevel::Trace => "trace",
-        }
-    }
 }
 
 impl AsRef<str> for LogLevel {
@@ -57,16 +41,30 @@ impl fmt::Display for LogLevel {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
-pub(super) enum LogStyle {
-    /// Standard text
+pub(crate) enum LogStyle {
+    /// Pretty printed logs, used as the default in the terminal
+    Pretty,
+    /// Standard text, used as the default when piping stdout to a file.
     Text,
     /// JSON objects
     Json,
 }
 
+impl Default for LogStyle {
+    fn default() -> Self {
+        let is_terminal = atty::is(atty::Stream::Stdout);
+        if is_terminal {
+            LogStyle::Pretty
+        } else {
+            LogStyle::Text
+        }
+    }
+}
+
 impl AsRef<str> for LogStyle {
     fn as_ref(&self) -> &str {
         match self {
+            LogStyle::Pretty => "pretty",
             LogStyle::Text => "text",
             LogStyle::Json => "json",
         }

--- a/gateway/crates/gateway-binary/src/main.rs
+++ b/gateway/crates/gateway-binary/src/main.rs
@@ -6,7 +6,6 @@ use mimalloc::MiMalloc;
 use tokio::runtime;
 
 use federated_server::ServerConfig;
-use grafbase_telemetry::span::GRAFBASE_TARGET;
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
@@ -50,7 +49,7 @@ fn main() -> anyhow::Result<()> {
         };
 
         let crate_version = crate_version!();
-        tracing::info!(target: GRAFBASE_TARGET, "Grafbase Gateway {crate_version}");
+        tracing::info!("Grafbase Gateway {crate_version}");
 
         let config = ServerConfig {
             listen_addr: args.listen_address(),


### PR DESCRIPTION
Current logs were filtering just way too much stuff and without pretty formatting it's just hard to read anything with span attributes. Pretty formatting is used by default in the terminal.

Removed the `GRAFBASE_TARGET` stuff everywhere but in `grafbase_telemetry`, I don't see any good reason to use it outside that crate. There are no filters on the target anymore in the gateway binary.

I've slightly improved trace events in engine_v2. Now we can see the executed query with variables and the response with `--log debug` in a somewhat readable manner.