### PR TITLE
chore: Improve docker build time

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -158,7 +158,7 @@ jobs:
   docker-grafbase:
     needs: [test]
     if: ${{ needs.detect-change-type.outputs.build == 'true' || startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubicloud-standard-8
+    runs-on: ubicloud-standard-16
     permissions:
       packages: write
     env:
@@ -210,7 +210,7 @@ jobs:
   docker-gateway:
     needs: [test]
     if: ${{ needs.detect-change-type.outputs.build == 'true' || startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubicloud-standard-8
+    runs-on: ubicloud-standard-16
     permissions:
       packages: write
     env:

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -19,8 +19,16 @@ RUN apk add --no-cache git npm && \
 # Using the same alpine image as oven/bun
 # https://github.com/oven-sh/bun/blob/bun-v1.1.12/dockerhub/alpine/Dockerfile
 FROM rust:1.80-alpine3.20 AS chef
+
+# Patching musl to use mimalloc, see docker/README.md.
+# Source: https://github.com/tweag/rust-alpine-mimalloc
+COPY docker/build.sh docker/mimalloc.diff /tmp/
+RUN /tmp/build.sh
+ENV LD_PRELOAD=/usr/lib/libmimalloc.so
+ENV RUSTFLAGS="-C target-feature=+crt-static"
+
 COPY rust-toolchain.toml rust-toolchain.toml
-RUN apk add --no-cache musl-dev && cargo install cargo-chef
+RUN apk add --no-cache musl-dev && cargo install --target "$(rustc -vV | sed -n "s|host: ||p")" cargo-chef
 WORKDIR /grafbase
 
 FROM chef AS planner
@@ -30,21 +38,22 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
 COPY --from=planner /grafbase/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
+RUN cargo chef cook --target "$(rustc -vV | sed -n "s|host: ||p")" --release --recipe-path recipe.json
 
 COPY Cargo.lock Cargo.lock
 COPY Cargo.toml Cargo.toml
-COPY ./gateway ./gateway
+COPY ./gateway/crates ./gateway/crates
 COPY ./cli ./cli
 COPY ./graphql-introspection ./graphql-introspection
 COPY ./graph-ref ./graph-ref
 COPY ./graphql-lint ./graphql-lint
 COPY ./gqlint ./gqlint
-COPY ./engine ./engine
+COPY ./engine/crates ./engine/crates
 COPY ./packages/grafbase-sdk/package.json ./packages/grafbase-sdk/package.json
 COPY --from=assets /grafbase/packages/cli-app/dist ./packages/cli-app/dist
 COPY --from=assets /grafbase/cli/wrappers/dist.js ./cli/wrappers/dist.js
-RUN cargo build --release --bin grafbase
+RUN cargo build --release --target "$(rustc -vV | sed -n "s|host: ||p")" --bin grafbase &&\
+    mv "/grafbase/target/$(rustc -vV | sed -n "s|host: ||p")/release/grafbase" /grafbase/target/release/grafbase
 
 #
 # === Final image ===
@@ -60,7 +69,7 @@ LABEL org.opencontainers.image.url='https://grafbase.com/cli' \
 
 # gosu is a better sudo/su to step down from root into the service user in the docker-entrypoint.sh script
 # See https://github.com/tianon/gosu/blob/master/INSTALL.md
-ENV GOSU_VERSION 1.17
+ENV GOSU_VERSION=1.17
 RUN set -eux; \
     \
     apk add --no-cache --virtual .gosu-deps \

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,8 @@
+Source: https://github.com/tweag/rust-alpine-mimalloc
+Explanation: https://www.tweag.io/blog/2023-08-10-rust-static-link-with-mimalloc/
+
+`build.sh` & `mimalloc.diff` were copy-pasted from e0720a1 (last commit as of 2024-08-29).
+
+The short version is that the musl allocator behaves poorly in multi-threaded scenarios. So the author patched musl to use mimalloc. Now on my machine build times are comparable to those without docker instead of spending an absurd amount of time in kernel threads.
+
+gateway docker build went from 15min to 5min and cli went from 19 to 6 in the CI with this fix.

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+set -eu
+
+MIMALLOC_VERSION=2.1.7
+
+cd /tmp
+
+apk upgrade --no-cache
+
+apk add --no-cache \
+    alpine-sdk \
+    cargo \
+    cmake \
+    curl \
+    mold \
+    ninja-is-really-ninja
+
+find /usr -type f -executable -name "ld" -exec sh -c 'ln -sf /usr/bin/ld.mold {}' \;
+
+curl -f -L --retry 5 https://github.com/microsoft/mimalloc/archive/refs/tags/v$MIMALLOC_VERSION.tar.gz | tar xz --strip-components=1
+
+patch -p1 <mimalloc.diff
+
+cmake \
+    -Bout \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DMI_BUILD_OBJECT=OFF \
+    -DMI_BUILD_TESTS=OFF \
+    -DMI_SKIP_COLLECT_ON_EXIT=ON \
+    -G Ninja \
+    .
+
+cmake --build out --target install -- -v
+
+for libc_path in $(find /usr -name libc.a); do
+    {
+        echo "CREATE libc.a"
+        echo "ADDLIB $libc_path"
+        echo "DELETE aligned_alloc.lo calloc.lo donate.lo free.lo libc_calloc.lo lite_malloc.lo malloc.lo malloc_usable_size.lo memalign.lo posix_memalign.lo realloc.lo reallocarray.lo valloc.lo"
+        echo "ADDLIB out/libmimalloc.a"
+        echo "SAVE"
+    } | ar -M
+    mv libc.a $libc_path
+done
+
+rm -rf /tmp/*

--- a/docker/mimalloc.diff
+++ b/docker/mimalloc.diff
@@ -1,0 +1,34 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2bcd1ef..6521343 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -422,7 +422,6 @@ endif()
+ # static library
+ if (MI_BUILD_STATIC)
+   add_library(mimalloc-static STATIC ${mi_sources})
+-  set_property(TARGET mimalloc-static PROPERTY POSITION_INDEPENDENT_CODE ON)
+   target_compile_definitions(mimalloc-static PRIVATE ${mi_defines} MI_STATIC_LIB)
+   target_compile_options(mimalloc-static PRIVATE ${mi_cflags})
+   target_link_libraries(mimalloc-static PRIVATE ${mi_libraries})
+diff --git a/src/alloc-override.c b/src/alloc-override.c
+index 873065d..10a1709 100644
+--- a/src/alloc-override.c
++++ b/src/alloc-override.c
+@@ -181,7 +181,7 @@ typedef struct mi_nothrow_s { int _tag; } mi_nothrow_t;
+   void* operator new[](std::size_t n, std::align_val_t al, const std::nothrow_t&) noexcept { return mi_new_aligned_nothrow(n, static_cast<size_t>(al)); }
+   #endif
+ 
+-#elif (defined(__GNUC__) || defined(__clang__))
++#elif 0
+   // ------------------------------------------------------
+   // Override by defining the mangled C++ names of the operators (as
+   // used by GCC and CLang).
+@@ -272,7 +272,7 @@ void* _aligned_malloc(size_t alignment, size_t size)    { return mi_aligned_allo
+   void  __libc_free(void* p)                            MI_FORWARD0(mi_free, p)
+   void* __libc_memalign(size_t alignment, size_t size)  { return mi_memalign(alignment, size); }
+ 
+-#elif defined(__GLIBC__) && defined(__linux__)
++#elif defined(__linux__)
+   // forward __libc interface (needed for glibc-based Linux distributions)
+   void* __libc_malloc(size_t size)                      MI_FORWARD1(mi_malloc,size)
+   void* __libc_calloc(size_t count, size_t size)        MI_FORWARD2(mi_calloc,count,size)

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -2,8 +2,16 @@
 # === Build image ===
 #
 FROM rust:1.80-alpine3.20 AS chef
+
+# Patching musl to use mimalloc, see docker/README.md.
+# Source: https://github.com/tweag/rust-alpine-mimalloc
+COPY docker/build.sh docker/mimalloc.diff /tmp/
+RUN /tmp/build.sh
+ENV LD_PRELOAD=/usr/lib/libmimalloc.so
+ENV RUSTFLAGS="-C target-feature=+crt-static"
+
 COPY rust-toolchain.toml rust-toolchain.toml
-RUN apk add --no-cache musl-dev && cargo install cargo-chef
+RUN apk add --no-cache musl-dev && cargo install --target "$(rustc -vV | sed -n "s|host: ||p")" cargo-chef
 WORKDIR /grafbase
 
 FROM chef AS planner
@@ -13,19 +21,20 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
 COPY --from=planner /grafbase/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
+RUN cargo chef cook --target "$(rustc -vV | sed -n "s|host: ||p")" --release --recipe-path recipe.json
 
 COPY Cargo.lock Cargo.lock
 COPY Cargo.toml Cargo.toml
-COPY ./gateway ./gateway
+COPY ./gateway/crates ./gateway/crates
 COPY ./cli ./cli
 COPY ./graphql-introspection ./graphql-introspection
 COPY ./graph-ref ./graph-ref
 COPY ./graphql-lint ./graphql-lint
 COPY ./gqlint ./gqlint
-COPY ./engine ./engine
+COPY ./engine/crates ./engine/crates
 
-RUN cargo build -p grafbase-gateway --release
+RUN cargo build --release --target "$(rustc -vV | sed -n "s|host: ||p")" --bin grafbase-gateway &&\
+    mv "/grafbase/target/$(rustc -vV | sed -n "s|host: ||p")/release/grafbase-gateway" /grafbase/target/release/grafbase-gateway
 
 #
 # === Final image ===
@@ -49,10 +58,6 @@ USER grafbase
 
 COPY --from=builder /grafbase/target/release/grafbase-gateway /bin/grafbase-gateway
 COPY --from=builder /grafbase/gateway/crates/federated-server/config/grafbase.toml /etc/grafbase.toml
-
-# these args should be set so the binary can start, they have to be changed for successfully running the gateway
-ARG GRAFBASE_GRAPH_REF
-ARG GRAFBASE_ACCESS_TOKEN
 
 VOLUME /data
 WORKDIR /data


### PR DESCRIPTION
To read a full explanation: https://www.tweag.io/blog/2023-08-10-rust-static-link-with-mimalloc/

It's an old problem that profoundly bothered me. As Graeme started taking a look at build times in general, got me curious again as to why cargo builds were so much slower within a docker build than without on my machine. Almost an order of magnitude.

The short version is that the musl allocator behaves poorly in multi-threaded scenarios. So the author patched musl to use mimalloc. Now on my machine build times are comparable to those without docker instead of spending an absurd amount of time in kernel threads.

|               | Gateway | CLI   |
|---------------|---------|-------|
| base          | 15m30   | 19m50 |
| mimalloc musl | 5m30    | 6m35  |
| 8 -> 16 cores | 4m      | 4m40  |