### PR TITLE
feat(gateway): better logs part 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3626,6 +3626,7 @@ dependencies = [
  "http",
  "indoc",
  "insta",
+ "itertools 0.13.0",
  "mimalloc",
  "opentelemetry-aws",
  "rand 0.8.5",

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -15,22 +15,23 @@ lambda = [
 ]
 
 [dependencies]
-anyhow = { version = "1.0.82", default-features = false }
-ascii = { version = "1.1.0", default-features = false }
-atty = "0.2.14"
-clap = { version = "4.5.4", features = ["cargo", "wrap_help", "derive", "env"] }
+anyhow = { version = "1", default-features = false }
+ascii = { version = "1", default-features = false }
+atty = "0.2"
+clap = { version = "4.5", features = ["cargo", "wrap_help", "derive", "env"] }
 federated-server.workspace = true
 gateway-config.workspace = true
 grafbase-telemetry = { workspace = true, features = ["otlp"] }
 graph-ref.workspace = true
-mimalloc = "0.1.41"
+itertools.workspace = true
+mimalloc = "0.1"
 opentelemetry-aws = { version = "0.10.0" }
 rustls = { workspace = true, features = ["ring"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
-toml = "0.8.12"
+toml = "0.8"
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["json"] }
-cfg-if = "1.0.0"
+cfg-if = "1"
 
 [lints]
 workspace = true

--- a/gateway/crates/gateway-binary/src/args.rs
+++ b/gateway/crates/gateway-binary/src/args.rs
@@ -12,7 +12,7 @@ pub(crate) use log::*;
 pub(crate) trait Args {
     fn listen_address(&self) -> Option<SocketAddr>;
 
-    fn log_level(&self) -> LogLevel;
+    fn log_level(&self) -> LogLevel<'_>;
 
     fn fetch_method(&self) -> anyhow::Result<GraphFetchMethod>;
 

--- a/gateway/crates/gateway-binary/src/args/lambda.rs
+++ b/gateway/crates/gateway-binary/src/args/lambda.rs
@@ -22,9 +22,16 @@ pub struct Args {
     /// to the Grafbase API.
     #[arg(env = "GRAFBASE_SCHEMA_PATH", default_value = "./federated.graphql")]
     pub schema: PathBuf,
-    /// Set the logging level
-    #[arg(env = "GRAFBASE_LOG", default_value_t = LogLevel::default())]
-    pub log_level: LogLevel,
+    /// Set the logging level, this applies to all spans, logs and trace events.
+    ///
+    /// Beware that *only* 'off', 'error', 'warn' and 'info' can be used safely in production. More
+    /// verbose levels, such as 'debug', will include sensitive information like request variables, responses, etc.
+    ///
+    /// Possible values are: 'off', 'error', 'warn', 'info', 'debug', 'trace' or a custom string.
+    /// In the last case, the string is passed on to [`tracing_subscriber::EnvFilter`] as is and is
+    /// only meant for debugging purposes. No stability guarantee is made on the format.
+    #[arg(long = "log", env = "GRAFBASE_LOG", default_value = "info")]
+    pub log_level: String,
     /// Set the style of log output
     #[arg(env = "GRAFBASE_LOG_STYLE", default_value_t = LogStyle::Text)]
     log_style: LogStyle,
@@ -67,7 +74,7 @@ impl super::Args for Args {
         None
     }
 
-    fn log_level(&self) -> LogLevel {
-        self.log_level
+    fn log_level(&self) -> LogLevel<'_> {
+        LogLevel(&self.log_level)
     }
 }

--- a/gateway/crates/gateway-binary/src/args/std.rs
+++ b/gateway/crates/gateway-binary/src/args/std.rs
@@ -46,11 +46,18 @@ pub struct Args {
     /// to the Grafbase API.
     #[arg(long, short, env = "GRAFBASE_SCHEMA_PATH")]
     pub schema: Option<PathBuf>,
-    /// Set the logging level
-    #[arg(long = "log", env = "GRAFBASE_LOG", default_value_t = LogLevel::default())]
-    pub log_level: LogLevel,
+    /// Set the logging level, this applies to all spans, logs and trace events.
+    ///
+    /// Beware that *only* 'off', 'error', 'warn' and 'info' can be used safely in production. More
+    /// verbose levels, such as 'debug', will include sensitive information like request variables, responses, etc.
+    ///
+    /// Possible values are: 'off', 'error', 'warn', 'info', 'debug', 'trace' or a custom string.
+    /// In the last case, the string is passed on to [`tracing_subscriber::EnvFilter`] as is and is
+    /// only meant for debugging purposes. No stability guarantee is made on the format.
+    #[arg(long = "log", env = "GRAFBASE_LOG", default_value = "info")]
+    pub log_level: String,
     /// Set the style of log output
-    #[arg(long, env = "GRAFBASE_LOG_STYLE", default_value_t = LogStyle::default())]
+    #[arg(long, env = "GRAFBASE_LOG_STYLE", default_value_t)]
     log_style: LogStyle,
     /// If set, parts of the configuration will get reloaded when changed.
     #[arg(long, action)]
@@ -132,7 +139,7 @@ impl super::Args for Args {
         self.listen_address
     }
 
-    fn log_level(&self) -> LogLevel {
-        self.log_level
+    fn log_level(&self) -> LogLevel<'_> {
+        LogLevel(&self.log_level)
     }
 }

--- a/gateway/crates/gateway-binary/src/main.rs
+++ b/gateway/crates/gateway-binary/src/main.rs
@@ -30,23 +30,7 @@ fn main() -> anyhow::Result<()> {
         .build()?;
 
     runtime.block_on(async move {
-        let telemetry = if std::env::var("__GRAFBASE_RUST_LOG").is_ok() {
-            let filter = tracing_subscriber::filter::EnvFilter::try_from_env("__GRAFBASE_RUST_LOG").unwrap_or_default();
-
-            tracing_subscriber::fmt()
-                .pretty()
-                .with_env_filter(filter)
-                .with_file(true)
-                .with_line_number(true)
-                .with_target(true)
-                .without_time()
-                .init();
-
-            tracing::warn!("Skipping OTEL configuration.");
-            Default::default()
-        } else {
-            telemetry::init(&args, config.telemetry.clone())?
-        };
+        let telemetry = telemetry::init(&args, &config.telemetry)?;
 
         let crate_version = crate_version!();
         tracing::info!("Grafbase Gateway {crate_version}");

--- a/gateway/crates/gateway-binary/src/telemetry.rs
+++ b/gateway/crates/gateway-binary/src/telemetry.rs
@@ -14,11 +14,11 @@ pub(crate) struct OpenTelemetryProviders {
     pub tracer: Option<TracerProvider>,
 }
 
-pub(crate) fn init(args: &impl Args, config: TelemetryConfig) -> anyhow::Result<OpenTelemetryProviders> {
+pub(crate) fn init(args: &impl Args, config: &TelemetryConfig) -> anyhow::Result<OpenTelemetryProviders> {
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
 
-    let env_filter = EnvFilter::new(args.log_level().as_ref());
+    let env_filter = EnvFilter::from(args.log_level());
 
     init_propagators(&config.tracing);
 


### PR DESCRIPTION
By default "debug" and "trace" produce way too much information with h2,
hyper etc. So forcing them to stay at info. I'm also adding the
possibility to fully customize the log filter with a custom input. The
goal is to remove `__GRAFBASE_RUST_LOG` and be able to adjust the log
levels as needed. This will also help figuring out the best default
values.