### PR TITLE
Use web_time::Instant instead of Instant from std in runtime::hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7611,6 +7611,7 @@ dependencies = [
  "tracing-futures",
  "ulid",
  "url",
+ "web-time",
 ]
 
 [[package]]

--- a/engine/crates/runtime/Cargo.toml
+++ b/engine/crates/runtime/Cargo.toml
@@ -31,6 +31,7 @@ ulid.workspace = true
 tracing.workspace = true
 tracing-futures.workspace = true
 url.workspace = true
+web-time.workspace = true
 
 postgres-connector-types = { path = "../postgres-connector-types" }
 common-types.workspace = true

--- a/engine/crates/runtime/src/hooks.rs
+++ b/engine/crates/runtime/src/hooks.rs
@@ -6,7 +6,8 @@ use grafbase_telemetry::gql_response_status::{GraphqlResponseStatus, SubgraphRes
 pub use test_utils::*;
 use url::Url;
 
-use std::{future::Future, time::Instant};
+use std::future::Future;
+use web_time::Instant;
 
 pub use http::HeaderMap;
 


### PR DESCRIPTION
Otherwise the engine stops working on wasm32-unknown-unknown