### PR TITLE
Add version to GraphRef

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2537,7 +2537,6 @@ dependencies = [
  "thiserror",
  "tower",
  "tracing",
- "ulid",
  "url",
  "web-time",
 ]
@@ -2885,6 +2884,7 @@ dependencies = [
  "tokio-stream",
  "tower-http",
  "tracing",
+ "ulid",
  "url",
 ]
 
@@ -2904,6 +2904,7 @@ dependencies = [
  "engine-v2-axum",
  "gateway-config",
  "grafbase-telemetry",
+ "graph-ref",
  "graphql-composition",
  "http",
  "lambda_http",

--- a/cli/crates/cli/src/cli_input/project_ref.rs
+++ b/cli/crates/cli/src/cli_input/project_ref.rs
@@ -87,7 +87,7 @@ impl ProjectRefOrGraphRef {
     pub(crate) fn branch(&self) -> Option<&str> {
         match self {
             ProjectRefOrGraphRef::ProjectRef(pr) => pr.branch(),
-            ProjectRefOrGraphRef::GraphRef(gr) => gr.branch_name(),
+            ProjectRefOrGraphRef::GraphRef(gr) => gr.branch(),
         }
     }
 
@@ -101,7 +101,7 @@ impl ProjectRefOrGraphRef {
     pub(crate) fn project(&self) -> &str {
         match self {
             ProjectRefOrGraphRef::ProjectRef(pr) => pr.graph(),
-            ProjectRefOrGraphRef::GraphRef(gr) => gr.graph_slug(),
+            ProjectRefOrGraphRef::GraphRef(gr) => gr.slug(),
         }
     }
 }

--- a/cli/crates/federated-dev/Cargo.toml
+++ b/cli/crates/federated-dev/Cargo.toml
@@ -33,6 +33,7 @@ tracing.workspace = true
 tokio = { workspace = true, features = ["sync", "rt", "io-std", "time"] }
 tokio-stream = { version = "0.1.15", features = ["sync"] }
 tower-http = { workspace = true, features = ["cors", "fs", "trace"] }
+ulid.workspace = true
 url = "2.5.0"
 
 common = { package = "grafbase-local-common", path = "../common", version = "0.79.2" }

--- a/engine/crates/engine-v2/Cargo.toml
+++ b/engine/crates/engine-v2/Cargo.toml
@@ -21,7 +21,6 @@ async-runtime.workspace = true
 base64.workspace = true
 blake3.workspace = true
 bytes.workspace = true
-ulid.workspace = true
 url.workspace = true
 crossbeam-queue = "0.3.11"
 enumset = "1"

--- a/engine/crates/engine-v2/schema/src/lib.rs
+++ b/engine/crates/engine-v2/schema/src/lib.rs
@@ -44,6 +44,22 @@ impl Schema {
     }
 }
 
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct Version(Vec<u8>);
+
+impl<T: AsRef<[u8]>> From<T> for Version {
+    fn from(value: T) -> Self {
+        Version(value.as_ref().to_vec())
+    }
+}
+
+impl std::ops::Deref for Version {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 /// /!\ This is *NOT* backwards-compatible. /!\
 /// Only a schema serialized with the exact same version is expected to work. For backwards
 /// compatibility use engine-v2-config instead.
@@ -51,6 +67,7 @@ impl Schema {
 pub struct Schema {
     data_sources: DataSources,
     pub graph: Graph,
+    pub version: Version,
 
     /// All strings deduplicated.
     #[indexed_by(StringId)]
@@ -65,6 +82,12 @@ pub struct Schema {
     header_rules: Vec<HeaderRule>,
 
     pub settings: Settings,
+}
+
+impl Schema {
+    pub fn build(config: config::latest::Config, version: Version) -> Result<Schema, BuildError> {
+        builder::build(config, version)
+    }
 }
 
 impl<T> std::ops::Index<T> for Schema

--- a/engine/crates/engine-v2/schema/tests/conversion.rs
+++ b/engine/crates/engine-v2/schema/tests/conversion.rs
@@ -1,5 +1,5 @@
 use config::latest::{HeaderRemove, HeaderRule, NameOrPattern};
-use engine_v2_schema::{Definition, Schema};
+use engine_v2_schema::{Definition, Schema, Version};
 use federated_graph::from_sdl;
 use pretty_assertions::assert_eq;
 use regex::Regex;
@@ -100,7 +100,7 @@ type User
 fn should_not_fail() {
     let graph = from_sdl(SCHEMA).unwrap();
     let config = config::VersionedConfig::V6(config::latest::Config::from_graph(graph)).into_latest();
-    let _schema = Schema::try_from(config).unwrap();
+    let _schema = Schema::build(config, Version::from("random")).unwrap();
 }
 
 const SCHEMA_WITH_INACCESSIBLES: &str = r#"
@@ -233,7 +233,7 @@ input BookInput2 {
 fn should_remove_all_inaccessible_items() {
     let graph = from_sdl(SCHEMA_WITH_INACCESSIBLES).unwrap();
     let config = config::VersionedConfig::V6(config::latest::Config::from_graph(graph)).into_latest();
-    let schema = Schema::try_from(config).unwrap();
+    let schema = Schema::build(config, Version::from("random")).unwrap();
 
     // Inaccessible types are still in the schema, they're just not reachable through input and output fields.
     assert!(schema.walker().definition_by_name("BookInput").is_some());
@@ -315,7 +315,7 @@ fn serde_roundtrip(#[case] sdl: &str) {
         name: NameOrPattern::Pattern(Regex::new("^foo*").unwrap()),
     }));
 
-    let schema = Schema::try_from(config).unwrap();
+    let schema = Schema::build(config, Version::from("random")).unwrap();
 
     let bytes = postcard::to_stdvec(&schema).unwrap();
     postcard::from_bytes::<Schema>(&bytes).unwrap();

--- a/engine/crates/engine-v2/src/engine/cache.rs
+++ b/engine/crates/engine-v2/src/engine/cache.rs
@@ -4,8 +4,6 @@ use base64::{display::Base64Display, engine::general_purpose::URL_SAFE_NO_PAD};
 use engine::PersistedQueryRequestExtension;
 use schema::Schema;
 
-use super::SchemaVersion;
-
 mod namespaces {
     pub const OPERATION: &str = "op";
 }
@@ -15,7 +13,7 @@ mod namespaces {
 pub(super) enum Key<'a> {
     Operation {
         name: Option<&'a str>,
-        schema_version: &'a SchemaVersion,
+        schema: &'a Schema,
         document: Document<'a>,
     },
 }
@@ -31,16 +29,12 @@ impl std::fmt::Display for Key<'_> {
         match self {
             // Schema version + Commit SHA ensures we don't need to care about
             // backwards-compatibility
-            Key::Operation {
-                name,
-                schema_version,
-                document,
-            } => {
+            Key::Operation { name, schema, document } => {
                 let mut hasher = blake3::Hasher::new();
                 hasher.update(&Schema::build_identifier().len().to_ne_bytes());
                 hasher.update(Schema::build_identifier());
-                hasher.update(&schema_version.len().to_ne_bytes());
-                hasher.update(schema_version);
+                hasher.update(&schema.version.len().to_ne_bytes());
+                hasher.update(&schema.version);
 
                 if let Some(name) = name {
                     hasher.update(name.as_bytes());

--- a/engine/crates/engine-v2/src/engine/execute.rs
+++ b/engine/crates/engine-v2/src/engine/execute.rs
@@ -114,7 +114,7 @@ impl<R: Runtime> Engine<R> {
                 )
             })?;
 
-            self.metrics.record_request_body_size(body.len());
+            self.runtime.metrics().record_request_body_size(body.len());
 
             serde_json::from_slice(&body).map_err(|err| {
                 Http::from(
@@ -180,7 +180,7 @@ impl<R: Runtime> Engine<R> {
                     );
                 };
 
-                self.metrics.record_batch_size(requests.len());
+                self.runtime.metrics().record_batch_size(requests.len());
 
                 let Some((responses, operation_hook_results)): Option<(Vec<_>, Vec<_>)> = self
                     .runtime

--- a/engine/crates/engine-v2/src/engine/execute/single.rs
+++ b/engine/crates/engine-v2/src/engine/execute/single.rs
@@ -37,7 +37,7 @@ impl<R: Runtime> Engine<R> {
             if let Some(operation_metrics_attributes) = operation_metrics_attributes.clone() {
                 span.record_gql_request((&operation_metrics_attributes).into());
 
-                self.metrics.record_operation_duration(
+                self.runtime.metrics().record_operation_duration(
                     GraphqlRequestMetricsAttributes {
                         operation: operation_metrics_attributes,
                         status,
@@ -52,7 +52,7 @@ impl<R: Runtime> Engine<R> {
 
             if let Some(attributes) = operation_metrics_attributes {
                 for error_code in response.distinct_error_codes() {
-                    self.metrics.increment_graphql_errors(GraphqlErrorAttributes {
+                    self.runtime.metrics().increment_graphql_errors(GraphqlErrorAttributes {
                         code: error_code.into(),
                         operation_name: attributes.name.clone(),
                         client: request_context.client.clone(),

--- a/engine/crates/engine-v2/src/engine/execute/stream.rs
+++ b/engine/crates/engine-v2/src/engine/execute/stream.rs
@@ -45,7 +45,7 @@ impl<R: Runtime> Engine<R> {
                 if let Some(operation_metrics_attributes) = operation_metrics_attributes {
                     span.record_gql_request((&operation_metrics_attributes).into());
 
-                    engine.metrics.record_operation_duration(
+                    engine.runtime.metrics().record_operation_duration(
                         GraphqlRequestMetricsAttributes {
                             operation: operation_metrics_attributes,
                             status,
@@ -151,7 +151,7 @@ impl<'ctx, R: Runtime> PreExecutionContext<'ctx, R> {
                 status: &mut status,
                 operation_name: metrics_attributes.as_ref().and_then(|a| a.name.clone()),
                 client: client.clone(),
-                metrics: &engine.metrics,
+                metrics: engine.runtime.metrics(),
             },
         )
         .await;

--- a/engine/crates/engine-v2/src/engine/runtime.rs
+++ b/engine/crates/engine-v2/src/engine/runtime.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 
-use grafbase_telemetry::otel::opentelemetry::metrics::Meter;
+use grafbase_telemetry::metrics::EngineMetrics;
 use runtime::{entity_cache::EntityCache, kv::KvStore, rate_limiting::RateLimiter};
 
 pub trait Runtime: Send + Sync + 'static {
@@ -11,7 +11,7 @@ pub trait Runtime: Send + Sync + 'static {
     fn fetcher(&self) -> &Self::Fetcher;
     fn kv(&self) -> &KvStore;
     fn trusted_documents(&self) -> &runtime::trusted_documents_client::Client;
-    fn meter(&self) -> &Meter;
+    fn metrics(&self) -> &EngineMetrics;
     fn hooks(&self) -> &Self::Hooks;
     fn operation_cache_factory(&self) -> &Self::OperationCacheFactory;
     fn rate_limiter(&self) -> &RateLimiter;

--- a/engine/crates/engine-v2/src/engine/trusted_documents.rs
+++ b/engine/crates/engine-v2/src/engine/trusted_documents.rs
@@ -38,17 +38,15 @@ impl<'ctx, R: Runtime> PreExecutionContext<'ctx, R> {
         'r: 'f,
     {
         let client_name = self.request_context.client.as_ref().map(|c| c.name.as_ref());
-        let trusted_documents_enabled = self.runtime.trusted_documents().is_enabled();
+        let trusted_documents = self.engine.runtime.trusted_documents();
         let persisted_query_extension = request.extensions.persisted_query.as_ref();
         let doc_id = request.doc_id.as_ref();
         let name = request.operation_name.as_deref();
-        let schema_version = &self.engine.schema_version;
+        let schema = &self.engine.schema;
 
-        match (trusted_documents_enabled, persisted_query_extension, doc_id) {
+        match (trusted_documents.is_enabled(), persisted_query_extension, doc_id) {
             (true, None, None) => {
-                if self
-                    .runtime
-                    .trusted_documents()
+                if trusted_documents
                     .bypass_header()
                     .map(|(name, value)| self.headers().get(name).and_then(|v| v.to_str().ok()) == Some(value))
                     .unwrap_or_default()
@@ -60,7 +58,7 @@ impl<'ctx, R: Runtime> PreExecutionContext<'ctx, R> {
                     Ok(OperationDocument {
                         cache_key: Key::Operation {
                             name,
-                            schema_version,
+                            schema,
                             document: Document::Text(document),
                         }
                         .to_string(),
@@ -97,7 +95,7 @@ impl<'ctx, R: Runtime> PreExecutionContext<'ctx, R> {
                 Ok(OperationDocument {
                     cache_key: Key::Operation {
                         name,
-                        schema_version,
+                        schema,
                         document: Document::TrustedDocumentId {
                             client_name,
                             doc_id: doc_id.clone(),
@@ -116,7 +114,7 @@ impl<'ctx, R: Runtime> PreExecutionContext<'ctx, R> {
                 Ok(OperationDocument {
                     cache_key: Key::Operation {
                         name,
-                        schema_version,
+                        schema,
                         document: Document::AutomaticallyPersistedQuery(ext),
                     }
                     .to_string(),
@@ -132,7 +130,7 @@ impl<'ctx, R: Runtime> PreExecutionContext<'ctx, R> {
                 Ok(OperationDocument {
                     cache_key: Key::Operation {
                         name,
-                        schema_version,
+                        schema,
                         document: Document::Text(document),
                     }
                     .to_string(),

--- a/engine/crates/engine-v2/src/execution/context.rs
+++ b/engine/crates/engine-v2/src/execution/context.rs
@@ -1,5 +1,6 @@
 use ::runtime::hooks::Hooks;
 use futures::future::BoxFuture;
+use grafbase_telemetry::metrics::EngineMetrics;
 use runtime::auth::AccessToken;
 use schema::{HeaderRuleWalker, Schema};
 
@@ -44,12 +45,9 @@ impl<'ctx, R: Runtime> PreExecutionContext<'ctx, R> {
     pub fn hooks(&self) -> RequestHooks<'ctx, R::Hooks> {
         self.into()
     }
-}
 
-impl<'ctx, R: Runtime> std::ops::Deref for PreExecutionContext<'ctx, R> {
-    type Target = Engine<R>;
-    fn deref(&self) -> &'ctx Self::Target {
-        self.engine
+    pub fn metrics(&self) -> &'ctx EngineMetrics {
+        self.engine.runtime.metrics()
     }
 }
 
@@ -89,5 +87,9 @@ impl<'ctx, R: Runtime> ExecutionContext<'ctx, R> {
 
     pub fn schema(&self) -> &'ctx Schema {
         &self.engine.schema
+    }
+
+    pub fn metrics(&self) -> &'ctx EngineMetrics {
+        self.engine.runtime.metrics()
     }
 }

--- a/engine/crates/engine-v2/src/execution/planner/builder.rs
+++ b/engine/crates/engine-v2/src/execution/planner/builder.rs
@@ -239,8 +239,8 @@ where
             tracing::trace!(
                 "requires {} in ({id}) {:#?}",
                 self.ctx
-                    .schema
-                    .walk(self.ctx.schema[required_field.id].definition_id)
+                    .schema()
+                    .walk(self.ctx.schema()[required_field.id].definition_id)
                     .name(),
                 self.walker().walk(*solved_requirements)
             );

--- a/engine/crates/engine-v2/src/execution/planner/mod.rs
+++ b/engine/crates/engine-v2/src/execution/planner/mod.rs
@@ -80,7 +80,7 @@ pub(super) async fn plan<'ctx, R: Runtime>(
         variables,
         subgraph_default_headers: create_subgraph_headers_with_rules(
             ctx.request_context,
-            ctx.schema.walker().default_header_rules(),
+            ctx.schema().walker().default_header_rules(),
             http::HeaderMap::new(),
         ),
         execution_plans: Default::default(),

--- a/engine/crates/engine-v2/src/lib.rs
+++ b/engine/crates/engine-v2/src/lib.rs
@@ -13,6 +13,6 @@ pub mod websocket;
 pub use engine::{Engine, Runtime, WebsocketSession};
 pub use graphql_over_http::Body;
 pub use response::error::ErrorCode;
-pub use schema::{BuildError, Schema};
+pub use schema::{BuildError, Schema, Version as SchemaVersion};
 
 pub use ::config::{latest as config, VersionedConfig};

--- a/engine/crates/engine-v2/src/operation/modifier/query.rs
+++ b/engine/crates/engine-v2/src/operation/modifier/query.rs
@@ -143,7 +143,7 @@ where
                     let result = self
                         .ctx
                         .hooks()
-                        .authorize_node_pre_execution(self.ctx.schema.walk(definition), directive.metadata())
+                        .authorize_node_pre_execution(self.ctx.schema().walk(definition), directive.metadata())
                         .await;
 
                     if let Err(err) = result {
@@ -224,7 +224,7 @@ where
 
     fn walker(&self) -> PreparedOperationWalker<'op, (), ()> {
         PreparedOperationWalker {
-            schema_walker: self.ctx.schema.walker(),
+            schema_walker: self.ctx.schema().walker(),
             operation: self.operation,
             variables: self.variables,
             item: (),

--- a/engine/crates/engine-v2/src/sources/graphql/record.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/record.rs
@@ -16,12 +16,10 @@ pub(super) fn subgraph_retry<R: Runtime>(
     endpoint: GraphqlEndpointWalker<'_>,
     aborted: bool,
 ) {
-    ctx.engine
-        .metrics
-        .record_subgraph_retry(SubgraphRequestRetryAttributes {
-            name: endpoint.subgraph_name().to_string(),
-            aborted,
-        });
+    ctx.metrics().record_subgraph_retry(SubgraphRequestRetryAttributes {
+        name: endpoint.subgraph_name().to_string(),
+        aborted,
+    });
 }
 
 pub(super) fn subgraph_duration<R: Runtime>(
@@ -31,7 +29,7 @@ pub(super) fn subgraph_duration<R: Runtime>(
     status_code: Option<http::StatusCode>,
     duration: Duration,
 ) {
-    ctx.engine.metrics.record_subgraph_duration(
+    ctx.metrics().record_subgraph_duration(
         SubgraphRequestDurationAttributes {
             name: endpoint.subgraph_name().to_string(),
             subgraph_status,
@@ -46,7 +44,7 @@ pub(super) fn subgraph_request_size<R: Runtime>(
     endpoint: GraphqlEndpointWalker<'_>,
     size: usize,
 ) {
-    ctx.engine.metrics.record_subgraph_request_size(
+    ctx.metrics().record_subgraph_request_size(
         SubgraphRequestBodySizeAttributes {
             name: endpoint.subgraph_name().to_string(),
         },
@@ -59,7 +57,7 @@ pub(super) fn subgraph_response_size<R: Runtime>(
     endpoint: GraphqlEndpointWalker<'_>,
     size: usize,
 ) {
-    ctx.engine.metrics.record_subgraph_response_size(
+    ctx.metrics().record_subgraph_response_size(
         SubgraphResponseBodySizeAttributes {
             name: endpoint.subgraph_name().to_string(),
         },
@@ -71,8 +69,7 @@ pub(super) fn increment_inflight_requests<R: Runtime>(
     ctx: ExecutionContext<'_, R>,
     endpoint: GraphqlEndpointWalker<'_>,
 ) {
-    ctx.engine
-        .metrics
+    ctx.metrics()
         .increment_subgraph_inflight_requests(SubgraphInFlightRequestAttributes {
             name: endpoint.subgraph_name().to_string(),
         });
@@ -82,28 +79,23 @@ pub(super) fn decrement_inflight_requests<R: Runtime>(
     ctx: ExecutionContext<'_, R>,
     endpoint: GraphqlEndpointWalker<'_>,
 ) {
-    ctx.engine
-        .metrics
+    ctx.metrics()
         .decrement_subgraph_inflight_requests(SubgraphInFlightRequestAttributes {
             name: endpoint.subgraph_name().to_string(),
         });
 }
 
 pub(super) fn record_subgraph_cache_hit<R: Runtime>(ctx: ExecutionContext<'_, R>, endpoint: GraphqlEndpointWalker<'_>) {
-    ctx.engine
-        .metrics
-        .record_subgraph_cache_hit(SubgraphCacheHitAttributes {
-            name: endpoint.subgraph_name().to_string(),
-        });
+    ctx.metrics().record_subgraph_cache_hit(SubgraphCacheHitAttributes {
+        name: endpoint.subgraph_name().to_string(),
+    });
 }
 
 pub(super) fn record_subgraph_cache_miss<R: Runtime>(
     ctx: ExecutionContext<'_, R>,
     endpoint: GraphqlEndpointWalker<'_>,
 ) {
-    ctx.engine
-        .metrics
-        .record_subgraph_cache_miss(SubgraphCacheMissAttributes {
-            name: endpoint.subgraph_name().to_string(),
-        });
+    ctx.metrics().record_subgraph_cache_miss(SubgraphCacheMissAttributes {
+        name: endpoint.subgraph_name().to_string(),
+    });
 }

--- a/engine/crates/engine/src/schema.rs
+++ b/engine/crates/engine/src/schema.rs
@@ -153,7 +153,7 @@ impl Schema {
             registry,
             data: Default::default(),
             extensions: Default::default(),
-            operation_metrics: EngineMetrics::build(&meter),
+            operation_metrics: EngineMetrics::build(&meter, None),
         }
     }
 

--- a/engine/crates/gateway-core/src/lib.rs
+++ b/engine/crates/gateway-core/src/lib.rs
@@ -94,7 +94,7 @@ where
             auth,
             authorizer,
             trusted_documents,
-            operation_metrics: EngineMetrics::build(&meter),
+            operation_metrics: EngineMetrics::build(&meter, None),
             rate_limiter,
         }
     }

--- a/engine/crates/integration-tests/src/federation/builder.rs
+++ b/engine/crates/integration-tests/src/federation/builder.rs
@@ -184,7 +184,9 @@ impl EngineV2Builder {
         }
         .into_latest();
 
-        let engine = engine_v2::Engine::new(Arc::new(config.try_into().unwrap()), None, self.runtime).await;
+        let schema =
+            engine_v2::Schema::build(config, engine_v2::SchemaVersion::from(ulid::Ulid::new().to_bytes())).unwrap();
+        let engine = engine_v2::Engine::new(Arc::new(schema), self.runtime).await;
 
         let (mock_subgraphs, docker_subgraphs) = subgraphs
             .into_iter()

--- a/engine/crates/integration-tests/src/federation/builder/bench.rs
+++ b/engine/crates/integration-tests/src/federation/builder/bench.rs
@@ -63,9 +63,10 @@ impl<'a> DeterministicEngineBuilder<'a> {
         let graph = federated_graph::from_sdl(self.schema).unwrap();
         let config = engine_v2::VersionedConfig::V6(engine_v2::config::Config::from_graph(graph)).into_latest();
 
+        let schema =
+            engine_v2::Schema::build(config, engine_v2::SchemaVersion::from(ulid::Ulid::new().to_bytes())).unwrap();
         let engine = engine_v2::Engine::new(
-            Arc::new(config.try_into().unwrap()),
-            None,
+            Arc::new(schema),
             TestRuntime {
                 fetcher: fetcher.into(),
                 ..self.runtime

--- a/engine/crates/telemetry/src/metrics/engine.rs
+++ b/engine/crates/telemetry/src/metrics/engine.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 pub struct EngineMetrics {
+    graph_version: Option<String>,
     operation_latency: Histogram<u64>,
     subgraph_latency: Histogram<u64>,
     subgraph_retries: Counter<u64>,
@@ -136,8 +137,9 @@ pub struct GraphqlErrorAttributes {
 }
 
 impl EngineMetrics {
-    pub fn build(meter: &Meter) -> Self {
+    pub fn build(meter: &Meter, graph_version: Option<String>) -> Self {
         Self {
+            graph_version,
             operation_latency: meter.u64_histogram("graphql.operation.duration").init(),
             subgraph_latency: meter.u64_histogram("graphql.subgraph.request.duration").init(),
             subgraph_retries: meter.u64_counter("graphql.subgraph.request.retries").init(),
@@ -186,6 +188,11 @@ impl EngineMetrics {
             attributes.push(KeyValue::new("graphql.operation.name", name));
         }
 
+        if let Some(version) = self.graph_version.clone() {
+            attributes.push(KeyValue::new("grafbase.graph_version", version))
+        }
+
+        // Used for v1
         if let Some(cache_status) = cache_status {
             attributes.push(KeyValue::new("graphql.response.cache.status", cache_status));
         }

--- a/engine/crates/telemetry/src/metrics/mod.rs
+++ b/engine/crates/telemetry/src/metrics/mod.rs
@@ -1,10 +1,10 @@
-mod operation;
+mod engine;
 mod request;
 
 use std::borrow::Cow;
 
+pub use engine::*;
 use opentelemetry::metrics::{Meter, MeterProvider};
-pub use operation::*;
 pub use request::*;
 
 pub fn meter_from_global_provider() -> Meter {

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -30,6 +30,7 @@ engine-config-builder.workspace = true
 engine-v2.workspace = true
 engine-v2-axum.workspace = true
 grafbase-telemetry = { workspace = true, features = ["tower", "otlp"] }
+graph-ref.workspace = true
 gateway-config.workspace = true
 graphql-composition.workspace = true
 http.workspace = true

--- a/gateway/crates/federated-server/src/lib.rs
+++ b/gateway/crates/federated-server/src/lib.rs
@@ -2,8 +2,6 @@
 //! where we contact the schema registry in the API to fetch the latest schema
 //! and send tracing and metrics to either our own or a 3rd party collector.
 
-#![deny(missing_docs)]
-
 mod hot_reload;
 pub use error::Error;
 pub use server::GdnResponse;

--- a/gateway/crates/federated-server/src/server/gateway.rs
+++ b/gateway/crates/federated-server/src/server/gateway.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use grafbase_telemetry::metrics::EngineMetrics;
 use runtime::entity_cache::EntityCache;
 use runtime_local::hooks::ChannelLogSender;
 use runtime_local::rate_limiting::in_memory::key_based::InMemoryRateLimiter;
@@ -20,6 +21,8 @@ use gateway_config::{Config, EntityCachingRedisConfig};
 
 use crate::hot_reload::ConfigWatcher;
 
+use super::GdnResponse;
+
 /// Send half of the gateway watch channel
 pub(crate) type GatewaySender = watch::Sender<Option<Arc<Engine<GatewayRuntime>>>>;
 
@@ -28,132 +31,182 @@ pub(crate) type GatewaySender = watch::Sender<Option<Arc<Engine<GatewayRuntime>>
 /// Anything part of the system that needs access to the gateway can use this
 pub(crate) type EngineWatcher = watch::Receiver<Option<Arc<Engine<GatewayRuntime>>>>;
 
+pub(crate) enum GraphDefinition {
+    Gdn(GdnResponse),
+    Sdl(String),
+}
+
 /// Creates a new gateway from federated schema.
 pub(super) async fn generate(
-    federated_schema: String,
-    branch_id: Option<ulid::Ulid>,
+    graph_definition: GraphDefinition,
     gateway_config: &Config,
     hot_reload_config_path: Option<PathBuf>,
     access_log_sender: ChannelLogSender,
 ) -> crate::Result<Engine<GatewayRuntime>> {
-    let schema_version = blake3::hash(federated_schema.as_bytes());
-    let graph = VersionedFederatedGraph::from_sdl(&federated_schema)
-        .map_err(|e| crate::Error::SchemaValidationError(e.to_string()))?;
-    let config = engine_config_builder::build_with_toml_config(gateway_config, graph.into_latest()).into_latest();
-
-    // TODO: https://linear.app/grafbase/issue/GB-6168/support-trusted-documents-in-air-gapped-mode
-    let trusted_documents = if gateway_config.trusted_documents.enabled {
-        let Some(branch_id) = branch_id else {
-            return Err(crate::Error::InternalError(
-                "Trusted documents are not implemented yet in airgapped mode".into(),
-            ));
-        };
-
-        runtime::trusted_documents_client::Client::new(super::trusted_documents_client::TrustedDocumentsClient::new(
-            Default::default(),
+    let (federated_sdl, schema_version, version_id, trusted_documents) = match graph_definition {
+        GraphDefinition::Gdn(GdnResponse {
             branch_id,
-            gateway_config
-                .trusted_documents
-                .bypass_header
-                .bypass_header_name
-                .as_ref()
-                .zip(
-                    gateway_config
-                        .trusted_documents
-                        .bypass_header
-                        .bypass_header_value
-                        .as_ref(),
-                )
-                .map(|(name, value)| (name.clone().into(), String::from(value.as_ref()))),
-        ))
-    } else {
-        runtime::trusted_documents_client::Client::new(NoopTrustedDocuments)
-    };
+            sdl,
+            version_id,
+            ..
+        }) => {
+            let version = engine_v2::SchemaVersion::from(
+                [b"id:".to_vec(), version_id.to_bytes().to_vec()]
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<u8>>(),
+            );
 
-    let mut redis_factory = RedisPoolFactory::default();
-
-    let watcher = ConfigWatcher::init(gateway_config.clone(), hot_reload_config_path)?;
-    let meter = grafbase_telemetry::metrics::meter_from_global_provider();
-
-    let rate_limiter = match config.rate_limit_config() {
-        Some(config) if config.storage.is_redis() => {
-            let tls = config.redis.tls.map(|tls| RedisTlsConfig {
-                cert: tls.cert,
-                key: tls.key,
-                ca: tls.ca,
-            });
-
-            let pool = redis_factory
-                .pool(config.redis.url, tls)
-                .map_err(|e| crate::Error::InternalError(e.to_string()))?;
-
-            let global_config = runtime_local::rate_limiting::redis::RateLimitRedisConfig {
-                key_prefix: config.redis.key_prefix,
+            let trusted_documents = if gateway_config.trusted_documents.enabled {
+                Some(runtime::trusted_documents_client::Client::new(
+                    super::trusted_documents_client::TrustedDocumentsClient::new(
+                        Default::default(),
+                        branch_id,
+                        gateway_config
+                            .trusted_documents
+                            .bypass_header
+                            .bypass_header_name
+                            .as_ref()
+                            .zip(
+                                gateway_config
+                                    .trusted_documents
+                                    .bypass_header
+                                    .bypass_header_value
+                                    .as_ref(),
+                            )
+                            .map(|(name, value)| (name.clone().into(), String::from(value.as_ref()))),
+                    ),
+                ))
+            } else {
+                None
             };
 
-            RedisRateLimiter::runtime(global_config, pool, watcher, &meter)
-                .await
-                .map_err(|e| crate::Error::InternalError(e.to_string()))?
+            (sdl, version, Some(version_id), trusted_documents)
         }
-        _ => InMemoryRateLimiter::runtime_with_watcher(watcher),
-    };
-
-    let entity_cache: Box<dyn EntityCache> = match gateway_config.entity_caching.storage {
-        gateway_config::EntityCachingStorage::Memory => Box::new(InMemoryEntityCache::default()),
-        gateway_config::EntityCachingStorage::Redis => {
-            let EntityCachingRedisConfig { url, key_prefix, tls } = &gateway_config.entity_caching.redis;
-            let tls = tls.as_ref().map(|tls| RedisTlsConfig {
-                cert: tls.cert.as_deref(),
-                key: tls.key.as_deref(),
-                ca: tls.ca.as_deref(),
-            });
-
-            let pool = redis_factory
-                .pool(url.as_str(), tls)
-                .map_err(|e| crate::Error::InternalError(e.to_string()))?;
-
-            Box::new(RedisEntityCache::new(pool, key_prefix))
+        GraphDefinition::Sdl(federated_sdl) => {
+            let version = engine_v2::SchemaVersion::from(
+                [
+                    b"hash:".to_vec(),
+                    blake3::hash(federated_sdl.as_bytes()).as_bytes().to_vec(),
+                ]
+                .into_iter()
+                .flatten()
+                .collect::<Vec<u8>>(),
+            );
+            // TODO: https://linear.app/grafbase/issue/GB-6168/support-trusted-documents-in-air-gapped-mode
+            (federated_sdl, version, None, None)
         }
     };
 
-    let hooks = gateway_config
-        .hooks
-        .clone()
-        .map(ComponentLoader::new)
-        .transpose()
-        .map_err(|e| crate::Error::InternalError(e.to_string()))?
-        .flatten();
-
-    let runtime = GatewayRuntime {
-        fetcher: NativeFetcher::default(),
-        kv: InMemoryKvStore::runtime(),
-        trusted_documents,
-        hooks: HooksWasi::new(hooks, &meter, access_log_sender),
-        meter,
-        rate_limiter,
-        entity_cache,
-        operation_cache_factory: InMemoryOperationCacheFactory::default(),
+    let config = {
+        let graph = VersionedFederatedGraph::from_sdl(&federated_sdl)
+            .map_err(|e| crate::Error::SchemaValidationError(e.to_string()))?;
+        engine_config_builder::build_with_toml_config(gateway_config, graph.into_latest()).into_latest()
     };
 
-    let config = config.try_into().map_err(|err| match err {
+    let mut runtime = GatewayRuntime::build(
+        gateway_config,
+        hot_reload_config_path,
+        &config,
+        version_id,
+        access_log_sender,
+    )
+    .await?;
+
+    if let Some(trusted_documents) = trusted_documents {
+        runtime.trusted_documents = trusted_documents;
+    }
+
+    let schema = engine_v2::Schema::build(config, schema_version).map_err(|err| match err {
         err @ engine_v2::BuildError::RequiredFieldArgumentCoercionError { .. } => {
             crate::Error::InternalError(format!("Failed to generate engine Schema: {err}"))
         }
         engine_v2::BuildError::GraphFromSdlError(err) => crate::Error::SchemaValidationError(err.to_string()),
     })?;
 
-    Ok(Engine::new(Arc::new(config), Some(schema_version.as_bytes()), runtime).await)
+    Ok(Engine::new(Arc::new(schema), runtime).await)
 }
 
 pub struct GatewayRuntime {
     fetcher: NativeFetcher,
     trusted_documents: runtime::trusted_documents_client::Client,
     kv: runtime::kv::KvStore,
-    meter: grafbase_telemetry::otel::opentelemetry::metrics::Meter,
+    metrics: EngineMetrics,
     hooks: HooksWasi,
     rate_limiter: runtime::rate_limiting::RateLimiter,
     entity_cache: Box<dyn EntityCache>,
     operation_cache_factory: InMemoryOperationCacheFactory,
+}
+
+impl GatewayRuntime {
+    async fn build(
+        gateway_config: &Config,
+        hot_reload_config_path: Option<PathBuf>,
+        config: &engine_v2::config::Config,
+        version_id: Option<ulid::Ulid>,
+        access_log_sender: ChannelLogSender,
+    ) -> Result<GatewayRuntime, crate::Error> {
+        let mut redis_factory = RedisPoolFactory::default();
+        let watcher = ConfigWatcher::init(gateway_config.clone(), hot_reload_config_path)?;
+        let meter = grafbase_telemetry::metrics::meter_from_global_provider();
+        let rate_limiter = match config.rate_limit_config() {
+            Some(config) if config.storage.is_redis() => {
+                let tls = config.redis.tls.map(|tls| RedisTlsConfig {
+                    cert: tls.cert,
+                    key: tls.key,
+                    ca: tls.ca,
+                });
+
+                let pool = redis_factory
+                    .pool(config.redis.url, tls)
+                    .map_err(|e| crate::Error::InternalError(e.to_string()))?;
+
+                let global_config = runtime_local::rate_limiting::redis::RateLimitRedisConfig {
+                    key_prefix: config.redis.key_prefix,
+                };
+
+                RedisRateLimiter::runtime(global_config, pool, watcher, &meter)
+                    .await
+                    .map_err(|e| crate::Error::InternalError(e.to_string()))?
+            }
+            _ => InMemoryRateLimiter::runtime_with_watcher(watcher),
+        };
+        let entity_cache: Box<dyn EntityCache> = match gateway_config.entity_caching.storage {
+            gateway_config::EntityCachingStorage::Memory => Box::new(InMemoryEntityCache::default()),
+            gateway_config::EntityCachingStorage::Redis => {
+                let EntityCachingRedisConfig { url, key_prefix, tls } = &gateway_config.entity_caching.redis;
+                let tls = tls.as_ref().map(|tls| RedisTlsConfig {
+                    cert: tls.cert.as_deref(),
+                    key: tls.key.as_deref(),
+                    ca: tls.ca.as_deref(),
+                });
+
+                let pool = redis_factory
+                    .pool(url.as_str(), tls)
+                    .map_err(|e| crate::Error::InternalError(e.to_string()))?;
+
+                Box::new(RedisEntityCache::new(pool, key_prefix))
+            }
+        };
+        let hooks = gateway_config
+            .hooks
+            .clone()
+            .map(ComponentLoader::new)
+            .transpose()
+            .map_err(|e| crate::Error::InternalError(e.to_string()))?
+            .flatten();
+        let runtime = GatewayRuntime {
+            fetcher: NativeFetcher::default(),
+            kv: InMemoryKvStore::runtime(),
+            trusted_documents: runtime::trusted_documents_client::Client::new(NoopTrustedDocuments),
+            hooks: HooksWasi::new(hooks, &meter, access_log_sender),
+            metrics: EngineMetrics::build(&meter, version_id.map(|id| id.to_string())),
+            rate_limiter,
+            entity_cache,
+            operation_cache_factory: InMemoryOperationCacheFactory::default(),
+        };
+        Ok(runtime)
+    }
 }
 
 impl engine_v2::Runtime for GatewayRuntime {
@@ -171,10 +224,6 @@ impl engine_v2::Runtime for GatewayRuntime {
 
     fn kv(&self) -> &runtime::kv::KvStore {
         &self.kv
-    }
-
-    fn meter(&self) -> &grafbase_telemetry::otel::opentelemetry::metrics::Meter {
-        &self.meter
     }
 
     fn hooks(&self) -> &HooksWasi {
@@ -195,5 +244,9 @@ impl engine_v2::Runtime for GatewayRuntime {
 
     fn entity_cache(&self) -> &dyn EntityCache {
         self.entity_cache.as_ref()
+    }
+
+    fn metrics(&self) -> &grafbase_telemetry::metrics::EngineMetrics {
+        &self.metrics
     }
 }

--- a/gateway/crates/gateway-binary/src/args/lambda.rs
+++ b/gateway/crates/gateway-binary/src/args/lambda.rs
@@ -40,11 +40,8 @@ pub struct Args {
 impl super::Args for Args {
     /// The method of fetching a graph
     fn fetch_method(&self) -> anyhow::Result<GraphFetchMethod> {
-        let federated_graph = fs::read_to_string(&self.schema).context("could not read federated schema file")?;
-
-        Ok(GraphFetchMethod::FromLocal {
-            federated_schema: federated_graph,
-        })
+        let federated_sdl = fs::read_to_string(&self.schema).context("could not read federated schema file")?;
+        Ok(GraphFetchMethod::FromSchema { federated_sdl })
     }
 
     /// The gateway configuration

--- a/gateway/crates/gateway-binary/src/args/std.rs
+++ b/gateway/crates/gateway-binary/src/args/std.rs
@@ -67,23 +67,20 @@ pub struct Args {
 impl super::Args for Args {
     /// The method of fetching a graph
     fn fetch_method(&self) -> anyhow::Result<GraphFetchMethod> {
-        match self.graph_ref.as_ref() {
-            Some(graph_ref) => Ok(GraphFetchMethod::FromApi {
+        match self.graph_ref.clone() {
+            Some(graph_ref) => Ok(GraphFetchMethod::FromGraphRef {
                 access_token: self
                     .grafbase_access_token
                     .clone()
                     .expect("present due to the arg group"),
-                graph_name: graph_ref.graph_slug().to_string(),
-                branch: graph_ref.branch_name().map(ToString::to_string),
+                graph_ref,
             }),
             None => {
-                let federated_graph =
+                let federated_sdl =
                     fs::read_to_string(self.schema.as_ref().expect("must exist if graph-ref is not defined"))
                         .context("could not read federated schema file")?;
 
-                Ok(GraphFetchMethod::FromLocal {
-                    federated_schema: federated_graph,
-                })
+                Ok(GraphFetchMethod::FromSchema { federated_sdl })
             }
         }
     }

--- a/graph-ref/src/lib.rs
+++ b/graph-ref/src/lib.rs
@@ -1,28 +1,66 @@
 use std::{borrow::Cow, fmt, str};
 
-/// Parsed graph reference. A graph reference is a string of the form `graph@branch`.
+/// Parsed graph reference. A graph reference is a string of the form `graph@branch#version`.
 #[derive(Clone, Hash, PartialEq, Eq, Debug)]
-pub struct GraphRef {
-    graph_slug: String,
-    branch_name: Option<String>,
+pub enum GraphRef {
+    LatestProductionVersion {
+        graph_slug: String,
+    },
+    LatestVersion {
+        graph_slug: String,
+        branch_name: String,
+    },
+    Id {
+        graph_slug: String,
+        branch_name: String,
+        version: String,
+    },
 }
 
 impl GraphRef {
     pub const ARG_DESCRIPTION: &'static str = r#"Graph reference following the format "graph@branch""#;
 
-    pub fn new(graph_slug: String, branch_name: Option<String>) -> Self {
-        GraphRef {
+    pub fn new(graph_slug: String, branch_name: String, version: String) -> Self {
+        GraphRef::Id {
+            graph_slug,
+            branch_name,
+            version,
+        }
+    }
+
+    pub fn latest_production_version(graph_slug: String) -> Self {
+        GraphRef::LatestProductionVersion { graph_slug }
+    }
+
+    pub fn lastest_version(graph_slug: String, branch_name: String) -> Self {
+        GraphRef::LatestVersion {
             graph_slug,
             branch_name,
         }
     }
 
-    pub fn graph_slug(&self) -> &str {
-        self.graph_slug.as_ref()
+    pub fn slug(&self) -> &str {
+        match self {
+            GraphRef::LatestProductionVersion { graph_slug } => graph_slug,
+            GraphRef::LatestVersion { graph_slug, .. } => graph_slug,
+            GraphRef::Id { graph_slug, .. } => graph_slug,
+        }
     }
 
-    pub fn branch_name(&self) -> Option<&str> {
-        self.branch_name.as_deref()
+    pub fn branch(&self) -> Option<&str> {
+        match self {
+            GraphRef::LatestProductionVersion { .. } => None,
+            GraphRef::LatestVersion { branch_name, .. } => Some(branch_name),
+            GraphRef::Id { branch_name, .. } => Some(branch_name),
+        }
+    }
+
+    pub fn version(&self) -> Option<&str> {
+        match self {
+            GraphRef::LatestProductionVersion { .. } => None,
+            GraphRef::LatestVersion { .. } => None,
+            GraphRef::Id { version, .. } => Some(version),
+        }
     }
 }
 
@@ -30,18 +68,30 @@ impl str::FromStr for GraphRef {
     type Err = Cow<'static, str>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (graph_slug, branch_name) = match s.split_once('@') {
-            Some((graph_slug, branch_name)) => (graph_slug, Some(branch_name)),
-            None => (s, None),
+        let graph = match s.split_once('@') {
+            Some((graph_slug, rest)) => match rest.split_once('#') {
+                Some((branch_name, version)) => GraphRef::Id {
+                    graph_slug: graph_slug.to_string(),
+                    branch_name: branch_name.to_string(),
+                    version: version.to_string(),
+                },
+                None => GraphRef::LatestVersion {
+                    graph_slug: graph_slug.to_string(),
+                    branch_name: rest.to_string(),
+                },
+            },
+            None => GraphRef::LatestProductionVersion {
+                graph_slug: s.to_string(),
+            },
         };
 
-        if graph_slug.is_empty() {
+        if graph.slug().is_empty() {
             return Err(Cow::Borrowed("The graph name is missing."));
         }
 
-        if graph_slug.contains('/') {
+        if graph.slug().contains('/') {
             let did_you_mean = 'split: {
-                let Some((_, graph_slug)) = graph_slug.split_once('/') else {
+                let Some((_, graph_slug)) = graph.slug().split_once('/') else {
                     break 'split String::new();
                 };
 
@@ -49,9 +99,10 @@ impl str::FromStr for GraphRef {
                     break 'split String::new();
                 }
 
-                let branch_name = branch_name.map(|branch| format!("@{branch}")).unwrap_or_default();
+                let branch_name = graph.branch().map(|branch| format!("@{branch}")).unwrap_or_default();
+                let version = graph.version().map(|version| format!("#{version}")).unwrap_or_default();
 
-                format!(" Did you mean: \"{graph_slug}{branch_name}\"")
+                format!(" Did you mean: \"{graph_slug}{branch_name}{version}\"")
             };
 
             let message = format!("Graph ref should not contain an account name.{did_you_mean}",);
@@ -59,20 +110,22 @@ impl str::FromStr for GraphRef {
             return Err(Cow::Owned(message));
         }
 
-        Ok(GraphRef {
-            graph_slug: graph_slug.to_owned(),
-            branch_name: branch_name.filter(|s| !s.is_empty()).map(String::from),
-        })
+        Ok(graph)
     }
 }
 
 impl fmt::Display for GraphRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.graph_slug)?;
+        f.write_str(self.slug())?;
 
-        if let Some(branch) = &self.branch_name {
+        if let Some(branch) = &self.branch() {
             f.write_str("@")?;
             f.write_str(branch)?;
+        }
+
+        if let Some(version) = &self.version() {
+            f.write_str("#")?;
+            f.write_str(version)?;
         }
 
         Ok(())
@@ -86,11 +139,13 @@ mod tests {
     #[test]
     fn graph_ref_ok() {
         let cases = [
+            "prjct",        // no branch
+            "prjct@branch", // no version
+            "prjct@branch#version",
             "windows@main",
             "project@master",
             "_____project-with-things@branch-here",
             "2@3",
-            "prjct", // no branch
         ];
 
         for case in cases {


### PR DESCRIPTION
Adding the `grafbase.graph.version` attribute in `EngineMetrics`. It is also included in the `engine_v2::Schema` instead of the engine. It's used to build the operation cache key. The `engine_v2::Schema` builder now requires the `engine_v2::Config` and `engine_v2::SchemaVersion`.

The federated-server will propagate this information if the graph comes from the GDN. Otherwise it'll just be empty for metrics and the hash of the SDL is used for the schema version (like before).

Not necessary anymore, but added support for a version in the `GraphRef` in the format of `graph@branch#version` which would require a specific version from the GDN.