### PR TITLE
chore: build before clippy

### DIFF
--- a/.github/what-rust-changed.toml
+++ b/.github/what-rust-changed.toml
@@ -11,12 +11,17 @@ mark-changed = ["grafbase"]
 
 [[path-rule]]
 # Trigger all for this GHA workflow
-globs = [".github/workflows/rust-prs.yaml"]
+globs = [".github/workflows/rust-prs.yml"]
 mark-changed = "all"
 
 [[path-rule]]
 # Ignore other github stuff
-globs = [".github/workflows/**", ".github/what-rust-changed.toml", ".github/ISSUE_TEMPLATE/**", ".github/CODEOWNERS"]
+globs = [
+    ".github/workflows/**",
+    ".github/what-rust-changed.toml",
+    ".github/ISSUE_TEMPLATE/**",
+    ".github/CODEOWNERS",
+]
 mark-changed = []
 
 [[path-rule]]

--- a/.github/workflows/rust-prs.yml
+++ b/.github/workflows/rust-prs.yml
@@ -314,6 +314,13 @@ jobs:
           path: cli/wrappers/
 
       # TODO: Add timing reports in here somehow...
+
+      - name: Build debug binaries
+        if: fromJson(needs.what-changed.outputs.rust).cargo-bin-specs
+        shell: bash
+        run: |
+          cargo build --target ${{ matrix.platform.target }} ${{ fromJson(needs.what-changed.outputs.rust).cargo-bin-specs }}
+
       - name: Clippy
         if: fromJson(needs.what-changed.outputs.rust).cargo-build-specs
         shell: bash
@@ -374,12 +381,6 @@ jobs:
           api_key: ${{ secrets.DATADOG_API_KEY }}
           junit_path: target/nextest/ci/junit.xml
           service: cli
-
-      - name: Build debug binaries
-        if: fromJson(needs.what-changed.outputs.rust).cargo-bin-specs
-        shell: bash
-        run: |
-          cargo build --target ${{ matrix.platform.target }} ${{ fromJson(needs.what-changed.outputs.rust).cargo-bin-specs }}
 
   docker-gateway:
     needs: [what-changed]


### PR DESCRIPTION
Prior to this change the order of things was:

1. Debug clippy run of all pacakges
2. Tests
3. Debug build of binaries

Not certain but I suspect that this ends up duplicating some work - my theory is that the cargo check that clippy runs is discarding some work that the later cargo build needs to duplicate.  It's also possible that the test in the middle is picking up a slightly different set of features to the original check and that is causing some rebuilds.

This PR changes the order to build, clippy, tests.

Anyway, as always it's hard to be certain but the two times I've ran this in CI it ran in about 16 minutes - which is faster than the 20ish we had before.