### PR TITLE
chore: remove rust caching from CI

### DIFF
--- a/.github/actions/init_rust_job/action.yml
+++ b/.github/actions/init_rust_job/action.yml
@@ -2,12 +2,6 @@ name: CLI rust job init
 description: Base steps for CLI jobs
 
 inputs:
-  cache-key:
-    required: true
-    description: The cache key used on buildjet/cache
-  restore-key:
-    required: true
-    description: A cache key prefix to fall back on if the above isnt found
   platform:
     type: choice
     description: Target platform to use when installing nextest
@@ -20,16 +14,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Cargo cache
-      uses: actions/cache@v4
-      continue-on-error: false
-      with:
-        key: ${{ inputs.cache-key }}
-        restore-keys: ${{ inputs.restore-key }}
-        path: |
-          ~/.cargo/
-          !~/.cargo/registry/src
-
     - name: Extract the Rust version to use from the `rust-toolchain.toml` file
       shell: bash
       run: |

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -72,8 +72,6 @@ jobs:
         uses: ./.github/actions/init_rust_job
         with:
           platform: linux
-          cache-key: ${{ runner.os }}-${{ runner.arch }}-cargo-dev-${{ hashFiles('Cargo.lock') }}
-          restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-dev
 
       - name: Prepare Grafbase assets
         uses: ./.github/actions/cli_assets
@@ -94,8 +92,6 @@ jobs:
         uses: ./.github/actions/init_rust_job
         with:
           platform: linux
-          cache-key: ${{ runner.os }}-${{ runner.arch }}-cargo-dev-${{ hashFiles('Cargo.lock') }}
-          restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-dev
 
       - name: Prepare Grafbase assets
         uses: ./.github/actions/cli_assets
@@ -131,8 +127,6 @@ jobs:
         uses: ./.github/actions/init_rust_job
         with:
           platform: linux
-          cache-key: ${{ runner.os }}-${{ runner.arch }}-cargo-build-${{ matrix.package }}-${{ hashFiles('Cargo.lock') }}
-          restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-build
 
       - name: Build assets
         if: ${{ matrix.package != 'grafbase-gateway' }}
@@ -184,8 +178,6 @@ jobs:
         uses: ./.github/actions/init_rust_job
         with:
           platform: linux
-          cache-key: ${{ runner.os }}-${{ runner.arch }}-cargo-dev-${{ hashFiles('Cargo.lock') }}
-          restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-dev
 
       - name: Docker tests
         run: |
@@ -275,8 +267,6 @@ jobs:
         uses: ./.github/actions/init_rust_job
         with:
           platform: ${{ matrix.archs.platform }}
-          cache-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release-${{ hashFiles('Cargo.lock') }}
-          restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release
 
       - name: Prepare Grafbase assets
         uses: ./.github/actions/cli_assets
@@ -391,8 +381,6 @@ jobs:
         uses: ./.github/actions/init_rust_job
         with:
           platform: windows
-          cache-key: ${{ runner.os }}-${{ runner.arch }}-x86_64-pc-windows-msvc-cargo-release-${{ hashFiles('Cargo.lock') }}
-          restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release
 
       - name: Prepare Grafbase assets
         uses: ./.github/actions/cli_assets
@@ -447,8 +435,6 @@ jobs:
         uses: ./.github/actions/init_rust_job
         with:
           platform: macos
-          cache-key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-cargo-release-${{ hashFiles('Cargo.lock') }}
-          restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release
 
       - name: Prepare Grafbase assets
         uses: ./.github/actions/cli_assets

--- a/.github/workflows/gateway-partial-release.yml
+++ b/.github/workflows/gateway-partial-release.yml
@@ -51,8 +51,6 @@ jobs:
         uses: ./.github/actions/init_rust_job
         with:
           platform: linux
-          cache-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release-${{ hashFiles('Cargo.lock') }}
-          restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release
 
       - name: Create release directories
         shell: bash

--- a/.github/workflows/grafbase-partial-release.yml
+++ b/.github/workflows/grafbase-partial-release.yml
@@ -51,8 +51,6 @@ jobs:
         uses: ./.github/actions/init_rust_job
         with:
           platform: linux
-          cache-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release-${{ hashFiles('Cargo.lock') }}
-          restore-key: ${{ runner.os }}-${{ runner.arch }}-cargo-release
 
       # This is annoying, but github doesn't pass env vars down to child workflows,
       # and you can't use them as input parameters either so lets read them out the


### PR DESCRIPTION
Our cli workflow currently puts a couple of cargo directories into the GHA cache.  I am skeptical that this is having a useful impact on our builds.

For a start, it very quickly generates way more than the maximum cache storage GH gives you.  I cleared the caches late last night and 3 builds of main later we are 83% of the way to the maximum storage.  I've also ran builds with & without this cache and it doesn't appear to have much of an impact on timings.  _Perhaps_ it helps on reliability, but that's hard to measure without a longer timeframe.

I have a few other things I'd like to try that might be more effective, but it's hard to try them when this particular caching constantly keeps us over the limit.  So, I want to remove this and see what happens.

Will keep an eye on metrics in datadog after merging this - can always revert if it turns out to be a major regression.