### PR TITLE
graphql-schema-diff: fix two bugs

### DIFF
--- a/engine/crates/graphql-schema-diff/src/patch/paths.rs
+++ b/engine/crates/graphql-schema-diff/src/patch/paths.rs
@@ -74,11 +74,7 @@ where
         self.paths[first..]
             .iter()
             .take_while(move |(diff_path, _)| diff_path == &path)
-            .enumerate()
-            .map(move |(idx, _)| ChangeView {
-                paths: self,
-                idx: first + idx,
-            })
+            .map(move |(_, idx)| ChangeView { paths: self, idx: *idx })
     }
 
     pub(crate) fn source(&self) -> &'a str {

--- a/engine/crates/graphql-schema-diff/src/patch/schema_definitions.rs
+++ b/engine/crates/graphql-schema-diff/src/patch/schema_definitions.rs
@@ -40,7 +40,10 @@ pub(super) fn patch_schema_definition<T: AsRef<str>>(
         ("mutation", new_mutation_type, definition.mutation_type()),
         ("subscription", new_subscription_type, definition.subscription_type()),
     ] {
-        if let Some(type_name) = maybe_replacement.or_else(|| in_source.map(|ty| ty.named_type())) {
+        if let Some(type_name) = maybe_replacement
+            .or_else(|| in_source.map(|ty| ty.named_type()))
+            .filter(|name| !name.is_empty())
+        {
             schema.push_str(INDENTATION);
             schema.push_str(operation_name);
             schema.push_str(": ");

--- a/engine/crates/graphql-schema-diff/src/patch/type_definitions.rs
+++ b/engine/crates/graphql-schema-diff/src/patch/type_definitions.rs
@@ -7,7 +7,6 @@ use crate::ChangeKind;
 use super::{directives::patch_directives, paths::Paths, INDENTATION};
 
 pub(super) fn patch_type_definition<T: AsRef<str>>(ty: TypeDefinition<'_>, schema: &mut String, paths: &Paths<'_, T>) {
-    dbg!(ty.name());
     for change in paths.iter_exact([ty.name(), "", ""]) {
         match change.kind() {
             ChangeKind::RemoveObjectType

--- a/engine/crates/graphql-schema-diff/src/patch/type_definitions.rs
+++ b/engine/crates/graphql-schema-diff/src/patch/type_definitions.rs
@@ -7,6 +7,7 @@ use crate::ChangeKind;
 use super::{directives::patch_directives, paths::Paths, INDENTATION};
 
 pub(super) fn patch_type_definition<T: AsRef<str>>(ty: TypeDefinition<'_>, schema: &mut String, paths: &Paths<'_, T>) {
+    dbg!(ty.name());
     for change in paths.iter_exact([ty.name(), "", ""]) {
         match change.kind() {
             ChangeKind::RemoveObjectType

--- a/engine/crates/graphql-schema-diff/tests/patch/repro.graphql
+++ b/engine/crates/graphql-schema-diff/tests/patch/repro.graphql
@@ -1,9 +1,21 @@
-type Query {
-  SecondSubgraph: String!
+schema {
+  query: Root
 }
 
-scalar SecondSubgraph
+type Root {
+  ping: Pong
+}
+
+scalar Pong
 
 # --- #
 
-scalar EditedNow
+schema {
+  mutation: Root
+}
+
+type Root {
+  pong: Pong
+}
+
+scalar Pong

--- a/engine/crates/graphql-schema-diff/tests/patch/repro.graphql
+++ b/engine/crates/graphql-schema-diff/tests/patch/repro.graphql
@@ -1,0 +1,9 @@
+type Query {
+  SecondSubgraph: String!
+}
+
+scalar SecondSubgraph
+
+# --- #
+
+scalar EditedNow


### PR DESCRIPTION
- Removing a root from a schema definition now works. We would previously end up with declarations like:

 ```graphql
 schema {
   query: Query
   mutation:
 }
 ```

 The reason being that graphql-schema-diff expresses removal as `ChangeQueryType` (or mutation, subscription, respectively) with an empty string as the type name. We may want to change that.

- In Paths::iter_exact(), we were taking the index of the path instead of the index of the change, which was incorrect any time the changes aren't sorted by path, which we can't guarantee.