### PR TITLE
chore: fix globs in what-rust-changed.toml

### DIFF
--- a/.github/what-rust-changed.toml
+++ b/.github/what-rust-changed.toml
@@ -45,7 +45,7 @@ mark-changed = []
 
 [[path-rule]]
 # Ignore various folders
-globs = ["auth-testing", "packages/", "nix/", "examples/", "docker/", ".vscode"]
+globs = ["auth-testing/**", "packages/**", "nix/**", "examples/**", "docker/**", ".vscode"]
 mark-changed = []
 
 [[path-rule]]


### PR DESCRIPTION
#2100 built the whole repository even though it should have only built wasi-component-loader and dependants.  The examples folder was also changed but it should have been ignored.

Turns out I'd messed up some globs in what-rust-changed.toml