### PR TITLE
Replace async-graphql-parser with cynic-parser in graphql-federated-graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3876,8 +3876,7 @@ dependencies = [
 name = "graphql-federated-graph"
 version = "0.4.0"
 dependencies = [
- "async-graphql-parser",
- "async-graphql-value",
+ "cynic-parser",
  "expect-test",
  "graphql-wrapping-types",
  "indexmap 2.2.6",

--- a/engine/crates/federated-graph/Cargo.toml
+++ b/engine/crates/federated-graph/Cargo.toml
@@ -16,8 +16,7 @@ serde = { version = "1.0.199", features = ["derive"] }
 serde_json = "1.0.116"
 indoc = "2.0.5"
 
-async-graphql-parser = { workspace = true, optional = true }
-async-graphql-value = { workspace = true, optional = true }
+cynic-parser = { workspace = true, optional = true }
 indexmap = { optional = true, version = "2.2.6" }
 
 [dev-dependencies]
@@ -27,4 +26,4 @@ serde_json.workspace = true
 [features]
 default = ["render_sdl", "from_sdl"]
 render_sdl = []
-from_sdl = ["async-graphql-parser", "async-graphql-value", "indexmap"]
+from_sdl = ["dep:cynic-parser", "dep:indexmap"]

--- a/engine/crates/federated-graph/src/from_sdl.rs
+++ b/engine/crates/federated-graph/src/from_sdl.rs
@@ -369,7 +369,7 @@ fn ingest_authorized_directives(parsed: &ast::TypeSystemDocument, state: &mut St
         let fields = authorized
             .get_argument("fields")
             .and_then(|arg| match arg.value() {
-                ast::Value::String(s) => Some(s),
+                ast::Value::String(s) | ast::Value::BlockString(s) => Some(s),
                 _ => None,
             })
             .map(|fields| parse_selection_set(fields).and_then(|doc| attach_field_set(&doc, definition, state)))
@@ -426,7 +426,7 @@ fn ingest_entity_keys(parsed: &ast::TypeSystemDocument, state: &mut State<'_>) -
             let fields = join_type
                 .get_argument("key")
                 .and_then(|arg| match arg.value() {
-                    ast::Value::String(s) => Some(s),
+                    ast::Value::String(s) | ast::Value::BlockString(s) => Some(s),
                     _ => None,
                 })
                 .map(|fields| parse_selection_set(fields).and_then(|doc| attach_field_set(&doc, definition, state)))
@@ -478,13 +478,14 @@ fn ingest_field_directives_after_graph<'a>(
         let ast::Definition::Type(typedef) = definition else {
             continue;
         };
-        let parent_id = state.definition_names[typedef.name()];
 
         let fields = match typedef {
             ast::TypeDefinition::Object(object) => object.fields(),
             ast::TypeDefinition::Interface(iface) => iface.fields(),
             _ => continue,
         };
+
+        let parent_id = state.definition_names[typedef.name()];
 
         ingest_join_field_directive(parent_id, || typedef.directives(), fields, state)?;
         ingest_authorized_directive(parent_id, fields, state)?;
@@ -561,7 +562,7 @@ where
             if let Some(field_provides) = directive
                 .get_argument("provides")
                 .and_then(|arg| match arg.value() {
-                    ast::Value::String(s) => Some(s),
+                    ast::Value::String(s) | ast::Value::BlockString(s) => Some(s),
                     _ => None,
                 })
                 .map(|provides| {
@@ -577,7 +578,7 @@ where
             if let Some(field_requires) = directive
                 .get_argument("requires")
                 .and_then(|arg| match arg.value() {
-                    ast::Value::String(s) => Some(s),
+                    ast::Value::String(s) | ast::Value::BlockString(s) => Some(s),
                     _ => None,
                 })
                 .map(|requires| {
@@ -621,7 +622,7 @@ fn ingest_authorized_directive<'a>(
                 arguments: directive
                     .get_argument("arguments")
                     .and_then(|arg| match arg.value() {
-                        ast::Value::String(s) => Some(s),
+                        ast::Value::String(s) | ast::Value::BlockString(s) => Some(s),
                         _ => None,
                     })
                     .map(|arguments| {
@@ -633,7 +634,7 @@ fn ingest_authorized_directive<'a>(
                 fields: directive
                     .get_argument("fields")
                     .and_then(|arg| match arg.value() {
-                        ast::Value::String(s) => Some(s),
+                        ast::Value::String(s) | ast::Value::BlockString(s) => Some(s),
                         _ => None,
                     })
                     .map(|fields| {
@@ -643,7 +644,7 @@ fn ingest_authorized_directive<'a>(
                 node: directive
                     .get_argument("node")
                     .and_then(|arg| match arg.value() {
-                        ast::Value::String(s) => Some(s),
+                        ast::Value::String(s) | ast::Value::BlockString(s) => Some(s),
                         _ => None,
                     })
                     .map(|fields| {
@@ -1243,7 +1244,7 @@ fn ingest_join_graph_enum<'a>(enm: ast::EnumDefinition<'a>, state: &mut State<'a
                 )
             })
             .and_then(|arg| match arg.value() {
-                ast::Value::String(s) => Ok(s),
+                ast::Value::String(s) | ast::Value::BlockString(s) => Ok(s),
                 _ => Err(DomainError(
                     "Unexpected type for `name` argument in `@join__graph` directive on `join__Graph` enum value."
                         .to_owned(),
@@ -1257,7 +1258,7 @@ fn ingest_join_graph_enum<'a>(enm: ast::EnumDefinition<'a>, state: &mut State<'a
                 )
             })
             .and_then(|arg| match arg.value() {
-                ast::Value::String(s) => Ok(s),
+                ast::Value::String(s) | ast::Value::BlockString(s) => Ok(s),
                 _ => Err(DomainError(
                     "Unexpected type for `url` argument in `@join__graph` directive on `join__Graph` enum value."
                         .to_owned(),
@@ -1300,7 +1301,7 @@ fn collect_composed_directives<'a>(
             "deprecated" => {
                 let directive = Directive::Deprecated {
                     reason: directive.get_argument("reason").and_then(|value| match value.value() {
-                        ast::Value::String(s) => Some(state.insert_string(s)),
+                        ast::Value::String(s) | ast::Value::BlockString(s) => Some(state.insert_string(s)),
                         _ => None,
                     }),
                 };

--- a/engine/crates/federated-graph/src/from_sdl/arguments.rs
+++ b/engine/crates/federated-graph/src/from_sdl/arguments.rs
@@ -1,0 +1,11 @@
+use super::ast;
+
+pub(super) trait GetArgumentsExt<'a> {
+    fn get_argument(&self, argument_name: &str) -> Option<ast::Argument<'a>>;
+}
+
+impl<'a> GetArgumentsExt<'a> for ast::Directive<'a> {
+    fn get_argument(&self, argument_name: &str) -> Option<ast::Argument<'a>> {
+        self.arguments().find(|arg| arg.name() == argument_name)
+    }
+}

--- a/engine/crates/federated-graph/src/from_sdl/value.rs
+++ b/engine/crates/federated-graph/src/from_sdl/value.rs
@@ -1,0 +1,51 @@
+use super::{ast, executable_ast};
+
+pub(super) fn executable_value_to_type_system_value(value: executable_ast::Value<'_>) -> ast::Value<'_> {
+    match value {
+        executable_ast::Value::Variable(v) => ast::Value::Variable(v),
+        executable_ast::Value::Int(v) => ast::Value::Int(v),
+        executable_ast::Value::Float(v) => ast::Value::Float(v),
+        executable_ast::Value::String(v) => ast::Value::String(v),
+        executable_ast::Value::Boolean(v) => ast::Value::Boolean(v),
+        executable_ast::Value::Enum(v) => ast::Value::Enum(v),
+        executable_ast::Value::List(v) => {
+            ast::Value::List(v.into_iter().map(executable_value_to_type_system_value).collect())
+        }
+        executable_ast::Value::Object(v) => ast::Value::Object(
+            v.into_iter()
+                .map(|(name, value)| (name, executable_value_to_type_system_value(value)))
+                .collect(),
+        ),
+        executable_ast::Value::Null => ast::Value::Null,
+    }
+}
+
+pub(super) trait IntoJson {
+    fn into_json(self) -> Option<serde_json::Value>;
+}
+
+impl IntoJson for ast::Value<'_> {
+    fn into_json(self) -> Option<serde_json::Value> {
+        use serde_json::Value;
+
+        Some(match self {
+            ast::Value::Variable(_) => return None,
+            ast::Value::Int(i) => Value::Number(i.into()),
+            ast::Value::Float(i) => Value::Number(serde_json::Number::from_f64(f64::from(i)).unwrap()),
+            ast::Value::String(s) | ast::Value::BlockString(s) => Value::String(s.to_owned()),
+            ast::Value::Boolean(b) => Value::Bool(b),
+            ast::Value::Null => Value::Null,
+            ast::Value::Enum(_enm) => return None,
+            ast::Value::List(list) => Value::Array(
+                list.into_iter()
+                    .map(|value| value.into_json())
+                    .collect::<Option<Vec<_>>>()?,
+            ),
+            ast::Value::Object(obj) => Value::Object(
+                obj.into_iter()
+                    .map(|(key, value)| Some((key.to_owned(), value.into_json()?)))
+                    .collect::<Option<serde_json::Map<_, _>>>()?,
+            ),
+        })
+    }
+}

--- a/engine/crates/federated-graph/src/render_sdl/display_utils.rs
+++ b/engine/crates/federated-graph/src/render_sdl/display_utils.rs
@@ -65,7 +65,15 @@ impl fmt::Display for Description<'_> {
 
         writeln!(f, r#"{indentation}""""#)?;
 
-        for line in description.lines() {
+        let mut lines = description.lines().skip_while(|line| line.is_empty()).peekable();
+
+        while let Some(line) = lines.next() {
+            let line = line.trim();
+
+            if line.is_empty() && lines.peek().map(|next| next.is_empty()).unwrap_or(true) {
+                continue;
+            }
+
             writeln!(f, r#"{indentation}{line}"#)?;
         }
 

--- a/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
@@ -635,7 +635,7 @@ mod tests {
             directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
             type Query {
-                field: String @deprecated(reason: "This is a \"deprecated\" reason\n\non multiple lines.\n\nyes, way") @dummy(test: "a \"test\"")
+                field: String @deprecated(reason: "This is a \"deprecated\" reason\n\n                on multiple lines.\n\n                yes, way\n\n                ") @dummy(test: "a \"test\"")
             }
         "#]];
 


### PR DESCRIPTION
For `from_sdl()`. We are standardizing on cynic-parser, and we want to make that function more robust, progressively, so this has to happen.