### PR TITLE
chore: more ci tweaks

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -1,0 +1,38 @@
+name: Install rust
+description: Pretty self explanitory I hope
+
+inputs:
+  components:
+    required: false
+    description: Comma separated list of rust components to install (e.g. clippy, rustfmt)
+  target:
+    required: false
+    description: A target to install if not the native target
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Extract the Rust version to use from the `rust-toolchain.toml` file
+      shell: bash
+      run: |
+        rust_version=$(grep "channel" rust-toolchain.toml | cut -d "=" -f 2 | cut -d " " -f 2)
+        echo "RUST_VERSION=$rust_version" >> $GITHUB_ENV
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ env.RUST_VERSION }}
+        components: ${{ inputs.components }}
+
+    # Adding this override prevents rust from reading rust-toolchain
+    # We want to do this because rust-toolchain has a bunch of targets in it
+    # we don't need here - I'm hoping this setting will prevent those from
+    # downloading automatically
+    - name: Set a rustup override
+      shell: bash
+      run: rustup override set ${{ env.RUST_VERSION }}
+
+    - name: Install target
+      if: ${{ inputs.target }}
+      shell: bash
+      run: rustup target add ${{ inputs.target }}

--- a/.github/actions/install-what-rust-changed/action.yml
+++ b/.github/actions/install-what-rust-changed/action.yml
@@ -29,11 +29,3 @@ runs:
           rm wrc.tar.gz
         fi
         echo "$HOME/.local/what-rust-changed" >> $GITHUB_PATH
-        cat $GITHUB_PATH
-        ls $HOME/.local/what-rust-changed
-
-    - name: Install what-rust-changed
-      shell: bash
-      run: |
-        echo "in the next step"
-        echo $PATH

--- a/.github/actions/install-what-rust-changed/action.yml
+++ b/.github/actions/install-what-rust-changed/action.yml
@@ -1,0 +1,39 @@
+name: Install what-rust-changed
+description: Pretty self explanitory I hope
+
+inputs:
+  version:
+    required: true
+    description: The version to install
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Cargo cache
+      uses: actions/cache@v4
+      continue-on-error: false
+      with:
+        key: what-rust-changed-${{ inputs.version }}
+        save-always: true
+        path: |
+          ~/.local/what-rust-changed/
+
+    - name: Install what-rust-changed
+      shell: bash
+      run: |
+        if [ ! -f ~/.local/what-rust-changed/what-rust-changed ]; then
+          mkdir -p ~/.local/what-rust-changed
+          curl -L https://github.com/grafbase/what-rust-changed/releases/download/${{ inputs.version }}/what-rust-changed-x86_64-unknown-linux-gnu.tar.gz --output ~/.local/what-rust-changed/wrc.tar.gz
+          cd ~/.local/what-rust-changed
+          tar xfv wrc.tar.gz
+          rm wrc.tar.gz
+        fi
+        echo "$HOME/.local/what-rust-changed" >> $GITHUB_PATH
+        cat $GITHUB_PATH
+        ls $HOME/.local/what-rust-changed
+
+    - name: Install what-rust-changed
+      shell: bash
+      run: |
+        echo "in the next step"
+        echo $PATH

--- a/.github/workflows/rust-prs.yml
+++ b/.github/workflows/rust-prs.yml
@@ -49,11 +49,9 @@ jobs:
       # If you're iterating on this you may want to change this to a cargo install
       # while you work
       - name: Install what-rust-changed
-        uses: jaxxstorm/action-install-gh-release@v1.12.0
+        uses: ./.github/actions/install-what-rust-changed
         with:
-          repo: grafbase/what-rust-changed
-          tag: v0.1.0
-          cache: enable
+          version: v0.1.0
 
       - name: Run what-rust-changed
         id: what-rust-changed

--- a/.github/workflows/rust-prs.yml
+++ b/.github/workflows/rust-prs.yml
@@ -34,17 +34,8 @@ jobs:
           # Seems like if it's not zero you dont get branches
           fetch-depth: 0
 
-      - name: Extract the Rust version to use from the `rust-toolchain.toml` file
-        shell: bash
-        run: |
-          rust_version=$(grep "channel" rust-toolchain.toml | cut -d "=" -f 2 | cut -d " " -f 2)
-          echo "RUST_VERSION=$rust_version" >> $GITHUB_ENV
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-          components: clippy, rustfmt
+      - name: Install rust
+        uses: ./.github/actions/install-rust
 
       # If you're iterating on this you may want to change this to a cargo install
       # while you work
@@ -97,16 +88,9 @@ jobs:
       - name: Get sources
         uses: actions/checkout@v4
 
-      - name: Extract the Rust version to use from the `rust-toolchain.toml` file
-        shell: bash
-        run: |
-          rust_version=$(grep "channel" rust-toolchain.toml | cut -d "=" -f 2 | cut -d " " -f 2)
-          echo "RUST_VERSION=$rust_version" >> $GITHUB_ENV
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+      - name: Install rust
+        uses: ./.github/actions/install-rust
         with:
-          toolchain: ${{ env.RUST_VERSION }}
           components: rustfmt
 
       - name: cargo fmt
@@ -225,16 +209,10 @@ jobs:
         run: |
           echo ${{ needs.what-changed.outputs.rust }}
 
-      - name: Extract the Rust version to use from the `rust-toolchain.toml` file
-        shell: bash
-        run: |
-          rust_version=$(grep "channel" rust-toolchain.toml | cut -d "=" -f 2 | cut -d " " -f 2)
-          echo "RUST_VERSION=$rust_version" >> $GITHUB_ENV
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+      - name: Install rust
+        uses: ./.github/actions/install-rust
         with:
-          toolchain: ${{ env.RUST_VERSION }}
+          target: ${{ matrix.platform.target }}
           components: clippy, rustfmt
 
       - name: Install musl-tools
@@ -444,12 +422,8 @@ jobs:
           rust_version=$(grep "channel" rust-toolchain.toml | cut -d "=" -f 2 | cut -d " " -f 2)
           echo "RUST_VERSION=$rust_version" >> $GITHUB_ENV
 
-      # TODO: Maybe refactor this?  Not sure
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-          components: clippy, rustfmt
+      - name: Install rust
+        uses: ./.github/actions/install-rust
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
This PR fixes a couple of things I noticed:

1. Somehow the action I was using to download what-rust-changed was consistently taking 3 minutes to run.  It only took around a minute to compile so 3 minutes to download was not an improvement. I've replaced it with a custom action that just downloads it directly and runs in a reasonable time.
2. I noticed that cargo was picking up the full list of targets from `rust-toolchain.toml` and installing all of them in every CI job.  Not a big deal, but it was slowing things down by a little bit for every job.  Using `rustup override set` causes rust to ignore the toolchains file, so I've done that.
3. Also extracted the rust install stuff into an action.  (There is the existing init-rust-job action I could put that in, but I want to leave the existing stuff alone for now)