### PR TITLE
graphql-federated-graph: translate Null to Null and not "null"

### DIFF
--- a/engine/crates/federated-graph/src/from_sdl.rs
+++ b/engine/crates/federated-graph/src/from_sdl.rs
@@ -109,7 +109,7 @@ impl<'a> State<'a> {
 
     fn insert_value(&mut self, node: ast::Value<'_>, expected_enum_type: Option<EnumId>) -> Value {
         match node {
-            ast::Value::Null => Value::String(self.insert_string("null")),
+            ast::Value::Null => Value::Null,
             ast::Value::Int(n) => Value::Int(i64::from(n)),
             ast::Value::Float(n) => Value::Float(f64::from(n)),
             ast::Value::String(s) | ast::Value::BlockString(s) => Value::String(self.insert_string(s)),


### PR DESCRIPTION
When converting values from the parser to a FederatedGraph, until now, when encountering `null` in the schema, that was translated to `"null"` as a string. We have Value::Null, so that feels like a mistake.

Noticed by @obmarg [here](https://github.com/grafbase/grafbase/pull/2105#discussion_r1747177815).