### PR TITLE
engine-v2: enforce inaccessibility of inaccessible arguments

### DIFF
--- a/engine/crates/engine-v2/src/operation/bind/field.rs
+++ b/engine/crates/engine-v2/src/operation/bind/field.rs
@@ -128,6 +128,15 @@ impl<'schema, 'p> Binder<'schema, 'p> {
                 });
             }
         }
+
+        if let Some(first_unknown_argument) = arguments.first() {
+            return Err(BindError::UnknownArgument {
+                field_name: format!("{}.{}", definition.parent_entity().name(), definition.name()),
+                argument_name: first_unknown_argument.0.node.to_string(),
+                location,
+            });
+        }
+
         let end = self.field_arguments.len();
         Ok((start..end).into())
     }

--- a/engine/crates/engine-v2/src/operation/bind/mod.rs
+++ b/engine/crates/engine-v2/src/operation/bind/mod.rs
@@ -32,6 +32,12 @@ pub use variables::*;
 pub enum BindError {
     #[error("Unknown type named '{name}'")]
     UnknownType { name: String, location: Location },
+    #[error("The field `{field_name}` does not have an argument named `{argument_name}")]
+    UnknownArgument {
+        field_name: String,
+        argument_name: String,
+        location: Location,
+    },
     #[error("{container} does not have a field named '{name}'")]
     UnknownField {
         container: String,
@@ -114,6 +120,7 @@ impl From<BindError> for GraphqlError {
     fn from(err: BindError) -> Self {
         let locations = match err {
             BindError::UnknownField { location, .. }
+            | BindError::UnknownArgument { location, .. }
             | BindError::UnknownType { location, .. }
             | BindError::UnknownFragment { location, .. }
             | BindError::UnionHaveNoFields { location, .. }

--- a/engine/crates/federated-graph/src/federated_graph/v4.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v4.rs
@@ -86,7 +86,7 @@ impl FederatedGraph {
     }
 }
 
-#[derive(PartialEq, PartialOrd, Clone)]
+#[derive(PartialEq, PartialOrd, Clone, Debug)]
 pub enum Directive {
     Authenticated,
     Deprecated {

--- a/engine/crates/integration-tests/tests/federation/inaccessible.rs
+++ b/engine/crates/integration-tests/tests/federation/inaccessible.rs
@@ -1,0 +1,53 @@
+use engine_v2::Engine;
+use integration_tests::{federation::EngineV2Ext, runtime};
+
+#[test]
+fn inaccessible_arguments_are_inaccessible() {
+    let response = runtime().block_on(async move {
+        let engine = Engine::builder()
+            .with_federated_sdl(
+                r#"
+            directive @join__field(graph: join__Graph, requires: String, provides: String) on FIELD_DEFINITION
+            directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+            enum join__Graph {
+              PRODUCTS @join__graph(name: "products", url: "http://127.0.0.1:46697")
+            }
+
+            type Query {
+              topProducts(one: Int, two: Boolean @inaccessible): [Int!] @join__field(graph: PRODUCTS)
+            }
+        "#,
+            )
+            .build()
+            .await;
+
+        engine
+            .post(
+                r#"query {
+                    topProducts(one: 1)
+                    topProductsWithInaccessibleArg: topProducts(one: 3, two: true)
+                }"#,
+            )
+            .await
+    });
+
+    insta::assert_json_snapshot!(response, @r#"
+    {
+      "errors": [
+        {
+          "message": "The field `Query.topProducts` does not have an argument named `two",
+          "locations": [
+            {
+              "line": 3,
+              "column": 21
+            }
+          ],
+          "extensions": {
+            "code": "OPERATION_VALIDATION_ERROR"
+          }
+        }
+      ]
+    }
+    "#);
+}

--- a/engine/crates/integration-tests/tests/federation/mod.rs
+++ b/engine/crates/integration-tests/tests/federation/mod.rs
@@ -4,6 +4,7 @@ mod basic;
 mod entity_caching;
 mod graphql_over_http;
 mod hooks;
+mod inaccessible;
 mod introspection;
 mod issues;
 mod subgraph_retries;


### PR DESCRIPTION
An argument with `@inaccessible` should be treated as if it wasn't defined at all. What I found out testing this is that so far, we have not been validating against the usage of unknown arguments (they were just ignored). So there are two tests in this commit: one for the general case, and one for inaccessible. The implementation is the same, becausue we were already (correctly) removing inaccessible arguments in the conversion from FederatedGraph to engine_v2::Schema.