### PR TITLE
chore: bump gateway to 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -3341,7 +3341,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-config"
-version = "0.6.1"
+version = "0.13.0"
 dependencies = [
  "ascii 1.1.0",
  "cfg-if",
@@ -3666,7 +3666,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",
@@ -7758,7 +7758,7 @@ dependencies = [
 
 [[package]]
 name = "rolling-logger"
-version = "0.79.2"
+version = "0.13.0"
 dependencies = [
  "grafbase-workspace-hack",
  "insta",

--- a/engine/crates/engine-v2/Cargo.toml
+++ b/engine/crates/engine-v2/Cargo.toml
@@ -6,7 +6,6 @@ homepage = "https://grafbase.com"
 keywords = ["graphql", "engine", "grafbase"]
 license = "MPL-2.0"
 name = "engine-v2"
-readme = "README.md"
 repository = "https://github.com/grafbase/grafbase"
 version = "3.0.31"
 

--- a/engine/crates/engine-v2/axum/Cargo.toml
+++ b/engine/crates/engine-v2/axum/Cargo.toml
@@ -6,7 +6,6 @@ homepage = "https://grafbase.com"
 keywords = ["graphql", "engine", "grafbase"]
 license = "MPL-2.0"
 name = "engine-v2-axum"
-readme = "README.md"
 repository = "https://github.com/grafbase/grafbase"
 version = "3.0.31"
 

--- a/engine/crates/engine-v2/schema/Cargo.toml
+++ b/engine/crates/engine-v2/schema/Cargo.toml
@@ -6,7 +6,6 @@ homepage = "https://grafbase.com"
 keywords = ["graphql", "engine", "grafbase"]
 license = "MPL-2.0"
 name = "engine-v2-schema"
-readme = "README.md"
 repository = "https://github.com/grafbase/grafbase"
 version = "3.0.31"
 build = "build.rs"

--- a/engine/crates/gateway-core/Cargo.toml
+++ b/engine/crates/gateway-core/Cargo.toml
@@ -4,7 +4,6 @@ version = "3.0.31"
 authors = ["Grafbase"]
 description = "Grafbase gateway core logic"
 edition = "2021"
-readme = "README.md"
 license = "MPL-2.0"
 homepage = "https://grafbase.com"
 repository = "https://github.com/grafbase/grafbase"

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.13.0] - 2024-09-12
+
+[CHANGELOG](changelog/0.13.0.md)
+
 ## [0.12.0] - 2024-09-05
 
 [CHANGELOG](changelog/0.12.0.md)

--- a/gateway/Makefile.toml
+++ b/gateway/Makefile.toml
@@ -23,7 +23,7 @@ description = "Bumps all packages to the specified version"
 dependencies = ["install-cargo-release", "install-sd"]
 script = '''
 VERSION=${@}
-cargo release version $VERSION --execute --no-confirm -p grafbase-gateway -p federated-server
+cargo release version $VERSION --execute --no-confirm -p grafbase-gateway -p federated-server -p rolling-logger -p gateway-config
 touch "changelog/$VERSION.md"
 '''
 

--- a/gateway/crates/config/Cargo.toml
+++ b/gateway/crates/config/Cargo.toml
@@ -5,7 +5,7 @@ keywords.workspace = true
 license = "MPL-2.0"
 name = "gateway-config"
 repository.workspace = true
-version = "0.6.1"
+version = "0.13.0"
 
 [lints]
 workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/crates/rolling-logger/Cargo.toml
+++ b/gateway/crates/rolling-logger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolling-logger"
-version.workspace = true
+version = "0.13.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
### Access Log Rotation by Size

In version 0.12.0, we introduced a streamlined method for logging and storing access information using the Gateway Hooks. In this version we rewrote the logger into a faster and more minimal version. Now, you can rotate the log based on file size, configurable as follows:

```toml
[gateway.access_logs]
enabled = true
path = "./logs"
rotate.size = 10_000_000 # bytes
```

The rotation mechanism is now standardized. The active log file is named `access.log`. When a rotation occurs, we rename this file to `access.log.X`, where X is the timestamp of the original log file's creation.

### Fixes

- Enforced inaccessibility of inaccessible arguments.
- Engine returns `null` for inaccessible enum values.
- Parser correctly handles null values.
- Replaced the parser crate with a faster alternative, improving performance for parsing large schemas.
