### PR TITLE
feat(gateway-config): Support specifying access log size as 2kiB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3355,7 +3355,6 @@ dependencies = [
  "serde",
  "serde-dynamic-string",
  "serde_regex",
- "serde_with",
  "size",
  "temp-env",
  "tempfile",

--- a/gateway/changelog/0.14.0.md
+++ b/gateway/changelog/0.14.0.md
@@ -1,0 +1,8 @@
+- Support specifying access log rotate size as a string with a unit such as:
+
+```toml
+[gateway.access_logs]
+enabled = true
+path = "./logs"
+rotate.size = "200MiB"
+```

--- a/gateway/crates/config/Cargo.toml
+++ b/gateway/crates/config/Cargo.toml
@@ -22,7 +22,6 @@ duration-str = "0.11.0"
 http.workspace = true
 regex.workspace = true
 serde.workspace = true
-serde_with.workspace = true
 serde-dynamic-string.workspace = true
 serde_regex = "1.1.0"
 size = "0.5.0-preview2"

--- a/gateway/crates/config/src/size_ext.rs
+++ b/gateway/crates/config/src/size_ext.rs
@@ -1,0 +1,45 @@
+use serde::{de::Visitor, Deserializer};
+use size::Size;
+
+pub(crate) fn deserialize_positive_size<'de, D>(deserializer: D) -> Result<Size, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct SizeVisitor;
+
+    impl Visitor<'_> for SizeVisitor {
+        type Value = Size;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("a size value as string or number of bytes")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Size, E>
+        where
+            E: serde::de::Error,
+        {
+            Size::from_str(value).map_err(serde::de::Error::custom)
+        }
+
+        fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(Size::from_bytes(v))
+        }
+
+        fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(Size::from_bytes(v))
+        }
+    }
+
+    let size = deserializer.deserialize_any(SizeVisitor)?;
+    if size.bytes() < 0 {
+        Err(serde::de::Error::custom("size must be positive"))
+    } else {
+        Ok(size)
+    }
+}

--- a/gateway/crates/federated-server/src/server/access_logs.rs
+++ b/gateway/crates/federated-server/src/server/access_logs.rs
@@ -14,7 +14,7 @@ pub(crate) fn start(
         RotateMode::Minutely => RotateStrategy::minutely(),
         RotateMode::Hourly => RotateStrategy::hourly(),
         RotateMode::Daily => RotateStrategy::daily(),
-        RotateMode::Size(max_size) => RotateStrategy::size(max_size),
+        RotateMode::Size(max_size) => RotateStrategy::size(max_size.bytes().max(0).unsigned_abs()),
     };
 
     let mut log = RollingLogger::new(&config.path.join("access.log"), strategy)


### PR DESCRIPTION
Support:

```toml
[gateway.access_logs]
enabled = true
path = "./logs"
rotate.size = "200MiB"
```