### PR TITLE
chore: deny warnings on pull requests

### DIFF
--- a/.github/workflows/rust-prs.yml
+++ b/.github/workflows/rust-prs.yml
@@ -198,6 +198,8 @@ jobs:
             }
           ]
     runs-on: ${{ matrix.platform.runner }}
+    env:
+      RUSTFLAGS: '-D warnings'
     steps:
       - name: Get sources
         uses: actions/checkout@v4


### PR DESCRIPTION
For some reason I thought this was already the case, but it wasn't - which was allowing issues like #2124 to get through CI