### PR TITLE
fix: some better conditionals in pr action

### DIFF
--- a/.github/workflows/rust-prs.yml
+++ b/.github/workflows/rust-prs.yml
@@ -260,38 +260,35 @@ jobs:
           bun-version: latest
 
       - name: Download pre-built example component
-        if: |
-          contains(fromJson(needs.what-changed.outputs.rust).changed-packages, 'integration-tests')
-          || contains(fromJson(needs.what-changed.outputs.rust).changed-packages, 'gateway-binary')
-          || contains(fromJson(needs.what-changed.outputs.rust).changed-packages, 'wasi-component-loader')
+        if: needs.example-component.result != 'skipped'
         uses: actions/download-artifact@v4
         with:
           name: example-component
           path: engine/crates/wasi-component-loader/examples/target/wasm32-wasip1/debug
 
       - name: Download pre-built ~/.grafbase
-        if: contains(fromJson(needs.what-changed.outputs.rust).changed-packages, 'grafbase')
+        if: needs.cli-assets.result != 'skipped'
         uses: actions/download-artifact@v4
         with:
           name: home-dot-grafbase
           path: ../home-dot-grafbase
 
       - name: Copy ~/.grafbase into place
-        if: contains(fromJson(needs.what-changed.outputs.rust).changed-packages, 'grafbase')
+        if: needs.cli-assets.result != 'skipped'
         shell: bash
         run: |
           mkdir ~/.grafbase
           cp -r ../home-dot-grafbase/* ~/.grafbase/
 
       - name: Download pre-built cli-app
-        if: contains(fromJson(needs.what-changed.outputs.rust).changed-packages, 'grafbase')
+        if: needs.cli-assets.result != 'skipped'
         uses: actions/download-artifact@v4
         with:
           name: cli-app-dist
           path: packages/cli-app/dist
 
       - name: Download pre-built wrappers
-        if: contains(fromJson(needs.what-changed.outputs.rust).changed-packages, 'grafbase')
+        if: needs.cli-assets.result != 'skipped'
         uses: actions/download-artifact@v4
         with:
           name: wrappers-dist.js


### PR DESCRIPTION
Some steps in the build job should only be run if one of the previous jobs has been run.  Instead of encoding that specifically I'd copied over the `if` statement from the previous job.  This is kinda fragile because if you change one condition you have to remember to change the other, which obviously is going to be forgotten and lead to problems.