### PR TITLE
fix: update Cargo.lock

### DIFF
--- a/.github/workflows/rust-prs.yml
+++ b/.github/workflows/rust-prs.yml
@@ -61,8 +61,10 @@ jobs:
           echo "Merge Base: $MERGE_BASE"
           git checkout $MERGE_BASE
           cargo metadata > /tmp/base.metadata.json
+          # Temp hack to get CI to pass
+          git checkout -- Cargo.lock
           git checkout $HEAD_REF
-          cargo metadata > /tmp/target.metadata.json
+          cargo metadata --locked > /tmp/target.metadata.json
           CHANGED_FILES=$(git diff --no-commit-id --name-only -r $MERGE_BASE HEAD)
           CHANGES=$(echo $CHANGED_FILES | xargs what-rust-changed /tmp/base.metadata.json /tmp/target.metadata.json)
           echo "rust=$CHANGES" >> "$GITHUB_OUTPUT"
@@ -306,7 +308,10 @@ jobs:
         if: fromJson(needs.what-changed.outputs.rust).cargo-build-specs
         shell: bash
         run: |
-          cargo clippy --target ${{ matrix.platform.target }} ${{ fromJson(needs.what-changed.outputs.rust).cargo-build-specs }}
+          cargo clippy \
+            --locked \
+            --target ${{ matrix.platform.target }} \
+            ${{ fromJson(needs.what-changed.outputs.rust).cargo-build-specs }}
 
       - name: Login to Docker Hub
         if: runner.os == 'Linux'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3926,7 +3926,6 @@ dependencies = [
  "jwt-compact",
  "lazy_static",
  "libc",
- "libz-sys",
  "linux-raw-sys",
  "log",
  "lru",
@@ -5330,7 +5329,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]


### PR DESCRIPTION
Not sure how, but missed this in 27b885a.  May have been a merge thing, or may have been broken on the branch because CI wasn't doing `--locked` (which I've also fixed in this)