### PR TITLE
chore: renovate should ignore workspace-hack

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,5 +14,8 @@
         "pin"
       ]
     }
+  ],
+  "ignorePaths": [
+    "workspace-hack/Cargo.toml"
   ]
 }


### PR DESCRIPTION
The workspace-hack Cargo.toml is generated with cargo hakari - if renovate goes in there and tries to update it will not do the right thing, so we should just ignore it for now.

A side effect of this that I hadn't considered is that we'll almost definitely need to run `cargo hakari` manually on renovate branches which is a little bit annoying.  Would be nice if there was some way to automate it though I can't see any obvious options. Although it does seem like these often need manual intervention anyway, so I'm not sure if this is a new problem.