### PR TITLE
fix(engine-v2): fix endless recursion in object debug

### DIFF
--- a/engine/crates/engine-v2/codegen/domain/schema.graphql
+++ b/engine/crates/engine-v2/codegen/domain/schema.graphql
@@ -57,7 +57,7 @@ type InterfaceDefinition
 type FieldDefinition @meta(module: "field") @indexed(id_size: "u32", max_id: "MAX_ID") {
   name: String!
   description: String
-  parent_entity: EntityDefinition!
+  parent_entity: EntityDefinition! @meta(debug: false)
   ty: Type!
   resolvers: [ResolverDefinition!]!
   """

--- a/engine/crates/engine-v2/codegen/src/domain.rs
+++ b/engine/crates/engine-v2/codegen/src/domain.rs
@@ -194,6 +194,17 @@ pub struct Meta {
 }
 
 #[derive(Debug)]
+pub struct FieldMeta {
+    pub debug: bool,
+}
+
+impl Default for FieldMeta {
+    fn default() -> Self {
+        Self { debug: true }
+    }
+}
+
+#[derive(Debug)]
 pub struct Indexed {
     pub id_struct_name: String,
     pub id_size: Option<String>,

--- a/engine/crates/engine-v2/codegen/src/domain/record.rs
+++ b/engine/crates/engine-v2/codegen/src/domain/record.rs
@@ -1,6 +1,6 @@
 use cynic_parser::common::WrappingType;
 
-use super::{Definition, Indexed, Meta};
+use super::{Definition, FieldMeta, Indexed, Meta};
 
 #[derive(Debug)]
 pub struct Object {
@@ -27,6 +27,7 @@ impl Object {
 
 #[derive(Debug)]
 pub struct Field {
+    pub meta: FieldMeta,
     pub name: String,
     pub description: Option<String>,
     pub record_field_name: String,

--- a/engine/crates/engine-v2/codegen/src/generation/object/debug.rs
+++ b/engine/crates/engine-v2/codegen/src/generation/object/debug.rs
@@ -20,7 +20,7 @@ impl ToTokens for WalkerDebug<'_> {
         let walker_struct = Ident::new(object.walker_name(), Span::call_site());
         let name_string = proc_macro2::Literal::string(object.walker_name());
 
-        let fields = fields.iter().map(DebugField);
+        let fields = fields.iter().filter(|field| field.meta.debug).map(DebugField);
 
         tokens.append_all(quote! {
             impl std::fmt::Debug for #walker_struct<'_> {

--- a/engine/crates/engine-v2/schema/src/generated/field.rs
+++ b/engine/crates/engine-v2/schema/src/generated/field.rs
@@ -24,7 +24,7 @@ use walker::{Iter, Walk};
 /// type FieldDefinition @meta(module: "field") @indexed(id_size: "u32", max_id: "MAX_ID") {
 ///   name: String!
 ///   description: String
-///   parent_entity: EntityDefinition!
+///   parent_entity: EntityDefinition! @meta(debug: false)
 ///   ty: Type!
 ///   resolvers: [ResolverDefinition!]!
 ///   """
@@ -135,7 +135,6 @@ impl std::fmt::Debug for FieldDefinition<'_> {
         f.debug_struct("FieldDefinition")
             .field("name", &self.name())
             .field("description", &self.description())
-            .field("parent_entity", &self.parent_entity())
             .field("ty", &self.ty())
             .field("resolvers", &self.resolvers())
             .field("only_resolvable_in", &self.only_resolvable_in())

--- a/engine/crates/engine-v2/schema/src/interface.rs
+++ b/engine/crates/engine-v2/schema/src/interface.rs
@@ -5,7 +5,7 @@ impl std::fmt::Debug for InterfaceDefinition<'_> {
         f.debug_struct("InterfaceDefinition")
             .field("name", &self.name())
             .field("description", &self.description())
-            .field("fields", &self.fields())
+            .field("fields", &self.fields().map(|field| field.name()))
             .field(
                 "interfaces",
                 &self.interfaces().map(|interface| interface.name()).collect::<Vec<_>>(),

--- a/engine/crates/engine-v2/schema/src/object.rs
+++ b/engine/crates/engine-v2/schema/src/object.rs
@@ -10,7 +10,7 @@ impl std::fmt::Debug for ObjectDefinition<'_> {
                 &self.interfaces().map(|interface| interface.name()).collect::<Vec<_>>(),
             )
             .field("directives", &self.directives())
-            .field("fields", &self.fields().collect::<Vec<_>>())
+            .field("fields", &self.fields().map(|f| f.name()).collect::<Vec<_>>())
             .finish()
     }
 }


### PR DESCRIPTION
Debug impl of an object adds the object fields to the output. If one of these fields references the same object, we have endless recursion.

This fix just prints the field name, not the whole field.