### PR TITLE
chore: a test to show requires breakage

### DIFF
--- a/engine/crates/integration-tests/src/federation/builder/bench.rs
+++ b/engine/crates/integration-tests/src/federation/builder/bench.rs
@@ -65,6 +65,7 @@ impl<'a> DeterministicEngineBuilder<'a> {
 
         let schema =
             engine_v2::Schema::build(config, engine_v2::SchemaVersion::from(ulid::Ulid::new().to_bytes())).unwrap();
+
         let engine = engine_v2::Engine::new(
             Arc::new(schema),
             TestRuntime {

--- a/engine/crates/integration-tests/tests/federation/subgraphs/requires.rs
+++ b/engine/crates/integration-tests/tests/federation/subgraphs/requires.rs
@@ -1,3 +1,4 @@
+use indoc::indoc;
 use integration_tests::runtime;
 
 #[test]
@@ -71,6 +72,24 @@ fn simple_requires() {
       }
     }
     "###);
+}
+
+#[test]
+fn requires_fields_not_part_of_the_parent() {
+    let response = runtime().block_on(super::execute(indoc! {r#"
+        query ExampleQuery {
+            me {
+                reviews {
+                    product {
+                        shippingEstimate
+                    }
+                }
+            }
+        }
+    "#}));
+
+    // This cannot be an error.
+    insta::assert_json_snapshot!(response, @r###""###);
 }
 
 #[test]


### PR DESCRIPTION
This PR is a demonstration on @requires breaking if the plan does not already include required fields.

So if we query:

```graphql
query {
  me {
    reviews {
      product {
        shippingEstimate
      }
    }
  }
}
```

we get the error. But if we query

```graphql
query {
  me {
    reviews {
      product {
        name
        shippingEstimate
      }
    }
  }
}
```

all the data can be loaded successfully.