### PR TITLE
composition: do not expect fields from unresolvable keys to be part of key

### DIFF
--- a/engine/crates/composition/src/ingest_subgraph/directives.rs
+++ b/engine/crates/composition/src/ingest_subgraph/directives.rs
@@ -204,6 +204,7 @@ pub(super) fn ingest_keys(
                     _ => None,
                 })
                 .unwrap_or(true); // defaults to true
+
             subgraphs.push_key(definition_id, fields_arg, is_resolvable).ok();
         }
     }

--- a/engine/crates/composition/tests/composition/entity_unresolvable_keys/api.graphql
+++ b/engine/crates/composition/tests/composition/entity_unresolvable_keys/api.graphql
@@ -4,8 +4,15 @@ type User {
 }
 
 type Post {
+    comments: [Comment]
     id: ID!
     name: String
+}
+
+type Comment {
+    content: String
+    id: ID!
+    postId: ID!
 }
 
 type Query {

--- a/engine/crates/composition/tests/composition/entity_unresolvable_keys/federated.graphql
+++ b/engine/crates/composition/tests/composition/entity_unresolvable_keys/federated.graphql
@@ -30,8 +30,18 @@ type Post
     @join__type(graph: ACCOUNTS, key: "id", resolvable: false)
     @join__type(graph: PRODUCTS, key: "id")
 {
+    comments: [Comment] @join__field(graph: PRODUCTS)
     id: ID!
     name: String @join__field(graph: PRODUCTS)
+}
+
+type Comment
+    @join__type(graph: ACCOUNTS, key: "id")
+    @join__type(graph: PRODUCTS, key: "id content postId", resolvable: false)
+{
+    content: String
+    id: ID!
+    postId: ID!
 }
 
 type Query {

--- a/engine/crates/composition/tests/composition/entity_unresolvable_keys/subgraphs/accounts.graphql
+++ b/engine/crates/composition/tests/composition/entity_unresolvable_keys/subgraphs/accounts.graphql
@@ -7,7 +7,12 @@ type User {
   posts: [Post!]!
 }
 
-type Post @key(fields: "id", resolvable: false)  {
+type Post @key(fields: "id", resolvable: false) {
   id: ID!
 }
 
+type Comment @key(fields: "id") {
+  id: ID!
+  # "The field `Comment.content` is part of `@key` in products but not in accounts" should happen _if comments were resolvable in the products subgraph_.
+  content: String @external
+}

--- a/engine/crates/composition/tests/composition/entity_unresolvable_keys/subgraphs/products.graphql
+++ b/engine/crates/composition/tests/composition/entity_unresolvable_keys/subgraphs/products.graphql
@@ -1,6 +1,11 @@
-type Post @key(fields: "id")  {
+type Post @key(fields: "id") {
   id: ID!
   name: String
+  comments: [Comment]
 }
 
-
+type Comment @key(fields: "id content postId", resolvable: false) {
+  id: ID!
+  content: String
+  postId: ID!
+}

--- a/gateway/crates/gateway-binary/tests/access_logs/mod.rs
+++ b/gateway/crates/gateway-binary/tests/access_logs/mod.rs
@@ -155,7 +155,7 @@ fn with_broken_query() {
         "###);
     });
 
-    let result = dbg!(std::fs::read_to_string(tmpdir.path().join("access.log")).unwrap());
+    let result = std::fs::read_to_string(tmpdir.path().join("access.log")).unwrap();
     let result = serde_json::from_str::<Log>(&result).unwrap();
 
     let result = serde_json::to_string_pretty(&result).unwrap();


### PR DESCRIPTION
...in the other subgraphs.

Composition validates that if a field is part of the key in a subgraph, it must be part of a key in any other subgraph that defines it. That logic should not apply to unresolvable keys, this is what this PR achieves. This popped up while reproducing a federation audit issue.

closes GB-7567