### PR TITLE
feat: run federation-audit-tests on ci

### DIFF
--- a/.github/workflows/federation-audit.yml
+++ b/.github/workflows/federation-audit.yml
@@ -140,7 +140,7 @@ jobs:
           run: |
             npm start serve
           wait-on: |
-            http://localhost:4200
+            http-get://localhost:4200
           tail: true
           wait-for: 10s
           log-output-if: failure

--- a/.github/workflows/federation-audit.yml
+++ b/.github/workflows/federation-audit.yml
@@ -165,8 +165,6 @@ jobs:
         with:
           report_paths: 'target/nextest/ci/junit.xml'
           annotate_only: true
-          #fail_on_failure: false
-          #require_tests: true
           job_name: 'Federation Audit Report'
           check_name: 'Federation Audit Report'
           comment: true

--- a/.github/workflows/federation-audit.yml
+++ b/.github/workflows/federation-audit.yml
@@ -1,0 +1,161 @@
+name: federation-audit
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_DEV_DEBUG: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
+  CARGO_TERM_COLOR: 'always'
+  DO_NOT_TRACK: 1
+  RUST_BACKTRACE: 1
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  what-changed:
+    runs-on: ubicloud-standard-2
+    outputs:
+      rust: ${{ steps.what-rust-changed.outputs.rust }}
+      github-action: ${{ steps.paths-changed.outputs.github-action }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          # TODO: Figure out how to not make this zero
+          # Seems like if it's not zero you dont get branches
+          fetch-depth: 0
+
+      - name: Install rust
+        uses: ./.github/actions/install-rust
+
+      # If you're iterating on this you may want to change this to a cargo install
+      # while you work
+      - name: Install what-rust-changed
+        uses: ./.github/actions/install-what-rust-changed
+        with:
+          version: v0.1.0
+
+      - name: Run what-rust-changed
+        id: what-rust-changed
+        shell: bash
+        env:
+          WHAT_RUST_CHANGED_CONFIG: .github/what-rust-changed.toml
+        # TODO: Much of this script could be moved into the what-rust-changed code
+        # (or it could have its own action) but don't have time for that right now.
+        run: |
+          set -euo pipefail
+          HEAD_REF="$(git rev-parse HEAD)"
+          BASE_REF="remotes/origin/${GITHUB_BASE_REF:-main}"
+          echo "Head: $HEAD_REF"
+          echo "Base: $BASE_REF"
+          MERGE_BASE=$(git merge-base $BASE_REF $HEAD_REF)
+          echo "Merge Base: $MERGE_BASE"
+          git checkout $MERGE_BASE
+          cargo metadata > /tmp/base.metadata.json
+          # Temp hack to get CI to pass
+          git checkout -- Cargo.lock
+          git checkout $HEAD_REF
+          cargo metadata --locked > /tmp/target.metadata.json
+          CHANGED_FILES=$(git diff --no-commit-id --name-only -r $MERGE_BASE HEAD)
+          CHANGES=$(echo $CHANGED_FILES | xargs what-rust-changed /tmp/base.metadata.json /tmp/target.metadata.json)
+          echo "rust=$CHANGES" >> "$GITHUB_OUTPUT"
+          echo "Done.  Output Contents:"
+          echo ""
+          cat $GITHUB_OUTPUT
+
+      - name: Check paths changed
+        uses: dorny/paths-filter@v3
+        id: paths-changed
+        with:
+          filters: |
+            github-action:
+              - .github/workflows/federation-audit.yml
+
+  audit:
+    needs: [what-changed]
+    if: |
+      contains(fromJson(needs.what-changed.outputs.rust).changed-packages, 'engine-v2')
+      || needs.what-changed.outputs.github-action == 'true'
+    runs-on: ubicloud-standard-8
+    env:
+      RUSTFLAGS: '-D warnings'
+    steps:
+      - name: Get sources
+        uses: actions/checkout@v4
+
+      - name: Dump inputs for debugging
+        shell: bash
+        run: |
+          echo ${{ needs.what-changed.outputs.rust }}
+
+      # Disabling caching for now because I'm worried about using up any more of our cache storage.
+      # Can revisit later if we need to.
+      # - uses: Swatinem/rust-cache@v2
+      #   if: ${{ !startsWith(github.head_ref, 'renovate-') }}
+      #   with:
+      #     # Our windows & mac runners are hosted by github, so using github for
+      #     # their cache makes sense.  Buildjet is faster (and offers more storage) for
+      #     # others though.
+      #     cache-provider: ${{ contains(matrix.platform.target, 'linux') && 'buildjet' || 'github' }}
+
+      - name: Install rust
+        uses: ./.github/actions/install-rust
+        with:
+          target: x86_64-unknown-linux-gnu
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
+      # https://github.com/actions/setup-node/issues/899
+      - name: Enable Corepack before setting up Node
+        shell: bash
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Build audit tests
+        shell: bash
+        run: |
+          cargo nextest run --no-run --profile ci -p federation-audit-tests
+
+      - name: Setup audit test repo
+        shell: bash
+        run: |
+          cargo nextest run --profile ci -p federation-audit-tests --test checkout || true
+
+      - name: Start audit test server
+        uses: JarvusInnovations/background-action@v1
+        with:
+          working-directory: engine/crates/federation-audit-tests/gateway-audit-repo
+          run: |
+            npm start serve
+          wait-on: |
+            http://localhost:4200
+          tail: true
+          wait-for: 10s
+          log-output-if: failure
+
+      - name: Run audit tests
+        shell: bash
+        run: |
+          cargo nextest run --profile ci -p federation-audit-tests
+
+      - name: Upload the JUnit files
+        if: ${{ ( success() || failure() ) && !contains(steps.tests.outputs.exitcode, '101') && !contains(steps.tests_docker.outputs.exitcode, '101') && matrix.platform.target != 'x86_64-apple-darwin'}}
+        uses: ./.github/actions/test_upload_datadog
+        with:
+          api_key: ${{ secrets.DATADOG_API_KEY }}
+          junit_path: target/nextest/ci/junit.xml
+          service: audit-tests
+
+      # TODO: Report on the PR

--- a/.github/workflows/federation-audit.yml
+++ b/.github/workflows/federation-audit.yml
@@ -164,8 +164,9 @@ jobs:
         if: success() || failure()
         with:
           report_paths: 'target/nextest/ci/junit.xml'
-          fail_on_failure: false
-          require_tests: true
+          annotate_only: true
+          #fail_on_failure: false
+          #require_tests: true
           job_name: 'Federation Audit Report'
           check_name: 'Federation Audit Report'
           comment: true

--- a/.github/workflows/federation-audit.yml
+++ b/.github/workflows/federation-audit.yml
@@ -82,6 +82,9 @@ jobs:
       contains(fromJson(needs.what-changed.outputs.rust).changed-packages, 'engine-v2')
       || needs.what-changed.outputs.github-action == 'true'
     runs-on: ubicloud-standard-8
+    permissions:
+      checks: write
+      pull-requests: write
     env:
       RUSTFLAGS: '-D warnings'
     steps:
@@ -146,17 +149,27 @@ jobs:
           log-output-if: failure
 
       - name: Run audit tests
+        id: tests
         shell: bash
         continue-on-error: true
         run: |
           cargo nextest run --profile ci -p federation-audit-tests
 
       - name: Upload the JUnit files
-        if: ${{ ( success() || failure() ) && !contains(steps.tests.outputs.exitcode, '101') && !contains(steps.tests_docker.outputs.exitcode, '101') && matrix.platform.target != 'x86_64-apple-darwin'}}
+        if: ${{ ( success() || failure() ) && !contains(steps.tests.outputs.exitcode, '101') }}
         uses: ./.github/actions/test_upload_datadog
         with:
           api_key: ${{ secrets.DATADOG_API_KEY }}
           junit_path: target/nextest/ci/junit.xml
           service: audit-tests
 
-      # TODO: Report on the PR
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v5.0.0-a03
+        if: success() || failure()
+        with:
+          report_paths: 'target/nextest/ci/junit.xml'
+          fail_on_failure: false
+          require_tests: true
+          job_name: 'Federation Audit Report'
+          check_name: 'Federation Audit Report'
+          comment: true

--- a/.github/workflows/federation-audit.yml
+++ b/.github/workflows/federation-audit.yml
@@ -45,8 +45,6 @@ jobs:
         shell: bash
         env:
           WHAT_RUST_CHANGED_CONFIG: .github/what-rust-changed.toml
-        # TODO: Much of this script could be moved into the what-rust-changed code
-        # (or it could have its own action) but don't have time for that right now.
         run: |
           set -euo pipefail
           HEAD_REF="$(git rev-parse HEAD)"
@@ -57,8 +55,6 @@ jobs:
           echo "Merge Base: $MERGE_BASE"
           git checkout $MERGE_BASE
           cargo metadata > /tmp/base.metadata.json
-          # Temp hack to get CI to pass
-          git checkout -- Cargo.lock
           git checkout $HEAD_REF
           cargo metadata --locked > /tmp/target.metadata.json
           CHANGED_FILES=$(git diff --no-commit-id --name-only -r $MERGE_BASE HEAD)

--- a/.github/workflows/federation-audit.yml
+++ b/.github/workflows/federation-audit.yml
@@ -147,6 +147,7 @@ jobs:
 
       - name: Run audit tests
         shell: bash
+        continue-on-error: true
         run: |
           cargo nextest run --profile ci -p federation-audit-tests
 

--- a/engine/crates/federation-audit-tests/tests/checkout.rs
+++ b/engine/crates/federation-audit-tests/tests/checkout.rs
@@ -2,6 +2,8 @@
 
 use std::process::Command;
 
+const GIT_REPO: &str = "https://github.com/the-guild-org/graphql-federation-gateway-audit.git";
+
 #[test]
 fn ensure_upstream_is_up_to_date() {
     // The tests in this crate are powered by the upstream graphql-federation-gateway-audit repo
@@ -21,16 +23,12 @@ fn ensure_upstream_is_up_to_date() {
 
     if !std::fs::exists("gateway-audit-repo").unwrap() {
         let status = Command::new("git")
-            .args([
-                "clone",
-                "git@github.com:the-guild-org/graphql-federation-gateway-audit.git",
-                "gateway-audit-repo",
-            ])
+            .args(["clone", GIT_REPO, "gateway-audit-repo"])
             .status()
             .unwrap();
 
         if !status.success() {
-            panic!("Could not clone git@github.com:the-guild-org/graphql-federation-gateway-audit.git - please do it yourself");
+            panic!("Could not clone {GIT_REPO} - please do it yourself");
         }
     }
 


### PR DESCRIPTION
Added the federation-audit-tests into their own workflow.  These will not fail the build, and will just post a comment summarising the current state of the audit tests.  

I wanted to output a non-failing check with more details but I couldn't find a way to make it non-failing, and having that red cross on every single build seemed annoying.