### PR TITLE
graphql-schema-diff: handle schema and type definition extensions

### DIFF
--- a/engine/crates/graphql-schema-diff/src/patch.rs
+++ b/engine/crates/graphql-schema-diff/src/patch.rs
@@ -41,13 +41,22 @@ where
 
     for definition in parsed.definitions() {
         match definition {
-            cynic_parser::type_system::Definition::Schema(def)
-            | cynic_parser::type_system::Definition::SchemaExtension(def) => {
-                schema_definitions::patch_schema_definition(def, &mut schema, &paths);
+            cynic_parser::type_system::Definition::Schema(def) => {
+                schema_definitions::patch_schema_definition(
+                    def,
+                    DefinitionOrExtension::Definition,
+                    &mut schema,
+                    &paths,
+                );
             }
-            cynic_parser::type_system::Definition::Type(ty)
-            | cynic_parser::type_system::Definition::TypeExtension(ty) => {
-                type_definitions::patch_type_definition(ty, &mut schema, &paths);
+            cynic_parser::type_system::Definition::SchemaExtension(def) => {
+                schema_definitions::patch_schema_definition(def, DefinitionOrExtension::Extension, &mut schema, &paths);
+            }
+            cynic_parser::type_system::Definition::Type(ty) => {
+                type_definitions::patch_type_definition(ty, DefinitionOrExtension::Definition, &mut schema, &paths);
+            }
+            cynic_parser::type_system::Definition::TypeExtension(ty) => {
+                type_definitions::patch_type_definition(ty, DefinitionOrExtension::Extension, &mut schema, &paths);
             }
             cynic_parser::type_system::Definition::Directive(directive_definition) => {
                 directives::patch_directive_definition(directive_definition, &mut schema, &paths);
@@ -56,6 +65,11 @@ where
     }
 
     Ok(PatchedSchema { schema })
+}
+
+enum DefinitionOrExtension {
+    Extension,
+    Definition,
 }
 
 /// A schema patched with [patch()].

--- a/engine/crates/graphql-schema-diff/src/patch/directives.rs
+++ b/engine/crates/graphql-schema-diff/src/patch/directives.rs
@@ -48,9 +48,13 @@ fn render_directive<T: AsRef<str>>(directive: Directive<'_>, schema: &mut String
 
     schema.push('(');
 
-    for argument in arguments {
+    while let Some(argument) = arguments.next() {
         let span = argument.span();
-        schema.push_str(&paths.source()[span.start..span.end])
+        schema.push_str(&paths.source()[span.start..span.end]);
+
+        if arguments.peek().is_some() {
+            schema.push_str(", ");
+        }
     }
 
     schema.push(')');

--- a/engine/crates/graphql-schema-diff/src/patch/type_definitions.rs
+++ b/engine/crates/graphql-schema-diff/src/patch/type_definitions.rs
@@ -4,9 +4,14 @@ use cynic_parser::type_system::{
 
 use crate::ChangeKind;
 
-use super::{directives::patch_directives, paths::Paths, INDENTATION};
+use super::{directives::patch_directives, paths::Paths, DefinitionOrExtension, INDENTATION};
 
-pub(super) fn patch_type_definition<T: AsRef<str>>(ty: TypeDefinition<'_>, schema: &mut String, paths: &Paths<'_, T>) {
+pub(super) fn patch_type_definition<T: AsRef<str>>(
+    ty: TypeDefinition<'_>,
+    definition_or_extension: super::DefinitionOrExtension,
+    schema: &mut String,
+    paths: &Paths<'_, T>,
+) {
     for change in paths.iter_exact([ty.name(), "", ""]) {
         match change.kind() {
             ChangeKind::RemoveObjectType
@@ -25,6 +30,10 @@ pub(super) fn patch_type_definition<T: AsRef<str>>(ty: TypeDefinition<'_>, schem
         let span = description.span();
         schema.push_str(&paths.source()[span.start..span.end]);
         schema.push('\n');
+    }
+
+    if let DefinitionOrExtension::Extension = definition_or_extension {
+        schema.push_str("extend ");
     }
 
     let prefix = match ty {

--- a/engine/crates/graphql-schema-diff/tests/patch/no_change.graphql
+++ b/engine/crates/graphql-schema-diff/tests/patch/no_change.graphql
@@ -1,9 +1,13 @@
+directive @core(feature: String!) repeatable on SCHEMA
+
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@override"])
+
 schema {
   query: Root
 }
 
 """A single film."""
-type Film implements Node {
+extend type Film implements Node {
   characterConnection(after: String, before: String, first: Int, last: Int): FilmCharactersConnection
   """The ISO 8601 date format of the time that this resource was created."""
   created: String
@@ -1001,12 +1005,16 @@ type VehiclesEdge {
 
 # --- #
 
+directive @core(feature: String!) repeatable on SCHEMA
+
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@override"])
+
 schema {
   query: Root
 }
 
 """A single film."""
-type Film implements Node {
+extend type Film implements Node {
   characterConnection(after: String, before: String, first: Int, last: Int): FilmCharactersConnection
   """The ISO 8601 date format of the time that this resource was created."""
   created: String


### PR DESCRIPTION
Before this commit, the "extend ..." would be lost in patching.

Additionally, two small fixes:

- Missing comma separator between arguments of directives, now correctly inserted.
- Do not render the curly braces in a schema definition / extension if it defines no root type.

closes GB-7600
