### PR TITLE
fix: the mysterious-external audit tests

### DIFF
--- a/.github/workflows/federation-audit.yml
+++ b/.github/workflows/federation-audit.yml
@@ -76,6 +76,7 @@ jobs:
     needs: [what-changed]
     if: |
       contains(fromJson(needs.what-changed.outputs.rust).changed-packages, 'engine-v2')
+      || contains(fromJson(needs.what-changed.outputs.rust).changed-packages, 'federation-audit-tests')
       || needs.what-changed.outputs.github-action == 'true'
     runs-on: ubicloud-standard-8
     permissions:
@@ -149,7 +150,7 @@ jobs:
         shell: bash
         continue-on-error: true
         run: |
-          cargo nextest run --profile ci -p federation-audit-tests
+          cargo nextest run --profile ci -p federation-audit-tests --test audit_tests
 
       - name: Upload the JUnit files
         if: ${{ ( success() || failure() ) && !contains(steps.tests.outputs.exitcode, '101') }}


### PR DESCRIPTION
Our implementation of the audit tests and the original one from the guild disagreed slightly: we had 2 more failures than they did.

This turned out to be the mysterious-external tests: their test data contains `price: 100` but the engine is returning `price: 100.0`. `serde_json` considers these to not be equal, so we were getting a false failure.

I've fixed that in this PR by just converting all numbers to floats before comparing.  There may be some edge cases for which this doesn't work, but it does give us the same numbers as the guild so I think we're good for now.