### PR TITLE
fix: show error details in failed audit tests

### DIFF
--- a/engine/crates/federation-audit-tests/src/audit_server.rs
+++ b/engine/crates/federation-audit-tests/src/audit_server.rs
@@ -103,7 +103,7 @@ pub struct Test {
     pub expected: ExpectedResponse,
 }
 
-#[derive(serde::Deserialize, Clone, Debug, PartialEq)]
+#[derive(serde::Deserialize, Clone, PartialEq, Debug)]
 pub struct ExpectedResponse {
     #[serde(default)]
     pub data: serde_json::Value,

--- a/engine/crates/federation-audit-tests/src/lib.rs
+++ b/engine/crates/federation-audit-tests/src/lib.rs
@@ -4,5 +4,9 @@ use grafbase_workspace_hack as _;
 
 pub mod audit_server;
 mod cache;
+mod response;
 
-pub use cache::{cached_tests, CachedTest};
+pub use self::{
+    cache::{cached_tests, CachedTest},
+    response::Response,
+};

--- a/engine/crates/federation-audit-tests/src/response.rs
+++ b/engine/crates/federation-audit-tests/src/response.rs
@@ -1,0 +1,14 @@
+use crate::audit_server::ExpectedResponse;
+
+/// Utility struct for comparing responses with ExpectedResponse
+#[derive(PartialEq, Debug)]
+pub struct Response<'a> {
+    pub data: serde_json::Value,
+    pub errors: &'a [serde_json::Value],
+}
+
+impl PartialEq<ExpectedResponse> for Response<'_> {
+    fn eq(&self, other: &ExpectedResponse) -> bool {
+        self.data == other.data && self.errors.is_empty() != other.errors
+    }
+}

--- a/engine/crates/federation-audit-tests/tests/audit_tests.rs
+++ b/engine/crates/federation-audit-tests/tests/audit_tests.rs
@@ -1,8 +1,8 @@
 #![allow(unused_crate_dependencies)]
 
 use federation_audit_tests::{
-    audit_server::{AuditServer, ExpectedResponse, Test},
-    cached_tests, CachedTest,
+    audit_server::{AuditServer, Test},
+    cached_tests, CachedTest, Response,
 };
 use integration_tests::federation::TestGatewayBuilder;
 use libtest_mimic::{Arguments, Failed, Trial};
@@ -44,9 +44,9 @@ async fn run_test(supergraph_sdl: String, mut test: Test) {
     test.expected.data = floatify_numbers(test.expected.data);
 
     similar_asserts::assert_eq!(
-        ExpectedResponse {
+        Response {
             data: floatify_numbers(response.body["data"].clone()),
-            errors: !response.errors().is_empty()
+            errors: &response.errors()
         },
         test.expected
     );


### PR DESCRIPTION
We were simplfiying to `errors: bool` for the sake of comparison but it's useful to actually see the errors when you get some unexpected errors.