### PR TITLE
fix: better diffs in failed audit tests

### DIFF
--- a/engine/crates/federation-audit-tests/src/audit_server.rs
+++ b/engine/crates/federation-audit-tests/src/audit_server.rs
@@ -1,4 +1,4 @@
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Serialize};
 
 use crate::CachedTest;
 
@@ -103,7 +103,7 @@ pub struct Test {
     pub expected: ExpectedResponse,
 }
 
-#[derive(serde::Deserialize, Clone, PartialEq, Debug)]
+#[derive(serde::Deserialize, Clone, PartialEq, Debug, Serialize)]
 pub struct ExpectedResponse {
     #[serde(default)]
     pub data: serde_json::Value,

--- a/engine/crates/federation-audit-tests/src/response.rs
+++ b/engine/crates/federation-audit-tests/src/response.rs
@@ -1,7 +1,9 @@
+use serde::Serialize;
+
 use crate::audit_server::ExpectedResponse;
 
 /// Utility struct for comparing responses with ExpectedResponse
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Serialize)]
 pub struct Response<'a> {
     pub data: serde_json::Value,
     pub errors: &'a [serde_json::Value],


### PR DESCRIPTION
Using the similar_asserts inners gets us a couple of improvements:

1. We can label the diffs with expected & actual rather than left & right.
2. We can diff on JSON which is less noisy than diffing on the Debug output that similar_asserts uses by default.

Before:

![image](https://github.com/user-attachments/assets/37ed2906-532d-4b7f-9f6c-4df88b9ea0df)

After: 

![image](https://github.com/user-attachments/assets/7c2cc2ca-d026-42a6-9a6c-38f24697d988)

