### PR TITLE
test: use audit tests to compare composition outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,7 +770,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "log",
@@ -1903,10 +1903,11 @@ dependencies = [
 [[package]]
 name = "cynic-codegen"
 version = "3.7.3"
-source = "git+https://github.com/grafbase/cynic?rev=920dd202101a0643a0c29031e1cfa0f20031c2d6#920dd202101a0643a0c29031e1cfa0f20031c2d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c0ec86f960a00ce087e96ff6f073f6ff28b6876d69ce8caa06c03fb4143981c"
 dependencies = [
  "counter",
- "cynic-parser",
+ "cynic-parser 0.4.5",
  "darling",
  "once_cell",
  "ouroboros",
@@ -1933,11 +1934,23 @@ dependencies = [
 [[package]]
 name = "cynic-parser"
 version = "0.4.5"
-source = "git+https://github.com/grafbase/cynic?rev=920dd202101a0643a0c29031e1cfa0f20031c2d6#920dd202101a0643a0c29031e1cfa0f20031c2d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718f6cd8c54ae5249fd42b0c86639df0100b8a86eea2e5f1b915cde2e1481453"
+dependencies = [
+ "indexmap 2.2.6",
+ "lalrpop-util 0.20.2",
+ "logos",
+]
+
+[[package]]
+name = "cynic-parser"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acbf4f3ed18c691698563a8d10419073a8178c833ae74f24aebae88af26d12a"
 dependencies = [
  "ariadne",
  "indexmap 2.2.6",
- "lalrpop-util",
+ "lalrpop-util 0.21.0",
  "logos",
  "pretty",
 ]
@@ -2668,7 +2681,7 @@ name = "engine-v2-codegen"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cynic-parser",
+ "cynic-parser 0.5.2",
  "grafbase-workspace-hack",
  "indoc",
  "itertools 0.13.0",
@@ -3047,7 +3060,7 @@ name = "federation-audit-tests"
 version = "0.79.2"
 dependencies = [
  "async-graphql-parser",
- "cynic-parser",
+ "cynic-parser 0.5.2",
  "grafbase-workspace-hack",
  "graphql-composition",
  "integration-tests",
@@ -3452,7 +3465,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "common-types",
- "cynic-parser",
+ "cynic-parser 0.5.2",
  "engine",
  "engine-parser",
  "engine-validation",
@@ -3780,7 +3793,7 @@ version = "0.79.2"
 dependencies = [
  "cynic",
  "cynic-introspection",
- "cynic-parser",
+ "cynic-parser 0.5.2",
  "grafbase-workspace-hack",
  "indoc",
  "reqwest",
@@ -3849,7 +3862,7 @@ dependencies = [
  "common-types",
  "const_format",
  "criterion",
- "cynic-parser",
+ "cynic-parser 0.5.2",
  "dotenv",
  "engine",
  "federated-dev",
@@ -3977,7 +3990,7 @@ dependencies = [
  "crossbeam-queue",
  "crossbeam-utils",
  "cynic-codegen",
- "cynic-parser",
+ "cynic-parser 0.5.2",
  "deadpool 0.12.1",
  "deadpool-runtime",
  "der",
@@ -4012,6 +4025,7 @@ dependencies = [
  "iana-time-zone",
  "indexmap 2.2.6",
  "insta",
+ "itertools 0.10.5",
  "jwt-compact",
  "lazy_static",
  "libc",
@@ -4160,7 +4174,7 @@ dependencies = [
 name = "graphql-federated-graph"
 version = "0.4.0"
 dependencies = [
- "cynic-parser",
+ "cynic-parser 0.5.2",
  "expect-test",
  "grafbase-workspace-hack",
  "graphql-wrapping-types",
@@ -4175,7 +4189,7 @@ name = "graphql-lint"
 version = "0.1.3"
 dependencies = [
  "criterion",
- "cynic-parser",
+ "cynic-parser 0.5.2",
  "grafbase-workspace-hack",
  "heck 0.5.0",
  "thiserror",
@@ -4223,7 +4237,7 @@ dependencies = [
 name = "graphql-schema-diff"
 version = "0.2.0"
 dependencies = [
- "cynic-parser",
+ "cynic-parser 0.5.2",
  "datatest-stable",
  "grafbase-workspace-hack",
  "miette 7.2.0",
@@ -4953,7 +4967,7 @@ dependencies = [
  "ctor",
  "cynic",
  "cynic-introspection",
- "cynic-parser",
+ "cynic-parser 0.5.2",
  "engine",
  "engine-config-builder",
  "engine-parser",
@@ -5265,6 +5279,15 @@ name = "lalrpop-util"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata 0.4.7",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "108dc8f5dabad92c65a03523055577d847f5dcc00f3e7d3a68bc4d48e01d8fe1"
 dependencies = [
  "regex-automata 0.4.7",
 ]
@@ -6627,7 +6650,7 @@ dependencies = [
  "anyhow",
  "blake3",
  "common-types",
- "cynic-parser",
+ "cynic-parser 0.5.2",
  "engine-value",
  "grafbase-workspace-hack",
  "graph-entities",
@@ -7668,7 +7691,7 @@ name = "registry-v2-generator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cynic-parser",
+ "cynic-parser 0.5.2",
  "grafbase-workspace-hack",
  "indexmap 2.2.6",
  "indoc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3046,7 +3046,10 @@ dependencies = [
 name = "federation-audit-tests"
 version = "0.79.2"
 dependencies = [
+ "async-graphql-parser",
+ "cynic-parser",
  "grafbase-workspace-hack",
+ "graphql-composition",
  "integration-tests",
  "libtest-mimic",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,6 @@ exclude = [
 
 [patch.crates-io]
 axum = { git = "https://github.com/grafbase/axum", rev = "c3146f9ca921907d9884fbf7549a1520e9e72eac" }                                 # axum-tungstenite-upgrade
-cynic-parser = { git = "https://github.com/grafbase/cynic", rev = "920dd202101a0643a0c29031e1cfa0f20031c2d6" }                        # more-spans
-cynic-codegen = { git = "https://github.com/grafbase/cynic", rev = "920dd202101a0643a0c29031e1cfa0f20031c2d6" }                       # more-spans
 multipart-stream = { git = "https://github.com/grafbase/multipart-stream-rs-fork", rev = "06ff198e4041c8a8c1c93e580c260d597727c193" } # http-1.0-fix-multipart-mixed
 names = { git = "https://github.com/grafbase/names", rev = "443800fbb7bc2936c1f2c16f3a5e116698b1454a" }                               # main
 # FIXME: Drop when a new version is released.
@@ -98,7 +96,7 @@ chrono = { version = "0.4.38", default-features = false }
 ctor = "0.2.8"
 cynic = "=3.7.3"
 cynic-introspection = "=3.7.3"
-cynic-parser = "=0.4.5"
+cynic-parser = "0.5.0"
 deadpool-postgres = "0.14"
 derive_more = "1.0.0-beta.6"
 jwt-compact = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,9 @@ exclude = [
 ]
 
 [patch.crates-io]
-axum = { git = "https://github.com/grafbase/axum", rev = "c3146f9ca921907d9884fbf7549a1520e9e72eac" } # axum-tungstenite-upgrade
-cynic-parser = { git = "https://github.com/grafbase/cynic", rev = "920dd202101a0643a0c29031e1cfa0f20031c2d6" } # more-spans
-cynic-codegen = { git = "https://github.com/grafbase/cynic", rev = "920dd202101a0643a0c29031e1cfa0f20031c2d6" } # more-spans
+axum = { git = "https://github.com/grafbase/axum", rev = "c3146f9ca921907d9884fbf7549a1520e9e72eac" }                                 # axum-tungstenite-upgrade
+cynic-parser = { git = "https://github.com/grafbase/cynic", rev = "920dd202101a0643a0c29031e1cfa0f20031c2d6" }                        # more-spans
+cynic-codegen = { git = "https://github.com/grafbase/cynic", rev = "920dd202101a0643a0c29031e1cfa0f20031c2d6" }                       # more-spans
 multipart-stream = { git = "https://github.com/grafbase/multipart-stream-rs-fork", rev = "06ff198e4041c8a8c1c93e580c260d597727c193" } # http-1.0-fix-multipart-mixed
 names = { git = "https://github.com/grafbase/names", rev = "443800fbb7bc2936c1f2c16f3a5e116698b1454a" }                               # main
 # FIXME: Drop when a new version is released.

--- a/engine/crates/engine-v2/codegen/src/loader.rs
+++ b/engine/crates/engine-v2/codegen/src/loader.rs
@@ -81,7 +81,7 @@ pub(super) fn load(path: PathBuf) -> anyhow::Result<domain::Domain> {
                         // Add any explicitly defined field name or leave empty to be generated
                         // afterwards.
                         record_field_name: parse_record_field_name(field.directives()).unwrap_or_default(),
-                        description: field.description().map(|s| s.description().to_cow().into_owned()),
+                        description: field.description().map(|s| s.to_string()),
                         type_name: field.ty().name().to_string(),
                         wrapping: field.ty().wrappers().collect(),
                     })
@@ -226,7 +226,7 @@ fn parse_union_kind(name: &str, directives: Iter<'_, Directive<'_>>) -> domain::
         }
     } else {
         domain::UnionKind::Record(domain::RecordUnion {
-            indexed: parse_indexed(name, directives),
+            indexed: parse_indexed(name, directives.clone()),
             copy: is_copy(directives),
             name: name.to_string(),
             walker_enum_name: format!("{name}Variant"),

--- a/engine/crates/federated-graph/src/from_sdl.rs
+++ b/engine/crates/federated-graph/src/from_sdl.rs
@@ -112,7 +112,7 @@ impl<'a> State<'a> {
     fn insert_value(&mut self, node: ast::Value<'_>, expected_enum_type: Option<EnumId>) -> Value {
         match node {
             ast::Value::Null => Value::Null,
-            ast::Value::Int(n) => Value::Int(i64::from(n)),
+            ast::Value::Int(n) => Value::Int(n.as_i64()),
             ast::Value::Float(n) => Value::Float(f64::from(n)),
             ast::Value::String(s) | ast::Value::BlockString(s) => Value::String(self.insert_string(s)),
             ast::Value::Boolean(b) => Value::Boolean(b),
@@ -489,7 +489,7 @@ fn ingest_field_directives_after_graph<'a>(
 
         let parent_id = state.definition_names[typedef.name()];
 
-        ingest_join_field_directive(parent_id, || typedef.directives(), fields, state)?;
+        ingest_join_field_directive(parent_id, || typedef.directives(), fields.clone(), state)?;
         ingest_authorized_directive(parent_id, fields, state)?;
     }
 
@@ -676,14 +676,14 @@ fn ingest_definitions<'a>(document: &'a ast::TypeSystemDocument, state: &mut Sta
                 let type_name_id = state.insert_string(type_name);
                 let description = typedef
                     .description()
-                    .map(|description| state.insert_string(description.description().raw_str()));
+                    .map(|description| state.insert_string(description.raw_str()));
                 let composed_directives = collect_composed_directives(typedef.directives(), state);
 
                 match typedef {
                     ast::TypeDefinition::Scalar(scalar) => {
                         let description = scalar
                             .description()
-                            .map(|description| state.insert_string(description.description().raw_str()));
+                            .map(|description| state.insert_string(description.raw_str()));
 
                         let scalar_id = ScalarId(state.scalars.push_return_idx(Scalar {
                             name: type_name_id,
@@ -745,7 +745,7 @@ fn ingest_definitions<'a>(document: &'a ast::TypeSystemDocument, state: &mut Sta
                                 let composed_directives = collect_composed_directives(value.directives(), state);
                                 let description = value
                                     .description()
-                                    .map(|description| state.insert_string(description.description().raw_str()));
+                                    .map(|description| state.insert_string(description.raw_str()));
 
                                 state
                                     .enum_values_map
@@ -832,7 +832,7 @@ fn ingest_field<'a>(
     for arg in ast_field.arguments() {
         let description = arg
             .description()
-            .map(|description| state.insert_string(description.description().raw_str()));
+            .map(|description| state.insert_string(description.raw_str()));
         let composed_directives = collect_composed_directives(arg.directives(), state);
         let name = state.insert_string(arg.name());
         let r#type = state.field_type(arg.ty())?;
@@ -930,7 +930,7 @@ fn ingest_field<'a>(
     let composed_directives = collect_composed_directives(ast_field.directives(), state);
     let description = ast_field
         .description()
-        .map(|description| state.insert_string(description.description().raw_str()));
+        .map(|description| state.insert_string(description.raw_str()));
 
     let field_id = FieldId(state.fields.push_return_idx(Field {
         name,
@@ -980,7 +980,7 @@ fn ingest_input_object<'a>(
         let composed_directives = collect_composed_directives(field.directives(), state);
         let description = field
             .description()
-            .map(|description| state.insert_string(description.description().raw_str()));
+            .map(|description| state.insert_string(description.raw_str()));
         let default = field
             .default_value()
             .map(|default| state.insert_value(default, r#type.definition.as_enum().copied()));

--- a/engine/crates/federated-graph/src/from_sdl/value.rs
+++ b/engine/crates/federated-graph/src/from_sdl/value.rs
@@ -30,7 +30,7 @@ impl IntoJson for ast::Value<'_> {
 
         Some(match self {
             ast::Value::Variable(_) => return None,
-            ast::Value::Int(i) => Value::Number(i.into()),
+            ast::Value::Int(i) => Value::Number(i.as_i64().into()),
             ast::Value::Float(i) => Value::Number(serde_json::Number::from_f64(f64::from(i)).unwrap()),
             ast::Value::String(s) | ast::Value::BlockString(s) => Value::String(s.to_owned()),
             ast::Value::Boolean(b) => Value::Bool(b),

--- a/engine/crates/federation-audit-tests/Cargo.toml
+++ b/engine/crates/federation-audit-tests/Cargo.toml
@@ -15,6 +15,9 @@ serde_json.workspace = true
 grafbase-workspace-hack.workspace = true
 
 [dev-dependencies]
+async-graphql-parser.workspace = true
+cynic-parser.workspace = true
+graphql-composition.workspace = true
 integration-tests.path = "../integration-tests"
 libtest-mimic = "0.7"
 similar-asserts = "1.5"
@@ -24,4 +27,8 @@ workspace = true
 
 [[test]]
 name = "audit_tests"
+harness = false
+
+[[test]]
+name = "composition_comparisons"
 harness = false

--- a/engine/crates/federation-audit-tests/src/audit_server.rs
+++ b/engine/crates/federation-audit-tests/src/audit_server.rs
@@ -29,11 +29,15 @@ impl AuditServer {
             .collect()
     }
 
-    pub fn lookup_test(&self, test: CachedTest) -> (TestSuite, Test) {
-        let suite = TestSuite {
+    pub fn lookup_suite(&self, id: String) -> TestSuite {
+        TestSuite {
             server: self.clone(),
-            id: test.suite,
-        };
+            id,
+        }
+    }
+
+    pub fn lookup_test(&self, test: CachedTest) -> (TestSuite, Test) {
+        let suite = self.lookup_suite(test.suite);
         let test = suite.tests().remove(test.index);
 
         (suite, test)

--- a/engine/crates/federation-audit-tests/src/cache.rs
+++ b/engine/crates/federation-audit-tests/src/cache.rs
@@ -26,4 +26,8 @@ impl CachedTest {
     pub fn name(&self) -> String {
         format!("{}::{}", self.suite, self.index)
     }
+
+    pub fn suite(&self) -> &str {
+        &self.suite
+    }
 }

--- a/engine/crates/federation-audit-tests/tests/composition_comparisons.rs
+++ b/engine/crates/federation-audit-tests/tests/composition_comparisons.rs
@@ -1,0 +1,50 @@
+#![allow(unused_crate_dependencies)]
+
+use federation_audit_tests::{audit_server::AuditServer, cached_tests};
+use libtest_mimic::{Arguments, Failed, Trial};
+
+fn main() {
+    let args = Arguments::from_args();
+
+    let cached_tests = cached_tests();
+    let mut suites = cached_tests.iter().map(|test| test.suite()).collect::<Vec<_>>();
+
+    suites.sort();
+    suites.dedup();
+
+    let tests = suites
+        .into_iter()
+        .map(|suite| Trial::test(suite, runner_for(suite.to_string())).with_ignored_flag(true))
+        .collect();
+
+    // Run all tests and exit the application appropriatly.
+    libtest_mimic::run(&args, tests).exit()
+}
+
+fn runner_for(suite: String) -> impl FnOnce() -> Result<(), Failed> + Send + 'static {
+    move || {
+        let audit_server = AuditServer::new_from_env();
+        let suite = audit_server.lookup_suite(suite);
+        let expected_supergraph_sdl = suite.supergraph_sdl();
+
+        let mut subgraphs = graphql_composition::Subgraphs::default();
+        for subgraph in suite.subgraphs() {
+            let parsed_schema = async_graphql_parser::parse_schema(&subgraph.sdl).unwrap();
+            subgraphs.ingest(&parsed_schema, &subgraph.name, &subgraph.url)
+        }
+
+        let output = graphql_composition::compose(&subgraphs)
+            .into_result()
+            .unwrap()
+            .into_federated_sdl();
+
+        similar_asserts::assert_eq!(prettify_sdl(&output), prettify_sdl(&expected_supergraph_sdl));
+
+        Ok(())
+    }
+}
+
+// Passes SDL through cynic parser to unify the formatting
+fn prettify_sdl(input: &str) -> String {
+    cynic_parser::parse_type_system_document(input).unwrap().to_sdl_pretty()
+}

--- a/engine/crates/federation-audit-tests/tests/composition_comparisons.rs
+++ b/engine/crates/federation-audit-tests/tests/composition_comparisons.rs
@@ -38,13 +38,24 @@ fn runner_for(suite: String) -> impl FnOnce() -> Result<(), Failed> + Send + 'st
             .unwrap()
             .into_federated_sdl();
 
-        similar_asserts::assert_eq!(prettify_sdl(&output), prettify_sdl(&expected_supergraph_sdl));
+        let output = prettify_sdl(&output);
+        let expected = prettify_sdl(&expected_supergraph_sdl);
+
+        assert_eq!(output, expected, "{}", diff(&output, &expected));
 
         Ok(())
     }
 }
 
+fn diff(grafbase: &str, apollo: &str) -> String {
+    similar_asserts::SimpleDiff::from_str(grafbase, apollo, "grafbase", "apollo").to_string()
+}
+
 // Passes SDL through cynic parser to unify the formatting
 fn prettify_sdl(input: &str) -> String {
-    cynic_parser::parse_type_system_document(input).unwrap().to_sdl_pretty()
+    cynic_parser::parse_type_system_document(input)
+        .unwrap()
+        .pretty_printer()
+        .sorted()
+        .to_string()
 }

--- a/engine/crates/partial-caching/src/planning/visitor.rs
+++ b/engine/crates/partial-caching/src/planning/visitor.rs
@@ -62,7 +62,7 @@ fn visit_selection_set(
     registry: &PartialCacheRegistry,
     ctx: &mut VisitorContext<'_>,
 ) {
-    for (id, selection) in selections.ids().zip(selections) {
+    for (id, selection) in selections.ids().into_iter().zip(selections) {
         ctx.visit(|visitor| visitor.enter_selection(id, selection));
         match selection {
             Selection::Field(selection) => {

--- a/engine/crates/partial-caching/src/query_subset/display.rs
+++ b/engine/crates/partial-caching/src/query_subset/display.rs
@@ -121,7 +121,7 @@ impl std::fmt::Display for QuerySubsetDisplay<'_> {
 
 impl fmt::Display for SelectionSetDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut selections = self.selections.peekable();
+        let mut selections = self.selections.clone().peekable();
         if selections.peek().is_none() {
             return Ok(());
         }

--- a/engine/crates/partial-caching/src/query_subset/field_iter.rs
+++ b/engine/crates/partial-caching/src/query_subset/field_iter.rs
@@ -33,13 +33,13 @@ impl<'a> Iterator for FieldIter<'a> {
                 Selection::Field(field) => return Some(field),
                 Selection::InlineFragment(fragment) => {
                     self.iter_stack
-                        .push(self.subset.selection_iter(fragment.selection_set()));
+                        .push(self.subset.selection_iter(&fragment.selection_set()));
                 }
                 Selection::FragmentSpread(spread) => {
                     let Some(fragment) = spread.fragment() else { continue };
 
                     self.iter_stack
-                        .push(self.subset.selection_iter(fragment.selection_set()));
+                        .push(self.subset.selection_iter(&fragment.selection_set()));
                 }
             }
         }

--- a/engine/crates/partial-caching/src/query_subset/mod.rs
+++ b/engine/crates/partial-caching/src/query_subset/mod.rs
@@ -84,7 +84,7 @@ impl QuerySubset {
 
     pub(crate) fn selection_iter<'doc, 'subset>(
         &'subset self,
-        selection_set: Iter<'doc, Selection<'doc>>,
+        selection_set: &Iter<'doc, Selection<'doc>>,
     ) -> FilteredSelectionSet<'doc, 'subset> {
         FilteredSelectionSet {
             visible_selections: &self.partition.selections,
@@ -93,16 +93,16 @@ impl QuerySubset {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub(crate) struct FilteredSelectionSet<'doc, 'subset> {
     visible_selections: &'subset IndexSet<SelectionId>,
     selections: IdIter<'doc, Selection<'doc>>,
 }
 
 impl FilteredSelectionSet<'_, '_> {
-    pub fn requires_synthetic_typename(self) -> bool {
+    pub fn requires_synthetic_typename(&self) -> bool {
         let mut result = false;
-        for selection in self {
+        for selection in self.clone() {
             match selection {
                 Selection::Field(field) if field.name() == "__typename" && field.alias().is_none() => {
                     // If we already have a typename there's no point in adding another

--- a/engine/crates/partial-caching/src/updating/ser.rs
+++ b/engine/crates/partial-caching/src/updating/ser.rs
@@ -109,6 +109,6 @@ impl serde::Serialize for ValueSerializer<'_> {
 
 impl<'a> ObjectSerializer<'a> {
     pub fn field_iter(&self) -> FieldIter<'a> {
-        FieldIter::new(self.ctx.subset.selection_iter(self.selection_set), self.ctx.subset)
+        FieldIter::new(self.ctx.subset.selection_iter(&self.selection_set), self.ctx.subset)
     }
 }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -47,7 +47,7 @@ crc32fast = { version = "1" }
 criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
 crossbeam-queue = { version = "0.3" }
 crossbeam-utils = { version = "0.8" }
-cynic-parser = { git = "https://github.com/grafbase/cynic", rev = "920dd202101a0643a0c29031e1cfa0f20031c2d6", features = ["pretty", "report"] }
+cynic-parser = { version = "0.5", features = ["pretty", "report"] }
 deadpool-runtime = { version = "0.1", default-features = false, features = ["tokio_1"] }
 der = { version = "0.7", default-features = false, features = ["oid", "pem", "std"] }
 deranged = { version = "0.3", default-features = false, features = ["powerfmt", "std"] }
@@ -177,8 +177,8 @@ crc32fast = { version = "1" }
 criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
 crossbeam-queue = { version = "0.3" }
 crossbeam-utils = { version = "0.8" }
-cynic-codegen = { git = "https://github.com/grafbase/cynic", rev = "920dd202101a0643a0c29031e1cfa0f20031c2d6", features = ["rkyv"] }
-cynic-parser = { git = "https://github.com/grafbase/cynic", rev = "920dd202101a0643a0c29031e1cfa0f20031c2d6", features = ["pretty", "report"] }
+cynic-codegen = { version = "3", features = ["rkyv"] }
+cynic-parser = { version = "0.5", features = ["pretty", "report"] }
 deadpool-runtime = { version = "0.1", default-features = false, features = ["tokio_1"] }
 der = { version = "0.7", default-features = false, features = ["oid", "pem", "std"] }
 deranged = { version = "0.3", default-features = false, features = ["powerfmt", "std"] }
@@ -432,6 +432,7 @@ zeroize = { version = "1", default-features = false, features = ["derive"] }
 [target.wasm32-unknown-unknown.dependencies]
 getrandom = { version = "0.2", default-features = false, features = ["js"] }
 gimli = { version = "0.29", default-features = false, features = ["read", "std", "write"] }
+itertools = { version = "0.10" }
 libc = { version = "0.2", features = ["extra_traits"] }
 miniz_oxide = { version = "0.7", default-features = false, features = ["with-alloc"] }
 nom = { version = "7" }
@@ -442,6 +443,7 @@ web-sys = { version = "0.3", default-features = false, features = ["BlobProperty
 [target.wasm32-unknown-unknown.build-dependencies]
 getrandom = { version = "0.2", default-features = false, features = ["js"] }
 gimli = { version = "0.29", default-features = false, features = ["read", "std", "write"] }
+itertools = { version = "0.10" }
 libc = { version = "0.2", features = ["extra_traits"] }
 miniz_oxide = { version = "0.7", default-features = false, features = ["with-alloc"] }
 nom = { version = "7" }


### PR DESCRIPTION
Runnable with

```sh
CLICOLOR_FORCE=1 cargo nextest run -p federation-audit-tests  --no-fail-fast --test composition_comparisons --run-ignored all
```