### PR TITLE
federated-graph: migrate more fields to TypeDefinition

### DIFF
--- a/engine/crates/composition/src/compose/context.rs
+++ b/engine/crates/composition/src/compose/context.rs
@@ -124,6 +124,7 @@ impl<'a> Context<'a> {
             name,
             description,
             directives: composed_directives,
+            kind: federated::TypeDefinitionKind::Interface,
         };
         let type_definition_id = self.ir.type_definitions.push_return_idx(type_definition).into();
 
@@ -166,6 +167,7 @@ impl<'a> Context<'a> {
             name,
             description,
             directives: composed_directives,
+            kind: federated::TypeDefinitionKind::Object,
         };
         let type_definition_id = self.ir.type_definitions.push_return_idx(type_definition).into();
 
@@ -193,16 +195,17 @@ impl<'a> Context<'a> {
         let name = self.ir.strings.insert(scalar_name);
         let description = description.map(|description| self.ir.strings.insert(description));
 
-        let scalar = federated::Scalar {
+        let scalar = federated::TypeDefinitionRecord {
             name,
-            composed_directives,
+            directives: composed_directives,
             description,
+            kind: federated::TypeDefinitionKind::Scalar,
         };
 
-        let id = federated::ScalarId(self.ir.scalars.push_return_idx(scalar));
+        let id = self.ir.type_definitions.push_return_idx(scalar);
         self.ir
             .definitions_by_name
-            .insert(name, federated::Definition::Scalar(id));
+            .insert(name, federated::Definition::Scalar(id.into()));
     }
 
     pub(crate) fn insert_union(

--- a/engine/crates/composition/src/compose/context.rs
+++ b/engine/crates/composition/src/compose/context.rs
@@ -120,15 +120,17 @@ impl<'a> Context<'a> {
     ) -> federated::InterfaceId {
         let description = description.map(|description| self.ir.strings.insert(description));
 
-        let type_definition = federated::TypeDefinitionRecord { name };
+        let type_definition = federated::TypeDefinitionRecord {
+            name,
+            description,
+            directives: composed_directives,
+        };
         let type_definition_id = self.ir.type_definitions.push_return_idx(type_definition).into();
 
         let interface = federated::Interface {
             type_definition_id,
             implements_interfaces: Vec::new(),
             keys: Vec::new(),
-            composed_directives,
-            description,
             fields: federated::NO_FIELDS,
             join_implements: Vec::new(),
         };
@@ -160,7 +162,11 @@ impl<'a> Context<'a> {
         composed_directives: federated::Directives,
     ) -> federated::ObjectId {
         let description = description.map(|description| self.ir.strings.insert(description.as_str()));
-        let type_definition = federated::TypeDefinitionRecord { name };
+        let type_definition = federated::TypeDefinitionRecord {
+            name,
+            description,
+            directives: composed_directives,
+        };
         let type_definition_id = self.ir.type_definitions.push_return_idx(type_definition).into();
 
         let object = federated::Object {
@@ -168,8 +174,6 @@ impl<'a> Context<'a> {
             implements_interfaces: Vec::new(),
             join_implements: Vec::new(),
             keys: Vec::new(),
-            composed_directives,
-            description,
             fields: federated::NO_FIELDS,
         };
         let id = federated::ObjectId(self.ir.objects.push_return_idx(object));

--- a/engine/crates/composition/src/composition_ir.rs
+++ b/engine/crates/composition/src/composition_ir.rs
@@ -23,7 +23,6 @@ pub(crate) struct CompositionIr {
     pub(crate) unions: Vec<federated::Union>,
     pub(crate) enums: Vec<federated::Enum>,
     pub(crate) enum_values: Vec<federated::EnumValue>,
-    pub(crate) scalars: Vec<federated::Scalar>,
     pub(crate) input_objects: Vec<federated::InputObject>,
     pub(crate) directives: Vec<Directive>,
     pub(crate) input_value_definitions: Vec<InputValueDefinitionIr>,

--- a/engine/crates/composition/src/emit_federated_graph.rs
+++ b/engine/crates/composition/src/emit_federated_graph.rs
@@ -29,7 +29,6 @@ pub(crate) fn emit_federated_graph(mut ir: CompositionIr, subgraphs: &Subgraphs)
         objects: mem::take(&mut ir.objects),
         interfaces: mem::take(&mut ir.interfaces),
         unions: mem::take(&mut ir.unions),
-        scalars: mem::take(&mut ir.scalars),
         input_objects: mem::take(&mut ir.input_objects),
         root_operation_types: RootOperationTypes {
             query: ir.query_type.unwrap(),
@@ -159,7 +158,7 @@ fn emit_input_value_definitions(input_value_definitions: &[InputValueDefinitionI
                 let r#type = ctx.insert_field_type(ctx.subgraphs.walk(*r#type));
                 let default = default
                     .as_ref()
-                    .map(|default| ctx.insert_value_with_type(default, r#type.definition.as_enum().copied()));
+                    .map(|default| ctx.insert_value_with_type(default, r#type.definition.as_enum()));
 
                 federated::InputValueDefinition {
                     name: *name,
@@ -525,7 +524,7 @@ fn attach_selection(
                                 .map(|idx| federated::InputValueDefinitionId(field_arguments_start + idx))
                                 .unwrap();
 
-                            let argument_enum_type = ctx.out[argument].r#type.definition.as_enum().copied();
+                            let argument_enum_type = ctx.out[argument].r#type.definition.as_enum();
                             let value = ctx.insert_value_with_type(value, argument_enum_type);
 
                             (argument, value)

--- a/engine/crates/engine-v2/schema/src/builder/graph.rs
+++ b/engine/crates/engine-v2/schema/src/builder/graph.rs
@@ -101,7 +101,7 @@ impl<'a> GraphBuilder<'a> {
             input_value_definitions.push(InputValueDefinitionRecord {
                 name_id: definition.name.into(),
                 description_id: definition.description.map(Into::into),
-                ty_record: definition.r#type.into(),
+                ty_record: self.convert_type(definition.r#type),
                 // Adding after ingesting all input values as input object fields are input values.
                 // So we need them for coercion.
                 default_value_id: None,
@@ -259,8 +259,9 @@ impl<'a> GraphBuilder<'a> {
     }
 
     fn ingest_scalars(&mut self, config: &mut Config) {
-        self.graph.scalar_definitions = take(&mut config.graph.scalars)
-            .into_iter()
+        self.graph.scalar_definitions = config
+            .graph
+            .iter_scalars()
             .map(|scalar| {
                 let name = StringId::from(scalar.name);
                 ScalarDefinitionRecord {
@@ -271,7 +272,7 @@ impl<'a> GraphBuilder<'a> {
                     directive_ids: self.push_directives(
                         config,
                         Directives {
-                            federated: scalar.composed_directives,
+                            federated: scalar.directives,
                             ..Default::default()
                         },
                     ),
@@ -569,7 +570,7 @@ impl<'a> GraphBuilder<'a> {
                 name_id: field.name.into(),
                 description_id: None,
                 parent_entity_id,
-                ty_record: field.r#type.into(),
+                ty_record: self.convert_type(field.r#type),
                 only_resolvable_in_ids: only_resolvable_in
                     .into_iter()
                     .map(SubgraphId::GraphqlEndpoint)
@@ -601,6 +602,24 @@ impl<'a> GraphBuilder<'a> {
                 argument_ids: self.ctx.idmaps.input_value.get_range(field.arguments),
                 directive_ids: directives,
             })
+        }
+    }
+
+    fn convert_type(&self, federated_graph::Type { wrapping, definition }: federated_graph::Type) -> TypeRecord {
+        TypeRecord {
+            definition_id: self.convert_definition(definition),
+            wrapping,
+        }
+    }
+
+    fn convert_definition(&self, definition: federated_graph::Definition) -> DefinitionId {
+        match definition {
+            federated_graph::Definition::Scalar(id) => DefinitionId::Scalar(self.ctx.idmaps.convert_scalar_id(id)),
+            federated_graph::Definition::Object(id) => DefinitionId::Object(id.into()),
+            federated_graph::Definition::Interface(id) => DefinitionId::Interface(id.into()),
+            federated_graph::Definition::Union(id) => DefinitionId::Union(id.into()),
+            federated_graph::Definition::Enum(id) => DefinitionId::Enum(id.into()),
+            federated_graph::Definition::InputObject(id) => DefinitionId::InputObject(id.into()),
         }
     }
 
@@ -867,28 +886,6 @@ pub(super) fn is_inaccessible(
     graph[directives]
         .iter()
         .any(|directive| matches!(directive, federated_graph::Directive::Inaccessible))
-}
-
-impl From<federated_graph::Definition> for DefinitionId {
-    fn from(definition: federated_graph::Definition) -> Self {
-        match definition {
-            federated_graph::Definition::Scalar(id) => DefinitionId::Scalar(id.into()),
-            federated_graph::Definition::Object(id) => DefinitionId::Object(id.into()),
-            federated_graph::Definition::Interface(id) => DefinitionId::Interface(id.into()),
-            federated_graph::Definition::Union(id) => DefinitionId::Union(id.into()),
-            federated_graph::Definition::Enum(id) => DefinitionId::Enum(id.into()),
-            federated_graph::Definition::InputObject(id) => DefinitionId::InputObject(id.into()),
-        }
-    }
-}
-
-impl From<federated_graph::Type> for TypeRecord {
-    fn from(field_type: federated_graph::Type) -> Self {
-        TypeRecord {
-            definition_id: field_type.definition.into(),
-            wrapping: field_type.wrapping,
-        }
-    }
 }
 
 impl IdMap<federated_graph::FieldId, FieldDefinitionId> {

--- a/engine/crates/engine-v2/schema/src/builder/mod.rs
+++ b/engine/crates/engine-v2/schema/src/builder/mod.rs
@@ -164,7 +164,6 @@ from_id_newtypes! {
     federated_graph::InputObjectId => InputObjectDefinitionId,
     federated_graph::InterfaceId => InterfaceDefinitionId,
     federated_graph::ObjectId => ObjectDefinitionId,
-    federated_graph::ScalarId => ScalarDefinitionId,
     federated_graph::StringId => StringId,
     federated_graph::SubgraphId => GraphqlEndpointId,
     federated_graph::UnionId => UnionDefinitionId,

--- a/engine/crates/federated-graph/src/federated_graph/v4.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v4.rs
@@ -413,7 +413,7 @@ impl From<super::FederatedGraphV3> for FederatedGraph {
             type_definitions.push(TypeDefinitionRecord {
                 name: object.name,
                 description: object.description,
-                directives: object.composed_directives.clone(),
+                directives: object.composed_directives,
                 kind: TypeDefinitionKind::Object,
             });
             definitions_map.insert(super::v3::Definition::Object(id), Definition::Object(id));
@@ -424,7 +424,7 @@ impl From<super::FederatedGraphV3> for FederatedGraph {
             type_definitions.push(TypeDefinitionRecord {
                 name: interface.name,
                 description: interface.description,
-                directives: interface.composed_directives.clone(),
+                directives: interface.composed_directives,
                 kind: TypeDefinitionKind::Interface,
             });
             definitions_map.insert(super::v3::Definition::Interface(id), Definition::Interface(id));
@@ -435,7 +435,7 @@ impl From<super::FederatedGraphV3> for FederatedGraph {
             type_definitions.push(TypeDefinitionRecord {
                 name: scalar.name,
                 description: scalar.description,
-                directives: scalar.composed_directives.clone(),
+                directives: scalar.composed_directives,
                 kind: TypeDefinitionKind::Scalar,
             });
             definitions_map.insert(super::v3::Definition::Scalar(idx.into()), Definition::Scalar(id));
@@ -507,7 +507,7 @@ impl From<super::FederatedGraphV3> for FederatedGraph {
                         r#type: Type {
                             definition: definitions_map
                                 .get(&r#type.definition)
-                                .map(|def| def.clone())
+                                .copied()
                                 .unwrap_or_else(|| Definition::Scalar(TypeDefinitionId::from(0))),
                             wrapping: r#type.wrapping,
                         },
@@ -552,7 +552,7 @@ impl From<super::FederatedGraphV3> for FederatedGraph {
                             wrapping: r#type.wrapping,
                             definition: definitions_map
                                 .get(&r#type.definition)
-                                .map(|def| def.clone())
+                                .copied()
                                 .unwrap_or_else(|| Definition::Scalar(TypeDefinitionId::from(0))),
                         },
                         directives,

--- a/engine/crates/federated-graph/src/federated_graph/v4/type.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v4/type.rs
@@ -1,0 +1,27 @@
+use super::{EnumId, InputObjectId, InterfaceId, ObjectId, TypeDefinitionId, UnionId, Wrapping};
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct Type {
+    pub wrapping: Wrapping,
+    pub definition: Definition,
+}
+
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum Definition {
+    Scalar(TypeDefinitionId),
+    Object(ObjectId),
+    Interface(InterfaceId),
+    Union(UnionId),
+    Enum(EnumId),
+    InputObject(InputObjectId),
+}
+
+impl Definition {
+    pub fn as_enum(&self) -> Option<EnumId> {
+        if let Self::Enum(v) = self {
+            Some(*v)
+        } else {
+            None
+        }
+    }
+}

--- a/engine/crates/federated-graph/src/federated_graph/v4/type_definitions.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v4/type_definitions.rs
@@ -1,10 +1,33 @@
 use super::{Directives, FederatedGraph, StringId, TypeDefinitionId};
 
+pub type TypeDefinitionView<'a> = super::view::ViewNested<'a, TypeDefinitionId, TypeDefinitionRecord>;
+
 #[derive(Clone, Debug)]
 pub struct TypeDefinitionRecord {
     pub name: StringId,
     pub description: Option<StringId>,
     pub directives: Directives,
+    pub kind: TypeDefinitionKind,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum TypeDefinitionKind {
+    Object,
+    Interface,
+    Enum,
+    Union,
+    Scalar,
+    InputObject,
+}
+
+impl TypeDefinitionKind {
+    /// Returns `true` if the type definition kind is [`Scalar`].
+    ///
+    /// [`Scalar`]: TypeDefinitionKind::Scalar
+    #[must_use]
+    pub fn is_scalar(&self) -> bool {
+        matches!(self, Self::Scalar)
+    }
 }
 
 impl FederatedGraph {

--- a/engine/crates/federated-graph/src/federated_graph/v4/type_definitions.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v4/type_definitions.rs
@@ -1,8 +1,10 @@
-use super::{FederatedGraph, StringId, TypeDefinitionId};
+use super::{Directives, FederatedGraph, StringId, TypeDefinitionId};
 
 #[derive(Clone, Debug)]
 pub struct TypeDefinitionRecord {
     pub name: StringId,
+    pub description: Option<StringId>,
+    pub directives: Directives,
 }
 
 impl FederatedGraph {

--- a/engine/crates/federated-graph/src/from_sdl.rs
+++ b/engine/crates/federated-graph/src/from_sdl.rs
@@ -45,7 +45,6 @@ struct State<'a> {
     enums: Vec<Enum>,
     enum_values: Vec<EnumValue>,
     unions: Vec<Union>,
-    scalars: Vec<Scalar>,
     input_objects: Vec<InputObject>,
 
     strings: IndexSet<String>,
@@ -170,7 +169,7 @@ impl<'a> State<'a> {
             Definition::Interface(interface_id) => {
                 self.graph.view(self.interfaces[interface_id.0].type_definition_id).name
             }
-            Definition::Scalar(scalar_id) => self.scalars[scalar_id.0].name,
+            Definition::Scalar(scalar_id) => self.graph[scalar_id].name,
             Definition::Enum(enum_id) => self.enums[enum_id.0].name,
             Definition::Union(union_id) => self.unions[union_id.0].name,
             Definition::InputObject(input_object_id) => self.input_objects[input_object_id.0].name,
@@ -211,6 +210,7 @@ pub fn from_sdl(sdl: &str) -> Result<FederatedGraph, DomainError> {
             name: query_string_id,
             description: None,
             directives: NO_DIRECTIVES,
+            kind: TypeDefinitionKind::Object,
         });
 
         state.objects.push(Object {
@@ -238,7 +238,6 @@ pub fn from_sdl(sdl: &str) -> Result<FederatedGraph, DomainError> {
         enums: state.enums,
         enum_values: state.enum_values,
         unions: state.unions,
-        scalars: state.scalars,
         input_objects: state.input_objects,
         strings: state.strings.into_iter().collect(),
         directives: state.directives,
@@ -829,20 +828,21 @@ fn ingest_definitions<'a>(document: &'a ast::TypeSystemDocument, state: &mut Sta
                     name: type_name_id,
                     description,
                     directives: composed_directives,
+                    kind: match typedef {
+                        ast::TypeDefinition::Scalar(_) => TypeDefinitionKind::Scalar,
+                        ast::TypeDefinition::Object(_) => TypeDefinitionKind::Object,
+                        ast::TypeDefinition::Interface(_) => TypeDefinitionKind::Interface,
+                        ast::TypeDefinition::Union(_) => TypeDefinitionKind::Union,
+                        ast::TypeDefinition::Enum(_) => TypeDefinitionKind::Enum,
+                        ast::TypeDefinition::InputObject(_) => TypeDefinitionKind::InputObject,
+                    },
                 });
 
                 match typedef {
-                    ast::TypeDefinition::Scalar(scalar) => {
-                        let description = scalar
-                            .description()
-                            .map(|description| state.insert_string(description.raw_str()));
-
-                        let scalar_id = ScalarId(state.scalars.push_return_idx(Scalar {
-                            name: type_name_id,
-                            composed_directives,
-                            description,
-                        }));
-                        state.definition_names.insert(type_name, Definition::Scalar(scalar_id));
+                    ast::TypeDefinition::Scalar(_) => {
+                        state
+                            .definition_names
+                            .insert(type_name, Definition::Scalar(type_definition_id));
                     }
                     ast::TypeDefinition::Object(_) => {
                         let object_id = ObjectId(state.objects.push_return_idx(Object {
@@ -939,11 +939,12 @@ fn ingest_definitions<'a>(document: &'a ast::TypeSystemDocument, state: &mut Sta
 fn insert_builtin_scalars(state: &mut State<'_>) {
     for name_str in ["String", "ID", "Float", "Boolean", "Int"] {
         let name = state.insert_string(name_str);
-        let id = ScalarId(state.scalars.push_return_idx(Scalar {
+        let id = state.graph.push_type_definition(TypeDefinitionRecord {
             name,
-            composed_directives: (DirectiveId(0), 0),
+            directives: (DirectiveId(0), 0),
             description: None,
-        }));
+            kind: TypeDefinitionKind::Scalar,
+        });
         state.definition_names.insert(name_str, Definition::Scalar(id));
     }
 }
@@ -989,7 +990,7 @@ fn ingest_field<'a>(
         let r#type = state.field_type(arg.ty())?;
         let default = arg
             .default_value()
-            .map(|default| state.insert_value(default, r#type.definition.as_enum().copied()));
+            .map(|default| state.insert_value(default, r#type.definition.as_enum()));
 
         state.input_value_definitions.push(InputValueDefinition {
             name,
@@ -1134,7 +1135,7 @@ fn ingest_input_object<'a>(
             .map(|description| state.insert_string(description.raw_str()));
         let default = field
             .default_value()
-            .map(|default| state.insert_value(default, r#type.definition.as_enum().copied()));
+            .map(|default| state.insert_value(default, r#type.definition.as_enum()));
 
         state.input_value_definitions.push(InputValueDefinition {
             name,
@@ -1266,11 +1267,7 @@ fn attach_selection_field(
                 .map(|idx| InputValueDefinitionId(start.0 + idx))
                 .expect("unknown argument");
 
-            let argument_type = state.input_value_definitions[argument_id.0]
-                .r#type
-                .definition
-                .as_enum()
-                .copied();
+            let argument_type = state.input_value_definitions[argument_id.0].r#type.definition.as_enum();
 
             let converted_value = executable_value_to_type_system_value(argument.value());
 

--- a/engine/crates/federated-graph/src/from_sdl.rs
+++ b/engine/crates/federated-graph/src/from_sdl.rs
@@ -207,18 +207,18 @@ pub fn from_sdl(sdl: &str) -> Result<FederatedGraph, DomainError> {
             .definition_names
             .insert(query_type_name, Definition::Object(object_id));
 
-        let type_definition_id = state
-            .graph
-            .push_type_definition(TypeDefinitionRecord { name: query_string_id });
+        let type_definition_id = state.graph.push_type_definition(TypeDefinitionRecord {
+            name: query_string_id,
+            description: None,
+            directives: NO_DIRECTIVES,
+        });
 
         state.objects.push(Object {
             type_definition_id,
             implements_interfaces: Vec::new(),
             join_implements: Vec::new(),
             keys: Vec::new(),
-            composed_directives: NO_DIRECTIVES,
             fields: NO_FIELDS,
-            description: None,
         });
 
         ingest_object_fields(object_id, std::iter::empty(), &mut state)?;
@@ -825,9 +825,11 @@ fn ingest_definitions<'a>(document: &'a ast::TypeSystemDocument, state: &mut Sta
                     .map(|description| state.insert_string(description.raw_str()));
                 let composed_directives = collect_composed_directives(typedef.directives(), state);
 
-                let type_definition_id = state
-                    .graph
-                    .push_type_definition(TypeDefinitionRecord { name: type_name_id });
+                let type_definition_id = state.graph.push_type_definition(TypeDefinitionRecord {
+                    name: type_name_id,
+                    description,
+                    directives: composed_directives,
+                });
 
                 match typedef {
                     ast::TypeDefinition::Scalar(scalar) => {
@@ -848,8 +850,6 @@ fn ingest_definitions<'a>(document: &'a ast::TypeSystemDocument, state: &mut Sta
                             implements_interfaces: Vec::new(),
                             join_implements: Vec::new(),
                             keys: Vec::new(),
-                            composed_directives,
-                            description,
                             fields: NO_FIELDS,
                         }));
 
@@ -860,8 +860,6 @@ fn ingest_definitions<'a>(document: &'a ast::TypeSystemDocument, state: &mut Sta
                             type_definition_id,
                             implements_interfaces: Vec::new(),
                             keys: Vec::new(),
-                            composed_directives,
-                            description,
                             fields: NO_FIELDS,
                             join_implements: Vec::new(),
                         }));

--- a/engine/crates/federated-graph/src/render_sdl/render_api_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl/render_api_sdl.rs
@@ -59,7 +59,9 @@ impl fmt::Display for Renderer<'_> {
         }
 
         for object in &graph.objects {
-            if has_inaccessible(&object.composed_directives, graph) {
+            let definition = graph.at(object.type_definition_id);
+
+            if has_inaccessible(&definition.directives, graph) {
                 continue;
             }
 
@@ -72,10 +74,10 @@ impl fmt::Display for Renderer<'_> {
 
             write_leading_whitespace(f)?;
 
-            write_description(f, object.description, "", graph)?;
+            write_description(f, definition.description, "", graph)?;
             f.write_str("type ")?;
-            f.write_str(&graph[graph.view(object.type_definition_id).name])?;
-            write_public_directives(f, object.composed_directives, graph)?;
+            f.write_str(definition.then(|def| def.name).as_str())?;
+            write_public_directives(f, definition.directives, graph)?;
             f.write_char(' ')?;
 
             write_block(f, |f| {
@@ -103,16 +105,18 @@ impl fmt::Display for Renderer<'_> {
         }
 
         for interface in &graph.interfaces {
-            if has_inaccessible(&interface.composed_directives, graph) {
+            let definition = graph.at(interface.type_definition_id);
+
+            if has_inaccessible(&definition.directives, graph) {
                 continue;
             }
 
             write_leading_whitespace(f)?;
 
-            write_description(f, interface.description, "", graph)?;
+            write_description(f, definition.description, "", graph)?;
             f.write_str("interface ")?;
-            f.write_str(&graph[graph.view(interface.type_definition_id).name])?;
-            write_public_directives(f, interface.composed_directives, graph)?;
+            f.write_str(definition.then(|def| def.name).as_str())?;
+            write_public_directives(f, definition.directives, graph)?;
             f.write_char(' ')?;
 
             write_block(f, |f| {

--- a/engine/crates/federated-graph/src/render_sdl/render_api_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl/render_api_sdl.rs
@@ -216,10 +216,10 @@ impl fmt::Display for Renderer<'_> {
             f.write_char('\n')?;
         }
 
-        for scalar in &graph.scalars {
-            let scalar_name = &graph[scalar.name];
+        for scalar in graph.iter_scalars() {
+            let scalar_name = scalar.then(|scalar| scalar.name).as_str();
 
-            if BUILTIN_SCALARS.contains(&scalar_name.as_str()) || has_inaccessible(&scalar.composed_directives, graph) {
+            if BUILTIN_SCALARS.contains(&scalar_name) || has_inaccessible(&scalar.directives, graph) {
                 continue;
             }
 
@@ -228,7 +228,7 @@ impl fmt::Display for Renderer<'_> {
             write_description(f, scalar.description, "", graph)?;
             f.write_str("scalar ")?;
             f.write_str(scalar_name)?;
-            write_public_directives(f, scalar.composed_directives, graph)?;
+            write_public_directives(f, scalar.directives, graph)?;
 
             f.write_char('\n')?;
         }

--- a/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
@@ -29,7 +29,8 @@ pub fn render_federated_sdl(graph: &FederatedGraph) -> Result<String, fmt::Error
     }
 
     for object in graph.iter_objects() {
-        let object_name = &graph[graph.view(object.type_definition_id).name];
+        let definition = graph.at(object.type_definition_id);
+        let object_name = definition.then(|def| def.name).as_str();
 
         let mut fields = graph[object.fields.clone()]
             .iter()
@@ -42,7 +43,7 @@ pub fn render_federated_sdl(graph: &FederatedGraph) -> Result<String, fmt::Error
             continue;
         }
 
-        if let Some(description) = object.description {
+        if let Some(description) = definition.description {
             write!(sdl, "{}", Description(&graph[description], ""))?;
         }
 
@@ -68,7 +69,7 @@ pub fn render_federated_sdl(graph: &FederatedGraph) -> Result<String, fmt::Error
         }
 
         with_formatter(&mut sdl, |f| {
-            render_composed_directives(object.composed_directives, f, graph)?;
+            render_composed_directives(definition.directives, f, graph)?;
 
             for authorized_directive in graph.object_authorized_directives(object.id()) {
                 render_authorized_directive(authorized_directive, f, graph)?;
@@ -108,9 +109,10 @@ pub fn render_federated_sdl(graph: &FederatedGraph) -> Result<String, fmt::Error
     }
 
     for interface in graph.iter_interfaces() {
-        let interface_name = &graph[graph.view(interface.type_definition_id).name];
+        let definition = graph.at(interface.type_definition_id);
+        let interface_name = definition.then(|def| def.name).as_str();
 
-        if let Some(description) = interface.description {
+        if let Some(description) = definition.description {
             write!(sdl, "{}", Description(&graph[description], ""))?;
         }
 
@@ -135,7 +137,7 @@ pub fn render_federated_sdl(graph: &FederatedGraph) -> Result<String, fmt::Error
                 render_authorized_directive(authorized_directive, f, graph)?;
             }
 
-            render_composed_directives(interface.composed_directives, f, graph)?;
+            render_composed_directives(definition.directives, f, graph)?;
 
             if !interface.join_implements.is_empty() {
                 for (subgraph_id, interface_id) in &interface.join_implements {

--- a/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
@@ -11,19 +11,19 @@ pub fn render_federated_sdl(graph: &FederatedGraph) -> Result<String, fmt::Error
 
     write_subgraphs_enum(graph, &mut sdl)?;
 
-    for scalar in &graph.scalars {
-        let name = &graph[scalar.name];
+    for scalar in graph.iter_scalars() {
+        let name = scalar.then(|scalar| scalar.name).as_str();
 
         if let Some(description) = scalar.description {
             write!(sdl, "{}", Description(&graph[description], ""))?;
         }
 
-        if BUILTIN_SCALARS.contains(&name.as_str()) {
+        if BUILTIN_SCALARS.contains(&name) {
             continue;
         }
 
         write!(sdl, "scalar {name}")?;
-        write_composed_directives(scalar.composed_directives, graph, &mut sdl)?;
+        write_composed_directives(scalar.directives, graph, &mut sdl)?;
         sdl.push('\n');
         sdl.push('\n');
     }


### PR DESCRIPTION
That already allows us to delete federated_graph::Scalar.