### PR TITLE
fix(tracing): remove spammy spans and nest subgraph things under subgraph request

### DIFF
--- a/engine/crates/engine-v2/src/execution/hooks/authorized.rs
+++ b/engine/crates/engine-v2/src/execution/hooks/authorized.rs
@@ -4,7 +4,6 @@ use runtime::{
     hooks::{AuthorizedHooks, EdgeDefinition, Hooks, NodeDefinition},
 };
 use schema::{Definition, FieldDefinition, SchemaInputValue};
-use tracing::{instrument, Level};
 
 use crate::{
     operation::FieldArgumentsView,
@@ -12,7 +11,6 @@ use crate::{
 };
 
 impl<'ctx, H: Hooks> super::RequestHooks<'ctx, H> {
-    #[instrument(skip_all, ret(level = Level::DEBUG))]
     pub async fn authorize_edge_pre_execution(
         &self,
         definition: FieldDefinition<'_>,
@@ -38,7 +36,6 @@ impl<'ctx, H: Hooks> super::RequestHooks<'ctx, H> {
             .map_err(Into::into)
     }
 
-    #[instrument(skip_all, ret(level = Level::DEBUG))]
     pub async fn authorize_parent_edge_post_execution(
         &self,
         definition: FieldDefinition<'_>,
@@ -64,7 +61,6 @@ impl<'ctx, H: Hooks> super::RequestHooks<'ctx, H> {
             .map_err(Into::into)
     }
 
-    #[instrument(skip_all, ret(level = Level::DEBUG))]
     pub async fn authorize_edge_node_post_execution(
         &self,
         definition: FieldDefinition<'_>,
@@ -90,7 +86,6 @@ impl<'ctx, H: Hooks> super::RequestHooks<'ctx, H> {
             .map_err(Into::into)
     }
 
-    #[instrument(skip_all, ret(level = Level::DEBUG))]
     pub async fn authorize_node_pre_execution(
         &self,
         definition: Definition<'_>,

--- a/engine/crates/engine-v2/src/execution/hooks/responses.rs
+++ b/engine/crates/engine-v2/src/execution/hooks/responses.rs
@@ -1,10 +1,8 @@
-use runtime::hooks::{ExecutedHttpRequest, ExecutedOperation, ExecutedSubgraphRequest, Hooks, ResponseHooks};
-use tracing::{instrument, Level};
+use runtime::hooks::{ExecutedOperation, ExecutedSubgraphRequest, Hooks, ResponseHooks};
 
 use crate::response::GraphqlError;
 
 impl<'ctx, H: Hooks> super::RequestHooks<'ctx, H> {
-    #[instrument(skip_all, ret(level = Level::DEBUG))]
     pub async fn on_subgraph_response(&self, request: ExecutedSubgraphRequest<'_>) -> Result<Vec<u8>, GraphqlError> {
         self.hooks
             .responses()
@@ -13,20 +11,10 @@ impl<'ctx, H: Hooks> super::RequestHooks<'ctx, H> {
             .map_err(Into::into)
     }
 
-    #[instrument(skip_all, ret(level = Level::DEBUG))]
     pub async fn on_operation_response(&self, operation: ExecutedOperation<'_>) -> Result<Vec<u8>, GraphqlError> {
         self.hooks
             .responses()
             .on_operation_response(self.context, operation)
-            .await
-            .map_err(Into::into)
-    }
-
-    #[instrument(skip_all, ret(level = Level::DEBUG))]
-    pub async fn on_http_response(&self, request: ExecutedHttpRequest) -> Result<(), GraphqlError> {
-        self.hooks
-            .responses()
-            .on_http_response(self.context, request)
             .await
             .map_err(Into::into)
     }

--- a/engine/crates/engine-v2/src/execution/hooks/subgraph.rs
+++ b/engine/crates/engine-v2/src/execution/hooks/subgraph.rs
@@ -1,11 +1,9 @@
 use http::HeaderMap;
 use runtime::hooks::{Hooks, SubgraphHooks};
-use tracing::{instrument, Level};
 
 use crate::response::GraphqlError;
 
 impl<'ctx, H: Hooks> super::RequestHooks<'ctx, H> {
-    #[instrument(skip_all, ret(level = Level::DEBUG))]
     pub async fn on_subgraph_request(
         &self,
         subgraph_name: &str,

--- a/engine/crates/telemetry/src/span/subgraph.rs
+++ b/engine/crates/telemetry/src/span/subgraph.rs
@@ -33,22 +33,15 @@ impl<'a> SubgraphRequestSpanBuilder<'a> {
             target: crate::span::GRAFBASE_TARGET,
             "subgraph-request",
             "grafbase.kind" = kind,
-            "otel.name" = Empty,
+            "otel.name" = self.subgraph_name,
             "otel.kind" = "Client",
             "otel.status_code" = Empty,
             "subgraph.name" = self.subgraph_name,
-            // "Describes a class of error the operation ended with."
-            "error.type" = Empty,
-            // Request
-            "http.request.method" = Empty,
-            "server.address" = Empty,
-            "server.port" = Empty,
-            "url.full" = Empty,
-            "http.request.resend_count" = Empty,
             "graphql.operation.type" = self.operation_type,
             "graphql.operation.document" = self.sanitized_query,
+            // "Describes a class of error the operation ended with."
+            "error.type" = Empty,
             // Response
-            "http.response.status_code" = Empty,
             "graphql.response.data.is_present"  = Empty,
             "graphql.response.data.is_null"  = Empty,
             "graphql.response.errors.count" = Empty,
@@ -58,13 +51,44 @@ impl<'a> SubgraphRequestSpanBuilder<'a> {
     }
 }
 
-impl SubgraphGraphqlRequestSpan {
-    pub fn record_http_request(&self, url: &Url, method: &http::Method) {
-        self.record("otel.name", format!("{} {}", method.as_str(), url.path()));
-        self.record("http.request.method", method.as_str());
-        self.record("server.address", url.host_str());
-        self.record("server.port", url.port());
-        self.record("url.full", url.as_str());
+#[derive(Clone)]
+pub struct SubgraphHttpRequestSpan {
+    span: Span,
+}
+
+impl std::ops::Deref for SubgraphHttpRequestSpan {
+    type Target = Span;
+    fn deref(&self) -> &Self::Target {
+        &self.span
+    }
+}
+
+impl SubgraphHttpRequestSpan {
+    pub fn new(url: &Url, method: &http::Method) -> Self {
+        let span = info_span!(
+            target: crate::span::GRAFBASE_TARGET,
+            "subgraph-http-request",
+            "otel.name" = format!("{} {}", method.as_str(), url.path()),
+            "http.request.method" = method.as_str(),
+            "server.address" = url.host_str(),
+            "server.port" = url.port(),
+            "url.full" = url.as_str(),
+            "http.response.status_code" = Empty,
+            "otel.status_code" = Empty,
+            "error.type" = Empty,
+            "http.request.resend_count" = Empty,
+        );
+
+        Self { span }
+    }
+
+    pub fn record_http_status_code(&self, status_code: http::StatusCode) {
+        self.record("http.response.status_code", status_code.as_u16());
+
+        if !status_code.is_success() {
+            self.record("otel.status_code", "Error");
+            self.record("error.type", status_code.as_str());
+        }
     }
 
     pub fn record_resend_count(&self, count: usize) {
@@ -72,14 +96,20 @@ impl SubgraphGraphqlRequestSpan {
             self.record("http.request.resend_count", count);
         }
     }
-    pub fn record_http_status_code(&self, status_code: http::StatusCode) {
-        self.record("http.response.status_code", status_code.as_u16());
-        if !status_code.is_success() {
-            self.record("otel.status_code", "Error");
-            self.record("error.type", status_code.as_str());
+
+    pub fn set_as_http_error(&self, status_code: Option<http::StatusCode>) {
+        if let Some(status_code) = status_code {
+            self.record_http_status_code(status_code);
         }
+        self.record("otel.status_code", "Error");
     }
 
+    pub fn span(&self) -> Span {
+        self.span.clone()
+    }
+}
+
+impl SubgraphGraphqlRequestSpan {
     pub fn record_graphql_response_status(&self, status: SubgraphResponseStatus) {
         match status {
             SubgraphResponseStatus::WellFormedGraphqlResponse(status) => {


### PR DESCRIPTION
So this goes from this trace:

![Screenshot 2024-09-30 at 14-21-26 julius-federated - Trace spans - Grafbase](https://github.com/user-attachments/assets/597bc2ff-3b07-4da7-b07d-cf7dba637133)

Into this:

![Screenshot 2024-09-30 at 14-22-33 julius-federated - Trace spans - Grafbase](https://github.com/user-attachments/assets/f6b01b99-1cba-4ee4-9882-934410d2a777)

And as a comparison, if disabling the access log hooks, we get this:

![Screenshot 2024-09-30 at 14-23-23 julius-federated - Trace spans - Grafbase](https://github.com/user-attachments/assets/534a23b1-af02-4d37-bb0f-40498623da4e)

And as a final thing, I added a span for the actual http request and renamed the subgraph span with the subgraph name, so now we look like this:

![image](https://github.com/user-attachments/assets/96122e01-9384-4a60-ac52-f4671da2e5b8)
