### PR TITLE
composition: add Subgraph::ingest_str()

### DIFF
--- a/engine/crates/composition/CHANGELOG.md
+++ b/engine/crates/composition/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Support the experimental @authorized directive
 - Selection sets inside `@requires` and `@provides` directives can now include inline fragments.
 - The selection sets in the "fields:" argument on `@requires` are now validated against the schema, with proper errors with context when invalid.
+- A new `Subgraphs::ingest_str()` method has been added to ingest a federated graph from a string, instead of from an async_graphql_parser AST. This is both for convenience and because async_graphql parser will soon not be part of the public API anymore.
 
 ### Fixes
 

--- a/engine/crates/composition/src/lib.rs
+++ b/engine/crates/composition/src/lib.rs
@@ -86,10 +86,11 @@ mod tests {
         let schema_path =
             Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../cli/crates/backend/src/api/graphql/api.graphql");
         let schema = fs::read_to_string(schema_path).unwrap();
-        let schema = async_graphql_parser::parse_schema(schema).unwrap();
 
         let mut subgraphs = Subgraphs::default();
-        subgraphs.ingest(&schema, "grafbase-api", "https://api.grafbase.com");
+        subgraphs
+            .ingest_str(&schema, "grafbase-api", "https://api.grafbase.com")
+            .unwrap();
         let result = compose(&subgraphs);
         assert!(!result.diagnostics().any_fatal());
     }

--- a/engine/crates/composition/src/subgraphs.rs
+++ b/engine/crates/composition/src/subgraphs.rs
@@ -72,10 +72,26 @@ impl Default for Subgraphs {
 
 const BUILTIN_SCALARS: [&str; 5] = ["ID", "String", "Boolean", "Int", "Float"];
 
+#[derive(Debug)]
+pub struct IngestError(async_graphql_parser::Error);
+
+impl std::fmt::Display for IngestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+
 impl Subgraphs {
     /// Add a subgraph to compose.
     pub fn ingest(&mut self, subgraph_schema: &async_graphql_parser::types::ServiceDocument, name: &str, url: &str) {
         crate::ingest_subgraph::ingest_subgraph(subgraph_schema, name, url, self);
+    }
+
+    /// Add a subgraph to compose.
+    pub fn ingest_str(&mut self, subgraph_schema: &str, name: &str, url: &str) -> Result<(), IngestError> {
+        let subgraph_schema = async_graphql_parser::parse_schema(subgraph_schema).map_err(IngestError)?;
+        crate::ingest_subgraph::ingest_subgraph(&subgraph_schema, name, url, self);
+        Ok(())
     }
 
     /// Iterate over groups of definitions to compose. The definitions are grouped by name. The

--- a/engine/crates/composition/tests/composition_special_cases.rs
+++ b/engine/crates/composition/tests/composition_special_cases.rs
@@ -4,15 +4,13 @@
 fn subgraph_names_that_differ_only_by_case_are_not_allowed() {
     let mut subgraphs = graphql_composition::Subgraphs::default();
 
-    {
-        let schema = async_graphql_parser::parse_schema("type Query { name: String }").unwrap();
-        subgraphs.ingest(&schema, "valid", "example.com");
-    }
+    subgraphs
+        .ingest_str("type Query { name: String }", "valid", "example.com")
+        .unwrap();
 
-    {
-        let schema = async_graphql_parser::parse_schema("type Query { fullName: String }").unwrap();
-        subgraphs.ingest(&schema, "Valid", "example.com");
-    }
+    subgraphs
+        .ingest_str("type Query { fullName: String }", "Valid", "example.com")
+        .unwrap();
 
     let result = graphql_composition::compose(&subgraphs);
     let diagnostics = result.diagnostics();

--- a/engine/crates/composition/tests/composition_tests.rs
+++ b/engine/crates/composition/tests/composition_tests.rs
@@ -1,8 +1,6 @@
-use grafbase_workspace_hack as _;
+#![allow(unused_crate_dependencies)]
 
-use async_graphql_value as _;
-use indexmap as _;
-use itertools::{self as _, Itertools as _};
+use itertools::Itertools as _;
 use std::{fs, path::Path, sync::OnceLock};
 
 fn update_expect() -> bool {
@@ -35,12 +33,11 @@ fn run_test(federated_graph_path: &Path) -> datatest_stable::Result<()> {
     let mut subgraphs = graphql_composition::Subgraphs::default();
 
     for (sdl, path) in subgraphs_sdl {
-        let parsed = async_graphql_parser::parse_schema(&sdl)
-            .map_err(|err| miette::miette!("Error parsing {}: {err}", path.display()))?;
-
         let name = path.file_stem().unwrap().to_str().unwrap().replace('_', "-");
 
-        subgraphs.ingest(&parsed, &name, &format!("http://example.com/{name}"));
+        subgraphs
+            .ingest_str(&sdl, &name, &format!("http://example.com/{name}"))
+            .map_err(|err| miette::miette!("Error parsing {}: {err}", path.display()))?;
     }
 
     let expected_federated_sdl = fs::read_to_string(federated_graph_path)

--- a/engine/crates/federation-audit-tests/tests/composition_comparisons.rs
+++ b/engine/crates/federation-audit-tests/tests/composition_comparisons.rs
@@ -29,8 +29,9 @@ fn runner_for(suite: String) -> impl FnOnce() -> Result<(), Failed> + Send + 'st
 
         let mut subgraphs = graphql_composition::Subgraphs::default();
         for subgraph in suite.subgraphs() {
-            let parsed_schema = async_graphql_parser::parse_schema(&subgraph.sdl).unwrap();
-            subgraphs.ingest(&parsed_schema, &subgraph.name, &subgraph.url)
+            subgraphs
+                .ingest_str(&subgraph.sdl, &subgraph.name, &subgraph.url)
+                .unwrap()
         }
 
         let output = graphql_composition::compose(&subgraphs)

--- a/engine/crates/integration-tests/src/federation/builder/engine.rs
+++ b/engine/crates/integration-tests/src/federation/builder/engine.rs
@@ -29,9 +29,9 @@ pub(super) async fn build(
                 graphql_composition::compose(&subgraphs.iter().fold(
                     graphql_composition::Subgraphs::default(),
                     |mut subgraphs, subgraph| {
-                        let schema =
-                            async_graphql_parser::parse_schema(subgraph.sdl()).expect("schema to be well formed");
-                        subgraphs.ingest(&schema, subgraph.name(), subgraph.url().as_ref());
+                        subgraphs
+                            .ingest_str(subgraph.sdl().as_ref(), subgraph.name(), subgraph.url().as_ref())
+                            .expect("schema to be well formed");
                         subgraphs
                     },
                 ))

--- a/gateway/crates/gateway-binary/tests/entity_caching/mod.rs
+++ b/gateway/crates/gateway-binary/tests/entity_caching/mod.rs
@@ -59,9 +59,10 @@ where
     F: Future<Output = ()>,
 {
     let federated_schema = {
-        let parsed = async_graphql_parser::parse_schema(subgraph_schema).unwrap();
         let mut subgraphs = graphql_composition::Subgraphs::default();
-        subgraphs.ingest(&parsed, "the-subgraph", subgraph_url);
+        subgraphs
+            .ingest_str(subgraph_schema, "the-subgraph", subgraph_url)
+            .unwrap();
         graphql_composition::compose(&subgraphs)
             .into_result()
             .unwrap()

--- a/gateway/crates/gateway-binary/tests/telemetry/tracing.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/tracing.rs
@@ -387,9 +387,10 @@ where
     let subgraph_server = runtime().block_on(async { graphql_mocks::MockGraphQlServer::new(subgraph_schema).await });
 
     let federated_schema = {
-        let parsed = async_graphql_parser::parse_schema(&subgraph_sdl).unwrap();
         let mut subgraphs = graphql_composition::Subgraphs::default();
-        subgraphs.ingest(&parsed, "the-subgraph", subgraph_server.url().as_str());
+        subgraphs
+            .ingest_str(&subgraph_sdl, "the-subgraph", subgraph_server.url().as_str())
+            .unwrap();
         graphql_composition::compose(&subgraphs)
             .into_result()
             .unwrap()


### PR DESCRIPTION
To avoid exposing async_graphql_parser as part of our public API.