### PR TITLE
feat(engine-v2/qp): Generate operation graph.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2756,6 +2756,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "engine-v2-query-planning"
+version = "0.0.0"
+dependencies = [
+ "ctor",
+ "engine-parser",
+ "engine-v2-config",
+ "engine-v2-id-derives",
+ "engine-v2-id-newtypes",
+ "engine-v2-schema",
+ "engine-v2-walker",
+ "grafbase-workspace-hack",
+ "graphql-federated-graph",
+ "insta",
+ "itertools 0.13.0",
+ "petgraph",
+ "serde",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "engine-v2-schema"
 version = "3.0.31"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "engine/crates/engine-v2/codegen",
   "engine/crates/engine-v2/walker",
   "engine/crates/engine-v2/schema",
+  "engine/crates/engine-v2/query-planning",
   "engine/crates/engine-v2/id-derives",
   "engine/crates/engine-v2/id-newtypes",
   "engine/crates/engine/derive",

--- a/engine/crates/engine-v2/query-planning/Cargo.toml
+++ b/engine/crates/engine-v2/query-planning/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+authors = ["Grafbase"]
+description = "Query planning"
+edition = "2021"
+homepage = "https://grafbase.com"
+keywords = ["graphql", "engine", "grafbase"]
+license = "MPL-2.0"
+name = "engine-v2-query-planning"
+repository = "https://github.com/grafbase/grafbase"
+
+[lints]
+workspace = true
+
+[dependencies]
+grafbase-workspace-hack.workspace = true
+id-newtypes = { path = "../id-newtypes", package = "engine-v2-id-newtypes" }
+id-derives = { path = "../id-derives", package = "engine-v2-id-derives" }
+walker = { path = "../walker", package = "engine-v2-walker" }
+petgraph = "0.6.5"
+serde.workspace = true
+itertools.workspace = true
+tracing.workspace = true
+schema = { path = "../schema", package = "engine-v2-schema" }
+
+
+[dev-dependencies]
+ctor.workspace = true
+engine-parser = { path = "../../engine/parser" }
+config = { path = "../config", package = "engine-v2-config" }
+federated-graph.workspace = true
+tracing-subscriber = { workspace = true, features = [
+  "fmt",
+  "tracing-log",
+  "env-filter",
+  "ansi",
+] }
+insta.workspace = true
+

--- a/engine/crates/engine-v2/query-planning/src/graph.rs
+++ b/engine/crates/engine-v2/query-planning/src/graph.rs
@@ -1,0 +1,88 @@
+mod builder;
+mod edge;
+mod node;
+
+pub use edge::*;
+pub use node::*;
+
+use schema::{FieldDefinitionId, RequiredField, Schema};
+use walker::Walk;
+
+use std::borrow::Cow;
+
+use petgraph::{
+    dot::{Config, Dot},
+    graph::NodeIndex,
+};
+
+pub trait Operation: std::fmt::Debug {
+    type FieldId: From<usize> + Into<usize> + Copy + std::fmt::Debug + Ord;
+
+    fn field_ids(&self) -> impl ExactSizeIterator<Item = Self::FieldId> + '_;
+    fn field_defintion(&self, field_id: Self::FieldId) -> Option<FieldDefinitionId>;
+    fn field_satisfies(&self, field_id: Self::FieldId, requirement: RequiredField<'_>) -> bool;
+    fn create_extra_field(&mut self, requirement: RequiredField<'_>) -> Self::FieldId;
+
+    fn root_selection_set(&self) -> impl ExactSizeIterator<Item = Self::FieldId> + '_;
+    fn subselection(&self, field_id: Self::FieldId) -> impl ExactSizeIterator<Item = Self::FieldId> + '_;
+
+    fn field_label(&self, field_id: Self::FieldId) -> Cow<'_, str>;
+}
+
+pub struct OperationGraph<'ctx, Op: Operation> {
+    schema: &'ctx Schema,
+    operation: &'ctx mut Op,
+    inner: petgraph::stable_graph::StableGraph<Node<Op::FieldId>, Edge>,
+    root: NodeIndex,
+    field_nodes: Vec<NodeIndex>,
+    leaf_nodes: Vec<NodeIndex>,
+}
+
+impl<'ctx, Op: Operation> std::ops::Index<Op::FieldId> for OperationGraph<'ctx, Op> {
+    type Output = NodeIndex;
+    fn index(&self, field_id: Op::FieldId) -> &Self::Output {
+        let ix: usize = field_id.into();
+        &self.field_nodes[ix]
+    }
+}
+
+impl<'ctx, Op: Operation> OperationGraph<'ctx, Op> {
+    pub fn new(schema: &'ctx Schema, operation: &'ctx mut Op) -> OperationGraph<'ctx, Op> {
+        Self::builder(schema, operation).build()
+    }
+
+    /// Use https://dreampuf.github.io/GraphvizOnline
+    /// or `echo '..." | dot -Tsvg` from graphviz
+    pub fn to_dot_graph(&self) -> String {
+        let node_str = |_, node_ref: (NodeIndex, &Node<Op::FieldId>)| match node_ref.1 {
+            Node::Root => r#"label = "root""#.to_string(),
+            Node::Field(id) => format!("label = \"{}\"", self.operation.field_label(*id)),
+            Node::FieldResolver(field_resolver) => format!(
+                "label = \"{}@{}\",shape=box,style=dashed,color=blue",
+                field_resolver.field_definition_id.walk(self.schema).name(),
+                field_resolver.resolver_definition_id.walk(self.schema).name()
+            ),
+            Node::Resolver(resolver) => {
+                format!(
+                    "label = \"{}\",shape=box,color=blue",
+                    resolver.definition_id.walk(self.schema).name()
+                )
+            }
+        };
+        format!(
+            "{:?}",
+            Dot::with_attr_getters(
+                &self.inner,
+                &[Config::NodeNoLabel],
+                &|_, edge| {
+                    match edge.weight() {
+                        Edge::Resolver(_) | Edge::CanResolveField(_) | Edge::Resolves => "color=blue".to_string(),
+                        Edge::Field | Edge::TypenameField => String::new(),
+                        Edge::Requires => "color=green".to_string(),
+                    }
+                },
+                &node_str
+            )
+        )
+    }
+}

--- a/engine/crates/engine-v2/query-planning/src/graph/builder.rs
+++ b/engine/crates/engine-v2/query-planning/src/graph/builder.rs
@@ -1,0 +1,350 @@
+use schema::{Definition, RequiredFieldSet, Schema, SubgraphId, TypeSystemDirective};
+use walker::Walk;
+
+use super::*;
+use petgraph::{graph::NodeIndex, visit::EdgeRef, Direction};
+
+pub(super) struct OperationGraphBuilder<'ctx, Op: Operation> {
+    graph: OperationGraph<'ctx, Op>,
+    field_ingestion_stack: Vec<Field<Op::FieldId>>,
+    requirement_ingestion_stack: Vec<Requirement<'ctx>>,
+}
+
+impl<'ctx, Op: Operation> std::ops::Deref for OperationGraphBuilder<'ctx, Op> {
+    type Target = OperationGraph<'ctx, Op>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.graph
+    }
+}
+
+impl<'ctx, Op: Operation> std::ops::DerefMut for OperationGraphBuilder<'ctx, Op> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.graph
+    }
+}
+
+struct Requirement<'ctx> {
+    parent_field_node: NodeIndex,
+    petitioner_node: NodeIndex,
+    required_field_set: RequiredFieldSet<'ctx>,
+}
+
+#[derive(Clone)]
+struct ParentResolver {
+    field_resolver_node: NodeIndex,
+    subgraph_id: SubgraphId,
+}
+
+struct Field<Id> {
+    parent_field_node: NodeIndex,
+    parent_field_resolver: Option<ParentResolver>,
+    field_id: Id,
+}
+
+impl<'ctx, Op: Operation> OperationGraph<'ctx, Op> {
+    pub(super) fn builder(schema: &'ctx Schema, operation: &'ctx mut Op) -> OperationGraphBuilder<'ctx, Op> {
+        let n = operation.field_ids().len();
+        let mut inner = petgraph::stable_graph::StableGraph::with_capacity(n * 2, n * 2);
+        let root = inner.add_node(Node::Root);
+
+        OperationGraphBuilder {
+            graph: OperationGraph {
+                schema,
+                operation,
+                root,
+                inner,
+                leaf_nodes: Vec::new(),
+                field_nodes: Vec::new(),
+            },
+            field_ingestion_stack: Vec::new(),
+            requirement_ingestion_stack: Vec::new(),
+        }
+    }
+}
+
+impl<'ctx, Op: Operation> OperationGraphBuilder<'ctx, Op> {
+    pub(super) fn build(mut self) -> OperationGraph<'ctx, Op> {
+        self.field_nodes = self
+            .graph
+            .operation
+            .field_ids()
+            .map(|field_id| self.graph.inner.add_node(Node::Field(field_id)))
+            .collect();
+
+        self.leaf_nodes = self
+            .operation
+            .field_ids()
+            .filter_map(|field_id| {
+                if self
+                    .operation
+                    .field_defintion(field_id)
+                    .walk(self.schema)
+                    .is_some_and(|definition| matches!(definition.ty().definition(), Definition::Scalar(_)))
+                {
+                    Some(self[field_id])
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        self.field_ingestion_stack = self
+            .operation
+            .root_selection_set()
+            .map(|field_id| Field {
+                parent_field_node: self.root,
+                parent_field_resolver: None,
+                field_id,
+            })
+            .collect();
+
+        // We first ingest all fields so that requirements can reference them. We use a double
+        // stack as requirement may means adding new fields and adding new fields may add new
+        // requirements.
+        loop {
+            if let Some(field) = self.field_ingestion_stack.pop() {
+                self.handle_field_resolvers(field)
+            } else if let Some(requirement) = self.requirement_ingestion_stack.pop() {
+                self.handle_requirements(requirement)
+            } else {
+                break;
+            }
+        }
+
+        self.graph
+    }
+
+    fn handle_field_resolvers(
+        &mut self,
+        Field {
+            parent_field_node,
+            parent_field_resolver,
+            field_id,
+        }: Field<Op::FieldId>,
+    ) {
+        let field_node = self[field_id];
+        let Some(definition_id) = self.operation.field_defintion(field_id) else {
+            self.inner.add_edge(parent_field_node, field_node, Edge::TypenameField);
+            return;
+        };
+        let field_definition = definition_id.walk(self.schema);
+
+        // if it's the first time we see this field, there won't be any edges and we add any requirements from type system
+        // directives. Otherwise it means we're not the first resolver path to this operation
+        // field.
+        if self.inner.edges(field_node).next().is_none() {
+            for required_field_set in field_definition.directives().filter_map(|directive| match directive {
+                TypeSystemDirective::Authenticated
+                | TypeSystemDirective::Deprecated(_)
+                | TypeSystemDirective::RequiresScopes(_) => None,
+                TypeSystemDirective::Authorized(directive) => directive.fields(),
+            }) {
+                self.requirement_ingestion_stack.push(Requirement {
+                    parent_field_node,
+                    petitioner_node: field_node,
+                    required_field_set,
+                })
+            }
+        }
+        self.inner.add_edge(parent_field_node, field_node, Edge::Field);
+
+        // --
+        // If resolvable withing the current subgraph. We skip requirements in this case.
+        // --
+        if let Some((parent_field_resolver_node, field_resolver, subgraph_id)) =
+            parent_field_resolver.as_ref().and_then(
+                |ParentResolver {
+                     field_resolver_node,
+                     subgraph_id,
+                 }| {
+                    self.inner[*field_resolver_node]
+                        .as_field_resolver()
+                        .unwrap()
+                        .child(self.schema, field_definition.id())
+                        .map(|child| (*field_resolver_node, child, *subgraph_id))
+                },
+            )
+        {
+            let field_resolver_node = self.inner.add_node(Node::FieldResolver(field_resolver));
+            self.inner.add_edge(field_resolver_node, field_node, Edge::Resolves);
+            self.inner.add_edge(
+                parent_field_resolver_node,
+                field_resolver_node,
+                Edge::CanResolveField(0),
+            );
+            for nested_field_id in self.graph.operation.subselection(field_id) {
+                self.field_ingestion_stack.push(Field {
+                    parent_field_node: field_node,
+                    parent_field_resolver: Some(ParentResolver {
+                        field_resolver_node,
+                        subgraph_id,
+                    }),
+                    field_id: nested_field_id,
+                })
+            }
+        }
+
+        // --
+        // Try to plan this field with alternative resolvers if any exist.
+        // --
+        let parent_resolver_node = parent_field_resolver
+            .as_ref()
+            .and_then(
+                |ParentResolver {
+                     field_resolver_node, ..
+                 }| self.inner[*field_resolver_node].as_field_resolver(),
+            )
+            .map(
+                |FieldResolver {
+                     parent_resolver_node, ..
+                 }| *parent_resolver_node,
+            )
+            .unwrap_or(self.root);
+        let parent_field_resolver_node = parent_field_resolver
+            .as_ref()
+            .map(
+                |ParentResolver {
+                     field_resolver_node, ..
+                 }| *field_resolver_node,
+            )
+            .unwrap_or(self.root);
+        let parent_subgraph_id = parent_field_resolver
+            .as_ref()
+            .map(|ParentResolver { subgraph_id, .. }| *subgraph_id);
+        for resolver_definition in field_definition.resolvers() {
+            // If within the same subgraph, we skip it. Resolvers are entrypoints.
+            if Some(resolver_definition.subgraph_id()) == parent_subgraph_id {
+                continue;
+            };
+            let resolver = FieldResolver::new(parent_resolver_node, resolver_definition.id(), field_definition);
+            let field_resolver_node = self.inner.add_node(Node::FieldResolver(resolver.clone()));
+
+            // if the field has specific requirements for this subgraph we add it to the stack.
+            if let Some(required_field_set) = field_definition.requires_for_subgraph(resolver_definition.subgraph_id())
+            {
+                self.requirement_ingestion_stack.push(Requirement {
+                    parent_field_node,
+                    petitioner_node: field_resolver_node,
+                    required_field_set,
+                })
+            }
+
+            // Try to find an existing resolver node if a sibling field already added it, otherwise
+            // create one.
+            let resolver_node = if let Some(edge) = self
+                .inner
+                .edges_directed(parent_field_resolver_node, Direction::Outgoing)
+                .find(|edge| {
+                    self.inner[edge.target()]
+                        .as_resolver()
+                        .is_some_and(|res| res.definition_id == resolver_definition.id())
+                }) {
+                edge.target()
+            } else {
+                let node = self.inner.add_node(Node::Resolver(Resolver {
+                    definition_id: resolver_definition.id(),
+                    parent_resolver_node,
+                }));
+                self.inner.add_edge(parent_field_resolver_node, node, Edge::Resolver(0));
+                if let Some(required_field_set) = resolver_definition.required_field_set() {
+                    self.requirement_ingestion_stack.push(Requirement {
+                        parent_field_node,
+                        petitioner_node: node,
+                        required_field_set,
+                    });
+                };
+
+                node
+            };
+
+            self.inner
+                .add_edge(resolver_node, field_resolver_node, Edge::CanResolveField(0));
+            self.inner.add_edge(field_resolver_node, field_node, Edge::Resolves);
+
+            for nested_field_id in self.graph.operation.subselection(field_id) {
+                self.field_ingestion_stack.push(Field {
+                    parent_field_node: field_node,
+                    parent_field_resolver: Some(ParentResolver {
+                        field_resolver_node,
+                        subgraph_id: resolver_definition.subgraph_id(),
+                    }),
+                    field_id: nested_field_id,
+                })
+            }
+        }
+    }
+
+    fn handle_requirements(
+        &mut self,
+        Requirement {
+            parent_field_node,
+            petitioner_node,
+            required_field_set,
+        }: Requirement<'ctx>,
+    ) {
+        for item in required_field_set.items() {
+            // Find an existing field that satisfies the requirement.
+            let existing_field = self
+                .inner
+                .edges_directed(parent_field_node, Direction::Outgoing)
+                .filter_map(|edge| {
+                    if matches!(edge.weight(), Edge::Field) {
+                        self.inner[edge.target()]
+                            .as_field()
+                            .map(|field_id| (edge.target(), field_id))
+                    } else {
+                        None
+                    }
+                })
+                .filter(|(_, field_id)| self.operation.field_satisfies(*field_id, item.field()))
+                // not sure if necessary but provides consistency
+                .min_by_key(|(_, field_id)| *field_id);
+
+            // Create the required field otherwise.
+            let required_node = existing_field.map(|(node, _)| node).unwrap_or_else(|| {
+                let field_id = self.operation.create_extra_field(item.field());
+                let field_node = self.inner.add_node(Node::Field(field_id));
+                self.inner.add_edge(parent_field_node, field_node, Edge::Field);
+                self.field_ingestion_stack.extend(
+                    self.graph
+                        .inner
+                        .edges_directed(parent_field_node, Direction::Incoming)
+                        .filter_map(|edge| {
+                            if matches!(edge.weight(), Edge::Resolves) {
+                                let node = edge.source();
+                                self.graph.inner[node].as_field_resolver().map(|r| (node, r))
+                            } else {
+                                None
+                            }
+                        })
+                        .map(|(field_resolver_node, field_resolver)| Field {
+                            parent_field_node,
+                            parent_field_resolver: Some(ParentResolver {
+                                field_resolver_node,
+                                subgraph_id: field_resolver
+                                    .resolver_definition_id
+                                    .walk(self.graph.schema)
+                                    .subgraph_id(),
+                            }),
+                            field_id,
+                        }),
+                );
+                self.field_nodes.push(field_node);
+                if matches!(item.field().definition().ty().definition(), Definition::Scalar(_)) {
+                    self.leaf_nodes.push(field_node);
+                }
+                field_node
+            });
+            self.inner.add_edge(petitioner_node, required_node, Edge::Requires);
+
+            if item.subselection().items().len() != 0 {
+                self.requirement_ingestion_stack.push(Requirement {
+                    parent_field_node: required_node,
+                    petitioner_node,
+                    required_field_set: item.subselection(),
+                })
+            }
+        }
+    }
+}

--- a/engine/crates/engine-v2/query-planning/src/graph/edge.rs
+++ b/engine/crates/engine-v2/query-planning/src/graph/edge.rs
@@ -1,0 +1,11 @@
+pub type Cost = u16;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Edge {
+    Resolver(Cost),
+    CanResolveField(Cost),
+    Resolves,
+    Field,
+    TypenameField,
+    Requires,
+}

--- a/engine/crates/engine-v2/query-planning/src/graph/node.rs
+++ b/engine/crates/engine-v2/query-planning/src/graph/node.rs
@@ -1,0 +1,77 @@
+use petgraph::graph::NodeIndex;
+use schema::{FieldDefinition, FieldDefinitionId, ResolverDefinitionId, Schema};
+use walker::Walk as _;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Node<F> {
+    Root,
+    Field(F),
+    Resolver(Resolver),
+    FieldResolver(FieldResolver),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Resolver {
+    pub parent_resolver_node: NodeIndex,
+    pub definition_id: ResolverDefinitionId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FieldResolver {
+    pub parent_resolver_node: NodeIndex,
+    pub resolver_definition_id: ResolverDefinitionId,
+    pub field_definition_id: FieldDefinitionId,
+}
+
+impl FieldResolver {
+    pub fn new(
+        parent_resolver_node: NodeIndex,
+        resolver_definition_id: ResolverDefinitionId,
+        field_definition: FieldDefinition<'_>,
+    ) -> Self {
+        FieldResolver {
+            parent_resolver_node,
+            resolver_definition_id,
+            field_definition_id: field_definition.id(),
+        }
+    }
+
+    pub fn child(&self, schema: &Schema, field_definition_id: FieldDefinitionId) -> Option<FieldResolver> {
+        let resolver_definition = self.resolver_definition_id.walk(schema);
+        if resolver_definition.can_provide(field_definition_id) {
+            Some(FieldResolver {
+                parent_resolver_node: self.parent_resolver_node,
+                resolver_definition_id: self.resolver_definition_id,
+                field_definition_id,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl<F> Node<F> {
+    pub fn as_resolver(&self) -> Option<&Resolver> {
+        match self {
+            Node::Resolver(r) => Some(r),
+            _ => None,
+        }
+    }
+
+    pub fn as_field_resolver(&self) -> Option<&FieldResolver> {
+        match self {
+            Node::FieldResolver(r) => Some(r),
+            _ => None,
+        }
+    }
+
+    pub fn as_field(&self) -> Option<F>
+    where
+        F: Copy,
+    {
+        match self {
+            Node::Field(field_id) => Some(*field_id),
+            _ => None,
+        }
+    }
+}

--- a/engine/crates/engine-v2/query-planning/src/lib.rs
+++ b/engine/crates/engine-v2/query-planning/src/lib.rs
@@ -1,0 +1,12 @@
+use grafbase_workspace_hack as _;
+use id_derives as _;
+use id_newtypes as _;
+use itertools as _;
+use serde as _;
+use tracing as _;
+
+#[cfg(test)]
+mod tests;
+
+mod graph;
+pub use graph::*;

--- a/engine/crates/engine-v2/query-planning/src/tests.rs
+++ b/engine/crates/engine-v2/query-planning/src/tests.rs
@@ -1,0 +1,258 @@
+use std::{borrow::Cow, num::NonZero};
+
+use engine_parser::{
+    types::{DocumentOperations, SelectionSet},
+    Positioned,
+};
+use schema::{Definition, FieldDefinitionId, ObjectDefinition, Schema, Version};
+use walker::Walk;
+
+#[ctor::ctor]
+fn setup_logging() {
+    let filter = tracing_subscriber::filter::EnvFilter::builder()
+        .parse(std::env::var("RUST_LOG").unwrap_or("engine_v2_query_planning=debug".to_string()))
+        .unwrap();
+    tracing_subscriber::fmt()
+        .pretty()
+        .with_env_filter(filter)
+        .with_file(true)
+        .with_line_number(true)
+        .with_target(true)
+        .without_time()
+        .init();
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
+struct ResolverId(NonZero<u16>);
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
+struct FieldId(NonZero<u16>);
+
+#[derive(Debug, id_derives::IndexedFields)]
+struct Operation {
+    // Query
+    root_selection_set: Vec<FieldId>,
+    #[indexed_by(FieldId)]
+    fields: Vec<Field>,
+}
+
+#[derive(Debug)]
+struct Field {
+    name: String,
+    definition_id: Option<FieldDefinitionId>,
+    subselection: Vec<FieldId>,
+}
+
+impl Operation {
+    fn bind(schema: &Schema, query: &str) -> Self {
+        let mut ctx = Operation {
+            root_selection_set: Vec::new(),
+            fields: Vec::new(),
+        };
+
+        let query = engine_parser::parse_query(query).unwrap();
+        let DocumentOperations::Single(Positioned { node: op, .. }) = &query.operations else {
+            unreachable!()
+        };
+        ctx.root_selection_set = ctx.bind_selection_set(
+            schema.graph.root_operation_types_record.query_id.walk(schema),
+            &op.selection_set,
+        );
+        ctx
+    }
+
+    fn bind_selection_set(&mut self, parent: ObjectDefinition<'_>, selection_set: &SelectionSet) -> Vec<FieldId> {
+        let mut field_ids = Vec::new();
+        for Positioned { node: selection, .. } in &selection_set.items {
+            let field = selection.as_field().unwrap();
+            if let Some(definition) = parent.fields().find(|def| def.name() == field.name.node.as_str()) {
+                let subselection = match definition.ty().definition() {
+                    Definition::Object(obj) => self.bind_selection_set(obj, &field.selection_set.node),
+                    _ => Vec::new(),
+                };
+
+                self.fields.push(Field {
+                    name: field.name.node.to_string(),
+                    definition_id: Some(definition.id()),
+                    subselection,
+                });
+            } else {
+                self.fields.push(Field {
+                    name: field.name.node.to_string(),
+                    definition_id: None,
+                    subselection: Vec::new(),
+                });
+            }
+            let field_id = (self.fields.len() - 1).into();
+            field_ids.push(field_id);
+        }
+        field_ids
+    }
+}
+
+impl crate::Operation for Operation {
+    type FieldId = FieldId;
+
+    fn field_ids(&self) -> impl ExactSizeIterator<Item = Self::FieldId> + '_ {
+        (0..self.fields.len()).map(FieldId::from)
+    }
+
+    fn root_selection_set(&self) -> impl ExactSizeIterator<Item = Self::FieldId> + '_ {
+        self.root_selection_set.iter().copied()
+    }
+
+    fn subselection(&self, field_id: Self::FieldId) -> impl ExactSizeIterator<Item = Self::FieldId> + '_ {
+        self[field_id].subselection.iter().copied()
+    }
+
+    fn field_label(&self, field_id: Self::FieldId) -> Cow<'_, str> {
+        Cow::Borrowed(&self[field_id].name)
+    }
+
+    fn field_defintion(&self, field_id: Self::FieldId) -> Option<FieldDefinitionId> {
+        self[field_id].definition_id
+    }
+
+    fn field_satisfies(&self, field_id: Self::FieldId, requirement: schema::RequiredField<'_>) -> bool {
+        self[field_id].definition_id == Some(requirement.definition_id)
+    }
+
+    fn create_extra_field(&mut self, requirement: schema::RequiredField<'_>) -> Self::FieldId {
+        self.fields.push(Field {
+            name: requirement.definition().name().to_string(),
+            definition_id: Some(requirement.definition_id),
+            subselection: Vec::new(),
+        });
+        (self.fields.len() - 1).into()
+    }
+}
+
+const SCHEMA: &str = r###"
+enum join__Graph {
+  ACCOUNTS @join__graph(name: "accounts", url: "http://accounts:4001/graphql")
+  INVENTORY @join__graph(name: "inventory", url: "http://inventory:4002/graphql")
+  PRODUCTS @join__graph(name: "products", url: "http://products:4003/graphql")
+  REVIEWS @join__graph(name: "reviews", url: "http://reviews:4004/graphql")
+}
+
+type Product
+  @join__type(graph: INVENTORY, key: "upc")
+  @join__type(graph: PRODUCTS, key: "upc")
+  @join__type(graph: REVIEWS, key: "upc")
+{
+  upc: String!
+  weight: Int @join__field(graph: INVENTORY, external: true) @join__field(graph: PRODUCTS)
+  price: Int @join__field(graph: INVENTORY, external: true) @join__field(graph: PRODUCTS)
+  inStock: Boolean @join__field(graph: INVENTORY)
+  shippingEstimate: Int @join__field(graph: INVENTORY, requires: "price weight")
+  name: String @join__field(graph: PRODUCTS)
+  reviews: [Review] @join__field(graph: REVIEWS)
+}
+
+type Query
+  @join__type(graph: ACCOUNTS)
+  @join__type(graph: INVENTORY)
+  @join__type(graph: PRODUCTS)
+  @join__type(graph: REVIEWS)
+{
+  me: User @join__field(graph: ACCOUNTS)
+  user(id: ID!): User @join__field(graph: ACCOUNTS)
+  users: [User] @join__field(graph: ACCOUNTS)
+  topProducts(first: Int = 5): [Product] @join__field(graph: PRODUCTS)
+}
+
+type Review
+  @join__type(graph: REVIEWS, key: "id")
+{
+  id: ID!
+  body: String
+  product: Product
+  author: User @join__field(graph: REVIEWS, provides: "username")
+}
+
+type User
+  @join__type(graph: ACCOUNTS, key: "id")
+  @join__type(graph: REVIEWS, key: "id")
+{
+  id: ID!
+  name: String @join__field(graph: ACCOUNTS)
+  username: String @join__field(graph: ACCOUNTS) @join__field(graph: REVIEWS, external: true)
+  birthday: Int @join__field(graph: ACCOUNTS)
+  reviews: [Review] @join__field(graph: REVIEWS)
+}
+"###;
+
+#[test]
+fn test_basic_operation_graph() {
+    let graph = federated_graph::from_sdl(SCHEMA).unwrap();
+    let config = config::VersionedConfig::V6(config::latest::Config::from_graph(graph)).into_latest();
+    let schema = Schema::build(config, Version::from(Vec::new())).unwrap();
+
+    let mut operation = Operation::bind(
+        &schema,
+        r#"
+    {
+        topProducts {
+            name
+            reviews {
+                author {
+                    name
+                }
+            }
+        }
+    }
+    "#,
+    );
+    let graph = crate::OperationGraph::new(&schema, &mut operation);
+
+    insta::assert_snapshot!(graph.to_dot_graph(), @r##"
+    digraph {
+        0 [ label = "root"]
+        1 [ label = "name"]
+        2 [ label = "name"]
+        3 [ label = "author"]
+        4 [ label = "reviews"]
+        5 [ label = "topProducts"]
+        6 [ label = "topProducts@Root#products",shape=box,style=dashed,color=blue]
+        7 [ label = "Root#products",shape=box,color=blue]
+        8 [ label = "reviews@FedEntity#reviews",shape=box,style=dashed,color=blue]
+        9 [ label = "FedEntity#reviews",shape=box,color=blue]
+        10 [ label = "author@FedEntity#reviews",shape=box,style=dashed,color=blue]
+        11 [ label = "name@FedEntity#accounts",shape=box,style=dashed,color=blue]
+        12 [ label = "FedEntity#accounts",shape=box,color=blue]
+        13 [ label = "name@Root#products",shape=box,style=dashed,color=blue]
+        14 [ label = "id"]
+        15 [ label = "id@FedEntity#reviews",shape=box,style=dashed,color=blue]
+        16 [ label = "upc"]
+        17 [ label = "upc@Root#products",shape=box,style=dashed,color=blue]
+        0 -> 5 [ label = "Field" ]
+        0 -> 7 [ label = "Resolver(0)" color=blue]
+        7 -> 6 [ label = "CanResolveField(0)" color=blue]
+        6 -> 5 [ label = "Resolves" color=blue]
+        5 -> 4 [ label = "Field" ]
+        6 -> 9 [ label = "Resolver(0)" color=blue]
+        9 -> 8 [ label = "CanResolveField(0)" color=blue]
+        8 -> 4 [ label = "Resolves" color=blue]
+        4 -> 3 [ label = "Field" ]
+        10 -> 3 [ label = "Resolves" color=blue]
+        8 -> 10 [ label = "CanResolveField(0)" color=blue]
+        3 -> 2 [ label = "Field" ]
+        10 -> 12 [ label = "Resolver(0)" color=blue]
+        12 -> 11 [ label = "CanResolveField(0)" color=blue]
+        11 -> 2 [ label = "Resolves" color=blue]
+        5 -> 1 [ label = "Field" ]
+        13 -> 1 [ label = "Resolves" color=blue]
+        6 -> 13 [ label = "CanResolveField(0)" color=blue]
+        3 -> 14 [ label = "Field" ]
+        12 -> 14 [ label = "Requires" color=green]
+        3 -> 14 [ label = "Field" ]
+        15 -> 14 [ label = "Resolves" color=blue]
+        10 -> 15 [ label = "CanResolveField(0)" color=blue]
+        5 -> 16 [ label = "Field" ]
+        9 -> 16 [ label = "Requires" color=green]
+        5 -> 16 [ label = "Field" ]
+        17 -> 16 [ label = "Resolves" color=blue]
+        6 -> 17 [ label = "CanResolveField(0)" color=blue]
+    }
+    "##);
+}

--- a/engine/crates/engine-v2/schema/src/field_set/requires.rs
+++ b/engine/crates/engine-v2/schema/src/field_set/requires.rs
@@ -95,7 +95,7 @@ impl<'a> RequiredFieldSetItem<'a> {
     pub fn field(&self) -> RequiredField<'a> {
         self.ref_.field_id.walk(self.schema)
     }
-    pub fn subselection(&self) -> RequiredFieldSet<'_> {
+    pub fn subselection(&self) -> RequiredFieldSet<'a> {
         self.ref_.subselection.walk(self.schema)
     }
 }

--- a/engine/crates/engine-v2/schema/src/subgraph.rs
+++ b/engine/crates/engine-v2/schema/src/subgraph.rs
@@ -1,5 +1,16 @@
 use std::time::Duration;
 
+use crate::Subgraph;
+
+impl<'a> Subgraph<'a> {
+    pub fn name(&self) -> &'a str {
+        match self {
+            Subgraph::GraphqlEndpoint(endpoint) => endpoint.subgraph_name(),
+            Subgraph::Introspection => "introspection",
+        }
+    }
+}
+
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct SubgraphConfig {
     pub timeout: Duration,

--- a/engine/crates/engine-v2/src/execution/planner/builder.rs
+++ b/engine/crates/engine-v2/src/execution/planner/builder.rs
@@ -193,16 +193,16 @@ where
         resolver: ResolverDefinition<'_>,
         field_ids: &Vec<FieldId>,
     ) -> (ResponseViewSelectionSet, Vec<FieldId>) {
-        let mut required_fields = Cow::Borrowed(resolver.requires());
+        let mut required_fields = Cow::Borrowed(resolver.requires_or_empty());
         let mut required_fields_by_selection_set_id = HashMap::new();
         for field_id in field_ids {
             let field = self.walker().walk(*field_id);
             if let Some(definition) = field.definition() {
-                let field_requirements = definition.requires_for_subgraph(resolver.as_ref().subgraph_id());
+                let field_requirements = definition.all_requires_for_subgraph(resolver.as_ref().subgraph_id());
                 required_fields = RequiredFieldSetRecord::union_cow(required_fields, field_requirements.clone());
                 let value = required_fields_by_selection_set_id
                     .entry(field.as_ref().parent_selection_set_id())
-                    .or_insert_with(|| Cow::Borrowed(resolver.requires()));
+                    .or_insert_with(|| Cow::Borrowed(resolver.requires_or_empty()));
                 *value = RequiredFieldSetRecord::union_cow(std::mem::take(value), field_requirements);
             }
         }

--- a/engine/crates/engine/parser/src/types/executable.rs
+++ b/engine/crates/engine/parser/src/types/executable.rs
@@ -173,6 +173,14 @@ impl Selection {
             Self::InlineFragment(fragment) => &mut fragment.node.directives,
         }
     }
+
+    /// Get as a field
+    pub fn as_field(&self) -> Option<&Field> {
+        match self {
+            Self::Field(field) => Some(&field.node),
+            _ => None,
+        }
+    }
 }
 
 /// A field being selected on an object, such as `name` or `weightKilos: weight(unit: KILOGRAMS)`.

--- a/engine/crates/wrapping/src/lib.rs
+++ b/engine/crates/wrapping/src/lib.rs
@@ -192,6 +192,14 @@ impl Wrapping {
         Wrapping(INNER_IS_REQUIRED_FLAG)
     }
 
+    pub fn wrapping_by_required(mut self) -> Self {
+        if self.pop_list_wrapping().is_some() {
+            self.wrapped_by_required_list()
+        } else {
+            Self::required()
+        }
+    }
+
     #[must_use]
     pub fn wrapped_by(self, list_wrapping: ListWrapping) -> Self {
         match list_wrapping {


### PR DESCRIPTION
Simple initial PR to generate the operation graph with all fields and
requirements recursively. Taken from the tests:
```graphql
enum join__Graph {
  ACCOUNTS @join__graph(name: "accounts", url: "http://accounts:4001/graphql")
  INVENTORY @join__graph(name: "inventory", url: "http://inventory:4002/graphql")
  PRODUCTS @join__graph(name: "products", url: "http://products:4003/graphql")
  REVIEWS @join__graph(name: "reviews", url: "http://reviews:4004/graphql")
}

type Product
  @join__type(graph: INVENTORY, key: "upc")
  @join__type(graph: PRODUCTS, key: "upc")
  @join__type(graph: REVIEWS, key: "upc")
{
  upc: String!
  weight: Int @join__field(graph: INVENTORY, external: true) @join__field(graph: PRODUCTS)
  price: Int @join__field(graph: INVENTORY, external: true) @join__field(graph: PRODUCTS)
  inStock: Boolean @join__field(graph: INVENTORY)
  shippingEstimate: Int @join__field(graph: INVENTORY, requires: "price weight")
  name: String @join__field(graph: PRODUCTS)
  reviews: [Review] @join__field(graph: REVIEWS)
}

type Query
  @join__type(graph: ACCOUNTS)
  @join__type(graph: INVENTORY)
  @join__type(graph: PRODUCTS)
  @join__type(graph: REVIEWS)
{
  me: User @join__field(graph: ACCOUNTS)
  user(id: ID!): User @join__field(graph: ACCOUNTS)
  users: [User] @join__field(graph: ACCOUNTS)
  topProducts(first: Int = 5): [Product] @join__field(graph: PRODUCTS)
}

type Review
  @join__type(graph: REVIEWS, key: "id")
{
  id: ID!
  body: String
  product: Product
  author: User @join__field(graph: REVIEWS, provides: "username")
}

type User
  @join__type(graph: ACCOUNTS, key: "id")
  @join__type(graph: REVIEWS, key: "id")
{
  id: ID!
  name: String @join__field(graph: ACCOUNTS)
  username: String @join__field(graph: ACCOUNTS) @join__field(graph: REVIEWS, external: true)
  birthday: Int @join__field(graph: ACCOUNTS)
  reviews: [Review] @join__field(graph: REVIEWS)
}
```

with the following query

```graphql
    {
        topProducts {
            name
            reviews {
                author {
                    name
                }
            }
        }
    }
```

generates the following graph. The black part is the query itself, the blue part the resolvers and green requirements.

![graphviz(7)](https://github.com/user-attachments/assets/080b5465-15ac-4a65-b56b-2ab4c6060b65)

