### PR TITLE
feat(gateway): provide way to disable/limit batching

### DIFF
--- a/engine/crates/engine-config-builder/src/from_sdl_config.rs
+++ b/engine/crates/engine-config-builder/src/from_sdl_config.rs
@@ -9,7 +9,7 @@ use config::{
     SubgraphConfig,
 };
 use engine_v2_config::{
-    latest::{self as config},
+    latest::{self as config, BatchingConfig},
     VersionedConfig,
 };
 use federated_graph::{FederatedGraph, FieldId, ObjectId, SubgraphId};
@@ -51,6 +51,10 @@ pub fn build_with_sdl_config(config: &FederatedGraphConfig, federated_graph: Fed
             retry_percent: config.retry_percent,
             retry_mutations: config.retry_mutations,
         }),
+        batching: BatchingConfig {
+            enabled: config.batching.enabled,
+            limit: config.batching.limit,
+        },
     })
 }
 

--- a/engine/crates/engine-config-builder/src/from_toml_config.rs
+++ b/engine/crates/engine-config-builder/src/from_toml_config.rs
@@ -1,7 +1,7 @@
 use engine_v2_config::VersionedConfig;
 use federated_graph::FederatedGraph;
 use gateway_config::{Config, RetryConfig};
-use parser_sdl::federation::{header::SubgraphHeaderRule, FederatedGraphConfig};
+use parser_sdl::federation::{header::SubgraphHeaderRule, BatchingConfig, FederatedGraphConfig};
 
 use crate::build_with_sdl_config;
 
@@ -29,6 +29,11 @@ pub fn build_with_toml_config(config: &Config, graph: FederatedGraph) -> Version
     graph_config.rate_limit = config.gateway.rate_limit.clone().map(Into::into);
     graph_config.entity_caching = config.entity_caching.clone().into();
     graph_config.retry = retry_config(Some(config.gateway.retry));
+
+    graph_config.batching = BatchingConfig {
+        enabled: config.gateway.batching.enabled,
+        limit: config.gateway.batching.limit.map(|limit| limit as usize),
+    };
 
     graph_config.subgraphs = config
         .subgraphs

--- a/engine/crates/engine-v2/config/src/lib.rs
+++ b/engine/crates/engine-v2/config/src/lib.rs
@@ -178,6 +178,7 @@ impl VersionedConfig {
                 timeout,
                 entity_caching,
                 retry,
+                batching: Default::default(),
             },
             VersionedConfig::V6(latest) => latest,
         }

--- a/engine/crates/engine-v2/config/src/v6.rs
+++ b/engine/crates/engine-v2/config/src/v6.rs
@@ -56,6 +56,15 @@ pub struct Config {
 
     #[serde(default)]
     pub retry: Option<RetryConfig>,
+
+    #[serde(default)]
+    pub batching: BatchingConfig,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Default)]
+pub struct BatchingConfig {
+    pub enabled: bool,
+    pub limit: Option<usize>,
 }
 
 impl Config {
@@ -75,6 +84,7 @@ impl Config {
             timeout: None,
             entity_caching: EntityCaching::Disabled,
             retry: None,
+            batching: Default::default(),
         }
     }
 

--- a/engine/crates/engine-v2/schema/src/builder/mod.rs
+++ b/engine/crates/engine-v2/schema/src/builder/mod.rs
@@ -140,6 +140,7 @@ impl BuildContext {
                 operation_limits: take(&mut config.operation_limits),
                 disable_introspection: config.disable_introspection,
                 retry: config.retry.map(Into::into),
+                batching: take(&mut config.batching),
             },
         })
     }

--- a/engine/crates/engine-v2/schema/src/lib.rs
+++ b/engine/crates/engine-v2/schema/src/lib.rs
@@ -124,6 +124,7 @@ pub struct Settings {
     pub operation_limits: config::latest::OperationLimits,
     pub disable_introspection: bool,
     pub retry: Option<RetryConfig>,
+    pub batching: config::latest::BatchingConfig,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, id_derives::IndexedFields)]

--- a/engine/crates/integration-tests/tests/federation/graphql_over_http/batch.rs
+++ b/engine/crates/integration-tests/tests/federation/graphql_over_http/batch.rs
@@ -1,11 +1,21 @@
 use engine_v2::Engine;
 use graphql_mocks::FakeGithubSchema;
+use indoc::indoc;
 use integration_tests::{federation::EngineV2Ext, runtime};
 
 #[test]
 fn success() {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let config = indoc! {r#"
+            [gateway.batching]
+            enabled = true
+        "#};
+
+        let engine = Engine::builder()
+            .with_toml_config(config)
+            .with_subgraph(FakeGithubSchema)
+            .build()
+            .await;
 
         // Query should work
         let response = engine
@@ -47,9 +57,166 @@ fn success() {
 }
 
 #[test]
-fn invalid_request() {
+fn disabled() {
     runtime().block_on(async move {
         let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+
+        // Query should work
+        let response = engine
+            .raw_execute(
+                http::Request::builder()
+                    .uri("http://localhost/graphql")
+                    .method(http::Method::POST)
+                    .header(http::header::ACCEPT, "application/json")
+                    .header(http::header::CONTENT_TYPE, "application/json")
+                    .body(
+                        serde_json::to_vec(&serde_json::json!([
+                            {"query": "{ first: __typename }"},
+                            {"query": "{ second: __typename }"},
+                        ]))
+                        .unwrap(),
+                    )
+                    .unwrap(),
+            )
+            .await;
+
+        let status = response.status();
+        let body: serde_json::Value = serde_json::from_slice(&response.into_body()).unwrap();
+        insta::assert_json_snapshot!(body, @r#"
+        {
+          "errors": [
+            {
+              "message": "Bad request: batching is not enabled for this service",
+              "extensions": {
+                "code": "BAD_REQUEST"
+              }
+            }
+          ]
+        }
+        "#);
+        assert_eq!(status, 200);
+    })
+}
+
+#[test]
+fn limit_reached() {
+    runtime().block_on(async move {
+        let config = indoc! {r#"
+            [gateway.batching]
+            enabled = true
+            limit = 1
+        "#};
+
+        let engine = Engine::builder()
+            .with_toml_config(config)
+            .with_subgraph(FakeGithubSchema)
+            .build()
+            .await;
+
+        // Query should work
+        let response = engine
+            .raw_execute(
+                http::Request::builder()
+                    .uri("http://localhost/graphql")
+                    .method(http::Method::POST)
+                    .header(http::header::ACCEPT, "application/json")
+                    .header(http::header::CONTENT_TYPE, "application/json")
+                    .body(
+                        serde_json::to_vec(&serde_json::json!([
+                            {"query": "{ first: __typename }"},
+                            {"query": "{ second: __typename }"},
+                        ]))
+                        .unwrap(),
+                    )
+                    .unwrap(),
+            )
+            .await;
+
+        let status = response.status();
+        let body: serde_json::Value = serde_json::from_slice(&response.into_body()).unwrap();
+        insta::assert_json_snapshot!(body, @r#"
+        {
+          "errors": [
+            {
+              "message": "Bad request: batch size exceeds limit of 1",
+              "extensions": {
+                "code": "BAD_REQUEST"
+              }
+            }
+          ]
+        }
+        "#);
+        assert_eq!(status, 200);
+    })
+}
+
+#[test]
+fn just_in_limit() {
+    runtime().block_on(async move {
+        let config = indoc! {r#"
+            [gateway.batching]
+            enabled = true
+            limit = 2
+        "#};
+
+        let engine = Engine::builder()
+            .with_toml_config(config)
+            .with_subgraph(FakeGithubSchema)
+            .build()
+            .await;
+
+        // Query should work
+        let response = engine
+            .raw_execute(
+                http::Request::builder()
+                    .uri("http://localhost/graphql")
+                    .method(http::Method::POST)
+                    .header(http::header::ACCEPT, "application/json")
+                    .header(http::header::CONTENT_TYPE, "application/json")
+                    .body(
+                        serde_json::to_vec(&serde_json::json!([
+                            {"query": "{ first: __typename }"},
+                            {"query": "{ second: __typename }"},
+                        ]))
+                        .unwrap(),
+                    )
+                    .unwrap(),
+            )
+            .await;
+
+        let status = response.status();
+        let body: serde_json::Value = serde_json::from_slice(&response.into_body()).unwrap();
+        insta::assert_json_snapshot!(body, @r#"
+        [
+          {
+            "data": {
+              "first": "Query"
+            }
+          },
+          {
+            "data": {
+              "second": "Query"
+            }
+          }
+        ]
+        "#);
+        assert_eq!(status, 200);
+    })
+}
+
+#[test]
+fn invalid_request() {
+    runtime().block_on(async move {
+        let config = indoc! {r#"
+            [gateway.batching]
+            enabled = true
+        "#};
+
+        let engine = Engine::builder()
+            .with_toml_config(config)
+            .with_subgraph(FakeGithubSchema)
+            .build()
+            .await;
 
         // Query should work
         let response = engine
@@ -98,7 +265,16 @@ fn invalid_request() {
 #[test]
 fn request_error() {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let config = indoc! {r#"
+            [gateway.batching]
+            enabled = true
+        "#};
+
+        let engine = Engine::builder()
+            .with_toml_config(config)
+            .with_subgraph(FakeGithubSchema)
+            .build()
+            .await;
 
         // Query should work
         let response = engine

--- a/engine/crates/parser-sdl/src/federation.rs
+++ b/engine/crates/parser-sdl/src/federation.rs
@@ -21,6 +21,7 @@ pub struct FederatedGraphConfig {
     pub timeout: Option<Duration>,
     pub entity_caching: EntityCachingConfig,
     pub retry: Option<RetryConfig>,
+    pub batching: BatchingConfig,
 }
 
 /// Configuration for a subgraph of the current federated graph
@@ -224,6 +225,14 @@ pub struct RetryConfig {
     pub retry_percent: Option<f32>,
     /// Whether mutations should be retried at all. False by default.
     pub retry_mutations: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct BatchingConfig {
+    /// If batching should be enabled.
+    pub enabled: bool,
+    /// The maximum number of queries that can be batched together.
+    pub limit: Option<usize>,
 }
 
 #[cfg(test)]

--- a/gateway/crates/config/src/lib.rs
+++ b/gateway/crates/config/src/lib.rs
@@ -90,6 +90,15 @@ impl Default for Config {
 
 #[derive(Clone, Debug, Default, serde::Deserialize)]
 #[serde(default, deny_unknown_fields)]
+pub struct BatchingConfig {
+    /// If batching should be enabled.
+    pub enabled: bool,
+    /// How many queries can a batch have.
+    pub limit: Option<u8>,
+}
+
+#[derive(Clone, Debug, Default, serde::Deserialize)]
+#[serde(default, deny_unknown_fields)]
 pub struct GatewayConfig {
     /// Timeout for gateway requests.
     #[serde(deserialize_with = "duration_str::deserialize_option_duration")]
@@ -103,6 +112,8 @@ pub struct GatewayConfig {
     pub retry: RetryConfig,
     /// Access logs configuration
     pub access_logs: AccessLogsConfig,
+    /// Query batching configuration
+    pub batching: BatchingConfig,
 }
 
 #[derive(Debug, Default, serde::Deserialize, Clone, Copy)]
@@ -1935,5 +1946,59 @@ mod tests {
             mode: Blocking,
         }
         "###);
+    }
+
+    #[test]
+    fn batching_default() {
+        let input = indoc! {r#"
+        "#};
+
+        let config: Config = toml::from_str(input).unwrap();
+
+        insta::assert_debug_snapshot!(&config.gateway.batching, @r#"
+        BatchingConfig {
+            enabled: false,
+            limit: None,
+        }
+        "#);
+    }
+
+    #[test]
+    fn batching_with_limit() {
+        let input = indoc! {r#"
+            [gateway.batching]
+            enabled = true
+            limit = 5
+        "#};
+
+        let config: Config = toml::from_str(input).unwrap();
+
+        insta::assert_debug_snapshot!(&config.gateway.batching, @r#"
+        BatchingConfig {
+            enabled: true,
+            limit: Some(
+                5,
+            ),
+        }
+        "#);
+    }
+
+    #[test]
+    fn batching_with_too_high_limit() {
+        let input = indoc! {r#"
+            [gateway.batching]
+            enabled = true
+            limit = 1000
+        "#};
+
+        let error = toml::from_str::<Config>(input).unwrap_err();
+
+        insta::assert_snapshot!(&error.to_string(), @r#"
+        TOML parse error at line 3, column 9
+          |
+        3 | limit = 1000
+          |         ^^^^
+        invalid value: integer `1000`, expected u8
+        "#);
     }
 }


### PR DESCRIPTION
Provides a config setting to limit/enable batching:

```toml
[gateway.batching]
enabled = true
limit = 5
```

If not set, batching is disabled. This disables batching for managed federated graphs. We are removing those anyhow...