### PR TITLE
GB-7719: Add support for disabling APQs and configuring the operation cache limit

### DIFF
--- a/cli/crates/gateway/src/lib.rs
+++ b/cli/crates/gateway/src/lib.rs
@@ -67,6 +67,7 @@ impl Gateway {
                 trusted_documents,
                 grafbase_telemetry::metrics::meter_from_global_provider(),
                 Box::new(rate_limiter),
+                gateway_core::AutomaticallyPersistedQueriesConfig::Enabled,
             )),
         })
     }

--- a/engine/crates/engine-config-builder/src/from_sdl_config.rs
+++ b/engine/crates/engine-config-builder/src/from_sdl_config.rs
@@ -9,7 +9,7 @@ use config::{
     SubgraphConfig,
 };
 use engine_v2_config::{
-    latest::{self as config, BatchingConfig},
+    latest::{self as config, AutomaticallyPersistedQueries, BatchingConfig, OperationCaching},
     VersionedConfig,
 };
 use federated_graph::{FederatedGraph, FieldId, ObjectId, SubgraphId};
@@ -54,6 +54,13 @@ pub fn build_with_sdl_config(config: &FederatedGraphConfig, federated_graph: Fed
         batching: BatchingConfig {
             enabled: config.batching.enabled,
             limit: config.batching.limit,
+        },
+        operation_caching: OperationCaching {
+            enabled: config.operation_caching.enabled,
+            limit: config.operation_caching.limit,
+        },
+        apq: AutomaticallyPersistedQueries {
+            enabled: config.apq.enabled,
         },
     })
 }

--- a/engine/crates/engine-v2/config/src/lib.rs
+++ b/engine/crates/engine-v2/config/src/lib.rs
@@ -179,6 +179,8 @@ impl VersionedConfig {
                 entity_caching,
                 retry,
                 batching: Default::default(),
+                apq: Default::default(),
+                operation_caching: Default::default(),
             },
             VersionedConfig::V6(latest) => latest,
         }

--- a/engine/crates/engine-v2/config/src/v6.rs
+++ b/engine/crates/engine-v2/config/src/v6.rs
@@ -55,6 +55,12 @@ pub struct Config {
     pub entity_caching: EntityCaching,
 
     #[serde(default)]
+    pub operation_caching: OperationCaching,
+
+    #[serde(default)]
+    pub apq: AutomaticallyPersistedQueries,
+
+    #[serde(default)]
     pub retry: Option<RetryConfig>,
 
     #[serde(default)]
@@ -65,6 +71,29 @@ pub struct Config {
 pub struct BatchingConfig {
     pub enabled: bool,
     pub limit: Option<usize>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Default, Clone, Copy)]
+pub struct OperationCaching {
+    pub enabled: bool,
+    pub limit: Option<usize>,
+}
+
+const DEFAULT_OPERATION_CACHE_LIMIT: usize = 1000;
+
+impl OperationCaching {
+    pub fn real_limit(self) -> usize {
+        if self.enabled {
+            self.limit.unwrap_or(DEFAULT_OPERATION_CACHE_LIMIT)
+        } else {
+            0
+        }
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Default, Clone, Copy)]
+pub struct AutomaticallyPersistedQueries {
+    pub enabled: bool,
 }
 
 impl Config {
@@ -85,6 +114,8 @@ impl Config {
             entity_caching: EntityCaching::Disabled,
             retry: None,
             batching: Default::default(),
+            operation_caching: Default::default(),
+            apq: Default::default(),
         }
     }
 

--- a/engine/crates/gateway-core/src/lib.rs
+++ b/engine/crates/gateway-core/src/lib.rs
@@ -70,6 +70,13 @@ pub struct Gateway<Executor: self::Executor> {
     authorizer: Box<dyn Authorizer<Context = Executor::Context>>,
     operation_metrics: EngineMetrics,
     rate_limiter: Box<dyn RateLimiterInner>,
+    apq_enabled: bool,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum AutomaticallyPersistedQueriesConfig {
+    Enabled,
+    Disabled,
 }
 
 impl<Executor> Gateway<Executor>
@@ -89,6 +96,7 @@ where
         trusted_documents: runtime::trusted_documents_client::Client,
         meter: grafbase_telemetry::otel::opentelemetry::metrics::Meter,
         rate_limiter: Box<dyn RateLimiterInner>,
+        apq_config: AutomaticallyPersistedQueriesConfig,
     ) -> Self {
         Self {
             executor,
@@ -99,6 +107,7 @@ where
             trusted_documents,
             operation_metrics: EngineMetrics::build(&meter, None),
             rate_limiter,
+            apq_enabled: apq_config == AutomaticallyPersistedQueriesConfig::Enabled,
         }
     }
 

--- a/engine/crates/gateway-core/src/trusted_documents.rs
+++ b/engine/crates/gateway-core/src/trusted_documents.rs
@@ -143,6 +143,9 @@ where
         if *version != 1 {
             return Err(PersistedQueryError::UnsupportedVersion);
         }
+        if !self.apq_enabled {
+            return Err(PersistedQueryError::NotFound);
+        }
 
         let cache = &self.cache;
         let key = cache.build_key(&format!("apq/sha256_{}", hex::encode(sha256_hash)));

--- a/engine/crates/integration-tests/src/engine_v1/gateway.rs
+++ b/engine/crates/integration-tests/src/engine_v1/gateway.rs
@@ -114,6 +114,7 @@ impl GatewayBuilder {
                 trusted_documents,
                 grafbase_telemetry::metrics::meter_from_global_provider(),
                 Box::new(rate_limiting),
+                gateway_core::AutomaticallyPersistedQueriesConfig::Enabled,
             )),
         }
     }

--- a/engine/crates/integration-tests/src/federation/builder/test_runtime.rs
+++ b/engine/crates/integration-tests/src/federation/builder/test_runtime.rs
@@ -32,7 +32,7 @@ impl Default for TestRuntime {
             hooks: Default::default(),
             rate_limiter: InMemoryRateLimiter::runtime_with_watcher(rx),
             entity_cache: InMemoryEntityCache::default(),
-            hot_cache_factory: Default::default(),
+            hot_cache_factory: InMemoryOperationCacheFactory::new(1000),
         }
     }
 }

--- a/engine/crates/parser-sdl/src/federation.rs
+++ b/engine/crates/parser-sdl/src/federation.rs
@@ -22,6 +22,8 @@ pub struct FederatedGraphConfig {
     pub entity_caching: EntityCachingConfig,
     pub retry: Option<RetryConfig>,
     pub batching: BatchingConfig,
+    pub operation_caching: OperationCaching,
+    pub apq: AutomaticallyPersistedQueries,
 }
 
 /// Configuration for a subgraph of the current federated graph
@@ -233,6 +235,21 @@ pub struct BatchingConfig {
     pub enabled: bool,
     /// The maximum number of queries that can be batched together.
     pub limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct OperationCaching {
+    /// If operation caching should be enabled.
+    pub enabled: bool,
+    /// The maximum number of operations that can be kept in the cache.
+    /// 1000 by default.
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AutomaticallyPersistedQueries {
+    /// If automatically persisted queries should be enabled.
+    pub enabled: bool,
 }
 
 #[cfg(test)]

--- a/engine/crates/runtime-local/src/operation_cache.rs
+++ b/engine/crates/runtime-local/src/operation_cache.rs
@@ -10,16 +10,12 @@ pub struct InMemoryOperationCacheFactory {
 
 impl InMemoryOperationCacheFactory {
     pub fn inactive() -> Self {
-        InMemoryOperationCacheFactory {
-            config: InMemoryOperationCacheConfig { limit: 0 },
-        }
+        Self::new(0)
     }
-}
 
-impl Default for InMemoryOperationCacheFactory {
-    fn default() -> Self {
-        InMemoryOperationCacheFactory {
-            config: InMemoryOperationCacheConfig { limit: 1000 },
+    pub fn new(limit: usize) -> Self {
+        Self {
+            config: InMemoryOperationCacheConfig { limit },
         }
     }
 }

--- a/gateway/crates/federated-server/src/server/gateway/gateway_runtime.rs
+++ b/gateway/crates/federated-server/src/server/gateway/gateway_runtime.rs
@@ -85,7 +85,7 @@ impl GatewayRuntime {
             metrics: EngineMetrics::build(&meter, version_id.map(|id| id.to_string())),
             rate_limiter,
             entity_cache,
-            operation_cache_factory: InMemoryOperationCacheFactory::default(),
+            operation_cache_factory: InMemoryOperationCacheFactory::new(config.operation_caching.real_limit()),
         };
 
         Ok(runtime)


### PR DESCRIPTION
# Description

Add support for disabling APQs and configuring the operation cache limit.

# Type of change

- [ ] 💔 Breaking
- [X] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
