### PR TITLE
federated-graph: stop rendering @authenticated and @requiresScope in api SDL

### DIFF
--- a/engine/crates/composition/tests/composition/authenticated_basic/api.graphql
+++ b/engine/crates/composition/tests/composition/authenticated_basic/api.graphql
@@ -1,10 +1,10 @@
 type Car {
-    id: String! @authenticated
+    id: String!
     km: Int!
-    spareParts: [String!] @authenticated
+    spareParts: [String!]
     year: Int!
 }
 
 type Query {
-    cars: [Car!]! @authenticated
+    cars: [Car!]!
 }

--- a/engine/crates/composition/tests/composition/requiresScopes_basic/api.graphql
+++ b/engine/crates/composition/tests/composition/requiresScopes_basic/api.graphql
@@ -1,11 +1,11 @@
 type B {
-    foo: String @requiresScopes(scopes: [["yolo", ], ["wolo", ], ["scope:1", "scope:2", ], ])
+    foo: String
     id: ID!
 }
 
 type A {
     id: ID!
-    names: String! @requiresScopes(scopes: [["read:others", "and:yetanother", ], ["read:profiles", "read:profiles2", "read:others", ], ])
+    names: String!
 }
 
 type User {

--- a/engine/crates/federated-graph/src/render_sdl/render_api_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl/render_api_sdl.rs
@@ -249,13 +249,12 @@ fn write_public_directives<'a, 'b: 'a>(
     graph: &'a FederatedGraph,
 ) -> fmt::Result {
     for directive in graph[directives].iter().filter(|directive| match directive {
-        Directive::Inaccessible | Directive::Policy(_) => false,
+        Directive::Inaccessible | Directive::Policy(_) | Directive::RequiresScopes(_) | Directive::Authenticated => {
+            false
+        }
 
         Directive::Other { name, .. } if graph[*name] == "tag" => false,
-        Directive::RequiresScopes(_)
-        | Directive::Authenticated
-        | Directive::Deprecated { .. }
-        | Directive::Other { .. } => true,
+        Directive::Deprecated { .. } | Directive::Other { .. } => true,
     }) {
         f.write_str(" ")?;
         write_composed_directive(f, directive, graph)?;


### PR DESCRIPTION
These are not public directives.

closes GB-7761