### PR TITLE
validation: do not consider schema extensions as schema definitions

### DIFF
--- a/engine/crates/validation/CHANGELOG.md
+++ b/engine/crates/validation/CHANGELOG.md
@@ -7,8 +7,11 @@
   the root (Query, Mutation or Subscription). This commit makes the validation
   stricter. If Query does not exist, it is an error. (#1502)
 
+### Fixes
+
 - Properly validate that object, interface and input object types define at least one field (https://github.com/graphql/graphql-spec/blame/October2021/spec/Section%203%20--%20Type%20System.md#L868). Previously, we were validating against `type Test {}` but not `type Test`.
 - Whenever we had a graph of input objects with multiple cycles in graphql-schema-validation, we would go into an infinite loop and stack overflow. This is fixed in this release.
+- Do not consider schema extensions as schema definitions for the purpose of duplicate schema definition validation.
 
 ## [0.1.3] - 2024-02-06
 

--- a/engine/crates/validation/src/context.rs
+++ b/engine/crates/validation/src/context.rs
@@ -20,17 +20,6 @@ pub(crate) struct Context<'a> {
 
     pub(crate) options: crate::Options,
 
-    /// The schema definition that was encountered, if any.
-    ///
-    /// Example schema definition:
-    ///
-    /// ```graphql
-    /// schema {
-    ///   query: Query
-    /// }
-    /// ```
-    pub(crate) schema_definition: Option<SchemaDefinition<'a>>,
-
     // Definition name, extended fields. Only populated in the presence of extensions.
     pub(crate) extended_fields: HashMap<&'a str, Vec<&'a [AstField]>>,
 
@@ -59,7 +48,6 @@ impl<'a> Context<'a> {
             definition_names,
             diagnostics,
             options,
-            schema_definition: None,
 
             strings_buf: HashMap::default(),
             directive_names: HashMap::default(),
@@ -185,4 +173,5 @@ pub(crate) struct SchemaDefinition<'a> {
     pub(crate) query: Option<&'a str>,
     pub(crate) mutation: Option<&'a str>,
     pub(crate) subscription: Option<&'a str>,
+    pub(crate) is_extension: bool,
 }

--- a/engine/crates/validation/src/validate.rs
+++ b/engine/crates/validation/src/validate.rs
@@ -18,20 +18,35 @@ use self::{
     directive_definitions::*, enums::*, input_objects::*, input_types::*, interfaces::*, objects::*, scalars::*,
     schema_definition::*, type_definition::*, unions::*,
 };
-use crate::{diagnostics, Context, Options};
+use crate::{diagnostics, Context, Options, SchemaDefinition};
 use async_graphql_parser::{types as ast, Positioned};
 
 pub(crate) fn validate<'a>(parsed_ast: &'a ast::ServiceDocument, ctx: &mut Context<'a>) {
+    let mut schema_definitions = Vec::new();
+
     for definition in &parsed_ast.definitions {
         match definition {
-            ast::TypeSystemDefinition::Schema(def) => validate_schema_definition(def, ctx),
+            ast::TypeSystemDefinition::Schema(def) => {
+                schema_definitions.push(SchemaDefinition {
+                    pos: def.pos,
+                    directives: &def.node.directives,
+                    query: def.node.query.as_ref().map(|node| node.node.as_str()),
+                    mutation: def.node.mutation.as_ref().map(|node| node.node.as_str()),
+                    subscription: def.node.subscription.as_ref().map(|node| node.node.as_str()),
+                    is_extension: def.node.extend,
+                });
+            }
             ast::TypeSystemDefinition::Type(typedef) => validate_type_definition(typedef, ctx),
             ast::TypeSystemDefinition::Directive(def) => validate_directive_definition(def, ctx),
         }
     }
 
-    validate_schema_definition_references(ctx);
-    validate_root_types(ctx);
+    validate_schema_definitions(&schema_definitions, ctx);
+
+    if schema_definitions.is_empty() {
+        validate_root_types(ctx);
+    }
+
     validate_definitions_second_pass(parsed_ast, ctx);
 }
 

--- a/engine/crates/validation/tests/valid_schemas/schema_extension_then_definition.graphql
+++ b/engine/crates/validation/tests/valid_schemas/schema_extension_then_definition.graphql
@@ -1,0 +1,18 @@
+extend schema
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.5"
+    import: ["@authenticated", "@composeDirective", "@external", "@extends", "@inaccessible"]
+  )
+
+schema {
+  query: Queries
+  mutation: Mutation
+}
+
+type Queries {
+  sayHello: String
+}
+
+type Mutation {
+  sayHi: String
+}


### PR DESCRIPTION
For the purpose of duplicate schema definition validation.

closes GB-7760