### PR TITLE
fix(engine): mark cpu-heavy parts as blocking in tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2431,6 +2431,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "thiserror",
+ "tokio",
  "tower 0.5.1",
  "tracing",
  "url",

--- a/engine/crates/engine-v2/Cargo.toml
+++ b/engine/crates/engine-v2/Cargo.toml
@@ -15,12 +15,16 @@ doctest = false
 [lints]
 workspace = true
 
+[features]
+default = ["tokio"]
+
 [dependencies]
 async-runtime.workspace = true
 base64.workspace = true
 blake3.workspace = true
 bytes.workspace = true
 url.workspace = true
+tokio = { workspace = true, optional = true }
 crossbeam-queue = "0.3.11"
 futures-util.workspace = true
 futures.workspace = true

--- a/engine/crates/engine-v2/src/execution/planner/mod.rs
+++ b/engine/crates/engine-v2/src/execution/planner/mod.rs
@@ -88,16 +88,18 @@ pub(super) async fn plan<'ctx, R: Runtime>(
         response_modifier_executors: Default::default(),
     };
 
-    let operation = ExecutionPlanner {
-        ctx,
-        build_context: BuildContext {
-            logical_plan_to_execution_plan_id: vec![None; operation.plan.logical_plans.len()],
-            io_fields: Vec::with_capacity(operation.fields.len()),
-            ..Default::default()
-        },
-        operation,
-    }
-    .plan()?;
+    let operation = crate::utils::block_in_place(|| {
+        ExecutionPlanner {
+            ctx,
+            build_context: BuildContext {
+                logical_plan_to_execution_plan_id: vec![None; operation.plan.logical_plans.len()],
+                io_fields: Vec::with_capacity(operation.fields.len()),
+                ..Default::default()
+            },
+            operation,
+        }
+        .plan()
+    })?;
 
     tracing::trace!(
         "== Plan Summary ==\n{}",

--- a/engine/crates/engine-v2/src/sources/graphql/federation.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/federation.rs
@@ -280,9 +280,9 @@ where
             cache_ttl,
         } = self;
 
-        let status = {
+        let status = crate::utils::block_in_place(|| {
             let response = subgraph_response.as_mut();
-            GraphqlResponseSeed::new(
+            let status = GraphqlResponseSeed::new(
                 EntitiesDataSeed {
                     ctx,
                     response: response.clone(),
@@ -290,8 +290,9 @@ where
                 },
                 EntitiesErrorsSeed::new(ctx, response),
             )
-            .deserialize(&mut serde_json::Deserializer::from_slice(http_response.body()))?
-        };
+            .deserialize(&mut serde_json::Deserializer::from_slice(http_response.body()))?;
+            ExecutionResult::Ok(status)
+        })?;
 
         let cache_ttl = calculate_cache_ttl(status, http_response.headers(), cache_ttl);
 

--- a/engine/crates/engine-v2/src/utils/mod.rs
+++ b/engine/crates/engine-v2/src/utils/mod.rs
@@ -1,3 +1,20 @@
 mod pool;
 
 pub(crate) use pool::*;
+
+/// Until engine-v2 is entirely remove
+#[cfg(feature = "tokio")]
+pub(crate) fn block_in_place<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    tokio::task::block_in_place(f)
+}
+
+#[cfg(not(feature = "tokio"))]
+pub(crate) fn block_in_place<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    f()
+}

--- a/engine/crates/integration-tests/src/lib.rs
+++ b/engine/crates/integration-tests/src/lib.rs
@@ -48,7 +48,9 @@ fn setup_logging() {
 pub fn runtime() -> &'static Runtime {
     static RUNTIME: OnceLock<Runtime> = OnceLock::new();
     RUNTIME.get_or_init(|| {
-        tokio::runtime::Builder::new_current_thread()
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .max_blocking_threads(8)
             .enable_all()
             .build()
             .unwrap()


### PR DESCRIPTION
Executing the cpu-heavy parts in `block_inplace` helps tokio achieve better latencies overall at the cost of higher CPU usage.

Added it behind a `tokio` feature flag so it can be disabled for CF