### PR TITLE
feat: metrics for wasm pool size

### DIFF
--- a/engine/crates/runtime-local/src/hooks/pool.rs
+++ b/engine/crates/runtime-local/src/hooks/pool.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use deadpool::managed;
+use grafbase_telemetry::otel::opentelemetry::{metrics::UpDownCounter, KeyValue};
 use tracing::{info_span, Instrument};
 use wasi_component_loader::{ComponentLoader, RecycleableComponentInstance};
 
@@ -29,13 +30,21 @@ impl<T: RecycleableComponentInstance> Pool<T> {
 
 pub(super) struct ComponentMananger<T> {
     component_loader: Arc<ComponentLoader>,
+    pool_size_counter: UpDownCounter<i64>,
+    counter_attributes: Vec<KeyValue>,
     _phantom: std::marker::PhantomData<fn() -> T>,
 }
 
 impl<T: RecycleableComponentInstance> ComponentMananger<T> {
     pub(super) fn new(component_loader: Arc<ComponentLoader>) -> Self {
+        let meter = grafbase_telemetry::metrics::meter_from_global_provider();
+        let pool_size_counter = meter.i64_up_down_counter("grafbase.hook.pool.size").init();
+        let counter_attributes = vec![KeyValue::new("grafbase.hook.interface", T::interface_name())];
+
         Self {
             component_loader,
+            pool_size_counter,
+            counter_attributes,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -44,11 +53,18 @@ impl<T: RecycleableComponentInstance> ComponentMananger<T> {
 impl<T: RecycleableComponentInstance> managed::Manager for ComponentMananger<T> {
     type Type = T;
     type Error = wasi_component_loader::Error;
+
     async fn create(&self) -> Result<Self::Type, Self::Error> {
+        self.pool_size_counter.add(1, &self.counter_attributes);
         T::new(&self.component_loader).await
     }
+
     async fn recycle(&self, instance: &mut Self::Type, _: &managed::Metrics) -> managed::RecycleResult<Self::Error> {
-        instance.recycle()?;
+        if let Err(e) = instance.recycle() {
+            self.pool_size_counter.add(-1, &self.counter_attributes);
+            return Err(e.into());
+        }
+
         Ok(())
     }
 }

--- a/gateway/crates/gateway-binary/tests/telemetry/metrics/access_log.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/metrics/access_log.rs
@@ -5,7 +5,7 @@ use crate::telemetry::metrics::{SumRow, METRICS_DELAY};
 use super::with_custom_gateway;
 
 #[test]
-fn basic() {
+fn measures_pending_logs() {
     let tmpdir = TempDir::new().unwrap();
     let path = tmpdir.path().to_str().unwrap();
 
@@ -54,5 +54,60 @@ fn basic() {
           "Attributes": {}
         }
         "###);
+    });
+}
+
+#[test]
+fn measures_pool_size() {
+    let tmpdir = TempDir::new().unwrap();
+    let path = tmpdir.path().to_str().unwrap();
+
+    let config = indoc::formatdoc! {r#"
+        [gateway.access_logs]
+        enabled = true
+        path = "{path}"
+
+        [hooks]
+        location = "../../../engine/crates/wasi-component-loader/examples/target/wasm32-wasip1/debug/response_hooks.wasm"
+    "#};
+
+    with_custom_gateway(&config, |service_name, _, gateway, clickhouse| async move {
+        let response = gateway
+            .gql::<serde_json::Value>("query Simple { __typename }")
+            .send()
+            .await;
+
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "__typename": "Query"
+          }
+        }"###);
+
+        tokio::time::sleep(METRICS_DELAY).await;
+
+        let row = clickhouse
+            .query(
+                r#"
+                SELECT Value, Attributes
+                FROM otel_metrics_sum
+                WHERE ServiceName = ?
+                    AND ScopeName = 'grafbase'
+                    AND MetricName = 'grafbase.hook.pool.size'
+                "#,
+            )
+            .bind(&service_name)
+            .fetch_one::<SumRow>()
+            .await
+            .unwrap();
+
+        insta::assert_json_snapshot!(row, @r#"
+        {
+          "Value": 1.0,
+          "Attributes": {
+            "grafbase.hook.interface": "component:grafbase/responses"
+          }
+        }
+        "#);
     });
 }

--- a/gateway/crates/gateway-binary/tests/telemetry/metrics/access_log.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/metrics/access_log.rs
@@ -93,7 +93,7 @@ fn measures_pool_size() {
                 FROM otel_metrics_sum
                 WHERE ServiceName = ?
                     AND ScopeName = 'grafbase'
-                    AND MetricName = 'grafbase.hook.pool.size'
+                    AND MetricName = 'grafbase.hook.pool.instances.busy'
                 "#,
             )
             .bind(&service_name)
@@ -103,7 +103,7 @@ fn measures_pool_size() {
 
         insta::assert_json_snapshot!(row, @r#"
         {
-          "Value": 1.0,
+          "Value": 0.0,
           "Attributes": {
             "grafbase.hook.interface": "component:grafbase/responses"
           }


### PR DESCRIPTION
New metric: `grafbase.hook.pool.instances.busy`, which is a up/down counter of the number of wasi instances in use in the pool. Goes up when taking an instance from the pool, and down when an instance is returned. Holds an attribute `grafbase.hook.interface` marking the interface instantiated in the pool.