### PR TITLE
feat: wasm pool size configuration option

### DIFF
--- a/engine/crates/integration-tests/src/federation/builder/engine.rs
+++ b/engine/crates/integration-tests/src/federation/builder/engine.rs
@@ -108,7 +108,7 @@ fn update_runtime_with_toml_config(
             .expect("Wasm examples weren't built, please run:\ncd engine/crates/wasi-component-loader/examples && cargo component build");
 
         let meter = meter_from_global_provider();
-        runtime.hooks = DynamicHooks::wrap(HooksWasi::new(Some(loader), &meter, access_log_sender));
+        runtime.hooks = DynamicHooks::wrap(HooksWasi::new(Some(loader), None, &meter, access_log_sender));
     }
 }
 

--- a/engine/crates/runtime-local/src/hooks.rs
+++ b/engine/crates/runtime-local/src/hooks.rs
@@ -194,13 +194,18 @@ impl HookStatus {
 }
 
 impl HooksWasi {
-    pub fn new(loader: Option<ComponentLoader>, meter: &Meter, sender: ChannelLogSender) -> Self {
+    pub fn new(
+        loader: Option<ComponentLoader>,
+        max_pool_size: Option<usize>,
+        meter: &Meter,
+        sender: ChannelLogSender,
+    ) -> Self {
         match loader.map(Arc::new) {
             Some(loader) => Self(Some(Arc::new(HooksWasiInner {
-                gateway: Pool::new(&loader),
-                authorization: Pool::new(&loader),
-                subgraph: Pool::new(&loader),
-                responses: Pool::new(&loader),
+                gateway: Pool::new(&loader, max_pool_size),
+                authorization: Pool::new(&loader, max_pool_size),
+                subgraph: Pool::new(&loader, max_pool_size),
+                responses: Pool::new(&loader, max_pool_size),
                 hook_latencies: meter.u64_histogram("grafbase.hook.duration").init(),
                 sender,
             }))),

--- a/engine/crates/wasi-component-loader/src/config.rs
+++ b/engine/crates/wasi-component-loader/src/config.rs
@@ -12,6 +12,7 @@ use wasmtime_wasi::{DirPerms, FilePerms, WasiCtx, WasiCtxBuilder};
 /// Returns a `WasiCtx` configured according to the specified settings in the `config`.
 pub(crate) fn build_wasi_context(
     Config {
+        max_pool_size: _,
         location: _,
         networking,
         environment_variables,

--- a/gateway/crates/config/src/hooks.rs
+++ b/gateway/crates/config/src/hooks.rs
@@ -16,6 +16,8 @@ pub struct HooksWasiConfig {
     pub stderr: bool,
     /// A list of directories that are preopened for the WASI component.
     pub preopened_directories: Vec<PreopenedDirectory>,
+    /// The maximum number of concurrent instances of the WASI component. Defaults to four times the number of CPUs.
+    pub max_pool_size: Option<usize>,
 }
 
 /// Configuration for a directory that is preopened for the WASI component.

--- a/gateway/crates/federated-server/src/server.rs
+++ b/gateway/crates/federated-server/src/server.rs
@@ -99,7 +99,8 @@ pub async fn serve(
         .map_err(|e| crate::Error::InternalError(e.to_string()))?
         .flatten();
 
-    let hooks = HooksWasi::new(loader, &meter, access_log_sender.clone());
+    let max_pool_size = config.hooks.as_ref().and_then(|config| config.max_pool_size);
+    let hooks = HooksWasi::new(loader, max_pool_size, &meter, access_log_sender.clone());
 
     fetch_method
         .start(


### PR DESCRIPTION
The user can now configure the size of an instance pool in the hooks:

```toml
[hooks]
location = "target/wasm32-wasip1/release/hooks.wasm"
max_pool_size = 1000
```

If not set, the default is four times the number of CPUs.