### PR TITLE
chore: bump Gateway to 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2779,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-config"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "ascii 1.1.0",
  "cfg-if",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",
@@ -7173,7 +7173,7 @@ dependencies = [
 
 [[package]]
 name = "rolling-logger"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "grafbase-workspace-hack",
  "insta",

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.16.0] - 2024-10-22
+
+[CHANGELOG](changelog/0.16.0.md)
+
 ## [0.15.0] - 2024-10-09
 
 [CHANGELOG](changelog/0.15.0.md)

--- a/gateway/changelog/0.16.0.md
+++ b/gateway/changelog/0.16.0.md
@@ -1,8 +1,39 @@
 ### Features
 
-- Subgraph URL can now be overridden in the TOML configuration:
+#### Subgraph URL Override in TOML Configuration
+
+Added a new configuration option to override the subgraph URL in the TOML configuration file. This option allows you to specify the URL of the subgraph that the gateway should use. By default the gateway uses the URL specified in the schema registry. By setting a different URL in the TOML configuration file, you can override the default behavior.
+
+Example configuration:
 
 ```toml
-[subgraphs.accounts]
-url = "http://custom-accounts:7890"
+[subgraphs.products]
+url = "https://example.com/graphql"
 ```
+
+#### Hooks Pool Size Configuration
+
+Introduced a new configuration option for hooks pool size. This configuration option allows you to set the maximum number of hooks that can be executed concurrently. The default value is four times the number of CPUs, but now you can adjust this value based on your requirements.
+
+Example configuration:
+
+```toml
+[hooks]
+max_pool_size = 1000
+```
+
+#### WASM Hook Pool Usage Metrics
+
+Added metrics to track instances currently in use in the WASM hook pool. These metrics provide insights into the usage of the WASM hook pool and help you optimize the pool size based on the usage patterns.
+
+See [documentation](https://grafbase.com/docs/self-hosted-gateway/telemetry#hook-pool-busy-instances).
+
+### Fixes
+
+- **Error Handling Improvement**: Fixed issue where errors could be null in subgraph responses.
+
+### Maintenance
+
+- **wasmtime update**: Bumped to version 25.0.2.
+- **Rust Version Update**: Updated the project to use Rust version 1.82.
+>>>>>>> Conflict 1 of 1 ends

--- a/gateway/crates/config/Cargo.toml
+++ b/gateway/crates/config/Cargo.toml
@@ -5,7 +5,7 @@ keywords.workspace = true
 license = "MPL-2.0"
 name = "gateway-config"
 repository.workspace = true
-version = "0.15.0"
+version = "0.16.0"
 
 [lints]
 workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/crates/rolling-logger/Cargo.toml
+++ b/gateway/crates/rolling-logger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolling-logger"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
### Features

#### Subgraph URL Override in TOML Configuration

Added a new configuration option to override the subgraph URL in the TOML configuration file. This option allows you to specify the URL of the subgraph that the gateway should use. By default the gateway uses the URL specified in the schema registry. By setting a different URL in the TOML configuration file, you can override the default behavior.

Example configuration:

```toml
[subgraphs.products]
url = "https://example.com/graphql"
```

#### Hooks Pool Size Configuration

Introduced a new configuration option for hooks pool size. This configuration option allows you to set the maximum number of hooks that can be executed concurrently. The default value is four times the number of CPUs, but now you can adjust this value based on your requirements.

Example configuration:

```toml
[hooks]
max_pool_size = 1000
```

#### WASM Hook Pool Usage Metrics

Added metrics to track instances currently in use in the WASM hook pool. These metrics provide insights into the usage of the WASM hook pool and help you optimize the pool size based on the usage patterns.

See [documentation](https://grafbase.com/docs/self-hosted-gateway/telemetry#hook-pool-busy-instances).

### Fixes

- **Error Handling Improvement**: Fixed issue where errors could be null in subgraph responses.

### Maintenance

- **wasmtime update**: Bumped to version 25.0.2.
- **Rust Version Update**: Updated the project to use Rust version 1.82.
