### PR TITLE
Coordinator futures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2431,6 +2431,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "thiserror",
+ "tokio",
  "tower 0.5.1",
  "tracing",
  "url",

--- a/engine/crates/engine-v2/Cargo.toml
+++ b/engine/crates/engine-v2/Cargo.toml
@@ -21,6 +21,7 @@ base64.workspace = true
 blake3.workspace = true
 bytes.workspace = true
 url.workspace = true
+tokio = { workspace = true, features = ["rt"] }
 crossbeam-queue = "0.3.11"
 futures-util.workspace = true
 futures.workspace = true

--- a/engine/crates/engine-v2/src/engine/execute.rs
+++ b/engine/crates/engine-v2/src/engine/execute.rs
@@ -135,13 +135,14 @@ impl<R: Runtime> Engine<R> {
         hooks_context: HooksContext<R>,
         request: BatchRequest,
     ) -> http::Response<Body> {
+        let request_context = Arc::new(request_context);
         match request {
             BatchRequest::Single(request) => match request_context.response_format {
                 ResponseFormat::Streaming(format) => {
                     Http::stream(
                         format,
                         hooks_context.clone(),
-                        self.execute_stream(Arc::new(request_context), hooks_context, request),
+                        self.execute_stream(request_context, hooks_context, request),
                     )
                     .await
                 }

--- a/engine/crates/engine-v2/src/engine/execute/prepare.rs
+++ b/engine/crates/engine-v2/src/engine/execute/prepare.rs
@@ -66,7 +66,7 @@ impl<'ctx, R: Runtime> PreExecutionContext<'ctx, R> {
         let operation = match result {
             Ok(operation) => operation,
             Err((cache_key, document)) => {
-                let operation = Operation::prepare(self.schema(), &request, &document)
+                let operation = tokio::task::block_in_place(|| Operation::prepare(self.schema(), &request, &document))
                     .map(Arc::new)
                     .map_err(|mut err| {
                         let attributes = err.take_operation_attributes();

--- a/engine/crates/engine-v2/src/engine/execute/single.rs
+++ b/engine/crates/engine-v2/src/engine/execute/single.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use engine_parser::types::OperationType;
 use grafbase_telemetry::{
     metrics::{GraphqlErrorAttributes, GraphqlRequestMetricsAttributes},
@@ -17,8 +19,8 @@ use crate::{
 
 impl<R: Runtime> Engine<R> {
     pub(super) async fn execute_single(
-        &self,
-        request_context: &RequestContext,
+        self: &Arc<Self>,
+        request_context: &Arc<RequestContext>,
         hooks_context: HooksContext<R>,
         request: Request,
     ) -> Response<<R::Hooks as Hooks>::OnOperationResponseOutput> {

--- a/engine/crates/engine-v2/src/execution/context.rs
+++ b/engine/crates/engine-v2/src/execution/context.rs
@@ -90,7 +90,7 @@ pub(crate) struct StaticContext<R: Runtime> {
 impl<R: Runtime> std::marker::Copy for ExecutionContext<'_, R> {}
 
 impl<'ctx, R: Runtime> ExecutionContext<'ctx, R> {
-    pub fn into_static_parts(self) -> StaticContext<R> {
+    pub fn into_static(self) -> StaticContext<R> {
         StaticContext {
             engine: Arc::clone(self.engine),
             operation: Arc::clone(self.operation),
@@ -99,7 +99,7 @@ impl<'ctx, R: Runtime> ExecutionContext<'ctx, R> {
         }
     }
 
-    pub fn from_static_parts(parts: &'ctx StaticContext<R>) -> Self {
+    pub fn from_static(parts: &'ctx StaticContext<R>) -> Self {
         let StaticContext {
             engine,
             operation,

--- a/engine/crates/engine-v2/src/execution/context.rs
+++ b/engine/crates/engine-v2/src/execution/context.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use futures::future::BoxFuture;
 use grafbase_telemetry::metrics::EngineMetrics;
 use runtime::{
@@ -16,8 +18,8 @@ use super::{header_rule::create_subgraph_headers_with_rules, ExecutableOperation
 /// Context before starting to operation plan execution.
 /// Background futures will be started in parallel to avoid delaying the plan.
 pub(crate) struct PreExecutionContext<'ctx, R: Runtime> {
-    pub(crate) engine: &'ctx Engine<R>,
-    pub(crate) request_context: &'ctx RequestContext,
+    pub(crate) engine: &'ctx Arc<Engine<R>>,
+    pub(crate) request_context: &'ctx Arc<RequestContext>,
     pub(crate) hooks_context: HooksContext<R>,
     pub(crate) executed_operation_builder: ExecutedOperationBuilder<<R::Hooks as Hooks>::OnSubgraphResponseOutput>,
     // needs to be Send so that futures are Send.
@@ -25,7 +27,11 @@ pub(crate) struct PreExecutionContext<'ctx, R: Runtime> {
 }
 
 impl<'ctx, R: Runtime> PreExecutionContext<'ctx, R> {
-    pub fn new(engine: &'ctx Engine<R>, request_context: &'ctx RequestContext, hooks_context: HooksContext<R>) -> Self {
+    pub fn new(
+        engine: &'ctx Arc<Engine<R>>,
+        request_context: &'ctx Arc<RequestContext>,
+        hooks_context: HooksContext<R>,
+    ) -> Self {
         Self {
             engine,
             request_context,
@@ -62,10 +68,10 @@ impl<'ctx, R: Runtime> PreExecutionContext<'ctx, R> {
 
 /// Data available during the executor life during its build & execution phases.
 pub(crate) struct ExecutionContext<'ctx, R: Runtime> {
-    pub engine: &'ctx Engine<R>,
-    pub operation: &'ctx ExecutableOperation,
-    pub(super) request_context: &'ctx RequestContext,
-    pub(super) hooks_context: &'ctx HooksContext<R>,
+    pub engine: &'ctx Arc<Engine<R>>,
+    pub operation: &'ctx Arc<ExecutableOperation>,
+    pub request_context: &'ctx Arc<RequestContext>,
+    pub hooks_context: &'ctx Arc<HooksContext<R>>,
 }
 
 impl<R: Runtime> Clone for ExecutionContext<'_, R> {
@@ -74,9 +80,40 @@ impl<R: Runtime> Clone for ExecutionContext<'_, R> {
     }
 }
 
+pub(crate) struct StaticContext<R: Runtime> {
+    pub engine: Arc<Engine<R>>,
+    pub operation: Arc<ExecutableOperation>,
+    pub request_context: Arc<RequestContext>,
+    pub hooks_context: Arc<HooksContext<R>>,
+}
+
 impl<R: Runtime> std::marker::Copy for ExecutionContext<'_, R> {}
 
 impl<'ctx, R: Runtime> ExecutionContext<'ctx, R> {
+    pub fn into_static_parts(self) -> StaticContext<R> {
+        StaticContext {
+            engine: Arc::clone(self.engine),
+            operation: Arc::clone(self.operation),
+            request_context: Arc::clone(self.request_context),
+            hooks_context: Arc::clone(self.hooks_context),
+        }
+    }
+
+    pub fn from_static_parts(parts: &'ctx StaticContext<R>) -> Self {
+        let StaticContext {
+            engine,
+            operation,
+            request_context,
+            hooks_context,
+        } = parts;
+        Self {
+            engine,
+            operation,
+            request_context,
+            hooks_context,
+        }
+    }
+
     #[allow(unused)]
     pub fn access_token(&self) -> &'ctx AccessToken {
         &self.request_context.access_token

--- a/engine/crates/engine-v2/src/execution/coordinator.rs
+++ b/engine/crates/engine-v2/src/execution/coordinator.rs
@@ -41,11 +41,13 @@ impl<'ctx, R: Runtime> PreExecutionContext<'ctx, R> {
 
         tracing::trace!("Starting execution...");
         if operation.query_modifications.root_error_ids.is_empty() {
+            let operation = Arc::new(operation);
+            let hooks_context = Arc::new(self.hooks_context);
             let ctx = ExecutionContext {
                 engine: self.engine,
                 operation: &operation,
                 request_context: self.request_context,
-                hooks_context: &self.hooks_context,
+                hooks_context: &hooks_context,
             };
             let response_fut = ctx.execute(self.executed_operation_builder);
             let (response, _) = futures_util::join!(response_fut, background_fut);
@@ -68,11 +70,13 @@ impl<'ctx, R: Runtime> PreExecutionContext<'ctx, R> {
 
         tracing::trace!("Starting execution...");
         if operation.query_modifications.root_error_ids.is_empty() {
+            let operation = Arc::new(operation);
+            let hooks_context = Arc::new(self.hooks_context);
             let ctx = ExecutionContext {
                 engine: self.engine,
                 operation: &operation,
                 request_context: self.request_context,
-                hooks_context: &self.hooks_context,
+                hooks_context: &hooks_context,
             };
 
             let subscription_fut = ctx.execute_subscription(self.executed_operation_builder, responses);

--- a/engine/crates/engine-v2/src/execution/planner/mod.rs
+++ b/engine/crates/engine-v2/src/execution/planner/mod.rs
@@ -88,16 +88,18 @@ pub(super) async fn plan<'ctx, R: Runtime>(
         response_modifier_executors: Default::default(),
     };
 
-    let operation = ExecutionPlanner {
-        ctx,
-        build_context: BuildContext {
-            logical_plan_to_execution_plan_id: vec![None; operation.plan.logical_plans.len()],
-            io_fields: Vec::with_capacity(operation.fields.len()),
-            ..Default::default()
-        },
-        operation,
-    }
-    .plan()?;
+    let operation = tokio::task::block_in_place(|| {
+        ExecutionPlanner {
+            ctx,
+            build_context: BuildContext {
+                logical_plan_to_execution_plan_id: vec![None; operation.plan.logical_plans.len()],
+                io_fields: Vec::with_capacity(operation.fields.len()),
+                ..Default::default()
+            },
+            operation,
+        }
+        .plan()
+    })?;
 
     tracing::trace!(
         "== Plan Summary ==\n{}",

--- a/engine/crates/engine-v2/src/sources/graphql/federation.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/federation.rs
@@ -280,9 +280,11 @@ where
             cache_ttl,
         } = self;
 
-        let status = {
+        let parts = ctx.into_static_parts();
+        let (status, subgraph_response, cache_entries, http_response) = tokio::task::spawn_blocking(move || {
+            let ctx = ExecutionContext::from_static_parts(&parts);
             let response = subgraph_response.as_mut();
-            GraphqlResponseSeed::new(
+            let status = GraphqlResponseSeed::new(
                 EntitiesDataSeed {
                     ctx,
                     response: response.clone(),
@@ -290,8 +292,11 @@ where
                 },
                 EntitiesErrorsSeed::new(ctx, response),
             )
-            .deserialize(&mut serde_json::Deserializer::from_slice(http_response.body()))?
-        };
+            .deserialize(&mut serde_json::Deserializer::from_slice(http_response.body()))?;
+            ExecutionResult::Ok((status, subgraph_response, cache_entries, http_response))
+        })
+        .await
+        .unwrap()?;
 
         let cache_ttl = calculate_cache_ttl(status, http_response.headers(), cache_ttl);
 

--- a/engine/crates/engine-v2/src/sources/graphql/root_fields.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/root_fields.rs
@@ -15,7 +15,7 @@ use super::{
     SubgraphContext,
 };
 use crate::{
-    execution::PlanningResult,
+    execution::{ExecutionError, PlanningResult},
     operation::{OperationType, PlanWalker},
     response::SubgraphResponse,
     sources::{graphql::request::SubgraphGraphqlRequest, ExecutionContext, ExecutionResult, Resolver},
@@ -157,26 +157,37 @@ where
     R: Runtime,
 {
     async fn ingest(
-        mut self,
+        self,
         http_response: http::Response<OwnedOrSharedBytes>,
-    ) -> Result<(GraphqlResponseStatus, SubgraphResponse), crate::execution::ExecutionError> {
-        let status = {
-            let response = self.subgraph_response.as_mut();
-            GraphqlResponseSeed::new(
-                response.next_seed(&self.ctx).ok_or("No object to update")?,
-                RootGraphqlErrors::new(&self.ctx, response),
-            )
-            .deserialize(&mut serde_json::Deserializer::from_slice(http_response.body()))?
-        };
+    ) -> Result<(GraphqlResponseStatus, SubgraphResponse), ExecutionError> {
+        let Self {
+            ctx,
+            mut subgraph_response,
+            cache_ttl,
+            cache_key,
+        } = self;
 
-        if let Some(cache_key) = self.cache_key {
-            let cache_ttl = calculate_cache_ttl(status, http_response.headers(), self.cache_ttl);
+        let parts = ctx.into_static_parts();
+        let (status, subgraph_response, http_response) = tokio::task::spawn_blocking(move || {
+            let ctx = ExecutionContext::from_static_parts(&parts);
+            let response = subgraph_response.as_mut();
+            let status = GraphqlResponseSeed::new(
+                response.next_seed(&ctx).ok_or("No object to update")?,
+                RootGraphqlErrors::new(&ctx, response),
+            )
+            .deserialize(&mut serde_json::Deserializer::from_slice(http_response.body()))?;
+            ExecutionResult::Ok((status, subgraph_response, http_response))
+        })
+        .await
+        .unwrap()?;
+
+        if let Some(cache_key) = cache_key {
+            let cache_ttl = calculate_cache_ttl(status, http_response.headers(), cache_ttl);
 
             if let Some(cache_ttl) = cache_ttl {
                 // We could probably put this call into the background at some point, but for
                 // simplicities sake I am not going to do that just now.
-                self.ctx
-                    .engine
+                ctx.engine
                     .runtime
                     .entity_cache()
                     .put(&cache_key, Cow::Borrowed(http_response.body().as_ref()), cache_ttl)
@@ -186,6 +197,6 @@ where
             }
         }
 
-        Ok((status, self.subgraph_response))
+        Ok((status, subgraph_response))
     }
 }

--- a/engine/crates/integration-tests/src/lib.rs
+++ b/engine/crates/integration-tests/src/lib.rs
@@ -48,7 +48,8 @@ fn setup_logging() {
 pub fn runtime() -> &'static Runtime {
     static RUNTIME: OnceLock<Runtime> = OnceLock::new();
     RUNTIME.get_or_init(|| {
-        tokio::runtime::Builder::new_current_thread()
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
             .enable_all()
             .build()
             .unwrap()


### PR DESCRIPTION
This PR improves our latencies with two improvements:
- use of `spawn_blocking`/ `block_inplace` in the most CPU-consuming parts to improve Tokio's scheduling. This improved my tail latencies in a few cases, but hard to measure accurately. This comes at the cost of additional CPU use.
- The core inner loop of the operation execution is roughly:
```rust
let subgraph_requests = FuturesUnordered::new();
while let Some(...) = subgraph_requests.next().await {
   // ingest response
   // prepare next subgraph requests
}
```
The problem is that we're not awaiting the `subgraph_requests` while doing the ingestion/preparation so it's not moved forward by Tokio. I've changed that so they're executed simultaneously