### PR TITLE
fix: add rate limit span if using redis

### DIFF
--- a/engine/crates/engine-v2/src/engine/execute/prepare.rs
+++ b/engine/crates/engine-v2/src/engine/execute/prepare.rs
@@ -2,6 +2,7 @@ use ::runtime::operation_cache::OperationCache;
 use futures::FutureExt;
 use runtime::hooks::Hooks;
 use std::sync::Arc;
+use tracing::{info_span, Instrument};
 
 use crate::{
     engine::{errors, trusted_documents::OperationDocument},
@@ -13,12 +14,12 @@ use crate::{
 };
 
 impl<'ctx, R: Runtime> PreExecutionContext<'ctx, R> {
-    #[tracing::instrument(skip_all)]
     pub(super) async fn prepare_operation(
         &mut self,
         request: Request,
     ) -> Result<ExecutableOperation, Response<<R::Hooks as Hooks>::OnOperationResponseOutput>> {
-        let result = self.prepare_operation_inner(request).await;
+        let span = info_span!("prepare operation");
+        let result = self.prepare_operation_inner(request).instrument(span).await;
         let duration = self.executed_operation_builder.track_prepare();
 
         match result {

--- a/engine/crates/engine-v2/src/sources/graphql/context.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/context.rs
@@ -105,10 +105,6 @@ impl<'ctx, R: Runtime> SubgraphContext<'ctx, R> {
         self.retry_budget
     }
 
-    pub fn send_count(&self) -> Option<usize> {
-        self.send_count.checked_sub(1)
-    }
-
     pub async fn finalize(
         self,
         subgraph_result: ExecutionResult<SubgraphResponse>,

--- a/engine/crates/engine-v2/src/sources/graphql/request/execute.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/request/execute.rs
@@ -14,7 +14,7 @@ use runtime::{
     rate_limiting::RateLimitKey,
 };
 use tower::retry::budget::Budget;
-use tracing::Instrument;
+use tracing::{Instrument, Span};
 use web_time::Duration;
 
 use crate::{
@@ -39,47 +39,48 @@ pub(crate) async fn execute_subgraph_request<'ctx, 'a, R: Runtime>(
 ) -> ExecutionResult<SubgraphResponse> {
     let endpoint = ctx.endpoint();
 
-    let http_span = SubgraphHttpRequestSpan::new(endpoint.url(), &http::Method::POST);
+    let mut headers = ctx
+        .hooks()
+        .on_subgraph_request(endpoint.subgraph_name(), http::Method::POST, endpoint.url(), headers)
+        .await
+        .inspect_err(|_| {
+            ctx.set_as_hook_error();
+            ctx.push_request_execution(SubgraphRequestExecutionKind::HookError);
+        })?;
 
-    let request = {
-        let mut headers = ctx
-            .hooks()
-            .on_subgraph_request(endpoint.subgraph_name(), http::Method::POST, endpoint.url(), headers)
-            .await
-            .inspect_err(|_| {
-                ctx.set_as_hook_error();
-                ctx.push_request_execution(SubgraphRequestExecutionKind::HookError);
-            })?;
+    headers.typed_insert(headers::ContentType::json());
+    headers.typed_insert(headers::ContentLength(body.len() as u64));
+    headers.insert(
+        http::header::ACCEPT,
+        http::HeaderValue::from_static(
+            "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8",
+        ),
+    );
 
-        headers.typed_insert(headers::ContentType::json());
-        headers.typed_insert(headers::ContentLength(body.len() as u64));
-        headers.insert(
-            http::header::ACCEPT,
-            http::HeaderValue::from_static(
-                "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8",
-            ),
-        );
-
-        grafbase_telemetry::otel::opentelemetry::global::get_text_map_propagator(|propagator| {
-            let context = http_span.context();
-
-            propagator.inject_context(&context, &mut grafbase_telemetry::http::HeaderInjector(&mut headers));
-        });
-
-        FetchRequest {
-            url: Cow::Borrowed(endpoint.url()),
-            headers,
-            method: http::Method::POST,
-            body,
-            timeout: endpoint.config.timeout,
-        }
+    let request = FetchRequest {
+        url: Cow::Borrowed(endpoint.url()),
+        headers,
+        method: http::Method::POST,
+        body,
+        timeout: endpoint.config.timeout,
     };
 
     ctx.record_request_size(&request);
 
     let fetcher = ctx.engine.runtime.fetcher();
     let fetch_result = retrying_fetch(ctx, || async {
-        let (fetch_result, info) = fetcher.fetch(request.clone()).instrument(http_span.span()).await;
+        let http_span = SubgraphHttpRequestSpan::new(endpoint.url(), &http::Method::POST);
+        let mut request = request.clone();
+
+        grafbase_telemetry::otel::opentelemetry::global::get_text_map_propagator(|propagator| {
+            let context = http_span.context();
+            propagator.inject_context(
+                &context,
+                &mut grafbase_telemetry::http::HeaderInjector(&mut request.headers),
+            );
+        });
+
+        let (fetch_result, info) = fetcher.fetch(request).instrument(http_span.span()).await;
 
         let fetch_result = fetch_result.and_then(|response| {
             tracing::debug!("Received response:\n{}", String::from_utf8_lossy(response.body()));
@@ -93,22 +94,25 @@ pub(crate) async fn execute_subgraph_request<'ctx, 'a, R: Runtime>(
             }
         });
 
+        match fetch_result {
+            Ok(ref response) => {
+                http_span.record_http_status_code(response.status());
+            }
+            Err(ref err) => {
+                http_span.set_as_http_error(err.as_invalid_status_code());
+            }
+        };
+
         (fetch_result, info)
     })
     .await;
 
-    if let Some(count) = ctx.send_count() {
-        http_span.record_resend_count(count);
-    }
-
     let response = match fetch_result {
         Ok(response) => {
-            http_span.record_http_status_code(response.status());
             ctx.record_http_response(&response);
             response
         }
         Err(err) => {
-            http_span.set_as_http_error(err.as_fetch_invalid_status_code());
             ctx.set_as_http_error(err.as_fetch_invalid_status_code());
             return Err(err);
         }
@@ -150,7 +154,7 @@ where
     F: Future<Output = (FetchResult<T>, Option<ResponseInfo>)> + Send,
     T: Send,
 {
-    let mut fetch_result = rate_limited_fetch(ctx, &fetch).await;
+    let mut fetch_result = rate_limited_fetch(ctx, &fetch).instrument(Span::current()).await;
 
     if ctx.retry_budget().is_none() {
         return fetch_result;

--- a/engine/crates/runtime/src/fetch.rs
+++ b/engine/crates/runtime/src/fetch.rs
@@ -5,7 +5,7 @@ use futures_util::{stream::BoxStream, Stream, StreamExt, TryFutureExt};
 
 use crate::{bytes::OwnedOrSharedBytes, hooks::ResponseInfo};
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Clone, Debug, thiserror::Error)]
 pub enum FetchError {
     #[error("{0}")]
     AnyError(String),


### PR DESCRIPTION
This was a bit trickier. So my first try was to just add the span if we define a global or subgraph limit, but the result was not quite right:

![image](https://github.com/user-attachments/assets/76e26772-0d95-44f1-ad43-bc04d1757c1e)

As we can see, in the subgraph, we have the rate limit span, but the request was never sent because we hit the rate limit. We still have the span `POST /graphql`, which was never actually requested.

Eventually the right fix to do is to create one `POST /graphql` span per HTTP request. First thing is that we create the span _only_ when we call the subgraph. This means if we retry, we will have more `POST /graphql` spans per retry. This makes the propagated spans from the subgraphs look nicer, because we can track which HTTP request triggered which span.

The result of the rate limited trace looks pretty nice after this PR:

![image](https://github.com/user-attachments/assets/930ca945-cefd-4550-b3f4-6fb715b8e217)

And this is how a successful trace looks like:

![image](https://github.com/user-attachments/assets/73f01264-646e-4e77-ac11-514dc4862043)

Additionally, to be consistent, I renamed the `prepare_operation` span as `prepare operation`.