### PR TITLE
Fix rendering of object literals in render_federated_sdl()

### DIFF
--- a/engine/crates/composition/CHANGELOG.md
+++ b/engine/crates/composition/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed the ingestion of numeric literals when creating a federated graph from a string.
 - Fixed the ingestion of `null` literals.
 - In federated_graph, when parsing a schema with `@join__type` and no key argument, then rendering it with `render_federated_sdl()` would produce a `@join__type` directive
+- Fix rendering of object literals in render_federated_sdl(). We were erroneously quoting the keys, like in a JSON object, that is {"a": true} instead of the correct GraphQL literal {a: true}. (https://github.com/grafbase/grafbase/pull/2247)
 
 ## 0.4.0 - 2024-06-11
 

--- a/engine/crates/composition/tests/composition/authorized_basic/federated.graphql
+++ b/engine/crates/composition/tests/composition/authorized_basic/federated.graphql
@@ -25,7 +25,7 @@ enum join__Graph {
 }
 
 type User {
-    accounts: [Account!]! @join__field(graph: BANK_ACCOUNT) @authorized(fields: "userId name", metadata: "{\"stuff\": true}")
+    accounts: [Account!]! @join__field(graph: BANK_ACCOUNT) @authorized(fields: "userId name", metadata: {stuff: true})
     email: String! @join__field(graph: BANK_ACCOUNT)
     name: String! @join__field(graph: BANK_ACCOUNT)
     userId: ID! @join__field(graph: BANK_ACCOUNT)
@@ -49,7 +49,7 @@ type Query {
 }
 
 type Mutation {
-    createAccount(userId: ID!, type: AccountType!, initialBalance: Float!, input: CreateAccountInput, included: Boolean, notIncluded: String): Account @join__field(graph: BANK_ACCOUNT) @authorized(arguments: "input { userId nested { name } } included", metadata: ["a", "b", "c", ])
+    createAccount(userId: ID!, type: AccountType!, initialBalance: Float!, input: CreateAccountInput, included: Boolean, notIncluded: String): Account @join__field(graph: BANK_ACCOUNT) @authorized(arguments: "input { userId nested { name } } included", metadata: ["a", "b", "c", {d: E}, ])
     createTransaction(amount: Float!, description: String, accountId: ID!): Transaction! @join__field(graph: BANK_ACCOUNT)
     createUser(name: String!, email: String!): User! @join__field(graph: BANK_ACCOUNT)
     deleteAccount(id: ID!): Account! @join__field(graph: BANK_ACCOUNT)

--- a/engine/crates/composition/tests/composition/authorized_basic/subgraphs/bank_account.graphql
+++ b/engine/crates/composition/tests/composition/authorized_basic/subgraphs/bank_account.graphql
@@ -7,7 +7,7 @@ type User {
   userId: ID!
   name: String!
   email: String!
-  accounts: [Account!]! @authorized(fields: "userId name", metadata: "{\"stuff\": true}")
+  accounts: [Account!]! @authorized(fields: "userId name", metadata: { stuff: true })
 }
 
 type Account @authorized(fields: "user { userId }") {
@@ -46,7 +46,7 @@ type Mutation {
   deleteAccount(id: ID!): Account!
   deleteTransaction(id: ID!): Transaction!
   createAccount(input: CreateAccountInput, included: Boolean, notIncluded: String): Account
-    @authorized(arguments: "input { userId nested { name } } included", metadata: ["a", "b", "c"])
+    @authorized(arguments: "input { userId nested { name } } included", metadata: ["a", "b", "c", { d: E }])
 }
 
 input CreateAccountInput {

--- a/engine/crates/federated-graph/src/render_sdl/display_utils.rs
+++ b/engine/crates/federated-graph/src/render_sdl/display_utils.rs
@@ -101,7 +101,7 @@ impl fmt::Display for ValueDisplay<'_> {
 
                 f.write_char('{')?;
                 while let Some((key, value)) = key_values.next() {
-                    write_quoted(f, &graph[*key])?;
+                    f.write_str(graph.str(*key))?;
                     f.write_str(": ")?;
                     ValueDisplay(value, graph).fmt(f)?;
                     if key_values.peek().is_some() {


### PR DESCRIPTION
We were erroneously quoting the keys, like in a JSON object, that is `{"a": true}` instead of the correct GraphQL literal `{a: true}`.

closes GB-7797
