### PR TITLE
graphql-federated-graph: handle us producing bad SDL without panicking

### DIFF
--- a/engine/crates/composition/src/lib.rs
+++ b/engine/crates/composition/src/lib.rs
@@ -14,7 +14,7 @@ mod subgraphs;
 mod validate;
 
 pub use self::{diagnostics::Diagnostics, result::CompositionResult, subgraphs::Subgraphs};
-pub use graphql_federated_graph::{render_api_sdl, render_federated_sdl, VersionedFederatedGraph};
+pub use graphql_federated_graph::{render_api_sdl, render_federated_sdl, FederatedGraph, VersionedFederatedGraph};
 
 use self::{
     compose::{compose_subgraphs, ComposeContext},

--- a/engine/crates/composition/tests/composition_tests.rs
+++ b/engine/crates/composition/tests/composition_tests.rs
@@ -47,9 +47,9 @@ fn run_test(federated_graph_path: &Path) -> datatest_stable::Result<()> {
         .ok();
     let (actual_federated_sdl, actual_api_sdl) = match graphql_composition::compose(&subgraphs).into_result() {
         Ok(federated_graph) => {
-            let federated_graph = federated_graph.into_latest();
+            let federated_graph = federated_graph.into_latest().expect("federated graph into_latest()");
             (
-                graphql_federated_graph::render_federated_sdl(&federated_graph).unwrap(),
+                graphql_federated_graph::render_federated_sdl(&federated_graph).expect("rendering federated SDL"),
                 Some(graphql_federated_graph::render_api_sdl(&federated_graph)),
             )
         }

--- a/engine/crates/engine-v2/config/src/lib.rs
+++ b/engine/crates/engine-v2/config/src/lib.rs
@@ -165,7 +165,9 @@ impl VersionedConfig {
                 entity_caching,
                 retry,
             }) => v6::Config {
-                graph: federated_graph::VersionedFederatedGraph::V3(graph).into_latest(),
+                graph: federated_graph::VersionedFederatedGraph::V3(graph)
+                    .into_latest()
+                    .expect("Failed to upgrade federated graph v3"),
                 strings,
                 paths,
                 header_rules,

--- a/engine/crates/federated-graph/src/federated_graph/v1.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v1.rs
@@ -1231,7 +1231,7 @@ mod tests {
         )
         .unwrap();
 
-        let schema = schema.into_latest();
+        let schema = schema.into_latest().unwrap();
         let query_object = &schema[schema.root_operation_types.query];
 
         for field_name in ["__type", "__schema"] {

--- a/engine/crates/federated-graph/src/federated_graph/v4.rs
+++ b/engine/crates/federated-graph/src/federated_graph/v4.rs
@@ -52,6 +52,12 @@ pub struct FederatedGraph {
 }
 
 impl FederatedGraph {
+    /// Instantiate a [FederatedGraph] from a federated schema string.
+    #[cfg(feature = "from_sdl")]
+    pub fn from_sdl(sdl: &str) -> Result<Self, crate::DomainError> {
+        crate::from_sdl(sdl)
+    }
+
     pub fn definition_name(&self, definition: Definition) -> &str {
         let name_id = match definition {
             Definition::Scalar(scalar_id) => self[scalar_id].name,

--- a/engine/crates/federated-graph/src/lib.rs
+++ b/engine/crates/federated-graph/src/lib.rs
@@ -29,19 +29,19 @@ impl VersionedFederatedGraph {
         Ok(VersionedFederatedGraph::Sdl(sdl.to_owned()))
     }
 
-    pub fn into_federated_sdl(self) -> String {
-        match self {
+    pub fn into_federated_sdl(self) -> Result<String, DomainError> {
+        Ok(match self {
             VersionedFederatedGraph::Sdl(sdl) => sdl,
-            other => render_federated_sdl(&other.into_latest()).unwrap(),
-        }
+            other => render_federated_sdl(&other.into_latest()?).unwrap(),
+        })
     }
 
-    pub fn into_latest(self) -> FederatedGraph {
-        match self {
-            VersionedFederatedGraph::V1(v1) => VersionedFederatedGraph::V2(FederatedGraphV2::from(v1)).into_latest(),
-            VersionedFederatedGraph::V2(v2) => VersionedFederatedGraph::V3(FederatedGraphV3::from(v2)).into_latest(),
+    pub fn into_latest(self) -> Result<FederatedGraph, DomainError> {
+        Ok(match self {
+            VersionedFederatedGraph::V1(v1) => VersionedFederatedGraph::V2(FederatedGraphV2::from(v1)).into_latest()?,
+            VersionedFederatedGraph::V2(v2) => VersionedFederatedGraph::V3(FederatedGraphV3::from(v2)).into_latest()?,
             VersionedFederatedGraph::V3(v3) => v3.into(),
-            VersionedFederatedGraph::Sdl(sdl) => from_sdl(&sdl).unwrap(),
-        }
+            VersionedFederatedGraph::Sdl(sdl) => from_sdl(&sdl)?,
+        })
     }
 }

--- a/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
+++ b/engine/crates/federated-graph/src/render_sdl/render_federated_sdl.rs
@@ -623,7 +623,7 @@ mod tests {
             crate::render_sdl::render_federated_sdl(&FederatedGraph::default()).unwrap(),
         );
 
-        let actual = render_federated_sdl(&empty.into_latest()).expect("valid");
+        let actual = render_federated_sdl(&empty.into_latest().unwrap()).expect("valid");
         let expected = expect![[r#"
             directive @core(feature: String!) repeatable on SCHEMA
 

--- a/engine/crates/federation-audit-tests/tests/composition_comparisons.rs
+++ b/engine/crates/federation-audit-tests/tests/composition_comparisons.rs
@@ -37,7 +37,8 @@ fn runner_for(suite: String) -> impl FnOnce() -> Result<(), Failed> + Send + 'st
         let output = graphql_composition::compose(&subgraphs)
             .into_result()
             .unwrap()
-            .into_federated_sdl();
+            .into_federated_sdl()
+            .expect("graph.into_latest()");
 
         let output = prettify_sdl(&output);
         let expected = prettify_sdl(&expected_supergraph_sdl);

--- a/engine/crates/integration-tests/src/federation/builder/engine.rs
+++ b/engine/crates/integration-tests/src/federation/builder/engine.rs
@@ -44,7 +44,7 @@ pub(super) async fn build(
 
     // Ensure SDL/JSON serialization work as a expected
     let graph = {
-        let sdl = graph.into_federated_sdl();
+        let sdl = graph.into_federated_sdl().expect("from_sdl()");
         println!("{sdl}");
         let mut graph = VersionedFederatedGraph::from_sdl(&sdl).unwrap();
         let json = serde_json::to_value(&graph).unwrap();
@@ -63,12 +63,12 @@ pub(super) async fn build(
             let config: gateway_config::Config = toml::from_str(&toml).unwrap();
 
             update_runtime_with_toml_config(&mut runtime, &config, access_log_sender);
-            build_with_toml_config(&config, graph.into_latest())
+            build_with_toml_config(&config, graph.into_latest().expect("Graph into latest"))
         }
         Some(ConfigSource::Sdl(mut sdl)) => {
             sdl.push_str("\nextend schema @graph(type: federated)");
             let config = parse_sdl_config(&sdl).await;
-            build_with_sdl_config(&config, graph.into_latest())
+            build_with_sdl_config(&config, graph.into_latest().expect("graph into latest"))
         }
         Some(ConfigSource::SdlWebsocket) => {
             let mut sdl = String::new();
@@ -82,9 +82,9 @@ pub(super) async fn build(
             }
 
             let config = parse_sdl_config(&sdl).await;
-            build_with_sdl_config(&config, graph.into_latest())
+            build_with_sdl_config(&config, graph.into_latest().expect("graph.into_latest()"))
         }
-        None => build_with_sdl_config(&Default::default(), graph.into_latest()),
+        None => build_with_sdl_config(&Default::default(), graph.into_latest().expect("graph.into_latest()")),
     }
     .into_latest();
 

--- a/gateway/crates/federated-server/src/server/gateway.rs
+++ b/gateway/crates/federated-server/src/server/gateway.rs
@@ -1,7 +1,7 @@
 use super::GdnResponse;
 use engine_v2::{Engine, SchemaVersion};
 use gateway_config::Config;
-use graphql_composition::VersionedFederatedGraph;
+use graphql_composition::FederatedGraph;
 use runtime::trusted_documents_client::Client;
 use runtime_local::HooksWasi;
 use std::{path::PathBuf, sync::Arc};
@@ -62,10 +62,10 @@ pub(super) async fn generate(
     };
 
     let config = {
-        let graph = VersionedFederatedGraph::from_sdl(&federated_sdl)
-            .map_err(|e| crate::Error::SchemaValidationError(e.to_string()))?;
+        let graph =
+            FederatedGraph::from_sdl(&federated_sdl).map_err(|e| crate::Error::SchemaValidationError(e.to_string()))?;
 
-        engine_config_builder::build_with_toml_config(gateway_config, graph.into_latest()).into_latest()
+        engine_config_builder::build_with_toml_config(gateway_config, graph).into_latest()
     };
 
     let mut runtime = GatewayRuntime::build(gateway_config, hot_reload_config_path, &config, version_id, hooks).await?;

--- a/gateway/crates/gateway-binary/tests/entity_caching/mod.rs
+++ b/gateway/crates/gateway-binary/tests/entity_caching/mod.rs
@@ -67,6 +67,7 @@ where
             .into_result()
             .unwrap()
             .into_federated_sdl()
+            .expect("graph.into_latest()")
     };
 
     crate::GatewayBuilder {

--- a/gateway/crates/gateway-binary/tests/telemetry/tracing.rs
+++ b/gateway/crates/gateway-binary/tests/telemetry/tracing.rs
@@ -395,6 +395,7 @@ where
             .into_result()
             .unwrap()
             .into_federated_sdl()
+            .expect("graph.into_latest()")
     };
 
     crate::GatewayBuilder {


### PR DESCRIPTION
When composition produces a FederatedGraph, and a rendering error in graphql-federated-graph produces bad SDL, that SDL gets parsed and the result unwrapped in `VersionedFederatedGraph::into_latest()`.

This makes `into_latest()` return a `Result`, and introduces `FederatedGraph::from_sdl()` for convenience. Errors are handled everywhere outside of tests now.

closes GB-7796
