### PR TITLE
feat: add gateway config for message signatures

### DIFF
--- a/gateway/crates/config/src/lib.rs
+++ b/gateway/crates/config/src/lib.rs
@@ -6,6 +6,7 @@ pub mod entity_caching;
 pub mod header;
 pub mod health;
 pub mod hooks;
+pub mod message_signatures;
 pub mod rate_limit;
 mod size_ext;
 pub mod telemetry;
@@ -19,6 +20,7 @@ pub use entity_caching::*;
 pub use header::*;
 pub use health::*;
 pub use hooks::*;
+pub use message_signatures::MessageSignaturesConfig;
 pub use rate_limit::*;
 use serde_dynamic_string::DynamicString;
 use size::Size;
@@ -114,6 +116,8 @@ pub struct GatewayConfig {
     pub access_logs: AccessLogsConfig,
     /// Query batching configuration
     pub batching: BatchingConfig,
+    /// Global message signatures config
+    pub message_signatures: MessageSignaturesConfig,
 }
 
 #[derive(Debug, Default, serde::Deserialize, Clone, Copy)]
@@ -180,6 +184,8 @@ pub struct SubgraphConfig {
     /// Subgraph specific entity caching config  this overrides the global config if there
     /// is any
     pub entity_caching: Option<EntityCachingConfig>,
+    /// Subgraph specific message signatures config
+    pub message_signatures: MessageSignaturesConfig,
 }
 
 #[derive(Debug, serde::Deserialize, Clone, Copy, Default, PartialEq)]
@@ -1399,7 +1405,7 @@ mod tests {
 
         let result: Config = toml::from_str(input).unwrap();
 
-        insta::assert_debug_snapshot!(&result.subgraphs, @r#"
+        insta::assert_debug_snapshot!(&result.subgraphs, @r###"
         {
             "products": SubgraphConfig {
                 url: None,
@@ -1421,9 +1427,21 @@ mod tests {
                 timeout: None,
                 retry: None,
                 entity_caching: None,
+                message_signatures: MessageSignaturesConfig {
+                    enabled: None,
+                    algorithm: None,
+                    key: None,
+                    expiry: None,
+                    headers: MessageSigningHeaders {
+                        include: [],
+                        exclude: [],
+                    },
+                    derived_components: [],
+                    signature_parameters: [],
+                },
             },
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -1471,7 +1489,7 @@ mod tests {
 
         let config: Config = toml::from_str(input).unwrap();
 
-        insta::assert_debug_snapshot!(&config.gateway, @r#"
+        insta::assert_debug_snapshot!(&config.gateway, @r###"
         GatewayConfig {
             timeout: Some(
                 1s,
@@ -1497,8 +1515,20 @@ mod tests {
                 enabled: false,
                 limit: None,
             },
+            message_signatures: MessageSignaturesConfig {
+                enabled: None,
+                algorithm: None,
+                key: None,
+                expiry: None,
+                headers: MessageSigningHeaders {
+                    include: [],
+                    exclude: [],
+                },
+                derived_components: [],
+                signature_parameters: [],
+            },
         }
-        "#);
+        "###);
     }
 
     #[test]
@@ -1849,7 +1879,7 @@ mod tests {
 
         let config: Config = toml::from_str(input).unwrap();
 
-        insta::assert_debug_snapshot!(&config.subgraphs, @r#"
+        insta::assert_debug_snapshot!(&config.subgraphs, @r###"
         {
             "products": SubgraphConfig {
                 url: None,
@@ -1867,9 +1897,21 @@ mod tests {
                     },
                 ),
                 entity_caching: None,
+                message_signatures: MessageSignaturesConfig {
+                    enabled: None,
+                    algorithm: None,
+                    key: None,
+                    expiry: None,
+                    headers: MessageSigningHeaders {
+                        include: [],
+                        exclude: [],
+                    },
+                    derived_components: [],
+                    signature_parameters: [],
+                },
             },
         }
-        "#);
+        "###);
     }
 
     #[test]

--- a/gateway/crates/config/src/message_signatures.rs
+++ b/gateway/crates/config/src/message_signatures.rs
@@ -59,6 +59,9 @@ impl<'de> serde::Deserialize<'de> for MessageSigningKey {
     }
 }
 
+/// Which of the derived components to include in the signature:
+///
+/// https://www.rfc-editor.org/rfc/rfc9421.html#name-derived-components
 #[derive(Debug, Clone, PartialEq, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DerivedComponent {
@@ -70,6 +73,7 @@ pub enum DerivedComponent {
     Path,
 }
 
+/// Which headers to include/exclude in the signature
 #[derive(Debug, Default, Clone, PartialEq, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct MessageSigningHeaders {
@@ -77,6 +81,9 @@ pub struct MessageSigningHeaders {
     pub exclude: Vec<String>,
 }
 
+/// Which of the signature parameters to include in the signature
+///
+/// https://www.rfc-editor.org/rfc/rfc9421.html#name-signature-parameters
 #[derive(Debug, Clone, PartialEq, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SignatureParameter {

--- a/gateway/crates/config/src/message_signatures.rs
+++ b/gateway/crates/config/src/message_signatures.rs
@@ -1,0 +1,268 @@
+use serde::de::Error;
+use std::time::Duration;
+
+#[derive(Debug, Default, serde::Deserialize, Clone, PartialEq)]
+#[serde(default, deny_unknown_fields)]
+pub struct MessageSignaturesConfig {
+    pub enabled: Option<bool>,
+    pub algorithm: Option<MessageSigningAlgorithm>,
+    pub key: Option<MessageSigningKey>,
+
+    #[serde(deserialize_with = "duration_str::deserialize_option_duration")]
+    pub expiry: Option<Duration>,
+
+    pub headers: MessageSigningHeaders,
+    #[serde(default = "defaults::derived_components")]
+    pub derived_components: Vec<DerivedComponent>,
+    #[serde(default = "defaults::signature_parameters")]
+    pub signature_parameters: Vec<SignatureParameter>,
+}
+
+#[derive(Debug, serde::Deserialize, Clone, PartialEq)]
+pub enum MessageSigningAlgorithm {
+    HmacSha256,
+    Ed25519,
+    EcdsaP256,
+    EcdsaP384,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MessageSigningKey {
+    File { name: String, id: Option<String> },
+    Inline { contents: String, id: Option<String> },
+}
+
+impl<'de> serde::Deserialize<'de> for MessageSigningKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct RawStruct {
+            file: Option<String>,
+            inline: Option<String>,
+            id: Option<String>,
+        }
+        let RawStruct { file, inline, id } = RawStruct::deserialize(deserializer)?;
+
+        match (file, inline) {
+            (None, None) => Err(D::Error::custom(
+                "one of raw or file must be provided in the message signing key",
+            )),
+            (Some(_), Some(_)) => Err(D::Error::custom(
+                "raw and file may not both be provided in a message signing key",
+            )),
+            (Some(name), None) => Ok(MessageSigningKey::File { name, id }),
+            (None, Some(contents)) => Ok(MessageSigningKey::Inline { contents, id }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DerivedComponent {
+    Method,
+    TargetUri,
+    Authority,
+    Scheme,
+    RequestTarget,
+    Path,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct MessageSigningHeaders {
+    pub include: Vec<String>,
+    pub exclude: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SignatureParameter {
+    Created,
+    #[serde(rename = "alg")]
+    Algorithm,
+    #[serde(rename = "kid")]
+    KeyId,
+    Nonce,
+}
+
+mod defaults {
+    use super::{DerivedComponent, SignatureParameter};
+
+    pub fn derived_components() -> Vec<DerivedComponent> {
+        vec![DerivedComponent::RequestTarget]
+    }
+
+    pub fn signature_parameters() -> Vec<SignatureParameter> {
+        vec![SignatureParameter::Created, SignatureParameter::Algorithm]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indoc::indoc;
+
+    #[test]
+    fn test_default_message_signatures_config() {
+        let config = toml::from_str::<MessageSignaturesConfig>("").unwrap();
+
+        insta::assert_debug_snapshot!(&config, @r###"
+        MessageSignaturesConfig {
+            enabled: None,
+            algorithm: None,
+            key: None,
+            expiry: None,
+            headers: MessageSigningHeaders {
+                include: [],
+                exclude: [],
+            },
+            derived_components: [
+                RequestTarget,
+            ],
+            signature_parameters: [
+                Created,
+                Algorithm,
+            ],
+        }
+        "###);
+    }
+
+    #[test]
+    fn test_valid_message_signatures_config() {
+        let config = indoc! {r#"
+            enabled = true
+            algorithm = "EcdsaP256"
+            key.file = "key.file"
+            key.id = "hello"
+            expiry = "1s"
+            headers.include = ["my-fave-header"]
+            headers.exclude = ["authorization"]
+            derived_components = ["request_target", "path"]
+            signature_parameters = ["created"]
+        "#};
+
+        let config = toml::from_str::<MessageSignaturesConfig>(config).unwrap();
+
+        insta::assert_debug_snapshot!(&config, @r###"
+        MessageSignaturesConfig {
+            enabled: Some(
+                true,
+            ),
+            algorithm: Some(
+                EcdsaP256,
+            ),
+            key: Some(
+                File {
+                    name: "key.file",
+                    id: Some(
+                        "hello",
+                    ),
+                },
+            ),
+            expiry: Some(
+                1s,
+            ),
+            headers: MessageSigningHeaders {
+                include: [
+                    "my-fave-header",
+                ],
+                exclude: [
+                    "authorization",
+                ],
+            },
+            derived_components: [
+                RequestTarget,
+                Path,
+            ],
+            signature_parameters: [
+                Created,
+            ],
+        }
+        "###);
+    }
+
+    #[test]
+    fn test_inline_key() {
+        let config = indoc! {r#"
+            key.file = "super-secret-key"
+            key.id = "hello"
+        "#};
+
+        let config = toml::from_str::<MessageSignaturesConfig>(config).unwrap();
+
+        insta::assert_debug_snapshot!(config.key, @r###"
+        Some(
+            File {
+                name: "super-secret-key",
+                id: Some(
+                    "hello",
+                ),
+            },
+        )
+        "###);
+    }
+
+    #[test]
+    fn test_inline_and_file_key() {
+        let config = indoc! {r#"
+            key.file = "super-secret-key"
+            key.inline = "hello"
+        "#};
+
+        let result = toml::from_str::<MessageSignaturesConfig>(config);
+
+        insta::assert_debug_snapshot!(result, @r###"
+        Err(
+            Error {
+                inner: Error {
+                    inner: TomlError {
+                        message: "raw and file may not both be provided in a message signing key",
+                        raw: Some(
+                            "key.file = \"super-secret-key\"\nkey.inline = \"hello\"\n",
+                        ),
+                        keys: [
+                            "key",
+                        ],
+                        span: Some(
+                            0..3,
+                        ),
+                    },
+                },
+            },
+        )
+        "###);
+    }
+
+    #[test]
+    fn test_empty_key() {
+        let config = indoc! {r#"
+            key = {}
+        "#};
+
+        let result = toml::from_str::<MessageSignaturesConfig>(config);
+
+        insta::assert_debug_snapshot!(result, @r###"
+        Err(
+            Error {
+                inner: Error {
+                    inner: TomlError {
+                        message: "one of raw or file must be provided in the message signing key",
+                        raw: Some(
+                            "key = {}\n",
+                        ),
+                        keys: [
+                            "key",
+                        ],
+                        span: Some(
+                            6..8,
+                        ),
+                    },
+                },
+            },
+        )
+        "###);
+    }
+}


### PR DESCRIPTION
Adds the config for message signatures as outlined in the RFC.  This doesn't do anything yet, I'll hook it up in a future PR.

Fixes GB-7772