### PR TITLE
composition: ignore `@composeDirective(name: "@authorized")`

### DIFF
--- a/engine/crates/composition/CHANGELOG.md
+++ b/engine/crates/composition/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed the ingestion of `null` literals.
 - In federated_graph, when parsing a schema with `@join__type` and no key argument, then rendering it with `render_federated_sdl()` would produce a `@join__type` directive
 - Fix rendering of object literals in render_federated_sdl(). We were erroneously quoting the keys, like in a JSON object, that is {"a": true} instead of the correct GraphQL literal {a: true}. (https://github.com/grafbase/grafbase/pull/2247)
+- Fixed double rendering of `@authorized` on fields in federated SDL when `@composeDirective(name: "@authorized")` is used. (https://github.com/grafbase/grafbase/pull/2251)
 
 ## 0.4.0 - 2024-06-11
 

--- a/engine/crates/composition/src/ingest_subgraph/directives.rs
+++ b/engine/crates/composition/src/ingest_subgraph/directives.rs
@@ -384,6 +384,13 @@ impl<'a> DirectiveMatcher<'a> {
     }
 
     pub(crate) fn is_composed_directive(&self, directive_name: &str) -> bool {
+        // The `@authorized` directive is an exception. Directives used in subgraph schemas are either built-in federation directives (`@requires`, `@key`, etc.) or custom, composed directives with `@composeDirective`. Since `@authorized` is not part of the federation spec, some frameworks like async-graphql (Rust) will produce an `@composeDirective` with the `@authorized` directive. We should not consider `@authorized` as a composed directive however, because that means we would emit it again.
+        //
+        // TODO: as for other imported composition directives, we should forbid their use in `@composeDirective`.
+        if directive_name == AUTHORIZED {
+            return false;
+        }
+
         self.composed_directives
             .contains(&directive_name.trim_start_matches('@'))
     }

--- a/engine/crates/composition/tests/composition/authorized_with_composeDirective/api.graphql
+++ b/engine/crates/composition/tests/composition/authorized_with_composeDirective/api.graphql
@@ -1,0 +1,24 @@
+type Pet {
+    age: String!
+    id: Int!
+    name: String!
+}
+
+type User {
+    address: Address
+    id: Int!
+    name: String!
+    pets: [Pet!]!
+}
+
+type Address {
+    street: String!
+}
+
+type Query {
+    pets: [Pet]!
+    user(id: Int!): User
+    users: [User]!
+}
+
+scalar _Any

--- a/engine/crates/composition/tests/composition/authorized_with_composeDirective/federated.graphql
+++ b/engine/crates/composition/tests/composition/authorized_with_composeDirective/federated.graphql
@@ -1,0 +1,56 @@
+directive @core(feature: String!) repeatable on SCHEMA
+
+directive @join__owner(graph: join__Graph!) on OBJECT
+
+directive @join__type(
+    graph: join__Graph!
+    key: String!
+    resolvable: Boolean = true
+) repeatable on OBJECT | INTERFACE
+
+directive @join__field(
+    graph: join__Graph
+    requires: String
+    provides: String
+) on FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+enum join__Graph {
+    PETS @join__graph(name: "pets", url: "http://example.com/pets")
+    USERS @join__graph(name: "users", url: "http://example.com/users")
+}
+
+scalar _Any
+
+type Pet
+    @join__type(graph: PETS, key: "id")
+{
+    age: String! @join__field(graph: PETS)
+    id: Int!
+    name: String! @join__field(graph: PETS)
+}
+
+type User
+    @join__type(graph: PETS, key: "id")
+    @join__type(graph: USERS, key: "id")
+{
+    address: Address @join__field(graph: USERS) @authorized(fields: "id")
+    id: Int!
+    name: String! @join__field(graph: USERS)
+    pets: [Pet!]! @join__field(graph: PETS)
+}
+
+type Address {
+    street: String! @join__field(graph: USERS)
+}
+
+type Query {
+    pets: [Pet]! @join__field(graph: PETS)
+    user(id: Int!): User @join__field(graph: USERS) @authorized(arguments: "id")
+    users: [User]! @join__field(graph: USERS) @authorized(node: "id", metadata: {role: "admin"})
+}

--- a/engine/crates/composition/tests/composition/authorized_with_composeDirective/subgraphs/pets.graphql
+++ b/engine/crates/composition/tests/composition/authorized_with_composeDirective/subgraphs/pets.graphql
@@ -1,0 +1,35 @@
+type Pet @key(fields: "id") {
+  id: Int!
+  name: String!
+  age: String!
+}
+
+type Query {
+  pets: [Pet]!
+}
+
+type User @key(fields: "id") {
+  id: Int!
+  pets: [Pet!]!
+}
+
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+extend schema
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.3"
+    import: [
+      "@key"
+      "@tag"
+      "@shareable"
+      "@inaccessible"
+      "@override"
+      "@external"
+      "@provides"
+      "@requires"
+      "@composeDirective"
+      "@interfaceObject"
+    ]
+  )

--- a/engine/crates/composition/tests/composition/authorized_with_composeDirective/subgraphs/users.graphql
+++ b/engine/crates/composition/tests/composition/authorized_with_composeDirective/subgraphs/users.graphql
@@ -1,0 +1,43 @@
+scalar _Any
+
+type Address {
+  street: String!
+}
+
+type Query {
+  users: [User]! @authorized(node: "id", metadata: { role: "admin" })
+  user(id: Int!): User @authorized(arguments: "id")
+}
+
+type User @key(fields: "id") {
+  id: Int!
+  name: String!
+  address: Address @authorized(fields: "id")
+}
+
+directive @authorized(arguments: String, fields: String, node: String, metadata: _Any) on FIELD_DEFINITION | OBJECT
+
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+extend schema
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.3"
+    import: [
+      "@key"
+      "@tag"
+      "@shareable"
+      "@inaccessible"
+      "@override"
+      "@external"
+      "@provides"
+      "@requires"
+      "@composeDirective"
+      "@interfaceObject"
+    ]
+  )
+
+extend schema
+  @link(url: "https://custom.spec.dev/extension/v1.0", import: ["@authorized"])
+  @composeDirective(name: "@authorized")


### PR DESCRIPTION
This fixes composed schemas with subgraphs schemas introspected from async-graphql having `@authorized` twice on fields.

The `@authorized` directive is a special case. Directives used in subgraph schemas are either built-in federation directives (`@requires`, `@key`, etc.) or custom, composed directives with `@composeDirective`. Since `@authorized` is not part of the federation spec, some frameworks like async-graphql (Rust) will produce an `@composeDirective` with the `@authorized` directive. We should not consider `@authorized` as a composed directive however, because that means we would emit it again.

closes GB-8706