### PR TITLE
chore(engine-v2): Add CompositeType for union/object/interface

### DIFF
--- a/engine/crates/engine-v2/codegen/domain/schema.graphql
+++ b/engine/crates/engine-v2/codegen/domain/schema.graphql
@@ -31,6 +31,12 @@ union EntityDefinition @id @meta(module: "entity") @variants(remove_suffix: "Def
   | ObjectDefinition
   | InterfaceDefinition
 
+"Composite type is the term previously used by the GraphQL spec to describe this union."
+union CompositeType @id @meta(module: "composite_type") @variants(remove_suffix: "Definition") =
+  | ObjectDefinition
+  | InterfaceDefinition
+  | UnionDefinition
+
 type JoinImplementsDefinition @meta(module: "join_implements") @copy {
   interface: InterfaceDefinition!
   subgraph: Subgraph!

--- a/engine/crates/engine-v2/codegen/src/domain/record.rs
+++ b/engine/crates/engine-v2/codegen/src/domain/record.rs
@@ -6,6 +6,7 @@ use super::{Definition, FieldMeta, Indexed, Meta};
 pub struct Object {
     pub meta: Meta,
     pub span: cynic_parser::Span,
+    pub description: Option<String>,
     pub indexed: Option<Indexed>,
     pub name: String,
     pub struct_name: String,

--- a/engine/crates/engine-v2/codegen/src/domain/union.rs
+++ b/engine/crates/engine-v2/codegen/src/domain/union.rs
@@ -5,6 +5,7 @@ pub struct Union {
     pub meta: Meta,
     pub kind: UnionKind,
     pub span: cynic_parser::Span,
+    pub description: Option<String>,
     pub variants: Vec<Variant>,
 }
 

--- a/engine/crates/engine-v2/codegen/src/generation/docstr.rs
+++ b/engine/crates/engine-v2/codegen/src/generation/docstr.rs
@@ -1,6 +1,13 @@
 use crate::domain::Domain;
+use std::fmt::Write;
 
-pub fn generated_from(domain: &Domain, span: cynic_parser::Span) -> String {
+pub fn generated_from(domain: &Domain, span: cynic_parser::Span, description: Option<&str>) -> String {
     let sdl = &domain.sdl[span.start..span.end];
-    format!("Generated from:\n\n```custom,{{.language-graphql}}\n{sdl}\n```")
+    let mut doc = String::new();
+    if let Some(description) = description {
+        doc.push_str(description);
+        doc.push_str("\n\n--------------\n");
+    }
+    write!(doc, "Generated from:\n\n```custom,{{.language-graphql}}\n{sdl}\n```").unwrap();
+    doc
 }

--- a/engine/crates/engine-v2/codegen/src/generation/object/struct_.rs
+++ b/engine/crates/engine-v2/codegen/src/generation/object/struct_.rs
@@ -35,7 +35,11 @@ pub fn generate_struct(
     };
 
     let struct_fields = fields.iter().map(StructField);
-    let docstr = proc_macro2::Literal::string(&docstr::generated_from(domain, object.span));
+    let docstr = proc_macro2::Literal::string(&docstr::generated_from(
+        domain,
+        object.span,
+        object.description.as_deref(),
+    ));
     let object_struct = quote! {
         #[doc = #docstr]
         #[derive(Debug, serde::Serialize, serde::Deserialize #additional_derives)]

--- a/engine/crates/engine-v2/codegen/src/generation/object/walker.rs
+++ b/engine/crates/engine-v2/codegen/src/generation/object/walker.rs
@@ -21,6 +21,14 @@ pub fn generate_walker(
     let struct_name = Ident::new(&object.struct_name, Span::call_site());
     let walker_name = Ident::new(object.walker_name(), Span::call_site());
     let walk_trait = Ident::new(WALKER_TRAIT, Span::call_site());
+    let doc = object
+        .description
+        .as_ref()
+        .map(|desc| {
+            let desc = proc_macro2::Literal::string(desc);
+            quote! { #[doc = #desc] }
+        })
+        .unwrap_or_default();
 
     let walker_field_methods = fields.iter().filter(|field| field.has_walker).map(WalkerFieldMethod);
     let mut code_sections = Vec::new();
@@ -29,6 +37,7 @@ pub fn generate_walker(
         let id_struct_name = Ident::new(&indexed.id_struct_name, Span::call_site());
 
         code_sections.push(quote! {
+            #doc
             #[derive(Clone, Copy)]
             pub struct #walker_name<'a> {
                 pub(crate) #graph_name: &'a #graph_type,
@@ -73,6 +82,7 @@ pub fn generate_walker(
         });
     } else if object.copy {
         code_sections.push(quote! {
+            #doc
             #[derive(Clone, Copy)]
             pub struct #walker_name<'a> {
                 pub(crate) #graph_name: &'a #graph_type,
@@ -113,6 +123,7 @@ pub fn generate_walker(
         });
     } else {
         code_sections.push(quote! {
+            #doc
             #[derive(Clone, Copy)]
             pub struct #walker_name<'a> {
                 pub(crate) #graph_name: &'a #graph_type,

--- a/engine/crates/engine-v2/codegen/src/generation/union/enum_.rs
+++ b/engine/crates/engine-v2/codegen/src/generation/union/enum_.rs
@@ -33,7 +33,11 @@ pub fn generate_enum(
         derives
     };
 
-    let docstr = proc_macro2::Literal::string(&docstr::generated_from(domain, union.span));
+    let docstr = proc_macro2::Literal::string(&docstr::generated_from(
+        domain,
+        union.span,
+        union.description.as_deref(),
+    ));
     let enum_variants = variants.iter().copied().map(EnumVariant);
     let union_enum = quote! {
         #[doc = #docstr]

--- a/engine/crates/engine-v2/codegen/src/generation/union/walker.rs
+++ b/engine/crates/engine-v2/codegen/src/generation/union/walker.rs
@@ -20,11 +20,20 @@ pub fn generate_walker(
     let graph_type = Ident::new(&domain.graph_type_name, Span::call_site());
     let walker_enum_name = Ident::new(union.walker_enum_name(), Span::call_site());
     let walk_trait = Ident::new(WALKER_TRAIT, Span::call_site());
+    let doc = union
+        .description
+        .as_ref()
+        .map(|desc| {
+            let desc = proc_macro2::Literal::string(desc);
+            quote! { #[doc = #desc] }
+        })
+        .unwrap_or_default();
 
     let mut code_sections = Vec::new();
 
     let walker_variants = variants.iter().copied().map(WalkerVariant);
     code_sections.push(quote! {
+        #doc
         #[derive(Clone, Copy)]
         pub enum #walker_enum_name<'a> {
             #(#walker_variants),*

--- a/engine/crates/engine-v2/codegen/src/loader.rs
+++ b/engine/crates/engine-v2/codegen/src/loader.rs
@@ -73,6 +73,7 @@ pub(super) fn load(path: PathBuf) -> anyhow::Result<domain::Domain> {
                 meta: parse_meta(object.directives()).unwrap_or_default(),
                 indexed: parse_indexed(object.name(), object.directives()),
                 span: object.span(),
+                description: object.description().map(|s| s.to_string()),
                 name: object.name().to_string(),
                 struct_name: format!("{}Record", object.name()),
                 copy: is_copy(object.directives()),
@@ -94,6 +95,7 @@ pub(super) fn load(path: PathBuf) -> anyhow::Result<domain::Domain> {
             TypeDefinition::Union(union) => domain::Union {
                 meta: parse_meta(union.directives()).unwrap_or_default(),
                 span: union.span(),
+                description: union.description().map(|s| s.to_string()),
                 kind: parse_union_kind(union.name(), union.directives()),
                 variants: {
                     let variant = parse_variants(union.directives()).unwrap_or_default();

--- a/engine/crates/engine-v2/schema/src/composite_type.rs
+++ b/engine/crates/engine-v2/schema/src/composite_type.rs
@@ -1,0 +1,53 @@
+use crate::{
+    CompositeType, CompositeTypeId, EntityDefinition, EntityDefinitionId, InterfaceDefinitionId, ObjectDefinitionId,
+    UnionDefinitionId,
+};
+
+impl From<EntityDefinitionId> for CompositeTypeId {
+    fn from(value: EntityDefinitionId) -> Self {
+        match value {
+            EntityDefinitionId::Interface(id) => CompositeTypeId::Interface(id),
+            EntityDefinitionId::Object(id) => CompositeTypeId::Object(id),
+        }
+    }
+}
+
+impl<'a> From<EntityDefinition<'a>> for CompositeType<'a> {
+    fn from(value: EntityDefinition<'a>) -> Self {
+        match value {
+            EntityDefinition::Interface(def) => CompositeType::Interface(def),
+            EntityDefinition::Object(def) => CompositeType::Object(def),
+        }
+    }
+}
+
+impl CompositeTypeId {
+    pub fn as_entity(&self) -> Option<EntityDefinitionId> {
+        match self {
+            CompositeTypeId::Interface(id) => Some(EntityDefinitionId::Interface(*id)),
+            CompositeTypeId::Object(id) => Some(EntityDefinitionId::Object(*id)),
+            CompositeTypeId::Union(_) => None,
+        }
+    }
+
+    pub fn as_object(&self) -> Option<ObjectDefinitionId> {
+        match self {
+            CompositeTypeId::Object(id) => Some(*id),
+            _ => None,
+        }
+    }
+
+    pub fn as_interface(&self) -> Option<InterfaceDefinitionId> {
+        match self {
+            CompositeTypeId::Interface(id) => Some(*id),
+            _ => None,
+        }
+    }
+
+    pub fn as_union(&self) -> Option<UnionDefinitionId> {
+        match self {
+            CompositeTypeId::Union(id) => Some(*id),
+            _ => None,
+        }
+    }
+}

--- a/engine/crates/engine-v2/schema/src/generated/composite_type.rs
+++ b/engine/crates/engine-v2/schema/src/generated/composite_type.rs
@@ -1,0 +1,99 @@
+//! ===================
+//! !!! DO NOT EDIT !!!
+//! ===================
+//! Generated with: `cargo run -p engine-v2-codegen`
+//! Source file: <engine-v2-codegen dir>/domain/schema.graphql
+use crate::{
+    generated::{
+        InterfaceDefinition, InterfaceDefinitionId, ObjectDefinition, ObjectDefinitionId, UnionDefinition,
+        UnionDefinitionId,
+    },
+    prelude::*,
+};
+use walker::Walk;
+
+/// Name previously used by the GraphQL spec to describe this union.
+///
+/// --------------
+/// Generated from:
+///
+/// ```custom,{.language-graphql}
+/// union CompositeType @id @meta(module: "composite_type") @variants(remove_suffix: "Definition") =
+///   | ObjectDefinition
+///   | InterfaceDefinition
+///   | UnionDefinition
+/// ```
+#[derive(serde::Serialize, serde::Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CompositeTypeId {
+    Interface(InterfaceDefinitionId),
+    Object(ObjectDefinitionId),
+    Union(UnionDefinitionId),
+}
+
+impl std::fmt::Debug for CompositeTypeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CompositeTypeId::Interface(variant) => variant.fmt(f),
+            CompositeTypeId::Object(variant) => variant.fmt(f),
+            CompositeTypeId::Union(variant) => variant.fmt(f),
+        }
+    }
+}
+
+impl From<InterfaceDefinitionId> for CompositeTypeId {
+    fn from(value: InterfaceDefinitionId) -> Self {
+        CompositeTypeId::Interface(value)
+    }
+}
+impl From<ObjectDefinitionId> for CompositeTypeId {
+    fn from(value: ObjectDefinitionId) -> Self {
+        CompositeTypeId::Object(value)
+    }
+}
+impl From<UnionDefinitionId> for CompositeTypeId {
+    fn from(value: UnionDefinitionId) -> Self {
+        CompositeTypeId::Union(value)
+    }
+}
+
+/// Name previously used by the GraphQL spec to describe this union.
+#[derive(Clone, Copy)]
+pub enum CompositeType<'a> {
+    Interface(InterfaceDefinition<'a>),
+    Object(ObjectDefinition<'a>),
+    Union(UnionDefinition<'a>),
+}
+
+impl std::fmt::Debug for CompositeType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CompositeType::Interface(variant) => variant.fmt(f),
+            CompositeType::Object(variant) => variant.fmt(f),
+            CompositeType::Union(variant) => variant.fmt(f),
+        }
+    }
+}
+
+impl Walk<Schema> for CompositeTypeId {
+    type Walker<'a> = CompositeType<'a>;
+    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+    where
+        Self: 'a,
+    {
+        match self {
+            CompositeTypeId::Interface(id) => CompositeType::Interface(id.walk(schema)),
+            CompositeTypeId::Object(id) => CompositeType::Object(id.walk(schema)),
+            CompositeTypeId::Union(id) => CompositeType::Union(id.walk(schema)),
+        }
+    }
+}
+
+impl CompositeType<'_> {
+    pub fn id(&self) -> CompositeTypeId {
+        match self {
+            CompositeType::Interface(walker) => CompositeTypeId::Interface(walker.id),
+            CompositeType::Object(walker) => CompositeTypeId::Object(walker.id),
+            CompositeType::Union(walker) => CompositeTypeId::Union(walker.id),
+        }
+    }
+}

--- a/engine/crates/engine-v2/schema/src/generated/mod.rs
+++ b/engine/crates/engine-v2/schema/src/generated/mod.rs
@@ -3,6 +3,7 @@
 //! ===================
 //! Generated with: `cargo run -p engine-v2-codegen`
 //! Source file: <engine-v2-codegen dir>/domain/schema.graphql
+mod composite_type;
 mod definition;
 mod directive;
 mod entity;
@@ -24,6 +25,7 @@ mod subgraph;
 mod ty;
 mod union;
 
+pub use composite_type::*;
 pub use definition::*;
 pub use directive::*;
 pub use entity::*;

--- a/engine/crates/engine-v2/schema/src/lib.rs
+++ b/engine/crates/engine-v2/schema/src/lib.rs
@@ -1,6 +1,7 @@
 use std::{str::FromStr, sync::OnceLock};
 
 mod builder;
+mod composite_type;
 mod definition;
 mod directive;
 mod entity;


### PR DESCRIPTION
Today I use `SelectionSetType` which isn't that great. So using the term the GraphQL spec used to use.
