### PR TITLE
chore: remove prepare_request span

### DIFF
--- a/engine/crates/engine-v2/src/sources/graphql/federation.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/federation.rs
@@ -63,7 +63,6 @@ impl FederationEntityResolver {
         )
     }
 
-    #[tracing::instrument(skip_all)]
     pub fn prepare_request<'ctx, R: Runtime>(
         &'ctx self,
         ctx: &SubgraphContext<'ctx, R>,


### PR DESCRIPTION
This is not useful in our tracing.