### PR TITLE
chore: bump gateway to 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "federated-server"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "ascii 1.1.0",
  "async-trait",
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "gateway-config"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "ascii 1.1.0",
  "cfg-if",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "ascii 1.1.0",
@@ -7154,7 +7154,7 @@ dependencies = [
 
 [[package]]
 name = "rolling-logger"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "grafbase-workspace-hack",
  "insta",

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.17.0] - 2024-10-30
+
+[CHANGELOG](changelog/0.17.0.md)
+
 ## [0.16.0] - 2024-10-22
 
 [CHANGELOG](changelog/0.16.0.md)

--- a/gateway/changelog/0.17.0.md
+++ b/gateway/changelog/0.17.0.md
@@ -1,0 +1,8 @@
+### Features
+
+- Include spans from Redis rate limiting in the tracing data (#2244)
+
+### Bug Fixes
+
+- Fix for propagating the correct span to subgraphs (#2243)
+- Hide a few unnecessary spans from the tracing data (#2268)

--- a/gateway/crates/config/Cargo.toml
+++ b/gateway/crates/config/Cargo.toml
@@ -5,7 +5,7 @@ keywords.workspace = true
 license = "MPL-2.0"
 name = "gateway-config"
 repository.workspace = true
-version = "0.16.0"
+version = "0.17.0"
 
 [lints]
 workspace = true

--- a/gateway/crates/federated-server/Cargo.toml
+++ b/gateway/crates/federated-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "federated-server"
-version = "0.16.0"
+version = "0.17.0"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.16.0"
+version = "0.17.0"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/crates/rolling-logger/Cargo.toml
+++ b/gateway/crates/rolling-logger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rolling-logger"
-version = "0.16.0"
+version = "0.17.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
### Features

- Include spans from Redis rate limiting in the tracing data (#2244)

### Bug Fixes

- Fix for propagating the correct span to subgraphs (#2243)
- Hide a few unnecessary spans from the tracing data (#2268)