### PR TITLE
graphql-schema-validation: fix validation of directive definition argument types

### DIFF
--- a/engine/crates/validation/CHANGELOG.md
+++ b/engine/crates/validation/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Improvements
+
 - When validating that the root types used in a schema definition exists,
   we were skipping the validation whenever the type is the default one for
   the root (Query, Mutation or Subscription). This commit makes the validation
@@ -12,6 +14,7 @@
 - Properly validate that object, interface and input object types define at least one field (https://github.com/graphql/graphql-spec/blame/October2021/spec/Section%203%20--%20Type%20System.md#L868). Previously, we were validating against `type Test {}` but not `type Test`.
 - Whenever we had a graph of input objects with multiple cycles in graphql-schema-validation, we would go into an infinite loop and stack overflow. This is fixed in this release.
 - Do not consider schema extensions as schema definitions for the purpose of duplicate schema definition validation.
+- Validation of the types of arguments inside directive definitions worked only for types defined before the directive definition. That would lead to incorrect validation errors about scalar or input types not existing. Validation of argument types in directive definitions now properly takes all types into account.
 
 ## [0.1.3] - 2024-02-06
 

--- a/engine/crates/validation/src/validate/directive_definitions.rs
+++ b/engine/crates/validation/src/validate/directive_definitions.rs
@@ -4,23 +4,10 @@ pub(crate) fn validate_directive_definition<'a>(
     definition: &'a Positioned<ast::DirectiveDefinition>,
     ctx: &mut Context<'a>,
 ) {
-    let directive_name = definition.node.name.node.as_str();
     if definition.node.name.node.starts_with("__") {
         ctx.push_error(miette::miette! {
             r#"Directive names must not start with "__""#,
         });
-    }
-
-    for arg in &definition.node.arguments {
-        let type_name = extract_type_name(&arg.node.ty.node.base);
-        let location = || format!("@{directive_name}({}:)", arg.node.name.node);
-        match validate_input_type(type_name, arg.node.ty.pos, ctx) {
-            ValidateInputTypeResult::Ok => (),
-            ValidateInputTypeResult::UnknownType => diagnostics::unknown_type(type_name, &location(), ctx),
-            ValidateInputTypeResult::NotAnInputType => {
-                diagnostics::output_type_in_input_position(type_name, &location(), ctx);
-            }
-        }
     }
 
     ctx.directive_names

--- a/engine/crates/validation/tests/valid_schemas/yoga_subgraph.graphql
+++ b/engine/crates/validation/tests/valid_schemas/yoga_subgraph.graphql
@@ -1,0 +1,72 @@
+schema @link(url: "https://specs.apollo.dev/link/v1.0") {
+  query: Query
+}
+
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key", "@shareable", "@inaccessible", "@override"])
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+
+directive @federation__tag(
+  name: String!
+) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+
+directive @federation__extends on OBJECT | INTERFACE
+
+directive @shareable repeatable on OBJECT | FIELD_DEFINITION
+
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @override(from: String!) on FIELD_DEFINITION
+
+directive @federation__composeDirective(name: String) repeatable on SCHEMA
+
+directive @federation__interfaceObject on OBJECT
+
+type Product @key(fields: "id") {
+  id: ID!
+  name: String!
+  brand: String!
+  size: Float!
+  color: String!
+  price: Float!
+}
+
+type Query {
+  product(id: ID!): Product
+  products: [Product]
+  _entities(representations: [_Any!]!): [_Entity]!
+  _service: _Service!
+}
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar link__Import
+
+scalar federation__FieldSet
+
+scalar _Any
+
+type _Service {
+  sdl: String
+}
+
+union _Entity = Product

--- a/engine/crates/validation/tests/validation_errors/directive_name_and_args.errors.txt
+++ b/engine/crates/validation/tests/validation_errors/directive_name_and_args.errors.txt
@@ -1,4 +1,4 @@
-  × The type of "@myDirective(firstArg:)" must be an input type, but got "Test", an output type.
-
-
   × Directive names must not start with "__"
+
+
+  × The type of "@myDirective(firstArg:)" must be an input type, but got "Test", an output type.


### PR DESCRIPTION
Validation of the types of arguments inside directive definitions worked only for types defined before the directive definition. That would lead to incorrect validation errors about scalar or input types not existing. Validation of argument types in directive definitions now properly takes all types into account.

The solution is, like for fields of types, to move validation of the arguments to the second pass of schema validation, where all types are known.

closes GB-7859