### PR TITLE
chore(engine-v2/qp): Generate response keys for extra fields

### DIFF
--- a/engine/crates/engine-v2/query-planning/src/graph/builder.rs
+++ b/engine/crates/engine-v2/query-planning/src/graph/builder.rs
@@ -327,7 +327,9 @@ impl<'ctx, Op: Operation> OperationGraphBuilder<'ctx, Op> {
                 required_query_field_ix
             } else {
                 // Create the QueryField Node
-                let field_id = self.operation.create_extra_field(petitioner_field_id, item.field());
+                let field_id = self
+                    .operation
+                    .create_potential_extra_field(petitioner_field_id, item.field());
                 let required_query_field_ix = self.push_query_field(
                     field_id,
                     if indispensable {

--- a/engine/crates/engine-v2/query-planning/src/tests/mod.rs
+++ b/engine/crates/engine-v2/query-planning/src/tests/mod.rs
@@ -121,7 +121,7 @@ impl crate::Operation for &mut TestOperation {
         self[field_id].definition_id == Some(requirement.definition_id)
     }
 
-    fn create_extra_field(
+    fn create_potential_extra_field(
         &mut self,
         _petitioner_field_id: Self::FieldId,
         requirement: schema::RequiredField<'_>,
@@ -133,6 +133,8 @@ impl crate::Operation for &mut TestOperation {
         });
         (self.fields.len() - 1).into()
     }
+
+    fn finalize_selection_set_extra_fields(&mut self, _extra: &[Self::FieldId], _existing: &[Self::FieldId]) {}
 }
 
 #[track_caller]

--- a/engine/crates/engine-v2/src/operation/plan/adapter.rs
+++ b/engine/crates/engine-v2/src/operation/plan/adapter.rs
@@ -6,15 +6,26 @@ use crate::{
         ExtraField, Field, FieldArgument, FieldArgumentId, FieldId, Operation, OperationWalker, QueryInputValue,
         SelectionSetId,
     },
-    response::ResponseEdge,
+    response::{ResponseEdge, ResponseKey, UnpackedResponseEdge},
 };
 
-pub(super) struct BoundOperationAdapter<'a> {
+pub(super) struct OperationAdapter<'a> {
     pub schema: &'a Schema,
     pub operation: &'a mut Operation,
+    tmp_response_keys: Vec<ResponseKey>,
 }
 
-impl<'a> query_planning::Operation for BoundOperationAdapter<'a> {
+impl<'a> OperationAdapter<'a> {
+    pub fn new(schema: &'a Schema, operation: &'a mut Operation) -> OperationAdapter<'a> {
+        OperationAdapter {
+            schema,
+            operation,
+            tmp_response_keys: Vec::new(),
+        }
+    }
+}
+
+impl<'a> query_planning::Operation for OperationAdapter<'a> {
     type FieldId = FieldId;
 
     fn field_ids(&self) -> impl ExactSizeIterator<Item = Self::FieldId> + 'static {
@@ -35,7 +46,7 @@ impl<'a> query_planning::Operation for BoundOperationAdapter<'a> {
         field.eq(&requirement)
     }
 
-    fn create_extra_field(
+    fn create_potential_extra_field(
         &mut self,
         petitioner_field_id: Self::FieldId,
         requirement: schema::RequiredField<'_>,
@@ -74,9 +85,59 @@ impl<'a> query_planning::Operation for BoundOperationAdapter<'a> {
     fn field_label(&self, field_id: Self::FieldId) -> std::borrow::Cow<'_, str> {
         self.operation.response_keys[self.operation[field_id].response_key()].into()
     }
+
+    fn finalize_selection_set_extra_fields(
+        &mut self,
+        extra_fields: &[Self::FieldId],
+        existing_fields: &[Self::FieldId],
+    ) {
+        self.tmp_response_keys.clear();
+        self.tmp_response_keys.extend(
+            existing_fields
+                .iter()
+                .filter_map(|id| self.operation[*id].response_edge().as_response_key()),
+        );
+        for extra_field_id in extra_fields {
+            let Some(definition_id) = self.operation[*extra_field_id].definition_id() else {
+                continue;
+            };
+            let name = self.schema.walk(definition_id).name();
+
+            let key = 'key: {
+                // Key doesn't exist in the operation at all
+                let Some(key) = self.operation.response_keys.get(name).map(ResponseKey::from) else {
+                    break 'key ResponseKey::from(self.operation.response_keys.get_or_intern(name));
+                };
+
+                // Key doesn't exist in the current selection set
+                if !self.tmp_response_keys.contains(&key) {
+                    break 'key key;
+                }
+
+                // Generate a likely unique key
+                let hex = hex::encode_upper(u32::from(definition_id).to_be_bytes());
+                let short_id = hex.trim_start_matches('0');
+
+                let name = format!("_{}{}", name, short_id);
+
+                let mut i: u8 = 0;
+                loop {
+                    let candidate = format!("{name}{}", hex::encode_upper(i.to_be_bytes()));
+                    if !self.operation.response_keys.contains(&candidate) {
+                        break 'key self.operation.response_keys.get_or_intern(&candidate).into();
+                    }
+                    i += 1;
+                }
+            };
+            if let Field::Extra(field) = &mut self.operation[*extra_field_id] {
+                field.edge = UnpackedResponseEdge::ExtraFieldResponseKey(key).pack();
+                self.tmp_response_keys.push(key);
+            };
+        }
+    }
 }
 
-impl<'a> BoundOperationAdapter<'a> {
+impl<'a> OperationAdapter<'a> {
     fn create_arguments_for(&mut self, requirement: schema::RequiredField<'_>) -> IdRange<FieldArgumentId> {
         let start = self.operation.field_arguments.len();
 

--- a/engine/crates/engine-v2/src/operation/plan/mod.rs
+++ b/engine/crates/engine-v2/src/operation/plan/mod.rs
@@ -1,4 +1,4 @@
-use adapter::BoundOperationAdapter;
+use adapter::OperationAdapter;
 use schema::Schema;
 
 use super::Operation;
@@ -9,13 +9,7 @@ mod error;
 pub type PlanResult<T> = Result<T, error::PlanError>;
 
 pub fn plan(schema: &Schema, mut operation: Operation) -> PlanResult<()> {
-    let mut graph = query_planning::OperationGraph::new(
-        schema,
-        BoundOperationAdapter {
-            schema,
-            operation: &mut operation,
-        },
-    )?;
+    let mut graph = query_planning::OperationGraph::new(schema, OperationAdapter::new(schema, &mut operation))?;
     graph.solve()?;
     Ok(())
 }


### PR DESCRIPTION
When adding extra fields I don't generate a response key immediately for them as they may not be needed. Once I know which one I need I do while ensuring it doesn't clash with any existing field in the same selection set.

The response key is the key in the final JSON response, so taking into account aliases, I also use it internally to keep track of the response path for errors and in the internal response data. So every field must have one.