### PR TITLE
feat: signature parameters for message signing

### DIFF
--- a/gateway/crates/config/src/message_signatures.rs
+++ b/gateway/crates/config/src/message_signatures.rs
@@ -112,11 +112,6 @@ pub struct MessageSigningHeaders {
 #[derive(Debug, Clone, PartialEq, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SignatureParameter {
-    Created,
-    #[serde(rename = "alg")]
-    Algorithm,
-    #[serde(rename = "kid")]
-    KeyId,
     Nonce,
 }
 
@@ -156,7 +151,7 @@ mod tests {
             headers.include = ["my-fave-header"]
             headers.exclude = ["authorization"]
             derived_components = ["request_target", "path"]
-            signature_parameters = ["created"]
+            signature_parameters = ["nonce"]
         "#};
 
         let config = toml::from_str::<MessageSignaturesConfig>(config).unwrap();
@@ -200,7 +195,7 @@ mod tests {
             ),
             signature_parameters: Some(
                 [
-                    Created,
+                    Nonce,
                 ],
             ),
         }


### PR DESCRIPTION
When implementing this I realised that the configuration I'd specified for message signing probably didn't make sense:

1. I'm not sure there's ever any harm in including a created date - httpsig does it by default, and if we removed it that could cause a panic if the user provided expiry.  Additionally its recommended that you include it in the spec. So unless someone requests that we remove I think it makes sense to just always have it
2. If we have a KID I think we should just include it, same with the algorithm.

This just leaves the nonce parameter, which I've added support for.

Fixes GB-7858