### PR TITLE
chore(engine-v2-codgen): Support imports & custom context type.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2493,6 +2493,7 @@ dependencies = [
  "engine-v2-walker",
  "fixedbitset 0.5.7",
  "grafbase-workspace-hack",
+ "itertools 0.13.0",
  "serde",
 ]
 

--- a/engine/crates/engine-v2/codegen/domain/schema.graphql
+++ b/engine/crates/engine-v2/codegen/domain/schema.graphql
@@ -1,4 +1,4 @@
-scalar Schema @graph(destination: "schema/src")
+scalar Schema @domain(destination: "schema/src")
 
 # std / lib
 scalar String @indexed(deduplicated: true)

--- a/engine/crates/engine-v2/codegen/src/domain/record.rs
+++ b/engine/crates/engine-v2/codegen/src/domain/record.rs
@@ -1,6 +1,6 @@
 use cynic_parser::common::WrappingType;
 
-use super::{Definition, FieldMeta, Indexed, Meta};
+use super::{Definition, Indexed, Meta};
 
 #[derive(Debug)]
 pub struct Object {
@@ -12,6 +12,7 @@ pub struct Object {
     pub struct_name: String,
     pub copy: bool,
     pub fields: Vec<Field>,
+    pub external_domain_name: Option<String>,
 }
 
 impl From<Object> for Definition {
@@ -28,7 +29,6 @@ impl Object {
 
 #[derive(Debug)]
 pub struct Field {
-    pub meta: FieldMeta,
     pub name: String,
     pub description: Option<String>,
     pub record_field_name: String,

--- a/engine/crates/engine-v2/codegen/src/domain/scalar.rs
+++ b/engine/crates/engine-v2/codegen/src/domain/scalar.rs
@@ -8,6 +8,8 @@ pub struct Scalar {
     pub struct_name: String,
     pub is_record: bool,
     pub copy: bool,
+    pub external_domain_name: Option<String>,
+    pub in_prelude: bool,
 }
 
 impl From<Scalar> for Definition {

--- a/engine/crates/engine-v2/codegen/src/domain/union.rs
+++ b/engine/crates/engine-v2/codegen/src/domain/union.rs
@@ -7,6 +7,7 @@ pub struct Union {
     pub span: cynic_parser::Span,
     pub description: Option<String>,
     pub variants: Vec<Variant>,
+    pub external_domain_name: Option<String>,
 }
 
 #[derive(Debug)]

--- a/engine/crates/engine-v2/codegen/src/formatter.rs
+++ b/engine/crates/engine-v2/codegen/src/formatter.rs
@@ -4,6 +4,8 @@ use regex::{Captures, Regex};
 pub(super) struct Formatter {
     shell: xshell::Shell,
     doc_re: Regex,
+    lifetime_re: Regex,
+    lifetime_constraint_re: Regex,
 }
 
 impl Formatter {
@@ -11,6 +13,8 @@ impl Formatter {
         Ok(Self {
             shell: xshell::Shell::new()?,
             doc_re: Regex::new(r#"(?m)^(?<spaces>\s*)#\[doc\s*=\s*"(?<doc>.*)"\]$"#)?,
+            lifetime_re: Regex::new(r#"\s*<\s*('\w)\s*>"#)?,
+            lifetime_constraint_re: Regex::new(r#"('\w)\s*:\s*('\w)"#)?,
         })
     }
 
@@ -56,6 +60,16 @@ impl Formatter {
                         &line[comment_indent..]
                     )))
                 )
+            })
+            .to_string();
+        let code = self
+            .lifetime_re
+            .replace_all(&code, |caps: &Captures| format!("<{}>", caps.get(1).unwrap().as_str()))
+            .to_string();
+        let code = self
+            .lifetime_constraint_re
+            .replace_all(&code, |caps: &Captures| {
+                format!("{}: {}", caps.get(1).unwrap().as_str(), caps.get(2).unwrap().as_str())
             })
             .to_string();
 

--- a/engine/crates/engine-v2/codegen/src/generation.rs
+++ b/engine/crates/engine-v2/codegen/src/generation.rs
@@ -63,6 +63,10 @@ pub fn generate_modules(formatter: &Formatter, domain: &Domain) -> anyhow::Resul
 
     for (_, name) in names {
         let definition = &domain.definitions_by_name[name];
+        if definition.external_domain_name().is_some() {
+            continue;
+        }
+
         let generated_code = match definition {
             Definition::Scalar(_) => continue,
             Definition::Object(object) => generate_object(domain, object)?,
@@ -85,6 +89,8 @@ pub fn generate_modules(formatter: &Formatter, domain: &Domain) -> anyhow::Resul
                 .or_default()
                 .submodules
                 .push(module_path.last().unwrap());
+        } else if module_path.is_empty() {
+            tracing::warn!("No module defined for '{name}'? Do we even support it?");
         }
     }
 

--- a/engine/crates/engine-v2/codegen/src/generation/id.rs
+++ b/engine/crates/engine-v2/codegen/src/generation/id.rs
@@ -3,7 +3,8 @@ use quote::quote;
 
 use crate::domain::{Domain, Indexed};
 
-pub fn generate_id(_domain: &Domain, indexed: &Indexed) -> anyhow::Result<Vec<TokenStream>> {
+pub fn generate_id(domain: &Domain, indexed: &Indexed) -> anyhow::Result<Vec<TokenStream>> {
+    let public = &domain.public_visibility;
     let id_struct_name = Ident::new(&indexed.id_struct_name, Span::call_site());
 
     let id_struct = if let Some(size) = &indexed.id_size {
@@ -13,12 +14,12 @@ pub fn generate_id(_domain: &Domain, indexed: &Indexed) -> anyhow::Result<Vec<To
             quote! {
                 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
                 #[max(#max_id)]
-                pub struct #id_struct_name(std::num::NonZero<#size>);
+                pub #public struct #id_struct_name(std::num::NonZero<#size>);
             }
         } else {
             quote! {
                 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-                pub struct #id_struct_name(std::num::NonZero<#size>);
+                pub #public struct #id_struct_name(std::num::NonZero<#size>);
             }
         }
     } else {

--- a/engine/crates/engine-v2/codegen/src/generation/module.rs
+++ b/engine/crates/engine-v2/codegen/src/generation/module.rs
@@ -14,9 +14,10 @@ where
     let mod_definitions = submodules
         .iter()
         .format_with("\n", |submodule, f| f(&format_args!("mod {submodule};")));
-    let pub_use_mod = submodules
-        .iter()
-        .format_with("\n", |submodule, f| f(&format_args!("pub use {submodule}::*;")));
+    let visibilty = domain.public_visibility.to_string();
+    let pub_use_mod = submodules.iter().format_with("\n", |submodule, f| {
+        f(&format_args!("pub {visibilty} use {submodule}::*;"))
+    });
 
     let mut contents = formatdoc!(
         r#"

--- a/engine/crates/engine-v2/codegen/src/generation/object/debug.rs
+++ b/engine/crates/engine-v2/codegen/src/generation/object/debug.rs
@@ -20,7 +20,7 @@ impl ToTokens for WalkerDebug<'_> {
         let walker_struct = Ident::new(object.walker_name(), Span::call_site());
         let name_string = proc_macro2::Literal::string(object.walker_name());
 
-        let fields = fields.iter().filter(|field| field.meta.debug).map(DebugField);
+        let fields = fields.iter().map(DebugField);
 
         tokens.append_all(quote! {
             impl std::fmt::Debug for #walker_struct<'_> {

--- a/engine/crates/engine-v2/codegen/src/generation/object/struct_.rs
+++ b/engine/crates/engine-v2/codegen/src/generation/object/struct_.rs
@@ -16,6 +16,7 @@ pub fn generate_struct(
     object: &Object,
     fields: &[FieldContext<'_>],
 ) -> anyhow::Result<Vec<TokenStream>> {
+    let public = &domain.public_visibility;
     let struct_name = Ident::new(&object.struct_name, Span::call_site());
 
     let additional_derives = {
@@ -43,7 +44,7 @@ pub fn generate_struct(
     let object_struct = quote! {
         #[doc = #docstr]
         #[derive(Debug, serde::Serialize, serde::Deserialize #additional_derives)]
-        pub struct #struct_name {
+        pub #public struct #struct_name {
             #(#struct_fields),*
         }
     };

--- a/engine/crates/engine-v2/codegen/src/generation/object/walker.rs
+++ b/engine/crates/engine-v2/codegen/src/generation/object/walker.rs
@@ -16,8 +16,14 @@ pub fn generate_walker(
     object: &Object,
     fields: &[FieldContext<'_>],
 ) -> anyhow::Result<Vec<TokenStream>> {
-    let graph_name = Ident::new(&domain.graph_var_name, Span::call_site());
-    let graph_type = Ident::new(&domain.graph_type_name, Span::call_site());
+    let public = &domain.public_visibility;
+    let allow_unused = if domain.public_visibility.is_empty() {
+        quote! {}
+    } else {
+        quote! { #[allow(unused)] }
+    };
+    let context_name = Ident::new(&domain.context_name, Span::call_site());
+    let context_type = &domain.context_type;
     let struct_name = Ident::new(&object.struct_name, Span::call_site());
     let walker_name = Ident::new(object.walker_name(), Span::call_site());
     let walk_trait = Ident::new(WALKER_TRAIT, Span::call_site());
@@ -29,19 +35,24 @@ pub fn generate_walker(
             quote! { #[doc = #desc] }
         })
         .unwrap_or_default();
+    let private = {
+        let m = &domain.module;
+        quote! { in #m }
+    };
 
     let walker_field_methods = fields.iter().filter(|field| field.has_walker).map(WalkerFieldMethod);
     let mut code_sections = Vec::new();
 
     if let Some(indexed) = &object.indexed {
         let id_struct_name = Ident::new(&indexed.id_struct_name, Span::call_site());
+        let domain_accessor = domain.domain_accessor(None);
 
         code_sections.push(quote! {
             #doc
             #[derive(Clone, Copy)]
-            pub struct #walker_name<'a> {
-                pub(crate) #graph_name: &'a #graph_type,
-                pub(crate) id: #id_struct_name,
+            pub #public struct #walker_name<'a> {
+                pub(#private) #context_name: #context_type,
+                pub(#private) id: #id_struct_name,
             }
         });
         code_sections.push(quote! {
@@ -53,28 +64,30 @@ pub fn generate_walker(
             }
         });
         code_sections.push(quote! {
+            #allow_unused
             impl <'a> #walker_name<'a> {
                 #[doc = "Prefer using Deref unless you need the 'a lifetime."]
                 #[allow(clippy::should_implement_trait)]
-                pub fn as_ref(&self) -> &'a #struct_name {
-                    &self.#graph_name[self.id]
+                pub #public fn as_ref(&self) -> &'a #struct_name {
+                    &self.#domain_accessor[self.id]
                 }
-                pub fn id(&self) -> #id_struct_name {
+                pub #public fn id(&self) -> #id_struct_name {
                     self.id
                 }
                 #(#walker_field_methods)*
             }
         });
         code_sections.push(quote! {
-            impl #walk_trait<#graph_type> for #id_struct_name {
-                type Walker<'a> = #walker_name<'a>;
+            impl<'a> #walk_trait<#context_type> for #id_struct_name {
+                type Walker<'w> = #walker_name<'w> where 'a: 'w;
 
-                fn walk<'a>(self, #graph_name: &'a #graph_type) -> Self::Walker<'a>
+                fn walk<'w>(self, #context_name: #context_type) -> Self::Walker<'w>
                 where
-                    Self: 'a
+                    Self: 'w,
+                    'a: 'w
                 {
                     #walker_name {
-                        #graph_name,
+                        #context_name,
                         id: self,
                     }
                 }
@@ -84,9 +97,9 @@ pub fn generate_walker(
         code_sections.push(quote! {
             #doc
             #[derive(Clone, Copy)]
-            pub struct #walker_name<'a> {
-                pub(crate) #graph_name: &'a #graph_type,
-                pub(crate) item: #struct_name,
+            pub #public struct #walker_name<'a> {
+                pub(#private) #context_name: #context_type,
+                pub(#private) item: #struct_name,
             }
         });
         code_sections.push(quote! {
@@ -100,22 +113,24 @@ pub fn generate_walker(
         code_sections.push(quote! {
             impl <'a> #walker_name<'a> {
                 #[allow(clippy::should_implement_trait)]
-                pub fn as_ref(&self) -> &#struct_name {
+                pub #public fn as_ref(&self) -> &#struct_name {
                     &self.item
                 }
                 #(#walker_field_methods)*
             }
         });
         code_sections.push(quote! {
-            impl #walk_trait<#graph_type> for #struct_name {
-                type Walker<'a> = #walker_name<'a>;
+            #allow_unused
+            impl<'a> #walk_trait<#context_type> for #struct_name {
+                type Walker<'w> = #walker_name<'w> where 'a: 'w;
 
-                fn walk<'a>(self, #graph_name: &'a #graph_type) -> Self::Walker<'a>
+                fn walk<'w>(self, #context_name: #context_type) -> Self::Walker<'w>
                 where
-                    Self: 'a
+                    Self: 'w,
+                    'a: 'w
                 {
                     #walker_name {
-                        #graph_name,
+                        #context_name,
                         item: self,
                     }
                 }
@@ -125,9 +140,9 @@ pub fn generate_walker(
         code_sections.push(quote! {
             #doc
             #[derive(Clone, Copy)]
-            pub struct #walker_name<'a> {
-                pub(crate) #graph_name: &'a #graph_type,
-                pub(crate) ref_: &'a #struct_name,
+            pub #public struct #walker_name<'a> {
+                pub(#private) #context_name: #context_type,
+                pub(#private) ref_: &'a #struct_name,
             }
         });
         code_sections.push(quote! {
@@ -139,26 +154,29 @@ pub fn generate_walker(
             }
         });
         code_sections.push(quote! {
+            #allow_unused
             impl <'a> #walker_name<'a> {
                 #[allow(clippy::should_implement_trait)]
-                pub fn as_ref(&self) -> &'a #struct_name {
+                pub #public fn as_ref(&self) -> &'a #struct_name {
                     self.ref_
                 }
                 #(#walker_field_methods)*
             }
         });
         code_sections.push(quote! {
-            impl #walk_trait<#graph_type> for &#struct_name {
-                type Walker<'a> = #walker_name<'a>
+            impl<'a> #walk_trait<#context_type> for &#struct_name {
+                type Walker<'w> = #walker_name<'w>
                 where
-                    Self: 'a;
+                    Self: 'w,
+                    'a: 'w;
 
-                fn walk<'a>(self, #graph_name: &'a #graph_type) -> Self::Walker<'a>
+                fn walk<'w>(self, #context_name: #context_type) -> Self::Walker<'w>
                 where
-                    Self: 'a
+                    Self: 'w,
+                    'a: 'w
                 {
                     #walker_name {
-                        #graph_name,
+                        #context_name,
                         ref_: self,
                     }
                 }
@@ -178,7 +196,7 @@ pub struct WalkerFieldMethod<'a>(&'a FieldContext<'a>);
 impl quote::ToTokens for WalkerFieldMethod<'_> {
     #[instrument(name = "walker_field_method", skip_all, fields(field = ?self.0.field))]
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let graph = Ident::new(&self.0.domain.graph_var_name, Span::call_site());
+        let ctx = self.0.domain.context_accessor(self.0.ty.external_domain_name());
         let field = Ident::new(&self.0.record_field_name, Span::call_site());
         let method = Ident::new(&self.0.walker_method_name(), Span::call_site());
         let ty = Ident::new(self.0.ty.walker_name(), Span::call_site());
@@ -199,22 +217,22 @@ impl quote::ToTokens for WalkerFieldMethod<'_> {
                 },
                 AccessKind::IdRef => quote! {
                     Option<&'a #ty> {
-                        self.#field.walk(self.#graph)
+                        self.#field.walk(self.#ctx)
                     }
                 },
                 AccessKind::IdWalker => quote! {
                     Option<#ty<'a>> {
-                        self.#field.walk(self.#graph)
+                        self.#field.walk(self.#ctx)
                     }
                 },
                 AccessKind::ItemWalker => quote! {
                     Option<#ty<'a>> {
-                        self.as_ref().#field.walk(self.#graph)
+                        self.as_ref().#field.walk(self.#ctx)
                     }
                 },
                 AccessKind::RefWalker => quote! {
                     Option<#ty<'a>> {
-                        self.as_ref().#field.walk(self.#graph)
+                        self.as_ref().#field.walk(self.#ctx)
                     }
                 },
             },
@@ -231,22 +249,22 @@ impl quote::ToTokens for WalkerFieldMethod<'_> {
                 },
                 AccessKind::IdRef => quote! {
                     &'a #ty {
-                        self.#field.walk(self.#graph)
+                        self.#field.walk(self.#ctx)
                     }
                 },
                 AccessKind::IdWalker => quote! {
                     #ty<'a> {
-                        self.#field.walk(self.#graph)
+                        self.#field.walk(self.#ctx)
                     }
                 },
                 AccessKind::ItemWalker => quote! {
                     #ty<'a> {
-                        self.#field.walk(self.#graph)
+                        self.#field.walk(self.#ctx)
                     }
                 },
                 AccessKind::RefWalker => quote! {
                     #ty<'a> {
-                        self.as_ref().#field.as_ref().walk(self.#graph)
+                        self.as_ref().#field.as_ref().walk(self.#ctx)
                     }
                 },
             },
@@ -265,13 +283,13 @@ impl quote::ToTokens for WalkerFieldMethod<'_> {
                     if list_as_id_range {
                         quote! {
                             impl Iter<Item = &'a #ty> + 'a {
-                                self.#field.walk(self.#graph)
+                                self.#field.walk(self.#ctx)
                             }
                         }
                     } else {
                         quote! {
                             impl Iter<Item = &'a #ty> + 'a {
-                                self.as_ref().#field.walk(self.#graph)
+                                self.as_ref().#field.walk(self.#ctx)
                             }
                         }
                     }
@@ -280,25 +298,25 @@ impl quote::ToTokens for WalkerFieldMethod<'_> {
                     if list_as_id_range {
                         quote! {
                             impl Iter<Item =  #ty<'a>> + 'a {
-                                self.#field.walk(self.#graph)
+                                self.#field.walk(self.#ctx)
                             }
                         }
                     } else {
                         quote! {
                             impl Iter<Item = #ty<'a>> + 'a {
-                                self.as_ref().#field.walk(self.#graph)
+                                self.as_ref().#field.walk(self.#ctx)
                             }
                         }
                     }
                 }
                 AccessKind::ItemWalker => quote! {
                     impl Iter<Item =  #ty<'a>> + 'a {
-                        self.as_ref().#field.walk(self.#graph)
+                        self.as_ref().#field.walk(self.#ctx)
                     }
                 },
                 AccessKind::RefWalker => quote! {
                     impl Iter<Item = #ty<'a>> + 'a {
-                        self.as_ref().#field.walk(self.#graph)
+                        self.as_ref().#field.walk(self.#ctx)
                     }
                 },
             },
@@ -306,7 +324,7 @@ impl quote::ToTokens for WalkerFieldMethod<'_> {
                 match kind {
                     AccessKind::IdRef => quote! {
                         impl Iter<Item: Iter<Item = &'a #ty> + 'a> + 'a {
-                            self.as_ref().#field.walk(self.#graph)
+                            self.as_ref().#field.walk(self.#ctx)
                         }
                     },
                     accessor => {
@@ -332,9 +350,10 @@ impl quote::ToTokens for WalkerFieldMethod<'_> {
             })
             .unwrap_or_default();
 
+        let public = &self.0.domain.public_visibility;
         tokens.append_all(quote! {
             #doc
-            pub fn #method(&self) -> #return_type_and_body
+            pub #public fn #method(&self) -> #return_type_and_body
         });
     }
 }

--- a/engine/crates/engine-v2/codegen/src/generation/union/enum_.rs
+++ b/engine/crates/engine-v2/codegen/src/generation/union/enum_.rs
@@ -15,6 +15,7 @@ pub fn generate_enum(
     union: &Union,
     variants: &[VariantContext<'_>],
 ) -> anyhow::Result<Vec<TokenStream>> {
+    let public = &domain.public_visibility;
     let enum_name = Ident::new(union.enum_name(), Span::call_site());
 
     let additional_derives = {
@@ -42,7 +43,7 @@ pub fn generate_enum(
     let union_enum = quote! {
         #[doc = #docstr]
         #[derive(serde::Serialize, serde::Deserialize #additional_derives)]
-        pub enum #enum_name {
+        pub #public enum #enum_name {
             #(#enum_variants),*
         }
     };

--- a/engine/crates/engine-v2/codegen/src/main.rs
+++ b/engine/crates/engine-v2/codegen/src/main.rs
@@ -11,6 +11,10 @@ const WALKER_TRAIT: &str = "Walk";
 const DOMAIN_DIR: &str = "domain";
 const GENERATED_MODULE: &str = "generated";
 
+fn domain_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(DOMAIN_DIR)
+}
+
 fn main() -> anyhow::Result<()> {
     let code_gen_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let engine_v2_dir = code_gen_dir.parent().unwrap();
@@ -30,7 +34,7 @@ fn main() -> anyhow::Result<()> {
 
     let formatter = formatter::Formatter::new()?;
 
-    for entry in std::fs::read_dir(code_gen_dir.join(DOMAIN_DIR))? {
+    for entry in std::fs::read_dir(domain_dir())? {
         let path = entry?.path();
         tracing::info!("Parsing {}", path.to_string_lossy());
         let domain = loader::load(path)?;

--- a/engine/crates/engine-v2/id-newtypes/Cargo.toml
+++ b/engine/crates/engine-v2/id-newtypes/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 serde.workspace = true
+itertools.workspace = true
 walker = { path = "../walker", package = "engine-v2-walker" }
 fixedbitset = { version = "0.5", features = ["serde"]}
 grafbase-workspace-hack.workspace = true

--- a/engine/crates/engine-v2/id-newtypes/src/many.rs
+++ b/engine/crates/engine-v2/id-newtypes/src/many.rs
@@ -1,3 +1,5 @@
+use itertools::Itertools;
+
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct IdToMany<Id, V>(Vec<(Id, V)>);
 
@@ -31,11 +33,11 @@ impl<Id, V> IdToMany<Id, V> {
         Self(relations)
     }
 
-    pub fn ids(&self) -> impl ExactSizeIterator<Item = Id> + '_
+    pub fn ids(&self) -> impl Iterator<Item = Id> + '_
     where
-        Id: Copy,
+        Id: Copy + PartialEq,
     {
-        self.0.iter().map(|(id, _)| *id)
+        self.0.iter().map(|(id, _)| *id).dedup()
     }
 
     pub fn find_all(&self, id: Id) -> impl Iterator<Item = &V> + '_

--- a/engine/crates/engine-v2/id-newtypes/src/range.rs
+++ b/engine/crates/engine-v2/id-newtypes/src/range.rs
@@ -139,13 +139,15 @@ impl<G, Id: Walk<G> + 'static> Walk<G> for IdRange<Id>
 where
     Id: From<usize> + Copy,
     usize: From<Id>,
+    G: Copy,
 {
     type Walker<'a> = WalkIterator<'a, IdRangeIterator<Id>, G>
     where G: 'a;
 
-    fn walk<'a>(self, graph: &'a G) -> Self::Walker<'a>
+    fn walk<'a>(self, graph: G) -> Self::Walker<'a>
     where
         Self: 'a,
+        G: 'a,
     {
         WalkIterator::new(self.into_iter(), graph)
     }

--- a/engine/crates/engine-v2/schema/src/directive/requires_scopes.rs
+++ b/engine/crates/engine-v2/schema/src/directive/requires_scopes.rs
@@ -65,11 +65,12 @@ impl<'a> RequiresScopesDirective<'a> {
     }
 }
 
-impl Walk<Schema> for RequiresScopesDirectiveId {
-    type Walker<'a> = RequiresScopesDirective<'a>;
-    fn walk<'s>(self, schema: &'s Schema) -> Self::Walker<'s>
+impl<'a> Walk<&'a Schema> for RequiresScopesDirectiveId {
+    type Walker<'w> = RequiresScopesDirective<'w> where 'a: 'w;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 's,
+        Self: 'w,
+        'a: 'w,
     {
         RequiresScopesDirective { schema, id: self }
     }

--- a/engine/crates/engine-v2/schema/src/field_set/requires.rs
+++ b/engine/crates/engine-v2/schema/src/field_set/requires.rs
@@ -20,11 +20,12 @@ pub struct RequiredFieldSetRecord(Vec<RequiredFieldSetItemRecord>);
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
 pub struct RequiredFieldSetId(std::num::NonZero<u32>);
 
-impl Walk<Schema> for RequiredFieldSetId {
-    type Walker<'a> = RequiredFieldSet<'a>;
-    fn walk<'s>(self, schema: &'s Schema) -> Self::Walker<'s>
+impl<'a> Walk<&'a Schema> for RequiredFieldSetId {
+    type Walker<'w> = RequiredFieldSet<'w> where 'a: 'w;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 's,
+        Self: 'w,
+        'a: 'w,
     {
         RequiredFieldSet {
             schema,
@@ -33,11 +34,12 @@ impl Walk<Schema> for RequiredFieldSetId {
     }
 }
 
-impl Walk<Schema> for &RequiredFieldSetRecord {
-    type Walker<'a> = RequiredFieldSet<'a> where Self: 'a;
-    fn walk<'s>(self, schema: &'s Schema) -> Self::Walker<'s>
+impl<'a> Walk<&'a Schema> for &RequiredFieldSetRecord {
+    type Walker<'w> = RequiredFieldSet<'w> where Self: 'w, 'a: 'w;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 's,
+        Self: 'w,
+        'a: 'w,
     {
         RequiredFieldSet { schema, ref_: self }
     }
@@ -75,11 +77,12 @@ pub struct RequiredFieldSetItemRecord {
     pub subselection: RequiredFieldSetRecord,
 }
 
-impl Walk<Schema> for &RequiredFieldSetItemRecord {
-    type Walker<'a> = RequiredFieldSetItem<'a> where Self: 'a;
-    fn walk<'s>(self, schema: &'s Schema) -> Self::Walker<'s>
+impl<'a> Walk<&'a Schema> for &RequiredFieldSetItemRecord {
+    type Walker<'w> = RequiredFieldSetItem<'w> where Self: 'w, 'a: 'w;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 's,
+        Self: 'w,
+        'a: 'w,
     {
         RequiredFieldSetItem { schema, ref_: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/composite_type.rs
+++ b/engine/crates/engine-v2/schema/src/generated/composite_type.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use walker::Walk;
 
-/// Name previously used by the GraphQL spec to describe this union.
+/// Composite type is the term previously used by the GraphQL spec to describe this union.
 ///
 /// --------------
 /// Generated from:
@@ -56,7 +56,7 @@ impl From<UnionDefinitionId> for CompositeTypeId {
     }
 }
 
-/// Name previously used by the GraphQL spec to describe this union.
+/// Composite type is the term previously used by the GraphQL spec to describe this union.
 #[derive(Clone, Copy)]
 pub enum CompositeType<'a> {
     Interface(InterfaceDefinition<'a>),
@@ -74,11 +74,12 @@ impl std::fmt::Debug for CompositeType<'_> {
     }
 }
 
-impl Walk<Schema> for CompositeTypeId {
-    type Walker<'a> = CompositeType<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for CompositeTypeId {
+    type Walker<'w> = CompositeType<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         match self {
             CompositeTypeId::Interface(id) => CompositeType::Interface(id.walk(schema)),

--- a/engine/crates/engine-v2/schema/src/generated/definition.rs
+++ b/engine/crates/engine-v2/schema/src/generated/definition.rs
@@ -101,11 +101,12 @@ impl std::fmt::Debug for Definition<'_> {
     }
 }
 
-impl Walk<Schema> for DefinitionId {
-    type Walker<'a> = Definition<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for DefinitionId {
+    type Walker<'w> = Definition<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         match self {
             DefinitionId::Enum(id) => Definition::Enum(id.walk(schema)),

--- a/engine/crates/engine-v2/schema/src/generated/directive.rs
+++ b/engine/crates/engine-v2/schema/src/generated/directive.rs
@@ -76,11 +76,12 @@ impl std::fmt::Debug for TypeSystemDirective<'_> {
     }
 }
 
-impl Walk<Schema> for TypeSystemDirectiveId {
-    type Walker<'a> = TypeSystemDirective<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for TypeSystemDirectiveId {
+    type Walker<'w> = TypeSystemDirective<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         match self {
             TypeSystemDirectiveId::Authenticated => TypeSystemDirective::Authenticated,

--- a/engine/crates/engine-v2/schema/src/generated/directive/authorized.rs
+++ b/engine/crates/engine-v2/schema/src/generated/directive/authorized.rs
@@ -61,11 +61,12 @@ impl<'a> AuthorizedDirective<'a> {
     }
 }
 
-impl Walk<Schema> for AuthorizedDirectiveId {
-    type Walker<'a> = AuthorizedDirective<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for AuthorizedDirectiveId {
+    type Walker<'w> = AuthorizedDirective<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         AuthorizedDirective { schema, id: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/directive/deprecated.rs
+++ b/engine/crates/engine-v2/schema/src/generated/directive/deprecated.rs
@@ -43,11 +43,12 @@ impl<'a> DeprecatedDirective<'a> {
     }
 }
 
-impl Walk<Schema> for DeprecatedDirectiveRecord {
-    type Walker<'a> = DeprecatedDirective<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for DeprecatedDirectiveRecord {
+    type Walker<'w> = DeprecatedDirective<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         DeprecatedDirective { schema, item: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/entity.rs
+++ b/engine/crates/engine-v2/schema/src/generated/entity.rs
@@ -57,11 +57,12 @@ impl std::fmt::Debug for EntityDefinition<'_> {
     }
 }
 
-impl Walk<Schema> for EntityDefinitionId {
-    type Walker<'a> = EntityDefinition<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for EntityDefinitionId {
+    type Walker<'w> = EntityDefinition<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         match self {
             EntityDefinitionId::Interface(id) => EntityDefinition::Interface(id.walk(schema)),

--- a/engine/crates/engine-v2/schema/src/generated/enum_def.rs
+++ b/engine/crates/engine-v2/schema/src/generated/enum_def.rs
@@ -68,11 +68,12 @@ impl<'a> EnumDefinition<'a> {
     }
 }
 
-impl Walk<Schema> for EnumDefinitionId {
-    type Walker<'a> = EnumDefinition<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for EnumDefinitionId {
+    type Walker<'w> = EnumDefinition<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         EnumDefinition { schema, id: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/enum_value.rs
+++ b/engine/crates/engine-v2/schema/src/generated/enum_value.rs
@@ -63,11 +63,12 @@ impl<'a> EnumValue<'a> {
     }
 }
 
-impl Walk<Schema> for EnumValueId {
-    type Walker<'a> = EnumValue<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for EnumValueId {
+    type Walker<'w> = EnumValue<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         EnumValue { schema, id: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/field.rs
+++ b/engine/crates/engine-v2/schema/src/generated/field.rs
@@ -120,11 +120,12 @@ impl<'a> FieldDefinition<'a> {
     }
 }
 
-impl Walk<Schema> for FieldDefinitionId {
-    type Walker<'a> = FieldDefinition<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for FieldDefinitionId {
+    type Walker<'w> = FieldDefinition<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         FieldDefinition { schema, id: self }
     }
@@ -135,6 +136,7 @@ impl std::fmt::Debug for FieldDefinition<'_> {
         f.debug_struct("FieldDefinition")
             .field("name", &self.name())
             .field("description", &self.description())
+            .field("parent_entity", &self.parent_entity())
             .field("ty", &self.ty())
             .field("resolvers", &self.resolvers())
             .field("only_resolvable_in", &self.only_resolvable_in())

--- a/engine/crates/engine-v2/schema/src/generated/field/provides.rs
+++ b/engine/crates/engine-v2/schema/src/generated/field/provides.rs
@@ -47,11 +47,12 @@ impl<'a> FieldProvides<'a> {
     }
 }
 
-impl Walk<Schema> for &FieldProvidesRecord {
-    type Walker < 'a > = FieldProvides < 'a > where Self : 'a ;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for &FieldProvidesRecord {
+    type Walker<'w> = FieldProvides<'w> where Self : 'w , 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         FieldProvides { schema, ref_: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/field/requires.rs
+++ b/engine/crates/engine-v2/schema/src/generated/field/requires.rs
@@ -50,11 +50,12 @@ impl<'a> FieldRequires<'a> {
     }
 }
 
-impl Walk<Schema> for FieldRequiresRecord {
-    type Walker<'a> = FieldRequires<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for FieldRequiresRecord {
+    type Walker<'w> = FieldRequires<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         FieldRequires { schema, item: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/field_set.rs
+++ b/engine/crates/engine-v2/schema/src/generated/field_set.rs
@@ -59,11 +59,12 @@ impl<'a> RequiredField<'a> {
     }
 }
 
-impl Walk<Schema> for RequiredFieldId {
-    type Walker<'a> = RequiredField<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for RequiredFieldId {
+    type Walker<'w> = RequiredField<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         RequiredField { schema, id: self }
     }
@@ -109,11 +110,12 @@ impl<'a> RequiredFieldArgument<'a> {
     }
 }
 
-impl Walk<Schema> for RequiredFieldArgumentRecord {
-    type Walker<'a> = RequiredFieldArgument<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for RequiredFieldArgumentRecord {
+    type Walker<'w> = RequiredFieldArgument<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         RequiredFieldArgument { schema, item: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/header_rule.rs
+++ b/engine/crates/engine-v2/schema/src/generated/header_rule.rs
@@ -61,11 +61,12 @@ impl std::fmt::Debug for NameOrPattern<'_> {
     }
 }
 
-impl Walk<Schema> for NameOrPatternId {
-    type Walker<'a> = NameOrPattern<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for NameOrPatternId {
+    type Walker<'w> = NameOrPattern<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         match self {
             NameOrPatternId::Name(id) => NameOrPattern::Name(&schema[id]),
@@ -160,11 +161,12 @@ impl<'a> HeaderRule<'a> {
     }
 }
 
-impl Walk<Schema> for HeaderRuleId {
-    type Walker<'a> = HeaderRule<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for HeaderRuleId {
+    type Walker<'w> = HeaderRule<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         HeaderRule { schema, id: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/header_rule/forward.rs
+++ b/engine/crates/engine-v2/schema/src/generated/header_rule/forward.rs
@@ -55,11 +55,12 @@ impl<'a> ForwardHeaderRule<'a> {
     }
 }
 
-impl Walk<Schema> for ForwardHeaderRuleRecord {
-    type Walker<'a> = ForwardHeaderRule<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for ForwardHeaderRuleRecord {
+    type Walker<'w> = ForwardHeaderRule<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         ForwardHeaderRule { schema, item: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/header_rule/insert.rs
+++ b/engine/crates/engine-v2/schema/src/generated/header_rule/insert.rs
@@ -46,11 +46,12 @@ impl<'a> InsertHeaderRule<'a> {
     }
 }
 
-impl Walk<Schema> for InsertHeaderRuleRecord {
-    type Walker<'a> = InsertHeaderRule<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for InsertHeaderRuleRecord {
+    type Walker<'w> = InsertHeaderRule<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         InsertHeaderRule { schema, item: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/header_rule/remove.rs
+++ b/engine/crates/engine-v2/schema/src/generated/header_rule/remove.rs
@@ -44,11 +44,12 @@ impl<'a> RemoveHeaderRule<'a> {
     }
 }
 
-impl Walk<Schema> for RemoveHeaderRuleRecord {
-    type Walker<'a> = RemoveHeaderRule<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for RemoveHeaderRuleRecord {
+    type Walker<'w> = RemoveHeaderRule<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         RemoveHeaderRule { schema, item: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/header_rule/rename_duplicate.rs
+++ b/engine/crates/engine-v2/schema/src/generated/header_rule/rename_duplicate.rs
@@ -51,11 +51,12 @@ impl<'a> RenameDuplicateHeaderRule<'a> {
     }
 }
 
-impl Walk<Schema> for RenameDuplicateHeaderRuleRecord {
-    type Walker<'a> = RenameDuplicateHeaderRule<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for RenameDuplicateHeaderRuleRecord {
+    type Walker<'w> = RenameDuplicateHeaderRule<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         RenameDuplicateHeaderRule { schema, item: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/input_object.rs
+++ b/engine/crates/engine-v2/schema/src/generated/input_object.rs
@@ -68,11 +68,12 @@ impl<'a> InputObjectDefinition<'a> {
     }
 }
 
-impl Walk<Schema> for InputObjectDefinitionId {
-    type Walker<'a> = InputObjectDefinition<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for InputObjectDefinitionId {
+    type Walker<'w> = InputObjectDefinition<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         InputObjectDefinition { schema, id: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/input_value.rs
+++ b/engine/crates/engine-v2/schema/src/generated/input_value.rs
@@ -73,11 +73,12 @@ impl<'a> InputValueDefinition<'a> {
     }
 }
 
-impl Walk<Schema> for InputValueDefinitionId {
-    type Walker<'a> = InputValueDefinition<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for InputValueDefinitionId {
+    type Walker<'w> = InputValueDefinition<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         InputValueDefinition { schema, id: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/interface.rs
+++ b/engine/crates/engine-v2/schema/src/generated/interface.rs
@@ -99,11 +99,12 @@ impl<'a> InterfaceDefinition<'a> {
     }
 }
 
-impl Walk<Schema> for InterfaceDefinitionId {
-    type Walker<'a> = InterfaceDefinition<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for InterfaceDefinitionId {
+    type Walker<'w> = InterfaceDefinition<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         InterfaceDefinition { schema, id: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/join_implements.rs
+++ b/engine/crates/engine-v2/schema/src/generated/join_implements.rs
@@ -49,11 +49,12 @@ impl<'a> JoinImplementsDefinition<'a> {
     }
 }
 
-impl Walk<Schema> for JoinImplementsDefinitionRecord {
-    type Walker<'a> = JoinImplementsDefinition<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for JoinImplementsDefinitionRecord {
+    type Walker<'w> = JoinImplementsDefinition<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         JoinImplementsDefinition { schema, item: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/join_member.rs
+++ b/engine/crates/engine-v2/schema/src/generated/join_member.rs
@@ -49,11 +49,12 @@ impl<'a> JoinMemberDefinition<'a> {
     }
 }
 
-impl Walk<Schema> for JoinMemberDefinitionRecord {
-    type Walker<'a> = JoinMemberDefinition<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for JoinMemberDefinitionRecord {
+    type Walker<'w> = JoinMemberDefinition<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         JoinMemberDefinition { schema, item: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/object.rs
+++ b/engine/crates/engine-v2/schema/src/generated/object.rs
@@ -94,11 +94,12 @@ impl<'a> ObjectDefinition<'a> {
     }
 }
 
-impl Walk<Schema> for ObjectDefinitionId {
-    type Walker<'a> = ObjectDefinition<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for ObjectDefinitionId {
+    type Walker<'w> = ObjectDefinition<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         ObjectDefinition { schema, id: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/resolver.rs
+++ b/engine/crates/engine-v2/schema/src/generated/resolver.rs
@@ -92,11 +92,12 @@ impl<'a> ResolverDefinition<'a> {
     }
 }
 
-impl Walk<Schema> for ResolverDefinitionId {
-    type Walker<'a> = ResolverDefinition<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for ResolverDefinitionId {
+    type Walker<'w> = ResolverDefinition<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         ResolverDefinition { schema, id: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/resolver/graphql.rs
+++ b/engine/crates/engine-v2/schema/src/generated/resolver/graphql.rs
@@ -45,11 +45,12 @@ impl<'a> GraphqlRootFieldResolverDefinition<'a> {
     }
 }
 
-impl Walk<Schema> for GraphqlRootFieldResolverDefinitionRecord {
-    type Walker<'a> = GraphqlRootFieldResolverDefinition<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for GraphqlRootFieldResolverDefinitionRecord {
+    type Walker<'w> = GraphqlRootFieldResolverDefinition<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         GraphqlRootFieldResolverDefinition { schema, item: self }
     }
@@ -103,11 +104,12 @@ impl<'a> GraphqlFederationEntityResolverDefinition<'a> {
     }
 }
 
-impl Walk<Schema> for GraphqlFederationEntityResolverDefinitionRecord {
-    type Walker<'a> = GraphqlFederationEntityResolverDefinition<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for GraphqlFederationEntityResolverDefinitionRecord {
+    type Walker<'w> = GraphqlFederationEntityResolverDefinition<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         GraphqlFederationEntityResolverDefinition { schema, item: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/root.rs
+++ b/engine/crates/engine-v2/schema/src/generated/root.rs
@@ -54,11 +54,12 @@ impl<'a> RootOperationTypes<'a> {
     }
 }
 
-impl Walk<Schema> for &RootOperationTypesRecord {
-    type Walker < 'a > = RootOperationTypes < 'a > where Self : 'a ;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for &RootOperationTypesRecord {
+    type Walker<'w> = RootOperationTypes<'w> where Self : 'w , 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         RootOperationTypes { schema, ref_: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/scalar.rs
+++ b/engine/crates/engine-v2/schema/src/generated/scalar.rs
@@ -70,11 +70,12 @@ impl<'a> ScalarDefinition<'a> {
     }
 }
 
-impl Walk<Schema> for ScalarDefinitionId {
-    type Walker<'a> = ScalarDefinition<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for ScalarDefinitionId {
+    type Walker<'w> = ScalarDefinition<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         ScalarDefinition { schema, id: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/subgraph.rs
+++ b/engine/crates/engine-v2/schema/src/generated/subgraph.rs
@@ -50,11 +50,12 @@ impl std::fmt::Debug for Subgraph<'_> {
     }
 }
 
-impl Walk<Schema> for SubgraphId {
-    type Walker<'a> = Subgraph<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for SubgraphId {
+    type Walker<'w> = Subgraph<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         match self {
             SubgraphId::GraphqlEndpoint(id) => Subgraph::GraphqlEndpoint(id.walk(schema)),

--- a/engine/crates/engine-v2/schema/src/generated/subgraph/graphql.rs
+++ b/engine/crates/engine-v2/schema/src/generated/subgraph/graphql.rs
@@ -70,11 +70,12 @@ impl<'a> GraphqlEndpoint<'a> {
     }
 }
 
-impl Walk<Schema> for GraphqlEndpointId {
-    type Walker<'a> = GraphqlEndpoint<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for GraphqlEndpointId {
+    type Walker<'w> = GraphqlEndpoint<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         GraphqlEndpoint { schema, id: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/ty.rs
+++ b/engine/crates/engine-v2/schema/src/generated/ty.rs
@@ -47,11 +47,12 @@ impl<'a> Type<'a> {
     }
 }
 
-impl Walk<Schema> for TypeRecord {
-    type Walker<'a> = Type<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for TypeRecord {
+    type Walker<'w> = Type<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         Type { schema, item: self }
     }

--- a/engine/crates/engine-v2/schema/src/generated/union.rs
+++ b/engine/crates/engine-v2/schema/src/generated/union.rs
@@ -84,11 +84,12 @@ impl<'a> UnionDefinition<'a> {
     }
 }
 
-impl Walk<Schema> for UnionDefinitionId {
-    type Walker<'a> = UnionDefinition<'a>;
-    fn walk<'a>(self, schema: &'a Schema) -> Self::Walker<'a>
+impl<'a> Walk<&'a Schema> for UnionDefinitionId {
+    type Walker<'w> = UnionDefinition<'w> where 'a: 'w ;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 'a,
+        Self: 'w,
+        'a: 'w,
     {
         UnionDefinition { schema, id: self }
     }

--- a/engine/crates/engine-v2/schema/src/ids.rs
+++ b/engine/crates/engine-v2/schema/src/ids.rs
@@ -15,11 +15,12 @@ pub(crate) const MAX_ID: u32 = (1 << 29) - 1;
 #[max(MAX_ID)]
 pub struct UrlId(NonZero<u32>);
 
-impl Walk<Schema> for UrlId {
-    type Walker<'a> = &'a Url;
-    fn walk<'s>(self, schema: &'s Schema) -> Self::Walker<'s>
+impl<'a> Walk<&'a Schema> for UrlId {
+    type Walker<'w> = &'w Url where 'a: 'w;
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 's,
+        Self: 'w,
+        'a: 'w,
     {
         &schema[self]
     }
@@ -29,12 +30,13 @@ impl Walk<Schema> for UrlId {
 #[max(MAX_ID)]
 pub struct StringId(NonZero<u32>);
 
-impl Walk<Schema> for StringId {
-    type Walker<'a> = &'a str;
+impl<'a> Walk<&'a Schema> for StringId {
+    type Walker<'w> = &'w str where 'a: 'w;
 
-    fn walk<'s>(self, schema: &'s Schema) -> Self::Walker<'s>
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 's,
+        Self: 'w,
+        'a: 'w,
     {
         &schema[self]
     }
@@ -44,12 +46,13 @@ impl Walk<Schema> for StringId {
 #[max(MAX_ID)]
 pub struct RegexId(NonZero<u32>);
 
-impl Walk<Schema> for RegexId {
-    type Walker<'a> = &'a Regex;
+impl<'a> Walk<&'a Schema> for RegexId {
+    type Walker<'w> = &'w Regex where 'a: 'w;
 
-    fn walk<'s>(self, schema: &'s Schema) -> Self::Walker<'s>
+    fn walk<'w>(self, schema: &'a Schema) -> Self::Walker<'w>
     where
-        Self: 's,
+        Self: 'w,
+        'a: 'w,
     {
         &schema[self]
     }

--- a/engine/crates/engine-v2/schema/src/input_value/mod.rs
+++ b/engine/crates/engine-v2/schema/src/input_value/mod.rs
@@ -31,12 +31,13 @@ pub struct SchemaInputValues {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, id_derives::Id)]
 pub struct SchemaInputValueId(NonZero<u32>);
 
-impl Walk<Schema> for SchemaInputValueId {
-    type Walker<'a> = SchemaInputValue<'a>;
+impl<'g> Walk<&'g Schema> for SchemaInputValueId {
+    type Walker<'a> = SchemaInputValue<'a> where 'g: 'a;
 
-    fn walk<'s>(self, schema: &'s Schema) -> Self::Walker<'s>
+    fn walk<'a>(self, schema: &'g Schema) -> Self::Walker<'a>
     where
-        Self: 's,
+        Self: 'a,
+        'g: 'a,
     {
         SchemaInputValue {
             schema,
@@ -48,12 +49,13 @@ impl Walk<Schema> for SchemaInputValueId {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, id_derives::Id)]
 pub struct SchemaInputObjectFieldValueId(NonZero<u32>);
 
-impl Walk<Schema> for SchemaInputObjectFieldValueId {
-    type Walker<'a> = (InputValueDefinition<'a>, SchemaInputValue<'a>);
+impl<'g> Walk<&'g Schema> for SchemaInputObjectFieldValueId {
+    type Walker<'a> = (InputValueDefinition<'a>, SchemaInputValue<'a>) where 'g: 'a;
 
-    fn walk<'s>(self, schema: &'s Schema) -> Self::Walker<'s>
+    fn walk<'a>(self, schema: &'g Schema) -> Self::Walker<'a>
     where
-        Self: 's,
+        Self: 'a,
+        'g: 'a,
     {
         let (input_value_definition, value) = &schema[self];
         (input_value_definition.walk(schema), value.walk(schema))
@@ -63,12 +65,13 @@ impl Walk<Schema> for SchemaInputObjectFieldValueId {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, id_derives::Id)]
 pub struct SchemaInputKeyValueId(NonZero<u32>);
 
-impl Walk<Schema> for SchemaInputKeyValueId {
-    type Walker<'a> = (&'a str, SchemaInputValue<'a>);
+impl<'g> Walk<&'g Schema> for SchemaInputKeyValueId {
+    type Walker<'a> = (&'a str, SchemaInputValue<'a>) where 'g: 'a;
 
-    fn walk<'s>(self, schema: &'s Schema) -> Self::Walker<'s>
+    fn walk<'a>(self, schema: &'g Schema) -> Self::Walker<'a>
     where
-        Self: 's,
+        Self: 'a,
+        'g: 'a,
     {
         let (key, value) = &schema[self];
         (key.walk(schema), value.walk(schema))
@@ -99,11 +102,12 @@ pub enum SchemaInputValueRecord {
     UnboundEnumValue(StringId),
 }
 
-impl Walk<Schema> for &SchemaInputValueRecord {
-    type Walker<'a> = SchemaInputValue<'a> where Self: 'a;
-    fn walk<'s>(self, schema: &'s Schema) -> Self::Walker<'s>
+impl<'g> Walk<&'g Schema> for &SchemaInputValueRecord {
+    type Walker<'a> = SchemaInputValue<'a> where Self: 'a, 'g: 'a;
+    fn walk<'a>(self, schema: &'g Schema) -> Self::Walker<'a>
     where
-        Self: 's,
+        Self: 'a,
+        'g: 'a,
     {
         SchemaInputValue { schema, value: self }
     }

--- a/engine/crates/engine-v2/schema/src/lib.rs
+++ b/engine/crates/engine-v2/schema/src/lib.rs
@@ -51,7 +51,7 @@ impl Schema {
     }
 }
 
-pub type Walker<'a, T> = walker::Walker<'a, T, Schema>;
+pub type Walker<'a, T> = walker::Walker<'a, T, &'a Schema>;
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct Version(Vec<u8>);
@@ -178,7 +178,7 @@ pub struct SubGraphs {
 }
 
 impl Schema {
-    pub fn walk<T: Walk<Self>>(&self, item: T) -> Walker<'_, T> {
+    pub fn walk<T: for<'s> Walk<&'s Self>>(&self, item: T) -> Walker<'_, T> {
         item.walk(self)
     }
 

--- a/engine/crates/engine-v2/walker/src/lib.rs
+++ b/engine/crates/engine-v2/walker/src/lib.rs
@@ -7,22 +7,24 @@ pub use iter::*;
 pub trait Iter: ExactSizeIterator + std::iter::FusedIterator + DoubleEndedIterator + std::fmt::Debug {}
 impl<T: ExactSizeIterator + std::iter::FusedIterator + DoubleEndedIterator + std::fmt::Debug> Iter for T {}
 
-pub trait Walk<G> {
+pub trait Walk<Ctx> {
     type Walker<'a>
     where
         Self: 'a,
-        G: 'a;
+        Ctx: 'a;
 
-    fn walk<'a>(self, graph: &'a G) -> Self::Walker<'a>
-    where
-        Self: 'a;
-}
-
-impl<G> Walk<G> for () {
-    type Walker<'a> = () where G: 'a;
-    fn walk<'a>(self, _: &'a G) -> Self::Walker<'a>
+    fn walk<'a>(self, ctx: Ctx) -> Self::Walker<'a>
     where
         Self: 'a,
+        Ctx: 'a;
+}
+
+impl<Ctx> Walk<Ctx> for () {
+    type Walker<'a> = () where Ctx: 'a;
+    fn walk<'a>(self, _: Ctx) -> Self::Walker<'a>
+    where
+        Self: 'a,
+        Ctx: 'a,
     {
     }
 }
@@ -31,47 +33,51 @@ pub type Walker<'a, T, G> = <T as Walk<G>>::Walker<'a>;
 
 // / Convenient implementation to write:
 // / `id.read(schema)` rather than `(*id).read(schema)` when id is a ref from the schema
-impl<G, T: Copy + Walk<G>> Walk<G> for &T {
-    type Walker<'a> = Walker<'a, T, G>
+impl<Ctx, T: Copy + Walk<Ctx>> Walk<Ctx> for &T {
+    type Walker<'a> = Walker<'a, T, Ctx>
     where
         Self: 'a,
-        G: 'a;
+        Ctx: 'a;
 
-    fn walk<'a>(self, graph: &'a G) -> Self::Walker<'a>
+    fn walk<'a>(self, ctx: Ctx) -> Self::Walker<'a>
     where
         Self: 'a,
+        Ctx: 'a,
     {
-        (*self).walk(graph)
+        (*self).walk(ctx)
     }
 }
 
-impl<G, T: Walk<G>> Walk<G> for Option<T> {
-    type Walker<'a> = Option<Walker<'a, T, G>>
+impl<Ctx, T: Walk<Ctx>> Walk<Ctx> for Option<T> {
+    type Walker<'a> = Option<Walker<'a, T, Ctx>>
     where
         Self: 'a,
-        G: 'a;
+        Ctx: 'a;
 
-    fn walk<'a>(self, graph: &'a G) -> Self::Walker<'a>
+    fn walk<'a>(self, ctx: Ctx) -> Self::Walker<'a>
     where
         Self: 'a,
+        Ctx: 'a,
     {
-        self.map(|value| value.walk(graph))
+        self.map(|value| value.walk(ctx))
     }
 }
 
-impl<G, T> Walk<G> for &[T]
+impl<Ctx, T> Walk<Ctx> for &[T]
 where
-    for<'a> &'a T: Walk<G>,
+    for<'a> &'a T: Walk<Ctx>,
+    Ctx: Copy,
 {
-    type Walker<'a> = WalkIterator<'a, std::slice::Iter<'a, T>, G>
+    type Walker<'a> = WalkIterator<'a, std::slice::Iter<'a, T>, Ctx>
     where
         Self: 'a,
-        G: 'a;
+        Ctx: 'a;
 
-    fn walk<'a>(self, graph: &'a G) -> Self::Walker<'a>
+    fn walk<'a>(self, ctx: Ctx) -> Self::Walker<'a>
     where
         Self: 'a,
+        Ctx: 'a,
     {
-        WalkIterator::new(self.iter(), graph)
+        WalkIterator::new(self.iter(), ctx)
     }
 }


### PR DESCRIPTION
Support importing another "domain" file, typically `schema.graphql` to be able to use `FieldDefinition` and add a few features to make it possible to generate operation-related structs:
- root module and use it as the private visibility `(in crate:...)`
- public visibility `(crate)` instead of nothing
- support for more complex "context" types in the walkers. So instead of just `&'a Schema`, no it's possible to use `Context<'a>` which can hold multiple references. This required changing the `Walk` trait which expected a reference.

This allows me to generate operations-related structs referencing the schema with codegen like in https://github.com/grafbase/grafbase/pull/2287.
