### PR TITLE
chore(engine-v2): Prepare engine-v2 for the new OperationPlan

### DIFF
--- a/engine/crates/engine-v2/src/execution/planner/builder.rs
+++ b/engine/crates/engine-v2/src/execution/planner/builder.rs
@@ -10,7 +10,8 @@ use walker::Walk;
 use crate::{
     execution::{ExecutableOperation, ExecutionPlan, ExecutionPlanId, PreExecutionContext, ResponseModifierExecutor},
     operation::{
-        FieldId, LogicalPlanId, OperationWalker, PlanWalker, ResponseModifierRule, SelectionSetId, SelectionSetType,
+        BoundFieldId, BoundSelectionSetId, LogicalPlanId, OperationWalker, PlanWalker, ResponseModifierRule,
+        SelectionSetType,
     },
     response::{ResponseObjectSetId, ResponseViewSelection, ResponseViewSelectionSet},
     sources::Resolver,
@@ -88,7 +89,7 @@ where
             // Where the field will be present in the response
             set_id: ResponseObjectSetId,
             // What field is impacted
-            field_id: FieldId,
+            field_id: BoundFieldId,
             field_logical_plan_id: LogicalPlanId,
         }
         let walker = self.walker();
@@ -191,8 +192,8 @@ where
     fn create_plan_view_and_list_dependencies(
         &mut self,
         resolver: ResolverDefinition<'_>,
-        field_ids: &Vec<FieldId>,
-    ) -> (ResponseViewSelectionSet, Vec<FieldId>) {
+        field_ids: &Vec<BoundFieldId>,
+    ) -> (ResponseViewSelectionSet, Vec<BoundFieldId>) {
         let mut required_fields = Cow::Borrowed(resolver.requires_or_empty());
         let mut required_fields_by_selection_set_id = HashMap::new();
         for field_id in field_ids {
@@ -231,9 +232,9 @@ where
 
     fn collect_dependencies(
         &mut self,
-        id: SelectionSetId,
+        id: BoundSelectionSetId,
         required_fields: &RequiredFieldSetRecord,
-        dependencies: &mut Vec<FieldId>,
+        dependencies: &mut Vec<BoundFieldId>,
     ) {
         for required_field in required_fields {
             let solved_requirements = &self.operation.solved_requirements_for(id).expect("Should be planned");

--- a/engine/crates/engine-v2/src/execution/planner/mod.rs
+++ b/engine/crates/engine-v2/src/execution/planner/mod.rs
@@ -12,7 +12,7 @@ use crate::{
         ExecutionPlan, ExecutionPlanId, PlanningResult, PreExecutionContext, QueryModifications,
         ResponseModifierExecutorId,
     },
-    operation::{FieldId, LogicalPlanId, PreparedOperation, Variables},
+    operation::{BoundFieldId, LogicalPlanId, PreparedOperation, Variables},
     response::{ResponseViewSelection, ResponseViews},
     utils::BufferPool,
     Runtime,
@@ -45,8 +45,8 @@ impl<'ctx, 'op, R: Runtime> std::ops::DerefMut for ExecutionPlanner<'ctx, 'op, R
 struct BuildContext {
     // Either an input or output field of a plan or response modifier
     #[indexed_by(IOFieldId)]
-    io_fields: Vec<FieldId>,
-    io_fields_buffer_pool: BufferPool<FieldId>,
+    io_fields: Vec<BoundFieldId>,
+    io_fields_buffer_pool: BufferPool<BoundFieldId>,
     response_modifier_executors: Vec<ResponseModifierExecutor>,
     response_modifier_executors_input_fields: Vec<IdRange<IOFieldId>>,
     response_modifier_executors_output_fields: Vec<IdRange<IOFieldId>>,
@@ -61,7 +61,7 @@ struct BuildContext {
 pub struct IOFieldId(std::num::NonZero<u16>);
 
 impl BuildContext {
-    fn push_io_fields(&mut self, mut fields: Vec<FieldId>) -> IdRange<IOFieldId> {
+    fn push_io_fields(&mut self, mut fields: Vec<BoundFieldId>) -> IdRange<IOFieldId> {
         let start = self.io_fields.len();
         self.io_fields.extend(&mut fields.drain(..));
         self.io_fields_buffer_pool.push(fields);

--- a/engine/crates/engine-v2/src/operation/bind/coercion/variable.rs
+++ b/engine/crates/engine-v2/src/operation/bind/coercion/variable.rs
@@ -5,7 +5,9 @@ use schema::{
     ScalarType, Schema, TypeRecord,
 };
 
-use crate::operation::{Location, VariableDefinition, VariableInputValue, VariableInputValueId, VariableInputValues};
+use crate::operation::{
+    Location, VariableDefinitionRecord, VariableInputValue, VariableInputValueId, VariableInputValues,
+};
 
 use super::{
     error::InputValueError,
@@ -15,7 +17,7 @@ use super::{
 pub fn coerce_variable(
     schema: &Schema,
     input_values: &mut VariableInputValues,
-    definition: &VariableDefinition,
+    definition: &VariableDefinitionRecord,
     value: ConstValue,
 ) -> Result<VariableInputValueId, InputValueError> {
     let mut ctx = VariableCoercionContext {
@@ -25,7 +27,7 @@ pub fn coerce_variable(
         value_path: Vec::new(),
         input_fields_buffer_pool: Vec::new(),
     };
-    let value = ctx.coerce_input_value(definition.ty, value)?;
+    let value = ctx.coerce_input_value(definition.ty_record, value)?;
     Ok(input_values.push_value(value))
 }
 

--- a/engine/crates/engine-v2/src/operation/bind/error.rs
+++ b/engine/crates/engine-v2/src/operation/bind/error.rs
@@ -1,0 +1,131 @@
+use itertools::Itertools;
+
+use crate::{operation::Location, response::GraphqlError, ErrorCode};
+
+use super::ErrorOperationName;
+
+#[derive(thiserror::Error, Debug)]
+pub enum BindError {
+    #[error("Unknown type named '{name}'")]
+    UnknownType { name: String, location: Location },
+    #[error("The field `{field_name}` does not have an argument named `{argument_name}")]
+    UnknownArgument {
+        field_name: String,
+        argument_name: String,
+        location: Location,
+    },
+    #[error("{container} does not have a field named '{name}'")]
+    UnknownField {
+        container: String,
+        name: String,
+        location: Location,
+    },
+    #[error("Unknown fragment named '{name}'")]
+    UnknownFragment { name: String, location: Location },
+    #[error("Field '{name}' does not exists on {ty}, it's a union. Only interfaces and objects have fields, consider using a fragment with a type condition.")]
+    UnionHaveNoFields {
+        name: String,
+        ty: String,
+        location: Location,
+    },
+    #[error("Field '{name}' cannot have a selection set, it's a {ty}. Only interfaces, unions and objects can.")]
+    CannotHaveSelectionSet {
+        name: String,
+        ty: String,
+        location: Location,
+    },
+    #[error("Type conditions cannot be declared on '{name}', only on unions, interfaces or objects.")]
+    InvalidTypeConditionTargetType { name: String, location: Location },
+    #[error("Type condition on '{name}' cannot be used in a '{parent}' selection_set")]
+    DisjointTypeCondition {
+        parent: String,
+        name: String,
+        location: Location,
+    },
+    #[error("Mutations are not defined on this schema.")]
+    NoMutationDefined,
+    #[error("Subscriptions are not defined on this schema.")]
+    NoSubscriptionDefined,
+    #[error("Leaf field '{name}' must be a scalar or an enum, but is a {ty}.")]
+    LeafMustBeAScalarOrEnum {
+        name: String,
+        ty: String,
+        location: Location,
+    },
+    #[error(
+        "Variable named '${name}' does not have a valid input type. Can only be a scalar, enum or input object. Found: '{ty}'."
+    )]
+    InvalidVariableType {
+        name: String,
+        ty: String,
+        location: Location,
+    },
+    #[error("Too many fields selection set.")]
+    TooManyFields { location: Location },
+    #[error("There can only be one variable named '${name}'")]
+    DuplicateVariable { name: String, location: Location },
+    #[error("Variable '${name}' is not used{operation}")]
+    UnusedVariable {
+        name: String,
+        operation: ErrorOperationName,
+        location: Location,
+    },
+    #[error("Fragment cycle detected: {}", .cycle.iter().join(", "))]
+    FragmentCycle { cycle: Vec<String>, location: Location },
+    #[error("Query is too big: {0}")]
+    QueryTooBig(String),
+    #[error("{0}")]
+    InvalidInputValue(#[from] super::coercion::InputValueError),
+    #[error("Missing argument named '{name}' for field '{field}'")]
+    MissingArgument {
+        field: String,
+        name: String,
+        location: Location,
+    },
+    #[error("Query is too complex.")]
+    QueryTooComplex { complexity: usize, location: Location },
+    #[error("Query is nested too deep.")]
+    QueryTooDeep { depth: usize, location: Location },
+    #[error("Query contains too many root fields.")]
+    QueryContainsTooManyRootFields { count: usize, location: Location },
+    #[error("Query contains too many aliases.")]
+    QueryContainsTooManyAliases { count: usize, location: Location },
+    #[error("Missing argument named '{name}' for directive '{directive}'")]
+    MissingDirectiveArgument {
+        name: String,
+        directive: String,
+        location: Location,
+    },
+}
+
+impl From<BindError> for GraphqlError {
+    fn from(err: BindError) -> Self {
+        let locations = match err {
+            BindError::UnknownField { location, .. }
+            | BindError::UnknownArgument { location, .. }
+            | BindError::UnknownType { location, .. }
+            | BindError::UnknownFragment { location, .. }
+            | BindError::UnionHaveNoFields { location, .. }
+            | BindError::InvalidTypeConditionTargetType { location, .. }
+            | BindError::CannotHaveSelectionSet { location, .. }
+            | BindError::DisjointTypeCondition { location, .. }
+            | BindError::InvalidVariableType { location, .. }
+            | BindError::TooManyFields { location }
+            | BindError::LeafMustBeAScalarOrEnum { location, .. }
+            | BindError::DuplicateVariable { location, .. }
+            | BindError::FragmentCycle { location, .. }
+            | BindError::MissingArgument { location, .. }
+            | BindError::MissingDirectiveArgument { location, .. }
+            | BindError::UnusedVariable { location, .. }
+            | BindError::QueryTooComplex { location, .. }
+            | BindError::QueryTooDeep { location, .. }
+            | BindError::QueryContainsTooManyAliases { location, .. }
+            | BindError::QueryContainsTooManyRootFields { location, .. } => vec![location],
+            BindError::InvalidInputValue(ref err) => vec![err.location()],
+            BindError::NoMutationDefined | BindError::NoSubscriptionDefined | BindError::QueryTooBig { .. } => {
+                vec![]
+            }
+        };
+        GraphqlError::new(err.to_string(), ErrorCode::OperationValidationError).with_locations(locations)
+    }
+}

--- a/engine/crates/engine-v2/src/operation/bind/selection_set.rs
+++ b/engine/crates/engine-v2/src/operation/bind/selection_set.rs
@@ -9,7 +9,7 @@ use super::{BindError, BindResult, Binder};
 use crate::operation::bind::coercion::coerce_query_value;
 use crate::operation::{QueryInputValueId, QueryModifierRule};
 use crate::{
-    operation::{FieldId, Location, QueryPosition, SelectionSet, SelectionSetId, SelectionSetType},
+    operation::{BoundFieldId, BoundSelectionSet, BoundSelectionSetId, Location, QueryPosition, SelectionSetType},
     response::SafeResponseKey,
 };
 
@@ -18,7 +18,7 @@ impl<'schema, 'p> Binder<'schema, 'p> {
         &mut self,
         ty: SelectionSetType,
         merged_selection_sets: &[&'p Positioned<engine_parser::types::SelectionSet>],
-    ) -> BindResult<SelectionSetId> {
+    ) -> BindResult<BoundSelectionSetId> {
         SelectionSetBinder::new(self).bind(ty, merged_selection_sets)
     }
 }
@@ -85,13 +85,13 @@ impl<'schema, 'p, 'binder> SelectionSetBinder<'schema, 'p, 'binder> {
         mut self,
         ty: SelectionSetType,
         merged_selection_sets: &[&'p Positioned<engine_parser::types::SelectionSet>],
-    ) -> BindResult<SelectionSetId> {
+    ) -> BindResult<BoundSelectionSetId> {
         for selection_set in merged_selection_sets {
             self.register_selection_set_fields(ty, selection_set, &ExecutableDirectives::default())?;
         }
 
-        let id = SelectionSetId::from(self.selection_sets.len());
-        self.selection_sets.push(SelectionSet::default());
+        let id = BoundSelectionSetId::from(self.selection_sets.len());
+        self.selection_sets.push(BoundSelectionSet::default());
 
         let mut field_ids = self.generate_fields(ty, id)?;
 
@@ -108,7 +108,7 @@ impl<'schema, 'p, 'binder> SelectionSetBinder<'schema, 'p, 'binder> {
         Ok(id)
     }
 
-    fn generate_fields(&mut self, ty: SelectionSetType, id: SelectionSetId) -> BindResult<Vec<FieldId>> {
+    fn generate_fields(&mut self, ty: SelectionSetType, id: BoundSelectionSetId) -> BindResult<Vec<BoundFieldId>> {
         let mut field_ids = Vec::with_capacity(self.fields.len());
 
         for ((response_key, definition_id), (query_position, fields, rules)) in std::mem::take(&mut self.fields) {

--- a/engine/crates/engine-v2/src/operation/blueprint/mod.rs
+++ b/engine/crates/engine-v2/src/operation/blueprint/mod.rs
@@ -14,7 +14,8 @@ use crate::{
 };
 
 use super::{
-    FieldId, LogicalPlanId, OperationPlan, OperationWalker, ResponseBlueprint, ResponseModifierRule, SelectionSetType,
+    BoundFieldId, LogicalPlanId, OperationPlan, OperationWalker, ResponseBlueprint, ResponseModifierRule,
+    SelectionSetType,
 };
 
 pub(super) struct ResponseBlueprintBuilder<'schema, 'op> {
@@ -22,8 +23,8 @@ pub(super) struct ResponseBlueprintBuilder<'schema, 'op> {
     operation: &'op Operation,
     plan: &'op OperationPlan,
     to_build_stack: Vec<ToBuild>,
-    field_shapes_buffer_pool: BufferPool<(FieldShape, Vec<FieldId>)>,
-    field_id_to_field_shape_ids_builder: Vec<(FieldId, FieldShapeId)>,
+    field_shapes_buffer_pool: BufferPool<(FieldShape, Vec<BoundFieldId>)>,
+    field_id_to_field_shape_ids_builder: Vec<(BoundFieldId, FieldShapeId)>,
     logical_plan_to_blueprint_builder: Vec<(LogicalPlanId, LogicalPlanResponseBlueprint)>,
     selection_set_to_response_object_set: Vec<Option<ResponseObjectSetId>>,
     blueprint: ResponseBlueprint,
@@ -32,7 +33,7 @@ pub(super) struct ResponseBlueprintBuilder<'schema, 'op> {
 struct ToBuild {
     logical_plan_id: LogicalPlanId,
     input_id: ResponseObjectSetId,
-    root_field_ids: Vec<FieldId>,
+    root_field_ids: Vec<BoundFieldId>,
 }
 
 impl<'schema, 'op> ResponseBlueprintBuilder<'schema, 'op>
@@ -97,7 +98,7 @@ where
     fn traverse_operation_and_build_blueprint(&mut self) {
         let walker = self.walker();
         let root_plans = walker.selection_set().fields().fold(
-            HashMap::<LogicalPlanId, Vec<FieldId>>::default(),
+            HashMap::<LogicalPlanId, Vec<BoundFieldId>>::default(),
             |mut acc, field| {
                 let plan_id = self.plan.field_to_logical_plan_id[usize::from(field.id())];
                 acc.entry(plan_id).or_default().push(field.id());

--- a/engine/crates/engine-v2/src/operation/ids.rs
+++ b/engine/crates/engine-v2/src/operation/ids.rs
@@ -4,25 +4,25 @@ use std::num::NonZero;
 pub struct LogicalPlanId(NonZero<u16>);
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-pub struct SelectionSetId(NonZero<u16>);
+pub struct BoundSelectionSetId(NonZero<u16>);
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
 pub struct VariableDefinitionId(NonZero<u16>);
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-pub struct FieldId(NonZero<u16>);
+pub struct BoundFieldId(NonZero<u16>);
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-pub struct FieldArgumentId(NonZero<u16>);
+pub struct BoundFieldArgumentId(NonZero<u16>);
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-pub struct ResponseModifierId(NonZero<u16>);
+pub struct BoundResponseModifierId(NonZero<u16>);
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-pub struct ResponseModifierImpactedFieldId(NonZero<u16>);
+pub struct BoundResponseModifierImpactedFieldId(NonZero<u16>);
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-pub struct QueryModifierId(NonZero<u16>);
+pub struct BoundQueryModifierId(NonZero<u16>);
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-pub struct QueryModifierImpactedFieldId(NonZero<u16>);
+pub struct BoundQueryModifierImpactedFieldId(NonZero<u16>);

--- a/engine/crates/engine-v2/src/operation/input_value/query/mod.rs
+++ b/engine/crates/engine-v2/src/operation/input_value/query/mod.rs
@@ -17,15 +17,15 @@ pub(crate) use view::*;
 pub(crate) struct QueryInputValues {
     /// Individual input values and list values
     #[indexed_by(QueryInputValueId)]
-    values: Vec<QueryInputValue>,
+    values: Vec<QueryInputValueRecord>,
 
     /// InputObject's fields
     #[indexed_by(QueryInputObjectFieldValueId)]
-    input_fields: Vec<(InputValueDefinitionId, QueryInputValue)>,
+    input_fields: Vec<(InputValueDefinitionId, QueryInputValueRecord)>,
 
     /// Object's fields (for JSON)
     #[indexed_by(QueryInputKeyValueId)]
-    key_values: Vec<(String, QueryInputValue)>,
+    key_values: Vec<(String, QueryInputValueRecord)>,
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, Id)]
@@ -38,7 +38,7 @@ pub struct QueryInputObjectFieldValueId(std::num::NonZero<u32>);
 pub struct QueryInputKeyValueId(std::num::NonZero<u32>);
 
 #[derive(Default, Clone, serde::Serialize, serde::Deserialize)]
-pub(crate) enum QueryInputValue {
+pub(crate) enum QueryInputValueRecord {
     #[default]
     Null,
     String(String),
@@ -63,7 +63,7 @@ pub(crate) enum QueryInputValue {
 }
 
 impl QueryInputValues {
-    pub fn push_value(&mut self, value: QueryInputValue) -> QueryInputValueId {
+    pub fn push_value(&mut self, value: QueryInputValueRecord) -> QueryInputValueId {
         let id = QueryInputValueId::from(self.values.len());
         self.values.push(value);
         id
@@ -75,7 +75,7 @@ impl QueryInputValues {
         let start = self.values.len();
         self.values.reserve(n);
         for _ in 0..n {
-            self.values.push(QueryInputValue::Null);
+            self.values.push(QueryInputValueRecord::Null);
         }
         (start..self.values.len()).into()
     }
@@ -85,14 +85,14 @@ impl QueryInputValues {
         let start = self.key_values.len();
         self.key_values.reserve(n);
         for _ in 0..n {
-            self.key_values.push((String::new(), QueryInputValue::Null));
+            self.key_values.push((String::new(), QueryInputValueRecord::Null));
         }
         (start..self.key_values.len()).into()
     }
 
     pub fn append_input_object(
         &mut self,
-        fields: &mut Vec<(InputValueDefinitionId, QueryInputValue)>,
+        fields: &mut Vec<(InputValueDefinitionId, QueryInputValueRecord)>,
     ) -> IdRange<QueryInputObjectFieldValueId> {
         let start = self.input_fields.len();
         self.input_fields.append(fields);
@@ -100,12 +100,12 @@ impl QueryInputValues {
     }
 }
 
-pub(crate) type QueryInputValueWalker<'a> = PreparedOperationWalker<'a, &'a QueryInputValue>;
+pub(crate) type QueryInputValueWalker<'a> = PreparedOperationWalker<'a, &'a QueryInputValueRecord>;
 
 impl<'a> QueryInputValueWalker<'a> {
     pub fn is_undefined(&self) -> bool {
         match self.item {
-            QueryInputValue::Variable(id) => self.walk(*id).as_value().is_undefined(),
+            QueryInputValueRecord::Variable(id) => self.walk(*id).as_value().is_undefined(),
             _ => false,
         }
     }
@@ -114,15 +114,15 @@ impl<'a> QueryInputValueWalker<'a> {
     /// present after query normalization.
     pub fn to_normalized_query_const_value_str(self) -> Option<&'a str> {
         Some(match self.item {
-            QueryInputValue::EnumValue(id) => self.schema.walk(*id).name(),
-            QueryInputValue::Boolean(b) => {
+            QueryInputValueRecord::EnumValue(id) => self.schema.walk(*id).name(),
+            QueryInputValueRecord::Boolean(b) => {
                 if *b {
                     "true"
                 } else {
                     "false"
                 }
             }
-            QueryInputValue::DefaultValue(id) => match &self.schema[*id] {
+            QueryInputValueRecord::DefaultValue(id) => match &self.schema[*id] {
                 SchemaInputValueRecord::EnumValue(id) => self.schema.walk(*id).name(),
                 SchemaInputValueRecord::Boolean(b) => {
                     if *b {
@@ -149,15 +149,15 @@ impl<'a> From<QueryInputValueWalker<'a>> for InputValue<'a> {
     fn from(walker: QueryInputValueWalker<'a>) -> Self {
         let input_values = &walker.operation.query_input_values;
         match walker.item {
-            QueryInputValue::Null => InputValue::Null,
-            QueryInputValue::String(s) => InputValue::String(s.as_str()),
-            QueryInputValue::EnumValue(id) => InputValue::EnumValue(walker.schema.walk(*id)),
-            QueryInputValue::UnboundEnumValue(s) => InputValue::UnboundEnumValue(s.as_str()),
-            QueryInputValue::Int(n) => InputValue::Int(*n),
-            QueryInputValue::BigInt(n) => InputValue::BigInt(*n),
-            QueryInputValue::Float(f) => InputValue::Float(*f),
-            QueryInputValue::Boolean(b) => InputValue::Boolean(*b),
-            QueryInputValue::InputObject(ids) => {
+            QueryInputValueRecord::Null => InputValue::Null,
+            QueryInputValueRecord::String(s) => InputValue::String(s.as_str()),
+            QueryInputValueRecord::EnumValue(id) => InputValue::EnumValue(walker.schema.walk(*id)),
+            QueryInputValueRecord::UnboundEnumValue(s) => InputValue::UnboundEnumValue(s.as_str()),
+            QueryInputValueRecord::Int(n) => InputValue::Int(*n),
+            QueryInputValueRecord::BigInt(n) => InputValue::BigInt(*n),
+            QueryInputValueRecord::Float(f) => InputValue::Float(*f),
+            QueryInputValueRecord::Boolean(b) => InputValue::Boolean(*b),
+            QueryInputValueRecord::InputObject(ids) => {
                 let mut fields = Vec::with_capacity(ids.len());
                 for (definition_id, value) in &input_values[*ids] {
                     let value = walker.walk(value);
@@ -168,14 +168,14 @@ impl<'a> From<QueryInputValueWalker<'a>> for InputValue<'a> {
                 }
                 InputValue::InputObject(fields)
             }
-            QueryInputValue::List(ids) => {
+            QueryInputValueRecord::List(ids) => {
                 let mut values = Vec::with_capacity(ids.len());
                 for id in *ids {
                     values.push(walker.walk(&input_values[id]).into());
                 }
                 InputValue::List(values)
             }
-            QueryInputValue::Map(ids) => {
+            QueryInputValueRecord::Map(ids) => {
                 let mut key_values = Vec::with_capacity(ids.len());
                 for (key, value) in &input_values[*ids] {
                     let value = walker.walk(value);
@@ -183,29 +183,29 @@ impl<'a> From<QueryInputValueWalker<'a>> for InputValue<'a> {
                 }
                 InputValue::Map(key_values)
             }
-            QueryInputValue::U64(n) => InputValue::U64(*n),
-            QueryInputValue::DefaultValue(id) => id.walk(walker.schema).into(),
-            QueryInputValue::Variable(id) => walker.walk(*id).as_value().to_input_value().unwrap_or_default(),
+            QueryInputValueRecord::U64(n) => InputValue::U64(*n),
+            QueryInputValueRecord::DefaultValue(id) => id.walk(walker.schema).into(),
+            QueryInputValueRecord::Variable(id) => walker.walk(*id).as_value().to_input_value().unwrap_or_default(),
         }
     }
 }
 
-impl PartialEq<SchemaInputValueRecord> for OperationWalker<'_, &QueryInputValue> {
+impl PartialEq<SchemaInputValueRecord> for OperationWalker<'_, &QueryInputValueRecord> {
     fn eq(&self, other: &SchemaInputValueRecord) -> bool {
         let input_values = &self.operation.query_input_values;
         match (self.item, other) {
-            (QueryInputValue::Null, SchemaInputValueRecord::Null) => true,
-            (QueryInputValue::String(l), SchemaInputValueRecord::String(r)) => l == &self.schema[*r],
-            (QueryInputValue::EnumValue(l), SchemaInputValueRecord::EnumValue(r)) => l == r,
-            (QueryInputValue::UnboundEnumValue(l), SchemaInputValueRecord::UnboundEnumValue(r)) => {
+            (QueryInputValueRecord::Null, SchemaInputValueRecord::Null) => true,
+            (QueryInputValueRecord::String(l), SchemaInputValueRecord::String(r)) => l == &self.schema[*r],
+            (QueryInputValueRecord::EnumValue(l), SchemaInputValueRecord::EnumValue(r)) => l == r,
+            (QueryInputValueRecord::UnboundEnumValue(l), SchemaInputValueRecord::UnboundEnumValue(r)) => {
                 l == &self.schema[*r]
             }
-            (QueryInputValue::Int(l), SchemaInputValueRecord::Int(r)) => l == r,
-            (QueryInputValue::BigInt(l), SchemaInputValueRecord::BigInt(r)) => l == r,
-            (QueryInputValue::U64(l), SchemaInputValueRecord::U64(r)) => l == r,
-            (QueryInputValue::Float(l), SchemaInputValueRecord::Float(r)) => l == r,
-            (QueryInputValue::Boolean(l), SchemaInputValueRecord::Boolean(r)) => l == r,
-            (QueryInputValue::InputObject(lids), SchemaInputValueRecord::InputObject(rids)) => {
+            (QueryInputValueRecord::Int(l), SchemaInputValueRecord::Int(r)) => l == r,
+            (QueryInputValueRecord::BigInt(l), SchemaInputValueRecord::BigInt(r)) => l == r,
+            (QueryInputValueRecord::U64(l), SchemaInputValueRecord::U64(r)) => l == r,
+            (QueryInputValueRecord::Float(l), SchemaInputValueRecord::Float(r)) => l == r,
+            (QueryInputValueRecord::Boolean(l), SchemaInputValueRecord::Boolean(r)) => l == r,
+            (QueryInputValueRecord::InputObject(lids), SchemaInputValueRecord::InputObject(rids)) => {
                 let op_input_values = &input_values[*lids];
                 let schema_input_values = &self.schema[*rids];
 
@@ -226,7 +226,7 @@ impl PartialEq<SchemaInputValueRecord> for OperationWalker<'_, &QueryInputValue>
 
                 true
             }
-            (QueryInputValue::List(lids), SchemaInputValueRecord::List(rids)) => {
+            (QueryInputValueRecord::List(lids), SchemaInputValueRecord::List(rids)) => {
                 let left = &input_values[*lids];
                 let right = &self.schema[*rids];
                 if left.len() != right.len() {
@@ -239,7 +239,7 @@ impl PartialEq<SchemaInputValueRecord> for OperationWalker<'_, &QueryInputValue>
                 }
                 true
             }
-            (QueryInputValue::Map(ids), SchemaInputValueRecord::Map(other_ids)) => {
+            (QueryInputValueRecord::Map(ids), SchemaInputValueRecord::Map(other_ids)) => {
                 let op_kv = &input_values[*ids];
                 let schema_kv = &self.schema[*other_ids];
 
@@ -256,21 +256,21 @@ impl PartialEq<SchemaInputValueRecord> for OperationWalker<'_, &QueryInputValue>
 
                 true
             }
-            (QueryInputValue::DefaultValue(id), value) => id.walk(self.schema).eq(&value.walk(self.schema)),
-            (QueryInputValue::Variable(_), _) => false,
+            (QueryInputValueRecord::DefaultValue(id), value) => id.walk(self.schema).eq(&value.walk(self.schema)),
+            (QueryInputValueRecord::Variable(_), _) => false,
             // A bit tedious, but avoids missing a case
-            (QueryInputValue::Null, _) => false,
-            (QueryInputValue::String(_), _) => false,
-            (QueryInputValue::EnumValue(_), _) => false,
-            (QueryInputValue::UnboundEnumValue(_), _) => false,
-            (QueryInputValue::Int(_), _) => false,
-            (QueryInputValue::BigInt(_), _) => false,
-            (QueryInputValue::U64(_), _) => false,
-            (QueryInputValue::Float(_), _) => false,
-            (QueryInputValue::Boolean(_), _) => false,
-            (QueryInputValue::InputObject(_), _) => false,
-            (QueryInputValue::List(_), _) => false,
-            (QueryInputValue::Map(_), _) => false,
+            (QueryInputValueRecord::Null, _) => false,
+            (QueryInputValueRecord::String(_), _) => false,
+            (QueryInputValueRecord::EnumValue(_), _) => false,
+            (QueryInputValueRecord::UnboundEnumValue(_), _) => false,
+            (QueryInputValueRecord::Int(_), _) => false,
+            (QueryInputValueRecord::BigInt(_), _) => false,
+            (QueryInputValueRecord::U64(_), _) => false,
+            (QueryInputValueRecord::Float(_), _) => false,
+            (QueryInputValueRecord::Boolean(_), _) => false,
+            (QueryInputValueRecord::InputObject(_), _) => false,
+            (QueryInputValueRecord::List(_), _) => false,
+            (QueryInputValueRecord::Map(_), _) => false,
         }
     }
 }
@@ -279,38 +279,42 @@ impl std::fmt::Debug for QueryInputValueWalker<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let input_values = &self.operation.query_input_values;
         match self.item {
-            QueryInputValue::Null => write!(f, "Null"),
-            QueryInputValue::String(s) => s.fmt(f),
-            QueryInputValue::EnumValue(id) => f.debug_tuple("EnumValue").field(&self.schema.walk(*id).name()).finish(),
-            QueryInputValue::UnboundEnumValue(s) => f.debug_tuple("UnboundEnumValue").field(&s).finish(),
-            QueryInputValue::Int(n) => f.debug_tuple("Int").field(n).finish(),
-            QueryInputValue::BigInt(n) => f.debug_tuple("BigInt").field(n).finish(),
-            QueryInputValue::U64(n) => f.debug_tuple("U64").field(n).finish(),
-            QueryInputValue::Float(n) => f.debug_tuple("Float").field(n).finish(),
-            QueryInputValue::Boolean(b) => b.fmt(f),
-            QueryInputValue::InputObject(ids) => {
+            QueryInputValueRecord::Null => write!(f, "Null"),
+            QueryInputValueRecord::String(s) => s.fmt(f),
+            QueryInputValueRecord::EnumValue(id) => {
+                f.debug_tuple("EnumValue").field(&self.schema.walk(*id).name()).finish()
+            }
+            QueryInputValueRecord::UnboundEnumValue(s) => f.debug_tuple("UnboundEnumValue").field(&s).finish(),
+            QueryInputValueRecord::Int(n) => f.debug_tuple("Int").field(n).finish(),
+            QueryInputValueRecord::BigInt(n) => f.debug_tuple("BigInt").field(n).finish(),
+            QueryInputValueRecord::U64(n) => f.debug_tuple("U64").field(n).finish(),
+            QueryInputValueRecord::Float(n) => f.debug_tuple("Float").field(n).finish(),
+            QueryInputValueRecord::Boolean(b) => b.fmt(f),
+            QueryInputValueRecord::InputObject(ids) => {
                 let mut map = f.debug_struct("InputObject");
                 for (input_value_definition_id, value) in &input_values[*ids] {
                     map.field(self.schema.walk(*input_value_definition_id).name(), &self.walk(value));
                 }
                 map.finish()
             }
-            QueryInputValue::List(ids) => {
+            QueryInputValueRecord::List(ids) => {
                 let mut seq = f.debug_list();
                 for value in &input_values[*ids] {
                     seq.entry(&self.walk(value));
                 }
                 seq.finish()
             }
-            QueryInputValue::Map(ids) => {
+            QueryInputValueRecord::Map(ids) => {
                 let mut map = f.debug_map();
                 for (key, value) in &input_values[*ids] {
                     map.entry(&key, &self.walk(value));
                 }
                 map.finish()
             }
-            QueryInputValue::DefaultValue(id) => f.debug_tuple("DefaultValue").field(&id.walk(self.schema)).finish(),
-            QueryInputValue::Variable(id) => f.debug_tuple("Variable").field(&self.walk(*id)).finish(),
+            QueryInputValueRecord::DefaultValue(id) => {
+                f.debug_tuple("DefaultValue").field(&id.walk(self.schema)).finish()
+            }
+            QueryInputValueRecord::Variable(id) => f.debug_tuple("Variable").field(&self.walk(*id)).finish(),
         }
     }
 }

--- a/engine/crates/engine-v2/src/operation/input_value/query/view.rs
+++ b/engine/crates/engine-v2/src/operation/input_value/query/view.rs
@@ -5,7 +5,7 @@ use serde::{
     ser::SerializeMap,
 };
 
-use super::{QueryInputValue, QueryInputValueWalker};
+use super::{QueryInputValueRecord, QueryInputValueWalker};
 
 pub(crate) struct QueryInputValueView<'a> {
     pub(super) inner: QueryInputValueWalker<'a>,
@@ -22,7 +22,7 @@ impl<'a> serde::Serialize for QueryInputValueView<'a> {
         if self.selection_set.is_empty() {
             return self.inner.serialize(serializer);
         }
-        let QueryInputValue::InputObject(fields) = self.inner.item else {
+        let QueryInputValueRecord::InputObject(fields) = self.inner.item else {
             return Err(serde::ser::Error::custom(
                 "Can only select fields within an input object.",
             ));
@@ -57,7 +57,7 @@ impl<'de> serde::Deserializer<'de> for QueryInputValueView<'de> {
             return self.inner.deserialize_any(visitor);
         }
 
-        let QueryInputValue::InputObject(fields) = self.inner.item else {
+        let QueryInputValueRecord::InputObject(fields) = self.inner.item else {
             return Err(serde::de::Error::custom(
                 "Can only select fields within an input object.",
             ));

--- a/engine/crates/engine-v2/src/operation/logical_planner/selection_set.rs
+++ b/engine/crates/engine-v2/src/operation/logical_planner/selection_set.rs
@@ -15,8 +15,9 @@ use walker::Walk;
 use super::{logic::PlanningLogic, LogicalPlanner, LogicalPlanningError, LogicalPlanningResult, ParentToChildEdge};
 use crate::{
     operation::{
-        ExtraField, Field, FieldArgument, FieldArgumentId, FieldId, LogicalPlanId, QueryInputValue, QueryPath,
-        SelectionSet, SelectionSetId, SolvedRequiredField, SolvedRequiredFieldSet,
+        BoundExtraField, BoundField, BoundFieldArgument, BoundFieldArgumentId, BoundFieldId, BoundSelectionSet,
+        BoundSelectionSetId, LogicalPlanId, QueryInputValueRecord, QueryPath, SolvedRequiredField,
+        SolvedRequiredFieldSet,
     },
     response::{SafeResponseKey, UnpackedResponseEdge},
 };
@@ -58,10 +59,10 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
     )]
     pub(super) fn solve(
         &mut self,
-        selection_set_id: SelectionSetId,
-        parent_field_requirements: Option<(FieldId, Cow<'schema, RequiredFieldSetRecord>)>,
-        planned_field_ids: Vec<FieldId>,
-        unplanned_field_ids: Vec<FieldId>,
+        selection_set_id: BoundSelectionSetId,
+        parent_field_requirements: Option<(BoundFieldId, Cow<'schema, RequiredFieldSetRecord>)>,
+        planned_field_ids: Vec<BoundFieldId>,
+        unplanned_field_ids: Vec<BoundFieldId>,
     ) -> LogicalPlanningResult<()> {
         tracing::trace!("Solving selection set {}", selection_set_id);
 
@@ -146,7 +147,11 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
         solved_fields
     }
 
-    fn build_planned_selection_set(&self, id: SelectionSetId, planned_field_ids: &[FieldId]) -> PlannedSelectionSet {
+    fn build_planned_selection_set(
+        &self,
+        id: BoundSelectionSetId,
+        planned_field_ids: &[BoundFieldId],
+    ) -> PlannedSelectionSet {
         let mut fields = HashMap::<_, Vec<_>>::with_capacity(planned_field_ids.len());
         for field_id in planned_field_ids {
             let field_id = *field_id;
@@ -168,7 +173,10 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
         PlannedSelectionSet { id: Some(id), fields }
     }
 
-    fn build_unplanned_fields(&self, unplanned_field_ids: Vec<FieldId>) -> HashMap<FieldId, FieldDefinition<'schema>> {
+    fn build_unplanned_fields(
+        &self,
+        unplanned_field_ids: Vec<BoundFieldId>,
+    ) -> HashMap<BoundFieldId, FieldDefinition<'schema>> {
         unplanned_field_ids
             .into_iter()
             .map(|field_id| {
@@ -198,14 +206,14 @@ impl<'schema, 'a> std::ops::DerefMut for SelectionSetLogicalPlanner<'schema, 'a>
 // TODO: add deleted fields
 struct PlannedSelectionSet {
     /// For extra fields sub selection set, we only reserve an id if it's actually needed.
-    id: Option<SelectionSetId>,
+    id: Option<BoundSelectionSetId>,
     fields: HashMap<FieldDefinitionId, Vec<PlannedField>>,
 }
 
 #[derive(Debug, Clone)]
 enum PlannedField {
     Query {
-        field_id: FieldId,
+        field_id: BoundFieldId,
         required_field_id: Option<RequiredFieldId>,
         plan_id: LogicalPlanId,
         lazy_subselection: Option<PlannedSelectionSet>,
@@ -215,8 +223,8 @@ enum PlannedField {
 
 #[derive(Debug, Clone)]
 pub struct ExtraPlannedField {
-    field_id: Option<FieldId>,
-    petitioner_field_id: FieldId,
+    field_id: Option<BoundFieldId>,
+    petitioner_field_id: BoundFieldId,
     required_field_id: RequiredFieldId,
     logical_plan_id: LogicalPlanId,
     subselection: PlannedSelectionSet,
@@ -236,7 +244,7 @@ struct ChildPlanCandidate<'schema> {
     entity_id: EntityDefinitionId,
     resolver_id: ResolverDefinitionId,
     /// Providable fields by the resolvers with their requirements
-    providable_fields: Vec<(FieldId, Cow<'schema, RequiredFieldSetRecord>)>,
+    providable_fields: Vec<(BoundFieldId, Cow<'schema, RequiredFieldSetRecord>)>,
 }
 
 impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
@@ -248,8 +256,8 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
     fn plan_selection_set(
         &mut self,
         planned_selection_set: &mut PlannedSelectionSet,
-        mut parent_field_requirements: Option<(FieldId, Cow<'schema, RequiredFieldSetRecord>)>,
-        mut unplanned_fields: HashMap<FieldId, FieldDefinition<'schema>>,
+        mut parent_field_requirements: Option<(BoundFieldId, Cow<'schema, RequiredFieldSetRecord>)>,
+        mut unplanned_fields: HashMap<BoundFieldId, FieldDefinition<'schema>>,
     ) -> LogicalPlanningResult<()> {
         // unplanned_field may be still be provided by the parent plan, but at this stage it
         // means they had requirements.
@@ -397,7 +405,7 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
         resolver_id: ResolverDefinitionId,
         requires: Cow<'_, RequiredFieldSetRecord>,
         entity_id: EntityDefinitionId,
-        root_field_ids: Vec<FieldId>,
+        root_field_ids: Vec<BoundFieldId>,
     ) -> LogicalPlanningResult<()> {
         let path = self.query_path.clone();
         let plan_id = self.planner.push_plan(path, resolver_id, entity_id, &root_field_ids)?;
@@ -477,7 +485,7 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
 
                     let selection_set_id = if !required_field.subselection.is_empty() {
                         if field.subselection.id.is_none() {
-                            self.operation.selection_sets.push(SelectionSet::default());
+                            self.operation.selection_sets.push(BoundSelectionSet::default());
                             field.subselection.id = Some((self.operation.selection_sets.len() - 1).into());
                             self.selection_set_to_objects_must_be_tracked.push(false);
                         }
@@ -510,15 +518,15 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
 
     fn insert_extra_field(
         &mut self,
-        parent_selection_set_id: SelectionSetId,
+        parent_selection_set_id: BoundSelectionSetId,
         definition_id: FieldDefinitionId,
-        selection_set_id: Option<SelectionSetId>,
+        selection_set_id: Option<BoundSelectionSetId>,
         planned_field: &mut ExtraPlannedField,
     ) {
         // Creating the field
         let key = self.generate_response_key_for(definition_id);
 
-        let field = Field::Extra(ExtraField {
+        let field = BoundField::Extra(BoundExtraField {
             edge: UnpackedResponseEdge::ExtraFieldResponseKey(key.into()).pack(),
             definition_id,
             selection_set_id,
@@ -541,9 +549,9 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
 
     fn insert_field_in_parent_selection_set(
         &mut self,
-        parent_selection_set_id: SelectionSetId,
+        parent_selection_set_id: BoundSelectionSetId,
         definition_id: FieldDefinitionId,
-        id: FieldId,
+        id: BoundFieldId,
     ) {
         // Inserting into its parent selection set in order.
         let mut field_ids = std::mem::take(
@@ -570,7 +578,7 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
 
     fn generate_all_candidates<'field>(
         &mut self,
-        unplanned_fields: &mut HashMap<FieldId, FieldDefinition<'schema>>,
+        unplanned_fields: &mut HashMap<BoundFieldId, FieldDefinition<'schema>>,
         planned_selection_set: &mut PlannedSelectionSet,
         candidates: &mut HashMap<ResolverDefinitionId, ChildPlanCandidate<'schema>>,
     ) -> LogicalPlanningResult<()>
@@ -642,9 +650,9 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
     /// based on the fields in types implementing the interface.
     fn replan_interface_fields(
         &mut self,
-        selection_set_id: SelectionSetId,
-        interface_fields_to_replan: Vec<(FieldId, Vec<FieldDefinition<'schema>>)>,
-        unplanned_fields: &mut HashMap<FieldId, FieldDefinition<'schema>>,
+        selection_set_id: BoundSelectionSetId,
+        interface_fields_to_replan: Vec<(BoundFieldId, Vec<FieldDefinition<'schema>>)>,
+        unplanned_fields: &mut HashMap<BoundFieldId, FieldDefinition<'schema>>,
     ) {
         for (interface_field_id, add_to_plan) in interface_fields_to_replan {
             unplanned_fields.remove(&interface_field_id);
@@ -665,7 +673,7 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
                     let operation_field = self.walker().walk(interface_field_id).as_ref().clone();
                     let selection_set_id = operation_field.selection_set_id();
 
-                    ExtraField {
+                    BoundExtraField {
                         edge: operation_field.response_edge(),
                         definition_id: field_definition.id(),
                         selection_set_id: selection_set_id.map(|id| self.clone_selection_set(id)),
@@ -678,7 +686,7 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
                 let parent_selection_set_id = field.parent_selection_set_id;
                 let definition_id = field.definition_id;
 
-                self.operation.fields.push(Field::Extra(field));
+                self.operation.fields.push(BoundField::Extra(field));
                 let id = (self.operation.fields.len() - 1).into();
                 unplanned_fields.insert(id, field_definition);
 
@@ -696,7 +704,7 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
     /// has been determined to be unplannable. It sets the logical plan ID to a maximum value
     /// to signal that the field cannot be included in any selection set planning. If the field
     /// is part of a selection set, it recursively marks any dependent fields as never planned.
-    fn mark_field_as_never_planned(&mut self, field_id: FieldId) {
+    fn mark_field_as_never_planned(&mut self, field_id: BoundFieldId) {
         self.field_to_logical_plan_id[usize::from(field_id)] = Some(LogicalPlanId::from(u16::MAX - 1));
         self.field_to_solved_requirement[usize::from(field_id)] = None;
 
@@ -716,12 +724,12 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
     /// This function creates a new selection set that replicates the fields and structures of the existing
     /// one while updating references such as `parent_selection_set_id` and `selection_set_id` in the
     /// cloned fields.
-    fn clone_selection_set(&mut self, selection_set_id: SelectionSetId) -> SelectionSetId {
-        self.operation.selection_sets.push(SelectionSet::default());
+    fn clone_selection_set(&mut self, selection_set_id: BoundSelectionSetId) -> BoundSelectionSetId {
+        self.operation.selection_sets.push(BoundSelectionSet::default());
 
         let previous = self.walker().walk(selection_set_id);
-        let selection_set_id = SelectionSetId::from(self.operation.selection_sets.len() - 1);
-        let mut next = SelectionSet::default();
+        let selection_set_id = BoundSelectionSetId::from(self.operation.selection_sets.len() - 1);
+        let mut next = BoundSelectionSet::default();
 
         for previous_field_id in previous
             .as_ref()
@@ -731,7 +739,7 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
             let previous_field = self.walker().walk(previous_field_id);
             let mut field = previous_field.as_ref().clone();
 
-            let Field::Query(ref mut query_field) = field else {
+            let BoundField::Query(ref mut query_field) = field else {
                 todo!("cloning non-query fields not yet supported");
             };
 
@@ -759,7 +767,7 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
     fn could_plan_requirements(
         &mut self,
         planned_selection_set: &mut PlannedSelectionSet,
-        petitioner_field_id: FieldId,
+        petitioner_field_id: BoundFieldId,
         requires: &RequiredFieldSetRecord,
     ) -> LogicalPlanningResult<bool> {
         if requires.is_empty() {
@@ -772,7 +780,7 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
         &mut self,
         parent_logical_plan_id: Option<LogicalPlanId>,
         planned_selection_set: &mut PlannedSelectionSet,
-        petitioner_field_id: FieldId,
+        petitioner_field_id: BoundFieldId,
         requires: &RequiredFieldSetRecord,
     ) -> LogicalPlanningResult<bool> {
         if requires.is_empty() {
@@ -910,7 +918,7 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
     fn could_plan_exra_field(
         &mut self,
         planned_selection_set: &mut PlannedSelectionSet,
-        petitioner_field_id: FieldId,
+        petitioner_field_id: BoundFieldId,
         logic: &PlanningLogic<'schema>,
         required: RequiredFieldSetItem<'_>,
     ) -> bool {
@@ -975,7 +983,7 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
         }
     }
 
-    fn create_arguments_for(&mut self, id: RequiredFieldId) -> IdRange<FieldArgumentId> {
+    fn create_arguments_for(&mut self, id: RequiredFieldId) -> IdRange<BoundFieldArgumentId> {
         let start = self.operation.field_arguments.len();
 
         for &RequiredFieldArgumentRecord {
@@ -986,9 +994,9 @@ impl<'schema, 'a> SelectionSetLogicalPlanner<'schema, 'a> {
             let input_value_id = self
                 .operation
                 .query_input_values
-                .push_value(QueryInputValue::DefaultValue(value_id));
+                .push_value(QueryInputValueRecord::DefaultValue(value_id));
 
-            self.operation.field_arguments.push(FieldArgument {
+            self.operation.field_arguments.push(BoundFieldArgument {
                 name_location: None,
                 value_location: None,
                 input_value_id,

--- a/engine/crates/engine-v2/src/operation/modifier/mod.rs
+++ b/engine/crates/engine-v2/src/operation/modifier/mod.rs
@@ -3,14 +3,16 @@ mod query;
 use id_newtypes::IdRange;
 use schema::{AuthorizedDirectiveId, DefinitionId, FieldDefinitionId, RequiresScopesDirectiveId};
 
-use super::{FieldArgumentId, QueryInputValueId, QueryModifierImpactedFieldId, ResponseModifierImpactedFieldId};
+use super::{
+    BoundFieldArgumentId, BoundQueryModifierImpactedFieldId, BoundResponseModifierImpactedFieldId, QueryInputValueId,
+};
 
 pub(crate) use query::*;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-pub(crate) struct QueryModifier {
+pub(crate) struct BoundQueryModifier {
     pub rule: QueryModifierRule,
-    pub impacted_fields: IdRange<QueryModifierImpactedFieldId>,
+    pub impacted_fields: IdRange<BoundQueryModifierImpactedFieldId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -20,7 +22,7 @@ pub(crate) enum QueryModifierRule {
     AuthorizedField {
         directive_id: AuthorizedDirectiveId,
         definition_id: FieldDefinitionId,
-        argument_ids: IdRange<FieldArgumentId>,
+        argument_ids: IdRange<BoundFieldArgumentId>,
     },
     AuthorizedDefinition {
         directive_id: AuthorizedDirectiveId,
@@ -33,9 +35,9 @@ pub(crate) enum QueryModifierRule {
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-pub(crate) struct ResponseModifier {
+pub(crate) struct BoundResponseModifier {
     pub rule: ResponseModifierRule,
-    pub impacted_fields: IdRange<ResponseModifierImpactedFieldId>,
+    pub impacted_fields: IdRange<BoundResponseModifierImpactedFieldId>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]

--- a/engine/crates/engine-v2/src/operation/modifier/query.rs
+++ b/engine/crates/engine-v2/src/operation/modifier/query.rs
@@ -5,8 +5,8 @@ use serde::Deserialize;
 use crate::{
     execution::{ErrorId, PlanningResult, PreExecutionContext},
     operation::{
-        FieldId, PreparedOperation, PreparedOperationWalker, QueryModifierId, QueryModifierImpactedFieldId,
-        QueryModifierRule, Variables,
+        BoundFieldId, BoundQueryModifierId, BoundQueryModifierImpactedFieldId, PreparedOperation,
+        PreparedOperationWalker, QueryModifierRule, Variables,
     },
     response::{ConcreteObjectShapeId, ErrorCode, FieldShapeId, GraphqlError},
     Runtime,
@@ -15,7 +15,7 @@ use crate::{
 #[derive(id_derives::IndexedFields)]
 pub(crate) struct QueryModifications {
     pub is_any_field_skipped: bool,
-    pub skipped_fields: BitSet<FieldId>,
+    pub skipped_fields: BitSet<BoundFieldId>,
     #[indexed_by(ErrorId)]
     pub errors: Vec<GraphqlError>,
     pub concrete_shape_has_error: BitSet<ConcreteObjectShapeId>,
@@ -84,7 +84,7 @@ where
         let mut scopes = None;
 
         for (i, modifier) in self.operation.query_modifiers.iter().enumerate() {
-            let modifier_id = QueryModifierId::from(i);
+            let modifier_id = BoundQueryModifierId::from(i);
 
             match modifier.rule {
                 QueryModifierRule::Authenticated => {
@@ -253,8 +253,8 @@ where
 
     fn handle_modifier_resulted_in_error(
         &mut self,
-        id: QueryModifierId,
-        impacted_fields: IdRange<QueryModifierImpactedFieldId>,
+        id: BoundQueryModifierId,
+        impacted_fields: IdRange<BoundQueryModifierImpactedFieldId>,
         error: GraphqlError,
     ) {
         self.modifications.is_any_field_skipped = true;

--- a/engine/crates/engine-v2/src/operation/variables.rs
+++ b/engine/crates/engine-v2/src/operation/variables.rs
@@ -6,12 +6,11 @@ use super::{
 };
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct VariableDefinition {
+pub struct VariableDefinitionRecord {
     pub name: String,
     pub name_location: Location,
-    pub default_value: Option<QueryInputValueId>,
-    pub in_use: bool,
-    pub ty: schema::TypeRecord,
+    pub default_value_id: Option<QueryInputValueId>,
+    pub ty_record: schema::TypeRecord,
 }
 
 pub struct Variables {

--- a/engine/crates/engine-v2/src/operation/walkers/field.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/field.rs
@@ -2,11 +2,11 @@ use schema::{FieldDefinition, RequiredFieldRecord};
 
 use super::{OperationWalker, SelectionSetWalker};
 use crate::{
-    operation::{ExtraField, Field, FieldId, Location, QueryField},
+    operation::{BoundExtraField, BoundField, BoundFieldId, BoundQueryField, Location},
     response::{ResponseEdge, ResponseKey},
 };
 
-pub type FieldWalker<'a> = OperationWalker<'a, FieldId>;
+pub type FieldWalker<'a> = OperationWalker<'a, BoundFieldId>;
 
 impl<'a> FieldWalker<'a> {
     pub fn name(&self) -> &'a str {
@@ -75,8 +75,8 @@ impl PartialEq<RequiredFieldRecord> for FieldWalker<'_> {
 impl<'a> std::fmt::Debug for FieldWalker<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.as_ref() {
-            Field::TypeName { .. } => "__typename".fmt(f),
-            Field::Query(QueryField { definition_id, .. }) => {
+            BoundField::TypeName { .. } => "__typename".fmt(f),
+            BoundField::Query(BoundQueryField { definition_id, .. }) => {
                 let mut fmt = f.debug_struct("Field");
                 fmt.field("id", &self.item);
                 let name = self.schema.walk(*definition_id).name();
@@ -87,7 +87,7 @@ impl<'a> std::fmt::Debug for FieldWalker<'a> {
                     .field("selection_set", &self.selection_set())
                     .finish()
             }
-            Field::Extra(ExtraField { definition_id, .. }) => {
+            BoundField::Extra(BoundExtraField { definition_id, .. }) => {
                 let mut fmt = f.debug_struct("ExtraField");
                 fmt.field("id", &self.item);
                 let name = self.schema.walk(*definition_id).name();

--- a/engine/crates/engine-v2/src/operation/walkers/plan/field.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/plan/field.rs
@@ -1,13 +1,13 @@
 use schema::FieldDefinition;
 
 use crate::{
-    operation::{FieldArgumentsWalker, FieldId, QueryInputValueWalker},
+    operation::{BoundFieldId, FieldArgumentsWalker, QueryInputValueWalker},
     response::ResponseKey,
 };
 
 use super::{PlanSelectionSet, PlanWalker};
 
-pub type PlanField<'a> = PlanWalker<'a, FieldId>;
+pub type PlanField<'a> = PlanWalker<'a, BoundFieldId>;
 
 impl<'a> PlanField<'a> {
     pub fn selection_set(&self) -> Option<PlanSelectionSet<'a>> {

--- a/engine/crates/engine-v2/src/operation/walkers/plan/selection_set.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/plan/selection_set.rs
@@ -1,11 +1,11 @@
-use crate::operation::SelectionSetId;
+use crate::operation::BoundSelectionSetId;
 
 use super::{PlanField, PlanWalker};
 
 #[derive(Clone, Copy)]
 pub enum PlanSelectionSet<'a> {
     RootFields(PlanWalker<'a, ()>),
-    SelectionSet(PlanWalker<'a, SelectionSetId>),
+    SelectionSet(PlanWalker<'a, BoundSelectionSetId>),
 }
 
 impl<'a> PlanSelectionSet<'a> {

--- a/engine/crates/engine-v2/src/operation/walkers/prepared/argument.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/prepared/argument.rs
@@ -2,7 +2,7 @@ use id_newtypes::{IdRange, IdRangeIterator};
 use schema::{InputValueDefinition, InputValueSerdeError, InputValueSet};
 use serde::{de::value::MapDeserializer, forward_to_deserialize_any};
 
-use crate::operation::{FieldArgumentId, QueryInputValueWalker};
+use crate::operation::{BoundFieldArgumentId, QueryInputValueWalker};
 
 mod view;
 
@@ -10,7 +10,7 @@ pub(crate) use view::*;
 
 use super::PreparedOperationWalker;
 
-pub type FieldArgumentWalker<'a> = PreparedOperationWalker<'a, FieldArgumentId>;
+pub type FieldArgumentWalker<'a> = PreparedOperationWalker<'a, BoundFieldArgumentId>;
 
 impl<'a> FieldArgumentWalker<'a> {
     pub fn value(&self) -> Option<QueryInputValueWalker<'a>> {
@@ -36,7 +36,7 @@ impl std::fmt::Debug for FieldArgumentWalker<'_> {
     }
 }
 
-pub type FieldArgumentsWalker<'a> = PreparedOperationWalker<'a, IdRange<FieldArgumentId>>;
+pub type FieldArgumentsWalker<'a> = PreparedOperationWalker<'a, IdRange<BoundFieldArgumentId>>;
 
 impl<'a> FieldArgumentsWalker<'a> {
     pub fn is_empty(&self) -> bool {
@@ -61,7 +61,7 @@ impl<'a> IntoIterator for FieldArgumentsWalker<'a> {
     }
 }
 
-pub(crate) struct FieldArgumentsIterator<'a>(PreparedOperationWalker<'a, IdRangeIterator<FieldArgumentId>>);
+pub(crate) struct FieldArgumentsIterator<'a>(PreparedOperationWalker<'a, IdRangeIterator<BoundFieldArgumentId>>);
 
 impl<'a> Iterator for FieldArgumentsIterator<'a> {
     type Item = FieldArgumentWalker<'a>;

--- a/engine/crates/engine-v2/src/operation/walkers/prepared/variable.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/prepared/variable.rs
@@ -12,7 +12,7 @@ impl<'a> VariableWalker<'a> {
     pub fn as_value(&self) -> VariableValueWalker<'a> {
         match self.variables[self.item] {
             VariableValue::Undefined => {
-                if let Some(id) = self.as_ref().default_value {
+                if let Some(id) = self.as_ref().default_value_id {
                     VariableValueWalker::DefaultValue(self.walk(&self.operation.query_input_values[id]))
                 } else {
                     VariableValueWalker::Undefined

--- a/engine/crates/engine-v2/src/operation/walkers/selection_set.rs
+++ b/engine/crates/engine-v2/src/operation/walkers/selection_set.rs
@@ -1,7 +1,7 @@
 use super::{FieldWalker, OperationWalker};
-use crate::operation::SelectionSetId;
+use crate::operation::BoundSelectionSetId;
 
-pub type SelectionSetWalker<'a> = OperationWalker<'a, SelectionSetId>;
+pub type SelectionSetWalker<'a> = OperationWalker<'a, BoundSelectionSetId>;
 
 impl<'a> SelectionSetWalker<'a> {
     pub fn fields(self) -> impl Iterator<Item = FieldWalker<'a>> + 'a {

--- a/engine/crates/engine-v2/src/response/shape.rs
+++ b/engine/crates/engine-v2/src/response/shape.rs
@@ -6,7 +6,7 @@ use schema::{
     UnionDefinitionId, Wrapping,
 };
 
-use crate::operation::FieldId;
+use crate::operation::BoundFieldId;
 
 use super::{ResponseEdge, ResponseObjectSetId, SafeResponseKey};
 
@@ -33,7 +33,7 @@ pub struct FieldShapeId(NonZero<u32>);
 pub(crate) struct FieldShape {
     pub expected_key: SafeResponseKey,
     pub edge: ResponseEdge,
-    pub id: FieldId,
+    pub id: BoundFieldId,
     pub required_field_id: Option<RequiredFieldId>,
     pub definition_id: FieldDefinitionId,
     pub shape: Shape,

--- a/engine/crates/engine-v2/src/response/write/deserialize/list.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/list.rs
@@ -7,13 +7,13 @@ use serde::{
 
 use super::SeedContext;
 use crate::{
-    operation::FieldId,
+    operation::BoundFieldId,
     response::{ErrorCode, GraphqlError, ResponseValue},
 };
 
 pub(super) struct ListSeed<'ctx, 'parent, Seed> {
     pub ctx: &'parent SeedContext<'ctx>,
-    pub field_id: FieldId,
+    pub field_id: BoundFieldId,
     pub seed: &'parent Seed,
 }
 

--- a/engine/crates/engine-v2/src/response/write/deserialize/nullable.rs
+++ b/engine/crates/engine-v2/src/response/write/deserialize/nullable.rs
@@ -7,13 +7,13 @@ use serde::{
 
 use super::SeedContext;
 use crate::{
-    operation::FieldId,
+    operation::BoundFieldId,
     response::{ErrorCode, GraphqlError, ResponseValue},
 };
 
 pub(super) struct NullableSeed<'ctx, 'parent, Seed> {
     pub ctx: &'parent SeedContext<'ctx>,
-    pub field_id: FieldId,
+    pub field_id: BoundFieldId,
     pub seed: Seed,
 }
 

--- a/engine/crates/engine-v2/src/sources/graphql/request/prepare.rs
+++ b/engine/crates/engine-v2/src/sources/graphql/request/prepare.rs
@@ -272,7 +272,7 @@ impl QueryBuilderContext {
         in_same_entity: bool,
         buffer: &mut String,
         entity: EntityDefinition<'_>,
-        fields: &[PlanWalker<'_, crate::operation::FieldId>],
+        fields: &[PlanWalker<'_, crate::operation::BoundFieldId>],
     ) -> Result<(), Error> {
         if !in_same_entity {
             write!(buffer, " ... on {} {{", entity.name())?;
@@ -293,7 +293,7 @@ impl QueryBuilderContext {
         &mut self,
         buffer: &mut String,
         type_name: &str,
-        fields: &[PlanWalker<'_, crate::operation::FieldId>],
+        fields: &[PlanWalker<'_, crate::operation::BoundFieldId>],
     ) -> Result<(), Error> {
         write!(buffer, " ... on {} {{", type_name)?;
 


### PR DESCRIPTION
- Moving binding error to a separate module for more clarity
- Prefixing most of the struct/ids produced by the binding step by `Bound` to differentiate them from the ones used after planning. They're slightly different and it was a mistake to re-use them exactly as is I think, the distinction ends up being done in the walkers `PlanFieldWalker` vs `FieldWalker`.
- I've suffixed `VariableDefinition` & `QueryInputValue` by `Record` to get closer to what the codegen would generate.

The goal later is to move what can be to the codegen and be consistent with it for everything else. I wanted to use the codegen right now for the binding result, but well, skipping it for now by lack of time.

