### PR TITLE
chore: add a user in dockerfile

### DIFF
--- a/engine/crates/integration-tests/data/sse-subgraph/Dockerfile
+++ b/engine/crates/integration-tests/data/sse-subgraph/Dockerfile
@@ -1,4 +1,8 @@
 FROM oven/bun:1.1.27-alpine
+
+RUN adduser -g wheel -D grafbase -h "/grafbase" && mkdir -p /grafbase && chown grafbase: /grafbase
+USER grafbase
+
 WORKDIR /grafbase
 COPY . .
 


### PR DESCRIPTION
Apparently semgrep is complaining that this Dockerfile doesn't have a user in it.  It's only for tests so it really doesn't matter, but it's also easy to fix.

Fixes GB-7912