### PR TITLE
fix: dont omit unused enums in composition

### DIFF
--- a/engine/crates/composition/src/compose/enums.rs
+++ b/engine/crates/composition/src/compose/enums.rs
@@ -30,7 +30,9 @@ pub(super) fn merge_enum_definitions<'a>(
             merge_exactly_matching(first, definitions, enum_id, ctx);
         }
         (false, false) => {
-            // The enum isn't used at all, omit it from the federated graph
+            // The enum isn't used at all, act as if it were used in return position
+            let enum_id = ctx.insert_enum(first.name().as_str(), description, composed_directives);
+            merge_union(first, definitions, enum_id, ctx);
         }
     }
 }

--- a/engine/crates/composition/tests/composition/enum_unused/api.graphql
+++ b/engine/crates/composition/tests/composition/enum_unused/api.graphql
@@ -1,3 +1,8 @@
+enum UserType {
+    ADMIN
+    REGULAR
+}
+
 type User {
     id: ID!
     name: String!

--- a/engine/crates/composition/tests/composition/enum_unused/federated.graphql
+++ b/engine/crates/composition/tests/composition/enum_unused/federated.graphql
@@ -32,3 +32,8 @@ type User {
 type Query {
     user: User @join__field(graph: THESCHEMA)
 }
+
+enum UserType {
+    ADMIN
+    REGULAR
+}


### PR DESCRIPTION
While testing a separate composition change I wrote a schema that didn't use an enum.  I was surprised to find that enum wasn't in the output of composition.  

It seems like this was intentional, but have been speaking to @tomhoule and we agreed it's probably not right.  It shouldn't _hurt_ to remove these types since they're not used, but we don't treat any other unused types like this so it's a bit surprising.