### PR TITLE
SSLeay-standalone and OpenSSL-standalone licenses

### DIFF
--- a/cli/about.toml
+++ b/cli/about.toml
@@ -11,11 +11,12 @@ accepted = [
     "MPL-2.0",
     "NOASSERTION",
     "OpenSSL",
+    "SSLeay",
     "Unicode-3.0",
     "Unicode-DFS-2016",
     "Unlicense",
     "Zlib",
-    "zlib-acknowledgement"
+    "zlib-acknowledgement",
 ]
 
 targets = [

--- a/cli/about.toml
+++ b/cli/about.toml
@@ -11,6 +11,7 @@ accepted = [
     "MPL-2.0",
     "NOASSERTION",
     "OpenSSL",
+    "OpenSSL-standalone",
     "SSLeay-standalone",
     "Unicode-3.0",
     "Unicode-DFS-2016",

--- a/cli/about.toml
+++ b/cli/about.toml
@@ -11,7 +11,7 @@ accepted = [
     "MPL-2.0",
     "NOASSERTION",
     "OpenSSL",
-    "SSLeay",
+    "SSLeay-standalone",
     "Unicode-3.0",
     "Unicode-DFS-2016",
     "Unlicense",


### PR DESCRIPTION
# Description

## Misc.

- Approve SSLeay-standalone and OpenSSL-standalone licenses, needed for `ring`

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
