### PR TITLE
GB-7972 - Remove `atty` due to security issues and native support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3069,7 +3069,6 @@ dependencies = [
  "anyhow",
  "ascii 1.1.0",
  "async-graphql-parser",
- "atty",
  "cfg-if",
  "chrono",
  "clap 4.5.20",

--- a/gateway/crates/gateway-binary/Cargo.toml
+++ b/gateway/crates/gateway-binary/Cargo.toml
@@ -17,7 +17,6 @@ lambda = [
 [dependencies]
 anyhow = { version = "1", default-features = false }
 ascii = { version = "1", default-features = false }
-atty = "0.2"
 chrono.workspace = true
 clap = { version = "4.5", features = ["cargo", "wrap_help", "derive", "env"] }
 federated-server.workspace = true

--- a/gateway/crates/gateway-binary/src/args/std.rs
+++ b/gateway/crates/gateway-binary/src/args/std.rs
@@ -1,5 +1,6 @@
 use std::{
     fs,
+    io::IsTerminal,
     net::SocketAddr,
     path::{Path, PathBuf},
 };
@@ -147,7 +148,7 @@ impl super::Args for Args {
     fn log_style(&self) -> LogStyle {
         self.log_style.unwrap_or_else(|| {
             let log_level = self.log_level();
-            if atty::is(atty::Stream::Stdout) && (log_level.contains("debug") || log_level.contains("trace")) {
+            if std::io::stdout().is_terminal() && (log_level.contains("debug") || log_level.contains("trace")) {
                 LogStyle::Pretty
             } else {
                 LogStyle::Text

--- a/gateway/crates/gateway-binary/src/telemetry.rs
+++ b/gateway/crates/gateway-binary/src/telemetry.rs
@@ -1,3 +1,5 @@
+use std::io::IsTerminal;
+
 use grafbase_telemetry::otel::opentelemetry_sdk::{logs::LoggerProvider, metrics::SdkMeterProvider};
 
 use grafbase_telemetry::config::TelemetryConfig;
@@ -78,7 +80,7 @@ pub(crate) fn init(args: &impl Args, config: &TelemetryConfig) -> anyhow::Result
         .with(tracer.map(|t| t.layer))
         .with(logger.map(|l| l.layer));
 
-    let is_terminal = atty::is(atty::Stream::Stdout);
+    let is_terminal = std::io::stdout().is_terminal();
     match args.log_style() {
         // for interactive terminals we provide colored output
         LogStyle::Pretty => registry


### PR DESCRIPTION
# Description

## Fixes

- Removes use of `atty` due to low level CVE and native Rust support

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [x] 🐛 Fix
- [ ] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
