### PR TITLE
composition: validate that subgraphs do not define join__Graph

### DIFF
--- a/engine/crates/composition/CHANGELOG.md
+++ b/engine/crates/composition/CHANGELOG.md
@@ -12,6 +12,7 @@
 - There is no longer a `VersionedFederatedGraph`. The serializable version of the federated graph is dropped — that role will be fulfilled by the federated SDL instead (https://github.com/grafbase/grafbase/pull/2310).
 - `graphql_composition` now reexports the companion `graphql_federated_graph` crate (https://github.com/grafbase/grafbase/pull/2310).
 - Added support for the `@cost` directive (https://github.com/grafbase/grafbase/pull/2305).
+- We now validate that subgraphs do not define the `join__Graph` enum. (https://github.com/grafbase/grafbase/pull/2325)
 
 ### Fixes
 

--- a/engine/crates/composition/README.md
+++ b/engine/crates/composition/README.md
@@ -8,7 +8,7 @@ An implementation of [GraphQL federated schema composition](https://www.apollogr
 ## Example
 
 ```rust
-use graphql_composition::{Subgraphs, compose};
+use graphql_composition::{Subgraphs, compose, render_federated_sdl};
 
 let user_subgraph = r#"
   extend schema
@@ -40,15 +40,13 @@ let cart_subgraph = r#"
   }
 "#;
 
-let [user_subgraph, cart_subgraph] = [user_subgraph, cart_subgraph]
-  .map(|sdl| async_graphql_parser::parse_schema(&sdl).unwrap());
-
 let mut subgraphs = Subgraphs::default();
 
-subgraphs.ingest(&user_subgraph, "users-service", "http://users.example.com");
-subgraphs.ingest(&cart_subgraph, "carts-service", "http://carts.example.com");
+subgraphs.ingest_str(&user_subgraph, "users-service", "http://users.example.com").unwrap();
+subgraphs.ingest_str(&cart_subgraph, "carts-service", "http://carts.example.com").unwrap();
 
-let composed = compose(&subgraphs).into_result().unwrap().into_federated_sdl();
+let composed = compose(&subgraphs).into_result().unwrap();
+let composed = render_federated_sdl(&composed).unwrap();
 
 let expected = r#"
 directive @core(feature: String!) repeatable on SCHEMA

--- a/engine/crates/composition/src/compose.rs
+++ b/engine/crates/composition/src/compose.rs
@@ -6,6 +6,7 @@ mod fields;
 mod input_object;
 mod interface;
 mod object;
+mod reserved_names;
 mod roots;
 mod scalar;
 
@@ -23,6 +24,10 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 pub(crate) fn compose_subgraphs(ctx: &mut Context<'_>) {
     ctx.subgraphs.iter_definition_groups(|definitions| {
         let Some(first) = definitions.first() else {
+            return;
+        };
+
+        if reserved_names::validate_definition_names(definitions, ctx) {
             return;
         };
 

--- a/engine/crates/composition/src/compose/reserved_names.rs
+++ b/engine/crates/composition/src/compose/reserved_names.rs
@@ -1,0 +1,25 @@
+use super::{ComposeContext, DefinitionWalker};
+
+/// This is a reserved name.
+const JOIN_GRAPH_ENUM_NAME: &str = "join__Graph";
+
+/// Validates reserved names. Returns true in case of error.
+pub(super) fn validate_definition_names(definitions: &[DefinitionWalker<'_>], ctx: &mut ComposeContext<'_>) -> bool {
+    let Some(first) = definitions.first() else {
+        return false;
+    };
+
+    if first.name().as_str() != JOIN_GRAPH_ENUM_NAME {
+        return false;
+    }
+
+    for definition in definitions {
+        ctx.diagnostics.push_fatal(format!(
+            "[{}] Definition name `{}` is a reserved federation definition name, it cannot be defined in subgraphs.",
+            definition.subgraph().name().as_str(),
+            JOIN_GRAPH_ENUM_NAME
+        ));
+    }
+
+    true
+}

--- a/engine/crates/composition/tests/composition/subgraph_defining_join__Graph/federated.graphql
+++ b/engine/crates/composition/tests/composition/subgraph_defining_join__Graph/federated.graphql
@@ -1,0 +1,1 @@
+# [bad] Definition name `join__Graph` is a reserved federation definition name, it cannot be defined in subgraphs.

--- a/engine/crates/composition/tests/composition/subgraph_defining_join__Graph/subgraphs/bad.graphql
+++ b/engine/crates/composition/tests/composition/subgraph_defining_join__Graph/subgraphs/bad.graphql
@@ -1,0 +1,12 @@
+type User {
+  id: ID!
+  name: String!
+}
+
+type Query {
+  getAllUsers: [User!]
+}
+
+enum join__Graph {
+  BAD @join__graph(name: "bad", url: "http://example.com/bad")
+}


### PR DESCRIPTION
It's a reserved name for the enum defined in the federated SDL.

closes GB-7946
