### PR TITLE
chore: consolidate parsing of `@cost` & `@deprecated`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3307,6 +3307,7 @@ name = "graphql-composition"
 version = "0.4.0"
 dependencies = [
  "cynic-parser",
+ "cynic-parser-deser",
  "datatest-stable",
  "grafbase-workspace-hack",
  "graphql-federated-graph",
@@ -3321,6 +3322,7 @@ name = "graphql-federated-graph"
 version = "0.4.0"
 dependencies = [
  "cynic-parser",
+ "cynic-parser-deser",
  "expect-test",
  "grafbase-workspace-hack",
  "graphql-wrapping-types",

--- a/engine/crates/composition/Cargo.toml
+++ b/engine/crates/composition/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 cynic-parser.workspace = true
+cynic-parser-deser.workspace = true
 grafbase-workspace-hack.workspace = true
 graphql-federated-graph = { path = "../federated-graph", version = "0.4.0" }
 indexmap.workspace = true

--- a/engine/crates/federated-graph/Cargo.toml
+++ b/engine/crates/federated-graph/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1.0.116"
 indoc = "2.0.5"
 
 cynic-parser = { workspace = true, optional = true }
+cynic-parser-deser.workspace = true
 indexmap = { optional = true, version = "2.2.6" }
 grafbase-workspace-hack.workspace = true
 

--- a/engine/crates/federated-graph/src/directives/complexity_control.rs
+++ b/engine/crates/federated-graph/src/directives/complexity_control.rs
@@ -1,0 +1,19 @@
+use cynic_parser_deser::ValueDeserialize;
+
+#[derive(ValueDeserialize)]
+pub struct CostDirective {
+    pub weight: i32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::directives::parse_directive;
+
+    #[test]
+    fn test_parsing_cost() {
+        let value = parse_directive::<CostDirective>("@cost(weight: 1)").unwrap();
+
+        assert_eq!(value.weight, 1);
+    }
+}

--- a/engine/crates/federated-graph/src/directives/deprecated.rs
+++ b/engine/crates/federated-graph/src/directives/deprecated.rs
@@ -1,0 +1,28 @@
+use cynic_parser_deser::ValueDeserialize;
+
+#[derive(ValueDeserialize)]
+pub struct DeprecatedDirective<'a> {
+    pub reason: Option<&'a str>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::directives::{directive_test_document, parse_from_test_document};
+
+    #[test]
+    fn test_parsing_no_reason() {
+        let doc = directive_test_document("@deprecated");
+        let value = parse_from_test_document::<DeprecatedDirective<'_>>(&doc).unwrap();
+
+        assert_eq!(value.reason, None);
+    }
+
+    #[test]
+    fn test_parsing_with_reason() {
+        let doc = directive_test_document("@deprecated(reason: \"because I wanted to\")");
+        let value = parse_from_test_document::<DeprecatedDirective<'_>>(&doc).unwrap();
+
+        assert_eq!(value.reason, None);
+    }
+}

--- a/engine/crates/federated-graph/src/directives/deprecated.rs
+++ b/engine/crates/federated-graph/src/directives/deprecated.rs
@@ -23,6 +23,6 @@ mod tests {
         let doc = directive_test_document("@deprecated(reason: \"because I wanted to\")");
         let value = parse_from_test_document::<DeprecatedDirective<'_>>(&doc).unwrap();
 
-        assert_eq!(value.reason, None);
+        assert_eq!(value.reason, Some("because I wanted to"));
     }
 }

--- a/engine/crates/federated-graph/src/directives/mod.rs
+++ b/engine/crates/federated-graph/src/directives/mod.rs
@@ -1,0 +1,38 @@
+mod complexity_control;
+mod deprecated;
+
+pub use self::{complexity_control::CostDirective, deprecated::DeprecatedDirective};
+
+#[cfg(test)]
+/// Helper for tests
+fn parse_directive<T>(input: &str) -> Result<T, cynic_parser_deser::Error>
+where
+    T: cynic_parser_deser::ValueDeserializeOwned,
+{
+    let doc = directive_test_document(input);
+    parse_from_test_document(&doc)
+}
+
+#[cfg(test)]
+/// Helper for tests where the directive has a lifetime
+///
+/// Should be used with parse_from_test_document
+fn directive_test_document(directive: &str) -> cynic_parser::TypeSystemDocument {
+    cynic_parser::parse_type_system_document(&format!("type Object {directive} {{name: String}}")).unwrap()
+}
+
+#[cfg(test)]
+/// Helper for tests where the directive has a lifetime
+///
+/// Should be used with the document from directive_test_document
+fn parse_from_test_document<'a, T>(doc: &'a cynic_parser::TypeSystemDocument) -> Result<T, cynic_parser_deser::Error>
+where
+    T: cynic_parser_deser::ValueDeserialize<'a>,
+{
+    use cynic_parser::type_system::Definition;
+    use cynic_parser_deser::ConstDeserializer;
+    let Definition::Type(definition) = doc.definitions().next().unwrap() else {
+        unreachable!()
+    };
+    definition.directives().next().unwrap().deserialize::<T>()
+}

--- a/engine/crates/federated-graph/src/lib.rs
+++ b/engine/crates/federated-graph/src/lib.rs
@@ -1,5 +1,6 @@
 use grafbase_workspace_hack as _;
 
+pub mod directives;
 mod federated_graph;
 
 pub use self::federated_graph::*;


### PR DESCRIPTION
This PR has two changes:

1. It pulls the crate I introduced in #2329 into composition so we can derive directive parsing based on structs.
2. It adds structs to cover `@cost` & `@deprecated` into `federated-graph` and updates the directive handling in `composition` & `federated-graph` to use them.

If we like this approach we can expand to the other directives later, this seemed like a small enough change to gather feedback & make sure things actually work.