### PR TITLE
chore(engine): Fix child-type-mismatch

### DIFF
--- a/crates/engine/codegen/domain/schema.graphql
+++ b/crates/engine/codegen/domain/schema.graphql
@@ -86,6 +86,7 @@ type FieldDefinition @meta(module: "field") @indexed(id_size: "u32", max_id: "MA
   will be specified in this Vec.
   """
   only_resolvable_in: [Subgraph!]!
+  distinct_type_in: [Subgraph!]!
   requires: [FieldRequires!]! @field(record_field_name: "requires_records")
   provides: [FieldProvides!]! @field(record_field_name: "provides_records")
   "The arguments referenced by this range are sorted by their name (string)"
@@ -172,7 +173,7 @@ type InputValueDefinition @meta(module: "input_value") @indexed(id_size: "u32", 
 # - FieldSet -
 # ------------
 
-scalar FieldSet @indexed @record 
+scalar FieldSet @indexed @record
 
 type SchemaField
   @meta(module: "field_set/field", derive: ["PartialEq", "Eq", "PartialOrd", "Ord"], debug: false)
@@ -207,9 +208,7 @@ type DeprecatedDirective
   reason: String
 }
 
-type RequiresScopesDirective @meta(module: "directive/requires_scopes") @indexed(id_size: "u32", max_id: "MAX_ID") {
-  possible_
-}
+scalar RequiresScopesDirective @indexed @record
 
 type AuthorizedDirective @meta(module: "directive/authorized") @indexed(id_size: "u32", max_id: "MAX_ID") {
   arguments: InputValueSet!

--- a/crates/engine/codegen/domain/solved_operation.graphql
+++ b/crates/engine/codegen/domain/solved_operation.graphql
@@ -38,6 +38,7 @@ type ResponseObjectSetDefinition @meta(module: "response_object_set") @indexed(i
 # ----------------
 
 scalar PositionedResponseKey @copy @prelude
+scalar SafeResponseKey @copy @prelude
 scalar Location @copy @prelude
 scalar QueryInputValueId @prelude @id
 
@@ -53,6 +54,7 @@ union Field @id @meta(module: "field") @variants(remove_suffix: true) = DataFiel
 "In opposition to a __typename field this field does retrieve data from a subgraph"
 type DataField @meta(module: "field/data", debug: false) @indexed(id_size: "u32") {
   key: PositionedResponseKey!
+  subgraph_key: SafeResponseKey!
   location: Location!
   definition: FieldDefinition!
   arguments: [FieldArgument!]!

--- a/crates/engine/query-solver/src/lib.rs
+++ b/crates/engine/query-solver/src/lib.rs
@@ -13,7 +13,7 @@ pub(crate) mod solve;
 pub use error::*;
 pub(crate) use operation::*;
 pub use petgraph;
-use schema::{FieldDefinitionId, ObjectDefinitionId, Schema, SchemaField};
+use schema::{CompositeTypeId, FieldDefinitionId, ObjectDefinitionId, Schema, SchemaField, SubgraphId};
 pub use solution::*;
 
 pub(crate) type Cost = u16;
@@ -32,7 +32,12 @@ pub trait Operation {
         petitioner_field_id: Self::FieldId,
         field: SchemaField<'_>,
     ) -> Self::FieldId;
-    fn finalize_selection_set_extra_fields(&mut self, extra: &[Self::FieldId], existing: &[Self::FieldId]);
+    fn finalize_selection_set(
+        &mut self,
+        parent_type: CompositeTypeId,
+        extra: &mut [(SubgraphId, Self::FieldId)],
+        existing: &mut [(SubgraphId, Self::FieldId)],
+    );
 
     fn root_selection_set(&self) -> impl ExactSizeIterator<Item = Self::FieldId> + '_;
     fn subselection(&self, field_id: Self::FieldId) -> impl ExactSizeIterator<Item = Self::FieldId> + '_;

--- a/crates/engine/query-solver/src/tests/mod.rs
+++ b/crates/engine/query-solver/src/tests/mod.rs
@@ -16,7 +16,9 @@ use engine_parser::{
     Positioned,
 };
 use itertools::Itertools;
-use schema::{Definition, FieldDefinitionId, ObjectDefinition, ObjectDefinitionId, Schema, Version};
+use schema::{
+    CompositeTypeId, Definition, FieldDefinitionId, ObjectDefinition, ObjectDefinitionId, Schema, SubgraphId, Version,
+};
 use walker::Walk;
 
 #[ctor::ctor]
@@ -146,8 +148,13 @@ impl crate::Operation for &mut TestOperation {
         (self.fields.len() - 1).into()
     }
 
-    fn finalize_selection_set_extra_fields(&mut self, extra: &[Self::FieldId], _existing: &[Self::FieldId]) {
-        for field_id in extra {
+    fn finalize_selection_set(
+        &mut self,
+        _parent_type: CompositeTypeId,
+        extra: &mut [(SubgraphId, Self::FieldId)],
+        _existing: &mut [(SubgraphId, Self::FieldId)],
+    ) {
+        for (_, field_id) in extra {
             self[*field_id].name.push('*');
         }
     }

--- a/crates/engine/schema/src/builder/graph.rs
+++ b/crates/engine/schema/src/builder/graph.rs
@@ -602,6 +602,17 @@ impl<'a> GraphBuilder<'a> {
                 name_id: field.name.into(),
                 description_id: None,
                 parent_entity_id,
+                distinct_type_in_ids: field
+                    .join_fields
+                    .iter()
+                    .filter_map(|join| {
+                        if join.r#type.as_ref().is_some_and(|ty| ty != &field.r#type) {
+                            Some(SubgraphId::GraphqlEndpoint(join.subgraph_id.into()))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect(),
                 ty_record: self.ctx.convert_type(field.r#type),
                 only_resolvable_in_ids: only_resolvable_in
                     .into_iter()

--- a/crates/engine/schema/src/generated/field.rs
+++ b/crates/engine/schema/src/generated/field.rs
@@ -33,6 +33,7 @@ use walker::{Iter, Walk};
 ///   will be specified in this Vec.
 ///   """
 ///   only_resolvable_in: [Subgraph!]!
+///   distinct_type_in: [Subgraph!]!
 ///   requires: [FieldRequires!]! @field(record_field_name: "requires_records")
 ///   provides: [FieldProvides!]! @field(record_field_name: "provides_records")
 ///   "The arguments referenced by this range are sorted by their name (string)"
@@ -51,6 +52,7 @@ pub struct FieldDefinitionRecord {
     /// It's up to the composition to ensure it. If this field is specific to some subgraphs, they
     /// will be specified in this Vec.
     pub only_resolvable_in_ids: Vec<SubgraphId>,
+    pub distinct_type_in_ids: Vec<SubgraphId>,
     pub requires_records: Vec<FieldRequiresRecord>,
     pub provides_records: Vec<FieldProvidesRecord>,
     /// The arguments referenced by this range are sorted by their name (string)
@@ -102,6 +104,9 @@ impl<'a> FieldDefinition<'a> {
     pub fn only_resolvable_in(&self) -> impl Iter<Item = Subgraph<'a>> + 'a {
         self.as_ref().only_resolvable_in_ids.walk(self.schema)
     }
+    pub fn distinct_type_in(&self) -> impl Iter<Item = Subgraph<'a>> + 'a {
+        self.as_ref().distinct_type_in_ids.walk(self.schema)
+    }
     pub fn requires(&self) -> impl Iter<Item = FieldRequires<'a>> + 'a {
         self.as_ref().requires_records.walk(self.schema)
     }
@@ -140,6 +145,7 @@ impl std::fmt::Debug for FieldDefinition<'_> {
             .field("ty", &self.ty())
             .field("resolvers", &self.resolvers())
             .field("only_resolvable_in", &self.only_resolvable_in())
+            .field("distinct_type_in", &self.distinct_type_in())
             .field("requires", &self.requires())
             .field("provides", &self.provides())
             .field("arguments", &self.arguments())

--- a/crates/engine/schema/src/introspection.rs
+++ b/crates/engine/schema/src/introspection.rs
@@ -690,6 +690,7 @@ impl<'a> IntrospectionBuilder<'a> {
                 directive_ids: Vec::new(),
                 resolver_ids: Vec::new(),
                 argument_ids: IdRange::empty(),
+                distinct_type_in_ids: Vec::new(),
             });
 
             out_fields.push((id, tag));

--- a/crates/engine/src/operation/bind/model/selection_set.rs
+++ b/crates/engine/src/operation/bind/model/selection_set.rs
@@ -3,7 +3,7 @@ use schema::{CompositeTypeId, FieldDefinitionId, InputValueDefinitionId};
 
 use crate::{
     operation::{Location, QueryInputValueId},
-    response::{PositionedResponseKey, SafeResponseKey},
+    response::SafeResponseKey,
 };
 
 use super::{BoundFieldArgumentId, BoundFieldId, BoundSelectionSetId};
@@ -39,35 +39,38 @@ pub(crate) enum BoundField {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub(crate) struct BoundTypeNameField {
-    pub(crate) type_condition: CompositeTypeId,
-    pub(crate) key: PositionedResponseKey,
-    pub(crate) location: Location,
+    pub type_condition: CompositeTypeId,
+    pub query_position: QueryPosition,
+    pub key: SafeResponseKey,
+    pub location: Location,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub(crate) struct BoundQueryField {
-    pub(crate) key: PositionedResponseKey,
-    pub(crate) location: Location,
-    pub(crate) definition_id: FieldDefinitionId,
-    pub(crate) argument_ids: IdRange<BoundFieldArgumentId>,
-    pub(crate) selection_set_id: Option<BoundSelectionSetId>,
+    pub query_position: QueryPosition,
+    pub key: SafeResponseKey,
+    pub subgraph_key: SafeResponseKey,
+    pub location: Location,
+    pub definition_id: FieldDefinitionId,
+    pub argument_ids: IdRange<BoundFieldArgumentId>,
+    pub selection_set_id: Option<BoundSelectionSetId>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub(crate) struct BoundExtraField {
     // Extra fields are added as soon as they might be necessary, and they're assigned a key if
     // they are.
-    pub(crate) key: Option<SafeResponseKey>,
-    pub(crate) definition_id: FieldDefinitionId,
-    pub(crate) argument_ids: IdRange<BoundFieldArgumentId>,
-    pub(crate) petitioner_location: Location,
+    pub key: Option<SafeResponseKey>,
+    pub definition_id: FieldDefinitionId,
+    pub argument_ids: IdRange<BoundFieldArgumentId>,
+    pub petitioner_location: Location,
 }
 
 impl BoundField {
     pub(crate) fn response_key(&self) -> Option<SafeResponseKey> {
         match self {
-            BoundField::TypeName(field) => Some(field.key.response_key),
-            BoundField::Query(field) => Some(field.key.response_key),
+            BoundField::TypeName(field) => Some(field.key),
+            BoundField::Query(field) => Some(field.key),
             BoundField::Extra(field) => field.key,
         }
     }

--- a/crates/engine/src/operation/plan/model/field/data.rs
+++ b/crates/engine/src/operation/plan/model/field/data.rs
@@ -27,8 +27,8 @@ impl<'a> PlanDataField<'a> {
     pub(crate) fn key(&self) -> PositionedResponseKey {
         self.as_ref().key
     }
-    pub(crate) fn response_key_str(&self) -> &'a str {
-        &self.ctx.solved_operation.response_keys[self.as_ref().key.response_key]
+    pub(crate) fn subgraph_response_key_str(&self) -> &'a str {
+        &self.ctx.solved_operation.response_keys[self.as_ref().subgraph_key]
     }
     pub(crate) fn location(&self) -> Location {
         self.as_ref().location

--- a/crates/engine/src/operation/solve/model/generated/field/data.rs
+++ b/crates/engine/src/operation/solve/model/generated/field/data.rs
@@ -22,6 +22,7 @@ use walker::{Iter, Walk};
 /// ```custom,{.language-graphql}
 /// type DataField @meta(module: "field/data", debug: false) @indexed(id_size: "u32") {
 ///   key: PositionedResponseKey!
+///   subgraph_key: SafeResponseKey!
 ///   location: Location!
 ///   definition: FieldDefinition!
 ///   arguments: [FieldArgument!]!
@@ -42,6 +43,7 @@ use walker::{Iter, Walk};
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct DataFieldRecord {
     pub key: PositionedResponseKey,
+    pub subgraph_key: SafeResponseKey,
     pub location: Location,
     pub definition_id: FieldDefinitionId,
     pub argument_ids: IdRange<FieldArgumentId>,

--- a/crates/engine/src/operation/solve/model/prelude.rs
+++ b/crates/engine/src/operation/solve/model/prelude.rs
@@ -1,6 +1,6 @@
 pub(super) use super::SolvedOperationContext;
 pub(super) use crate::{
     operation::{Location, QueryInputValueId, QueryModifierRule, ResponseModifierRule},
-    response::{ConcreteObjectShapeId, PositionedResponseKey},
+    response::{ConcreteObjectShapeId, PositionedResponseKey, SafeResponseKey},
 };
 pub(super) use id_newtypes::IdRange;

--- a/crates/engine/src/operation/solve/solver/adapter.rs
+++ b/crates/engine/src/operation/solve/solver/adapter.rs
@@ -1,7 +1,10 @@
 use std::borrow::Cow;
 
 use id_newtypes::IdRange;
-use schema::{ObjectDefinitionId, Schema, SchemaField};
+use im::HashMap;
+use schema::{
+    CompositeTypeId, FieldDefinition, FieldDefinitionId, ObjectDefinitionId, Schema, SchemaField, SubgraphId,
+};
 use walker::Walk;
 
 use crate::{
@@ -9,13 +12,14 @@ use crate::{
         BoundExtraField, BoundField, BoundFieldArgument, BoundFieldArgumentId, BoundFieldId, BoundOperation,
         QueryInputValueRecord, QueryPosition,
     },
-    response::SafeResponseKey,
+    response::{ResponseKeys, SafeResponseKey},
 };
 
 pub(super) struct OperationAdapter<'a> {
     pub schema: &'a Schema,
     pub operation: &'a mut BoundOperation,
     tmp_response_keys: Vec<SafeResponseKey>,
+    field_with_distinct_type_to_unique_key: HashMap<FieldDefinitionId, SafeResponseKey>,
 }
 
 impl<'a> OperationAdapter<'a> {
@@ -24,6 +28,7 @@ impl<'a> OperationAdapter<'a> {
             schema,
             operation,
             tmp_response_keys: Vec::new(),
+            field_with_distinct_type_to_unique_key: HashMap::new(),
         }
     }
 }
@@ -35,7 +40,7 @@ impl<'a> query_solver::Operation for OperationAdapter<'a> {
         (0..self.operation.fields.len()).map(BoundFieldId::from)
     }
 
-    fn field_definition(&self, field_id: BoundFieldId) -> Option<schema::FieldDefinitionId> {
+    fn field_definition(&self, field_id: BoundFieldId) -> Option<FieldDefinitionId> {
         self.operation[field_id].definition_id()
     }
 
@@ -77,8 +82,8 @@ impl<'a> query_solver::Operation for OperationAdapter<'a> {
 
     fn field_label(&self, field_id: BoundFieldId) -> std::borrow::Cow<'_, str> {
         match &self.operation[field_id] {
-            BoundField::TypeName(field) => Cow::Borrowed(&self.operation.response_keys[field.key.response_key]),
-            BoundField::Query(field) => Cow::Borrowed(&self.operation.response_keys[field.key.response_key]),
+            BoundField::TypeName(field) => Cow::Borrowed(&self.operation.response_keys[field.key]),
+            BoundField::Query(field) => Cow::Borrowed(&self.operation.response_keys[field.key]),
             // For extra fields we didn't create a response key yet.
             BoundField::Extra(field) => {
                 if let Some(key) = field.key {
@@ -90,45 +95,45 @@ impl<'a> query_solver::Operation for OperationAdapter<'a> {
         }
     }
 
-    fn finalize_selection_set_extra_fields(&mut self, extra_fields: &[BoundFieldId], existing_fields: &[BoundFieldId]) {
+    fn finalize_selection_set(
+        &mut self,
+        parent_type: CompositeTypeId,
+        extra_fields: &mut [(SubgraphId, Self::FieldId)],
+        existing_fields: &mut [(SubgraphId, Self::FieldId)],
+    ) {
         self.tmp_response_keys.clear();
         self.tmp_response_keys.extend(
             existing_fields
                 .iter()
-                .filter_map(|id| self.operation[*id].response_key()),
+                .filter_map(|(_, id)| self.operation[*id].response_key()),
         );
-        for extra_field_id in extra_fields {
+
+        // If the parent type is an object we don't need to deal with distinct types as we'll only
+        // query a single object from the subgraph.
+        if !parent_type.is_object() {
+            for (subgraph_id, field_id) in existing_fields.iter().copied() {
+                let Some(definition) = self.operation[field_id].definition_id().walk(self.schema) else {
+                    continue;
+                };
+                if definition.distinct_type_in_ids.contains(&subgraph_id) {
+                    let key = self.generate_new_distinct_type_key(definition);
+                    if let BoundField::Query(field) = &mut self.operation[field_id] {
+                        field.subgraph_key = key;
+                        self.tmp_response_keys.push(key);
+                    };
+                }
+            }
+        }
+
+        for (_, extra_field_id) in extra_fields {
             let Some(definition_id) = self.operation[*extra_field_id].definition_id() else {
                 continue;
             };
-            let name = self.schema.walk(definition_id).name();
-
-            let key = 'key: {
-                // Key doesn't exist in the operation at all
-                let Some(key) = self.operation.response_keys.get(name) else {
-                    break 'key self.operation.response_keys.get_or_intern(name);
-                };
-
-                // Key doesn't exist in the current selection set
-                if !self.tmp_response_keys.contains(&key) {
-                    break 'key key;
-                }
-
-                // Generate a likely unique key
-                let hex = hex::encode_upper(u32::from(definition_id).to_be_bytes());
-                let short_id = hex.trim_start_matches('0');
-
-                let name = format!("_{}{}", name, short_id);
-
-                let mut i: u8 = 0;
-                loop {
-                    let candidate = format!("{name}{}", hex::encode_upper(i.to_be_bytes()));
-                    if !self.operation.response_keys.contains(&candidate) {
-                        break 'key self.operation.response_keys.get_or_intern(&candidate);
-                    }
-                    i += 1;
-                }
-            };
+            let key = generate_new_extra_field_key(
+                &mut self.operation.response_keys,
+                &self.tmp_response_keys,
+                definition_id.walk(self.schema),
+            );
             if let BoundField::Extra(field) = &mut self.operation[*extra_field_id] {
                 field.key = Some(key);
                 self.tmp_response_keys.push(key);
@@ -142,14 +147,104 @@ impl<'a> query_solver::Operation for OperationAdapter<'a> {
 
     fn field_query_position(&self, field_id: Self::FieldId) -> usize {
         match &self.operation[field_id] {
-            BoundField::TypeName(field) => usize::from(field.key.query_position.unwrap()),
-            BoundField::Query(field) => usize::from(field.key.query_position.unwrap()),
+            BoundField::TypeName(field) => usize::from(field.query_position),
+            BoundField::Query(field) => usize::from(field.query_position),
             BoundField::Extra(_) => QueryPosition::EXTRA,
         }
     }
 }
 
 impl<'a> OperationAdapter<'a> {
+    /// Generate a new response key for a field with an distinct type, but compatible, than the super-graph.
+    /// This can happen when a subgraph A defines:
+    ///
+    /// ```ignore,graphql
+    /// type User {
+    ///   id: ID @shareable
+    /// }
+    /// ```
+    ///
+    /// and subgraph B defines:
+    ///
+    /// ```ignore,graphql
+    /// type User @key(fields: "id") {
+    ///   id: ID!
+    /// }
+    /// type Admin {
+    ///   id: ID
+    /// }
+    /// ```
+    ///
+    /// In this case the super-graph will use `id: ID`. A problem arises if we query something
+    /// like this on an `UserOrAdmin` union:
+    /// ```ignore,graphql
+    /// {
+    ///   userOrAdmin {
+    ///     ... on User {
+    ///       id
+    ///       name
+    ///     }
+    ///     ... on Admin {
+    ///       id
+    ///       name
+    ///     }
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// In this case the subgraph will complain that `User.id` and `Admin.id` have different types.
+    /// So the federated SDL will actually track this with:
+    ///
+    /// ```ignore,graphql
+    ///   id: ID @join__field(graph: A, type: "ID") @join__field(graph: B, type: "ID!")
+    /// ```
+    ///
+    /// Whenever a user request a field with a distinct type such as `User.id` we need to rename
+    /// it in the subgraph query. As we need to deal with selection set merging we have to be
+    /// consistent with this name, so we generate an unique name per `FieldDefinitionId`.
+    ///
+    /// Luckily for us we won't need to deal with interface fields when response merging. An
+    /// interface needs to be consistent with its object so if `User` implemented an interface with
+    /// an `id` field it would either be inconsistent at the super-graph or subgraph level. So we
+    /// will never need to worry about merging with interface fields.
+    fn generate_new_distinct_type_key(&mut self, definition: FieldDefinition<'_>) -> SafeResponseKey {
+        if let Some(key) = self.field_with_distinct_type_to_unique_key.get(&definition.id) {
+            return *key;
+        }
+
+        let name = definition.name();
+
+        // Key doesn't exist in the operation at all
+        if !self.operation.response_keys.contains(name) {
+            let key = self.operation.response_keys.get_or_intern(name);
+            self.field_with_distinct_type_to_unique_key.insert(definition.id, key);
+            return key;
+        }
+
+        // Generate a likely unique key
+        let hex = hex::encode_upper(u32::from(definition.id).to_be_bytes());
+        let short_id = hex.trim_start_matches('0');
+
+        let name = format!("_{}{}", name, short_id);
+
+        let mut i: u8 = 0;
+        loop {
+            let candidate = format!("{name}{}", hex::encode_upper(i.to_be_bytes()));
+
+            // Key doesn't exist in the operation at all
+            if !self.operation.response_keys.contains(&candidate) {
+                let key = self.operation.response_keys.get_or_intern(&candidate);
+                self.field_with_distinct_type_to_unique_key.insert(definition.id, key);
+                return key;
+            };
+
+            i = i.wrapping_add(1);
+            if i == 0 {
+                unimplemented!("Couldn not find a unique field name.")
+            }
+        }
+    }
+
     fn create_arguments_for(&mut self, requirement: SchemaField<'_>) -> IdRange<BoundFieldArgumentId> {
         let start = self.operation.field_arguments.len();
 
@@ -169,5 +264,56 @@ impl<'a> OperationAdapter<'a> {
 
         let end = self.operation.field_arguments.len();
         (start..end).into()
+    }
+}
+
+/// Generating a response key for an extra field, a field we added during planning to satisfy a
+/// requirement. Contrary to `generate_new_distinct_type_key` those fields will never be exposed to
+/// the client so their response key doesn't matter, but it needs to be unique within the selection
+/// set we send to the subgraph to generate a proper query string.
+///
+/// We don't need to keep track of this later, because we identify requirements by
+/// their associated `SchemaFieldId` rather than
+fn generate_new_extra_field_key(
+    response_keys: &mut ResponseKeys,
+    selection_set: &[SafeResponseKey],
+    definition: FieldDefinition<'_>,
+) -> SafeResponseKey {
+    let name = definition.name();
+
+    // Key doesn't exist in the operation at all
+    let Some(key) = response_keys.get(name) else {
+        return response_keys.get_or_intern(name);
+    };
+
+    // Key doesn't exist in the current selection set
+    if !selection_set.contains(&key) {
+        return key;
+    }
+
+    // Generate a likely unique key
+    let hex = hex::encode_upper(u32::from(definition.id).to_be_bytes());
+    let short_id = hex.trim_start_matches('0');
+
+    let name = format!("_{}{}", name, short_id);
+
+    let mut i: u8 = 0;
+    loop {
+        let candidate = format!("{name}{}", hex::encode_upper(i.to_be_bytes()));
+
+        // Key doesn't exist in the operation at all
+        let Some(key) = response_keys.get(&candidate) else {
+            return response_keys.get_or_intern(&candidate);
+        };
+
+        // Key doesn't exist in the current selection set
+        if !selection_set.contains(&key) {
+            return key;
+        }
+
+        i = i.wrapping_add(1);
+        if i == 0 {
+            unimplemented!("Couldn not find a unique field name.")
+        }
     }
 }

--- a/crates/engine/src/operation/solve/solver/mod.rs
+++ b/crates/engine/src/operation/solve/solver/mod.rs
@@ -473,7 +473,8 @@ impl BoundField {
     ) -> Result<DataFieldRecord, TypenameFieldRecord> {
         match self {
             BoundField::Query(field) => Ok(DataFieldRecord {
-                key: field.key,
+                key: field.key.with_position(field.query_position),
+                subgraph_key: field.subgraph_key,
                 location: field.location,
                 definition_id: field.definition_id,
                 argument_ids: IdRange::from_start_and_end(field.argument_ids.start, field.argument_ids.end),
@@ -498,6 +499,7 @@ impl BoundField {
                     query_position: None,
                     response_key: field.key.unwrap(),
                 },
+                subgraph_key: field.key.unwrap(),
                 location: field.petitioner_location,
                 definition_id: field.definition_id,
                 argument_ids: IdRange::from_start_and_end(field.argument_ids.start, field.argument_ids.end),
@@ -516,7 +518,7 @@ impl BoundField {
                 shape_ids: IdRange::empty(),
             }),
             BoundField::TypeName(field) => Err(TypenameFieldRecord {
-                key: field.key,
+                key: field.key.with_position(field.query_position),
                 location: field.location,
                 type_condition_id: field.type_condition,
             }),

--- a/crates/engine/src/operation/solve/solver/shapes/mod.rs
+++ b/crates/engine/src/operation/solve/solver/shapes/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     response::{
         ConcreteObjectShapeId, ConcreteObjectShapeRecord, FieldShapeId, FieldShapeRecord, ObjectIdentifier,
-        PolymorphicObjectShapeId, PolymorphicObjectShapeRecord, SafeResponseKey, Shape, Shapes,
+        PolymorphicObjectShapeId, PolymorphicObjectShapeRecord, Shape, Shapes,
     },
     utils::BufferPool,
 };
@@ -173,7 +173,7 @@ impl<'ctx> ShapesBuilder<'ctx> {
             );
 
             if let Some(field) = fields_buffer.first().copied() {
-                let shape = self.create_data_field_shape(response_key, &mut fields_buffer, field);
+                let shape = self.create_data_field_shape(&mut fields_buffer, field);
                 field_shapes_buffer.push((shape, fields_buffer.iter().map(|field| field.id).collect()));
             }
             start = end;
@@ -203,12 +203,7 @@ impl<'ctx> ShapesBuilder<'ctx> {
         self.push_concrete_shape(shape)
     }
 
-    fn create_data_field_shape(
-        &mut self,
-        response_key: SafeResponseKey,
-        fields: &mut [DataField<'ctx>],
-        field: DataField<'ctx>,
-    ) -> FieldShapeRecord {
+    fn create_data_field_shape(&mut self, fields: &mut [DataField<'ctx>], field: DataField<'ctx>) -> FieldShapeRecord {
         let ty = field.definition().ty();
         let shape = match ty.definition_id {
             DefinitionId::Scalar(id) => Shape::Scalar(id.walk(self.schema).ty),
@@ -223,11 +218,10 @@ impl<'ctx> ShapesBuilder<'ctx> {
         let required_field_id = fields.iter().find_map(|field| field.matching_requirement_id);
 
         FieldShapeRecord {
-            expected_key: response_key,
+            expected_key: field.subgraph_key,
             key: field.key,
             id: field.id,
             required_field_id,
-            definition_id: field.definition().id,
             shape,
             wrapping: ty.wrapping,
         }

--- a/crates/engine/src/resolver/graphql/request/prepare.rs
+++ b/crates/engine/src/resolver/graphql/request/prepare.rs
@@ -306,7 +306,7 @@ impl QueryBuilderContext {
     }
 
     fn write_field(&mut self, buffer: &mut String, field: PlanDataField<'_>) -> Result<(), Error> {
-        let response_key = field.response_key_str();
+        let response_key = field.subgraph_response_key_str();
         let name = field.definition().name();
         buffer.push(' ');
         if response_key == name {

--- a/crates/engine/src/response/key/private.rs
+++ b/crates/engine/src/response/key/private.rs
@@ -46,8 +46,8 @@ impl ResponseKeys {
         self.0.get_or_intern(s)
     }
 
-    pub fn contains(&self, s: &str) -> bool {
-        self.0.contains(s)
+    pub fn contains(&self, key: &str) -> bool {
+        self.0.contains(key)
     }
 
     pub fn try_resolve(&self, key: ResponseKey) -> Option<&str> {
@@ -106,7 +106,7 @@ mod tests {
 
     #[test]
     fn field_name_value_out_of_range() {
-        let key = SafeResponseKey::try_from_usize(100_000_usize);
+        let key = SafeResponseKey::try_from_usize(u64::MAX as usize);
         assert!(key.is_none());
 
         let key = SafeResponseKey::try_from_usize(u32::MAX as usize);

--- a/crates/engine/src/response/shape/field.rs
+++ b/crates/engine/src/response/shape/field.rs
@@ -1,6 +1,6 @@
 use std::num::NonZero;
 
-use schema::{EnumDefinitionId, FieldDefinitionId, ScalarType, SchemaFieldId, Wrapping};
+use schema::{EnumDefinitionId, ScalarType, SchemaFieldId, Wrapping};
 use walker::Walk;
 
 use crate::{
@@ -16,7 +16,6 @@ pub(crate) struct FieldShapeRecord {
     pub key: PositionedResponseKey,
     pub id: DataFieldId,
     pub required_field_id: Option<SchemaFieldId>,
-    pub definition_id: FieldDefinitionId,
     pub shape: Shape,
     pub wrapping: Wrapping,
 }

--- a/crates/federation-audit-tests/tests.json
+++ b/crates/federation-audit-tests/tests.json
@@ -312,6 +312,10 @@
     "index": 6
   },
   {
+    "suite": "null-keys",
+    "index": 0
+  },
+  {
     "suite": "override-type-interface",
     "index": 0
   },

--- a/crates/graphql-composition/src/emit_federated_graph.rs
+++ b/crates/graphql-composition/src/emit_federated_graph.rs
@@ -282,6 +282,7 @@ fn emit_fields<'a>(
                 resolvable_in,
                 composed_directives,
                 description,
+                join_fields: Vec::new(),
             };
 
             let field_id = federated::FieldId::from(ctx.out.fields.push_return_idx(field));

--- a/crates/graphql-federated-graph/src/federated_graph.rs
+++ b/crates/graphql-federated-graph/src/federated_graph.rs
@@ -225,6 +225,8 @@ pub struct Field {
 
     pub arguments: InputValueDefinitions,
 
+    pub join_fields: Vec<JoinField>,
+
     /// This is populated only of fields of entities. The Vec includes all subgraphs the field can
     /// be resolved in. For a regular field of an entity, it will be one subgraph, the subgraph
     /// where the entity field is defined. For a shareable field in an entity, this contains the
@@ -247,6 +249,13 @@ pub struct Field {
     pub composed_directives: Directives,
 
     pub description: Option<StringId>,
+}
+
+#[derive(Clone)]
+pub struct JoinField {
+    pub subgraph_id: SubgraphId,
+    // Only present if different from the field type.
+    pub r#type: Option<Type>,
 }
 
 impl Value {
@@ -349,6 +358,7 @@ impl Default for FederatedGraph {
                         wrapping: Default::default(),
                         definition: Definition::Scalar(0usize.into()),
                     },
+                    join_fields: Vec::new(),
                     arguments: NO_INPUT_VALUE_DEFINITION,
                     resolvable_in: Vec::new(),
                     provides: Vec::new(),
@@ -363,6 +373,7 @@ impl Default for FederatedGraph {
                         wrapping: Default::default(),
                         definition: Definition::Scalar(0usize.into()),
                     },
+                    join_fields: Vec::new(),
                     arguments: NO_INPUT_VALUE_DEFINITION,
                     resolvable_in: Vec::new(),
                     provides: Vec::new(),

--- a/crates/graphql-federated-graph/src/render_sdl/render_federated_sdl.rs
+++ b/crates/graphql-federated-graph/src/render_sdl/render_federated_sdl.rs
@@ -403,6 +403,7 @@ fn write_field(field_id: FieldId, field: &Field, graph: &FederatedGraph, sdl: &m
     write_requires(field, graph, sdl)?;
     write_composed_directives(field.composed_directives, graph, sdl)?;
     write_overrides(field, graph, sdl)?;
+    write_join_field_type(field, graph, sdl)?;
     write_authorized(field_id, graph, sdl)?;
 
     sdl.push('\n');
@@ -443,6 +444,21 @@ fn write_resolvable_in(subgraph: SubgraphId, field: &Field, graph: &FederatedGra
             .map(|fieldset| format!(", requires: {}", SelectionSetDisplay(&fieldset.fields, graph))),
     );
     write!(sdl, " @join__field(graph: {subgraph_name}{provides}{requires})")?;
+
+    Ok(())
+}
+
+fn write_join_field_type(field: &Field, graph: &FederatedGraph, sdl: &mut String) -> fmt::Result {
+    for JoinField { subgraph_id, r#type } in &field.join_fields {
+        let subgraph_name = GraphEnumVariantName(&graph[graph[*subgraph_id].name]);
+        if let Some(ty) = r#type {
+            write!(
+                sdl,
+                " @join__field(graph: {subgraph_name}, type: \"{}\")",
+                render_field_type(ty, graph)
+            )?;
+        }
+    }
 
     Ok(())
 }

--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,10 @@
 
             # SQLx macros
             libiconv
+
+            # federation-audit test
+            nodejs_22
+            typescript
           ]
           ++ optional (system == systems.aarch64-darwin) [
             cargo-binstall


### PR DESCRIPTION
Had to add the `JoinFields` struct in federated graph to keep track of the `type` in `@join__field`. I'll change that in a further PR to keep track of all the `@join_field` information in a `directives` attributes.

Explained the problem there https://github.com/grafbase/grafbase/pull/2344/files#diff-ac90207e5a538e9a94040951df4e2fcc504f9ecad005a706274a4a1709764479 near the end. In short, the subgraph has a field of type `ID!` and in the supergraph it ends being `ID`. That's fine most of time except when you send an union to the subgraph where it can break with something like:
```graphql
{ ... on User { id } ... on Account { id } }
```
In the supergraph both have the same type `ID`, but in the subgraph one has `ID!` and the other has `ID`, so the query fails. So we need to send the following instead:
```graphql
{ ... on User { alias: id } ... on Account { id } }
```