### PR TITLE
fix: redo `@listSize` in composition

### DIFF
--- a/crates/engine/schema/src/builder/graph.rs
+++ b/crates/engine/schema/src/builder/graph.rs
@@ -791,8 +791,8 @@ impl<'a> GraphBuilder<'a> {
                         reason_id: reason.map(Into::into),
                     })
                 }
-                federated_graph::Directive::Cost { .. } | federated_graph::Directive::ListSize(_) => {
-                    // TODO: Implement these
+                federated_graph::Directive::Cost { .. } => {
+                    // TODO: Implement this
                     continue;
                 }
                 federated_graph::Directive::Other { .. }

--- a/crates/graphql-composition/src/compose.rs
+++ b/crates/graphql-composition/src/compose.rs
@@ -117,7 +117,7 @@ fn merge_object_definitions<'a>(
     fields::for_each_field_group(definitions, |fields| {
         let Some(first) = fields.first() else { return };
 
-        object::compose_object_fields(object_id, is_shareable, *first, fields, ctx);
+        object::compose_object_fields(object_id, object_name, is_shareable, *first, fields, ctx);
     });
 }
 

--- a/crates/graphql-composition/src/compose/context.rs
+++ b/crates/graphql-composition/src/compose/context.rs
@@ -310,4 +310,13 @@ impl<'a> Context<'a> {
             .object_fields_from_entity_interfaces
             .insert((object_name, field_id));
     }
+
+    pub(crate) fn insert_list_size_directive(
+        &mut self,
+        definition_name: graphql_federated_graph::StringId,
+        field_name: graphql_federated_graph::StringId,
+        directive: graphql_federated_graph::directives::ListSizeDirective,
+    ) {
+        self.ir.list_sizes.insert((definition_name, field_name), directive);
+    }
 }

--- a/crates/graphql-composition/src/compose/directives.rs
+++ b/crates/graphql-composition/src/compose/directives.rs
@@ -60,10 +60,6 @@ pub(super) fn collect_composed_directives<'a>(
         push_directive(ctx, ir::Directive::Cost { weight })
     }
 
-    if let Some(directive) = list_size {
-        push_directive(ctx, ir::Directive::ListSize(directive))
-    }
-
     // @requiresScopes
     {
         let mut scopes: Vec<Vec<federated::StringId>> = Vec::new();

--- a/crates/graphql-composition/src/compose/fields.rs
+++ b/crates/graphql-composition/src/compose/fields.rs
@@ -109,3 +109,18 @@ pub(super) fn compose_argument_types<'a>(
         }
     }
 }
+
+pub(super) fn insert_list_size_directives<'a>(
+    fields: impl Iterator<Item = &'a subgraphs::Walker<'a, (subgraphs::FieldId, subgraphs::FieldTuple)>>,
+    ctx: &mut ComposeContext<'_>,
+    definition_name: federated::StringId,
+    field_name: federated::StringId,
+) {
+    let list_size_directive = fields
+        .filter_map(|field| field.directives().list_size().cloned())
+        .reduce(|lhs, rhs| lhs.merge(rhs));
+
+    if let Some(directive) = list_size_directive {
+        ctx.insert_list_size_directive(definition_name, field_name, directive);
+    }
+}

--- a/crates/graphql-composition/src/compose/interface.rs
+++ b/crates/graphql-composition/src/compose/interface.rs
@@ -61,6 +61,8 @@ pub(super) fn merge_interface_definitions<'a>(
 
         let arguments = merge_field_arguments(fields, ctx);
 
+        fields::insert_list_size_directives(fields.iter().map(|(_, f)| f), ctx, interface_name, field_name);
+
         ctx.insert_field(ir::FieldIr {
             parent_definition: federated::Definition::Interface(interface_id),
             field_name,

--- a/crates/graphql-composition/src/compose/object.rs
+++ b/crates/graphql-composition/src/compose/object.rs
@@ -162,6 +162,7 @@ fn required_argument_not_in_intersection_error(
 
 pub(super) fn compose_object_fields<'a>(
     parent_definition: federated::ObjectId,
+    parent_definition_name: federated::StringId,
     object_is_shareable: bool,
     first: FieldWalker<'a>,
     fields: &[FieldWalker<'a>],
@@ -249,6 +250,8 @@ pub(super) fn compose_object_fields<'a>(
     };
 
     let field_name = ctx.insert_string(field_name.id);
+
+    fields::insert_list_size_directives(fields.iter(), ctx, parent_definition_name, field_name);
 
     ctx.insert_field(ir::FieldIr {
         parent_definition: federated::Definition::Object(parent_definition),

--- a/crates/graphql-composition/src/compose/roots.rs
+++ b/crates/graphql-composition/src/compose/roots.rs
@@ -77,7 +77,7 @@ fn merge_fields<'a>(
 
     super::fields::for_each_field_group(definitions, |fields| {
         let Some(first) = fields.first() else { return };
-        object::compose_object_fields(object_id, false, *first, fields, ctx);
+        object::compose_object_fields(object_id, type_name, false, *first, fields, ctx);
     });
 
     Some(object_id)

--- a/crates/graphql-composition/src/composition_ir/directive.rs
+++ b/crates/graphql-composition/src/composition_ir/directive.rs
@@ -1,5 +1,5 @@
 use crate::subgraphs;
-use graphql_federated_graph::{self as federated, directives::ListSizeDirective};
+use graphql_federated_graph::{self as federated};
 
 #[derive(PartialEq, PartialOrd, Clone)]
 pub enum Directive {
@@ -13,7 +13,6 @@ pub enum Directive {
     Cost {
         weight: i32,
     },
-    ListSize(ListSizeDirective),
 
     Other {
         name: federated::StringId,

--- a/crates/graphql-composition/src/emit_federated_graph/context.rs
+++ b/crates/graphql-composition/src/emit_federated_graph/context.rs
@@ -34,6 +34,14 @@ impl<'a> Context<'a> {
         self.strings_ir.insert(string.as_str())
     }
 
+    pub(crate) fn lookup_str(&self, string: &str) -> Option<federated::StringId> {
+        self.strings_ir.lookup(string)
+    }
+
+    pub(crate) fn lookup_string_id(&self, string: federated::StringId) -> &str {
+        &self.strings_ir[string]
+    }
+
     pub(crate) fn insert_value(&mut self, value: &subgraphs::Value) -> federated::Value {
         self.insert_value_with_type(value, None)
     }

--- a/crates/graphql-composition/src/emit_federated_graph/emit_list_sizes.rs
+++ b/crates/graphql-composition/src/emit_federated_graph/emit_list_sizes.rs
@@ -1,0 +1,57 @@
+use graphql_federated_graph::directives::ListSizeDirective;
+
+use super::{context::Context, federated, CompositionIr};
+
+pub fn emit_list_sizes(ir: &CompositionIr, ctx: &mut Context<'_>) {
+    for ((definition_name, field_name), list_size) in &ir.list_sizes {
+        let Some(definition) = ctx.definitions.get(definition_name) else {
+            continue;
+        };
+        let Some(field_id) = ctx.selection_map.get(&(*definition, *field_name)).copied() else {
+            continue;
+        };
+        let field = &ctx.out[field_id];
+        let ListSizeDirective {
+            assumed_size,
+            slicing_arguments,
+            sized_fields,
+            require_one_slicing_argument,
+        } = list_size;
+
+        let argument_base_id = field.arguments.0;
+        let arguments = &ctx.out[field.arguments];
+        let slicing_arguments = slicing_arguments
+            .iter()
+            .filter_map(|argument| {
+                let (index, _) = arguments
+                    .iter()
+                    .enumerate()
+                    .find(|(_, value)| ctx.lookup_string_id(value.name) == *argument)?;
+
+                Some(federated::InputValueDefinitionId::from(
+                    index + usize::from(argument_base_id),
+                ))
+            })
+            .collect();
+
+        let child_type_id = field.r#type.definition;
+        let sized_fields = sized_fields
+            .iter()
+            .filter_map(|field| {
+                let field_name = ctx.lookup_str(field)?;
+                ctx.selection_map.get(&(child_type_id, field_name)).copied()
+            })
+            .collect();
+
+        ctx.out.list_sizes.push((
+            field_id,
+            federated::ListSize {
+                assumed_size: *assumed_size,
+                slicing_arguments,
+                sized_fields,
+                require_one_slicing_argument: *require_one_slicing_argument,
+            },
+        ));
+    }
+    ctx.out.list_sizes.sort_by_key(|(field_id, _)| *field_id);
+}

--- a/crates/graphql-composition/src/subgraphs/directives.rs
+++ b/crates/graphql-composition/src/subgraphs/directives.rs
@@ -268,8 +268,8 @@ impl<'a> DirectiveSiteWalker<'a> {
         self.subgraphs.directives.costs.get(&self.id).copied()
     }
 
-    pub(crate) fn list_size(self) -> Option<ListSizeDirective> {
-        self.subgraphs.directives.list_sizes.get(&self.id).cloned()
+    pub(crate) fn list_size(self) -> Option<&'a ListSizeDirective> {
+        self.subgraphs.directives.list_sizes.get(&self.id)
     }
 }
 

--- a/crates/graphql-composition/tests/composition/list_size/api.graphql
+++ b/crates/graphql-composition/tests/composition/list_size/api.graphql
@@ -1,5 +1,5 @@
 type BarCollection {
-    length: Int
+    items: [Int]
 }
 
 type Query {

--- a/crates/graphql-composition/tests/composition/list_size/federated.graphql
+++ b/crates/graphql-composition/tests/composition/list_size/federated.graphql
@@ -32,11 +32,11 @@ enum join__Graph {
 }
 
 type BarCollection {
-    length: Int @join__field(graph: A)
+    items: [Int] @join__field(graph: A)
 }
 
 type Query {
-    bar(slice: Int!): BarCollection @join__field(graph: A) @listSize(slicingArguments: ["slice"], sizedFields: ["length"], requireOneSlicingArgument: false)
+    bar(slice: Int!): BarCollection @join__field(graph: A) @listSize(slicingArguments: ["slice"], sizedFields: ["items"], requireOneSlicingArgument: false)
     baz(slice: Int!): [String] @join__field(graph: A) @listSize(slicingArguments: ["slice"])
     foo: [String!] @join__field(graph: A) @listSize(assumedSize: 10)
 }

--- a/crates/graphql-composition/tests/composition/list_size/subgraphs/a.graphql
+++ b/crates/graphql-composition/tests/composition/list_size/subgraphs/a.graphql
@@ -1,11 +1,11 @@
 type Query {
   foo: [String!] @listSize(assumedSize: 10)
   bar(slice: Int!): BarCollection
-    @listSize(slicingArguments: ["slice"], sizedFields: ["length"], requireOneSlicingArgument: false)
+    @listSize(slicingArguments: ["slice"], sizedFields: ["items"], requireOneSlicingArgument: false)
 
   baz(slice: Int!): [String] @listSize(slicingArguments: ["slice"], requireOneSlicingArgument: true)
 }
 
 type BarCollection {
-  length: Int
+  items: [Int]
 }

--- a/crates/graphql-federated-graph/src/directives/complexity_control.rs
+++ b/crates/graphql-federated-graph/src/directives/complexity_control.rs
@@ -40,6 +40,24 @@ impl ListSizeDirective {
             ) on FIELD_DEFINITION
         "#}
     }
+
+    pub fn merge(self, other: ListSizeDirective) -> Self {
+        let mut slicing_arguments = self.slicing_arguments;
+        slicing_arguments.extend(other.slicing_arguments);
+
+        let mut sized_fields = self.sized_fields;
+        sized_fields.extend(other.sized_fields);
+
+        ListSizeDirective {
+            assumed_size: match (self.assumed_size, other.assumed_size) {
+                (Some(lhs), Some(rhs)) => Some(std::cmp::max(lhs, rhs)),
+                (lhs, rhs) => lhs.or(rhs),
+            },
+            slicing_arguments,
+            sized_fields,
+            require_one_slicing_argument: self.require_one_slicing_argument || other.require_one_slicing_argument,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/graphql-federated-graph/src/federated_graph.rs
+++ b/crates/graphql-federated-graph/src/federated_graph.rs
@@ -8,8 +8,6 @@ mod r#type;
 mod type_definitions;
 mod view;
 
-use crate::directives::ListSizeDirective;
-
 pub use self::{
     directives::*,
     enum_values::{EnumValue, EnumValueRecord},
@@ -50,6 +48,8 @@ pub struct FederatedGraph {
     pub field_authorized_directives: Vec<(FieldId, AuthorizedDirectiveId)>,
     pub object_authorized_directives: Vec<(ObjectId, AuthorizedDirectiveId)>,
     pub interface_authorized_directives: Vec<(InterfaceId, AuthorizedDirectiveId)>,
+
+    pub list_sizes: Vec<(FieldId, ListSize)>,
 }
 
 impl FederatedGraph {
@@ -167,8 +167,6 @@ pub enum Directive {
     Cost {
         weight: i32,
     },
-    ListSize(ListSizeDirective),
-
     Other {
         name: StringId,
         arguments: Vec<(StringId, Value)>,
@@ -385,6 +383,7 @@ impl Default for FederatedGraph {
             field_authorized_directives: Vec::new(),
             object_authorized_directives: Vec::new(),
             interface_authorized_directives: Vec::new(),
+            list_sizes: Vec::new(),
         }
     }
 }

--- a/crates/graphql-federated-graph/src/federated_graph/directives.rs
+++ b/crates/graphql-federated-graph/src/federated_graph/directives.rs
@@ -1,3 +1,5 @@
+mod list_size;
 mod r#override;
 
+pub use self::list_size::*;
 pub use self::r#override::*;

--- a/crates/graphql-federated-graph/src/federated_graph/directives/list_size.rs
+++ b/crates/graphql-federated-graph/src/federated_graph/directives/list_size.rs
@@ -1,0 +1,11 @@
+use crate::{FieldId, InputValueDefinitionId};
+
+#[derive(Clone, Debug)]
+pub struct ListSize {
+    pub assumed_size: Option<u32>,
+    // Arguments on the current field to interpret as slice size
+    pub slicing_arguments: Vec<InputValueDefinitionId>,
+    // Fields on the child object that this size directive applies to
+    pub sized_fields: Vec<FieldId>,
+    pub require_one_slicing_argument: bool,
+}

--- a/crates/graphql-federated-graph/src/from_sdl/list_size.rs
+++ b/crates/graphql-federated-graph/src/from_sdl/list_size.rs
@@ -1,0 +1,63 @@
+use cynic_parser_deser::ConstDeserializer;
+
+use crate::{directives::ListSizeDirective, InputValueDefinitionId, ListSize};
+
+use super::{ast, Definition, DomainError, State};
+
+pub fn ingest_list_size_directive<'a>(
+    parent_id: Definition,
+    fields: impl Iterator<Item = ast::FieldDefinition<'a>>,
+    state: &mut State<'a>,
+) -> Result<(), DomainError> {
+    for field in fields {
+        let directive = field
+            .directives()
+            .find(|field| field.name() == "listSize")
+            .and_then(|directive| directive.deserialize::<ListSizeDirective>().ok());
+
+        let Some(directive) = directive else { continue };
+        let Some(field_id) = state.selection_map.get(&(parent_id, field.name())).copied() else {
+            continue;
+        };
+        let field = &state.fields[usize::from(field_id)];
+
+        let ListSizeDirective {
+            assumed_size,
+            slicing_arguments,
+            sized_fields,
+            require_one_slicing_argument,
+        } = directive;
+
+        let argument_base_index = usize::from(field.arguments.0);
+        let arguments = &state.input_value_definitions[argument_base_index..argument_base_index + field.arguments.1];
+        let slicing_arguments = slicing_arguments
+            .iter()
+            .filter_map(|argument| {
+                let (index, _) = arguments
+                    .iter()
+                    .enumerate()
+                    .find(|(_, value)| state[value.name] == *argument)?;
+
+                Some(InputValueDefinitionId::from(index + argument_base_index))
+            })
+            .collect();
+
+        let child_type_id = field.r#type.definition;
+        let sized_fields = sized_fields
+            .iter()
+            .filter_map(|field| state.selection_map.get(&(child_type_id, field)).copied())
+            .collect();
+
+        state.list_sizes.push((
+            field_id,
+            ListSize {
+                assumed_size,
+                slicing_arguments,
+                sized_fields,
+                require_one_slicing_argument,
+            },
+        ));
+    }
+
+    Ok(())
+}

--- a/crates/graphql-federated-graph/src/render_sdl/display_utils.rs
+++ b/crates/graphql-federated-graph/src/render_sdl/display_utils.rs
@@ -1,5 +1,3 @@
-use directives::ListSizeDirective;
-
 use crate::*;
 use std::fmt::{self, Display, Write};
 
@@ -361,30 +359,6 @@ pub(crate) fn write_composed_directive<'a, 'b: 'a>(
         }
         Directive::Cost { weight } => {
             DirectiveWriter::new("cost", f, graph)?.arg("weight", Value::Int(*weight as i64))?;
-        }
-        Directive::ListSize(ListSizeDirective {
-            assumed_size,
-            slicing_arguments,
-            sized_fields,
-            require_one_slicing_argument,
-        }) => {
-            let mut writer = DirectiveWriter::new("listSize", f, graph)?;
-            if let Some(size) = assumed_size {
-                writer = writer.arg("assumedSize", Value::Int(*size as i64))?;
-            }
-            if !slicing_arguments.is_empty() {
-                writer = writer.arg("slicingArguments", serde_json::to_value(slicing_arguments).unwrap())?;
-            }
-            if !sized_fields.is_empty() {
-                writer = writer.arg("sizedFields", serde_json::to_value(sized_fields).unwrap())?;
-            }
-            if !require_one_slicing_argument {
-                // require_one_slicing_argument defaults to true so we omit it unless its false
-                writer.arg(
-                    "requireOneSlicingArgument",
-                    Value::Boolean(*require_one_slicing_argument),
-                )?;
-            }
         }
         Directive::Other { name, arguments } => {
             let mut directive = DirectiveWriter::new(&graph[*name], f, graph)?;

--- a/crates/graphql-federated-graph/src/render_sdl/render_api_sdl.rs
+++ b/crates/graphql-federated-graph/src/render_sdl/render_api_sdl.rs
@@ -253,8 +253,7 @@ fn write_public_directives<'a, 'b: 'a>(
         | Directive::Policy(_)
         | Directive::RequiresScopes(_)
         | Directive::Authenticated
-        | Directive::Cost { .. }
-        | Directive::ListSize(_) => false,
+        | Directive::Cost { .. } => false,
 
         Directive::Other { name, .. } if graph[*name] == "tag" => false,
         Directive::Deprecated { .. } | Directive::Other { .. } => true,


### PR DESCRIPTION
I added support for `@listSize` in #2338 - but once I started trying to use it in engine I realised that I'd done a bad job.  I'd kept the two `[String]` arguments as strings - but these refer to fields & arguments so would be better converted into the corresponding Ids so that the engine doesn't have to do a bunch of string lookups when it's trying to calculate the complexity.

This was harder than it sounds, because the `sizedFields` argument refers to the fields of another object, which isn't necessarily available at the point where we're handling most of the directives.  Got there in the end though.

Fixes GB-7642 (again)