### PR TITLE
composition: remove the usage of FieldId in CompositionIr

### DIFF
--- a/crates/graphql-composition/src/compose/context.rs
+++ b/crates/graphql-composition/src/compose/context.rs
@@ -82,31 +82,8 @@ impl<'a> Context<'a> {
         }))
     }
 
-    pub(crate) fn insert_field(&mut self, ir: ir::FieldIr) {
-        let field_name = ir.field_name;
-        let definition_name = match &ir.parent_definition {
-            graphql_federated_graph::Definition::Scalar(type_definition_id) => {
-                self.ir.type_definitions[usize::from(*type_definition_id)].name
-            }
-            graphql_federated_graph::Definition::Object(object_id) => {
-                let type_definition_id = self.ir.objects[usize::from(*object_id)].type_definition_id;
-                self.ir.type_definitions[usize::from(type_definition_id)].name
-            }
-            graphql_federated_graph::Definition::Interface(interface_id) => {
-                let type_definition_id = self.ir.interfaces[usize::from(*interface_id)].type_definition_id;
-                self.ir.type_definitions[usize::from(type_definition_id)].name
-            }
-            graphql_federated_graph::Definition::Union(union_id) => self.ir.unions[usize::from(*union_id)].name,
-            graphql_federated_graph::Definition::Enum(type_definition_id) => {
-                self.ir.type_definitions[usize::from(*type_definition_id)].name
-            }
-            graphql_federated_graph::Definition::InputObject(input_object_id) => {
-                self.ir.input_objects[usize::from(*input_object_id)].name
-            }
-        };
-
-        let idx = self.ir.fields.push_return_idx(ir);
-        self.ir.fields_by_name.insert([definition_name, field_name], idx);
+    pub(crate) fn insert_field(&mut self, ir: ir::FieldIr) -> ir::FieldIrId {
+        ir::FieldIrId::from(self.ir.fields.push_return_idx(ir))
     }
 
     pub(crate) fn insert_input_object(
@@ -327,12 +304,11 @@ impl<'a> Context<'a> {
     pub(crate) fn insert_object_field_from_entity_interface(
         &mut self,
         object_name: federated::StringId,
-        entity_interface_name: federated::StringId,
-        field_name: federated::StringId,
+        field_id: ir::FieldIrId,
     ) {
         self.ir
             .object_fields_from_entity_interfaces
-            .insert((object_name, [entity_interface_name, field_name]));
+            .insert((object_name, field_id));
     }
 
     pub(crate) fn insert_list_size_directive(

--- a/crates/graphql-composition/src/compose/entity_interface.rs
+++ b/crates/graphql-composition/src/compose/entity_interface.rs
@@ -199,14 +199,18 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
         }
     }
 
-    let field_ids: Vec<(StringId, _)> = fields
+    let field_names: Vec<(StringId, _)> = fields
         .into_iter()
         .map(|(name, (field, list_size_directive))| {
             if let Some(directive) = list_size_directive {
                 ctx.insert_list_size_directive(interface_name, field.field_name, directive.clone());
             }
 
-            (name, ctx.insert_field(field))
+            let field_name = field.field_name;
+
+            ctx.insert_field(field);
+
+            (name, field_name)
         })
         .collect();
 
@@ -230,14 +234,14 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
 
         let object_name = ctx.insert_string(object.name().id);
 
-        let fields_to_add = field_ids
+        let fields_to_add = field_names
             .iter()
             // Avoid adding fields that are already present on the object by virtue of the object implementing the interface.
             .filter(|(name, _)| object.find_field(*name).is_none())
             .map(|(_, field_id)| field_id);
 
-        for field_id in fields_to_add {
-            ctx.insert_object_field_from_entity_interface(object_name, *field_id);
+        for field_name in fields_to_add {
+            ctx.insert_object_field_from_entity_interface(object_name, interface_name, *field_name);
         }
     }
 }

--- a/crates/graphql-composition/src/compose/entity_interface.rs
+++ b/crates/graphql-composition/src/compose/entity_interface.rs
@@ -199,18 +199,14 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
         }
     }
 
-    let field_names: Vec<(StringId, _)> = fields
+    let field_ids: Vec<(StringId, _)> = fields
         .into_iter()
         .map(|(name, (field, list_size_directive))| {
             if let Some(directive) = list_size_directive {
                 ctx.insert_list_size_directive(interface_name, field.field_name, directive.clone());
             }
 
-            let field_name = field.field_name;
-
-            ctx.insert_field(field);
-
-            (name, field_name)
+            (name, ctx.insert_field(field))
         })
         .collect();
 
@@ -234,14 +230,14 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
 
         let object_name = ctx.insert_string(object.name().id);
 
-        let fields_to_add = field_names
+        let fields_to_add = field_ids
             .iter()
             // Avoid adding fields that are already present on the object by virtue of the object implementing the interface.
             .filter(|(name, _)| object.find_field(*name).is_none())
             .map(|(_, field_id)| field_id);
 
-        for field_name in fields_to_add {
-            ctx.insert_object_field_from_entity_interface(object_name, interface_name, *field_name);
+        for field_id in fields_to_add {
+            ctx.insert_object_field_from_entity_interface(object_name, *field_id);
         }
     }
 }

--- a/crates/graphql-composition/src/composition_ir.rs
+++ b/crates/graphql-composition/src/composition_ir.rs
@@ -1,6 +1,7 @@
 mod directive;
+mod field_ir;
 
-pub(crate) use self::directive::Directive;
+pub(crate) use self::{directive::Directive, field_ir::*};
 use crate::subgraphs::{self, SubgraphId};
 use graphql_federated_graph::{self as federated, directives::ListSizeDirective};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -16,7 +17,6 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 #[derive(Default)]
 pub(crate) struct CompositionIr {
     pub(crate) definitions_by_name: HashMap<federated::StringId, federated::Definition>,
-    pub(crate) fields_by_name: HashMap<[federated::StringId; 2], usize>,
 
     pub(crate) type_definitions: Vec<federated::TypeDefinitionRecord>,
     pub(crate) objects: Vec<federated::Object>,
@@ -45,8 +45,8 @@ pub(crate) struct CompositionIr {
     /// Fields of an interface entity that are contributed by other subgraphs and must be added to
     /// the interface's implementers in the federated schema.
     ///
-    /// (object_name, field_path)
-    pub(crate) object_fields_from_entity_interfaces: BTreeSet<(federated::StringId, [federated::StringId; 2])>,
+    /// (object_name, field_id)
+    pub(crate) object_fields_from_entity_interfaces: BTreeSet<(federated::StringId, FieldIrId)>,
 
     /// @authorized directives on objects
     pub(crate) object_authorized_directives: Vec<(federated::ObjectId, subgraphs::DirectiveSiteId)>,
@@ -61,32 +61,6 @@ pub(crate) struct CompositionIr {
     // These are separate from FieldIr because they need to reference fields on other types
     // so should be constructed last.
     pub(crate) list_sizes: BTreeMap<(federated::StringId, federated::StringId), ListSizeDirective>,
-}
-
-#[derive(Clone)]
-pub(crate) struct FieldIr {
-    pub(crate) parent_definition: federated::Definition,
-    pub(crate) field_name: federated::StringId,
-    pub(crate) field_type: subgraphs::FieldTypeId,
-    pub(crate) arguments: federated::InputValueDefinitions,
-
-    pub(crate) resolvable_in: Vec<federated::SubgraphId>,
-
-    /// Subgraph fields corresponding to this federated graph field that have an `@provides`.
-    pub(crate) provides: Vec<subgraphs::FieldId>,
-
-    /// Subgraph fields corresponding to this federated graph field that have an `@requires`.
-    pub(crate) requires: Vec<subgraphs::FieldId>,
-
-    /// Subgraph fields corresponding to this federated graph field that have an `@authorized`.
-    pub(crate) authorized_directives: Vec<subgraphs::FieldId>,
-
-    // @join__field(graph: ..., override: ...)
-    pub(crate) overrides: Vec<federated::Override>,
-
-    pub(crate) composed_directives: federated::Directives,
-
-    pub(crate) description: Option<federated::StringId>,
 }
 
 #[derive(Clone)]

--- a/crates/graphql-composition/src/composition_ir.rs
+++ b/crates/graphql-composition/src/composition_ir.rs
@@ -16,6 +16,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 #[derive(Default)]
 pub(crate) struct CompositionIr {
     pub(crate) definitions_by_name: HashMap<federated::StringId, federated::Definition>,
+    pub(crate) fields_by_name: HashMap<[federated::StringId; 2], usize>,
 
     pub(crate) type_definitions: Vec<federated::TypeDefinitionRecord>,
     pub(crate) objects: Vec<federated::Object>,
@@ -42,8 +43,10 @@ pub(crate) struct CompositionIr {
     pub(crate) keys: Vec<KeyIr>,
 
     /// Fields of an interface entity that are contributed by other subgraphs and must be added to
-    /// the interface's implementers in the federated schema
-    pub(crate) object_fields_from_entity_interfaces: BTreeSet<(federated::StringId, federated::FieldId)>,
+    /// the interface's implementers in the federated schema.
+    ///
+    /// (object_name, field_path)
+    pub(crate) object_fields_from_entity_interfaces: BTreeSet<(federated::StringId, [federated::StringId; 2])>,
 
     /// @authorized directives on objects
     pub(crate) object_authorized_directives: Vec<(federated::ObjectId, subgraphs::DirectiveSiteId)>,

--- a/crates/graphql-composition/src/composition_ir/field_ir.rs
+++ b/crates/graphql-composition/src/composition_ir/field_ir.rs
@@ -1,0 +1,52 @@
+use std::ops::Index;
+
+use super::*;
+
+#[derive(Debug, Clone, Copy, Ord, PartialEq, Eq, PartialOrd)]
+pub(crate) struct FieldIrId(usize);
+
+impl Index<FieldIrId> for CompositionIr {
+    type Output = FieldIr;
+
+    fn index(&self, index: FieldIrId) -> &Self::Output {
+        &self.fields[index.0]
+    }
+}
+
+impl From<usize> for FieldIrId {
+    fn from(value: usize) -> Self {
+        FieldIrId(value)
+    }
+}
+
+impl From<FieldIrId> for usize {
+    fn from(value: FieldIrId) -> Self {
+        value.0
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct FieldIr {
+    pub(crate) parent_definition: federated::Definition,
+    pub(crate) field_name: federated::StringId,
+    pub(crate) field_type: subgraphs::FieldTypeId,
+    pub(crate) arguments: federated::InputValueDefinitions,
+
+    pub(crate) resolvable_in: Vec<federated::SubgraphId>,
+
+    /// Subgraph fields corresponding to this federated graph field that have an `@provides`.
+    pub(crate) provides: Vec<subgraphs::FieldId>,
+
+    /// Subgraph fields corresponding to this federated graph field that have an `@requires`.
+    pub(crate) requires: Vec<subgraphs::FieldId>,
+
+    /// Subgraph fields corresponding to this federated graph field that have an `@authorized`.
+    pub(crate) authorized_directives: Vec<subgraphs::FieldId>,
+
+    // @join__field(graph: ..., override: ...)
+    pub(crate) overrides: Vec<federated::Override>,
+
+    pub(crate) composed_directives: federated::Directives,
+
+    pub(crate) description: Option<federated::StringId>,
+}


### PR DESCRIPTION
These are just indices into fields Vec, they shouldn't be typed as FieldIds because they wouldn't refer to valid fields in the federated graph.