### PR TITLE
composition: simplify entity interfaces in composition IR

### DIFF
--- a/crates/graphql-composition/src/compose.rs
+++ b/crates/graphql-composition/src/compose.rs
@@ -117,7 +117,7 @@ fn merge_object_definitions<'a>(
     fields::for_each_field_group(definitions, |fields| {
         let Some(first) = fields.first() else { return };
 
-        object::compose_object_fields(object_id, object_name, is_shareable, *first, fields, ctx);
+        object::compose_object_fields(object_name, is_shareable, *first, fields, ctx);
     });
 }
 

--- a/crates/graphql-composition/src/compose/context.rs
+++ b/crates/graphql-composition/src/compose/context.rs
@@ -82,8 +82,8 @@ impl<'a> Context<'a> {
         }))
     }
 
-    pub(crate) fn insert_field(&mut self, ir: ir::FieldIr) -> ir::FieldIrId {
-        ir::FieldIrId::from(self.ir.fields.push_return_idx(ir))
+    pub(crate) fn insert_field(&mut self, ir: ir::FieldIr) {
+        self.ir.fields.push(ir);
     }
 
     pub(crate) fn insert_input_object(
@@ -299,16 +299,6 @@ impl<'a> Context<'a> {
 
     pub(crate) fn set_subscription(&mut self, id: federated::ObjectId) {
         self.ir.subscription_type = Some(id);
-    }
-
-    pub(crate) fn insert_object_field_from_entity_interface(
-        &mut self,
-        object_name: federated::StringId,
-        field_id: ir::FieldIrId,
-    ) {
-        self.ir
-            .object_fields_from_entity_interfaces
-            .insert((object_name, field_id));
     }
 
     pub(crate) fn insert_list_size_directive(

--- a/crates/graphql-composition/src/compose/entity_interface.rs
+++ b/crates/graphql-composition/src/compose/entity_interface.rs
@@ -73,6 +73,7 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
         ctx.insert_interface_authorized(interface_id, authorized.id);
     }
 
+    // The fields of the entity interface. They are defined not only in the subgraph where the entity interface is an interface: more fields are contributed by other subgraphs where there are objects with `@interfaceObject`. These fields from other subgraphs are later automatically added to the implementers of the interface in the subgraph where the interface is defined.
     let mut fields = BTreeMap::new();
 
     for field in interface_def.fields() {

--- a/crates/graphql-composition/src/compose/entity_interface.rs
+++ b/crates/graphql-composition/src/compose/entity_interface.rs
@@ -91,7 +91,7 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
             };
 
             let ir = ir::FieldIr {
-                parent_definition: federated::Definition::Interface(interface_id),
+                parent_definition: interface_name,
                 field_name: ctx.insert_string(field.name().id),
                 field_type: field.r#type().id,
                 arguments,
@@ -180,7 +180,7 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
                 };
 
                 let ir = ir::FieldIr {
-                    parent_definition: federated::Definition::Interface(interface_id),
+                    parent_definition: interface_name,
                     field_name: ctx.insert_string(field.name().id),
                     field_type: field.r#type().id,
                     arguments: translate_arguments(field, ctx),
@@ -199,18 +199,21 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
         }
     }
 
-    let field_ids: Vec<(StringId, _)> = fields
+    let fields_to_add: Vec<(StringId, _)> = fields
         .into_iter()
         .map(|(name, (field, list_size_directive))| {
             if let Some(directive) = list_size_directive {
                 ctx.insert_list_size_directive(interface_name, field.field_name, directive.clone());
             }
 
-            (name, ctx.insert_field(field))
+            // Insert here for the entity. But also return it for the implementers of the interface further down.
+            ctx.insert_field(field.clone());
+
+            (name, field)
         })
         .collect();
 
-    // Contribute the interface fields from the interface object definitions to the implementer of
+    // Contribute the interface fields from the interface object definitions to the implementers of
     // that interface.
     for object in interface_def.subgraph().interface_implementers(first.name().id) {
         match object.entity_keys().next() {
@@ -230,14 +233,16 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
 
         let object_name = ctx.insert_string(object.name().id);
 
-        let fields_to_add = field_ids
+        let fields_to_add = fields_to_add
             .iter()
             // Avoid adding fields that are already present on the object by virtue of the object implementing the interface.
             .filter(|(name, _)| object.find_field(*name).is_none())
-            .map(|(_, field_id)| field_id);
+            .map(|(_, field_ir)| field_ir);
 
-        for field_id in fields_to_add {
-            ctx.insert_object_field_from_entity_interface(object_name, *field_id);
+        for field_ir in fields_to_add {
+            let mut field_ir = field_ir.clone();
+            field_ir.parent_definition = object_name;
+            ctx.insert_field(field_ir);
         }
     }
 }

--- a/crates/graphql-composition/src/compose/interface.rs
+++ b/crates/graphql-composition/src/compose/interface.rs
@@ -64,7 +64,7 @@ pub(super) fn merge_interface_definitions<'a>(
         fields::insert_list_size_directives(fields.iter().map(|(_, f)| f), ctx, interface_name, field_name);
 
         ctx.insert_field(ir::FieldIr {
-            parent_definition: federated::Definition::Interface(interface_id),
+            parent_definition: interface_name,
             field_name,
             field_type,
             arguments,

--- a/crates/graphql-composition/src/compose/object.rs
+++ b/crates/graphql-composition/src/compose/object.rs
@@ -161,7 +161,6 @@ fn required_argument_not_in_intersection_error(
 }
 
 pub(super) fn compose_object_fields<'a>(
-    parent_definition: federated::ObjectId,
     parent_definition_name: federated::StringId,
     object_is_shareable: bool,
     first: FieldWalker<'a>,
@@ -254,7 +253,7 @@ pub(super) fn compose_object_fields<'a>(
     fields::insert_list_size_directives(fields.iter(), ctx, parent_definition_name, field_name);
 
     ctx.insert_field(ir::FieldIr {
-        parent_definition: federated::Definition::Object(parent_definition),
+        parent_definition: parent_definition_name,
         field_name,
         field_type,
         arguments,

--- a/crates/graphql-composition/src/compose/roots.rs
+++ b/crates/graphql-composition/src/compose/roots.rs
@@ -60,7 +60,7 @@ fn merge_fields<'a>(
             };
 
             ctx.insert_field(ir::FieldIr {
-                parent_definition: federated::Definition::Object(object_id),
+                parent_definition: type_name,
                 field_name,
                 field_type,
                 arguments: federated::NO_INPUT_VALUE_DEFINITION,
@@ -77,7 +77,7 @@ fn merge_fields<'a>(
 
     super::fields::for_each_field_group(definitions, |fields| {
         let Some(first) = fields.first() else { return };
-        object::compose_object_fields(object_id, type_name, false, *first, fields, ctx);
+        object::compose_object_fields(type_name, false, *first, fields, ctx);
     });
 
     Some(object_id)

--- a/crates/graphql-composition/src/composition_ir.rs
+++ b/crates/graphql-composition/src/composition_ir.rs
@@ -42,12 +42,6 @@ pub(crate) struct CompositionIr {
     pub(crate) union_join_members: BTreeMap<(federated::StringId, federated::StringId), Vec<SubgraphId>>,
     pub(crate) keys: Vec<KeyIr>,
 
-    /// Fields of an interface entity that are contributed by other subgraphs and must be added to
-    /// the interface's implementers in the federated schema.
-    ///
-    /// (object_name, field_id)
-    pub(crate) object_fields_from_entity_interfaces: BTreeSet<(federated::StringId, FieldIrId)>,
-
     /// @authorized directives on objects
     pub(crate) object_authorized_directives: Vec<(federated::ObjectId, subgraphs::DirectiveSiteId)>,
     /// @authorized directives on interfaces

--- a/crates/graphql-composition/src/composition_ir/field_ir.rs
+++ b/crates/graphql-composition/src/composition_ir/field_ir.rs
@@ -1,33 +1,8 @@
-use std::ops::Index;
-
 use super::*;
-
-#[derive(Debug, Clone, Copy, Ord, PartialEq, Eq, PartialOrd)]
-pub(crate) struct FieldIrId(usize);
-
-impl Index<FieldIrId> for CompositionIr {
-    type Output = FieldIr;
-
-    fn index(&self, index: FieldIrId) -> &Self::Output {
-        &self.fields[index.0]
-    }
-}
-
-impl From<usize> for FieldIrId {
-    fn from(value: usize) -> Self {
-        FieldIrId(value)
-    }
-}
-
-impl From<FieldIrId> for usize {
-    fn from(value: FieldIrId) -> Self {
-        value.0
-    }
-}
 
 #[derive(Clone)]
 pub(crate) struct FieldIr {
-    pub(crate) parent_definition: federated::Definition,
+    pub(crate) parent_definition: federated::StringId,
     pub(crate) field_name: federated::StringId,
     pub(crate) field_type: subgraphs::FieldTypeId,
     pub(crate) arguments: federated::InputValueDefinitions,

--- a/crates/graphql-composition/src/emit_federated_graph/emit_fields.rs
+++ b/crates/graphql-composition/src/emit_federated_graph/emit_fields.rs
@@ -4,7 +4,7 @@ use graphql_federated_graph as federated;
 /// Takes each group of consecutive fields with the same parent definition and calls `f` with each.
 pub(super) fn for_each_field_group<F>(fields: &[FieldIr], mut f: F)
 where
-    F: FnMut(federated::Definition, &mut Vec<FieldIr>),
+    F: FnMut(federated::StringId, &mut Vec<FieldIr>),
 {
     let mut start = 0;
     let mut buf = Vec::new();


### PR DESCRIPTION
Remove object_fields_from_entity_interfaces. That required changing the parent definition from DefinitionId to StringId in FieldIr, because we may not have the definition for the implementers of the interface yet when we compose the interface.