### PR TITLE
feat: warn on unknown directive in composition

### DIFF
--- a/crates/graphql-composition/src/diagnostics.rs
+++ b/crates/graphql-composition/src/diagnostics.rs
@@ -16,6 +16,13 @@ impl Diagnostics {
         self.0.iter().map(|diagnostic| diagnostic.message.as_str())
     }
 
+    pub(crate) fn push_warning(&mut self, message: String) {
+        self.0.push(Diagnostic {
+            message,
+            is_fatal: false,
+        });
+    }
+
     pub(crate) fn push_fatal(&mut self, message: String) {
         self.0.push(Diagnostic {
             message,

--- a/crates/graphql-composition/src/subgraphs.rs
+++ b/crates/graphql-composition/src/subgraphs.rs
@@ -148,6 +148,11 @@ impl Subgraphs {
             .push_fatal(format!("[{}]: {message}", self.walk_subgraph(subgraph).name().as_str()));
     }
 
+    pub(crate) fn push_ingestion_warning(&mut self, subgraph: SubgraphId, message: String) {
+        self.ingestion_diagnostics
+            .push_warning(format!("[{}]: {message}", self.walk_subgraph(subgraph).name().as_str()));
+    }
+
     pub(crate) fn walk<Id>(&self, id: Id) -> Walker<'_, Id> {
         Walker { id, subgraphs: self }
     }

--- a/crates/graphql-composition/tests/composition/subgraph_defining_join__Graph/federated.graphql
+++ b/crates/graphql-composition/tests/composition/subgraph_defining_join__Graph/federated.graphql
@@ -1,1 +1,2 @@
+# [bad]: Unknown directive join__graph expected one of authenticated, authorized, composeDirective, cost, external, inaccessible, interfaceObject, key, listSize, override, policy, provides, requires, requiresScopes, shareable, tag
 # [bad] Definition name `join__Graph` is a reserved federation definition name, it cannot be defined in subgraphs.


### PR DESCRIPTION
This change is up for debate, but it would have saved me an hour or two of digging and seems like something a customer could run into.

I was trying to integration test `@cost`, but for some reason none of the validations were failing.  This turned out to be because the `@link` directive was used in my schema but didn't explicitly list `@cost`.  In this scenario we still support `@cost` but we expect it to be named something like `@federated__cost` - if we see `@cost` it is just ignored.

The behaviour around renames is correct, but we could make it a lot easier to notice when this sort of thing has happpened.  This PR is an attempt to do that: when we encounter a directive that we do not know about we'll put out a warning telling the user.