### PR TITLE
feat(engine): Add control over what gets exposed with grafbase response extension

### DIFF
--- a/crates/engine/config/src/response_extensions.rs
+++ b/crates/engine/config/src/response_extensions.rs
@@ -5,7 +5,9 @@ use gateway_config::telemetry::exporters::ResponseExtensionExporterConfig;
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct ResponseExtensionConfig {
     /// Whether the traceId is exposed in the grafbase response extension. Defaults to true.
-    pub trace_id: bool,
+    pub include_trace_id: bool,
+    /// Whether the query plan is exposed in the grafbase response extension. Defaults to true.
+    pub include_query_plan: bool,
     /// Defines under which conditions the grafbase response extension will be added.
     /// Defaults to a simple header rule, the presence of `x-grafbase-telemetry` is enough.
     pub access_control: Vec<AccessControl>,
@@ -20,7 +22,8 @@ impl Default for ResponseExtensionConfig {
 impl From<ResponseExtensionExporterConfig> for ResponseExtensionConfig {
     fn from(config: ResponseExtensionExporterConfig) -> Self {
         ResponseExtensionConfig {
-            trace_id: config.trace_id,
+            include_trace_id: config.trace_id,
+            include_query_plan: config.query_plan,
             access_control: config
                 .access_control
                 .into_iter()

--- a/crates/engine/src/engine/execute/response_extension.rs
+++ b/crates/engine/src/engine/execute/response_extension.rs
@@ -37,8 +37,11 @@ impl<R: Runtime> Engine<R> {
         if !ctx.include_grafbase_response_extension {
             return None;
         }
-        Some(GrafbaseResponseExtension::new(
-            tracing::Span::current().context().span().span_context().trace_id(),
-        ))
+        Some(if self.schema.settings.response_extension.include_trace_id {
+            let trace_id = tracing::Span::current().context().span().span_context().trace_id();
+            GrafbaseResponseExtension::default().with_trace_id(trace_id)
+        } else {
+            GrafbaseResponseExtension::default()
+        })
     }
 }

--- a/crates/engine/src/prepare/context.rs
+++ b/crates/engine/src/prepare/context.rs
@@ -74,7 +74,7 @@ impl<'ctx, R: Runtime> PrepareContext<'ctx, R> {
         self.engine
             .default_grafbase_response_extension(self.request_context)
             .map(|ext| {
-                if let Some(op) = operation {
+                if let Some(op) = operation.filter(|_| self.schema().settings.response_extension.include_query_plan) {
                     ext.with_query_plan(self.schema(), op)
                 } else {
                     ext

--- a/crates/gateway-config/src/telemetry/exporters/response_extension.rs
+++ b/crates/gateway-config/src/telemetry/exporters/response_extension.rs
@@ -9,6 +9,8 @@ use serde_dynamic_string::DynamicString;
 pub struct ResponseExtensionExporterConfig {
     /// Whether the traceId is exposed in the grafbase response extension. Defaults to true.
     pub trace_id: bool,
+    /// Whether queryPlan is exposed in the grafbase response extension. Defaults to true.
+    pub query_plan: bool,
     /// Defines under which conditions the grafbase response extension will be added.
     /// Defaults to a simple header rule, the presence of `x-grafbase-telemetry` is enough.
     pub access_control: Vec<AccessControl>,
@@ -18,6 +20,7 @@ impl Default for ResponseExtensionExporterConfig {
     fn default() -> Self {
         Self {
             trace_id: true,
+            query_plan: true,
             access_control: vec![AccessControl::Header(HeaderAccessControl {
                 name: DynamicString::from(AsciiString::from_str("x-grafbase-telemetry").unwrap()),
                 value: None,


### PR DESCRIPTION
Setting for the trace id was there, but not used properly before. Added
the equivalent for the query plan:
```toml
[telemetry.exporters.response_extension]
query_plan = false
```
