### PR TITLE
chore: remove buildjet caching

### DIFF
--- a/.github/workflows/rust-prs.yml
+++ b/.github/workflows/rust-prs.yml
@@ -181,11 +181,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         if: ${{ !startsWith(github.head_ref, 'renovate-') }}
-        with:
-          # Our windows & mac runners are hosted by github, so using github for
-          # their cache makes sense.  Buildjet is faster (and offers more storage) for
-          # others though.
-          cache-provider: ${{ contains(matrix.platform.target, 'linux') && 'buildjet' || 'github' }}
 
       - name: Install Rust
         uses: ./.github/actions/install-rust


### PR DESCRIPTION
Caching _should_ be able to use ubicloud transparently now, let's test it out.