### PR TITLE
fix(ci): broken latest dockage image push

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -159,21 +159,24 @@ jobs:
           docker pull ghcr.io/grafbase/gateway:latest || true
           docker build -f gateway/Dockerfile -t ghcr.io/grafbase/gateway:$COMMIT_SHA .
 
-      - name: Tag latest version
+      - name: Push docker image
+        run: |
+          docker push ghcr.io/grafbase/gateway:$COMMIT_SHA
+
+      - name: Push latest version
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           docker tag ghcr.io/grafbase/gateway:$COMMIT_SHA ghcr.io/grafbase/gateway:latest
+          docker push ghcr.io/grafbase/gateway:latest
 
-      - name: Tag released gateway version
+      - name: Push released gateway version
         if: ${{ startsWith(github.ref, 'refs/tags') && startsWith(github.ref_name, 'gateway-') }}
         run: |
-          docker tag ghcr.io/grafbase/gateway:$COMMIT_SHA ghcr.io/grafbase/gateway:$(echo "$REF" | sed -e "s/^refs\/tags\/gateway-//")
+          RELEASE_VERSION="$(echo "$REF" | sed -e "s/^refs\/tags\/gateway-//")"
+          docker tag ghcr.io/grafbase/gateway:$COMMIT_SHA ghcr.io/grafbase/gateway:$RELEASE_VERSION
+          docker push ghcr.io/grafbase/gateway:$RELEASE_VERSION
         env:
           REF: ${{ github.ref }}
-
-      - name: Push docker image
-        run: |
-          docker push --all-tags ghcr.io/grafbase/gateway
 
   linux:
     needs: [test]

--- a/.github/workflows/rust-prs.yml
+++ b/.github/workflows/rust-prs.yml
@@ -356,7 +356,7 @@ jobs:
 
       - name: Push Docker image
         run: |
-          docker push --all-tags ghcr.io/grafbase/gateway
+          docker push ghcr.io/grafbase/gateway:$COMMIT_SHA
 
   after-build-rust:
     # This job is responsible for reacting to build success or failure. It must


### PR DESCRIPTION
The `docker push --all-tags` pushes all local image tags, that includes
`latest` that the CI always pulls to speed up a bit the docker image
build.

So our feature branch ended up pushing whatever latest tag they
retrieved, overwriting any docker image pushed by a commit merged to
main in the meantime.
