### PR TITLE
Fix nix derivations for gateway and cli

### DIFF
--- a/cli/nix/cli.nix
+++ b/cli/nix/cli.nix
@@ -1,7 +1,6 @@
 { pkgs
 , crane
 , lib
-, config
 , ...
 }:
 let
@@ -22,9 +21,9 @@ let
     /renovate.json
     /scripts
 
-    !/engine/crates/validation/README.md
-    !/engine/crates/composition/README.md
-    !/engine/crates/graphql-schema-diff/README.md
+    !/crates/graphql-schema-validation/README.md
+    !/crates/graphql-composition/README.md
+    !/crates/graphql-schema-diff/README.md
   '';
 
   src = pkgs.nix-gitignore.gitignoreSource [ extraIgnores ] (lib.cleanSourceWith {
@@ -46,7 +45,7 @@ in
     version = builtins.readFile version;
     stdenv = pkgs.clangStdenv;
 
-    cargoBuildFlags = "-p grafbase";
+    cargoExtraArgs = "-p grafbase";
 
     RUSTFLAGS = builtins.concatStringsSep " " [
       "-Arust-2018-idioms -Aunused-crate-dependencies"

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1725409566,
-        "narHash": "sha256-PrtLmqhM6UtJP7v7IGyzjBFhbG4eOAHT6LPYOFmYfbk=",
+        "lastModified": 1731974733,
+        "narHash": "sha256-enYSSZVVl15FI5p+0Y5/Ckf5DZAvXe6fBrHxyhA/njc=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "7e4586bad4e3f8f97a9271def747cf58c4b68f3c",
+        "rev": "3cb338ce81076ce5e461cf77f7824476addb0e1c",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1726153070,
-        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -53,11 +53,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726142289,
-        "narHash": "sha256-Jks8O42La+nm5AMTSq/PvM5O+fUAhIy0Ce1QYqLkyZ4=",
+        "lastModified": 1731890469,
+        "narHash": "sha256-D1FNZ70NmQEwNxpSSdTXCSklBH1z2isPR84J6DQrJGs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "280db3decab4cbeb22a4599bd472229ab74d25e1",
+        "rev": "5083ec887760adfe12af64830a66807423a859a7",
         "type": "github"
       },
       "original": {
@@ -69,14 +69,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1725233747,
-        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
+        "lastModified": 1730504152,
+        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       }
     },
     "root": {
@@ -95,11 +95,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726194362,
-        "narHash": "sha256-cM7zFscFqdsA5KohUUYndzIp20kUqjj39qnj6Voj+f8=",
+        "lastModified": 1732156292,
+        "narHash": "sha256-XuTCME5ZausokOJ28AsIoayBVD1soscdoiKweT4VY50=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a71b1240e29f1ec68612ed5306c328086bed91f9",
+        "rev": "2d484c7a0db32f2700e253160bcd2aaa6cdca3ba",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,15 +12,11 @@
   description = "Grafbase development environment";
 
   inputs = {
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs = {
         nixpkgs.follows = "nixpkgs";
-        flake-utils.follows = "flake-utils";
       };
     };
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";

--- a/gateway/nix/grafbase-gateway.nix
+++ b/gateway/nix/grafbase-gateway.nix
@@ -20,12 +20,10 @@ let
     /flake.lock
     /renovate.json
     /scripts
-    /packages/**/src
 
-    !/engine/crates/validation/README.md
-    !/engine/crates/composition/README.md
-    !/engine/crates/graphql-schema-diff/README.md
-    !/packages/grafbase-sdk/package.json
+    !/crates/graphql-schema-validation/README.md
+    !/crates/graphql-composition/README.md
+    !/crates/graphql-schema-diff/README.md
   '';
 
   src = pkgs.nix-gitignore.gitignoreSource [ extraIgnores ] (lib.cleanSourceWith {
@@ -35,7 +33,7 @@ let
 
   version = pkgs.runCommand "getVersion" { } ''
     ${pkgs.dasel}/bin/dasel \
-      --file ${../../crates/gateway-binary/Cargo.toml} \
+      --file ${../Cargo.toml} \
       --selector package.version\
       --write - | tr -d "\n" > $out
   '';
@@ -47,7 +45,6 @@ in
     version = builtins.readFile version;
     stdenv = pkgs.clangStdenv;
 
-    cargoBuildFlags = "-p grafbase-gateway";
     cargoExtraArgs = "-p grafbase-gateway";
 
     RUSTFLAGS = builtins.concatStringsSep " " [


### PR DESCRIPTION
They haven't been maintained in a while, they were broken with the recent cleanups.

This commit freshens up flake.nix, and makes `nix build .#cli` and `nix build .#gateway` work again.