### PR TITLE
fix(engine): Support __typename alias & rework key generation

### DIFF
--- a/crates/engine/src/operation/bind/model/selection_set.rs
+++ b/crates/engine/src/operation/bind/model/selection_set.rs
@@ -65,6 +65,13 @@ pub(crate) struct BoundExtraField {
 }
 
 impl BoundField {
+    pub(crate) fn as_query_field(&self) -> Option<&BoundQueryField> {
+        match self {
+            BoundField::Query(field) => Some(field),
+            _ => None,
+        }
+    }
+
     pub(crate) fn response_key(&self) -> Option<SafeResponseKey> {
         match self {
             BoundField::TypeName(field) => Some(field.key),

--- a/crates/engine/src/operation/solve/solver/adapter.rs
+++ b/crates/engine/src/operation/solve/solver/adapter.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use id_newtypes::IdRange;
 use im::HashMap;
 use schema::{
-    CompositeTypeId, FieldDefinition, FieldDefinitionId, ObjectDefinitionId, Schema, SchemaField, SubgraphId,
+    CompositeTypeId, DefinitionId, FieldDefinitionId, ObjectDefinitionId, Schema, SchemaField, StringId, SubgraphId,
 };
 use walker::Walk;
 
@@ -12,14 +12,24 @@ use crate::{
         BoundExtraField, BoundField, BoundFieldArgument, BoundFieldArgumentId, BoundFieldId, BoundOperation,
         QueryInputValueRecord, QueryPosition,
     },
-    response::{ResponseKeys, SafeResponseKey},
+    response::SafeResponseKey,
 };
 
 pub(super) struct OperationAdapter<'a> {
     pub schema: &'a Schema,
     pub operation: &'a mut BoundOperation,
-    tmp_response_keys: Vec<SafeResponseKey>,
-    field_with_distinct_type_to_unique_key: HashMap<FieldDefinitionId, SafeResponseKey>,
+    field_renames: HashMap<FieldRenameConsistencyKey, SafeResponseKey>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum FieldRenameConsistencyKey {
+    FieldWithDistinctType {
+        key: SafeResponseKey,
+        field_definition_id: FieldDefinitionId,
+    },
+    FieldNamedTypename {
+        output_definition_id: DefinitionId,
+    },
 }
 
 impl<'a> OperationAdapter<'a> {
@@ -27,8 +37,7 @@ impl<'a> OperationAdapter<'a> {
         OperationAdapter {
             schema,
             operation,
-            tmp_response_keys: Vec::new(),
-            field_with_distinct_type_to_unique_key: HashMap::new(),
+            field_renames: HashMap::new(),
         }
     }
 }
@@ -101,8 +110,8 @@ impl<'a> query_solver::Operation for OperationAdapter<'a> {
         extra_fields: &mut [(SubgraphId, Self::FieldId)],
         existing_fields: &mut [(SubgraphId, Self::FieldId)],
     ) {
-        self.tmp_response_keys.clear();
-        self.tmp_response_keys.extend(
+        let mut selection_set_keys = Vec::with_capacity(extra_fields.len() + existing_fields.len());
+        selection_set_keys.extend(
             existing_fields
                 .iter()
                 .filter_map(|(_, id)| self.operation[*id].response_key()),
@@ -112,16 +121,38 @@ impl<'a> query_solver::Operation for OperationAdapter<'a> {
         // query a single object from the subgraph.
         if !parent_type.is_object() {
             for (subgraph_id, field_id) in existing_fields.iter().copied() {
-                let Some(definition) = self.operation[field_id].definition_id().walk(self.schema) else {
+                let Some((key, subgraph_key, definition_id)) = self.operation[field_id]
+                    .as_query_field()
+                    .map(|field| (field.key, field.subgraph_key, field.definition_id))
+                else {
                     continue;
                 };
-                if definition.distinct_type_in_ids.contains(&subgraph_id) {
-                    let key = self.generate_new_distinct_type_key(definition);
-                    if let BoundField::Query(field) = &mut self.operation[field_id] {
-                        field.subgraph_key = key;
-                        self.tmp_response_keys.push(key);
-                    };
-                }
+                let definition = definition_id.walk(self.schema);
+
+                let new_key = if definition.distinct_type_in_ids.contains(&subgraph_id) {
+                    self.generate_new_key(
+                        Some(FieldRenameConsistencyKey::FieldWithDistinctType {
+                            key,
+                            field_definition_id: definition.id,
+                        }),
+                        &selection_set_keys,
+                        definition.name_id,
+                    )
+                } else if &self.operation.response_keys[subgraph_key] == "__typename" {
+                    self.generate_new_key(
+                        Some(FieldRenameConsistencyKey::FieldNamedTypename {
+                            output_definition_id: definition.ty().definition_id,
+                        }),
+                        &selection_set_keys,
+                        definition.name_id,
+                    )
+                } else {
+                    continue;
+                };
+                if let BoundField::Query(field) = &mut self.operation[field_id] {
+                    field.subgraph_key = new_key;
+                    selection_set_keys.push(new_key);
+                };
             }
         }
 
@@ -129,14 +160,10 @@ impl<'a> query_solver::Operation for OperationAdapter<'a> {
             let Some(definition_id) = self.operation[*extra_field_id].definition_id() else {
                 continue;
             };
-            let key = generate_new_extra_field_key(
-                &mut self.operation.response_keys,
-                &self.tmp_response_keys,
-                definition_id.walk(self.schema),
-            );
+            let key = self.generate_new_key(None, &selection_set_keys, definition_id.walk(self.schema).name_id);
             if let BoundField::Extra(field) = &mut self.operation[*extra_field_id] {
                 field.key = Some(key);
-                self.tmp_response_keys.push(key);
+                selection_set_keys.push(key);
             };
         }
     }
@@ -155,6 +182,15 @@ impl<'a> query_solver::Operation for OperationAdapter<'a> {
 }
 
 impl<'a> OperationAdapter<'a> {
+    /// There are three cases today for renaming a field:
+    ///  1. The field has a distinct type in the subgraph than the one we have in the supergraph.
+    ///  2. Field is named `__typename` which will clash with the `__typename` field we expect to
+    ///     retrieve the type name.
+    ///  3. We're adding a extra field to satisfy a requirement.
+    ///
+    ///
+    /// 1. Distinct type
+    /// ----------------
     /// Generate a new response key for a field with an distinct type, but compatible, than the super-graph.
     /// This can happen when a subgraph A defines:
     ///
@@ -201,28 +237,59 @@ impl<'a> OperationAdapter<'a> {
     ///
     /// Whenever a user request a field with a distinct type such as `User.id` we need to rename
     /// it in the subgraph query. As we need to deal with selection set merging we have to be
-    /// consistent with this name, so we generate an unique name per `FieldDefinitionId`.
+    /// consistent with this name, so we generate an unique name per `(SafeResponseKey, FieldDefinitionId)`
+    /// as we may have aliases with different arguments.
     ///
     /// Luckily for us we won't need to deal with interface fields when response merging. An
     /// interface needs to be consistent with its object so if `User` implemented an interface with
     /// an `id` field it would either be inconsistent at the super-graph or subgraph level. So we
     /// will never need to worry about merging with interface fields.
-    fn generate_new_distinct_type_key(&mut self, definition: FieldDefinition<'_>) -> SafeResponseKey {
-        if let Some(key) = self.field_with_distinct_type_to_unique_key.get(&definition.id) {
+    ///
+    /// 2. Typename
+    /// -----------
+    /// Similar to the previous case we need to ensure consistent renaming across selection sets to
+    /// ensure proper merging. However, we do need to handle interfaces this time. So we the output
+    /// DefinitionId as the key to ensure that we end up merging fields even if field with
+    /// different definitions end up being merged together.
+    ///
+    /// 3. Extra field
+    /// --------------
+    /// Contrary to the other cases those fields will never be exposed to the client so their
+    /// response key doesn't matter, but it needs to be unique within the selection
+    /// set we send to the subgraph to generate a proper query string.
+    ///
+    /// We don't need to keep track of this later, because we identify requirements by
+    /// their associated `SchemaFieldId` rather than
+    fn generate_new_key(
+        &mut self,
+        rename_consistency_key: Option<FieldRenameConsistencyKey>,
+        selection_set_keys: &[SafeResponseKey],
+        name_suggestion: StringId,
+    ) -> SafeResponseKey {
+        if let Some(key) = rename_consistency_key.as_ref().and_then(|k| self.field_renames.get(k)) {
             return *key;
         }
 
-        let name = definition.name();
+        let name = name_suggestion.walk(self.schema);
 
         // Key doesn't exist in the operation at all
-        if !self.operation.response_keys.contains(name) {
+        let Some(key) = self.operation.response_keys.get(name) else {
             let key = self.operation.response_keys.get_or_intern(name);
-            self.field_with_distinct_type_to_unique_key.insert(definition.id, key);
+            if let Some(field_rename_key) = rename_consistency_key {
+                self.field_renames.insert(field_rename_key, key);
+            }
+            return key;
+        };
+
+        // if we don't need to care about being consistent with the renaming across selection set,
+        // we can just return the key if it's not present within the current one.
+        // This is only present to generate nicer subgraph queries.
+        if rename_consistency_key.is_none() && !selection_set_keys.contains(&key) {
             return key;
         }
 
         // Generate a likely unique key
-        let hex = hex::encode_upper(u32::from(definition.id).to_be_bytes());
+        let hex = hex::encode_upper(u32::from(name_suggestion).to_be_bytes());
         let short_id = hex.trim_start_matches('0');
 
         let name = format!("_{}{}", name, short_id);
@@ -234,7 +301,9 @@ impl<'a> OperationAdapter<'a> {
             // Key doesn't exist in the operation at all
             if !self.operation.response_keys.contains(&candidate) {
                 let key = self.operation.response_keys.get_or_intern(&candidate);
-                self.field_with_distinct_type_to_unique_key.insert(definition.id, key);
+                if let Some(field_rename_key) = rename_consistency_key {
+                    self.field_renames.insert(field_rename_key, key);
+                }
                 return key;
             };
 
@@ -264,56 +333,5 @@ impl<'a> OperationAdapter<'a> {
 
         let end = self.operation.field_arguments.len();
         (start..end).into()
-    }
-}
-
-/// Generating a response key for an extra field, a field we added during planning to satisfy a
-/// requirement. Contrary to `generate_new_distinct_type_key` those fields will never be exposed to
-/// the client so their response key doesn't matter, but it needs to be unique within the selection
-/// set we send to the subgraph to generate a proper query string.
-///
-/// We don't need to keep track of this later, because we identify requirements by
-/// their associated `SchemaFieldId` rather than
-fn generate_new_extra_field_key(
-    response_keys: &mut ResponseKeys,
-    selection_set: &[SafeResponseKey],
-    definition: FieldDefinition<'_>,
-) -> SafeResponseKey {
-    let name = definition.name();
-
-    // Key doesn't exist in the operation at all
-    let Some(key) = response_keys.get(name) else {
-        return response_keys.get_or_intern(name);
-    };
-
-    // Key doesn't exist in the current selection set
-    if !selection_set.contains(&key) {
-        return key;
-    }
-
-    // Generate a likely unique key
-    let hex = hex::encode_upper(u32::from(definition.id).to_be_bytes());
-    let short_id = hex.trim_start_matches('0');
-
-    let name = format!("_{}{}", name, short_id);
-
-    let mut i: u8 = 0;
-    loop {
-        let candidate = format!("{name}{}", hex::encode_upper(i.to_be_bytes()));
-
-        // Key doesn't exist in the operation at all
-        let Some(key) = response_keys.get(&candidate) else {
-            return response_keys.get_or_intern(&candidate);
-        };
-
-        // Key doesn't exist in the current selection set
-        if !selection_set.contains(&key) {
-            return key;
-        }
-
-        i = i.wrapping_add(1);
-        if i == 0 {
-            unimplemented!("Couldn not find a unique field name.")
-        }
     }
 }

--- a/crates/integration-tests/tests/federation/basic/mod.rs
+++ b/crates/integration-tests/tests/federation/basic/mod.rs
@@ -15,6 +15,7 @@ mod operations;
 mod scalars;
 mod skip_include;
 mod streaming;
+mod typename;
 mod variables;
 
 use engine::Engine;

--- a/crates/integration-tests/tests/federation/basic/typename.rs
+++ b/crates/integration-tests/tests/federation/basic/typename.rs
@@ -1,0 +1,56 @@
+use engine::Engine;
+use graphql_mocks::FakeGithubSchema;
+use integration_tests::{federation::EngineExt, runtime};
+
+#[test]
+fn typename_alias_should_work() {
+    let response = runtime().block_on(async move {
+        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+
+        engine
+            .post(
+                r#"
+                query {
+                    pullRequestsAndIssues(filter: { search: "1" }) {
+                        a: __typename
+                        __typename: author { ... on User { email } }
+                        ... on PullRequest {
+                            __typename: author { ... on User { name } }
+                        }
+                        ... on Issue {
+                            __typename: author { ... on User { name } }
+                        }
+                    }
+                }
+                "#,
+            )
+            .await
+    });
+
+    insta::assert_json_snapshot!(response, @r#"
+    {
+      "data": {
+        "pullRequestsAndIssues": [
+          {
+            "a": "PullRequest",
+            "__typename": {
+              "name": "Jim",
+              "email": "jim@example.com"
+            }
+          },
+          {
+            "a": "PullRequest",
+            "__typename": {}
+          },
+          {
+            "a": "Issue",
+            "__typename": {
+              "name": "The Pessimist",
+              "email": "pessimist@example.com"
+            }
+          }
+        ]
+      }
+    }
+    "#);
+}

--- a/crates/integration-tests/tests/federation/mod.rs
+++ b/crates/integration-tests/tests/federation/mod.rs
@@ -1,7 +1,6 @@
 mod apq;
 mod auth;
 mod basic;
-mod complexity_control;
 mod config;
 mod entity_caching;
 mod extensions;


### PR DESCRIPTION
It's really an edge case, but I do rely on `__typename` being available
and used for the __typename in subgraph queries. It's a bit tricky to
synchronize properly what the shapes expect and the query we generate,
the easiest that came to mind right now is to rename fields before we generate the shapes,
ensuring `__typename` is available.

So we re-use the same new key generation technique used for extra fields
& field with distinct types in their subgraph. I refactored a bit the
implementation to be common this time.
