### PR TITLE
chore(engine): Rename Concrete/PolymorphicObjectShape

### DIFF
--- a/crates/engine/codegen/domain/solved_operation.graphql
+++ b/crates/engine/codegen/domain/solved_operation.graphql
@@ -18,7 +18,7 @@ scalar FieldShapeRefId @id
 # - QuerySection -
 # ----------------
 
-scalar ConcreteObjectShapeId @prelude @id
+scalar ConcreteShapeId @prelude @id
 
 type QueryPartition @indexed(id_size: "u16") @meta(module: "query_partition") {
   entity_definition: EntityDefinition!
@@ -26,7 +26,7 @@ type QueryPartition @indexed(id_size: "u16") @meta(module: "query_partition") {
   selection_set: SelectionSet!
   required_fields: [DataFieldRef!]!
   input: ResponseObjectSetDefinition!
-  shape_id: ConcreteObjectShapeId!
+  shape_id: ConcreteShapeId!
 }
 
 type ResponseObjectSetDefinition @meta(module: "response_object_set") @indexed(id_size: "u16", deduplicated: true) {

--- a/crates/engine/schema/src/generated/field.rs
+++ b/crates/engine/schema/src/generated/field.rs
@@ -24,7 +24,7 @@ use walker::{Iter, Walk};
 /// type FieldDefinition @meta(module: "field") @indexed(id_size: "u32", max_id: "MAX_ID") {
 ///   name: String!
 ///   description: String
-///   parent_entity: EntityDefinition! @meta(debug: false)
+///   parent_entity: EntityDefinition!
 ///   ty: Type!
 ///   resolvers: [ResolverDefinition!]!
 ///   """

--- a/crates/engine/src/operation/plan/model/plan.rs
+++ b/crates/engine/src/operation/plan/model/plan.rs
@@ -4,7 +4,7 @@ use walker::Walk;
 use crate::{
     operation::{QueryPartition, ResponseObjectSetDefinitionId},
     resolver::Resolver,
-    response::{ConcreteObjectShape, ConcreteObjectShapeId},
+    response::{ConcreteShape, ConcreteShapeId},
 };
 
 use super::{Plan, PlanSelectionSet};
@@ -32,10 +32,10 @@ impl<'a> Plan<'a> {
             requires_typename: false,
         }
     }
-    pub(crate) fn shape_id(&self) -> ConcreteObjectShapeId {
+    pub(crate) fn shape_id(&self) -> ConcreteShapeId {
         self.query_partition().shape_id
     }
-    pub(crate) fn shape(&self) -> ConcreteObjectShape<'a> {
+    pub(crate) fn shape(&self) -> ConcreteShape<'a> {
         self.query_partition().shape_id.walk(self.ctx)
     }
 }

--- a/crates/engine/src/operation/plan/query_modifications.rs
+++ b/crates/engine/src/operation/plan/query_modifications.rs
@@ -11,7 +11,7 @@ use crate::{
         SolvedOperationContext, TypenameFieldId, Variables,
     },
     prepare::{CachedOperation, PrepareContext},
-    response::{ConcreteObjectShapeId, ErrorCode, FieldShapeId, GraphqlError},
+    response::{ConcreteShapeId, ErrorCode, FieldShapeId, GraphqlError},
     Runtime,
 };
 
@@ -25,7 +25,7 @@ pub(crate) struct QueryModifications {
     pub skipped_typename_fields: BitSet<TypenameFieldId>,
     #[indexed_by(ErrorId)]
     pub errors: Vec<GraphqlError>,
-    pub concrete_shape_has_error: BitSet<ConcreteObjectShapeId>,
+    pub concrete_shape_has_error: BitSet<ConcreteShapeId>,
     pub field_shape_id_to_error_ids: IdToMany<FieldShapeId, ErrorId>,
     pub skipped_field_shapes: BitSet<FieldShapeId>,
     pub root_error_ids: Vec<ErrorId>,
@@ -211,7 +211,7 @@ where
                             std::cmp::Ordering::Equal => {
                                 self.modifications
                                     .concrete_shape_has_error
-                                    .set(ConcreteObjectShapeId::from(concrete_shape_id), true);
+                                    .set(ConcreteShapeId::from(concrete_shape_id), true);
                                 break;
                             }
                             std::cmp::Ordering::Greater => {

--- a/crates/engine/src/operation/solve/model/generated/query_partition.rs
+++ b/crates/engine/src/operation/solve/model/generated/query_partition.rs
@@ -22,7 +22,7 @@ use walker::{Iter, Walk};
 ///   selection_set: SelectionSet!
 ///   required_fields: [DataFieldRef!]!
 ///   input: ResponseObjectSetDefinition!
-///   shape_id: ConcreteObjectShapeId!
+///   shape_id: ConcreteShapeId!
 /// }
 /// ```
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -32,7 +32,7 @@ pub(crate) struct QueryPartitionRecord {
     pub selection_set_record: SelectionSetRecord,
     pub required_field_ids: IdRange<DataFieldRefId>,
     pub input_id: ResponseObjectSetDefinitionId,
-    pub shape_id: ConcreteObjectShapeId,
+    pub shape_id: ConcreteShapeId,
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]

--- a/crates/engine/src/operation/solve/model/prelude.rs
+++ b/crates/engine/src/operation/solve/model/prelude.rs
@@ -1,6 +1,6 @@
 pub(super) use super::SolvedOperationContext;
 pub(super) use crate::{
     operation::{Location, QueryInputValueId, QueryModifierRule, ResponseModifierRule},
-    response::{ConcreteObjectShapeId, PositionedResponseKey, SafeResponseKey},
+    response::{ConcreteShapeId, PositionedResponseKey, SafeResponseKey},
 };
 pub(super) use id_newtypes::IdRange;

--- a/crates/engine/src/operation/solve/solver/mod.rs
+++ b/crates/engine/src/operation/solve/solver/mod.rs
@@ -15,7 +15,7 @@ use crate::{
         BoundField, BoundFieldArgument, BoundFieldArgumentId, BoundFieldId, BoundOperation, BoundQueryModifierId,
         BoundVariableDefinition, BoundVariableDefinitionId, DataFieldRefId, SolveError,
     },
-    response::{ConcreteObjectShapeId, PositionedResponseKey, Shapes},
+    response::{ConcreteShapeId, PositionedResponseKey, Shapes},
     utils::BufferPool,
 };
 
@@ -161,7 +161,7 @@ impl<'a> Solver<'a> {
             input_id,
             // Populated later
             required_field_ids: IdRange::empty(),
-            shape_id: ConcreteObjectShapeId::from(0usize),
+            shape_id: ConcreteShapeId::from(0usize),
         });
         self.query_partition_to_node.push((query_partition_id, source_ix));
     }

--- a/crates/engine/src/resolver/introspection/writer.rs
+++ b/crates/engine/src/resolver/introspection/writer.rs
@@ -12,8 +12,7 @@ use crate::{
     execution::ExecutionContext,
     operation::Plan,
     response::{
-        ConcreteObjectShapeId, FieldShapeRecord, ResponseObject, ResponseObjectField, ResponseValue, ResponseWriter,
-        Shapes,
+        ConcreteShapeId, FieldShapeRecord, ResponseObject, ResponseObjectField, ResponseValue, ResponseWriter, Shapes,
     },
     Runtime,
 };
@@ -28,7 +27,7 @@ pub(super) struct IntrospectionWriter<'ctx, R: Runtime> {
 }
 
 impl<'ctx, R: Runtime> IntrospectionWriter<'ctx, R> {
-    pub(super) fn execute(self, id: ConcreteObjectShapeId) {
+    pub(super) fn execute(self, id: ConcreteShapeId) {
         let shape = &self.ctx.shapes()[id];
         let mut fields = Vec::with_capacity(shape.field_shape_ids.len() + shape.typename_response_edges.len());
         for field_shape in &self.shapes[shape.field_shape_ids] {
@@ -78,7 +77,7 @@ impl<'ctx, R: Runtime> IntrospectionWriter<'ctx, R> {
     fn object<E: Copy, const N: usize>(
         &self,
         object: &'ctx IntrospectionObject<E, N>,
-        shape_id: ConcreteObjectShapeId,
+        shape_id: ConcreteShapeId,
         build: impl Fn(&'ctx FieldShapeRecord, E) -> ResponseValue,
     ) -> ResponseValue {
         let shape = &self.shapes[shape_id];
@@ -105,7 +104,7 @@ impl<'ctx, R: Runtime> IntrospectionWriter<'ctx, R> {
         self.response.push_object(ResponseObject::new(fields)).into()
     }
 
-    fn __schema(&self, shape_id: ConcreteObjectShapeId) -> ResponseValue {
+    fn __schema(&self, shape_id: ConcreteShapeId) -> ResponseValue {
         self.object(&self.metadata.__schema, shape_id, |field, __schema| {
             match __schema {
                 __Schema::Description => self.schema.graph.description_id.into(),
@@ -147,7 +146,7 @@ impl<'ctx, R: Runtime> IntrospectionWriter<'ctx, R> {
         })
     }
 
-    fn __type(&self, ty: Type<'ctx>, shape_id: ConcreteObjectShapeId) -> ResponseValue {
+    fn __type(&self, ty: Type<'ctx>, shape_id: ConcreteShapeId) -> ResponseValue {
         self.__type_list_wrapping(ty.definition(), ty.wrapping, shape_id)
     }
 
@@ -155,7 +154,7 @@ impl<'ctx, R: Runtime> IntrospectionWriter<'ctx, R> {
         &self,
         definition: Definition<'ctx>,
         mut wrapping: Wrapping,
-        shape_id: ConcreteObjectShapeId,
+        shape_id: ConcreteShapeId,
     ) -> ResponseValue {
         match wrapping.pop_list_wrapping() {
             Some(list_wrapping) => match list_wrapping {
@@ -190,7 +189,7 @@ impl<'ctx, R: Runtime> IntrospectionWriter<'ctx, R> {
         &self,
         definition: Definition<'ctx>,
         wrapping: Wrapping,
-        shape_id: ConcreteObjectShapeId,
+        shape_id: ConcreteShapeId,
     ) -> ResponseValue {
         self.object(&self.metadata.__type, shape_id, |field, __type| match __type {
             __Type::Kind => self.metadata.type_kind.non_null.into(),
@@ -201,7 +200,7 @@ impl<'ctx, R: Runtime> IntrospectionWriter<'ctx, R> {
         })
     }
 
-    fn __type_inner(&self, definition: Definition<'ctx>, shape_id: ConcreteObjectShapeId) -> ResponseValue {
+    fn __type_inner(&self, definition: Definition<'ctx>, shape_id: ConcreteShapeId) -> ResponseValue {
         match definition {
             Definition::Scalar(scalar) => self.object(&self.metadata.__type, shape_id, |_, __type| match __type {
                 __Type::Kind => self.metadata.type_kind.scalar.into(),
@@ -336,7 +335,7 @@ impl<'ctx, R: Runtime> IntrospectionWriter<'ctx, R> {
         self.response.push_list(values).into()
     }
 
-    fn __field(&self, target: FieldDefinition<'ctx>, shape_id: ConcreteObjectShapeId) -> ResponseValue {
+    fn __field(&self, target: FieldDefinition<'ctx>, shape_id: ConcreteShapeId) -> ResponseValue {
         self.object(&self.metadata.__field, shape_id, |field, __field| match __field {
             _Field::Name => target.as_ref().name_id.into(),
             _Field::Description => target.as_ref().description_id.into(),
@@ -357,7 +356,7 @@ impl<'ctx, R: Runtime> IntrospectionWriter<'ctx, R> {
         })
     }
 
-    fn __input_value(&self, target: InputValueDefinition<'ctx>, shape_id: ConcreteObjectShapeId) -> ResponseValue {
+    fn __input_value(&self, target: InputValueDefinition<'ctx>, shape_id: ConcreteShapeId) -> ResponseValue {
         self.object(
             &self.metadata.__input_value,
             shape_id,
@@ -374,7 +373,7 @@ impl<'ctx, R: Runtime> IntrospectionWriter<'ctx, R> {
         )
     }
 
-    fn __enum_value(&self, target: EnumValue<'ctx>, shape_id: ConcreteObjectShapeId) -> ResponseValue {
+    fn __enum_value(&self, target: EnumValue<'ctx>, shape_id: ConcreteShapeId) -> ResponseValue {
         self.object(
             &self.metadata.__enum_value,
             shape_id,

--- a/crates/engine/src/response/shape/concrete.rs
+++ b/crates/engine/src/response/shape/concrete.rs
@@ -12,9 +12,9 @@ use crate::{
 use super::{FieldShape, FieldShapeId};
 
 /// Being concrete does not mean it's only associated with a single object definition id
-/// only that we know exactly which fields must be present for one or multiple of them.
+/// only that we know exactly which fields must be present.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
-pub(crate) struct ConcreteObjectShapeRecord {
+pub(crate) struct ConcreteShapeRecord {
     pub set_id: Option<ResponseObjectSetDefinitionId>,
     pub identifier: ObjectIdentifier,
     pub typename_response_edges: Vec<PositionedResponseKey>,
@@ -23,39 +23,39 @@ pub(crate) struct ConcreteObjectShapeRecord {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-pub(crate) struct ConcreteObjectShapeId(NonZero<u32>);
+pub(crate) struct ConcreteShapeId(NonZero<u32>);
 
-impl std::ops::Deref for ConcreteObjectShape<'_> {
-    type Target = ConcreteObjectShapeRecord;
+impl std::ops::Deref for ConcreteShape<'_> {
+    type Target = ConcreteShapeRecord;
     fn deref(&self) -> &Self::Target {
         self.as_ref()
     }
 }
 
-impl<'ctx> Walk<OperationPlanContext<'ctx>> for ConcreteObjectShapeId {
-    type Walker<'w> = ConcreteObjectShape<'w> where 'ctx: 'w;
+impl<'ctx> Walk<OperationPlanContext<'ctx>> for ConcreteShapeId {
+    type Walker<'w> = ConcreteShape<'w> where 'ctx: 'w;
 
     fn walk<'w>(self, ctx: impl Into<OperationPlanContext<'ctx>>) -> Self::Walker<'w>
     where
         Self: 'w,
         'ctx: 'w,
     {
-        ConcreteObjectShape {
+        ConcreteShape {
             ctx: ctx.into(),
             id: self,
         }
     }
 }
 
-pub(crate) struct ConcreteObjectShape<'a> {
+pub(crate) struct ConcreteShape<'a> {
     pub(super) ctx: OperationPlanContext<'a>,
-    pub(super) id: ConcreteObjectShapeId,
+    pub(super) id: ConcreteShapeId,
 }
 
-impl<'a> ConcreteObjectShape<'a> {
+impl<'a> ConcreteShape<'a> {
     /// Prefer using Deref unless you need the 'a lifetime.
     #[allow(clippy::should_implement_trait)]
-    pub(crate) fn as_ref(&self) -> &'a ConcreteObjectShapeRecord {
+    pub(crate) fn as_ref(&self) -> &'a ConcreteShapeRecord {
         &self.ctx.solved_operation.shapes[self.id]
     }
     pub(crate) fn has_errors(&self) -> bool {

--- a/crates/engine/src/response/shape/field.rs
+++ b/crates/engine/src/response/shape/field.rs
@@ -8,7 +8,7 @@ use crate::{
     response::{GraphqlError, PositionedResponseKey, SafeResponseKey},
 };
 
-use super::{ConcreteObjectShapeId, PolymorphicObjectShapeId};
+use super::{ConcreteShapeId, PolymorphicShapeId};
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct FieldShapeRecord {
@@ -82,14 +82,14 @@ impl std::fmt::Debug for FieldShape<'_> {
 pub(crate) enum Shape {
     Scalar(ScalarType),
     Enum(EnumDefinitionId),
-    ConcreteObject(ConcreteObjectShapeId),
-    PolymorphicObject(PolymorphicObjectShapeId),
+    Concrete(ConcreteShapeId),
+    Polymorphic(PolymorphicShapeId),
 }
 
 impl Shape {
-    pub(crate) fn as_concrete_object(&self) -> Option<ConcreteObjectShapeId> {
+    pub(crate) fn as_concrete_object(&self) -> Option<ConcreteShapeId> {
         match self {
-            Shape::ConcreteObject(id) => Some(*id),
+            Shape::Concrete(id) => Some(*id),
             _ => None,
         }
     }

--- a/crates/engine/src/response/shape/mod.rs
+++ b/crates/engine/src/response/shape/mod.rs
@@ -8,10 +8,10 @@ pub(crate) use polymorphic::*;
 
 #[derive(Default, serde::Serialize, serde::Deserialize, id_derives::IndexedFields)]
 pub(crate) struct Shapes {
-    #[indexed_by(PolymorphicObjectShapeId)]
-    pub polymorphic: Vec<PolymorphicObjectShapeRecord>,
-    #[indexed_by(ConcreteObjectShapeId)]
-    pub concrete: Vec<ConcreteObjectShapeRecord>,
+    #[indexed_by(PolymorphicShapeId)]
+    pub polymorphic: Vec<PolymorphicShapeRecord>,
+    #[indexed_by(ConcreteShapeId)]
+    pub concrete: Vec<ConcreteShapeRecord>,
     #[indexed_by(FieldShapeId)]
     pub fields: Vec<FieldShapeRecord>,
 }

--- a/crates/engine/src/response/shape/polymorphic.rs
+++ b/crates/engine/src/response/shape/polymorphic.rs
@@ -5,48 +5,48 @@ use walker::Walk;
 
 use crate::operation::OperationPlanContext;
 
-use super::ConcreteObjectShapeId;
+use super::ConcreteShapeId;
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
-pub(crate) struct PolymorphicObjectShapeRecord {
+pub(crate) struct PolymorphicShapeRecord {
     // Sorted by Object typename
-    pub possibilities: Vec<(ObjectDefinitionId, ConcreteObjectShapeId)>,
+    pub possibilities: Vec<(ObjectDefinitionId, ConcreteShapeId)>,
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-pub(crate) struct PolymorphicObjectShapeId(NonZero<u32>);
+pub(crate) struct PolymorphicShapeId(NonZero<u32>);
 
-impl<'ctx> Walk<OperationPlanContext<'ctx>> for PolymorphicObjectShapeId {
-    type Walker<'w> = PolymorphicObjectShape<'w> where 'ctx: 'w;
+impl<'ctx> Walk<OperationPlanContext<'ctx>> for PolymorphicShapeId {
+    type Walker<'w> = PolymorphicShape<'w> where 'ctx: 'w;
 
     fn walk<'w>(self, ctx: impl Into<OperationPlanContext<'ctx>>) -> Self::Walker<'w>
     where
         Self: 'w,
         'ctx: 'w,
     {
-        PolymorphicObjectShape {
+        PolymorphicShape {
             ctx: ctx.into(),
             id: self,
         }
     }
 }
 
-impl std::ops::Deref for PolymorphicObjectShape<'_> {
-    type Target = PolymorphicObjectShapeRecord;
+impl std::ops::Deref for PolymorphicShape<'_> {
+    type Target = PolymorphicShapeRecord;
     fn deref(&self) -> &Self::Target {
         self.as_ref()
     }
 }
 
-pub(crate) struct PolymorphicObjectShape<'a> {
+pub(crate) struct PolymorphicShape<'a> {
     pub(super) ctx: OperationPlanContext<'a>,
-    pub(super) id: PolymorphicObjectShapeId,
+    pub(super) id: PolymorphicShapeId,
 }
 
-impl<'a> PolymorphicObjectShape<'a> {
+impl<'a> PolymorphicShape<'a> {
     /// Prefer using Deref unless you need the 'a lifetime.
     #[allow(clippy::should_implement_trait)]
-    pub(crate) fn as_ref(&self) -> &'a PolymorphicObjectShapeRecord {
+    pub(crate) fn as_ref(&self) -> &'a PolymorphicShapeRecord {
         &self.ctx.solved_operation.shapes[self.id]
     }
 }

--- a/crates/engine/src/response/write/deserialize/field.rs
+++ b/crates/engine/src/response/write/deserialize/field.rs
@@ -3,7 +3,7 @@ use serde::de::DeserializeSeed;
 use walker::Walk;
 
 use super::{
-    object::{ConcreteObjectSeed, PolymorphicObjectSeed},
+    object::{ConcreteShapeSeed, PolymorphicShapeSeed},
     EnumValueSeed, ListSeed, NullableSeed, ScalarTypeSeed, SeedContext,
 };
 use crate::response::{ErrorCode, FieldShapeRecord, GraphqlError, ResponseValue, Shape};
@@ -45,12 +45,8 @@ impl<'de, 'ctx, 'parent> DeserializeSeed<'de> for FieldSeed<'ctx, 'parent> {
                     is_extra: self.field.key.query_position.is_none(),
                 }
                 .deserialize(deserializer),
-                Shape::ConcreteObject(shape_id) => {
-                    ConcreteObjectSeed::new(self.ctx, shape_id).deserialize(deserializer)
-                }
-                Shape::PolymorphicObject(shape_id) => {
-                    PolymorphicObjectSeed::new(self.ctx, shape_id).deserialize(deserializer)
-                }
+                Shape::Concrete(shape_id) => ConcreteShapeSeed::new(self.ctx, shape_id).deserialize(deserializer),
+                Shape::Polymorphic(shape_id) => PolymorphicShapeSeed::new(self.ctx, shape_id).deserialize(deserializer),
             }
         } else {
             match self.field.shape {
@@ -70,16 +66,16 @@ impl<'de, 'ctx, 'parent> DeserializeSeed<'de> for FieldSeed<'ctx, 'parent> {
                     },
                 }
                 .deserialize(deserializer),
-                Shape::ConcreteObject(shape_id) => NullableSeed {
+                Shape::Concrete(shape_id) => NullableSeed {
                     ctx: self.ctx,
                     field_id: self.field.id,
-                    seed: ConcreteObjectSeed::new(self.ctx, shape_id),
+                    seed: ConcreteShapeSeed::new(self.ctx, shape_id),
                 }
                 .deserialize(deserializer),
-                Shape::PolymorphicObject(shape_id) => NullableSeed {
+                Shape::Polymorphic(shape_id) => NullableSeed {
                     ctx: self.ctx,
                     field_id: self.field.id,
-                    seed: PolymorphicObjectSeed::new(self.ctx, shape_id),
+                    seed: PolymorphicShapeSeed::new(self.ctx, shape_id),
                 }
                 .deserialize(deserializer),
             }

--- a/crates/engine/src/response/write/deserialize/mod.rs
+++ b/crates/engine/src/response/write/deserialize/mod.rs
@@ -3,7 +3,7 @@ use std::{
     fmt,
 };
 
-use object::ConcreteObjectSeed;
+use object::ConcreteShapeSeed;
 use serde::{
     de::{DeserializeSeed, Visitor},
     Deserializer,
@@ -11,7 +11,7 @@ use serde::{
 
 use crate::{
     execution::ExecutionContext,
-    response::{ConcreteObjectShapeId, ErrorCode, GraphqlError, ResponseWriter},
+    response::{ConcreteShapeId, ErrorCode, GraphqlError, ResponseWriter},
     Runtime,
 };
 
@@ -32,13 +32,13 @@ use scalar::*;
 
 pub(crate) struct UpdateSeed<'ctx> {
     ctx: SeedContext<'ctx>,
-    shape_id: ConcreteObjectShapeId,
+    shape_id: ConcreteShapeId,
 }
 
 impl<'ctx> UpdateSeed<'ctx> {
     pub(super) fn new<R: Runtime>(
         ctx: ExecutionContext<'ctx, R>,
-        shape_id: ConcreteObjectShapeId,
+        shape_id: ConcreteShapeId,
         writer: ResponseWriter<'ctx>,
     ) -> Self {
         let path = RefCell::new(writer.root_path().iter().copied().collect());
@@ -64,7 +64,7 @@ impl<'de, 'ctx> DeserializeSeed<'de> for UpdateSeed<'ctx> {
     {
         let UpdateSeed { ctx, shape_id } = self;
         let result = deserializer.deserialize_option(NullableVisitor(
-            ConcreteObjectSeed::new(&ctx, shape_id).into_fields_seed(),
+            ConcreteShapeSeed::new(&ctx, shape_id).into_fields_seed(),
         ));
 
         match result {

--- a/crates/engine/src/response/write/deserialize/object/concrete.rs
+++ b/crates/engine/src/response/write/deserialize/object/concrete.rs
@@ -9,24 +9,24 @@ use crate::{
     response::{
         value::ResponseObjectField,
         write::deserialize::{field::FieldSeed, key::Key, SeedContext},
-        ConcreteObjectShapeId, FieldShapeId, FieldShapeRecord, GraphqlError, ObjectIdentifier, PositionedResponseKey,
+        ConcreteShapeId, FieldShapeId, FieldShapeRecord, GraphqlError, ObjectIdentifier, PositionedResponseKey,
         ResponseObject, ResponseObjectRef, ResponseValue,
     },
 };
 
-pub(crate) struct ConcreteObjectSeed<'ctx, 'seed> {
+pub(crate) struct ConcreteShapeSeed<'ctx, 'seed> {
     ctx: &'seed SeedContext<'ctx>,
     set_id: Option<ResponseObjectSetDefinitionId>,
-    fields_seed: ConcreteObjectFieldsSeed<'ctx, 'seed>,
+    fields_seed: ConcreteShapeFieldsSeed<'ctx, 'seed>,
 }
 
-impl<'ctx, 'seed> ConcreteObjectSeed<'ctx, 'seed> {
-    pub fn new(ctx: &'seed SeedContext<'ctx>, shape_id: ConcreteObjectShapeId) -> Self {
+impl<'ctx, 'seed> ConcreteShapeSeed<'ctx, 'seed> {
+    pub fn new(ctx: &'seed SeedContext<'ctx>, shape_id: ConcreteShapeId) -> Self {
         let shape = shape_id.walk(ctx);
         Self {
             ctx,
             set_id: shape.set_id,
-            fields_seed: ConcreteObjectFieldsSeed {
+            fields_seed: ConcreteShapeFieldsSeed {
                 ctx,
                 has_error: shape.has_errors(),
                 object_identifier: shape.identifier,
@@ -38,14 +38,14 @@ impl<'ctx, 'seed> ConcreteObjectSeed<'ctx, 'seed> {
 
     pub fn new_with_object_id(
         ctx: &'seed SeedContext<'ctx>,
-        shape_id: ConcreteObjectShapeId,
+        shape_id: ConcreteShapeId,
         object_id: ObjectDefinitionId,
     ) -> Self {
         let shape = shape_id.walk(ctx);
         Self {
             ctx,
             set_id: shape.set_id,
-            fields_seed: ConcreteObjectFieldsSeed {
+            fields_seed: ConcreteShapeFieldsSeed {
                 ctx,
                 has_error: shape.has_errors(),
                 object_identifier: ObjectIdentifier::Known(object_id),
@@ -55,12 +55,12 @@ impl<'ctx, 'seed> ConcreteObjectSeed<'ctx, 'seed> {
         }
     }
 
-    pub(crate) fn into_fields_seed(self) -> ConcreteObjectFieldsSeed<'ctx, 'seed> {
+    pub(crate) fn into_fields_seed(self) -> ConcreteShapeFieldsSeed<'ctx, 'seed> {
         self.fields_seed
     }
 }
 
-pub(crate) struct ConcreteObjectFieldsSeed<'ctx, 'seed> {
+pub(crate) struct ConcreteShapeFieldsSeed<'ctx, 'seed> {
     ctx: &'seed SeedContext<'ctx>,
     has_error: bool,
     object_identifier: ObjectIdentifier,
@@ -68,7 +68,7 @@ pub(crate) struct ConcreteObjectFieldsSeed<'ctx, 'seed> {
     typename_response_edges: &'ctx [PositionedResponseKey],
 }
 
-impl<'de, 'ctx, 'parent> DeserializeSeed<'de> for ConcreteObjectSeed<'ctx, 'parent> {
+impl<'de, 'ctx, 'parent> DeserializeSeed<'de> for ConcreteShapeSeed<'ctx, 'parent> {
     type Value = ResponseValue;
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -79,7 +79,7 @@ impl<'de, 'ctx, 'parent> DeserializeSeed<'de> for ConcreteObjectSeed<'ctx, 'pare
     }
 }
 
-impl<'de, 'ctx, 'parent> Visitor<'de> for ConcreteObjectSeed<'ctx, 'parent> {
+impl<'de, 'ctx, 'parent> Visitor<'de> for ConcreteShapeSeed<'ctx, 'parent> {
     type Value = ResponseValue;
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -109,7 +109,7 @@ impl<'de, 'ctx, 'parent> Visitor<'de> for ConcreteObjectSeed<'ctx, 'parent> {
     }
 }
 
-impl<'de, 'ctx, 'seed> DeserializeSeed<'de> for ConcreteObjectFieldsSeed<'ctx, 'seed> {
+impl<'de, 'ctx, 'seed> DeserializeSeed<'de> for ConcreteShapeFieldsSeed<'ctx, 'seed> {
     type Value = (Option<ObjectDefinitionId>, Vec<ResponseObjectField>);
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -120,7 +120,7 @@ impl<'de, 'ctx, 'seed> DeserializeSeed<'de> for ConcreteObjectFieldsSeed<'ctx, '
     }
 }
 
-impl<'de, 'ctx, 'seed> Visitor<'de> for ConcreteObjectFieldsSeed<'ctx, 'seed> {
+impl<'de, 'ctx, 'seed> Visitor<'de> for ConcreteShapeFieldsSeed<'ctx, 'seed> {
     type Value = (Option<ObjectDefinitionId>, Vec<ResponseObjectField>);
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -183,7 +183,7 @@ impl<'de, 'ctx, 'seed> Visitor<'de> for ConcreteObjectFieldsSeed<'ctx, 'seed> {
     }
 }
 
-impl<'de, 'ctx, 'seed> ConcreteObjectFieldsSeed<'ctx, 'seed> {
+impl<'de, 'ctx, 'seed> ConcreteShapeFieldsSeed<'ctx, 'seed> {
     fn post_process<A: MapAccess<'de>>(&self, response_fields: &mut Vec<ResponseObjectField>) -> Result<(), A::Error> {
         if self.has_error {
             let mut required_field_error = false;

--- a/crates/engine/src/response/write/deserialize/object/polymorphic.rs
+++ b/crates/engine/src/response/write/deserialize/object/polymorphic.rs
@@ -6,18 +6,18 @@ use walker::Walk;
 
 use crate::response::{
     write::deserialize::{key::Key, SeedContext},
-    ConcreteObjectShapeId, PolymorphicObjectShapeId, ResponseObject, ResponseValue,
+    ConcreteShapeId, PolymorphicShapeId, ResponseObject, ResponseValue,
 };
 
-use super::concrete::ConcreteObjectSeed;
+use super::concrete::ConcreteShapeSeed;
 
-pub(crate) struct PolymorphicObjectSeed<'ctx, 'seed> {
+pub(crate) struct PolymorphicShapeSeed<'ctx, 'seed> {
     ctx: &'seed SeedContext<'ctx>,
-    possibilities: &'ctx [(ObjectDefinitionId, ConcreteObjectShapeId)],
+    possibilities: &'ctx [(ObjectDefinitionId, ConcreteShapeId)],
 }
 
-impl<'ctx, 'seed> PolymorphicObjectSeed<'ctx, 'seed> {
-    pub fn new(ctx: &'seed SeedContext<'ctx>, shape_id: PolymorphicObjectShapeId) -> Self {
+impl<'ctx, 'seed> PolymorphicShapeSeed<'ctx, 'seed> {
+    pub fn new(ctx: &'seed SeedContext<'ctx>, shape_id: PolymorphicShapeId) -> Self {
         let polymorphic = shape_id.walk(ctx);
         Self {
             ctx,
@@ -26,7 +26,7 @@ impl<'ctx, 'seed> PolymorphicObjectSeed<'ctx, 'seed> {
     }
 }
 
-impl<'de, 'ctx, 'parent> DeserializeSeed<'de> for PolymorphicObjectSeed<'ctx, 'parent> {
+impl<'de, 'ctx, 'parent> DeserializeSeed<'de> for PolymorphicShapeSeed<'ctx, 'parent> {
     type Value = ResponseValue;
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -37,7 +37,7 @@ impl<'de, 'ctx, 'parent> DeserializeSeed<'de> for PolymorphicObjectSeed<'ctx, 'p
     }
 }
 
-impl<'de, 'ctx, 'parent> Visitor<'de> for PolymorphicObjectSeed<'ctx, 'parent> {
+impl<'de, 'ctx, 'parent> Visitor<'de> for PolymorphicShapeSeed<'ctx, 'parent> {
     type Value = ResponseValue;
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -60,7 +60,7 @@ impl<'de, 'ctx, 'parent> Visitor<'de> for PolymorphicObjectSeed<'ctx, 'parent> {
                     .binary_search_by(|(id, _)| schema[schema[*id].name_id].as_str().cmp(typename))
                 {
                     let (object_id, shape_id) = self.possibilities[i];
-                    return ConcreteObjectSeed::new_with_object_id(self.ctx, shape_id, object_id).visit_map(
+                    return ConcreteShapeSeed::new_with_object_id(self.ctx, shape_id, object_id).visit_map(
                         ChainedMapAcces {
                             before: content,
                             next_value: None,

--- a/crates/engine/src/response/write/mod.rs
+++ b/crates/engine/src/response/write/mod.rs
@@ -17,7 +17,7 @@ use schema::{ObjectDefinitionId, Schema};
 use self::deserialize::UpdateSeed;
 
 use super::{
-    value::ResponseObjectField, ConcreteObjectShapeId, ErrorCode, ErrorCodeCounter, ExecutedResponse, GraphqlError,
+    value::ResponseObjectField, ConcreteShapeId, ErrorCode, ErrorCodeCounter, ExecutedResponse, GraphqlError,
     InputResponseObjectSet, OutputResponseObjectSets, PositionedResponseKey, Response, ResponseData, ResponseEdge,
     ResponseObject, ResponseObjectRef, ResponseObjectSet, ResponsePath, ResponseValue, UnpackedResponseEdge,
 };
@@ -88,7 +88,7 @@ impl ResponseBuilder {
 
     pub fn new_subgraph_response(
         &mut self,
-        shape_id: ConcreteObjectShapeId,
+        shape_id: ConcreteShapeId,
         root_response_object_set: Arc<InputResponseObjectSet>,
     ) -> SubgraphResponse {
         let id = ResponseDataPartId::from(self.parts.len());
@@ -487,7 +487,7 @@ enum ResponseValueId {
 
 pub(crate) struct SubgraphResponse {
     data: ResponseDataPart,
-    shape_id: ConcreteObjectShapeId,
+    shape_id: ConcreteShapeId,
     root_response_object_set: Arc<InputResponseObjectSet>,
     errors: Vec<GraphqlError>,
     updates: Vec<UpdateSlot>,
@@ -498,7 +498,7 @@ pub(crate) struct SubgraphResponse {
 impl SubgraphResponse {
     fn new(
         data: ResponseDataPart,
-        shape_id: ConcreteObjectShapeId,
+        shape_id: ConcreteShapeId,
         root_response_object_set: Arc<InputResponseObjectSet>,
     ) -> Self {
         Self {


### PR DESCRIPTION
Was confused for a moment as to why `ConcreteObjectShape` could have
interfaces/unions. But it's just ill-named, it's a `ConcreteShape` with
known fields. It doesn't mean it's only a single object. So renamed
`ConcreteObjectShape` to `ConcreteObject` and `PolymorphicObjectShape`
to `PolymorphicShape`.
