### PR TITLE
fix: add error message on unlikely complexity control path

### DIFF
--- a/crates/engine/src/prepare/operation/mod.rs
+++ b/crates/engine/src/prepare/operation/mod.rs
@@ -108,6 +108,7 @@ fn validate_prepared_operation(operation: &PreparedOperation, settings: &Setting
         return Ok(());
     };
     let Some(complexity) = operation.complexity else {
+        tracing::error!("Complexity control is enabled but complexity could not be calculated!");
         return Ok(());
     };
     if complexity > limit {


### PR DESCRIPTION
This case should never really happen, but it'd be better to not be completely silent if it does.