### PR TITLE
cli: remove --header argument in publish

### DIFF
--- a/cli/src/cli_input/publish.rs
+++ b/cli/src/cli_input/publish.rs
@@ -24,8 +24,4 @@ pub struct PublishCommand {
     /// The message to annotate the publication with
     #[arg(long, short = 'm')]
     pub(crate) message: Option<String>,
-
-    /// Add a header to the introspection request
-    #[clap(short = 'H', long, value_parser, num_args = 0..)]
-    header: Vec<String>,
 }


### PR DESCRIPTION
What is up with that argument? It is not used, and there is no introspection involved in publish, so it is misleading.

![image](https://github.com/user-attachments/assets/d6f61e8b-5f17-4d89-b5e3-3bd42a5e76de)
