### PR TITLE
fix: otlp http exporters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5298,6 +5298,7 @@ dependencies = [
  "bytes",
  "http 1.1.0",
  "opentelemetry",
+ "reqwest 0.12.9",
 ]
 
 [[package]]
@@ -5314,6 +5315,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
+ "reqwest 0.12.9",
  "thiserror 1.0.68",
  "tokio",
  "tonic",

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -46,10 +46,11 @@ opentelemetry-stdout = { workspace = true, features = [
 ] }
 opentelemetry-otlp = { workspace = true, features = [
     "grpc-tonic",
-    "tls",
-    "tonic",
     "http-proto",
     "logs",
+    "reqwest-client",
+    "tls",
+    "tonic",
 ], optional = true }
 ascii = { version = "1.1.0", features = ["serde"] }
 cfg-if = "1.0.0"


### PR DESCRIPTION
Was playing about with prometheus & jaeger locally just there, and configured my gateway to export otlp using http, but on startup the server got this message:

> Error: unable to configure span exporter: Exporter otlp encountered the following error(s): no http client, you must select one from features or provide your own implementation

Enabling one of the http client feature flags fixes this.