### PR TITLE
fix(engine): mutation test

### DIFF
--- a/crates/engine/query-solver/src/solution/dot_graph.rs
+++ b/crates/engine/query-solver/src/solution/dot_graph.rs
@@ -78,7 +78,7 @@ impl SolutionEdge {
             Self::Field => Attrs::default(),
             Self::RequiredBySubgraph => Attrs::default().with("color=orangered,arrowhead=inv"),
             Self::RequiredBySupergraph => Attrs::default().with("color=orangered,arrowhead=inv,style=dashed"),
-            Self::MutationExecutedAfter => Attrs::default().with("color=red"),
+            Self::MutationExecutedAfter => Attrs::default().with("color=red,arrowhead=inv,style=dashed"),
         }
         .to_string()
     }

--- a/crates/engine/query-solver/src/tests/mutation.rs
+++ b/crates/engine/query-solver/src/tests/mutation.rs
@@ -5,6 +5,9 @@ enum join__Graph {
   ACCOUNTS @join__graph(name: "accounts", url: "http://accounts:4001/graphql")
   PRODUCTS @join__graph(name: "products", url: "http://products:4003/graphql")
   REVIEWS @join__graph(name: "reviews", url: "http://reviews:4004/graphql")
+  A @join__graph(name: "a", url: "http://accounts:4001/a")
+  B @join__graph(name: "b", url: "http://products:4003/b")
+  C @join__graph(name: "c", url: "http://reviews:4004/c")
 }
 
 type Product
@@ -18,6 +21,9 @@ type Mutation
   @join__type(graph: ACCOUNTS)
   @join__type(graph: PRODUCTS)
   @join__type(graph: REVIEWS)
+  @join__type(graph: A)
+  @join__type(graph: B)
+  @join__type(graph: C)
 {
   createUser: User @join__field(graph: ACCOUNTS)
   updateUser: User @join__field(graph: ACCOUNTS)
@@ -25,6 +31,10 @@ type Mutation
   updateProduct: Product @join__field(graph: PRODUCTS)
   createReview: Review @join__field(graph: REVIEWS)
   updateReview: Review @join__field(graph: REVIEWS)
+
+  multiply(by: Int!, requestId: String!): Int! @join__field(graph: A)
+  delete(requestId: String!): Int! @join__field(graph: B)
+  add(num: Int!, requestId: String!): Int! @join__field(graph: C)
 }
 
 type Query @join__type(graph: ACCOUNTS) {
@@ -105,6 +115,22 @@ fn interleaved_subgraph_fields() {
           updateProduct { upc }
           updateUser { id }
           updateReview { id }
+        }
+        "#
+    );
+}
+
+#[test]
+fn audit_test() {
+    assert_solving_snapshots!(
+        "audit_test",
+        SCHEMA,
+        r#"
+        mutation {
+          five: add(num: 5, requestId: "${randomId}")
+          ten: multiply(by: 2, requestId: "${randomId}")
+          twelve: add(num: 2, requestId: "${randomId}")
+          final: delete(requestId: "${randomId}")
         }
         "#
     );

--- a/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__mutation__audit_test-finalized-solution.snap
+++ b/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__mutation__audit_test-finalized-solution.snap
@@ -1,0 +1,26 @@
+---
+source: crates/engine/query-solver/src/tests/mutation.rs
+expression: "digraph {\n    0 [ label = \"root\" ]\n    1 [ label = \"Root#b\", color=royalblue,shape=parallelogram ]\n    2 [ label = \"delete\" ]\n    3 [ label = \"Root#c\", color=royalblue,shape=parallelogram ]\n    4 [ label = \"add\" ]\n    5 [ label = \"add\" ]\n    6 [ label = \"Root#a\", color=royalblue,shape=parallelogram ]\n    7 [ label = \"multiply\" ]\n    8 [ label = \"Root#c\", color=royalblue,shape=parallelogram ]\n    0 -> 1 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    1 -> 2 [ label = \"\" ]\n    0 -> 3 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    0 -> 8 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    3 -> 5 [ label = \"\" ]\n    0 -> 6 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    6 -> 7 [ label = \"\" ]\n    8 -> 4 [ label = \"\" ]\n    6 -> 3 [ label = \"\", color=red,arrowhead=inv,style=dashed ]\n    8 -> 6 [ label = \"\", color=red,arrowhead=inv,style=dashed ]\n    1 -> 8 [ label = \"\", color=red,arrowhead=inv,style=dashed ]\n}\n"
+---
+digraph {
+    0 [ label = "root" ]
+    1 [ label = "Root#b" ]
+    2 [ label = "delete" ]
+    3 [ label = "Root#c" ]
+    4 [ label = "add" ]
+    5 [ label = "add" ]
+    6 [ label = "Root#a" ]
+    7 [ label = "multiply" ]
+    8 [ label = "Root#c" ]
+    0 -> 1 [ label = "QueryPartition" ]
+    1 -> 2 [ label = "Field" ]
+    0 -> 3 [ label = "QueryPartition" ]
+    0 -> 8 [ label = "QueryPartition" ]
+    3 -> 5 [ label = "Field" ]
+    0 -> 6 [ label = "QueryPartition" ]
+    6 -> 7 [ label = "Field" ]
+    8 -> 4 [ label = "Field" ]
+    6 -> 3 [ label = "MutationExecutedAfter" ]
+    8 -> 6 [ label = "MutationExecutedAfter" ]
+    1 -> 8 [ label = "MutationExecutedAfter" ]
+}

--- a/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__mutation__audit_test-graph.snap
+++ b/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__mutation__audit_test-graph.snap
@@ -1,0 +1,36 @@
+---
+source: crates/engine/query-solver/src/tests/mutation.rs
+expression: "digraph {\n    0 [ label = \"root\" ]\n    1 [ label = \"add\" ]\n    2 [ label = \"multiply\" ]\n    3 [ label = \"add\" ]\n    4 [ label = \"delete\" ]\n    5 [ label = \"Root#b\", shape=parallelogram, color=dodgerblue ]\n    6 [ label = \"delete#b\", shape=box, color=dodgerblue ]\n    7 [ label = \"Root#c\", shape=parallelogram, color=dodgerblue ]\n    8 [ label = \"add#c\", shape=box, color=dodgerblue ]\n    9 [ label = \"Root#a\", shape=parallelogram, color=dodgerblue ]\n    10 [ label = \"multiply#a\", shape=box, color=dodgerblue ]\n    11 [ label = \"add#c\", shape=box, color=dodgerblue ]\n    0 -> 4 [ label = \"\" ]\n    0 -> 5 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    0 -> 5 [ label = \"\", style=dashed,arrowhead=none ]\n    5 -> 6 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    6 -> 4 [ label = \"\", color=violet,arrowhead=none ]\n    0 -> 3 [ label = \"\" ]\n    0 -> 7 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    0 -> 7 [ label = \"\", style=dashed,arrowhead=none ]\n    7 -> 8 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    8 -> 3 [ label = \"\", color=violet,arrowhead=none ]\n    0 -> 2 [ label = \"\" ]\n    0 -> 9 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    0 -> 9 [ label = \"\", style=dashed,arrowhead=none ]\n    9 -> 10 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    10 -> 2 [ label = \"\", color=violet,arrowhead=none ]\n    0 -> 1 [ label = \"\" ]\n    7 -> 11 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    11 -> 1 [ label = \"\", color=violet,arrowhead=none ]\n}\n"
+---
+digraph {
+    0 [ root]
+    1 [ add]
+    2 [ multiply]
+    3 [ add]
+    4 [ delete]
+    5 [ Root#b]
+    6 [ delete#b]
+    7 [ Root#c]
+    8 [ add#c]
+    9 [ Root#a]
+    10 [ multiply#a]
+    11 [ add#c]
+    0 -> 4 [ label = "Field" ]
+    0 -> 5 [ label = "CreateChildResolver" ]
+    0 -> 5 [ label = "HasChildResolver" ]
+    5 -> 6 [ label = "CanProvide" ]
+    6 -> 4 [ label = "Provides" ]
+    0 -> 3 [ label = "Field" ]
+    0 -> 7 [ label = "CreateChildResolver" ]
+    0 -> 7 [ label = "HasChildResolver" ]
+    7 -> 8 [ label = "CanProvide" ]
+    8 -> 3 [ label = "Provides" ]
+    0 -> 2 [ label = "Field" ]
+    0 -> 9 [ label = "CreateChildResolver" ]
+    0 -> 9 [ label = "HasChildResolver" ]
+    9 -> 10 [ label = "CanProvide" ]
+    10 -> 2 [ label = "Provides" ]
+    0 -> 1 [ label = "Field" ]
+    7 -> 11 [ label = "CanProvide" ]
+    11 -> 1 [ label = "Provides" ]
+}

--- a/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__mutation__audit_test-partial-solution.snap
+++ b/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__mutation__audit_test-partial-solution.snap
@@ -1,0 +1,21 @@
+---
+source: crates/engine/query-solver/src/tests/mutation.rs
+expression: "digraph {\n    0 [ label = \"root\" ]\n    1 [ label = \"Root#b\", color=royalblue,shape=parallelogram ]\n    2 [ label = \"delete\" ]\n    3 [ label = \"Root#c\", color=royalblue,shape=parallelogram ]\n    4 [ label = \"add\" ]\n    5 [ label = \"add\" ]\n    6 [ label = \"Root#a\", color=royalblue,shape=parallelogram ]\n    7 [ label = \"multiply\" ]\n    0 -> 1 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    1 -> 2 [ label = \"\" ]\n    0 -> 3 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    3 -> 4 [ label = \"\" ]\n    3 -> 5 [ label = \"\" ]\n    0 -> 6 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    6 -> 7 [ label = \"\" ]\n}\n"
+---
+digraph {
+    0 [ label = "root" ]
+    1 [ label = "Root#b" ]
+    2 [ label = "delete" ]
+    3 [ label = "Root#c" ]
+    4 [ label = "add" ]
+    5 [ label = "add" ]
+    6 [ label = "Root#a" ]
+    7 [ label = "multiply" ]
+    0 -> 1 [ label = "QueryPartition" ]
+    1 -> 2 [ label = "Field" ]
+    0 -> 3 [ label = "QueryPartition" ]
+    3 -> 4 [ label = "Field" ]
+    3 -> 5 [ label = "Field" ]
+    0 -> 6 [ label = "QueryPartition" ]
+    6 -> 7 [ label = "Field" ]
+}

--- a/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__mutation__audit_test-solved.snap
+++ b/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__mutation__audit_test-solved.snap
@@ -1,0 +1,31 @@
+---
+source: crates/engine/query-solver/src/tests/mutation.rs
+expression: "digraph {\n    0 [ label = \"root\", color=forestgreen ]\n    1 [ label = \"add\", color=forestgreen ]\n    2 [ label = \"multiply\", color=forestgreen ]\n    3 [ label = \"add\", color=forestgreen ]\n    4 [ label = \"delete\", color=forestgreen ]\n    5 [ label = \"Root#b\", shape=parallelogram, color=dodgerblue, color=forestgreen ]\n    6 [ label = \"delete#b\", shape=box, color=dodgerblue, color=forestgreen ]\n    7 [ label = \"Root#c\", shape=parallelogram, color=dodgerblue, color=forestgreen ]\n    8 [ label = \"add#c\", shape=box, color=dodgerblue, color=forestgreen ]\n    9 [ label = \"Root#a\", shape=parallelogram, color=dodgerblue, color=forestgreen ]\n    10 [ label = \"multiply#a\", shape=box, color=dodgerblue, color=forestgreen ]\n    11 [ label = \"add#c\", shape=box, color=dodgerblue, color=forestgreen ]\n    12 [ label=\"\", style=dashed]\n    0 -> 5 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    5 -> 6 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    6 -> 4 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    0 -> 7 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    7 -> 8 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    8 -> 3 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    0 -> 9 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    9 -> 10 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    10 -> 2 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    7 -> 11 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    11 -> 1 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    12 -> 0 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n}\n"
+---
+digraph {
+    0 [ label = "root", steiner=1 ]
+    1 [ label = "add", steiner=1 ]
+    2 [ label = "multiply", steiner=1 ]
+    3 [ label = "add", steiner=1 ]
+    4 [ label = "delete", steiner=1 ]
+    5 [ label = "Root#b", steiner=1 ]
+    6 [ label = "delete#b", steiner=1 ]
+    7 [ label = "Root#c", steiner=1 ]
+    8 [ label = "add#c", steiner=1 ]
+    9 [ label = "Root#a", steiner=1 ]
+    10 [ label = "multiply#a", steiner=1 ]
+    11 [ label = "add#c", steiner=1 ]
+    12 [ label="", style=dashed]
+    0 -> 5 [ cost=0, steiner=1]
+    5 -> 6 [ cost=0, steiner=1]
+    6 -> 4 [ cost=0, steiner=1]
+    0 -> 7 [ cost=0, steiner=1]
+    7 -> 8 [ cost=0, steiner=1]
+    8 -> 3 [ cost=0, steiner=1]
+    0 -> 9 [ cost=0, steiner=1]
+    9 -> 10 [ cost=0, steiner=1]
+    10 -> 2 [ cost=0, steiner=1]
+    7 -> 11 [ cost=0, steiner=1]
+    11 -> 1 [ cost=0, steiner=1]
+    12 -> 0 [ cost=0, steiner=0]
+}

--- a/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__mutation__audit_test-solver.snap
+++ b/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__mutation__audit_test-solver.snap
@@ -1,0 +1,31 @@
+---
+source: crates/engine/query-solver/src/tests/mutation.rs
+expression: "digraph {\n    0 [ label = \"root\", color=forestgreen ]\n    1 [ label = \"add\", style=dashed ]\n    2 [ label = \"multiply\", style=dashed ]\n    3 [ label = \"add\", style=dashed ]\n    4 [ label = \"delete\", style=dashed ]\n    5 [ label = \"Root#b\", shape=parallelogram, color=dodgerblue, style=dashed ]\n    6 [ label = \"delete#b\", shape=box, color=dodgerblue, style=dashed ]\n    7 [ label = \"Root#c\", shape=parallelogram, color=dodgerblue, style=dashed ]\n    8 [ label = \"add#c\", shape=box, color=dodgerblue, style=dashed ]\n    9 [ label = \"Root#a\", shape=parallelogram, color=dodgerblue, style=dashed ]\n    10 [ label = \"multiply#a\", shape=box, color=dodgerblue, style=dashed ]\n    11 [ label = \"add#c\", shape=box, color=dodgerblue, style=dashed ]\n    12 [ label=\"\", style=dashed]\n    0 -> 5 [ label = <<b>1</b>>, color=royalblue,fontcolor=royalblue,style=dashed ]\n    5 -> 6 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n    6 -> 4 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n    0 -> 7 [ label = <<b>1</b>>, color=royalblue,fontcolor=royalblue,style=dashed ]\n    7 -> 8 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n    8 -> 3 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n    0 -> 9 [ label = <<b>1</b>>, color=royalblue,fontcolor=royalblue,style=dashed ]\n    9 -> 10 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n    10 -> 2 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n    7 -> 11 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n    11 -> 1 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n    12 -> 0 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n}\n"
+---
+digraph {
+    0 [ label = "root", steiner=1 ]
+    1 [ label = "add", steiner=0 ]
+    2 [ label = "multiply", steiner=0 ]
+    3 [ label = "add", steiner=0 ]
+    4 [ label = "delete", steiner=0 ]
+    5 [ label = "Root#b", steiner=0 ]
+    6 [ label = "delete#b", steiner=0 ]
+    7 [ label = "Root#c", steiner=0 ]
+    8 [ label = "add#c", steiner=0 ]
+    9 [ label = "Root#a", steiner=0 ]
+    10 [ label = "multiply#a", steiner=0 ]
+    11 [ label = "add#c", steiner=0 ]
+    12 [ label="", style=dashed]
+    0 -> 5 [ cost=1, steiner=0]
+    5 -> 6 [ cost=0, steiner=0]
+    6 -> 4 [ cost=0, steiner=0]
+    0 -> 7 [ cost=1, steiner=0]
+    7 -> 8 [ cost=0, steiner=0]
+    8 -> 3 [ cost=0, steiner=0]
+    0 -> 9 [ cost=1, steiner=0]
+    9 -> 10 [ cost=0, steiner=0]
+    10 -> 2 [ cost=0, steiner=0]
+    7 -> 11 [ cost=0, steiner=0]
+    11 -> 1 [ cost=0, steiner=0]
+    12 -> 0 [ cost=0, steiner=0]
+}

--- a/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__mutation__consecutive_subgraphs-finalized-solution.snap
+++ b/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__mutation__consecutive_subgraphs-finalized-solution.snap
@@ -1,6 +1,6 @@
 ---
-source: engine/crates/engine/query-solver/src/tests/mutation.rs
-expression: "digraph {\n    0 [ label = \"root\" ]\n    1 [ label = \"Root#reviews\", color=royalblue,shape=parallelogram ]\n    2 [ label = \"createReview\" ]\n    3 [ label = \"id\" ]\n    4 [ label = \"Root#products\", color=royalblue,shape=parallelogram ]\n    5 [ label = \"createProduct\" ]\n    6 [ label = \"upc\" ]\n    7 [ label = \"Root#accounts\", color=royalblue,shape=parallelogram ]\n    8 [ label = \"createUser\" ]\n    9 [ label = \"id\" ]\n    0 -> 1 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    8 -> 9 [ label = \"\" ]\n    2 -> 3 [ label = \"\" ]\n    0 -> 4 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    7 -> 4 [ label = \"\", color=red ]\n    5 -> 6 [ label = \"\" ]\n    0 -> 7 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    4 -> 1 [ label = \"\", color=red ]\n    7 -> 8 [ label = \"\" ]\n    4 -> 5 [ label = \"\" ]\n    1 -> 2 [ label = \"\" ]\n}\n"
+source: crates/engine/query-solver/src/tests/mutation.rs
+expression: "digraph {\n    0 [ label = \"root\" ]\n    1 [ label = \"Root#reviews\", color=royalblue,shape=parallelogram ]\n    2 [ label = \"createReview\" ]\n    3 [ label = \"id\" ]\n    4 [ label = \"Root#products\", color=royalblue,shape=parallelogram ]\n    5 [ label = \"createProduct\" ]\n    6 [ label = \"upc\" ]\n    7 [ label = \"Root#accounts\", color=royalblue,shape=parallelogram ]\n    8 [ label = \"createUser\" ]\n    9 [ label = \"id\" ]\n    0 -> 1 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    1 -> 2 [ label = \"\" ]\n    2 -> 3 [ label = \"\" ]\n    0 -> 4 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    4 -> 5 [ label = \"\" ]\n    5 -> 6 [ label = \"\" ]\n    0 -> 7 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    7 -> 8 [ label = \"\" ]\n    8 -> 9 [ label = \"\" ]\n    4 -> 7 [ label = \"\", color=red,arrowhead=inv,style=dashed ]\n    1 -> 4 [ label = \"\", color=red,arrowhead=inv,style=dashed ]\n}\n"
 ---
 digraph {
     0 [ label = "root" ]
@@ -14,14 +14,14 @@ digraph {
     8 [ label = "createUser" ]
     9 [ label = "id" ]
     0 -> 1 [ label = "QueryPartition" ]
-    8 -> 9 [ label = "Field" ]
+    1 -> 2 [ label = "Field" ]
     2 -> 3 [ label = "Field" ]
     0 -> 4 [ label = "QueryPartition" ]
-    7 -> 4 [ label = "MutationExecutedAfter" ]
+    4 -> 5 [ label = "Field" ]
     5 -> 6 [ label = "Field" ]
     0 -> 7 [ label = "QueryPartition" ]
-    4 -> 1 [ label = "MutationExecutedAfter" ]
     7 -> 8 [ label = "Field" ]
-    4 -> 5 [ label = "Field" ]
-    1 -> 2 [ label = "Field" ]
+    8 -> 9 [ label = "Field" ]
+    4 -> 7 [ label = "MutationExecutedAfter" ]
+    1 -> 4 [ label = "MutationExecutedAfter" ]
 }

--- a/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__mutation__consecutive_subgraphs_with_multiple_fields-finalized-solution.snap
+++ b/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__mutation__consecutive_subgraphs_with_multiple_fields-finalized-solution.snap
@@ -1,6 +1,6 @@
 ---
-source: engine/crates/engine/query-solver/src/tests/mutation.rs
-expression: "digraph {\n    0 [ label = \"root\" ]\n    1 [ label = \"Root#reviews\", color=royalblue,shape=parallelogram ]\n    2 [ label = \"updateReview\" ]\n    3 [ label = \"id\" ]\n    4 [ label = \"createReview\" ]\n    5 [ label = \"id\" ]\n    6 [ label = \"Root#products\", color=royalblue,shape=parallelogram ]\n    7 [ label = \"updateProduct\" ]\n    8 [ label = \"upc\" ]\n    9 [ label = \"createProduct\" ]\n    10 [ label = \"upc\" ]\n    11 [ label = \"Root#accounts\", color=royalblue,shape=parallelogram ]\n    12 [ label = \"updateUser\" ]\n    13 [ label = \"id\" ]\n    14 [ label = \"createUser\" ]\n    15 [ label = \"id\" ]\n    0 -> 1 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    11 -> 6 [ label = \"\", color=red ]\n    2 -> 3 [ label = \"\" ]\n    12 -> 13 [ label = \"\" ]\n    4 -> 5 [ label = \"\" ]\n    0 -> 6 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    6 -> 1 [ label = \"\", color=red ]\n    7 -> 8 [ label = \"\" ]\n    14 -> 15 [ label = \"\" ]\n    9 -> 10 [ label = \"\" ]\n    0 -> 11 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    11 -> 14 [ label = \"\" ]\n    11 -> 12 [ label = \"\" ]\n    6 -> 9 [ label = \"\" ]\n    6 -> 7 [ label = \"\" ]\n    1 -> 4 [ label = \"\" ]\n    1 -> 2 [ label = \"\" ]\n}\n"
+source: crates/engine/query-solver/src/tests/mutation.rs
+expression: "digraph {\n    0 [ label = \"root\" ]\n    1 [ label = \"Root#reviews\", color=royalblue,shape=parallelogram ]\n    2 [ label = \"updateReview\" ]\n    3 [ label = \"id\" ]\n    4 [ label = \"createReview\" ]\n    5 [ label = \"id\" ]\n    6 [ label = \"Root#products\", color=royalblue,shape=parallelogram ]\n    7 [ label = \"updateProduct\" ]\n    8 [ label = \"upc\" ]\n    9 [ label = \"createProduct\" ]\n    10 [ label = \"upc\" ]\n    11 [ label = \"Root#accounts\", color=royalblue,shape=parallelogram ]\n    12 [ label = \"updateUser\" ]\n    13 [ label = \"id\" ]\n    14 [ label = \"createUser\" ]\n    15 [ label = \"id\" ]\n    0 -> 1 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    1 -> 2 [ label = \"\" ]\n    2 -> 3 [ label = \"\" ]\n    1 -> 4 [ label = \"\" ]\n    4 -> 5 [ label = \"\" ]\n    0 -> 6 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    6 -> 7 [ label = \"\" ]\n    7 -> 8 [ label = \"\" ]\n    6 -> 9 [ label = \"\" ]\n    9 -> 10 [ label = \"\" ]\n    0 -> 11 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    11 -> 12 [ label = \"\" ]\n    12 -> 13 [ label = \"\" ]\n    11 -> 14 [ label = \"\" ]\n    14 -> 15 [ label = \"\" ]\n    6 -> 11 [ label = \"\", color=red,arrowhead=inv,style=dashed ]\n    1 -> 6 [ label = \"\", color=red,arrowhead=inv,style=dashed ]\n}\n"
 ---
 digraph {
     0 [ label = "root" ]
@@ -20,20 +20,20 @@ digraph {
     14 [ label = "createUser" ]
     15 [ label = "id" ]
     0 -> 1 [ label = "QueryPartition" ]
-    11 -> 6 [ label = "MutationExecutedAfter" ]
+    1 -> 2 [ label = "Field" ]
     2 -> 3 [ label = "Field" ]
-    12 -> 13 [ label = "Field" ]
+    1 -> 4 [ label = "Field" ]
     4 -> 5 [ label = "Field" ]
     0 -> 6 [ label = "QueryPartition" ]
-    6 -> 1 [ label = "MutationExecutedAfter" ]
+    6 -> 7 [ label = "Field" ]
     7 -> 8 [ label = "Field" ]
-    14 -> 15 [ label = "Field" ]
+    6 -> 9 [ label = "Field" ]
     9 -> 10 [ label = "Field" ]
     0 -> 11 [ label = "QueryPartition" ]
-    11 -> 14 [ label = "Field" ]
     11 -> 12 [ label = "Field" ]
-    6 -> 9 [ label = "Field" ]
-    6 -> 7 [ label = "Field" ]
-    1 -> 4 [ label = "Field" ]
-    1 -> 2 [ label = "Field" ]
+    12 -> 13 [ label = "Field" ]
+    11 -> 14 [ label = "Field" ]
+    14 -> 15 [ label = "Field" ]
+    6 -> 11 [ label = "MutationExecutedAfter" ]
+    1 -> 6 [ label = "MutationExecutedAfter" ]
 }

--- a/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__mutation__interleaved_subgraph_fields-finalized-solution.snap
+++ b/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__mutation__interleaved_subgraph_fields-finalized-solution.snap
@@ -1,6 +1,6 @@
 ---
-source: engine/crates/engine/query-solver/src/tests/mutation.rs
-expression: "digraph {\n    0 [ label = \"root\" ]\n    1 [ label = \"Root#reviews\", color=royalblue,shape=parallelogram ]\n    2 [ label = \"updateReview\" ]\n    3 [ label = \"id\" ]\n    4 [ label = \"createReview\" ]\n    5 [ label = \"id\" ]\n    6 [ label = \"Root#accounts\", color=royalblue,shape=parallelogram ]\n    7 [ label = \"updateUser\" ]\n    8 [ label = \"id\" ]\n    9 [ label = \"createUser\" ]\n    10 [ label = \"id\" ]\n    11 [ label = \"Root#products\", color=royalblue,shape=parallelogram ]\n    12 [ label = \"updateProduct\" ]\n    13 [ label = \"upc\" ]\n    14 [ label = \"createProduct\" ]\n    15 [ label = \"upc\" ]\n    16 [ label = \"Root#products\", color=royalblue,shape=parallelogram ]\n    17 [ label = \"Root#accounts\", color=royalblue,shape=parallelogram ]\n    18 [ label = \"Root#reviews\", color=royalblue,shape=parallelogram ]\n    0 -> 1 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    0 -> 18 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    2 -> 3 [ label = \"\" ]\n    1 -> 16 [ label = \"\", color=red ]\n    4 -> 5 [ label = \"\" ]\n    0 -> 6 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    0 -> 17 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    7 -> 8 [ label = \"\" ]\n    17 -> 18 [ label = \"\", color=red ]\n    9 -> 10 [ label = \"\" ]\n    0 -> 11 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    0 -> 16 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    12 -> 13 [ label = \"\" ]\n    16 -> 17 [ label = \"\", color=red ]\n    14 -> 15 [ label = \"\" ]\n    11 -> 1 [ label = \"\", color=red ]\n    6 -> 11 [ label = \"\", color=red ]\n    17 -> 9 [ label = \"\" ]\n    16 -> 14 [ label = \"\" ]\n    18 -> 4 [ label = \"\" ]\n    16 -> 12 [ label = \"\" ]\n    17 -> 7 [ label = \"\" ]\n    18 -> 2 [ label = \"\" ]\n}\n"
+source: crates/engine/query-solver/src/tests/mutation.rs
+expression: "digraph {\n    0 [ label = \"root\" ]\n    1 [ label = \"Root#reviews\", color=royalblue,shape=parallelogram ]\n    2 [ label = \"updateReview\" ]\n    3 [ label = \"id\" ]\n    4 [ label = \"createReview\" ]\n    5 [ label = \"id\" ]\n    6 [ label = \"Root#accounts\", color=royalblue,shape=parallelogram ]\n    7 [ label = \"updateUser\" ]\n    8 [ label = \"id\" ]\n    9 [ label = \"createUser\" ]\n    10 [ label = \"id\" ]\n    11 [ label = \"Root#products\", color=royalblue,shape=parallelogram ]\n    12 [ label = \"updateProduct\" ]\n    13 [ label = \"upc\" ]\n    14 [ label = \"createProduct\" ]\n    15 [ label = \"upc\" ]\n    16 [ label = \"Root#products\", color=royalblue,shape=parallelogram ]\n    17 [ label = \"Root#accounts\", color=royalblue,shape=parallelogram ]\n    18 [ label = \"Root#reviews\", color=royalblue,shape=parallelogram ]\n    0 -> 1 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    0 -> 18 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    2 -> 3 [ label = \"\" ]\n    1 -> 4 [ label = \"\" ]\n    4 -> 5 [ label = \"\" ]\n    0 -> 6 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    0 -> 17 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    7 -> 8 [ label = \"\" ]\n    6 -> 9 [ label = \"\" ]\n    9 -> 10 [ label = \"\" ]\n    0 -> 11 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    0 -> 16 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    12 -> 13 [ label = \"\" ]\n    11 -> 14 [ label = \"\" ]\n    14 -> 15 [ label = \"\" ]\n    16 -> 12 [ label = \"\" ]\n    17 -> 7 [ label = \"\" ]\n    18 -> 2 [ label = \"\" ]\n    11 -> 6 [ label = \"\", color=red,arrowhead=inv,style=dashed ]\n    1 -> 11 [ label = \"\", color=red,arrowhead=inv,style=dashed ]\n    16 -> 1 [ label = \"\", color=red,arrowhead=inv,style=dashed ]\n    17 -> 16 [ label = \"\", color=red,arrowhead=inv,style=dashed ]\n    18 -> 17 [ label = \"\", color=red,arrowhead=inv,style=dashed ]\n}\n"
 ---
 digraph {
     0 [ label = "root" ]
@@ -25,24 +25,24 @@ digraph {
     0 -> 1 [ label = "QueryPartition" ]
     0 -> 18 [ label = "QueryPartition" ]
     2 -> 3 [ label = "Field" ]
-    1 -> 16 [ label = "MutationExecutedAfter" ]
+    1 -> 4 [ label = "Field" ]
     4 -> 5 [ label = "Field" ]
     0 -> 6 [ label = "QueryPartition" ]
     0 -> 17 [ label = "QueryPartition" ]
     7 -> 8 [ label = "Field" ]
-    17 -> 18 [ label = "MutationExecutedAfter" ]
+    6 -> 9 [ label = "Field" ]
     9 -> 10 [ label = "Field" ]
     0 -> 11 [ label = "QueryPartition" ]
     0 -> 16 [ label = "QueryPartition" ]
     12 -> 13 [ label = "Field" ]
-    16 -> 17 [ label = "MutationExecutedAfter" ]
+    11 -> 14 [ label = "Field" ]
     14 -> 15 [ label = "Field" ]
-    11 -> 1 [ label = "MutationExecutedAfter" ]
-    6 -> 11 [ label = "MutationExecutedAfter" ]
-    17 -> 9 [ label = "Field" ]
-    16 -> 14 [ label = "Field" ]
-    18 -> 4 [ label = "Field" ]
     16 -> 12 [ label = "Field" ]
     17 -> 7 [ label = "Field" ]
     18 -> 2 [ label = "Field" ]
+    11 -> 6 [ label = "MutationExecutedAfter" ]
+    1 -> 11 [ label = "MutationExecutedAfter" ]
+    16 -> 1 [ label = "MutationExecutedAfter" ]
+    17 -> 16 [ label = "MutationExecutedAfter" ]
+    18 -> 17 [ label = "MutationExecutedAfter" ]
 }

--- a/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__mutation__single_subgraph-finalized-solution.snap
+++ b/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__mutation__single_subgraph-finalized-solution.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/engine/query-solver/src/tests/mutation.rs
-expression: "digraph {\n    0 [ label = \"root\" ]\n    1 [ label = \"Root#accounts\", color=royalblue,shape=parallelogram ]\n    2 [ label = \"updateUser\" ]\n    3 [ label = \"id\" ]\n    4 [ label = \"createUser\" ]\n    5 [ label = \"id\" ]\n    0 -> 1 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    4 -> 5 [ label = \"\" ]\n    2 -> 3 [ label = \"\" ]\n    1 -> 4 [ label = \"\" ]\n    1 -> 2 [ label = \"\" ]\n}\n"
+expression: "digraph {\n    0 [ label = \"root\" ]\n    1 [ label = \"Root#accounts\", color=royalblue,shape=parallelogram ]\n    2 [ label = \"updateUser\" ]\n    3 [ label = \"id\" ]\n    4 [ label = \"createUser\" ]\n    5 [ label = \"id\" ]\n    0 -> 1 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    1 -> 2 [ label = \"\" ]\n    2 -> 3 [ label = \"\" ]\n    1 -> 4 [ label = \"\" ]\n    4 -> 5 [ label = \"\" ]\n}\n"
 ---
 digraph {
     0 [ label = "root" ]
@@ -10,8 +10,8 @@ digraph {
     4 [ label = "createUser" ]
     5 [ label = "id" ]
     0 -> 1 [ label = "QueryPartition" ]
-    4 -> 5 [ label = "Field" ]
+    1 -> 2 [ label = "Field" ]
     2 -> 3 [ label = "Field" ]
     1 -> 4 [ label = "Field" ]
-    1 -> 2 [ label = "Field" ]
+    4 -> 5 [ label = "Field" ]
 }


### PR DESCRIPTION
There are two ordering problems with the query partitions generated by the query-solver:

- mutation ordering is ignored
- dependencies: a -> b -> c with a & c coming from the same subgraph. a and c have to be resolved in two steps.

Both have dedicated functions and I was running the latter the same way for mutations and queries. So the second would change whatever the first one did for mutations. I just go lucky in my tests that it worked.

I also realized I had the inverted ordering of mutations... as I didn't use the usual arrow shape for requirements.
