### PR TITLE
graphql-schema-diff: overhaul path strings

### DIFF
--- a/crates/graphql-schema-diff/CHANGELOG.md
+++ b/crates/graphql-schema-diff/CHANGELOG.md
@@ -6,6 +6,7 @@
 - New top-level export: `patch()`. This lets you take a diff and spans resolved from it, and apply it to a schema. (https://github.com/grafbase/grafbase/pull/2072)
 - The `ChangeKind` enum now has a `ChangeKind::as_str()` function and a `FromStr` implementation, implementing respectively its conversion to and from strings.
 - Implemented `ChangeKind::AddSchemaExtension` and `ChangeKind::RemoveSchemaExtension`. Schema extensions are assumed to be in the same order between the schemas.
+- BREAKING: Overhaul the path string format, and add a typed version (`Path`) with parsing and display implementations.
 
 ## 0.2.0 - 2024-07-16
 

--- a/crates/graphql-schema-diff/src/change.rs
+++ b/crates/graphql-schema-diff/src/change.rs
@@ -8,6 +8,8 @@ pub struct Change {
     /// Where the change happened in the schema. It is dot separated where relevant. For example if
     /// the change happened in a field argument, the path will be something like
     /// `ParentTypeName.fieldName.argumentName`.
+    ///
+    /// See [crate::path::Path] for the full documentation.
     pub path: String,
     /// The nature of the change.
     pub kind: ChangeKind,

--- a/crates/graphql-schema-diff/src/lib.rs
+++ b/crates/graphql-schema-diff/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![allow(unused_crate_dependencies)]
-#![deny(missing_docs)]
+
+pub mod path;
 
 mod change;
 mod patch;

--- a/crates/graphql-schema-diff/src/patch/schema_definitions.rs
+++ b/crates/graphql-schema-diff/src/patch/schema_definitions.rs
@@ -14,7 +14,12 @@ pub(super) fn patch_schema_definition<T: AsRef<str>>(
     let mut new_mutation_type = None;
     let mut new_subscription_type = None;
 
-    for change in paths.iter_exact([""; 3]) {
+    let prefix = match definition_or_extension {
+        DefinitionOrExtension::Extension => ":schema[0]",
+        DefinitionOrExtension::Definition => ":schema",
+    };
+
+    for change in paths.iter_exact([prefix, "", ""]) {
         match change.kind() {
             ChangeKind::ChangeQueryType => {
                 new_query_type = Some(change.resolved_str());

--- a/crates/graphql-schema-diff/src/path.rs
+++ b/crates/graphql-schema-diff/src/path.rs
@@ -1,0 +1,157 @@
+//! A structured path to a specific location in a schema. See the docs on [Path].
+
+mod display;
+mod parse;
+
+use std::fmt;
+
+type ParseResult<T> = Result<T, ParseError>;
+
+#[derive(Debug)]
+pub struct ParseError;
+
+/// A structured path to a specific location in a schema.
+///
+/// Paths have a structured string representation.
+///
+/// Each level in a path is separated by a '.' character. Directive uses, type definition extensions and schema definition extensions have an index to distinguish between them. The index is optional.
+///
+/// First level:
+///
+/// - Type definitions are unprefixed.
+/// - Type extensions have an index, for example `Query[3]`.
+/// - Directive definitions are prefixed with an `@`: `@authorized`.
+/// - `:schema` for schema definitions, `:schema[1]` (index) for extensions.
+///
+/// Second level:
+///
+/// - Fields, union members, enum values and input object fields are unprefixed.
+/// - Directives on types and schema definitions are prefixed with an `@` and followed by an index: `@key[0]`.
+/// - Interface implementations are prefixed with an `&`: `&SomeInterface`.
+///
+/// Third level:
+///
+/// - Field arguments are unprefixed.
+/// - Directives on fields and enum values are prefixed with an `@` and followed by an index: `@include[0]`.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub enum Path<'a> {
+    SchemaDefinition,
+    SchemaExtension(usize),
+    TypeDefinition(&'a str, Option<PathInType<'a>>),
+    TypeExtension(&'a str, usize, Option<PathInType<'a>>),
+    DirectiveDefinition(&'a str),
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub enum PathInType<'a> {
+    InField(&'a str, Option<PathInField<'a>>),
+    InDirective(&'a str, usize),
+    InterfaceImplementation(&'a str),
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub enum PathInField<'a> {
+    InArgument(&'a str),
+    InDirective(&'a str, usize),
+}
+
+fn is_valid_graphql_name(s: &str) -> bool {
+    let mut chars = s.chars();
+
+    let Some(first_char) = chars.next() else {
+        return false;
+    };
+
+    if !first_char.is_ascii_alphabetic() && first_char != '_' {
+        return false;
+    }
+
+    for c in chars {
+        if !c.is_ascii_alphanumeric() && c != '_' {
+            return false;
+        }
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic)]
+
+    use super::*;
+
+    #[test]
+    fn error_tests() {
+        fn expect_error(path: &str) {
+            match Path::parse(path) {
+                Err(_) => (),
+                Ok(found) => panic!("Expected error for path: {path}, got: {found:?}"),
+            }
+        }
+
+        for case in [
+            "",
+            "s:",
+            "s:meow",
+            ":schema[-1]",
+            ":schema.something",
+            ":s",
+            ":s[1]",
+            ":something",
+            "t:something",
+            "something.:s",
+            "10",
+            "test.",
+            "test[10].",
+            "test.@siblings.",
+            // Directive applications without index.
+            "myObject._abc1.@requires",
+            "_my_object.@key",
+            // Empty directive name
+            "@",
+            "_my_object.@",
+            // Index on a directive definition
+            "@test[0]",
+            "myObject.&MyInterface.a",
+            "myObject.&MyInterface.",
+        ] {
+            expect_error(case);
+        }
+    }
+
+    #[test]
+    fn roundtrip_tests() {
+        fn test(path: &str) {
+            let Ok(parsed) = Path::parse(path) else {
+                panic!("Failed to parse path: {path}")
+            };
+            let formatted = parsed.to_string();
+            assert_eq!(path, formatted);
+        }
+
+        for case in [
+            ":schema",
+            ":schema[0]",
+            ":schema[1]",
+            ":schema[100]",
+            "@meow",
+            "@deprecated",
+            "@something__else",
+            "@join__type",
+            "my_union",
+            "__my_input_object[32]",
+            "_my_object.id",
+            "_my_object.@key[0]",
+            "myObject[10].id",
+            "myObject.@join__type[0]",
+            "myObject._abc1",
+            "myObject._abc1.@requires[0]",
+            "myObject._abc1.@requires[100]",
+            "myObject._abc1.arg1",
+            "myObject.&MyInterface",
+        ] {
+            test(case);
+        }
+    }
+}

--- a/crates/graphql-schema-diff/src/path/display.rs
+++ b/crates/graphql-schema-diff/src/path/display.rs
@@ -1,0 +1,83 @@
+use super::*;
+
+impl fmt::Display for Path<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Path::SchemaDefinition => f.write_str(":schema"),
+            Path::SchemaExtension(idx) => {
+                f.write_str(":schema")?;
+                write_index(idx, f)
+            }
+            Path::TypeDefinition(type_name, path_in_type) => {
+                f.write_str(type_name)?;
+
+                if let Some(path_in_type) = path_in_type {
+                    f.write_str(".")?;
+                    path_in_type.fmt(f)
+                } else {
+                    Ok(())
+                }
+            }
+            Path::TypeExtension(type_name, extension_idx, path_in_type) => {
+                f.write_str(type_name)?;
+                write_index(extension_idx, f)?;
+
+                if let Some(path_in_type) = path_in_type {
+                    f.write_str(".")?;
+                    path_in_type.fmt(f)
+                } else {
+                    Ok(())
+                }
+            }
+            Path::DirectiveDefinition(directive_name) => {
+                f.write_str("@")?;
+                f.write_str(directive_name)
+            }
+        }
+    }
+}
+
+impl fmt::Display for PathInType<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PathInType::InField(field_name, path_in_field) => {
+                f.write_str(field_name)?;
+
+                if let Some(path_in_field) = path_in_field {
+                    f.write_str(".")?;
+                    path_in_field.fmt(f)
+                } else {
+                    Ok(())
+                }
+            }
+            PathInType::InDirective(directive_name, directive_index) => {
+                f.write_str("@")?;
+                f.write_str(directive_name)?;
+                write_index(directive_index, f)
+            }
+            PathInType::InterfaceImplementation(interface_name) => {
+                f.write_str("&")?;
+                f.write_str(interface_name)
+            }
+        }
+    }
+}
+
+impl fmt::Display for PathInField<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PathInField::InArgument(arg_name) => f.write_str(arg_name),
+            PathInField::InDirective(directive_name, directive_idx) => {
+                f.write_str("@")?;
+                f.write_str(directive_name)?;
+                write_index(directive_idx, f)
+            }
+        }
+    }
+}
+
+fn write_index(idx: &usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str("[")?;
+    fmt::Display::fmt(&idx, f)?;
+    f.write_str("]")
+}

--- a/crates/graphql-schema-diff/src/path/parse.rs
+++ b/crates/graphql-schema-diff/src/path/parse.rs
@@ -1,0 +1,173 @@
+use super::*;
+
+impl<'a> Path<'a> {
+    pub fn parse(s: &'a str) -> ParseResult<Path<'a>> {
+        let mut segments = s.split('.');
+
+        let first_segment = segments.next().filter(|s| !s.is_empty()).ok_or(ParseError)?;
+
+        // Is it a schema definition or extension?
+        if let Some(suffix) = first_segment.strip_prefix(":schema") {
+            if segments.next().is_some() {
+                return Err(ParseError);
+            }
+
+            if suffix.is_empty() {
+                return Ok(Path::SchemaDefinition);
+            }
+
+            let index = parse_index(suffix)?;
+            return Ok(Path::SchemaExtension(index));
+        }
+
+        // Is it a directive definition?
+        if let Some(name) = first_segment.strip_prefix('@') {
+            if !is_valid_graphql_name(name) {
+                return Err(ParseError);
+            }
+
+            if segments.next().is_some() {
+                return Err(ParseError);
+            }
+
+            return Ok(Path::DirectiveDefinition(name));
+        }
+
+        // The only remaining possibility is a type definition
+        let (name, idx) = parse_name_and_optional_index(first_segment)?;
+
+        if let Some(idx) = idx {
+            Ok(Path::TypeExtension(name, idx, Self::parse_path_in_type(segments)?))
+        } else {
+            Ok(Path::TypeDefinition(name, Self::parse_path_in_type(segments)?))
+        }
+    }
+
+    fn parse_path_in_type(mut segments: impl Iterator<Item = &'a str>) -> ParseResult<Option<PathInType<'a>>> {
+        let segment = match segments.next() {
+            Some("") => return Err(ParseError),
+            Some(segment) => segment,
+            None => return Ok(None),
+        };
+
+        // Is it a directive path?
+        if let Some(suffix) = segment.strip_prefix('@') {
+            let (name, idx) = parse_name_and_optional_index(suffix)?;
+
+            if segments.next().is_some() {
+                return Err(ParseError);
+            }
+
+            let Some(idx) = idx else {
+                return Err(ParseError);
+            };
+
+            return Ok(Some(PathInType::InDirective(name, idx)));
+        }
+
+        // Is it an interface implementation?
+        if let Some(suffix) = segment.strip_prefix('&') {
+            if !is_valid_graphql_name(suffix) {
+                return Err(ParseError);
+            }
+
+            if segments.next().is_some() {
+                return Err(ParseError);
+            }
+
+            return Ok(Some(PathInType::InterfaceImplementation(suffix)));
+        }
+
+        // The only other possibility is that we have a field / union member / enum value name.
+        if !is_valid_graphql_name(segment) {
+            return Err(ParseError);
+        }
+
+        Ok(Some(PathInType::InField(segment, Self::parse_path_in_field(segments)?)))
+    }
+
+    fn parse_path_in_field(mut segments: impl Iterator<Item = &'a str>) -> ParseResult<Option<PathInField<'a>>> {
+        let segment = match segments.next() {
+            Some("") => return Err(ParseError),
+            Some(segment) => segment,
+            None => return Ok(None),
+        };
+
+        // To be implemented.
+        if segments.next().is_some() {
+            return Err(ParseError);
+        }
+
+        // Is it a directive path?
+        if let Some(suffix) = segment.strip_prefix('@') {
+            let (name, Some(idx)) = parse_name_and_optional_index(suffix)? else {
+                return Err(ParseError);
+            };
+
+            if segments.next().is_some() {
+                return Err(ParseError);
+            }
+
+            return Ok(Some(PathInField::InDirective(name, idx)));
+        }
+
+        // The only other possibility is that we have an argument name.
+        if !is_valid_graphql_name(segment) {
+            return Err(ParseError);
+        }
+
+        Ok(Some(PathInField::InArgument(segment)))
+    }
+}
+
+fn parse_name_and_optional_index(s: &str) -> ParseResult<(&str, Option<usize>)> {
+    let bracket_idx = s.chars().position(|c| c == '[');
+
+    let name = bracket_idx.map(|idx| &s[..idx]).unwrap_or(s);
+
+    if !is_valid_graphql_name(name) {
+        return Err(ParseError);
+    }
+
+    let idx = if let Some(bracket_idx) = bracket_idx {
+        Some(parse_index(&s[bracket_idx..])?)
+    } else {
+        None
+    };
+
+    Ok((name, idx))
+}
+
+fn parse_index(s: &str) -> ParseResult<usize> {
+    if !s.starts_with('[') || !s.ends_with(']') {
+        return Err(ParseError);
+    }
+
+    let idx = &s[1..s.len() - 1];
+
+    if !idx.chars().any(|char| char.is_ascii_digit()) {
+        return Err(ParseError);
+    }
+
+    idx.parse::<usize>().map_err(|_| ParseError)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_index_tests() {
+        assert_eq!(parse_index("[0]").unwrap(), 0);
+        assert_eq!(parse_index("[10]").unwrap(), 10);
+        assert_eq!(parse_index("[1243247]").unwrap(), 1243247);
+        assert_eq!(parse_index("[03]").unwrap(), 3);
+
+        assert!(parse_index("3").is_err());
+        assert!(parse_index("[3").is_err());
+        assert!(parse_index("3]").is_err());
+        assert!(parse_index("[[3]]").is_err());
+        assert!(parse_index("[0x3]").is_err());
+        assert!(parse_index("[-3]").is_err());
+    }
+}

--- a/crates/graphql-schema-diff/tests/diff/add_schema_definition.snapshot.json
+++ b/crates/graphql-schema-diff/tests/diff/add_schema_definition.snapshot.json
@@ -1,7 +1,7 @@
 {
   "src → target": [
     {
-      "path": "",
+      "path": ":schema",
       "kind": "AddSchemaDefinition",
       "span": {
         "start": 57,
@@ -11,7 +11,7 @@
   ],
   "target → src": [
     {
-      "path": "",
+      "path": ":schema",
       "kind": "RemoveSchemaDefinition",
       "span": {
         "start": 0,

--- a/crates/graphql-schema-diff/tests/diff/add_schema_extension.snapshot.json
+++ b/crates/graphql-schema-diff/tests/diff/add_schema_extension.snapshot.json
@@ -1,7 +1,7 @@
 {
   "src → target": [
     {
-      "path": "",
+      "path": ":schema[0]",
       "kind": "RemoveSchemaExtension",
       "span": {
         "start": 7,
@@ -11,7 +11,7 @@
   ],
   "target → src": [
     {
-      "path": "",
+      "path": ":schema[0]",
       "kind": "AddSchemaExtension",
       "span": {
         "start": 7,

--- a/crates/graphql-schema-diff/tests/diff/interface_implements_interface.snapshot.json
+++ b/crates/graphql-schema-diff/tests/diff/interface_implements_interface.snapshot.json
@@ -1,7 +1,7 @@
 {
   "src → target": [
     {
-      "path": "Candy.Cookie",
+      "path": "Cookie.&Candy",
       "kind": "AddInterfaceImplementation",
       "span": {
         "start": 0,
@@ -11,7 +11,7 @@
   ],
   "target → src": [
     {
-      "path": "Candy.Cookie",
+      "path": "Cookie.&Candy",
       "kind": "RemoveInterfaceImplementation",
       "span": {
         "start": 0,

--- a/crates/graphql-schema-diff/tests/diff/mutation_type_changed.snapshot.json
+++ b/crates/graphql-schema-diff/tests/diff/mutation_type_changed.snapshot.json
@@ -1,7 +1,7 @@
 {
   "src → target": [
     {
-      "path": "",
+      "path": ":schema",
       "kind": "ChangeMutationType",
       "span": {
         "start": 45,
@@ -11,7 +11,7 @@
   ],
   "target → src": [
     {
-      "path": "",
+      "path": ":schema",
       "kind": "ChangeMutationType",
       "span": {
         "start": 45,

--- a/crates/graphql-schema-diff/tests/diff/object_interface.snapshot.json
+++ b/crates/graphql-schema-diff/tests/diff/object_interface.snapshot.json
@@ -1,7 +1,7 @@
 {
   "src → target": [
     {
-      "path": "Candy.Cookie",
+      "path": "Cookie.&Candy",
       "kind": "AddInterfaceImplementation",
       "span": {
         "start": 0,
@@ -11,7 +11,7 @@
   ],
   "target → src": [
     {
-      "path": "Candy.Cookie",
+      "path": "Cookie.&Candy",
       "kind": "RemoveInterfaceImplementation",
       "span": {
         "start": 0,

--- a/crates/graphql-schema-diff/tests/diff/query_type_changed.snapshot.json
+++ b/crates/graphql-schema-diff/tests/diff/query_type_changed.snapshot.json
@@ -1,7 +1,7 @@
 {
   "src → target": [
     {
-      "path": "",
+      "path": ":schema",
       "kind": "ChangeQueryType",
       "span": {
         "start": 52,
@@ -11,7 +11,7 @@
   ],
   "target → src": [
     {
-      "path": "",
+      "path": ":schema",
       "kind": "ChangeQueryType",
       "span": {
         "start": 32,

--- a/crates/graphql-schema-diff/tests/diff/subscription_type_changed.snapshot.json
+++ b/crates/graphql-schema-diff/tests/diff/subscription_type_changed.snapshot.json
@@ -1,7 +1,7 @@
 {
   "src → target": [
     {
-      "path": "",
+      "path": ":schema",
       "kind": "ChangeMutationType",
       "span": {
         "start": 63,
@@ -9,7 +9,7 @@
       }
     },
     {
-      "path": "",
+      "path": ":schema",
       "kind": "ChangeSubscriptionType",
       "span": {
         "start": 80,
@@ -19,7 +19,7 @@
   ],
   "target → src": [
     {
-      "path": "",
+      "path": ":schema",
       "kind": "ChangeMutationType",
       "span": {
         "start": 49,
@@ -27,7 +27,7 @@
       }
     },
     {
-      "path": "",
+      "path": ":schema",
       "kind": "ChangeSubscriptionType",
       "span": {
         "start": 66,

--- a/crates/operation-checks/src/check/rules.rs
+++ b/crates/operation-checks/src/check/rules.rs
@@ -282,19 +282,19 @@ pub(super) fn remove_interface_implementation(
         change, check_params, ..
     }: CheckArgs<'_, '_>,
 ) -> Option<CheckDiagnostic> {
+    let (type_name, interface_name) = change.path.split_once('.')?;
+    let interface_name = interface_name.trim_start_matches('&');
+
     if !&check_params
         .field_usage
         .type_condition_counts
-        .contains_key(&change.path)
+        .contains_key(&format!("{interface_name}.{type_name}"))
     {
         return None;
     }
 
     Some(CheckDiagnostic {
-        message: format!(
-            "The interface implementation `{}` was removed but it is still used by clients.",
-            change.path
-        ),
+        message: format!("The interface implementation for `{interface_name}` on `{type_name}` was removed but it is still used by clients."),
         severity: Severity::Error,
     })
 }

--- a/crates/operation-checks/tests/cases/remove_used_interface_implementer.snapshot
+++ b/crates/operation-checks/tests/cases/remove_used_interface_implementer.snapshot
@@ -1,7 +1,7 @@
 Forward:
 [
     CheckDiagnostic {
-        message: "The interface implementation `SpeechCondition.Lisp` was removed but it is still used by clients.",
+        message: "The interface implementation for `SpeechCondition` on `Lisp` was removed but it is still used by clients.",
         severity: Error,
     },
 ]


### PR DESCRIPTION
Until now, the paths in a change have been of the format `a.b.c`, just nesting a path. This PR introduces a more structured representation, along with a new string representation, that should address three problems and allow us to represent any path within a GraphQL schema.

1. We need to be able to address items that don't have their own names. These are schema and type extensions, as well as repeatable directives. So I introduced indexing, like `:schema[2]`, `Query[0]`, `@tag[3]`, etc.

2. Introduce tokens to distinguish between different namespaces that could be addressed by a path. On type definitions, we want to distinguish paths leading to fields (or enum values, etc.) and paths to directives on the types. To give an example, disambiguate cases like this:
  ```graphql
  # What does the path "Test.key" refer to?
  type Test @key(fields: "id") {
    id: ID!
    key: String!
  }
  ```
  Similar problem at the top level. This is valid GraphQL:

  ```graphql
  type test { id: ID! }
  directive @test
  ```
  So for directives, we have the `@` prefix. This gives us `test` vs `@test` in the example above.

3. This results in a small grammar. So there should be a single way to parse and print it, and that should be tested. So that is done in the new `path` module.

This PR started as a port of https://github.com/grafbase/api/blob/37969f88372f774f973e247174b1d5ef6c2c0f20/services/graphql/src/application/schema_proposal/comment/sdl_map/path.rs, with a suggestion from @obmarg on a more readable syntax (`@directive` instead of `d:directive`). I changed how indexes are represented (`type[0]` instead of `t:type:0` for example) and had to introduce special syntax (`&`) for interface implementations, since those were missing.

The path module in grafbase/api will be immediately replaced with the implementation in this PR.

closes GB-7919