### PR TITLE
chore(engine): Simplify id_derives

### DIFF
--- a/crates/engine/codegen/domain/schema.graphql
+++ b/crates/engine/codegen/domain/schema.graphql
@@ -19,7 +19,7 @@ type RootOperationTypes @meta(module: "root") {
 }
 
 union Definition @id @meta(module: "definition") @variants(remove_suffix: true) =
-    ObjectDefinition
+  | ObjectDefinition
   | InterfaceDefinition
   | UnionDefinition
   | EnumDefinition
@@ -27,12 +27,12 @@ union Definition @id @meta(module: "definition") @variants(remove_suffix: true) 
   | ScalarDefinition
 
 union EntityDefinition @id @meta(module: "entity") @variants(remove_suffix: "Definition") =
-    ObjectDefinition
+  | ObjectDefinition
   | InterfaceDefinition
 
 "Composite type is the term previously used by the GraphQL spec to describe this union."
 union CompositeType @id @meta(module: "composite_type") @variants(remove_suffix: "Definition") =
-    ObjectDefinition
+  | ObjectDefinition
   | InterfaceDefinition
   | UnionDefinition
 
@@ -41,9 +41,7 @@ type JoinImplementsDefinition @meta(module: "join_implements") @copy {
   subgraph: Subgraph!
 }
 
-type ObjectDefinition
-  @meta(module: "object", debug: false)
-  @indexed(deduplicated: true, id_size: "u32", max_id: "MAX_ID") {
+type ObjectDefinition @meta(module: "object", debug: false) @indexed(deduplicated: true, id_size: "u32") {
   name: String!
   description: String
   interfaces: [InterfaceDefinition!]!
@@ -55,9 +53,7 @@ type ObjectDefinition
   exists_in_subgraphs: [Subgraph!]!
 }
 
-type InterfaceDefinition
-  @meta(module: "interface", debug: false)
-  @indexed(deduplicated: true, id_size: "u32", max_id: "MAX_ID") {
+type InterfaceDefinition @meta(module: "interface", debug: false) @indexed(deduplicated: true, id_size: "u32") {
   name: String!
   description: String
   fields: [FieldDefinition!]!
@@ -74,7 +70,7 @@ type InterfaceDefinition
   not_fully_implemented_in: [Subgraph!]!
 }
 
-type FieldDefinition @meta(module: "field") @indexed(id_size: "u32", max_id: "MAX_ID") {
+type FieldDefinition @meta(module: "field") @indexed(id_size: "u32") {
   name: String!
   description: String
   parent_entity: EntityDefinition!
@@ -110,14 +106,14 @@ type Type @meta(module: "ty") @copy {
 }
 scalar Wrapping @copy
 
-type EnumDefinition @meta(module: "enum_def") @indexed(id_size: "u32", max_id: "MAX_ID") {
+type EnumDefinition @meta(module: "enum_def") @indexed(id_size: "u32") {
   name: String!
   description: String
   values: [EnumValue!]!
   directives: [TypeSystemDirective!]!
 }
 
-type EnumValue @meta(module: "enum_value") @indexed(id_size: "u32", max_id: "MAX_ID") {
+type EnumValue @meta(module: "enum_value") @indexed(id_size: "u32") {
   name: String!
   description: String
   directives: [TypeSystemDirective!]!
@@ -128,7 +124,7 @@ type JoinMemberDefinition @meta(module: "join_member") @copy {
   subgraph: Subgraph!
 }
 
-type UnionDefinition @meta(module: "union", debug: false) @indexed(id_size: "u32", max_id: "MAX_ID") {
+type UnionDefinition @meta(module: "union", debug: false) @indexed(id_size: "u32") {
   name: String!
   description: String
   possible_types: [ObjectDefinition!]!
@@ -144,7 +140,7 @@ type UnionDefinition @meta(module: "union", debug: false) @indexed(id_size: "u32
   not_fully_implemented_in: [Subgraph!]!
 }
 
-type ScalarDefinition @meta(module: "scalar") @indexed(id_size: "u32", max_id: "MAX_ID") {
+type ScalarDefinition @meta(module: "scalar") @indexed(id_size: "u32") {
   name: String!
   ty: ScalarType!
   description: String
@@ -154,14 +150,14 @@ type ScalarDefinition @meta(module: "scalar") @indexed(id_size: "u32", max_id: "
 
 scalar ScalarType @copy
 
-type InputObjectDefinition @meta(module: "input_object") @indexed(id_size: "u32", max_id: "MAX_ID") {
+type InputObjectDefinition @meta(module: "input_object") @indexed(id_size: "u32") {
   name: String!
   description: String
   input_fields: [InputValueDefinition!]!
   directives: [TypeSystemDirective!]!
 }
 
-type InputValueDefinition @meta(module: "input_value") @indexed(id_size: "u32", max_id: "MAX_ID") {
+type InputValueDefinition @meta(module: "input_value") @indexed(id_size: "u32") {
   name: String!
   description: String
   ty: Type!
@@ -198,7 +194,7 @@ union TypeSystemDirective
   @id
   @meta(module: "directive")
   @variants(empty: ["Authenticated"], remove_suffix: "Directive") =
-    DeprecatedDirective
+  | DeprecatedDirective
   | RequiresScopesDirective
   | AuthorizedDirective
   | CostDirective
@@ -212,7 +208,7 @@ type DeprecatedDirective
 
 scalar RequiresScopesDirective @indexed @record
 
-type AuthorizedDirective @meta(module: "directive/authorized") @indexed(id_size: "u32", max_id: "MAX_ID") {
+type AuthorizedDirective @meta(module: "directive/authorized") @indexed(id_size: "u32") {
   arguments: InputValueSet!
   fields: FieldSet @field(record_field_name: "fields_id")
   node: FieldSet
@@ -254,8 +250,8 @@ union NameOrPattern @id @meta(module: "header_rule") @variants(names: ["Pattern"
 union HeaderRule
   @meta(module: "header_rule")
   @variants(remove_suffix: true)
-  @indexed(id_size: "u32", max_id: "MAX_ID", deduplicated: true) =
-    ForwardHeaderRule
+  @indexed(id_size: "u32", deduplicated: true) =
+  | ForwardHeaderRule
   | InsertHeaderRule
   | RemoveHeaderRule
   | RenameDuplicateHeaderRule
@@ -288,8 +284,8 @@ type RenameDuplicateHeaderRule @meta(module: "header_rule/rename_duplicate") @co
 union ResolverDefinition
   @meta(module: "resolver")
   @variants(empty: ["Introspection"], remove_suffix: true)
-  @indexed(deduplicated: true, id_size: "u32", max_id: "MAX_ID") =
-    GraphqlRootFieldResolverDefinition
+  @indexed(deduplicated: true, id_size: "u32") =
+  | GraphqlRootFieldResolverDefinition
   | GraphqlFederationEntityResolverDefinition
 
 type GraphqlRootFieldResolverDefinition @meta(module: "resolver/graphql") @copy {

--- a/crates/engine/codegen/src/domain.rs
+++ b/crates/engine/codegen/src/domain.rs
@@ -282,6 +282,5 @@ pub struct Meta {
 pub struct Indexed {
     pub id_struct_name: String,
     pub id_size: Option<String>,
-    pub max_id: Option<String>,
     pub deduplicated: bool,
 }

--- a/crates/engine/codegen/src/generation/id.rs
+++ b/crates/engine/codegen/src/generation/id.rs
@@ -9,18 +9,9 @@ pub fn generate_id(domain: &Domain, indexed: &Indexed) -> anyhow::Result<Vec<Tok
 
     let id_struct = if let Some(size) = &indexed.id_size {
         let size = Ident::new(size, Span::call_site());
-        if let Some(max_id) = &indexed.max_id {
-            let max_id = Ident::new(max_id, Span::call_site());
-            quote! {
-                #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-                #[max(#max_id)]
-                pub #public struct #id_struct_name(std::num::NonZero<#size>);
-            }
-        } else {
-            quote! {
-                #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-                pub #public struct #id_struct_name(std::num::NonZero<#size>);
-            }
+        quote! {
+            #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
+            pub #public struct #id_struct_name(std::num::NonZero<#size>);
         }
     } else {
         quote! {}

--- a/crates/engine/codegen/src/loader.rs
+++ b/crates/engine/codegen/src/loader.rs
@@ -444,22 +444,16 @@ fn parse_meta<'a>(mut directives: Iter<'a, Directive<'a>>) -> Option<domain::Met
 #[deser(default)]
 struct IndexedDirective {
     id_size: Option<String>,
-    max_id: Option<String>,
     deduplicated: bool,
 }
 
 fn parse_indexed<'a>(name: &str, mut directives: Iter<'a, Directive<'a>>) -> Option<domain::Indexed> {
     let directive = directives.find(|directive| directive.name() == "indexed")?;
-    let IndexedDirective {
-        id_size,
-        max_id,
-        deduplicated,
-    } = directive.deserialize().unwrap();
+    let IndexedDirective { id_size, deduplicated } = directive.deserialize().unwrap();
 
     Some(domain::Indexed {
         id_struct_name: format!("{name}Id"),
         id_size,
-        max_id,
         deduplicated,
     })
 }

--- a/crates/engine/schema/src/directive/requires_scopes.rs
+++ b/crates/engine/schema/src/directive/requires_scopes.rs
@@ -1,6 +1,6 @@
 use walker::{Iter, Walk};
 
-use crate::{Schema, StringId, MAX_ID};
+use crate::{Schema, StringId};
 
 #[derive(Debug, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct RequiresScopesDirectiveRecord {
@@ -18,7 +18,6 @@ impl RequiresScopesDirectiveRecord {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-#[max(MAX_ID)]
 pub struct RequiresScopesDirectiveId(std::num::NonZero<u32>);
 
 /// An index into the outer vector of an instance of RequiredScopes

--- a/crates/engine/schema/src/field_set/mod.rs
+++ b/crates/engine/schema/src/field_set/mod.rs
@@ -6,7 +6,7 @@ use walker::{Iter, Walk};
 
 pub use item::*;
 
-use crate::{Schema, MAX_ID};
+use crate::Schema;
 
 static EMPTY: FieldSetRecord = FieldSetRecord(Vec::new());
 
@@ -80,7 +80,6 @@ impl<'a> Walk<&'a Schema> for &FieldSetRecord {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-#[max(MAX_ID)]
 pub struct FieldSetId(std::num::NonZero<u32>);
 
 impl<'a> Walk<&'a Schema> for FieldSetId {

--- a/crates/engine/schema/src/generated/composite_type.rs
+++ b/crates/engine/schema/src/generated/composite_type.rs
@@ -19,7 +19,7 @@ use walker::Walk;
 ///
 /// ```custom,{.language-graphql}
 /// union CompositeType @id @meta(module: "composite_type") @variants(remove_suffix: "Definition") =
-///     ObjectDefinition
+///   | ObjectDefinition
 ///   | InterfaceDefinition
 ///   | UnionDefinition
 /// ```

--- a/crates/engine/schema/src/generated/definition.rs
+++ b/crates/engine/schema/src/generated/definition.rs
@@ -17,7 +17,7 @@ use walker::Walk;
 ///
 /// ```custom,{.language-graphql}
 /// union Definition @id @meta(module: "definition") @variants(remove_suffix: true) =
-///     ObjectDefinition
+///   | ObjectDefinition
 ///   | InterfaceDefinition
 ///   | UnionDefinition
 ///   | EnumDefinition

--- a/crates/engine/schema/src/generated/directive.rs
+++ b/crates/engine/schema/src/generated/directive.rs
@@ -20,7 +20,7 @@ use walker::Walk;
 ///   @id
 ///   @meta(module: "directive")
 ///   @variants(empty: ["Authenticated"], remove_suffix: "Directive") =
-///     DeprecatedDirective
+///   | DeprecatedDirective
 ///   | RequiresScopesDirective
 ///   | AuthorizedDirective
 ///   | CostDirective

--- a/crates/engine/schema/src/generated/directive/authorized.rs
+++ b/crates/engine/schema/src/generated/directive/authorized.rs
@@ -9,7 +9,7 @@ use walker::Walk;
 /// Generated from:
 ///
 /// ```custom,{.language-graphql}
-/// type AuthorizedDirective @meta(module: "directive/authorized") @indexed(id_size: "u32", max_id: "MAX_ID") {
+/// type AuthorizedDirective @meta(module: "directive/authorized") @indexed(id_size: "u32") {
 ///   arguments: InputValueSet!
 ///   fields: FieldSet @field(record_field_name: "fields_id")
 ///   node: FieldSet
@@ -25,7 +25,6 @@ pub struct AuthorizedDirectiveRecord {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-#[max(MAX_ID)]
 pub struct AuthorizedDirectiveId(std::num::NonZero<u32>);
 
 #[derive(Clone, Copy)]

--- a/crates/engine/schema/src/generated/entity.rs
+++ b/crates/engine/schema/src/generated/entity.rs
@@ -13,7 +13,7 @@ use walker::Walk;
 ///
 /// ```custom,{.language-graphql}
 /// union EntityDefinition @id @meta(module: "entity") @variants(remove_suffix: "Definition") =
-///     ObjectDefinition
+///   | ObjectDefinition
 ///   | InterfaceDefinition
 /// ```
 #[derive(serde::Serialize, serde::Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/engine/schema/src/generated/enum_def.rs
+++ b/crates/engine/schema/src/generated/enum_def.rs
@@ -13,7 +13,7 @@ use walker::{Iter, Walk};
 /// Generated from:
 ///
 /// ```custom,{.language-graphql}
-/// type EnumDefinition @meta(module: "enum_def") @indexed(id_size: "u32", max_id: "MAX_ID") {
+/// type EnumDefinition @meta(module: "enum_def") @indexed(id_size: "u32") {
 ///   name: String!
 ///   description: String
 ///   values: [EnumValue!]!
@@ -29,7 +29,6 @@ pub struct EnumDefinitionRecord {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-#[max(MAX_ID)]
 pub struct EnumDefinitionId(std::num::NonZero<u32>);
 
 #[derive(Clone, Copy)]

--- a/crates/engine/schema/src/generated/enum_value.rs
+++ b/crates/engine/schema/src/generated/enum_value.rs
@@ -13,7 +13,7 @@ use walker::{Iter, Walk};
 /// Generated from:
 ///
 /// ```custom,{.language-graphql}
-/// type EnumValue @meta(module: "enum_value") @indexed(id_size: "u32", max_id: "MAX_ID") {
+/// type EnumValue @meta(module: "enum_value") @indexed(id_size: "u32") {
 ///   name: String!
 ///   description: String
 ///   directives: [TypeSystemDirective!]!
@@ -27,7 +27,6 @@ pub struct EnumValueRecord {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-#[max(MAX_ID)]
 pub struct EnumValueId(std::num::NonZero<u32>);
 
 #[derive(Clone, Copy)]

--- a/crates/engine/schema/src/generated/field.rs
+++ b/crates/engine/schema/src/generated/field.rs
@@ -21,7 +21,7 @@ use walker::{Iter, Walk};
 /// Generated from:
 ///
 /// ```custom,{.language-graphql}
-/// type FieldDefinition @meta(module: "field") @indexed(id_size: "u32", max_id: "MAX_ID") {
+/// type FieldDefinition @meta(module: "field") @indexed(id_size: "u32") {
 ///   name: String!
 ///   description: String
 ///   parent_entity: EntityDefinition!
@@ -61,7 +61,6 @@ pub struct FieldDefinitionRecord {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-#[max(MAX_ID)]
 pub struct FieldDefinitionId(std::num::NonZero<u32>);
 
 #[derive(Clone, Copy)]

--- a/crates/engine/schema/src/generated/header_rule.rs
+++ b/crates/engine/schema/src/generated/header_rule.rs
@@ -124,8 +124,8 @@ impl<'a> NameOrPattern<'a> {
 /// union HeaderRule
 ///   @meta(module: "header_rule")
 ///   @variants(remove_suffix: true)
-///   @indexed(id_size: "u32", max_id: "MAX_ID", deduplicated: true) =
-///     ForwardHeaderRule
+///   @indexed(id_size: "u32", deduplicated: true) =
+///   | ForwardHeaderRule
 ///   | InsertHeaderRule
 ///   | RemoveHeaderRule
 ///   | RenameDuplicateHeaderRule
@@ -189,7 +189,6 @@ impl HeaderRuleRecord {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-#[max(MAX_ID)]
 pub struct HeaderRuleId(std::num::NonZero<u32>);
 
 #[derive(Clone, Copy)]

--- a/crates/engine/schema/src/generated/input_object.rs
+++ b/crates/engine/schema/src/generated/input_object.rs
@@ -13,7 +13,7 @@ use walker::{Iter, Walk};
 /// Generated from:
 ///
 /// ```custom,{.language-graphql}
-/// type InputObjectDefinition @meta(module: "input_object") @indexed(id_size: "u32", max_id: "MAX_ID") {
+/// type InputObjectDefinition @meta(module: "input_object") @indexed(id_size: "u32") {
 ///   name: String!
 ///   description: String
 ///   input_fields: [InputValueDefinition!]!
@@ -29,7 +29,6 @@ pub struct InputObjectDefinitionRecord {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-#[max(MAX_ID)]
 pub struct InputObjectDefinitionId(std::num::NonZero<u32>);
 
 #[derive(Clone, Copy)]

--- a/crates/engine/schema/src/generated/input_value.rs
+++ b/crates/engine/schema/src/generated/input_value.rs
@@ -13,7 +13,7 @@ use walker::{Iter, Walk};
 /// Generated from:
 ///
 /// ```custom,{.language-graphql}
-/// type InputValueDefinition @meta(module: "input_value") @indexed(id_size: "u32", max_id: "MAX_ID") {
+/// type InputValueDefinition @meta(module: "input_value") @indexed(id_size: "u32") {
 ///   name: String!
 ///   description: String
 ///   ty: Type!
@@ -31,7 +31,6 @@ pub struct InputValueDefinitionRecord {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-#[max(MAX_ID)]
 pub struct InputValueDefinitionId(std::num::NonZero<u32>);
 
 #[derive(Clone, Copy)]

--- a/crates/engine/schema/src/generated/interface.rs
+++ b/crates/engine/schema/src/generated/interface.rs
@@ -16,9 +16,7 @@ use walker::{Iter, Walk};
 /// Generated from:
 ///
 /// ```custom,{.language-graphql}
-/// type InterfaceDefinition
-///   @meta(module: "interface", debug: false)
-///   @indexed(deduplicated: true, id_size: "u32", max_id: "MAX_ID") {
+/// type InterfaceDefinition @meta(module: "interface", debug: false) @indexed(deduplicated: true, id_size: "u32") {
 ///   name: String!
 ///   description: String
 ///   fields: [FieldDefinition!]!
@@ -52,7 +50,6 @@ pub struct InterfaceDefinitionRecord {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-#[max(MAX_ID)]
 pub struct InterfaceDefinitionId(std::num::NonZero<u32>);
 
 #[derive(Clone, Copy)]

--- a/crates/engine/schema/src/generated/object.rs
+++ b/crates/engine/schema/src/generated/object.rs
@@ -16,9 +16,7 @@ use walker::{Iter, Walk};
 /// Generated from:
 ///
 /// ```custom,{.language-graphql}
-/// type ObjectDefinition
-///   @meta(module: "object", debug: false)
-///   @indexed(deduplicated: true, id_size: "u32", max_id: "MAX_ID") {
+/// type ObjectDefinition @meta(module: "object", debug: false) @indexed(deduplicated: true, id_size: "u32") {
 ///   name: String!
 ///   description: String
 ///   interfaces: [InterfaceDefinition!]!
@@ -44,7 +42,6 @@ pub struct ObjectDefinitionRecord {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-#[max(MAX_ID)]
 pub struct ObjectDefinitionId(std::num::NonZero<u32>);
 
 #[derive(Clone, Copy)]

--- a/crates/engine/schema/src/generated/resolver.rs
+++ b/crates/engine/schema/src/generated/resolver.rs
@@ -15,8 +15,8 @@ use walker::Walk;
 /// union ResolverDefinition
 ///   @meta(module: "resolver")
 ///   @variants(empty: ["Introspection"], remove_suffix: true)
-///   @indexed(deduplicated: true, id_size: "u32", max_id: "MAX_ID") =
-///     GraphqlRootFieldResolverDefinition
+///   @indexed(deduplicated: true, id_size: "u32") =
+///   | GraphqlRootFieldResolverDefinition
 ///   | GraphqlFederationEntityResolverDefinition
 /// ```
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -61,7 +61,6 @@ impl ResolverDefinitionRecord {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-#[max(MAX_ID)]
 pub struct ResolverDefinitionId(std::num::NonZero<u32>);
 
 #[derive(Clone, Copy)]

--- a/crates/engine/schema/src/generated/scalar.rs
+++ b/crates/engine/schema/src/generated/scalar.rs
@@ -13,7 +13,7 @@ use walker::{Iter, Walk};
 /// Generated from:
 ///
 /// ```custom,{.language-graphql}
-/// type ScalarDefinition @meta(module: "scalar") @indexed(id_size: "u32", max_id: "MAX_ID") {
+/// type ScalarDefinition @meta(module: "scalar") @indexed(id_size: "u32") {
 ///   name: String!
 ///   ty: ScalarType!
 ///   description: String
@@ -31,7 +31,6 @@ pub struct ScalarDefinitionRecord {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-#[max(MAX_ID)]
 pub struct ScalarDefinitionId(std::num::NonZero<u32>);
 
 #[derive(Clone, Copy)]

--- a/crates/engine/schema/src/generated/union.rs
+++ b/crates/engine/schema/src/generated/union.rs
@@ -16,7 +16,7 @@ use walker::{Iter, Walk};
 /// Generated from:
 ///
 /// ```custom,{.language-graphql}
-/// type UnionDefinition @meta(module: "union", debug: false) @indexed(id_size: "u32", max_id: "MAX_ID") {
+/// type UnionDefinition @meta(module: "union", debug: false) @indexed(id_size: "u32") {
 ///   name: String!
 ///   description: String
 ///   possible_types: [ObjectDefinition!]!
@@ -48,7 +48,6 @@ pub struct UnionDefinitionRecord {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-#[max(MAX_ID)]
 pub struct UnionDefinitionId(std::num::NonZero<u32>);
 
 #[derive(Clone, Copy)]

--- a/crates/engine/schema/src/ids.rs
+++ b/crates/engine/schema/src/ids.rs
@@ -6,11 +6,6 @@ use walker::Walk;
 
 use crate::Schema;
 
-/// Reserving the 4 upper bits for some fun with bit packing. It still leaves 268 million possible values.
-/// And it's way easier to increase that limit if needed that to reserve some bits later!
-/// Currently, we use the two upper bits of the FieldId for the ResponseEdge in the engine.
-pub(crate) const MAX_ID: u32 = (1 << 29) - 1;
-
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
 #[max(MAX_ID)]
 pub struct UrlId(NonZero<u32>);

--- a/crates/engine/schema/src/prelude.rs
+++ b/crates/engine/schema/src/prelude.rs
@@ -1,4 +1,3 @@
-pub(crate) use crate::ids::MAX_ID;
 /// A prelude module for all the generated modules
 ///
 /// Anything in here will be pulled into scope for the modules

--- a/crates/engine/src/operation/solve/model/mod.rs
+++ b/crates/engine/src/operation/solve/model/mod.rs
@@ -5,8 +5,6 @@ mod hydrate;
 mod prelude;
 mod selection_set;
 
-use std::num::NonZero;
-
 use crate::{
     operation::QueryInputValues,
     response::{FieldShapeId, ResponseKeys, Shapes},
@@ -96,7 +94,7 @@ pub(crate) struct SolvedOperation {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-pub struct FieldRefId(NonZero<u32>);
+pub struct FieldRefId(u32);
 
 impl<'a> Walk<SolvedOperationContext<'a>> for FieldRefId {
     type Walker<'w> = Field<'w> where 'a: 'w;
@@ -111,7 +109,7 @@ impl<'a> Walk<SolvedOperationContext<'a>> for FieldRefId {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-pub struct DataFieldRefId(NonZero<u32>);
+pub struct DataFieldRefId(u32);
 
 impl<'a> Walk<SolvedOperationContext<'a>> for DataFieldRefId {
     type Walker<'w> = DataField<'w> where 'a: 'w;
@@ -126,4 +124,4 @@ impl<'a> Walk<SolvedOperationContext<'a>> for DataFieldRefId {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-pub struct FieldShapeRefId(NonZero<u32>);
+pub struct FieldShapeRefId(u32);


### PR DESCRIPTION
Remove the max id stuff, useless. And added support to just have `u32`
instead of `NonZero<u32>`. I put a lot of `NonZero`, but not sure it's
that useful.
