### PR TITLE
chore(engine): Make non-mutable Wrapping

### DIFF
--- a/crates/engine/schema/src/introspection.rs
+++ b/crates/engine/schema/src/introspection.rs
@@ -390,7 +390,7 @@ impl<'a> IntrospectionBuilder<'a> {
 
         let args = TypeRecord {
             definition_id: __input_value.into(),
-            wrapping: Wrapping::required().wrapped_by_required_list(),
+            wrapping: Wrapping::required().wrap_list_non_null(),
         };
 
         /*
@@ -418,7 +418,7 @@ impl<'a> IntrospectionBuilder<'a> {
 
         let locations = TypeRecord {
             definition_id: __directive_location.into(),
-            wrapping: Wrapping::required().wrapped_by_required_list(),
+            wrapping: Wrapping::required().wrap_list_non_null(),
         };
 
         let __directive = self.insert_object_fields(
@@ -454,15 +454,15 @@ impl<'a> IntrospectionBuilder<'a> {
         };
         let input_fields = TypeRecord {
             definition_id: __input_value.into(),
-            wrapping: Wrapping::required().wrapped_by_nullable_list(),
+            wrapping: Wrapping::required().wrap_list(),
         };
         let nullable__field_list = TypeRecord {
             definition_id: __field.into(),
-            wrapping: Wrapping::required().wrapped_by_nullable_list(),
+            wrapping: Wrapping::required().wrap_list(),
         };
         let nullable__enum_value_list = TypeRecord {
             definition_id: __enum_value.id.into(),
-            wrapping: Wrapping::required().wrapped_by_nullable_list(),
+            wrapping: Wrapping::required().wrap_list(),
         };
 
         let required__type = TypeRecord {
@@ -475,11 +475,11 @@ impl<'a> IntrospectionBuilder<'a> {
         };
         let required__type_list = TypeRecord {
             definition_id: __type.into(),
-            wrapping: Wrapping::required().wrapped_by_required_list(),
+            wrapping: Wrapping::required().wrap_list_non_null(),
         };
         let nullable__type_list = TypeRecord {
             definition_id: __type.into(),
-            wrapping: Wrapping::required().wrapped_by_nullable_list(),
+            wrapping: Wrapping::required().wrap_list(),
         };
 
         let __type = self.insert_object_fields(
@@ -550,7 +550,7 @@ impl<'a> IntrospectionBuilder<'a> {
         */
         let required__directive_list = TypeRecord {
             definition_id: __directive.id.into(),
-            wrapping: Wrapping::required().wrapped_by_required_list(),
+            wrapping: Wrapping::required().wrap_list_non_null(),
         };
         let __schema = self.insert_object("__Schema");
 

--- a/crates/engine/schema/src/ty.rs
+++ b/crates/engine/schema/src/ty.rs
@@ -1,45 +1,8 @@
-use wrapping::ListWrapping;
-
 use crate::{Type, TypeRecord};
-
-impl TypeRecord {
-    pub fn wrapped_by(self, list_wrapping: ListWrapping) -> Self {
-        Self {
-            wrapping: self.wrapping.wrapped_by(list_wrapping),
-            ..self
-        }
-    }
-}
-
-impl Type<'_> {
-    pub fn wrapped_by(self, list_wrapping: ListWrapping) -> Self {
-        Self {
-            item: self.item.wrapped_by(list_wrapping),
-            ..self
-        }
-    }
-
-    pub fn pop_list_wrapping(&mut self) -> Option<ListWrapping> {
-        self.item.wrapping.pop_list_wrapping()
-    }
-}
 
 impl std::fmt::Display for Type<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for _ in 0..self.wrapping.list_wrappings().len() {
-            write!(f, "[")?;
-        }
-        write!(f, "{}", self.definition().name())?;
-        if self.wrapping.inner_is_required() {
-            write!(f, "!")?;
-        }
-        for wrapping in self.wrapping.list_wrappings() {
-            write!(f, "]")?;
-            if wrapping == ListWrapping::RequiredList {
-                write!(f, "!")?;
-            }
-        }
-        Ok(())
+        self.wrapping.write_type_string(self.definition().name(), f)
     }
 }
 

--- a/crates/engine/src/response/write/deserialize/object/concrete.rs
+++ b/crates/engine/src/response/write/deserialize/object/concrete.rs
@@ -362,7 +362,7 @@ impl ConcreteShapeFieldsSeed<'_, '_> {
             let result = map.next_value_seed(FieldSeed {
                 ctx: self.ctx,
                 field,
-                wrapping: field.wrapping,
+                wrapping: field.wrapping.to_mutable(),
             });
             self.ctx.path().pop();
             response_fields.push(ResponseObjectField {
@@ -383,7 +383,7 @@ impl ConcreteShapeFieldsSeed<'_, '_> {
                 let result = FieldSeed {
                     ctx: self.ctx,
                     field,
-                    wrapping: field.wrapping,
+                    wrapping: field.wrapping.to_mutable(),
                 }
                 .deserialize(serde_value::ValueDeserializer::new(stored_value.clone()));
                 self.ctx.path().pop();

--- a/crates/graphql-composition/src/emit_federated_graph/field_types_map.rs
+++ b/crates/graphql-composition/src/emit_federated_graph/field_types_map.rs
@@ -31,8 +31,8 @@ impl Context<'_> {
 
                 for wrapper in field_type.iter_wrappers() {
                     wrapping = match wrapper {
-                        subgraphs::WrapperTypeKind::List => wrapping.wrapped_by_nullable_list(),
-                        subgraphs::WrapperTypeKind::NonNullList => wrapping.wrapped_by_required_list(),
+                        subgraphs::WrapperTypeKind::List => wrapping.wrap_list(),
+                        subgraphs::WrapperTypeKind::NonNullList => wrapping.wrap_list_non_null(),
                     };
                 }
 

--- a/crates/graphql-federated-graph/src/from_sdl.rs
+++ b/crates/graphql-federated-graph/src/from_sdl.rs
@@ -153,9 +153,9 @@ impl<'a> State<'a> {
             wrapping = match wrappers.peek() {
                 Some(WrappingType::NonNull) => {
                     wrappers.next();
-                    wrapping.wrapped_by_required_list()
+                    wrapping.wrap_list_non_null()
                 }
-                None | Some(WrappingType::List) => wrapping.wrapped_by_nullable_list(),
+                None | Some(WrappingType::List) => wrapping.wrap_list(),
             }
         }
 

--- a/crates/graphql-wrapping-types/src/lib.rs
+++ b/crates/graphql-wrapping-types/src/lib.rs
@@ -1,71 +1,36 @@
-//! Wrapping is compacted into a u32 to be Copy. It's copied at various places to keep track of
-//! current wrapping. It's functionally equivalent to:
-//!
-//! ```ignore
-//! struct Wrapping {
-//!   inner_is_required: bool,
-//!   /// Innermost to outermost.
-//!   list_wrappings: VecDeque<ListWrapping>
-//! }
-//! ```
-//!
-//! Since ListWrapping has only two cases and we won't encounter absurd levels of wrapping, we
-//! can bitpack it. The current structure supports up to 21 list_wrappings.
-//!
-//! It's structured as follows:
-//!
-//!```text
-//!       start (5 bits)
-//!       ↓               ↓ list_wrapping (1 == Required / 0 == Nullable)
-//!   ┌────┐      ┌────────────────────────┐
-//!  0000_0000_0000_0000_0000_0000_0000_0000
-//!         └────┘
-//!            ↑ end (5 bits)
-//!  ↑
-//!  inner_is_required flag (1 == required)
-//!```
-//!
-//! The list_wrapping is stored from innermost to outermost and use the start and end
-//! as the positions within the list_wrapping bits. Acting like a simplified fixed capacity VecDeque.
-//! For simplicity of bit shifts the list wrapping is stored from right to left.
+mod mutable;
 
 use grafbase_workspace_hack as _;
+pub use mutable::MutableWrapping;
 
-const START_MASK: u32 = 0b0111_1100_0000_0000_0000_0000_0000_0000;
-const START_SHIFT: u32 = START_MASK.trailing_zeros();
-const END_MASK: u32 = 0b0000_0011_1110_0000_0000_0000_0000_0000;
-const END_SHIFT: u32 = END_MASK.trailing_zeros();
-const LIST_WRAPPINGS_MASK: u32 = 0b0000_0000_0001_1111_1111_1111_1111_1111;
-const MAX_LIST_WRAPINGS: u32 = LIST_WRAPPINGS_MASK.trailing_ones();
-const INNER_IS_REQUIRED_FLAG: u32 = 0b1000_0000_0000_0000_0000_0000_0000_0000;
+const LIST_WRAPPER_LENGTH_MASK: u16 = 0b0111_1000_0000_0000;
+const LIST_WRAPPER_SHIFT: u32 = LIST_WRAPPER_LENGTH_MASK.trailing_zeros();
+const LIST_WRAPPER_MASK: u16 = 0b0000_0111_1111_1111;
+const MAX_LIST_WRAPINGS: u32 = LIST_WRAPPER_MASK.trailing_ones();
+const INNER_IS_REQUIRED_FLAG: u16 = 0b1000_0000_0000_0000;
+const INNER_IS_REQUIRED_SHIFT: u32 = INNER_IS_REQUIRED_FLAG.trailing_zeros();
 
+/// It's structured as follows:
+///
+///```text
+///       list wrapper length (4 bits)
+//        |
+///       ↓     ↓ list_wrapping (1 == Required / 0 == Nullable)
+///   ┌───┐┌───────────┐
+///  0000_0000_0000_0000
+///  ↑
+///  inner_is_required flag (1 == required)
+///```
+///
+/// The list_wrapping is stored from innermost to outermost and use the start and end
+/// as the positions within the list_wrapping bits. Acting like a simplified fixed capacity VecDeque.
+/// For simplicity of bit shifts the list wrapping is stored from right to left.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
-pub struct Wrapping(u32);
+pub struct Wrapping(u16);
 
 impl Default for Wrapping {
     fn default() -> Self {
         Self::nullable()
-    }
-}
-
-impl From<Wrapping> for u32 {
-    fn from(value: Wrapping) -> Self {
-        value.0
-    }
-}
-
-impl From<u32> for Wrapping {
-    fn from(value: u32) -> Self {
-        Wrapping(value)
-    }
-}
-
-impl std::fmt::Debug for Wrapping {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Wrapping")
-            .field("inner_is_required", &self.inner_is_required())
-            .field("list_wrappings", &self.list_wrappings().collect::<Vec<_>>())
-            .finish()
     }
 }
 
@@ -85,8 +50,72 @@ impl Wrapping {
     /// Innermost to outermost.
     pub fn list_wrappings(
         self,
-    ) -> impl DoubleEndedIterator<Item = ListWrapping> + Copy + ExactSizeIterator<Item = ListWrapping> {
+    ) -> impl DoubleEndedIterator<Item = ListWrapping> + ExactSizeIterator<Item = ListWrapping> {
+        self.to_mutable()
+    }
+
+    fn get_list_length(&self) -> u8 {
+        ((self.0 & LIST_WRAPPER_LENGTH_MASK) >> LIST_WRAPPER_SHIFT) as u8
+    }
+
+    fn set_list_length(&mut self, len: u8) {
+        assert!((len as u32) < MAX_LIST_WRAPINGS, "list wrapper overflow");
+        self.0 = (self.0 & !LIST_WRAPPER_LENGTH_MASK) | ((len as u16) << LIST_WRAPPER_SHIFT);
+    }
+
+    pub fn to_mutable(self) -> MutableWrapping {
+        self.into()
+    }
+
+    pub fn nullable() -> Self {
+        Wrapping(0)
+    }
+
+    pub fn required() -> Self {
+        Wrapping(INNER_IS_REQUIRED_FLAG)
+    }
+
+    #[must_use]
+    pub fn wrap_list(mut self) -> Self {
+        let len = self.get_list_length();
+        self.set_list_length(len + 1);
+        self.0 &= !(1 << len);
         self
+    }
+
+    #[must_use]
+    pub fn wrap_list_non_null(mut self) -> Self {
+        let len = self.get_list_length();
+        self.set_list_length(len + 1);
+        self.0 |= 1 << len;
+        self
+    }
+
+    #[must_use]
+    pub fn wrap_non_null(mut self) -> Self {
+        let len = self.get_list_length();
+        if len == 0 {
+            self.0 |= INNER_IS_REQUIRED_FLAG;
+        } else {
+            self.0 |= 1 << (len - 1);
+        }
+        self
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ListWrapping {
+    RequiredList,
+    NullableList,
+}
+
+impl Wrapping {
+    pub fn new(required: bool) -> Self {
+        if required {
+            Self::required()
+        } else {
+            Self::nullable()
+        }
     }
 
     pub fn is_nullable(self) -> bool {
@@ -104,135 +133,8 @@ impl Wrapping {
         self.list_wrappings().next().is_some()
     }
 
-    fn start(self) -> u32 {
-        (self.0 & START_MASK) >> START_SHIFT
-    }
-
-    fn inc_start(&mut self) {
-        let start = self.start() + 1;
-        self.0 = (self.0 & !START_MASK) | (start << START_SHIFT);
-    }
-
-    fn end(self) -> u32 {
-        (self.0 & END_MASK) >> END_SHIFT
-    }
-    fn inc_end(&mut self) {
-        let end = self.end() + 1;
-        assert!(end < MAX_LIST_WRAPINGS + 1, "Too many list wrappings");
-        self.0 = (self.0 & !END_MASK) | (end << END_SHIFT);
-    }
-
-    fn dec_end(&mut self) {
-        let end = self.end() - 1;
-        self.0 = (self.0 & !END_MASK) | (end << END_SHIFT);
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ListWrapping {
-    RequiredList,
-    NullableList,
-}
-
-impl Iterator for Wrapping {
-    type Item = ListWrapping;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let start = self.start();
-        if start == self.end() {
-            return None;
-        }
-        self.inc_start();
-        let bit_mask = 1 << start;
-        if self.0 & bit_mask != 0 {
-            Some(ListWrapping::RequiredList)
-        } else {
-            Some(ListWrapping::NullableList)
-        }
-    }
-}
-
-impl ExactSizeIterator for Wrapping {
-    fn len(&self) -> usize {
-        (self.end() - self.start()) as usize
-    }
-}
-
-impl DoubleEndedIterator for Wrapping {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        let end = self.end();
-        if end == self.start() {
-            return None;
-        }
-        self.dec_end();
-        // end is exclusive
-        let bit_mask = 1 << (end - 1);
-        if self.0 & bit_mask != 0 {
-            Some(ListWrapping::RequiredList)
-        } else {
-            Some(ListWrapping::NullableList)
-        }
-    }
-}
-
-impl Wrapping {
-    pub fn new(required: bool) -> Self {
-        if required {
-            Self::required()
-        } else {
-            Self::nullable()
-        }
-    }
-
-    pub fn nullable() -> Self {
-        Wrapping(0)
-    }
-
-    pub fn required() -> Self {
-        Wrapping(INNER_IS_REQUIRED_FLAG)
-    }
-
-    pub fn wrapping_by_required(mut self) -> Self {
-        if self.pop_list_wrapping().is_some() {
-            self.wrapped_by_required_list()
-        } else {
-            Self::required()
-        }
-    }
-
-    #[must_use]
-    pub fn wrapped_by(self, list_wrapping: ListWrapping) -> Self {
-        match list_wrapping {
-            ListWrapping::RequiredList => self.wrapped_by_required_list(),
-            ListWrapping::NullableList => self.wrapped_by_nullable_list(),
-        }
-    }
-
-    #[must_use]
-    pub fn wrapped_by_nullable_list(mut self) -> Self {
-        let end = self.end();
-        self.inc_end();
-        let bit_mask = 1 << end;
-        self.0 &= !bit_mask;
-        self
-    }
-
-    #[must_use]
-    pub fn wrapped_by_required_list(mut self) -> Self {
-        let end = self.end();
-        self.inc_end();
-        let bit_mask = 1 << end;
-        self.0 |= bit_mask;
-        self
-    }
-
-    /// Outermost wrapping
-    pub fn pop_list_wrapping(&mut self) -> Option<ListWrapping> {
-        self.next_back()
-    }
-
     pub fn write_type_string(self, name: &str, mut formatter: &mut dyn std::fmt::Write) -> Result<(), std::fmt::Error> {
-        for _ in 0..self.len() {
+        for _ in 0..self.list_wrappings().len() {
             write!(formatter, "[")?;
         }
 
@@ -242,7 +144,7 @@ impl Wrapping {
             write!(formatter, "!")?;
         }
 
-        for wrapping in self {
+        for wrapping in self.list_wrappings() {
             match wrapping {
                 ListWrapping::RequiredList => write!(&mut formatter, "]!")?,
                 ListWrapping::NullableList => write!(&mut formatter, "]")?,
@@ -250,6 +152,15 @@ impl Wrapping {
         }
 
         Ok(())
+    }
+}
+
+impl std::fmt::Debug for Wrapping {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Wrapping")
+            .field("inner_is_required", &self.inner_is_required())
+            .field("list_wrappings", &self.list_wrappings().collect::<Vec<_>>())
+            .finish()
     }
 }
 
@@ -271,7 +182,7 @@ mod tests {
         assert!(!wrapping.is_list());
         assert_eq!(wrapping.list_wrappings().collect::<Vec<_>>(), vec![]);
 
-        wrapping = wrapping.wrapped_by_nullable_list();
+        wrapping = wrapping.wrap_list();
         assert!(!wrapping.inner_is_required());
         assert!(!wrapping.is_required());
         assert!(wrapping.is_list());
@@ -280,7 +191,7 @@ mod tests {
             vec![ListWrapping::NullableList]
         );
 
-        wrapping = wrapping.wrapped_by_required_list();
+        wrapping = wrapping.wrap_list_non_null();
         assert!(!wrapping.inner_is_required());
         assert!(wrapping.is_required());
         assert!(wrapping.is_list());
@@ -289,7 +200,7 @@ mod tests {
             vec![ListWrapping::NullableList, ListWrapping::RequiredList]
         );
 
-        wrapping = wrapping.wrapped_by_nullable_list();
+        wrapping = wrapping.wrap_list();
         assert!(!wrapping.inner_is_required());
         assert!(!wrapping.is_required());
         assert!(wrapping.is_list());
@@ -302,30 +213,100 @@ mod tests {
             ]
         );
 
-        assert_eq!(wrapping.pop_list_wrapping(), Some(ListWrapping::NullableList));
-        assert!(!wrapping.inner_is_required());
+        let mut wrapping = wrapping.to_mutable();
+        assert_eq!(wrapping.pop_outermost_list_wrapping(), Some(ListWrapping::NullableList));
         assert!(wrapping.is_required());
-        assert!(wrapping.is_list());
         assert_eq!(
-            wrapping.list_wrappings().collect::<Vec<_>>(),
+            wrapping.clone().collect::<Vec<_>>(),
             vec![ListWrapping::NullableList, ListWrapping::RequiredList]
         );
 
-        assert_eq!(wrapping.pop_list_wrapping(), Some(ListWrapping::RequiredList));
-        assert!(!wrapping.inner_is_required());
+        assert_eq!(wrapping.pop_outermost_list_wrapping(), Some(ListWrapping::RequiredList));
         assert!(!wrapping.is_required());
-        assert!(wrapping.is_list());
+        assert_eq!(wrapping.clone().collect::<Vec<_>>(), vec![ListWrapping::NullableList]);
+
+        assert_eq!(wrapping.pop_outermost_list_wrapping(), Some(ListWrapping::NullableList));
+        assert!(!wrapping.is_required());
+        assert_eq!(wrapping.clone().collect::<Vec<_>>(), vec![]);
+
+        assert_eq!(wrapping.pop_outermost_list_wrapping(), None);
+    }
+
+    #[test]
+    fn test_wrapping_order() {
+        let wrapping = Wrapping::default()
+            .wrap_non_null()
+            .wrap_list()
+            .wrap_list()
+            .wrap_list_non_null()
+            .wrap_list();
+        assert!(wrapping.inner_is_required());
         assert_eq!(
             wrapping.list_wrappings().collect::<Vec<_>>(),
-            vec![ListWrapping::NullableList]
+            vec![
+                ListWrapping::NullableList,
+                ListWrapping::NullableList,
+                ListWrapping::RequiredList,
+                ListWrapping::NullableList
+            ]
         );
 
-        assert_eq!(wrapping.pop_list_wrapping(), Some(ListWrapping::NullableList));
-        assert!(!wrapping.inner_is_required());
-        assert!(!wrapping.is_required());
-        assert!(!wrapping.is_list());
-        assert_eq!(wrapping.list_wrappings().collect::<Vec<_>>(), vec![]);
+        let wrapping = Wrapping::required()
+            .wrap_list()
+            .wrap_list()
+            .wrap_list_non_null()
+            .wrap_list()
+            .wrap_non_null();
+        assert!(wrapping.inner_is_required());
+        assert_eq!(
+            wrapping.list_wrappings().collect::<Vec<_>>(),
+            vec![
+                ListWrapping::NullableList,
+                ListWrapping::NullableList,
+                ListWrapping::RequiredList,
+                ListWrapping::RequiredList
+            ]
+        );
 
-        assert_eq!(wrapping.pop_list_wrapping(), None);
+        let mut wrapping = Wrapping::required()
+            .wrap_list()
+            .wrap_list()
+            .wrap_list_non_null()
+            .wrap_list()
+            .to_mutable();
+        assert_eq!(wrapping.pop_outermost_list_wrapping(), Some(ListWrapping::NullableList));
+        assert_eq!(wrapping.pop_outermost_list_wrapping(), Some(ListWrapping::RequiredList));
+        assert_eq!(wrapping.pop_outermost_list_wrapping(), Some(ListWrapping::NullableList));
+        assert_eq!(wrapping.pop_outermost_list_wrapping(), Some(ListWrapping::NullableList));
+
+        let mut wrapping = Wrapping::required()
+            .wrap_list()
+            .wrap_list()
+            .wrap_list_non_null()
+            .wrap_list()
+            .to_mutable();
+        assert_eq!(wrapping.pop_innermost_list_wrapping(), Some(ListWrapping::NullableList));
+        assert_eq!(wrapping.pop_innermost_list_wrapping(), Some(ListWrapping::NullableList));
+        assert_eq!(wrapping.pop_innermost_list_wrapping(), Some(ListWrapping::RequiredList));
+        assert_eq!(wrapping.pop_innermost_list_wrapping(), Some(ListWrapping::NullableList));
+    }
+
+    #[test]
+    fn back_and_forth() {
+        let original = Wrapping::required().wrap_list_non_null();
+        let mut wrapping = original.to_mutable();
+        let list_wrapping = wrapping.pop_outermost_list_wrapping().unwrap();
+        wrapping.push_outermost_list_wrapping(list_wrapping);
+        assert_eq!(Wrapping::from(wrapping), original);
+
+        let original = Wrapping::nullable().wrap_list();
+        let mut wrapping = original.to_mutable();
+        let list_wrapping = wrapping.pop_outermost_list_wrapping().unwrap();
+        wrapping.push_outermost_list_wrapping(list_wrapping);
+        assert_eq!(Wrapping::from(wrapping), original);
+
+        let mut wrapping = Wrapping::nullable().wrap_list().wrap_list_non_null().to_mutable();
+        wrapping.pop_innermost_list_wrapping();
+        assert_eq!(Wrapping::from(wrapping), Wrapping::nullable().wrap_list_non_null());
     }
 }

--- a/crates/graphql-wrapping-types/src/mutable.rs
+++ b/crates/graphql-wrapping-types/src/mutable.rs
@@ -1,0 +1,94 @@
+use crate::{ListWrapping, Wrapping, INNER_IS_REQUIRED_SHIFT, LIST_WRAPPER_MASK, LIST_WRAPPER_SHIFT};
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+pub struct MutableWrapping {
+    pub(super) start: u8,
+    pub(super) inner: Wrapping,
+}
+
+impl MutableWrapping {
+    pub fn is_nullable(&self) -> bool {
+        self.inner.is_nullable()
+    }
+
+    pub fn is_required(&self) -> bool {
+        self.inner.is_required()
+    }
+
+    pub fn pop_outermost_list_wrapping(&mut self) -> Option<ListWrapping> {
+        let end = self.inner.get_list_length();
+        if self.start == end {
+            return None;
+        }
+        self.inner.set_list_length(end - 1);
+        // end is exclusive
+        let bit_mask = 1u16 << (end - 1);
+        if self.inner.0 & bit_mask != 0 {
+            Some(ListWrapping::RequiredList)
+        } else {
+            Some(ListWrapping::NullableList)
+        }
+    }
+
+    pub fn push_outermost_list_wrapping(&mut self, list_wrapping: ListWrapping) {
+        self.inner = match list_wrapping {
+            ListWrapping::RequiredList => self.inner.wrap_list_non_null(),
+            ListWrapping::NullableList => self.inner.wrap_list(),
+        };
+    }
+
+    pub fn pop_innermost_list_wrapping(&mut self) -> Option<ListWrapping> {
+        if self.start == self.inner.get_list_length() {
+            return None;
+        }
+        self.start += 1;
+        let bit_mask = 1u16 << (self.start - 1);
+        if self.inner.0 & bit_mask != 0 {
+            Some(ListWrapping::RequiredList)
+        } else {
+            Some(ListWrapping::NullableList)
+        }
+    }
+}
+
+impl From<MutableWrapping> for Wrapping {
+    fn from(wrapping: MutableWrapping) -> Self {
+        let MutableWrapping { start, inner } = wrapping;
+        let len = inner.get_list_length() - start;
+        let inner_is_required = inner.inner_is_required();
+        let list_wrappers_bits = (inner.0 & LIST_WRAPPER_MASK) >> start;
+
+        Wrapping(
+            list_wrappers_bits
+                | ((inner_is_required as u16) << INNER_IS_REQUIRED_SHIFT)
+                | ((len as u16) << LIST_WRAPPER_SHIFT),
+        )
+    }
+}
+
+impl From<Wrapping> for MutableWrapping {
+    fn from(inner: Wrapping) -> Self {
+        let start = 0;
+        Self { start, inner }
+    }
+}
+
+impl Iterator for MutableWrapping {
+    type Item = ListWrapping;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.pop_innermost_list_wrapping()
+    }
+}
+
+impl ExactSizeIterator for MutableWrapping {
+    fn len(&self) -> usize {
+        (self.inner.get_list_length() - self.start) as usize
+    }
+}
+
+impl DoubleEndedIterator for MutableWrapping {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.pop_outermost_list_wrapping()
+    }
+}


### PR DESCRIPTION
Today Wrapping is mutable, is itself an iterator and Copy which makes it easy
to misuse. So made it more explicit by separating the mutations to a
wrapper type which is also the iterator `MutableWrapping`. Reduced the
size to a u16, which is still 11 list wrappings
