### PR TITLE
chore: make engine use cynic-parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,9 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "cynic-parser"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421220154aa57cc1a72c886d6dc068c8fd9fdb81c860cbc299b0a9fce9ce8f08"
+checksum = "b33b82bcdeebc7a3111be52b1a6a582206ff18d2811dd8575be9809cf6d4c88e"
 dependencies = [
  "ariadne",
  "indexmap 2.6.0",
@@ -1663,9 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "cynic-parser-deser"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "103ce09bd9544cd53dacf5378dc639ed50bcb9892d748f28761f8e0486b27013"
+checksum = "f1dd5d39cff773c8dc43dba03b76241ba4c7b9d14fc3c3cf2666126b9eb7b8d0"
 dependencies = [
  "cynic-parser",
  "cynic-parser-deser-macros",
@@ -1673,9 +1673,9 @@ dependencies = [
 
 [[package]]
 name = "cynic-parser-deser-macros"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2279c3daf2045405622e51e971e718f2bba74c86651a98c8d8332657684232"
+checksum = "1aa54a0bd4090179071ba638b9b4e4279d40a0ee74274978018ca230f2671f7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2096,11 +2096,11 @@ dependencies = [
  "blake3",
  "bytes",
  "crossbeam-queue",
+ "cynic-parser",
  "engine-auth",
  "engine-config",
  "engine-id-derives",
  "engine-id-newtypes",
- "engine-parser",
  "engine-query-solver",
  "engine-schema",
  "engine-value",

--- a/crates/engine-config-builder/src/from_toml_config.rs
+++ b/crates/engine-config-builder/src/from_toml_config.rs
@@ -52,6 +52,11 @@ pub fn build_with_toml_config(config: &gateway_config::Config, graph: FederatedG
         apq: engine_config::AutomaticPersistedQueries {
             enabled: config.apq.enabled,
         },
+        executable_document_limit_bytes: config
+            .executable_document_limit
+            .bytes()
+            .try_into()
+            .expect("executable document limit should not be negative"),
     }
 }
 

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -25,6 +25,7 @@ blake3.workspace = true
 bytes.workspace = true
 url.workspace = true
 crossbeam-queue = "0.3.11"
+cynic-parser.workspace = true
 futures-util.workspace = true
 fixedbitset.workspace = true
 futures.workspace = true
@@ -53,7 +54,6 @@ web-time.workspace = true
 engine-auth = { path = "./auth" }
 operation-normalizer = { path = "../operation-normalizer" }
 config = { package = "engine-config", path = "./config" }
-engine-parser = { path = "./parser" }
 engine-value = { path = "./value" }
 schema = { path = "./schema", package = "engine-schema" }
 walker = { path = "./walker", package = "engine-walker" }

--- a/crates/engine/config/src/lib.rs
+++ b/crates/engine/config/src/lib.rs
@@ -45,6 +45,8 @@ pub struct Config {
     pub header_rules: Vec<HeaderRule>,
     pub default_header_rules: Vec<HeaderRuleId>,
 
+    pub executable_document_limit_bytes: usize,
+
     /// Additional configuration for our subgraphs
     pub subgraph_configs: BTreeMap<SubgraphId, SubgraphConfig>,
 
@@ -131,6 +133,7 @@ impl Config {
             complexity_control: Default::default(),
             response_extension: Default::default(),
             apq: Default::default(),
+            executable_document_limit_bytes: (32 * 1024),
         }
     }
 

--- a/crates/engine/schema/src/builder/mod.rs
+++ b/crates/engine/schema/src/builder/mod.rs
@@ -146,6 +146,7 @@ impl BuildContext {
                 complexity_control: take(&mut config.complexity_control),
                 response_extension: config.response_extension,
                 apq_enabled: config.apq.enabled,
+                executable_document_limit_bytes: config.executable_document_limit_bytes,
             },
         })
     }

--- a/crates/engine/schema/src/lib.rs
+++ b/crates/engine/schema/src/lib.rs
@@ -134,6 +134,7 @@ pub struct Settings {
     pub complexity_control: config::ComplexityControl,
     pub response_extension: ResponseExtensionConfig,
     pub apq_enabled: bool,
+    pub executable_document_limit_bytes: usize,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, id_derives::IndexedFields)]

--- a/crates/engine/src/analytics/mod.rs
+++ b/crates/engine/src/analytics/mod.rs
@@ -26,7 +26,7 @@ pub fn compute_post_execution_analytics<'a>(
         return Default::default();
     };
 
-    let Ok(operation) = crate::operation::bind(schema, parsed_operation) else {
+    let Ok(operation) = crate::operation::bind(schema, &parsed_operation) else {
         return Default::default();
     };
     let used_fields = Some(self::used_fields::compute(schema, &operation));

--- a/crates/engine/src/analytics/operation_name.rs
+++ b/crates/engine/src/analytics/operation_name.rs
@@ -1,5 +1,14 @@
+use cynic_parser::executable::{Iter, Selection};
+
 use crate::operation::ParsedOperation;
 
 pub(crate) fn compute(operation: &ParsedOperation) -> Option<String> {
-    engine_parser::find_first_field_name(&operation.fragments, &operation.definition.selection_set)
+    fn first_field_in_set(mut selection_set: Iter<'_, Selection<'_>>) -> Option<String> {
+        selection_set.find_map(|selection| match &selection {
+            Selection::Field(field) => Some(field.alias().unwrap_or(field.name()).to_string()),
+            Selection::InlineFragment(fragment) => first_field_in_set(fragment.selection_set()),
+            Selection::FragmentSpread(spread) => first_field_in_set(spread.fragment()?.selection_set()),
+        })
+    }
+    first_field_in_set(operation.operation().selection_set())
 }

--- a/crates/engine/src/operation/attributes.rs
+++ b/crates/engine/src/operation/attributes.rs
@@ -1,4 +1,4 @@
-use grafbase_telemetry::graphql::OperationName;
+use grafbase_telemetry::graphql::{OperationName, OperationType};
 
 use crate::prepare::CachedOperationAttributes;
 
@@ -8,7 +8,7 @@ pub(crate) fn extract_attributes(operation: &ParsedOperation, document: &str) ->
     operation_normalizer::normalize(document, operation.name.as_deref())
         .ok()
         .map(|sanitized_query| CachedOperationAttributes {
-            ty: operation.definition.ty.into(),
+            ty: convert_operation_type(operation.operation().operation_type()),
             name: if let Some(name) = operation.name.clone() {
                 OperationName::Original(name)
             } else if let Some(name) = crate::analytics::operation_name::compute(operation) {
@@ -21,4 +21,12 @@ pub(crate) fn extract_attributes(operation: &ParsedOperation, document: &str) ->
             },
             sanitized_query: sanitized_query.into(),
         })
+}
+
+fn convert_operation_type(ty: cynic_parser::common::OperationType) -> OperationType {
+    match ty {
+        cynic_parser::common::OperationType::Query => OperationType::Query,
+        cynic_parser::common::OperationType::Mutation => OperationType::Mutation,
+        cynic_parser::common::OperationType::Subscription => OperationType::Subscription,
+    }
 }

--- a/crates/engine/src/operation/bind/coercion/error.rs
+++ b/crates/engine/src/operation/bind/coercion/error.rs
@@ -1,5 +1,3 @@
-use engine_value::{ConstValue, Value};
-
 use crate::operation::Location;
 
 #[derive(Debug, thiserror::Error)]
@@ -113,14 +111,16 @@ pub enum ValueKind {
     Null,
 }
 
-impl From<ConstValue> for ValueKind {
-    fn from(value: ConstValue) -> Self {
+impl From<engine_value::ConstValue> for ValueKind {
+    fn from(value: engine_value::ConstValue) -> Self {
         (&value).into()
     }
 }
 
-impl From<&ConstValue> for ValueKind {
-    fn from(value: &ConstValue) -> Self {
+impl From<&engine_value::ConstValue> for ValueKind {
+    fn from(value: &engine_value::ConstValue) -> Self {
+        use engine_value::ConstValue;
+
         match value {
             ConstValue::Null => ValueKind::Null,
             ConstValue::Number(number) if number.is_f64() => ValueKind::Float,
@@ -135,21 +135,21 @@ impl From<&ConstValue> for ValueKind {
     }
 }
 
-impl From<Value> for ValueKind {
-    fn from(value: Value) -> Self {
-        (&value).into()
+impl From<cynic_parser::ConstValue<'_>> for ValueKind {
+    fn from(value: cynic_parser::ConstValue<'_>) -> Self {
+        cynic_parser::Value::from(value).into()
     }
 }
 
-impl From<&Value> for ValueKind {
-    fn from(value: &Value) -> Self {
+impl From<cynic_parser::Value<'_>> for ValueKind {
+    fn from(value: cynic_parser::Value<'_>) -> Self {
+        use cynic_parser::Value;
         match value {
-            Value::Null => ValueKind::Null,
-            Value::Number(number) if number.is_f64() => ValueKind::Float,
-            Value::Number(_) => ValueKind::Integer,
+            Value::Null(_) => ValueKind::Null,
+            Value::Float(_) => ValueKind::Float,
+            Value::Int(_) => ValueKind::Integer,
             Value::String(_) => ValueKind::String,
             Value::Boolean(_) => ValueKind::Boolean,
-            Value::Binary(_) => ValueKind::String,
             Value::Enum(_) => ValueKind::Enum,
             Value::List(_) => ValueKind::List,
             Value::Object(_) => ValueKind::Object,

--- a/crates/engine/src/operation/bind/location.rs
+++ b/crates/engine/src/operation/bind/location.rs
@@ -30,28 +30,3 @@ impl fmt::Display for Location {
         write!(f, "{}:{}", self.line(), self.column())
     }
 }
-
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum LocationError {
-    #[error("Too many lines ({0})")]
-    TooManyLines(usize),
-    #[error("Too many columns ({0})")]
-    TooManyColumns(usize),
-}
-
-impl TryFrom<engine_parser::Pos> for Location {
-    type Error = LocationError;
-
-    fn try_from(value: engine_parser::Pos) -> Result<Self, Self::Error> {
-        Ok(Self::new(
-            value
-                .line
-                .try_into()
-                .map_err(|_| LocationError::TooManyLines(value.line))?,
-            value
-                .column
-                .try_into()
-                .map_err(|_| LocationError::TooManyColumns(value.column))?,
-        ))
-    }
-}

--- a/crates/engine/src/operation/bind/model/mod.rs
+++ b/crates/engine/src/operation/bind/model/mod.rs
@@ -3,7 +3,7 @@ mod modifier;
 mod selection_set;
 mod variables;
 
-pub(crate) use engine_parser::types::OperationType;
+use grafbase_telemetry::graphql::OperationType;
 use id_derives::IndexedFields;
 pub(crate) use ids::*;
 pub(crate) use modifier::*;

--- a/crates/engine/src/operation/bind/model/selection_set.rs
+++ b/crates/engine/src/operation/bind/model/selection_set.rs
@@ -110,8 +110,6 @@ impl BoundField {
 /// Represents arguments that were specified in the query with a value
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub(crate) struct BoundFieldArgument {
-    pub(crate) name_location: Option<Location>,
-    pub(crate) value_location: Option<Location>,
     pub(crate) input_value_definition_id: InputValueDefinitionId,
     pub(crate) input_value_id: QueryInputValueId,
 }

--- a/crates/engine/src/operation/bind/validation/introspection.rs
+++ b/crates/engine/src/operation/bind/validation/introspection.rs
@@ -13,9 +13,7 @@ pub(super) fn ensure_introspection_is_accepted(schema: &Schema, operation: Opera
 fn detect_introspection(selection_set: SelectionSetWalker<'_>) -> BindResult<()> {
     for field in selection_set.fields() {
         if matches!(field.name(), "__schema" | "__type") {
-            return Err(BindError::IntrospectionIsDisabled {
-                location: field.location(),
-            });
+            return Err(BindError::IntrospectionIsDisabled { span: field.location() });
         }
     }
     Ok(())

--- a/crates/engine/src/operation/bind/walkers/mod.rs
+++ b/crates/engine/src/operation/bind/walkers/mod.rs
@@ -2,7 +2,7 @@ mod argument;
 mod field;
 mod selection_set;
 
-use engine_parser::types::OperationType;
+use grafbase_telemetry::graphql::OperationType;
 use schema::Schema;
 
 pub(crate) use field::*;

--- a/crates/engine/src/operation/input_value/query/mod.rs
+++ b/crates/engine/src/operation/input_value/query/mod.rs
@@ -90,7 +90,7 @@ impl<'ctx> Walk<InputValueContext<'ctx>> for QueryInputKeyValueId {
     }
 }
 
-#[derive(Default, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Default, Clone, serde::Serialize, serde::Deserialize, Debug)]
 pub(crate) enum QueryInputValueRecord {
     #[default]
     Null,

--- a/crates/engine/src/operation/input_value/variable/mod.rs
+++ b/crates/engine/src/operation/input_value/variable/mod.rs
@@ -9,7 +9,7 @@ pub(crate) use walker::*;
 
 use super::InputValueContext;
 
-#[derive(Default, IndexedFields)]
+#[derive(Default, IndexedFields, Debug)]
 pub(crate) struct VariableInputValues {
     /// Individual input values and list values
     #[indexed_by(VariableInputValueId)]
@@ -86,7 +86,7 @@ impl<'ctx> Walk<InputValueContext<'ctx>> for VariableInputKeyValueId {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub(crate) enum VariableInputValueRecord {
     #[default]
     Null,

--- a/crates/engine/src/operation/parse/error.rs
+++ b/crates/engine/src/operation/parse/error.rs
@@ -1,52 +1,53 @@
+use cynic_parser::Span;
 use itertools::Itertools;
 
 use crate::{response::GraphqlError, ErrorCode};
 
-use super::{Location, LocationError};
+use super::offsets::LineOffsets;
 
-pub(crate) type ParseResult<T> = Result<T, ParseError>;
+pub(super) type ParseResult<T> = Result<T, ParseError>;
 
-#[derive(thiserror::Error, Debug)]
-pub(crate) enum ParseError {
+#[derive(thiserror::Error, Debug, Clone)]
+pub(super) enum ParseError {
     #[error("Unknown operation named '{0}'.")]
     UnknowOperation(String),
     #[error("Missing operation name.")]
     MissingOperationName,
+    #[error("The document does not contain any operations")]
+    MissingOperations,
     #[error(transparent)]
-    ParserError(#[from] engine_parser::Error),
+    ParserError(#[from] cynic_parser::Error),
     #[error("Query is too complex.")]
-    QueryTooComplex { complexity: usize, location: Location },
+    QueryTooComplex { complexity: usize, span: Span },
     #[error("Query contains too many root fields.")]
-    QueryContainsTooManyRootFields { count: usize, location: Location },
+    QueryContainsTooManyRootFields { count: usize, span: Span },
     #[error("Query contains too many aliases.")]
-    QueryContainsTooManyAliases { count: usize, location: Location },
+    QueryContainsTooManyAliases { count: usize, span: Span },
     #[error("Query is nested too deep.")]
-    QueryTooDeep { depth: usize, location: Location },
+    QueryTooDeep { depth: usize, span: Span },
     #[error("Unknown fragment named '{name}'")]
-    UnknownFragment { name: String, location: Location },
+    UnknownFragment { name: String, span: Span },
     #[error("Fragment cycle detected: {}", .cycle.iter().join(", "))]
-    FragmentCycle { cycle: Vec<String>, location: Location },
-    #[error("Query is too big: {0}")]
-    QueryTooBig(#[from] LocationError),
+    FragmentCycle { cycle: Vec<String>, span: Span },
 }
 
-impl From<ParseError> for GraphqlError {
-    fn from(err: ParseError) -> Self {
-        let message = err.to_string();
-        match err {
+impl ParseError {
+    pub fn into_graphql_error(self, offsets: &LineOffsets) -> GraphqlError {
+        let message = self.to_string();
+        match self {
             ParseError::ParserError(err) => GraphqlError::new(message, ErrorCode::OperationParsingError)
-                .with_locations(err.positions().filter_map(|pos| pos.try_into().ok())),
-            ParseError::QueryTooBig(_) => GraphqlError::new(message, ErrorCode::OperationParsingError),
-            ParseError::UnknowOperation(_) | ParseError::MissingOperationName => {
+                .with_locations(offsets.span_to_location(err.span())),
+            ParseError::UnknowOperation(_) | ParseError::MissingOperationName | ParseError::MissingOperations => {
                 GraphqlError::new(message, ErrorCode::OperationValidationError)
             }
-            ParseError::QueryTooComplex { location, .. }
-            | ParseError::QueryContainsTooManyRootFields { location, .. }
-            | ParseError::QueryContainsTooManyAliases { location, .. }
-            | ParseError::QueryTooDeep { location, .. }
-            | ParseError::UnknownFragment { location, .. }
-            | ParseError::FragmentCycle { location, .. } => {
-                GraphqlError::new(message, ErrorCode::OperationValidationError).with_locations([location])
+            ParseError::QueryTooComplex { span: location, .. }
+            | ParseError::QueryContainsTooManyRootFields { span: location, .. }
+            | ParseError::QueryContainsTooManyAliases { span: location, .. }
+            | ParseError::QueryTooDeep { span: location, .. }
+            | ParseError::UnknownFragment { span: location, .. }
+            | ParseError::FragmentCycle { span: location, .. } => {
+                GraphqlError::new(message, ErrorCode::OperationValidationError)
+                    .with_locations(offsets.span_to_location(location))
             }
         }
     }

--- a/crates/engine/src/operation/parse/offsets.rs
+++ b/crates/engine/src/operation/parse/offsets.rs
@@ -1,0 +1,59 @@
+use cynic_parser::Span;
+
+use crate::operation::Location;
+
+/// Tracks the offsets of newlines in a string.
+///
+/// We use this to convert cynic_parser::Span (which uses byte offsets) -> Location (which uses
+/// line/column)
+pub(super) struct LineOffsets(Vec<u32>);
+
+impl LineOffsets {
+    pub fn new(doc: &str) -> Self {
+        LineOffsets(
+            doc.char_indices()
+                .filter(|(_, char)| *char == '\n')
+                .map(|(index, _)| index as u32)
+                .collect(),
+        )
+    }
+
+    pub fn span_to_location(&self, span: Span) -> Option<Location> {
+        let offsets = &self.0;
+
+        let target_offset = span.start;
+        let index = offsets.partition_point(|line_offset| (*line_offset as usize) <= target_offset);
+
+        // We here + 1 to account for one-indexing
+        let line = index + 1;
+
+        let line_start = if index == 0 {
+            0
+        } else {
+            (offsets.get(index - 1).copied()? + 1) as usize
+        };
+        let column = (target_offset - line_start) + 1;
+
+        Some(Location::new(u16::try_from(line).ok()?, u16::try_from(column).ok()?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_offset_translation() {
+        let offsets = LineOffsets::new("Hello\nThere\nFool");
+        assert_eq!(offsets.span_to_location(span(0)), Some(Location::new(1, 1)));
+        assert_eq!(offsets.span_to_location(span(1)), Some(Location::new(1, 2)));
+        assert_eq!(offsets.span_to_location(span(4)), Some(Location::new(1, 5)));
+        assert_eq!(offsets.span_to_location(span(6)), Some(Location::new(2, 1)));
+        assert_eq!(offsets.span_to_location(span(10)), Some(Location::new(2, 5)));
+        assert_eq!(offsets.span_to_location(span(12)), Some(Location::new(3, 1)));
+    }
+
+    fn span(start: usize) -> Span {
+        Span::new(start, start + 1)
+    }
+}

--- a/crates/engine/src/operation/solve/model/prelude.rs
+++ b/crates/engine/src/operation/solve/model/prelude.rs
@@ -1,6 +1,6 @@
 pub(super) use super::SolvedOperationContext;
 pub(super) use crate::{
-    operation::{Location, QueryInputValueId, QueryModifierRule, ResponseModifierRule},
+    operation::{bind::Location, QueryInputValueId, QueryModifierRule, ResponseModifierRule},
     response::{ConcreteShapeId, PositionedResponseKey, SafeResponseKey},
 };
 pub(super) use id_newtypes::IdRange;

--- a/crates/engine/src/operation/solve/solver/adapter.rs
+++ b/crates/engine/src/operation/solve/solver/adapter.rs
@@ -324,8 +324,6 @@ impl OperationAdapter<'_> {
                 .push_value(QueryInputValueRecord::DefaultValue(argument.value_id));
 
             self.operation.field_arguments.push(BoundFieldArgument {
-                name_location: None,
-                value_location: None,
                 input_value_id,
                 input_value_definition_id: argument.definition_id,
             });

--- a/crates/engine/src/prepare/error.rs
+++ b/crates/engine/src/prepare/error.rs
@@ -32,7 +32,7 @@ pub(super) enum PrepareError {
     ComplexityLimitReached,
     #[error("Expected exactly one slicing argument on {0}")]
     ExpectedOneSlicingArgument(String),
-    #[error("Query is too big")]
+    #[error("Executable document exceeded the maximum configured size")]
     QueryTooBig,
 }
 

--- a/crates/engine/src/prepare/error.rs
+++ b/crates/engine/src/prepare/error.rs
@@ -1,7 +1,7 @@
 use grafbase_telemetry::graphql::GraphqlOperationAttributes;
 
 use crate::{
-    operation::{BindError, ParseError, PlanError, SolveError},
+    operation::{PlanError, SolveError},
     response::{ErrorCode, GraphqlError},
 };
 
@@ -9,12 +9,12 @@ pub(super) type PrepareResult<T> = std::result::Result<T, PrepareError>;
 
 #[derive(Debug, thiserror::Error)]
 pub(super) enum PrepareError {
-    #[error(transparent)]
-    Parse(#[from] ParseError),
+    #[error("{0}")]
+    Parse(GraphqlError),
     #[error("{err}")]
     Bind {
         attributes: Box<Option<GraphqlOperationAttributes>>,
-        err: BindError,
+        err: GraphqlError,
     },
     #[error("{err}")]
     Solve {
@@ -32,19 +32,21 @@ pub(super) enum PrepareError {
     ComplexityLimitReached,
     #[error("Expected exactly one slicing argument on {0}")]
     ExpectedOneSlicingArgument(String),
+    #[error("Query is too big")]
+    QueryTooBig,
 }
 
 impl From<PrepareError> for GraphqlError {
-    fn from(err: PrepareError) -> Self {
-        match err {
-            PrepareError::Bind { err, .. } => err.into(),
-            PrepareError::Parse(err) => err.into(),
+    fn from(val: PrepareError) -> Self {
+        match val {
+            PrepareError::Bind { err, .. } => err,
+            PrepareError::Parse(err) => err,
             PrepareError::Plan { err, .. } => err.into(),
             PrepareError::Solve { err, .. } => err.into(),
-            PrepareError::NormalizationError => GraphqlError::new(err.to_string(), ErrorCode::InternalServerError),
-            PrepareError::ComplexityLimitReached | PrepareError::ExpectedOneSlicingArgument(_) => {
-                GraphqlError::new(err.to_string(), ErrorCode::OperationValidationError)
-            }
+            PrepareError::NormalizationError => GraphqlError::new(val.to_string(), ErrorCode::InternalServerError),
+            PrepareError::ComplexityLimitReached
+            | PrepareError::ExpectedOneSlicingArgument(_)
+            | PrepareError::QueryTooBig => GraphqlError::new(val.to_string(), ErrorCode::OperationValidationError),
         }
     }
 }

--- a/crates/engine/src/prepare/operation/before_variables.rs
+++ b/crates/engine/src/prepare/operation/before_variables.rs
@@ -13,15 +13,22 @@ impl<R: Runtime> PrepareContext<'_, R> {
         request: &Request,
         document: &str,
     ) -> PrepareResult<CachedOperation> {
-        let parsed_operation = crate::operation::parse(self.schema(), request.operation_name.as_deref(), document)?;
+        // TODO: Make the number here configurable probably?
+        if document.len() >= 1024 * 1024 {
+            return Err(PrepareError::QueryTooBig);
+        }
+
+        let parsed_operation = crate::operation::parse(self.schema(), request.operation_name.as_deref(), document)
+            .map_err(PrepareError::Parse)?;
+
         let attributes = crate::operation::extract_attributes(&parsed_operation, document);
 
-        let bound_operation = match crate::operation::bind(self.schema(), parsed_operation) {
+        let bound_operation = match crate::operation::bind(self.schema(), &parsed_operation) {
             Ok(op) => op,
             Err(err) => {
                 return Err(PrepareError::Bind {
                     attributes: Box::new(attributes.map(CachedOperationAttributes::attributes_for_error)),
-                    err,
+                    err: err.into_graphql_error(&parsed_operation),
                 })
             }
         };

--- a/crates/engine/src/prepare/operation/before_variables.rs
+++ b/crates/engine/src/prepare/operation/before_variables.rs
@@ -13,8 +13,7 @@ impl<R: Runtime> PrepareContext<'_, R> {
         request: &Request,
         document: &str,
     ) -> PrepareResult<CachedOperation> {
-        // TODO: Make the number here configurable probably?
-        if document.len() >= 1024 * 1024 {
+        if document.len() >= self.schema().settings.executable_document_limit_bytes {
             return Err(PrepareError::QueryTooBig);
         }
 

--- a/crates/engine/src/prepare/operation/complexity_control.rs
+++ b/crates/engine/src/prepare/operation/complexity_control.rs
@@ -1,4 +1,4 @@
-use engine_parser::types::OperationType;
+use grafbase_telemetry::graphql::OperationType;
 use schema::{InputObjectDefinition, Schema};
 use serde::Deserialize;
 

--- a/crates/engine/src/resolver/graphql/federation.rs
+++ b/crates/engine/src/resolver/graphql/federation.rs
@@ -1,6 +1,9 @@
 use bytes::Bytes;
 use futures::future::join_all;
-use grafbase_telemetry::{graphql::GraphqlResponseStatus, span::subgraph::SubgraphRequestSpanBuilder};
+use grafbase_telemetry::{
+    graphql::{GraphqlResponseStatus, OperationType},
+    span::subgraph::SubgraphRequestSpanBuilder,
+};
 use http::HeaderMap;
 use runtime::bytes::OwnedOrSharedBytes;
 use schema::{GraphqlEndpoint, GraphqlEndpointId, GraphqlFederationEntityResolverDefinition};
@@ -12,7 +15,7 @@ use walker::Walk;
 
 use crate::{
     execution::{ExecutionContext, ExecutionError},
-    operation::{OperationType, Plan, PlanError, PlanQueryPartition, PlanResult},
+    operation::{Plan, PlanError, PlanQueryPartition, PlanResult},
     resolver::{
         graphql::{
             deserialize::{EntitiesErrorsSeed, GraphqlResponseSeed},

--- a/crates/engine/src/response/error.rs
+++ b/crates/engine/src/response/error.rs
@@ -1,5 +1,6 @@
-pub(crate) mod code;
 use std::borrow::Cow;
+
+pub(crate) mod code;
 
 pub(crate) use code::*;
 

--- a/crates/gateway-config/src/lib.rs
+++ b/crates/gateway-config/src/lib.rs
@@ -47,6 +47,9 @@ pub struct Config {
     /// Maximum size of the request body in bytes
     #[serde(deserialize_with = "size_ext::deserialize_positive_size")]
     pub request_body_limit: Size,
+    /// Maximum size of the executable document in bytes
+    #[serde(deserialize_with = "size_ext::deserialize_positive_size")]
+    pub executable_document_limit: Size,
     /// Cross-site request forgery settings
     pub csrf: CsrfConfig,
     /// Cross-origin resource sharing settings
@@ -86,6 +89,7 @@ impl Default for Config {
             network: Default::default(),
             gateway: Default::default(),
             request_body_limit: Size::from_mebibytes(2),
+            executable_document_limit: Size::from_kibibytes(32),
             csrf: Default::default(),
             cors: Default::default(),
             tls: Default::default(),

--- a/crates/integration-tests/tests/federation/basic/errors.rs
+++ b/crates/integration-tests/tests/federation/basic/errors.rs
@@ -490,7 +490,7 @@ fn unknown_argument() {
           "locations": [
             {
               "line": 1,
-              "column": 9
+              "column": 12
             }
           ],
           "extensions": {

--- a/crates/integration-tests/tests/federation/basic/fragments.rs
+++ b/crates/integration-tests/tests/federation/basic/fragments.rs
@@ -91,7 +91,7 @@ fn named_fragment_cycle() {
             .await
     });
 
-    insta::assert_json_snapshot!(response, @r###"
+    insta::assert_json_snapshot!(response, @r#"
     {
       "errors": [
         {
@@ -99,7 +99,7 @@ fn named_fragment_cycle() {
           "locations": [
             {
               "line": 19,
-              "column": 29
+              "column": 32
             }
           ],
           "extensions": {
@@ -108,7 +108,7 @@ fn named_fragment_cycle() {
         }
       ]
     }
-    "###);
+    "#);
 }
 
 #[test]

--- a/crates/integration-tests/tests/federation/extensions.rs
+++ b/crates/integration-tests/tests/federation/extensions.rs
@@ -186,41 +186,35 @@ fn grafbase_extension_on_subgraph_error() {
 #[test]
 fn grafbase_extension_on_invalid_request() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
-            .with_subgraph(FakeGithubSchema)
-            .build()
-            .await;
+        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
 
-        let response = engine
-            .post("query x }")
-            .header("x-grafbase-telemetry", "yes")
-            .await;
+        let response = engine.post("query x }").header("x-grafbase-telemetry", "yes").await;
 
         insta::assert_json_snapshot!(
             response,
             @r#"
+        {
+          "errors": [
             {
-              "errors": [
+              "message": "unexpected closing brace ('}') token (expected one of , \"{\"\"(\", \"@\")",
+              "locations": [
                 {
-                  "message": " --> 1:9\n  |\n1 | query x }\n  |         ^---\n  |\n  = expected variable_definitions, selection_set, or directive",
-                  "locations": [
-                    {
-                      "line": 1,
-                      "column": 9
-                    }
-                  ],
-                  "extensions": {
-                    "code": "OPERATION_PARSING_ERROR"
-                  }
+                  "line": 1,
+                  "column": 9
                 }
               ],
               "extensions": {
-                "grafbase": {
-                  "traceId": "0"
-                }
+                "code": "OPERATION_PARSING_ERROR"
               }
             }
-            "#
+          ],
+          "extensions": {
+            "grafbase": {
+              "traceId": "0"
+            }
+          }
+        }
+        "#
         );
     })
 }

--- a/crates/integration-tests/tests/federation/graphql_over_http/mod.rs
+++ b/crates/integration-tests/tests/federation/graphql_over_http/mod.rs
@@ -290,11 +290,11 @@ fn content_type_with_parameters(#[case] accept: &'static str) {
             .await;
         let status = response.status();
         let body: serde_json::Value = serde_json::from_slice(&response.into_body()).unwrap();
-        insta::assert_json_snapshot!(body, @r###"
+        insta::assert_json_snapshot!(body, @r#"
         {
           "errors": [
             {
-              "message": " --> 1:1\n  |\n1 | __typename\n  | ^---\n  |\n  = expected executable_definition",
+              "message": "unexpected non-variable identifier (e.g. 'x' or 'Foo') token (expected one of , \"{\"query, mutation, subscription, fragment)",
               "locations": [
                 {
                   "line": 1,
@@ -307,7 +307,7 @@ fn content_type_with_parameters(#[case] accept: &'static str) {
             }
           ]
         }
-        "###);
+        "#);
         assert_ne!(status, 405);
     })
 }

--- a/crates/integration-tests/tests/federation/inaccessible.rs
+++ b/crates/integration-tests/tests/federation/inaccessible.rs
@@ -142,7 +142,7 @@ fn inaccessible_argument() {
               "locations": [
                 {
                   "line": 1,
-                  "column": 9
+                  "column": 27
                 }
               ],
               "extensions": {
@@ -442,7 +442,7 @@ fn inaccessible_input_object() {
               "locations": [
                 {
                   "line": 1,
-                  "column": 9
+                  "column": 19
                 }
               ],
               "extensions": {

--- a/gateway/tests/access_logs/mod.rs
+++ b/gateway/tests/access_logs/mod.rs
@@ -135,15 +135,15 @@ fn with_broken_query() {
             .send()
             .await;
 
-        insta::assert_json_snapshot!(resp, @r###"
+        insta::assert_json_snapshot!(resp, @r#"
         {
           "errors": [
             {
-              "message": " --> 1:16\n  |\n1 | query Simple { \n  |                ^---\n  |\n  = expected selection",
+              "message": "unexpected end of file (expected one of , \"...\"RawIdent, schema, query, mutation, subscription, ty, input, true, false, null, implements, interface, \"enum\", union, scalar, extend, directive, repeatable, on, fragment)",
               "locations": [
                 {
                   "line": 1,
-                  "column": 16
+                  "column": 15
                 }
               ],
               "extensions": {
@@ -152,7 +152,7 @@ fn with_broken_query() {
             }
           ]
         }
-        "###);
+        "#);
     });
 
     let result = std::fs::read_to_string(tmpdir.path().join("access.log")).unwrap();

--- a/gateway/tests/telemetry/metrics/operation.rs
+++ b/gateway/tests/telemetry/metrics/operation.rs
@@ -577,11 +577,11 @@ fn prepare_duration_fail() {
             .send()
             .await;
 
-        insta::assert_json_snapshot!(resp, @r###"
+        insta::assert_json_snapshot!(resp, @r#"
         {
           "errors": [
             {
-              "message": " --> 1:31\n  |\n1 | query SimpleQuery { __typename\n  |                               ^---\n  |\n  = expected selection_set, selection, directive, or arguments",
+              "message": "unexpected end of file (expected one of , \":\"\"{\", \"}\", \"(\", \"@\", \"...\", RawIdent, schema, query, mutation, subscription, ty, input, true, false, null, implements, interface, \"enum\", union, scalar, extend, directive, repeatable, on, fragment)",
               "locations": [
                 {
                   "line": 1,
@@ -594,7 +594,7 @@ fn prepare_duration_fail() {
             }
           ]
         }
-        "###);
+        "#);
 
         tokio::time::sleep(METRICS_DELAY).await;
 

--- a/gateway/tests/telemetry/metrics/request.rs
+++ b/gateway/tests/telemetry/metrics/request.rs
@@ -54,11 +54,11 @@ fn basic() {
 fn request_error() {
     with_gateway(|service_name, start_time_unix, gateway, clickhouse| async move {
         let resp = gateway.gql::<serde_json::Value>(" __typ__ename }").send().await;
-        insta::assert_json_snapshot!(resp, @r###"
+        insta::assert_json_snapshot!(resp, @r#"
         {
           "errors": [
             {
-              "message": " --> 1:2\n  |\n1 |  __typ__ename }\n  |  ^---\n  |\n  = expected executable_definition",
+              "message": "unexpected non-variable identifier (e.g. 'x' or 'Foo') token (expected one of , \"{\"query, mutation, subscription, fragment)",
               "locations": [
                 {
                   "line": 1,
@@ -71,7 +71,7 @@ fn request_error() {
             }
           ]
         }
-        "###);
+        "#);
 
         tokio::time::sleep(METRICS_DELAY).await;
 


### PR DESCRIPTION
We decided a while ago to standardise on cynic-parser as it's faster & a bit more ergonomic than `async-graphql-parser` (and therefore `engine-parser`, which is just a fork of `async-graphql-parser`.  So this PR swaps the parser in `engine` to `cynic-parser`.

It's a fairly mechanical swap, the only complicating factor is cynic-parser tracking Spans as byte offsets, whereas we need line & column info for the `position` field in GraphQL errors.  So I've added some translation code for that.

Running our benchmarks this sees a 13-17% decrease in time in the benchmarks without an operation cache.  Although I wouldn't expect to see similar results in production since the operation cache bypasses parsing and waiting on subgraphs is likely to be much slower than parsing ever was.