### PR TITLE
cli: release 0.81.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "engine-config-builder"
-version = "0.80.4"
+version = "0.81.0"
 dependencies = [
  "engine-config",
  "gateway-config",
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "federation-audit-tests"
-version = "0.80.4"
+version = "0.81.0"
 dependencies = [
  "async-graphql-parser",
  "cynic-parser",
@@ -2960,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.80.4"
+version = "0.81.0"
 dependencies = [
  "assert_matches",
  "async-graphql",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-graphql-introspection"
-version = "0.80.4"
+version = "0.81.0"
 dependencies = [
  "cynic",
  "cynic-introspection",
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-backend"
-version = "0.80.4"
+version = "0.81.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-local-common"
-version = "0.80.4"
+version = "0.81.0"
 dependencies = [
  "const_format",
  "dirs",
@@ -3322,7 +3322,7 @@ dependencies = [
 
 [[package]]
 name = "graph-ref"
-version = "0.80.4"
+version = "0.81.0"
 dependencies = [
  "grafbase-workspace-hack",
 ]
@@ -5428,7 +5428,7 @@ dependencies = [
 
 [[package]]
 name = "operation-checks"
-version = "0.80.4"
+version = "0.81.0"
 dependencies = [
  "async-graphql-parser",
  "async-graphql-value",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "operation-normalizer"
-version = "0.80.4"
+version = "0.81.0"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -6943,7 +6943,7 @@ dependencies = [
 
 [[package]]
 name = "serde-dynamic-string"
-version = "0.80.4"
+version = "0.81.0"
 dependencies = [
  "ascii 1.1.0",
  "grafbase-workspace-hack",
@@ -8404,7 +8404,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-component-loader"
-version = "0.80.4"
+version = "0.81.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,13 @@ exclude = ["crates/wasi-component-loader/examples", "examples/hooks-template"]
 
 [patch.crates-io]
 multipart-stream = { git = "https://github.com/grafbase/multipart-stream-rs-fork", rev = "06ff198e4041c8a8c1c93e580c260d597727c193" } # http-1.0-fix-multipart-mixed
-# FIXME: Drop when a new version is released.
 # Make sure we use the workspace-hack package when building
 # this repo, but not when pulling it in
 # See https://docs.rs/cargo-hakari/0.9.30/cargo_hakari/patch_directive/index.html for details
 grafbase-workspace-hack.path = "crates/grafbase-workspace-hack"
 
 [workspace.package]
-version = "0.80.4"
+version = "0.81.0"
 edition = "2021"
 license = "MPL-2.0"
 homepage = "https://grafbase.com"

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.81.0] - 2024-11-27
+
+[CHANGELOG](changelog/0.81.0.md)
+
 ## [0.80.3] - 2024-11-15
 
 [CHANGELOG](changelog/0.80.3.md)

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -46,8 +46,8 @@ url = "2.5.0"
 uuid = { version = "1.8.0", features = ["v4"] }
 webbrowser = "1.0"
 
-common = { package = "grafbase-local-common", path = "../crates/grafbase-local-common", version = "0.80.4" }
-backend = { package = "grafbase-local-backend", path = "../crates/grafbase-local-backend", version = "0.80.4" }
+common = { package = "grafbase-local-common", path = "../crates/grafbase-local-common", version = "0.81.0" }
+backend = { package = "grafbase-local-backend", path = "../crates/grafbase-local-backend", version = "0.81.0" }
 grafbase-graphql-introspection.workspace = true
 graphql-lint.workspace = true
 graph-ref.workspace = true

--- a/cli/changelog/0.81.0.md
+++ b/cli/changelog/0.81.0.md
@@ -1,0 +1,3 @@
+## Changes
+
+- The `grafbase publish` command will now report when you publish a subgraph and neither the subgraph schema nor the url changes (they are identical to what is already published). In that case, no deployment will be created in the schema registry. (https://github.com/grafbase/grafbase/pull/2401)

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.80.4",
+  "version": "0.81.0",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.80.4",
+  "version": "0.81.0",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.80.4",
+  "version": "0.81.0",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.80.4",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.80.4",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.80.4",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.80.4",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.80.4"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.81.0",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.81.0",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.81.0",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.81.0",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.81.0"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.80.4",
+  "version": "0.81.0",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.80.4",
+  "version": "0.81.0",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.80.4",
+  "version": "0.81.0",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/crates/grafbase-local-backend/Cargo.toml
+++ b/crates/grafbase-local-backend/Cargo.toml
@@ -28,7 +28,7 @@ toml.workspace = true
 tower-http = { workspace = true, features = ["trace"] }
 urlencoding = "2.1.3"
 
-common = { package = "grafbase-local-common", path = "../grafbase-local-common", version = "0.80.4" }
+common = { package = "grafbase-local-common", path = "../grafbase-local-common", version = "0.81.0" }
 grafbase-workspace-hack.workspace = true
 grafbase-graphql-introspection.workspace = true
 gateway-config.workspace = true

--- a/crates/runtime-local/Cargo.toml
+++ b/crates/runtime-local/Cargo.toml
@@ -48,7 +48,7 @@ redis = { workspace = true, optional = true }
 
 reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 
-wasi-component-loader = { version = "0.80.4", path = "../wasi-component-loader", optional = true }
+wasi-component-loader = { version = "0.81.0", path = "../wasi-component-loader", optional = true }
 deadpool = { workspace = true, optional = true }
 grafbase-telemetry.workspace = true
 anyhow.workspace = true


### PR DESCRIPTION
## Changes

- The `grafbase publish` command will now report when you publish a subgraph and neither the subgraph schema nor the url changes (they are identical to what is already published). In that case, no deployment will be created in the schema registry. (https://github.com/grafbase/grafbase/pull/2401)