### PR TITLE
graphql-schema-diff: do not emit AddArgument on top of AddField

### DIFF
--- a/crates/graphql-schema-diff/CHANGELOG.md
+++ b/crates/graphql-schema-diff/CHANGELOG.md
@@ -7,6 +7,7 @@
 - The `ChangeKind` enum now has a `ChangeKind::as_str()` function and a `FromStr` implementation, implementing respectively its conversion to and from strings.
 - Implemented `ChangeKind::AddSchemaExtension` and `ChangeKind::RemoveSchemaExtension`. Schema extensions are assumed to be in the same order between the schemas.
 - BREAKING: Overhaul the path string format, and add a typed version (`Path`) with parsing and display implementations.
+- BREAKING: `diff()` no longer emits `AddFieldArgument` where there is already an `AddField` for the parent field, it will only be emitted if the field existed in the source schema. This is for consistency with similar nesting cases.
 
 ## 0.2.0 - 2024-07-16
 

--- a/crates/graphql-schema-diff/src/state.rs
+++ b/crates/graphql-schema-diff/src/state.rs
@@ -136,7 +136,11 @@ fn push_argument_changes(
     push_change: PushChangeFn<'_>,
 ) {
     for ([type_name, field_name, arg_name], (src, target)) in arguments_map {
-        let parent_is_gone = || matches!(&fields_map[&[*type_name, *field_name]], (Some(_), None));
+        let parent_is_gone = match fields_map[&[*type_name, *field_name]] {
+            (Some(_), None) => true,
+            (None, Some(_)) => continue,
+            _ => false,
+        };
 
         let argument_path = path::Path::TypeDefinition(
             type_name,
@@ -151,7 +155,7 @@ fn push_argument_changes(
             (None, Some(target)) => {
                 push_change(argument_path, ChangeKind::AddFieldArgument, target.span().into());
             }
-            (Some(_), None) if !parent_is_gone() => {
+            (Some(_), None) if !parent_is_gone => {
                 push_change(argument_path, ChangeKind::RemoveFieldArgument, Span::empty());
             }
             (Some(_), None) => (),

--- a/crates/graphql-schema-diff/tests/diff/add_fields_with_arguments.graphql
+++ b/crates/graphql-schema-diff/tests/diff/add_fields_with_arguments.graphql
@@ -1,0 +1,34 @@
+# An interface representing a generic Dr. Seuss character
+interface SeussCharacter {
+  id: ID!
+}
+
+# A specific object implementing the SeussCharacter interface, representing the Cat in the Hat
+type CatInHat implements SeussCharacter {
+  id: ID!
+}
+
+# An input object used when creating a new character in the world of Dr. Seuss
+input CreateSeussCharacterInput {
+  name: String!
+}
+
+# --- #
+
+interface SeussCharacter {
+  id: ID!
+  name: String!
+  whimsicalQuote(language: String, withExclamation: Boolean, mood: String): String!
+}
+
+type CatInHat implements SeussCharacter {
+  id: ID!
+  name(style: String, caps: Boolean): String!
+  whimsicalQuote(language: String, withExclamation: Boolean, mood: String): String!
+  hatStripes(color: String, pattern: String): Int!
+}
+
+input CreateSeussCharacterInput {
+  name: String!
+  favoriteRhyme: String!
+}

--- a/crates/graphql-schema-diff/tests/diff/add_fields_with_arguments.snapshot.json
+++ b/crates/graphql-schema-diff/tests/diff/add_fields_with_arguments.snapshot.json
@@ -1,0 +1,102 @@
+{
+  "src → target": [
+    {
+      "path": "CatInHat.hatStripes",
+      "kind": "AddField",
+      "span": {
+        "start": 326,
+        "end": 375
+      }
+    },
+    {
+      "path": "CatInHat.name",
+      "kind": "AddField",
+      "span": {
+        "start": 196,
+        "end": 242
+      }
+    },
+    {
+      "path": "CatInHat.whimsicalQuote",
+      "kind": "AddField",
+      "span": {
+        "start": 242,
+        "end": 326
+      }
+    },
+    {
+      "path": "CreateSeussCharacterInput.favoriteRhyme",
+      "kind": "AddField",
+      "span": {
+        "start": 430,
+        "end": 453
+      }
+    },
+    {
+      "path": "SeussCharacter.name",
+      "kind": "AddField",
+      "span": {
+        "start": 41,
+        "end": 57
+      }
+    },
+    {
+      "path": "SeussCharacter.whimsicalQuote",
+      "kind": "AddField",
+      "span": {
+        "start": 57,
+        "end": 139
+      }
+    }
+  ],
+  "target → src": [
+    {
+      "path": "CatInHat.hatStripes",
+      "kind": "RemoveField",
+      "span": {
+        "start": 0,
+        "end": 0
+      }
+    },
+    {
+      "path": "CatInHat.name",
+      "kind": "RemoveField",
+      "span": {
+        "start": 0,
+        "end": 0
+      }
+    },
+    {
+      "path": "CatInHat.whimsicalQuote",
+      "kind": "RemoveField",
+      "span": {
+        "start": 0,
+        "end": 0
+      }
+    },
+    {
+      "path": "CreateSeussCharacterInput.favoriteRhyme",
+      "kind": "RemoveField",
+      "span": {
+        "start": 0,
+        "end": 0
+      }
+    },
+    {
+      "path": "SeussCharacter.name",
+      "kind": "RemoveField",
+      "span": {
+        "start": 0,
+        "end": 0
+      }
+    },
+    {
+      "path": "SeussCharacter.whimsicalQuote",
+      "kind": "RemoveField",
+      "span": {
+        "start": 0,
+        "end": 0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
We do not emit, for example, AddField changes in a new type (e.g. AddObjectType). But we do emit AddFieldArgument changes in a new field. This is not consistent. This commit changes the behavior to not emit AddFieldArgument changes in a new field.