### PR TITLE
Fix helptext in gateway download script

### DIFF
--- a/cli/install/gateway
+++ b/cli/install/gateway
@@ -121,7 +121,7 @@ tildify() {
 success "grafbase-gateway was installed successfully to $Bold_Green$(tildify "$exe")"
 
 if command -v grafbase >/dev/null; then
-    echo "Run 'gateway --help' to get started"
+    echo "Run 'grafbase-gateway --help' to get started"
     exit
 fi
 


### PR DESCRIPTION
This is a message you see at the end when you run `curl -fsSL https://grafbase.com/downloads/gateway | bash`.

Since the binary is called grafbase-gateway, the suggestion doesn't work.