### PR TITLE
fix(engine): propagate null for inaccessible objects found behind an interface/object

### DIFF
--- a/crates/engine/schema/src/interface.rs
+++ b/crates/engine/schema/src/interface.rs
@@ -16,6 +16,10 @@ impl<'a> InterfaceDefinition<'a> {
     pub fn is_inaccessible(&self) -> bool {
         self.schema.graph.inaccessible_interface_definitions[self.id]
     }
+
+    pub fn has_inaccessible_implementors(&self) -> bool {
+        self.schema.graph.interface_has_inaccessible_implementors[self.id]
+    }
 }
 
 impl std::fmt::Debug for InterfaceDefinition<'_> {

--- a/crates/engine/schema/src/lib.rs
+++ b/crates/engine/schema/src/lib.rs
@@ -150,6 +150,7 @@ pub struct Graph {
     #[indexed_by(InterfaceDefinitionId)]
     interface_definitions: Vec<InterfaceDefinitionRecord>,
     inaccessible_interface_definitions: BitSet<InterfaceDefinitionId>,
+    interface_has_inaccessible_implementors: BitSet<InterfaceDefinitionId>,
     #[indexed_by(FieldDefinitionId)]
     field_definitions: Vec<FieldDefinitionRecord>,
     inaccessible_field_definitions: BitSet<FieldDefinitionId>,
@@ -159,6 +160,7 @@ pub struct Graph {
     #[indexed_by(UnionDefinitionId)]
     union_definitions: Vec<UnionDefinitionRecord>,
     inaccessible_union_definitions: BitSet<UnionDefinitionId>,
+    union_has_inaccessible_member: BitSet<UnionDefinitionId>,
     #[indexed_by(ScalarDefinitionId)]
     scalar_definitions: Vec<ScalarDefinitionRecord>,
     inaccessible_scalar_definitions: BitSet<ScalarDefinitionId>,

--- a/crates/engine/schema/src/union.rs
+++ b/crates/engine/schema/src/union.rs
@@ -19,6 +19,10 @@ impl UnionDefinition<'_> {
     pub fn is_inaccessible(&self) -> bool {
         self.schema.graph.inaccessible_union_definitions[self.id]
     }
+
+    pub fn has_inaccessible_member(&self) -> bool {
+        self.schema.graph.union_has_inaccessible_member[self.id]
+    }
 }
 
 impl std::fmt::Debug for UnionDefinition<'_> {

--- a/crates/engine/src/operation/plan/model/plan.rs
+++ b/crates/engine/src/operation/plan/model/plan.rs
@@ -26,11 +26,7 @@ impl<'a> Plan<'a> {
         self.query_partition().resolver_definition()
     }
     pub(crate) fn selection_set(&self) -> PlanSelectionSet<'a> {
-        PlanSelectionSet {
-            ctx: self.ctx,
-            item: self.query_partition().selection_set_record,
-            requires_typename: false,
-        }
+        self.ctx.view(self.query_partition_id).selection_set()
     }
     pub(crate) fn shape_id(&self) -> ConcreteShapeId {
         self.query_partition().shape_id

--- a/crates/engine/src/operation/plan/model/query_partition.rs
+++ b/crates/engine/src/operation/plan/model/query_partition.rs
@@ -32,8 +32,12 @@ impl<'a> PlanQueryPartition<'a> {
         PlanSelectionSet {
             ctx: self.ctx,
             item: self.as_ref().selection_set_record,
-            // Never required for the initial selection set as the parent plan provides the type.
-            requires_typename: false,
+            // If we may encounter an inaccessible object, we have to detect it
+            requires_typename: self
+                .entity_definition()
+                .as_interface()
+                .map(|inf| inf.has_inaccessible_implementors())
+                .unwrap_or_default(),
         }
     }
 }

--- a/crates/engine/src/operation/plan/model/selection_set.rs
+++ b/crates/engine/src/operation/plan/model/selection_set.rs
@@ -38,6 +38,7 @@ impl std::fmt::Debug for PlanSelectionSet<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SelectionSet")
             .field("fields", &self.fields().collect::<Vec<_>>())
+            .field("requiress_typename", &self.requires_typename())
             .finish()
     }
 }

--- a/crates/engine/src/response/shape/field.rs
+++ b/crates/engine/src/response/shape/field.rs
@@ -91,7 +91,7 @@ pub(crate) enum Shape {
 }
 
 impl Shape {
-    pub(crate) fn as_concrete_object(&self) -> Option<ConcreteShapeId> {
+    pub(crate) fn as_concrete(&self) -> Option<ConcreteShapeId> {
         match self {
             Shape::Concrete(id) => Some(*id),
             _ => None,

--- a/crates/engine/src/response/write/deserialize/enum.rs
+++ b/crates/engine/src/response/write/deserialize/enum.rs
@@ -29,7 +29,6 @@ impl<'de> DeserializeSeed<'de> for EnumValueSeed<'_, '_> {
 
         let string_value = std::borrow::Cow::<str>::deserialize(deserializer)?;
 
-        tracing::debug!("EnumDefinition {:#?}", id.walk(ctx.schema));
         match id.walk(ctx.schema).find_value_by_name(string_value.as_ref()) {
             // If inaccessible propagating an error without any message.
             Some(enum_value) => {

--- a/crates/integration-tests/tests/federation/inaccessible/mod.rs
+++ b/crates/integration-tests/tests/federation/inaccessible/mod.rs
@@ -1,3 +1,6 @@
+mod object_behind_interface;
+mod object_behind_union;
+
 use integration_tests::{federation::DeterministicEngine, runtime};
 use serde_json::json;
 

--- a/crates/integration-tests/tests/federation/inaccessible/object_behind_interface.rs
+++ b/crates/integration-tests/tests/federation/inaccessible/object_behind_interface.rs
@@ -1,0 +1,256 @@
+use std::future::Future;
+
+use engine::Engine;
+use graphql_mocks::dynamic::DynamicSchema;
+use integration_tests::{
+    federation::{EngineExt, TestGateway},
+    runtime,
+};
+use serde_json::json;
+
+const SCHEMA: &str = r#"
+type Query {
+  node: Node
+  nodes: [Node]!
+  requiredNode: Node!
+  listOfRequiredNodes: [Node!]!
+}
+
+interface Node {
+    id: ID!
+}
+
+type A implements Node {
+    id: ID!
+}
+
+type B implements Node @inaccessible {
+    id: ID!
+}
+"#;
+
+fn with_gateway<F: Future>(nodes: serde_json::Value, f: impl FnOnce(TestGateway) -> F) -> F::Output {
+    runtime().block_on(async move {
+        let gateway = Engine::builder()
+            .with_subgraph(
+                DynamicSchema::builder(SCHEMA)
+                    .with_resolver("Query", "node", nodes[0].clone())
+                    .with_resolver("Query", "requiredNode", nodes[0].clone())
+                    .with_resolver("Query", "nodes", nodes.clone())
+                    .with_resolver("Query", "listOfRequiredNodes", nodes.clone())
+                    .into_subgraph("test"),
+            )
+            .build()
+            .await;
+        f(gateway).await
+    })
+}
+
+#[test]
+fn accessible() {
+    with_gateway(json!([{"__typename": "A", "id": "a"}]), |gateway| async move {
+        let response = gateway
+            .post(
+                r#"{
+                    node { id }
+                    nodes { id }
+                    requiredNode { id }
+                    listOfRequiredNodes { id }
+                }"#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "node": {
+              "id": "a"
+            },
+            "nodes": [
+              {
+                "id": "a"
+              }
+            ],
+            "requiredNode": {
+              "id": "a"
+            },
+            "listOfRequiredNodes": [
+              {
+                "id": "a"
+              }
+            ]
+          }
+        }
+        "#);
+    });
+}
+
+#[test]
+fn inaccessible() {
+    with_gateway(json!([{"__typename": "B", "id": "b"}]), |gateway| async move {
+        let response = gateway
+            .post(
+                r#"{
+                    node { id }
+                }"#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "node": null
+          }
+        }
+        "#);
+
+        let response = gateway
+            .post(
+                r#"{
+                    nodes { id }
+                }"#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "nodes": [
+              null
+            ]
+          }
+        }
+        "#);
+
+        let response = gateway
+            .post(
+                r#"{
+                    requiredNode { id }
+                }"#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": null
+        }
+        "#);
+
+        let response = gateway
+            .post(
+                r#"{
+                    listOfRequiredNodes { id }
+                }"#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": null
+        }
+        "#);
+    });
+}
+
+#[test]
+fn partially_inaccessible() {
+    with_gateway(
+        json!([{"__typename": "B", "id": "b"}, {"__typename": "A", "id": "a"}]),
+        |gateway| async move {
+            let response = gateway
+                .post(
+                    r#"{
+                    node { id }
+                }"#,
+                )
+                .await;
+            insta::assert_json_snapshot!(response, @r#"
+            {
+              "data": {
+                "node": null
+              }
+            }
+            "#);
+
+            let response = gateway
+                .post(
+                    r#"{
+                    nodes { id }
+                }"#,
+                )
+                .await;
+            insta::assert_json_snapshot!(response, @r#"
+            {
+              "data": {
+                "nodes": [
+                  null,
+                  {
+                    "id": "a"
+                  }
+                ]
+              }
+            }
+            "#);
+
+            let response = gateway
+                .post(
+                    r#"{
+                    requiredNode { id }
+                }"#,
+                )
+                .await;
+            insta::assert_json_snapshot!(response, @r#"
+            {
+              "data": null
+            }
+            "#);
+
+            let response = gateway
+                .post(
+                    r#"{
+                    listOfRequiredNodes { id }
+                }"#,
+                )
+                .await;
+            insta::assert_json_snapshot!(response, @r#"
+            {
+              "data": null
+            }
+            "#);
+        },
+    );
+}
+
+#[test]
+fn inaccessible_extra() {
+    runtime().block_on(async move {
+        let gateway = Engine::builder()
+            .with_subgraph(
+                DynamicSchema::builder(SCHEMA)
+                    .with_resolver("Query", "node", json!({"__typename": "B", "id": "b"}))
+                    .into_subgraph("x"),
+            )
+            .with_subgraph(
+                DynamicSchema::builder(
+                    r#"
+                type Query {
+                    node: Node @external
+                    other: String @requires(fields: "node { id }")
+                }
+
+                interface Node @external {
+                    id: ID!
+                }
+                "#,
+                )
+                .with_resolver("Query", "other", json!("yes"))
+                .into_subgraph("y"),
+            )
+            .build()
+            .await;
+
+        let response = gateway.post("{ other }").await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "other": "yes"
+          }
+        }
+        "#);
+    })
+}

--- a/crates/integration-tests/tests/federation/inaccessible/object_behind_union.rs
+++ b/crates/integration-tests/tests/federation/inaccessible/object_behind_union.rs
@@ -1,0 +1,256 @@
+use std::future::Future;
+
+use engine::Engine;
+use graphql_mocks::dynamic::DynamicSchema;
+use integration_tests::{
+    federation::{EngineExt, TestGateway},
+    runtime,
+};
+use serde_json::json;
+
+const SCHEMA: &str = r#"
+type Query {
+  node: Node
+  nodes: [Node]!
+  requiredNode: Node!
+  listOfRequiredNodes: [Node!]!
+}
+
+union Node = A | B
+
+type A {
+    id: ID!
+}
+
+type B @inaccessible {
+    id: ID!
+}
+"#;
+
+fn with_gateway<F: Future>(nodes: serde_json::Value, f: impl FnOnce(TestGateway) -> F) -> F::Output {
+    runtime().block_on(async move {
+        let gateway = Engine::builder()
+            .with_subgraph(
+                DynamicSchema::builder(SCHEMA)
+                    .with_resolver("Query", "node", nodes[0].clone())
+                    .with_resolver("Query", "requiredNode", nodes[0].clone())
+                    .with_resolver("Query", "nodes", nodes.clone())
+                    .with_resolver("Query", "listOfRequiredNodes", nodes.clone())
+                    .into_subgraph("test"),
+            )
+            .build()
+            .await;
+        f(gateway).await
+    })
+}
+
+#[test]
+fn accessible() {
+    with_gateway(json!([{"__typename": "A", "id": "a"}]), |gateway| async move {
+        let response = gateway
+            .post(
+                r#"{
+                    node { __typename }
+                    nodes { __typename }
+                    requiredNode { __typename }
+                    listOfRequiredNodes { __typename }
+                }"#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "node": {
+              "__typename": "A"
+            },
+            "nodes": [
+              {
+                "__typename": "A"
+              }
+            ],
+            "requiredNode": {
+              "__typename": "A"
+            },
+            "listOfRequiredNodes": [
+              {
+                "__typename": "A"
+              }
+            ]
+          }
+        }
+        "#);
+    });
+}
+
+#[test]
+fn inaccessible() {
+    with_gateway(json!([{"__typename": "B", "id": "b"}]), |gateway| async move {
+        let response = gateway
+            .post(
+                r#"{
+                    node { __typename }
+                }"#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "node": null
+          }
+        }
+        "#);
+
+        let response = gateway
+            .post(
+                r#"{
+                    nodes { __typename }
+                }"#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "nodes": [
+              null
+            ]
+          }
+        }
+        "#);
+
+        let response = gateway
+            .post(
+                r#"{
+                    requiredNode { __typename }
+                }"#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": null
+        }
+        "#);
+
+        let response = gateway
+            .post(
+                r#"{
+                    listOfRequiredNodes { __typename }
+                }"#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": null
+        }
+        "#);
+    });
+}
+
+#[test]
+fn partially_inaccessible() {
+    with_gateway(
+        json!([{"__typename": "B", "id": "b"}, {"__typename": "A", "id": "a"}]),
+        |gateway| async move {
+            let response = gateway
+                .post(
+                    r#"{
+                    node { __typename }
+                }"#,
+                )
+                .await;
+            insta::assert_json_snapshot!(response, @r#"
+            {
+              "data": {
+                "node": null
+              }
+            }
+            "#);
+
+            let response = gateway
+                .post(
+                    r#"{
+                    nodes { __typename }
+                }"#,
+                )
+                .await;
+            insta::assert_json_snapshot!(response, @r#"
+            {
+              "data": {
+                "nodes": [
+                  null,
+                  {
+                    "__typename": "A"
+                  }
+                ]
+              }
+            }
+            "#);
+
+            let response = gateway
+                .post(
+                    r#"{
+                    requiredNode { __typename }
+                }"#,
+                )
+                .await;
+            insta::assert_json_snapshot!(response, @r#"
+            {
+              "data": null
+            }
+            "#);
+
+            let response = gateway
+                .post(
+                    r#"{
+                    listOfRequiredNodes { __typename }
+                }"#,
+                )
+                .await;
+            insta::assert_json_snapshot!(response, @r#"
+            {
+              "data": null
+            }
+            "#);
+        },
+    );
+}
+
+#[test]
+fn inaccessible_extra() {
+    runtime().block_on(async move {
+        let gateway = Engine::builder()
+            .with_subgraph(
+                DynamicSchema::builder(SCHEMA)
+                    .with_resolver("Query", "node", json!({"__typename": "B", "id": "b"}))
+                    .into_subgraph("x"),
+            )
+            .with_subgraph(
+                DynamicSchema::builder(
+                    r#"
+                type Query {
+                    node: Node @external
+                    other: String @requires(fields: "node { ... on B { id } }")
+                }
+
+                union Node = B
+
+                type B {
+                    id: ID! @external
+                }
+                "#,
+                )
+                .with_resolver("Query", "other", json!("yes"))
+                .into_subgraph("y"),
+            )
+            .build()
+            .await;
+
+        let response = gateway.post("{ other }").await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "other": "yes"
+          }
+        }
+        "#);
+    })
+}


### PR DESCRIPTION
When encountering an inaccessible object behind an interface/union we have to propagate a null without any error.

So keeping track of unions & interfaces with inaccessible possible types and forcing the type detection for those to ensure we only return accessible objects.