### PR TITLE
fix: make derive as a default feature for grafbase-hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3086,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-hooks"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "grafbase-hooks-derive",
  "serde",

--- a/crates/grafbase-hooks/Cargo.toml
+++ b/crates/grafbase-hooks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-hooks"
-version = "0.1.7"
+version = "0.1.8"
 description = "An SDK to implement hooks for the Grafbase Gateway"
 edition.workspace = true
 license.workspace = true
@@ -9,6 +9,7 @@ keywords.workspace = true
 repository.workspace = true
 
 [features]
+default = ["derive"]
 derive = ["dep:grafbase-hooks-derive"]
 
 [dependencies]

--- a/crates/wasi-component-loader/examples/Cargo.lock
+++ b/crates/wasi-component-loader/examples/Cargo.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-hooks"
-version = "0.1.6"
+version = "0.1.8"
 dependencies = [
  "grafbase-hooks-derive",
  "serde",

--- a/crates/wasi-component-loader/examples/Cargo.toml
+++ b/crates/wasi-component-loader/examples/Cargo.toml
@@ -21,4 +21,4 @@ lto = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 base64 = "0.22"
-grafbase-hooks = { path = "../../grafbase-hooks", features = ["derive"] }
+grafbase-hooks = { path = "../../grafbase-hooks" }

--- a/examples/access-logs/Cargo.lock
+++ b/examples/access-logs/Cargo.lock
@@ -581,9 +581,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "grafbase-hooks"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25436b84a7775d94cec6686745f7903e0db680503e3d85ef03dd283ce03ceda5"
+checksum = "a20055027fe610ec9c976afea7c46165c38beb79cf43835b5ba8365f55e75c53"
 dependencies = [
  "grafbase-hooks-derive",
  "serde",

--- a/examples/access-logs/hooks/Cargo.toml
+++ b/examples/access-logs/hooks/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 postcard = { version = "1.0.10", features = ["use-std"] }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.118"
-grafbase-hooks = { version = "0.1.7", features = ["derive"] }
+grafbase-hooks = "0.1.8"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/gateway-hooks/Cargo.lock
+++ b/examples/gateway-hooks/Cargo.lock
@@ -578,9 +578,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "grafbase-hooks"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25436b84a7775d94cec6686745f7903e0db680503e3d85ef03dd283ce03ceda5"
+checksum = "a20055027fe610ec9c976afea7c46165c38beb79cf43835b5ba8365f55e75c53"
 dependencies = [
  "grafbase-hooks-derive",
  "serde",

--- a/examples/gateway-hooks/hooks/Cargo.toml
+++ b/examples/gateway-hooks/hooks/Cargo.toml
@@ -14,7 +14,7 @@ serde_json = "1.0.118"
 tracing = "0.1.40"
 itertools = "0.13"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-grafbase-hooks = { version = "0.1.7", features = ["derive"] }
+grafbase-hooks = "0.1.8"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/hooks-template/Cargo.lock
+++ b/examples/hooks-template/Cargo.lock
@@ -60,9 +60,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "grafbase-hooks"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25436b84a7775d94cec6686745f7903e0db680503e3d85ef03dd283ce03ceda5"
+checksum = "a20055027fe610ec9c976afea7c46165c38beb79cf43835b5ba8365f55e75c53"
 dependencies = [
  "grafbase-hooks-derive",
  "serde",

--- a/examples/hooks-template/Cargo.toml
+++ b/examples/hooks-template/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["grafbase"]
 repository = "https://github.com/grafbase/grafbase"
 
 [dependencies]
-grafbase-hooks = { version = "0.1.7", features = ["derive"] }
+grafbase-hooks = "0.1.8"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/request-hook/Cargo.lock
+++ b/examples/request-hook/Cargo.lock
@@ -587,9 +587,9 @@ checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
 name = "grafbase-hooks"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25436b84a7775d94cec6686745f7903e0db680503e3d85ef03dd283ce03ceda5"
+checksum = "a20055027fe610ec9c976afea7c46165c38beb79cf43835b5ba8365f55e75c53"
 dependencies = [
  "grafbase-hooks-derive",
  "serde",

--- a/examples/request-hook/request-hook/Cargo.toml
+++ b/examples/request-hook/request-hook/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-grafbase-hooks = { version = "0.1.7", features = ["derive"] }
+grafbase-hooks = "0.1.8"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
The users will always want it anyhow.