### PR TITLE
chore: start using wasm32-wasip2 target instead of cargo-component

### DIFF
--- a/.github/workflows/rust-prs.yml
+++ b/.github/workflows/rust-prs.yml
@@ -130,20 +130,15 @@ jobs:
       - name: Install cargo binstall
         uses: cargo-bins/cargo-binstall@v1.10.15
 
-      - name: Install cargo-component
-        shell: bash
-        run: |
-          cargo binstall cargo-component --secure -y
-
       - name: Build the WASI components for tests
         shell: bash
         working-directory: crates/wasi-component-loader/examples
-        run: cargo component build
+        run: cargo build --target wasm32-wasip2
 
       - uses: actions/upload-artifact@v4
         with:
           name: example-component
-          path: crates/wasi-component-loader/examples/target/wasm32-wasip1/debug/*.wasm
+          path: crates/wasi-component-loader/examples/target/wasm32-wasip2/debug/*.wasm
           retention-days: 5
 
   builds:
@@ -227,7 +222,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: example-component
-          path: crates/wasi-component-loader/examples/target/wasm32-wasip1/debug
+          path: crates/wasi-component-loader/examples/target/wasm32-wasip2/debug
 
       # TODO: Add timing reports in here somehow...
 

--- a/cli/src/dev.rs
+++ b/cli/src/dev.rs
@@ -7,6 +7,7 @@ pub fn dev(cmd: DevCommand) -> Result<(), CliError> {
         graph: graph_ref.graph().to_owned(),
         branch: graph_ref.branch().map(|branch| branch.to_owned()),
     });
+
     backend::dev::start(full_graph_ref, cmd.gateway_config, cmd.graph_overrides, cmd.port)
         .map_err(CliError::BackendError)
 }

--- a/crates/grafbase-hooks/README.md
+++ b/crates/grafbase-hooks/README.md
@@ -6,9 +6,20 @@ A hook is a function that is called by the gateway at specific points in the req
 Build your own hooks by implementing the [`Hooks`] trait, add the [`grafbase_hooks`] attribute on top of the hooks
 implementation and register the hooks type to the gateway using the [`register_hooks`] macro.
 
-The hooks component is a WASM module that is loaded by the gateway at startup. Your hooks library must be compiled with the
-[`cargo-component`](https://github.com/bytecodealliance/cargo-component) toolchain, which compiles the hooks as a wasm32-wasip1
-module, and inserts the needed shims so the module can act as a wasm32-wasip2 component.
+The hooks component is a WASM module that is loaded by the gateway at startup. If you are using Rust version 1.83 or later,
+you can install the `wasm32-wasip2` target with the following command:
+
+```bash
+rustup target add wasm32-wasip2
+```
+
+For older versions of Rust, you can use the `wasm32-wasip1` target, but you must compile your hooks with the
+[`cargo-component`](https://github.com/bytecodealliance/cargo-component) toolchain, which adds a compatibility
+layer to the hooks module so it can be loaded by the gateway:
+
+```bash
+cargo install cargo-component
+```
 
 ## Usage
 
@@ -63,14 +74,22 @@ for every request.
 The [`grafbase_hooks`] attribute is used to generate the necessary code for the hooks implementation and
 the [`register_hooks`] macro registers the hooks type to the gateway. The macro must be called in the library crate root.
 
-The hooks are compiled with the `cargo-component` subcommand:
+To compile the hooks with Rust 1.83 or later:
+
+```
+cargo build --target wasm32-wasip2 --release
+```
+
+With older versions of Rust, the hooks are compiled with the `cargo-component` subcommand:
 
 ```bash
 cargo component build --release
 ```
 
-The compiled hooks wasm module is located in the `target/wasm32-wasip1/release` directory. You can configure the gateway to load
-the hooks in the `grafbase.toml` configuration file:
+With Rust 1.83 or later, the compiled hooks wasm module is located in the `target/wasm32-wasip2/release` directory. With older
+versions of Rust, the compiled hooks wasm module is located in the `target/wasm32-wasip1/release` directory.
+
+You can configure the gateway to load the hooks in the `grafbase.toml` configuration file:
 
 ```toml
 [hooks]

--- a/crates/integration-tests/src/federation/builder/engine.rs
+++ b/crates/integration-tests/src/federation/builder/engine.rs
@@ -93,7 +93,7 @@ async fn update_runtime_with_toml_config(
         let loader = ComponentLoader::new(hooks_config)
             .ok()
             .flatten()
-            .expect("Wasm examples weren't built, please run:\ncd crates/wasi-component-loader/examples && cargo component build");
+            .expect("Wasm examples weren't built, please run:\ncd crates/wasi-component-loader/examples && cargo build --target wasm32-wasip2");
 
         let meter = meter_from_global_provider();
         let hooks = HooksWasi::new(Some(loader), None, &meter, access_log_sender).await;

--- a/crates/integration-tests/tests/federation/hooks/on_subgraph_request.rs
+++ b/crates/integration-tests/tests/federation/hooks/on_subgraph_request.rs
@@ -22,7 +22,7 @@ fn wasi() {
                 name = "hi"
 
                 [hooks]
-                location = "../wasi-component-loader/examples/target/wasm32-wasip1/debug/subgraph_request.wasm"
+                location = "../wasi-component-loader/examples/target/wasm32-wasip2/debug/subgraph_request.wasm"
                 "###,
             )
             .build()

--- a/crates/wasi-component-loader/README.md
+++ b/crates/wasi-component-loader/README.md
@@ -1,44 +1,7 @@
-# Wasm component loader for the Grafbase Gateway
+# Wasm Component Loader for the Grafbase Gateway
 
-Adds support for loading WebAssembly components in the Grafbase Gateway. The Wasm file has to be in a form of WASI Preview 2 component, which can be created using the [cargo-component](https://github.com/bytecodealliance/cargo-component) tooling. See the examples for simple guest components, which are all tested in CI for this crate and work together with the host library.
+Adds support for loading WebAssembly components in the Grafbase Gateway. The Wasm file has to be in a form of WASI Preview 2 component. Compile all examples with the `wasm32-wasip2` target. See the examples for simple guest components, which are all tested in CI for this crate and work together with the host library.
 
-The component interface must define the types defined in a wit file:
+You can create a hooks component using the [grafbase-hooks](/grafbase/grafbase/tree/main/crates/grafbase-hooks) crate.
 
-```wit
-package component:grafbase;
-
-interface types {
-    enum header-error {
-        invalid-header-value,
-        invalid-header-name,
-    }
-
-    resource headers {
-        get: func(name: string) -> result<option<string>, header-error>;
-        set: func(name: string, value: string) -> result<_, header-error>;
-        delete: func(name: string) -> result<option<string>, header-error>;
-    }
-
-    resource gateway-request {
-        get-operation-name: func() -> option<string>;
-        set-operation-name: func(name: option<string>);
-        get-document-id: func() -> option<string>;
-        set-document-id: func(id: option<string>);
-    }
-
-    record error-response {
-        status: option<u16>,
-        message: string,
-    }
-}
-
-world gateway {
-    use types.{headers, gateway-request, error-response};
-
-    export on-gateway-request: func(headers: headers, request: gateway-request) -> result<_, error-response>;
-}
-```
-
-The world defines the functions the guest is interested to plug into. If not wanting to handle this exact hook, the hook should be removed from the wit definition. If the host cannot find that exact function from the guest, the host hook will be a no-op.
-
-Only tested with Rust guests so far. If using another guest language, your mileage may vary.
+The component defines the functions the guest is interested to plug into. If the host cannot find that exact function from the guest, the host hook will be a no-op.

--- a/crates/wasi-component-loader/src/tests.rs
+++ b/crates/wasi-component-loader/src/tests.rs
@@ -36,7 +36,7 @@ async fn missing_hook() {
     // the guest code in examples/missing_hook/src/lib.rs
 
     let config = indoc! {r#"
-        location = "examples/target/wasm32-wasip1/debug/missing_hook.wasm"
+        location = "examples/target/wasm32-wasip2/debug/missing_hook.wasm"
         stdout = true
         stderr = true
     "#};
@@ -61,7 +61,7 @@ async fn simple_no_io() {
     std::env::set_var("GRAFBASE_WASI_TEST", "meow");
 
     let config = indoc! {r#"
-        location = "examples/target/wasm32-wasip1/debug/simple.wasm"
+        location = "examples/target/wasm32-wasip2/debug/simple.wasm"
         environment_variables = true
         stdout = true
         stderr = true
@@ -93,7 +93,7 @@ async fn dir_access_read_only() {
     let path_str = path.to_str().unwrap().escape_default();
 
     let config = formatdoc! {r#"
-        location = "examples/target/wasm32-wasip1/debug/dir_access.wasm"
+        location = "examples/target/wasm32-wasip2/debug/dir_access.wasm"
         stdout = true
         stderr = true
 
@@ -132,7 +132,7 @@ async fn dir_access_write() {
     let path_str = path.to_str().unwrap().escape_default();
 
     let config = formatdoc! {r#"
-        location = "examples/target/wasm32-wasip1/debug/dir_access.wasm"
+        location = "examples/target/wasm32-wasip2/debug/dir_access.wasm"
         stdout = true
         stderr = true
 
@@ -176,7 +176,7 @@ async fn http_client() {
     std::env::set_var("MOCK_SERVER_ADDRESS", format!("http://{}", server.address()));
 
     let config = formatdoc! {r#"
-        location = "examples/target/wasm32-wasip1/debug/http_client.wasm"
+        location = "examples/target/wasm32-wasip2/debug/http_client.wasm"
         environment_variables = true
         stdout = true
         stderr = true
@@ -198,7 +198,7 @@ async fn guest_error() {
     // the guest code in examples/error/src/lib.rs
 
     let config = indoc! {r#"
-        location = "examples/target/wasm32-wasip1/debug/error.wasm"
+        location = "examples/target/wasm32-wasip2/debug/error.wasm"
     "#};
 
     let config: Config = toml::from_str(config).unwrap();
@@ -229,7 +229,7 @@ async fn authorize_edge_pre_execution_error() {
     // the guest code in examples/authorization/src/lib.rs
 
     let config = indoc! {r#"
-        location = "examples/target/wasm32-wasip1/debug/authorization.wasm"
+        location = "examples/target/wasm32-wasip2/debug/authorization.wasm"
     "#};
 
     let config: Config = toml::from_str(config).unwrap();
@@ -278,7 +278,7 @@ async fn authorize_edge_pre_execution_success() {
     // the guest code in examples/authorization/src/lib.rs
 
     let config = indoc! {r#"
-        location = "examples/target/wasm32-wasip1/debug/authorization.wasm"
+        location = "examples/target/wasm32-wasip2/debug/authorization.wasm"
     "#};
 
     let config: Config = toml::from_str(config).unwrap();
@@ -319,7 +319,7 @@ async fn authorize_node_pre_execution_error() {
     // the guest code in examples/authorization/src/lib.rs
 
     let config = indoc! {r#"
-        location = "examples/target/wasm32-wasip1/debug/authorization.wasm"
+        location = "examples/target/wasm32-wasip2/debug/authorization.wasm"
     "#};
 
     let config: Config = toml::from_str(config).unwrap();
@@ -362,7 +362,7 @@ async fn authorize_node_pre_execution_success() {
     // the guest code in examples/authorization/src/lib.rs
 
     let config = indoc! {r#"
-        location = "examples/target/wasm32-wasip1/debug/authorization.wasm"
+        location = "examples/target/wasm32-wasip2/debug/authorization.wasm"
     "#};
 
     let config: Config = toml::from_str(config).unwrap();
@@ -397,7 +397,7 @@ async fn authorize_parent_edge_post_execution() {
     // the guest code in examples/authorization/src/lib.rs
 
     let config = indoc! {r#"
-        location = "examples/target/wasm32-wasip1/debug/authorization.wasm"
+        location = "examples/target/wasm32-wasip2/debug/authorization.wasm"
     "#};
 
     let config: Config = toml::from_str(config).unwrap();
@@ -455,7 +455,7 @@ async fn authorize_edge_node_post_execution() {
     // the guest code in examples/authorization/src/lib.rs
 
     let config = indoc! {r#"
-        location = "examples/target/wasm32-wasip1/debug/authorization.wasm"
+        location = "examples/target/wasm32-wasip2/debug/authorization.wasm"
     "#};
 
     let config: Config = toml::from_str(config).unwrap();
@@ -509,7 +509,7 @@ async fn authorize_edge_post_execution() {
     // the guest code in examples/authorization/src/lib.rs
 
     let config = indoc! {r#"
-        location = "examples/target/wasm32-wasip1/debug/authorization.wasm"
+        location = "examples/target/wasm32-wasip2/debug/authorization.wasm"
         stdout = true
         stderr = true
     "#};
@@ -588,7 +588,7 @@ async fn on_subgraph_request() {
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 
     let config = indoc! {r#"
-        location = "examples/target/wasm32-wasip1/debug/subgraph_request.wasm"
+        location = "examples/target/wasm32-wasip2/debug/subgraph_request.wasm"
     "#};
 
     let config: Config = toml::from_str(config).unwrap();
@@ -663,7 +663,7 @@ async fn on_subgraph_request() {
 #[tokio::test]
 async fn response_hooks() {
     let config = indoc! {r#"
-        location = "examples/target/wasm32-wasip1/debug/response_hooks.wasm"
+        location = "examples/target/wasm32-wasip2/debug/response_hooks.wasm"
         stdout = true
         stderr = true
     "#};

--- a/examples/access-logs/README.md
+++ b/examples/access-logs/README.md
@@ -16,7 +16,8 @@ To run this example, you'll need:
 - Grafbase Gateway version 0.12.0 or later ([install instructions](https://grafbase.com/docs/self-hosted-gateway/))
 - A C compiler (e.g., clang) and pkg-config
 - Rust compiler ([installation guide](https://www.rust-lang.org/learn/get-started))
-- Cargo component ([installation guide](https://github.com/bytecodealliance/cargo-component?tab=readme-ov-file#installation))
+- The wasm32-wasip2 target for Rust version 1.83 or later (`rustup target add wasm32-wasip2`)
+- Cargo component for Rust version 1.82 or earlier ([installation guide](https://github.com/bytecodealliance/cargo-component?tab=readme-ov-file#installation))
 
 For advanced users using nix with flakes support:
 
@@ -39,14 +40,23 @@ cd subgraph
 cargo run --release
 ```
 
-Compile the WebAssembly hook functions into a Wasm component in another terminal:
+Compile the WebAssembly hook functions into a Wasm component in another terminal.
+
+On Rust 1.83 or later:
+
+```bash
+cd hooks
+cargo build --target wasm32-wasip2
+```
+
+On Rust 1.82 or earlier:
 
 ```bash
 cd hooks
 cargo component build --release
 ```
 
-After a successful build, the component will be found at `target/wasm32-wasip1/release/hooks.wasm`. This file must exist to continue.
+After a successful build, the component will be found at `target/wasm32-wasip(1 or 2)/release/hooks.wasm`. This file must exist to continue.
 
 Finally, start the `grafbase-gateway`:
 

--- a/examples/access-logs/grafbase.toml
+++ b/examples/access-logs/grafbase.toml
@@ -2,7 +2,7 @@
 introspection = true
 
 [hooks]
-location = "target/wasm32-wasip1/release/hooks.wasm"
+location = "target/wasm32-wasip2/release/hooks.wasm"
 
 [gateway.access_logs]
 enabled = true

--- a/examples/gateway-hooks/README.md
+++ b/examples/gateway-hooks/README.md
@@ -20,7 +20,8 @@ Additionally, the following tools are needed:
 - A C compiler, such as clang together with pkg-config (install based on your system, `cc` command is required)
 - If on Linux, cargo-component depends on OpenSSL (`libssl-dev` on Debian)
 - Rust compiler ([install docs](https://www.rust-lang.org/learn/get-started))
-- Cargo component ([install docs](https://github.com/bytecodealliance/cargo-component?tab=readme-ov-file#installation))
+- Cargo component on Rust 1.82 or older ([install docs](https://github.com/bytecodealliance/cargo-component?tab=readme-ov-file#installation))
+- Rust target wasm32-wasip2 for Rust 1.83 or later (`rustup target add wasm32-wasip2`)
 - A GraphQL client, such as [Altair](https://altair-gql.sirmuel.design/)
 
 For the advanced users using nix with flakes support:
@@ -37,14 +38,23 @@ First, start the subgraph in one terminal:
 docker compose up --force-recreate --build -d
 ```
 
-Next compile the WebAssembly hook functions into a Wasm component in another terminal:
+Next compile the WebAssembly hook functions into a Wasm component in another terminal.
+
+On Rust 1.83 or later:
+
+```bash
+cd hooks
+cargo build --target wasm32-wasip2
+```
+
+On Rust 1.82 or earlier:
 
 ```bash
 cd hooks
 cargo component build --release
 ```
 
-After a successful build, the Wasm component should be located at `target/wasm32-wasip1/release/demo_hooks.wasm`.
+After a successful build, the Wasm component should be located at `target/wasm32-wasip(1 or 2)/release/demo_hooks.wasm`.
 
 The `grafbase-gateway` is already started in the docker compose file, restart it to take the hook changes into account:
 

--- a/examples/gateway-hooks/grafbase.toml
+++ b/examples/gateway-hooks/grafbase.toml
@@ -2,7 +2,7 @@
 introspection = true
 
 [hooks]
-location = "target/wasm32-wasip1/release/hooks.wasm"
+location = "target/wasm32-wasip2/release/hooks.wasm"
 stdout = true
 stderr = true
 environment_variables = true

--- a/examples/gateway-hooks/rust-toolchain.toml
+++ b/examples/gateway-hooks/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 profile = "default"
-channel = "1.80.0"
+channel = "1.83.0"
 targets = [
     "aarch64-apple-darwin",
     "x86_64-apple-darwin",

--- a/examples/hooks-template/README.md
+++ b/examples/hooks-template/README.md
@@ -3,13 +3,19 @@
 Use this template as the basis of your Grafbase hooks. For development, you need:
 
 - Rust ([install](https://rustup.rs/))
-- Cargo Component ([install](https://github.com/bytecodealliance/cargo-component))
-- A C compiler (e.g., clang) and pkg-config
+- Cargo Component, if using older Rust than 1.83 ([install](https://github.com/bytecodealliance/cargo-component))
+- The wasm32-wasip2 target for Rust version 1.83 or later (`rustup target add wasm32-wasip2`)
 
-To compile the hooks, run:
+To compile the hooks with Rust 1.83 or later, run:
+
+```bash
+cargo build --release --target wasm32-wasip2
+```
+
+To compile the hooks with Rust 1.82 or older, run:
 
 ```bash
 cargo component build --release
 ```
 
-The compiled hooks are in the `target/wasm32-wasip1/release/hooks_template.wasm` file. To change the name of the file, rename the crate in the `Cargo.toml` file. This file should be deployed together with the Grafbase Gateway.
+The compiled hooks are in the `target/wasm32-wasip2/release/hooks_template.wasm` file with Rust 1.83 or later, and in `target/wasm32-wasip1/release/hooks_template.wasm` file for earlier rust versions. To change the name of the file, rename the crate in the `Cargo.toml` file. This file should be deployed together with the Grafbase Gateway.

--- a/examples/request-hook/README.md
+++ b/examples/request-hook/README.md
@@ -16,7 +16,8 @@ To run this example, you need the following:
 - Grafbase Gateway version 0.12.0 or later ([installation instructions](https://grafbase.com/docs/self-hosted-gateway/))
 - A C compiler (e.g., clang) and pkg-config
 - Rust compiler ([installation guide](https://www.rust-lang.org/learn/get-started))
-- Cargo component ([installation guide](https://github.com/bytecodealliance/cargo-component?tab=readme-ov-file#installation))
+- The wasm32-wasip2 target for Rust 1.83 or later (`rustup target add wasm32-wasip2`)
+- Cargo component ([installation guide](https://github.com/bytecodealliance/cargo-component?tab=readme-ov-file#installation)) for Rust 1.82 or earlier.
 
 For advanced users with nix and flakes support, run the following:
 
@@ -33,14 +34,23 @@ nix develop
    cargo run --release
    ```
 
-2. **Compile the WebAssembly Hook**: Open another terminal and navigate to the request-hook directory. Compile the WebAssembly hook functions into a Wasm component:
+2. **Compile the WebAssembly Hook**: Open another terminal and navigate to the request-hook directory. Compile the WebAssembly hook functions into a Wasm component.
+
+   With Rust 1.83 or later:
+
+   ```bash
+   cd request-hook
+   cargo build --target wasm32-wasip2 --release
+   ```
+
+   With Rust 1.82 or earlier:
 
    ```bash
    cd request-hook
    cargo component build --release
    ```
 
-   After a successful build, you will find the component at `target/wasm32-wasip1/request-hook/hooks.wasm`. This file must exist to proceed.
+   After a successful build, you will find the component at `target/wasm32-wasip(1 or 2)/request-hook/hooks.wasm`. This file must exist to proceed.
 
 3. **Start the Grafbase Gateway**: Finally, start the Grafbase Gateway with the following command:
 

--- a/flake.nix
+++ b/flake.nix
@@ -53,7 +53,6 @@
             # Testing
             cargo-insta
             cargo-nextest
-            cargo-component
             cargo-expand
 
             # Benchmark tool to send multiple requests

--- a/gateway/tests/access_logs/mod.rs
+++ b/gateway/tests/access_logs/mod.rs
@@ -804,7 +804,7 @@ where
 {
     let wasi_module_path = concat!(
         env!("CARGO_MANIFEST_DIR"),
-        "/../crates/wasi-component-loader/examples/target/wasm32-wasip1/debug/response_hooks.wasm"
+        "/../crates/wasi-component-loader/examples/target/wasm32-wasip2/debug/response_hooks.wasm"
     );
 
     let config = &formatdoc! {r#"

--- a/gateway/tests/telemetry/metrics/access_log.rs
+++ b/gateway/tests/telemetry/metrics/access_log.rs
@@ -15,7 +15,7 @@ fn measures_pending_logs() {
         path = "{path}"
 
         [hooks]
-        location = "../crates/wasi-component-loader/examples/target/wasm32-wasip1/debug/response_hooks.wasm"
+        location = "../crates/wasi-component-loader/examples/target/wasm32-wasip2/debug/response_hooks.wasm"
     "#};
 
     with_custom_gateway(&config, |service_name, _, gateway, clickhouse| async move {
@@ -68,7 +68,7 @@ fn measures_pool_busy() {
         path = "{path}"
 
         [hooks]
-        location = "../crates/wasi-component-loader/examples/target/wasm32-wasip1/debug/response_hooks.wasm"
+        location = "../crates/wasi-component-loader/examples/target/wasm32-wasip2/debug/response_hooks.wasm"
     "#};
 
     with_custom_gateway(&config, |service_name, _, gateway, clickhouse| async move {
@@ -123,7 +123,7 @@ fn measures_pool_size() {
         path = "{path}"
 
         [hooks]
-        location = "../crates/wasi-component-loader/examples/target/wasm32-wasip1/debug/response_hooks.wasm"
+        location = "../crates/wasi-component-loader/examples/target/wasm32-wasip2/debug/response_hooks.wasm"
     "#};
 
     with_custom_gateway(&config, |service_name, _, gateway, clickhouse| async move {

--- a/gateway/tests/telemetry/metrics/operation/hooks.rs
+++ b/gateway/tests/telemetry/metrics/operation/hooks.rs
@@ -4,7 +4,7 @@ use crate::telemetry::metrics::{with_custom_gateway, ExponentialHistogramRow, ME
 fn on_gateway_request_success() {
     let config = indoc::indoc! {r#"
         [hooks]
-        location = "../crates/wasi-component-loader/examples/target/wasm32-wasip1/debug/gateway_request_no_op.wasm"
+        location = "../crates/wasi-component-loader/examples/target/wasm32-wasip2/debug/gateway_request_no_op.wasm"
     "#};
 
     with_custom_gateway(config, |service_name, _, gateway, clickhouse| async move {
@@ -55,7 +55,7 @@ fn on_gateway_request_success() {
 fn on_gateway_request_host_error() {
     let config = indoc::indoc! {r#"
         [hooks]
-        location = "../crates/wasi-component-loader/examples/target/wasm32-wasip1/debug/simple.wasm"
+        location = "../crates/wasi-component-loader/examples/target/wasm32-wasip2/debug/simple.wasm"
     "#};
 
     with_custom_gateway(config, |service_name, _, gateway, clickhouse| async move {
@@ -111,7 +111,7 @@ fn on_gateway_request_host_error() {
 fn on_gateway_request_guest_error() {
     let config = indoc::indoc! {r#"
         [hooks]
-        location = "../crates/wasi-component-loader/examples/target/wasm32-wasip1/debug/error.wasm"
+        location = "../crates/wasi-component-loader/examples/target/wasm32-wasip2/debug/error.wasm"
     "#};
 
     with_custom_gateway(config, |service_name, _, gateway, clickhouse| async move {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -7,5 +7,5 @@ targets = [
     "x86_64-pc-windows-msvc",
     "x86_64-unknown-linux-musl",
     "aarch64-unknown-linux-musl",
-    "wasm32-unknown-unknown",
+    "wasm32-wasip2",
 ]


### PR DESCRIPTION
All examples can now be compiled with

```bash
cargo build --target wasm32-wasip2
```