### PR TITLE
Configure unused-crate-dependencies lint back to default (allow)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,6 @@ codegen-units = 1
 [workspace.lints.rust]
 nonstandard-style = "deny"
 rust-2018-idioms = "deny"
-unused-crate-dependencies = "deny"
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/cli/nix/cli.nix
+++ b/cli/nix/cli.nix
@@ -1,9 +1,9 @@
-{ pkgs
-, crane
-, lib
-, ...
-}:
-let
+{
+  pkgs,
+  crane,
+  lib,
+  ...
+}: let
   rustToolchain = pkgs.rust-bin.stable.latest.default;
   craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
   workspaceRoot = builtins.path {
@@ -26,19 +26,18 @@ let
     !/crates/graphql-schema-diff/README.md
   '';
 
-  src = pkgs.nix-gitignore.gitignoreSource [ extraIgnores ] (lib.cleanSourceWith {
+  src = pkgs.nix-gitignore.gitignoreSource [extraIgnores] (lib.cleanSourceWith {
     filter = lib.cleanSourceFilter;
     src = workspaceRoot;
   });
 
-  version = pkgs.runCommand "getVersion" { } ''
+  version = pkgs.runCommand "getVersion" {} ''
     ${pkgs.dasel}/bin/dasel \
       --file ${../../Cargo.toml} \
       --selector workspace.package.version\
       --write - | tr -d "\n" > $out
   '';
-in
-{
+in {
   packages.cli = craneLib.buildPackage {
     inherit src;
     pname = "grafbase";
@@ -48,7 +47,7 @@ in
     cargoExtraArgs = "-p grafbase";
 
     RUSTFLAGS = builtins.concatStringsSep " " [
-      "-Arust-2018-idioms -Aunused-crate-dependencies"
+      "-Arust-2018-idioms"
       "-C linker=clang -C link-arg=-fuse-ld=lld"
     ];
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,7 +1,4 @@
-#![cfg_attr(test, allow(unused_crate_dependencies))]
 #![forbid(unsafe_code)]
-
-use grafbase_workspace_hack as _;
 
 mod branch;
 mod check;

--- a/crates/engine-config-builder/src/lib.rs
+++ b/crates/engine-config-builder/src/lib.rs
@@ -1,5 +1,3 @@
-use grafbase_workspace_hack as _;
-
 mod from_toml_config;
 mod paths;
 mod strings;

--- a/crates/engine/auth/src/lib.rs
+++ b/crates/engine/auth/src/lib.rs
@@ -1,5 +1,4 @@
 use engine_config::{AuthConfig, AuthProviderConfig};
-use grafbase_workspace_hack as _;
 
 mod anonymous;
 mod jwt;

--- a/crates/engine/axum/src/lib.rs
+++ b/crates/engine/axum/src/lib.rs
@@ -1,5 +1,3 @@
-use grafbase_workspace_hack as _;
-
 use std::sync::Arc;
 
 use axum::{response::IntoResponse, Json};

--- a/crates/engine/codegen/src/main.rs
+++ b/crates/engine/codegen/src/main.rs
@@ -1,7 +1,5 @@
 use std::path::PathBuf;
 
-use grafbase_workspace_hack as _;
-
 mod domain;
 mod formatter;
 mod generation;

--- a/crates/engine/id-newtypes/src/lib.rs
+++ b/crates/engine/id-newtypes/src/lib.rs
@@ -5,8 +5,6 @@ pub use bitset::*;
 pub use many::*;
 pub use range::*;
 
-use grafbase_workspace_hack as _;
-
 #[macro_export]
 macro_rules! forward {
     ($(impl Index<$index:ident, Output = $output:tt> for $ty:ident$(.$field:ident)+,)*) => {

--- a/crates/engine/query-solver/src/lib.rs
+++ b/crates/engine/query-solver/src/lib.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
 
-use grafbase_workspace_hack as _;
-
 #[cfg(test)]
 mod tests;
 

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,7 +1,5 @@
 #![deny(clippy::future_not_send)]
 
-use grafbase_workspace_hack as _;
-
 pub mod analytics;
 mod engine;
 mod execution;

--- a/crates/engine/walker/src/lib.rs
+++ b/crates/engine/walker/src/lib.rs
@@ -1,5 +1,3 @@
-use grafbase_workspace_hack as _;
-
 mod iter;
 
 pub use iter::*;

--- a/crates/federated-server/src/lib.rs
+++ b/crates/federated-server/src/lib.rs
@@ -2,8 +2,6 @@
 //! where we contact the schema registry in the API to fetch the latest schema
 //! and send tracing and metrics to either our own or a 3rd party collector.
 
-use grafbase_workspace_hack as _;
-
 mod hot_reload;
 pub use error::Error;
 pub use server::GdnResponse;

--- a/crates/federated-server/src/server.rs
+++ b/crates/federated-server/src/server.rs
@@ -16,7 +16,6 @@ use tokio::sync::watch;
 use ulid::Ulid;
 
 use axum::{extract::State, response::IntoResponse, routing::get, Router};
-use axum_server as _;
 use engine_axum::{
     middleware::{ResponseHookLayer, TelemetryLayer},
     websocket::{WebsocketAccepter, WebsocketService},

--- a/crates/federation-audit-tests/src/lib.rs
+++ b/crates/federation-audit-tests/src/lib.rs
@@ -1,7 +1,3 @@
-#![cfg_attr(test, allow(unused_crate_dependencies))]
-
-use grafbase_workspace_hack as _;
-
 pub mod audit_server;
 mod cache;
 mod response;

--- a/crates/federation-audit-tests/tests/audit_tests.rs
+++ b/crates/federation-audit-tests/tests/audit_tests.rs
@@ -1,5 +1,3 @@
-#![allow(unused_crate_dependencies)]
-
 use federation_audit_tests::{
     audit_server::{AuditServer, ExpectedResponse, Test},
     cached_tests, CachedTest, Response,

--- a/crates/federation-audit-tests/tests/cache_freshness.rs
+++ b/crates/federation-audit-tests/tests/cache_freshness.rs
@@ -1,4 +1,4 @@
-#![allow(unused_crate_dependencies, clippy::panic)]
+#![allow(clippy::panic)]
 
 use federation_audit_tests::{audit_server::AuditServer, cached_tests, CachedTest};
 

--- a/crates/federation-audit-tests/tests/checkout.rs
+++ b/crates/federation-audit-tests/tests/checkout.rs
@@ -1,4 +1,4 @@
-#![allow(unused_crate_dependencies, clippy::panic)]
+#![allow(clippy::panic)]
 
 use std::process::Command;
 

--- a/crates/federation-audit-tests/tests/composition_comparisons.rs
+++ b/crates/federation-audit-tests/tests/composition_comparisons.rs
@@ -1,5 +1,3 @@
-#![allow(unused_crate_dependencies)]
-
 use federation_audit_tests::{audit_server::AuditServer, cached_tests};
 use libtest_mimic::{Arguments, Failed, Trial};
 

--- a/crates/gateway-config/src/lib.rs
+++ b/crates/gateway-config/src/lib.rs
@@ -1,5 +1,4 @@
 use apq::AutomaticPersistedQueries;
-use grafbase_workspace_hack as _;
 use operation_caching::OperationCaching;
 
 pub mod apq;

--- a/crates/gateway-config/src/telemetry/mod.rs
+++ b/crates/gateway-config/src/telemetry/mod.rs
@@ -128,7 +128,6 @@ mod tests {
     use std::path::PathBuf;
     #[cfg(feature = "otlp")]
     use std::str::FromStr;
-    use tempfile as _;
     #[cfg(feature = "otlp")]
     use url::Url;
 

--- a/crates/gqlint/src/main.rs
+++ b/crates/gqlint/src/main.rs
@@ -1,5 +1,3 @@
-use grafbase_workspace_hack as _;
-
 use clap::Parser;
 use colored::Colorize;
 use graphql_lint::{lint, LinterError, Severity};

--- a/crates/grafbase-graphql-introspection/src/lib.rs
+++ b/crates/grafbase-graphql-introspection/src/lib.rs
@@ -1,5 +1,3 @@
-use grafbase_workspace_hack as _;
-
 mod standard;
 mod subgraph;
 

--- a/crates/grafbase-local-backend/src/lib.rs
+++ b/crates/grafbase-local-backend/src/lib.rs
@@ -20,8 +20,6 @@ let (server_port, server_handle) = start_server(PORT, SEARCH).unwrap();
 
 #![forbid(unsafe_code)]
 
-use grafbase_workspace_hack as _;
-
 pub mod api;
 pub mod dev;
 pub mod errors;

--- a/crates/grafbase-local-common/src/lib.rs
+++ b/crates/grafbase-local-common/src/lib.rs
@@ -4,11 +4,6 @@ The common crate provides shared functionality for Grafbase developer tools
 
 #![forbid(unsafe_code)]
 
-use grafbase_workspace_hack as _;
-
-#[cfg(not(test))]
-use expect_test as _;
-
 pub mod channels;
 pub mod consts;
 pub mod debug_macros;

--- a/crates/graph-ref/src/lib.rs
+++ b/crates/graph-ref/src/lib.rs
@@ -1,5 +1,3 @@
-use grafbase_workspace_hack as _;
-
 use std::{borrow::Cow, fmt, str};
 
 /// Parsed graph reference. A graph reference is a string of the form `graph@branch#version`.

--- a/crates/graphql-composition/src/ingest_subgraph/directives.rs
+++ b/crates/graphql-composition/src/ingest_subgraph/directives.rs
@@ -547,9 +547,6 @@ fn read_imports<'a>(ast_imports: ConstList<'a>, out: &mut Vec<(&'a str, &'a str)
 
 #[cfg(test)]
 mod federation_directives_matcher_tests {
-    use datatest_stable as _;
-    use miette as _;
-    use similar as _;
 
     use super::*;
 

--- a/crates/graphql-composition/src/lib.rs
+++ b/crates/graphql-composition/src/lib.rs
@@ -2,8 +2,6 @@
 #![allow(clippy::option_option)]
 #![doc = include_str!("../README.md")]
 
-use grafbase_workspace_hack as _;
-
 mod compose;
 mod composition_ir;
 mod diagnostics;

--- a/crates/graphql-composition/tests/composition_special_cases.rs
+++ b/crates/graphql-composition/tests/composition_special_cases.rs
@@ -1,5 +1,3 @@
-#![allow(unused_crate_dependencies)]
-
 #[test]
 fn subgraph_names_that_differ_only_by_case_are_not_allowed() {
     let mut subgraphs = graphql_composition::Subgraphs::default();

--- a/crates/graphql-composition/tests/composition_tests.rs
+++ b/crates/graphql-composition/tests/composition_tests.rs
@@ -1,6 +1,3 @@
-#![allow(unused_crate_dependencies)]
-
-use itertools::Itertools as _;
 use std::{fs, path::Path, sync::OnceLock};
 
 fn update_expect() -> bool {
@@ -55,7 +52,7 @@ fn run_test(federated_graph_path: &Path) -> datatest_stable::Result<()> {
                 "{}\n",
                 diagnostics
                     .iter_messages()
-                    .map(|msg| format!("# {}", msg.lines().join("\\n")))
+                    .map(|msg| format!("# {}", msg.lines().collect::<Vec<_>>().join("\\n")))
                     .collect::<Vec<_>>()
                     .join("\n"),
             ),

--- a/crates/graphql-federated-graph/src/lib.rs
+++ b/crates/graphql-federated-graph/src/lib.rs
@@ -1,5 +1,3 @@
-use grafbase_workspace_hack as _;
-
 pub mod directives;
 mod federated_graph;
 

--- a/crates/graphql-lint/benches/benchmark.rs
+++ b/crates/graphql-lint/benches/benchmark.rs
@@ -1,4 +1,3 @@
-#![allow(unused_crate_dependencies)]
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use graphql_lint::lint;
 
@@ -16,7 +15,7 @@ fn criterion_benchmark(criterion: &mut Criterion) {
         enum lowercase_Enum {
           an_enum_member @deprecated
         }
-        
+
         type Query {
           __test: String,
           getHello(name: String!): Enum_lowercase!

--- a/crates/graphql-lint/src/lib.rs
+++ b/crates/graphql-lint/src/lib.rs
@@ -1,5 +1,3 @@
-use grafbase_workspace_hack as _;
-
 use cynic_parser::type_system::{
     Definition, Directive, DirectiveDefinition, EnumDefinition, EnumValueDefinition, FieldDefinition,
     InputObjectDefinition, InputValueDefinition, InterfaceDefinition, ObjectDefinition, ScalarDefinition,
@@ -446,8 +444,6 @@ impl<'a> SchemaLinter {
 
 #[test]
 fn linter() {
-    use criterion as _;
-
     let schema = r#"
         directive @WithDeprecatedArgs(
           ARG: String @deprecated(reason: "Use `newArg`")

--- a/crates/graphql-mocks/src/lib.rs
+++ b/crates/graphql-mocks/src/lib.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::panic)]
 //! A mock GraphQL server for testing the GraphQL connector
 
-use grafbase_workspace_hack as _;
 use http::Uri;
 use serde_json::json;
 

--- a/crates/graphql-schema-diff/src/lib.rs
+++ b/crates/graphql-schema-diff/src/lib.rs
@@ -1,5 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![allow(unused_crate_dependencies)]
 
 pub mod path;
 

--- a/crates/graphql-schema-diff/tests/diff_tests.rs
+++ b/crates/graphql-schema-diff/tests/diff_tests.rs
@@ -1,5 +1,3 @@
-#![allow(unused_crate_dependencies)]
-
 use std::{fs, path::Path, sync::LazyLock};
 
 static UPDATE_EXPECT: LazyLock<bool> = LazyLock::new(|| std::env::var("UPDATE_EXPECT").is_ok());

--- a/crates/graphql-schema-diff/tests/patch_tests.rs
+++ b/crates/graphql-schema-diff/tests/patch_tests.rs
@@ -1,5 +1,3 @@
-#![allow(unused_crate_dependencies)]
-
 use std::{fs, path::Path};
 
 fn read_schemas(case: &Path) -> datatest_stable::Result<(String, String)> {

--- a/crates/graphql-schema-validation/src/lib.rs
+++ b/crates/graphql-schema-validation/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(unsafe_code, missing_docs, rust_2018_idioms)]
-#![allow(unused_crate_dependencies)]
 #![doc = include_str!("../README.md")]
 
 mod context;

--- a/crates/graphql-schema-validation/tests/validation_tests.rs
+++ b/crates/graphql-schema-validation/tests/validation_tests.rs
@@ -1,5 +1,3 @@
-#![allow(unused_crate_dependencies)]
-
 use graphql_schema_validation::Options;
 use std::{
     fs,

--- a/crates/graphql-wrapping-types/src/lib.rs
+++ b/crates/graphql-wrapping-types/src/lib.rs
@@ -1,6 +1,5 @@
 mod mutable;
 
-use grafbase_workspace_hack as _;
 pub use mutable::MutableWrapping;
 
 const LIST_WRAPPER_LENGTH_MASK: u16 = 0b0111_1000_0000_0000;

--- a/crates/integration-tests/benches/bench.rs
+++ b/crates/integration-tests/benches/bench.rs
@@ -1,5 +1,3 @@
-#![allow(unused_crate_dependencies)]
-
 #[cfg(unix)]
 mod federation;
 

--- a/crates/integration-tests/src/lib.rs
+++ b/crates/integration-tests/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(unused_crate_dependencies, clippy::panic)]
+#![allow(clippy::panic)]
 
 pub mod federation;
 pub mod fetch;

--- a/crates/integration-tests/tests/integration_tests.rs
+++ b/crates/integration-tests/tests/integration_tests.rs
@@ -1,3 +1,1 @@
-#![allow(unused_crate_dependencies)]
-
 mod federation;

--- a/crates/operation-checks/src/lib.rs
+++ b/crates/operation-checks/src/lib.rs
@@ -6,7 +6,6 @@
 //! - Aggregate field usage from the operations with [aggregate_field_usage()].
 //! - Run the checks with [check()].
 
-#![allow(unused_crate_dependencies)]
 #![deny(missing_docs)]
 
 mod aggregate_field_usage;

--- a/crates/operation-checks/tests/operation_check_tests.rs
+++ b/crates/operation-checks/tests/operation_check_tests.rs
@@ -1,5 +1,3 @@
-#![allow(unused_crate_dependencies)]
-
 use operation_checks::CheckParams;
 use std::{fs, path::Path, sync::OnceLock};
 

--- a/crates/operation-normalizer/src/lib.rs
+++ b/crates/operation-normalizer/src/lib.rs
@@ -18,8 +18,6 @@
 
 #![deny(missing_docs)]
 
-use grafbase_workspace_hack as _;
-
 mod arguments;
 mod directives;
 mod operation;

--- a/crates/rolling-logger/src/lib.rs
+++ b/crates/rolling-logger/src/lib.rs
@@ -19,7 +19,6 @@ mod strategy;
 
 pub use strategy::RotateStrategy;
 
-use grafbase_workspace_hack as _;
 use log_file::LogFile;
 use std::{
     io::{self, Write},

--- a/crates/runtime-local/src/fetch/signing.rs
+++ b/crates/runtime-local/src/fetch/signing.rs
@@ -1,5 +1,3 @@
-use p256 as _; // Don't use this directly but we need to enable its JWK feature
-use p384 as _;
 use serde::Deserialize;
 use serde_json::json; // Don't use this directly but we need to enable its JWK feature
 

--- a/crates/runtime-local/src/lib.rs
+++ b/crates/runtime-local/src/lib.rs
@@ -1,5 +1,3 @@
-use grafbase_workspace_hack as _;
-
 mod entity_cache;
 mod fetch;
 #[cfg(feature = "wasi")]

--- a/crates/runtime-noop/src/lib.rs
+++ b/crates/runtime-noop/src/lib.rs
@@ -1,5 +1,3 @@
-use grafbase_workspace_hack as _;
-
 pub mod kv;
 pub mod rate_limiting;
 pub mod trusted_documents;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,7 +1,5 @@
 #![deny(clippy::future_not_send)]
 
-use grafbase_workspace_hack as _;
-
 pub mod auth;
 pub mod bytes;
 pub mod cursor;

--- a/crates/serde-dynamic-string/src/lib.rs
+++ b/crates/serde-dynamic-string/src/lib.rs
@@ -1,5 +1,3 @@
-use grafbase_workspace_hack as _;
-
 use std::{
     fmt::{self, Write},
     ops::Deref,

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(unused_crate_dependencies)]
 //! Grafbase [tracing](https://docs.rs/tracing/latest/tracing/) integration
 
 pub use gateway_config::telemetry as config;

--- a/crates/wasi-component-loader/src/lib.rs
+++ b/crates/wasi-component-loader/src/lib.rs
@@ -8,8 +8,6 @@
 
 #![deny(missing_docs)]
 
-use grafbase_workspace_hack as _;
-
 mod access_log;
 mod config;
 mod context;

--- a/gateway/nix/grafbase-gateway.nix
+++ b/gateway/nix/grafbase-gateway.nix
@@ -1,9 +1,9 @@
-{ pkgs
-, crane
-, lib
-, ...
-}:
-let
+{
+  pkgs,
+  crane,
+  lib,
+  ...
+}: let
   rustToolchain = pkgs.rust-bin.stable.latest.default;
   craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
   workspaceRoot = builtins.path {
@@ -26,19 +26,18 @@ let
     !/crates/graphql-schema-diff/README.md
   '';
 
-  src = pkgs.nix-gitignore.gitignoreSource [ extraIgnores ] (lib.cleanSourceWith {
+  src = pkgs.nix-gitignore.gitignoreSource [extraIgnores] (lib.cleanSourceWith {
     filter = lib.cleanSourceFilter;
     src = workspaceRoot;
   });
 
-  version = pkgs.runCommand "getVersion" { } ''
+  version = pkgs.runCommand "getVersion" {} ''
     ${pkgs.dasel}/bin/dasel \
       --file ${../Cargo.toml} \
       --selector package.version\
       --write - | tr -d "\n" > $out
   '';
-in
-{
+in {
   packages.grafbase-gateway = craneLib.buildPackage {
     inherit src;
     pname = "grafbase-gateway";
@@ -48,7 +47,7 @@ in
     cargoExtraArgs = "-p grafbase-gateway";
 
     RUSTFLAGS = builtins.concatStringsSep " " [
-      "-Arust-2018-idioms -Aunused-crate-dependencies"
+      "-Arust-2018-idioms"
       "-C linker=clang -C link-arg=-fuse-ld=lld"
     ];
 

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -1,7 +1,3 @@
-#![cfg_attr(test, allow(unused_crate_dependencies))]
-
-use grafbase_workspace_hack as _;
-
 use args::Args;
 use clap::crate_version;
 use mimalloc::MiMalloc;

--- a/gateway/tests/integration_tests.rs
+++ b/gateway/tests/integration_tests.rs
@@ -1,5 +1,3 @@
-#![allow(unused_crate_dependencies, clippy::panic)]
-
 mod access_logs;
 mod entity_caching;
 mod mocks;


### PR DESCRIPTION
As discussed. The cost to benefit ratio isn't great, and there are false negatives.