### PR TITLE
chore(engine): Use ResponseKey to identify requirements

### DIFF
--- a/crates/engine/codegen/domain/operation_plan.graphql
+++ b/crates/engine/codegen/domain/operation_plan.graphql
@@ -12,20 +12,23 @@ union Executable @id @meta(module: "executable") = Plan | ResponseModifier
 
 scalar QueryPartitionId @prelude @id
 scalar Resolver @prelude
+scalar RequiredFieldSet @record @prelude
 
 # Overriding the schema one as we inline it
 scalar FieldSetRecord @prelude
 
 type Plan @indexed(id_size: "u16") @meta(module: "plan") {
   query_partition_id: QueryPartitionId!
-  requires: FieldSetRecord!
+  required_fields: RequiredFieldSet!
   resolver: Resolver!
   parent_count: usize!
   children: [Executable!]!
 }
 
+scalar ResponseModifierRule @prelude @copy
+
 type ResponseModifier @indexed(id_size: "u16") @meta(module: "response_modifier") {
-  definition: ResponseModifierDefinition!
+  rule: ResponseModifierRule!
   sorted_targets: [ResponseModifierTarget!]!
   parent_count: usize!
   children: [Executable!]!
@@ -37,5 +40,5 @@ scalar ResponseKey @copy @prelude
 type ResponseModifierTarget @meta(module: "response_modifier/target") {
   set_id: ResponseObjectSetDefinitionId!
   ty: CompositeType!
-  key: ResponseKey!
+  field: DataField!
 }

--- a/crates/engine/codegen/domain/solved_operation.graphql
+++ b/crates/engine/codegen/domain/solved_operation.graphql
@@ -24,7 +24,7 @@ type QueryPartition @indexed(id_size: "u16") @meta(module: "query_partition") {
   entity_definition: EntityDefinition!
   resolver_definition: ResolverDefinition!
   selection_set: SelectionSet!
-  required_fields: [DataFieldRef!]!
+  required_fields: RequiredFieldSet!
   input: ResponseObjectSetDefinition!
   shape_id: ConcreteShapeId!
 }
@@ -41,6 +41,7 @@ scalar PositionedResponseKey @copy @prelude
 scalar ResponseKey @copy @prelude
 scalar Location @copy @prelude
 scalar QueryInputValueId @prelude @id
+scalar RequiredFieldSet @record
 
 type SelectionSet @meta(module: "selection_set") @copy {
   data_fields_ordered_by_parent_entity_id_then_key: [DataField!]!
@@ -58,9 +59,9 @@ type DataField @meta(module: "field/data", debug: false) @indexed(id_size: "u32"
   location: Location!
   definition: FieldDefinition!
   arguments: [FieldArgument!]!
-  required_fields: [DataFieldRef!]!
+  required_fields: RequiredFieldSet!
   "Requirement of @authorized, etc."
-  required_fields_by_supergraph: [DataFieldRef!]! @field(record_field_name: "required_field_ids_by_supergraph")
+  required_fields_by_supergraph: RequiredFieldSet! @field(record_field_name: "required_fields_record_by_supergraph")
   "All field shape ids generated for this field"
   shape_ids: [FieldShapeRefId!]!
   parent_field_output: ResponseObjectSetDefinition
@@ -68,7 +69,6 @@ type DataField @meta(module: "field/data", debug: false) @indexed(id_size: "u32"
   selection_set: SelectionSet!
   "Whether __typename should be requested from the subgraph for this selection set"
   selection_set_requires_typename: Boolean!
-  matching_requirement: SchemaField
   query_partition: QueryPartition!
 }
 
@@ -101,11 +101,4 @@ type QueryModifierDefinition @meta(module: "modifier") {
   rule: QueryModifierRule!
   impacts_root_object: Boolean!
   impacted_fields: [FieldRef!]!
-}
-
-scalar ResponseModifierRule @prelude
-
-type ResponseModifierDefinition @meta(module: "modifier") @indexed(id_size: "u16") {
-  rule: ResponseModifierRule!
-  impacted_fields: [DataFieldRef!]!
 }

--- a/crates/engine/codegen/src/generation/object/walker.rs
+++ b/crates/engine/codegen/src/generation/object/walker.rs
@@ -261,7 +261,7 @@ impl quote::ToTokens for WalkerFieldMethod<'_> {
                 },
                 AccessKind::RefWalker => quote! {
                     #ty<'a> {
-                        self.as_ref().#field.as_ref().walk(self.#ctx)
+                        self.as_ref().#field.walk(self.#ctx)
                     }
                 },
             },

--- a/crates/engine/query-solver/src/operation/node.rs
+++ b/crates/engine/query-solver/src/operation/node.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use schema::{EntityDefinitionId, FieldSetRecord, ResolverDefinitionId, SchemaFieldId, SubgraphId};
+use schema::{EntityDefinitionId, FieldSetRecord, ResolverDefinitionId, SubgraphId};
 use walker::Walk as _;
 
 use crate::{dot_graph::Attrs, FieldFlags, Operation};
@@ -68,7 +68,6 @@ impl<FieldId: Copy> Node<'_, FieldId> {
 #[derive(Debug, Clone)]
 pub(crate) struct QueryField<FieldId> {
     pub id: FieldId,
-    pub matching_requirement_id: Option<SchemaFieldId>,
     pub flags: FieldFlags,
 }
 

--- a/crates/engine/query-solver/src/solution.rs
+++ b/crates/engine/query-solver/src/solution.rs
@@ -2,7 +2,7 @@ mod dot_graph;
 
 use bitflags::bitflags;
 use petgraph::{graph::NodeIndex, Graph};
-use schema::{EntityDefinitionId, ResolverDefinitionId, Schema, SchemaFieldId};
+use schema::{EntityDefinitionId, ResolverDefinitionId, Schema};
 
 use crate::Operation;
 
@@ -15,7 +15,6 @@ pub enum SolutionNode<FieldId> {
     },
     Field {
         id: FieldId,
-        matching_requirement_id: Option<SchemaFieldId>,
         flags: FieldFlags,
     },
 }

--- a/crates/engine/query-solver/src/solve/solution.rs
+++ b/crates/engine/query-solver/src/solve/solution.rs
@@ -52,7 +52,6 @@ impl<'ctx, Op: Operation> Solution<'ctx, Op> {
                     if let Node::QueryField(field) = &operation_graph.graph[edge.target()] {
                         let typename_field_ix = graph.add_node(SolutionNode::Field {
                             id: field.id,
-                            matching_requirement_id: field.matching_requirement_id,
                             flags: field.flags,
                         });
                         graph.add_edge(root_node_ix, typename_field_ix, SolutionEdge::Field);
@@ -100,7 +99,6 @@ impl<'ctx, Op: Operation> Solution<'ctx, Op> {
 
                     let field_solution_node_ix = graph.add_node(SolutionNode::Field {
                         id: field.id,
-                        matching_requirement_id: field.matching_requirement_id,
                         flags: field.flags,
                     });
                     graph.add_edge(parent_solution_node_ix, field_solution_node_ix, SolutionEdge::Field);
@@ -118,7 +116,6 @@ impl<'ctx, Op: Operation> Solution<'ctx, Op> {
                                 if let Node::QueryField(field) = &operation_graph[edge.target()] {
                                     let typename_field_ix = graph.add_node(SolutionNode::Field {
                                         id: field.id,
-                                        matching_requirement_id: field.matching_requirement_id,
                                         flags: field.flags,
                                     });
                                     graph.add_edge(field_solution_node_ix, typename_field_ix, SolutionEdge::Field);
@@ -137,7 +134,6 @@ impl<'ctx, Op: Operation> Solution<'ctx, Op> {
                 Node::QueryField(field) if field.is_typename() => {
                     let ix = graph.add_node(SolutionNode::Field {
                         id: field.id,
-                        matching_requirement_id: field.matching_requirement_id,
                         flags: field.flags,
                     });
                     graph.add_edge(parent_solution_node_ix, ix, SolutionEdge::Field);

--- a/crates/engine/schema/src/builder/field_set.rs
+++ b/crates/engine/schema/src/builder/field_set.rs
@@ -138,8 +138,7 @@ impl Converter<'_> {
             .or_insert_with(|| SchemaFieldId::from(n));
 
         Ok(Some(FieldSetItemRecord {
-            alias_id: self.graph[field_definition_id].name_id,
-            id,
+            field_id: id,
             subselection_record: self.convert_set(subselection)?,
         }))
     }

--- a/crates/engine/schema/src/field_set/item.rs
+++ b/crates/engine/schema/src/field_set/item.rs
@@ -1,12 +1,10 @@
 use walker::Walk;
 
-use crate::{FieldSet, FieldSetRecord, Schema, SchemaField, SchemaFieldId, StringId};
+use crate::{FieldSet, FieldSetRecord, Schema, SchemaField, SchemaFieldId};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct FieldSetItemRecord {
-    /// If no alias is provided, it's set to field name
-    pub alias_id: StringId,
-    pub id: SchemaFieldId,
+    pub field_id: SchemaFieldId,
     pub subselection_record: FieldSetRecord,
 }
 
@@ -36,7 +34,7 @@ pub struct FieldSetItem<'a> {
 
 impl<'a> FieldSetItem<'a> {
     pub fn field(&self) -> SchemaField<'a> {
-        self.ref_.id.walk(self.schema)
+        self.ref_.field_id.walk(self.schema)
     }
     pub fn subselection(&self) -> FieldSet<'a> {
         self.ref_.subselection_record.walk(self.schema)

--- a/crates/engine/schema/src/field_set/mod.rs
+++ b/crates/engine/schema/src/field_set/mod.rs
@@ -28,9 +28,9 @@ impl std::ops::Deref for FieldSetRecord {
 
 impl FromIterator<FieldSetItemRecord> for FieldSetRecord {
     fn from_iter<T: IntoIterator<Item = FieldSetItemRecord>>(iter: T) -> Self {
-        let mut items_record = iter.into_iter().collect::<Vec<_>>();
-        items_record.sort_unstable_by_key(|field| field.id);
-        Self(items_record)
+        let mut items = iter.into_iter().collect::<Vec<_>>();
+        items.sort_unstable_by(|a, b| a.field_id.cmp(&b.field_id));
+        Self(items)
     }
 }
 

--- a/crates/engine/schema/src/field_set/union.rs
+++ b/crates/engine/schema/src/field_set/union.rs
@@ -26,7 +26,7 @@ impl FieldSetRecord {
         while l < left_set.len() && r < right_set.len() {
             let left = &left_set[l];
             let right = &right_set[r];
-            match left.alias_id.cmp(&right.alias_id).then(left.id.cmp(&right.id)) {
+            match left.field_id.cmp(&right.field_id) {
                 Ordering::Less => {
                     fields.push(left.clone());
                     l += 1;
@@ -37,8 +37,7 @@ impl FieldSetRecord {
                 }
                 Ordering::Equal => {
                     fields.push(FieldSetItemRecord {
-                        alias_id: left.alias_id,
-                        id: left.id,
+                        field_id: left.field_id,
                         subselection_record: if left.subselection_record.is_empty() {
                             right.subselection_record.clone()
                         } else {

--- a/crates/engine/src/execution/coordinator.rs
+++ b/crates/engine/src/execution/coordinator.rs
@@ -544,9 +544,11 @@ impl<'ctx, R: Runtime> OperationExecution<'ctx, R> {
             .response
             .new_subgraph_response(plan.shape_id(), Arc::clone(&root_response_object_set));
 
-        let root_response_objects =
-            self.response
-                .read(self.ctx.schema(), Arc::clone(&root_response_object_set), &plan.requires);
+        let root_response_objects = self.response.read(
+            self.ctx.schema(),
+            Arc::clone(&root_response_object_set),
+            plan.required_fields(),
+        );
 
         let fut = plan
             .as_ref()

--- a/crates/engine/src/execution/response_modifier.rs
+++ b/crates/engine/src/execution/response_modifier.rs
@@ -18,159 +18,126 @@ impl<'ctx, R: Runtime> ExecutionContext<'ctx, R> {
         response: &mut ResponseBuilder,
         response_modifier: ResponseModifier<'ctx>,
     ) {
-        // First step is aggregating all the object refs we must read into a single
-        // InputdResponseObjectSet.
-        // As the AuthorizedField resolver applies on a specific field, we have to keep track of
-        // which ResponseKeys (~field in the output) would be impacted if unauthorized. As multiple
-        // fields might be impacted in a given object set (because of aliases), we keep a range of
-        // of those keys for each ResponseObjectSet we add to the input.
-        let mut input = InputResponseObjectSet::default();
-        let mut input_associated_targets_range = Vec::new();
-        for (set_id, chunk) in response_modifier
-            .sorted_targets()
-            .enumerate()
-            .chunk_by(|(_, target)| target.set_id)
-            .into_iter()
-        {
-            // With query modifications, this response object set might never exist.
-            let Some(refs) = state[set_id].as_ref() else {
+        for target in response_modifier.sorted_targets() {
+            let Some(refs) = state[target.set_id].as_ref() else {
                 continue;
             };
-
-            for (ty_id, mut chunk) in chunk.into_iter().chunk_by(|(_, target)| target.ty_id).into_iter() {
-                let (start, _) = chunk.next().unwrap();
-                let end = chunk.last().map(|(last, _)| last).unwrap_or(start) + 1;
-                input_associated_targets_range.push(start..end);
-
-                if self.operation.cached.solved[set_id].ty_id == ty_id {
-                    input = input.with_response_objects(refs.clone());
-                } else {
-                    input = input.with_filtered_response_objects(self.schema(), ty_id, refs.clone());
-                }
-            }
-        }
-
-        if input.is_empty() {
-            return;
-        }
-
-        // Now we can execute the hook and propagate any errors.
-        match response_modifier.definition().rule {
-            ResponseModifierRule::AuthorizedParentEdge {
-                directive_id,
-                definition_id,
-            } => {
-                let definition = self.schema().walk(definition_id);
-                let directive = self.schema().walk(directive_id);
-                let input = Arc::new(input);
-                let parents = response.read(
+            let input = if self.operation.cached.solved[target.set_id].ty_id == target.ty_id {
+                InputResponseObjectSet::default().with_response_objects(refs.clone())
+            } else {
+                InputResponseObjectSet::default().with_filtered_response_objects(
                     self.schema(),
-                    input.clone(),
-                    directive_id.walk(self).fields().unwrap().as_ref(),
-                );
-                let result = self
-                    .hooks()
-                    .authorize_parent_edge_post_execution(definition, parents, directive.metadata())
-                    .await;
-                // FIXME: make this efficient
-                let result = match result {
-                    Ok(result) => {
-                        tracing::debug!("Authorized result: {result:#?}");
-                        if result.len() == input.len() {
-                            result
-                                .into_iter()
-                                .map(|res| res.map_err(GraphqlError::from))
-                                .collect::<Vec<_>>()
-                        } else {
-                            // TODO: should be an error log instead not add any GraphQL error I
-                            // guess
-                            (0..input.len())
-                                .map(|_| {
-                                    Err(GraphqlError::new(
-                                        "Incorrect number of authorization replies",
-                                        ErrorCode::HookError,
-                                    ))
-                                })
-                                .collect()
-                        }
-                    }
-                    Err(err) => (0..input.len()).map(|_| Err(err.clone())).collect(),
-                };
+                    target.ty_id,
+                    refs.clone(),
+                )
+            };
 
-                for ((i, obj_ref), result) in input.iter().enumerate().zip_eq(result) {
-                    if let Err(err) = result {
-                        // If the current field is required, the error must be propagated upwards,
-                        // so the parent object path is enough.
-                        if definition.ty().wrapping.is_required() {
-                            for target in
-                                &response_modifier.sorted_target_records[input_associated_targets_range[i].clone()]
-                            {
-                                response.propagate_null(&obj_ref.path);
-                                response.push_error(err.clone().with_path((&obj_ref.path, target.key)));
+            if input.is_empty() {
+                continue;
+            }
+
+            // to be reworked.
+            let target_field = target.field();
+
+            // Now we can execute the hook and propagate any errors.
+            match response_modifier.rule {
+                ResponseModifierRule::AuthorizedParentEdge {
+                    directive_id,
+                    definition_id,
+                } => {
+                    let definition = definition_id.walk(self);
+                    let directive = directive_id.walk(self);
+                    let input = Arc::new(input);
+                    let parents = response.read(
+                        self.schema(),
+                        input.clone(),
+                        // FIXME: Total hack, assumes there is only one authorized directive on the field. Need
+                        target_field.required_fields_by_supergraph(),
+                    );
+                    let result = self
+                        .hooks()
+                        .authorize_parent_edge_post_execution(definition, parents, directive.metadata())
+                        .await;
+                    tracing::debug!("Authorized result: {result:#?}");
+                    // FIXME: make this efficient
+                    let result = match result {
+                        Ok(result) => {
+                            if result.len() == input.len() {
+                                result
+                                    .into_iter()
+                                    .map(|res| res.map_err(GraphqlError::from))
+                                    .collect::<Vec<_>>()
+                            } else {
+                                tracing::error!("Incorrect number of authorization replies");
+                                (0..input.len())
+                                    .map(|_| Err(GraphqlError::new("Authorization failure", ErrorCode::HookError)))
+                                    .collect()
                             }
-                        } else {
-                            // Otherwise we don't need to propagate anything and just need to mark
-                            // the current value as inaccessible. So null for the client, but
-                            // available for requirements to be sent to subgraphs.
-                            for target in
-                                &response_modifier.sorted_target_records[input_associated_targets_range[i].clone()]
-                            {
+                        }
+                        Err(err) => (0..input.len()).map(|_| Err(err.clone())).collect(),
+                    };
+
+                    for (obj_ref, result) in input.iter().zip_eq(result) {
+                        if let Err(err) = result {
+                            // If the current field is required, the error must be propagated upwards,
+                            // so the parent object path is enough.
+                            if definition.ty().wrapping.is_required() {
+                                response.propagate_null(&obj_ref.path);
+                            } else {
+                                // Otherwise we don't need to propagate anything and just need to mark
+                                // the current value as inaccessible. So null for the client, but
+                                // available for requirements to be sent to subgraphs.
                                 response.make_inacessible(ResponseValueId::Field {
                                     object_id: obj_ref.id,
-                                    key: target.key,
+                                    key: target_field.key.response_key,
                                     nullable: true,
                                 });
-                                response.push_error(err.clone().with_path((&obj_ref.path, target.key)));
                             }
+                            response.push_error(err.clone().with_path((&obj_ref.path, target_field.key)));
                         }
                     }
                 }
-            }
-            ResponseModifierRule::AuthorizedEdgeChild {
-                directive_id,
-                definition_id,
-            } => {
-                let definition = self.schema().walk(definition_id);
-                let directive = self.schema().walk(directive_id);
-                let input = Arc::new(input);
-                let nodes = response.read(
-                    self.schema(),
-                    input.clone(),
-                    directive_id.walk(self).node().unwrap().as_ref(),
-                );
-                let result = self
-                    .hooks()
-                    .authorize_edge_node_post_execution(definition, nodes, directive.metadata())
-                    .await;
-                // FIXME: make this efficient
-                let result = match result {
-                    Ok(result) => {
-                        tracing::debug!("Authorized result: {result:#?}");
-                        if result.len() == input.len() {
-                            result
-                                .into_iter()
-                                .map(|res| res.map_err(GraphqlError::from))
-                                .collect::<Vec<_>>()
-                        } else {
-                            // TODO: should be an error log instead not add any GraphQL error I
-                            // guess
-                            (0..input.len())
-                                .map(|_| {
-                                    Err(GraphqlError::new(
-                                        "Incorrect number of authorization replies",
-                                        ErrorCode::HookError,
-                                    ))
-                                })
-                                .collect()
+                ResponseModifierRule::AuthorizedEdgeChild {
+                    directive_id,
+                    definition_id,
+                } => {
+                    let definition = self.schema().walk(definition_id);
+                    let directive = self.schema().walk(directive_id);
+                    let input = Arc::new(input);
+                    let nodes = response.read(
+                        self.schema(),
+                        input.clone(),
+                        // FIXME: Total hack, assumes there is only one authorized directive on the field. Need
+                        target_field.required_fields_by_supergraph(),
+                    );
+                    let result = self
+                        .hooks()
+                        .authorize_edge_node_post_execution(definition, nodes, directive.metadata())
+                        .await;
+                    tracing::debug!("Authorized result: {result:#?}");
+                    // FIXME: make this efficient
+                    let result = match result {
+                        Ok(result) => {
+                            if result.len() == input.len() {
+                                result
+                                    .into_iter()
+                                    .map(|res| res.map_err(GraphqlError::from))
+                                    .collect::<Vec<_>>()
+                            } else {
+                                tracing::error!("Incorrect number of authorization replies");
+                                (0..input.len())
+                                    .map(|_| Err(GraphqlError::new("Authorization failure", ErrorCode::HookError)))
+                                    .collect()
+                            }
                         }
-                    }
-                    Err(err) => (0..input.len()).map(|_| Err(err.clone())).collect(),
-                };
+                        Err(err) => (0..input.len()).map(|_| Err(err.clone())).collect(),
+                    };
 
-                for (obj_ref, result) in input.iter().zip_eq(result) {
-                    if let Err(err) = result {
-                        response.propagate_null(&obj_ref.path);
-                        response.push_error(err.clone().with_path(&obj_ref.path));
+                    for (obj_ref, result) in input.iter().zip_eq(result) {
+                        if let Err(err) = result {
+                            response.propagate_null(&obj_ref.path);
+                            response.push_error(err.clone().with_path(&obj_ref.path));
+                        }
                     }
                 }
             }

--- a/crates/engine/src/operation/plan/builder.rs
+++ b/crates/engine/src/operation/plan/builder.rs
@@ -1,12 +1,12 @@
 use id_newtypes::IdToMany;
 use itertools::Itertools;
-use schema::{CompositeTypeId, FieldSetRecord};
+use schema::CompositeTypeId;
 use walker::Walk;
 
 use crate::{
     operation::{
-        PlanError, QueryPartition, QueryPartitionId, ResponseModifierDefinition, ResponseModifierRule,
-        SolvedOperationContext,
+        DataField, PlanError, QueryPartition, QueryPartitionId, RequiredFieldSet, RequiredFieldSetRecord,
+        ResponseModifierRule, SolvedOperationContext,
     },
     prepare::{CachedOperation, PrepareContext},
     resolver::Resolver,
@@ -35,11 +35,13 @@ impl OperationPlan {
             operation_plan: OperationPlan {
                 query_modifications,
                 plans: Vec::with_capacity(operation.solved.query_partitions.len()),
-                response_modifiers: Vec::with_capacity(operation.solved.response_modifier_definitions.len()),
+                response_modifiers: Vec::with_capacity(
+                    operation.solved.response_modifier_rule_to_impacted_fields.len(),
+                ),
             },
             dependencies: Vec::with_capacity(operation.solved.data_field_refs.len()),
             partition_to_plan: vec![None; operation.solved.query_partitions.len()],
-            partition_modifiers: Vec::with_capacity(operation.solved.response_modifier_definitions.len()),
+            partition_modifiers: Vec::with_capacity(operation.solved.response_modifier_rule_to_impacted_fields.len()),
         }
         .build()?;
 
@@ -58,14 +60,14 @@ struct Builder<'op, 'ctx, R: Runtime> {
     partition_to_plan: Vec<Option<PlanId>>,
 }
 
-impl<R: Runtime> Builder<'_, '_, R> {
+impl<'op, R: Runtime> Builder<'op, '_, R> {
     fn build(mut self) -> PlanResult<OperationPlan> {
         for query_partition in self.solve_ctx.query_partitions() {
             self.generate_plan(query_partition)?;
         }
 
-        for definition in self.solve_ctx.response_modifier_definitions() {
-            self.generate_response_modifier(definition)?;
+        for (rule, impacted_fields) in self.solve_ctx.response_modifier_rules() {
+            self.generate_response_modifier(rule, impacted_fields)?;
         }
 
         self.finalize()
@@ -127,13 +129,17 @@ impl<R: Runtime> Builder<'_, '_, R> {
         Ok(self.operation_plan)
     }
 
-    fn generate_response_modifier(&mut self, definition: ResponseModifierDefinition<'_>) -> PlanResult<()> {
+    fn generate_response_modifier(
+        &mut self,
+        rule: ResponseModifierRule,
+        impacted_fields_iter: impl Iterator<Item = DataField<'op>>,
+    ) -> PlanResult<()> {
         let mut impacted_fields = Vec::new();
-        for field in definition.impacted_fields() {
+        for field in impacted_fields_iter {
             if self.operation_plan.query_modifications.skipped_data_fields[field.id] {
                 continue;
             }
-            let (set_id, composite_type_id) = match definition.rule {
+            let (set_id, composite_type_id) = match rule {
                 ResponseModifierRule::AuthorizedParentEdge { .. } => (
                     field.parent_field_output_id.ok_or_else(|| {
                         tracing::error!("Missing response object set id.");
@@ -149,13 +155,7 @@ impl<R: Runtime> Builder<'_, '_, R> {
                     CompositeTypeId::maybe_from(field.definition().ty().definition_id).unwrap(),
                 ),
             };
-            impacted_fields.push((
-                field.query_partition_id,
-                set_id,
-                composite_type_id,
-                field.key.response_key,
-                field.id,
-            ));
+            impacted_fields.push((field.query_partition_id, set_id, composite_type_id, field.id));
         }
 
         impacted_fields.sort_unstable();
@@ -163,23 +163,27 @@ impl<R: Runtime> Builder<'_, '_, R> {
         for (partition_id, targets) in impacted_fields
             .into_iter()
             .dedup()
-            .chunk_by(|(partition_id, _, _, _, _)| *partition_id)
+            .chunk_by(|(partition_id, _, _, _)| *partition_id)
             .into_iter()
         {
             let modifier_id = ResponseModifierId::from(self.operation_plan.response_modifiers.len());
-
+            let sorted_target_records = targets
+                .into_iter()
+                .map(|(_, set_id, ty_id, field_id)| {
+                    self.register_dependencies(
+                        modifier_id.into(),
+                        field_id.walk(self.solve_ctx).required_fields_by_supergraph(),
+                    );
+                    ResponseModifierTargetRecord {
+                        set_id,
+                        ty_id,
+                        field_id,
+                    }
+                })
+                .collect();
             self.operation_plan.response_modifiers.push(ResponseModifierRecord {
-                definition_id: definition.id,
-                sorted_target_records: targets
-                    .into_iter()
-                    .map(|(_, set_id, ty_id, key, id)| {
-                        for required_field in id.walk(self.solve_ctx).required_fields_by_supergraph() {
-                            self.dependencies
-                                .push((modifier_id.into(), required_field.query_partition_id));
-                        }
-                        ResponseModifierTargetRecord { set_id, ty_id, key }
-                    })
-                    .collect(),
+                rule,
+                sorted_target_records,
                 // Set later
                 parent_count: 0,
                 children_ids: Vec::new(),
@@ -193,11 +197,12 @@ impl<R: Runtime> Builder<'_, '_, R> {
     fn generate_plan(&mut self, query_partition: QueryPartition<'_>) -> PlanResult<()> {
         let plan_id = PlanId::from(self.operation_plan.plans.len());
         self.partition_to_plan[usize::from(query_partition.id)] = Some(plan_id);
+        let required_fields_record = self.create_required_field_set_for_query_partition(query_partition);
 
-        self.register_dependencies(plan_id, query_partition);
+        self.register_dependencies(plan_id.into(), required_fields_record.walk(self.solve_ctx));
         let plan_resolver = PlanRecord {
             query_partition_id: query_partition.id,
-            requires: self.create_required_field_set_for_query_partition(query_partition),
+            required_fields_record,
             resolver: self.prepare_resolver(query_partition)?,
             // Set later
             parent_count: 0,
@@ -207,47 +212,40 @@ impl<R: Runtime> Builder<'_, '_, R> {
         Ok(())
     }
 
-    fn create_required_field_set_for_query_partition(&mut self, query_partition: QueryPartition<'_>) -> FieldSetRecord {
-        let resolver_definition = query_partition.resolver_definition();
-        let subgraph_id = resolver_definition.subgraph_id();
-        let mut requires = resolver_definition
-            .required_field_set()
-            .map(|field_set| field_set.as_ref().clone())
-            .unwrap_or_default();
+    fn create_required_field_set_for_query_partition(
+        &mut self,
+        query_partition: QueryPartition<'_>,
+    ) -> RequiredFieldSetRecord {
+        let mut required_fields = query_partition.required_fields_record.clone();
 
         for field in self
             .view_plan_query_partition(query_partition.id)
             .selection_set()
             .fields()
         {
-            if let Some(field_requires) = field.definition().requires_for_subgraph(subgraph_id) {
-                requires = FieldSetRecord::union(&requires, field_requires.as_ref());
-            }
+            required_fields = required_fields.union(&field.id().walk(self.solve_ctx).required_fields_record);
         }
 
-        requires
+        required_fields
     }
 
-    fn register_dependencies(&mut self, plan_id: PlanId, query_partition: QueryPartition<'_>) {
+    fn register_dependencies(&mut self, executable_id: ExecutableId, required_fields: RequiredFieldSet<'_>) {
         let mut partition_ids = Vec::new();
-        for field in query_partition.required_fields() {
-            partition_ids.push(field.query_partition_id);
-        }
-        for field in self
-            .view_plan_query_partition(query_partition.id)
-            .selection_set()
-            .fields()
-        {
-            let plan_field = field.id().walk(self.solve_ctx);
-
-            for required_field in plan_field.required_fields() {
-                debug_assert!(required_field.query_partition_id != query_partition.id);
-                partition_ids.push(required_field.query_partition_id);
+        let mut stack = Vec::new();
+        stack.push(required_fields);
+        while let Some(required_fields) = stack.pop() {
+            for required_field in required_fields.iter() {
+                partition_ids.push(required_field.data_field().query_partition_id);
+                let subselection = required_field.subselection();
+                if !subselection.is_empty() {
+                    stack.push(subselection);
+                }
             }
         }
+
         partition_ids.sort_unstable();
         for dependency_id in partition_ids.into_iter().dedup() {
-            self.dependencies.push((plan_id.into(), dependency_id));
+            self.dependencies.push((executable_id, dependency_id));
         }
     }
 

--- a/crates/engine/src/operation/plan/model/generated/plan.rs
+++ b/crates/engine/src/operation/plan/model/generated/plan.rs
@@ -14,7 +14,7 @@ use walker::{Iter, Walk};
 /// ```custom,{.language-graphql}
 /// type Plan @indexed(id_size: "u16") @meta(module: "plan") {
 ///   query_partition_id: QueryPartitionId!
-///   requires: FieldSetRecord!
+///   required_fields: RequiredFieldSet!
 ///   resolver: Resolver!
 ///   parent_count: usize!
 ///   children: [Executable!]!
@@ -23,7 +23,7 @@ use walker::{Iter, Walk};
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct PlanRecord {
     pub query_partition_id: QueryPartitionId,
-    pub requires: FieldSetRecord,
+    pub required_fields_record: RequiredFieldSetRecord,
     pub resolver: Resolver,
     pub parent_count: usize,
     pub children_ids: Vec<ExecutableId>,
@@ -52,6 +52,9 @@ impl<'a> Plan<'a> {
     pub(crate) fn as_ref(&self) -> &'a PlanRecord {
         &self.ctx.operation_plan[self.id]
     }
+    pub(crate) fn required_fields(&self) -> RequiredFieldSet<'a> {
+        self.as_ref().required_fields_record.walk(self.ctx)
+    }
     pub(crate) fn children(&self) -> impl Iter<Item = Executable<'a>> + 'a {
         self.as_ref().children_ids.walk(self.ctx)
     }
@@ -78,7 +81,7 @@ impl std::fmt::Debug for Plan<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Plan")
             .field("query_partition_id", &self.query_partition_id)
-            .field("requires", &self.requires)
+            .field("required_fields", &self.required_fields())
             .field("resolver", &self.resolver)
             .field("parent_count", &self.parent_count)
             .field("children", &self.children())

--- a/crates/engine/src/operation/plan/model/generated/response_modifier.rs
+++ b/crates/engine/src/operation/plan/model/generated/response_modifier.rs
@@ -9,7 +9,6 @@ use crate::operation::plan::model::{
     generated::{Executable, ExecutableId},
     prelude::*,
 };
-use crate::operation::solve::{ResponseModifierDefinition, ResponseModifierDefinitionId};
 pub(crate) use target::*;
 use walker::{Iter, Walk};
 
@@ -17,7 +16,7 @@ use walker::{Iter, Walk};
 ///
 /// ```custom,{.language-graphql}
 /// type ResponseModifier @indexed(id_size: "u16") @meta(module: "response_modifier") {
-///   definition: ResponseModifierDefinition!
+///   rule: ResponseModifierRule!
 ///   sorted_targets: [ResponseModifierTarget!]!
 ///   parent_count: usize!
 ///   children: [Executable!]!
@@ -25,7 +24,7 @@ use walker::{Iter, Walk};
 /// ```
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct ResponseModifierRecord {
-    pub definition_id: ResponseModifierDefinitionId,
+    pub rule: ResponseModifierRule,
     pub sorted_target_records: Vec<ResponseModifierTargetRecord>,
     pub parent_count: usize,
     pub children_ids: Vec<ExecutableId>,
@@ -53,9 +52,6 @@ impl<'a> ResponseModifier<'a> {
     #[allow(clippy::should_implement_trait)]
     pub(crate) fn as_ref(&self) -> &'a ResponseModifierRecord {
         &self.ctx.operation_plan[self.id]
-    }
-    pub(crate) fn definition(&self) -> ResponseModifierDefinition<'a> {
-        self.definition_id.walk(self.ctx)
     }
     pub(crate) fn sorted_targets(&self) -> impl Iter<Item = ResponseModifierTarget<'a>> + 'a {
         self.as_ref().sorted_target_records.walk(self.ctx)
@@ -85,7 +81,7 @@ impl<'a> Walk<OperationPlanContext<'a>> for ResponseModifierId {
 impl std::fmt::Debug for ResponseModifier<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ResponseModifier")
-            .field("definition", &self.definition())
+            .field("rule", &self.rule)
             .field("sorted_targets", &self.sorted_targets())
             .field("parent_count", &self.parent_count)
             .field("children", &self.children())

--- a/crates/engine/src/operation/plan/model/generated/response_modifier/target.rs
+++ b/crates/engine/src/operation/plan/model/generated/response_modifier/target.rs
@@ -4,6 +4,7 @@
 //! Generated with: `cargo run -p engine-codegen`
 //! Source file: <engine-codegen dir>/domain/operation_plan.graphql
 use crate::operation::plan::model::prelude::*;
+use crate::operation::solve::{DataField, DataFieldId};
 use schema::{CompositeType, CompositeTypeId};
 use walker::Walk;
 
@@ -13,14 +14,14 @@ use walker::Walk;
 /// type ResponseModifierTarget @meta(module: "response_modifier/target") {
 ///   set_id: ResponseObjectSetDefinitionId!
 ///   ty: CompositeType!
-///   key: ResponseKey!
+///   field: DataField!
 /// }
 /// ```
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct ResponseModifierTargetRecord {
     pub set_id: ResponseObjectSetDefinitionId,
     pub ty_id: CompositeTypeId,
-    pub key: ResponseKey,
+    pub field_id: DataFieldId,
 }
 
 #[derive(Clone, Copy)]
@@ -44,6 +45,9 @@ impl<'a> ResponseModifierTarget<'a> {
     }
     pub(crate) fn ty(&self) -> CompositeType<'a> {
         self.ty_id.walk(self.ctx)
+    }
+    pub(crate) fn field(&self) -> DataField<'a> {
+        self.field_id.walk(self.ctx)
     }
 }
 
@@ -70,7 +74,7 @@ impl std::fmt::Debug for ResponseModifierTarget<'_> {
         f.debug_struct("ResponseModifierTarget")
             .field("set_id", &self.set_id)
             .field("ty", &self.ty())
-            .field("key", &self.key)
+            .field("field", &self.field())
             .finish()
     }
 }

--- a/crates/engine/src/operation/plan/model/prelude.rs
+++ b/crates/engine/src/operation/plan/model/prelude.rs
@@ -1,6 +1,8 @@
 pub(super) use super::OperationPlanContext;
 pub(super) use crate::{
-    operation::{QueryPartitionId, ResponseModifierRule, ResponseObjectSetDefinitionId},
+    operation::{
+        QueryPartitionId, RequiredFieldSet, RequiredFieldSetRecord, ResponseModifierRule, ResponseObjectSetDefinitionId,
+    },
     resolver::Resolver,
     response::ResponseKey,
 };

--- a/crates/engine/src/operation/solve/model/generated/modifier.rs
+++ b/crates/engine/src/operation/solve/model/generated/modifier.rs
@@ -3,11 +3,7 @@
 //! ===================
 //! Generated with: `cargo run -p engine-codegen`
 //! Source file: <engine-codegen dir>/domain/solved_operation.graphql
-use crate::operation::solve::model::{
-    generated::{DataField, Field},
-    prelude::*,
-    DataFieldRefId, FieldRefId,
-};
+use crate::operation::solve::model::{generated::Field, prelude::*, FieldRefId};
 use walker::{Iter, Walk};
 
 /// Generated from:
@@ -73,74 +69,6 @@ impl std::fmt::Debug for QueryModifierDefinition<'_> {
         f.debug_struct("QueryModifierDefinition")
             .field("rule", &self.rule)
             .field("impacts_root_object", &self.impacts_root_object)
-            .field("impacted_fields", &self.impacted_fields())
-            .finish()
-    }
-}
-
-/// Generated from:
-///
-/// ```custom,{.language-graphql}
-/// type ResponseModifierDefinition @meta(module: "modifier") @indexed(id_size: "u16") {
-///   rule: ResponseModifierRule!
-///   impacted_fields: [DataFieldRef!]!
-/// }
-/// ```
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-pub(crate) struct ResponseModifierDefinitionRecord {
-    pub rule: ResponseModifierRule,
-    pub impacted_field_ids: IdRange<DataFieldRefId>,
-}
-
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-pub(crate) struct ResponseModifierDefinitionId(std::num::NonZero<u16>);
-
-#[derive(Clone, Copy)]
-pub(crate) struct ResponseModifierDefinition<'a> {
-    pub(in crate::operation::solve::model) ctx: SolvedOperationContext<'a>,
-    pub(crate) id: ResponseModifierDefinitionId,
-}
-
-impl std::ops::Deref for ResponseModifierDefinition<'_> {
-    type Target = ResponseModifierDefinitionRecord;
-    fn deref(&self) -> &Self::Target {
-        self.as_ref()
-    }
-}
-
-#[allow(unused)]
-impl<'a> ResponseModifierDefinition<'a> {
-    /// Prefer using Deref unless you need the 'a lifetime.
-    #[allow(clippy::should_implement_trait)]
-    pub(crate) fn as_ref(&self) -> &'a ResponseModifierDefinitionRecord {
-        &self.ctx.operation[self.id]
-    }
-    pub(crate) fn impacted_fields(&self) -> impl Iter<Item = DataField<'a>> + 'a {
-        self.as_ref().impacted_field_ids.walk(self.ctx)
-    }
-}
-
-impl<'a> Walk<SolvedOperationContext<'a>> for ResponseModifierDefinitionId {
-    type Walker<'w>
-        = ResponseModifierDefinition<'w>
-    where
-        'a: 'w;
-    fn walk<'w>(self, ctx: impl Into<SolvedOperationContext<'a>>) -> Self::Walker<'w>
-    where
-        Self: 'w,
-        'a: 'w,
-    {
-        ResponseModifierDefinition {
-            ctx: ctx.into(),
-            id: self,
-        }
-    }
-}
-
-impl std::fmt::Debug for ResponseModifierDefinition<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ResponseModifierDefinition")
-            .field("rule", &self.rule)
             .field("impacted_fields", &self.impacted_fields())
             .finish()
     }

--- a/crates/engine/src/operation/solve/model/generated/query_partition.rs
+++ b/crates/engine/src/operation/solve/model/generated/query_partition.rs
@@ -4,14 +4,12 @@
 //! Generated with: `cargo run -p engine-codegen`
 //! Source file: <engine-codegen dir>/domain/solved_operation.graphql
 use crate::operation::solve::model::{
-    generated::{
-        DataField, ResponseObjectSetDefinition, ResponseObjectSetDefinitionId, SelectionSet, SelectionSetRecord,
-    },
+    generated::{ResponseObjectSetDefinition, ResponseObjectSetDefinitionId, SelectionSet, SelectionSetRecord},
     prelude::*,
-    DataFieldRefId,
+    RequiredFieldSet, RequiredFieldSetRecord,
 };
 use schema::{EntityDefinition, EntityDefinitionId, ResolverDefinition, ResolverDefinitionId};
-use walker::{Iter, Walk};
+use walker::Walk;
 
 /// Generated from:
 ///
@@ -20,7 +18,7 @@ use walker::{Iter, Walk};
 ///   entity_definition: EntityDefinition!
 ///   resolver_definition: ResolverDefinition!
 ///   selection_set: SelectionSet!
-///   required_fields: [DataFieldRef!]!
+///   required_fields: RequiredFieldSet!
 ///   input: ResponseObjectSetDefinition!
 ///   shape_id: ConcreteShapeId!
 /// }
@@ -30,7 +28,7 @@ pub(crate) struct QueryPartitionRecord {
     pub entity_definition_id: EntityDefinitionId,
     pub resolver_definition_id: ResolverDefinitionId,
     pub selection_set_record: SelectionSetRecord,
-    pub required_field_ids: IdRange<DataFieldRefId>,
+    pub required_fields_record: RequiredFieldSetRecord,
     pub input_id: ResponseObjectSetDefinitionId,
     pub shape_id: ConcreteShapeId,
 }
@@ -67,8 +65,8 @@ impl<'a> QueryPartition<'a> {
     pub(crate) fn selection_set(&self) -> SelectionSet<'a> {
         self.selection_set_record.walk(self.ctx)
     }
-    pub(crate) fn required_fields(&self) -> impl Iter<Item = DataField<'a>> + 'a {
-        self.as_ref().required_field_ids.walk(self.ctx)
+    pub(crate) fn required_fields(&self) -> RequiredFieldSet<'a> {
+        self.as_ref().required_fields_record.walk(self.ctx)
     }
     pub(crate) fn input(&self) -> ResponseObjectSetDefinition<'a> {
         self.input_id.walk(self.ctx)

--- a/crates/engine/src/operation/solve/model/required_field_set.rs
+++ b/crates/engine/src/operation/solve/model/required_field_set.rs
@@ -1,0 +1,179 @@
+use std::cmp::Ordering;
+
+use walker::Walk;
+
+use super::{DataField, DataFieldId, SolvedOperationContext};
+
+#[derive(Clone, Default, Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct RequiredFieldSetRecord(Vec<RequiredFieldSetItemRecord>);
+
+impl std::ops::Deref for RequiredFieldSetRecord {
+    type Target = [RequiredFieldSetItemRecord];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<Vec<RequiredFieldSetItemRecord>> for RequiredFieldSetRecord {
+    fn from(mut items: Vec<RequiredFieldSetItemRecord>) -> Self {
+        items.sort_unstable_by(|a, b| a.data_field_id.cmp(&b.data_field_id));
+        Self(items)
+    }
+}
+
+impl FromIterator<RequiredFieldSetItemRecord> for RequiredFieldSetRecord {
+    fn from_iter<T: IntoIterator<Item = RequiredFieldSetItemRecord>>(iter: T) -> Self {
+        iter.into_iter().collect::<Vec<_>>().into()
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct RequiredFieldSet<'a> {
+    ctx: SolvedOperationContext<'a>,
+    ref_: &'a RequiredFieldSetRecord,
+}
+
+impl<'a> RequiredFieldSet<'a> {
+    pub fn len(&self) -> usize {
+        self.ref_.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.ref_.0.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = RequiredFieldSetItem<'a>> + 'a {
+        let ctx = self.ctx;
+        self.ref_.0.iter().map(move |field| field.walk(ctx))
+    }
+}
+
+impl<'a> Walk<SolvedOperationContext<'a>> for &RequiredFieldSetRecord {
+    type Walker<'w>
+        = RequiredFieldSet<'w>
+    where
+        Self: 'w,
+        'a: 'w;
+    fn walk<'w>(self, ctx: impl Into<SolvedOperationContext<'a>>) -> Self::Walker<'w>
+    where
+        Self: 'w,
+        'a: 'w,
+    {
+        RequiredFieldSet {
+            ctx: ctx.into(),
+            ref_: self,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct RequiredFieldSetItemRecord {
+    pub data_field_id: DataFieldId,
+    pub subselection_record: RequiredFieldSetRecord,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct RequiredFieldSetItem<'a> {
+    ctx: SolvedOperationContext<'a>,
+    ref_: &'a RequiredFieldSetItemRecord,
+}
+
+impl std::ops::Deref for RequiredFieldSetItem<'_> {
+    type Target = RequiredFieldSetItemRecord;
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl<'a> RequiredFieldSetItem<'a> {
+    /// Prefer using Deref unless you need the 'a lifetime.
+    #[allow(clippy::should_implement_trait)]
+    pub(crate) fn as_ref(&self) -> &'a RequiredFieldSetItemRecord {
+        self.ref_
+    }
+    pub fn data_field(&self) -> DataField<'a> {
+        self.ref_.data_field_id.walk(self.ctx)
+    }
+    pub fn subselection(&self) -> RequiredFieldSet<'a> {
+        self.ref_.subselection_record.walk(self.ctx)
+    }
+}
+
+impl<'a> Walk<SolvedOperationContext<'a>> for &RequiredFieldSetItemRecord {
+    type Walker<'w>
+        = RequiredFieldSetItem<'w>
+    where
+        Self: 'w,
+        'a: 'w;
+    fn walk<'w>(self, ctx: impl Into<SolvedOperationContext<'a>>) -> Self::Walker<'w>
+    where
+        Self: 'w,
+        'a: 'w,
+    {
+        RequiredFieldSetItem {
+            ctx: ctx.into(),
+            ref_: self,
+        }
+    }
+}
+
+impl std::fmt::Debug for RequiredFieldSetItem<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Field")
+            .field("field", &&self.ctx.operation.response_keys[self.data_field().key])
+            .field("subselection", &self.subselection_record.walk(self.ctx))
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for RequiredFieldSet<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("FieldSet").field(&self.ref_.0.walk(self.ctx)).finish()
+    }
+}
+
+impl RequiredFieldSetRecord {
+    pub fn union(&self, right_set: &Self) -> Self {
+        let left_set = &self;
+        let right_set = &right_set;
+
+        // Allocating too much, but doesn't really matter. FieldSet will always be relatively small
+        // anyway.
+        let mut fields = Vec::with_capacity(left_set.len() + right_set.len());
+        let mut l = 0;
+        let mut r = 0;
+        while l < left_set.len() && r < right_set.len() {
+            let left = &left_set[l];
+            let right = &right_set[r];
+            match left.data_field_id.cmp(&right.data_field_id) {
+                Ordering::Less => {
+                    fields.push(left.clone());
+                    l += 1;
+                }
+                Ordering::Greater => {
+                    fields.push(right.clone());
+                    r += 1;
+                }
+                Ordering::Equal => {
+                    fields.push(RequiredFieldSetItemRecord {
+                        data_field_id: left.data_field_id,
+                        subselection_record: if left.subselection_record.is_empty() {
+                            right.subselection_record.clone()
+                        } else {
+                            left.subselection_record.union(&right.subselection_record)
+                        },
+                    });
+                    l += 1;
+                    r += 1;
+                }
+            }
+        }
+        if l < left_set.len() {
+            fields.extend_from_slice(&left_set[l..]);
+        } else if r < right_set.len() {
+            fields.extend_from_slice(&right_set[r..]);
+        }
+
+        Self(fields)
+    }
+}

--- a/crates/engine/src/operation/solve/solver/requires.rs
+++ b/crates/engine/src/operation/solve/solver/requires.rs
@@ -1,0 +1,84 @@
+use itertools::Itertools;
+use query_solver::{
+    petgraph::{graph::NodeIndex, visit::EdgeRef},
+    SolutionEdge as Edge,
+};
+
+use crate::operation::{DataFieldId, RequiredFieldSetItemRecord, RequiredFieldSetRecord, SolveResult};
+
+use super::Solver;
+
+impl Solver<'_> {
+    pub(super) fn populate_requirements_after_partition_generation(&mut self) -> SolveResult<()> {
+        self.node_to_field.sort_unstable();
+
+        debug_assert!(!self.query_partition_to_node.is_empty());
+        let query_partition_to_node = std::mem::take(&mut self.query_partition_to_node);
+        for (query_partition_id, query_partition_root_node_ix) in query_partition_to_node.iter().copied() {
+            self.operation[query_partition_id].required_fields_record =
+                self.create_required_field_set(query_partition_root_node_ix, Edge::RequiredBySubgraph);
+        }
+        self.query_partition_to_node = query_partition_to_node;
+
+        for (field_id, node_ix) in std::mem::take(&mut self.field_to_node) {
+            self.operation[field_id].required_fields_record =
+                self.create_required_field_set(node_ix, Edge::RequiredBySubgraph);
+            self.operation[field_id].required_fields_record_by_supergraph =
+                self.create_required_field_set(node_ix, Edge::RequiredBySupergraph);
+        }
+
+        Ok(())
+    }
+
+    fn create_required_field_set(&self, dependent_node_ix: NodeIndex, kind: Edge) -> RequiredFieldSetRecord {
+        let mut dependencies = self
+            .graph
+            .edges(dependent_node_ix)
+            .filter(|edge| edge.weight() == &kind)
+            .map(|edge| edge.target())
+            .collect::<Vec<_>>();
+
+        let mut required_fields = Vec::new();
+        while let Some(i) = dependencies.iter().position_min() {
+            let start = dependencies.swap_remove(i);
+            required_fields.push(RequiredFieldSetItemRecord {
+                data_field_id: self.get_field_id_for(start).unwrap(),
+                subselection_record: self.create_subselection(start, &mut dependencies),
+            });
+        }
+        required_fields.into()
+    }
+
+    fn create_subselection(&self, parent: NodeIndex, dependencies: &mut Vec<NodeIndex>) -> RequiredFieldSetRecord {
+        let mut subselection = Vec::new();
+        let mut stack = vec![parent];
+        while let Some(parent) = stack.pop() {
+            for edge in self.graph.edges(parent) {
+                match edge.weight() {
+                    Edge::Field => {
+                        let Some(i) = dependencies.iter().position(|ix| *ix == edge.target()) else {
+                            continue;
+                        };
+                        dependencies.swap_remove(i);
+                        subselection.push(RequiredFieldSetItemRecord {
+                            data_field_id: self.get_field_id_for(edge.target()).unwrap(),
+                            subselection_record: self.create_subselection(edge.target(), dependencies),
+                        });
+                    }
+                    Edge::QueryPartition => {
+                        stack.push(edge.target());
+                    }
+                    _ => {}
+                }
+            }
+        }
+        subselection.into()
+    }
+
+    fn get_field_id_for(&self, node_ix: NodeIndex) -> Option<DataFieldId> {
+        self.node_to_field
+            .binary_search_by(|probe| probe.0.cmp(&node_ix))
+            .map(|i| self.node_to_field[i].1)
+            .ok()
+    }
+}

--- a/crates/engine/src/operation/solve/solver/shapes/mod.rs
+++ b/crates/engine/src/operation/solve/solver/shapes/mod.rs
@@ -240,13 +240,10 @@ impl<'ctx> ShapesBuilder<'ctx> {
             Definition::InputObject(_) => unreachable!("Cannot be an output"),
         };
 
-        let required_field_id = group.iter().find_map(|field| field.matching_requirement_id);
-
         FieldShapeRecord {
             expected_key: first.subgraph_key,
             key: first.key,
             id: first.id,
-            required_field_id,
             shape,
             wrapping: ty.wrapping,
         }

--- a/crates/engine/src/resolver/introspection/writer.rs
+++ b/crates/engine/src/resolver/introspection/writer.rs
@@ -40,7 +40,6 @@ impl<'ctx, R: Runtime> IntrospectionWriter<'ctx, R> {
                     let name = arguments.get_arg_value_as::<&str>("name");
                     fields.push(ResponseObjectField {
                         key: field_shape.key,
-                        required_field_id: None,
                         value: self
                             .schema
                             .definition_by_name(name)
@@ -52,7 +51,6 @@ impl<'ctx, R: Runtime> IntrospectionWriter<'ctx, R> {
                 IntrospectionField::Schema => {
                     fields.push(ResponseObjectField {
                         key: field_shape.key,
-                        required_field_id: None,
                         value: self.__schema(field_shape.shape.as_concrete().unwrap()),
                     });
                 }
@@ -66,7 +64,6 @@ impl<'ctx, R: Runtime> IntrospectionWriter<'ctx, R> {
             for edge in &shape.typename_response_keys {
                 fields.push(ResponseObjectField {
                     key: *edge,
-                    required_field_id: None,
                     value: name_id.into(),
                 });
             }
@@ -88,7 +85,6 @@ impl<'ctx, R: Runtime> IntrospectionWriter<'ctx, R> {
             let field = &self.shapes[id];
             fields.push(ResponseObjectField {
                 key: field.key,
-                required_field_id: None,
                 value: build(field, object[field.id.walk(&self.ctx).definition_id]),
             });
         }
@@ -97,7 +93,6 @@ impl<'ctx, R: Runtime> IntrospectionWriter<'ctx, R> {
             for edge in &shape.typename_response_keys {
                 fields.push(ResponseObjectField {
                     key: *edge,
-                    required_field_id: None,
                     value: name.into(),
                 });
             }

--- a/crates/engine/src/response/read/mod.rs
+++ b/crates/engine/src/response/read/mod.rs
@@ -1,10 +1,12 @@
 use std::sync::Arc;
 
+use crate::operation::RequiredFieldSet;
+
 use super::{InputResponseObjectSet, ResponseBuilder};
 mod ser;
 mod view;
 
-use schema::{FieldSetRecord, Schema};
+use schema::Schema;
 pub(crate) use view::*;
 
 impl ResponseBuilder {
@@ -13,10 +15,10 @@ impl ResponseBuilder {
         &'a self,
         schema: &'a Schema,
         response_object_set: Arc<InputResponseObjectSet>,
-        selection_set: &'a FieldSetRecord,
+        selection_set: RequiredFieldSet<'a>,
     ) -> ResponseObjectsView<'a> {
         ResponseObjectsView {
-            ctx: ViewContext { schema, response: self },
+            ctx: ViewContext { response: self },
             response_object_set,
             selection_set,
         }

--- a/crates/engine/src/response/read/view/mod.rs
+++ b/crates/engine/src/response/read/view/mod.rs
@@ -3,13 +3,15 @@ mod ser;
 
 use std::{borrow::Cow, sync::Arc};
 
-use schema::{FieldSetRecord, Schema};
+use crate::{
+    operation::RequiredFieldSet,
+    response::{InputObjectId, InputResponseObjectSet, ResponseBuilder, ResponseObject, ResponseValue},
+};
 
-use crate::response::{InputObjectId, InputResponseObjectSet, ResponseBuilder, ResponseObject, ResponseValue};
-
+// A struct to wrap this ref is overkill, but I've changed this so many times that I'm keeping
+// Context as it's easier to modify.
 #[derive(Clone, Copy)]
 pub(super) struct ViewContext<'a> {
-    pub(super) schema: &'a Schema,
     pub(super) response: &'a ResponseBuilder,
 }
 
@@ -17,14 +19,14 @@ pub(super) struct ViewContext<'a> {
 pub(crate) struct ResponseObjectsView<'a> {
     pub(super) ctx: ViewContext<'a>,
     pub(super) response_object_set: Arc<InputResponseObjectSet>,
-    pub(super) selection_set: &'a FieldSetRecord,
+    pub(super) selection_set: RequiredFieldSet<'a>,
 }
 
 #[derive(Clone)]
 pub(crate) struct ResponseObjectsViewWithExtraFields<'a> {
     ctx: ViewContext<'a>,
     response_object_set: Arc<InputResponseObjectSet>,
-    selection_set: &'a FieldSetRecord,
+    selection_set: RequiredFieldSet<'a>,
     extra_constant_fields: Vec<(Cow<'static, str>, serde_json::Value)>,
 }
 
@@ -46,7 +48,6 @@ impl<'a> ResponseObjectsView<'a> {
         self.response_object_set
     }
 
-    #[allow(unused)]
     pub fn with_extra_constant_fields(
         self,
         extra_constant_fields: Vec<(Cow<'static, str>, serde_json::Value)>,
@@ -83,18 +84,18 @@ impl ResponseObjectsViewWithExtraFields<'_> {
 pub(crate) struct ResponseObjectView<'a> {
     ctx: ViewContext<'a>,
     response_object: &'a ResponseObject,
-    selection_set: &'a FieldSetRecord,
+    selection_set: RequiredFieldSet<'a>,
 }
 
 pub(crate) struct ResponseObjectViewWithExtraFields<'a> {
     ctx: ViewContext<'a>,
     response_object: &'a ResponseObject,
-    selection_set: &'a FieldSetRecord,
+    selection_set: RequiredFieldSet<'a>,
     extra_constant_fields: &'a [(Cow<'static, str>, serde_json::Value)],
 }
 
 struct ResponseValueView<'a> {
     ctx: ViewContext<'a>,
     value: &'a ResponseValue,
-    selection_set: &'a FieldSetRecord,
+    selection_set: RequiredFieldSet<'a>,
 }

--- a/crates/engine/src/response/read/view/ser.rs
+++ b/crates/engine/src/response/read/view/ser.rs
@@ -1,6 +1,5 @@
 use schema::EntityDefinition;
 use serde::ser::{Error, SerializeMap};
-use walker::Walk;
 
 use super::{ResponseObjectView, ResponseObjectViewWithExtraFields, ResponseValueView};
 use crate::response::ResponseValue;
@@ -16,17 +15,16 @@ impl serde::Serialize for ResponseObjectViewWithExtraFields<'_> {
             map.serialize_entry(name, value)?
         }
 
-        for selection in self.selection_set {
-            let key = self.ctx.schema[selection.alias_id].as_str();
+        for selection in self.selection_set.iter() {
+            let field = selection.data_field();
+            let key = field.definition().name();
             let value = ResponseValueView {
                 ctx: self.ctx,
-                value: self.response_object.find_required_field(selection.id).ok_or_else(|| {
-                    S::Error::custom(format!(
-                        "Could not retrieve field {}",
-                        selection.id.walk(self.ctx.schema).definition().name()
-                    ))
-                })?,
-                selection_set: &selection.subselection_record,
+                value: self
+                    .response_object
+                    .find_by_response_key(field.key.response_key)
+                    .ok_or_else(|| S::Error::custom(format!("Could not retrieve field {key}",)))?,
+                selection_set: selection.subselection(),
             };
             map.serialize_entry(key, &value)?;
         }
@@ -41,19 +39,16 @@ impl serde::Serialize for ResponseObjectView<'_> {
         S: serde::Serializer,
     {
         let mut map = serializer.serialize_map(Some(self.selection_set.len()))?;
-        if let Some(definition_id) = self.response_object.definition_id {
-            tracing::debug!("{}", definition_id.walk(self.ctx.schema).name());
-        }
-        for selection in self.selection_set {
-            let key = self.ctx.schema[selection.alias_id].as_str();
-            let value = match self.response_object.find_required_field(selection.id) {
+        for selection in self.selection_set.iter() {
+            let field = selection.data_field();
+            let key = field.definition().name();
+            let value = match self.response_object.find_by_response_key(field.key.response_key) {
                 Some(value) => value,
                 None => {
                     // If this field doesn't match the actual response object, meaning this field
                     // was in a fragment that doesn't apply to this object, we can safely skip it.
-                    let field_definition = selection.id.walk(self.ctx.schema).definition();
                     if let Some(definition_id) = self.response_object.definition_id {
-                        match field_definition.parent_entity() {
+                        match field.definition().parent_entity() {
                             EntityDefinition::Interface(inf) => {
                                 if inf.possible_type_ids.binary_search(&definition_id).is_err() {
                                     continue;
@@ -68,16 +63,15 @@ impl serde::Serialize for ResponseObjectView<'_> {
                     }
 
                     return Err(S::Error::custom(format_args!(
-                        "Could not retrieve field {}.{}",
-                        field_definition.parent_entity().name(),
-                        field_definition.name()
+                        "Could not retrieve field {}.{key}",
+                        field.definition().parent_entity().name(),
                     )));
                 }
             };
             let value = ResponseValueView {
                 ctx: self.ctx,
                 value,
-                selection_set: &selection.subselection_record,
+                selection_set: selection.subselection(),
             };
             map.serialize_entry(key, &value)?;
         }
@@ -103,7 +97,7 @@ impl serde::Serialize for ResponseValueView<'_> {
             ResponseValue::Int { value, .. } => value.serialize(serializer),
             ResponseValue::Float { value, .. } => value.serialize(serializer),
             ResponseValue::String { value, .. } => value.serialize(serializer),
-            ResponseValue::StringId { id, .. } => self.ctx.schema[*id].serialize(serializer),
+            ResponseValue::StringId { id, .. } => self.ctx.response.schema[*id].serialize(serializer),
             ResponseValue::BigInt { value, .. } => value.serialize(serializer),
             &ResponseValue::List { id, .. } => {
                 let values = &self.ctx.response.data_parts[id];

--- a/crates/engine/src/response/shape/field.rs
+++ b/crates/engine/src/response/shape/field.rs
@@ -1,6 +1,6 @@
 use std::num::NonZero;
 
-use schema::{EnumDefinitionId, ScalarType, SchemaFieldId, Wrapping};
+use schema::{EnumDefinitionId, ScalarType, Wrapping};
 use walker::Walk;
 
 use crate::{
@@ -15,7 +15,6 @@ pub(crate) struct FieldShapeRecord {
     pub expected_key: ResponseKey,
     pub key: PositionedResponseKey,
     pub id: DataFieldId,
-    pub required_field_id: Option<SchemaFieldId>,
     pub shape: Shape,
     pub wrapping: Wrapping,
 }

--- a/crates/engine/src/response/value.rs
+++ b/crates/engine/src/response/value.rs
@@ -1,6 +1,8 @@
-use schema::{ObjectDefinitionId, SchemaFieldId, StringId};
+use schema::{ObjectDefinitionId, StringId};
 
-use super::{PositionedResponseKey, ResponseInaccessibleValueId, ResponseListId, ResponseMapId, ResponseObjectId};
+use super::{
+    PositionedResponseKey, ResponseInaccessibleValueId, ResponseKey, ResponseListId, ResponseMapId, ResponseObjectId,
+};
 
 #[derive(Debug)]
 pub(crate) struct ResponseObject {
@@ -12,7 +14,6 @@ pub(crate) struct ResponseObject {
 #[derive(Debug, Clone)]
 pub(crate) struct ResponseObjectField {
     pub key: PositionedResponseKey,
-    pub required_field_id: Option<SchemaFieldId>,
     pub value: ResponseValue,
 }
 
@@ -45,11 +46,10 @@ impl ResponseObject {
         self.fields_sorted_by_query_position.iter()
     }
 
-    pub(super) fn find_required_field(&self, id: SchemaFieldId) -> Option<&ResponseValue> {
+    pub fn find_by_response_key(&self, key: ResponseKey) -> Option<&ResponseValue> {
         self.fields_sorted_by_query_position
             .iter()
-            .rev()
-            .find(|field| field.required_field_id == Some(id))
+            .find(|field| field.key.response_key == key)
             .map(|field| &field.value)
     }
 }

--- a/crates/engine/src/response/write/deserialize/object/concrete.rs
+++ b/crates/engine/src/response/write/deserialize/object/concrete.rs
@@ -285,7 +285,6 @@ impl<'de> Visitor<'de> for ConcreteShapeFieldsSeed<'_, '_> {
             for key in self.typename_response_keys {
                 response_fields.push(ResponseObjectField {
                     key: *key,
-                    required_field_id: None,
                     value: name_id.into(),
                 });
             }
@@ -427,7 +426,6 @@ impl<'ctx> ConcreteShapeFieldsSeed<'ctx, '_> {
                     } else {
                         response_fields.push(ResponseObjectField {
                             key: field_shape.key,
-                            required_field_id: field_shape.required_field_id,
                             value: ResponseValue::Null,
                         });
                     }
@@ -482,7 +480,6 @@ impl<'ctx> ConcreteShapeFieldsSeed<'ctx, '_> {
                     } else {
                         response_fields.push(ResponseObjectField {
                             key: field_shape.key,
-                            required_field_id: field_shape.required_field_id,
                             value: ResponseValue::Null,
                         });
                     }
@@ -585,16 +582,11 @@ impl<'ctx> ConcreteShapeFieldsSeed<'ctx, '_> {
         {
             response_fields.push(ResponseObjectField {
                 key: other_field.key,
-                required_field_id: other_field.required_field_id,
                 value: value.clone(),
             });
         }
 
-        response_fields.push(ResponseObjectField {
-            key: field.key,
-            required_field_id: field.required_field_id,
-            value,
-        });
+        response_fields.push(ResponseObjectField { key: field.key, value });
 
         Ok(())
     }

--- a/crates/engine/src/response/write/mod.rs
+++ b/crates/engine/src/response/write/mod.rs
@@ -18,7 +18,7 @@ pub(crate) use subgraph_response::*;
 
 pub(crate) struct ResponseBuilder {
     // will be None if an error propagated up to the root.
-    schema: Arc<Schema>,
+    pub(in crate::response) schema: Arc<Schema>,
     operation: Arc<CachedOperation>,
     pub(super) root: Option<(ResponseObjectId, ObjectDefinitionId)>,
     pub(super) data_parts: DataParts,
@@ -222,7 +222,6 @@ impl ResponseBuilder {
                 let name: ResponseValue = object_id.walk(self.schema.as_ref()).as_ref().name_id.into();
                 fields.extend(shape.typename_response_keys.iter().map(|&key| ResponseObjectField {
                     key,
-                    required_field_id: None,
                     value: name.clone(),
                 }))
             } else {
@@ -238,7 +237,6 @@ impl ResponseBuilder {
             }
             fields.push(ResponseObjectField {
                 key: field_shape.key,
-                required_field_id: field_shape.required_field_id,
                 value: ResponseValue::Null,
             })
         }


### PR DESCRIPTION
Today I rely on an id generated during schema generation as a unique identifier for requirements, so it's tied to the `FieldDefinitionId` which doesn't work well if we want to replace object fields with interface ones or the opposite. It's unnecessary as I can rely on the `ResponseKey`, but made things simpler. Now I don't support multiple `@authorized` post-execution directives on the same field and batching is less good. But well, we'll see how to improve that later.

I've removed the initial alias support, I can't add it for "free" anymore and we have no use for it today.