### PR TITLE
fix(engine): Replace object field by parent interface field.

### DIFF
--- a/crates/engine/query-solver/src/lib.rs
+++ b/crates/engine/query-solver/src/lib.rs
@@ -11,7 +11,9 @@ pub(crate) mod solve;
 pub use error::*;
 pub(crate) use operation::*;
 pub use petgraph;
-use schema::{CompositeTypeId, FieldDefinitionId, ObjectDefinitionId, Schema, SchemaField, SubgraphId};
+use schema::{
+    CompositeTypeId, FieldDefinition, FieldDefinitionId, ObjectDefinitionId, Schema, SchemaField, SubgraphId,
+};
 pub use solution::*;
 
 pub(crate) type Cost = u16;
@@ -25,10 +27,15 @@ pub trait Operation {
     fn field_query_position(&self, field_id: Self::FieldId) -> usize;
     fn field_definition(&self, field_id: Self::FieldId) -> Option<FieldDefinitionId>;
     fn field_is_equivalent_to(&self, field_id: Self::FieldId, field: SchemaField<'_>) -> bool;
-    fn create_potential_extra_field(
+    fn create_potential_extra_field_from_requirement(
         &mut self,
         petitioner_field_id: Self::FieldId,
         field: SchemaField<'_>,
+    ) -> Self::FieldId;
+    fn create_potential_extra_interface_field_alternative(
+        &mut self,
+        original: Self::FieldId,
+        interface_field_definition: FieldDefinition<'_>,
     ) -> Self::FieldId;
     fn finalize_selection_set(
         &mut self,

--- a/crates/engine/query-solver/src/operation/builder/alternative.rs
+++ b/crates/engine/query-solver/src/operation/builder/alternative.rs
@@ -1,0 +1,106 @@
+use petgraph::{stable_graph::NodeIndex, visit::EdgeRef, Direction};
+use schema::{CompositeType, FieldDefinition};
+use walker::Walk;
+
+use super::{builder::OperationGraphBuilder, Edge, Operation, QueryField};
+
+impl<'ctx, Op: Operation> OperationGraphBuilder<'ctx, Op> {
+    pub(super) fn try_providing_an_alternative_field(&mut self, query_field_ix: NodeIndex) -> bool {
+        let Some((parent_query_field_ix, parent_query_node)) = self
+            .graph
+            .edges_directed(query_field_ix, Direction::Incoming)
+            .filter(|edge| matches!(edge.weight(), Edge::Field))
+            .filter_map(|edge| {
+                self.graph[edge.source()]
+                    .as_query_field()
+                    .map(|node| (edge.source(), node))
+            })
+            .next()
+        else {
+            return false;
+        };
+
+        let Some(parent_output) = self
+            .operation
+            .field_definition(parent_query_node.id)
+            .walk(self.schema)
+            .and_then(|def| def.ty().definition().as_composite_type())
+        else {
+            return false;
+        };
+
+        let Some((node, field_definition)) = self.graph[query_field_ix].as_query_field().and_then(|node| {
+            self.operation
+                .field_definition(node.id)
+                .map(|def| (*node, def.walk(self.schema)))
+        }) else {
+            return false;
+        };
+
+        tracing::debug!(
+            "Trying to find alternative for field {}.{}",
+            field_definition.parent_entity().name(),
+            field_definition.name()
+        );
+        self.try_providing_field_through_interface(
+            parent_output,
+            parent_query_field_ix,
+            query_field_ix,
+            node,
+            field_definition,
+        )
+    }
+
+    fn try_providing_field_through_interface(
+        &mut self,
+        parent_output: CompositeType<'ctx>,
+        parent_query_field_ix: NodeIndex,
+        existing_query_field_ix: NodeIndex,
+        existing_node: QueryField<Op::FieldId>,
+        field_definition: FieldDefinition<'ctx>,
+    ) -> bool {
+        tracing::debug!("Trying to provide field through interface.");
+        let implemented_interfaces = field_definition.parent_entity().interface_ids();
+
+        // If parent is an implemented interface.
+        if let Some(interface) = parent_output
+            .as_interface()
+            .filter(|inf| implemented_interfaces.contains(&inf.id))
+        {
+            if let Some(interface_field_definition) = interface.find_field_by_name(field_definition.name()) {
+                // FIXME: Should not add extra field if the interface field is already present.
+                let new_field_id = self
+                    .operation
+                    .create_potential_extra_interface_field_alternative(existing_node.id, interface_field_definition);
+                let new_query_field_ix = self.push_query_field(new_field_id, existing_node.flags);
+                if self.could_provide_new_field(parent_query_field_ix, new_field_id) {
+                    self.replace_query_node(existing_query_field_ix, new_query_field_ix);
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+
+    fn replace_query_node(&mut self, existing: NodeIndex, new: NodeIndex) {
+        let mut edges = self.graph.neighbors_directed(existing, Direction::Outgoing).detach();
+        while let Some((edge_ix, target)) = edges.next(&self.graph) {
+            self.graph.add_edge(new, target, self.graph[edge_ix]);
+        }
+        let mut edges = self.graph.neighbors_directed(existing, Direction::Incoming).detach();
+        while let Some((edge_ix, source)) = edges.next(&self.graph) {
+            // Field edge is already added as we try to provide the new field.
+            if self.graph[edge_ix] != Edge::Field {
+                self.graph.add_edge(source, new, self.graph[edge_ix]);
+            }
+        }
+        self.graph.remove_node(existing);
+    }
+
+    fn could_provide_new_field(&mut self, parent_query_field_ix: NodeIndex, field_id: Op::FieldId) -> bool {
+        self.push_field_to_provide(parent_query_field_ix, field_id);
+        self.loop_over_ingestion_stacks();
+        self.providable_fields_bitset[field_id.into()]
+    }
+}

--- a/crates/engine/query-solver/src/operation/builder/prune.rs
+++ b/crates/engine/query-solver/src/operation/builder/prune.rs
@@ -1,5 +1,5 @@
 use petgraph::{
-    visit::{EdgeRef, IntoNodeReferences},
+    visit::{EdgeRef, IntoNodeReferences, NodeIndexable},
     Direction,
 };
 
@@ -9,7 +9,7 @@ use super::{builder::OperationGraphBuilder, Edge, Node, Operation};
 
 impl<Op: Operation> OperationGraphBuilder<'_, Op> {
     pub(super) fn prune_resolvers_not_leading_any_leafs(&mut self) {
-        let mut visited = fixedbitset::FixedBitSet::with_capacity(self.graph.node_count());
+        let mut visited = fixedbitset::FixedBitSet::with_capacity(self.graph.node_bound());
 
         let mut stack = Vec::new();
         let mut extra_leafs = Vec::new();

--- a/crates/engine/query-solver/src/operation/mod.rs
+++ b/crates/engine/query-solver/src/operation/mod.rs
@@ -1,7 +1,6 @@
 mod builder;
 mod edge;
 mod node;
-mod prune;
 
 pub(crate) use edge::*;
 pub(crate) use node::*;

--- a/crates/engine/query-solver/src/operation/node.rs
+++ b/crates/engine/query-solver/src/operation/node.rs
@@ -65,7 +65,7 @@ impl<FieldId: Copy> Node<'_, FieldId> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct QueryField<FieldId> {
     pub id: FieldId,
     pub flags: FieldFlags,

--- a/crates/engine/query-solver/src/tests/interface.rs
+++ b/crates/engine/query-solver/src/tests/interface.rs
@@ -1,0 +1,87 @@
+use crate::assert_solving_snapshots;
+
+const SCHEMA: &str = r#"
+enum join__Graph {
+    A @join__graph(name: "a", url: "http://localhost:4200/simple-interface-object/a")
+    B @join__graph(name: "b", url: "http://localhost:4200/simple-interface-object/b")
+    C @join__graph(name: "c", url: "http://localhost:4200/simple-interface-object/c")
+}
+
+type Admin implements Account
+    @join__implements(graph: A, interface: "Account")
+    @join__type(graph: A, key: "id")
+{
+    id: ID!
+    isMain: Boolean!
+    isActive: Boolean!
+    name: String!
+}
+
+type Query
+    @join__type(graph: A)
+    @join__type(graph: B)
+    @join__type(graph: C)
+{
+    users: [NodeWithName!]! @join__field(graph: A)
+    anotherUsers: [NodeWithName] @join__field(graph: B)
+    accounts: [Account] @join__field(graph: B)
+}
+
+type Regular implements Account
+    @join__implements(graph: A, interface: "Account")
+    @join__type(graph: A, key: "id")
+{
+    id: ID!
+    isMain: Boolean!
+    name: String!
+    isActive: Boolean!
+}
+
+type User implements NodeWithName
+    @join__implements(graph: A, interface: "NodeWithName")
+    @join__type(graph: A, key: "id")
+{
+    id: ID!
+    name: String
+    age: Int
+    username: String
+}
+
+interface Account
+    @join__type(graph: A, key: "id")
+    @join__type(graph: B, key: "id", isInterfaceObject: true)
+    @join__type(graph: C, key: "id", isInterfaceObject: true)
+{
+    id: ID!
+    name: String! @join__field(graph: B)
+    isActive: Boolean! @join__field(graph: C)
+}
+
+interface NodeWithName
+    @join__type(graph: A, key: "id")
+    @join__type(graph: B, key: "id", isInterfaceObject: true)
+{
+    id: ID!
+    name: String @join__field(graph: A)
+    username: String @join__field(graph: B)
+}
+"#;
+
+#[test]
+fn interface_field_providing_object_field() {
+    // age is coming from subgraph A, but needs User.id for this. `anotherUsers` returns an
+    // interface though, so need to retrieve the `NodeWithName.id` as an alternative for `User.id`
+    assert_solving_snapshots!(
+        "interface_field_providing_object_field",
+        SCHEMA,
+        r#"
+        query {
+          anotherUsers {
+            ... on User {
+              age
+            }
+          }
+        }
+        "#
+    );
+}

--- a/crates/engine/query-solver/src/tests/mod.rs
+++ b/crates/engine/query-solver/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod basic;
 mod cycle;
 mod entities;
+mod interface;
 mod introspection;
 mod mutation;
 mod provides;
@@ -164,7 +165,7 @@ impl crate::Operation for &mut TestOperation {
         self[field_id].definition_id == Some(requirement.definition_id)
     }
 
-    fn create_potential_extra_field(
+    fn create_potential_extra_field_from_requirement(
         &mut self,
         _petitioner_field_id: Self::FieldId,
         requirement: schema::SchemaField<'_>,
@@ -173,6 +174,19 @@ impl crate::Operation for &mut TestOperation {
             name: requirement.definition().name().to_string(),
             definition_id: Some(requirement.definition_id),
             subselection: Vec::new(),
+        });
+        (self.fields.len() - 1).into()
+    }
+    fn create_potential_extra_interface_field_alternative(
+        &mut self,
+        original: Self::FieldId,
+        interface_field_definition: schema::FieldDefinition<'_>,
+    ) -> Self::FieldId {
+        let original = self[original].clone();
+        self.fields.push(Field {
+            name: original.name,
+            definition_id: Some(interface_field_definition.id),
+            subselection: original.subselection,
         });
         (self.fields.len() - 1).into()
     }

--- a/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__interface__interface_field_providing_object_field-finalized-solution.snap
+++ b/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__interface__interface_field_providing_object_field-finalized-solution.snap
@@ -1,0 +1,18 @@
+---
+source: crates/engine/query-solver/src/tests/interface.rs
+expression: "digraph {\n    0 [ label = \"root\" ]\n    1 [ label = \"Root#b\", color=royalblue,shape=parallelogram ]\n    2 [ label = \"anotherUsers\" ]\n    3 [ label = \"FedEntity#a\", color=royalblue,shape=parallelogram ]\n    4 [ label = \"age\" ]\n    5 [ label = \"*id*\" ]\n    0 -> 1 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    3 -> 5 [ label = \"\", color=orangered,arrowhead=inv ]\n    2 -> 3 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    1 -> 2 [ label = \"\" ]\n    2 -> 5 [ label = \"\" ]\n    3 -> 4 [ label = \"\" ]\n}\n"
+---
+digraph {
+    0 [ label = "root" ]
+    1 [ label = "Root#b" ]
+    2 [ label = "anotherUsers" ]
+    3 [ label = "FedEntity#a" ]
+    4 [ label = "age" ]
+    5 [ label = "*id*" ]
+    0 -> 1 [ label = "QueryPartition" ]
+    3 -> 5 [ label = "RequiredBySubgraph" ]
+    2 -> 3 [ label = "QueryPartition" ]
+    1 -> 2 [ label = "Field" ]
+    2 -> 5 [ label = "Field" ]
+    3 -> 4 [ label = "Field" ]
+}

--- a/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__interface__interface_field_providing_object_field-graph.snap
+++ b/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__interface__interface_field_providing_object_field-graph.snap
@@ -1,0 +1,29 @@
+---
+source: crates/engine/query-solver/src/tests/interface.rs
+expression: "digraph {\n    0 [ label = \"root\" ]\n    1 [ label = \"age\" ]\n    2 [ label = \"anotherUsers\" ]\n    3 [ label = \"Root#b\", shape=parallelogram, color=dodgerblue ]\n    4 [ label = \"anotherUsers#b\", shape=box, color=dodgerblue ]\n    5 [ label = \"FedEntity#a\", shape=parallelogram, color=dodgerblue ]\n    6 [ label = \"age#a\", shape=box, color=dodgerblue ]\n    8 [ label = \"*id\" ]\n    9 [ label = \"id#b\", shape=box, color=dodgerblue ]\n    0 -> 2 [ label = \"\" ]\n    0 -> 3 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    0 -> 3 [ label = \"\", style=dashed,arrowhead=none ]\n    3 -> 4 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    4 -> 2 [ label = \"\", color=violet,arrowhead=none ]\n    2 -> 1 [ label = \"\" ]\n    4 -> 5 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    2 -> 5 [ label = \"\", style=dashed,arrowhead=none ]\n    5 -> 6 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    6 -> 1 [ label = \"\", color=violet,arrowhead=none ]\n    2 -> 8 [ label = \"\" ]\n    4 -> 9 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    9 -> 8 [ label = \"\", color=violet,arrowhead=none ]\n    5 -> 8 [ label = \"\", color=orangered,arrowhead=inv ]\n}\n"
+---
+digraph {
+    0 [ root]
+    1 [ age]
+    2 [ anotherUsers]
+    3 [ Root#b]
+    4 [ anotherUsers#b]
+    5 [ FedEntity#a]
+    6 [ age#a]
+    8 [ *id]
+    9 [ id#b]
+    0 -> 2 [ label = "Field" ]
+    0 -> 3 [ label = "CreateChildResolver" ]
+    0 -> 3 [ label = "HasChildResolver" ]
+    3 -> 4 [ label = "CanProvide" ]
+    4 -> 2 [ label = "Provides" ]
+    2 -> 1 [ label = "Field" ]
+    4 -> 5 [ label = "CreateChildResolver" ]
+    2 -> 5 [ label = "HasChildResolver" ]
+    5 -> 6 [ label = "CanProvide" ]
+    6 -> 1 [ label = "Provides" ]
+    2 -> 8 [ label = "Field" ]
+    4 -> 9 [ label = "CanProvide" ]
+    9 -> 8 [ label = "Provides" ]
+    5 -> 8 [ label = "Requires" ]
+}

--- a/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__interface__interface_field_providing_object_field-partial-solution.snap
+++ b/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__interface__interface_field_providing_object_field-partial-solution.snap
@@ -1,0 +1,18 @@
+---
+source: crates/engine/query-solver/src/tests/interface.rs
+expression: "digraph {\n    0 [ label = \"root\" ]\n    1 [ label = \"Root#b\", color=royalblue,shape=parallelogram ]\n    2 [ label = \"anotherUsers\" ]\n    3 [ label = \"FedEntity#a\", color=royalblue,shape=parallelogram ]\n    4 [ label = \"age\" ]\n    5 [ label = \"*id\" ]\n    0 -> 1 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    1 -> 2 [ label = \"\" ]\n    2 -> 3 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    3 -> 4 [ label = \"\" ]\n    2 -> 5 [ label = \"\" ]\n    3 -> 5 [ label = \"\", color=orangered,arrowhead=inv ]\n}\n"
+---
+digraph {
+    0 [ label = "root" ]
+    1 [ label = "Root#b" ]
+    2 [ label = "anotherUsers" ]
+    3 [ label = "FedEntity#a" ]
+    4 [ label = "age" ]
+    5 [ label = "*id" ]
+    0 -> 1 [ label = "QueryPartition" ]
+    1 -> 2 [ label = "Field" ]
+    2 -> 3 [ label = "QueryPartition" ]
+    3 -> 4 [ label = "Field" ]
+    2 -> 5 [ label = "Field" ]
+    3 -> 5 [ label = "RequiredBySubgraph" ]
+}

--- a/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__interface__interface_field_providing_object_field-solved.snap
+++ b/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__interface__interface_field_providing_object_field-solved.snap
@@ -1,0 +1,23 @@
+---
+source: crates/engine/query-solver/src/tests/interface.rs
+expression: "digraph {\n    0 [ label = \"root\", color=forestgreen ]\n    1 [ label = \"age\", color=forestgreen ]\n    2 [ label = \"Root#b\", shape=parallelogram, color=dodgerblue, color=forestgreen ]\n    3 [ label = \"anotherUsers#b\", shape=box, color=dodgerblue, color=forestgreen ]\n    4 [ label = \"FedEntity#a\", shape=parallelogram, color=dodgerblue, color=forestgreen ]\n    5 [ label = \"age#a\", shape=box, color=dodgerblue, color=forestgreen ]\n    6 [ label = \"*id\", color=forestgreen ]\n    7 [ label = \"id#b\", shape=box, color=dodgerblue, color=forestgreen ]\n    8 [ label=\"\", style=dashed]\n    0 -> 2 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    2 -> 3 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    3 -> 4 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    4 -> 5 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    5 -> 1 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    3 -> 7 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    7 -> 6 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    8 -> 0 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n}\n"
+---
+digraph {
+    0 [ label = "root", steiner=1 ]
+    1 [ label = "age", steiner=1 ]
+    2 [ label = "Root#b", steiner=1 ]
+    3 [ label = "anotherUsers#b", steiner=1 ]
+    4 [ label = "FedEntity#a", steiner=1 ]
+    5 [ label = "age#a", steiner=1 ]
+    6 [ label = "*id", steiner=1 ]
+    7 [ label = "id#b", steiner=1 ]
+    8 [ label="", style=dashed]
+    0 -> 2 [ cost=0, steiner=1]
+    2 -> 3 [ cost=0, steiner=1]
+    3 -> 4 [ cost=0, steiner=1]
+    4 -> 5 [ cost=0, steiner=1]
+    5 -> 1 [ cost=0, steiner=1]
+    3 -> 7 [ cost=0, steiner=1]
+    7 -> 6 [ cost=0, steiner=1]
+    8 -> 0 [ cost=0, steiner=0]
+}

--- a/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__interface__interface_field_providing_object_field-solver.snap
+++ b/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__interface__interface_field_providing_object_field-solver.snap
@@ -1,0 +1,23 @@
+---
+source: crates/engine/query-solver/src/tests/interface.rs
+expression: "digraph {\n    0 [ label = \"root\", color=forestgreen ]\n    1 [ label = \"age\", style=dashed ]\n    2 [ label = \"Root#b\", shape=parallelogram, color=dodgerblue, style=dashed ]\n    3 [ label = \"anotherUsers#b\", shape=box, color=dodgerblue, style=dashed ]\n    4 [ label = \"FedEntity#a\", shape=parallelogram, color=dodgerblue, style=dashed ]\n    5 [ label = \"age#a\", shape=box, color=dodgerblue, style=dashed ]\n    6 [ label = \"*id\", style=dashed ]\n    7 [ label = \"id#b\", shape=box, color=dodgerblue, style=dashed ]\n    8 [ label=\"\", style=dashed]\n    0 -> 2 [ label = <<b>1</b>>, color=royalblue,fontcolor=royalblue,style=dashed ]\n    2 -> 3 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n    3 -> 4 [ label = <<b>1</b>>, color=royalblue,fontcolor=royalblue,style=dashed ]\n    4 -> 5 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n    5 -> 1 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n    3 -> 7 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n    7 -> 6 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n    8 -> 0 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n}\n"
+---
+digraph {
+    0 [ label = "root", steiner=1 ]
+    1 [ label = "age", steiner=0 ]
+    2 [ label = "Root#b", steiner=0 ]
+    3 [ label = "anotherUsers#b", steiner=0 ]
+    4 [ label = "FedEntity#a", steiner=0 ]
+    5 [ label = "age#a", steiner=0 ]
+    6 [ label = "*id", steiner=0 ]
+    7 [ label = "id#b", steiner=0 ]
+    8 [ label="", style=dashed]
+    0 -> 2 [ cost=1, steiner=0]
+    2 -> 3 [ cost=0, steiner=0]
+    3 -> 4 [ cost=1, steiner=0]
+    4 -> 5 [ cost=0, steiner=0]
+    5 -> 1 [ cost=0, steiner=0]
+    3 -> 7 [ cost=0, steiner=0]
+    7 -> 6 [ cost=0, steiner=0]
+    8 -> 0 [ cost=0, steiner=0]
+}

--- a/crates/engine/schema/src/entity.rs
+++ b/crates/engine/schema/src/entity.rs
@@ -1,6 +1,8 @@
 use walker::{Iter, Walk};
 
-use crate::{DefinitionId, EntityDefinition, EntityDefinitionId, TypeSystemDirective};
+use crate::{
+    DefinitionId, EntityDefinition, EntityDefinitionId, InterfaceDefinition, InterfaceDefinitionId, TypeSystemDirective,
+};
 
 impl EntityDefinitionId {
     pub fn maybe_from(definition: DefinitionId) -> Option<EntityDefinitionId> {
@@ -26,6 +28,21 @@ impl<'a> EntityDefinition<'a> {
             EntityDefinition::Interface(item) => (item.schema, &item.as_ref().directive_ids),
         };
         directive_ids.walk(schema)
+    }
+
+    pub fn interface_ids(&self) -> &'a [InterfaceDefinitionId] {
+        match self {
+            EntityDefinition::Object(item) => &item.as_ref().interface_ids,
+            EntityDefinition::Interface(item) => &item.as_ref().interface_ids,
+        }
+    }
+
+    pub fn interfaces(&self) -> impl Iter<Item = InterfaceDefinition<'a>> + 'a {
+        let (schema, interface_ids) = match self {
+            EntityDefinition::Object(item) => (item.schema, &item.as_ref().interface_ids),
+            EntityDefinition::Interface(item) => (item.schema, &item.as_ref().interface_ids),
+        };
+        interface_ids.walk(schema)
     }
 }
 

--- a/crates/engine/src/operation/solve/solver/requires.rs
+++ b/crates/engine/src/operation/solve/solver/requires.rs
@@ -38,6 +38,11 @@ impl Solver<'_> {
             .map(|edge| edge.target())
             .collect::<Vec<_>>();
 
+        // We rely on the fact that fields in the SolutionGraph are created in depth order, so a
+        // node will always have a higher id than its parents. This means that the node with the
+        // minimum id in the dependencies is necessarily a scalar requirement or a parent
+        // field of other field requirements. From this parent we just do a breadth-first search
+        // to find other dependencies and build so iteratively a FieldSet structure.
         let mut required_fields = Vec::new();
         while let Some(i) = dependencies.iter().position_min() {
             let start = dependencies.swap_remove(i);


### PR DESCRIPTION
With a schema like:
```graphql
type Query {
  node: Node! @join__field(graph: B)
}

interface Node {
  id: ID
}

type User implements Node @join__type(graph: A) {
  id: ID
  name: String
}
```

and a query:
```graphql
{
  node {
    ... on User { name }
  }
}
```

We need to retrieve the `User.id` but the `B` graph cannot provide it, instead it can provide `Node.id` which represents the same underlying data. So adding the necessary code to add it. It's not perfect and will improve it a bit later, but for now the new problem is that we don't track in the composition that fields we add to an object from entity interfaces are only resolvable through the interface
