### PR TITLE
fix: do not panic if no config is passed for dev

### DIFF
--- a/examples/gateway-hooks/grafbase.toml
+++ b/examples/gateway-hooks/grafbase.toml
@@ -8,6 +8,3 @@ stderr = true
 environment_variables = true
 networking = true
 
-[entity_caching]
-enabled = true
-ttl = "60s"

--- a/examples/gateway-hooks/overrides.toml
+++ b/examples/gateway-hooks/overrides.toml
@@ -1,0 +1,2 @@
+[subgraphs.pets]
+introspection_url = "http://localhost:4002/graphql"


### PR DESCRIPTION
Nice catch after releasing the CLI. If you didn't pass config file to it, the dev would just panic. What we do here is we either load the config, or load a default config and let the merges happen after that.