### PR TITLE
chore: make introspection optional in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,16 +1101,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
-name = "cli-table"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53f9241f288a7b12c56565f04aaeaeeab6b8923d42d99255d4ca428b4d97f89"
-dependencies = [
- "termcolor",
- "unicode-width 0.1.14",
-]
-
-[[package]]
 name = "clickhouse"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3126,7 +3116,6 @@ version = "0.82.3"
 dependencies = [
  "axum",
  "chrono",
- "cli-table",
  "crossterm 0.28.1",
  "cynic",
  "cynic-codegen",

--- a/crates/engine-config-builder/src/from_toml_config.rs
+++ b/crates/engine-config-builder/src/from_toml_config.rs
@@ -21,7 +21,7 @@ pub fn build_with_toml_config(config: &gateway_config::Config, graph: FederatedG
         subgraph_configs: context.subgraph_configs,
         auth: build_auth_config(config),
         operation_limits: build_operation_limits(config),
-        disable_introspection: !config.graph.introspection,
+        disable_introspection: !config.graph.introspection.unwrap_or_default(),
         rate_limit: context.rate_limit,
         timeout: config.gateway.timeout,
         entity_caching: if config.entity_caching.enabled.unwrap_or_default() {

--- a/crates/gateway-config/src/lib.rs
+++ b/crates/gateway-config/src/lib.rs
@@ -232,7 +232,7 @@ pub struct RetryConfig {
 #[serde(default, deny_unknown_fields)]
 pub struct GraphConfig {
     pub path: Option<String>,
-    pub introspection: bool,
+    pub introspection: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default, serde::Deserialize)]
@@ -381,7 +381,7 @@ mod tests {
     fn graph_defaults() {
         let config: Config = toml::from_str("").unwrap();
 
-        assert!(!config.graph.introspection);
+        assert!(config.graph.introspection.is_none());
         assert_eq!(None, config.graph.path.as_deref());
     }
 
@@ -395,7 +395,7 @@ mod tests {
 
         let config: Config = toml::from_str(input).unwrap();
 
-        assert!(config.graph.introspection);
+        assert!(config.graph.introspection.unwrap());
         assert_eq!(Some("/enterprise"), config.graph.path.as_deref());
     }
 

--- a/crates/grafbase-local-backend/Cargo.toml
+++ b/crates/grafbase-local-backend/Cargo.toml
@@ -47,7 +47,6 @@ graphql-composition.workspace = true
 federated-graph.workspace = true
 serde-dynamic-string.workspace = true
 url.workspace = true
-cli-table = { version = "0.4.9", default-features = false }
 
 [build-dependencies]
 cynic-codegen.workspace = true

--- a/crates/grafbase-local-backend/src/dev.rs
+++ b/crates/grafbase-local-backend/src/dev.rs
@@ -4,10 +4,6 @@ mod pathfinder;
 mod subgraphs;
 
 use super::errors::BackendError;
-use cli_table::{
-    format::{Border, Justify, Separator},
-    print_stdout, Cell, Style, Table,
-};
 use configurations::get_and_merge_configurations;
 use federated_server::{serve, GraphFetchMethod, ServerConfig, ServerRouter, ServerRuntime};
 use gateway_config::Config;
@@ -180,22 +176,8 @@ fn output_handler(
         url.port().unwrap()
     );
 
-    let table = vec![
-        vec![
-            "GraphQL endpoint:".cell().justify(Justify::Left),
-            url.to_string().cell().justify(Justify::Left).bold(true),
-        ],
-        vec![
-            "Pathfinder:".cell().justify(Justify::Left),
-            pathfinder_url.cell().justify(Justify::Left).bold(true),
-        ],
-    ]
-    .table()
-    .border(Border::builder().build())
-    .separator(Separator::builder().build());
-
-    print_stdout(table).unwrap();
-    println!();
+    println!("GraphQL endpoint:  {}", url.to_string().bold());
+    println!("Pathfinder:        {}\n", pathfinder_url.bold());
 
     if introspection_forced {
         tracing::info!("introspection is always enabled in the dev mode, config overriden");

--- a/crates/grafbase-local-backend/src/dev/configurations.rs
+++ b/crates/grafbase-local-backend/src/dev/configurations.rs
@@ -84,8 +84,8 @@ pub async fn get_and_merge_configurations(
         .map(|config| config.subgraphs.into_keys().collect::<HashSet<_>>())
         .unwrap_or_default();
 
-    let introspection_forced = !merged_configuration.graph.introspection;
-    merged_configuration.graph.introspection = true;
+    let introspection_forced = merged_configuration.graph.introspection == Some(false);
+    merged_configuration.graph.introspection = Some(true);
 
     Ok(DevConfiguration {
         introspection_forced,


### PR DESCRIPTION
- dev is always enabled, if the setting is explicitly false, we log a nag
- prod is by default false