### PR TITLE
chore: remove OperationCacheFactory trait

### DIFF
--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -1,4 +1,4 @@
-use ::runtime::{hooks::Hooks as _, operation_cache::OperationCacheFactory};
+use ::runtime::hooks::Hooks as _;
 use bytes::Bytes;
 use engine_auth::AuthService;
 use futures::{StreamExt, TryFutureExt};
@@ -31,7 +31,7 @@ pub struct Engine<R: Runtime> {
     pub(crate) runtime: R,
     auth: AuthService,
     retry_budgets: RetryBudgets,
-    pub(crate) operation_cache: <R::OperationCacheFactory as OperationCacheFactory>::Cache<Arc<CachedOperation>>,
+    // pub(crate) operation_cache: <R::OperationCacheFactory as OperationCacheFactory>::Cache<Arc<CachedOperation>>,
     default_response_format: ResponseFormat,
 }
 
@@ -47,7 +47,7 @@ impl<R: Runtime> Engine<R> {
         Self {
             auth,
             retry_budgets: RetryBudgets::build(&schema),
-            operation_cache: runtime.operation_cache_factory().create().await,
+            // operation_cache: runtime.operation_cache_factory().create().await,
             schema,
             runtime,
             // Could be coming from configuration one day

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -31,7 +31,6 @@ pub struct Engine<R: Runtime> {
     pub(crate) runtime: R,
     auth: AuthService,
     retry_budgets: RetryBudgets,
-    // pub(crate) operation_cache: <R::OperationCacheFactory as OperationCacheFactory>::Cache<Arc<CachedOperation>>,
     default_response_format: ResponseFormat,
 }
 
@@ -47,7 +46,6 @@ impl<R: Runtime> Engine<R> {
         Self {
             auth,
             retry_budgets: RetryBudgets::build(&schema),
-            // operation_cache: runtime.operation_cache_factory().create().await,
             schema,
             runtime,
             // Could be coming from configuration one day

--- a/crates/engine/src/engine/runtime.rs
+++ b/crates/engine/src/engine/runtime.rs
@@ -1,21 +1,23 @@
-use std::future::Future;
+use std::{future::Future, sync::Arc};
 
 use grafbase_telemetry::metrics::EngineMetrics;
 use runtime::{entity_cache::EntityCache, kv::KvStore, rate_limiting::RateLimiter};
+
+use super::CachedOperation;
 
 pub type HooksContext<R> = <<R as Runtime>::Hooks as runtime::hooks::Hooks>::Context;
 
 pub trait Runtime: Send + Sync + 'static {
     type Hooks: runtime::hooks::Hooks;
     type Fetcher: runtime::fetch::Fetcher;
-    type OperationCacheFactory: runtime::operation_cache::OperationCacheFactory;
+    type OperationCache: runtime::operation_cache::OperationCache<Arc<CachedOperation>>;
 
     fn fetcher(&self) -> &Self::Fetcher;
     fn kv(&self) -> &KvStore;
     fn trusted_documents(&self) -> &runtime::trusted_documents_client::Client;
     fn metrics(&self) -> &EngineMetrics;
     fn hooks(&self) -> &Self::Hooks;
-    fn operation_cache_factory(&self) -> &Self::OperationCacheFactory;
+    fn operation_cache(&self) -> &Self::OperationCache;
     fn rate_limiter(&self) -> &RateLimiter;
     fn sleep(&self, duration: std::time::Duration) -> impl Future<Output = ()> + Send;
     fn entity_cache(&self) -> &dyn EntityCache;

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -15,4 +15,5 @@ pub mod websocket;
 pub use self::engine::{Engine, Runtime, WebsocketSession};
 pub use ::config;
 pub use graphql_over_http::{Body, ErrorCode, HooksExtension, TelemetryExtension};
+pub use prepare::CachedOperation;
 pub use schema::{BuildError, Schema, Version as SchemaVersion};

--- a/crates/engine/src/prepare/context.rs
+++ b/crates/engine/src/prepare/context.rs
@@ -5,7 +5,6 @@ use grafbase_telemetry::metrics::EngineMetrics;
 use runtime::{
     auth::AccessToken,
     hooks::{ExecutedOperation, ExecutedOperationBuilder, Hooks},
-    operation_cache::OperationCache,
 };
 use schema::Schema;
 
@@ -16,7 +15,7 @@ use crate::{
     Engine, Runtime,
 };
 
-use super::{CachedOperation, PreparedOperation};
+use super::PreparedOperation;
 
 /// Context before starting to operation plan execution.
 /// Background futures will be started in parallel to avoid delaying the plan.
@@ -68,7 +67,7 @@ impl<'ctx, R: Runtime> PrepareContext<'ctx, R> {
         self.engine.runtime.metrics()
     }
 
-    pub fn operation_cache(&self) -> &'ctx impl OperationCache<Arc<CachedOperation>> {
+    pub fn operation_cache(&self) -> &'ctx R::OperationCache {
         self.engine.runtime.operation_cache()
     }
 

--- a/crates/engine/src/prepare/context.rs
+++ b/crates/engine/src/prepare/context.rs
@@ -5,6 +5,7 @@ use grafbase_telemetry::metrics::EngineMetrics;
 use runtime::{
     auth::AccessToken,
     hooks::{ExecutedOperation, ExecutedOperationBuilder, Hooks},
+    operation_cache::OperationCache,
 };
 use schema::Schema;
 
@@ -15,7 +16,7 @@ use crate::{
     Engine, Runtime,
 };
 
-use super::PreparedOperation;
+use super::{CachedOperation, PreparedOperation};
 
 /// Context before starting to operation plan execution.
 /// Background futures will be started in parallel to avoid delaying the plan.
@@ -65,6 +66,10 @@ impl<'ctx, R: Runtime> PrepareContext<'ctx, R> {
 
     pub fn metrics(&self) -> &'ctx EngineMetrics {
         self.engine.runtime.metrics()
+    }
+
+    pub fn operation_cache(&self) -> &'ctx impl OperationCache<Arc<CachedOperation>> {
+        self.engine.runtime.operation_cache()
     }
 
     pub fn grafbase_response_extension(

--- a/crates/engine/src/prepare/mod.rs
+++ b/crates/engine/src/prepare/mod.rs
@@ -45,12 +45,12 @@ impl<'ctx, R: Runtime> PrepareContext<'ctx, R> {
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
-pub(crate) struct CachedOperation {
-    pub solved: SolvedOperation,
-    pub attributes: CachedOperationAttributes,
+pub struct CachedOperation {
+    pub(crate) solved: SolvedOperation,
+    pub(crate) attributes: CachedOperationAttributes,
     // This is optional because we only currently need it for complexity control
     // That may change in the future...
-    pub operation: Option<BoundOperation>,
+    pub(crate) operation: Option<BoundOperation>,
 }
 
 impl CachedOperation {

--- a/crates/engine/src/prepare/operation/mod.rs
+++ b/crates/engine/src/prepare/operation/mod.rs
@@ -31,7 +31,7 @@ impl<'ctx, R: Runtime> PrepareContext<'ctx, R> {
                 Err(err) => return Err(Response::refuse_request_with(http::StatusCode::BAD_REQUEST, vec![err])),
             };
 
-            if let Some(operation) = self.engine.operation_cache.get(&cache_key).await {
+            if let Some(operation) = self.operation_cache().get(&cache_key).await {
                 self.executed_operation_builder.set_cached_plan();
                 self.metrics().record_operation_cache_hit();
 
@@ -56,7 +56,7 @@ impl<'ctx, R: Runtime> PrepareContext<'ctx, R> {
                             Response::request_error(attributes, [err])
                         })?;
 
-                let cache_fut = self.engine.operation_cache.insert(cache_key, cached_operation.clone());
+                let cache_fut = self.operation_cache().insert(cache_key, cached_operation.clone());
                 self.push_background_future(cache_fut.boxed());
 
                 cached_operation

--- a/crates/integration-tests/src/federation/builder/bench.rs
+++ b/crates/integration-tests/src/federation/builder/bench.rs
@@ -13,7 +13,7 @@ use runtime::{
     fetch::{dynamic::DynFetcher, FetchRequest, FetchResult},
     hooks::{DynamicHooks, ResponseInfo},
 };
-use runtime_local::InMemoryOperationCacheFactory;
+use runtime_local::InMemoryOperationCache;
 
 use crate::federation::{GraphqlResponse, GraphqlStreamingResponse};
 
@@ -49,7 +49,7 @@ impl<'a> DeterministicEngineBuilder<'a> {
     }
 
     pub fn without_operation_cache(mut self) -> Self {
-        self.runtime.hot_cache_factory = InMemoryOperationCacheFactory::inactive();
+        self.runtime.operation_cache = InMemoryOperationCache::inactive();
         self
     }
 

--- a/crates/runtime-local/src/lib.rs
+++ b/crates/runtime-local/src/lib.rs
@@ -13,7 +13,7 @@ pub use entity_cache::memory::InMemoryEntityCache;
 pub use entity_cache::redis::RedisEntityCache;
 pub use fetch::NativeFetcher;
 pub use kv::*;
-pub use operation_cache::{InMemoryOperationCache, InMemoryOperationCacheFactory};
+pub use operation_cache::InMemoryOperationCache;
 
 #[cfg(feature = "wasi")]
 pub use hooks::{ComponentLoader, HooksWasi, HooksWasiConfig};

--- a/crates/runtime/src/operation_cache.rs
+++ b/crates/runtime/src/operation_cache.rs
@@ -1,17 +1,5 @@
 use std::future::Future;
 
-pub trait OperationCacheFactory: Send + Sync + 'static {
-    type Cache<V>: OperationCache<V>
-    where
-        V: Clone + Send + Sync + 'static + serde::Serialize + serde::de::DeserializeOwned;
-
-    /// A new instance provides a convenient interface on how values are handled. Keys
-    /// still live in the same namespace and MUST be unique.
-    fn create<V>(&self) -> impl Future<Output = Self::Cache<V>> + Send
-    where
-        V: Clone + Send + Sync + 'static + serde::Serialize + serde::de::DeserializeOwned;
-}
-
 /// Cache meant to store data in a really fast cache, ideally directly in-memory.
 /// It is *not* meant for response caching.
 /// It's up to the implementation to decide how to evict values to save space.
@@ -30,22 +18,6 @@ where
     // moka-cache does require a &String rather than a &str
     #[allow(clippy::ptr_arg)]
     fn get(&self, key: &String) -> impl Future<Output = Option<V>> + Send;
-}
-
-// ---------------------------//
-// -- No-op implementation -- //
-// ---------------------------//
-impl OperationCacheFactory for () {
-    type Cache<V>
-        = ()
-    where
-        V: Clone + Send + Sync + 'static + serde::Serialize + serde::de::DeserializeOwned;
-
-    async fn create<V>(&self) -> Self::Cache<V>
-    where
-        V: Clone + Send + Sync + 'static + serde::Serialize + serde::de::DeserializeOwned,
-    {
-    }
 }
 
 impl<V> OperationCache<V> for ()


### PR DESCRIPTION
To do query warming I need to reach into the operation cache to fetch queries to prewarm.  I wanted to do this in the runtime, but currently the runtime doesn't have access to the operation cache, only an OperationCacheFactory.  

I can't see much reason for this factory.  Things seem to work fine without it, so I've removed it.  If I've missed something please let me know and I'll revert.