### PR TITLE
chore: rework engine & config updates in gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2504,6 +2504,7 @@ dependencies = [
  "engine",
  "engine-axum",
  "engine-config-builder",
+ "futures-lite 2.5.0",
  "gateway-config",
  "grafbase-telemetry",
  "grafbase-workspace-hack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ flexbuffers = "2"
 fixedbitset = "0.5"
 futures = "0.3.30"
 futures-channel = "0.3.30"
+futures-lite = "2"
 futures-util = "0.3.30"
 graphql-ws-client = { version = "0.11.0", features = ["tungstenite"] }
 handlebars = "5.1.2"

--- a/crates/engine/axum/src/websocket/accepter.rs
+++ b/crates/engine/axum/src/websocket/accepter.rs
@@ -8,7 +8,7 @@ use tokio::sync::{mpsc, watch};
 use super::service::MessageConvert;
 use engine::websocket::{Event, Message};
 
-pub type EngineWatcher<R> = watch::Receiver<Option<Arc<Engine<R>>>>;
+pub type EngineWatcher<R> = watch::Receiver<Arc<Engine<R>>>;
 pub type WebsocketSender = tokio::sync::mpsc::Sender<WebSocket>;
 pub type WebsocketReceiver = tokio::sync::mpsc::Receiver<WebSocket>;
 
@@ -166,17 +166,7 @@ async fn accept_websocket<R: Runtime>(
             Event::ConnectionInit {
                 payload: InitPayload { headers },
             } => {
-                let Some(engine) = engine.borrow().clone() else {
-                    websocket
-                        .send(
-                            Message::<R>::close(4995, "register a subgraph before connecting")
-                                .to_axum_message()
-                                .unwrap(),
-                        )
-                        .await
-                        .ok();
-                    return None;
-                };
+                let engine = engine.borrow().clone();
 
                 let Ok(session) = engine.create_websocket_session(headers).await else {
                     websocket

--- a/crates/federated-server/Cargo.toml
+++ b/crates/federated-server/Cargo.toml
@@ -23,6 +23,7 @@ cfg-if = "1"
 engine-config-builder.workspace = true
 engine.workspace = true
 engine-axum.workspace = true
+futures-lite.workspace = true
 grafbase-telemetry = { workspace = true, features = ["otlp"] }
 grafbase-workspace-hack.workspace = true
 graph-ref.workspace = true

--- a/crates/federated-server/src/server.rs
+++ b/crates/federated-server/src/server.rs
@@ -1,6 +1,7 @@
 mod access_logs;
 mod cors;
 mod csrf;
+mod engine_reloader;
 mod gateway;
 mod graph_fetch_method;
 mod graph_updater;
@@ -12,7 +13,6 @@ pub use graph_fetch_method::GraphFetchMethod;
 pub use state::ServerState;
 
 use runtime_local::{hooks, ComponentLoader, HooksWasi};
-use tokio::sync::watch;
 use ulid::Ulid;
 
 use axum::{extract::State, response::IntoResponse, routing::get, Router};
@@ -20,10 +20,11 @@ use engine_axum::{
     middleware::{ResponseHookLayer, TelemetryLayer},
     websocket::{WebsocketAccepter, WebsocketService},
 };
+use engine_reloader::EngineReloader;
 use gateway_config::{Config, TlsConfig};
 use std::{net::SocketAddr, path::PathBuf};
-use tokio::signal;
 use tokio::sync::mpsc;
+use tokio::{signal, sync::watch};
 use tower_http::cors::CorsLayer;
 
 pub type ServerRouter<T> = Router<ServerState<T>>;
@@ -33,7 +34,7 @@ pub struct ServerConfig {
     /// The GraphQL endpoint listen address.
     pub listen_addr: Option<SocketAddr>,
     /// The gateway configuration.
-    pub config: Config,
+    pub config: watch::Receiver<Config>,
     /// The config file path for hot reload.
     pub config_path: Option<PathBuf>,
     /// If true, watches changes to the config
@@ -82,17 +83,15 @@ impl ServerRuntime for () {
 pub async fn serve(
     ServerConfig {
         listen_addr,
-        config,
+        config: config_receiver,
         config_path,
         fetch_method,
         config_hot_reload,
     }: ServerConfig,
     server_runtime: impl ServerRuntime,
 ) -> crate::Result<()> {
+    let config = config_receiver.borrow().clone();
     let path = config.graph.path.as_deref().unwrap_or("/graphql");
-
-    let (sender, mut gateway) = watch::channel(None);
-    gateway.mark_unchanged();
 
     let meter = grafbase_telemetry::metrics::meter_from_global_provider();
     let pending_logs_counter = meter.i64_up_down_counter("grafbase.gateway.access_log.pending").build();
@@ -111,14 +110,17 @@ pub async fn serve(
     let max_pool_size = config.hooks.as_ref().and_then(|config| config.max_pool_size);
     let hooks = HooksWasi::new(loader, max_pool_size, &meter, access_log_sender.clone()).await;
 
-    fetch_method
-        .start(
-            &config,
-            config_hot_reload.then_some(config_path).flatten(),
-            sender,
-            hooks.clone(),
-        )
-        .await?;
+    let update_handler = EngineReloader::spawn(
+        config_receiver,
+        config_hot_reload.then_some(config_path).flatten(),
+        hooks.clone(),
+    )
+    .await?;
+
+    fetch_method.start(update_handler.graph_sender()).await?;
+
+    let mut gateway = update_handler.engine_watcher();
+    gateway.mark_unchanged();
 
     if config.gateway.access_logs.enabled {
         access_logs::start(&config.gateway.access_logs, access_log_receiver, pending_logs_counter)?;
@@ -329,7 +331,7 @@ async fn graceful_shutdown(handle: axum_server::Handle) {
     handle.graceful_shutdown(Some(std::time::Duration::from_secs(3)));
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 #[allow(dead_code)]
 /// Response from the API containing graph information
 pub struct GdnResponse {

--- a/crates/federated-server/src/server.rs
+++ b/crates/federated-server/src/server.rs
@@ -34,7 +34,7 @@ pub struct ServerConfig {
     /// The GraphQL endpoint listen address.
     pub listen_addr: Option<SocketAddr>,
     /// The gateway configuration.
-    pub config: watch::Receiver<Config>,
+    pub config_receiver: watch::Receiver<Config>,
     /// The config file path for hot reload.
     pub config_path: Option<PathBuf>,
     /// If true, watches changes to the config
@@ -83,7 +83,7 @@ impl ServerRuntime for () {
 pub async fn serve(
     ServerConfig {
         listen_addr,
-        config: config_receiver,
+        config_receiver,
         config_path,
         fetch_method,
         config_hot_reload,

--- a/crates/federated-server/src/server/engine_reloader.rs
+++ b/crates/federated-server/src/server/engine_reloader.rs
@@ -30,8 +30,13 @@ enum Update {
 
 impl EngineReloader {
     pub async fn spawn(
+        // A receiver that passes the config in.  In the gateway this is usually
+        // static, but in federated dev it will change on reloads.
         gateway_config: watch::Receiver<gateway_config::Config>,
         mut graph_stream: GraphStream,
+        // The config path that should be used to hot reloading in the gateway.
+        // In federated dev this is None.  We should probably merge this
+        // functionality into gateway_config above at some point...
         hot_reload_config_path: Option<PathBuf>,
         hooks: HooksWasi,
     ) -> crate::Result<Self> {

--- a/crates/federated-server/src/server/engine_reloader.rs
+++ b/crates/federated-server/src/server/engine_reloader.rs
@@ -1,0 +1,142 @@
+use std::{path::PathBuf, sync::Arc};
+
+use engine::Engine;
+use futures_lite::{pin, StreamExt};
+use runtime_local::HooksWasi;
+use tokio::{
+    sync::{mpsc, watch},
+    task::JoinHandle,
+};
+use tokio_stream::{
+    wrappers::{ReceiverStream, WatchStream},
+    Stream,
+};
+
+use crate::server::gateway;
+
+use super::gateway::{EngineSender, EngineWatcher, GatewayRuntime, GraphDefinition};
+
+/// Handles graph and config updates by constructing a new engine
+pub(super) struct EngineReloader {
+    graph_sender: GraphSender,
+    engine_watcher: EngineWatcher,
+}
+
+pub(crate) type GraphSender = mpsc::Sender<GraphDefinition>;
+
+enum Update {
+    Graph(GraphDefinition),
+    Config(gateway_config::Config),
+}
+
+impl EngineReloader {
+    pub async fn spawn(
+        gateway_config: watch::Receiver<gateway_config::Config>,
+        hot_reload_config_path: Option<PathBuf>,
+        hooks: HooksWasi,
+    ) -> crate::Result<Self> {
+        let (graph_sender, mut graph_receiver) = mpsc::channel::<GraphDefinition>(4);
+        let (engine_sender, engine_watcher) = watch::channel::<Option<Arc<Engine<GatewayRuntime>>>>(None);
+
+        let context = Context {
+            hot_reload_config_path,
+            hooks,
+            engine_sender,
+        };
+
+        let Some(graph_definition) = graph_receiver.recv().await else {
+            // This shouldn't really happen, but someone could mess up
+            return Err(crate::Error::InternalError("No initial graph setup".into()));
+        };
+
+        build_new_engine(
+            gateway_config.borrow().clone(),
+            graph_definition.clone(),
+            context.clone(),
+        )
+        .await?;
+
+        tokio::spawn(async move {
+            let graph_stream = ReceiverStream::new(graph_receiver).map(Update::Graph);
+            let config_stream = WatchStream::from_changes(gateway_config.clone()).map(Update::Config);
+            let updates = graph_stream.race(config_stream);
+            let current_config = gateway_config.borrow().clone();
+
+            update_loop(updates, current_config, graph_definition, context).await
+        });
+
+        Ok(EngineReloader {
+            graph_sender,
+            engine_watcher,
+        })
+    }
+
+    pub fn graph_sender(&self) -> GraphSender {
+        self.graph_sender.clone()
+    }
+
+    pub fn engine_watcher(&self) -> EngineWatcher {
+        self.engine_watcher.clone()
+    }
+}
+
+#[derive(Clone)]
+struct Context {
+    hot_reload_config_path: Option<PathBuf>,
+    hooks: HooksWasi,
+    engine_sender: EngineSender,
+}
+
+async fn update_loop(
+    updates: impl Stream<Item = Update>,
+    mut current_config: gateway_config::Config,
+    mut graph_definition: GraphDefinition,
+    context: Context,
+) {
+    let mut in_progress_reload: Option<JoinHandle<()>> = None;
+
+    pin!(updates);
+
+    while let Some(update) = updates.next().await {
+        if let Some(in_progress_reload) = in_progress_reload.take() {
+            in_progress_reload.abort();
+        }
+
+        match update {
+            Update::Graph(new_graph) => graph_definition = new_graph,
+            Update::Config(config) => current_config = config,
+        }
+
+        in_progress_reload = Some(tokio::spawn({
+            let context = context.clone();
+            let current_config = current_config.clone();
+            let graph_definition = graph_definition.clone();
+
+            async move {
+                if let Err(err) = build_new_engine(current_config, graph_definition, context).await {
+                    tracing::error!("Could not build engine from latest graph: {err}")
+                }
+            }
+        }));
+    }
+}
+
+async fn build_new_engine(
+    current_config: gateway_config::Config,
+    graph_definition: GraphDefinition,
+    context: Context,
+) -> crate::Result<()> {
+    let engine = gateway::generate(
+        graph_definition,
+        &current_config,
+        context.hot_reload_config_path,
+        context.hooks,
+    )
+    .await?;
+
+    let engine = Arc::new(engine);
+
+    context.engine_sender.send(Some(engine))?;
+
+    Ok(())
+}

--- a/crates/federated-server/src/server/gateway.rs
+++ b/crates/federated-server/src/server/gateway.rs
@@ -13,12 +13,12 @@ pub use gateway_runtime::GatewayRuntime;
 mod gateway_runtime;
 
 /// Send half of the gateway watch channel
-pub(crate) type EngineSender = watch::Sender<Option<Arc<Engine<GatewayRuntime>>>>;
+pub(crate) type EngineSender = watch::Sender<Arc<Engine<GatewayRuntime>>>;
 
 /// Receive half of the gateway watch channel.
 ///
 /// Anything part of the system that needs access to the gateway can use this
-pub(crate) type EngineWatcher = watch::Receiver<Option<Arc<Engine<GatewayRuntime>>>>;
+pub(crate) type EngineWatcher = watch::Receiver<Arc<Engine<GatewayRuntime>>>;
 
 #[derive(Clone)]
 pub(crate) enum GraphDefinition {

--- a/crates/federated-server/src/server/gateway.rs
+++ b/crates/federated-server/src/server/gateway.rs
@@ -13,13 +13,14 @@ pub use gateway_runtime::GatewayRuntime;
 mod gateway_runtime;
 
 /// Send half of the gateway watch channel
-pub(crate) type GatewaySender = watch::Sender<Option<Arc<Engine<GatewayRuntime>>>>;
+pub(crate) type EngineSender = watch::Sender<Option<Arc<Engine<GatewayRuntime>>>>;
 
 /// Receive half of the gateway watch channel.
 ///
 /// Anything part of the system that needs access to the gateway can use this
 pub(crate) type EngineWatcher = watch::Receiver<Option<Arc<Engine<GatewayRuntime>>>>;
 
+#[derive(Clone)]
 pub(crate) enum GraphDefinition {
     /// Response from GDN.
     Gdn(GdnResponse),

--- a/crates/federated-server/src/server/health.rs
+++ b/crates/federated-server/src/server/health.rs
@@ -13,6 +13,7 @@ pub(crate) enum HealthState {
     Healthy,
 
     /// Indicates that the server is unhealthy and not operational.
+    #[expect(dead_code)] // I assume we'll use this sometime
     Unhealthy,
 }
 
@@ -25,12 +26,8 @@ pub(crate) enum HealthState {
 /// # Returns
 ///
 /// A tuple containing the HTTP status code and a JSON representation of the health status.
-pub(crate) async fn health<SR>(State(state): State<ServerState<SR>>) -> (StatusCode, Json<HealthState>) {
-    if state.gateway.borrow().is_some() {
-        (StatusCode::OK, Json(HealthState::Healthy))
-    } else {
-        (StatusCode::SERVICE_UNAVAILABLE, Json(HealthState::Unhealthy))
-    }
+pub(crate) async fn health<SR>(State(_state): State<ServerState<SR>>) -> (StatusCode, Json<HealthState>) {
+    (StatusCode::OK, Json(HealthState::Healthy))
 }
 
 /// Binds the health check endpoint to the specified address and configuration.

--- a/crates/grafbase-local-backend/src/dev.rs
+++ b/crates/grafbase-local-backend/src/dev.rs
@@ -118,7 +118,7 @@ pub async fn start(
         listen_addr: Some(listen_address),
         config_path: None,
         config_hot_reload: false,
-        config: config_receiver,
+        config_receiver,
         fetch_method: GraphFetchMethod::FromSchemaReloadable { sdl_receiver },
     };
 

--- a/crates/grafbase-local-backend/src/dev/hot_reload.rs
+++ b/crates/grafbase-local-backend/src/dev/hot_reload.rs
@@ -292,9 +292,11 @@ pub async fn hot_reload(
     dev_configuration: DevConfiguration,
 ) {
     // start hot reloading once the server is ready
+    eprintln!("Waiting on ready receiver");
     if ready_receiver.recv().await.is_err() {
         return;
     }
+    eprintln!("Ready recievier says go");
 
     if gateway_config_path.is_none() && graph_overrides_path.is_none() {
         // return early since we don't hot reload graphs from the API

--- a/gateway/src/args/lambda.rs
+++ b/gateway/src/args/lambda.rs
@@ -41,10 +41,7 @@ impl super::Args for Args {
     /// The method of fetching a graph
     fn fetch_method(&self) -> anyhow::Result<GraphFetchMethod> {
         let federated_sdl = fs::read_to_string(&self.schema).context("could not read federated schema file")?;
-        Ok(GraphFetchMethod::FromSchema {
-            federated_sdl,
-            reload_signal: None,
-        })
+        Ok(GraphFetchMethod::FromSchema { federated_sdl })
     }
 
     /// The gateway configuration

--- a/gateway/src/args/std.rs
+++ b/gateway/src/args/std.rs
@@ -83,10 +83,7 @@ impl super::Args for Args {
                     fs::read_to_string(self.schema.as_ref().expect("must exist if graph-ref is not defined"))
                         .context("could not read federated schema file")?;
 
-                Ok(GraphFetchMethod::FromSchema {
-                    federated_sdl,
-                    reload_signal: None,
-                })
+                Ok(GraphFetchMethod::FromSchema { federated_sdl })
             }
         }
     }

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -35,7 +35,7 @@ fn main() -> anyhow::Result<()> {
 
         let config = ServerConfig {
             listen_addr: args.listen_address(),
-            config: config_channel(config),
+            config_receiver: config_recevier(config),
             config_path: args.config_path().map(|p| p.to_owned()),
             config_hot_reload: args.hot_reload(),
             fetch_method: args.fetch_method()?,
@@ -53,10 +53,12 @@ fn main() -> anyhow::Result<()> {
     })
 }
 
-fn config_channel(config: gateway_config::Config) -> watch::Receiver<gateway_config::Config> {
+fn config_recevier(config: gateway_config::Config) -> watch::Receiver<gateway_config::Config> {
     let (sender, receiver) = watch::channel(config);
 
     // Leak the sender so the channel never closes
+    //
+    // This should be safe since this function is only ever called once from fn main()
     Box::leak(Box::new(sender));
 
     receiver


### PR DESCRIPTION
I need to hook into the engine creation process in the gateway to add query warming.  Prior to this change that happened in three places: inside the GraphUpdater when using a graph ref to fetch from the GDN & a couple of places inside GraphFetchMethod::start when using a schema file.  This made it a bit awkward to add in query warming.

This refactors things a bit so that GraphUpdater & GraphFetchMethod::start both just send a `GraphDefinition` on a channel, where a new `EngineReloader` (name suggestions welcome) is listening and will handle the update.  There's also some logic to cancel a running reload if another one comes in afterwards.

I also separated out config updates from graph updates in the `reload_signal` used by federated dev - config updates now go over their own `tokio::sync::watch` channel, rather than sometimes being passed as an argument and sometimes being passed through a channel along with a GraphDef.

Finally, I changed the engine watcher to not contain an `Option`.  As far as I could tell the case where this is `None` could only be ever be observed by the websocket handler - we only ever set it to `Some(engine)` and we have a `watcher.changed().await` before we start up the main server.  So it seems like a reasonable simplification.