### PR TITLE
fix(engine): Do not send subgraph request with impossible implementors

### DIFF
--- a/crates/engine/src/resolver/graphql/request/prepare.rs
+++ b/crates/engine/src/resolver/graphql/request/prepare.rs
@@ -221,8 +221,18 @@ impl QueryBuilderContext {
         let parent_is_fully_implemented = parent_type.is_fully_implemented_in_subgraph(subgraph_id);
         for (entity, fields) in entity_fields.into_iter() {
             let interface = match entity {
-                EntityDefinition::Object(_) => {
-                    self.write_type_condition_and_entity_fields(buffer, entity, fields)?;
+                EntityDefinition::Object(object) => {
+                    match parent_type {
+                        CompositeType::Interface(interface)
+                            if object.implements_interface_in_subgraph(&subgraph_id, &interface.id) =>
+                        {
+                            self.write_type_condition_and_entity_fields(buffer, entity, fields)?;
+                        }
+                        CompositeType::Union(union) if union.has_member_in_subgraph(subgraph_id, object.id) => {
+                            self.write_type_condition_and_entity_fields(buffer, entity, fields)?;
+                        }
+                        _ => (),
+                    }
                     continue;
                 }
                 EntityDefinition::Interface(interface) => interface,


### PR DESCRIPTION
Sometimes queries end up with a case like:
```
products {
   ... on Oven { id }
   ... on Kettle { id }
}
```
where in the subgraph `Oven` doesn't implement `Product` even if it exists in the subgraph. Oven implements it in another subgraph. I'm not sure if this is really the right way to do it, planning should likely take this into account. But still an improvement.