### PR TITLE
fix(engine): Take into account type overrides when generatin subgraph query

### DIFF
--- a/crates/engine/codegen/domain/schema.graphql
+++ b/crates/engine/codegen/domain/schema.graphql
@@ -79,12 +79,18 @@ type FieldDefinition @meta(module: "field") @indexed(id_size: "u32") {
   ty: Type!
   resolvers: [ResolverDefinition!]!
   exists_in_subgraphs: [Subgraph!]!
-  distinct_type_in: [Subgraph!]!
+  "Present if subgraph has a different type from the supergraph"
+  subgraph_types: [SubgraphType!]!
   requires: [FieldRequires!]! @field(record_field_name: "requires_records")
   provides: [FieldProvides!]! @field(record_field_name: "provides_records")
   "The arguments referenced by this range are sorted by their name (string)"
   arguments: [InputValueDefinition!]!
   directives: [TypeSystemDirective!]!
+}
+
+type SubgraphType @meta(module: "field/subgraph_type") @copy {
+  subgraph: Subgraph!
+  ty: Type!
 }
 
 type FieldProvides @meta(module: "field/provides") @copy {

--- a/crates/engine/schema/src/builder/graph.rs
+++ b/crates/engine/schema/src/builder/graph.rs
@@ -501,7 +501,7 @@ impl<'a> GraphBuilder<'a> {
                 name: field.name.into(),
             };
 
-            let mut distinct_type_in_ids = Vec::new();
+            let mut subgraph_type_records = Vec::new();
             let mut requires_records = Vec::new();
             let mut provides_records = Vec::new();
             // BTreeSet to ensures consistent ordering of resolvers.
@@ -519,8 +519,11 @@ impl<'a> GraphBuilder<'a> {
                 has_join_field = true;
                 if let Some(federated_subgraph_id) = federated_subgraph_id {
                     let subgraph_id = SubgraphId::GraphqlEndpoint((*federated_subgraph_id).into());
-                    if r#type.as_ref().is_some_and(|ty| ty != &field.r#type) {
-                        distinct_type_in_ids.push(subgraph_id);
+                    if let Some(r#type) = r#type.filter(|ty| ty != &field.r#type) {
+                        subgraph_type_records.push(SubgraphTypeRecord {
+                            subgraph_id,
+                            ty_record: self.ctx.convert_type(r#type),
+                        });
                     }
                     if let Some(provides) = provides.as_ref().filter(|provides| !provides.is_empty()) {
                         let field_set_id = self.field_sets.push(field_schema_location, provides.clone());
@@ -645,7 +648,7 @@ impl<'a> GraphBuilder<'a> {
                 name_id: field.name.into(),
                 description_id: field.description.map(Into::into),
                 parent_entity_id,
-                distinct_type_in_ids,
+                subgraph_type_records,
                 ty_record: self.ctx.convert_type(field.r#type),
                 exists_in_subgraph_ids: resolvable_in_ids,
                 resolver_ids,

--- a/crates/engine/schema/src/generated/field.rs
+++ b/crates/engine/schema/src/generated/field.rs
@@ -5,6 +5,7 @@
 //! Source file: <engine-codegen dir>/domain/schema.graphql
 mod provides;
 mod requires;
+mod subgraph_type;
 
 use crate::{
     generated::{
@@ -16,6 +17,7 @@ use crate::{
 };
 pub use provides::*;
 pub use requires::*;
+pub use subgraph_type::*;
 use walker::{Iter, Walk};
 
 /// Generated from:
@@ -28,7 +30,8 @@ use walker::{Iter, Walk};
 ///   ty: Type!
 ///   resolvers: [ResolverDefinition!]!
 ///   exists_in_subgraphs: [Subgraph!]!
-///   distinct_type_in: [Subgraph!]!
+///   "Present if subgraph has a different type from the supergraph"
+///   subgraph_types: [SubgraphType!]!
 ///   requires: [FieldRequires!]! @field(record_field_name: "requires_records")
 ///   provides: [FieldProvides!]! @field(record_field_name: "provides_records")
 ///   "The arguments referenced by this range are sorted by their name (string)"
@@ -44,7 +47,8 @@ pub struct FieldDefinitionRecord {
     pub ty_record: TypeRecord,
     pub resolver_ids: Vec<ResolverDefinitionId>,
     pub exists_in_subgraph_ids: Vec<SubgraphId>,
-    pub distinct_type_in_ids: Vec<SubgraphId>,
+    /// Present if subgraph has a different type from the supergraph
+    pub subgraph_type_records: Vec<SubgraphTypeRecord>,
     pub requires_records: Vec<FieldRequiresRecord>,
     pub provides_records: Vec<FieldProvidesRecord>,
     /// The arguments referenced by this range are sorted by their name (string)
@@ -92,8 +96,9 @@ impl<'a> FieldDefinition<'a> {
     pub fn exists_in_subgraphs(&self) -> impl Iter<Item = Subgraph<'a>> + 'a {
         self.as_ref().exists_in_subgraph_ids.walk(self.schema)
     }
-    pub fn distinct_type_in(&self) -> impl Iter<Item = Subgraph<'a>> + 'a {
-        self.as_ref().distinct_type_in_ids.walk(self.schema)
+    /// Present if subgraph has a different type from the supergraph
+    pub fn subgraph_types(&self) -> impl Iter<Item = SubgraphType<'a>> + 'a {
+        self.as_ref().subgraph_type_records.walk(self.schema)
     }
     pub fn requires(&self) -> impl Iter<Item = FieldRequires<'a>> + 'a {
         self.as_ref().requires_records.walk(self.schema)
@@ -136,7 +141,7 @@ impl std::fmt::Debug for FieldDefinition<'_> {
             .field("ty", &self.ty())
             .field("resolvers", &self.resolvers())
             .field("exists_in_subgraphs", &self.exists_in_subgraphs())
-            .field("distinct_type_in", &self.distinct_type_in())
+            .field("subgraph_types", &self.subgraph_types())
             .field("requires", &self.requires())
             .field("provides", &self.provides())
             .field("arguments", &self.arguments())

--- a/crates/engine/schema/src/generated/field/subgraph_type.rs
+++ b/crates/engine/schema/src/generated/field/subgraph_type.rs
@@ -1,0 +1,76 @@
+//! ===================
+//! !!! DO NOT EDIT !!!
+//! ===================
+//! Generated with: `cargo run -p engine-codegen`
+//! Source file: <engine-codegen dir>/domain/schema.graphql
+use crate::{
+    generated::{Subgraph, SubgraphId, Type, TypeRecord},
+    prelude::*,
+};
+use walker::Walk;
+
+/// Generated from:
+///
+/// ```custom,{.language-graphql}
+/// type SubgraphType @meta(module: "field/subgraph_type") @copy {
+///   subgraph: Subgraph!
+///   ty: Type!
+/// }
+/// ```
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone, Copy)]
+pub struct SubgraphTypeRecord {
+    pub subgraph_id: SubgraphId,
+    pub ty_record: TypeRecord,
+}
+
+#[derive(Clone, Copy)]
+pub struct SubgraphType<'a> {
+    pub(crate) schema: &'a Schema,
+    pub(crate) item: SubgraphTypeRecord,
+}
+
+impl std::ops::Deref for SubgraphType<'_> {
+    type Target = SubgraphTypeRecord;
+    fn deref(&self) -> &Self::Target {
+        &self.item
+    }
+}
+
+impl<'a> SubgraphType<'a> {
+    #[allow(clippy::should_implement_trait)]
+    pub fn as_ref(&self) -> &SubgraphTypeRecord {
+        &self.item
+    }
+    pub fn subgraph(&self) -> Subgraph<'a> {
+        self.subgraph_id.walk(self.schema)
+    }
+    pub fn ty(&self) -> Type<'a> {
+        self.ty_record.walk(self.schema)
+    }
+}
+
+impl<'a> Walk<&'a Schema> for SubgraphTypeRecord {
+    type Walker<'w>
+        = SubgraphType<'w>
+    where
+        'a: 'w;
+    fn walk<'w>(self, schema: impl Into<&'a Schema>) -> Self::Walker<'w>
+    where
+        Self: 'w,
+        'a: 'w,
+    {
+        SubgraphType {
+            schema: schema.into(),
+            item: self,
+        }
+    }
+}
+
+impl std::fmt::Debug for SubgraphType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SubgraphType")
+            .field("subgraph", &self.subgraph())
+            .field("ty", &self.ty())
+            .finish()
+    }
+}

--- a/crates/engine/schema/src/introspection.rs
+++ b/crates/engine/schema/src/introspection.rs
@@ -688,7 +688,7 @@ impl<'a> IntrospectionBuilder<'a> {
                 directive_ids: Vec::new(),
                 resolver_ids: Vec::new(),
                 argument_ids: IdRange::empty(),
-                distinct_type_in_ids: Vec::new(),
+                subgraph_type_records: Vec::new(),
             });
 
             out_fields.push((id, tag));

--- a/crates/engine/src/operation/solve/solver/adapter.rs
+++ b/crates/engine/src/operation/solve/solver/adapter.rs
@@ -185,7 +185,11 @@ impl<'a> query_solver::Operation for OperationAdapter<'a> {
                 };
                 let definition = definition_id.walk(self.schema);
 
-                let new_key = if definition.distinct_type_in_ids.contains(&subgraph_id) {
+                let new_key = if definition
+                    .subgraph_type_records
+                    .iter()
+                    .any(|record| record.subgraph_id == subgraph_id)
+                {
                     self.generate_new_key(
                         Some(FieldRenameConsistencyKey::FieldWithDistinctType {
                             key,

--- a/crates/engine/src/resolver/graphql/request/prepare.rs
+++ b/crates/engine/src/resolver/graphql/request/prepare.rs
@@ -327,7 +327,14 @@ impl QueryBuilderContext {
             write!(buffer, "{response_key}: {name}")?;
         }
         self.write_arguments(buffer, field.arguments())?;
-        if let Some(ty) = field.definition().ty().definition().as_composite_type() {
+        if let Some(ty) = field
+            .definition()
+            .subgraph_types()
+            .find(|record| record.subgraph_id == self.subgraph_id)
+            .and_then(|record| record.ty().definition().as_composite_type())
+        {
+            self.write_selection_set(ParentType::CompositeType(ty), buffer, field.selection_set())?;
+        } else if let Some(ty) = field.definition().ty().definition().as_composite_type() {
             self.write_selection_set(ParentType::CompositeType(ty), buffer, field.selection_set())?;
         }
         Ok(())

--- a/crates/graphql-federated-graph/src/federated_graph/type.rs
+++ b/crates/graphql-federated-graph/src/federated_graph/type.rs
@@ -2,7 +2,7 @@ use super::{
     EntityDefinitionId, EnumDefinitionId, InputObjectId, InterfaceId, ObjectId, ScalarDefinitionId, UnionId, Wrapping,
 };
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Debug)]
 pub struct Type {
     pub wrapping: Wrapping,
     pub definition: Definition,

--- a/crates/graphql-federated-graph/src/from_sdl/directive.rs
+++ b/crates/graphql-federated-graph/src/from_sdl/directive.rs
@@ -276,7 +276,7 @@ fn parse_join_field_directive<'a>(
     directive: ast::Directive<'a>,
     state: &mut State<'a>,
 ) -> Result<Option<Directive>, DomainError> {
-    let field_type = state.graph[field_id].r#type.clone();
+    let field_type = state.graph[field_id].r#type;
     let is_external = directive
         .get_argument("external")
         .map(|arg| arg.as_bool().unwrap_or_default())
@@ -347,7 +347,7 @@ fn parse_authorized_field_directive<'a>(
     directive: ast::Directive<'a>,
     state: &mut State<'a>,
 ) -> Result<Directive, DomainError> {
-    let field_type = state.graph[field_id].r#type.clone();
+    let field_type = state.graph[field_id].r#type;
 
     Ok(Directive::Authorized(AuthorizedDirective {
         arguments: directive


### PR DESCRIPTION
Subgraph may have a different but compatible type for a field:
```graphql
type Query {
   node: [Node] @join__field(graph: A, type: "[Product]") @join__field(graph: B)
}
```

this means that in subgraph A we have:
```graphql
type Query {
  product: [Product]
}
```

So we have to take it into account during query generation. If we do:
```graphql
{
  nodes {
     ... on Table { id }
   }
}
```
and it ends up being sent to subgraph A, we have to ensure that `Table` is a possible type of `Product`, not `Node`.