### PR TITLE
feat: allow specific port in graphql-mocks

### DIFF
--- a/crates/graphql-mocks/src/builder.rs
+++ b/crates/graphql-mocks/src/builder.rs
@@ -1,0 +1,35 @@
+use std::{future::IntoFuture, sync::Arc};
+
+use futures::{future::BoxFuture, FutureExt};
+
+use crate::{MockGraphQlServer, Schema};
+
+pub struct MockGraphQlServerBuilder {
+    schema: Arc<dyn Schema>,
+    port: Option<u16>,
+}
+
+impl MockGraphQlServerBuilder {
+    pub(super) fn new(schema: Arc<dyn Schema>) -> Self {
+        MockGraphQlServerBuilder { schema, port: None }
+    }
+
+    pub fn with_port(mut self, port: u16) -> Self {
+        self.port = Some(port);
+        self
+    }
+
+    pub async fn build(self) -> MockGraphQlServer {
+        MockGraphQlServer::new_impl(self.schema, self.port).await
+    }
+}
+
+impl IntoFuture for MockGraphQlServerBuilder {
+    type Output = MockGraphQlServer;
+
+    type IntoFuture = BoxFuture<'static, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        self.build().boxed()
+    }
+}


### PR DESCRIPTION
`graphql-mocks` was originally written for use in our tests.  As a result it always just picks a random port to run on.  But I.'ve been using it for building demo graphs recently where this property is quite annoying.

This is a quick refactor that adds a builder API to allow you to specify your own port.  It's a bit messy, but this crate in general is quite messy.  Should maybe tidy it up sometime.