### PR TITLE
graphql-schema-diff: do not emit unnecessary {Add,Remove}InterfaceImplementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3431,7 +3431,6 @@ dependencies = [
  "cynic-parser",
  "datatest-stable",
  "grafbase-workspace-hack",
- "miette",
  "serde",
  "serde_json",
  "similar",
@@ -5438,7 +5437,6 @@ dependencies = [
  "expect-test",
  "grafbase-workspace-hack",
  "graphql-schema-diff",
- "miette",
  "similar",
 ]
 

--- a/crates/graphql-schema-diff/CHANGELOG.md
+++ b/crates/graphql-schema-diff/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Implemented `ChangeKind::AddSchemaExtension` and `ChangeKind::RemoveSchemaExtension`. Schema extensions are assumed to be in the same order between the schemas.
 - BREAKING: Overhaul the path string format, and add a typed version (`Path`) with parsing and display implementations.
 - BREAKING: `diff()` no longer emits `AddFieldArgument` where there is already an `AddField` for the parent field, it will only be emitted if the field existed in the source schema. This is for consistency with similar nesting cases.
+- BREAKING: `diff()` no longer emits `AddInterfaceImplementation` where there is already an `AddObject` or `AddInterface` for the parent type. It will only be added if the parent type existed in the source schema. This is for consistency with similar nesting cases. The converse also applies for `RemoveInterfaceImplementation`.
 
 ## 0.2.0 - 2024-07-16
 

--- a/crates/graphql-schema-diff/Cargo.toml
+++ b/crates/graphql-schema-diff/Cargo.toml
@@ -22,7 +22,6 @@ workspace = true
 [dev-dependencies]
 datatest-stable.workspace = true
 similar = "2.5.0"
-miette = { workspace = true, features = ["fancy"] }
 serde_json.workspace = true
 
 [[test]]

--- a/crates/graphql-schema-diff/src/state.rs
+++ b/crates/graphql-schema-diff/src/state.rs
@@ -105,8 +105,9 @@ fn push_schema_extension_changes(
 fn push_interface_implementer_changes(interface_impls: DiffMap<&str, Vec<&str>>, push_change: PushChangeFn<'_>) {
     // O(n²) but n should always be small enough to not matter
     for (implementer, (src, target)) in &interface_impls {
-        let src = src.as_deref().unwrap_or(&[]);
-        let target = target.as_deref().unwrap_or(&[]);
+        let Some((src, target)) = src.as_deref().zip(target.as_deref()) else {
+            continue;
+        };
 
         for src_impl in src {
             if !target.contains(src_impl) {

--- a/crates/graphql-schema-diff/tests/diff/add_interface_with_implementers.graphql
+++ b/crates/graphql-schema-diff/tests/diff/add_interface_with_implementers.graphql
@@ -1,0 +1,22 @@
+interface Node {
+  id: ID!
+}
+
+interface Node {
+  name: String!
+}
+
+# --- #
+
+interface Node {
+  id: ID!
+}
+
+interface Node {
+  name: String!
+}
+
+interface Test implements Node & Named {
+  id: ID!
+  name: String!
+}

--- a/crates/graphql-schema-diff/tests/diff/add_interface_with_implementers.snapshot.json
+++ b/crates/graphql-schema-diff/tests/diff/add_interface_with_implementers.snapshot.json
@@ -1,0 +1,22 @@
+{
+  "src → target": [
+    {
+      "path": "Test",
+      "kind": "AddInterface",
+      "span": {
+        "start": 68,
+        "end": 136
+      }
+    }
+  ],
+  "target → src": [
+    {
+      "path": "Test",
+      "kind": "RemoveInterface",
+      "span": {
+        "start": 68,
+        "end": 136
+      }
+    }
+  ]
+}

--- a/crates/operation-checks/Cargo.toml
+++ b/crates/operation-checks/Cargo.toml
@@ -17,7 +17,6 @@ grafbase-workspace-hack.workspace = true
 datatest-stable.workspace = true
 expect-test = "1.5.0"
 similar = "2.5.0"
-miette = { workspace = true, features = ["fancy"] }
 
 [lints]
 workspace = true

--- a/crates/operation-checks/src/schema.rs
+++ b/crates/operation-checks/src/schema.rs
@@ -20,6 +20,10 @@ pub struct Schema {
     // Invariant: sorted
     pub(crate) field_arguments: Vec<FieldArgument>,
 
+    /// (implementer, interface)
+    /// Invariant: sorted
+    pub(crate) interface_implementations: Vec<(String, String)>,
+
     pub(crate) input_objects: HashSet<String>,
 
     pub(crate) query_type_name: String,
@@ -81,6 +85,20 @@ impl Schema {
             )
             .enumerate()
             .map(move |(idx, arg)| (ArgumentId(idx + start), arg))
+    }
+
+    pub(crate) fn iter_interface_implementations<'a>(
+        &'a self,
+        type_name: &'a str,
+    ) -> impl Iterator<Item = &'a str> + 'a {
+        let start = self
+            .interface_implementations
+            .partition_point(|(implementer, _interface)| implementer.as_str() < type_name);
+
+        self.interface_implementations[start..]
+            .iter()
+            .take_while(move |(implementer, _interface)| implementer == type_name)
+            .map(|(_implementer, interface)| interface.as_str())
     }
 }
 

--- a/crates/operation-checks/tests/operation_check_tests.rs
+++ b/crates/operation-checks/tests/operation_check_tests.rs
@@ -1,5 +1,21 @@
 use operation_checks::CheckParams;
-use std::{fs, path::Path, sync::OnceLock};
+use std::{fmt, fs, path::Path, sync::OnceLock};
+
+struct DiffError(String);
+
+impl fmt::Debug for DiffError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl fmt::Display for DiffError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl std::error::Error for DiffError {}
 
 fn update_expect() -> bool {
     static UPDATE_EXPECT: OnceLock<bool> = OnceLock::new();
@@ -69,7 +85,7 @@ fn run_test(case_path: &Path) -> datatest_stable::Result<()> {
     }
 
     if snapshot != result {
-        return Err(miette::miette!(
+        return Err(DiffError(format!(
             "{}\n\n\n=== Hint: run the tests again with UPDATE_EXPECT=1 to update the snapshot. ===",
             similar::udiff::unified_diff(
                 similar::Algorithm::default(),
@@ -78,7 +94,7 @@ fn run_test(case_path: &Path) -> datatest_stable::Result<()> {
                 5,
                 Some(("Snapshot", "Actual"))
             )
-        )
+        ))
         .into());
     }
 


### PR DESCRIPTION
That is, added interface implementations for new objects and interfaces, and removed interface implementations for removed interfaces and objects.

closes GB-8195