### PR TITLE
fix: selinux compatible compose mounts

### DIFF
--- a/crates/integration-tests/docker-compose.yml
+++ b/crates/integration-tests/docker-compose.yml
@@ -18,13 +18,8 @@ services:
       - '4445:4445' # Admin port
     command: serve -c /etc/config/hydra/hydra.yml all --dev
     volumes:
-      - type: volume
-        source: hydra-sqlite
-        target: /var/lib/sqlite
-        read_only: false
-      - type: bind
-        source: ./data/hydra-config
-        target: /etc/config/hydra
+      - hydra-sqlite:/var/lib/sqlite:Z
+      - ./data/hydra-config:/etc/config/hydra:Z
     environment:
       DSN: 'sqlite:///var/lib/sqlite/db.sqlite?_fk=true'
       URLS_SELF_ISSUER: 'http://127.0.0.1:4444'
@@ -40,13 +35,8 @@ services:
       DSN: 'sqlite:///var/lib/sqlite/db.sqlite?_fk=true'
     command: migrate -c /etc/config/hydra/hydra.yml sql -e --yes
     volumes:
-      - type: volume
-        source: hydra-sqlite
-        target: /var/lib/sqlite
-        read_only: false
-      - type: bind
-        source: ./data/hydra-config
-        target: /etc/config/hydra
+      - hydra-sqlite:/var/lib/sqlite:Z
+      - ./data/hydra-config:/etc/config/hydra:Z
     restart: on-failure
     networks:
       - hydra
@@ -59,13 +49,8 @@ services:
       - '4455:4455' # Admin port
     command: serve -c /etc/config/hydra/hydra.yml all --dev
     volumes:
-      - type: volume
-        source: hydra-2-sqlite
-        target: /var/lib/sqlite
-        read_only: false
-      - type: bind
-        source: ./data/hydra-config
-        target: /etc/config/hydra
+      - hydra-2-sqlite:/var/lib/sqlite:Z
+      - ./data/hydra-config:/etc/config/hydra:Z
     environment:
       DSN: 'sqlite:///var/lib/sqlite/db.sqlite?_fk=true'
       URLS_SELF_ISSUER: 'http://127.0.0.1:4454'
@@ -83,13 +68,8 @@ services:
       DSN: 'sqlite:///var/lib/sqlite/db.sqlite?_fk=true'
     command: migrate -c /etc/config/hydra/hydra.yml sql -e --yes
     volumes:
-      - type: volume
-        source: hydra-2-sqlite
-        target: /var/lib/sqlite
-        read_only: false
-      - type: bind
-        source: ./data/hydra-config
-        target: /etc/config/hydra
+      - hydra-2-sqlite:/var/lib/sqlite:Z
+      - ./data/hydra-config:/etc/config/hydra:Z
     restart: on-failure
     networks:
       - hydra-2

--- a/gateway/docker-compose.yml
+++ b/gateway/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - '--config=/etc/otel-collector-config.yml'
       - '--set=service.telemetry.logs.level=INFO'
     volumes:
-      - ./data/otel/otel-collector-config.yml:/etc/otel-collector-config.yml
+      - ./data/otel/otel-collector-config.yml:/etc/otel-collector-config.yml:Z
     ports:
       - '4318:4317'
     depends_on:
@@ -28,7 +28,7 @@ services:
     networks:
       - otel-clickhouse
     volumes:
-      - ./data/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d/
+      - ./data/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d/:Z
 
   redis:
     restart: unless-stopped


### PR DESCRIPTION
I started using a distro with SELinux enabled. This is one of the things you _have to do_ with docker mounts to work. It does absolutely nothing on systems which do not use SELinux.

https://www.perplexity.ai/search/what-does-z-do-in-docker-mount-CD3IfXHRSUiZZeI5Yyrr.w