### PR TITLE
chore: more traces for caching 

### DIFF
--- a/crates/engine/src/operation/bind/mod.rs
+++ b/crates/engine/src/operation/bind/mod.rs
@@ -47,6 +47,7 @@ pub struct Binder<'schema, 'p> {
     response_modifiers: HashMap<ResponseModifierRule, (BoundResponseModifierId, Vec<BoundFieldId>)>,
 }
 
+#[tracing::instrument(name = "bind", level = "debug", skip_all)]
 pub(crate) fn bind(schema: &Schema, parsed_operation: &ParsedOperation) -> BindResult<BoundOperation> {
     let operation = parsed_operation.operation();
     let root_object_id = match operation.operation_type() {

--- a/crates/engine/src/operation/parse/mod.rs
+++ b/crates/engine/src/operation/parse/mod.rs
@@ -40,6 +40,7 @@ impl ParsedOperation {
 }
 
 /// Returns a valid GraphQL operation from the query string before.
+#[tracing::instrument(name = "parse", level = "debug", skip_all)]
 pub(crate) fn parse(
     schema: &Schema,
     operation_name: Option<&str>,

--- a/crates/engine/src/operation/plan/mod.rs
+++ b/crates/engine/src/operation/plan/mod.rs
@@ -14,6 +14,7 @@ use crate::{
 
 use super::Variables;
 
+#[tracing::instrument(name = "plan", level = "debug", skip_all)]
 pub async fn plan(
     ctx: &mut PrepareContext<'_, impl Runtime>,
     operation: &CachedOperation,

--- a/crates/engine/src/operation/solve/mod.rs
+++ b/crates/engine/src/operation/solve/mod.rs
@@ -13,6 +13,7 @@ pub(crate) use model::*;
 ///    which part of query and all the field dependencies.
 /// 2. Take the SolutionGraph and the BoundOperation to create all the QueryPartitions in the SolvedOperation
 /// 3. Compute all the field shapes for each partition.
+#[tracing::instrument(name = "solve", level = "debug", skip_all)]
 pub(crate) fn solve(schema: &Schema, bound_operation: BoundOperation) -> SolveResult<SolvedOperation> {
     solver::Solver::build(schema, bound_operation)?.solve()
 }

--- a/crates/engine/src/prepare/operation/before_variables.rs
+++ b/crates/engine/src/prepare/operation/before_variables.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 impl<R: Runtime> PrepareContext<'_, R> {
+    #[tracing::instrument(name = "build operation" skip_all)]
     pub(crate) fn build_cached_operation(
         &self,
         operation_name: Option<&str>,


### PR DESCRIPTION
As I mentioned in my demo last week, it's not super obvious from traces whether or not you hit the operation cache.  This is because it all happens under the "prepare operation" span.  We could put a `is_cached` property on this span, but I think there's an opportunity to show users how they could/couldn't benefit from better caching.  This PR is an attempt to do that:

1. Added a span on `build_cached_operation` - which builds the operation that will be cached.  I named it build operation because `build_cached_operation` seems a little ambiguous to me  - very much sounds like it could be building an operation that _was_ cached.
2. Added some spans on fetching a trusted document, since that also seemed like a faintly sensible thing.
3. Moved the spans I'd added on bind/parse/plan etc. to debug spans, so we can turn them on if we want (I think they're interesting) but users don't see them by default.

Fixes GB-8193