### PR TITLE
rename pathfinder to explorer

### DIFF
--- a/cli/src/backend/dev.rs
+++ b/cli/src/backend/dev.rs
@@ -170,7 +170,7 @@ fn output_handler(
 
     stdout().queue(MoveUp(2))?.queue(Clear(ClearType::CurrentLine))?;
 
-    let pathfinder_url = format!(
+    let explorer_url = format!(
         "http://{}:{}",
         url.host()
             .map(|h| h.to_string())
@@ -178,11 +178,11 @@ fn output_handler(
         url.port().unwrap()
     );
 
-    println!("GraphQL endpoint:  {}", url.to_string().bold());
-    println!("Pathfinder:        {}\n", pathfinder_url.bold());
+    println!("GraphQL endpoint: {}", url.to_string().bold());
+    println!("Explorer:         {}\n", explorer_url.bold());
 
     if introspection_forced {
-        tracing::info!("introspection is always enabled in the dev mode, config overriden");
+        tracing::info!("introspection is always enabled in dev mode, config overriden");
     }
 
     Ok(())

--- a/crates/federated-server/src/server/graph_updater.rs
+++ b/crates/federated-server/src/server/graph_updater.rs
@@ -239,7 +239,7 @@ impl GraphUpdater {
                 }
             };
 
-            tracing::info!("Fetched new Graph");
+            tracing::info!("Fetched new graph");
 
             let version_id = response.version_id;
 


### PR DESCRIPTION
This pull request includes changes to improve the clarity and consistency of log messages and output labels in the codebase. The most important changes include renaming variables for better readability and updating log messages for consistency.

Improvements to output labels and log messages:

* [`cli/src/backend/dev.rs`](diffhunk://#diff-5f7d6465b742be2714e2323e82d686408101a4f2b5f3f9cdb10058c7a236cb6eL173-R173): Renamed `pathfinder_url` to `explorer_url` and updated the corresponding output label from "Pathfinder" to "Explorer". [[1]](diffhunk://#diff-5f7d6465b742be2714e2323e82d686408101a4f2b5f3f9cdb10058c7a236cb6eL173-R173) [[2]](diffhunk://#diff-5f7d6465b742be2714e2323e82d686408101a4f2b5f3f9cdb10058c7a236cb6eL182-R185)
* [`crates/federated-server/src/server/graph_updater.rs`](diffhunk://#diff-e6b51d02b096947a25912b3571eba98000e51c6824f156b5e04a4cb8cf1d7de9L242-R242): Updated the log message from "Fetched new Graph" to "Fetched new graph" for consistency.