### PR TITLE
Release graphql-composition and graphql-federated-graph 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3378,7 +3378,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-composition"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cynic-parser",
  "cynic-parser-deser",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-federated-graph"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cynic-parser",
  "cynic-parser-deser",

--- a/crates/graphql-composition/CHANGELOG.md
+++ b/crates/graphql-composition/CHANGELOG.md
@@ -1,11 +1,10 @@
 # Changelog
 
-## Unreleased
+## 0.5.0 - 2025-01-06
 
 ### Features
 
 - Added composition for default values of output field arguments and input fields. They are now reflected in the federated graph.
-- Support the experimental @authorized directive
 - Selection sets inside `@requires` and `@provides` directives can now include inline fragments.
 - The selection sets in the "fields:" argument on `@requires` are now validated against the schema, with proper errors with context when invalid.
 - A new `Subgraphs::ingest_str()` method has been added to ingest a federated graph from a string, instead of from an async_graphql_parser AST. This is both for convenience and because async_graphql parser will soon not be part of the public API anymore.
@@ -13,6 +12,7 @@
 - `graphql_composition` now reexports the companion `graphql_federated_graph` crate (https://github.com/grafbase/grafbase/pull/2310).
 - Added support for the `@cost` directive (https://github.com/grafbase/grafbase/pull/2305).
 - We now validate that subgraphs do not define the `join__Graph` enum. (https://github.com/grafbase/grafbase/pull/2325)
+- Support the experimental `@authorized` directive
 
 ### Fixes
 

--- a/crates/graphql-composition/Cargo.toml
+++ b/crates/graphql-composition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graphql-composition"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MPL-2.0"
 description = "An implementation of GraphQL federated schema composition"
@@ -14,7 +14,7 @@ workspace = true
 cynic-parser.workspace = true
 cynic-parser-deser.workspace = true
 grafbase-workspace-hack.workspace = true
-graphql-federated-graph = { path = "../graphql-federated-graph", version = "0.4.0" }
+graphql-federated-graph = { path = "../graphql-federated-graph", version = "0.5.0" }
 indexmap.workspace = true
 itertools.workspace = true
 

--- a/crates/graphql-federated-graph/Cargo.toml
+++ b/crates/graphql-federated-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graphql-federated-graph"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MPL-2.0"
 description = "A serializable federated GraphQL graph representation"


### PR DESCRIPTION
Features

 - Added composition for default values of output field arguments and input fields. They are now reflected in the federated graph.
- Selection sets inside `@requires` and `@provides` directives can now include inline fragments.
- The selection sets in the "fields:" argument on `@requires` are now validated against the schema, with proper errors with context when invalid.
- A new Subgraphs::ingest_str() method has been added to ingest a federated graph from a string, instead of from an async_graphql_parser AST. This is both for convenience and because async_graphql parser will soon not be part of the public API anymore.
- There is no longer a VersionedFederatedGraph. The serializable version of the federated graph is dropped — that role will be fulfilled by the federated SDL instead (https://github.com/grafbase/grafbase/pull/2310).
    graphql_composition now reexports the companion graphql_federated_graph crate (https://github.com/grafbase/grafbase/pull/2310).
 - Added support for the `@cost` directive (https://github.com/grafbase/grafbase/pull/2305).
 - We now validate that subgraphs do not define the join__Graph enum. (https://github.com/grafbase/grafbase/pull/2325)
- Support the experimental @authorized directive

Fixes

-  Fixed the ingestion of numeric literals when creating a federated graph from a string
-  Fixed the ingestion of null literals.
-  In federated_graph, when parsing a schema with @join__type and no key argument, then rendering it with render_federated_sdl() would produce a @join__type directive
- Fix rendering of object literals in render_federated_sdl(). We were erroneously quoting the keys, like in a JSON object, that is {"a": true} instead of the correct GraphQL literal {a: true}. (https://github.com/grafbase/grafbase/pull/2247)
-  Fixed double rendering of @authorized on fields in federated SDL when @composeDirective(name: "@authorized") is used. (https://github.com/grafbase/grafbase/pull/2251)