### PR TITLE
Release graphql-wrapping-types 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3477,7 +3477,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-wrapping-types"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "grafbase-workspace-hack",
  "serde",

--- a/crates/graphql-federated-graph/Cargo.toml
+++ b/crates/graphql-federated-graph/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["graphql", "federation"]
 workspace = true
 
 [dependencies]
-wrapping = { path = "../graphql-wrapping-types", package = "graphql-wrapping-types", version = "0.1.0" }
+wrapping = { path = "../graphql-wrapping-types", package = "graphql-wrapping-types", version = "0.2.0" }
 serde = { version = "1.0.199", features = ["derive"] }
 serde_json = "1.0.116"
 indoc.workspace = true

--- a/crates/graphql-wrapping-types/Cargo.toml
+++ b/crates/graphql-wrapping-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graphql-wrapping-types"
 description = "Compact representation for GraphQL list and required wrapping types"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
Needed for the graphql-federated-graph, and transitively for the graphql-composition release.