### PR TITLE
engine: implement trusted documents incremental adoption

### DIFF
--- a/crates/engine-config-builder/src/from_toml_config.rs
+++ b/crates/engine-config-builder/src/from_toml_config.rs
@@ -57,6 +57,7 @@ pub fn build_with_toml_config(config: &gateway_config::Config, graph: FederatedG
             .bytes()
             .try_into()
             .expect("executable document limit should not be negative"),
+        trusted_documents: config.trusted_documents.clone().into(),
     }
 }
 

--- a/crates/engine/config/src/lib.rs
+++ b/crates/engine/config/src/lib.rs
@@ -7,6 +7,7 @@ mod rate_limit;
 pub mod response_extensions;
 mod retry;
 mod subgraph;
+mod trusted_documents;
 
 use std::{
     collections::BTreeMap,
@@ -14,6 +15,7 @@ use std::{
     time::Duration,
 };
 
+pub use self::trusted_documents::{LogLevel, TrustedDocumentsConfig};
 pub use auth::{AuthConfig, AuthProviderConfig, JwksConfig, JwtConfig};
 pub use complexity_control::ComplexityControl;
 pub use entity_caching::EntityCaching;
@@ -81,6 +83,9 @@ pub struct Config {
 
     #[serde(default)]
     pub apq: AutomaticPersistedQueries,
+
+    #[serde(default)]
+    pub trusted_documents: TrustedDocumentsConfig,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Default, Clone, Copy)]
@@ -134,6 +139,7 @@ impl Config {
             response_extension: Default::default(),
             apq: Default::default(),
             executable_document_limit_bytes: (32 * 1024),
+            trusted_documents: Default::default(),
         }
     }
 

--- a/crates/engine/config/src/trusted_documents.rs
+++ b/crates/engine/config/src/trusted_documents.rs
@@ -1,0 +1,33 @@
+pub use gateway_config::LogLevel;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TrustedDocumentsConfig {
+    pub document_id_unknown_log_level: LogLevel,
+    pub document_id_and_query_mismatch_log_level: LogLevel,
+    pub inline_document_unknown_log_level: LogLevel,
+}
+
+impl Default for TrustedDocumentsConfig {
+    fn default() -> Self {
+        gateway_config::TrustedDocumentsConfig::default().into()
+    }
+}
+
+impl From<gateway_config::TrustedDocumentsConfig> for TrustedDocumentsConfig {
+    fn from(
+        gateway_config::TrustedDocumentsConfig {
+            document_id_unknown_log_level,
+            document_id_and_query_mismatch_log_level,
+            inline_document_unknown_log_level,
+            ..
+        }: gateway_config::TrustedDocumentsConfig,
+    ) -> Self {
+        TrustedDocumentsConfig {
+            document_id_unknown_log_level,
+            document_id_and_query_mismatch_log_level,
+            inline_document_unknown_log_level,
+        }
+    }
+}

--- a/crates/engine/schema/src/builder/mod.rs
+++ b/crates/engine/schema/src/builder/mod.rs
@@ -146,6 +146,7 @@ impl BuildContext {
                 response_extension: config.response_extension,
                 apq_enabled: config.apq.enabled,
                 executable_document_limit_bytes: config.executable_document_limit_bytes,
+                trusted_documents: config.trusted_documents,
             },
         })
     }

--- a/crates/engine/schema/src/lib.rs
+++ b/crates/engine/schema/src/lib.rs
@@ -141,6 +141,7 @@ pub struct Settings {
     pub response_extension: ResponseExtensionConfig,
     pub apq_enabled: bool,
     pub executable_document_limit_bytes: usize,
+    pub trusted_documents: config::TrustedDocumentsConfig,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, id_derives::IndexedFields)]

--- a/crates/engine/src/prepare/mod.rs
+++ b/crates/engine/src/prepare/mod.rs
@@ -63,7 +63,7 @@ impl<R: Runtime> PrepareContext<'_, R> {
     ) -> Result<PreparedOperation, Response<<R::Hooks as Hooks>::OnOperationResponseOutput>> {
         let variables = std::mem::take(&mut request.variables);
         let cache_result = {
-            let extracted = match self.extract_operation_document(&request) {
+            let extracted = match self.extract_operation_document(&request).await {
                 Ok(doc) => doc,
                 // If we have an error a this stage, it means we couldn't determine what document
                 // to load, so we don't consider it a well-formed GraphQL-over-HTTP request.

--- a/crates/engine/src/prepare/trusted_documents.rs
+++ b/crates/engine/src/prepare/trusted_documents.rs
@@ -5,10 +5,12 @@ use crate::{
     response::{ErrorCode, GraphqlError},
     Engine, Runtime,
 };
-use futures::{future::BoxFuture, FutureExt};
+use config::LogLevel;
+use futures::{future::BoxFuture, FutureExt, TryFutureExt as _};
 use grafbase_telemetry::grafbase_client::X_GRAFBASE_CLIENT_NAME;
 use operation::{extensions::PersistedQueryRequestExtension, Request};
-use runtime::trusted_documents_client::TrustedDocumentsError;
+use runtime::trusted_documents_client::{TrustedDocumentsEnforcementMode, TrustedDocumentsError};
+use sha2::Digest;
 use std::borrow::Cow;
 use tracing::Instrument;
 
@@ -61,9 +63,10 @@ impl<'ctx, R: Runtime> PrepareContext<'ctx, R> {
         let persisted_query_extension = request.extensions.persisted_query.as_ref();
         let doc_id = request.doc_id.as_ref();
         let operation_name = request.operation_name.as_deref().map(Cow::Borrowed);
+        let apq_enabled = self.engine.schema.settings.apq_enabled;
 
-        match (trusted_documents.is_enabled(), persisted_query_extension, doc_id) {
-            (true, None, None) => {
+        match (trusted_documents.enforcement_mode(), persisted_query_extension, doc_id) {
+            (TrustedDocumentsEnforcementMode::Enforce, None, None) => {
                 if trusted_documents
                     .bypass_header()
                     .map(|(name, value)| self.headers().get(name).and_then(|v| v.to_str().ok()) == Some(value))
@@ -81,24 +84,55 @@ impl<'ctx, R: Runtime> PrepareContext<'ctx, R> {
                         },
                         document_or_future: wrap_document(document),
                     })
+                } else if let Some(query) = request.query.as_deref().filter(|query| !query.is_empty()) {
+                    // Just an inline document.
+                    let Some(client_name) = client_name else {
+                        return Err(missing_client_name_error());
+                    };
+
+                    //  We have to take a guess on the document id here. The best guess is a sha256, because that's what is the most common across the ecosystem.
+                    let hash = sha2::Sha256::digest(query.as_bytes());
+                    let doc_id = hex::encode(hash);
+
+                    Ok(ExtractedOperationDocument {
+                        key: DocumentKey::TrustedDocumentId {
+                            operation_name,
+                            client_name: Cow::Borrowed(client_name),
+                            doc_id: Cow::Owned(doc_id.clone()),
+                        },
+                        document_or_future: DocumentOrFuture::Future(
+                            handle_trusted_document_query(self.engine, client_name, Cow::Owned(doc_id.clone()))
+                                .map_err({
+                                    let log_level = self
+                                        .engine
+                                        .schema
+                                        .settings
+                                        .trusted_documents
+                                        .inline_document_unknown_log_level;
+
+                                    move |err| {
+                                        log_unknown_inline_document(log_level, doc_id.as_str());
+                                        GraphqlError::new(
+                                            format!("The query document does not match any trusted document. ({err})"),
+                                            err.code,
+                                        )
+                                    }
+                                })
+                                .boxed(),
+                        ),
+                    })
                 } else {
                     let graphql_error = GraphqlError::new(
-                        "Cannot execute a trusted document query: missing documentId, doc_id or the persistedQuery extension.",
-                        ErrorCode::TrustedDocumentError
+                        "Cannot execute a trusted document query.",
+                        ErrorCode::TrustedDocumentError,
                     );
                     Err(graphql_error)
                 }
             }
             // Apollo Client style trusted document query
-            (true, maybe_ext, maybe_doc_id) => {
+            (TrustedDocumentsEnforcementMode::Enforce, maybe_ext, maybe_doc_id) => {
                 let Some(client_name) = client_name else {
-                    return Err(GraphqlError::new(
-                        format!(
-                            "Trusted document queries must include the {} header",
-                            X_GRAFBASE_CLIENT_NAME.as_str()
-                        ),
-                        ErrorCode::TrustedDocumentError,
-                    ));
+                    return Err(missing_client_name_error());
                 };
 
                 let doc_id = if let Some(ext) = maybe_ext {
@@ -120,8 +154,76 @@ impl<'ctx, R: Runtime> PrepareContext<'ctx, R> {
                     ),
                 })
             }
-            (false, Some(ext), _) => {
-                if !self.engine.schema.settings.apq_enabled {
+            (TrustedDocumentsEnforcementMode::Allow, _, Some(doc_id)) => {
+                let Some(client_name) = client_name else {
+                    return Err(missing_client_name_error());
+                };
+
+                let query = request.query.as_deref();
+
+                Ok(ExtractedOperationDocument {
+                    // Reflect what actually gets executed. If there is an inline query document, it will always take priority.
+                    key: query
+                        .map({
+                            let operation_name = operation_name.clone();
+                            move |query| DocumentKey::Text {
+                                operation_name,
+                                document: Cow::Borrowed(query),
+                            }
+                        })
+                        .unwrap_or_else(|| DocumentKey::TrustedDocumentId {
+                            operation_name,
+                            client_name: Cow::Borrowed(client_name),
+                            doc_id: Cow::Borrowed(doc_id),
+                        }),
+                    document_or_future: DocumentOrFuture::Future(
+                        handle_trusted_document_query_and_check_that_query_matches(
+                            self.engine,
+                            client_name,
+                            Cow::Borrowed(doc_id),
+                            query,
+                        )
+                        .boxed(),
+                    ),
+                })
+            }
+            (TrustedDocumentsEnforcementMode::Allow, Some(ext), _) if !apq_enabled => {
+                let Some(client_name) = client_name else {
+                    return Err(missing_client_name_error());
+                };
+
+                let query = request.query.as_deref();
+                let doc_id: Cow<'_, str> = Cow::Owned(hex::encode(&ext.sha256_hash));
+
+                Ok(ExtractedOperationDocument {
+                    // Reflect what actually gets executed. If there is an inline query document, it will always take priority.
+                    key: query
+                        .map({
+                            let operation_name = operation_name.clone();
+                            |query| DocumentKey::Text {
+                                operation_name,
+                                document: Cow::Borrowed(query),
+                            }
+                        })
+                        .unwrap_or_else(|| DocumentKey::TrustedDocumentId {
+                            operation_name,
+                            client_name: Cow::Borrowed(client_name),
+                            doc_id: doc_id.clone(),
+                        }),
+                    document_or_future: DocumentOrFuture::Future(
+                        handle_trusted_document_query_and_check_that_query_matches(
+                            self.engine,
+                            client_name,
+                            doc_id,
+                            query,
+                        )
+                        .boxed(),
+                    ),
+                })
+            }
+            (TrustedDocumentsEnforcementMode::Ignore, Some(ext), _)
+            | (TrustedDocumentsEnforcementMode::Allow, Some(ext), _) => {
+                if !apq_enabled {
                     return Err(GraphqlError::new(
                         "Persisted query not found",
                         ErrorCode::PersistedQueryNotFound,
@@ -141,7 +243,8 @@ impl<'ctx, R: Runtime> PrepareContext<'ctx, R> {
                     document_or_future: DocumentOrFuture::Future(handle_apq(query, ext).boxed()),
                 })
             }
-            (false, None, _) => {
+            (TrustedDocumentsEnforcementMode::Ignore, None, _)
+            | (TrustedDocumentsEnforcementMode::Allow, None, None) => {
                 let document = request
                     .query
                     .as_deref()
@@ -156,6 +259,41 @@ impl<'ctx, R: Runtime> PrepareContext<'ctx, R> {
                 })
             }
         }
+    }
+}
+
+fn missing_client_name_error() -> GraphqlError {
+    GraphqlError::new(
+        format!(
+            "Trusted document queries must include the {} header",
+            X_GRAFBASE_CLIENT_NAME.as_str()
+        ),
+        ErrorCode::TrustedDocumentError,
+    )
+}
+
+async fn handle_trusted_document_query_and_check_that_query_matches<'ctx, 'r, R: Runtime>(
+    engine: &'ctx Engine<R>,
+    client_name: &'ctx str,
+    document_id: Cow<'r, str>,
+    inline_document: Option<&'r str>,
+) -> Result<Cow<'r, str>, GraphqlError> {
+    let fetch_trusted_doc_result = handle_trusted_document_query(engine, client_name, document_id.clone()).await;
+
+    match (fetch_trusted_doc_result, inline_document.filter(|doc| !doc.is_empty())) {
+        (Ok(fetched), Some(received)) => {
+            if fetched != received {
+                log_document_id_and_query_mismatch(engine, document_id.as_ref());
+            }
+
+            Ok(Cow::Borrowed(received))
+        }
+        (Ok(fetched), None) => Ok(fetched),
+        (Err(_), Some(received)) => Ok(Cow::Borrowed(received)),
+        (Err(err), None) => Err(GraphqlError::new(
+            format!("Could not resolve query from document id nor from `query` key ({err})"),
+            ErrorCode::BadRequest,
+        )),
     }
 }
 
@@ -175,10 +313,14 @@ async fn handle_trusted_document_query<'ctx, 'r, R: Runtime>(
             format!("Internal server error while fetching trusted document: {err}"),
             ErrorCode::TrustedDocumentError,
         )),
-        Err(TrustedDocumentsError::DocumentNotFound) => Err(GraphqlError::new(
-            format!("Unknown document id: '{document_id}'"),
-            ErrorCode::TrustedDocumentError,
-        )),
+        Err(TrustedDocumentsError::DocumentNotFound) => {
+            log_unknown_trusted_document_id(engine, document_id.as_ref());
+
+            Err(GraphqlError::new(
+                format!("Unknown trusted document id: '{document_id}'"),
+                ErrorCode::TrustedDocumentError,
+            ))
+        }
         Ok(document_text) => Ok(Cow::Owned(document_text)),
     }
 }
@@ -214,4 +356,48 @@ async fn handle_apq<'r, 'f>(
         "Persisted query not found",
         ErrorCode::PersistedQueryNotFound,
     ))
+}
+
+/// When a request contains a trusted document id, but the trusted document is not found in GDN. Default: INFO.
+fn log_unknown_trusted_document_id<R: Runtime>(engine: &Engine<R>, document_id: &str) {
+    const MESSAGE: &str = "Unknown trusted document";
+
+    match engine.schema.settings.trusted_documents.document_id_unknown_log_level {
+        LogLevel::Off => (),
+        LogLevel::Debug => tracing::debug!(MESSAGE, document_id),
+        LogLevel::Info => tracing::info!(MESSAGE, document_id),
+        LogLevel::Warn => tracing::warn!(MESSAGE, document_id),
+        LogLevel::Error => tracing::error!(MESSAGE, document_id),
+    }
+}
+
+/// When a request contains a trusted document id and an inline document in `query`, but the trusted document body does not match the inline document.
+fn log_document_id_and_query_mismatch<R: Runtime>(engine: &Engine<R>, document_id: &str) {
+    const MESSAGE: &str = "The request contained both a GraphQL query document and a document id, but the trusted document with that ID does not match the inline query document.";
+
+    match engine
+        .schema
+        .settings
+        .trusted_documents
+        .document_id_and_query_mismatch_log_level
+    {
+        LogLevel::Off => (),
+        LogLevel::Debug => tracing::debug!(MESSAGE, document_id),
+        LogLevel::Info => tracing::info!(MESSAGE, document_id),
+        LogLevel::Warn => tracing::warn!(MESSAGE, document_id),
+        LogLevel::Error => tracing::error!(MESSAGE, document_id),
+    }
+}
+
+/// When a request contains only an inline document but it does not correspond to any trusted document.
+fn log_unknown_inline_document(log_level: LogLevel, document_id: &str) {
+    const MESSAGE: &str = "The GraphQL query document in the request does not match any trusted document.";
+
+    match log_level {
+        LogLevel::Off => (),
+        LogLevel::Debug => tracing::debug!(MESSAGE, document_id),
+        LogLevel::Info => tracing::info!(MESSAGE, document_id),
+        LogLevel::Warn => tracing::warn!(MESSAGE, document_id),
+        LogLevel::Error => tracing::error!(MESSAGE, document_id),
+    }
 }

--- a/crates/federated-server/src/server/gateway.rs
+++ b/crates/federated-server/src/server/gateway.rs
@@ -2,7 +2,7 @@ use super::GdnResponse;
 use engine::{Engine, SchemaVersion};
 use gateway_config::Config;
 use graphql_composition::FederatedGraph;
-use runtime::trusted_documents_client::Client;
+use runtime::trusted_documents_client::{Client, TrustedDocumentsEnforcementMode};
 use runtime_local::HooksWasi;
 use std::{path::PathBuf, sync::Arc};
 use tokio::sync::watch;
@@ -118,6 +118,12 @@ fn gdn_graph(
     );
 
     let trusted_documents = if gateway_config.trusted_documents.enabled {
+        let enforcement_mode = if gateway_config.trusted_documents.enforced {
+            TrustedDocumentsEnforcementMode::Enforce
+        } else {
+            TrustedDocumentsEnforcementMode::Allow
+        };
+
         Some(runtime::trusted_documents_client::Client::new(
             super::trusted_documents_client::TrustedDocumentsClient::new(
                 Default::default(),
@@ -135,6 +141,7 @@ fn gdn_graph(
                             .as_ref(),
                     )
                     .map(|(name, value)| (name.clone().into(), String::from(value.as_ref()))),
+                enforcement_mode,
             ),
         ))
     } else {

--- a/crates/federated-server/src/server/trusted_documents_client.rs
+++ b/crates/federated-server/src/server/trusted_documents_client.rs
@@ -1,3 +1,5 @@
+use runtime::trusted_documents_client::TrustedDocumentsEnforcementMode;
+
 const GRAFBASE_PRODUCTION_TRUSTED_DOCUMENTS_BUCKET: &str = "https://pub-72f3517515a34104921bb714721a885a.r2.dev";
 const GRAFBASE_ASSETS_URL_ENV_VAR: &str = "GRAFBASE_ASSETS_URL";
 
@@ -13,6 +15,8 @@ pub(crate) struct TrustedDocumentsClient {
 
     /// Optional header for bypassing into trusted document storage.
     bypass_header: Option<(String, String)>,
+
+    enforcement_mode: TrustedDocumentsEnforcementMode,
 }
 
 impl TrustedDocumentsClient {
@@ -31,6 +35,7 @@ impl TrustedDocumentsClient {
         http_client: reqwest::Client,
         branch_id: ulid::Ulid,
         bypass_header: Option<(String, String)>,
+        enforcement_mode: TrustedDocumentsEnforcementMode,
     ) -> Self {
         let assets_host: url::Url = std::env::var(GRAFBASE_ASSETS_URL_ENV_VAR)
             .unwrap_or(GRAFBASE_PRODUCTION_TRUSTED_DOCUMENTS_BUCKET.to_string())
@@ -42,14 +47,15 @@ impl TrustedDocumentsClient {
             http_client,
             branch_id,
             bypass_header,
+            enforcement_mode,
         }
     }
 }
 
 #[async_trait::async_trait]
 impl runtime::trusted_documents_client::TrustedDocumentsClient for TrustedDocumentsClient {
-    fn is_enabled(&self) -> bool {
-        true
+    fn enforcement_mode(&self) -> TrustedDocumentsEnforcementMode {
+        self.enforcement_mode
     }
 
     fn bypass_header(&self) -> Option<(&str, &str)> {

--- a/crates/gateway-config/src/log_level.rs
+++ b/crates/gateway-config/src/log_level.rs
@@ -1,0 +1,108 @@
+use serde::{Deserialize, Deserializer, Serialize};
+use std::{fmt, str::FromStr};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogLevel {
+    Off,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl Serialize for LogLevel {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl LogLevel {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            LogLevel::Off => "off",
+            LogLevel::Debug => "debug",
+            LogLevel::Info => "info",
+            LogLevel::Warn => "warn",
+            LogLevel::Error => "error",
+        }
+    }
+}
+
+impl fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for LogLevel {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        const VALUES: &[(&str, LogLevel)] = &[
+            ("off", LogLevel::Off),
+            ("debug", LogLevel::Debug),
+            ("info", LogLevel::Info),
+            ("warn", LogLevel::Warn),
+            ("error", LogLevel::Error),
+        ];
+
+        VALUES
+            .iter()
+            .find(|(string, _log_level)| string.eq_ignore_ascii_case(s))
+            .map(|(_, log_level)| *log_level)
+            .ok_or_else(|| {
+                format!(
+                    r#""{s}" is not a valid log level (expected one of {})."#,
+                    VALUES
+                        .iter()
+                        .map(|(string, _log_level)| *string)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            })
+    }
+}
+
+impl<'de> Deserialize<'de> for LogLevel {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        FromStr::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_level_from_string() {
+        assert_eq!(LogLevel::from_str("off"), Ok(LogLevel::Off));
+        assert_eq!(LogLevel::from_str("debug"), Ok(LogLevel::Debug));
+        assert_eq!(LogLevel::from_str("info"), Ok(LogLevel::Info));
+        assert_eq!(LogLevel::from_str("warn"), Ok(LogLevel::Warn));
+        assert_eq!(LogLevel::from_str("error"), Ok(LogLevel::Error));
+    }
+
+    #[test]
+    fn log_level_from_string_any_case() {
+        assert_eq!(LogLevel::from_str("OFF"), Ok(LogLevel::Off));
+        assert_eq!(LogLevel::from_str("dEbUg"), Ok(LogLevel::Debug));
+        assert_eq!(LogLevel::from_str("InFo"), Ok(LogLevel::Info));
+        assert_eq!(LogLevel::from_str("WARN"), Ok(LogLevel::Warn));
+        assert_eq!(LogLevel::from_str("ERROR"), Ok(LogLevel::Error));
+    }
+
+    #[test]
+    fn log_level_from_invalid_string() {
+        assert_eq!(
+            LogLevel::from_str("invalid"),
+            Err(r#""invalid" is not a valid log level (expected one of off, debug, info, warn, error)."#.to_owned())
+        );
+    }
+}

--- a/crates/gateway-config/src/trusted_documents.rs
+++ b/crates/gateway-config/src/trusted_documents.rs
@@ -1,0 +1,45 @@
+use ascii::AsciiString;
+use serde_dynamic_string::DynamicString;
+
+use crate::LogLevel;
+
+#[derive(Debug, serde::Deserialize, Clone)]
+#[serde(default, deny_unknown_fields)]
+pub struct TrustedDocumentsConfig {
+    /// If true, the engine will resolve trusted documents ids in queries, with or without `query` key in the request. Default: false.
+    pub enabled: bool,
+    /// Accept only trusted document queries. These can include a string in query, the extension with the doc id (relay or apollo), or both. Default: false.
+    pub enforced: bool,
+    /// See [BypassHeader]
+    #[serde(flatten)]
+    pub bypass_header: BypassHeader,
+    /// The log level to emit logs when a request contains a trusted document id, but the trusted document is not found in GDN. Default: INFO.
+    pub document_id_unknown_log_level: LogLevel,
+    /// The log level to emit logs when a request contains a trusted document id and an inline document in `query`, but the trusted document body does not match the inline document. Default: INFO.
+    pub document_id_and_query_mismatch_log_level: LogLevel,
+    /// The log level to emit logs when a request contains only an inline document but it does not correspond to any trusted document. Default: INFO.
+    pub inline_document_unknown_log_level: LogLevel,
+}
+
+impl Default for TrustedDocumentsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            enforced: false,
+            bypass_header: Default::default(),
+            document_id_unknown_log_level: LogLevel::Info,
+            document_id_and_query_mismatch_log_level: LogLevel::Info,
+            inline_document_unknown_log_level: LogLevel::Info,
+        }
+    }
+}
+
+/// An optional header that can be passed by clients to bypass trusted documents enforcement, allowing arbitrary queries.
+#[derive(Debug, serde::Deserialize, Clone, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct BypassHeader {
+    /// Name of the optional header that can be set to bypass trusted documents enforcement, when `enabled = true`. Only meaningful in combination with `bypass_header_value`.
+    pub bypass_header_name: Option<AsciiString>,
+    /// Value of the optional header that can be set to bypass trusted documents enforcement, when `enabled = true`. Only meaningful in combination with `bypass_header_value`.
+    pub bypass_header_value: Option<DynamicString<String>>,
+}

--- a/crates/integration-tests/src/federation/builder.rs
+++ b/crates/integration-tests/src/federation/builder.rs
@@ -10,7 +10,11 @@ pub use bench::*;
 use futures::{future::BoxFuture, FutureExt};
 use gateway_config::Config;
 use graphql_mocks::MockGraphQlServer;
-use runtime::{fetch::dynamic::DynamicFetcher, hooks::DynamicHooks, trusted_documents_client};
+use runtime::{
+    fetch::dynamic::DynamicFetcher,
+    hooks::DynamicHooks,
+    trusted_documents_client::{self, TrustedDocumentsEnforcementMode},
+};
 pub use test_runtime::*;
 
 use super::{subgraph::Subgraphs, DockerSubgraph, TestGateway};
@@ -76,10 +80,14 @@ impl TestGatewayBuilder {
     // Prefer passing through either the TOML / SDL config when relevant, see update_runtime_with_toml_config
     //--
 
-    pub fn with_mock_trusted_documents(mut self, branch_id: String, documents: Vec<TestTrustedDocument>) -> Self {
+    pub fn with_mock_trusted_documents(
+        mut self,
+        enforcement_mode: TrustedDocumentsEnforcementMode,
+        documents: Vec<TestTrustedDocument>,
+    ) -> Self {
         self.trusted_documents = Some(trusted_documents_client::Client::new(MockTrustedDocumentsClient {
-            _branch_id: branch_id,
             documents,
+            enforcement_mode,
         }));
         self
     }

--- a/crates/integration-tests/src/mock_trusted_documents.rs
+++ b/crates/integration-tests/src/mock_trusted_documents.rs
@@ -1,4 +1,6 @@
-use runtime::trusted_documents_client::{TrustedDocumentsError, TrustedDocumentsResult};
+use runtime::trusted_documents_client::{
+    TrustedDocumentsEnforcementMode, TrustedDocumentsError, TrustedDocumentsResult,
+};
 
 #[derive(Debug, Clone)]
 pub struct TestTrustedDocument {
@@ -8,16 +10,24 @@ pub struct TestTrustedDocument {
     pub document_text: &'static str,
 }
 
-#[derive(Default)]
 pub(super) struct MockTrustedDocumentsClient {
     pub(crate) documents: Vec<TestTrustedDocument>,
-    pub(crate) _branch_id: String,
+    pub(crate) enforcement_mode: TrustedDocumentsEnforcementMode,
+}
+
+impl Default for MockTrustedDocumentsClient {
+    fn default() -> Self {
+        MockTrustedDocumentsClient {
+            documents: Vec::new(),
+            enforcement_mode: TrustedDocumentsEnforcementMode::Ignore,
+        }
+    }
 }
 
 #[async_trait::async_trait]
 impl runtime::trusted_documents_client::TrustedDocumentsClient for MockTrustedDocumentsClient {
-    fn is_enabled(&self) -> bool {
-        !self.documents.is_empty()
+    fn enforcement_mode(&self) -> TrustedDocumentsEnforcementMode {
+        self.enforcement_mode
     }
 
     fn bypass_header(&self) -> Option<(&str, &str)> {

--- a/crates/runtime-noop/src/trusted_documents.rs
+++ b/crates/runtime-noop/src/trusted_documents.rs
@@ -1,11 +1,11 @@
-use runtime::trusted_documents_client::TrustedDocumentsResult;
+use runtime::trusted_documents_client::{TrustedDocumentsEnforcementMode, TrustedDocumentsResult};
 
 pub struct NoopTrustedDocuments;
 
 #[async_trait::async_trait]
 impl runtime::trusted_documents_client::TrustedDocumentsClient for NoopTrustedDocuments {
-    fn is_enabled(&self) -> bool {
-        false
+    fn enforcement_mode(&self) -> TrustedDocumentsEnforcementMode {
+        TrustedDocumentsEnforcementMode::Ignore
     }
 
     async fn fetch(&self, _client_name: &str, _document_id: &str) -> TrustedDocumentsResult<String> {

--- a/crates/runtime/src/trusted_documents_client.rs
+++ b/crates/runtime/src/trusted_documents_client.rs
@@ -25,10 +25,17 @@ pub enum TrustedDocumentsError {
 
 pub type TrustedDocumentsResult<T> = Result<T, TrustedDocumentsError>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrustedDocumentsEnforcementMode {
+    Ignore,
+    Allow,
+    Enforce,
+}
+
 /// A handle to trusted documents configuration and retrieval.
 #[async_trait::async_trait]
 pub trait TrustedDocumentsClient: Send + Sync {
-    fn is_enabled(&self) -> bool;
+    fn enforcement_mode(&self) -> TrustedDocumentsEnforcementMode;
 
     /// Users can optionally configure a header (name, value) which, when it is
     /// sent with a request, will bypass the trusted documents checks and allow running

--- a/gateway/changelog/unreleased.md
+++ b/gateway/changelog/unreleased.md
@@ -1,0 +1,32 @@
+# Unreleased
+
+## Features
+
+### Trusted documents incremental adoption
+
+Until now, trusted documents would be either disabled, or fully enforced. However in practice, organizations follow a more incremental migration path. The following options are now available in `grafbase.toml`:
+
+```toml
+[trusted_documents]
+enabled = true # default: false
+enforced = true # default: false
+bypass_header_name = "my-header-name" # default null
+bypass_header_value = "my-secret-is-{{ env.SECRET_HEADER_VALUE }}" # default null
+document_id_unknown_log_level = "error" # default: info
+document_id_and_query_mismatch_log_level = "off" # default: info
+inline_document_unknown_log_level = "warn" # default: info
+```
+
+The `bypass_header_name` and `bypass_header_value` settings are unchanged.
+
+The `enabled` setting is now much weaker. When trusted documents are only `enabled`, the gateway will not enforce trusted documents, but will still fetch and cache them. This is useful for organizations that want to gradually adopt trusted documents.
+
+The `enforce` setting matches the previous behavior: when `true`, the gateway will enforce trusted documents. Additionally, we now allow trusted document requests with only an inline document, without document id, as long as the query is a trusted document. This is useful for organizations that want to enforce trusted documents, but have not yet migrated all their clients to send the document id.
+
+The three new log options allow monitoring proper usage of trusted documents before you enforce them:
+
+- `document_id_unknown_log_level`: logged when a document id is present in the request, but the corresponding trusted document cannot be found.
+- `document_id_and_query_mismatch_log_level`: logged when both a query document and a document id are sent, when the retrieved trusted document does not match the inline query document.
+- `inline_document_unknown_log_level`: logged when an inline document (a string in the `"query"` key of a the request) is sent, but no trusted document is found with the id matching the sha256 hash of the inline document.
+
+They can all take `off`, `error`, `warn`, `info`, or `debug` as values. The default is `info`.


### PR DESCRIPTION
The aim of this change is to offer an incremental adoption path for trusted documents.

Until now, trusted documents would be either disabled, or fully enforced. However in practice, organizations follow a more incremental migration path. The following options are now available in `grafbase.toml`:

```toml
[trusted_documents]
enabled = true # default: false
enforced = true # default: false
bypass_header_name = "my-header-name" # default null
bypass_header_value = "my-secret-is-{{ env.SECRET_HEADER_VALUE }}" # default null
document_id_unknown_log_level = "error" # default: info
document_id_and_query_mismatch_log_level = "off" # default: info
inline_document_unknown_log_level = "warn" # default: info
```

The `bypass_header_name` and `bypass_header_value` settings are unchanged.

The `enabled` setting is now much weaker. When trusted documents are only `enabled`, the gateway will not enforce trusted documents, but will still fetch and cache them. This is useful for organizations that want to gradually adopt trusted documents.

The `enforced` setting matches the previous behavior: when `true`, the gateway will enforce trusted documents. Additionally, we now allow trusted document requests with only an inline document, without document id, as long as the query is a trusted document. This is useful for organizations that want to enforce trusted documents, but have not yet migrated all their clients to send the document id.

The three new log options allow monitoring proper usage of trusted documents before you enforce them:

- `document_id_unknown_log_level`: logged when a document id is present in the request, but the corresponding trusted document cannot be found.
- `document_id_and_query_mismatch_log_level`: logged when both a query document and a document id are sent, when the retrieved trusted document does not match the inline query document.
- `inline_document_unknown_log_level`: logged when an inline document (a string in the `"query"` key of a the request) is sent, but no trusted document is found with the id matching the sha256 hash of the inline document.

They can all take `off`, `error`, `warn`, `info`, or `debug` as values. The default is `info`.

closes GB-7799
closes GB-6180