### PR TITLE
fix(engine): incorrect handling of skip/include during deserialization

### DIFF
--- a/crates/engine/src/response/write/deserialize/object/concrete.rs
+++ b/crates/engine/src/response/write/deserialize/object/concrete.rs
@@ -447,10 +447,7 @@ impl<'ctx> ConcreteShapeFieldsSeed<'ctx, '_> {
                 if field_shape.is_skipped() {
                     continue;
                 }
-                if response_fields[0..n]
-                    .binary_search_by(|field| field.key.cmp(&field_shape.key))
-                    .is_err()
-                {
+                if !response_fields[0..n].iter().any(|field| field.key == field_shape.key) {
                     if field_shape.wrapping.is_required() {
                         // If part of the query fields the user requested. We don't propagate null
                         // for extra fields.


### PR DESCRIPTION
I was expecting fields to be sorted and used binary search but this
changed at some point, sorting later. Didn't catch the regression with
existing tests.

As we have rarely more than few dozens of fields, linear search will do
perfectly fine here.

Fixes #2502
