### PR TITLE
engine: tolerate unknown trusted doc ids in Allow mode

### DIFF
--- a/crates/integration-tests/tests/federation/trusted_documents.rs
+++ b/crates/integration-tests/tests/federation/trusted_documents.rs
@@ -367,6 +367,40 @@ fn allow_mode_both_inline_document_and_document_id() {
 }
 
 #[test]
+fn allow_mode_both_inline_document_and_unknown_document_id() {
+    test(TrustedDocumentsEnforcementMode::Allow, |engine| async move {
+        let response = engine
+            .post(GraphQlRequest {
+                query: Some("query { pullRequestsAndIssues(filter: { search: \"1\" }) { __typename } }".to_string()),
+                operation_name: None,
+                variables: None,
+                extensions: None,
+                doc_id: Some("this-document-id-is-bogus".to_owned()),
+            })
+            .header("x-grafbase-client-name", "ios-app")
+            .await;
+
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "pullRequestsAndIssues": [
+              {
+                "__typename": "PullRequest"
+              },
+              {
+                "__typename": "PullRequest"
+              },
+              {
+                "__typename": "Issue"
+              }
+            ]
+          }
+        }
+        "#);
+    })
+}
+
+#[test]
 fn allow_mode_only_document_id() {
     test(TrustedDocumentsEnforcementMode::Allow, |engine| async move {
         let response = engine


### PR DESCRIPTION
In allow / audit mode, before this commit, we try to fetch the trusted document every time there is a trusted document id in the query, and we return an error if it doesn't exist. This is not in the spirit of allow mode: we have a setting to log, in that case. We should allow for a soft transition.

This commit changes the behaviour to try and fetch the trusted document from the trusted document id, but without hard error in case of failure, unless there is no inline document — there would be nothing to execute in that case, so we can't proceed to handle the request.

closes GB-8282