### PR TITLE
gateway: release 0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3131,7 +3131,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "ascii",

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.26.0] - 2025-01-20
+
+[CHANGELOG](changelog/0.26.0.md)
+
+## [0.25.1] - 2025-01-17
+
+[CHANGELOG](changelog/0.25.1.md)
+
+## [0.25.0] - 2025-01-16
+
+[CHANGELOG](changelog/0.25.0.md)
+
 ## [0.24.0] - 2025-01-14
 
 [CHANGELOG](changelog/0.24.0.md)

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.25.1"
+version = "0.26.0"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/changelog/0.26.0.md
+++ b/gateway/changelog/0.26.0.md
@@ -1,0 +1,28 @@
+## Features
+
+### Websocket connection init payload forwarding
+
+The gateway implements the [graphql-transport-ws protocol](https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverWebSocket.md). In that protocol, the first message on a websocket connection will be connection_init. That message contains an optional payload field that is a JSON object with arbitrary values. Typically, information that would go in HTTP headers for queries and mutations flows instead in that connection_init message's payload. Data like tokens that would otherwise go into the `Authorization` header are passed there instead.
+
+Before this release, the ConnectionInit payload was not forwarded to the subgraph resolving the subscription. It is now forwarded by default. That behaviour can be disabled with the following configuration:
+
+```toml
+[websockets]
+forward_connection_init_payload = false
+```
+
+Docs are available at https://grafbase.com/docs/reference/gateway/configuration/websockets
+
+Implemented in https://github.com/grafbase/grafbase/pull/2508
+
+## Improvements
+
+### Trusted document incremental adoption
+
+When `trusted_documents.enabled = true` and `trusted_documents.enforced = false`, the gateway fetches the trusted document whenever a trusted document id is present in the request. In 0.25.0 and 0.25.1, the gateway would return a hard error when no trusted document exists with that id, even when an inline document was in the query.
+
+This is not in the spirit of audit mode: there is the `document_id_unknown_log_level` setting to log, potentailly with error level, to detect this problem, but it should not block the request. We now allow for a soft transition: when no trusted document is found, but an inline document is present, we will use the inline document to execute the query. This is useful for organizations who want to gradually adopt trusted documents.
+
+Docs: https://grafbase.com/docs/reference/gateway/configuration/trusted-documents
+
+Implemented in https://github.com/grafbase/grafbase/pull/2512


### PR DESCRIPTION
## Features

### Websocket connection init payload forwarding

The gateway implements the [graphql-transport-ws protocol](https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverWebSocket.md). In that protocol, the first message on a websocket connection will be connection_init. That message contains an optional payload field that is a JSON object with arbitrary values. Typically, information that would go in HTTP headers for queries and mutations flows instead in that connection_init message's payload. Data like tokens that would otherwise go into the `Authorization` header are passed there instead.

Before this release, the ConnectionInit payload was not forwarded to the subgraph resolving the subscription. It is now forwarded by default. That behaviour can be disabled with the following configuration:

```toml
[websockets]
forward_connection_init_payload = false
```

Docs are available at https://grafbase.com/docs/reference/gateway/configuration/websockets

Implemented in https://github.com/grafbase/grafbase/pull/2508

## Improvements

### Trusted document incremental adoption

When `trusted_documents.enabled = true` and `trusted_documents.enforced = false`, the gateway fetches the trusted document whenever a trusted document id is present in the request. In 0.25.0 and 0.25.1, the gateway would return a hard error when no trusted document exists with that id, even when an inline document was in the query.

This is not in the spirit of audit mode: there is the `document_id_unknown_log_level` setting to log, potentailly with error level, to detect this problem, but it should not block the request. We now allow for a soft transition: when no trusted document is found, but an inline document is present, we will use the inline document to execute the query. This is useful for organizations who want to gradually adopt trusted documents.

Docs: https://grafbase.com/docs/reference/gateway/configuration/trusted-documents

Implemented in https://github.com/grafbase/grafbase/pull/2512
