### PR TITLE
chore: Bump Gateway to 0.27.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3135,7 +3135,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "anyhow",
  "ascii",

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.27.1] - 2025-01-23
+
+[CHANGELOG](changelog/0.27.1.md)
+
 ## [0.27.0] - 2025-01-22
 
 [CHANGELOG](changelog/0.27.0.md)

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.27.0"
+version = "0.27.1"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/changelog/0.27.1.md
+++ b/gateway/changelog/0.27.1.md
@@ -1,0 +1,5 @@
+## Fixes
+
+- Enable `--graph-ref` together with `--schema`, so one can use telemetry without using GDN
+- Query planner performance improvements
+- Properly merge default object on subgraph request error

--- a/gateway/helm/README.md
+++ b/gateway/helm/README.md
@@ -2,6 +2,17 @@
 
 Helm chart for installing Grafbase Gateway.
 
+## Usage
+
+It is recommended to not use this chart as-is due to it pointing to the latest unstable version.
+
+Instead, find the latest Grafbase Gateway version you want to use, and override the tag in your values.yaml:
+
+```yaml
+image:
+  tag: <VERSION>
+```
+
 ## Releasing
 
 ```bash


### PR DESCRIPTION
This also adds helm chart to the release process:

- instead of using `latest` tag, use the current version tag
- bump the minor version of the chart