### PR TITLE
Scope the CLI version to the grafbase crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "engine-config-builder"
-version = "0.82.4"
+version = "0.0.0"
 dependencies = [
  "engine-config",
  "gateway-config",
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "federation-audit-tests"
-version = "0.82.4"
+version = "0.0.0"
 dependencies = [
  "cynic-parser",
  "grafbase-workspace-hack",
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-graphql-introspection"
-version = "0.82.4"
+version = "0.0.0"
 dependencies = [
  "cynic",
  "cynic-introspection",
@@ -3387,7 +3387,7 @@ dependencies = [
 
 [[package]]
 name = "graph-ref"
-version = "0.82.4"
+version = "0.0.0"
 dependencies = [
  "grafbase-workspace-hack",
 ]
@@ -5524,7 +5524,7 @@ dependencies = [
 
 [[package]]
 name = "operation-checks"
-version = "0.82.4"
+version = "0.0.0"
 dependencies = [
  "async-graphql-parser",
  "async-graphql-value",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "operation-normalizer"
-version = "0.82.4"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "cynic-parser",
@@ -7022,7 +7022,7 @@ dependencies = [
 
 [[package]]
 name = "serde-dynamic-string"
-version = "0.82.4"
+version = "0.0.0"
 dependencies = [
  "ascii",
  "grafbase-workspace-hack",
@@ -8427,7 +8427,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-component-loader"
-version = "0.82.4"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,11 @@ members = [
     "crates/engine/id-derives",
     "crates/engine/id-newtypes",
 ]
-exclude = ["crates/wasi-component-loader/examples", "examples/hooks-template", "examples/query_plan"]
+exclude = [
+    "crates/wasi-component-loader/examples",
+    "examples/hooks-template",
+    "examples/query_plan",
+]
 
 [patch.crates-io]
 multipart-stream = { git = "https://github.com/grafbase/multipart-stream-rs-fork", rev = "06ff198e4041c8a8c1c93e580c260d597727c193" } # http-1.0-fix-multipart-mixed
@@ -26,7 +30,6 @@ multipart-stream = { git = "https://github.com/grafbase/multipart-stream-rs-fork
 grafbase-workspace-hack.path = "crates/grafbase-workspace-hack"
 
 [workspace.package]
-version = "0.82.4"
 edition = "2021"
 license = "MPL-2.0"
 homepage = "https://grafbase.com"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
+version = "0.82.4"
 name = "grafbase"
 description = "The Grafbase command line interface"
 categories = ["command-line-utilities"]
 readme = "README.md"
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/engine-config-builder/Cargo.toml
+++ b/crates/engine-config-builder/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "engine-config-builder"
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/federation-audit-tests/Cargo.toml
+++ b/crates/federation-audit-tests/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "federation-audit-tests"
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/grafbase-graphql-introspection/Cargo.toml
+++ b/crates/grafbase-graphql-introspection/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "grafbase-graphql-introspection"
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/graph-ref/Cargo.toml
+++ b/crates/graph-ref/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "graph-ref"
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/operation-checks/Cargo.toml
+++ b/crates/operation-checks/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "operation-checks"
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/operation-normalizer/Cargo.toml
+++ b/crates/operation-normalizer/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "operation-normalizer"
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/runtime-local/Cargo.toml
+++ b/crates/runtime-local/Cargo.toml
@@ -49,7 +49,7 @@ redis = { workspace = true, optional = true }
 
 reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 
-wasi-component-loader = { version = "0.82.4", path = "../wasi-component-loader", optional = true }
+wasi-component-loader = { path = "../wasi-component-loader", optional = true }
 deadpool = { workspace = true, optional = true }
 grafbase-telemetry.workspace = true
 anyhow.workspace = true

--- a/crates/serde-dynamic-string/Cargo.toml
+++ b/crates/serde-dynamic-string/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "serde-dynamic-string"
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/wasi-component-loader/Cargo.toml
+++ b/crates/wasi-component-loader/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "wasi-component-loader"
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/wasi-component-loader/examples/crates/authorization/Cargo.toml
+++ b/crates/wasi-component-loader/examples/crates/authorization/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "authorization"
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/wasi-component-loader/examples/crates/dir_access/Cargo.toml
+++ b/crates/wasi-component-loader/examples/crates/dir_access/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "dir_access"
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/wasi-component-loader/examples/crates/error/Cargo.toml
+++ b/crates/wasi-component-loader/examples/crates/error/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "error"
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/wasi-component-loader/examples/crates/gateway_request_no_op/Cargo.toml
+++ b/crates/wasi-component-loader/examples/crates/gateway_request_no_op/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "gateway_request_no_op"
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/wasi-component-loader/examples/crates/http_client/Cargo.toml
+++ b/crates/wasi-component-loader/examples/crates/http_client/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "http-client"
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/wasi-component-loader/examples/crates/missing_hook/Cargo.toml
+++ b/crates/wasi-component-loader/examples/crates/missing_hook/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "missing_hook"
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/wasi-component-loader/examples/crates/response-hooks/Cargo.toml
+++ b/crates/wasi-component-loader/examples/crates/response-hooks/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "response-hooks"
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/wasi-component-loader/examples/crates/simple/Cargo.toml
+++ b/crates/wasi-component-loader/examples/crates/simple/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "simple"
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/wasi-component-loader/examples/crates/subgraph_request/Cargo.toml
+++ b/crates/wasi-component-loader/examples/crates/subgraph_request/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "subgraph_request"
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/examples/access-logs/hooks/Cargo.toml
+++ b/examples/access-logs/hooks/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "hooks"
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/examples/gateway-hooks/hooks/Cargo.toml
+++ b/examples/gateway-hooks/hooks/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "hooks"
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
Until this commit, the CLI inherits its version from the workspace. So the workspace version is the CLI version. Other crates used to inherit it but that is no longer the case. The cli version shouldn't have precedence over versions for other crates that are decoupled from it, like the gateway or grafbase-composition.

So this commit scopes the version of the cli to the Cargo.toml of the grafbase crate.