### PR TITLE
gateway: release 0.28.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3135,7 +3135,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.27.1"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "ascii",

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.28.0] - 2025-01-25
+
+[CHANGELOG](changelog/0.28.0.md)
+
 ## [0.27.1] - 2025-01-23
 
 [CHANGELOG](changelog/0.27.1.md)

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.27.1"
+version = "0.28.0"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/changelog/0.28.0.md
+++ b/gateway/changelog/0.28.0.md
@@ -1,0 +1,3 @@
+## Fixes
+
+- The default download location for trusted documents has been updated to the new Grafbase CDN URL. This does not affect self-hosted enterprise platform deployments (https://github.com/grafbase/grafbase/pull/2530).


### PR DESCRIPTION
## Fixes

- The default download location for trusted documents has been updated to the new Grafbase CDN URL. This does not affect self-hosted enterprise platform deployments (https://github.com/grafbase/grafbase/pull/2530).