### PR TITLE
graphql-composition: ingest directive definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3410,6 +3410,7 @@ dependencies = [
 name = "graphql-composition"
 version = "0.5.0"
 dependencies = [
+ "bitflags 2.8.0",
  "cynic-parser",
  "cynic-parser-deser",
  "datatest-stable",

--- a/crates/graphql-composition/CHANGELOG.md
+++ b/crates/graphql-composition/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Implemented the rule that any directive composed with `@composeDirective` must have the same definition in all subgraphs. (https://github.com/grafbase/grafbase/pull/2532)
+
 ## 0.5.0 - 2025-01-06
 
 ### Features

--- a/crates/graphql-composition/Cargo.toml
+++ b/crates/graphql-composition/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["graphql", "federation"]
 workspace = true
 
 [dependencies]
+bitflags.workspace = true
 cynic-parser = { workspace = true, features = ["report"] }
 cynic-parser-deser.workspace = true
 grafbase-workspace-hack.workspace = true

--- a/crates/graphql-composition/src/ingest_subgraph.rs
+++ b/crates/graphql-composition/src/ingest_subgraph.rs
@@ -1,6 +1,7 @@
 //! This is a separate module because we want to use only the public API of [Subgraphs] and avoid
 //! mixing GraphQL parser logic and types with our internals.
 
+mod directive_definitions;
 mod directives;
 mod enums;
 mod fields;
@@ -34,7 +35,7 @@ pub(crate) fn ingest_subgraph(document: &ast::TypeSystemDocument, name: &str, ur
     ingest_nested_key_fields(subgraph_id, subgraphs);
 
     for name in directive_matcher.iter_composed_directives() {
-        subgraphs.insert_composed_directive(subgraph_id, name)
+        subgraphs.insert_composed_directive(name)
     }
 }
 
@@ -146,7 +147,10 @@ fn ingest_top_level_definitions(
                     directive_matcher,
                 );
             }
-            ast::Definition::Schema(_) | ast::Definition::SchemaExtension(_) | ast::Definition::Directive(_) => (),
+            ast::Definition::Directive(directive_definition) => {
+                directive_definitions::ingest_directive_definition(directive_definition, subgraph_id, subgraphs);
+            }
+            ast::Definition::Schema(_) | ast::Definition::SchemaExtension(_) => (),
         }
     }
 }

--- a/crates/graphql-composition/src/ingest_subgraph/directive_definitions.rs
+++ b/crates/graphql-composition/src/ingest_subgraph/directive_definitions.rs
@@ -1,0 +1,76 @@
+use super::*;
+
+pub(super) fn ingest_directive_definition(
+    directive_definition: ast::DirectiveDefinition<'_>,
+    subgraph_id: SubgraphId,
+    subgraphs: &mut Subgraphs,
+) {
+    let name = subgraphs.strings.intern(directive_definition.name());
+    let mut locations = subgraphs::DirectiveLocations::default();
+
+    for location in directive_definition.locations() {
+        let location = match location {
+            ast::DirectiveLocation::Query => subgraphs::DirectiveLocations::QUERY,
+            ast::DirectiveLocation::Mutation => subgraphs::DirectiveLocations::MUTATION,
+            ast::DirectiveLocation::Subscription => subgraphs::DirectiveLocations::SUBSCRIPTION,
+            ast::DirectiveLocation::Field => subgraphs::DirectiveLocations::FIELD,
+            ast::DirectiveLocation::FragmentDefinition => subgraphs::DirectiveLocations::FRAGMENT_DEFINITION,
+            ast::DirectiveLocation::FragmentSpread => subgraphs::DirectiveLocations::FRAGMENT_SPREAD,
+            ast::DirectiveLocation::InlineFragment => subgraphs::DirectiveLocations::INLINE_FRAGMENT,
+            ast::DirectiveLocation::VariableDefinition => subgraphs::DirectiveLocations::VARIABLE_DEFINITION,
+            ast::DirectiveLocation::Schema => subgraphs::DirectiveLocations::SCHEMA,
+            ast::DirectiveLocation::Scalar => subgraphs::DirectiveLocations::SCALAR,
+            ast::DirectiveLocation::Object => subgraphs::DirectiveLocations::OBJECT,
+            ast::DirectiveLocation::FieldDefinition => subgraphs::DirectiveLocations::FIELD_DEFINITION,
+            ast::DirectiveLocation::ArgumentDefinition => subgraphs::DirectiveLocations::ARGUMENT_DEFINITION,
+            ast::DirectiveLocation::Interface => subgraphs::DirectiveLocations::INTERFACE,
+            ast::DirectiveLocation::Union => subgraphs::DirectiveLocations::UNION,
+            ast::DirectiveLocation::Enum => subgraphs::DirectiveLocations::ENUM,
+            ast::DirectiveLocation::EnumValue => subgraphs::DirectiveLocations::ENUM_VALUE,
+            ast::DirectiveLocation::InputObject => subgraphs::DirectiveLocations::INPUT_OBJECT,
+            ast::DirectiveLocation::InputFieldDefinition => subgraphs::DirectiveLocations::INPUT_FIELD_DEFINITION,
+        };
+
+        locations |= location;
+    }
+
+    let mut arguments = Vec::with_capacity(directive_definition.arguments().len());
+
+    for argument in directive_definition.arguments() {
+        let argument_name = subgraphs.strings.intern(argument.name());
+        let r#type = subgraphs.intern_field_type(argument.ty());
+        let default_value = argument
+            .default_value()
+            .map(|default| crate::ast_value_to_subgraph_value(default, subgraphs));
+
+        let directives = argument
+            .directives()
+            .map(|directive| subgraphs::Directive {
+                name: subgraphs.strings.intern(directive.name()),
+                arguments: directive
+                    .arguments()
+                    .map(|arg| {
+                        (
+                            subgraphs.strings.intern(arg.name()),
+                            crate::ast_value_to_subgraph_value(arg.value(), subgraphs),
+                        )
+                    })
+                    .collect(),
+            })
+            .collect();
+
+        arguments.push(subgraphs::InputValueDefinition {
+            name: argument_name,
+            r#type,
+            default_value,
+            directives,
+        });
+    }
+
+    subgraphs.push_directive_definition(subgraphs::DirectiveDefinition {
+        subgraph_id,
+        name,
+        locations,
+        arguments,
+    });
+}

--- a/crates/graphql-composition/src/subgraphs/definitions.rs
+++ b/crates/graphql-composition/src/subgraphs/definitions.rs
@@ -1,6 +1,5 @@
-use std::collections::btree_map;
-
 use super::*;
+use std::collections::btree_map;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct DefinitionId(pub(super) usize);

--- a/crates/graphql-composition/src/subgraphs/directives/directive_definition.rs
+++ b/crates/graphql-composition/src/subgraphs/directives/directive_definition.rs
@@ -1,0 +1,176 @@
+use super::*;
+use bitflags::bitflags;
+use std::fmt::Display;
+
+pub(crate) struct DirectiveDefinition {
+    pub(crate) subgraph_id: SubgraphId,
+    pub(crate) name: StringId,
+    pub(crate) locations: DirectiveLocations,
+    pub(crate) arguments: Vec<InputValueDefinition>,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub(crate) struct InputValueDefinition {
+    pub(crate) name: StringId,
+    pub(crate) r#type: FieldTypeId,
+    pub(crate) default_value: Option<Value>,
+    pub(crate) directives: Vec<Directive>,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub(crate) struct Directive {
+    pub(crate) name: StringId,
+    pub(crate) arguments: Vec<(StringId, Value)>,
+}
+
+impl Display for Walker<'_, InputValueDefinition> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.subgraphs.walk(self.id.name).as_str())?;
+        f.write_str(": ")?;
+        Display::fmt(&self.subgraphs.walk(self.id.r#type), f)?;
+
+        if let Some(default) = &self.id.default_value {
+            f.write_str(" = ")?;
+            Display::fmt(&self.subgraphs.walk(default), f)?;
+        }
+
+        for directive in &self.id.directives {
+            f.write_str(" ")?;
+            Display::fmt(&self.subgraphs.walk(directive), f)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Display for Walker<'_, &'_ Value> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let subgraphs = self.subgraphs;
+        match self.id {
+            Value::String(string_id) => {
+                graphql_federated_graph::display_graphql_string_literal(subgraphs.walk(*string_id).as_str(), f)
+            }
+            Value::Int(int) => Display::fmt(int, f),
+            Value::Float(float) => Display::fmt(float, f),
+            Value::Boolean(b) => Display::fmt(b, f),
+            Value::Enum(string_id) => Display::fmt(subgraphs.walk(*string_id).as_str(), f),
+            Value::Object(vec) => {
+                f.write_str("{")?;
+                for (key, value) in vec {
+                    Display::fmt(subgraphs.walk(*key).as_str(), f)?;
+                    f.write_str(": ")?;
+                    Display::fmt(&subgraphs.walk(value), f)?;
+                }
+                f.write_str("}")
+            }
+            Value::List(vec) => {
+                f.write_str("[")?;
+                for value in vec {
+                    Display::fmt(&subgraphs.walk(value), f)?;
+                }
+                f.write_str("]")
+            }
+            Value::Null => f.write_str("null"),
+        }
+    }
+}
+
+impl Display for Walker<'_, &'_ Directive> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("@")?;
+        f.write_str(self.subgraphs.walk(self.id.name).as_str())?;
+
+        if self.id.arguments.is_empty() {
+            return Ok(());
+        }
+
+        f.write_str("(")?;
+
+        for argument in &self.id.arguments {
+            f.write_str(self.subgraphs.walk(argument.0).as_str())?;
+            f.write_str(": ")?;
+            Display::fmt(&self.subgraphs.walk(&argument.1), f)?;
+        }
+
+        f.write_str(")")
+    }
+}
+
+bitflags! {
+    /// https://spec.graphql.org/October2021/#sec-The-__Directive-Type
+    #[derive(Default, PartialEq, Eq, PartialOrd, Ord)]
+    pub(crate) struct DirectiveLocations: u32 {
+        const QUERY = 0b1 << 0;
+        const MUTATION = 0b1 << 1;
+        const SUBSCRIPTION = 0b1 << 2;
+        const FIELD = 0b1 << 3;
+        const FRAGMENT_DEFINITION = 0b1 << 4;
+        const FRAGMENT_SPREAD = 0b1 << 5;
+        const INLINE_FRAGMENT = 0b1 << 6;
+        const VARIABLE_DEFINITION = 0b1 << 7;
+        const SCHEMA = 0b1 << 8;
+        const SCALAR = 0b1 << 9;
+        const OBJECT = 0b1 << 10;
+        const FIELD_DEFINITION = 0b1 << 11;
+        const ARGUMENT_DEFINITION = 0b1 << 12;
+        const INTERFACE = 0b1 << 13;
+        const UNION = 0b1 << 14;
+        const ENUM = 0b1 << 15;
+        const ENUM_VALUE = 0b1 << 16;
+        const INPUT_OBJECT = 0b1 << 17;
+        const INPUT_FIELD_DEFINITION = 0b1 << 18;
+    }
+}
+
+impl Display for DirectiveLocations {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut locations = self.iter().peekable();
+
+        while let Some(location) = locations.next() {
+            let name = match location {
+                DirectiveLocations::QUERY => "QUERY",
+                DirectiveLocations::MUTATION => "MUTATION",
+                DirectiveLocations::SUBSCRIPTION => "SUBSCRIPTION",
+                DirectiveLocations::FIELD => "FIELD",
+                DirectiveLocations::FRAGMENT_DEFINITION => "FRAGMENT_DEFINITION",
+                DirectiveLocations::FRAGMENT_SPREAD => "FRAGMENT_SPREAD",
+                DirectiveLocations::INLINE_FRAGMENT => "INLINE_FRAGMENT",
+                DirectiveLocations::VARIABLE_DEFINITION => "VARIABLE_DEFINITION",
+                DirectiveLocations::SCHEMA => "SCHEMA",
+                DirectiveLocations::SCALAR => "SCALAR",
+                DirectiveLocations::OBJECT => "OBJECT",
+                DirectiveLocations::FIELD_DEFINITION => "FIELD_DEFINITION",
+                DirectiveLocations::ARGUMENT_DEFINITION => "ARGUMENT_DEFINITION",
+                DirectiveLocations::INTERFACE => "INTERFACE",
+                DirectiveLocations::UNION => "UNION",
+                DirectiveLocations::ENUM => "ENUM",
+                DirectiveLocations::ENUM_VALUE => "ENUM_VALUE",
+                DirectiveLocations::INPUT_OBJECT => "INPUT_OBJECT",
+                DirectiveLocations::INPUT_FIELD_DEFINITION => "INPUT_FIELD_DEFINITION",
+                _ => unreachable!(),
+            };
+
+            f.write_str(name)?;
+
+            if locations.peek().is_some() {
+                f.write_str(" | ")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn directive_definitions_display() {
+        let all = DirectiveLocations::all().to_string();
+
+        let expected = "QUERY | MUTATION | SUBSCRIPTION | FIELD | FRAGMENT_DEFINITION | FRAGMENT_SPREAD | INLINE_FRAGMENT | VARIABLE_DEFINITION | SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION";
+
+        assert_eq!(all, expected);
+    }
+}

--- a/crates/graphql-composition/src/validate.rs
+++ b/crates/graphql-composition/src/validate.rs
@@ -1,5 +1,6 @@
 use crate::subgraphs;
 
+mod compose_directive;
 mod input_selection;
 mod selection;
 mod subgraph_names;
@@ -11,6 +12,7 @@ pub(crate) fn validate(ctx: &mut ValidateContext<'_>) {
     subgraph_names::validate_subgraph_names(ctx);
     validate_query_nonempty(ctx);
     validate_fields(ctx);
+    compose_directive::validate_compose_directive(ctx);
 }
 
 fn validate_query_nonempty(ctx: &mut ValidateContext<'_>) {

--- a/crates/graphql-composition/src/validate/compose_directive.rs
+++ b/crates/graphql-composition/src/validate/compose_directive.rs
@@ -1,0 +1,68 @@
+use super::ValidateContext;
+use std::fmt::Write as _;
+
+pub(crate) fn validate_compose_directive(ctx: &mut ValidateContext<'_>) {
+    let directive_definitions = ctx.subgraphs.directive_definitions();
+    let mut composed_directive_definitions_sorted_by_name: Vec<usize> = directive_definitions
+        .iter()
+        .enumerate()
+        .filter(|(_, def)| ctx.subgraphs.is_composed_directive(def.name))
+        .map(|(idx, _)| idx)
+        .collect();
+
+    composed_directive_definitions_sorted_by_name.sort_unstable_by_key(|&idx| directive_definitions[idx].name);
+
+    for chunk in composed_directive_definitions_sorted_by_name
+        .chunk_by(|idx_1, idx_2| directive_definitions[*idx_1].name == directive_definitions[*idx_2].name)
+    {
+        let first_definition = &directive_definitions[chunk[0]];
+
+        for definition_idx in &chunk[1..] {
+            let definition = &directive_definitions[*definition_idx];
+            debug_assert_eq!(definition.name, first_definition.name);
+
+            if definition.locations != first_definition.locations {
+                let mut diagnostic = format!(
+                    "Directive `{}` is defined with different locations:\n",
+                    ctx.subgraphs.walk(first_definition.name).as_str()
+                );
+
+                for def in [first_definition, definition] {
+                    writeln!(
+                        diagnostic,
+                        " {} in {}",
+                        def.locations,
+                        ctx.subgraphs.walk_subgraph(def.subgraph_id).name().as_str(),
+                    )
+                    .unwrap();
+                }
+
+                ctx.diagnostics.push_fatal(diagnostic);
+            }
+
+            if definition.arguments != first_definition.arguments {
+                let mut diagnostic = format!(
+                    "Directive `{}` is defined with different arguments:\n",
+                    ctx.subgraphs.walk(first_definition.name).as_str()
+                );
+
+                for def in [first_definition, definition] {
+                    writeln!(
+                        diagnostic,
+                        "- ({}) in {}",
+                        def.arguments
+                            .iter()
+                            .cloned()
+                            .map(|arg| ctx.subgraphs.walk(arg).to_string())
+                            .collect::<Vec<_>>()
+                            .join(", "),
+                        ctx.subgraphs.walk_subgraph(def.subgraph_id).name().as_str(),
+                    )
+                    .unwrap();
+                }
+
+                ctx.diagnostics.push_fatal(diagnostic);
+            }
+        }
+    }
+}

--- a/crates/graphql-composition/tests/composition/compose_directive_different_definitions/federated.graphql
+++ b/crates/graphql-composition/tests/composition/compose_directive_different_definitions/federated.graphql
@@ -1,0 +1,6 @@
+# Directive `jkl` is defined with different arguments:\n- (a: Int, b: String!) in chocolate\n- (a: Int, b: String!, c: [Float]) in nougat
+# Directive `mno` is defined with different arguments:\n- (a: Int, b: String) in chocolate\n- (a: Int, b: String!) in nougat
+# Directive `pqr` is defined with different locations:\n FIELD_DEFINITION in chocolate\n OBJECT | FIELD_DEFINITION in nougat
+# Directive `stu` is defined with different arguments:\n- (a: String = "NO CAP") in chocolate\n- (a: String = "TEST") in nougat
+# Directive `vwx` is defined with different arguments:\n- (a: Int, b: String! @b @c(d: "boom")) in chocolate\n- (a: Int, b: String! @b @c(d: "e")) in nougat
+# Directive `yz` is defined with different arguments:\n- (a: Int, b: String! @b(d: "e")) in chocolate\n- (a: Int, b: String!) in nougat

--- a/crates/graphql-composition/tests/composition/compose_directive_different_definitions/subgraphs/chocolate.graphql
+++ b/crates/graphql-composition/tests/composition/compose_directive_different_definitions/subgraphs/chocolate.graphql
@@ -1,0 +1,24 @@
+directive @abc on FIELD_DEFINITION
+directive @def(a: Int) on FIELD_DEFINITION
+directive @ghi(a: Int, b: String!) on FIELD_DEFINITION
+directive @jkl(a: Int, b: String!) on FIELD_DEFINITION
+directive @mno(a: Int, b: String) on FIELD_DEFINITION # argument b does not match
+directive @pqr on FIELD_DEFINITION # location does not match
+directive @stu(a: String = "NO CAP") on FIELD_DEFINITION # different default value
+directive @vwx(a: Int, b: String! @b @c(d: "boom")) on FIELD_DEFINITION # different directive on argument
+directive @yz(a: Int, b: String! @b(d: "e")) on FIELD_DEFINITION # no directive on argument
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@composeDirective"])
+  @composeDirective(name: "@abc")
+  @composeDirective(name: "@def")
+  @composeDirective(name: "@jkl")
+  @composeDirective(name: "@mno")
+  @composeDirective(name: "@stu")
+
+type Chocolate {
+  id: ID! @ghi(a: 1, b: "2")
+}
+
+type Query {
+  chocolates: [Chocolate!]! @abc
+}

--- a/crates/graphql-composition/tests/composition/compose_directive_different_definitions/subgraphs/nougat.graphql
+++ b/crates/graphql-composition/tests/composition/compose_directive_different_definitions/subgraphs/nougat.graphql
@@ -1,0 +1,22 @@
+directive @ghi(a: Int, b: Float) on FIELD_DEFINITION # not in `@composeDirective`, so it does not matter that it doesn't match
+directive @pqr on FIELD_DEFINITION | OBJECT # location does not match
+directive @def(a: Int) on FIELD_DEFINITION # matches
+directive @mno(a: Int, b: String!) on FIELD_DEFINITION # argument b does not match
+directive @abc on FIELD_DEFINITION
+directive @jkl(a: Int, b: String!, c: [Float]) on FIELD_DEFINITION # argument c does not exist in the other subgraph
+directive @stu(a: String = "TEST") on FIELD_DEFINITION # different default value
+directive @vwx(a: Int, b: String! @b @c(d: "e")) on FIELD_DEFINITION # different directive on argument
+directive @yz(a: Int, b: String!) on FIELD_DEFINITION # no directive on argument
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@composeDirective"])
+  @composeDirective(name: "@abc")
+  @composeDirective(name: "@def")
+  @composeDirective(name: "@jkl")
+  @composeDirective(name: "@mno")
+  @composeDirective(name: "@pqr")
+  @composeDirective(name: "@vwx")
+  @composeDirective(name: "@yz")
+
+type Nougat {
+  id: ID! @ghi(a: 1, b: "2")
+}

--- a/crates/graphql-federated-graph/src/lib.rs
+++ b/crates/graphql-federated-graph/src/lib.rs
@@ -10,7 +10,7 @@ pub use self::federated_graph::*;
 pub use directives::*;
 
 #[cfg(feature = "render_sdl")]
-pub use render_sdl::{render_api_sdl, render_federated_sdl};
+pub use render_sdl::{display_graphql_string_literal, render_api_sdl, render_federated_sdl};
 
 #[cfg(feature = "from_sdl")]
 pub use from_sdl::DomainError;

--- a/crates/graphql-federated-graph/src/render_sdl.rs
+++ b/crates/graphql-federated-graph/src/render_sdl.rs
@@ -3,4 +3,7 @@ mod display_utils;
 mod render_api_sdl;
 mod render_federated_sdl;
 
-pub use self::{render_api_sdl::render_api_sdl, render_federated_sdl::render_federated_sdl};
+pub use self::{
+    display_utils::display_graphql_string_literal, render_api_sdl::render_api_sdl,
+    render_federated_sdl::render_federated_sdl,
+};


### PR DESCRIPTION
As a first use case, this implements the federation spec rule that any directive composed using `@composeDirective` must have the same definition in all subgraphs.

closes GB-8317