### PR TITLE
feat: very basic rest extension that can do a GET

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,6 +1050,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "chumsky"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3214,6 +3223,7 @@ dependencies = [
 name = "grafbase-sdk"
 version = "0.1.0"
 dependencies = [
+ "grafbase-sdk-derive",
  "grafbase-workspace-hack",
  "http 1.2.0",
  "minicbor-serde",
@@ -3223,6 +3233,16 @@ dependencies = [
  "serde_urlencoded",
  "url",
  "wit-bindgen",
+]
+
+[[package]]
+name = "grafbase-sdk-derive"
+version = "0.1.0"
+dependencies = [
+ "grafbase-workspace-hack",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3396,6 +3416,7 @@ dependencies = [
  "winapi",
  "windows-sys 0.52.0",
  "windows-sys 0.59.0",
+ "zerocopy",
  "zeroize",
 ]
 
@@ -3731,6 +3752,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hifijson"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9958ab3ce3170c061a27679916bd9b969eceeb5e8b120438e6751d0987655c42"
 
 [[package]]
 name = "hkdf"
@@ -4515,6 +4542,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "jaq-interpret"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe95ec3c24af3fd9f3dd1091593f5e49b003a66c496a8aa39d764d0a06ae17b"
+dependencies = [
+ "ahash 0.8.11",
+ "dyn-clone",
+ "hifijson",
+ "indexmap 2.7.0",
+ "jaq-syn",
+ "once_cell",
+ "serde_json",
+]
+
+[[package]]
+name = "jaq-parse"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0346d7d3146cdda8acd929581f3d6626a332356c74d5c95aeaffaac2eb6dee82"
+dependencies = [
+ "chumsky",
+ "jaq-syn",
+]
+
+[[package]]
+name = "jaq-syn"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba44fe4428c71304604261ecbae047ee9cfb60c4f1a6bd222ebbb31726d3948"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6594,6 +6655,19 @@ dependencies = [
  "pin-project-lite",
  "reqwest 0.12.12",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "rest"
+version = "0.1.0"
+dependencies = [
+ "grafbase-sdk",
+ "grafbase-workspace-hack",
+ "http 1.2.0",
+ "jaq-interpret",
+ "jaq-parse",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [workspace]
-resolver = "2"
 members = [
     "cli",
     "gateway",
     "crates/*",
+    "extensions/*",
     "crates/grafbase-hooks/derive",
+    "crates/grafbase-sdk/derive",
     "crates/engine/auth",
     "crates/engine/config",
     "crates/engine/axum",
@@ -16,6 +17,7 @@ members = [
     "crates/engine/id-derives",
     "crates/engine/id-newtypes",
 ]
+resolver = "2"
 exclude = [
     "crates/wasi-component-loader/examples",
     "examples/hooks-template",
@@ -159,6 +161,7 @@ graphql-lint = { path = "crates/graphql-lint" }
 federated-server = { path = "crates/federated-server" }
 gateway-config = { path = "crates/gateway-config" }
 rolling-logger = { path = "crates/rolling-logger" }
+grafbase-sdk = { path = "crates/grafbase-sdk" }
 
 # Engine
 engine-config-builder = { path = "crates/engine-config-builder" }

--- a/crates/grafbase-sdk/derive/Cargo.toml
+++ b/crates/grafbase-sdk/derive/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "grafbase-sdk-derive"
+version = "0.1.0"
+description = "A proc macro for the grafbase-sdk crate"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.93"
+quote = "1.0.37"
+syn = { version = "2.0.89", features = ["full"] }
+grafbase-workspace-hack.workspace = true

--- a/crates/grafbase-sdk/derive/src/lib.rs
+++ b/crates/grafbase-sdk/derive/src/lib.rs
@@ -1,0 +1,44 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::DeriveInput;
+
+#[proc_macro_derive(ResolverExtension)]
+pub fn resolver_extension(input: TokenStream) -> TokenStream {
+    let ast = syn::parse_macro_input!(input as DeriveInput);
+    expand(resolver_init(ast))
+}
+
+fn expand(init: proc_macro2::TokenStream) -> TokenStream {
+    let token_stream = quote! {
+        #[doc(hidden)]
+        #[export_name = "register_extension"]
+        pub extern "C" fn __register_extension(host_version: u64) -> i64 {
+            let version_result = grafbase_sdk::check_host_version(host_version);
+
+            if version_result < 0 {
+                return version_result;
+            }
+
+            #init
+
+            version_result
+        }
+    };
+
+    TokenStream::from(token_stream)
+}
+
+fn resolver_init(ast: DeriveInput) -> proc_macro2::TokenStream {
+    let name = &ast.ident;
+
+    let (_, ty_generics, _) = ast.generics.split_for_impl();
+
+    quote! {
+        let init_fn = |directives| {
+            let result = <#name #ty_generics as grafbase_sdk::Extension>::new(directives);
+            result.map(|extension| Box::new(extension) as Box<dyn grafbase_sdk::Resolver>)
+        };
+
+        grafbase_sdk::extension::resolver::register(Box::new(init_fn));
+    }
+}

--- a/crates/grafbase-sdk/wit/world.wit
+++ b/crates/grafbase-sdk/wit/world.wit
@@ -37,12 +37,6 @@ world sdk {
       outputs: list<result<list<u8>, error>>
     }
 
-    record field-input {
-        definition: field-definition,
-        // Serialized metadata/arguments/response data as defined by the directive in CBOR
-        inputs: list<list<u8>>
-    }
-
     enum extension-type {
         resolver
     }
@@ -140,7 +134,8 @@ world sdk {
     export resolve-field: func(
        context: shared-context,
        directive: directive,
-       inputs: list<field-input>
+       definition: field-definition,
+       inputs: list<list<u8>>
     ) -> result<field-output, error>;
 
     // The extension registration function. Must be called before initialization.

--- a/crates/grafbase-workspace-hack/Cargo.toml
+++ b/crates/grafbase-workspace-hack/Cargo.toml
@@ -20,6 +20,7 @@ publish = false
 
 ### BEGIN HAKARI SECTION
 [dependencies]
+ahash = { version = "0.8" }
 aho-corasick = { version = "1" }
 ascii = { version = "1", features = ["serde"] }
 axum-c38e5c1d305a1b54 = { package = "axum", version = "0.8", default-features = false, features = ["http1", "json", "macros", "query", "ws"] }
@@ -64,6 +65,7 @@ futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std"] }
 futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
+getrandom = { version = "0.2", default-features = false, features = ["std"] }
 group = { version = "0.13", default-features = false, features = ["alloc"] }
 hashbrown-3575ec1268b04181 = { package = "hashbrown", version = "0.15" }
 hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", features = ["raw", "serde"] }
@@ -131,9 +133,11 @@ ulid = { version = "1", features = ["serde"] }
 url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 wasmparser = { version = "0.221", default-features = false, features = ["component-model", "features", "serde", "simd", "std", "validate"] }
+zerocopy = { version = "0.7", features = ["derive", "simd"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 
 [build-dependencies]
+ahash = { version = "0.8" }
 aho-corasick = { version = "1" }
 ascii = { version = "1", features = ["serde"] }
 axum-c38e5c1d305a1b54 = { package = "axum", version = "0.8", default-features = false, features = ["http1", "json", "macros", "query", "ws"] }
@@ -180,6 +184,7 @@ futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std"] }
 futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
+getrandom = { version = "0.2", default-features = false, features = ["std"] }
 group = { version = "0.13", default-features = false, features = ["alloc"] }
 hashbrown-3575ec1268b04181 = { package = "hashbrown", version = "0.15" }
 hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", features = ["raw", "serde"] }
@@ -248,12 +253,11 @@ ulid = { version = "1", features = ["serde"] }
 url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 wasmparser = { version = "0.221", default-features = false, features = ["component-model", "features", "serde", "simd", "std", "validate"] }
+zerocopy = { version = "0.7", features = ["derive", "simd"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 
 [target.aarch64-apple-darwin.dependencies]
-ahash = { version = "0.8" }
 axum-ca01ad9e24f5d932 = { package = "axum", version = "0.7", default-features = false, features = ["ws"] }
-getrandom = { version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 libc = { version = "0.2", features = ["extra_traits"] }
@@ -266,9 +270,7 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 tungstenite-adf3d7031871b0af = { package = "tungstenite", version = "0.24", features = ["__rustls-tls"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
-ahash = { version = "0.8" }
 axum-ca01ad9e24f5d932 = { package = "axum", version = "0.7", default-features = false, features = ["ws"] }
-getrandom = { version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 libc = { version = "0.2", features = ["extra_traits"] }
@@ -281,9 +283,7 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 tungstenite-adf3d7031871b0af = { package = "tungstenite", version = "0.24", features = ["__rustls-tls"] }
 
 [target.x86_64-apple-darwin.dependencies]
-ahash = { version = "0.8" }
 axum-ca01ad9e24f5d932 = { package = "axum", version = "0.7", default-features = false, features = ["ws"] }
-getrandom = { version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 libc = { version = "0.2", features = ["extra_traits"] }
@@ -297,9 +297,7 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 tungstenite-adf3d7031871b0af = { package = "tungstenite", version = "0.24", features = ["__rustls-tls"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
-ahash = { version = "0.8" }
 axum-ca01ad9e24f5d932 = { package = "axum", version = "0.7", default-features = false, features = ["ws"] }
-getrandom = { version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 libc = { version = "0.2", features = ["extra_traits"] }
@@ -314,7 +312,6 @@ tungstenite-adf3d7031871b0af = { package = "tungstenite", version = "0.24", feat
 
 [target.x86_64-pc-windows-msvc.dependencies]
 axum-ca01ad9e24f5d932 = { package = "axum", version = "0.7", default-features = false, features = ["ws"] }
-getrandom = { version = "0.2", default-features = false, features = ["std"] }
 spin = { version = "0.9" }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features = false, features = ["timeout"] }
 tungstenite-adf3d7031871b0af = { package = "tungstenite", version = "0.24", features = ["__rustls-tls"] }
@@ -324,7 +321,6 @@ windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52", feat
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
 axum-ca01ad9e24f5d932 = { package = "axum", version = "0.7", default-features = false, features = ["ws"] }
-getrandom = { version = "0.2", default-features = false, features = ["std"] }
 spin = { version = "0.9" }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features = false, features = ["timeout"] }
 tungstenite-adf3d7031871b0af = { package = "tungstenite", version = "0.24", features = ["__rustls-tls"] }
@@ -333,9 +329,7 @@ windows-sys-73dcd821b1037cfd = { package = "windows-sys", version = "0.59", feat
 windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Foundation", "Win32_NetworkManagement_IpHelper", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Kernel", "Win32_System_LibraryLoader", "Win32_System_Performance", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
 
 [target.x86_64-unknown-linux-musl.dependencies]
-ahash = { version = "0.8" }
 axum-ca01ad9e24f5d932 = { package = "axum", version = "0.7", default-features = false, features = ["ws"] }
-getrandom = { version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 libc = { version = "0.2", features = ["extra_traits"] }
@@ -350,9 +344,7 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 tungstenite-adf3d7031871b0af = { package = "tungstenite", version = "0.24", features = ["__rustls-tls"] }
 
 [target.x86_64-unknown-linux-musl.build-dependencies]
-ahash = { version = "0.8" }
 axum-ca01ad9e24f5d932 = { package = "axum", version = "0.7", default-features = false, features = ["ws"] }
-getrandom = { version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 libc = { version = "0.2", features = ["extra_traits"] }
@@ -367,9 +359,7 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 tungstenite-adf3d7031871b0af = { package = "tungstenite", version = "0.24", features = ["__rustls-tls"] }
 
 [target.aarch64-unknown-linux-musl.dependencies]
-ahash = { version = "0.8" }
 axum-ca01ad9e24f5d932 = { package = "axum", version = "0.7", default-features = false, features = ["ws"] }
-getrandom = { version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 libc = { version = "0.2", features = ["extra_traits"] }
@@ -383,9 +373,7 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 tungstenite-adf3d7031871b0af = { package = "tungstenite", version = "0.24", features = ["__rustls-tls"] }
 
 [target.aarch64-unknown-linux-musl.build-dependencies]
-ahash = { version = "0.8" }
 axum-ca01ad9e24f5d932 = { package = "axum", version = "0.7", default-features = false, features = ["ws"] }
-getrandom = { version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 libc = { version = "0.2", features = ["extra_traits"] }

--- a/extensions/rest/Cargo.toml
+++ b/extensions/rest/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "grafbase-sdk"
+name = "rest"
 version = "0.1.0"
 edition.workspace = true
 license.workspace = true
@@ -8,16 +8,13 @@ keywords.workspace = true
 repository.workspace = true
 
 [dependencies]
-grafbase-sdk-derive = { path = "./derive" }
-http.workspace = true
-minicbor-serde = { version = "0.3.2", features = ["alloc"] }
-semver = "1.0.25"
+grafbase-sdk.workspace = true
+jaq-interpret = "1.5.0"
+jaq-parse = "1.0.3"
 serde.workspace = true
 serde_json.workspace = true
-serde_urlencoded.workspace = true
-url.workspace = true
-wit-bindgen.workspace = true
 grafbase-workspace-hack.workspace = true
+http.workspace = true
 
 [lints]
 workspace = true

--- a/extensions/rest/src/lib.rs
+++ b/extensions/rest/src/lib.rs
@@ -1,0 +1,174 @@
+use grafbase_sdk::{
+    host_io::http::{self, HttpRequest, Url},
+    types::{Directive, FieldDefinition, FieldInputs, FieldOutput},
+    Error, Extension, Resolver, ResolverExtension, SharedContext,
+};
+use jaq_interpret::{Ctx, Filter, FilterT, ParseCtx, RcIter, Val};
+use std::collections::HashMap;
+
+#[derive(ResolverExtension)]
+struct RestExtension {
+    endpoints: Vec<RestEndpoint>,
+    filters: HashMap<String, Filter>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RestEndpoint {
+    name: String,
+    http: HttpSettings,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HttpSettings {
+    base_url: String,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Rest<'a> {
+    endpoint: &'a str,
+    http: HttpCall<'a>,
+    selection: &'a str,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HttpCall<'a> {
+    method: HttpMethod,
+    path: &'a str,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+enum HttpMethod {
+    Get,
+}
+
+impl From<HttpMethod> for ::http::Method {
+    fn from(method: HttpMethod) -> Self {
+        match method {
+            HttpMethod::Get => Self::GET,
+        }
+    }
+}
+
+impl Extension for RestExtension {
+    fn new(schema_directives: Vec<Directive>) -> Result<Self, Box<dyn std::error::Error>> {
+        let mut endpoints = Vec::<RestEndpoint>::new();
+
+        for directive in schema_directives {
+            endpoints.push(directive.arguments()?);
+        }
+
+        endpoints.sort_by(|a, b| a.name.cmp(&b.name));
+
+        Ok(Self {
+            endpoints,
+            filters: HashMap::new(),
+        })
+    }
+}
+
+impl RestExtension {
+    pub fn get_endpoint(&self, endpoint: &str) -> Option<&RestEndpoint> {
+        self.endpoints
+            .binary_search_by(|e| e.name.as_str().cmp(endpoint))
+            .map(|i| &self.endpoints[i])
+            .ok()
+    }
+
+    pub fn create_filter<'a>(&'a mut self, selection: &str) -> Result<&'a Filter, Error> {
+        if !self.filters.contains_key(selection) {
+            let mut defs = ParseCtx::new(Vec::new());
+
+            let (filter, errors) = jaq_parse::parse(selection, jaq_parse::main());
+
+            if !errors.is_empty() {
+                return Err(Error {
+                    extensions: Vec::new(),
+                    message: format!("The selection is not in valid jq syntax: {errors:?}"),
+                });
+            }
+
+            let filter = defs.compile(filter.expect("we handled errors above"));
+
+            if !defs.errs.is_empty() {
+                return Err(Error {
+                    extensions: Vec::new(),
+                    message: "Error compiling jq filter".to_string(),
+                });
+            }
+
+            self.filters.insert(selection.to_string(), filter);
+        }
+
+        Ok(self.filters.get(selection).unwrap())
+    }
+}
+
+impl Resolver for RestExtension {
+    fn resolve_field(
+        &mut self,
+        _: SharedContext,
+        directive: Directive,
+        _: FieldDefinition,
+        _: FieldInputs,
+    ) -> Result<FieldOutput, Error> {
+        let rest: Rest<'_> = directive.arguments().map_err(|e| Error {
+            extensions: Vec::new(),
+            message: format!("Could not parse directive arguments: {e}"),
+        })?;
+
+        let Some(endpoint) = self.get_endpoint(rest.endpoint) else {
+            return Err(Error {
+                extensions: Vec::new(),
+                message: format!("Endpoint not found: {}", rest.endpoint),
+            });
+        };
+
+        let url = Url::parse(&format!("{}/{}", endpoint.http.base_url, rest.http.path)).map_err(|e| Error {
+            extensions: Vec::new(),
+            message: format!("Could not parse URL: {e}"),
+        })?;
+
+        let request = HttpRequest::builder(url, rest.http.method.into()).build();
+
+        let result = http::execute(&request).map_err(|e| Error {
+            extensions: Vec::new(),
+            message: format!("HTTP request failed: {e}"),
+        })?;
+
+        if !result.status().is_success() {
+            return Err(Error {
+                extensions: Vec::new(),
+                message: format!("HTTP request failed with status: {}", result.status()),
+            });
+        }
+
+        let data: serde_json::Value = result.json().map_err(|e| Error {
+            extensions: Vec::new(),
+            message: format!("Error deserializing response: {e}"),
+        })?;
+
+        let filter = self.create_filter(rest.selection)?;
+        let inputs = RcIter::new(core::iter::empty());
+
+        let filtered = filter.run((Ctx::new([], &inputs), Val::from(data)));
+
+        let mut results = FieldOutput::new();
+
+        for result in filtered {
+            match result {
+                Ok(result) => results.push_value(serde_json::Value::from(result)),
+                Err(e) => results.push_error(Error {
+                    extensions: Vec::new(),
+                    message: format!("Error parsing result value: {e}"),
+                }),
+            }
+        }
+
+        Ok(results)
+    }
+}


### PR DESCRIPTION
Adds a very simple REST extension, which should show how an extension could look like. Notable things:

```rust
#[derive(grafbase_sdk::ResolverExtension)]
struct MyExtension;
```

This will generate the needed initialization code, and fail because the struct needs to implement the `Extension` and `Resolver` traits. The user implements these traits, the code compiles and should be ready to use in the gateway.