### PR TITLE
chore(extension): Initial manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2526,6 +2526,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "extension"
+version = "0.0.0"
+dependencies = [
+ "grafbase-workspace-hack",
+ "semver",
+ "serde",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ wiremock = "0.6.0"
 wit-bindgen = "0.38.0"
 fnv = "1.0.7"
 sha2 = "0.10.8"
+semver = "1"
 
 # Serde
 serde = { version = "1.0.199", features = ["derive"] }

--- a/crates/extension/Cargo.toml
+++ b/crates/extension/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license = "MPL-2.0"
+name = "extension"
+repository.workspace = true
+
+[lints]
+workspace = true
+
+
+[dependencies]
+semver = { workspace = true, features = ["serde"] }
+grafbase-workspace-hack.workspace = true
+serde.workspace = true

--- a/crates/extension/src/id.rs
+++ b/crates/extension/src/id.rs
@@ -1,0 +1,74 @@
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Id {
+    /// From where was this extension manifest retrieved? For example:
+    /// - URL: https://grafbase.com/extensions
+    /// - Local directory: file:///home/x/my-extension/build
+    pub origin: String,
+    pub name: String,
+    pub version: semver::Version,
+}
+
+impl Id {
+    /// After loading extensions as defined in the Gateway configuration, we need to identify which
+    /// one of those matches which directives in the federated GraphQL schema. So here `Self` is
+    /// the extension loaded by the Gateway and `expected` the one defined in the SDL.
+    pub fn is_compatible_with(&self, expected: &Id) -> bool {
+        if self.origin != expected.origin || self.name != expected.name {
+            return false;
+        }
+        let expected_version = semver::Comparator {
+            op: semver::Op::Caret,
+            major: expected.version.major,
+            minor: Some(expected.version.minor),
+            patch: Some(expected.version.patch),
+            pre: Default::default(),
+        };
+        expected_version.matches(&self.version)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_is_compatible_with() {
+        let expected = Id {
+            origin: "https://grafbase.com/extensions".to_string(),
+            name: "my-extension".to_string(),
+            version: semver::Version::parse("1.0.0").unwrap(),
+        };
+        let id = expected.clone();
+        assert!(id.is_compatible_with(&expected));
+
+        let id = Id {
+            version: semver::Version::parse("1.1.0").unwrap(),
+            ..expected.clone()
+        };
+        assert!(id.is_compatible_with(&expected));
+
+        let id = Id {
+            version: semver::Version::parse("1.0.1").unwrap(),
+            ..expected.clone()
+        };
+        assert!(id.is_compatible_with(&expected));
+
+        let id = Id {
+            version: semver::Version::parse("2.0.0").unwrap(),
+            ..expected.clone()
+        };
+        assert!(!id.is_compatible_with(&expected));
+
+        let id = Id {
+            origin: "file:///home/x/my-extension/build".to_string(),
+            ..expected.clone()
+        };
+        assert!(!id.is_compatible_with(&expected));
+
+        let id = Id {
+            name: "another-extension".to_string(),
+            ..expected.clone()
+        };
+        assert!(!id.is_compatible_with(&expected));
+    }
+}

--- a/crates/extension/src/lib.rs
+++ b/crates/extension/src/lib.rs
@@ -1,0 +1,5 @@
+mod id;
+mod manifest;
+
+pub use id::*;
+pub use manifest::*;

--- a/crates/extension/src/manifest/mod.rs
+++ b/crates/extension/src/manifest/mod.rs
@@ -1,0 +1,19 @@
+mod v1;
+
+// importing latest version of the manifest.
+pub use v1::*;
+
+/// Suitable for long-term storage as backwards-compatibility will be maintained.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "version", rename_all = "lowercase")]
+pub enum VersionedManifest {
+    V1(v1::Manifest),
+}
+
+impl VersionedManifest {
+    pub fn into_latest(self) -> Manifest {
+        match self {
+            VersionedManifest::V1(v1) => v1,
+        }
+    }
+}

--- a/crates/extension/src/manifest/v1.rs
+++ b/crates/extension/src/manifest/v1.rs
@@ -1,0 +1,16 @@
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Manifest {
+    pub name: String,
+    pub version: semver::Version,
+    pub kind: Kind,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum Kind {
+    FieldResolver(FieldResolver),
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FieldResolver {
+    resolver_directives: Vec<String>,
+}


### PR DESCRIPTION
Defining the extension id which includes three core components:

- the name & version, coming from the manifest
- the origin of the manifest: This one will likely require further
  processing later. But the idea is to distinguish a local extension
  developed locally from one in our registry or a self-hosted one.

The federated SDL will associate every extension directive with a
relevant extension id. Every extension loaded by the gateway will also
have an id. The engine will then match those to find the relevant Wasm
to run for each directives if relevant.
