### PR TITLE
graphql-composition: compose descriptions of field arguments

### DIFF
--- a/crates/graphql-composition/CHANGELOG.md
+++ b/crates/graphql-composition/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Implemented the rule that any directive composed with `@composeDirective` must have the same definition in all subgraphs. (https://github.com/grafbase/grafbase/pull/2532)
 
+### Fixes
+
+- Descriptions of field arguments was not implemented. They are now properly included in the federated graph. (https://github.com/grafbase/grafbase/pull/2544)
+
 ## 0.5.0 - 2025-01-06
 
 ### Features

--- a/crates/graphql-composition/src/compose/object.rs
+++ b/crates/graphql-composition/src/compose/object.rs
@@ -83,12 +83,17 @@ pub(super) fn merge_field_arguments<'a>(
             ));
         }
 
+        let description = arguments
+            .iter()
+            .find_map(|(_, arg)| arg.description())
+            .map(|description| ctx.insert_string(description.id));
+
         let name = ctx.insert_string(argument_name);
         let id = ctx.insert_input_value_definition(ir::InputValueDefinitionIr {
             name,
             r#type: argument_type,
             directives,
-            description: None,
+            description,
             default,
         });
 

--- a/crates/graphql-composition/src/subgraphs/fields.rs
+++ b/crates/graphql-composition/src/subgraphs/fields.rs
@@ -263,4 +263,10 @@ impl<'a> FieldArgumentWalker<'a> {
     pub(crate) fn default(&self) -> Option<&'a Value> {
         self.subgraphs.fields.field_argument_defaults.get(&self.id.0)
     }
+
+    pub(crate) fn description(&self) -> Option<StringWalker<'a>> {
+        let (_, tuple) = self.id;
+        let description = tuple.description?;
+        Some(self.walk(description))
+    }
 }

--- a/crates/graphql-composition/tests/composition/descriptions_basic/federated.graphql
+++ b/crates/graphql-composition/tests/composition/descriptions_basic/federated.graphql
@@ -54,7 +54,7 @@ type Tofu
     """
     List of recipes that include this tofu.
     """
-    recipes(filter: RecipeFilter): [Recipe]
+    recipes("Which recipes to include. See [RecipeFilter]." filter: RecipeFilter): [Recipe]
     """
     The texture profile of the tofu, expressed through a custom scalar.
     """

--- a/crates/graphql-composition/tests/composition/descriptions_basic/subgraphs/selfExplanatoryTofu.graphql
+++ b/crates/graphql-composition/tests/composition/descriptions_basic/subgraphs/selfExplanatoryTofu.graphql
@@ -3,7 +3,12 @@ type Tofu @shareable {
   name: String!
   type: TofuType
   nutrition: Nutrition
-  recipes(filter: RecipeFilter): [Recipe]
+  recipes(
+    """
+    Which recipes to include. See [RecipeFilter].
+    """
+    filter: RecipeFilter
+  ): [Recipe]
   texture: TextureProfile
 }
 

--- a/crates/graphql-federated-graph/src/render_sdl/render_federated_sdl.rs
+++ b/crates/graphql-federated-graph/src/render_sdl/render_federated_sdl.rs
@@ -426,12 +426,21 @@ fn render_field_arguments(args: &[InputValueDefinition], graph: &FederatedGraph)
                 let r#type = render_field_type(&arg.r#type, graph);
                 let directives = &arg.directives;
                 let default = arg.default.as_ref();
-                (name, r#type, directives, default)
+                let description = arg.description;
+                (name, r#type, directives, default, description)
             })
             .peekable();
         let mut out = String::from('(');
 
-        while let Some((name, ty, directives, default)) = inner.next() {
+        while let Some((name, ty, directives, default, description)) = inner.next() {
+            if let Some(description) = description {
+                with_formatter(&mut out, |f| {
+                    display_graphql_string_literal(&graph[description], f)?;
+                    f.write_str(" ")
+                })
+                .unwrap();
+            }
+
             out.push_str(name);
             out.push_str(": ");
             out.push_str(&ty);


### PR DESCRIPTION
This was an omission. The composition rule is the same as for other descriptions: take the first non-null description we encounter.

closes GB-8353