### PR TITLE
graphql-federated-graph: add forgotten description rendering in render_api_sdl()

### DIFF
--- a/crates/graphql-composition/tests/composition/descriptions_basic/api.graphql
+++ b/crates/graphql-composition/tests/composition/descriptions_basic/api.graphql
@@ -26,7 +26,7 @@ type Tofu {
     """
     List of recipes that include this tofu.
     """
-    recipes(filter: RecipeFilter): [Recipe]
+    recipes("Which recipes to include. See [RecipeFilter]." filter: RecipeFilter): [Recipe]
     """
     The texture profile of the tofu, expressed through a custom scalar.
     """

--- a/crates/graphql-federated-graph/src/render_sdl/render_api_sdl.rs
+++ b/crates/graphql-federated-graph/src/render_sdl/render_api_sdl.rs
@@ -290,13 +290,19 @@ fn write_field_arguments<'a, 'b: 'a>(
             let r#type = render_field_type(&arg.r#type, graph);
             let directives = &arg.directives;
             let default = arg.default.as_ref();
-            (name, r#type, directives, default)
+            let description = arg.description;
+            (name, r#type, directives, default, description)
         })
         .peekable();
 
     f.write_str("(")?;
 
-    while let Some((name, ty, directives, default)) = inner.next() {
+    while let Some((name, ty, directives, default, description)) = inner.next() {
+        if let Some(description) = description {
+            display_graphql_string_literal(&graph[description], f)?;
+            f.write_str(" ")?;
+        }
+
         f.write_str(name)?;
         f.write_str(": ")?;
         f.write_str(&ty)?;


### PR DESCRIPTION
Missed this function in https://github.com/grafbase/grafbase/pull/2544