### PR TITLE
add resources for gateway

### DIFF
--- a/gateway/helm/Chart.yaml
+++ b/gateway/helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: gateway
 description: A Helm chart for the Grafbase Gateway
 type: application
-version: 0.1.0
+version: 0.2.0

--- a/gateway/helm/values.yaml
+++ b/gateway/helm/values.yaml
@@ -95,7 +95,7 @@ resources:
     cpu: 4
     memory: 1Gi
   limits:
-    cpu: 4
+    cpu: 10
     memory: 2Gi
 
 # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/gateway/helm/values.yaml
+++ b/gateway/helm/values.yaml
@@ -90,7 +90,13 @@ ingress:
 
 # Resource requests and limits for the Grafbase gateway containers.
 # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-resources: {}
+resources:
+  requests:
+    cpu: 4
+    memory: 1Gi
+  limits:
+    cpu: 4
+    memory: 2Gi
 
 # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 autoscaling:
@@ -98,13 +104,13 @@ autoscaling:
   enabled: true
 
   # Minimum number of replicas.
-  minReplicas: 1
+  minReplicas: 2
 
   # Maximum number of replicas.
-  maxReplicas: 2
+  maxReplicas: 20
 
   # Target CPU utilization for scaling.
-  targetCPUUtilizationPercentage: 50
+  targetCPUUtilizationPercentage: 70
 
 # Node selector for pod scheduling.
 # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector


### PR DESCRIPTION
HPA works based on pod resources.
This PR adds resources for the gateway deployment.

Values for resources where taken from [this](https://app.datadoghq.com/dashboard/svn-yjm-8zc/cf--grafbase-prod?fromUser=true&refresh_mode=sliding&tpl_var_deployment%5B0%5D=gateway&from_ts=1737581399819&to_ts=1738186199819&live=true) dashboard:
- with 4 cores and 70% HPA, it looks like most of the time it will only need 1 pod (with the caveat from the next change).

This also increases the number of min pods to 2, so that the gateway availability is not dependent on one single point of failure.