### PR TITLE
feat: generate extension catalog, generate the wasi loader on gateway launch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2681,6 +2681,7 @@ dependencies = [
  "engine",
  "engine-axum",
  "engine-config-builder",
+ "extension-catalog",
  "futures-lite 2.6.0",
  "gateway-config",
  "grafbase-telemetry",
@@ -2696,6 +2697,7 @@ dependencies = [
  "runtime-local",
  "runtime-noop",
  "serde",
+ "serde_json",
  "thiserror 2.0.11",
  "tokio",
  "tokio-stream",
@@ -3021,6 +3023,7 @@ dependencies = [
  "indoc",
  "insta",
  "regex",
+ "semver",
  "serde",
  "serde-dynamic-string",
  "serde_regex",
@@ -3309,7 +3312,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "grafbase-sdk-derive",
  "http 1.2.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6937,6 +6937,7 @@ dependencies = [
  "reqwest 0.12.12",
  "reqwest-eventsource",
  "runtime",
+ "semver",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3209,6 +3209,7 @@ dependencies = [
  "serde-toml-merge",
  "serde_derive",
  "serde_json",
+ "serde_valid",
  "sha2",
  "slugify",
  "strum",
@@ -6152,6 +6153,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7330,6 +7352,51 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_valid"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b615bed66931a7a9809b273937adc8a402d038b1e509d027fcaf62f084d33d1"
+dependencies = [
+ "indexmap 2.7.0",
+ "itertools 0.13.0",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_valid_derive",
+ "serde_valid_literal",
+ "thiserror 1.0.69",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "serde_valid_derive"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa1a5a21ea5aab06d2e6a6b59837d450fb2be9695be97735a711edfbe79ea07"
+dependencies = [
+ "itertools 0.13.0",
+ "paste",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "serde_valid_literal"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd07331596ea967dccf9a35bde71ecd757490e09827b938a5c6226c648e3a25e"
+dependencies = [
+ "paste",
+ "regex",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -79,6 +79,7 @@ semver.workspace = true
 wasmparser = "0.224.0"
 extension.workspace = true
 cynic-parser = { workspace = true, features = ["report"] }
+serde_valid = "1.0.5"
 
 [dev-dependencies]
 async-graphql-axum.workspace = true

--- a/cli/tests/extension/mod.rs
+++ b/cli/tests/extension/mod.rs
@@ -26,7 +26,7 @@ fn init() {
     license = "Apache-2.0"
 
     [dependencies]
-    grafbase-sdk = "0.1.2"
+    grafbase-sdk = "0.1.3"
 
     [lib]
     crate-type = ["cdylib"]

--- a/crates/engine/schema/src/lib.rs
+++ b/crates/engine/schema/src/lib.rs
@@ -272,6 +272,7 @@ impl Schema {
             let id = VirtualSubgraphId::from(i);
             Subgraph::from(id.walk(self))
         });
+
         self.graphql_endpoints()
             .map(Into::into)
             .chain(virt)

--- a/crates/engine/schema/src/lib.rs
+++ b/crates/engine/schema/src/lib.rs
@@ -268,7 +268,7 @@ impl Schema {
     }
 
     pub fn subgraphs(&self) -> impl Iterator<Item = Subgraph<'_>> + '_ {
-        let virt = (0..self.subgraphs.graphql_endpoints.len()).map(move |i| {
+        let virt = (0..self.subgraphs.virtual_subgraphs.len()).map(move |i| {
             let id = VirtualSubgraphId::from(i);
             Subgraph::from(id.walk(self))
         });

--- a/crates/extension-catalog/src/catalog.rs
+++ b/crates/extension-catalog/src/catalog.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 pub use extension::*;
 
 #[derive(Clone, Copy, PartialEq, Hash, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, id_derives::Id)]
@@ -12,7 +14,7 @@ pub struct ExtensionCatalog {
 pub struct Extension {
     pub id: Id,
     pub manifest: Manifest,
-    pub wasm: Vec<u8>,
+    pub wasm_path: PathBuf,
 }
 
 #[derive(Default)]
@@ -52,5 +54,18 @@ impl ExtensionCatalog {
     pub fn push(&mut self, extension: Extension) -> ExtensionId {
         self.extensions.push(extension);
         (self.extensions.len() - 1).into()
+    }
+
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &Extension> {
+        self.extensions.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.extensions.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 }

--- a/crates/extension-catalog/src/catalog.rs
+++ b/crates/extension-catalog/src/catalog.rs
@@ -5,12 +5,13 @@ pub use extension::*;
 #[derive(Clone, Copy, PartialEq, Hash, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, id_derives::Id)]
 pub struct ExtensionId(u16);
 
-#[derive(Default, id_derives::IndexedFields)]
+#[derive(Debug, Default, id_derives::IndexedFields)]
 pub struct ExtensionCatalog {
     #[indexed_by(ExtensionId)]
     extensions: Vec<Extension>,
 }
 
+#[derive(Debug)]
 pub struct Extension {
     pub id: Id,
     pub manifest: Manifest,

--- a/crates/federated-server/Cargo.toml
+++ b/crates/federated-server/Cargo.toml
@@ -51,3 +51,5 @@ notify = "8.0.0"
 tower = { workspace = true, optional = true }
 lambda_http = { workspace = true, optional = true }
 either = "1.13.0"
+extension-catalog.workspace = true
+serde_json.workspace = true

--- a/crates/federated-server/src/server/engine_reloader.rs
+++ b/crates/federated-server/src/server/engine_reloader.rs
@@ -2,7 +2,7 @@ use std::{path::PathBuf, sync::Arc};
 
 use engine::{CachedOperation, Engine};
 use futures_lite::{pin, StreamExt};
-use runtime_local::wasi::{extensions::WasiExtensions, hooks::HooksWasi};
+use runtime_local::wasi::hooks::{ChannelLogSender, HooksWasi};
 use tokio::{
     sync::{mpsc, watch},
     task::JoinHandle,
@@ -39,12 +39,12 @@ impl EngineReloader {
         // functionality into gateway_config above at some point...
         hot_reload_config_path: Option<PathBuf>,
         hooks: HooksWasi,
-        extensions: WasiExtensions,
+        access_log: ChannelLogSender,
     ) -> crate::Result<Self> {
         let context = Context {
             hot_reload_config_path,
             hooks,
-            extensions,
+            access_log,
         };
 
         tracing::debug!("Waiting for a graph...");
@@ -87,7 +87,7 @@ impl EngineReloader {
 struct Context {
     hot_reload_config_path: Option<PathBuf>,
     hooks: HooksWasi,
-    extensions: WasiExtensions,
+    access_log: ChannelLogSender,
 }
 
 async fn update_loop(
@@ -146,7 +146,7 @@ async fn build_new_engine(
         &config,
         context.hot_reload_config_path,
         context.hooks,
-        context.extensions,
+        context.access_log,
     )
     .await?;
 

--- a/crates/federated-server/src/server/gateway/gateway_runtime.rs
+++ b/crates/federated-server/src/server/gateway/gateway_runtime.rs
@@ -23,7 +23,7 @@ pub struct GatewayRuntime {
     kv: runtime::kv::KvStore,
     metrics: EngineMetrics,
     hooks: HooksWasi,
-    extensions: WasiExtensions,
+    pub(crate) extensions: WasiExtensions,
     rate_limiter: runtime::rate_limiting::RateLimiter,
     entity_cache: Box<dyn EntityCache>,
     pub(crate) operation_cache: TieredOperationCache<Arc<CachedOperation>>,

--- a/crates/gateway-config/Cargo.toml
+++ b/crates/gateway-config/Cargo.toml
@@ -28,6 +28,7 @@ tower-http = { workspace = true, features = ["cors", "timeout"] }
 url = { workspace = true, features = ["serde"] }
 cfg-if = "1.0.0"
 grafbase-workspace-hack.workspace = true
+semver = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 indoc.workspace = true

--- a/crates/gateway-config/src/extensions.rs
+++ b/crates/gateway-config/src/extensions.rs
@@ -11,6 +11,7 @@ pub enum ExtensionsConfig {
 
 #[derive(PartialEq, serde::Deserialize, Debug, Clone)]
 pub struct StructuredExtensionsConfig {
+    #[serde(default = "default_version")]
     pub version: VersionReq,
     #[serde(default)]
     pub path: Option<PathBuf>,
@@ -24,6 +25,10 @@ pub struct StructuredExtensionsConfig {
     pub environment_variables: bool,
     #[serde(default)]
     pub max_pool_size: Option<usize>,
+}
+
+fn default_version() -> VersionReq {
+    VersionReq::parse("*").unwrap()
 }
 
 #[derive(Debug, Clone)]

--- a/crates/gateway-config/src/extensions.rs
+++ b/crates/gateway-config/src/extensions.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use semver::VersionReq;
 
@@ -12,10 +12,17 @@ pub enum ExtensionsConfig {
 #[derive(PartialEq, serde::Deserialize, Debug, Clone)]
 pub struct StructuredExtensionsConfig {
     pub version: VersionReq,
+    #[serde(default)]
+    pub path: Option<PathBuf>,
+    #[serde(default)]
     pub networking: bool,
+    #[serde(default)]
     pub stdout: bool,
+    #[serde(default)]
     pub stderr: bool,
+    #[serde(default)]
     pub environment_variables: bool,
+    #[serde(default)]
     pub max_pool_size: Option<usize>,
 }
 
@@ -68,6 +75,13 @@ impl ExtensionsConfig {
         match self {
             ExtensionsConfig::Version(_) => None,
             ExtensionsConfig::Structured(config) => config.max_pool_size,
+        }
+    }
+
+    pub fn path(&self) -> Option<&Path> {
+        match self {
+            ExtensionsConfig::Version(_) => None,
+            ExtensionsConfig::Structured(config) => config.path.as_deref(),
         }
     }
 }

--- a/crates/gateway-config/src/lib.rs
+++ b/crates/gateway-config/src/lib.rs
@@ -2115,7 +2115,19 @@ mod tests {
         Some(
             {
                 "rest": Version(
-                    "0.1",
+                    VersionReq {
+                        comparators: [
+                            Comparator {
+                                op: Caret,
+                                major: 0,
+                                minor: Some(
+                                    1,
+                                ),
+                                patch: None,
+                                pre: Prerelease(""),
+                            },
+                        ],
+                    },
                 ),
             },
         )
@@ -2126,7 +2138,7 @@ mod tests {
     fn extension_structured() {
         let input = indoc! {r#"
             [extensions.rest]
-            version = "0.1"
+            version = "0.1.0"
             networking = false
             stdout = false
             stderr = false
@@ -2141,12 +2153,28 @@ mod tests {
             {
                 "rest": Structured(
                     StructuredExtensionsConfig {
-                        version: "0.1",
+                        version: VersionReq {
+                            comparators: [
+                                Comparator {
+                                    op: Caret,
+                                    major: 0,
+                                    minor: Some(
+                                        1,
+                                    ),
+                                    patch: Some(
+                                        0,
+                                    ),
+                                    pre: Prerelease(""),
+                                },
+                            ],
+                        },
                         networking: false,
                         stdout: false,
                         stderr: false,
                         environment_variables: false,
-                        max_pool_size: 1000,
+                        max_pool_size: Some(
+                            1000,
+                        ),
                     },
                 ),
             },

--- a/crates/gateway-config/src/lib.rs
+++ b/crates/gateway-config/src/lib.rs
@@ -2168,6 +2168,7 @@ mod tests {
                                 },
                             ],
                         },
+                        path: None,
                         networking: false,
                         stdout: false,
                         stderr: false,

--- a/crates/grafbase-sdk/Cargo.toml
+++ b/crates/grafbase-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-sdk"
-version = "0.1.2"
+version = "0.1.3"
 description = "An SDK to implement extensions for the Grafbase Gateway"
 edition.workspace = true
 license.workspace = true

--- a/crates/grafbase-sdk/src/types.rs
+++ b/crates/grafbase-sdk/src/types.rs
@@ -13,6 +13,11 @@ impl Directive {
         &self.0.name
     }
 
+    /// The name of the subgraph this directive is part of.
+    pub fn subgraph_name(&self) -> &str {
+        &self.0.subgraph_name
+    }
+
     /// The directive arguments. The output is a Serde structure, that must map to
     /// the arguments of the directive.
     ///

--- a/crates/grafbase-sdk/wit/world.wit
+++ b/crates/grafbase-sdk/wit/world.wit
@@ -3,6 +3,7 @@ package component:grafbase-sdk;
 world sdk {
     record directive {
         name: string,
+        subgraph-name: string,
         // serialized in CBOR
         arguments: list<u8>
     }

--- a/crates/integration-tests/src/federation/runtime/extension.rs
+++ b/crates/integration-tests/src/federation/runtime/extension.rs
@@ -1,4 +1,4 @@
-use engine_schema::SubgraphId;
+use engine_schema::Subgraph;
 use extension_catalog::{Extension, ExtensionCatalog, ExtensionId, Id};
 use runtime::{
     error::PartialGraphqlError,
@@ -37,7 +37,7 @@ impl TestExtensions {
                 minimum_gateway_version: "0.0.0".parse().unwrap(),
                 sdl: None,
             },
-            wasm: Vec::new(),
+            wasm_path: Default::default(),
         });
         self.field_resolvers.push(FieldResolver {
             id,
@@ -68,7 +68,7 @@ impl runtime::extension::ExtensionRuntime for TestExtensions {
     async fn resolve_field<'a>(
         &self,
         extension_id: ExtensionId,
-        _subgraph_id: SubgraphId,
+        _subgraph: Subgraph<'a>,
         context: &Self::SharedContext,
         field: EdgeDefinition<'a>,
         directive: ExtensionDirective<'a, impl Anything<'a>>,

--- a/crates/runtime-local/Cargo.toml
+++ b/crates/runtime-local/Cargo.toml
@@ -57,3 +57,4 @@ grafbase-telemetry.workspace = true
 anyhow.workspace = true
 grafbase-workspace-hack.workspace = true
 enumflags2 = "0.7.10"
+semver.workspace = true

--- a/crates/runtime-local/src/wasi/extensions.rs
+++ b/crates/runtime-local/src/wasi/extensions.rs
@@ -8,6 +8,7 @@ use runtime::{
     extension::{Data, ExtensionDirective, ExtensionRuntime},
     hooks::{Anything, EdgeDefinition},
 };
+use semver::Version;
 use std::{collections::HashMap, sync::Arc};
 use wasi_component_loader::{ChannelLogSender, ComponentLoader, FieldDefinition, SharedContext};
 pub use wasi_component_loader::{Directive, ExtensionType};
@@ -35,6 +36,8 @@ impl WasiExtensions {
                 extension_type: config.extension_type,
                 schema_directives: config.schema_directives,
             };
+
+            tracing::info!("Loading extension {} {}", config.name, config.version);
 
             let Some(loader) = ComponentLoader::extensions(config.name, config.wasi_config)? else {
                 continue;
@@ -124,6 +127,7 @@ struct WasiExtensionsInner {
 pub struct ExtensionConfig {
     pub id: ExtensionId,
     pub name: String,
+    pub version: Version,
     pub extension_type: ExtensionType,
     pub schema_directives: Vec<Directive>,
     pub max_pool_size: Option<usize>,

--- a/crates/runtime/src/extension.rs
+++ b/crates/runtime/src/extension.rs
@@ -1,4 +1,4 @@
-use engine_schema::SubgraphId;
+use engine_schema::Subgraph;
 use extension_catalog::ExtensionId;
 
 use crate::{
@@ -23,7 +23,7 @@ pub trait ExtensionRuntime: Send + Sync + 'static {
     async fn resolve_field<'a>(
         &self,
         extension_id: ExtensionId,
-        subgraph_id: SubgraphId,
+        subgraph: Subgraph<'a>,
         context: &Self::SharedContext,
         field: EdgeDefinition<'a>,
         directive: ExtensionDirective<'a, impl Anything<'a>>,
@@ -37,7 +37,7 @@ impl ExtensionRuntime for () {
     async fn resolve_field<'a>(
         &self,
         _extension_id: ExtensionId,
-        _subgraph_id: SubgraphId,
+        _subgraph: Subgraph<'a>,
         _context: &Self::SharedContext,
         _field: EdgeDefinition<'a>,
         _directive: ExtensionDirective<'a, impl Anything<'a>>,

--- a/crates/wasi-component-loader/examples/Cargo.lock
+++ b/crates/wasi-component-loader/examples/Cargo.lock
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "grafbase-sdk-derive",
  "http",

--- a/crates/wasi-component-loader/src/instance/extensions/types.rs
+++ b/crates/wasi-component-loader/src/instance/extensions/types.rs
@@ -17,15 +17,20 @@ pub enum ExtensionType {
 #[derive(Debug, Clone, Lower, ComponentType)]
 #[component(record)]
 pub struct Directive {
+    #[component(name = "name")]
     name: String,
+    #[component(name = "subgraph-name")]
+    subgraph_name: String,
+    #[component(name = "arguments")]
     arguments: Vec<u8>,
 }
 
 impl Directive {
     /// Creates a new directive with the specified name and arguments.
-    pub fn new<S: serde::Serialize>(name: String, arguments: &S) -> Self {
+    pub fn new<S: serde::Serialize>(name: String, subgraph_name: String, arguments: &S) -> Self {
         Self {
             name,
+            subgraph_name,
             arguments: minicbor_serde::to_vec(arguments).unwrap(),
         }
     }

--- a/crates/wasi-component-loader/src/tests/extensions.rs
+++ b/crates/wasi-component-loader/src/tests/extensions.rs
@@ -25,14 +25,13 @@ async fn simple_resolver() {
         stdout: false,
         stderr: false,
         environment_variables: false,
-        max_pool_size: None,
     };
 
     assert!(config.location.exists());
 
     let (access_log, _) = create_log_channel();
     let loader = ComponentLoader::extensions(String::new(), config).unwrap().unwrap();
-    let schema_directive = Directive::new("schemaArgs".into(), &SchemaArgs { id: 10 });
+    let schema_directive = Directive::new("schemaArgs".into(), "mySubgraph".into(), &SchemaArgs { id: 10 });
 
     let mut extension =
         ExtensionsComponentInstance::new(&loader, ExtensionType::Resolver, vec![schema_directive], access_log)
@@ -41,7 +40,7 @@ async fn simple_resolver() {
 
     let context = SharedContext::new(Arc::new(HashMap::new()), TraceId::INVALID);
 
-    let field_directive = Directive::new("myDirective".into(), &FieldArgs { name: "cat" });
+    let field_directive = Directive::new("myDirective".into(), "mySubgraph".into(), &FieldArgs { name: "cat" });
 
     let definition = FieldDefinition {
         type_name: "Query".into(),

--- a/extensions/rest/.gitignore
+++ b/extensions/rest/.gitignore
@@ -1,0 +1,2 @@
+build
+target

--- a/extensions/rest/Cargo.lock
+++ b/extensions/rest/Cargo.lock
@@ -206,7 +206,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "grafbase-sdk-derive",
  "http",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "rest"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "grafbase-sdk",
  "http",

--- a/extensions/rest/Cargo.toml
+++ b/extensions/rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rest"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MPL-2"
 homepage = "https://grafbase.com"

--- a/extensions/rest/extension.toml
+++ b/extensions/rest/extension.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "rest"
-version = "0.1.0"
+version = "0.1.1"
 kind = "resolver"
 
 [directives]


### PR DESCRIPTION
I need some schema to test this with. With just a random schema the gateway crashes with:

```
[crates/engine/schema/src/generated/subgraph/virtual_.rs:53:10] &self.schema = Schema { .. }
thread 'main' panicked at crates/engine/schema/src/generated/subgraph/virtual_.rs:53:28:
index out of bounds: the len is 0 but the index is 0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```