### PR TITLE
gateway: config option for subscription transport to subgraphs

### DIFF
--- a/crates/engine-config-builder/src/from_toml_config/context.rs
+++ b/crates/engine-config-builder/src/from_toml_config/context.rs
@@ -54,6 +54,7 @@ impl<'a> BuildContext<'a> {
                 rate_limit,
                 timeout,
                 entity_caching,
+                subscriptions_protocol,
                 ..
             } = config;
 
@@ -88,6 +89,7 @@ impl<'a> BuildContext<'a> {
                     url: url.clone(),
                     headers,
                     websocket_url,
+                    subscriptions_protocol: *subscriptions_protocol,
                     rate_limit,
                     timeout: *timeout,
                     retry,

--- a/crates/engine/codegen/domain/schema.graphql
+++ b/crates/engine/codegen/domain/schema.graphql
@@ -245,6 +245,7 @@ type ExtensionDirective @meta(module: "directive/extension") @indexed(id_size: "
 # -------------
 
 scalar SubgraphConfig
+scalar SubscriptionsProtocol @copy
 
 union Subgraph @id @meta(module: "subgraph") @variants(empty: ["Introspection"], remove_suffix: "Subgraph") =
   | GraphqlEndpoint
@@ -258,6 +259,8 @@ type GraphqlEndpoint @meta(module: "subgraph/graphql") @indexed(id_size: "u16") 
   config: SubgraphConfig!
   "Schema directives applied by the given subgraph"
   schema_directives: [TypeSystemDirective!]!
+  "The protocol to use for subscriptions from this subgraph"
+  subscriptions_protocol: SubscriptionsProtocol!
 }
 
 "Virtual subgraphs have no dedicated support on the engine side, everything is resolved through extensions."

--- a/crates/engine/config/src/subgraph.rs
+++ b/crates/engine/config/src/subgraph.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use federated_graph::StringId;
+use gateway_config::SubscriptionsProtocol;
 use url::Url;
 
 use crate::{EntityCaching, GraphRateLimit, HeaderRuleId, RetryConfig};
@@ -11,6 +12,7 @@ pub struct SubgraphConfig {
     pub name: StringId,
     pub url: Option<Url>,
     pub websocket_url: Option<StringId>,
+    pub subscriptions_protocol: Option<SubscriptionsProtocol>,
     pub headers: Vec<HeaderRuleId>,
     #[serde(default)]
     pub rate_limit: Option<GraphRateLimit>,

--- a/crates/engine/schema/src/generated/subgraph/graphql.rs
+++ b/crates/engine/schema/src/generated/subgraph/graphql.rs
@@ -6,7 +6,7 @@
 use crate::{
     generated::{HeaderRule, HeaderRuleId, TypeSystemDirective, TypeSystemDirectiveId},
     prelude::*,
-    StringId, SubgraphConfig, UrlId,
+    StringId, SubgraphConfig, SubscriptionsProtocol, UrlId,
 };
 use walker::{Iter, Walk};
 
@@ -21,6 +21,8 @@ use walker::{Iter, Walk};
 ///   config: SubgraphConfig!
 ///   "Schema directives applied by the given subgraph"
 ///   schema_directives: [TypeSystemDirective!]!
+///   "The protocol to use for subscriptions from this subgraph"
+///   subscriptions_protocol: SubscriptionsProtocol!
 /// }
 /// ```
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -32,6 +34,8 @@ pub struct GraphqlEndpointRecord {
     pub config: SubgraphConfig,
     /// Schema directives applied by the given subgraph
     pub schema_directive_ids: Vec<TypeSystemDirectiveId>,
+    /// The protocol to use for subscriptions from this subgraph
+    pub subscriptions_protocol: SubscriptionsProtocol,
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
@@ -100,6 +104,7 @@ impl std::fmt::Debug for GraphqlEndpoint<'_> {
             .field("header_rules", &self.header_rules())
             .field("config", &self.config)
             .field("schema_directives", &self.schema_directives())
+            .field("subscriptions_protocol", &self.subscriptions_protocol)
             .finish()
     }
 }

--- a/crates/engine/schema/src/lib.rs
+++ b/crates/engine/schema/src/lib.rs
@@ -29,6 +29,7 @@ use config::ResponseExtensionConfig;
 pub use directive::*;
 use extension_catalog::ExtensionCatalog;
 pub use field_set::*;
+pub use gateway_config::SubscriptionsProtocol;
 pub use generated::*;
 use id_newtypes::{BitSet, IdRange};
 pub use ids::*;

--- a/crates/gateway-config/src/lib.rs
+++ b/crates/gateway-config/src/lib.rs
@@ -15,14 +15,17 @@ pub mod message_signatures;
 pub mod operation_caching;
 pub mod rate_limit;
 mod size_ext;
+mod subscriptions_protocol;
 pub mod telemetry;
 mod trusted_documents;
 mod websockets_config;
 
 use std::{collections::BTreeMap, net::SocketAddr, path::PathBuf, time::Duration};
 
-pub use self::websockets_config::WebsocketsConfig;
-pub use self::{log_level::*, trusted_documents::*};
+pub use self::{
+    log_level::*, subscriptions_protocol::SubscriptionsProtocol, trusted_documents::*,
+    websockets_config::WebsocketsConfig,
+};
 pub use authentication::*;
 pub use complexity_control::*;
 pub use cors::*;
@@ -222,6 +225,8 @@ pub struct SubgraphConfig {
     pub introspection_url: Option<Url>,
     /// Header configuration for subgraph introspection (dev only).
     pub introspection_headers: Option<BTreeMap<String, DynamicString<String>>>,
+    /// The protocol used for subscriptions
+    pub subscriptions_protocol: Option<SubscriptionsProtocol>,
 }
 
 #[derive(Debug, serde::Deserialize, Clone, Copy, Default, PartialEq)]
@@ -1437,7 +1442,7 @@ mod tests {
 
         let result: Config = toml::from_str(input).unwrap();
 
-        insta::assert_debug_snapshot!(&result.subgraphs, @r###"
+        insta::assert_debug_snapshot!(&result.subgraphs, @r#"
         {
             "products": SubgraphConfig {
                 url: None,
@@ -1463,9 +1468,10 @@ mod tests {
                 schema_path: None,
                 introspection_url: None,
                 introspection_headers: None,
+                subscriptions_protocol: None,
             },
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -1903,7 +1909,7 @@ mod tests {
 
         let config: Config = toml::from_str(input).unwrap();
 
-        insta::assert_debug_snapshot!(&config.subgraphs, @r###"
+        insta::assert_debug_snapshot!(&config.subgraphs, @r#"
         {
             "products": SubgraphConfig {
                 url: None,
@@ -1925,9 +1931,10 @@ mod tests {
                 schema_path: None,
                 introspection_url: None,
                 introspection_headers: None,
+                subscriptions_protocol: None,
             },
         }
-        "###);
+        "#);
     }
 
     #[test]

--- a/crates/gateway-config/src/subscriptions_protocol.rs
+++ b/crates/gateway-config/src/subscriptions_protocol.rs
@@ -1,0 +1,38 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, PartialEq, Eq, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubscriptionsProtocol {
+    ServerSentEvents,
+    Websocket,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Deserialize, PartialEq, Eq)]
+    struct TestStruct {
+        subscriptions_protocol: SubscriptionsProtocol,
+    }
+
+    impl TestStruct {
+        fn new(subscriptions_protocol: SubscriptionsProtocol) -> Self {
+            Self { subscriptions_protocol }
+        }
+    }
+
+    #[test]
+    fn subscriptions_protocol_deserialize_sse() {
+        let expected = TestStruct::new(SubscriptionsProtocol::ServerSentEvents);
+        let actual = toml::from_str(r#"subscriptions_protocol = "server_sent_events""#).unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn subscriptions_protocol_deserialize_websockets() {
+        let expected = TestStruct::new(SubscriptionsProtocol::Websocket);
+        let actual = toml::from_str(r#"subscriptions_protocol = "websocket""#).unwrap();
+        assert_eq!(expected, actual);
+    }
+}


### PR DESCRIPTION
When the gateway receives a subscription request, it can use either server-sent events or websockets to communicate with the subgraph serving the subscription. This is independent from the protocol used by the client to connect to the gateway. Until now, the logic was that if a `websocket_url` was defined in the subgraph configuration, the gateway would use a websocket connection, otherwise default to server sent events. This is opaque, and not flexible enough.

This pull request introduces a new subgraph configuration option in `grafbase.toml`:

```toml
[subgraphs.my-subgraph]
subscriptions_protocol = "websockets"
```

The value must be either "websockets" or "server_sent_events". The gateway will follow the choice of protocol for the subgraph. If this option is omitted, the previous logic applies.

Implementation note: I had to introduce enums to the engine schema codegen, I hope I didn't miss the mark.

closes GB-8386