### PR TITLE
graphql-composition: generic @link support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ target
 # misc
 .DS_Store
 *.pem
+/.cargo
 
 # debug
 npm-debug.log*
@@ -47,14 +48,10 @@ yarn-error.log*
 # Jujutsu
 .jj/
 
-# Direnv
-.envrc
-.env
-.direnv/
-
 # Nix
 /result
 
 # CLI assets
 /cli/assets
+
 .aider*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3534,6 +3534,7 @@ dependencies = [
  "miette",
  "similar",
  "thiserror 2.0.11",
+ "url",
 ]
 
 [[package]]

--- a/crates/graphql-composition/Cargo.toml
+++ b/crates/graphql-composition/Cargo.toml
@@ -13,12 +13,13 @@ workspace = true
 [dependencies]
 cynic-parser = { workspace = true, features = ["report"] }
 cynic-parser-deser.workspace = true
-grafbase-workspace-hack.workspace = true
 graphql-federated-graph = { path = "../graphql-federated-graph", version = "0.5.0" }
 indexmap.workspace = true
 itertools.workspace = true
+url.workspace = true
 
 [dev-dependencies]
+grafbase-workspace-hack.workspace = true
 datatest-stable.workspace = true
 similar = "2.5.0"
 thiserror.workspace = true

--- a/crates/graphql-composition/src/diagnostics.rs
+++ b/crates/graphql-composition/src/diagnostics.rs
@@ -16,13 +16,6 @@ impl Diagnostics {
         self.0.iter().map(|diagnostic| diagnostic.message.as_str())
     }
 
-    pub(crate) fn push_warning(&mut self, message: String) {
-        self.0.push(Diagnostic {
-            message,
-            is_fatal: false,
-        });
-    }
-
     pub(crate) fn push_fatal(&mut self, message: String) {
         self.0.push(Diagnostic {
             message,

--- a/crates/graphql-composition/src/ingest_subgraph.rs
+++ b/crates/graphql-composition/src/ingest_subgraph.rs
@@ -21,48 +21,50 @@ const SERVICE_TYPE_NAME: &str = "_Service";
 /// _Entity is a special union type exposed by subgraphs. It should not be composed.
 const ENTITY_UNION_NAME: &str = "_Entity";
 
+struct Context<'a> {
+    document: &'a ast::TypeSystemDocument,
+    subgraph_id: SubgraphId,
+    subgraphs: &'a mut Subgraphs,
+    root_type_matcher: RootTypeMatcher<'a>,
+}
+
 pub(crate) fn ingest_subgraph(document: &ast::TypeSystemDocument, name: &str, url: &str, subgraphs: &mut Subgraphs) {
     let subgraph_id = subgraphs.push_subgraph(name, url);
 
-    let root_type_matcher = ingest_schema_definition(document);
+    let mut ctx = Context {
+        document,
+        subgraph_id,
+        subgraphs,
+        root_type_matcher: Default::default(),
+    };
 
-    let directive_matcher = ingest_directive_definitions(document, |error| {
-        subgraphs.push_ingestion_diagnostic(subgraph_id, error);
-    });
+    ingest_schema_definitions(&mut ctx);
 
-    ingest_top_level_definitions(subgraph_id, document, subgraphs, &directive_matcher, &root_type_matcher);
-    ingest_definition_bodies(subgraph_id, document, subgraphs, &directive_matcher, &root_type_matcher);
-    ingest_nested_key_fields(subgraph_id, subgraphs);
-
-    for name in directive_matcher.iter_composed_directives() {
-        subgraphs.insert_composed_directive(name)
-    }
+    ingest_top_level_definitions(&mut ctx);
+    ingest_definition_bodies(&mut ctx);
+    ingest_nested_key_fields(&mut ctx);
 }
 
-fn ingest_top_level_definitions(
-    subgraph_id: SubgraphId,
-    document: &ast::TypeSystemDocument,
-    subgraphs: &mut Subgraphs,
-    directive_matcher: &DirectiveMatcher<'_>,
-    root_type_matcher: &RootTypeMatcher<'_>,
-) {
-    for definition in document.definitions() {
+fn ingest_top_level_definitions(ctx: &mut Context<'_>) {
+    let subgraph_id = ctx.subgraph_id;
+
+    for definition in ctx.document.definitions() {
         match definition {
             ast::Definition::Type(type_definition) | ast::Definition::TypeExtension(type_definition) => {
                 let type_name = type_definition.name();
 
                 let description = type_definition
                     .description()
-                    .map(|description| subgraphs.strings.intern(description.to_cow()));
+                    .map(|description| ctx.subgraphs.strings.intern(description.to_cow()));
 
-                let directives = subgraphs.new_directive_site();
+                let directives = ctx.subgraphs.new_directive_site();
 
                 let definition_id = match type_definition {
                     ast::TypeDefinition::Object(_) if type_name == SERVICE_TYPE_NAME => continue,
                     ast::TypeDefinition::Union(_) if type_name == ENTITY_UNION_NAME => continue,
 
                     ast::TypeDefinition::Object(_) => {
-                        let definition_id = subgraphs.push_definition(
+                        let definition_id = ctx.subgraphs.push_definition(
                             subgraph_id,
                             type_name,
                             DefinitionKind::Object,
@@ -70,39 +72,39 @@ fn ingest_top_level_definitions(
                             directives,
                         );
 
-                        match root_type_matcher.match_name(type_name) {
+                        match ctx.root_type_matcher.match_name(type_name) {
                             RootTypeMatch::Query => {
-                                subgraphs.set_query_type(subgraph_id, definition_id);
+                                ctx.subgraphs.set_query_type(subgraph_id, definition_id);
                             }
                             RootTypeMatch::Mutation => {
-                                subgraphs.set_mutation_type(subgraph_id, definition_id);
+                                ctx.subgraphs.set_mutation_type(subgraph_id, definition_id);
                             }
                             RootTypeMatch::Subscription => {
-                                subgraphs.set_subscription_type(subgraph_id, definition_id);
+                                ctx.subgraphs.set_subscription_type(subgraph_id, definition_id);
                             }
                             RootTypeMatch::NotRootButHasDefaultRootName => {
-                                subgraphs.push_ingestion_diagnostic(subgraph_id, format!("The {type_name} type has the default name for a root but is itself not a root. This is not valid in a federation context."));
+                                ctx.subgraphs.push_ingestion_diagnostic(subgraph_id, format!("The {type_name} type has the default name for a root but is itself not a root. This is not valid in a federation context."));
                             }
                             RootTypeMatch::NotRoot => (),
                         }
 
                         definition_id
                     }
-                    ast::TypeDefinition::Interface(_interface_type) => subgraphs.push_definition(
+                    ast::TypeDefinition::Interface(_interface_type) => ctx.subgraphs.push_definition(
                         subgraph_id,
                         type_name,
                         DefinitionKind::Interface,
                         description,
                         directives,
                     ),
-                    ast::TypeDefinition::Union(_) => subgraphs.push_definition(
+                    ast::TypeDefinition::Union(_) => ctx.subgraphs.push_definition(
                         subgraph_id,
                         type_name,
                         DefinitionKind::Union,
                         description,
                         directives,
                     ),
-                    ast::TypeDefinition::InputObject(_) => subgraphs.push_definition(
+                    ast::TypeDefinition::InputObject(_) => ctx.subgraphs.push_definition(
                         subgraph_id,
                         type_name,
                         DefinitionKind::InputObject,
@@ -110,7 +112,7 @@ fn ingest_top_level_definitions(
                         directives,
                     ),
 
-                    ast::TypeDefinition::Scalar(_) => subgraphs.push_definition(
+                    ast::TypeDefinition::Scalar(_) => ctx.subgraphs.push_definition(
                         subgraph_id,
                         type_name,
                         DefinitionKind::Scalar,
@@ -119,49 +121,34 @@ fn ingest_top_level_definitions(
                     ),
 
                     ast::TypeDefinition::Enum(enum_type) => {
-                        let definition_id = subgraphs.push_definition(
+                        let definition_id = ctx.subgraphs.push_definition(
                             subgraph_id,
                             type_name,
                             DefinitionKind::Enum,
                             description,
                             directives,
                         );
-                        enums::ingest_enum(definition_id, enum_type, subgraphs, directive_matcher, subgraph_id);
+                        enums::ingest_enum(ctx, definition_id, enum_type);
                         definition_id
                     }
                 };
 
-                directives::ingest_directives(
-                    directives,
-                    type_definition.directives(),
-                    subgraphs,
-                    directive_matcher,
-                    subgraph_id,
-                    |_| type_name.to_owned(),
-                );
+                directives::ingest_directives(ctx, directives, type_definition.directives(), |_| type_name.to_owned());
 
-                directives::ingest_keys(
-                    definition_id,
-                    type_definition.directives(),
-                    subgraphs,
-                    directive_matcher,
-                );
+                directives::ingest_keys(definition_id, type_definition.directives(), ctx);
             }
             ast::Definition::Directive(directive_definition) => {
-                directive_definitions::ingest_directive_definition(directive_definition, subgraph_id, subgraphs);
+                directive_definitions::ingest_directive_definition(directive_definition, ctx);
             }
             ast::Definition::Schema(_) | ast::Definition::SchemaExtension(_) => (),
         }
     }
 }
 
-fn ingest_definition_bodies(
-    subgraph_id: SubgraphId,
-    document: &ast::TypeSystemDocument,
-    subgraphs: &mut Subgraphs,
-    federation_directives_matcher: &DirectiveMatcher<'_>,
-    root_type_matcher: &RootTypeMatcher<'_>,
-) {
+fn ingest_definition_bodies(ctx: &mut Context<'_>) {
+    let document = ctx.document;
+    let subgraph_id = ctx.subgraph_id;
+
     let type_definitions = document.definitions().filter_map(|def| match def {
         ast::Definition::Type(ty) | ast::Definition::TypeExtension(ty) => Some(ty),
         _ => None,
@@ -171,63 +158,43 @@ fn ingest_definition_bodies(
         match definition {
             ast::TypeDefinition::Union(_) if definition.name() == ENTITY_UNION_NAME => continue,
             ast::TypeDefinition::Union(union) => {
-                let union_id = subgraphs.definition_by_name(definition.name(), subgraph_id);
+                let union_id = ctx.subgraphs.definition_by_name(definition.name(), subgraph_id);
 
                 for member in union.members() {
-                    let member_id = subgraphs.definition_by_name(member.name(), subgraph_id);
-                    subgraphs.push_union_member(union_id, member_id);
+                    let member_id = ctx.subgraphs.definition_by_name(member.name(), subgraph_id);
+                    ctx.subgraphs.push_union_member(union_id, member_id);
                 }
             }
             ast::TypeDefinition::InputObject(input_object) => {
-                let definition_id = subgraphs.definition_by_name(definition.name(), subgraph_id);
-                fields::ingest_input_fields(
-                    definition_id,
-                    input_object.fields(),
-                    federation_directives_matcher,
-                    subgraphs,
-                    subgraph_id,
-                );
+                let definition_id = ctx.subgraphs.definition_by_name(definition.name(), subgraph_id);
+                fields::ingest_input_fields(ctx, definition_id, input_object.fields());
             }
             ast::TypeDefinition::Interface(interface) => {
-                let definition_id = subgraphs.definition_by_name(interface.name(), subgraph_id);
+                let definition_id = ctx.subgraphs.definition_by_name(interface.name(), subgraph_id);
 
                 for implemented_interface in interface.implements_interfaces() {
-                    let implemented_interface = subgraphs.definition_by_name(implemented_interface, subgraph_id);
+                    let implemented_interface = ctx.subgraphs.definition_by_name(implemented_interface, subgraph_id);
 
-                    subgraphs.push_interface_impl(definition_id, implemented_interface);
+                    ctx.subgraphs.push_interface_impl(definition_id, implemented_interface);
                 }
 
                 let is_query_root_type = false; // interfaces can't be at the root
 
-                fields::ingest_fields(
-                    definition_id,
-                    interface.fields(),
-                    federation_directives_matcher,
-                    is_query_root_type,
-                    subgraph_id,
-                    subgraphs,
-                );
+                fields::ingest_fields(ctx, definition_id, interface.fields(), is_query_root_type);
             }
             ast::TypeDefinition::Object(_) if definition.name() == SERVICE_TYPE_NAME => continue,
             ast::TypeDefinition::Object(object_type) => {
-                let definition_id = subgraphs.definition_by_name(definition.name(), subgraph_id);
+                let definition_id = ctx.subgraphs.definition_by_name(definition.name(), subgraph_id);
 
                 for implemented_interface in object_type.implements_interfaces() {
-                    let implemented_interface = subgraphs.definition_by_name(implemented_interface, subgraph_id);
+                    let implemented_interface = ctx.subgraphs.definition_by_name(implemented_interface, subgraph_id);
 
-                    subgraphs.push_interface_impl(definition_id, implemented_interface);
+                    ctx.subgraphs.push_interface_impl(definition_id, implemented_interface);
                 }
 
-                let is_query_root_type = root_type_matcher.is_query(definition.name());
+                let is_query_root_type = ctx.root_type_matcher.is_query(definition.name());
 
-                fields::ingest_fields(
-                    definition_id,
-                    object_type.fields(),
-                    federation_directives_matcher,
-                    is_query_root_type,
-                    subgraph_id,
-                    subgraphs,
-                );
+                fields::ingest_fields(ctx, definition_id, object_type.fields(), is_query_root_type);
             }
             _ => (),
         }

--- a/crates/graphql-composition/src/ingest_subgraph/directive_definitions.rs
+++ b/crates/graphql-composition/src/ingest_subgraph/directive_definitions.rs
@@ -1,13 +1,11 @@
 use super::*;
 use graphql_federated_graph::DirectiveLocations;
 
-pub(super) fn ingest_directive_definition(
-    directive_definition: ast::DirectiveDefinition<'_>,
-    subgraph_id: SubgraphId,
-    subgraphs: &mut Subgraphs,
-) {
-    let name = subgraphs.strings.intern(directive_definition.name());
+pub(super) fn ingest_directive_definition(directive_definition: ast::DirectiveDefinition<'_>, ctx: &mut Context<'_>) {
+    let name = ctx.subgraphs.strings.intern(directive_definition.name());
     let mut locations = DirectiveLocations::default();
+    let subgraphs = &mut ctx.subgraphs;
+    let subgraph_id = ctx.subgraph_id;
 
     for location in directive_definition.locations() {
         let location = match location {

--- a/crates/graphql-composition/src/ingest_subgraph/directives.rs
+++ b/crates/graphql-composition/src/ingest_subgraph/directives.rs
@@ -1,214 +1,193 @@
 mod authorized;
 mod consts;
+mod match_name;
 
-use cynic_parser::values::ConstList;
+pub(super) use match_name::*;
+
 use cynic_parser_deser::ConstDeserializer;
 use graphql_federated_graph::directives::{CostDirective, DeprecatedDirective, ListSizeDirective};
 
 use self::consts::*;
 use super::*;
-use std::{borrow::Cow, collections::BTreeSet};
 
 pub(super) fn ingest_directives(
+    ctx: &mut Context<'_>,
     directive_site_id: DirectiveSiteId,
     directives_node: ast::iter::Iter<'_, ast::Directive<'_>>,
-    subgraphs: &mut Subgraphs,
-    directive_matcher: &DirectiveMatcher<'_>,
-    subgraph: SubgraphId,
     location: impl Fn(&mut Subgraphs) -> String,
 ) {
     for directive in directives_node {
-        let directive_name = directive.name();
+        let (directive_name_id, match_result) = match_directive_name(ctx, directive.name());
 
-        if !directive_matcher.is_known_directive(directive_name) {
-            subgraphs.push_ingestion_warning(
-                subgraph,
-                format!(
-                    "Unknown directive {directive_name} expected one of {}",
-                    directive_matcher.iter_known_directives().collect::<Vec<_>>().join(", ")
-                ),
-            );
-        }
+        dbg!(directive.name());
+        dbg!(match_result);
 
-        if directive_matcher.is_shareable(directive_name) {
-            subgraphs.set_shareable(directive_site_id);
-            continue;
-        }
-
-        if directive_matcher.is_external(directive_name) {
-            subgraphs.set_external(directive_site_id);
-            continue;
-        }
-
-        if directive_matcher.is_interface_object(directive_name) {
-            subgraphs.set_interface_object(directive_site_id);
-            continue;
-        }
-
-        if directive_matcher.is_inaccessible(directive_name) {
-            subgraphs.set_inaccessible(directive_site_id);
-            continue;
-        }
-
-        if directive_matcher.is_override(directive_name) {
-            let from = directive
-                .argument("from")
-                .and_then(|v| v.value().as_str())
-                .map(|s| subgraphs.strings.intern(s));
-
-            let label = directive
-                .argument("label")
-                .and_then(|v| v.value().as_str())
-                .map(|s| subgraphs.strings.intern(s));
-
-            let Some(from) = from else { continue };
-
-            subgraphs.set_override(directive_site_id, subgraphs::OverrideDirective { from, label });
-            continue;
-        }
-
-        if directive_matcher.is_requires(directive_name) {
-            let fields_arg = directive.argument("fields").and_then(|arg| arg.value().as_str());
-            let Some(fields_arg) = fields_arg else {
-                continue;
-            };
-            if let Err(err) = subgraphs.insert_requires(directive_site_id, fields_arg) {
-                subgraphs.push_ingestion_diagnostic(subgraph, err.to_string());
-            };
-            continue;
-        }
-
-        if directive_matcher.is_provides(directive_name) {
-            let fields_arg = directive.argument("fields").and_then(|arg| arg.value().as_str());
-            let Some(fields_arg) = fields_arg else {
-                continue;
-            };
-            if let Err(err) = subgraphs.insert_provides(directive_site_id, fields_arg) {
-                subgraphs.push_ingestion_diagnostic(subgraph, err.to_string());
+        match match_result {
+            DirectiveNameMatch::NoMatch
+            | DirectiveNameMatch::Imported(_)
+            | DirectiveNameMatch::Qualified(_, _)
+            | DirectiveNameMatch::ComposeDirective
+            | DirectiveNameMatch::Key => (),
+            DirectiveNameMatch::Authorized => {
+                if let Err(err) = authorized::ingest(directive_site_id, directive, ctx.subgraphs) {
+                    let location = location(ctx.subgraphs);
+                    ctx.subgraphs.push_ingestion_diagnostic(
+                        ctx.subgraph_id,
+                        format!("Error validating the @authorized directive at {location}: {err}",),
+                    );
+                };
             }
-            continue;
+            DirectiveNameMatch::Cost => match directive.deserialize::<CostDirective>() {
+                Ok(cost) => {
+                    ctx.subgraphs.set_cost(directive_site_id, cost.weight);
+                }
+                Err(error) => {
+                    let location = location(ctx.subgraphs);
+                    ctx.subgraphs.push_ingestion_diagnostic(
+                        ctx.subgraph_id,
+                        format!("Error validating the @cost directive at {location}: {error}"),
+                    );
+                }
+            },
+            DirectiveNameMatch::ListSize => match directive.deserialize::<ListSizeDirective>() {
+                Ok(directive) => {
+                    ctx.subgraphs.set_list_size(directive_site_id, directive);
+                }
+                Err(error) => {
+                    let location = location(ctx.subgraphs);
+                    ctx.subgraphs.push_ingestion_diagnostic(
+                        ctx.subgraph_id,
+                        format!("Error validating the @listSize directive at {location}: {error}"),
+                    );
+                }
+            },
+            DirectiveNameMatch::Authenticated => {
+                ctx.subgraphs.insert_authenticated(directive_site_id);
+            }
+            DirectiveNameMatch::Deprecated => match directive.deserialize::<DeprecatedDirective<'_>>() {
+                Ok(directive) => ctx.subgraphs.insert_deprecated(directive_site_id, directive.reason),
+                Err(err) => {
+                    let location = location(ctx.subgraphs);
+                    ctx.subgraphs.push_ingestion_diagnostic(
+                        ctx.subgraph_id,
+                        format!("Error validating the @deprecated directive at {location}: {err}",),
+                    );
+                }
+            },
+            DirectiveNameMatch::External => {
+                ctx.subgraphs.set_external(directive_site_id);
+            }
+            DirectiveNameMatch::Inaccessible => {
+                ctx.subgraphs.set_inaccessible(directive_site_id);
+            }
+            DirectiveNameMatch::InterfaceObject => {
+                ctx.subgraphs.set_interface_object(directive_site_id);
+            }
+            DirectiveNameMatch::Override => {
+                let from = directive
+                    .argument("from")
+                    .and_then(|v| v.value().as_str())
+                    .map(|s| ctx.subgraphs.strings.intern(s));
+
+                let label = directive
+                    .argument("label")
+                    .and_then(|v| v.value().as_str())
+                    .map(|s| ctx.subgraphs.strings.intern(s));
+
+                let Some(from) = from else { continue };
+
+                ctx.subgraphs
+                    .set_override(directive_site_id, subgraphs::OverrideDirective { from, label });
+            }
+            DirectiveNameMatch::Policy => {
+                let policies = directive
+                    .argument("policies")
+                    .into_iter()
+                    .flat_map(|scopes| scopes.value().as_items())
+                    .flatten();
+                for policy in policies {
+                    let inner_policies: Vec<subgraphs::StringId> = match policy {
+                        ConstValue::List(policies) => policies
+                            .items()
+                            .filter_map(|policy| match policy {
+                                ConstValue::String(string) => Some(ctx.subgraphs.strings.intern(string.as_str())),
+                                _ => None,
+                            })
+                            .collect(),
+                        _ => vec![],
+                    };
+                    ctx.subgraphs.insert_policy(directive_site_id, inner_policies);
+                }
+            }
+            DirectiveNameMatch::Provides => {
+                let fields_arg = directive.argument("fields").and_then(|arg| arg.value().as_str());
+                let Some(fields_arg) = fields_arg else {
+                    continue;
+                };
+                if let Err(err) = ctx.subgraphs.insert_provides(directive_site_id, fields_arg) {
+                    ctx.subgraphs
+                        .push_ingestion_diagnostic(ctx.subgraph_id, err.to_string());
+                }
+            }
+            DirectiveNameMatch::Requires => {
+                let fields_arg = directive.argument("fields").and_then(|arg| arg.value().as_str());
+
+                let Some(fields_arg) = fields_arg else {
+                    continue;
+                };
+
+                if let Err(err) = ctx.subgraphs.insert_requires(directive_site_id, fields_arg) {
+                    ctx.subgraphs
+                        .push_ingestion_diagnostic(ctx.subgraph_id, err.to_string());
+                };
+            }
+            DirectiveNameMatch::RequiresScopes => {
+                let scopes = directive
+                    .argument("scopes")
+                    .into_iter()
+                    .flat_map(|scopes| scopes.value().as_items())
+                    .flatten();
+                for scope in scopes {
+                    let inner_scopes: Vec<subgraphs::StringId> = match scope {
+                        ConstValue::List(scopes) => scopes
+                            .items()
+                            .filter_map(|scope| match scope {
+                                ConstValue::String(string) => Some(ctx.subgraphs.strings.intern(string.as_str())),
+                                _ => None,
+                            })
+                            .collect(),
+                        _ => vec![],
+                    };
+                    ctx.subgraphs.append_required_scopes(directive_site_id, inner_scopes);
+                }
+            }
+            DirectiveNameMatch::Shareable => {
+                ctx.subgraphs.set_shareable(directive_site_id);
+            }
+            DirectiveNameMatch::Tag => {
+                let Some(argument) = directive.argument("name") else {
+                    continue;
+                };
+
+                if let Some(s) = argument.value().as_str() {
+                    ctx.subgraphs.insert_tag(directive_site_id, s);
+                }
+            }
         }
 
-        if directive_matcher.is_composed_directive(directive_name) {
+        // FIXME: should happen in composition, not in ingestion. GB-8398.
+        if ctx.subgraphs.is_composed_directive(directive_name_id) {
             let arguments = directive
                 .arguments()
                 .map(|argument| {
                     (
-                        subgraphs.strings.intern(argument.name()),
-                        ast_value_to_subgraph_value(argument.value(), subgraphs),
+                        ctx.subgraphs.strings.intern(argument.name()),
+                        ast_value_to_subgraph_value(argument.value(), ctx.subgraphs),
                     )
                 })
                 .collect();
-            subgraphs.insert_composed_directive_instance(directive_site_id, directive_name, arguments);
-        }
-
-        if directive_matcher.is_tag(directive_name) {
-            let Some(argument) = directive.argument("name") else {
-                continue;
-            };
-
-            if let Some(s) = argument.value().as_str() {
-                subgraphs.insert_tag(directive_site_id, s);
-            }
-        }
-
-        if directive_matcher.is_authenticated(directive_name) {
-            subgraphs.insert_authenticated(directive_site_id);
-        }
-
-        if directive_matcher.is_requires_scope(directive_name) {
-            let scopes = directive
-                .argument("scopes")
-                .into_iter()
-                .flat_map(|scopes| scopes.value().as_items())
-                .flatten();
-            for scope in scopes {
-                let inner_scopes: Vec<subgraphs::StringId> = match scope {
-                    ConstValue::List(scopes) => scopes
-                        .items()
-                        .filter_map(|scope| match scope {
-                            ConstValue::String(string) => Some(subgraphs.strings.intern(string.as_str())),
-                            _ => None,
-                        })
-                        .collect(),
-                    _ => vec![],
-                };
-                subgraphs.append_required_scopes(directive_site_id, inner_scopes);
-            }
-        }
-
-        if directive_matcher.is_policy(directive_name) {
-            let policies = directive
-                .argument("policies")
-                .into_iter()
-                .flat_map(|scopes| scopes.value().as_items())
-                .flatten();
-            for policy in policies {
-                let inner_policies: Vec<subgraphs::StringId> = match policy {
-                    ConstValue::List(policies) => policies
-                        .items()
-                        .filter_map(|policy| match policy {
-                            ConstValue::String(string) => Some(subgraphs.strings.intern(string.as_str())),
-                            _ => None,
-                        })
-                        .collect(),
-                    _ => vec![],
-                };
-                subgraphs.insert_policy(directive_site_id, inner_policies);
-            }
-        }
-
-        if directive_name == "deprecated" {
-            match directive.deserialize::<DeprecatedDirective<'_>>() {
-                Ok(directive) => subgraphs.insert_deprecated(directive_site_id, directive.reason),
-                Err(err) => {
-                    let location = location(subgraphs);
-                    subgraphs.push_ingestion_diagnostic(
-                        subgraph,
-                        format!("Error validating the @deprecated directive at {location}: {err}",),
-                    );
-                }
-            }
-        }
-
-        if directive_matcher.is_authorized(directive_name) {
-            if let Err(err) = authorized::ingest(directive_site_id, directive, subgraphs) {
-                let location = location(subgraphs);
-                subgraphs.push_ingestion_diagnostic(
-                    subgraph,
-                    format!("Error validating the @authorized directive at {location}: {err}",),
-                );
-            };
-        }
-
-        if directive_matcher.is_cost(directive_name) {
-            match directive.deserialize::<CostDirective>() {
-                Ok(cost) => {
-                    subgraphs.set_cost(directive_site_id, cost.weight);
-                }
-                Err(error) => {
-                    let location = location(subgraphs);
-                    subgraphs.push_ingestion_diagnostic(
-                        subgraph,
-                        format!("Error validating the @cost directive at {location}: {error}"),
-                    );
-                }
-            }
-        }
-
-        if directive_matcher.is_list_size(directive_name) {
-            match directive.deserialize::<ListSizeDirective>() {
-                Ok(directive) => {
-                    subgraphs.set_list_size(directive_site_id, directive);
-                }
-                Err(error) => {
-                    let location = location(subgraphs);
-                    subgraphs.push_ingestion_diagnostic(
-                        subgraph,
-                        format!("Error validating the @listSize directive at {location}: {error}"),
-                    );
-                }
-            }
+            ctx.subgraphs
+                .insert_composed_directive_instance(directive_site_id, directive.name(), arguments);
         }
     }
 }
@@ -216,13 +195,13 @@ pub(super) fn ingest_directives(
 pub(super) fn ingest_keys(
     definition_id: DefinitionId,
     directives_node: ast::iter::Iter<'_, ast::Directive<'_>>,
-    subgraphs: &mut Subgraphs,
-    directive_matcher: &DirectiveMatcher<'_>,
+    ctx: &mut Context<'_>,
 ) {
     for directive in directives_node {
         let directive_name = directive.name();
+        let (_, match_result) = match_directive_name(ctx, directive_name);
 
-        if directive_matcher.is_key(directive_name) {
+        if let DirectiveNameMatch::Key = match_result {
             let fields_arg = directive.argument("fields").and_then(|v| v.value().as_str());
             let Some(fields_arg) = fields_arg else {
                 continue;
@@ -231,421 +210,7 @@ pub(super) fn ingest_keys(
                 .argument("resolvable")
                 .and_then(|v| v.value().as_bool())
                 .unwrap_or(true); // defaults to true
-            subgraphs.push_key(definition_id, fields_arg, is_resolvable).ok();
+            ctx.subgraphs.push_key(definition_id, fields_arg, is_resolvable).ok();
         }
-    }
-}
-
-pub(super) fn ingest_directive_definitions(
-    document: &ast::TypeSystemDocument,
-    mut push_error: impl FnMut(String),
-) -> DirectiveMatcher<'_> {
-    let schema_definition_directives = document
-        .definitions()
-        .filter_map(|def| match def {
-            ast::Definition::Schema(schema_definition) => Some(schema_definition),
-            ast::Definition::SchemaExtension(schema_definition) => Some(schema_definition),
-            _ => None,
-        })
-        .flat_map(|definition| definition.directives());
-
-    let mut directive_matcher = schema_definition_directives
-        .clone()
-        .find(|d| DirectiveMatcher::is_federation_directive(*d))
-        .map(DirectiveMatcher::new)
-        .unwrap_or_default();
-
-    let mut composed_directives = BTreeSet::new();
-
-    for name in schema_definition_directives
-        .filter(|directive| directive_matcher.is_compose_directive(directive.name()))
-        .filter_map(|directive| directive.argument("name"))
-        .filter_map(|argument| argument.value().as_str())
-    {
-        composed_directives.insert(name.trim_start_matches('@'));
-
-        if !name.starts_with('@') {
-            push_error(format!(
-                "The `{}` directive is missing the `@` prefix in @composeDirective.",
-                name
-            ));
-        }
-    }
-
-    directive_matcher
-        .all_known_directives
-        .extend(composed_directives.iter().map(|directive| Cow::Borrowed(*directive)));
-
-    directive_matcher.composed_directives = composed_directives;
-
-    directive_matcher
-        .all_known_directives
-        .extend(document.definitions().filter_map(|def| match def {
-            ast::Definition::Directive(def) => Some(Cow::Borrowed(def.name())),
-            _ => None,
-        }));
-
-    directive_matcher
-}
-
-/// This struct is the source of truth for matching federation directives by name when ingesting a
-/// subgraph's GraphQL SDL.
-///
-/// The names of federation directives are influenced by `@link` directives on schema definitions
-/// or extensions in two ways:
-///
-/// - Imports in link directives bring the directives in scope, with optional renaming.
-///   Example: `@link(url: "...", import: [{ name: "@shareable", as: "@federationShareable"}])
-///   Example: `@link(url: "...", import: ["@key"])`
-///
-/// - The `as` argument: `@link(url: "...", as: "compositionDirectives")
-///   - In the absence of an `@link` or `as` argument, all directives are in scope prefixed with
-///     `@federation__`, for example `@federation__shareable`.
-///   - With an `@link(as: "something")`, they are in scope under the `@something__` prefix.
-///
-/// Last rule: if a directive is `import`ed, it is no longer available under the prefix.
-#[derive(Debug)]
-pub(crate) struct DirectiveMatcher<'a> {
-    shareable: Cow<'a, str>,
-    key: Cow<'a, str>,
-    external: Cow<'a, str>,
-    provides: Cow<'a, str>,
-    requires: Cow<'a, str>,
-    inaccessible: Cow<'a, str>,
-    interface_object: Cow<'a, str>,
-    r#override: Cow<'a, str>,
-    compose_directive: Cow<'a, str>,
-    requires_scopes: Cow<'a, str>,
-    authenticated: Cow<'a, str>,
-    policy: Cow<'a, str>,
-    tag: Cow<'a, str>,
-    cost: Cow<'a, str>,
-    list_size: Cow<'a, str>,
-
-    composed_directives: BTreeSet<&'a str>,
-
-    all_known_directives: BTreeSet<Cow<'a, str>>,
-}
-
-const DEFAULT_FEDERATION_PREFIX: &str = "federation__";
-
-impl Default for DirectiveMatcher<'_> {
-    fn default() -> Self {
-        let mut all_known_directives = default_known_directives();
-
-        let mut record = |directive: &'static str| {
-            let directive = Cow::Borrowed(directive);
-            all_known_directives.insert(directive.clone());
-            directive
-        };
-
-        DirectiveMatcher {
-            authenticated: record(AUTHENTICATED),
-            compose_directive: record(COMPOSE_DIRECTIVE),
-            composed_directives: BTreeSet::new(),
-            external: record(EXTERNAL),
-            inaccessible: record(INACCESSIBLE),
-            interface_object: record(INTERFACE_OBJECT),
-            key: record(KEY),
-            policy: record(POLICY),
-            provides: record(PROVIDES),
-            r#override: record(OVERRIDE),
-            requires: record(REQUIRES),
-            requires_scopes: record(REQUIRES_SCOPES),
-            shareable: record(SHAREABLE),
-            tag: record(TAG),
-            cost: record(COST),
-            list_size: record(LIST_SIZE),
-            all_known_directives,
-        }
-    }
-}
-
-impl<'a> DirectiveMatcher<'a> {
-    pub(crate) fn is_federation_directive(directive: ast::Directive<'_>) -> bool {
-        if directive.name() != "link" {
-            return false;
-        }
-
-        directive
-            .argument("url")
-            .map(|url| match url.value() {
-                ConstValue::String(s) => s.value().contains("dev/federation/v2"),
-                _ => false,
-            })
-            .unwrap_or_default()
-    }
-
-    /// Matcher for federation directives in a given subgraph. See [DirectiveMatcher] for more docs.
-    pub(crate) fn new(directive: ast::Directive<'a>) -> DirectiveMatcher<'a> {
-        let mut r#as = None;
-        let mut imported: Vec<(&str, &str)> = Vec::new();
-
-        for argument in directive.arguments() {
-            match (argument.name(), argument.value()) {
-                ("as", ConstValue::String(value)) => r#as = Some(value.as_str()),
-                ("import", ConstValue::List(imports)) => read_imports(imports, &mut imported),
-                _ => (),
-            }
-        }
-
-        let mut all_known_directives = default_known_directives();
-
-        let federation_prefix = r#as
-            .map(|prefix| Cow::Owned(format!("{prefix}__")))
-            .unwrap_or(Cow::Borrowed(DEFAULT_FEDERATION_PREFIX));
-        let mut final_name = |directive_name: &str| {
-            let name = imported
-                .iter()
-                .find(|(original, _alias)| *original == directive_name)
-                .map(|(_, alias)| Cow::Borrowed(*alias))
-                .unwrap_or_else(|| Cow::Owned(format!("{federation_prefix}{directive_name}")));
-
-            all_known_directives.insert(name.clone());
-            name
-        };
-
-        DirectiveMatcher {
-            authenticated: final_name(AUTHENTICATED),
-            compose_directive: final_name(COMPOSE_DIRECTIVE),
-            composed_directives: BTreeSet::new(),
-            external: final_name(EXTERNAL),
-            inaccessible: final_name(INACCESSIBLE),
-            interface_object: final_name(INTERFACE_OBJECT),
-            key: final_name(KEY),
-            policy: final_name(POLICY),
-            provides: final_name(PROVIDES),
-            r#override: final_name(OVERRIDE),
-            requires: final_name(REQUIRES),
-            requires_scopes: final_name(REQUIRES_SCOPES),
-            shareable: final_name(SHAREABLE),
-            tag: final_name(TAG),
-            cost: final_name(COST),
-            list_size: final_name(LIST_SIZE),
-            all_known_directives,
-        }
-    }
-
-    pub(crate) fn is_authorized(&self, directive_name: &str) -> bool {
-        directive_name == AUTHORIZED
-    }
-
-    pub(crate) fn is_compose_directive(&self, directive_name: &str) -> bool {
-        self.compose_directive == directive_name
-    }
-
-    pub(crate) fn is_composed_directive(&self, directive_name: &str) -> bool {
-        // The `@authorized` directive is an exception. Directives used in subgraph schemas are either built-in federation directives (`@requires`, `@key`, etc.) or custom, composed directives with `@composeDirective`. Since `@authorized` is not part of the federation spec, some frameworks like async-graphql (Rust) will produce an `@composeDirective` with the `@authorized` directive. We should not consider `@authorized` as a composed directive however, because that means we would emit it again.
-        //
-        // TODO: as for other imported composition directives, we should forbid their use in `@composeDirective`.
-        if directive_name == AUTHORIZED {
-            return false;
-        }
-
-        self.composed_directives
-            .contains(&directive_name.trim_start_matches('@'))
-    }
-
-    pub(crate) fn iter_composed_directives(&self) -> impl Iterator<Item = &str> {
-        self.composed_directives.iter().copied()
-    }
-
-    pub(crate) fn iter_known_directives(&self) -> impl Iterator<Item = &str> {
-        self.all_known_directives.iter().map(|directive| directive.as_ref())
-    }
-
-    pub(crate) fn is_known_directive(&self, directive_name: &str) -> bool {
-        self.all_known_directives.contains(directive_name)
-    }
-
-    pub(crate) fn is_external(&self, directive_name: &str) -> bool {
-        self.external == directive_name
-    }
-
-    pub(crate) fn is_interface_object(&self, directive_name: &str) -> bool {
-        self.interface_object == directive_name
-    }
-
-    pub(crate) fn is_shareable(&self, directive_name: &str) -> bool {
-        self.shareable == directive_name
-    }
-
-    pub(crate) fn is_override(&self, directive_name: &str) -> bool {
-        self.r#override == directive_name
-    }
-
-    pub(crate) fn is_requires(&self, directive_name: &str) -> bool {
-        self.requires == directive_name
-    }
-
-    pub(crate) fn is_provides(&self, directive_name: &str) -> bool {
-        self.provides == directive_name
-    }
-
-    pub(crate) fn is_key(&self, directive_name: &str) -> bool {
-        self.key == directive_name
-    }
-
-    pub(crate) fn is_inaccessible(&self, directive_name: &str) -> bool {
-        self.inaccessible == directive_name
-    }
-
-    pub(crate) fn is_authenticated(&self, directive_name: &str) -> bool {
-        self.authenticated == directive_name
-    }
-
-    pub(crate) fn is_policy(&self, directive_name: &str) -> bool {
-        self.policy == directive_name
-    }
-
-    pub(crate) fn is_requires_scope(&self, directive_name: &str) -> bool {
-        self.requires_scopes == directive_name
-    }
-
-    pub(crate) fn is_tag(&self, directive_name: &str) -> bool {
-        self.tag == directive_name
-    }
-
-    fn is_cost(&self, directive_name: &str) -> bool {
-        self.cost == directive_name
-    }
-
-    fn is_list_size(&self, directive_name: &str) -> bool {
-        self.list_size == directive_name
-    }
-}
-
-fn default_known_directives<'a>() -> BTreeSet<Cow<'a, str>> {
-    let mut hash_set = BTreeSet::new();
-    hash_set.insert(Cow::Borrowed("authorized"));
-    hash_set
-}
-
-fn read_imports<'a>(ast_imports: ConstList<'a>, out: &mut Vec<(&'a str, &'a str)>) {
-    for import in ast_imports.items() {
-        match import {
-            ConstValue::String(import) => {
-                let import = import.as_str().trim_start_matches('@');
-                out.push((import, import));
-            }
-            ConstValue::Object(obj) => {
-                if let Some(ConstValue::String(name)) = obj.get("name") {
-                    let alias = obj.get("as").and_then(|value| match value {
-                        ConstValue::String(s) => Some(s),
-                        _ => None,
-                    });
-                    out.push((
-                        name.as_str().trim_start_matches('@'),
-                        alias.unwrap_or(name).as_str().trim_start_matches('@'),
-                    ));
-                }
-            }
-            _ => (),
-        }
-    }
-}
-
-#[cfg(test)]
-mod federation_directives_matcher_tests {
-
-    use super::*;
-
-    #[allow(clippy::panic)]
-    fn with_matcher_for_schema(graphql_sdl: &str, test: impl FnOnce(DirectiveMatcher<'_>)) {
-        let ast = cynic_parser::parse_type_system_document(graphql_sdl).unwrap();
-        let matcher = ingest_directive_definitions(&ast, |error| panic!("{error}"));
-        test(matcher);
-    }
-
-    #[test]
-    fn no_link_declaration() {
-        with_matcher_for_schema("type Irrelevant { id: ID! }", |matcher| {
-            assert!(matcher.is_shareable("shareable"));
-            assert!(matcher.is_key("key"));
-            assert!(!matcher.is_key("@key"));
-            assert!(!matcher.is_key("federation__key"));
-            assert!(!matcher.is_shareable("federation__shareable"));
-        });
-    }
-
-    #[test]
-    fn bare_link_declaration() {
-        let schema = r#"extend schema @link(url: "https://specs.apollo.dev/federation/v2.3")"#;
-        with_matcher_for_schema(schema, |matcher| {
-            assert!(matcher.is_key("federation__key"));
-            assert!(matcher.is_shareable("federation__shareable"));
-            assert!(!matcher.is_key("key"));
-            assert!(!matcher.is_key("@key"));
-            assert!(!matcher.is_shareable("shareable"));
-        });
-    }
-
-    #[test]
-    fn irrelevant_link_declaration() {
-        let schema = r#"extend schema @link(url: "https://bad.horse", as: "horse")"#;
-        with_matcher_for_schema(schema, |matcher| {
-            assert!(matcher.is_key("key"));
-            assert!(matcher.is_shareable("shareable"));
-            assert!(!matcher.is_key("federation__key"));
-            assert!(!matcher.is_shareable("federation__shareable"));
-            assert!(!matcher.is_key("@key"));
-        });
-    }
-
-    #[test]
-    fn alias() {
-        let schema = r#"extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", as: "romulans")"#;
-        with_matcher_for_schema(schema, |matcher| {
-            assert!(!matcher.is_key("federation__key"));
-            assert!(matcher.is_key("romulans__key"));
-            assert!(!matcher.is_shareable("federation__shareable"));
-            assert!(!matcher.is_shareable("@federation__shareable"));
-            assert!(matcher.is_shareable("romulans__shareable"));
-            assert!(!matcher.is_key("key"));
-            assert!(!matcher.is_key("@key"));
-            assert!(!matcher.is_shareable("shareable"));
-        });
-    }
-
-    #[test]
-    fn direct_import_and_alias() {
-        let schema = r#"
-            extend schema @link(
-                url: "https://specs.apollo.dev/federation/v2.3",
-                as: "romulans"
-                import: [{ name: "@shareable", as: "partageable" }]
-            )
-        "#;
-        with_matcher_for_schema(schema, |matcher| {
-            assert!(!matcher.is_key("federation__key"));
-            assert!(!matcher.is_shareable("romulans__shareable"));
-            assert!(!matcher.is_shareable("romulans__partageable"));
-            assert!(!matcher.is_shareable("romulans__shareable"));
-            assert!(!matcher.is_shareable("@federation__shareable"));
-            assert!(!matcher.is_key("key"));
-
-            assert!(matcher.is_key("romulans__key"));
-            assert!(matcher.is_shareable("partageable"));
-        });
-    }
-
-    #[test]
-    fn regular_imports() {
-        let schema = r#"
-            extend schema @link(
-                url: "https://specs.apollo.dev/federation/v2.3",
-                as: "romulans"
-                import: [{ name: "@key" }, "@shareable"]
-            )
-        "#;
-        with_matcher_for_schema(schema, |matcher| {
-            assert!(!matcher.is_key("federation__key"));
-            assert!(!matcher.is_shareable("federation__shareable"));
-            assert!(!matcher.is_shareable("romulans__shareable"));
-            assert!(!matcher.is_shareable("@federation__shareable"));
-
-            assert!(matcher.is_key("key"));
-            assert!(matcher.is_shareable("shareable"));
-        });
     }
 }

--- a/crates/graphql-composition/src/ingest_subgraph/directives/match_name.rs
+++ b/crates/graphql-composition/src/ingest_subgraph/directives/match_name.rs
@@ -1,0 +1,133 @@
+use crate::subgraphs::StringId;
+
+use super::*;
+
+/// This function is the source of truth for matching directives by name when ingesting a
+/// subgraph's GraphQL SDL.
+///
+/// The names of federation and other directives are influenced by `@link` directives on schema definitions
+/// or extensions in two ways:
+///
+/// - Imports in link directives bring the directives in scope, with optional renaming.
+///   Example: `@link(url: "...", import: [{ name: "@shareable", as: "@federationShareable"}])
+///   Example: `@link(url: "...", import: ["@key"])`
+///
+/// - The `as` argument: `@link(url: "...", as: "compositionDirectives")
+///   - In the absence of an `@link` or `as` argument, all directives are in scope prefixed with
+///     `@federation__`, for example `@federation__shareable`.
+///   - With an `@link(as: "something")`, they are in scope under the `@something__` prefix.
+///
+/// Last rule: if a directive is `import`ed, it is no longer available under the prefix.
+pub(in crate::ingest_subgraph) fn match_directive_name(
+    ctx: &mut Context<'_>,
+    directive_name: &str,
+) -> (StringId, DirectiveNameMatch) {
+    let (namespace, directive_name) = directive_name
+        .split_once("__")
+        .map(|(namespace, name)| {
+            let namespace = ctx.subgraphs.strings.intern(namespace);
+            (Some(namespace), name)
+        })
+        .unwrap_or((None, directive_name));
+
+    let linked_schema_id = namespace.and_then(|namespace_str| ctx.subgraphs.get_linked_schema(namespace_str));
+
+    let directive_name_id = ctx.subgraphs.strings.intern(directive_name);
+
+    let matched = match_directive_name_inner(ctx, directive_name_id, linked_schema_id, directive_name);
+
+    (directive_name_id, matched)
+}
+
+fn match_directive_name_inner(
+    ctx: &mut Context<'_>,
+    directive_name_id: StringId,
+    linked_schema_id: Option<subgraphs::LinkedSchemaId>,
+    directive_name: &str,
+) -> DirectiveNameMatch {
+    if let Some(linked_schema) = linked_schema_id {
+        // TODO: first check that the directive hasn't been imported.
+
+        if ctx.subgraphs.at(linked_schema).is_federation_v2(ctx.subgraphs) {
+            return match_federation_directive_by_original_name(directive_name);
+        }
+
+        return DirectiveNameMatch::Qualified(linked_schema, directive_name_id);
+    }
+
+    if let Some(imported_definition_id) = ctx.subgraphs.get_imported_definition(directive_name_id) {
+        let imported_definition = ctx.subgraphs.at(imported_definition_id);
+        let linked_schema = ctx.subgraphs.at(imported_definition.linked_schema_id);
+
+        if linked_schema.is_federation_v2(ctx.subgraphs) {
+            let original_name = &ctx.subgraphs.strings.resolve(imported_definition.original_name);
+            return match_federation_directive_by_original_name(original_name);
+        }
+
+        return DirectiveNameMatch::Imported(imported_definition_id);
+    }
+
+    match directive_name {
+        // FIXME: built-in, and has no schema url to import from. We should change that.
+        AUTHORIZED => return DirectiveNameMatch::Authorized,
+        // GraphQL built-in, this one is fine.
+        "deprecated" => return DirectiveNameMatch::Deprecated,
+        _ => (),
+    }
+
+    let federation_schema_has_been_linked = ctx.subgraphs.subgraph_links_federation_v2(ctx.subgraph_id);
+
+    if !federation_schema_has_been_linked {
+        return match_federation_directive_by_original_name(directive_name);
+    }
+
+    DirectiveNameMatch::NoMatch
+}
+
+fn match_federation_directive_by_original_name(original_name: &str) -> DirectiveNameMatch {
+    match original_name {
+        AUTHENTICATED => DirectiveNameMatch::Authenticated,
+        COMPOSE_DIRECTIVE => DirectiveNameMatch::ComposeDirective,
+        COST => DirectiveNameMatch::Cost,
+        EXTERNAL => DirectiveNameMatch::External,
+        INACCESSIBLE => DirectiveNameMatch::Inaccessible,
+        INTERFACE_OBJECT => DirectiveNameMatch::InterfaceObject,
+        KEY => DirectiveNameMatch::Key,
+        LIST_SIZE => DirectiveNameMatch::ListSize,
+        OVERRIDE => DirectiveNameMatch::Override,
+        POLICY => DirectiveNameMatch::Policy,
+        PROVIDES => DirectiveNameMatch::Provides,
+        REQUIRES => DirectiveNameMatch::Requires,
+        REQUIRES_SCOPES => DirectiveNameMatch::RequiresScopes,
+        SHAREABLE => DirectiveNameMatch::Shareable,
+        TAG => DirectiveNameMatch::Tag,
+        _ => DirectiveNameMatch::NoMatch,
+    }
+}
+
+#[expect(unused)]
+#[derive(Debug, Clone, Copy)]
+pub(in crate::ingest_subgraph) enum DirectiveNameMatch {
+    NoMatch,
+    Qualified(subgraphs::LinkedSchemaId, StringId),
+    Imported(subgraphs::LinkedDefinitionId),
+
+    Authorized,
+    Deprecated,
+
+    Authenticated,
+    ComposeDirective,
+    Cost,
+    External,
+    Inaccessible,
+    InterfaceObject,
+    Key,
+    ListSize,
+    Override,
+    Policy,
+    Provides,
+    Requires,
+    RequiresScopes,
+    Shareable,
+    Tag,
+}

--- a/crates/graphql-composition/src/ingest_subgraph/enums.rs
+++ b/crates/graphql-composition/src/ingest_subgraph/enums.rs
@@ -1,25 +1,15 @@
 use super::*;
 
-pub(super) fn ingest_enum(
-    definition_id: DefinitionId,
-    enum_type: ast::EnumDefinition<'_>,
-    subgraphs: &mut Subgraphs,
-    federation_directives_matcher: &DirectiveMatcher<'_>,
-    subgraph: SubgraphId,
-) {
+pub(super) fn ingest_enum(ctx: &mut Context<'_>, definition_id: DefinitionId, enum_type: ast::EnumDefinition<'_>) {
     for value in enum_type.values() {
-        let value_name = subgraphs.strings.intern(value.value());
-        let value_directives = subgraphs.new_directive_site();
+        let value_name = ctx.subgraphs.strings.intern(value.value());
+        let value_directives = ctx.subgraphs.new_directive_site();
 
-        subgraphs.push_enum_value(definition_id, value_name, value_directives);
+        ctx.subgraphs
+            .push_enum_value(definition_id, value_name, value_directives);
 
-        directives::ingest_directives(
-            value_directives,
-            value.directives(),
-            subgraphs,
-            federation_directives_matcher,
-            subgraph,
-            |subgraphs| subgraphs.walk(definition_id).name().as_str().to_owned(),
-        );
+        directives::ingest_directives(ctx, value_directives, value.directives(), |subgraphs| {
+            subgraphs.walk(definition_id).name().as_str().to_owned()
+        });
     }
 }

--- a/crates/graphql-composition/src/ingest_subgraph/nested_key_fields.rs
+++ b/crates/graphql-composition/src/ingest_subgraph/nested_key_fields.rs
@@ -1,8 +1,10 @@
+use super::Context;
 use crate::subgraphs::*;
 
 /// See [crate::subgraphs::Keys::nested_key_fields].
-pub(super) fn ingest_nested_key_fields(subgraph_id: SubgraphId, subgraphs: &mut Subgraphs) {
-    subgraphs.with_nested_key_fields(|subgraphs, nested_key_fields| {
+pub(super) fn ingest_nested_key_fields(ctx: &mut Context<'_>) {
+    let subgraph_id = ctx.subgraph_id;
+    ctx.subgraphs.with_nested_key_fields(|subgraphs, nested_key_fields| {
         for definition in subgraphs.walk_subgraph(subgraph_id).definitions() {
             for key in definition.entity_keys() {
                 for selection in key.fields() {

--- a/crates/graphql-composition/src/ingest_subgraph/schema_definitions/link.rs
+++ b/crates/graphql-composition/src/ingest_subgraph/schema_definitions/link.rs
@@ -1,0 +1,148 @@
+use super::*;
+use cynic_parser_deser::ConstDeserializer;
+
+pub(super) fn ingest_link_directive(directive: ast::Directive<'_>, subgraph_id: SubgraphId, subgraphs: &mut Subgraphs) {
+    let graphql_federated_graph::link::LinkDirective {
+        url,
+        r#as,
+        import,
+        r#for: _,
+    }: graphql_federated_graph::link::LinkDirective<'_> = match directive.deserialize() {
+        Ok(directive) => directive,
+        Err(err) => {
+            subgraphs.push_ingestion_diagnostic(subgraph_id, format!("Invalid `@link` directive: {err}"));
+            return;
+        }
+    };
+
+    let (name, version) = parse_link_url(url)
+        .map(|url| (url.name, url.version))
+        .unwrap_or_default();
+
+    let name = name.map(|name| subgraphs.strings.intern(name));
+    let version = version.map(|version| subgraphs.strings.intern(version));
+
+    let url = subgraphs.strings.intern(url);
+    let r#as = r#as.map(|r#as| subgraphs.strings.intern(r#as));
+
+    let linked_schema_id = subgraphs.push_linked_schema(subgraphs::LinkedSchemaRecord {
+        subgraph_id,
+        url,
+        r#as,
+        name_from_url: name,
+        version_from_url: version,
+    });
+
+    for import in import.into_iter().flatten() {
+        match import {
+            graphql_federated_graph::link::Import::String(name) => {
+                let name = name.trim_start_matches("@");
+                let original_name = subgraphs.strings.intern(name);
+
+                subgraphs.push_linked_definition(subgraphs::LinkedDefinitionRecord {
+                    linked_schema_id,
+                    original_name,
+                    imported_as: None,
+                });
+            }
+            graphql_federated_graph::link::Import::Qualified(graphql_federated_graph::link::QualifiedImport {
+                name,
+                r#as,
+            }) => {
+                let name = name.trim_start_matches("@");
+                let original_name = subgraphs.strings.intern(name);
+                let imported_as = r#as.map(|r#as| subgraphs.strings.intern(r#as));
+
+                subgraphs.push_linked_definition(subgraphs::LinkedDefinitionRecord {
+                    linked_schema_id,
+                    original_name,
+                    imported_as,
+                });
+            }
+        }
+    }
+}
+
+struct LinkUrl {
+    #[expect(unused)]
+    url: url::Url,
+    name: Option<String>,
+    version: Option<String>,
+}
+
+/// https://specs.apollo.dev/link/v1.0/#@link.url
+fn parse_link_url(url: &str) -> Option<LinkUrl> {
+    // Must be a url, or treated as an opaque identifier (which is valid).
+    let url = url::Url::parse(url).ok()?;
+
+    let segments = url.path_segments()?;
+
+    let mut reversed_segments = segments.rev();
+
+    let Some(maybe_version_or_name) = reversed_segments.next() else {
+        return Some(LinkUrl {
+            url,
+            name: None,
+            version: None,
+        });
+    };
+
+    if is_valid_version(maybe_version_or_name) {
+        let name = reversed_segments
+            .next()
+            .filter(|s| is_valid_graphql_name(s))
+            .map(String::from);
+
+        let version = Some(maybe_version_or_name.to_owned());
+
+        Some(LinkUrl { url, name, version })
+    } else if is_valid_graphql_name(maybe_version_or_name) {
+        let name = Some(maybe_version_or_name.to_owned());
+
+        Some(LinkUrl {
+            url,
+            name,
+            version: None,
+        })
+    } else {
+        Some(LinkUrl {
+            url,
+            name: None,
+            version: None,
+        })
+    }
+}
+
+fn is_valid_version(s: &str) -> bool {
+    let mut chars = s.chars();
+
+    let Some('v') = chars.next() else { return false };
+
+    let Some(digit) = chars.next() else { return false };
+
+    if !digit.is_ascii_digit() {
+        return false;
+    };
+
+    chars.all(|char| char.is_ascii_digit() || char == '.')
+}
+
+fn is_valid_graphql_name(s: &str) -> bool {
+    let mut chars = s.chars();
+
+    let Some(first_char) = chars.next() else {
+        return false;
+    };
+
+    if !first_char.is_ascii_alphabetic() && first_char != '_' {
+        return false;
+    }
+
+    for c in chars {
+        if !c.is_ascii_alphanumeric() && c != '_' {
+            return false;
+        }
+    }
+
+    true
+}

--- a/crates/graphql-composition/src/subgraphs.rs
+++ b/crates/graphql-composition/src/subgraphs.rs
@@ -3,10 +3,13 @@ mod directives;
 mod enums;
 mod field_types;
 mod fields;
+mod ids;
 mod keys;
+mod linked_schemas;
 mod strings;
 mod top;
 mod unions;
+mod view;
 mod walker;
 
 pub(crate) use self::{
@@ -14,7 +17,9 @@ pub(crate) use self::{
     directives::*,
     field_types::*,
     fields::*,
+    ids::*,
     keys::*,
+    linked_schemas::*,
     strings::{StringId, StringWalker},
     top::*,
     walker::Walker,
@@ -34,6 +39,7 @@ pub struct Subgraphs {
     field_types: field_types::FieldTypes,
     keys: keys::Keys,
     unions: unions::Unions,
+    linked_schemas: linked_schemas::LinkedSchemas,
 
     ingestion_diagnostics: crate::Diagnostics,
 
@@ -66,6 +72,7 @@ impl Default for Subgraphs {
             unions: Default::default(),
             ingestion_diagnostics: Default::default(),
             definition_names: Default::default(),
+            linked_schemas: Default::default(),
         }
     }
 }
@@ -146,11 +153,6 @@ impl Subgraphs {
     pub(crate) fn push_ingestion_diagnostic(&mut self, subgraph: SubgraphId, message: String) {
         self.ingestion_diagnostics
             .push_fatal(format!("[{}]: {message}", self.walk_subgraph(subgraph).name().as_str()));
-    }
-
-    pub(crate) fn push_ingestion_warning(&mut self, subgraph: SubgraphId, message: String) {
-        self.ingestion_diagnostics
-            .push_warning(format!("[{}]: {message}", self.walk_subgraph(subgraph).name().as_str()));
     }
 
     pub(crate) fn walk<Id>(&self, id: Id) -> Walker<'_, Id> {

--- a/crates/graphql-composition/src/subgraphs/directives.rs
+++ b/crates/graphql-composition/src/subgraphs/directives.rs
@@ -109,6 +109,13 @@ impl Subgraphs {
     }
 
     pub(crate) fn is_composed_directive(&self, name_id: StringId) -> bool {
+        // The `@authorized` directive is an exception. Directives used in subgraph schemas are either built-in federation directives (`@requires`, `@key`, etc.) or custom, composed directives with `@composeDirective`. Since `@authorized` is not part of the federation spec, some frameworks like async-graphql (Rust) will produce an `@composeDirective` with the `@authorized` directive. We should not consider `@authorized` as a composed directive however, because that means we would emit it again.
+        //
+        // TODO: as for other imported composition directives, we should forbid their use in `@composeDirective`.
+        if Some(name_id) == self.strings.lookup("authorized") {
+            return false;
+        }
+
         self.directives.composed_directives.contains(&name_id)
     }
 

--- a/crates/graphql-composition/src/subgraphs/ids.rs
+++ b/crates/graphql-composition/src/subgraphs/ids.rs
@@ -1,0 +1,29 @@
+use super::*;
+
+macro_rules! make_ids {
+    ($($($path:ident),* [ $id_type_name:ident ] -> $out:ident, )*) => {
+        $(
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub(crate) struct $id_type_name(usize);
+
+        impl From<usize> for $id_type_name {
+            fn from(value: usize) -> Self {
+                $id_type_name(value)
+            }
+        }
+
+        impl std::ops::Index<$id_type_name> for Subgraphs {
+            type Output = $out;
+
+            fn index(&self, index: $id_type_name) -> &$out {
+                &self$(.$path)*[index.0]
+            }
+        }
+        )*
+    };
+}
+
+make_ids! {
+    linked_schemas,schemas[LinkedSchemaId] -> LinkedSchemaRecord,
+    linked_schemas,definitions[LinkedDefinitionId] -> LinkedDefinitionRecord,
+}

--- a/crates/graphql-composition/src/subgraphs/linked_schemas.rs
+++ b/crates/graphql-composition/src/subgraphs/linked_schemas.rs
@@ -1,0 +1,95 @@
+use super::*;
+
+/// Schemas linked with `@link`.
+#[derive(Default)]
+pub(crate) struct LinkedSchemas {
+    pub(super) schemas: Vec<LinkedSchemaRecord>,
+    namespaces: HashMap<StringId, LinkedSchemaId>,
+    /// Directives that have been `@import`ed, and can be used with their unqualified, maybe aliased name.
+    pub(super) definitions: Vec<LinkedDefinitionRecord>,
+    imported_definitions_by_name: HashMap<StringId, LinkedDefinitionId>,
+    subgraphs_with_federation_v2_link: HashSet<SubgraphId>,
+}
+
+/// A schema imported with `@link`.
+pub(crate) struct LinkedSchemaRecord {
+    /// The subgraph where the schema is @link'ed (imported).
+    pub(crate) subgraph_id: SubgraphId,
+    /// The url of the schema.
+    pub(crate) url: StringId,
+    pub(crate) name_from_url: Option<StringId>,
+    #[expect(unused)]
+    pub(crate) version_from_url: Option<StringId>,
+    pub(crate) r#as: Option<StringId>,
+}
+
+impl LinkedSchemaRecord {
+    /// The prefix for the qualified imports from this schema. This can be None, when the url is not a url, or it doesn't have a path segment representing the name, and no `as:` argument is provided. The definitions linked from that `@link()` are then not addressable.
+    pub(crate) fn namespace(&self) -> Option<StringId> {
+        self.r#as.or(self.name_from_url)
+    }
+
+    pub(crate) fn is_federation_v2(&self, subgraphs: &Subgraphs) -> bool {
+        let url = subgraphs.strings.resolve(self.url);
+        url.contains("dev/federation/v2")
+    }
+}
+
+/// A definition from a schema imported with `@link`.
+pub(crate) struct LinkedDefinitionRecord {
+    pub(crate) linked_schema_id: LinkedSchemaId,
+    pub(crate) original_name: StringId,
+    pub(crate) imported_as: Option<StringId>,
+}
+
+impl LinkedDefinitionRecord {
+    pub(crate) fn final_name(&self) -> StringId {
+        self.imported_as.unwrap_or(self.original_name)
+    }
+}
+
+impl Subgraphs {
+    pub(crate) fn get_linked_schema(&self, namespace: StringId) -> Option<LinkedSchemaId> {
+        self.linked_schemas.namespaces.get(&namespace).copied()
+    }
+
+    pub(crate) fn get_imported_definition(&self, name: StringId) -> Option<LinkedDefinitionId> {
+        self.linked_schemas.imported_definitions_by_name.get(&name).copied()
+    }
+
+    pub(crate) fn push_linked_definition(&mut self, linked_definition: LinkedDefinitionRecord) -> LinkedDefinitionId {
+        let id = LinkedDefinitionId::from(self.linked_schemas.definitions.len());
+
+        self.linked_schemas
+            .imported_definitions_by_name
+            .insert(linked_definition.final_name(), id);
+
+        self.linked_schemas.definitions.push(linked_definition);
+
+        id
+    }
+
+    pub(crate) fn push_linked_schema(&mut self, linked_schema: LinkedSchemaRecord) -> LinkedSchemaId {
+        let id = LinkedSchemaId::from(self.linked_schemas.schemas.len());
+
+        if linked_schema.is_federation_v2(self) {
+            self.linked_schemas
+                .subgraphs_with_federation_v2_link
+                .insert(linked_schema.subgraph_id);
+        }
+
+        if let Some(namespace) = linked_schema.namespace() {
+            self.linked_schemas.namespaces.insert(namespace, id);
+        }
+
+        self.linked_schemas.schemas.push(linked_schema);
+
+        id
+    }
+
+    pub(crate) fn subgraph_links_federation_v2(&self, subgraph_id: SubgraphId) -> bool {
+        self.linked_schemas
+            .subgraphs_with_federation_v2_link
+            .contains(&subgraph_id)
+    }
+}

--- a/crates/graphql-composition/src/subgraphs/view.rs
+++ b/crates/graphql-composition/src/subgraphs/view.rs
@@ -1,0 +1,26 @@
+use super::Subgraphs;
+use std::ops::{Deref, Index};
+
+pub(crate) struct View<'a, Id, Record> {
+    #[expect(unused)]
+    pub(crate) id: Id,
+    pub(crate) record: &'a Record,
+}
+
+impl<Id, Record> Deref for View<'_, Id, Record> {
+    type Target = Record;
+
+    fn deref(&self) -> &Self::Target {
+        self.record
+    }
+}
+
+impl Subgraphs {
+    pub(crate) fn at<Id, Record>(&self, id: Id) -> View<'_, Id, Record>
+    where
+        Id: Copy,
+        Subgraphs: Index<Id, Output = Record>,
+    {
+        View { id, record: &self[id] }
+    }
+}

--- a/crates/graphql-composition/tests/composition/authorized_with_composeDirective/api.graphql
+++ b/crates/graphql-composition/tests/composition/authorized_with_composeDirective/api.graphql
@@ -1,5 +1,3 @@
-directive @authorized(arguments: String, fields: String, node: String, metadata: _Any) on OBJECT | FIELD_DEFINITION
-
 type Pet {
     age: String!
     id: Int!

--- a/crates/graphql-composition/tests/composition/authorized_with_composeDirective/federated.graphql
+++ b/crates/graphql-composition/tests/composition/authorized_with_composeDirective/federated.graphql
@@ -1,5 +1,3 @@
-directive @authorized(arguments: String, fields: String, node: String, metadata: _Any) on OBJECT | FIELD_DEFINITION
-
 directive @join__unionMember(graph: join__Graph!, member: String!) on UNION
 
 directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT | INTERFACE

--- a/crates/graphql-composition/tests/composition/authorized_with_composeDirective/subgraphs/users.graphql
+++ b/crates/graphql-composition/tests/composition/authorized_with_composeDirective/subgraphs/users.graphql
@@ -38,6 +38,4 @@ extend schema
     ]
   )
 
-extend schema
-  @link(url: "https://custom.spec.dev/extension/v1.0", import: ["@authorized"])
-  @composeDirective(name: "@authorized")
+extend schema @composeDirective(name: "@authorized")

--- a/crates/graphql-composition/tests/composition/compose_directive_different_definitions/federated.graphql
+++ b/crates/graphql-composition/tests/composition/compose_directive_different_definitions/federated.graphql
@@ -1,6 +1,6 @@
 # Directive `jkl` is defined with different arguments:\n- (a: Int, b: String!) in chocolate\n- (a: Int, b: String!, c: [Float]) in nougat
 # Directive `mno` is defined with different arguments:\n- (a: Int, b: String) in chocolate\n- (a: Int, b: String!) in nougat
-# Directive `pqr` is defined with different locations:\n FIELD_DEFINITION in chocolate\n OBJECT | FIELD_DEFINITION in nougat
 # Directive `stu` is defined with different arguments:\n- (a: String = "NO CAP") in chocolate\n- (a: String = "TEST") in nougat
+# Directive `pqr` is defined with different locations:\n FIELD_DEFINITION in chocolate\n OBJECT | FIELD_DEFINITION in nougat
 # Directive `vwx` is defined with different arguments:\n- (a: Int, b: String! @b @c(d: "boom")) in chocolate\n- (a: Int, b: String! @b @c(d: "e")) in nougat
 # Directive `yz` is defined with different arguments:\n- (a: Int, b: String! @b(d: "e")) in chocolate\n- (a: Int, b: String!) in nougat

--- a/crates/graphql-composition/tests/composition/compose_directive_missing_leading_at/federated.graphql
+++ b/crates/graphql-composition/tests/composition/compose_directive_missing_leading_at/federated.graphql
@@ -1,1 +1,1 @@
-# [sg]: The `noAt` directive is missing the `@` prefix in @composeDirective.
+# [sg]: Invalid `@composeDirective` directive: `name` argument must start with `@`

--- a/crates/graphql-composition/tests/composition/namespaced_directive_without_import_are_ignored/subgraphs/api.graphql
+++ b/crates/graphql-composition/tests/composition/namespaced_directive_without_import_are_ignored/subgraphs/api.graphql
@@ -1,0 +1,26 @@
+enum Severity {
+    OK
+    FINE
+    GREAT
+}
+
+type Alert {
+    id: ID!
+    message: String!
+    severity: Severity!
+}
+
+type Review {
+    author: ID!
+    id: ID!
+    message: String!
+}
+
+type Query {
+    alert(id: ID!): Alert
+}
+
+type Mutation {
+    createAlert(message: String!, severity: Severity!): Alert
+    createReview(message: String!, author: ID!): Alert
+}

--- a/crates/graphql-composition/tests/composition/namespaced_directive_without_import_are_ignored/subgraphs/federated.graphql
+++ b/crates/graphql-composition/tests/composition/namespaced_directive_without_import_are_ignored/subgraphs/federated.graphql
@@ -1,0 +1,54 @@
+directive @join__unionMember(graph: join__Graph!, member: String!) on UNION
+
+directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT | INTERFACE
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+
+directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+
+directive @join__owner(graph: join__Graph!) on OBJECT
+
+scalar join__FieldSet
+
+type Alert
+    @join__type(graph: ALERTS, key: "id")
+{
+    id: ID!
+    message: String!
+    severity: Severity!
+}
+
+type Review
+    @join__type(graph: REVIEWS, key: "id")
+{
+    author: ID!
+    id: ID!
+    message: String!
+}
+
+type Query
+{
+    alert(id: ID!): Alert @join__field(graph: ALERTS)
+}
+
+type Mutation
+{
+    createAlert(message: String!, severity: Severity!): Alert @join__field(graph: ALERTS)
+    createReview(message: String!, author: ID!): Alert @join__field(graph: REVIEWS)
+}
+
+enum Severity
+    @join__type(graph: ALERTS)
+{
+    OK
+    FINE
+    GREAT
+}
+
+enum join__Graph
+{
+    ALERTS @join__graph(name: "alerts", url: "http://example.com/alerts")
+    REVIEWS @join__graph(name: "reviews", url: "http://example.com/reviews")
+}

--- a/crates/graphql-composition/tests/composition/namespaced_directive_without_import_are_ignored/subgraphs/subgraphs/alerts.graphql
+++ b/crates/graphql-composition/tests/composition/namespaced_directive_without_import_are_ignored/subgraphs/subgraphs/alerts.graphql
@@ -1,0 +1,19 @@
+type Alert @key(fields: "id") {
+  id: ID!
+  message: String!
+  severity: Severity!
+}
+
+enum Severity {
+  OK
+  FINE
+  GREAT
+}
+
+type Mutation {
+  createAlert(message: String!, severity: Severity!): Alert @kafka__post(topic: "alerts")
+}
+
+type Query {
+  alert(id: ID!): Alert
+}

--- a/crates/graphql-composition/tests/composition/namespaced_directive_without_import_are_ignored/subgraphs/subgraphs/reviews.graphql
+++ b/crates/graphql-composition/tests/composition/namespaced_directive_without_import_are_ignored/subgraphs/subgraphs/reviews.graphql
@@ -1,0 +1,11 @@
+extend schema @link(url: "https://example.com/kafka/v2.3")
+
+type Review @key(fields: "id") {
+  id: ID!
+  message: String!
+  author: ID!
+}
+
+type Mutation {
+  createReview(message: String!, author: ID!): Alert @kafka__post(topic: "reviews")
+}

--- a/crates/graphql-composition/tests/composition/namespaced_directives_basic/api.graphql
+++ b/crates/graphql-composition/tests/composition/namespaced_directives_basic/api.graphql
@@ -1,0 +1,30 @@
+enum Severity {
+    FINE
+    OK
+    GOOD
+}
+
+type Alert {
+    id: ID!
+    message: String!
+    severity: Severity!
+}
+
+type Review {
+    author: ID!
+    id: ID!
+    message: String!
+}
+
+type Query {
+    alert(id: ID!): Alert
+}
+
+type Mutation {
+    createAlert(message: String!, severity: Severity!): Alert
+    createReview(message: String!, author: ID!): Alert
+}
+
+type Subscription {
+    alert(id: ID!): Alert
+}

--- a/crates/graphql-composition/tests/composition/namespaced_directives_basic/federated.graphql
+++ b/crates/graphql-composition/tests/composition/namespaced_directives_basic/federated.graphql
@@ -1,0 +1,59 @@
+directive @join__unionMember(graph: join__Graph!, member: String!) on UNION
+
+directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT | INTERFACE
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+
+directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+
+directive @join__owner(graph: join__Graph!) on OBJECT
+
+scalar join__FieldSet
+
+type Alert
+    @join__type(graph: ALERTS, key: "id")
+{
+    id: ID!
+    message: String!
+    severity: Severity!
+}
+
+type Review
+    @join__type(graph: REVIEWS, key: "id")
+{
+    author: ID!
+    id: ID!
+    message: String!
+}
+
+type Query
+{
+    alert(id: ID!): Alert @join__field(graph: ALERTS)
+}
+
+type Mutation
+{
+    createAlert(message: String!, severity: Severity!): Alert @join__field(graph: ALERTS)
+    createReview(message: String!, author: ID!): Alert @join__field(graph: REVIEWS)
+}
+
+type Subscription
+{
+    alert(id: ID!): Alert @join__field(graph: ALERTS)
+}
+
+enum Severity
+    @join__type(graph: ALERTS)
+{
+    FINE
+    OK
+    GOOD
+}
+
+enum join__Graph
+{
+    ALERTS @join__graph(name: "alerts", url: "http://example.com/alerts")
+    REVIEWS @join__graph(name: "reviews", url: "http://example.com/reviews")
+}

--- a/crates/graphql-composition/tests/composition/namespaced_directives_basic/subgraphs/alerts.graphql
+++ b/crates/graphql-composition/tests/composition/namespaced_directives_basic/subgraphs/alerts.graphql
@@ -1,0 +1,25 @@
+extend schema @link(url: "https://example.com/kafka/v2.3")
+
+type Alert @key(fields: "id") {
+  id: ID!
+  message: String!
+  severity: Severity!
+}
+
+enum Severity {
+  FINE
+  OK
+  GOOD
+}
+
+type Mutation {
+  createAlert(message: String!, severity: Severity!): Alert @kafka__post(topic: "alerts")
+}
+
+type Query {
+  alert(id: ID!): Alert
+}
+
+type Subscription {
+  alert(id: ID!): Alert @kafka__subscribe(topic: "alerts")
+}

--- a/crates/graphql-composition/tests/composition/namespaced_directives_basic/subgraphs/reviews.graphql
+++ b/crates/graphql-composition/tests/composition/namespaced_directives_basic/subgraphs/reviews.graphql
@@ -1,0 +1,11 @@
+extend schema @link(url: "https://example.com/nats/v2.3", as: "queue")
+
+type Review @key(fields: "id") {
+  id: ID!
+  message: String!
+  author: ID!
+}
+
+type Mutation {
+  createReview(message: String!, author: ID!): Alert @queue__post(topic: "reviews")
+}

--- a/crates/graphql-composition/tests/composition/subgraph_defining_join__Graph/federated.graphql
+++ b/crates/graphql-composition/tests/composition/subgraph_defining_join__Graph/federated.graphql
@@ -1,2 +1,1 @@
-# [bad]: Unknown directive join__graph expected one of authenticated, authorized, composeDirective, cost, external, inaccessible, interfaceObject, key, listSize, override, policy, provides, requires, requiresScopes, shareable, tag
 # [bad] Definition name `join__Graph` is a reserved federation definition name, it cannot be defined in subgraphs.

--- a/crates/graphql-federated-graph/src/federated_graph/directives.rs
+++ b/crates/graphql-federated-graph/src/federated_graph/directives.rs
@@ -1,3 +1,4 @@
+pub mod link;
 mod list_size;
 mod r#override;
 

--- a/crates/graphql-federated-graph/src/federated_graph/directives/link.rs
+++ b/crates/graphql-federated-graph/src/federated_graph/directives/link.rs
@@ -1,0 +1,153 @@
+use std::collections::HashMap;
+
+use cynic_parser_deser::{ConstDeserializer, ValueDeserialize};
+use serde::Deserialize;
+
+/// directive @link(
+///   url: String!,
+///   as: String,
+///   import: [Import],
+///   for: Purpose)
+///   repeatable on SCHEMA
+///
+/// Source: https://specs.apollo.dev/link/v1.0/
+#[derive(Debug)]
+pub struct LinkDirective<'a> {
+    pub url: &'a str,
+    pub r#as: Option<&'a str>,
+    pub import: Option<Vec<Import<'a>>>,
+    pub r#for: Option<Purpose>,
+}
+
+impl<'a> ValueDeserialize<'a> for LinkDirective<'a> {
+    fn deserialize(input: cynic_parser_deser::DeserValue<'a>) -> Result<Self, cynic_parser_deser::Error> {
+        let fields = input
+            .as_object()
+            .ok_or_else(|| cynic_parser_deser::Error::custom("Bad link directive", input.span()))?;
+
+        let mut url = None;
+        let mut r#as = None;
+        let mut import = None;
+        let mut r#for = None;
+
+        for field in fields {
+            match field.name() {
+                "url" => {
+                    url = Some(field.value().as_str().ok_or_else(|| {
+                        cynic_parser_deser::Error::custom("Bad `url` argument in `@link` directive", field.name_span())
+                    })?)
+                }
+                "as" => {
+                    r#as = Some(field.value().as_str().ok_or_else(|| {
+                        cynic_parser_deser::Error::custom("Bad `as` argument in `@link` directive", field.name_span())
+                    })?)
+                }
+                "for" => r#for = Some(field.value().deserialize()?),
+                "import" => import = Some(field.value().deserialize()?),
+                other => {
+                    return Err(cynic_parser_deser::Error::custom(
+                        format!("Unknown argument `{}` in `@link` directive", other),
+                        field.name_span(),
+                    ))
+                }
+            }
+        }
+
+        let Some(url) = url else {
+            return Err(cynic_parser_deser::Error::custom(
+                "Missing `url` argument in `@link` directive",
+                input.span(),
+            ));
+        };
+
+        Ok(LinkDirective {
+            url,
+            r#as,
+            import,
+            r#for,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub enum Purpose {
+    Security,
+    Execution,
+}
+
+impl<'a> ValueDeserialize<'a> for Purpose {
+    fn deserialize(input: cynic_parser_deser::DeserValue<'a>) -> Result<Self, cynic_parser_deser::Error> {
+        let str: &str = input.deserialize()?;
+
+        match str {
+            "SECURITY" => Ok(Purpose::Security),
+            "EXECUTION" => Ok(Purpose::Execution),
+            _ => Err(cynic_parser_deser::Error::custom("Bad purpose", input.span())),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Import<'a> {
+    String(&'a str),
+    Qualified(QualifiedImport<'a>),
+}
+
+#[derive(Debug)]
+pub struct QualifiedImport<'a> {
+    pub name: &'a str,
+    pub r#as: Option<&'a str>,
+}
+
+impl<'a> ValueDeserialize<'a> for QualifiedImport<'a> {
+    fn deserialize(input: cynic_parser_deser::DeserValue<'a>) -> Result<Self, cynic_parser_deser::Error> {
+        let Some(object) = input.as_object() else {
+            return Err(cynic_parser_deser::Error::Custom {
+                text: "Bad import".to_owned(),
+                span: input.span(),
+            });
+        };
+
+        let mut fields: HashMap<&str, _> = object.fields().map(|field| (field.name(), field)).collect();
+
+        if fields.len() > 2 {
+            return Err(cynic_parser_deser::Error::Custom {
+                text: "Bad import".to_owned(),
+                span: input.span(),
+            });
+        }
+
+        let Some(name) = fields.remove("name").and_then(|field| field.value().as_str()) else {
+            return Err(cynic_parser_deser::Error::Custom {
+                text: "Bad import".to_owned(),
+                span: input.span(),
+            });
+        };
+
+        let r#as = fields
+            .remove("as")
+            .map(|alias| {
+                alias
+                    .value()
+                    .as_str()
+                    .ok_or_else(|| cynic_parser_deser::Error::custom("Bad import", input.span()))
+            })
+            .transpose()?;
+
+        Ok(QualifiedImport { name, r#as })
+    }
+}
+
+impl<'a> ValueDeserialize<'a> for Import<'a> {
+    fn deserialize(input: cynic_parser_deser::DeserValue<'a>) -> Result<Self, cynic_parser_deser::Error> {
+        if let Some(string) = input.as_str() {
+            return Ok(Import::String(string));
+        }
+
+        if input.as_object().is_some() {
+            return Ok(Import::Qualified(input.deserialize()?));
+        }
+
+        Err(cynic_parser_deser::Error::custom("Bad import", input.span()))
+    }
+}

--- a/crates/integration-tests/src/openid.rs
+++ b/crates/integration-tests/src/openid.rs
@@ -27,7 +27,7 @@ impl Default for OryHydraOpenIDProvider {
         Self {
             issuer: IssuerUrl::new(ISSUER.to_string()).unwrap(),
             ory_config: Configuration {
-                base_path: dbg!(HYDRA_ADMIN_URL.to_string()),
+                base_path: HYDRA_ADMIN_URL.to_string(),
                 ..Default::default()
             },
         }


### PR DESCRIPTION
Composition previously only dealt with `@link` for the federation directives. Now, we take into account every `@link` and internalize them in the Subgraphs struct. The federated graph output is not changed at the moment, because only the only linked schema with an effect is the federation schema. But this is the infrastructure we need for arbitrary directives from extensions.

closes GB-8313