### PR TITLE
gateway: configurable websocket route

### DIFF
--- a/crates/federated-server/src/server.rs
+++ b/crates/federated-server/src/server.rs
@@ -92,6 +92,7 @@ pub async fn serve(
 ) -> crate::Result<()> {
     let config = config_receiver.borrow().clone();
     let path = config.graph.path.as_deref().unwrap_or("/graphql");
+    let websocket_path = config.graph.websocket_path.as_deref().unwrap_or("/ws");
 
     let meter = grafbase_telemetry::metrics::meter_from_global_provider();
     let pending_logs_counter = meter.i64_up_down_counter("grafbase.gateway.access_log.pending").build();
@@ -147,7 +148,7 @@ pub async fn serve(
         .get_external_router()
         .unwrap_or_default()
         .route(path, get(engine_execute).post(engine_execute))
-        .route_service("/ws", WebsocketService::new(websocket_sender))
+        .route_service(websocket_path, WebsocketService::new(websocket_sender))
         .layer(ResponseHookLayer::new(hooks))
         .layer(TelemetryLayer::new(
             grafbase_telemetry::metrics::meter_from_global_provider(),

--- a/crates/gateway-config/src/lib.rs
+++ b/crates/gateway-config/src/lib.rs
@@ -249,6 +249,7 @@ pub struct RetryConfig {
 #[serde(default, deny_unknown_fields)]
 pub struct GraphConfig {
     pub path: Option<String>,
+    pub websocket_path: Option<String>,
     pub introspection: Option<bool>,
 }
 
@@ -380,6 +381,7 @@ mod tests {
 
         assert!(config.graph.introspection.is_none());
         assert_eq!(None, config.graph.path.as_deref());
+        assert!(config.graph.websocket_path.is_none());
     }
 
     #[test]
@@ -394,6 +396,22 @@ mod tests {
 
         assert!(config.graph.introspection.unwrap());
         assert_eq!(Some("/enterprise"), config.graph.path.as_deref());
+        assert!(config.graph.websocket_path.is_none());
+    }
+
+    #[test]
+    fn graph_with_websocket_path() {
+        let input = indoc! {r#"
+            [graph]
+            path = "/enterprise"
+            websocket_path = "/subscriptions"
+        "#};
+
+        let config: Config = toml::from_str(input).unwrap();
+
+        assert!(config.graph.introspection.is_none());
+        assert_eq!(Some("/enterprise"), config.graph.path.as_deref());
+        assert_eq!(Some("/subscriptions"), config.graph.websocket_path.as_deref());
     }
 
     #[test]

--- a/crates/integration-tests/src/federation/builder.rs
+++ b/crates/integration-tests/src/federation/builder.rs
@@ -137,7 +137,7 @@ impl TestGatewayBuilder {
         let subgraphs = Subgraphs::load(mock_subgraphs, docker_subgraphs).await;
 
         let (engine, context) = self::engine::build(federated_sdl, config, runtime, &subgraphs).await;
-        let router = self::router::build(engine.clone());
+        let router = self::router::build(engine.clone(), &gateway_config);
 
         TestGateway {
             router,

--- a/crates/integration-tests/src/federation/builder/engine.rs
+++ b/crates/integration-tests/src/federation/builder/engine.rs
@@ -61,6 +61,7 @@ pub(super) async fn build(
             "#});
         }
     }
+
     let config = toml::from_str(&config.toml).unwrap();
 
     update_runtime_with_toml_config(&mut runtime, &config, access_log_sender).await;

--- a/crates/integration-tests/src/federation/builder/router.rs
+++ b/crates/integration-tests/src/federation/builder/router.rs
@@ -3,18 +3,22 @@ use std::sync::Arc;
 use axum::{extract::State, response::IntoResponse, routing::get, Router};
 use engine::Engine;
 use engine_axum::websocket::{WebsocketAccepter, WebsocketService};
+use gateway_config::Config;
 
 use super::TestRuntime;
 
-pub(super) fn build(engine: Arc<Engine<TestRuntime>>) -> Router {
+pub(super) fn build(engine: Arc<Engine<TestRuntime>>, config: &Config) -> Router {
     let (websocket_sender, websocket_receiver) = tokio::sync::mpsc::channel(16);
     let (_, engine_watcher) = tokio::sync::watch::channel(engine.clone());
     let websocket_accepter = WebsocketAccepter::new(websocket_receiver, engine_watcher);
     tokio::spawn(websocket_accepter.handler());
 
+    let graphql_path = config.graph.path.as_deref().unwrap_or("/graphql");
+    let websocket_path = config.graph.websocket_path.as_deref().unwrap_or("/ws");
+
     Router::new()
-        .route("/graphql", get(execute).post(execute))
-        .route_service("/ws", WebsocketService::new(websocket_sender))
+        .route(graphql_path, get(execute).post(execute))
+        .route_service(websocket_path, WebsocketService::new(websocket_sender))
         .with_state(engine)
 }
 

--- a/crates/integration-tests/src/federation/mod.rs
+++ b/crates/integration-tests/src/federation/mod.rs
@@ -88,6 +88,7 @@ impl TestGateway {
             gql: request.into(),
             headers: http::HeaderMap::default(),
             init_payload: None,
+            path: "/ws",
         }
     }
 

--- a/crates/integration-tests/tests/federation/subscriptions/websockets.rs
+++ b/crates/integration-tests/tests/federation/subscriptions/websockets.rs
@@ -4,6 +4,60 @@ use graphql_mocks::FederatedProductsSchema;
 use integration_tests::{federation::EngineExt as _, runtime};
 
 #[test]
+fn custom_websocket_path() {
+    runtime().block_on(async move {
+        let engine = Engine::builder()
+            .with_subgraph(FederatedProductsSchema)
+            .with_websocket_urls()
+            .with_toml_config(
+                r#"
+               [graph]
+               websocket_path = "/web3socket"
+            "#,
+            )
+            .build()
+            .await;
+
+        // Default path.
+        let Err(err) = engine.ws("subscription { newProducts { upc } }").await else {
+            panic!("Expected a 404 response, got a stream");
+        };
+
+        assert_eq!(err.to_string(), "HTTP error: 404 Not Found");
+
+        // Custom path.
+        let mut stream = engine
+            .ws("subscription { newProducts { upc } }")
+            .with_path("/web3socket")
+            .await
+            .unwrap();
+
+        let first = stream.next().await.unwrap();
+        let second = stream.next().await.unwrap();
+        assert!(stream.next().await.is_none());
+
+        insta::assert_json_snapshot!([first, second], @r#"
+        [
+          {
+            "data": {
+              "newProducts": {
+                "upc": "top-4"
+              }
+            }
+          },
+          {
+            "data": {
+              "newProducts": {
+                "upc": "top-5"
+              }
+            }
+          }
+        ]
+        "#);
+    });
+}
+
+#[test]
 fn websockets_basic_no_init_payload() {
     let (first, second) = runtime().block_on(async move {
         let engine = Engine::builder()

--- a/crates/integration-tests/tests/integration_tests.rs
+++ b/crates/integration-tests/tests/integration_tests.rs
@@ -1,1 +1,3 @@
+#![allow(clippy::panic)] // panic is OK in tests
+
 mod federation;


### PR DESCRIPTION
The gateway has a configuration option for the graphql endpoint:

```toml
[graph]
path = "/custom" # default: "/graphql"
```

But the websocket endpoint is always exposed at `/ws`. This PR introduces a `websocket_path` option to configure this.

```toml
[graph]
path = "/custom" # default: "/graphql"
websocket_path = "/subscriptions" # default: "/ws"
```

closes GB-8392