### PR TITLE
graphql-federated-graph: delete Value::UnboundEnum

### DIFF
--- a/crates/engine/schema/src/builder/coerce/error.rs
+++ b/crates/engine/schema/src/builder/coerce/error.rs
@@ -80,7 +80,7 @@ impl From<&Value> for ValueKind {
             Value::Null => ValueKind::Null,
             Value::List(_) => ValueKind::List,
             Value::Object(_) => ValueKind::Object,
-            Value::UnboundEnumValue(_) | Value::EnumValue(_) => ValueKind::Enum,
+            Value::EnumValue(_) => ValueKind::Enum,
         }
     }
 }

--- a/crates/engine/schema/src/builder/coerce/mod.rs
+++ b/crates/engine/schema/src/builder/coerce/mod.rs
@@ -183,19 +183,6 @@ impl<'a, 'c> InputValueCoercer<'a, 'c> {
         let r#enum = &self.graph[enum_id];
         match &value {
             Value::EnumValue(id) => Ok(SchemaInputValueRecord::EnumValue((*id).into())),
-            Value::UnboundEnumValue(id) => {
-                let string_value = &self.ctx.strings[(*id).into()];
-                for id in r#enum.value_ids {
-                    if &self.ctx.strings[self.graph[id].name_id] == string_value {
-                        return Ok(SchemaInputValueRecord::EnumValue(id));
-                    }
-                }
-                Err(InputValueError::UnknownEnumValue {
-                    r#enum: self.ctx.strings[r#enum.name_id].to_string(),
-                    value: string_value.to_string(),
-                    path: self.path(),
-                })
-            }
             value => Err(InputValueError::IncorrectEnumValueType {
                 r#enum: self.ctx.strings[r#enum.name_id].to_string(),
                 actual: value.into(),

--- a/crates/engine/schema/src/builder/input_values.rs
+++ b/crates/engine/schema/src/builder/input_values.rs
@@ -9,7 +9,6 @@ impl SchemaInputValues {
         match value {
             Value::Null => SchemaInputValueRecord::Null,
             Value::String(id) => SchemaInputValueRecord::String(id.into()),
-            Value::UnboundEnumValue(id) => SchemaInputValueRecord::UnboundEnumValue(id.into()),
             Value::Int(n) => SchemaInputValueRecord::BigInt(n),
             Value::Float(f) => SchemaInputValueRecord::Float(f),
             Value::Boolean(b) => SchemaInputValueRecord::Boolean(b),

--- a/crates/graphql-composition/src/emit_federated_graph/context.rs
+++ b/crates/graphql-composition/src/emit_federated_graph/context.rs
@@ -70,13 +70,11 @@ impl<'a> Context<'a> {
             subgraphs::Value::Boolean(value) => federated::Value::Boolean(*value),
             subgraphs::Value::Enum(value) => {
                 let value_name = self.insert_string(self.subgraphs.walk(*value));
-                let enum_value = enum_type.and_then(|enum_id| self.out.find_enum_value_by_name_id(enum_id, value_name));
+                let enum_value = enum_type
+                    .and_then(|enum_id| self.out.find_enum_value_by_name_id(enum_id, value_name))
+                    .expect("Failed to find enum value in enum");
 
-                if let Some(enum_value) = enum_value {
-                    federated::Value::EnumValue(enum_value.id())
-                } else {
-                    federated::Value::UnboundEnumValue(value_name)
-                }
+                federated::Value::EnumValue(enum_value.id())
             }
             subgraphs::Value::Object(value) => federated::Value::Object(
                 value

--- a/crates/graphql-federated-graph/src/federated_graph.rs
+++ b/crates/graphql-federated-graph/src/federated_graph.rs
@@ -141,9 +141,9 @@ pub struct Subgraph {
 
 #[derive(Clone, Debug)]
 pub struct Extension {
-    /// Name of the extension within the federated graph. It does NOT necessarily matches the extension's name
+    /// Enum value representing the extension within the federated graph. It does NOT necessarily matches the extension's name
     /// in its manifest, see the `id` field for this.
-    pub enum_value_name: StringId,
+    pub enum_value_id: EnumValueId,
     pub url: StringId,
 
     // -- loaded from the extension manifest --
@@ -189,9 +189,6 @@ pub enum Value {
     /// Different from `String`.
     ///
     /// `@tag(name: "SOMETHING")` vs `@tag(name: SOMETHING)`
-    ///
-    /// FIXME: This is currently required because we do not keep accurate track of the directives in use in the schema, but we should strive towards removing UnboundEnumValue in favour of EnumValue.
-    UnboundEnumValue(StringId),
     EnumValue(EnumValueId),
     Object(Box<[(StringId, Value)]>),
     List(Box<[Value]>),

--- a/crates/graphql-federated-graph/src/federated_graph/directive_definitions.rs
+++ b/crates/graphql-federated-graph/src/federated_graph/directive_definitions.rs
@@ -27,6 +27,27 @@ impl FederatedGraph {
             })
     }
 
+    pub fn find_directive_definition_argument_by_name(
+        &self,
+        definition_id: DirectiveDefinitionId,
+        name: StringId,
+    ) -> Option<&InputValueDefinition> {
+        let start = self
+            .directive_definition_arguments
+            .partition_point(|arg| arg.directive_definition_id < definition_id);
+
+        self.directive_definition_arguments[start..]
+            .iter()
+            .take_while(|arg| arg.directive_definition_id == definition_id)
+            .find_map(|arg| {
+                if arg.input_value_definition.name == name {
+                    Some(&arg.input_value_definition)
+                } else {
+                    None
+                }
+            })
+    }
+
     pub fn push_directive_definition_argument(
         &mut self,
         directive_definition_id: DirectiveDefinitionId,

--- a/crates/graphql-federated-graph/src/from_sdl/directive_definition.rs
+++ b/crates/graphql-federated-graph/src/from_sdl/directive_definition.rs
@@ -44,6 +44,10 @@ pub(super) fn ingest_directive_definition<'a>(
     let directive_definition_id = state.graph.directive_definitions.len().into();
     state.graph.directive_definitions.push(definition);
 
+    state
+        .directive_definition_names
+        .insert(directive_definition.name(), directive_definition_id);
+
     for argument in directive_definition.arguments() {
         let input_value_definition = convert_input_value_definition(argument, state)?;
         state

--- a/crates/graphql-federated-graph/src/render_sdl/directive.rs
+++ b/crates/graphql-federated-graph/src/render_sdl/directive.rs
@@ -102,10 +102,13 @@ fn render_extension_directive(
     graph: &FederatedGraph,
 ) -> fmt::Result {
     let writer = DirectiveWriter::new("grafbase__extensionDirective", f, graph)?
-        .arg("graph", Value::UnboundEnumValue(graph[directive.subgraph_id].name))?
+        .arg(
+            "graph",
+            Value::EnumValue(graph.at(directive.subgraph_id).join_graph_enum_value),
+        )?
         .arg(
             "extension",
-            Value::UnboundEnumValue(graph[directive.extension_id].enum_value_name),
+            Value::EnumValue(graph[directive.extension_id].enum_value_id),
         )?
         .arg("name", Value::String(directive.name))?;
     if let Some(arguments) = directive.arguments.as_ref() {

--- a/crates/graphql-federated-graph/src/render_sdl/display_utils.rs
+++ b/crates/graphql-federated-graph/src/render_sdl/display_utils.rs
@@ -98,7 +98,6 @@ impl fmt::Display for ValueDisplay<'_> {
             crate::Value::String(s) => display_graphql_string_literal(&graph[*s], f),
             crate::Value::Int(i) => Display::fmt(i, f),
             crate::Value::Float(val) => Display::fmt(val, f),
-            crate::Value::UnboundEnumValue(val) => f.write_str(&graph[*val]),
             crate::Value::EnumValue(val) => f.write_str(&graph[graph[*val].value]),
             crate::Value::Boolean(true) => f.write_str("true"),
             crate::Value::Boolean(false) => f.write_str("false"),

--- a/crates/graphql-federated-graph/src/render_sdl/render_federated_sdl.rs
+++ b/crates/graphql-federated-graph/src/render_sdl/render_federated_sdl.rs
@@ -248,9 +248,10 @@ fn write_extensions_enum(graph: &FederatedGraph, sdl: &mut String) -> fmt::Resul
         "enum {} {{\n{}\n}}\n",
         EXTENSION_LINK_ENUM,
         graph.extensions.iter().format_with("\n", |ext, f| {
+            let enum_value = graph.at(ext.enum_value_id).then(|value| value.value).as_str();
             f(&format_args!(
-                r#"  {} @{}(url: "{}")"#,
-                graph[ext.enum_value_name], EXTENSION_LINK_DIRECTIVE, graph[ext.url],
+                r#"  {enum_value} @{}(url: "{}")"#,
+                EXTENSION_LINK_DIRECTIVE, graph[ext.url],
             ))
         })
     )


### PR DESCRIPTION
All enums are now represented in the federated graph.