### PR TITLE
fix: extension build defaults to release mode

### DIFF
--- a/cli/src/cli_input/extension.rs
+++ b/cli/src/cli_input/extension.rs
@@ -28,9 +28,9 @@ pub struct ExtensionBuildCommand {
     /// Output path for the built extension.
     #[arg(short, long, default_value = "./build")]
     pub output_dir: PathBuf,
-    /// Builds the extension in release mode.
+    /// Builds the extension in debug mode.
     #[arg(long)]
-    pub release: bool,
+    pub debug: bool,
     /// Path to the extension source code.
     #[arg(short, long, default_value = ".")]
     pub source_dir: PathBuf,


### PR DESCRIPTION
It's confusing the default is --debug, and your extension is then easily 100 megabytes. The dev work is anyhow using cargo check, and rust-analyzer.