### PR TITLE
fix(engine): Avoid sending duplicate ACCEPT header for SSE

### DIFF
--- a/crates/engine/src/resolver/graphql/subscription.rs
+++ b/crates/engine/src/resolver/graphql/subscription.rs
@@ -164,10 +164,6 @@ impl GraphqlResolver {
 
             headers.typed_insert(headers::ContentType::json());
             headers.typed_insert(headers::ContentLength(body.len() as u64));
-            headers.insert(
-                http::header::ACCEPT,
-                http::HeaderValue::from_static("text/even-stream,application/json;q=0.9"),
-            );
             FetchRequest {
                 websocket_init_payload: None,
                 subgraph_name: endpoint.subgraph_name(),

--- a/crates/graphql-composition/src/ingest_subgraph/directives.rs
+++ b/crates/graphql-composition/src/ingest_subgraph/directives.rs
@@ -19,9 +19,6 @@ pub(super) fn ingest_directives(
     for directive in directives_node {
         let (directive_name_id, match_result) = match_directive_name(ctx, directive.name());
 
-        dbg!(directive.name());
-        dbg!(match_result);
-
         match match_result {
             DirectiveNameMatch::NoMatch
             | DirectiveNameMatch::Imported(_)

--- a/crates/graphql-composition/tests/composition_tests.rs
+++ b/crates/graphql-composition/tests/composition_tests.rs
@@ -72,7 +72,7 @@ fn test_sdl_roundtrip(sdl: &str) -> anyhow::Result<()> {
     }
 
     let roundtripped = graphql_federated_graph::render_federated_sdl(
-        &FederatedGraph::from_sdl(&sdl).map_err(|err| anyhow::anyhow!("Error ingesting SDL: {err}\n\nSDL:\n{sdl}"))?,
+        &FederatedGraph::from_sdl(sdl).map_err(|err| anyhow::anyhow!("Error ingesting SDL: {err}\n\nSDL:\n{sdl}"))?,
     )?;
 
     if roundtripped == sdl {


### PR DESCRIPTION
Might fix a SSE problem as we're sending `text/event-stream,application/json;q=0.9` instead of just `text/event-stream`. The underlying library already adds the ACCEPT header.
