### PR TITLE
feat: loader/host side of authentication extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2489,16 +2489,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "erased-serde"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d"
-dependencies = [
- "serde",
- "typeid",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6902,7 +6892,6 @@ dependencies = [
  "elliptic-curve",
  "engine-schema",
  "enumflags2",
- "erased-serde",
  "extension-catalog",
  "futures-util",
  "gateway-config",
@@ -8484,12 +8473,6 @@ name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
-
-[[package]]
-name = "typeid"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
 
 [[package]]
 name = "typenum"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2489,6 +2489,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d"
+dependencies = [
+ "serde",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3284,7 +3294,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "grafbase-sdk-derive",
  "http 1.2.0",
@@ -3299,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk-derive"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3368,7 +3378,6 @@ dependencies = [
  "console",
  "crc32fast",
  "criterion",
- "crossbeam-channel",
  "crossbeam-queue",
  "crossbeam-utils",
  "cynic",
@@ -6893,6 +6902,7 @@ dependencies = [
  "elliptic-curve",
  "engine-schema",
  "enumflags2",
+ "erased-serde",
  "extension-catalog",
  "futures-util",
  "gateway-config",
@@ -8476,6 +8486,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
+name = "typeid"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8659,6 +8675,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "crossbeam",
+ "dashmap 6.1.0",
  "either",
  "enumflags2",
  "expect-test",
@@ -8669,6 +8686,7 @@ dependencies = [
  "http 1.2.0",
  "indoc",
  "insta",
+ "mini-moka",
  "minicbor-serde",
  "reqwest 0.12.12",
  "serde",
@@ -8679,6 +8697,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "ulid",
  "url",
  "wasmtime",
  "wasmtime-wasi",

--- a/cli/templates/extension/src/lib.rs.template
+++ b/cli/templates/extension/src/lib.rs.template
@@ -1,5 +1,5 @@
 use grafbase_sdk::{
-    types::{Directive, FieldDefinition, FieldInputs, FieldOutput},
+    types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
     Error, Extension, Resolver, ResolverExtension, SharedContext,
 };
 
@@ -7,7 +7,7 @@ use grafbase_sdk::{
 struct {{name}};
 
 impl Extension for {{name}} {
-    fn new(schema_directives: Vec<Directive>) -> Result<Self, Box<dyn std::error::Error>> {
+    fn new(schema_directives: Vec<Directive>, config: Configuration) -> Result<Self, Box<dyn std::error::Error>> {
         Ok(Self)
     }
 }

--- a/cli/tests/extension/mod.rs
+++ b/cli/tests/extension/mod.rs
@@ -26,7 +26,7 @@ fn init() {
     license = "Apache-2.0"
 
     [dependencies]
-    grafbase-sdk = "0.1.3"
+    grafbase-sdk = "0.1.4"
 
     [lib]
     crate-type = ["cdylib"]
@@ -60,7 +60,7 @@ fn init() {
 
     insta::assert_snapshot!(&lib_rs, @r##"
     use grafbase_sdk::{
-        types::{Directive, FieldDefinition, FieldInputs, FieldOutput},
+        types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
         Error, Extension, Resolver, ResolverExtension, SharedContext,
     };
 
@@ -68,7 +68,7 @@ fn init() {
     struct TestProject;
 
     impl Extension for TestProject {
-        fn new(schema_directives: Vec<Directive>) -> Result<Self, Box<dyn std::error::Error>> {
+        fn new(schema_directives: Vec<Directive>, config: Configuration) -> Result<Self, Box<dyn std::error::Error>> {
             Ok(Self)
         }
     }

--- a/crates/federated-server/src/server/gateway.rs
+++ b/crates/federated-server/src/server/gateway.rs
@@ -135,7 +135,7 @@ fn create_wasi_extension_configs(
             max_pool_size: extension_config.max_pool_size(),
             wasi_config,
             // TODO: we actually need to pass the extension config here, sigh :(
-            extension_config: Box::new(""),
+            extension_config: Vec::new(),
         });
     }
 

--- a/crates/federated-server/src/server/gateway.rs
+++ b/crates/federated-server/src/server/gateway.rs
@@ -134,6 +134,8 @@ fn create_wasi_extension_configs(
             schema_directives: Vec::new(),
             max_pool_size: extension_config.max_pool_size(),
             wasi_config,
+            // TODO: we actually need to pass the extension config here, sigh :(
+            extension_config: Box::new(""),
         });
     }
 

--- a/crates/grafbase-sdk/Cargo.toml
+++ b/crates/grafbase-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-sdk"
-version = "0.1.3"
+version = "0.1.4"
 description = "An SDK to implement extensions for the Grafbase Gateway"
 edition.workspace = true
 license.workspace = true
@@ -9,7 +9,7 @@ keywords.workspace = true
 repository.workspace = true
 
 [dependencies]
-grafbase-sdk-derive = { version = "0.1.1", path = "derive" }
+grafbase-sdk-derive = { version = "0.1.2", path = "derive" }
 http.workspace = true
 minicbor-serde = { workspace = true, features = ["alloc"] }
 serde.workspace = true

--- a/crates/grafbase-sdk/derive/Cargo.toml
+++ b/crates/grafbase-sdk/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-sdk-derive"
-version = "0.1.1"
+version = "0.1.2"
 description = "A proc macro for the grafbase-sdk crate"
 edition = "2021"
 license = "MPL-2.0"

--- a/crates/grafbase-sdk/derive/src/lib.rs
+++ b/crates/grafbase-sdk/derive/src/lib.rs
@@ -8,6 +8,12 @@ pub fn resolver_extension(input: TokenStream) -> TokenStream {
     expand(resolver_init(ast))
 }
 
+#[proc_macro_derive(AuthenticationExtension)]
+pub fn authentication_extension(input: TokenStream) -> TokenStream {
+    let ast = syn::parse_macro_input!(input as DeriveInput);
+    expand(authentication_init(ast))
+}
+
 fn expand(init: proc_macro2::TokenStream) -> TokenStream {
     let token_stream = quote! {
         #[doc(hidden)]
@@ -26,11 +32,26 @@ fn resolver_init(ast: DeriveInput) -> proc_macro2::TokenStream {
     let (_, ty_generics, _) = ast.generics.split_for_impl();
 
     quote! {
-        let init_fn = |directives| {
-            let result = <#name #ty_generics as grafbase_sdk::Extension>::new(directives);
+        let init_fn = |directives, config| {
+            let result = <#name #ty_generics as grafbase_sdk::Extension>::new(directives, config);
             result.map(|extension| Box::new(extension) as Box<dyn grafbase_sdk::Resolver>)
         };
 
         grafbase_sdk::extension::resolver::register(Box::new(init_fn));
+    }
+}
+
+fn authentication_init(ast: DeriveInput) -> proc_macro2::TokenStream {
+    let name = &ast.ident;
+
+    let (_, ty_generics, _) = ast.generics.split_for_impl();
+
+    quote! {
+        let init_fn = |directives, config| {
+            let result = <#name #ty_generics as grafbase_sdk::Extension>::new(directives, config);
+            result.map(|extension| Box::new(extension) as Box<dyn grafbase_sdk::Authenticator>)
+        };
+
+        grafbase_sdk::extension::authentication::register(Box::new(init_fn));
     }
 }

--- a/crates/grafbase-sdk/src/extension/authentication.rs
+++ b/crates/grafbase-sdk/src/extension/authentication.rs
@@ -1,0 +1,50 @@
+use crate::{
+    types::{Configuration, Directive, ErrorResponse, Token},
+    wit::Headers,
+    Error,
+};
+
+use super::Extension;
+
+type InitFn = Box<dyn Fn(Vec<Directive>, Configuration) -> Result<Box<dyn Authenticator>, Box<dyn std::error::Error>>>;
+
+pub(super) static mut EXTENSION: Option<Box<dyn Authenticator>> = None;
+pub static mut INIT_FN: Option<InitFn> = None;
+
+pub(super) fn get_extension() -> Result<&'static mut dyn Authenticator, Error> {
+    // Safety: This is hidden, only called by us. Every extension call to an instance happens
+    // in a single-threaded environment. Do not call this multiple times from different threads.
+    unsafe {
+        EXTENSION.as_deref_mut().ok_or_else(|| Error {
+            message: "Resolver extension not initialized correctly.".to_string(),
+            extensions: Vec::new(),
+        })
+    }
+}
+
+/// Initializes the resolver extension with the provided directives using the closure
+/// function created with the `register_extension!` macro.
+pub(super) fn init(directives: Vec<Directive>, configuration: Configuration) -> Result<(), Box<dyn std::error::Error>> {
+    // Safety: This function is only called from the SDK macro, so we can assume that there is only one caller at a time.
+    unsafe {
+        let init = INIT_FN.as_ref().expect("Resolver extension not initialized correctly.");
+        EXTENSION = Some(init(directives, configuration)?);
+    }
+
+    Ok(())
+}
+
+/// This function gets called when the extension is registered in the user code with the `register_extension!` macro.
+///
+/// This should never be called manually by the user.
+#[doc(hidden)]
+pub fn register(f: InitFn) {
+    // Safety: This function is only called from the SDK macro, so we can assume that there is only one caller at a time.
+    unsafe {
+        INIT_FN = Some(f);
+    }
+}
+
+pub trait Authenticator: Extension {
+    fn authenticate(&mut self, headers: Headers) -> Result<Token, ErrorResponse>;
+}

--- a/crates/grafbase-sdk/src/extension/resolver.rs
+++ b/crates/grafbase-sdk/src/extension/resolver.rs
@@ -1,11 +1,11 @@
 use crate::{
-    types::{Directive, FieldDefinition, FieldInputs, FieldOutput},
+    types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
     wit::{Error, SharedContext},
 };
 
 use super::Extension;
 
-type InitFn = Box<dyn Fn(Vec<Directive>) -> Result<Box<dyn Resolver>, Box<dyn std::error::Error>>>;
+type InitFn = Box<dyn Fn(Vec<Directive>, Configuration) -> Result<Box<dyn Resolver>, Box<dyn std::error::Error>>>;
 
 pub(super) static mut EXTENSION: Option<Box<dyn Resolver>> = None;
 pub static mut INIT_FN: Option<InitFn> = None;
@@ -23,11 +23,11 @@ pub(super) fn get_extension() -> Result<&'static mut dyn Resolver, Error> {
 
 /// Initializes the resolver extension with the provided directives using the closure
 /// function created with the `register_extension!` macro.
-pub(super) fn init(directives: Vec<Directive>) -> Result<(), Box<dyn std::error::Error>> {
+pub(super) fn init(directives: Vec<Directive>, configuration: Configuration) -> Result<(), Box<dyn std::error::Error>> {
     // Safety: This function is only called from the SDK macro, so we can assume that there is only one caller at a time.
     unsafe {
         let init = INIT_FN.as_ref().expect("Resolver extension not initialized correctly.");
-        EXTENSION = Some(init(directives)?);
+        EXTENSION = Some(init(directives, configuration)?);
     }
 
     Ok(())

--- a/crates/grafbase-sdk/src/lib.rs
+++ b/crates/grafbase-sdk/src/lib.rs
@@ -6,9 +6,9 @@ pub mod extension;
 pub mod host_io;
 pub mod types;
 
-pub use extension::{Extension, Resolver};
-pub use grafbase_sdk_derive::ResolverExtension;
-pub use wit::{Error, ExtensionType, SharedContext};
+pub use extension::{Authenticator, Extension, Resolver};
+pub use grafbase_sdk_derive::{AuthenticationExtension, ResolverExtension};
+pub use wit::{Error, ExtensionType, Headers, SharedContext};
 
 struct Component;
 

--- a/crates/grafbase-sdk/src/types.rs
+++ b/crates/grafbase-sdk/src/types.rs
@@ -220,7 +220,7 @@ pub struct Token {
 
 impl From<Token> for wit::Token {
     fn from(token: Token) -> wit::Token {
-        wit::Token { claims: token.claims }
+        wit::Token { raw: token.claims }
     }
 }
 

--- a/crates/grafbase-sdk/src/types.rs
+++ b/crates/grafbase-sdk/src/types.rs
@@ -1,8 +1,13 @@
 //! Type definitions of the input and output data structures of the SDK.
 
+use std::time::Duration;
+
+pub use http::StatusCode;
 pub use minicbor_serde::error::DecodeError;
 pub use serde::Deserialize;
-use serde::Serialize;
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::wit;
 
 /// The directive and its arguments which define the extension in the GraphQL SDK.
 pub struct Directive(crate::wit::Directive);
@@ -122,5 +127,136 @@ impl FieldInputs {
             .iter()
             .map(|input| minicbor_serde::from_slice(input).map_err(|e| Box::new(e) as Box<dyn std::error::Error>))
             .collect()
+    }
+}
+
+/// Configuration data for the extension, from the gateway toml config.
+pub struct Configuration(Vec<u8>);
+
+impl Configuration {
+    /// Creates a new `Configuration` from a CBOR byte vector.
+    pub(crate) fn new(config: Vec<u8>) -> Self {
+        Self(config)
+    }
+
+    /// Deserializes the configuration bytes into the requested type.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if deserialization fails.
+    pub fn deserialize<'de, T>(&'de self) -> Result<T, Box<dyn std::error::Error>>
+    where
+        T: Deserialize<'de>,
+    {
+        minicbor_serde::from_slice(&self.0).map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
+    }
+}
+
+/// A cache implementation for storing data between requests.
+pub struct Cache;
+
+impl Cache {
+    /// Retrieves a value from the cache by key, initializing it if not present.
+    ///
+    /// If the value exists in the cache, deserializes and returns it.
+    /// If not found, calls the initialization function, caches the result, and returns it.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The cache key to look up
+    /// * `init` - Function to initialize the value if not found in cache
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if serialization/deserialization fails or if the init function fails
+    pub fn get<F, T>(key: &str, init: F) -> Result<T, Box<dyn std::error::Error>>
+    where
+        F: FnOnce() -> Result<CachedItem<T>, Box<dyn std::error::Error>>,
+        T: Serialize + DeserializeOwned,
+    {
+        let value = crate::wit::Cache::get(key);
+
+        if let Some(value) = value {
+            Ok(minicbor_serde::from_slice(&value)?)
+        } else {
+            let value = init()?;
+            let serialized = minicbor_serde::to_vec(&value.value)?;
+
+            crate::wit::Cache::set(key, &serialized, value.duration.map(|d| d.as_millis() as u64));
+
+            Ok(value.value)
+        }
+    }
+}
+
+/// A value to be stored in the cache with an optional time-to-live duration.
+pub struct CachedItem<T> {
+    value: T,
+    duration: Option<Duration>,
+}
+
+impl<T> CachedItem<T>
+where
+    T: Serialize,
+{
+    /// Creates a new cached item with the given value and optional TTL duration.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The value to cache
+    /// * `duration` - Optional time-to-live duration after which the item expires
+    pub fn new(value: T, duration: Option<Duration>) -> Self
+    where
+        T: Serialize,
+    {
+        Self { value, duration }
+    }
+}
+
+/// A structure representing an authentication token claims.
+pub struct Token {
+    claims: Vec<u8>,
+}
+
+impl From<Token> for wit::Token {
+    fn from(token: Token) -> wit::Token {
+        wit::Token { claims: token.claims }
+    }
+}
+
+impl Token {
+    /// Creates a new `Token` with the given claims.
+    pub fn new<T>(claims: T) -> Self
+    where
+        T: Serialize,
+    {
+        Self {
+            claims: minicbor_serde::to_vec(&claims)
+                .expect("serialization error is Infallible, so it should never happen"),
+        }
+    }
+}
+
+/// A response containing a status code and multiple errors.
+pub struct ErrorResponse(crate::wit::ErrorResponse);
+
+impl From<ErrorResponse> for crate::wit::ErrorResponse {
+    fn from(resp: ErrorResponse) -> Self {
+        resp.0
+    }
+}
+
+impl ErrorResponse {
+    /// Creates a new `ErrorResponse` with the given HTTP status code.
+    pub fn new(status_code: http::StatusCode) -> Self {
+        Self(crate::wit::ErrorResponse {
+            status_code: status_code.as_u16(),
+            errors: Vec::new(),
+        })
+    }
+
+    /// Adds a new error to the response.
+    pub fn push_error(&mut self, error: crate::wit::Error) {
+        self.0.errors.push(error);
     }
 }

--- a/crates/grafbase-sdk/wit/world.wit
+++ b/crates/grafbase-sdk/wit/world.wit
@@ -150,7 +150,7 @@ world sdk {
     }
 
     record token {
-        claims: list<u8>,
+        raw: list<u8>,
     }
 
     resource cache {

--- a/crates/grafbase-sdk/wit/world.wit
+++ b/crates/grafbase-sdk/wit/world.wit
@@ -16,6 +16,14 @@ world sdk {
         trace-id: func() -> string;
     }
 
+    // An HTTP error response.
+    record error-response {
+        // HTTP status code. Must be a valid status code. If not, the status code will be 500.
+        status-code: u16,
+        // List of GraphQL errors.
+        errors: list<error>,
+    }
+
     // An error response can be used to inject an error to the GraphQL response.
     record error {
         // Adds the given extensions to the response extensions. The first item in
@@ -39,7 +47,8 @@ world sdk {
     }
 
     enum extension-type {
-        resolver
+        resolver,
+        authentication,
     }
 
     // A sender for the system access log.
@@ -136,12 +145,26 @@ world sdk {
         connect(string),
     }
 
+    resource headers {
+        get: func(name: string) -> option<string>;
+    }
+
+    record token {
+        claims: list<u8>,
+    }
+
+    resource cache {
+        get: static func(key: string) -> option<list<u8>>;
+        set: static func(key: string, value: list<u8>, ttl-ms: option<u64>) -> ();
+    }
+
     // initialization function called to set up the wasm extension
     // if an error happens here, the gateway will refuse to continue.
     // Receives a list of schema directives associated with the extension
     export init-gateway-extension: func(
         extension-type: extension-type,
-        schema-directives: list<directive>
+        schema-directives: list<directive>,
+        configuration: list<u8>,
     ) -> result<_, string>;
 
     // for each input and each edges inside we return a result<list<u8>, error>,
@@ -152,6 +175,10 @@ world sdk {
        definition: field-definition,
        inputs: list<list<u8>>
     ) -> result<field-output, error>;
+
+    export authenticate: func(
+        headers: headers,
+    ) -> result<token, error-response>;
 
     // The extension registration function. Must be called before initialization.
     export register-extension: func();

--- a/crates/grafbase-workspace-hack/Cargo.toml
+++ b/crates/grafbase-workspace-hack/Cargo.toml
@@ -38,7 +38,6 @@ concurrent-queue = { version = "2" }
 console = { version = "0.15", default-features = false, features = ["ansi-parsing", "unicode-width"] }
 crc32fast = { version = "1" }
 criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
-crossbeam-channel = { version = "0.5" }
 crossbeam-queue = { version = "0.3" }
 crossbeam-utils = { version = "0.8" }
 cynic = { version = "3", features = ["http-reqwest"] }
@@ -156,7 +155,6 @@ concurrent-queue = { version = "2" }
 console = { version = "0.15", default-features = false, features = ["ansi-parsing", "unicode-width"] }
 crc32fast = { version = "1" }
 criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
-crossbeam-channel = { version = "0.5" }
 crossbeam-queue = { version = "0.3" }
 crossbeam-utils = { version = "0.8" }
 cynic = { version = "3", features = ["http-reqwest"] }

--- a/crates/runtime-local/Cargo.toml
+++ b/crates/runtime-local/Cargo.toml
@@ -58,4 +58,3 @@ anyhow.workspace = true
 grafbase-workspace-hack.workspace = true
 enumflags2 = "0.7.10"
 semver.workspace = true
-erased-serde = "0.4.5"

--- a/crates/runtime-local/Cargo.toml
+++ b/crates/runtime-local/Cargo.toml
@@ -58,3 +58,4 @@ anyhow.workspace = true
 grafbase-workspace-hack.workspace = true
 enumflags2 = "0.7.10"
 semver.workspace = true
+erased-serde = "0.4.5"

--- a/crates/runtime-local/src/wasi/extensions.rs
+++ b/crates/runtime-local/src/wasi/extensions.rs
@@ -59,7 +59,14 @@ async fn create_pools(
 
             match ComponentLoader::extensions(config.name, config.wasi_config)? {
                 Some(loader) => {
-                    let pool = Pool::new(loader, manager_config, config.max_pool_size, access_log);
+                    let pool = Pool::new(
+                        loader,
+                        manager_config,
+                        config.max_pool_size,
+                        config.extension_config,
+                        access_log,
+                    );
+
                     Ok(Some((config.id, pool)))
                 }
                 None => Ok(None),
@@ -155,7 +162,6 @@ struct WasiExtensionsInner {
     instance_pools: HashMap<ExtensionId, Pool>,
 }
 
-#[derive(Debug, Clone)]
 pub struct ExtensionConfig {
     pub id: ExtensionId,
     pub name: String,
@@ -164,4 +170,5 @@ pub struct ExtensionConfig {
     pub schema_directives: Vec<Directive>,
     pub max_pool_size: Option<usize>,
     pub wasi_config: WasiExtensionsConfig,
+    pub extension_config: Box<dyn erased_serde::Serialize + Send + Sync>,
 }

--- a/crates/runtime-local/src/wasi/extensions.rs
+++ b/crates/runtime-local/src/wasi/extensions.rs
@@ -170,5 +170,6 @@ pub struct ExtensionConfig {
     pub schema_directives: Vec<Directive>,
     pub max_pool_size: Option<usize>,
     pub wasi_config: WasiExtensionsConfig,
-    pub extension_config: Box<dyn erased_serde::Serialize + Send + Sync>,
+    // CBOR encoded extension configuration
+    pub extension_config: Vec<u8>,
 }

--- a/crates/runtime-local/src/wasi/extensions/pool.rs
+++ b/crates/runtime-local/src/wasi/extensions/pool.rs
@@ -31,7 +31,7 @@ impl Pool {
         loader: ComponentLoader,
         config: ComponentManagerConfig,
         size: Option<usize>,
-        extension_config: Box<dyn erased_serde::Serialize + Send + Sync>,
+        extension_config: Vec<u8>,
         access_log: ChannelLogSender,
     ) -> Self {
         let mgr = ComponentManager::new(loader, access_log, config, extension_config);
@@ -64,7 +64,7 @@ pub(super) struct ComponentManager {
     access_log: ChannelLogSender,
     extension_type: ExtensionType,
     schema_directives: Vec<Directive>,
-    config: Box<dyn erased_serde::Serialize + Send + Sync>,
+    config: Vec<u8>,
 }
 
 impl ComponentManager {
@@ -72,7 +72,7 @@ impl ComponentManager {
         component_loader: ComponentLoader,
         access_log: ChannelLogSender,
         config: ComponentManagerConfig,
-        extension_config: Box<dyn erased_serde::Serialize + Send + Sync>,
+        extension_config: Vec<u8>,
     ) -> Self {
         Self {
             component_loader,
@@ -93,7 +93,7 @@ impl Manager for ComponentManager {
             &self.component_loader,
             self.extension_type,
             self.schema_directives.clone(),
-            &self.config,
+            self.config.clone(),
             self.access_log.clone(),
         )
         .await

--- a/crates/runtime-local/src/wasi/extensions/pool.rs
+++ b/crates/runtime-local/src/wasi/extensions/pool.rs
@@ -31,9 +31,10 @@ impl Pool {
         loader: ComponentLoader,
         config: ComponentManagerConfig,
         size: Option<usize>,
+        extension_config: Box<dyn erased_serde::Serialize + Send + Sync>,
         access_log: ChannelLogSender,
     ) -> Self {
-        let mgr = ComponentManager::new(loader, access_log, config);
+        let mgr = ComponentManager::new(loader, access_log, config, extension_config);
         let mut builder = managed::Pool::builder(mgr);
 
         if let Some(size) = size {
@@ -63,6 +64,7 @@ pub(super) struct ComponentManager {
     access_log: ChannelLogSender,
     extension_type: ExtensionType,
     schema_directives: Vec<Directive>,
+    config: Box<dyn erased_serde::Serialize + Send + Sync>,
 }
 
 impl ComponentManager {
@@ -70,12 +72,14 @@ impl ComponentManager {
         component_loader: ComponentLoader,
         access_log: ChannelLogSender,
         config: ComponentManagerConfig,
+        extension_config: Box<dyn erased_serde::Serialize + Send + Sync>,
     ) -> Self {
         Self {
             component_loader,
             access_log,
             extension_type: config.extension_type,
             schema_directives: config.schema_directives,
+            config: extension_config,
         }
     }
 }
@@ -89,6 +93,7 @@ impl Manager for ComponentManager {
             &self.component_loader,
             self.extension_type,
             self.schema_directives.clone(),
+            &self.config,
             self.access_log.clone(),
         )
         .await

--- a/crates/wasi-component-loader/Cargo.toml
+++ b/crates/wasi-component-loader/Cargo.toml
@@ -24,6 +24,9 @@ enumflags2 = "0.7.10"
 serde.workspace = true
 minicbor-serde = { version = "0.3.2", features = ["alloc"] }
 either = "1.13.0"
+dashmap = "6.1.0"
+mini-moka.workspace = true
+ulid.workspace = true
 
 [dependencies.wasmtime]
 version = "29"

--- a/crates/wasi-component-loader/examples/Cargo.lock
+++ b/crates/wasi-component-loader/examples/Cargo.lock
@@ -57,6 +57,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
+name = "caching-auth"
+version = "0.1.0"
+dependencies = [
+ "grafbase-sdk",
+ "serde",
+]
+
+[[package]]
 name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "grafbase-sdk-derive",
  "http",
@@ -284,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk-derive"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/wasi-component-loader/examples/extensions/caching-auth/Cargo.toml
+++ b/crates/wasi-component-loader/examples/extensions/caching-auth/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "caching-auth"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+repository.workspace = true
+
+[dependencies]
+grafbase-sdk.workspace = true
+serde.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+

--- a/crates/wasi-component-loader/examples/extensions/caching-auth/src/lib.rs
+++ b/crates/wasi-component-loader/examples/extensions/caching-auth/src/lib.rs
@@ -37,14 +37,15 @@ impl Authenticator for CachingProvider {
             .get("Authorization")
             .ok_or_else(|| ErrorResponse::new(StatusCode::UNAUTHORIZED))?;
 
+        let value = headers.get("value").unwrap_or_else(|| String::from("default"));
+
         let cache_key = format!("auth:{}:{header}", self.config.cache_config);
 
         let jwks: Jwks = Cache::get(&cache_key, || {
             std::thread::sleep(Duration::from_millis(300));
 
-            let jwks = Jwks { key: header };
-
-            let item = CachedItem::new(jwks, Some(Duration::from_millis(900)));
+            let jwks = Jwks { key: value };
+            let item = CachedItem::new(jwks, None);
 
             Ok(item)
         })

--- a/crates/wasi-component-loader/examples/extensions/caching-auth/src/lib.rs
+++ b/crates/wasi-component-loader/examples/extensions/caching-auth/src/lib.rs
@@ -1,0 +1,55 @@
+use std::time::Duration;
+
+use grafbase_sdk::{
+    types::{Cache, CachedItem, Configuration, Directive, ErrorResponse, StatusCode, Token},
+    AuthenticationExtension, Authenticator, Extension, Headers,
+};
+
+#[derive(AuthenticationExtension)]
+struct CachingProvider {
+    config: ProviderConfig,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ProviderConfig {
+    cache_config: String,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct Jwks {
+    key: String,
+}
+
+impl Extension for CachingProvider {
+    fn new(_: Vec<Directive>, config: Configuration) -> Result<Self, Box<dyn std::error::Error>>
+    where
+        Self: Sized,
+    {
+        let config: ProviderConfig = config.deserialize()?;
+
+        Ok(Self { config })
+    }
+}
+
+impl Authenticator for CachingProvider {
+    fn authenticate(&mut self, headers: Headers) -> Result<Token, ErrorResponse> {
+        let header = headers
+            .get("Authorization")
+            .ok_or_else(|| ErrorResponse::new(StatusCode::UNAUTHORIZED))?;
+
+        let cache_key = format!("auth:{}:{header}", self.config.cache_config);
+
+        let jwks: Jwks = Cache::get(&cache_key, || {
+            std::thread::sleep(Duration::from_millis(300));
+
+            let jwks = Jwks { key: header };
+
+            let item = CachedItem::new(jwks, Some(Duration::from_millis(900)));
+
+            Ok(item)
+        })
+        .unwrap();
+
+        Ok(Token::new(jwks))
+    }
+}

--- a/crates/wasi-component-loader/examples/extensions/simple-resolver/src/lib.rs
+++ b/crates/wasi-component-loader/examples/extensions/simple-resolver/src/lib.rs
@@ -1,5 +1,5 @@
 use grafbase_sdk::{
-    types::{Directive, FieldDefinition, FieldInputs, FieldOutput},
+    types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
     Error, Extension, Resolver, ResolverExtension, SharedContext,
 };
 
@@ -25,7 +25,7 @@ struct ResponseOutput<'a> {
 }
 
 impl Extension for SimpleResolver {
-    fn new(schema_directives: Vec<Directive>) -> Result<Self, Box<dyn std::error::Error>> {
+    fn new(schema_directives: Vec<Directive>, _: Configuration) -> Result<Self, Box<dyn std::error::Error>> {
         let schema_args = schema_directives
             .into_iter()
             .filter(|d| d.name() == "schemaArgs")

--- a/crates/wasi-component-loader/src/cache.rs
+++ b/crates/wasi-component-loader/src/cache.rs
@@ -1,0 +1,182 @@
+use std::{
+    future::Future,
+    time::{Duration, Instant, SystemTime},
+};
+
+use dashmap::DashMap;
+use futures::TryFutureExt;
+use tokio::sync::{mpsc, oneshot, Semaphore};
+use ulid::Ulid;
+use wasmtime::{
+    component::{LinkerInstance, ResourceType},
+    StoreContextMut,
+};
+
+use crate::{
+    names::{CACHE_GET_FUNCTION, CACHE_RESOURCE, CACHE_SET_FUNCTION},
+    state::WasiState,
+};
+
+type WaitListReceiver = mpsc::Receiver<oneshot::Sender<Vec<u8>>>;
+type WaitListSender = mpsc::Sender<oneshot::Sender<Vec<u8>>>;
+
+pub(crate) fn inject_mapping(types: &mut LinkerInstance<'_, WasiState>) -> crate::Result<()> {
+    types.resource(CACHE_RESOURCE, ResourceType::host::<()>(), |_, _| Ok(()))?;
+    types.func_wrap_async(CACHE_GET_FUNCTION, cache_get)?;
+    types.func_wrap_async(CACHE_SET_FUNCTION, cache_set)?;
+
+    Ok(())
+}
+
+type CacheGetResult<'a> = Box<dyn Future<Output = anyhow::Result<(Option<Vec<u8>>,)>> + Send + 'a>;
+type CacheSetResult<'a> = Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>;
+
+fn cache_get(store: StoreContextMut<'_, WasiState>, (key,): (String,)) -> CacheGetResult<'_> {
+    Box::new(async move {
+        let value = store.data().cache().get(&key).await;
+
+        Ok((value,))
+    })
+}
+
+fn cache_set(
+    store: StoreContextMut<'_, WasiState>,
+    (key, value, ttl_ms): (String, Vec<u8>, Option<u64>),
+) -> CacheSetResult<'_> {
+    Box::new(async move {
+        store.data().cache().set(&key, value, ttl_ms).await;
+        Ok(())
+    })
+}
+
+pub(crate) struct Cache {
+    cache: DashMap<String, CachedValue>,
+    semaphore: Semaphore,
+    wait_list: DashMap<String, (Ulid, WaitListSender, WaitListReceiver)>,
+}
+
+struct CachedValue {
+    data: Vec<u8>,
+    expires_at: Option<Instant>,
+}
+
+impl Cache {
+    pub fn new() -> Self {
+        Self {
+            cache: DashMap::new(),
+            semaphore: Semaphore::new(1024),
+            wait_list: DashMap::new(),
+        }
+    }
+
+    /// Gets a value from the cache by key. If this function returns None, the caller must set a new one.
+    pub async fn get(&self, key: &str) -> Option<Vec<u8>> {
+        if let Some(value) = self.cache.get(key) {
+            if value.expires_at.map(|expiry| expiry < Instant::now()) == Some(true) {
+                self.cache.remove(key);
+            } else {
+                return Some(value.data.clone());
+            }
+        }
+
+        // This will short-circuit a `None` out if there is no wait list. The function creates a new list,
+        // and the caller must call set with a new value. Subsequent calls will get the wait list
+        // and yield until the first caller creates the value.
+        let (wait_list_sender, wait_list_id) = self.get_or_create_wait_list(key).await?;
+
+        // We have to have a timeout here, because the guest can do IO to get the cache value in the
+        // init. If this never finishes, we will leak memory when new callers are added to the list.
+        let fut = tokio::time::timeout(Duration::from_secs(5), async move {
+            let (value_sender, value_receiver) = oneshot::channel();
+            wait_list_sender.send(value_sender).await.ok()?;
+            value_receiver.await.ok()
+        });
+
+        let fut = fut.inspect_err(|_| {
+            tracing::error!("timed out waiting for cached value in extension cache to be available");
+        });
+
+        if let Some(value) = fut.await.ok().flatten() {
+            return Some(value);
+        };
+
+        // This happens only if our wait list timed out. We must clean the list so we do not leak
+        // memory.
+        if self
+            .wait_list
+            .remove_if(key, |_, (id, _, _)| *id == wait_list_id)
+            .is_some()
+        {
+            let now = SystemTime::now();
+
+            let timestamp = Duration::from_millis(wait_list_id.timestamp_ms());
+            let created_at = SystemTime::UNIX_EPOCH.checked_add(timestamp);
+
+            let time_ago = created_at
+                .and_then(|created_at| now.duration_since(created_at).ok())
+                .unwrap_or_default()
+                .as_secs();
+
+            tracing::info!("Removed dead wait extension list, created {time_ago}s ago");
+        }
+
+        None
+    }
+
+    /// Sets a value in the cache with an optional time-to-live duration in milliseconds.
+    pub async fn set(&self, key: &str, value: Vec<u8>, ttl_ms: Option<u64>) {
+        let cached_value = CachedValue {
+            data: value.clone(),
+            expires_at: ttl_ms.map(|ms| Instant::now() + std::time::Duration::from_millis(ms)),
+        };
+
+        self.cache.insert(key.to_string(), cached_value);
+
+        // We remove the wait list so subsequent calls do not add themselves to the list. The value
+        // is already in the cache. We use receive all listeners from the wait list, and send the
+        // new value for them so they can continue execution.
+        if let Some((_, (_, _, mut receiver))) = self.wait_list.remove(key) {
+            while let Ok(waiter) = receiver.try_recv() {
+                let _ = waiter.send(value.clone()).ok();
+            }
+        }
+    }
+
+    /// Gets or creates a wait list for the given cache key. The first caller to a cache value that is
+    /// missing will create a new wait list, this function returns None and the caller must initialize
+    /// a new value in the guest, and set a new value in the cache.
+    ///
+    /// The subsequent callers for this value will get the wait list, and add themselves to it.
+    /// When the first caller sets a new value, this will send the value to everybody waiting
+    /// in the wait list.
+    async fn get_or_create_wait_list(&self, key: &str) -> Option<(WaitListSender, Ulid)> {
+        match self.wait_list.entry(key.to_string()) {
+            dashmap::Entry::Occupied(mut entry) => {
+                let (id, sender, _) = entry.get();
+
+                if sender.is_closed() {
+                    let permit = self.semaphore.acquire().await.expect("we never close the semaphore");
+                    let (sender, receiver) = mpsc::channel(1024);
+                    let id = Ulid::new();
+
+                    entry.insert((id, sender, receiver));
+                    drop(permit);
+
+                    None
+                } else {
+                    Some((sender.clone(), *id))
+                }
+            }
+            dashmap::Entry::Vacant(entry) => {
+                let permit = self.semaphore.acquire().await.expect("we never close the semaphore");
+                let (sender, receiver) = mpsc::channel(1024);
+                let id = Ulid::new();
+
+                entry.insert((id, sender, receiver));
+                drop(permit);
+
+                None
+            }
+        }
+    }
+}

--- a/crates/wasi-component-loader/src/cache.rs
+++ b/crates/wasi-component-loader/src/cache.rs
@@ -79,10 +79,12 @@ impl Cache {
             }
         }
 
-        // This will short-circuit a `None` out if there is no wait list. The function creates a new list,
-        // and the caller must call set with a new value. Subsequent calls will get the wait list
-        // and yield until the first caller creates the value.
-        let (wait_list_sender, wait_list_id) = self.get_or_create_wait_list(key).await?;
+        let Some((wait_list_sender, wait_list_id)) = self.get_or_create_wait_list(key).await else {
+            // This will short-circuit a `None` out if there is no wait list. The function creates a new list,
+            // and the caller must call set with a new value. Subsequent calls will get the wait list
+            // and yield until the first caller creates the value.
+            return None;
+        };
 
         // We have to have a timeout here, because the guest can do IO to get the cache value in the
         // init. If this never finishes, we will leak memory when new callers are added to the list.

--- a/crates/wasi-component-loader/src/instance/extensions.rs
+++ b/crates/wasi-component-loader/src/instance/extensions.rs
@@ -24,16 +24,13 @@ pub struct ExtensionsComponentInstance {
 
 impl ExtensionsComponentInstance {
     /// Creates a new extension component instance.
-    pub async fn new<T>(
+    pub async fn new(
         loader: &ComponentLoader,
         r#type: ExtensionType,
         schema_directives: Vec<Directive>,
-        configuration: &T,
+        configuration: Vec<u8>,
         access_log: ChannelLogSender,
-    ) -> crate::Result<Self>
-    where
-        T: serde::Serialize,
-    {
+    ) -> crate::Result<Self> {
         let mut component = ComponentInstance::new(loader, access_log).await?;
 
         let register = component
@@ -112,18 +109,14 @@ impl ExtensionsComponentInstance {
         Ok((headers, result?.deserialize()?))
     }
 
-    async fn init_gateway_extension<T>(
+    async fn init_gateway_extension(
         &mut self,
         r#type: ExtensionType,
         schema_directives: Vec<Directive>,
-        configuration: &T,
-    ) -> crate::Result<()>
-    where
-        T: serde::Serialize,
-    {
+        configuration: Vec<u8>,
+    ) -> crate::Result<()> {
         type Params = (ExtensionType, Vec<Directive>, Vec<u8>);
 
-        let configuration = minicbor_serde::to_vec(configuration).unwrap();
         let params = (r#type, schema_directives, configuration);
 
         let result = self

--- a/crates/wasi-component-loader/src/instance/extensions/types.rs
+++ b/crates/wasi-component-loader/src/instance/extensions/types.rs
@@ -79,8 +79,8 @@ impl FieldOutput {
 #[derive(Clone, Lift, ComponentType)]
 #[component(record)]
 pub struct Token {
-    #[component(name = "claims")]
-    claims: Vec<u8>,
+    #[component(name = "raw")]
+    raw: Vec<u8>,
 }
 
 impl Token {
@@ -88,6 +88,6 @@ impl Token {
     where
         S: DeserializeOwned,
     {
-        Ok(minicbor_serde::from_slice(&self.claims)?)
+        Ok(minicbor_serde::from_slice(&self.raw)?)
     }
 }

--- a/crates/wasi-component-loader/src/names.rs
+++ b/crates/wasi-component-loader/src/names.rs
@@ -42,3 +42,8 @@ pub(crate) const HEADERS_ENTRIES_METHOD: &str = "[method]headers.entries";
 pub(crate) const REGISTER_EXTENSION_FUNCTION: &str = "register-extension";
 pub(crate) const INIT_GATEWAY_EXTENSION_FUNCTION: &str = "init-gateway-extension";
 pub(crate) const RESOLVE_FIELD_EXTENSION_FUNCTION: &str = "resolve-field";
+pub(crate) const AUTEHNTICATE_EXTENSION_FUNCTION: &str = "authenticate";
+
+pub(crate) const CACHE_RESOURCE: &str = "cache";
+pub(crate) const CACHE_GET_FUNCTION: &str = "[static]cache.get";
+pub(crate) const CACHE_SET_FUNCTION: &str = "[static]cache.set";

--- a/crates/wasi-component-loader/src/state.rs
+++ b/crates/wasi-component-loader/src/state.rs
@@ -32,7 +32,7 @@ pub(crate) struct WasiState {
     /// A sender for the access log channel.
     access_log: ChannelLogSender,
 
-    /// A cache to be used for storing data betwee.
+    /// A cache to be used for storing data between calls to different instances of the same extension.
     cache: Arc<Cache>,
 }
 

--- a/crates/wasi-component-loader/src/state.rs
+++ b/crates/wasi-component-loader/src/state.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+
+use super::cache::Cache;
 use grafbase_telemetry::{metrics::meter_from_global_provider, otel::opentelemetry::metrics::Histogram};
 use wasmtime::component::Resource;
 use wasmtime_wasi::{ResourceTable, WasiCtx, WasiView};
@@ -28,6 +31,9 @@ pub(crate) struct WasiState {
 
     /// A sender for the access log channel.
     access_log: ChannelLogSender,
+
+    /// A cache to be used for storing data betwee.
+    cache: Arc<Cache>,
 }
 
 impl WasiState {
@@ -41,7 +47,7 @@ impl WasiState {
     ///
     /// A new `WasiState` instance initialized with the provided context and default
     /// HTTP and resource table contexts.
-    pub fn new(ctx: WasiCtx, access_log: ChannelLogSender) -> Self {
+    pub fn new(ctx: WasiCtx, access_log: ChannelLogSender, cache: Arc<Cache>) -> Self {
         let meter = meter_from_global_provider();
         let request_durations = meter.u64_histogram("grafbase.hook.http_request.duration").build();
         let http_client = reqwest::Client::new();
@@ -53,6 +59,7 @@ impl WasiState {
             request_durations,
             http_client,
             access_log,
+            cache,
         }
     }
 
@@ -98,6 +105,11 @@ impl WasiState {
     /// Returns a reference to the access log sender.
     pub fn access_log(&self) -> &ChannelLogSender {
         &self.access_log
+    }
+
+    /// Returns a reference to the cache.
+    pub fn cache(&self) -> &Cache {
+        &self.cache
     }
 }
 

--- a/crates/wasi-component-loader/src/tests/extensions.rs
+++ b/crates/wasi-component-loader/src/tests/extensions.rs
@@ -6,6 +6,8 @@ use crate::{
 };
 use gateway_config::WasiExtensionsConfig;
 use grafbase_telemetry::otel::opentelemetry::trace::TraceId;
+use http::{HeaderMap, HeaderValue};
+use serde_json::json;
 
 #[tokio::test]
 async fn simple_resolver() {
@@ -33,10 +35,15 @@ async fn simple_resolver() {
     let loader = ComponentLoader::extensions(String::new(), config).unwrap().unwrap();
     let schema_directive = Directive::new("schemaArgs".into(), "mySubgraph".into(), &SchemaArgs { id: 10 });
 
-    let mut extension =
-        ExtensionsComponentInstance::new(&loader, ExtensionType::Resolver, vec![schema_directive], access_log)
-            .await
-            .unwrap();
+    let mut extension = ExtensionsComponentInstance::new(
+        &loader,
+        ExtensionType::Resolver,
+        vec![schema_directive],
+        &"",
+        access_log,
+    )
+    .await
+    .unwrap();
 
     let context = SharedContext::new(Arc::new(HashMap::new()), TraceId::INVALID);
 
@@ -60,4 +67,135 @@ async fn simple_resolver() {
       "name": "cat"
     }
     "#);
+}
+
+#[tokio::test]
+async fn single_call_caching_auth() {
+    let config = WasiExtensionsConfig {
+        location: PathBuf::from("examples/target/wasm32-wasip2/debug/caching_auth.wasm"),
+        networking: false,
+        stdout: false,
+        stderr: false,
+        environment_variables: false,
+    };
+
+    assert!(config.location.exists());
+
+    let (access_log, _) = create_log_channel();
+    let loader = ComponentLoader::extensions(String::new(), config).unwrap().unwrap();
+
+    let config = json!({
+        "cache_config": "test"
+    });
+
+    let mut extension =
+        ExtensionsComponentInstance::new(&loader, ExtensionType::Authentication, Vec::new(), &config, access_log)
+            .await
+            .unwrap();
+
+    let mut headers = HeaderMap::new();
+    headers.insert("Authorization", HeaderValue::from_static("valid"));
+
+    let (headers, output): (_, serde_json::Value) = extension.authenticate(headers).await.unwrap();
+
+    assert!(headers.len() == 1);
+    assert_eq!(Some(&HeaderValue::from_static("valid")), headers.get("Authorization"));
+
+    insta::assert_json_snapshot!(output, @r#"
+    {
+      "key": "valid"
+    }
+    "#);
+}
+
+#[tokio::test]
+async fn single_call_caching_auth_invalid() {
+    let config = WasiExtensionsConfig {
+        location: PathBuf::from("examples/target/wasm32-wasip2/debug/caching_auth.wasm"),
+        networking: false,
+        stdout: false,
+        stderr: false,
+        environment_variables: false,
+    };
+
+    assert!(config.location.exists());
+
+    let (access_log, _) = create_log_channel();
+    let loader = ComponentLoader::extensions(String::new(), config).unwrap().unwrap();
+
+    let config = json!({
+        "cache_config": "test"
+    });
+
+    let mut extension =
+        ExtensionsComponentInstance::new(&loader, ExtensionType::Authentication, Vec::new(), &config, access_log)
+            .await
+            .unwrap();
+
+    let result = extension
+        .authenticate::<serde_json::Value>(HeaderMap::new())
+        .await
+        .unwrap_err();
+
+    insta::assert_debug_snapshot!(result, @r#"
+    Guest(
+        ErrorResponse {
+            status_code: 401,
+            errors: [],
+        },
+    )
+    "#);
+}
+
+#[tokio::test]
+async fn multiple_cache_calls() {
+    let config = WasiExtensionsConfig {
+        location: PathBuf::from("examples/target/wasm32-wasip2/debug/caching_auth.wasm"),
+        networking: false,
+        stdout: false,
+        stderr: false,
+        environment_variables: false,
+    };
+
+    assert!(config.location.exists());
+
+    let (access_log, _) = create_log_channel();
+    let loader = ComponentLoader::extensions(String::new(), config).unwrap().unwrap();
+
+    let config = json!({
+        "cache_config": "test"
+    });
+
+    let mut extension =
+        ExtensionsComponentInstance::new(&loader, ExtensionType::Authentication, Vec::new(), &config, access_log)
+            .await
+            .unwrap();
+
+    for _ in 0..20 {
+        let mut headers = HeaderMap::new();
+        headers.insert("Authorization", HeaderValue::from_static("valid"));
+
+        let (_, output): (_, serde_json::Value) = extension.authenticate(headers).await.unwrap();
+
+        insta::allow_duplicates! {
+            insta::assert_json_snapshot!(output, @r#"
+            {
+              "key": "valid"
+            }
+            "#);
+        }
+    }
+
+    let mut headers = HeaderMap::new();
+    headers.insert("Authorization", HeaderValue::from_static("nonvalid"));
+
+    let (_, output): (_, serde_json::Value) = extension.authenticate(headers).await.unwrap();
+
+    insta::allow_duplicates! {
+        insta::assert_json_snapshot!(output, @r#"
+        {
+          "key": "nonvalid"
+        }
+        "#);
+    }
 }

--- a/gateway/docker-compose.yml
+++ b/gateway/docker-compose.yml
@@ -21,7 +21,7 @@ services:
 
   clickhouse:
     restart: unless-stopped
-    image: clickhouse/clickhouse-server:latest
+    image: clickhouse/clickhouse-server:25.1.2-alpine
     ports:
       - '9001:9000'
       - '8124:8123'


### PR DESCRIPTION
This adds the wasi loader side of auth extensions with a concurrent cache. I'm doing the actual authenticator for JWT and running the integration tests in a subsequent pull request.

## Cache

We can't have all extensions triggering HTTP requests concurrently, e.g. when fetching JWKs for a JWT authenticator. What we do here is we let the first one getting a cache miss from the host, letting the guest to run the init function to get the needed value. Other callers will now wait for this one fetcher to be done, and they will get the value from the init function when it's finished.

## Configuration

The auth extensions need special configuration. We need to figure out how to pass this to the loader. We will need a separate loader per authenticator, so if the user has more than one auth provider with the same extension, they will run in separate instances. The current idea defined in the RFC is to let the authentication config define configuration for the extension, I'm not completely sure how great this idea is, but we'll see again in the next pull request how it's going to look like.