### PR TITLE
composition: make the url optional in `Subgraphs::ingest()`

### DIFF
--- a/cli/src/backend/dev/hot_reload.rs
+++ b/cli/src/backend/dev/hot_reload.rs
@@ -398,7 +398,7 @@ async fn reload_subgraphs(
         .filter(|(name, _)| !overridden_subgraphs.contains(**name))
     {
         subgraphs
-            .ingest_str(&remote_subgraph.schema, name, &remote_subgraph.url)
+            .ingest_str(&remote_subgraph.schema, name, Some(&remote_subgraph.url))
             .map_err(BackendError::IngestSubgraph)?;
     }
 

--- a/cli/src/backend/dev/subgraphs.rs
+++ b/cli/src/backend/dev/subgraphs.rs
@@ -77,7 +77,7 @@ pub async fn get_subgraph_sdls(
             };
 
             subgraphs
-                .ingest_str(&subgraph.schema, &subgraph.name, url)
+                .ingest_str(&subgraph.schema, &subgraph.name, Some(url))
                 .map_err(BackendError::IngestSubgraph)?;
         }
     }
@@ -155,7 +155,7 @@ pub async fn get_subgraph_sdls(
 
     for (sdl, name, url) in results {
         subgraphs
-            .ingest_str(&sdl, name, url)
+            .ingest_str(&sdl, name, Some(url))
             .map_err(BackendError::IngestSubgraph)?;
     }
 

--- a/crates/federation-audit-tests/tests/composition_comparisons.rs
+++ b/crates/federation-audit-tests/tests/composition_comparisons.rs
@@ -28,7 +28,7 @@ fn runner_for(suite: String) -> impl FnOnce() -> Result<(), Failed> + Send + 'st
         let mut subgraphs = graphql_composition::Subgraphs::default();
         for subgraph in suite.subgraphs() {
             subgraphs
-                .ingest_str(&subgraph.sdl, &subgraph.name, &subgraph.url)
+                .ingest_str(&subgraph.sdl, &subgraph.name, Some(&subgraph.url))
                 .unwrap()
         }
 

--- a/crates/graphql-composition/CHANGELOG.md
+++ b/crates/graphql-composition/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Implemented the rule that any directive composed with `@composeDirective` must have the same definition in all subgraphs. (https://github.com/grafbase/grafbase/pull/2532)
 - The definitions for directives composed with `@composeDirective` are now included in the composed federated graph. (https://github.com/grafbase/grafbase/pull/2539)
+- The `url` argument of `Subgraph::ingest()` is now optional, to support virtual subgraphs that have no associated url.
 
 ### Fixes
 

--- a/crates/graphql-composition/src/emit_federated_graph.rs
+++ b/crates/graphql-composition/src/emit_federated_graph.rs
@@ -357,14 +357,14 @@ fn emit_subgraphs(ctx: &mut Context<'_>) -> federated::EnumDefinitionId {
 
     for subgraph in ctx.subgraphs.iter_subgraphs() {
         let name = ctx.insert_string(subgraph.name());
-        let url = ctx.insert_string(subgraph.url());
+        let url = subgraph.url().map(|url| ctx.insert_string(url));
         let join_graph_enum_value_name = ctx.insert_str(&join_graph_enum_variant_name(subgraph.name().as_str()));
         let join_graph_enum_value_id = ctx.out.push_enum_value(federated::EnumValueRecord {
             enum_id: join_graph_enum_id,
             value: join_graph_enum_value_name,
             directives: vec![federated::Directive::JoinGraph(federated::JoinGraphDirective {
                 name,
-                url: Some(url),
+                url,
             })],
             description: None,
         });
@@ -372,7 +372,7 @@ fn emit_subgraphs(ctx: &mut Context<'_>) -> federated::EnumDefinitionId {
         ctx.out.subgraphs.push(federated::Subgraph {
             name,
             join_graph_enum_value: join_graph_enum_value_id,
-            url: Some(url),
+            url,
         });
     }
 

--- a/crates/graphql-composition/src/ingest_subgraph.rs
+++ b/crates/graphql-composition/src/ingest_subgraph.rs
@@ -29,7 +29,12 @@ struct Context<'a> {
     root_type_matcher: RootTypeMatcher<'a>,
 }
 
-pub(crate) fn ingest_subgraph(document: &ast::TypeSystemDocument, name: &str, url: &str, subgraphs: &mut Subgraphs) {
+pub(crate) fn ingest_subgraph(
+    document: &ast::TypeSystemDocument,
+    name: &str,
+    url: Option<&str>,
+    subgraphs: &mut Subgraphs,
+) {
     let subgraph_id = subgraphs.push_subgraph(name, url);
 
     let mut ctx = Context {

--- a/crates/graphql-composition/src/lib.rs
+++ b/crates/graphql-composition/src/lib.rs
@@ -92,7 +92,7 @@ mod tests {
 
         let mut subgraphs = Subgraphs::default();
         subgraphs
-            .ingest_str(&schema, "grafbase-api", "https://api.grafbase.com")
+            .ingest_str(&schema, "grafbase-api", Some("https://api.grafbase.com"))
             .unwrap();
         let result = compose(&subgraphs);
         assert!(!result.diagnostics().any_fatal());

--- a/crates/graphql-composition/src/subgraphs.rs
+++ b/crates/graphql-composition/src/subgraphs.rs
@@ -109,12 +109,12 @@ impl std::fmt::Display for IngestError {
 
 impl Subgraphs {
     /// Add a subgraph to compose.
-    pub fn ingest(&mut self, subgraph_schema: &cynic_parser::TypeSystemDocument, name: &str, url: &str) {
+    pub fn ingest(&mut self, subgraph_schema: &cynic_parser::TypeSystemDocument, name: &str, url: Option<&str>) {
         crate::ingest_subgraph::ingest_subgraph(subgraph_schema, name, url, self);
     }
 
     /// Add a subgraph to compose.
-    pub fn ingest_str(&mut self, subgraph_schema: &str, name: &str, url: &str) -> Result<(), IngestError> {
+    pub fn ingest_str(&mut self, subgraph_schema: &str, name: &str, url: Option<&str>) -> Result<(), IngestError> {
         let subgraph_schema =
             cynic_parser::parse_type_system_document(subgraph_schema).map_err(|error| IngestError {
                 report: error.to_report(subgraph_schema).to_string(),

--- a/crates/graphql-composition/src/subgraphs/top.rs
+++ b/crates/graphql-composition/src/subgraphs/top.rs
@@ -15,10 +15,12 @@ impl Subgraphs {
         })
     }
 
-    pub(crate) fn push_subgraph(&mut self, name: &str, url: &str) -> SubgraphId {
+    pub(crate) fn push_subgraph(&mut self, name: &str, url: Option<&str>) -> SubgraphId {
+        let url = url.map(|url| self.strings.intern(url));
+
         let subgraph = Subgraph {
             name: self.strings.intern(name),
-            url: self.strings.intern(url),
+            url,
 
             query_type: None,
             mutation_type: None,
@@ -52,7 +54,7 @@ pub(crate) struct Subgraph {
     /// The name of the subgraph. It is not contained in the GraphQL schema of the subgraph, it
     /// only makes sense within a project.
     name: StringId,
-    url: StringId,
+    url: Option<StringId>,
 
     query_type: Option<DefinitionId>,
     mutation_type: Option<DefinitionId>,
@@ -101,7 +103,7 @@ impl<'a> SubgraphWalker<'a> {
         self.walk(self.subgraph().name)
     }
 
-    pub(crate) fn url(self) -> StringWalker<'a> {
-        self.walk(self.subgraph().url)
+    pub(crate) fn url(self) -> Option<StringWalker<'a>> {
+        self.subgraph().url.map(|url| self.walk(url))
     }
 }

--- a/crates/graphql-composition/tests/composition_special_cases.rs
+++ b/crates/graphql-composition/tests/composition_special_cases.rs
@@ -3,11 +3,11 @@ fn subgraph_names_that_differ_only_by_case_are_not_allowed() {
     let mut subgraphs = graphql_composition::Subgraphs::default();
 
     subgraphs
-        .ingest_str("type Query { name: String }", "valid", "example.com")
+        .ingest_str("type Query { name: String }", "valid", Some("example.com"))
         .unwrap();
 
     subgraphs
-        .ingest_str("type Query { fullName: String }", "Valid", "example.com")
+        .ingest_str("type Query { fullName: String }", "Valid", Some("example.com"))
         .unwrap();
 
     let result = graphql_composition::compose(&subgraphs);

--- a/crates/graphql-composition/tests/composition_tests.rs
+++ b/crates/graphql-composition/tests/composition_tests.rs
@@ -36,7 +36,7 @@ fn run_test(test_path: &Path) -> anyhow::Result<()> {
         let name = path.file_stem().unwrap().to_str().unwrap().replace('_', "-");
 
         subgraphs
-            .ingest_str(&sdl, &name, &format!("http://example.com/{name}"))
+            .ingest_str(&sdl, &name, Some(&format!("http://example.com/{name}")))
             .map_err(|err| anyhow::anyhow!("Error parsing {}: \n{err:#}", path.display()))?;
     }
 

--- a/crates/integration-tests/src/federation/builder/engine.rs
+++ b/crates/integration-tests/src/federation/builder/engine.rs
@@ -24,7 +24,7 @@ pub(super) async fn build(
                     graphql_composition::Subgraphs::default(),
                     |mut subgraphs, subgraph| {
                         subgraphs
-                            .ingest_str(subgraph.sdl().as_ref(), subgraph.name(), subgraph.url().as_ref())
+                            .ingest_str(subgraph.sdl().as_ref(), subgraph.name(), Some(subgraph.url().as_ref()))
                             .expect("schema to be well formed");
                         subgraphs
                     },

--- a/gateway/tests/entity_caching/mod.rs
+++ b/gateway/tests/entity_caching/mod.rs
@@ -61,7 +61,7 @@ where
     let federated_schema = {
         let mut subgraphs = graphql_composition::Subgraphs::default();
         subgraphs
-            .ingest_str(subgraph_schema, "the-subgraph", subgraph_url)
+            .ingest_str(subgraph_schema, "the-subgraph", Some(subgraph_url))
             .unwrap();
         let graph = graphql_composition::compose(&subgraphs).into_result().unwrap();
         graphql_composition::render_federated_sdl(&graph).unwrap()

--- a/gateway/tests/telemetry/tracing.rs
+++ b/gateway/tests/telemetry/tracing.rs
@@ -435,7 +435,7 @@ where
     let federated_schema = {
         let mut subgraphs = graphql_composition::Subgraphs::default();
         subgraphs
-            .ingest_str(&subgraph_sdl, "the-subgraph", subgraph_server.url().as_str())
+            .ingest_str(&subgraph_sdl, "the-subgraph", Some(subgraph_server.url().as_str()))
             .unwrap();
         let graph = graphql_composition::compose(&subgraphs).into_result().unwrap();
         graphql_composition::render_federated_sdl(&graph).unwrap()


### PR DESCRIPTION
We have virtual subgraph support in graphql-federated-graph and the gateway, so this is just acknowledging it.