### PR TITLE
graphql-federated-graph: completely special case ingestion of extension__Link

### DIFF
--- a/crates/graphql-composition/src/emit_federated_graph/emit_extensions.rs
+++ b/crates/graphql-composition/src/emit_federated_graph/emit_extensions.rs
@@ -57,7 +57,7 @@ pub(super) fn emit_extensions(ctx: &mut Context<'_>, ir: &CompositionIr) {
         });
 
         ctx.out.push_extension(federated::Extension {
-            enum_value: enum_value_id,
+            enum_value_id,
             url,
             schema_directives,
         });

--- a/crates/graphql-federated-graph/src/federated_graph/extensions.rs
+++ b/crates/graphql-federated-graph/src/federated_graph/extensions.rs
@@ -4,7 +4,7 @@ use super::*;
 pub struct Extension {
     /// Name of the extension within the federated graph. It does NOT necessarily matches the extension's name
     /// in its manifest, see the `id` field for this.
-    pub enum_value: EnumValueId,
+    pub enum_value_id: EnumValueId,
     pub url: StringId,
     pub schema_directives: Vec<ExtensionLinkSchemaDirective>,
 }

--- a/crates/graphql-federated-graph/src/from_sdl/directive.rs
+++ b/crates/graphql-federated-graph/src/from_sdl/directive.rs
@@ -458,7 +458,7 @@ pub(super) fn parse_extension_link(
         .to_string();
 
     let schema_directives = directive
-        .get_argument("schema_directives")
+        .get_argument("schemaDirectives")
         .and_then(|arg| arg.as_list())
         .map(|directives| {
             directives

--- a/crates/graphql-federated-graph/src/render_sdl/directive.rs
+++ b/crates/graphql-federated-graph/src/render_sdl/directive.rs
@@ -103,7 +103,10 @@ fn render_extension_directive(
             "graph",
             Value::EnumValue(graph[directive.subgraph_id].join_graph_enum_value),
         )?
-        .arg("extension", Value::EnumValue(graph[directive.extension_id].enum_value))?
+        .arg(
+            "extension",
+            Value::EnumValue(graph[directive.extension_id].enum_value_id),
+        )?
         .arg("name", Value::String(directive.name))?;
     if let Some(arguments) = directive.arguments.as_ref() {
         writer.arg("arguments", arguments)?;

--- a/crates/graphql-federated-graph/src/render_sdl/render_federated_sdl.rs
+++ b/crates/graphql-federated-graph/src/render_sdl/render_federated_sdl.rs
@@ -165,24 +165,16 @@ pub fn render_federated_sdl(graph: &FederatedGraph) -> Result<String, fmt::Error
 
             write!(sdl, "{INDENT}{value_name}")?;
             with_formatter(&mut sdl, |f| {
-                let mut has_extension_link_directive = false;
-
                 for directive in &value.directives {
                     f.write_str(" ")?;
                     write_directive(f, directive, graph)?;
-
-                    if let Directive::Other { name, .. } = directive {
-                        if graph[*name] == "extension__link" {
-                            has_extension_link_directive = true;
-                        }
-                    }
                 }
 
-                if is_extension_link && !has_extension_link_directive {
+                if is_extension_link {
                     if let Some(extension) = graph
                         .extensions
                         .iter()
-                        .find(|extension| extension.enum_value == value.id())
+                        .find(|extension| extension.enum_value_id == value.id())
                     {
                         super::directive::render_extension_link_directive(
                             f,


### PR DESCRIPTION
We want to treat the directives on the values differently, because we don't want a Directive::Other for `@extension__link`.

Also make sure we use schemaDirectives instead of schemaDirective as an argument name everywhere.