### PR TITLE
fix(engine): Do not expect field resolver to return an entity

### DIFF
--- a/cli/tests/integration/data/echo_extension/src/lib.rs
+++ b/cli/tests/integration/data/echo_extension/src/lib.rs
@@ -22,7 +22,7 @@ impl Resolver for EchoExtension {
         &mut self,
         _context: SharedContext,
         directive: Directive,
-        field_definition: FieldDefinition,
+        _field_definition: FieldDefinition,
         _inputs: FieldInputs,
     ) -> Result<FieldOutput, Error> {
         let value = match directive.name() {
@@ -38,9 +38,8 @@ impl Resolver for EchoExtension {
 
         let mut output = FieldOutput::new();
 
-        let field_name = field_definition.name();
-        output.push_value(serde_json::json!({ field_name: value }));
+        output.push_value(serde_json::json!(value));
 
-        return Ok(output);
+        Ok(output)
     }
 }

--- a/crates/engine/src/response/write/deserialize/field_to_entity.rs
+++ b/crates/engine/src/response/write/deserialize/field_to_entity.rs
@@ -1,0 +1,482 @@
+use std::marker::PhantomData;
+
+use serde::{de::MapAccess, Deserializer};
+
+pub(super) struct FieldToEntityDeserializer<'k, D> {
+    pub key: &'k str,
+    pub deserializer: D,
+}
+
+impl<'k, 'de, D: Deserializer<'de>> Deserializer<'de> for FieldToEntityDeserializer<'k, D>
+where
+    'k: 'de,
+{
+    type Error = D::Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        self.deserialize_map(visitor)
+    }
+
+    fn deserialize_bool<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_i8<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_i16<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_i32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_i64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_u8<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_u16<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_u32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_u64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_f32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_f64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_str<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_string<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_option<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_unit<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_unit_struct<V>(self, _name: &'static str, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_newtype_struct<V>(self, _name: &'static str, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_seq<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_tuple_struct<V>(self, _name: &'static str, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_map(EntityMap(Some((self.key, self.deserializer))))
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_identifier<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+}
+
+struct EntityMap<'k, D>(Option<(&'k str, D)>);
+
+impl<'k, 'de, D: Deserializer<'de>> MapAccess<'de> for EntityMap<'k, D>
+where
+    'k: 'de,
+{
+    type Error = D::Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: serde::de::DeserializeSeed<'de>,
+    {
+        self.0
+            .as_ref()
+            .map(|(key, _)| {
+                seed.deserialize(Key {
+                    key,
+                    phantom: PhantomData::<D>,
+                })
+            })
+            .transpose()
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::DeserializeSeed<'de>,
+    {
+        let (_, deserializer) = self.0.take().expect("Should have checked with next_key_seed");
+        seed.deserialize(deserializer)
+    }
+}
+
+struct Key<'k, D> {
+    key: &'k str,
+    phantom: PhantomData<D>,
+}
+
+impl<'k, D: Deserializer<'k>> Deserializer<'k> for Key<'k, D> {
+    type Error = D::Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        visitor.visit_borrowed_str(self.key)
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        visitor.visit_borrowed_str(self.key)
+    }
+
+    fn deserialize_bool<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_i8<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_i16<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_i32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_i64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_u8<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_u16<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_u32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_u64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_f32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_f64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_string<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_option<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_unit<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_unit_struct<V>(self, _name: &'static str, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_seq<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_tuple_struct<V>(self, _name: &'static str, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_map<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_identifier<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+
+    fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'k>,
+    {
+        unreachable!("We own the visitor, it should never call this.")
+    }
+}

--- a/crates/engine/src/response/write/deserialize/mod.rs
+++ b/crates/engine/src/response/write/deserialize/mod.rs
@@ -1,7 +1,8 @@
 use std::cell::{Cell, Ref, RefCell};
 
+use field_to_entity::FieldToEntityDeserializer;
 use object::{ConcreteShapeFieldsSeed, ObjectValue};
-use serde::de::DeserializeSeed;
+use serde::{de::DeserializeSeed, Deserializer};
 use walker::Walk;
 
 use crate::{
@@ -14,6 +15,7 @@ use crate::{
 mod ctx;
 mod r#enum;
 mod field;
+mod field_to_entity;
 mod key;
 mod list;
 mod object;
@@ -51,6 +53,17 @@ impl<'ctx> UpdateSeed<'ctx> {
             shape_id,
             id,
         }
+    }
+
+    pub fn deserialize_field_as_entity<'k, 'de, D: Deserializer<'de>>(
+        self,
+        key: &'k str,
+        deserializer: D,
+    ) -> Result<(), D::Error>
+    where
+        'k: 'de,
+    {
+        self.deserialize(FieldToEntityDeserializer { key, deserializer })
     }
 }
 

--- a/crates/integration-tests/tests/federation/extensions/basic.rs
+++ b/crates/integration-tests/tests/federation/extensions/basic.rs
@@ -53,12 +53,7 @@ impl TestExtension for Ext {
         _directive: ExtensionDirective<'a, serde_json::Value>,
         inputs: Vec<serde_json::Value>,
     ) -> Result<Vec<Result<serde_json::Value, PartialGraphqlError>>, PartialGraphqlError> {
-        Ok(vec![
-            Ok(serde_json::json!({
-                "greeting": "Hi"
-            }));
-            inputs.len()
-        ])
+        Ok(vec![Ok(serde_json::json!("Hi!")); inputs.len()])
     }
 }
 
@@ -91,7 +86,7 @@ fn simple_resolver_from_federated_sdl() {
     insta::assert_json_snapshot!(response, @r#"
     {
       "data": {
-        "greeting": "Hi"
+        "greeting": "Hi!"
       }
     }
     "#);
@@ -122,7 +117,7 @@ fn simple_resolver_from_subgraph_sdl() {
     insta::assert_json_snapshot!(response, @r#"
     {
       "data": {
-        "greeting": "Hi"
+        "greeting": "Hi!"
       }
     }
     "#);


### PR DESCRIPTION
GraphQL resolvers always returned an object, but here a resolver returns
the value for an arbitrary type. Before for something like

```graphql
type Query {
  countries: [String!]
}
```

I was wrongly expecting:

```json
{"countries": [...]}
```

So changed to accept the inner part.
