### PR TITLE
graphql-composition: fix @link aliased directive imports, and enforce import types

### DIFF
--- a/crates/graphql-composition/CHANGELOG.md
+++ b/crates/graphql-composition/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Make the `url` argument optional in the definition of the `@join__graph` directive, to reflect the optionality of url introduced for virtual subgraphs in https://github.com/grafbase/grafbase/pull/2589.
+- (BREAKING) Take the `@` prefix into account in aliased imports from `@link` directives. Previously, the `as:` argument for individual directives would only work if you did not prefix the alias with an `@`. But the link spec is clear: if you import a directive, you have to import it with an `@` prefix, and other types should be imported without. This behaviour is fixed, and the presence or absence of `@` is now enforced.
 
 ## 0.6.0 - 2025-02-10
 

--- a/crates/graphql-composition/tests/composition/link_import_as_errors/api.graphql.snap
+++ b/crates/graphql-composition/tests/composition/link_import_as_errors/api.graphql.snap
@@ -1,0 +1,18 @@
+---
+source: crates/graphql-composition/tests/composition_tests.rs
+expression: actual_api_sdl
+input_file: crates/graphql-composition/tests/composition/link_import_as_errors/test.md
+---
+type AppleSauce {
+    appleVariety: String
+    chunky: Boolean!
+    id: ID!
+    organic: Boolean
+    servingSize: Float
+    sweetness: Int!
+}
+
+type Query {
+    allAppleSauces: [AppleSauce!]!
+    getAppleSauce(id: ID!): AppleSauce
+}

--- a/crates/graphql-composition/tests/composition/link_import_as_errors/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/link_import_as_errors/federated.graphql.snap
@@ -1,0 +1,7 @@
+---
+source: crates/graphql-composition/tests/composition_tests.rs
+expression: "Imports _must_ be of the same type, meaning if the original name has an `@` prefix, the imported name must also have an `@` prefix, and conversely, if the original name does not have an `@` prefix, the imported name must also not have an `@` prefix.\n\nReference: https://specs.apollo.dev/link/v1.0/#Import"
+input_file: crates/graphql-composition/tests/composition/link_import_as_errors/test.md
+---
+# [tagged]: Error in @link import: `@tag` is a directive, but it is imported as `label`. Missing @ prefix.
+# [tagged]: Error in @link import: `purpose` is not a directive, but it is imported as `@purpose`. Consider removing the @ prefix.

--- a/crates/graphql-composition/tests/composition/link_import_as_errors/subgraphs/tagged.graphql
+++ b/crates/graphql-composition/tests/composition/link_import_as_errors/subgraphs/tagged.graphql
@@ -1,0 +1,19 @@
+extend schema
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.0"
+    import: ["@key", { name: "@tag", as: "label" }, { name: "purpose", as: "@purpose" }]
+  )
+
+type AppleSauce @key(fields: "id") @label(name: "apple_sauce") {
+  id: ID!
+  sweetness: Int!
+  chunky: Boolean!
+  appleVariety: String
+  servingSize: Float
+  organic: Boolean
+}
+
+type Query {
+  getAppleSauce(id: ID!): AppleSauce
+  allAppleSauces: [AppleSauce!]!
+}

--- a/crates/graphql-composition/tests/composition/link_import_as_errors/test.md
+++ b/crates/graphql-composition/tests/composition/link_import_as_errors/test.md
@@ -1,0 +1,3 @@
+Imports _must_ be of the same type, meaning if the original name has an `@` prefix, the imported name must also have an `@` prefix, and conversely, if the original name does not have an `@` prefix, the imported name must also not have an `@` prefix.
+
+Reference: https://specs.apollo.dev/link/v1.0/#Import

--- a/crates/graphql-composition/tests/composition/link_import_as_valid/api.graphql.snap
+++ b/crates/graphql-composition/tests/composition/link_import_as_valid/api.graphql.snap
@@ -1,0 +1,18 @@
+---
+source: crates/graphql-composition/tests/composition_tests.rs
+expression: actual_api_sdl
+input_file: crates/graphql-composition/tests/composition/link_import_as_valid/test.md
+---
+type AppleSauce {
+    appleVariety: String
+    chunky: Boolean!
+    id: ID!
+    organic: Boolean
+    servingSize: Float
+    sweetness: Int!
+}
+
+type Query {
+    allAppleSauces: [AppleSauce!]!
+    getAppleSauce(id: ID!): AppleSauce
+}

--- a/crates/graphql-composition/tests/composition/link_import_as_valid/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/link_import_as_valid/federated.graphql.snap
@@ -1,0 +1,41 @@
+---
+source: crates/graphql-composition/tests/composition_tests.rs
+expression: "We want to test that a directive can be imported and renamed with `as`.\nExample: `@link(url: \"...\", import: [{name: \"@shareable\", as: \"@partageable\"}])`."
+input_file: crates/graphql-composition/tests/composition/link_import_as_valid/test.md
+---
+directive @join__unionMember(graph: join__Graph!, member: String!) on UNION
+
+directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT | INTERFACE
+
+directive @join__graph(name: String!, url: String) on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+
+directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+
+directive @join__owner(graph: join__Graph!) on OBJECT
+
+scalar join__FieldSet
+
+type AppleSauce
+    @tag(name: "apple_sauce")
+    @join__type(graph: TAGGED, key: "id")
+{
+    appleVariety: String
+    chunky: Boolean!
+    id: ID!
+    organic: Boolean
+    servingSize: Float
+    sweetness: Int!
+}
+
+type Query
+{
+    allAppleSauces: [AppleSauce!]! @join__field(graph: TAGGED)
+    getAppleSauce(id: ID!): AppleSauce @join__field(graph: TAGGED)
+}
+
+enum join__Graph
+{
+    TAGGED @join__graph(name: "tagged", url: "http://example.com/tagged")
+}

--- a/crates/graphql-composition/tests/composition/link_import_as_valid/subgraphs/tagged.graphql
+++ b/crates/graphql-composition/tests/composition/link_import_as_valid/subgraphs/tagged.graphql
@@ -1,0 +1,15 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", { name: "@tag", as: "@label" }])
+
+type AppleSauce @key(fields: "id") @label(name: "apple_sauce") {
+  id: ID!
+  sweetness: Int!
+  chunky: Boolean!
+  appleVariety: String
+  servingSize: Float
+  organic: Boolean
+}
+
+type Query {
+  getAppleSauce(id: ID!): AppleSauce
+  allAppleSauces: [AppleSauce!]!
+}

--- a/crates/graphql-composition/tests/composition/link_import_as_valid/test.md
+++ b/crates/graphql-composition/tests/composition/link_import_as_valid/test.md
@@ -1,0 +1,2 @@
+We want to test that a directive can be imported and renamed with `as`.
+Example: `@link(url: "...", import: [{name: "@shareable", as: "@partageable"}])`.

--- a/crates/graphql-composition/tests/composition/shareable_basic/subgraphs/marketing.graphql
+++ b/crates/graphql-composition/tests/composition/shareable_basic/subgraphs/marketing.graphql
@@ -1,12 +1,12 @@
 extend schema
-    @link(
-        url: "https://specs.apollo.dev/federation/v2.3",
-        import: [{ name: "@shareable", as: "@partageable" }, "@inaccessible"]
-     )
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.3"
+    import: [{ name: "@shareable", as: "@partageable" }, "@inaccessible"]
+  )
 
 type Customer @partageable {
-    id: ID!
-    name: String
-    
-    newsletterSubscribed: Boolean @inaccessible
+  id: ID!
+  name: String
+
+  newsletterSubscribed: Boolean @inaccessible
 }


### PR DESCRIPTION
Take the `@` prefix into account in aliased imports from `@link` directives. Previously, the `as:` argument for individual directives would only work if you did not prefix the alias with an `@`. But the link spec is clear: if you import a directive, you have to import it with an `@` prefix, and other types should be imported without. This behaviour is fixed, and the presence or absence of `@` is now enforced.

By import types, "directive" or "not directive" is meant here.

closes GB-8446