### PR TITLE
fix: add test for base url with a path

### DIFF
--- a/extensions/rest/tests/integration_tests.rs
+++ b/extensions/rest/tests/integration_tests.rs
@@ -372,3 +372,102 @@ async fn with_bad_jq() {
     }
     "#);
 }
+
+#[tokio::test]
+async fn with_path_in_the_endpoint() {
+    let response_body = json!([
+        {
+            "id": "1",
+            "name": "John Doe",
+            "age": 30,
+            "nonimportant": 2,
+        },
+        {
+            "id": "2",
+            "name": "Jane Doe",
+            "age": 25,
+            "nonimportant": 3,
+        }
+    ]);
+
+    let template = ResponseTemplate::new(200).set_body_json(response_body);
+    let mock_server = mock_server("/admin/users", template).await;
+    let extension_path = std::env::current_dir().unwrap().join("build");
+    let path_str = format!("file://{}", extension_path.display());
+    let rest_endpoint = mock_server.uri();
+
+    let schema = formatdoc! {r#"
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@shareable"])
+          @link(url: "{path_str}", import: ["@restEndpoint", "@rest"])
+
+        @restEndpoint(
+          name: "endpoint",
+          http: {{
+            baseURL: "{rest_endpoint}/admin"
+          }}
+        )
+
+        type Query {{
+          users: [User!]! @rest(
+            endpoint: "endpoint",
+            http: {{
+              method: GET,
+              path: "/users"
+            }}
+            selection: "[.[] | {{ id, name, age }}]"
+          )
+        }}
+
+        type User {{
+          id: ID!
+          name: String!
+          age: Int!
+        }}
+    "#};
+
+    let subgraph = DynamicSchema::builder(schema)
+        .into_extension_only_subgraph("test", &extension_path)
+        .unwrap();
+
+    let config = TestConfigBuilder::new()
+        .with_cli(CLI_PATH)
+        .with_gateway(GATEWAY_PATH)
+        .with_subgraph(subgraph)
+        .enable_networking()
+        .build("")
+        .unwrap();
+
+    let runner = TestRunner::new(config).await.unwrap();
+
+    let query = indoc! {r#"
+        query {
+          users {
+            id
+            name
+            age
+          }
+        }
+    "#};
+
+    let result: serde_json::Value = runner.graphql_query(query).send().await.unwrap();
+
+    insta::assert_json_snapshot!(result, @r#"
+    {
+      "data": {
+        "users": [
+          {
+            "id": "1",
+            "name": "John Doe",
+            "age": 30
+          },
+          {
+            "id": "2",
+            "name": "Jane Doe",
+            "age": 25
+          }
+        ]
+      }
+    }
+    "#);
+}


### PR DESCRIPTION
This is one case we should test. The subtle bug here can be improper usage of `Url`.

Example

- The base url is `http://127.0.0.1/foo`
- The path is `/bar`
- One can use `Url::join` and the final url becomes `http://127.0.0.1/bar`, which is wrong.