### PR TITLE
cli: release 0.84.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3122,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.84.6"
+version = "0.84.7"
 dependencies = [
  "anyhow",
  "askama",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## [0.84.5] - 2025-02-10
+## [0.84.7] - 2025-02-12
 
-[CHANGELOG](changelog/0.82.6.md)
+[CHANGELOG](changelog/0.84.7.md)
+
+## [0.84.6] - 2025-02-10
+
+[CHANGELOG](changelog/0.84.6.md)
 
 ## [0.84.5] - 2025-01-31
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.84.6"
+version = "0.84.7"
 name = "grafbase"
 description = "The Grafbase command line interface"
 categories = ["command-line-utilities"]

--- a/cli/changelog/0.84.7.md
+++ b/cli/changelog/0.84.7.md
@@ -1,0 +1,4 @@
+## Fixes
+
+- The GraphQL Explorer (Pathfinder) bundled in grafbase dev was not loading.
+- In grafbase dev, new validations are introduced for bad imports and bad directive usages in subgraph SDLs. The optionality of the `url` argument is also now reflected in the emitted directive definitions for `@join__graph` (https://github.com/grafbase/grafbase/pull/2600).

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.84.6",
+  "version": "0.84.7",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.84.6",
+  "version": "0.84.7",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.84.6",
+  "version": "0.84.7",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.84.6",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.84.6",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.84.6",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.84.6",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.84.6"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.84.7",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.84.7",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.84.7",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.84.7",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.84.7"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.84.6",
+  "version": "0.84.7",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.84.6",
+  "version": "0.84.7",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.84.6",
+  "version": "0.84.7",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
**Fixes**

- The GraphQL Explorer (Pathfinder) bundled in grafbase dev was not loading.
- In grafbase dev, new validations are introduced for bad imports and bad directive usages in subgraph SDLs. The optionality of the `url` argument is also now reflected in the emitted directive definitions for `@join__graph` (https://github.com/grafbase/grafbase/pull/2600).