### PR TITLE
graphql-schema-diff: expose diffing of ASTs

### DIFF
--- a/.github/workflows/rust-prs.yml
+++ b/.github/workflows/rust-prs.yml
@@ -214,7 +214,8 @@ jobs:
         if: needs.what-changed.outputs.cargo-bin-specs
         shell: bash
         run: |
-          cargo build --target ${{ matrix.platform.target }} ${{ needs.what-changed.outputs.cargo-bin-specs }}
+          # grafbase and grafbase-gateway are required for extension integration tests, so they can't be skipped
+          cargo build --target ${{ matrix.platform.target }} ${{ needs.what-changed.outputs.cargo-bin-specs }} --bin grafbase --bin grafbase-gateway
 
       - name: Clippy
         if: needs.what-changed.outputs.cargo-build-specs

--- a/crates/graphql-schema-diff/CHANGELOG.md
+++ b/crates/graphql-schema-diff/CHANGELOG.md
@@ -9,6 +9,7 @@
 - BREAKING: Overhaul the path string format, and add a typed version (`Path`) with parsing and display implementations.
 - BREAKING: `diff()` no longer emits `AddFieldArgument` where there is already an `AddField` for the parent field, it will only be emitted if the field existed in the source schema. This is for consistency with similar nesting cases.
 - BREAKING: `diff()` no longer emits `AddInterfaceImplementation` where there is already an `AddObject` or `AddInterface` for the parent type. It will only be added if the parent type existed in the source schema. This is for consistency with similar nesting cases. The converse also applies for `RemoveInterfaceImplementation`.
+- Add `diff_asts()` entrypoint to diff without parsing, and infallibly, if you already have `cynic-parser` ASTs.
 
 ## 0.2.0 - 2024-07-16
 


### PR DESCRIPTION
Instead of strings. I need this in the API, and it is useful in general as a lower level API.