### PR TITLE
cli: release 0.84.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.84.8"
+version = "0.84.9"
 dependencies = [
  "anyhow",
  "askama",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.84.8"
+version = "0.84.9"
 name = "grafbase"
 description = "The Grafbase command line interface"
 categories = ["command-line-utilities"]

--- a/cli/changelog/0.84.9.md
+++ b/cli/changelog/0.84.9.md
@@ -1,0 +1,3 @@
+## Features
+
+- `grafbase dev` now displays composition warnings, for example when it encounters unknown directives in subgraph schemas. (https://github.com/grafbase/grafbase/pull/2622)

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.84.8",
+  "version": "0.84.9",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.84.8",
+  "version": "0.84.9",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.84.8",
+  "version": "0.84.9",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.84.8",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.84.8",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.84.8",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.84.8",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.84.8"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.84.9",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.84.9",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.84.9",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.84.9",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.84.9"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.84.8",
+  "version": "0.84.9",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.84.8",
+  "version": "0.84.9",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.84.8",
+  "version": "0.84.9",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
## Features

- `grafbase dev` now displays composition warnings, for example when it encounters unknown directives in subgraph schemas. (https://github.com/grafbase/grafbase/pull/2622)