### PR TITLE
fix(engine): coerce extension directive default values

### DIFF
--- a/crates/engine/schema/src/builder/coerce/error.rs
+++ b/crates/engine/schema/src/builder/coerce/error.rs
@@ -100,3 +100,18 @@ impl From<&Value> for ValueKind {
         }
     }
 }
+
+impl From<cynic_parser::ConstValue<'_>> for ValueKind {
+    fn from(value: cynic_parser::ConstValue) -> Self {
+        match value {
+            cynic_parser::ConstValue::Int(_) => ValueKind::Integer,
+            cynic_parser::ConstValue::Float(_) => ValueKind::Float,
+            cynic_parser::ConstValue::String(_) => ValueKind::String,
+            cynic_parser::ConstValue::Boolean(_) => ValueKind::Boolean,
+            cynic_parser::ConstValue::Null(_) => ValueKind::Null,
+            cynic_parser::ConstValue::Enum(_) => ValueKind::Enum,
+            cynic_parser::ConstValue::List(_) => ValueKind::List,
+            cynic_parser::ConstValue::Object(_) => ValueKind::Object,
+        }
+    }
+}

--- a/crates/engine/schema/src/builder/coerce/extension.rs
+++ b/crates/engine/schema/src/builder/coerce/extension.rs
@@ -12,7 +12,7 @@ use cynic_parser::{
 };
 use federated_graph::Value;
 
-use super::{value_path_to_string, ExtensionInputValueError, InputValueError};
+use super::{can_coerce_to_int, value_path_to_string, ExtensionInputValueError, InputValueError};
 
 pub(crate) struct ExtensionInputValueCoercer<'a, 'b> {
     pub ctx: &'a mut GraphContext<'b>,
@@ -44,9 +44,9 @@ impl ExtensionInputValueCoercer<'_, '_> {
         self.value_path.push(def.name().into());
         self.current_injection_stage = Default::default();
         let value = if let Some(value) = value {
-            self.coerce_input_value(def.ty(), value)?
+            self.coerce_input_fed_value(def.ty(), value)?
         } else if let Some(value) = def.default_value() {
-            self.ingest_default_value(value)
+            self.coerce_input_cynic_value(def.ty(), value)?
         } else if def.ty().is_non_null() {
             return Err(InputValueError::MissingRequiredArgument(def.name().to_string()).into());
         } else {
@@ -55,23 +55,39 @@ impl ExtensionInputValueCoercer<'_, '_> {
         Ok(Some((value, self.current_injection_stage)))
     }
 
-    fn coerce_input_value(
+    fn coerce_input_fed_value(
         &mut self,
         ty: Type<'_>,
         value: &Value,
     ) -> Result<ExtensionInputValueRecord, ExtensionInputValueError> {
         if ty.is_list() && !value.is_list() && !value.is_null() {
-            let mut value = self.coerce_named_type(ty.name(), value)?;
+            let mut value = self.coerce_named_type_fed_value(ty.name(), value)?;
             for _ in ty.wrappers().filter(|w| matches!(w, WrappingType::List)) {
                 value = ExtensionInputValueRecord::List(vec![value]);
             }
             return Ok(value);
         }
 
-        self.coerce_type(ty.name(), ty.wrappers(), value)
+        self.coerce_type_fed_value(ty.name(), ty.wrappers(), value)
     }
 
-    fn coerce_type(
+    fn coerce_input_cynic_value(
+        &mut self,
+        ty: Type<'_>,
+        value: cynic_parser::ConstValue<'_>,
+    ) -> Result<ExtensionInputValueRecord, ExtensionInputValueError> {
+        if ty.is_list() && !value.is_list() && !value.is_null() {
+            let mut value = self.coerce_named_type_cynic_value(ty.name(), value)?;
+            for _ in ty.wrappers().filter(|w| matches!(w, WrappingType::List)) {
+                value = ExtensionInputValueRecord::List(vec![value]);
+            }
+            return Ok(value);
+        }
+
+        self.coerce_type_cynic_value(ty.name(), ty.wrappers(), value)
+    }
+
+    fn coerce_type_fed_value(
         &mut self,
         name: &str,
         mut wrappers: TypeWrappersIter,
@@ -81,7 +97,7 @@ impl ExtensionInputValueCoercer<'_, '_> {
             if value.is_null() {
                 return Ok(ExtensionInputValueRecord::Null);
             }
-            return self.coerce_named_type(name, value);
+            return self.coerce_named_type_fed_value(name, value);
         };
 
         match wrapper {
@@ -93,7 +109,7 @@ impl ExtensionInputValueCoercer<'_, '_> {
                     }
                     .into())
                 } else {
-                    self.coerce_type(name, wrappers, value)
+                    self.coerce_type_fed_value(name, wrappers, value)
                 }
             }
             WrappingType::List => match value {
@@ -102,7 +118,7 @@ impl ExtensionInputValueCoercer<'_, '_> {
                     .enumerate()
                     .map(|(ix, value)| {
                         self.value_path.push(ix.into());
-                        let value = self.coerce_type(name, wrappers.clone(), value)?;
+                        let value = self.coerce_type_fed_value(name, wrappers.clone(), value)?;
                         self.value_path.pop();
                         Ok(value)
                     })
@@ -118,13 +134,60 @@ impl ExtensionInputValueCoercer<'_, '_> {
         }
     }
 
-    fn coerce_named_type(
+    fn coerce_type_cynic_value(
+        &mut self,
+        name: &str,
+        mut wrappers: TypeWrappersIter,
+        value: cynic_parser::ConstValue<'_>,
+    ) -> Result<ExtensionInputValueRecord, ExtensionInputValueError> {
+        let Some(wrapper) = wrappers.next() else {
+            if value.is_null() {
+                return Ok(ExtensionInputValueRecord::Null);
+            }
+            return self.coerce_named_type_cynic_value(name, value);
+        };
+
+        match wrapper {
+            WrappingType::NonNull => {
+                if value.is_null() {
+                    Err(InputValueError::UnexpectedNull {
+                        expected: self.type_name(name, wrappers, Some(WrappingType::NonNull)),
+                        path: self.path(),
+                    }
+                    .into())
+                } else {
+                    self.coerce_type_cynic_value(name, wrappers, value)
+                }
+            }
+            WrappingType::List => match value {
+                cynic_parser::ConstValue::List(array) => array
+                    .into_iter()
+                    .enumerate()
+                    .map(|(ix, value)| {
+                        self.value_path.push(ix.into());
+                        let value = self.coerce_type_cynic_value(name, wrappers.clone(), value)?;
+                        self.value_path.pop();
+                        Ok(value)
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+                    .map(ExtensionInputValueRecord::List),
+                _ => Err(InputValueError::MissingList {
+                    actual: value.into(),
+                    expected: self.type_name(name, wrappers, Some(WrappingType::List)),
+                    path: self.path(),
+                }
+                .into()),
+            },
+        }
+    }
+
+    fn coerce_named_type_fed_value(
         &mut self,
         name: &str,
         value: &Value,
     ) -> Result<ExtensionInputValueRecord, ExtensionInputValueError> {
         if matches!(name, "ID" | "String" | "Int" | "BigInt" | "Float" | "Boolean") {
-            return self.coerce_scalar(name, value);
+            return self.coerce_scalar_fed_value(name, value);
         }
         if let Some((_, scalar)) = self.sdl.grafbase_scalars.iter().find(|(s, _)| s == name) {
             return match scalar {
@@ -152,14 +215,54 @@ impl ExtensionInputValueCoercer<'_, '_> {
             return Err(ExtensionInputValueError::UnknownType { name: name.to_string() });
         };
         match def {
-            TypeDefinition::Scalar(def) => self.coerce_scalar(def.name(), value),
-            TypeDefinition::Enum(def) => self.coerce_enum(def, value),
-            TypeDefinition::InputObject(def) => self.coerce_input_objet(def, value),
+            TypeDefinition::Scalar(def) => self.coerce_scalar_fed_value(def.name(), value),
+            TypeDefinition::Enum(def) => self.coerce_enum_fed_value(def, value),
+            TypeDefinition::InputObject(def) => self.coerce_input_objet_fed_value(def, value),
             _ => Err(ExtensionInputValueError::NotAnInputType { name: name.to_string() }),
         }
     }
 
-    fn coerce_input_objet(
+    fn coerce_named_type_cynic_value(
+        &mut self,
+        name: &str,
+        value: cynic_parser::ConstValue<'_>,
+    ) -> Result<ExtensionInputValueRecord, ExtensionInputValueError> {
+        if matches!(name, "ID" | "String" | "Int" | "BigInt" | "Float" | "Boolean") {
+            return self.coerce_scalar_cynic_value(name, value);
+        }
+        if let Some((_, scalar)) = self.sdl.grafbase_scalars.iter().find(|(s, _)| s == name) {
+            return match scalar {
+                GrafbaseScalar::InputValueSet => match value.as_str() {
+                    Some(selection_set) => {
+                        self.current_injection_stage = self.current_injection_stage.max(InjectionStage::Query);
+                        self.coerce_input_value_set(selection_set)
+                            .map(Into::into)
+                            .map_err(Into::into)
+                    }
+                    _ => Err(InputValueError::IncorrectScalarType {
+                        actual: value.into(),
+                        expected: name.to_string(),
+                        path: self.path(),
+                    }
+                    .into()),
+                },
+            };
+        }
+        let Some(def) = self.sdl.parsed.definitions().find_map(|def| match def {
+            Definition::Type(def) if def.name() == name => Some(def),
+            _ => None,
+        }) else {
+            return Err(ExtensionInputValueError::UnknownType { name: name.to_string() });
+        };
+        match def {
+            TypeDefinition::Scalar(def) => self.coerce_scalar_cynic_value(def.name(), value),
+            TypeDefinition::Enum(def) => self.coerce_enum_cynic_value(def, value),
+            TypeDefinition::InputObject(def) => self.coerce_input_objet_cynic_value(def, value),
+            _ => Err(ExtensionInputValueError::NotAnInputType { name: name.to_string() }),
+        }
+    }
+
+    fn coerce_input_objet_fed_value(
         &mut self,
         def: InputObjectDefinition<'_>,
         value: &Value,
@@ -177,31 +280,31 @@ impl ExtensionInputValueCoercer<'_, '_> {
         let mut fields = fields.iter().collect::<Vec<_>>();
 
         for input_value_def in def.fields() {
-            if let Some(index) = fields
+            let name_id = self.strings.get_or_new(input_value_def.name());
+            self.value_path.push(name_id.into());
+
+            let value = if let Some(index) = fields
                 .iter()
                 .position(|(id, _)| self.federated_graph[*id] == input_value_def.name())
             {
-                let (name_id, value) = fields.swap_remove(index);
-                let name_id = self.get_or_insert_str(*name_id);
-                self.value_path.push(name_id.into());
+                let (_, value) = fields.swap_remove(index);
 
-                let value = self.coerce_input_value(input_value_def.ty(), value)?;
-                map.push((name_id, value));
-
-                self.value_path.pop();
+                self.coerce_input_fed_value(input_value_def.ty(), value)?
             } else if let Some(default_value) = input_value_def.default_value() {
-                map.push((
-                    self.strings.get_or_new(input_value_def.name()),
-                    self.ingest_default_value(default_value),
-                ));
+                self.coerce_input_cynic_value(input_value_def.ty(), default_value)?
             } else if input_value_def.ty().is_non_null() {
-                self.value_path.push(input_value_def.name().into());
                 let error = InputValueError::UnexpectedNull {
                     expected: self.type_name(input_value_def.ty().name(), input_value_def.ty().wrappers(), None),
                     path: self.path(),
                 };
                 return Err(error.into());
-            }
+            } else {
+                self.value_path.pop();
+                continue;
+            };
+
+            map.push((name_id, value));
+            self.value_path.pop();
         }
 
         if let Some((name, _)) = fields.first() {
@@ -217,7 +320,62 @@ impl ExtensionInputValueCoercer<'_, '_> {
         Ok(ExtensionInputValueRecord::Map(map))
     }
 
-    fn coerce_enum(
+    fn coerce_input_objet_cynic_value(
+        &mut self,
+        def: InputObjectDefinition<'_>,
+        obj: cynic_parser::ConstValue<'_>,
+    ) -> Result<ExtensionInputValueRecord, ExtensionInputValueError> {
+        let cynic_parser::ConstValue::Object(obj) = obj else {
+            return Err(InputValueError::MissingObject {
+                name: def.name().to_string(),
+                actual: obj.into(),
+                path: self.path(),
+            }
+            .into());
+        };
+
+        let mut map = Vec::new();
+        let mut fields = obj.fields().collect::<Vec<_>>();
+
+        for input_value_def in def.fields() {
+            let name_id = self.strings.get_or_new(input_value_def.name());
+            self.value_path.push(name_id.into());
+
+            let value = if let Some(index) = fields.iter().position(|field| field.name() == input_value_def.name()) {
+                let field = fields.swap_remove(index);
+                self.coerce_input_cynic_value(input_value_def.ty(), field.value())?
+            } else if let Some(default_value) = input_value_def.default_value() {
+                self.coerce_input_cynic_value(input_value_def.ty(), default_value)?
+            } else if input_value_def.ty().is_non_null() {
+                self.value_path.push(input_value_def.name().into());
+                let error = InputValueError::UnexpectedNull {
+                    expected: self.type_name(input_value_def.ty().name(), input_value_def.ty().wrappers(), None),
+                    path: self.path(),
+                };
+                return Err(error.into());
+            } else {
+                self.value_path.pop();
+                continue;
+            };
+
+            map.push((name_id, value));
+            self.value_path.pop();
+        }
+
+        if let Some(field) = fields.first() {
+            let error = InputValueError::UnknownInputField {
+                input_object: def.name().to_string(),
+                name: field.name().to_string(),
+                path: self.path(),
+            };
+
+            return Err(error.into());
+        }
+
+        Ok(ExtensionInputValueRecord::Map(map))
+    }
+
+    fn coerce_enum_fed_value(
         &mut self,
         def: EnumDefinition<'_>,
         value: &Value,
@@ -246,7 +404,36 @@ impl ExtensionInputValueCoercer<'_, '_> {
         .into())
     }
 
-    fn coerce_scalar(
+    fn coerce_enum_cynic_value(
+        &mut self,
+        def: EnumDefinition<'_>,
+        value: cynic_parser::ConstValue<'_>,
+    ) -> Result<ExtensionInputValueRecord, ExtensionInputValueError> {
+        let string_value = match value {
+            cynic_parser::ConstValue::Enum(enm) => enm.as_str(),
+            value => {
+                return Err(InputValueError::IncorrectEnumValueType {
+                    r#enum: def.name().to_string(),
+                    actual: value.into(),
+                    path: self.path(),
+                }
+                .into());
+            }
+        };
+        if def.values().any(|value| value.value() == string_value) {
+            return Ok(ExtensionInputValueRecord::EnumValue(
+                self.strings.get_or_new(string_value),
+            ));
+        }
+        Err(InputValueError::UnknownEnumValue {
+            r#enum: def.name().to_string(),
+            value: string_value.to_string(),
+            path: self.path(),
+        }
+        .into())
+    }
+
+    fn coerce_scalar_fed_value(
         &mut self,
         name: &str,
         value: &Value,
@@ -282,7 +469,7 @@ impl ExtensionInputValueCoercer<'_, '_> {
                 Value::Boolean(b) => Some(ExtensionInputValueRecord::Boolean(*b)),
                 _ => None,
             },
-            _ => return Ok(self.ingest_arbitrary_scalar(value)),
+            _ => return Ok(self.ingest_arbitrary_fed_value(value)),
         }
         .ok_or_else(|| {
             InputValueError::IncorrectScalarType {
@@ -294,7 +481,60 @@ impl ExtensionInputValueCoercer<'_, '_> {
         })
     }
 
-    fn ingest_arbitrary_scalar(&mut self, value: &Value) -> ExtensionInputValueRecord {
+    fn coerce_scalar_cynic_value(
+        &mut self,
+        name: &str,
+        value: cynic_parser::ConstValue<'_>,
+    ) -> Result<ExtensionInputValueRecord, ExtensionInputValueError> {
+        use cynic_parser::ConstValue;
+        match name {
+            "String" | "ID" => match value {
+                ConstValue::String(s) => Some(ExtensionInputValueRecord::String(self.strings.get_or_new(s.value()))),
+                _ => None,
+            },
+            "Float" => match value {
+                ConstValue::Int(n) => Some(ExtensionInputValueRecord::Float(n.value() as f64)),
+                ConstValue::Float(f) => Some(ExtensionInputValueRecord::Float(f.value())),
+                _ => None,
+            },
+            "Int" => match value {
+                ConstValue::Int(n) => {
+                    let n = i32::try_from(n.value()).map_err(|_| InputValueError::IncorrectScalarValue {
+                        actual: n.to_string(),
+                        expected: name.to_string(),
+                        path: self.path(),
+                    })?;
+                    Some(ExtensionInputValueRecord::Int(n))
+                }
+                ConstValue::Float(f) if can_coerce_to_int(f.value()) => {
+                    Some(ExtensionInputValueRecord::Int(f.value() as i32))
+                }
+                _ => None,
+            },
+            "BigInt" => match value {
+                ConstValue::Int(n) => Some(ExtensionInputValueRecord::BigInt(n.value())),
+                ConstValue::Float(f) if can_coerce_to_int(f.value()) => {
+                    Some(ExtensionInputValueRecord::BigInt(f.value() as i64))
+                }
+                _ => None,
+            },
+            "Boolean" => match value {
+                ConstValue::Boolean(b) => Some(ExtensionInputValueRecord::Boolean(b.value())),
+                _ => None,
+            },
+            _ => return Ok(self.ingest_arbitrary_cynic_value(value)),
+        }
+        .ok_or_else(|| {
+            InputValueError::IncorrectScalarType {
+                actual: value.into(),
+                expected: name.to_string(),
+                path: self.path(),
+            }
+            .into()
+        })
+    }
+
+    fn ingest_arbitrary_fed_value(&mut self, value: &Value) -> ExtensionInputValueRecord {
         match value {
             Value::Null => ExtensionInputValueRecord::Null,
             Value::String(id) => ExtensionInputValueRecord::String(self.get_or_insert_str(*id)),
@@ -311,17 +551,19 @@ impl ExtensionInputValueCoercer<'_, '_> {
                     .iter()
                     .map(|(name, value)| {
                         let name = self.get_or_insert_str(*name);
-                        (name, self.ingest_arbitrary_scalar(value))
+                        (name, self.ingest_arbitrary_fed_value(value))
                     })
                     .collect(),
             ),
-            Value::List(list) => {
-                ExtensionInputValueRecord::List(list.iter().map(|value| self.ingest_arbitrary_scalar(value)).collect())
-            }
+            Value::List(list) => ExtensionInputValueRecord::List(
+                list.iter()
+                    .map(|value| self.ingest_arbitrary_fed_value(value))
+                    .collect(),
+            ),
         }
     }
 
-    fn ingest_default_value(&mut self, value: ConstValue) -> ExtensionInputValueRecord {
+    fn ingest_arbitrary_cynic_value(&mut self, value: ConstValue) -> ExtensionInputValueRecord {
         match value {
             ConstValue::Null(_) => ExtensionInputValueRecord::Null,
             ConstValue::String(s) => ExtensionInputValueRecord::String(self.strings.get_or_new(s.value())),
@@ -330,21 +572,23 @@ impl ExtensionInputValueCoercer<'_, '_> {
             ConstValue::Boolean(b) => ExtensionInputValueRecord::Boolean(b.value()),
             ConstValue::Enum(s) => ExtensionInputValueRecord::EnumValue(self.strings.get_or_new(s.as_str())),
             ConstValue::List(list) => ExtensionInputValueRecord::List(
-                list.into_iter().map(|value| self.ingest_default_value(value)).collect(),
+                list.into_iter()
+                    .map(|value| self.ingest_arbitrary_cynic_value(value))
+                    .collect(),
             ),
             ConstValue::Object(fields) => ExtensionInputValueRecord::Map(
                 fields
                     .into_iter()
                     .map(|field| {
                         let name = self.strings.get_or_new(field.name());
-                        (name, self.ingest_default_value(field.value()))
+                        (name, self.ingest_arbitrary_cynic_value(field.value()))
                     })
                     .collect(),
             ),
         }
     }
 
-    fn type_name(&self, name: &str, iter: TypeWrappersIter, outer: Option<WrappingType>) -> String {
+    pub(super) fn type_name(&self, name: &str, iter: TypeWrappersIter, outer: Option<WrappingType>) -> String {
         let mut out = String::new();
         let mut wrappers = Vec::new();
         wrappers.extend(outer);
@@ -364,11 +608,7 @@ impl ExtensionInputValueCoercer<'_, '_> {
         out
     }
 
-    fn path(&self) -> String {
+    pub(super) fn path(&self) -> String {
         value_path_to_string(self, &self.value_path)
     }
-}
-
-fn can_coerce_to_int(float: f64) -> bool {
-    float.floor() == float && float < (i32::MAX as f64)
 }

--- a/crates/integration-tests/tests/federation/extensions/injection/input_value_set/selection_set.rs
+++ b/crates/integration-tests/tests/federation/extensions/injection/input_value_set/selection_set.rs
@@ -311,3 +311,66 @@ fn default_values_star() {
         "#);
     });
 }
+
+#[test]
+fn extension_directive_default_value() {
+    runtime().block_on(async move {
+        let response = Engine::builder()
+            .with_subgraph_sdl(
+                "a",
+                r#"
+                extend schema
+                    @link(url: "echo-1.0.0", import: ["@echo"])
+
+                scalar JSON
+
+                type Query {
+                    echo(first: Int = 100, limit: Int, after: String, filters: Filters): JSON @echo
+                }
+
+                input Filters {
+                    latest: Boolean = false
+                    nested: Nested
+                }
+
+                input Nested {
+                    id: ID
+                    name: String
+                }
+                "#,
+            )
+            .with_extension(EchoExt::with_sdl(
+                r#"
+                extend schema @link(url: "https://specs.grafbase.com/grafbase", import: ["InputValueSet"])
+
+                directive @echo(input: InputValueSet! = "*") on FIELD_DEFINITION
+                "#,
+            ))
+            .build()
+            .await
+            .post(r#"query { echo(after: "79", filters: { nested: { id: "78", name: "Hi!" } }) }"#)
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "echo": {
+              "schema": {},
+              "directive": {
+                "input": {
+                  "first": 100,
+                  "after": "79",
+                  "filters": {
+                    "latest": false,
+                    "nested": {
+                      "id": "78",
+                      "name": "Hi!"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        "#);
+    });
+}

--- a/crates/integration-tests/tests/federation/extensions/validation/default_value.rs
+++ b/crates/integration-tests/tests/federation/extensions/validation/default_value.rs
@@ -43,13 +43,15 @@ fn default_values() {
               "schema": {
                 "meta": {
                   "a": {
-                    "x": 3
+                    "x": 3,
+                    "y": "default"
                   }
                 }
               },
               "directive": {
                 "a": {
-                  "x": 3
+                  "x": 3,
+                  "y": "default"
                 }
               }
             }


### PR DESCRIPTION
Previously an extensions directive's default value such as:

```graphql
extend schema @link(url: "https://specs.grafbase.com/grafbase", import: ["InputValueSet"])

directive @echo(input: InputValueSet! = "*") on FIELD_DEFINITION
```

wouldn't be coerced into the right type.

Need to duplicate again the coercion logic. Input values are really
messy now will improve this once we remove `@authorized` in favor of
extensions.
