### PR TITLE
ci: use paths instead of taking file contents from stdin in upload.sh

### DIFF
--- a/cli/install/upload.sh
+++ b/cli/install/upload.sh
@@ -31,7 +31,7 @@ env -i \
     AWS_REGION=auto \
     AWS_ACCESS_KEY_ID="$CLOUDFLARE_ASSETS_R2_ACCESS_KEY_ID" \
     AWS_SECRET_ACCESS_KEY="$CLOUDFLARE_ASSETS_R2_SECRET_ACCESS_KEY" \
-    aws --endpoint-url "$endpoint_url" s3 cp --no-progress - "$s3_path" < "$1"
+    aws --endpoint-url "$endpoint_url" s3 cp --no-progress "$1" "$s3_path"
 
 env -i \
     PATH="$PATH" \


### PR DESCRIPTION
This behaviour does not exist anymore in awscli v2.