### PR TITLE
feat(rest): use arguments to generate the path

### DIFF
--- a/extensions/jwt/Cargo.lock
+++ b/extensions/jwt/Cargo.lock
@@ -1585,6 +1585,7 @@ version = "0.1.0"
 dependencies = [
  "ahash 0.8.11",
  "aho-corasick",
+ "arrayvec 0.7.6",
  "ascii",
  "axum",
  "axum-core",

--- a/extensions/rest/Cargo.lock
+++ b/extensions/rest/Cargo.lock
@@ -166,6 +166,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,6 +1508,7 @@ version = "0.1.0"
 dependencies = [
  "ahash 0.8.11",
  "aho-corasick",
+ "arrayvec 0.7.6",
  "ascii",
  "axum",
  "axum-core",
@@ -2939,7 +2946,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b55c4d17d994b637e2f4daf6e5dc5d660d209d5642377d675d7a1c3ab69fa579"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "typed-arena",
  "unicode-width 0.1.14",
 ]

--- a/extensions/rest/README.md
+++ b/extensions/rest/README.md
@@ -174,3 +174,22 @@ type Mutation {
 ```
 
 The extension checks static data first, then searches for a body in an argument named `input`.
+
+## Arguments
+
+The path argument is used to specify the path to the REST endpoint. You can use the input arguments to construct the path:
+
+```graphql
+type Mutation {
+  getCountry(id: Int!): Country @rest(
+    endpoint: "restCountries",
+    http: {
+      method: GET,
+      path: "/fetch/{{ args.id }}"
+    },
+    selection: "{ name: .name.official }"
+  )
+}
+```
+
+The extension will generate the path based on the `id` argument.

--- a/extensions/rest/definitions.graphql
+++ b/extensions/rest/definitions.graphql
@@ -1,4 +1,4 @@
-extend schema @link(url: "https://specs.grafbase.com/grafbase", import: ["InputValueSet"])
+extend schema @link(url: "https://specs.grafbase.com/grafbase", import: ["InputValueSet", "UrlTemplate"])
 
 directive @restEndpoint(name: String!, http: HttpEndpointDefinition!) repeatable on SCHEMA
 
@@ -17,12 +17,12 @@ input Body {
 }
 
 input HttpEndpointDefinition {
-  baseURL: String
+  baseURL: String!
 }
 
 input HttpRequestDefinition {
-  method: HttpMethod
-  path: String
+  method: HttpMethod!
+  path: UrlTemplate!
 }
 
 enum HttpMethod {

--- a/extensions/rest/src/types.rs
+++ b/extensions/rest/src/types.rs
@@ -61,6 +61,13 @@ pub struct HttpCall<'a> {
 pub enum HttpMethod {
     Get,
     Post,
+    Put,
+    Delete,
+    Head,
+    Options,
+    Connect,
+    Trace,
+    Patch,
 }
 
 impl From<HttpMethod> for ::http::Method {
@@ -68,6 +75,13 @@ impl From<HttpMethod> for ::http::Method {
         match method {
             HttpMethod::Get => Self::GET,
             HttpMethod::Post => Self::POST,
+            HttpMethod::Put => Self::PUT,
+            HttpMethod::Delete => Self::DELETE,
+            HttpMethod::Head => Self::HEAD,
+            HttpMethod::Options => Self::OPTIONS,
+            HttpMethod::Connect => Self::CONNECT,
+            HttpMethod::Trace => Self::TRACE,
+            HttpMethod::Patch => Self::PATCH,
         }
     }
 }


### PR DESCRIPTION
Mainly just using the new `UrlTemplate` type, testing fetching with an id, deletions and updates. Enables all verbs.