### PR TITLE
chore: Use taplo to format & check TOML

### DIFF
--- a/.config/workspace-schema.json
+++ b/.config/workspace-schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "$defs": {
+    "dependencyEntries": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "oneOf": [
+          {
+            "properties": {
+              "workspace": {
+                "type": "boolean",
+                "enum": [true]
+              }
+            },
+            "required": ["workspace"]
+          },
+          {
+            "properties": {
+              "path": {
+                "type": "string"
+              }
+            },
+            "required": ["path"]
+          }
+        ]
+      }
+    }
+  },
+  "properties": {
+    "dependencies": { "$ref": "#/$defs/dependencyEntries" },
+    "dev-dependencies": { "$ref": "#/$defs/dependencyEntries" },
+    "build-dependencies": { "$ref": "#/$defs/dependencyEntries" }
+  }
+}

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -4,10 +4,13 @@ description: Run cargo fmt, clippy, test
 runs:
   using: 'composite'
   steps:
+    - uses: uncenter/setup-taplo@v1
+      with:
+        version: '0.9.3'
+
     - name: taplo fmt check
       shell: bash
       run: |
-        curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-linux-x86_64.gz | gzip -d - | install -m 755 /dev/stdin /usr/local/bin/taplo
         taplo fmt --check
         taplo check
 

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -4,6 +4,13 @@ description: Run cargo fmt, clippy, test
 runs:
   using: 'composite'
   steps:
+    - name: taplo fmt check
+      shell: bash
+      run: |
+        curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-linux-x86_64.gz | gzip -d - | install -m 755 /dev/stdin /usr/local/bin/taplo
+        taplo fmt --check
+        taplo check
+
     - name: cargo fmt
       shell: bash
       run: |

--- a/.github/workflows/rust-prs.yml
+++ b/.github/workflows/rust-prs.yml
@@ -99,6 +99,13 @@ jobs:
         run: |
           cargo fmt --check
 
+      - name: taplo fmt check
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-linux-x86_64.gz | gzip -d - | install -m 755 /dev/stdin /usr/local/bin/taplo
+          taplo fmt --check
+          taplo check
+
   example-component:
     if: |
       needs.what-changed.outputs.changed-packages != '[]'

--- a/.github/workflows/rust-prs.yml
+++ b/.github/workflows/rust-prs.yml
@@ -99,10 +99,13 @@ jobs:
         run: |
           cargo fmt --check
 
+      - uses: uncenter/setup-taplo@v1
+        with:
+          version: '0.9.3'
+
       - name: taplo fmt check
         shell: bash
         run: |
-          curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-linux-x86_64.gz | gzip -d - | install -m 755 /dev/stdin /usr/local/bin/taplo
           taplo fmt --check
           taplo check
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,11 +2027,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -2094,16 +2114,16 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "duration-str"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ad6b66883f70e2f38f1ee99e3797b9d7e7b7fb051ed2e23e027c81753056c8"
+checksum = "99b55e40ba8fc1ef074c9f9031b4cb88bb1f30c946f80a9305df44973c0b9a2d"
 dependencies = [
  "chrono",
  "rust_decimal",
  "serde",
  "thiserror 2.0.11",
  "time",
- "winnow",
+ "winnow 0.6.8",
 ]
 
 [[package]]
@@ -2415,8 +2435,8 @@ dependencies = [
  "fxhash",
  "gateway-config",
  "grafbase-workspace-hack",
- "graphql-federated-graph 0.6.0",
- "graphql-wrapping-types 0.2.0",
+ "graphql-federated-graph",
+ "graphql-wrapping-types",
  "hex",
  "http 1.2.0",
  "indexmap 2.7.0",
@@ -2671,7 +2691,7 @@ dependencies = [
  "grafbase-telemetry",
  "grafbase-workspace-hack",
  "graph-ref",
- "graphql-composition 0.6.1",
+ "graphql-composition",
  "http 1.2.0",
  "lambda_http",
  "minicbor-serde",
@@ -2701,7 +2721,7 @@ version = "0.0.0"
 dependencies = [
  "cynic-parser",
  "grafbase-workspace-hack",
- "graphql-composition 0.6.1",
+ "graphql-composition",
  "integration-tests",
  "libtest-mimic",
  "reqwest 0.12.12",
@@ -3057,6 +3077,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3138,7 +3170,7 @@ dependencies = [
  "cynic",
  "cynic-codegen",
  "cynic-parser",
- "dirs",
+ "dirs 6.0.0",
  "duct",
  "expect-test",
  "extension",
@@ -3152,8 +3184,8 @@ dependencies = [
  "grafbase-graphql-introspection",
  "grafbase-workspace-hack",
  "graph-ref",
- "graphql-composition 0.6.1",
- "graphql-federated-graph 0.6.0",
+ "graphql-composition",
+ "graphql-federated-graph",
  "graphql-lint",
  "graphql-mocks",
  "ignore",
@@ -3217,7 +3249,7 @@ dependencies = [
  "grafbase-telemetry",
  "grafbase-workspace-hack",
  "graph-ref",
- "graphql-composition 0.6.1",
+ "graphql-composition",
  "graphql-mocks",
  "handlebars 6.3.0",
  "http 1.2.0",
@@ -3283,8 +3315,8 @@ dependencies = [
  "futures-util",
  "grafbase-sdk-derive",
  "grafbase-sdk-mock",
- "graphql-composition 0.6.0",
- "graphql-federated-graph 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "graphql-composition",
+ "graphql-federated-graph",
  "http 1.2.0",
  "indoc",
  "minicbor-serde",
@@ -3369,6 +3401,7 @@ version = "0.1.0"
 dependencies = [
  "ahash 0.8.11",
  "aho-corasick",
+ "anyhow",
  "arrayvec 0.7.6",
  "ascii",
  "axum 0.8.1",
@@ -3510,27 +3543,13 @@ dependencies = [
 
 [[package]]
 name = "graphql-composition"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2967e890033c51901c701518daa689ce6cbccb37859c216ddfd2571018833f"
-dependencies = [
- "cynic-parser",
- "cynic-parser-deser",
- "graphql-federated-graph 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 2.7.0",
- "itertools 0.14.0",
- "url",
-]
-
-[[package]]
-name = "graphql-composition"
 version = "0.6.1"
 dependencies = [
  "anyhow",
  "cynic-parser",
  "cynic-parser-deser",
  "grafbase-workspace-hack",
- "graphql-federated-graph 0.6.0",
+ "graphql-federated-graph",
  "indexmap 2.7.0",
  "insta",
  "itertools 0.14.0",
@@ -3549,7 +3568,7 @@ dependencies = [
  "cynic-parser-deser",
  "expect-test",
  "grafbase-workspace-hack",
- "graphql-wrapping-types 0.2.0",
+ "graphql-wrapping-types",
  "indexmap 2.7.0",
  "indoc",
  "itertools 0.14.0",
@@ -3559,24 +3578,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "url",
-]
-
-[[package]]
-name = "graphql-federated-graph"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "895a55bf1a7fcc72ec3908239921a11b0cf661fe3a6cfc550e89a2a6e0580fac"
-dependencies = [
- "bitflags 2.8.0",
- "cynic-parser",
- "cynic-parser-deser",
- "grafbase-workspace-hack",
- "graphql-wrapping-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 2.7.0",
- "indoc",
- "itertools 0.14.0",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -3652,16 +3653,6 @@ dependencies = [
 [[package]]
 name = "graphql-wrapping-types"
 version = "0.2.0"
-dependencies = [
- "grafbase-workspace-hack",
- "serde",
-]
-
-[[package]]
-name = "graphql-wrapping-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165aca8d4b7bba95daaac55f7e1e139475043a674768a659a4da80792ff74f96"
 dependencies = [
  "grafbase-workspace-hack",
  "serde",
@@ -4520,7 +4511,6 @@ dependencies = [
  "cynic",
  "cynic-introspection",
  "cynic-parser",
- "dyn-clone",
  "ed25519-compact",
  "elliptic-curve",
  "engine",
@@ -4532,8 +4522,8 @@ dependencies = [
  "gateway-config",
  "grafbase-telemetry",
  "grafbase-workspace-hack",
- "graphql-composition 0.6.1",
- "graphql-federated-graph 0.6.0",
+ "graphql-composition",
+ "graphql-federated-graph",
  "graphql-mocks",
  "graphql-ws-client",
  "headers",
@@ -7515,6 +7505,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
+dependencies = [
+ "dirs 4.0.0",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7954,13 +7953,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
 dependencies = [
  "cfg-if",
  "fastrand 2.2.0",
- "getrandom 0.2.15",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -8222,15 +8221,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap 2.7.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.7.2",
 ]
 
 [[package]]
@@ -8424,7 +8423,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -8676,6 +8674,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt 0.33.0",
+]
 
 [[package]]
 name = "wasi-component-loader"
@@ -9118,6 +9125,7 @@ dependencies = [
  "trait-variant",
  "url",
  "wasmtime",
+ "wiggle",
  "windows-sys 0.59.0",
 ]
 
@@ -9175,6 +9183,15 @@ dependencies = [
 
 [[package]]
 name = "wast"
+version = "35.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wast"
 version = "221.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc4470b9de917ba199157d1f0ae104f2ae362be728c43e68c571c7715bd629e"
@@ -9192,7 +9209,7 @@ version = "1.221.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1f3c6d82af47286494c6caea1d332037f5cbeeac82bbf5ef59cb8c201c466e"
 dependencies = [
- "wast",
+ "wast 221.0.2",
 ]
 
 [[package]]
@@ -9264,6 +9281,48 @@ dependencies = [
  "env_home",
  "rustix",
  "winsafe",
+]
+
+[[package]]
+name = "wiggle"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9af35bc9629c52c261465320a9a07959164928b4241980ba1cf923b9e6751d"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags 2.8.0",
+ "thiserror 1.0.69",
+ "tracing",
+ "wasmtime",
+ "wiggle-macro",
+]
+
+[[package]]
+name = "wiggle-generate"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cf267dd05673912c8138f4b54acabe6bd53407d9d1536f0fadb6520dd16e101"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "shellexpand",
+ "syn 2.0.96",
+ "witx",
+]
+
+[[package]]
+name = "wiggle-macro"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c5c473d4198e6c2d377f3809f713ff0c110cab88a0805ae099a82119ee250c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+ "wiggle-generate",
 ]
 
 [[package]]
@@ -9570,9 +9629,18 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
 dependencies = [
  "memchr",
 ]
@@ -9633,7 +9701,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b550e454e4cce8984398539a94a0226511e1f295b14afdc8f08b4e2e2ff9de3a"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen-rt 0.38.0",
  "wit-bindgen-rust-macro",
 ]
 
@@ -9646,6 +9714,15 @@ dependencies = [
  "anyhow",
  "heck 0.5.0",
  "wit-parser 0.224.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -9743,6 +9820,18 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.224.0",
+]
+
+[[package]]
+name = "witx"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
+dependencies = [
+ "anyhow",
+ "log",
+ "thiserror 1.0.69",
+ "wast 35.0.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,10 @@ keywords = ["grafbase"]
 repository = "https://github.com/grafbase/grafbase"
 
 [workspace.dependencies]
-anyhow = "1"
+anyhow = { version = "1", default-features = false }
+ascii = "1"
+askama = "0.12"
+assert_matches = "1"
 async-graphql = "7.0.15"
 async-graphql-axum = "7.0.15"
 async-graphql-parser = "7.0.15"
@@ -50,135 +53,213 @@ async-sse = "5"
 async-trait = "0.1.80"
 async-tungstenite = "0.28.0"
 axum = { version = "0.8.0", default-features = false }
+axum-extra = "0.10"
 axum-server = { version = "0.7", default-features = false }
+backtrace = "0.3"
 base64 = "0.22.1"
 bitflags = "2"
 bitvec = "1"
 blake3 = "1.5.1"
 bytes = "1.6.0"
+case = "1"
+cfg-if = "1"
 chrono = { version = "0.4.38", default-features = false }
+clap = "4"
+clap_complete = "4.5"
+cli-table = { version = "0.4", default-features = false }
+clickhouse = "0.13"
+colored = "3"
+const_format = "0.2"
+convert_case = "0.7"
+criterion = "0.5"
+crossbeam = "0.8"
+crossbeam-queue = "0.3"
+crossterm = "0.28"
 ctor = "0.2.8"
 cynic = "3.9"
 cynic-codegen = { version = "3.9", features = ["rkyv"] }
 cynic-introspection = "3.9"
 cynic-parser = "0.8.7"
 cynic-parser-deser = "0.8.7"
+dashmap = "6.1"
 datatest-stable = "0.3.0"
 deadpool = { version = "0.12.1", features = ["rt_tokio_1"] }
 derive_more = "2.0.0"
-jwt-compact = "0.8"
+dirs = "6"
+duct = "0.13"
+duration-str = "0.13"
+ed25519-compact = "2"
+either = "1.13"
+elliptic-curve = "0.13"
+enumflags2 = "0.7"
+expect-test = "1.5"
 fixedbitset = "0.5"
+flate2 = "1"
+fnv = "1.0.7"
 form_urlencoded = "1"
+fslock = "0.2"
 futures = "0.3.30"
 futures-channel = "0.3.30"
 futures-lite = "2"
 futures-util = "0.3.30"
 fxhash = "0.2"
+governor = "0.8"
+graphql-parser = { git = "https://github.com/graphql-rust/graphql-parser", version = "0.4.0" }
 graphql-ws-client = { version = "0.11.0", features = ["tungstenite"] }
 handlebars = "6.0.0"
+hashbrown = "0.15"
 headers = "0.4"
+heck = "0.5"
 hex = "0.4.3"
 http = "1.1.0"
+http-body = "1"
+http-body-util = "0.1"
 httpsig = "0.0.17"
 httpsig-hyper = "0.0.17"
 hyper = { version = "1.3.1", features = ["http2"] }
 hyper-util = "0.1.3"
+ignore = "0.4"
+im = "15"
 indexmap = "2.2.6"
+indicatif = "0.17"
 indoc = "2"
+inquire = "0.7"
 insta = { version = "1.39.0", features = ["json", "redactions", "glob"] }
 internment = { version = "0.8", features = ["serde", "arc"] }
 itertools = "0.14.0"
 jsonwebtoken = "9.3.0"
+jwt-compact = "0.8"
 lambda_http = "0.14.0"
-governor = "0.8"
-minicbor-serde = "0.3.2"
-mini-moka = "0.10"
-miette = "7.4"
-multipart-stream = "0.1.2"
+lasso2 = "0.8"
+libtest-mimic = "0.8"
+log = "0.4"
 mediatype = "0.19"
+miette = "7.4"
+mimalloc = "0.1"
+mime = "0.3"
+mini-moka = "0.10"
+minicbor-serde = "0.3.2"
+multipart-stream = "0.1.2"
+notify = "8"
+notify-debouncer-full = "0.5"
 num-traits = "0.2.18"
 openidconnect = "4.0.0-rc.1"
+opentelemetry = "0.27"
+opentelemetry-appender-tracing = "0.27"
+opentelemetry-aws = "0.15"
+opentelemetry-otlp = "0.27"
+opentelemetry-stdout = "0.27"
+opentelemetry_sdk = "0.27"
+ory-client = "1.9"
+os_type = "2"
+p256 = "0.13"
+p384 = "0.13"
+percent-encoding = "2"
 petgraph = "0.7"
-pprof = "0.14"
 postcard = { version = "1", features = ["use-std"] }
-ramhorns = { git = "https://github.com/grafbase/ramhorns", branch = "grafbase", default-features = false, features = ["indexes", "export_derive"] }
+pprof = "0.14"
+pretty_assertions = "1"
+proc-macro2 = "1"
+quote = "1"
+ramhorns = { git = "https://github.com/grafbase/ramhorns", branch = "grafbase", default-features = false, features = [
+    "indexes",
+    "export_derive",
+] }
 rand = "0.8"
-regex = "1.10.4"
+rapidhash = "1"
 redis = { version = "0.28.0", features = [
     "tokio-rustls-comp",
     "connection-manager",
 ] }
+regex = "1.10.4"
 reqwest = { version = "0.12.8", default-features = false, features = ["http2"] }
+reqwest-eventsource = "0.6"
 rmp-serde = "1.3.0"
 rstest = "0.24"
 rustls = { version = "0.23.5", default-features = false }
 rustls-pemfile = { version = "2.1.2", default-features = false }
 rustls-webpki = { version = "0.102.3", default-features = false }
 secrecy = "0.10"
+semver = "1"
 send_wrapper = "0.6"
+serde = { version = "1.0.199", features = ["derive"] }
+serde-toml-merge = "0.3"
+serde-value = "0.7"
+serde_derive = "1"
+serde_dynamo = "4.2.14"
+serde_json = { version = "1.0.116", features = ["preserve_order"] }
+serde_path_to_error = "0.1"
+serde_regex = "1"
+serde_urlencoded = "0.7"
+serde_valid = "1"
+serde_with = "3.8.1"
+sha2 = "0.10.8"
+similar = "2.5"
+similar-asserts = "1.5"
+size = "0.5.0-preview2"
+slugify = "0.1"
 strum = "0.26.2"
 strum_macros = "0.26.2"
+syn = "2"
+syntect = "5"
 tar = "0.4.40"
+temp-env = "0.3"
+tempfile = "3.16"
 thiserror = "2.0.0"
 tokio = "1.37.0"
 tokio-rustls = { version = "0.26.0", default-features = false }
+tokio-stream = "0.1"
 tokio-tungstenite = { version = "0.26.0", default-features = false }
+tokio-util = "0.7"
 toml = "0.8"
-tungstenite = { version = "0.26.0", default-features = false }
 tonic = "0.12.0"
 tower = "0.5.0"
 tower-http = "0.6.0"
 tower-service = "0.3.2"
-url = "2.5.0"
-uuid = "1.8.0"
-ulid = "1.1.2"
-which = "7.0.0"
-wiremock = "0.6.0"
-wit-bindgen = "0.38.0"
-fnv = "1.0.7"
-sha2 = "0.10.8"
-semver = "1"
-
-# Serde
-serde = { version = "1.0.199", features = ["derive"] }
-serde_dynamo = "4.2.14"
-serde_json = { version = "1.0.116", features = ["preserve_order"] }
-serde_urlencoded = "0.7"
-serde_with = "3.8.1"
-
-# Tracing
 tracing = "0.1.40"
-tracing-subscriber = "0.3.18"
 tracing-futures = "0.2.5"
 tracing-mock = "0.1"
 tracing-opentelemetry = "0.28"
-opentelemetry = "0.27"
-opentelemetry_sdk = "0.27"
-opentelemetry-stdout = "0.27"
-opentelemetry-otlp = "0.27"
-opentelemetry-appender-tracing = "0.27"
+tracing-subscriber = { version = "0.3.18", default-features = false }
+tungstenite = { version = "0.26.0", default-features = false }
+ulid = "1.1.2"
+url = "2.5.0"
+urlencoding = "2.1"
+uuid = "1.8.0"
+wasmparser = "0.224.0"
+wasmtime = "29"
+wasmtime-wasi = "29"
+wasmtime-wasi-http = "29"
+webbrowser = "1"
+which = "7.0.0"
+wiremock = "0.6.0"
+wit-bindgen = "0.38.0"
+xshell = "0.2"
 
 # Common
-graph-ref = { path = "crates/graph-ref" }
-graphql-schema-validation = { path = "crates/graphql-schema-validation" }
 grafbase-graphql-introspection = { path = "crates/grafbase-graphql-introspection" }
+graph-ref = { path = "crates/graph-ref" }
+graphql-federated-graph = { path = "crates/graphql-federated-graph" }
 graphql-lint = { path = "crates/graphql-lint" }
+graphql-schema-validation = { path = "crates/graphql-schema-validation" }
 
 # Gateway
-federated-server = { path = "crates/federated-server" }
-gateway-config = { path = "crates/gateway-config" }
-rolling-logger = { path = "crates/rolling-logger" }
-grafbase-sdk = { path = "crates/grafbase-sdk" }
 extension = { path = "crates/extension" }
 extension-catalog = { path = "crates/extension-catalog" }
+federated-server = { path = "crates/federated-server" }
+gateway-config = { path = "crates/gateway-config" }
+grafbase-sdk = { path = "crates/grafbase-sdk" }
+rolling-logger = { path = "crates/rolling-logger" }
 
 # Engine
 engine = { path = "crates/engine" }
-engine-schema = { path = "crates/engine/schema" }
 engine-auth = { path = "crates/engine/auth" }
 engine-axum = { path = "crates/engine/axum" }
+engine-schema = { path = "crates/engine/schema" }
 federated-graph = { path = "crates/graphql-federated-graph", package = "graphql-federated-graph" }
+grafbase-hooks = { path = "crates/grafbase-hooks" }
 grafbase-telemetry = { path = "crates/telemetry" }
+grafbase-workspace-hack = { path = "crates/grafbase-workspace-hack", version = "0.1" }
 graphql-composition = { path = "crates/graphql-composition" }
 graphql-mocks = { path = "crates/graphql-mocks" }
 operation-normalizer = { path = "crates/operation-normalizer" }
@@ -186,8 +267,6 @@ runtime = { path = "crates/runtime" }
 runtime-local = { path = "crates/runtime-local" }
 runtime-noop = { path = "crates/runtime-noop" }
 serde-dynamic-string = { path = "crates/serde-dynamic-string" }
-grafbase-hooks = { path = "crates/grafbase-hooks" }
-grafbase-workspace-hack = { path = "crates/grafbase-workspace-hack", version = "0.1" }
 wrapping = { path = "crates/graphql-wrapping-types", package = "graphql-wrapping-types" }
 
 [profile.bench]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,86 +11,86 @@ keywords.workspace = true
 repository.workspace = true
 
 [dependencies]
-assert_matches = "1.5.0"
+assert_matches.workspace = true
 axum = { workspace = true, features = ["http1", "tokio"] }
-backtrace = "0.3.71"
-chrono = "0.4.38"
-clap = { version = "4", features = ["cargo", "wrap_help", "derive", "env"] }
-clap_complete = "4.5.2"
-cli-table = { version = "0.4.9", default-features = false }
-colored = "3.0.0"
-const_format = "0.2.32"
-crossterm = "0.28.1"
+backtrace.workspace = true
+chrono.workspace = true
+clap = { workspace = true, features = ["cargo", "wrap_help", "derive", "env"] }
+clap_complete.workspace = true
+cli-table = { workspace = true, default-features = false }
+colored.workspace = true
+const_format.workspace = true
+crossterm.workspace = true
 cynic = { workspace = true, features = ["http-reqwest"] }
-dirs = "6.0.0"
-expect-test = "1.5.0"
-flate2 = "1.0.35"
-fslock = "0.2.1"
+dirs.workspace = true
+expect-test.workspace = true
+flate2.workspace = true
+fslock.workspace = true
 futures.workspace = true
-futures-util = "0.3.30"
-indicatif = "0.17.8"
+futures-util.workspace = true
+ignore.workspace = true
+indicatif.workspace = true
 indoc.workspace = true
-ignore = "0.4.22"
-inquire = "0.7.5"
-log = "0.4.21"
-mimalloc = "0.1.41"
-notify-debouncer-full = "0.5.0"
-os_type = "2.6.0"
+inquire.workspace = true
+log.workspace = true
+mimalloc.workspace = true
+notify-debouncer-full.workspace = true
+os_type.workspace = true
 reqwest = { workspace = true, features = [
     "rustls-tls",
     "stream",
     "json",
 ], default-features = false }
 rustls = { workspace = true, features = ["ring", "tls12"] }
-serde = "1.0.199"
-serde_derive = "1.0.199"
+serde.workspace = true
 serde-dynamic-string.workspace = true
+serde-toml-merge.workspace = true
+serde_derive.workspace = true
 serde_json.workspace = true
-serde-toml-merge = "0.3.8"
-slugify = "0.1.0"
-strum = { version = "0.26.2", features = ["derive"] }
-syntect = "5.2.0"
+slugify.workspace = true
+strum = { workspace = true, features = ["derive"] }
+syntect.workspace = true
 tar.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
-tokio-stream = "0.1.16"
-tokio-util = { version = "0.7.12", features = ["futures-io", "compat"] }
+tokio-stream.workspace = true
+tokio-util = { workspace = true, features = ["futures-io", "compat"] }
 toml.workspace = true
 tower-http = { workspace = true, features = ["trace", "fs", "set-header"] }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 url.workspace = true
-urlencoding = "2.1.3"
-uuid = { version = "1.8.0", features = ["v4"] }
-webbrowser = "1.0"
+urlencoding.workspace = true
+uuid = { workspace = true, features = ["v4"] }
+webbrowser.workspace = true
 
+anyhow.workspace = true
+askama.workspace = true
+convert_case.workspace = true
+cynic-parser = { workspace = true, features = ["report"] }
 extension.workspace = true
 extension-catalog.workspace = true
 federated-graph.workspace = true
 federated-server.workspace = true
 gateway-config.workspace = true
 grafbase-graphql-introspection.workspace = true
+grafbase-workspace-hack.workspace = true
+graph-ref.workspace = true
 graphql-composition.workspace = true
 graphql-lint.workspace = true
-graph-ref.workspace = true
-grafbase-workspace-hack.workspace = true
-anyhow.workspace = true
-convert_case = "0.7.1"
-askama = "0.12.1"
 semver.workspace = true
-wasmparser = "0.224.0"
-cynic-parser = { workspace = true, features = ["report"] }
-serde_valid = "1.0.5"
+serde_valid.workspace = true
+wasmparser.workspace = true
 
 [dev-dependencies]
 graphql-mocks.workspace = true
 integration-tests = { path = "../crates/integration-tests" }
 
-duct = "0.13.7"
+duct.workspace = true
 insta = { workspace = true, features = ["json", "redactions", "yaml"] }
 rand.workspace = true
 reqwest.workspace = true
-tempfile = "3.10.1"
+tempfile.workspace = true
 
 [build-dependencies]
 cynic-codegen.workspace = true

--- a/cli/tests/integration/data/Cargo.toml
+++ b/cli/tests/integration/data/Cargo.toml
@@ -18,8 +18,8 @@ strip = true
 lto = true
 
 [workspace.dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 base64 = "0.22"
 grafbase-hooks = { path = "../../../../crates/grafbase-hooks" }
 grafbase-sdk = { path = "../../../../crates/grafbase-sdk" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -18,47 +18,47 @@ workspace = true
 base64.workspace = true
 blake3.workspace = true
 bytes.workspace = true
-url.workspace = true
-crossbeam-queue = "0.3.11"
-futures-util.workspace = true
-futures-lite.workspace = true
+crossbeam-queue.workspace = true
 fixedbitset.workspace = true
 futures.workspace = true
+futures-lite.workspace = true
+futures-util.workspace = true
 grafbase-telemetry.workspace = true
+headers.workspace = true
 hex.workspace = true
-id-newtypes = { path = "./id-newtypes", package = "engine-id-newtypes" }
+http.workspace = true
 id-derives = { path = "./id-derives", package = "engine-id-derives" }
-im = "15.1.0"
+id-newtypes = { path = "./id-newtypes", package = "engine-id-newtypes" }
+im.workspace = true
 itertools.workspace = true
 mediatype.workspace = true
+percent-encoding.workspace = true
+ramhorns.workspace = true
 serde = { workspace = true, features = ["rc"] }
-serde-value = "0.7"
-serde_urlencoded.workspace = true
+serde-value.workspace = true
 serde_json = { workspace = true, features = ["raw_value"] }
+serde_urlencoded.workspace = true
 sha2.workspace = true
-strum_macros.workspace = true
 strum.workspace = true
+strum_macros.workspace = true
 thiserror.workspace = true
 tower = { workspace = true, features = ["retry"] }
 tracing.workspace = true
-http.workspace = true
-headers.workspace = true
-ramhorns.workspace = true
-percent-encoding = "2"
+url.workspace = true
 
+async-sse.workspace = true
 engine-auth = { path = "./auth" }
+extension-catalog.workspace = true
+grafbase-workspace-hack.workspace = true
+mime.workspace = true
+minicbor-serde = { workspace = true, features = ["alloc"] }
+multipart-stream.workspace = true
 operation = { path = "./operation", package = "engine-operation" }
-schema = { path = "./schema", package = "engine-schema" }
-walker = { path = "./walker", package = "engine-walker" }
 query-solver = { path = "./query-solver", package = "engine-query-solver" }
 rand.workspace = true
 runtime.workspace = true
-grafbase-workspace-hack.workspace = true
-async-sse.workspace = true
-minicbor-serde = { workspace = true, features = ["alloc"] }
-mime = "0.3.17"
-multipart-stream.workspace = true
-extension-catalog.workspace = true
+schema = { path = "./schema", package = "engine-schema" }
+walker = { path = "./walker", package = "engine-walker" }
 
 [dev-dependencies]
-pretty_assertions = "1"
+pretty_assertions.workspace = true

--- a/crates/engine/auth/Cargo.toml
+++ b/crates/engine/auth/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 base64.workspace = true
 futures-util.workspace = true
+grafbase-workspace-hack.workspace = true
 http.workspace = true
 jwt-compact = { workspace = true, features = [
     "clock",
@@ -21,13 +22,12 @@ jwt-compact = { workspace = true, features = [
     "ed25519-compact",
     "p256",
 ] }
+reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 runtime.workspace = true
+schema = { path = "../schema", package = "engine-schema" }
 serde.workspace = true
-serde_with.workspace = true
 serde_json.workspace = true
+serde_with.workspace = true
 sha2.workspace = true
 strum.workspace = true
 tracing.workspace = true
-grafbase-workspace-hack.workspace = true
-schema = { path = "../schema", package = "engine-schema" }
-reqwest = { workspace = true, features = ["json", "rustls-tls"] }

--- a/crates/engine/axum/Cargo.toml
+++ b/crates/engine/axum/Cargo.toml
@@ -16,20 +16,20 @@ default = []
 lambda = ["dep:lambda_http", "dep:hyper"]
 
 [dependencies]
-async-trait = { version = "0.1.80" }
+async-trait.workspace = true
 axum = { workspace = true, features = ["ws", "json"] }
-http-body-util = "0.1"
 engine.workspace = true
 futures-util.workspace = true
+grafbase-telemetry.workspace = true
+grafbase-workspace-hack.workspace = true
+http.workspace = true
+http-body.workspace = true
+http-body-util.workspace = true
+hyper = { workspace = true, optional = true }
+lambda_http = { workspace = true, optional = true }
 runtime.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
-tower-service.workspace = true
-http.workspace = true
-tracing.workspace = true
 tower.workspace = true
-grafbase-telemetry.workspace = true
-http-body = "1.0.1"
-grafbase-workspace-hack.workspace = true
-lambda_http = { workspace = true, optional = true }
-hyper = { version = "1", optional = true }
+tower-service.workspace = true
+tracing.workspace = true

--- a/crates/engine/codegen/Cargo.toml
+++ b/crates/engine/codegen/Cargo.toml
@@ -4,14 +4,15 @@ name = "engine-codegen"
 publish = false
 
 [dependencies]
-anyhow = "1"
-case = "1"
+anyhow.workspace = true
+case.workspace = true
 cynic-parser = { workspace = true, features = ["report"] }
 cynic-parser-deser.workspace = true
-indoc = "2"
-itertools = "0.14"
-proc-macro2 = "1"
-quote = "1"
+grafbase-workspace-hack.workspace = true
+indoc.workspace = true
+itertools.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true
 regex.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = [
@@ -20,5 +21,4 @@ tracing-subscriber = { workspace = true, features = [
     "env-filter",
     "ansi",
 ] }
-xshell = "0.2"
-grafbase-workspace-hack.workspace = true
+xshell.workspace = true

--- a/crates/engine/id-derives/Cargo.toml
+++ b/crates/engine/id-derives/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1"
-quote = "1"
-syn = "2"
 grafbase-workspace-hack.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true

--- a/crates/engine/id-newtypes/Cargo.toml
+++ b/crates/engine/id-newtypes/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/grafbase/grafbase"
 workspace = true
 
 [dependencies]
-serde.workspace = true
-itertools.workspace = true
-walker = { path = "../walker", package = "engine-walker" }
 fixedbitset = { workspace = true, features = ["serde"] }
 grafbase-workspace-hack.workspace = true
+itertools.workspace = true
+serde.workspace = true
+walker = { path = "../walker", package = "engine-walker" }

--- a/crates/engine/operation/Cargo.toml
+++ b/crates/engine/operation/Cargo.toml
@@ -21,20 +21,19 @@ qp = []
 [dependencies]
 blake3.workspace = true
 cynic-parser.workspace = true
-strum.workspace = true
 grafbase-telemetry.workspace = true
-id-newtypes = { path = "../id-newtypes", package = "engine-id-newtypes" }
 id-derives = { path = "../id-derives", package = "engine-id-derives" }
+id-newtypes = { path = "../id-newtypes", package = "engine-id-newtypes" }
 itertools.workspace = true
-lasso2 = { version = "0.8.2", features = ["serialize"] }
+lasso2 = { workspace = true, features = ["serialize"] }
 serde = { workspace = true, features = ["rc"] }
 serde_json = { workspace = true, features = ["raw_value"] }
+strum.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
+grafbase-workspace-hack.workspace = true
 operation-normalizer = { path = "../../operation-normalizer" }
 schema = { path = "../schema", package = "engine-schema" }
-walker = { path = "../walker", package = "engine-walker" }
-grafbase-workspace-hack.workspace = true
 serde_with = { workspace = true, features = ["hex"] }
-
+walker = { path = "../walker", package = "engine-walker" }

--- a/crates/engine/query-solver/Cargo.toml
+++ b/crates/engine/query-solver/Cargo.toml
@@ -12,33 +12,32 @@ repository = "https://github.com/grafbase/grafbase"
 workspace = true
 
 [dependencies]
-grafbase-workspace-hack.workspace = true
-id-newtypes = { path = "../id-newtypes", package = "engine-id-newtypes" }
-id-derives = { path = "../id-derives", package = "engine-id-derives" }
-operation = { path = "../operation", package = "engine-operation" }
-walker = { path = "../walker", package = "engine-walker" }
-fixedbitset.workspace = true
 bitflags.workspace = true
-petgraph.workspace = true
-itertools.workspace = true
-serde.workspace = true
-tracing.workspace = true
-thiserror.workspace = true
-strum.workspace = true
-hex.workspace = true
-schema = { path = "../schema", package = "engine-schema" }
+fixedbitset.workspace = true
 fxhash.workspace = true
-hashbrown = "0.15"
-
+grafbase-workspace-hack.workspace = true
+hashbrown.workspace = true
+hex.workspace = true
+id-derives = { path = "../id-derives", package = "engine-id-derives" }
+id-newtypes = { path = "../id-newtypes", package = "engine-id-newtypes" }
+itertools.workspace = true
+operation = { path = "../operation", package = "engine-operation" }
+petgraph.workspace = true
+schema = { path = "../schema", package = "engine-schema" }
+serde.workspace = true
+strum.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+walker = { path = "../walker", package = "engine-walker" }
 
 [dev-dependencies]
 ctor.workspace = true
-similar = "2"
+insta.workspace = true
+similar.workspace = true
+tokio.workspace = true
 tracing-subscriber = { workspace = true, features = [
     "fmt",
     "tracing-log",
     "env-filter",
     "ansi",
 ] }
-insta.workspace = true
-tokio.workspace = true

--- a/crates/engine/schema/Cargo.toml
+++ b/crates/engine/schema/Cargo.toml
@@ -14,39 +14,39 @@ anyhow.workspace = true
 rand.workspace = true
 
 [dependencies]
-rapidhash = "1"
+fxhash.workspace = true
+gateway-config.workspace = true
 hex.workspace = true
 id-derives = { path = "../id-derives", package = "engine-id-derives" }
 id-newtypes = { path = "../id-newtypes", package = "engine-id-newtypes" }
-walker = { path = "../walker", package = "engine-walker" }
 indexmap.workspace = true
+itertools.workspace = true
+rapidhash.workspace = true
 serde.workspace = true
 serde_with.workspace = true
 strum = { workspace = true, features = ["derive"] }
 strum_macros.workspace = true
 thiserror.workspace = true
 url.workspace = true
-gateway-config.workspace = true
-fxhash.workspace = true
-itertools.workspace = true
+walker = { path = "../walker", package = "engine-walker" }
 
-federated-graph.workspace = true
-wrapping.workspace = true
-regex.workspace = true
-http.workspace = true
-serde_regex = "1.1.0"
-tracing.workspace = true
-grafbase-workspace-hack.workspace = true
-extension-catalog.workspace = true
 cynic-parser.workspace = true
 cynic-parser-deser.workspace = true
+extension-catalog.workspace = true
+federated-graph.workspace = true
+grafbase-workspace-hack.workspace = true
+http.workspace = true
 ramhorns.workspace = true
+regex.workspace = true
+serde_regex.workspace = true
+tracing.workspace = true
+wrapping.workspace = true
 
 [dev-dependencies]
 insta.workspace = true
-serde_json.workspace = true
-toml.workspace = true
-tokio.workspace = true
-rstest.workspace = true
-serde_path_to_error = "0.1"
 postcard.workspace = true
+rstest.workspace = true
+serde_json.workspace = true
+serde_path_to_error.workspace = true
+tokio.workspace = true
+toml.workspace = true

--- a/crates/engine/walker/Cargo.toml
+++ b/crates/engine/walker/Cargo.toml
@@ -5,4 +5,3 @@ publish = false
 
 [dependencies]
 grafbase-workspace-hack.workspace = true
-

--- a/crates/extension-catalog/Cargo.toml
+++ b/crates/extension-catalog/Cargo.toml
@@ -11,15 +11,14 @@ workspace = true
 
 [dependencies]
 extension.workspace = true
+grafbase-workspace-hack.workspace = true
 id-derives = { path = "../engine/id-derives", package = "engine-id-derives" }
 id-newtypes = { path = "../engine/id-newtypes", package = "engine-id-newtypes" }
-serde.workspace = true
-grafbase-workspace-hack.workspace = true
-url.workspace = true
 reqwest.workspace = true
+serde.workspace = true
 serde_json.workspace = true
+url.workspace = true
 
 [dev-dependencies]
+tempfile.workspace = true
 tokio.workspace = true
-tempfile = "3"
-

--- a/crates/extension/Cargo.toml
+++ b/crates/extension/Cargo.toml
@@ -9,10 +9,8 @@ repository.workspace = true
 [lints]
 workspace = true
 
-
 [dependencies]
-semver = { workspace = true, features = ["serde"] }
 grafbase-workspace-hack.workspace = true
+semver = { workspace = true, features = ["serde"] }
 serde.workspace = true
 url.workspace = true
-

--- a/crates/federated-server/Cargo.toml
+++ b/crates/federated-server/Cargo.toml
@@ -14,21 +14,22 @@ default = []
 lambda = ["engine-axum/lambda", "dep:tower", "dep:lambda_http"]
 
 [dependencies]
-ascii = { version = "1.1.0", features = ["serde"] }
-async-trait = "0.1.80"
+ascii = { workspace = true, features = ["serde"] }
+async-trait.workspace = true
 axum = { workspace = true, features = ["macros", "ws", "query", "json"] }
-axum-server = { version = "0.7.0", features = ["tls-rustls"] }
+axum-server = { workspace = true, features = ["tls-rustls"] }
 blake3.workspace = true
-cfg-if = "1"
+cfg-if.workspace = true
 engine.workspace = true
 engine-axum.workspace = true
 futures-lite.workspace = true
+gateway-config.workspace = true
 grafbase-telemetry = { workspace = true, features = ["otlp"] }
 grafbase-workspace-hack.workspace = true
 graph-ref.workspace = true
-gateway-config.workspace = true
 graphql-composition.workspace = true
 http.workspace = true
+notify.workspace = true
 reqwest = { workspace = true, features = ["http2", "json", "rustls-tls"] }
 rolling-logger.workspace = true
 runtime.workspace = true
@@ -36,20 +37,19 @@ runtime-local = { workspace = true, features = ["wasi", "redis"] }
 runtime-noop.workspace = true
 serde.workspace = true
 thiserror.workspace = true
-toml.workspace = true
 tokio = { workspace = true, features = ["signal", "time", "net"] }
-tokio-stream = { version = "0.1.16", features = ["sync"] }
-tokio-util = { version = "0.7.13", features = ["codec"] }
+tokio-stream = { workspace = true, features = ["sync"] }
+tokio-util = { workspace = true, features = ["codec"] }
+toml.workspace = true
 tower-http = { workspace = true, features = ["cors", "timeout"] }
 tracing.workspace = true
 ulid = { workspace = true, features = ["serde"] }
 url = { workspace = true, features = ["serde"] }
-notify = "8.0.0"
 
 # Lambda dependencies
-tower = { workspace = true, optional = true }
-lambda_http = { workspace = true, optional = true }
-either = "1.13.0"
+either.workspace = true
 extension-catalog.workspace = true
-serde_json.workspace = true
+lambda_http = { workspace = true, optional = true }
 minicbor-serde = { workspace = true, features = ["alloc"] }
+serde_json.workspace = true
+tower = { workspace = true, optional = true }

--- a/crates/federation-audit-tests/Cargo.toml
+++ b/crates/federation-audit-tests/Cargo.toml
@@ -7,18 +7,18 @@ keywords.workspace = true
 repository.workspace = true
 
 [dependencies]
+grafbase-workspace-hack.workspace = true
 reqwest.features = ["blocking"]
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-grafbase-workspace-hack.workspace = true
 
 [dev-dependencies]
 cynic-parser.workspace = true
 graphql-composition.workspace = true
-integration-tests.path = "../integration-tests"
-libtest-mimic = "0.8"
-similar-asserts = "1.5"
+integration-tests = { path = "../integration-tests" }
+libtest-mimic.workspace = true
+similar-asserts.workspace = true
 
 [lints]
 workspace = true

--- a/crates/gateway-config/Cargo.toml
+++ b/crates/gateway-config/Cargo.toml
@@ -14,26 +14,26 @@ workspace = true
 otlp = ["dep:tonic"]
 
 [dependencies]
+ascii = { workspace = true, features = ["serde"] }
+cfg-if.workspace = true
 chrono.workspace = true
-ascii = { version = "1.1.0", features = ["serde"] }
-tonic = { workspace = true, optional = true, features = ["tls-roots"] }
-duration-str = "0.12.0"
+duration-str.workspace = true
+grafbase-workspace-hack.workspace = true
 http.workspace = true
 regex.workspace = true
+semver = { workspace = true, features = ["serde"] }
 serde.workspace = true
 serde-dynamic-string.workspace = true
-serde_regex = "1.1.0"
-size = "0.5.0-preview2"
+serde_regex.workspace = true
+size.workspace = true
+toml.workspace = true
+tonic = { workspace = true, optional = true, features = ["tls-roots"] }
 tower-http = { workspace = true, features = ["cors", "timeout"] }
 url = { workspace = true, features = ["serde"] }
-cfg-if = "1.0.0"
-grafbase-workspace-hack.workspace = true
-semver = { workspace = true, features = ["serde"] }
-toml = "0.8.12"
 
 [dev-dependencies]
 indoc.workspace = true
 insta.workspace = true
-temp-env = "0.3.6"
-toml = "0.8.12"
-tempfile = "3.10.1"
+temp-env.workspace = true
+tempfile.workspace = true
+toml.workspace = true

--- a/crates/gateway-config/src/message_signatures.rs
+++ b/crates/gateway-config/src/message_signatures.rs
@@ -232,26 +232,24 @@ mod tests {
 
         let result = toml::from_str::<MessageSignaturesConfig>(config);
 
-        insta::assert_debug_snapshot!(result, @r###"
+        insta::assert_debug_snapshot!(result, @r#"
         Err(
             Error {
-                inner: Error {
-                    inner: TomlError {
-                        message: "raw and file may not both be provided in a message signing key",
-                        raw: Some(
-                            "key.file = \"super-secret-key\"\nkey.inline = \"hello\"\n",
-                        ),
-                        keys: [
-                            "key",
-                        ],
-                        span: Some(
-                            0..3,
-                        ),
-                    },
+                inner: TomlError {
+                    message: "raw and file may not both be provided in a message signing key",
+                    raw: Some(
+                        "key.file = \"super-secret-key\"\nkey.inline = \"hello\"\n",
+                    ),
+                    keys: [
+                        "key",
+                    ],
+                    span: Some(
+                        0..3,
+                    ),
                 },
             },
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -262,25 +260,23 @@ mod tests {
 
         let result = toml::from_str::<MessageSignaturesConfig>(config);
 
-        insta::assert_debug_snapshot!(result, @r###"
+        insta::assert_debug_snapshot!(result, @r#"
         Err(
             Error {
-                inner: Error {
-                    inner: TomlError {
-                        message: "one of raw or file must be provided in the message signing key",
-                        raw: Some(
-                            "key = {}\n",
-                        ),
-                        keys: [
-                            "key",
-                        ],
-                        span: Some(
-                            6..8,
-                        ),
-                    },
+                inner: TomlError {
+                    message: "one of raw or file must be provided in the message signing key",
+                    raw: Some(
+                        "key = {}\n",
+                    ),
+                    keys: [
+                        "key",
+                    ],
+                    span: Some(
+                        6..8,
+                    ),
                 },
             },
         )
-        "###);
+        "#);
     }
 }

--- a/crates/gqlint/Cargo.toml
+++ b/crates/gqlint/Cargo.toml
@@ -10,11 +10,11 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4", features = ["derive"] }
-colored = "3.0.0"
-graphql-lint = { path = "../graphql-lint", version = "0.1.3" }
-thiserror.workspace = true
+clap = { workspace = true, features = ["derive"] }
+colored.workspace = true
 grafbase-workspace-hack.workspace = true
+graphql-lint = { path = "../graphql-lint" }
+thiserror.workspace = true
 
 [lints]
 workspace = true

--- a/crates/grafbase-graphql-introspection/Cargo.toml
+++ b/crates/grafbase-graphql-introspection/Cargo.toml
@@ -10,10 +10,10 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-indoc.workspace = true
-reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 cynic = { workspace = true, features = ["http-reqwest"] }
 cynic-introspection.workspace = true
 cynic-parser = { workspace = true, features = ["pretty"] }
-serde = "1.0.199"
 grafbase-workspace-hack.workspace = true
+indoc.workspace = true
+reqwest = { workspace = true, features = ["json", "rustls-tls"] }
+serde.workspace = true

--- a/crates/grafbase-hooks/Cargo.toml
+++ b/crates/grafbase-hooks/Cargo.toml
@@ -13,7 +13,7 @@ default = ["derive"]
 derive = ["dep:grafbase-hooks-derive"]
 
 [dependencies]
-grafbase-hooks-derive = { version = "0.1.0", path = "derive", optional = true }
+grafbase-hooks-derive = { path = "derive", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 wit-bindgen.workspace = true

--- a/crates/grafbase-hooks/derive/Cargo.toml
+++ b/crates/grafbase-hooks/derive/Cargo.toml
@@ -12,9 +12,9 @@ repository.workspace = true
 proc-macro = true
 
 [dependencies]
-enumflags2 = "0.7.10"
-quote = "1.0.37"
-syn = { version = "2.0.89", features = ["full"] }
+enumflags2.workspace = true
+quote.workspace = true
+syn = { workspace = true, features = ["full"] }
 
 [lints]
 workspace = true

--- a/crates/grafbase-sdk/Cargo.toml
+++ b/crates/grafbase-sdk/Cargo.toml
@@ -29,7 +29,7 @@ test-utils = [
 graphql-federated-graph = ["dep:graphql-federated-graph"]
 
 [dependencies]
-grafbase-sdk-derive = { version = "0.1.3", path = "derive" }
+grafbase-sdk-derive = { path = "derive" }
 http.workspace = true
 minicbor-serde = { workspace = true, features = ["alloc"] }
 serde.workspace = true
@@ -40,22 +40,22 @@ wit-bindgen.workspace = true
 
 # for tests
 anyhow = { workspace = true, optional = true }
-duct = { version = "0.13.7", optional = true }
-fslock = { version = "0.2.1", optional = true }
-indoc = { workspace = true, optional = true }
-reqwest = { workspace = true, features = ["json"], optional = true }
-tempfile = { version = "3", optional = true }
-toml = { workspace = true, optional = true }
-which = { workspace = true, optional = true }
+duct = { workspace = true, optional = true }
+fslock = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }
-graphql-composition = { version = "0.6", features = [
+grafbase-sdk-mock = { path = "mock", optional = true }
+graphql-composition = { workspace = true, features = [
     "grafbase-extensions",
 ], optional = true }
-graphql-federated-graph = { version = "0.6", optional = true }
-grafbase-sdk-mock = { version = "0.1.1", path = "mock", optional = true }
+graphql-federated-graph = { workspace = true, optional = true }
+indoc = { workspace = true, optional = true }
+reqwest = { workspace = true, features = ["json"], optional = true }
+tempfile = { workspace = true, optional = true }
+toml = { workspace = true, optional = true }
+which = { workspace = true, optional = true }
 
 [lints]
 workspace = true
 
 [build-dependencies]
-semver = "1.0.25"
+semver.workspace = true

--- a/crates/grafbase-sdk/derive/Cargo.toml
+++ b/crates/grafbase-sdk/derive/Cargo.toml
@@ -9,6 +9,6 @@ license = "MPL-2.0"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.93"
-quote = "1.0.37"
-syn = { version = "2.0.89", features = ["full"] }
+proc-macro2.workspace = true
+quote.workspace = true
+syn = { workspace = true, features = ["full"] }

--- a/crates/grafbase-sdk/mock/Cargo.toml
+++ b/crates/grafbase-sdk/mock/Cargo.toml
@@ -6,13 +6,13 @@ description = "Subgraph mock server for testing Grafbase extensions"
 license = "MPL-2.0"
 
 [dependencies]
-axum = { workspace = true, features = ["tokio", "http1"] }
+anyhow = { workspace = true }
 async-graphql = { workspace = true, features = ["dynamic-schema"] }
 async-graphql-axum = { workspace = true }
-anyhow = { workspace = true }
+axum = { workspace = true, features = ["tokio", "http1"] }
 cynic-parser = { workspace = true, features = ["report"] }
+grafbase-workspace-hack.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 url.workspace = true
-grafbase-workspace-hack.workspace = true

--- a/crates/grafbase-workspace-hack/Cargo.toml
+++ b/crates/grafbase-workspace-hack/Cargo.toml
@@ -21,6 +21,7 @@ publish = false
 ### BEGIN HAKARI SECTION
 [dependencies]
 aho-corasick = { version = "1" }
+anyhow = { version = "1" }
 arrayvec = { version = "0.7" }
 ascii = { version = "1", features = ["serde"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "macros", "original-uri", "query", "tracing", "ws"] }
@@ -29,7 +30,7 @@ base16ct = { version = "0.2", default-features = false, features = ["alloc"] }
 bitflags = { version = "2", default-features = false, features = ["std"] }
 byteorder = { version = "1" }
 bytes = { version = "1", features = ["serde"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "wasmbind"] }
 ciborium = { version = "0.2" }
 clap = { version = "4", features = ["cargo", "derive", "env", "wrap_help"] }
 clap_builder = { version = "4", default-features = false, features = ["cargo", "color", "env", "std", "suggestions", "usage", "wrap_help"] }
@@ -128,7 +129,7 @@ tower-http = { version = "0.6", features = ["cors", "fs", "set-header", "timeout
 tracing = { version = "0.1", features = ["log"] }
 tracing-core = { version = "0.1" }
 tracing-log = { version = "0.2" }
-tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "env-filter", "json", "tracing-log"] }
 tungstenite = { version = "0.26", default-features = false, features = ["handshake", "url"] }
 ulid = { version = "1", features = ["serde"] }
 url = { version = "2", features = ["serde"] }
@@ -138,6 +139,7 @@ zeroize = { version = "1", features = ["zeroize_derive"] }
 
 [build-dependencies]
 aho-corasick = { version = "1" }
+anyhow = { version = "1" }
 arrayvec = { version = "0.7" }
 ascii = { version = "1", features = ["serde"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "macros", "original-uri", "query", "tracing", "ws"] }
@@ -147,7 +149,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 byteorder = { version = "1" }
 bytes = { version = "1", features = ["serde"] }
 cc = { version = "1", default-features = false, features = ["parallel"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "wasmbind"] }
 ciborium = { version = "0.2" }
 clap = { version = "4", features = ["cargo", "derive", "env", "wrap_help"] }
 clap_builder = { version = "4", default-features = false, features = ["cargo", "color", "env", "std", "suggestions", "usage", "wrap_help"] }
@@ -248,7 +250,7 @@ tower-http = { version = "0.6", features = ["cors", "fs", "set-header", "timeout
 tracing = { version = "0.1", features = ["log"] }
 tracing-core = { version = "0.1" }
 tracing-log = { version = "0.2" }
-tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "env-filter", "json", "tracing-log"] }
 tungstenite = { version = "0.26", default-features = false, features = ["handshake", "url"] }
 ulid = { version = "1", features = ["serde"] }
 url = { version = "2", features = ["serde"] }

--- a/crates/graphql-composition/Cargo.toml
+++ b/crates/graphql-composition/Cargo.toml
@@ -17,15 +17,15 @@ workspace = true
 [dependencies]
 cynic-parser = { workspace = true, features = ["report"] }
 cynic-parser-deser.workspace = true
-graphql-federated-graph = { path = "../graphql-federated-graph", version = "0.6.0" }
+graphql-federated-graph = { path = "../graphql-federated-graph" }
 indexmap.workspace = true
 itertools.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-grafbase-workspace-hack.workspace = true
 anyhow.workspace = true
+grafbase-workspace-hack.workspace = true
 insta.workspace = true
-pretty_assertions = "1"
+pretty_assertions.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/crates/graphql-federated-graph/Cargo.toml
+++ b/crates/graphql-federated-graph/Cargo.toml
@@ -12,24 +12,23 @@ workspace = true
 
 [dependencies]
 bitflags.workspace = true
-wrapping = { path = "../graphql-wrapping-types", package = "graphql-wrapping-types", version = "0.2.0" }
+indoc.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-indoc.workspace = true
+wrapping = { path = "../graphql-wrapping-types", package = "graphql-wrapping-types", version = "0.2.0" }
 
-itertools.workspace = true
 cynic-parser = { workspace = true, optional = true }
 cynic-parser-deser.workspace = true
-indexmap = { optional = true, workspace = true }
 grafbase-workspace-hack.workspace = true
-
+indexmap = { optional = true, workspace = true }
+itertools.workspace = true
 
 [dev-dependencies]
-expect-test = "1.5"
-tempfile = "3"
-tokio.workspace = true
+expect-test.workspace = true
+pretty_assertions.workspace = true
 serde_json.workspace = true
-pretty_assertions = "1"
+tempfile.workspace = true
+tokio.workspace = true
 url.workspace = true
 
 [features]

--- a/crates/graphql-lint/Cargo.toml
+++ b/crates/graphql-lint/Cargo.toml
@@ -9,12 +9,12 @@ repository.workspace = true
 
 [dependencies]
 cynic-parser.workspace = true
-heck = "0.5.0"
-thiserror.workspace = true
 grafbase-workspace-hack.workspace = true
+heck.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
-criterion = { version = "0.5.1", features = ["html_reports"] }
+criterion = { workspace = true, features = ["html_reports"] }
 
 [[bench]]
 name = "benchmark"

--- a/crates/graphql-mocks/Cargo.toml
+++ b/crates/graphql-mocks/Cargo.toml
@@ -10,25 +10,25 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-graphql-axum.workspace = true
 async-graphql = { workspace = true, features = ["dynamic-schema"] }
-async-trait = "0.1.80"
+async-graphql-axum.workspace = true
+async-trait.workspace = true
 axum = { workspace = true, features = ["tokio", "http1"] }
+axum-extra.workspace = true
+crossbeam-queue.workspace = true
 cynic-parser.workspace = true
 futures.workspace = true
+futures-util.workspace = true
+grafbase-workspace-hack.workspace = true
 headers.workspace = true
+http.workspace = true
 httpsig.workspace = true
 httpsig-hyper.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
-crossbeam-queue = "0.3"
-http.workspace = true
-url.workspace = true
-grafbase-workspace-hack.workspace = true
 tower.workspace = true
-futures-util.workspace = true
-axum-extra = "0.10.0"
+url.workspace = true
 
 [lints]
 workspace = true

--- a/crates/graphql-schema-diff/Cargo.toml
+++ b/crates/graphql-schema-diff/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/grafbase/grafbase/tree/main/crates/graphql-sche
 
 [dependencies]
 cynic-parser.workspace = true
-serde = { workspace = true, optional = true, features = ["derive"] }
 grafbase-workspace-hack.workspace = true
+serde = { workspace = true, optional = true, features = ["derive"] }
 
 [features]
 default = ["serde"]
@@ -21,8 +21,8 @@ workspace = true
 
 [dev-dependencies]
 datatest-stable.workspace = true
-similar = "2.5.0"
 serde_json.workspace = true
+similar.workspace = true
 
 [[test]]
 name = "diff_tests"

--- a/crates/graphql-schema-validation/Cargo.toml
+++ b/crates/graphql-schema-validation/Cargo.toml
@@ -13,14 +13,14 @@ workspace = true
 [dependencies]
 async-graphql-parser.workspace = true
 async-graphql-value.workspace = true
-miette.workspace = true
 bitflags.workspace = true
 grafbase-workspace-hack.workspace = true
+miette.workspace = true
 
 [dev-dependencies]
-datatest-stable = "0.3.0"
-similar = "2.5.0"
+datatest-stable.workspace = true
 miette = { workspace = true, features = ["fancy"] }
+similar.workspace = true
 
 [[test]]
 name = "validation_tests"

--- a/crates/graphql-wrapping-types/Cargo.toml
+++ b/crates/graphql-wrapping-types/Cargo.toml
@@ -9,8 +9,8 @@ keywords.workspace = true
 repository.workspace = true
 
 [dependencies]
-serde.workspace = true
 grafbase-workspace-hack.workspace = true
+serde.workspace = true
 
 [lints]
 workspace = true

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -7,84 +7,78 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-cfg-if = "1"
-axum.workspace = true
 async-graphql.workspace = true
 async-sse.workspace = true
 async-trait.workspace = true
+async-tungstenite.workspace = true
+axum.workspace = true
 bytes.workspace = true
-crossbeam-queue = "0.3"
+cfg-if.workspace = true
+crossbeam-queue.workspace = true
+ctor.workspace = true
 cynic.workspace = true
 cynic-introspection.workspace = true
+engine.workspace = true
 engine-axum.workspace = true
 engine-schema.workspace = true
-engine.workspace = true
-graphql-mocks.workspace = true
-httpsig.workspace = true
-futures = "0.3.30"
-gateway-config.workspace = true
-graphql-composition = { workspace = true, features = ["grafbase-extensions"] }
+extension-catalog.workspace = true
 federated-graph.workspace = true
+futures.workspace = true
+futures-util.workspace = true
+gateway-config.workspace = true
+grafbase-telemetry.workspace = true
+grafbase-workspace-hack.workspace = true
+graphql-composition = { workspace = true, features = ["grafbase-extensions"] }
+graphql-mocks.workspace = true
+graphql-ws-client.workspace = true
 headers.workspace = true
 http.workspace = true
-http-body-util = "0.1.0"
+http-body-util.workspace = true
+httpsig.workspace = true
 indoc.workspace = true
 insta.workspace = true
 itertools.workspace = true
 multipart-stream.workspace = true
 openidconnect.workspace = true
+ory-client.workspace = true # overridden by patch, pointing to their last release on GitHub
 reqwest.workspace = true
-serde.workspace = true
-serde_urlencoded.workspace = true
-serde_json.workspace = true
-thiserror.workspace = true
-ulid.workspace = true
-url.workspace = true
+runtime = { workspace = true, features = ["test-utils"] }
 runtime-local = { workspace = true, features = ["wasi", "redis"] }
 runtime-noop.workspace = true
-ory-client = "1.9.0" # overridden by patch, pointing to their last release on GitHub
-tracing-subscriber = { version = "0.3.18", default-features = false, features = [
+rustls = { workspace = true, features = ["ring"] }
+serde.workspace = true
+serde_json.workspace = true
+serde_urlencoded.workspace = true
+serde_with = { workspace = true, features = ["hex"] }
+tempfile.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["full"] }
+toml.workspace = true
+tower.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true, default-features = false, features = [
     "fmt",
     "tracing-log",
     "env-filter",
     "ansi",
 ] }
-ctor.workspace = true
-rustls = { workspace = true, features = ["ring"] }
-toml.workspace = true
-tower.workspace = true
-tracing.workspace = true
-runtime = { workspace = true, features = ["test-utils"] }
-grafbase-workspace-hack.workspace = true
-serde_with = { workspace = true, features = ["hex"] }
-graphql-ws-client.workspace = true
-async-tungstenite.workspace = true
-futures-util.workspace = true
-extension-catalog.workspace = true
-tempfile = "3"
-dyn-clone = "1"
-
-[dependencies.tokio]
-version = "1.37"
-features = ["full"]
-
-[dependencies.grafbase-telemetry]
-workspace = true
+ulid.workspace = true
+url.workspace = true
 
 [dev-dependencies]
-mimalloc = "0.1"
 base64.workspace = true
-criterion = { version = "0.5.1", features = ["async_tokio"] }
+criterion = { workspace = true, features = ["async_tokio"] }
 cynic-parser.workspace = true
-ed25519-compact = "2"
-elliptic-curve = "0.13"
+ed25519-compact.workspace = true
+elliptic-curve.workspace = true
 headers.workspace = true
 hex.workspace = true
-pretty_assertions = "1"
+mimalloc.workspace = true
+pretty_assertions.workspace = true
 rand.workspace = true
 rstest.workspace = true
 sha2.workspace = true
-similar-asserts = { version = "1.5", features = ["serde"] }
+similar-asserts = { workspace = true, features = ["serde"] }
 
 [target.'cfg(unix)'.dependencies]
 pprof = { workspace = true, features = ["criterion", "flamegraph"] }

--- a/crates/integration-tests/tests/federation/extensions/injection/template/json.rs
+++ b/crates/integration-tests/tests/federation/extensions/injection/template/json.rs
@@ -214,7 +214,6 @@ fn json_should_render_lists_as_json() {
     });
 }
 
-#[ignore]
 #[test]
 fn complex_template() {
     runtime().block_on(async move {
@@ -228,19 +227,19 @@ fn complex_template() {
                 scalar JSON
 
                 type Query {
-                    echo(data: [String]): JSON @echo(data: """[{{#args.data}} { "value":{{.}} } {{/args.data}}]""")
+                    echo(data: JSON): JSON @echo(data: """[{{#args.data}} { "value":{{name}} } {{/args.data}}]""")
                 }
                 "#,
             )
             .with_extension(EchoJsonExt)
             .build()
             .await
-            .post(r#"query { echo(data: ["meow", "Alice"]) }"#)
+            .post(r#"query { echo(data: [{name: "Alice"}]) }"#)
             .await;
         insta::assert_json_snapshot!(response, @r#"
         {
           "data": {
-            "echo": {}
+            "echo": []
           }
         }
         "#);

--- a/crates/operation-checks/Cargo.toml
+++ b/crates/operation-checks/Cargo.toml
@@ -9,13 +9,13 @@ repository.workspace = true
 [dependencies]
 async-graphql-parser.workspace = true
 async-graphql-value.workspace = true
-graphql-schema-diff.path = "../graphql-schema-diff"
 grafbase-workspace-hack.workspace = true
+graphql-schema-diff = { path = "../graphql-schema-diff" }
 
 [dev-dependencies]
 datatest-stable.workspace = true
-expect-test = "1.5.0"
-similar = "2.5.0"
+expect-test.workspace = true
+similar.workspace = true
 
 [lints]
 workspace = true

--- a/crates/operation-normalizer/Cargo.toml
+++ b/crates/operation-normalizer/Cargo.toml
@@ -9,14 +9,14 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.82"
-graphql-parser = { git = "https://github.com/graphql-rust/graphql-parser", version = "0.4.0" }
-grafbase-workspace-hack.workspace = true
+anyhow.workspace = true
 cynic-parser.workspace = true
+grafbase-workspace-hack.workspace = true
+graphql-parser.workspace = true
 
 [lints]
 workspace = true
 
 [dev-dependencies]
-expect-test = "1.5.0"
+expect-test.workspace = true
 indoc.workspace = true

--- a/crates/rolling-logger/Cargo.toml
+++ b/crates/rolling-logger/Cargo.toml
@@ -14,4 +14,4 @@ workspace = true
 
 [dev-dependencies]
 insta.workspace = true
-tempfile = "3.12.0"
+tempfile.workspace = true

--- a/crates/runtime-local/Cargo.toml
+++ b/crates/runtime-local/Cargo.toml
@@ -24,37 +24,37 @@ async-tungstenite = { workspace = true, features = [
 ] }
 base64.workspace = true
 bytes.workspace = true
-ed25519-compact = "2"
-elliptic-curve = { version = "0.13", features = ["jwk"] }
+ed25519-compact.workspace = true
+elliptic-curve = { workspace = true, features = ["jwk"] }
+engine-schema.workspace = true
+extension-catalog.workspace = true
 futures-util.workspace = true
-graphql-ws-client.workspace = true
+gateway-config.workspace = true
 governor.workspace = true
+graphql-ws-client.workspace = true
 http.workspace = true
 httpsig.workspace = true
 httpsig-hyper.workspace = true
-p256 = { version = "0.13", features = ["jwk"] }
-p384 = { version = "0.13", features = ["jwk"] }
+mini-moka.workspace = true
+p256 = { workspace = true, features = ["jwk"] }
+p384 = { workspace = true, features = ["jwk"] }
 postcard.workspace = true
-reqwest-eventsource = "0.6"
+redis = { workspace = true, optional = true }
+reqwest-eventsource.workspace = true
+runtime.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, features = ["raw_value"] }
+tokio = { workspace = true, features = ["macros", "sync"] }
 tracing.workspace = true
 tungstenite = { workspace = true, features = ["url", "handshake"] }
-tokio = { workspace = true, features = ["macros", "sync"] }
-runtime.workspace = true
-extension-catalog.workspace = true
-engine-schema.workspace = true
-gateway-config.workspace = true
 url = { workspace = true, optional = true }
-mini-moka.workspace = true
-redis = { workspace = true, optional = true }
 
 reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 
-wasi-component-loader = { path = "../wasi-component-loader", optional = true }
-deadpool = { workspace = true, optional = true }
-grafbase-telemetry.workspace = true
 anyhow.workspace = true
+deadpool = { workspace = true, optional = true }
+enumflags2.workspace = true
+grafbase-telemetry.workspace = true
 grafbase-workspace-hack.workspace = true
-enumflags2 = "0.7.10"
 semver.workspace = true
+wasi-component-loader = { path = "../wasi-component-loader", optional = true }

--- a/crates/runtime-noop/Cargo.toml
+++ b/crates/runtime-noop/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["runtime", "grafbase"]
 workspace = true
 
 [dependencies]
-async-trait = "0.1.80"
-thiserror.workspace = true
-runtime.workspace = true
+async-trait.workspace = true
 futures.workspace = true
 grafbase-workspace-hack.workspace = true
+runtime.workspace = true
+thiserror.workspace = true

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -16,21 +16,20 @@ workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 bytes.workspace = true
+engine-schema.workspace = true
+extension.workspace = true
+extension-catalog.workspace = true
 futures-util.workspace = true
 grafbase-telemetry.workspace = true
+grafbase-workspace-hack.workspace = true
 http.workspace = true
+id-derives = { path = "../engine/id-derives", package = "engine-id-derives" }
+semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 url.workspace = true
-semver = "1"
-id-derives = { path = "../engine/id-derives", package = "engine-id-derives" }
-extension.workspace = true
-extension-catalog.workspace = true
-engine-schema.workspace = true
-grafbase-workspace-hack.workspace = true
 
 [features]
 test-utils = []
-

--- a/crates/serde-dynamic-string/Cargo.toml
+++ b/crates/serde-dynamic-string/Cargo.toml
@@ -7,16 +7,16 @@ keywords.workspace = true
 repository.workspace = true
 
 [dependencies]
+grafbase-workspace-hack.workspace = true
 itertools.workspace = true
 regex.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_with.workspace = true
-grafbase-workspace-hack.workspace = true
 
 [lints]
 workspace = true
 
 [dev-dependencies]
-ascii = "1.1.0"
+ascii.workspace = true
 insta.workspace = true
-temp-env = "0.3.6"
+temp-env.workspace = true

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -12,40 +12,31 @@ keywords = ["tracing", "grafbase"]
 workspace = true
 
 [dependencies]
-chrono.workspace = true
 base64.workspace = true
-hex.workspace = true
 blake3.workspace = true
+chrono.workspace = true
+gateway-config.workspace = true
+headers.workspace = true
+hex.workspace = true
 http.workspace = true
-http-body = "1.0"
+http-body.workspace = true
+itertools.workspace = true
+postcard.workspace = true
 serde.workspace = true
+serde-dynamic-string.workspace = true
+strum.workspace = true
 thiserror.workspace = true
 tonic = { workspace = true, optional = true, features = ["tls-roots"] }
 url = { workspace = true, features = ["serde"] }
-headers.workspace = true
-serde-dynamic-string.workspace = true
-postcard.workspace = true
-gateway-config.workspace = true
-itertools.workspace = true
-strum.workspace = true
 
 # tracing
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
-tracing-opentelemetry.workspace = true
+ascii = { workspace = true, features = ["serde"] }
+cfg-if.workspace = true
+either.workspace = true
+grafbase-workspace-hack.workspace = true
+opentelemetry = { workspace = true, features = ["otel_unstable", "trace"] }
 opentelemetry-appender-tracing = { workspace = true, features = [
     "experimental_metadata_attributes",
-] }
-opentelemetry = { workspace = true, features = ["otel_unstable", "trace"] }
-opentelemetry_sdk = { workspace = true, features = [
-    "rt-tokio",
-    "logs",
-    "spec_unstable_metrics_views",
-] }
-opentelemetry-stdout = { workspace = true, features = [
-    "trace",
-    "metrics",
-    "logs",
 ] }
 opentelemetry-otlp = { workspace = true, features = [
     "grpc-tonic",
@@ -56,10 +47,19 @@ opentelemetry-otlp = { workspace = true, features = [
     "tonic",
     "metrics",
 ], optional = true }
-ascii = { version = "1.1.0", features = ["serde"] }
-cfg-if = "1.0.0"
-either = "1.13.0"
-grafbase-workspace-hack.workspace = true
+opentelemetry-stdout = { workspace = true, features = [
+    "trace",
+    "metrics",
+    "logs",
+] }
+opentelemetry_sdk = { workspace = true, features = [
+    "rt-tokio",
+    "logs",
+    "spec_unstable_metrics_views",
+] }
+tracing = { workspace = true }
+tracing-opentelemetry.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [features]
 default = []
@@ -68,6 +68,6 @@ lambda = []
 
 [dev-dependencies]
 indoc.workspace = true
-insta = "1.38.0"
-tempfile = "3.10.1"
-toml = "0.8.12"
+insta.workspace = true
+tempfile.workspace = true
+toml.workspace = true

--- a/crates/wasi-component-loader/Cargo.toml
+++ b/crates/wasi-component-loader/Cargo.toml
@@ -8,45 +8,38 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-http.workspace = true
-thiserror.workspace = true
-tracing.workspace = true
-url.workspace = true
+crossbeam = { workspace = true, features = ["crossbeam-channel"] }
+dashmap.workspace = true
+either.workspace = true
+enumflags2.workspace = true
+futures.workspace = true
 gateway-config.workspace = true
-crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
-tokio = { workspace = true, features = ["time", "rt"] }
 grafbase-telemetry.workspace = true
 grafbase-workspace-hack.workspace = true
-reqwest.workspace = true
-futures.workspace = true
-strum = { workspace = true, features = ["derive"] }
-enumflags2 = "0.7.10"
-serde.workspace = true
+http.workspace = true
 minicbor-serde = { workspace = true, features = ["alloc"] }
-either = "1.13.0"
-dashmap = "6.1.0"
+reqwest.workspace = true
+serde.workspace = true
+strum = { workspace = true, features = ["derive"] }
+thiserror.workspace = true
+tokio = { workspace = true, features = ["time", "rt"] }
+tracing.workspace = true
 ulid.workspace = true
-
-[dependencies.wasmtime]
-version = "29"
-
-[dependencies.wasmtime-wasi]
-version = "29"
-default-features = false
-
-[dependencies.wasmtime-wasi-http]
-version = "29"
+url.workspace = true
+wasmtime.workspace = true
+wasmtime-wasi.workspace = true
+wasmtime-wasi-http.workspace = true
 
 [lints]
 workspace = true
 
 [dev-dependencies]
-expect-test = "1.5.0"
-indoc.workspace = true
-serde_json.workspace = true
 base64.workspace = true
+expect-test.workspace = true
+indoc.workspace = true
 insta.workspace = true
-tempfile = "3.14.0"
+serde_json.workspace = true
+tempfile.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 toml.workspace = true
 wiremock.workspace = true

--- a/crates/wasi-component-loader/examples/Cargo.toml
+++ b/crates/wasi-component-loader/examples/Cargo.toml
@@ -18,8 +18,8 @@ strip = true
 lto = true
 
 [workspace.dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 base64 = "0.22"
 grafbase-hooks = { path = "../../grafbase-hooks" }
 grafbase-sdk = { path = "../../grafbase-sdk" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/wasi-component-loader/examples/extensions/caching-auth/Cargo.toml
+++ b/crates/wasi-component-loader/examples/extensions/caching-auth/Cargo.toml
@@ -13,4 +13,3 @@ serde.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
-

--- a/crates/wasi-component-loader/examples/hooks/response-hooks/Cargo.toml
+++ b/crates/wasi-component-loader/examples/hooks/response-hooks/Cargo.toml
@@ -8,9 +8,9 @@ repository.workspace = true
 
 [dependencies]
 grafbase-hooks.workspace = true
-serde_json.workspace = true
-serde.workspace = true
 postcard = { version = "1.0.10", features = ["use-std"] }
+serde.workspace = true
+serde_json.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/wasi-component-loader/examples/hooks/subgraph_request/Cargo.toml
+++ b/crates/wasi-component-loader/examples/hooks/subgraph_request/Cargo.toml
@@ -7,9 +7,9 @@ keywords.workspace = true
 repository.workspace = true
 
 [dependencies]
+base64.workspace = true
 grafbase-hooks.workspace = true
 serde_json.workspace = true
-base64.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/access-logs/hooks/Cargo.toml
+++ b/examples/access-logs/hooks/Cargo.toml
@@ -7,10 +7,10 @@ keywords.workspace = true
 repository.workspace = true
 
 [dependencies]
+grafbase-hooks = "0.1.8"
 postcard = { version = "1.0.10", features = ["use-std"] }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.118"
-grafbase-hooks = "0.1.8"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/access-logs/subgraph/Cargo.toml
+++ b/examples/access-logs/subgraph/Cargo.toml
@@ -11,4 +11,3 @@ axum = "0.8.0"
 postcard = { version = "1.0.10", features = ["use-std"] }
 serde_json = "1.0.120"
 tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }
-

--- a/examples/gateway-hooks/auth-service/Cargo.toml
+++ b/examples/gateway-hooks/auth-service/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 axum = "0.8.0"
-tower-http = { version = "0.6", features = ["trace"] }
-serde_json = "1.0.120"
 serde = { version = "1", features = ["derive"] }
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-tracing = "0.1"
+serde_json = "1.0.120"
 tokio = { version = "1.38.0", features = [
     "macros",
     "rt-multi-thread",
     "signal",
 ] }
+tower-http = { version = "0.6", features = ["trace"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/examples/gateway-hooks/hooks/Cargo.toml
+++ b/examples/gateway-hooks/hooks/Cargo.toml
@@ -8,12 +8,12 @@ repository.workspace = true
 
 [dependencies]
 anyhow = "1.0.86"
+grafbase-hooks = "0.1.8"
+itertools = "0.14"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.118"
 tracing = "0.1.40"
-itertools = "0.14"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-grafbase-hooks = "0.1.8"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/gateway-hooks/subgraphs/pets/Cargo.toml
+++ b/examples/gateway-hooks/subgraphs/pets/Cargo.toml
@@ -8,8 +8,7 @@ anyhow = "1"
 async-graphql = { version = "7", features = ["time"] }
 async-graphql-axum = "7"
 axum = "0.8"
+rand = "0.8"
 serde_json = "1"
 time = "0.3"
-rand = "0.8"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
-

--- a/examples/gateway-hooks/subgraphs/users/Cargo.toml
+++ b/examples/gateway-hooks/subgraphs/users/Cargo.toml
@@ -10,4 +10,3 @@ async-graphql-axum = "7"
 axum = "0.8"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
-

--- a/examples/query_plan/subgraph/Cargo.toml
+++ b/examples/query_plan/subgraph/Cargo.toml
@@ -11,4 +11,3 @@ axum = "0.8.0"
 postcard = { version = "1.0.10", features = ["use-std"] }
 serde_json = "1.0.120"
 tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }
-

--- a/extensions/jwt/Cargo.toml
+++ b/extensions/jwt/Cargo.toml
@@ -29,11 +29,11 @@ lto = true
 codegen-units = 1
 
 [dev-dependencies]
-indoc = "2.0.5"
-tokio = { version = "1.43.0", features = ["rt-multi-thread", "macros", "test-util"] }
-grafbase-sdk = { path = "../../crates/grafbase-sdk", features = ["test-utils"] }
-insta = { version = "1.42.1", features = ["json"] }
-ory-client = "1.9.0"
-openidconnect = "4.0.0"
-reqwest = "0.12.12"
 base64 = "0.22.1"
+grafbase-sdk = { path = "../../crates/grafbase-sdk", features = ["test-utils"] }
+indoc = "2.0.5"
+insta = { version = "1.42.1", features = ["json"] }
+openidconnect = "4.0.0"
+ory-client = "1.9.0"
+reqwest = "0.12.12"
+tokio = { version = "1.43.0", features = ["rt-multi-thread", "macros", "test-util"] }

--- a/extensions/rest/Cargo.toml
+++ b/extensions/rest/Cargo.toml
@@ -9,13 +9,13 @@ repository = "https://github.com/grafbase/grafbase"
 
 [dependencies]
 grafbase-sdk = { path = "../../crates/grafbase-sdk" }
-jaq-parse = "1.0.3"
-serde = "1"
-serde_json = "1"
 http = "1"
 jaq-core = "2.1.0"
 jaq-json = { version = "1.1.0", features = ["serde_json"] }
+jaq-parse = "1.0.3"
 jaq-std = "2.1.0"
+serde = "1"
+serde_json = "1"
 
 [lib]
 crate-type = ["cdylib"]

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,8 @@
             cargo-nextest
             cargo-expand
 
+            taplo
+
             # Benchmark tool to send multiple requests
             hey
             k6

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -15,47 +15,47 @@ lambda = [
 ]
 
 [dependencies]
-anyhow = { version = "1", default-features = false }
-ascii = { version = "1", default-features = false }
+anyhow = { workspace = true, default-features = false }
+ascii.workspace = true
+cfg-if.workspace = true
 chrono.workspace = true
-clap = { version = "4", features = ["cargo", "wrap_help", "derive", "env"] }
+clap = { workspace = true, features = ["cargo", "wrap_help", "derive", "env"] }
 federated-server.workspace = true
 gateway-config.workspace = true
 grafbase-telemetry = { workspace = true, features = ["otlp"] }
+grafbase-workspace-hack.workspace = true
 graph-ref.workspace = true
 itertools.workspace = true
-mimalloc = "0.1"
-opentelemetry-aws = { version = "0.15.0" }
+mimalloc.workspace = true
+opentelemetry-aws = { workspace = true }
 rustls = { workspace = true, features = ["ring"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
-toml = "0.8"
+toml.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["json"] }
-cfg-if = "1"
-grafbase-workspace-hack.workspace = true
 
 [lints]
 workspace = true
 
 [dev-dependencies]
 async-graphql-parser.workspace = true
-clickhouse = { version = "0.13" }
+clickhouse.workspace = true
 ctor.workspace = true
-duct = "0.13.7"
-fslock = "0.2.1"
+duct.workspace = true
+fslock.workspace = true
 futures-util.workspace = true
-graphql-composition.workspace = true
 grafbase-graphql-introspection.workspace = true
+graphql-composition.workspace = true
 graphql-mocks.workspace = true
+handlebars.workspace = true
 http.workspace = true
 indoc.workspace = true
 insta = { workspace = true, features = ["json", "redactions", "yaml"] }
 rand.workspace = true
 reqwest.workspace = true
 serde.workspace = true
-serde_with.workspace = true
 serde_json.workspace = true
-tempfile = "3.10.1"
-wiremock.workspace = true
+serde_with.workspace = true
+tempfile.workspace = true
 ulid.workspace = true
-handlebars.workspace = true
+wiremock.workspace = true

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,52 @@
+## https://taplo.tamasfe.dev/configuration/file.html
+
+include = [
+    "taplo.toml",
+    "Cargo.toml",
+    "crates/**/Cargo.toml",
+    "gateway/**/Cargo.toml",
+    "cli/**/Cargo.toml",
+    "examples/**/Cargo.toml",
+]
+exclude = ["**/.*", "crates/grafbase-workspace-hack/Cargo.toml"]
+
+[formatting]
+# Align consecutive entries vertically.
+align_entries = false
+# Append trailing commas for multi-line arrays.
+array_trailing_comma = true
+# Expand arrays to multiple lines that exceed the maximum column width.
+array_auto_expand = true
+# Collapse arrays that don't exceed the maximum column width and don't contain comments.
+array_auto_collapse = false
+# Omit white space padding from single-line arrays
+compact_arrays = true
+# Omit white space padding from the start and end of inline tables.
+compact_inline_tables = false
+# Maximum column width in characters, affects array expansion and collapse, this doesn't take whitespace into account.
+# Note that this is not set in stone, and works on a best-effort basis.
+column_width = 120
+# Indent based on tables and arrays of tables and their subtables, subtables out of order are not indented.
+indent_tables = false
+# The substring that is used for indentation, should be tabs or spaces (but technically can be anything).
+indent_string = '    '
+# Add trailing newline at the end of the file if not present.
+trailing_newline = true
+# Alphabetically reorder keys that are not separated by empty lines.
+reorder_keys = false
+# Maximum amount of allowed consecutive blank lines. This does not affect the whitespace at the end of the document, as it is always stripped.
+allowed_blank_lines = 1
+# Use CRLF for line endings.
+crlf = false
+
+[[rule]]
+keys = ["dependencies", "dev-dependencies", "build-dependencies", "workspace.dependencies", "patch.crates-io"]
+formatting = { reorder_keys = true }
+
+# This rule is used to enforce all deps to be declared at root.
+#
+# All crates inside `src`, `tests` must use `workspace = true` instead.
+[[rule]]
+schema = { path = ".config/workspace-schema.json" }
+include = ["crates/**/Cargo.toml", "gateway/**/Cargo.toml", "cli/**/Cargo.toml"]
+exclude = ["crates/wasi-component-loader/examples/**/Cargo.toml", "crates/grafbase-workspace-hack/Cargo.toml"]


### PR DESCRIPTION
Enforced in CI. `taplo fmt` to format all TOML files, `taplo check` for
linting. A LSP server exists for automatic formatting in IDEs.

It'll also enforce that all dependencies use `workspace = true`.
