### PR TITLE
gateway: release 0.28.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3230,7 +3230,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.28.4"
+version = "0.28.5"
 dependencies = [
  "anyhow",
  "ascii",

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.28.5] - 2025-02-14
+
+[CHANGELOG](changelog/0.28.5.md)
+
+
 ## [0.28.4] - 2025-02-06
 
 [CHANGELOG](changelog/0.28.4.md)

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.28.4"
+version = "0.28.5"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/changelog/0.28.5.md
+++ b/gateway/changelog/0.28.5.md
@@ -1,0 +1,3 @@
+## Improvements
+
+- The `[authentication.providers.jwt.jwks]` section in gateway configuration can now take an array for the `audience` field. This allows the JWT to match any of the audiences in the array.


### PR DESCRIPTION
## Improvements

- The `[authentication.providers.jwt.jwks]` section in gateway configuration can now take an array for the `audience` field. This allows the JWT to match any of the audiences in the array.