### PR TITLE
chore: Do not send any operation/request metrics for subscriptions

### DIFF
--- a/crates/engine/src/engine/execute/single.rs
+++ b/crates/engine/src/engine/execute/single.rs
@@ -44,7 +44,7 @@ impl<R: Runtime> Engine<R> {
                     });
                 }
 
-                self.runtime.metrics().record_operation_duration(
+                self.runtime.metrics().record_query_or_mutation_duration(
                     GraphqlRequestMetricsAttributes {
                         operation,
                         status,

--- a/crates/engine/src/engine/execute/stream.rs
+++ b/crates/engine/src/engine/execute/stream.rs
@@ -97,7 +97,7 @@ impl<R: Runtime> Engine<R> {
                                 });
                         }
 
-                        engine.runtime.metrics().record_operation_duration(
+                        engine.runtime.metrics().record_query_or_mutation_duration(
                             GraphqlRequestMetricsAttributes {
                                 operation,
                                 status,

--- a/crates/telemetry/src/metrics/request.rs
+++ b/crates/telemetry/src/metrics/request.rs
@@ -29,7 +29,10 @@ pub struct RequestMetricsAttributes {
 impl RequestMetrics {
     pub fn build(meter: &Meter) -> Self {
         Self {
-            latency: meter.u64_histogram("http.server.request.duration").build(),
+            latency: meter
+                .u64_histogram("http.server.request.duration")
+                .with_unit("ms")
+                .build(),
             connected_clients: meter.i64_up_down_counter("http.server.connected.clients").build(),
             response_body_sizes: meter.u64_histogram("http.server.response.body.size").build(),
         }


### PR DESCRIPTION
Those are geared towards query/mutations, so latency in particular
doesn't make any sense. We have to come up with appropriate metrics for
subscriptions later.
