### PR TITLE
chore: rework @external

### DIFF
--- a/crates/engine/src/resolver/extension/field_resolver.rs
+++ b/crates/engine/src/resolver/extension/field_resolver.rs
@@ -94,6 +94,8 @@ impl<'ctx> FieldResolverExtensionRequest<'ctx> {
                     match result {
                         Ok(data) => match data {
                             Data::JsonBytes(bytes) => {
+                                tracing::debug!("Received:\n{}", String::from_utf8_lossy(&bytes));
+
                                 response
                                     .seed(&ctx, id)
                                     .deserialize_field_as_entity(
@@ -106,6 +108,14 @@ impl<'ctx> FieldResolverExtensionRequest<'ctx> {
                                     })?;
                             }
                             Data::CborBytes(bytes) => {
+                                tracing::debug!(
+                                    "Received:\n{}",
+                                    minicbor_serde::from_slice(&bytes)
+                                        .ok()
+                                        .and_then(|v: serde_json::Value| serde_json::to_string_pretty(&v).ok())
+                                        .unwrap_or_else(|| "<error>".to_string())
+                                );
+
                                 response
                                     .seed(&ctx, id)
                                     .deserialize_field_as_entity(

--- a/crates/graphql-composition/src/compose/object.rs
+++ b/crates/graphql-composition/src/compose/object.rs
@@ -267,15 +267,11 @@ fn ingest_join_field_directives(
     out: &mut Vec<ir::Directive>,
 ) {
     for field in fields {
-        // If part of the key, it can't be external.
-        if field.directives().external() && !field.is_part_of_key() {
-            continue;
-        }
-
         let mut directive = ir::JoinFieldDirective {
             source_field: field.id,
             r#override: None,
             override_label: None,
+            external: field.directives().external() && !field.is_part_of_key(),
             r#type: if field.r#type() != composed_field_type {
                 Some(field.r#type().id)
             } else {

--- a/crates/graphql-composition/src/composition_ir/directive.rs
+++ b/crates/graphql-composition/src/composition_ir/directive.rs
@@ -47,6 +47,7 @@ pub struct JoinInputFieldDirective {
 pub struct JoinFieldDirective {
     pub source_field: (FieldId, FieldTuple),
     pub r#override: Option<OverrideSource>,
+    pub external: bool,
     pub override_label: Option<OverrideLabel>,
     pub r#type: Option<FieldTypeId>,
 }

--- a/crates/graphql-composition/src/emit_federated_graph/directive.rs
+++ b/crates/graphql-composition/src/emit_federated_graph/directive.rs
@@ -36,6 +36,7 @@ pub(super) fn transform_input_value_directives(
                     requires: None,
                     provides: None,
                     r#type: dir.r#type.map(|ty| ctx.insert_field_type(ctx.subgraphs.walk(ty))),
+                    external: false,
                     r#override: None,
                     override_label: None,
                 }))
@@ -270,6 +271,7 @@ fn transform_join_field_directive(
     field_id: federated::FieldId,
     ir::JoinFieldDirective {
         source_field,
+        external,
         r#override,
         override_label,
         r#type,
@@ -289,6 +291,7 @@ fn transform_join_field_directive(
             .provides()
             .map(|field_set| attach_selection(field_set, ctx.out[field_id].r#type.definition, ctx)),
         r#type: r#type.map(|ty| ctx.insert_field_type(ctx.subgraphs.walk(ty))),
+        external: *external,
         r#override: r#override.clone(),
         override_label: override_label.clone(),
     })

--- a/crates/graphql-composition/src/emit_federated_graph/federation_builtins.rs
+++ b/crates/graphql-composition/src/emit_federated_graph/federation_builtins.rs
@@ -146,6 +146,10 @@ pub(super) fn emit_federation_builtins(ctx: &mut Context<'_>, join_graph_enum_id
     //     graph: join__Graph
     //     requires: join__FieldSet
     //     provides: join__FieldSet
+    //     type: String,
+    //     external: Boolean,
+    //     override: String,
+    //     overrideLabel: String
     // ) on FIELD_DEFINITION
     {
         let directive_name = ctx.insert_str("field");
@@ -200,6 +204,58 @@ pub(super) fn emit_federation_builtins(ctx: &mut Context<'_>, join_graph_enum_id
                 default: None,
             },
         );
+
+        let argument = federated::InputValueDefinition {
+            name: ctx.insert_str("type"),
+            r#type: federated::Type {
+                wrapping: Wrapping::nullable(),
+                definition: string_definition,
+            },
+            directives: Vec::new(),
+            description: None,
+            default: None,
+        };
+        ctx.out
+            .push_directive_definition_argument(directive_definition_id, argument);
+
+        let argument = federated::InputValueDefinition {
+            name: ctx.insert_str("external"),
+            r#type: federated::Type {
+                wrapping: Wrapping::nullable(),
+                definition: boolean_definition,
+            },
+            directives: Vec::new(),
+            description: None,
+            default: None,
+        };
+        ctx.out
+            .push_directive_definition_argument(directive_definition_id, argument);
+
+        let argument = federated::InputValueDefinition {
+            name: ctx.insert_str("override"),
+            r#type: federated::Type {
+                wrapping: Wrapping::nullable(),
+                definition: string_definition,
+            },
+            directives: Vec::new(),
+            description: None,
+            default: None,
+        };
+        ctx.out
+            .push_directive_definition_argument(directive_definition_id, argument);
+
+        let argument = federated::InputValueDefinition {
+            name: ctx.insert_str("overrideLabel"),
+            r#type: federated::Type {
+                wrapping: Wrapping::nullable(),
+                definition: string_definition,
+            },
+            directives: Vec::new(),
+            description: None,
+            default: None,
+        };
+        ctx.out
+            .push_directive_definition_argument(directive_definition_id, argument);
     }
 
     // directive @join__type(

--- a/crates/graphql-composition/tests/composition/authenticated_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/authenticated_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/authorized_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/authorized_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/authorized_with_composeDirective/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/authorized_with_composeDirective/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/composed_directives_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/composed_directives_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/cost_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/cost_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/custom_query_root/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/custom_query_root/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/custom_query_root_as_non_root_in_other_subgraph/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/custom_query_root_as_non_root_in_other_subgraph/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/custom_scalars_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/custom_scalars_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/default_values/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/default_values/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/descriptions_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/descriptions_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/disjoint_keys/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/disjoint_keys/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/entity_composite_key_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_composite_key_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/entity_composite_key_nested/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_composite_key_nested/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/entity_interface_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_interface_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/entity_interfaces_multi_subgraph/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_interfaces_multi_subgraph/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/entity_interfaces_with_requires/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_interfaces_with_requires/federated.graphql.snap
@@ -43,7 +43,7 @@ interface Media
 {
     id: ID!
     reviews: [Review!]! @join__field(graph: B, requires: "title")
-    title: String! @join__field(graph: A)
+    title: String! @join__field(graph: A) @join__field(graph: B, external: true)
 }
 
 enum join__Graph

--- a/crates/graphql-composition/tests/composition/entity_interfaces_with_requires/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_interfaces_with_requires/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/entity_multiple_keys_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_multiple_keys_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/entity_staggered_composite_key/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_staggered_composite_key/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/entity_unresolvable_keys/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_unresolvable_keys/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/enum_only_inputs/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/enum_only_inputs/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/enum_only_outputs/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/enum_only_outputs/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/enum_unused/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/enum_unused/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/extensions_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/extensions_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/extensions_directives_on_schema_definition/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/extensions_directives_on_schema_definition/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/field_type_composition/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/field_type_composition/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/inaccessible_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/inaccessible_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/inaccessible_in_one_subgraph_is_enough/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/inaccessible_in_one_subgraph_is_enough/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/input_object_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/input_object_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/interface_implementing_interface_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/interface_implementing_interface_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/interfaces_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/interfaces_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/interfaces_single_subgraph/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/interfaces_single_subgraph/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/kebab_case_subgraph_names/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/kebab_case_subgraph_names/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/link_import_as_valid/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/link_import_as_valid/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/list_size/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/list_size/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/namespaced_directive_without_import_are_ignored/subgraphs/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/namespaced_directive_without_import_are_ignored/subgraphs/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/namespaced_directives_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/namespaced_directives_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/object_field_arguments_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/object_field_arguments_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/objects_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/objects_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/override_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/override_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/override_label/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/override_label/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/policy_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/policy_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/provides_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/provides_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/provides_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/provides_basic/federated.graphql.snap
@@ -39,7 +39,7 @@ type User
 {
     email: String @join__field(graph: USERS)
     id: ID!
-    name: String @join__field(graph: USERS)
+    name: String @join__field(graph: PRODUCTS, external: true) @join__field(graph: USERS)
 }
 
 type Query

--- a/crates/graphql-composition/tests/composition/requiresScopes_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/requiresScopes_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/requires_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/requires_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/requires_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/requires_basic/federated.graphql.snap
@@ -22,7 +22,7 @@ type Farm
     @join__type(graph: FARMS, key: "id")
 {
     chiliDetails: ChiliVariety @join__field(graph: CHILIES, requires: "chiliId")
-    chiliId: ID! @join__field(graph: FARMS)
+    chiliId: ID! @join__field(graph: CHILIES, external: true) @join__field(graph: FARMS)
     id: ID!
     location: String! @join__field(graph: FARMS)
     name: String! @join__field(graph: FARMS)

--- a/crates/graphql-composition/tests/composition/requires_with_arguments/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/requires_with_arguments/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/requires_with_arguments/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/requires_with_arguments/federated.graphql.snap
@@ -23,8 +23,8 @@ type WasabiPlant
     cultivationArea: String
     harvestTime: String @join__field(graph: WASABI, requires: "variety name(language: \"latin\")")
     id: ID!
-    name(language: String!): String!
-    variety: String!
+    name(language: String!): String! @join__field(graph: WASABI, external: true)
+    variety: String! @join__field(graph: WASABI, external: true)
 }
 
 type WasabiProduct

--- a/crates/graphql-composition/tests/composition/requires_with_nested_inline_fragment/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/requires_with_nested_inline_fragment/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/requires_with_nested_inline_fragment/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/requires_with_nested_inline_fragment/federated.graphql.snap
@@ -23,10 +23,10 @@ type Producer implements MusicEntity
     @join__implements(graph: PAYROLL, interface: "MusicEntity")
     @join__implements(graph: REGISTRY, interface: "MusicEntity")
 {
-    albumsProduced: [String!]! @join__field(graph: REGISTRY)
+    albumsProduced: [String!]! @join__field(graph: PAYROLL, external: true) @join__field(graph: REGISTRY)
     id: ID!
     name: String!
-    studioName: String! @join__field(graph: REGISTRY)
+    studioName: String! @join__field(graph: PAYROLL, external: true) @join__field(graph: REGISTRY)
 }
 
 type Band implements MusicEntity
@@ -37,7 +37,7 @@ type Band implements MusicEntity
 {
     genre: String! @join__field(graph: REGISTRY)
     id: ID!
-    members: [String!]! @join__field(graph: REGISTRY)
+    members: [String!]! @join__field(graph: PAYROLL, external: true) @join__field(graph: REGISTRY)
     name: String!
 }
 

--- a/crates/graphql-composition/tests/composition/shareable_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/shareable_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/shareable_is_repeatable/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/shareable_is_repeatable/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/subgraph_query_fields_service_entities/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/subgraph_query_fields_service_entities/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/subscriptions_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/subscriptions_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/tag_directive_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/tag_directive_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-composition/tests/composition/unions_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/unions_basic/federated.graphql.snap
@@ -9,7 +9,7 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
 directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
 

--- a/crates/graphql-federated-graph/src/directives/federation.rs
+++ b/crates/graphql-federated-graph/src/directives/federation.rs
@@ -34,6 +34,7 @@ pub struct JoinFieldDirective {
     pub requires: Option<SelectionSet>,
     pub provides: Option<SelectionSet>,
     pub r#type: Option<Type>,
+    pub external: bool,
     pub r#override: Option<OverrideSource>,
     pub override_label: Option<OverrideLabel>,
 }

--- a/crates/graphql-federated-graph/src/from_sdl/directive.rs
+++ b/crates/graphql-federated-graph/src/from_sdl/directive.rs
@@ -286,14 +286,10 @@ fn parse_join_field_directive<'a>(
     state: &mut State<'a>,
 ) -> Result<Option<Directive>, DomainError> {
     let field_type = state.graph[field_id].r#type;
-    let is_external = directive
+    let external = directive
         .get_argument("external")
         .map(|arg| arg.as_bool().unwrap_or_default())
         .unwrap_or_default();
-
-    if is_external {
-        return Ok(None);
-    }
 
     let subgraph_id = directive
         .get_argument("graph")
@@ -345,6 +341,7 @@ fn parse_join_field_directive<'a>(
         requires,
         provides,
         r#type,
+        external,
         r#override,
         override_label,
     })))

--- a/crates/graphql-federated-graph/src/render_sdl/directive.rs
+++ b/crates/graphql-federated-graph/src/render_sdl/directive.rs
@@ -151,6 +151,10 @@ fn render_join_field_directive(
         writer = writer.arg("type", render_field_type(ty, graph))?;
     }
 
+    if directive.external {
+        writer = writer.arg("external", Value::Boolean(true))?;
+    }
+
     if let Some(r#override) = &directive.r#override {
         let name = match r#override {
             OverrideSource::Subgraph(subgraph_id) => &graph.at(*subgraph_id).then(|subgraph| subgraph.name),

--- a/crates/graphql-federated-graph/src/render_sdl/render_federated_sdl.rs
+++ b/crates/graphql-federated-graph/src/render_sdl/render_federated_sdl.rs
@@ -339,8 +339,11 @@ fn write_field_directives(
                 fully_overridden_subgraph_ids.push(*id);
             }
             join_field_subgraph_ids.extend(dir.subgraph_id);
-            join_field_must_be_present |=
-                dir.r#override.is_some() | dir.requires.is_some() | dir.provides.is_some() | dir.r#type.is_some();
+            join_field_must_be_present |= dir.r#override.is_some()
+                | dir.requires.is_some()
+                | dir.provides.is_some()
+                | dir.r#type.is_some()
+                | dir.external;
         }
     }
 

--- a/crates/integration-tests/tests/federation/extensions/mod.rs
+++ b/crates/integration-tests/tests/federation/extensions/mod.rs
@@ -1,3 +1,4 @@
 mod basic;
 mod injection;
+mod subgraph;
 mod validation;

--- a/crates/integration-tests/tests/federation/extensions/subgraph.rs
+++ b/crates/integration-tests/tests/federation/extensions/subgraph.rs
@@ -1,0 +1,63 @@
+use engine::Engine;
+use graphql_mocks::dynamic::DynamicSchema;
+use integration_tests::{federation::EngineExt, runtime};
+use serde_json::json;
+
+use crate::federation::extensions::basic::GreetExt;
+
+#[test]
+fn extension_mixed_with_graphql_subgraph_root_fields() {
+    runtime().block_on(async move {
+        let response = Engine::builder()
+            .with_subgraph(
+                DynamicSchema::builder(
+                    r#"
+                    type User {
+                        name: String!
+                    }
+
+                    type Query {
+                        user: User
+                    }
+                    "#,
+                )
+                .with_resolver("Query", "user", json!({"name": "Alice"}))
+                .into_subgraph("x"),
+            )
+            .with_subgraph_sdl(
+                "y",
+                r#"
+                    extend schema
+                        @link(url: "greet-1.0.0", import: ["@greet"])
+
+                    scalar JSON
+
+                    type Query {
+                        greet: JSON @greet
+                    }
+
+                "#,
+            )
+            .with_extension(GreetExt::with_sdl(
+                r#"
+                    extend schema @link(url: "http://specs.grafbase.com/grafbase")
+                    directive @greet on FIELD_DEFINITION
+                "#,
+            ))
+            .build()
+            .await
+            .post("{ greet user { name } }")
+            .await;
+
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "greet": "Hi!",
+            "user": {
+              "name": "Alice"
+            }
+          }
+        }
+        "#);
+    });
+}


### PR DESCRIPTION
Initially wanted to have extensions in a GraphQL subgraph, but realized that:

- it's kind of weird for a subgraph to have `@external` on a field if it ends up providing the field anyway, even if through a different mechanism
- Subgraphs in the engine fundamentally define what resolvers can provide. Resolvers are entry points eventually with requirements, they don't define what's accessible. So as an extension would be unlikely to provide the same as the GraphQL subgraph it would be pretty weird to support both together in the same subgraph. Plus the fact that outside of tests it's a weird thing to do.

So add a test with mixed gql & extension and keeping better track of external. I remember having to need it for some federation-audit tests anyway.