### PR TITLE
fix(engine): extension field resolver must be called within the same subgraph

### DIFF
--- a/crates/engine/query-solver/src/tests/extension.rs
+++ b/crates/engine/query-solver/src/tests/extension.rs
@@ -1,0 +1,59 @@
+use crate::assert_solving_snapshots;
+
+const SCHEMA: &str = r#"
+enum join__Graph {
+    CATEGORY @join__graph(name: "category", url: "http://example.com/category")
+    PRODUCTS @join__graph(name: "products", url: "http://example.com/products")
+    SUBCATEGORIES @join__graph(name: "subcategories", url: "http://example.com/subcategories")
+}
+
+type Product
+    @join__type(graph: CATEGORY, key: "id")
+    @join__type(graph: PRODUCTS, key: "id")
+{
+    categories: [Category] @join__field(graph: CATEGORY)
+    id: ID!
+}
+
+type Category
+    @join__type(graph: CATEGORY, key: "id")
+    @join__type(graph: SUBCATEGORIES, key: "id")
+{
+    id: ID!
+    """
+    This field is provided by Query.products
+    and we deliberately don't resolve it.
+    The test suite is about checking if @provides is used correctly.
+    """
+    name: String @join__field(graph: CATEGORY)
+    kind: String @join__field(graph: CATEGORY)
+    subCategories: [Category] @join__field(graph: SUBCATEGORIES, provides: "kind")
+}
+
+type Query {
+    products: [Product] @join__field(graph: PRODUCTS, provides: "categories { id name subCategories { id name } }")
+}
+"#;
+
+#[tokio::test]
+async fn resolvers_define_boundaries() {
+    assert_solving_snapshots!(
+        "provides_full",
+        SCHEMA,
+        r#"
+        query {
+          products {
+            id
+            categories {
+              id
+              name
+              subCategories {
+                id
+                name
+              }
+            }
+          }
+        }
+        "#
+    );
+}

--- a/crates/engine/query-solver/src/tests/mod.rs
+++ b/crates/engine/query-solver/src/tests/mod.rs
@@ -2,6 +2,7 @@ mod abstract_types;
 mod basic;
 mod cycle;
 mod entities;
+mod extension;
 mod flatten;
 mod inaccessible;
 mod interface;

--- a/crates/engine/schema/src/subgraph.rs
+++ b/crates/engine/schema/src/subgraph.rs
@@ -24,6 +24,17 @@ impl<'a> Subgraph<'a> {
 
         ids.walk(schema)
     }
+
+    /// Defines whether resolvers should also be treated as boundaries in addition to being
+    /// entrypoints. Meaning that if we encounter a field with a resolver from the same subgraph,
+    /// do we need to call it or can we just provide this field from the parent resolver?
+    pub fn resolvers_define_boundaries(&self) -> bool {
+        match self {
+            Subgraph::GraphqlEndpoint(_) => false,
+            Subgraph::Virtual(_) => true,
+            Subgraph::Introspection(_) => false,
+        }
+    }
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/crates/integration-tests/tests/federation/extensions/subgraph.rs
+++ b/crates/integration-tests/tests/federation/extensions/subgraph.rs
@@ -1,6 +1,13 @@
+use std::sync::Arc;
+
 use engine::Engine;
+use extension_catalog::Id;
 use graphql_mocks::dynamic::DynamicSchema;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{
+    federation::{EngineExt, TestExtension, TestExtensionBuilder, TestExtensionConfig},
+    runtime,
+};
+use runtime::{error::PartialGraphqlError, extension::ExtensionFieldDirective, hooks::DynHookContext};
 use serde_json::json;
 
 use crate::federation::extensions::basic::GreetExt;
@@ -55,6 +62,97 @@ fn extension_mixed_with_graphql_subgraph_root_fields() {
             "greet": "Hi!",
             "user": {
               "name": "Alice"
+            }
+          }
+        }
+        "#);
+    });
+}
+
+#[derive(Default)]
+struct ResolveExt;
+
+impl TestExtensionBuilder for ResolveExt {
+    fn config(&self) -> TestExtensionConfig {
+        TestExtensionConfig {
+            kind: extension_catalog::Kind::FieldResolver(extension_catalog::FieldResolver {
+                resolver_directives: vec!["echo".to_string(), "echoArgs".to_string()],
+            }),
+            sdl: Some(
+                r#"
+                extend schema @link(url: "https://specs.grafbase.com/grafbase", import: ["FieldSet"])
+                scalar JSON
+                directive @resolve(value: JSON, requires: FieldSet) on FIELD_DEFINITION
+            "#,
+            ),
+        }
+    }
+
+    fn build(&self, _: Vec<(&str, serde_json::Value)>) -> Arc<dyn TestExtension> {
+        Arc::new(ResolveInstance)
+    }
+
+    fn id(&self) -> extension_catalog::Id
+    where
+        Self: Sized,
+    {
+        Id {
+            name: "resolve".to_string(),
+            version: "1.0.0".parse().unwrap(),
+        }
+    }
+}
+
+struct ResolveInstance;
+
+#[async_trait::async_trait]
+impl TestExtension for ResolveInstance {
+    async fn resolve<'a>(
+        &self,
+        _context: &DynHookContext,
+        directive: ExtensionFieldDirective<'a, serde_json::Value>,
+        inputs: Vec<serde_json::Value>,
+    ) -> Result<Vec<Result<serde_json::Value, PartialGraphqlError>>, PartialGraphqlError> {
+        Ok(inputs
+            .into_iter()
+            .map(|_| Ok(directive.arguments["value"].clone()))
+            .collect())
+    }
+}
+
+#[test]
+fn nested_extension_in_same_subgraph() {
+    runtime().block_on(async move {
+        let response = Engine::builder()
+            .with_subgraph_sdl(
+                "y",
+                r#"
+                    extend schema
+                        @link(url: "resolve-1.0.0", import: ["@resolve"])
+
+                    type User {
+                        name: String!
+                        age: Int! @resolve(value: 892, requires: "name")
+                    }
+
+                    type Query {
+                        user: User @resolve(value: { name: "Alice" })
+                    }
+
+                "#,
+            )
+            .with_extension(ResolveExt)
+            .build()
+            .await
+            .post("{ user { name age } }")
+            .await;
+
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "user": {
+              "name": "Alice",
+              "age": 892
             }
           }
         }


### PR DESCRIPTION
For GraphQL subgraph we only treat resolvers as entrypoint, if a field
is reachable given its definition, it's assumed to be providable
