### PR TITLE
feat: after-merge fixes to the subscribe api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,8 +2314,6 @@ dependencies = [
  "strum 0.27.1",
  "strum_macros 0.27.1",
  "thiserror 2.0.11",
- "tokio",
- "tokio-stream",
  "tower 0.5.2",
  "tracing",
  "url",
@@ -7037,7 +7035,6 @@ dependencies = [
  "serde_json",
  "strum 0.27.1",
  "thiserror 2.0.11",
- "tokio",
  "url",
 ]
 
@@ -8892,6 +8889,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.11",
  "tokio",
+ "tokio-stream",
  "toml",
  "tracing",
  "ulid",

--- a/cli/templates/extension/src/resolver.rs.template
+++ b/cli/templates/extension/src/resolver.rs.template
@@ -1,5 +1,5 @@
 use grafbase_sdk::{
-    host_io::pubsub::Subscriber,
+    host_io::pubsub::Subscription,
     types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
     Error, Extension, Resolver, ResolverExtension, SharedContext,
 };
@@ -29,7 +29,7 @@ impl Resolver for {{name}} {
         context: SharedContext,
         directive: Directive,
         field_definition: FieldDefinition,
-    ) -> Result<Box<dyn Subscriber>, Error> {
+    ) -> Result<Box<dyn Subscription>, Error> {
         todo!()
     }
 }

--- a/cli/templates/extension/src/resolver.rs.template
+++ b/cli/templates/extension/src/resolver.rs.template
@@ -1,4 +1,5 @@
 use grafbase_sdk::{
+    host_io::pubsub::Subscriber,
     types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
     Error, Extension, Resolver, ResolverExtension, SharedContext,
 };
@@ -28,11 +29,7 @@ impl Resolver for {{name}} {
         context: SharedContext,
         directive: Directive,
         field_definition: FieldDefinition,
-    ) -> Result<(), Error> {
-        todo!()
-    }
-
-    fn resolve_next_subscription_item(&mut self) -> Result<Option<FieldOutput>, Error> {
+    ) -> Result<Box<dyn Subscriber>, Error> {
         todo!()
     }
 }

--- a/cli/tests/extension/mod.rs
+++ b/cli/tests/extension/mod.rs
@@ -35,12 +35,12 @@ fn init_resolver() {
     codegen-units = 1
 
     [dependencies]
-    grafbase-sdk = "0.2.1"
+    grafbase-sdk = "0.3.0"
 
     [dev-dependencies]
     indoc = "2"
     insta = { version = "1.42.1", features = ["json"] }
-    grafbase-sdk = { version = "0.2.1", features = ["test-utils"] }
+    grafbase-sdk = { version = "0.3.0", features = ["test-utils"] }
     tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }
     serde_json = "1"
     "#);
@@ -77,6 +77,7 @@ fn init_resolver() {
 
     insta::assert_snapshot!(&lib_rs, @r##"
     use grafbase_sdk::{
+        host_io::pubsub::Subscriber,
         types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
         Error, Extension, Resolver, ResolverExtension, SharedContext,
     };
@@ -106,11 +107,7 @@ fn init_resolver() {
             context: SharedContext,
             directive: Directive,
             field_definition: FieldDefinition,
-        ) -> Result<(), Error> {
-            todo!()
-        }
-
-        fn resolve_next_subscription_item(&mut self) -> Result<Option<FieldOutput>, Error> {
+        ) -> Result<Box<dyn Subscriber>, Error> {
             todo!()
         }
     }
@@ -276,12 +273,12 @@ fn init_auth() {
     codegen-units = 1
 
     [dependencies]
-    grafbase-sdk = "0.2.1"
+    grafbase-sdk = "0.3.0"
 
     [dev-dependencies]
     indoc = "2"
     insta = { version = "1.42.1", features = ["json"] }
-    grafbase-sdk = { version = "0.2.1", features = ["test-utils"] }
+    grafbase-sdk = { version = "0.3.0", features = ["test-utils"] }
     tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }
     serde_json = "1"
     "#);

--- a/cli/tests/extension/mod.rs
+++ b/cli/tests/extension/mod.rs
@@ -35,12 +35,12 @@ fn init_resolver() {
     codegen-units = 1
 
     [dependencies]
-    grafbase-sdk = "0.3.0"
+    grafbase-sdk = "0.4.0"
 
     [dev-dependencies]
     indoc = "2"
     insta = { version = "1.42.1", features = ["json"] }
-    grafbase-sdk = { version = "0.3.0", features = ["test-utils"] }
+    grafbase-sdk = { version = "0.4.0", features = ["test-utils"] }
     tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }
     serde_json = "1"
     "#);
@@ -77,7 +77,7 @@ fn init_resolver() {
 
     insta::assert_snapshot!(&lib_rs, @r##"
     use grafbase_sdk::{
-        host_io::pubsub::Subscriber,
+        host_io::pubsub::Subscription,
         types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
         Error, Extension, Resolver, ResolverExtension, SharedContext,
     };
@@ -107,7 +107,7 @@ fn init_resolver() {
             context: SharedContext,
             directive: Directive,
             field_definition: FieldDefinition,
-        ) -> Result<Box<dyn Subscriber>, Error> {
+        ) -> Result<Box<dyn Subscription>, Error> {
             todo!()
         }
     }
@@ -273,12 +273,12 @@ fn init_auth() {
     codegen-units = 1
 
     [dependencies]
-    grafbase-sdk = "0.3.0"
+    grafbase-sdk = "0.4.0"
 
     [dev-dependencies]
     indoc = "2"
     insta = { version = "1.42.1", features = ["json"] }
-    grafbase-sdk = { version = "0.3.0", features = ["test-utils"] }
+    grafbase-sdk = { version = "0.4.0", features = ["test-utils"] }
     tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }
     serde_json = "1"
     "#);

--- a/cli/tests/integration/data/echo_extension/src/lib.rs
+++ b/cli/tests/integration/data/echo_extension/src/lib.rs
@@ -1,5 +1,6 @@
 use grafbase_sdk::{
     Error, Extension, Resolver, ResolverExtension, SharedContext,
+    host_io::pubsub::Subscriber,
     types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
 };
 
@@ -43,11 +44,12 @@ impl Resolver for EchoExtension {
         Ok(output)
     }
 
-    fn resolve_subscription(&mut self, _: SharedContext, _: Directive, _: FieldDefinition) -> Result<(), Error> {
-        todo!()
-    }
-
-    fn resolve_next_subscription_item(&mut self) -> Result<Option<FieldOutput>, Error> {
+    fn resolve_subscription(
+        &mut self,
+        _: SharedContext,
+        _: Directive,
+        _: FieldDefinition,
+    ) -> Result<Box<dyn Subscriber>, Error> {
         todo!()
     }
 }

--- a/cli/tests/integration/data/echo_extension/src/lib.rs
+++ b/cli/tests/integration/data/echo_extension/src/lib.rs
@@ -1,6 +1,6 @@
 use grafbase_sdk::{
     Error, Extension, Resolver, ResolverExtension, SharedContext,
-    host_io::pubsub::Subscriber,
+    host_io::pubsub::Subscription,
     types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
 };
 
@@ -49,7 +49,7 @@ impl Resolver for EchoExtension {
         _: SharedContext,
         _: Directive,
         _: FieldDefinition,
-    ) -> Result<Box<dyn Subscriber>, Error> {
+    ) -> Result<Box<dyn Subscription>, Error> {
         todo!()
     }
 }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -58,8 +58,6 @@ query-solver = { path = "./query-solver", package = "engine-query-solver" }
 rand.workspace = true
 runtime.workspace = true
 schema = { path = "./schema", package = "engine-schema" }
-tokio = { workspace = true, features = ["sync"] }
-tokio-stream.workspace = true
 walker = { path = "./walker", package = "engine-walker" }
 
 [dev-dependencies]

--- a/crates/engine/src/resolver/extension/mod.rs
+++ b/crates/engine/src/resolver/extension/mod.rs
@@ -59,7 +59,7 @@ impl FieldResolverExtension {
             .engine
             .runtime
             .extensions()
-            .resolve_field_subscription(ctx.hooks_context, extension_directive)
+            .resolve_subscription(ctx.hooks_context, extension_directive)
             .boxed();
 
         SubscriptionResolverExtensionRequest { field, future }

--- a/crates/grafbase-sdk/Cargo.toml
+++ b/crates/grafbase-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-sdk"
-version = "0.2.1"
+version = "0.3.0"
 description = "An SDK to implement extensions for the Grafbase Gateway"
 edition = "2021"
 license.workspace = true

--- a/crates/grafbase-sdk/Cargo.toml
+++ b/crates/grafbase-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-sdk"
-version = "0.3.0"
+version = "0.4.0"
 description = "An SDK to implement extensions for the Grafbase Gateway"
 edition = "2021"
 license.workspace = true

--- a/crates/grafbase-sdk/src/extension.rs
+++ b/crates/grafbase-sdk/src/extension.rs
@@ -64,18 +64,21 @@ impl Guest for Component {
         result.map(Into::into)
     }
 
-    fn resolve_field_subscription(
+    fn resolve_subscription(
         context: SharedContext,
         directive: Directive,
         definition: FieldDefinition,
     ) -> Result<(), Error> {
-        resolver::get_extension()?.resolve_subscription(context, directive.into(), definition.into())
+        let subscriber =
+            resolver::get_extension()?.resolve_subscription(context, directive.into(), definition.into())?;
+
+        resolver::set_subscriber(subscriber);
+
+        Ok(())
     }
 
     fn resolve_next_subscription_item() -> Result<Option<FieldOutput>, Error> {
-        resolver::get_extension()?
-            .resolve_next_subscription_item()
-            .map(|v| v.map(Into::into))
+        Ok(resolver::get_subscriber()?.next()?.map(Into::into))
     }
 
     fn authenticate(headers: Headers) -> Result<Token, crate::wit::ErrorResponse> {

--- a/crates/grafbase-sdk/src/extension/resolver.rs
+++ b/crates/grafbase-sdk/src/extension/resolver.rs
@@ -1,4 +1,5 @@
 use crate::{
+    host_io::pubsub::Subscriber,
     types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
     wit::{Error, SharedContext},
 };
@@ -10,12 +11,29 @@ type InitFn = Box<dyn Fn(Vec<Directive>, Configuration) -> Result<Box<dyn Resolv
 pub(super) static mut EXTENSION: Option<Box<dyn Resolver>> = None;
 pub static mut INIT_FN: Option<InitFn> = None;
 
+pub(super) static mut SUBSCRIBER: Option<Box<dyn Subscriber>> = None;
+
 pub(super) fn get_extension() -> Result<&'static mut dyn Resolver, Error> {
     // Safety: This is hidden, only called by us. Every extension call to an instance happens
     // in a single-threaded environment. Do not call this multiple times from different threads.
     unsafe {
         EXTENSION.as_deref_mut().ok_or_else(|| Error {
             message: "Resolver extension not initialized correctly.".to_string(),
+            extensions: Vec::new(),
+        })
+    }
+}
+
+pub(super) fn set_subscriber(subscriber: Box<dyn Subscriber>) {
+    unsafe {
+        SUBSCRIBER = Some(subscriber);
+    }
+}
+
+pub(super) fn get_subscriber() -> Result<&'static mut dyn Subscriber, Error> {
+    unsafe {
+        SUBSCRIBER.as_deref_mut().ok_or_else(|| Error {
+            message: "No active subscription.".to_string(),
             extensions: Vec::new(),
         })
     }
@@ -71,29 +89,21 @@ pub trait Resolver: Extension {
         inputs: FieldInputs,
     ) -> Result<FieldOutput, Error>;
 
-    /// Resolves a subscription field based on the given context, directive, and definition.
-    ///
-    /// The function should initialize a subscription internally, but not return any data.
-    /// Use the `resolve_next_subscription_item` method to retrieve the next item in the subscription.
+    /// Resolves a subscription field by setting up a subscription handler.
     ///
     /// # Arguments
     ///
     /// * `context` - The shared context containing runtime information
-    /// * `directive` - The directive associated with this subscription
-    /// * `definition` - The field definition containing metadata
+    /// * `directive` - The directive associated with this subscription field
+    /// * `definition` - The field definition containing metadata about the subscription
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing either a boxed `Subscriber` implementation or an `Error`
     fn resolve_subscription(
         &mut self,
         context: SharedContext,
         directive: Directive,
         definition: FieldDefinition,
-    ) -> Result<(), Error>;
-
-    /// Retrieves the next item in a subscription stream.
-    ///
-    /// This method is called repeatedly to get sequential items from an active subscription.
-    ///
-    /// # Returns
-    ///
-    /// Returns a `Result` containing either the next `FieldOutput` value in the subscription stream or an `Error`
-    fn resolve_next_subscription_item(&mut self) -> Result<Option<FieldOutput>, Error>;
+    ) -> Result<Box<dyn Subscriber>, Error>;
 }

--- a/crates/grafbase-sdk/src/extension/resolver.rs
+++ b/crates/grafbase-sdk/src/extension/resolver.rs
@@ -1,5 +1,5 @@
 use crate::{
-    host_io::pubsub::Subscriber,
+    host_io::pubsub::Subscription,
     types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
     wit::{Error, SharedContext},
 };
@@ -11,7 +11,7 @@ type InitFn = Box<dyn Fn(Vec<Directive>, Configuration) -> Result<Box<dyn Resolv
 pub(super) static mut EXTENSION: Option<Box<dyn Resolver>> = None;
 pub static mut INIT_FN: Option<InitFn> = None;
 
-pub(super) static mut SUBSCRIBER: Option<Box<dyn Subscriber>> = None;
+pub(super) static mut SUBSCRIBER: Option<Box<dyn Subscription>> = None;
 
 pub(super) fn get_extension() -> Result<&'static mut dyn Resolver, Error> {
     // Safety: This is hidden, only called by us. Every extension call to an instance happens
@@ -24,13 +24,13 @@ pub(super) fn get_extension() -> Result<&'static mut dyn Resolver, Error> {
     }
 }
 
-pub(super) fn set_subscriber(subscriber: Box<dyn Subscriber>) {
+pub(super) fn set_subscriber(subscriber: Box<dyn Subscription>) {
     unsafe {
         SUBSCRIBER = Some(subscriber);
     }
 }
 
-pub(super) fn get_subscriber() -> Result<&'static mut dyn Subscriber, Error> {
+pub(super) fn get_subscriber() -> Result<&'static mut dyn Subscription, Error> {
     unsafe {
         SUBSCRIBER.as_deref_mut().ok_or_else(|| Error {
             message: "No active subscription.".to_string(),
@@ -105,5 +105,5 @@ pub trait Resolver: Extension {
         context: SharedContext,
         directive: Directive,
         definition: FieldDefinition,
-    ) -> Result<Box<dyn Subscriber>, Error>;
+    ) -> Result<Box<dyn Subscription>, Error>;
 }

--- a/crates/grafbase-sdk/src/host_io.rs
+++ b/crates/grafbase-sdk/src/host_io.rs
@@ -7,4 +7,4 @@
 pub mod access_log;
 pub mod cache;
 pub mod http;
-pub mod nats;
+pub mod pubsub;

--- a/crates/grafbase-sdk/src/host_io/pubsub.rs
+++ b/crates/grafbase-sdk/src/host_io/pubsub.rs
@@ -8,11 +8,18 @@ use crate::{types::FieldOutput, Error};
 
 pub mod nats;
 
-/// A trait for subscribing to a stream of field outputs.
-pub trait Subscriber {
-    /// Gets the next field output from the stream.
+/// A trait for consuming field outputs from streams.
+///
+/// This trait provides an abstraction over different implementations
+/// of subscriptions to field output streams. Implementors should handle
+/// the details of their specific transport mechanism while providing a
+/// consistent interface for consumers.
+pub trait Subscription {
+    /// Retrieves the next field output from the subscription.
     ///
-    /// Returns `Ok(Some(output))` if a field output is available,
-    /// `Ok(None)` if the stream has ended, or `Err` if an error occurred.
+    /// Returns:
+    /// - `Ok(Some(FieldOutput))` if a field output was available
+    /// - `Ok(None)` if the subscription has ended normally
+    /// - `Err(Error)` if an error occurred while retrieving the next field output
     fn next(&mut self) -> Result<Option<FieldOutput>, Error>;
 }

--- a/crates/grafbase-sdk/src/host_io/pubsub.rs
+++ b/crates/grafbase-sdk/src/host_io/pubsub.rs
@@ -1,0 +1,18 @@
+//! Subscriber module providing interfaces for consuming field outputs from streams.
+//!
+//! This module defines the core `Subscriber` trait that abstracts over different
+//! implementations of subscribing to field output streams, allowing extensions to
+//! handle field outputs in a transport-agnostic way.
+
+use crate::{types::FieldOutput, Error};
+
+pub mod nats;
+
+/// A trait for subscribing to a stream of field outputs.
+pub trait Subscriber {
+    /// Gets the next field output from the stream.
+    ///
+    /// Returns `Ok(Some(output))` if a field output is available,
+    /// `Ok(None)` if the stream has ended, or `Err` if an error occurred.
+    fn next(&mut self) -> Result<Option<FieldOutput>, Error>;
+}

--- a/crates/grafbase-sdk/src/host_io/pubsub/nats.rs
+++ b/crates/grafbase-sdk/src/host_io/pubsub/nats.rs
@@ -136,7 +136,7 @@ pub fn connect_with_auth(
     Ok(NatsClient { inner })
 }
 
-impl super::Subscriber for NatsSubscriber {
+impl super::Subscription for NatsSubscriber {
     fn next(&mut self) -> Result<Option<types::FieldOutput>, Error> {
         let item = match NatsSubscriber::next(self) {
             Some(item) => item,

--- a/crates/grafbase-sdk/wit/world.wit
+++ b/crates/grafbase-sdk/wit/world.wit
@@ -217,7 +217,7 @@ interface extension {
     ) -> result<field-output, error>;
 
     // initializes a new subscription stream
-    resolve-field-subscription: func(
+    resolve-subscription: func(
         context: shared-context,
         directive: directive,
         definition: field-definition,

--- a/crates/integration-tests/src/federation/runtime/extension.rs
+++ b/crates/integration-tests/src/federation/runtime/extension.rs
@@ -187,7 +187,7 @@ impl runtime::extension::ExtensionRuntime for TestExtensions {
         })
     }
 
-    async fn resolve_field_subscription<'ctx, 'f>(
+    async fn resolve_subscription<'ctx, 'f>(
         &'ctx self,
         _: &'ctx Self::SharedContext,
         _: ExtensionFieldDirective<'ctx, impl Anything<'ctx>>,

--- a/crates/integration-tests/src/federation/runtime/extension.rs
+++ b/crates/integration-tests/src/federation/runtime/extension.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, future::Future, sync::Arc};
 
 use engine_schema::SubgraphId;
 use extension_catalog::{Extension, ExtensionCatalog, ExtensionId, Id, Manifest};
+use futures::stream::BoxStream;
 use runtime::{
     error::{ErrorResponse, PartialGraphqlError},
     extension::{Data, ExtensionFieldDirective},
@@ -191,7 +192,7 @@ impl runtime::extension::ExtensionRuntime for TestExtensions {
         &'ctx self,
         _: &'ctx Self::SharedContext,
         _: ExtensionFieldDirective<'ctx, impl Anything<'ctx>>,
-    ) -> Result<tokio::sync::mpsc::Receiver<Result<Data, PartialGraphqlError>>, PartialGraphqlError>
+    ) -> Result<BoxStream<'f, Result<Data, PartialGraphqlError>>, PartialGraphqlError>
     where
         'ctx: 'f,
     {

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -29,7 +29,6 @@ serde.workspace = true
 serde_json.workspace = true
 strum.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["sync"] }
 url.workspace = true
 
 [features]

--- a/crates/runtime/src/extension.rs
+++ b/crates/runtime/src/extension.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 
 use engine_schema::{FieldDefinition, Subgraph};
 use extension_catalog::ExtensionId;
-use tokio::sync::mpsc;
+use futures_util::stream::BoxStream;
 
 #[derive(Clone, Copy, PartialEq, Hash, Eq, PartialOrd, Ord, id_derives::Id)]
 pub struct AuthorizerId(u16);
@@ -45,7 +45,7 @@ pub trait ExtensionRuntime: Send + Sync + 'static {
         &'ctx self,
         context: &'ctx Self::SharedContext,
         directive: ExtensionFieldDirective<'ctx, impl Anything<'ctx>>,
-    ) -> impl Future<Output = Result<mpsc::Receiver<Result<Data, PartialGraphqlError>>, PartialGraphqlError>> + Send + 'f
+    ) -> impl Future<Output = Result<BoxStream<'f, Result<Data, PartialGraphqlError>>, PartialGraphqlError>> + Send + 'f
     where
         'ctx: 'f;
 
@@ -89,7 +89,7 @@ impl ExtensionRuntime for () {
         &'ctx self,
         _: &'ctx Self::SharedContext,
         _: ExtensionFieldDirective<'ctx, impl Anything<'ctx>>,
-    ) -> Result<mpsc::Receiver<Result<Data, PartialGraphqlError>>, PartialGraphqlError>
+    ) -> Result<BoxStream<'f, Result<Data, PartialGraphqlError>>, PartialGraphqlError>
     where
         'ctx: 'f,
     {

--- a/crates/runtime/src/extension.rs
+++ b/crates/runtime/src/extension.rs
@@ -41,7 +41,7 @@ pub trait ExtensionRuntime: Send + Sync + 'static {
     where
         'ctx: 'f;
 
-    fn resolve_field_subscription<'ctx, 'f>(
+    fn resolve_subscription<'ctx, 'f>(
         &'ctx self,
         context: &'ctx Self::SharedContext,
         directive: ExtensionFieldDirective<'ctx, impl Anything<'ctx>>,
@@ -85,7 +85,7 @@ impl ExtensionRuntime for () {
         })
     }
 
-    async fn resolve_field_subscription<'ctx, 'f>(
+    async fn resolve_subscription<'ctx, 'f>(
         &'ctx self,
         _: &'ctx Self::SharedContext,
         _: ExtensionFieldDirective<'ctx, impl Anything<'ctx>>,

--- a/crates/wasi-component-loader/Cargo.toml
+++ b/crates/wasi-component-loader/Cargo.toml
@@ -29,6 +29,7 @@ serde_json.workspace = true
 strum = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["time", "rt"] }
+tokio-stream.workspace = true
 tracing.workspace = true
 ulid.workspace = true
 url.workspace = true

--- a/crates/wasi-component-loader/examples/extensions/simple-resolver/src/lib.rs
+++ b/crates/wasi-component-loader/examples/extensions/simple-resolver/src/lib.rs
@@ -1,5 +1,6 @@
 use grafbase_sdk::{
     Error, Extension, Resolver, ResolverExtension, SharedContext,
+    host_io::pubsub::Subscriber,
     types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
 };
 
@@ -57,11 +58,12 @@ impl Resolver for SimpleResolver {
         Ok(output)
     }
 
-    fn resolve_subscription(&mut self, _: SharedContext, _: Directive, _: FieldDefinition) -> Result<(), Error> {
-        todo!()
-    }
-
-    fn resolve_next_subscription_item(&mut self) -> Result<Option<FieldOutput>, Error> {
+    fn resolve_subscription(
+        &mut self,
+        _: SharedContext,
+        _: Directive,
+        _: FieldDefinition,
+    ) -> Result<Box<dyn Subscriber>, Error> {
         todo!()
     }
 }

--- a/crates/wasi-component-loader/examples/extensions/simple-resolver/src/lib.rs
+++ b/crates/wasi-component-loader/examples/extensions/simple-resolver/src/lib.rs
@@ -1,6 +1,6 @@
 use grafbase_sdk::{
     Error, Extension, Resolver, ResolverExtension, SharedContext,
-    host_io::pubsub::Subscriber,
+    host_io::pubsub::Subscription,
     types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
 };
 
@@ -63,7 +63,7 @@ impl Resolver for SimpleResolver {
         _: SharedContext,
         _: Directive,
         _: FieldDefinition,
-    ) -> Result<Box<dyn Subscriber>, Error> {
+    ) -> Result<Box<dyn Subscription>, Error> {
         todo!()
     }
 }

--- a/crates/wasi-component-loader/src/extension/instance.rs
+++ b/crates/wasi-component-loader/src/extension/instance.rs
@@ -51,7 +51,7 @@ impl ExtensionInstance {
         }
     }
 
-    pub async fn resolve_field_subscription(
+    pub async fn resolve_subscription(
         &mut self,
         context: wit::SharedContext,
         directive: wit::Directive<'_>,
@@ -62,7 +62,7 @@ impl ExtensionInstance {
         let result = self
             .inner
             .grafbase_sdk_extension()
-            .call_resolve_field_subscription(&mut self.store, context, directive, definition)
+            .call_resolve_subscription(&mut self.store, context, directive, definition)
             .await;
 
         match result {

--- a/crates/wasi-component-loader/src/extension/runtime.rs
+++ b/crates/wasi-component-loader/src/extension/runtime.rs
@@ -199,7 +199,7 @@ impl ExtensionRuntime for ExtensionsWasiRuntime {
         }
     }
 
-    async fn resolve_field_subscription<'ctx, 'f>(
+    async fn resolve_subscription<'ctx, 'f>(
         &'ctx self,
         context: &'ctx Self::SharedContext,
         directive: ExtensionFieldDirective<'ctx, impl Anything<'ctx>>,
@@ -240,7 +240,7 @@ impl ExtensionRuntime for ExtensionsWasiRuntime {
         };
 
         let result = instance
-            .resolve_field_subscription(context.clone(), directive, definition)
+            .resolve_subscription(context.clone(), directive, definition)
             .await;
 
         match result {

--- a/extensions/jwt/Cargo.lock
+++ b/extensions/jwt/Cargo.lock
@@ -1542,7 +1542,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/extensions/jwt/Cargo.lock
+++ b/extensions/jwt/Cargo.lock
@@ -1542,7 +1542,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/extensions/nats/Cargo.lock
+++ b/extensions/nats/Cargo.lock
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/extensions/nats/Cargo.lock
+++ b/extensions/nats/Cargo.lock
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/extensions/nats/src/lib.rs
+++ b/extensions/nats/src/lib.rs
@@ -1,27 +1,26 @@
 mod config;
+mod subscriber;
 mod types;
 
-use std::{collections::HashMap, str::FromStr};
+use std::{cell::RefCell, collections::HashMap, rc::Rc, str::FromStr};
 
 use config::AuthConfig;
 use grafbase_sdk::{
-    host_io::nats::{self, NatsClient, NatsSubscriber},
+    host_io::pubsub::{
+        nats::{self, NatsClient},
+        Subscriber,
+    },
     jq_selection::JqSelection,
     types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
     Error, Extension, NatsAuth, Resolver, ResolverExtension, SharedContext,
 };
+use subscriber::FilteringSubscriber;
 use types::{DirectiveKind, NatsPublishResult, PublishArguments, SubscribeArguments};
 
 #[derive(ResolverExtension)]
 struct Nats {
     clients: HashMap<String, NatsClient>,
-    active_subscription: Option<ActiveSubscription>,
-    jq_selection: JqSelection,
-}
-
-struct ActiveSubscription {
-    subscriber: NatsSubscriber,
-    selection: Option<String>,
+    jq_selection: Rc<RefCell<JqSelection>>,
 }
 
 impl Extension for Nats {
@@ -49,8 +48,7 @@ impl Extension for Nats {
 
         Ok(Self {
             clients,
-            active_subscription: None,
-            jq_selection: JqSelection::default(),
+            jq_selection: Rc::new(RefCell::new(JqSelection::default())),
         })
     }
 }
@@ -87,7 +85,7 @@ impl Resolver for Nats {
         _: SharedContext,
         directive: Directive,
         _: FieldDefinition,
-    ) -> Result<(), Error> {
+    ) -> Result<Box<dyn Subscriber>, Error> {
         let args: SubscribeArguments<'_> = directive.arguments().map_err(|e| Error {
             extensions: Vec::new(),
             message: format!("Error deserializing directive arguments: {e}"),
@@ -105,61 +103,11 @@ impl Resolver for Nats {
             message: format!("Failed to subscribe to subject '{}': {e}", args.subject),
         })?;
 
-        self.active_subscription = Some(ActiveSubscription {
+        Ok(Box::new(FilteringSubscriber::new(
             subscriber,
-            selection: args.selection.map(ToString::to_string),
-        });
-
-        Ok(())
-    }
-
-    fn resolve_next_subscription_item(&mut self) -> Result<Option<FieldOutput>, Error> {
-        let Some(ActiveSubscription {
-            ref subscriber,
-            ref selection,
-        }) = self.active_subscription
-        else {
-            return Err(Error {
-                extensions: Vec::new(),
-                message: "No active subscription".to_string(),
-            });
-        };
-
-        match subscriber.next() {
-            Some(item) => {
-                let mut field_output = FieldOutput::default();
-
-                let payload: serde_json::Value = item.payload().map_err(|e| Error {
-                    extensions: Vec::new(),
-                    message: format!("Error parsing NATS value as JSON: {e}"),
-                })?;
-
-                match selection {
-                    Some(ref selection) => {
-                        let filtered = self.jq_selection.select(selection, payload).map_err(|e| Error {
-                            extensions: Vec::new(),
-                            message: format!("Failed to filter with selection: {e}"),
-                        })?;
-
-                        for payload in filtered {
-                            match payload {
-                                Ok(payload) => field_output.push_value(payload),
-                                Err(error) => field_output.push_error(Error {
-                                    extensions: Vec::new(),
-                                    message: format!("Error parsing result value: {error}"),
-                                }),
-                            }
-                        }
-                    }
-                    None => {
-                        field_output.push_value(payload);
-                    }
-                };
-
-                Ok(Some(field_output))
-            }
-            None => Ok(None),
-        }
+            self.jq_selection.clone(),
+            args.selection,
+        )))
     }
 }
 

--- a/extensions/nats/src/subscriber.rs
+++ b/extensions/nats/src/subscriber.rs
@@ -1,0 +1,69 @@
+use std::{cell::RefCell, rc::Rc};
+
+use grafbase_sdk::{
+    host_io::pubsub::{
+        nats::{self, NatsSubscriber},
+        Subscriber,
+    },
+    jq_selection::JqSelection,
+    types::FieldOutput,
+    Error,
+};
+
+pub struct FilteringSubscriber {
+    nats: nats::NatsSubscriber,
+    jq_selection: Rc<RefCell<JqSelection>>,
+    selection: Option<String>,
+}
+
+impl FilteringSubscriber {
+    pub fn new(nats: NatsSubscriber, jq_selection: Rc<RefCell<JqSelection>>, selection: Option<String>) -> Self {
+        Self {
+            nats,
+            jq_selection,
+            selection,
+        }
+    }
+}
+
+impl Subscriber for FilteringSubscriber {
+    fn next(&mut self) -> Result<Option<FieldOutput>, Error> {
+        let item = match self.nats.next() {
+            Some(item) => item,
+            None => return Ok(None),
+        };
+
+        let mut field_output = FieldOutput::default();
+
+        let payload: serde_json::Value = item.payload().map_err(|e| Error {
+            extensions: Vec::new(),
+            message: format!("Error parsing NATS value as JSON: {e}"),
+        })?;
+
+        match self.selection {
+            Some(ref selection) => {
+                let mut jq = self.jq_selection.borrow_mut();
+
+                let filtered = jq.select(selection, payload).map_err(|e| Error {
+                    extensions: Vec::new(),
+                    message: format!("Failed to filter with selection: {e}"),
+                })?;
+
+                for payload in filtered {
+                    match payload {
+                        Ok(payload) => field_output.push_value(payload),
+                        Err(error) => field_output.push_error(Error {
+                            extensions: Vec::new(),
+                            message: format!("Error parsing result value: {error}"),
+                        }),
+                    }
+                }
+            }
+            None => {
+                field_output.push_value(payload);
+            }
+        };
+
+        Ok(Some(field_output))
+    }
+}

--- a/extensions/nats/src/subscription.rs
+++ b/extensions/nats/src/subscription.rs
@@ -3,20 +3,20 @@ use std::{cell::RefCell, rc::Rc};
 use grafbase_sdk::{
     host_io::pubsub::{
         nats::{self, NatsSubscriber},
-        Subscriber,
+        Subscription,
     },
     jq_selection::JqSelection,
     types::FieldOutput,
     Error,
 };
 
-pub struct FilteringSubscriber {
+pub struct FilteredSubscription {
     nats: nats::NatsSubscriber,
     jq_selection: Rc<RefCell<JqSelection>>,
     selection: Option<String>,
 }
 
-impl FilteringSubscriber {
+impl FilteredSubscription {
     pub fn new(nats: NatsSubscriber, jq_selection: Rc<RefCell<JqSelection>>, selection: Option<String>) -> Self {
         Self {
             nats,
@@ -26,7 +26,7 @@ impl FilteringSubscriber {
     }
 }
 
-impl Subscriber for FilteringSubscriber {
+impl Subscription for FilteredSubscription {
     fn next(&mut self) -> Result<Option<FieldOutput>, Error> {
         let item = match self.nats.next() {
             Some(item) => item,

--- a/extensions/nats/src/types.rs
+++ b/extensions/nats/src/types.rs
@@ -58,7 +58,7 @@ pub struct NatsPublishResult {
 pub struct SubscribeArguments<'a> {
     pub provider: &'a str,
     pub subject: &'a str,
-    pub selection: Option<&'a str>,
+    pub selection: Option<String>,
     #[allow(dead_code)] // will get to this with jetstream
     pub stream_config: Option<NatsStreamConfiguration<'a>>,
 }

--- a/extensions/rest/Cargo.lock
+++ b/extensions/rest/Cargo.lock
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/extensions/rest/Cargo.lock
+++ b/extensions/rest/Cargo.lock
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/extensions/rest/src/lib.rs
+++ b/extensions/rest/src/lib.rs
@@ -3,7 +3,10 @@ mod types;
 
 use grafbase_sdk::{
     Error, Extension, Resolver, ResolverExtension, SharedContext,
-    host_io::http::{self, HttpRequest, Url},
+    host_io::{
+        http::{self, HttpRequest, Url},
+        pubsub::Subscriber,
+    },
     jq_selection::JqSelection,
     types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
 };
@@ -140,11 +143,12 @@ impl Resolver for RestExtension {
         Ok(results)
     }
 
-    fn resolve_subscription(&mut self, _: SharedContext, _: Directive, _: FieldDefinition) -> Result<(), Error> {
-        unreachable!()
-    }
-
-    fn resolve_next_subscription_item(&mut self) -> Result<Option<FieldOutput>, Error> {
+    fn resolve_subscription(
+        &mut self,
+        _: SharedContext,
+        _: Directive,
+        _: FieldDefinition,
+    ) -> Result<Box<dyn Subscriber>, Error> {
         unreachable!()
     }
 }

--- a/extensions/rest/src/lib.rs
+++ b/extensions/rest/src/lib.rs
@@ -5,7 +5,7 @@ use grafbase_sdk::{
     Error, Extension, Resolver, ResolverExtension, SharedContext,
     host_io::{
         http::{self, HttpRequest, Url},
-        pubsub::Subscriber,
+        pubsub::Subscription,
     },
     jq_selection::JqSelection,
     types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
@@ -148,7 +148,7 @@ impl Resolver for RestExtension {
         _: SharedContext,
         _: Directive,
         _: FieldDefinition,
-    ) -> Result<Box<dyn Subscriber>, Error> {
+    ) -> Result<Box<dyn Subscription>, Error> {
         unreachable!()
     }
 }


### PR DESCRIPTION
The user-facing API for subscriptions is now just one method. We will handle polling behind the scenes.

The host side returns stream instead of a channel.