### PR TITLE
chore(extension): Easier extension trait definition

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,6 @@
 [profile.ci]
-slow-timeout = { period = "1m", terminate-after = 2 }
+# grafbase extension build test compile tons of stuff and thus a super slow.
+slow-timeout = { period = "3m", terminate-after = 6 }
 retries = 2
 failure-output = "immediate-final"
 fail-fast = false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3229,6 +3229,7 @@ dependencies = [
  "notify-debouncer-full",
  "os_type",
  "rand 0.9.0",
+ "regex",
  "reqwest 0.12.12",
  "rustls 0.23.23",
  "semver",
@@ -3337,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-tungstenite",
@@ -3372,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk-derive"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3318,7 +3318,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-hooks"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "grafbase-hooks-derive",
  "serde",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -89,6 +89,7 @@ integration-tests = { path = "../crates/integration-tests" }
 duct.workspace = true
 insta = { workspace = true, features = ["json", "redactions", "yaml"] }
 rand.workspace = true
+regex.workspace = true
 reqwest.workspace = true
 tempfile.workspace = true
 

--- a/cli/templates/extension/src/resolver.rs.template
+++ b/cli/templates/extension/src/resolver.rs.template
@@ -1,7 +1,6 @@
 use grafbase_sdk::{
-    host_io::pubsub::Subscription,
     types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
-    Error, Extension, Resolver, ResolverExtension, SharedContext,
+    Error, Extension, Resolver, ResolverExtension, SharedContext, Subscription
 };
 
 #[derive(ResolverExtension)]

--- a/cli/tests/integration/data/Cargo.lock
+++ b/cli/tests/integration/data/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.2.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "grafbase-sdk-derive",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk-derive"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/tests/integration/data/echo_extension/src/lib.rs
+++ b/cli/tests/integration/data/echo_extension/src/lib.rs
@@ -1,6 +1,5 @@
 use grafbase_sdk::{
-    Error, Extension, Resolver, ResolverExtension, SharedContext,
-    host_io::pubsub::Subscription,
+    Error, Extension, Resolver, ResolverExtension, SharedContext, Subscription,
     types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
 };
 

--- a/crates/grafbase-hooks/Cargo.toml
+++ b/crates/grafbase-hooks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-hooks"
-version = "0.2.0"
+version = "0.3.0"
 description = "An SDK to implement hooks for the Grafbase Gateway"
 edition.workspace = true
 license.workspace = true

--- a/crates/grafbase-sdk/Cargo.toml
+++ b/crates/grafbase-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-sdk"
-version = "0.4.0"
+version = "0.5.0"
 description = "An SDK to implement extensions for the Grafbase Gateway"
 edition = "2021"
 license.workspace = true
@@ -42,7 +42,7 @@ async-tungstenite = { workspace = true, optional = true, features = ["tokio-runt
 duct = { workspace = true, optional = true }
 fslock = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }
-grafbase-sdk-derive = { version = "0.1.3", path = "derive" }
+grafbase-sdk-derive = { version = "0.2.0", path = "derive" }
 grafbase-sdk-mock = { version = "0.1.1", path = "mock", optional = true }
 graphql-composition = { version = "0.6.2", features = [
     "grafbase-extensions",

--- a/crates/grafbase-sdk/derive/Cargo.toml
+++ b/crates/grafbase-sdk/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-sdk-derive"
-version = "0.1.3"
+version = "0.2.0"
 description = "A proc macro for the grafbase-sdk crate"
 edition = "2024"
 license = "MPL-2.0"

--- a/crates/grafbase-sdk/derive/src/lib.rs
+++ b/crates/grafbase-sdk/derive/src/lib.rs
@@ -40,12 +40,7 @@ fn resolver_init(ast: DeriveInput) -> proc_macro2::TokenStream {
     let (_, ty_generics, _) = ast.generics.split_for_impl();
 
     quote! {
-        let init_fn = |directives, config| {
-            let result = <#name #ty_generics as grafbase_sdk::Extension>::new(directives, config);
-            result.map(|extension| Box::new(extension) as Box<dyn grafbase_sdk::Resolver>)
-        };
-
-        grafbase_sdk::extension::resolver::register(Box::new(init_fn));
+        grafbase_sdk::extension::resolver::register::<#name #ty_generics>();
     }
 }
 
@@ -55,11 +50,6 @@ fn authentication_init(ast: DeriveInput) -> proc_macro2::TokenStream {
     let (_, ty_generics, _) = ast.generics.split_for_impl();
 
     quote! {
-        let init_fn = |directives, config| {
-            let result = <#name #ty_generics as grafbase_sdk::Extension>::new(directives, config);
-            result.map(|extension| Box::new(extension) as Box<dyn grafbase_sdk::Authenticator>)
-        };
-
-        grafbase_sdk::extension::authentication::register(Box::new(init_fn));
+        grafbase_sdk::extension::authentication::register::<#name #ty_generics>();
     }
 }

--- a/crates/grafbase-sdk/src/component/extension.rs
+++ b/crates/grafbase-sdk/src/component/extension.rs
@@ -1,0 +1,43 @@
+use crate::{
+    extension::resolver::Subscription,
+    types::{Directive, ErrorResponse, FieldDefinition, FieldInputs, FieldOutput, Token},
+    wit::{Headers, SharedContext},
+    Error,
+};
+
+#[allow(unused_variables)]
+pub(crate) trait AnyExtension {
+    fn authenticate(&mut self, headers: Headers) -> Result<Token, ErrorResponse> {
+        Err(
+            ErrorResponse::new(http::StatusCode::INTERNAL_SERVER_ERROR).with_error(Error {
+                extensions: Vec::new(),
+                message: String::from("Is not an authentication extension."),
+            }),
+        )
+    }
+
+    fn resolve_field(
+        &mut self,
+        context: SharedContext,
+        directive: Directive,
+        definition: FieldDefinition,
+        inputs: FieldInputs,
+    ) -> Result<FieldOutput, Error> {
+        Err(Error {
+            message: "Resolver extension not initialized correctly.".to_string(),
+            extensions: Vec::new(),
+        })
+    }
+
+    fn resolve_subscription(
+        &mut self,
+        context: SharedContext,
+        directive: Directive,
+        definition: FieldDefinition,
+    ) -> Result<Box<dyn Subscription>, Error> {
+        Err(Error {
+            message: "Resolver extension not initialized correctly.".to_string(),
+            extensions: Vec::new(),
+        })
+    }
+}

--- a/crates/grafbase-sdk/src/component/mod.rs
+++ b/crates/grafbase-sdk/src/component/mod.rs
@@ -1,0 +1,59 @@
+mod extension;
+mod state;
+
+use crate::{
+    types::{Configuration, FieldInputs},
+    wit::{Directive, Error, FieldDefinition, FieldOutput, Guest, Headers, SharedContext, Token},
+};
+
+pub(crate) use extension::AnyExtension;
+pub(crate) use state::register_extension;
+
+pub(crate) struct Component;
+
+impl Guest for Component {
+    fn init_gateway_extension(directives: Vec<Directive>, configuration: Vec<u8>) -> Result<(), String> {
+        let directives = directives.into_iter().map(Into::into).collect();
+        let config = Configuration::new(configuration);
+        state::init(directives, config).map_err(|e| e.to_string())
+    }
+
+    fn resolve_field(
+        context: SharedContext,
+        directive: Directive,
+        definition: FieldDefinition,
+        inputs: Vec<Vec<u8>>,
+    ) -> Result<FieldOutput, Error> {
+        let result =
+            state::extension()?.resolve_field(context, directive.into(), definition.into(), FieldInputs::new(inputs));
+
+        result.map(Into::into)
+    }
+
+    fn resolve_subscription(
+        context: SharedContext,
+        directive: Directive,
+        definition: FieldDefinition,
+    ) -> Result<(), Error> {
+        let subscription = state::extension()?.resolve_subscription(context, directive.into(), definition.into())?;
+
+        state::set_subscription(subscription);
+
+        Ok(())
+    }
+
+    fn resolve_next_subscription_item() -> Result<Option<FieldOutput>, Error> {
+        Ok(state::subscription()?.next()?.map(Into::into))
+    }
+
+    fn authenticate(headers: Headers) -> Result<Token, crate::wit::ErrorResponse> {
+        let result = state::extension()
+            .map_err(|err| crate::wit::ErrorResponse {
+                status_code: 500,
+                errors: vec![err],
+            })?
+            .authenticate(headers);
+
+        result.map(Into::into).map_err(Into::into)
+    }
+}

--- a/crates/grafbase-sdk/src/component/state.rs
+++ b/crates/grafbase-sdk/src/component/state.rs
@@ -1,0 +1,64 @@
+#![allow(static_mut_refs)]
+
+use crate::{
+    extension::resolver::Subscription,
+    types::{Configuration, Directive},
+    Error,
+};
+
+use super::extension::AnyExtension;
+
+type InitFn = Box<dyn Fn(Vec<Directive>, Configuration) -> Result<Box<dyn AnyExtension>, Box<dyn std::error::Error>>>;
+
+static mut EXTENSION: Option<Box<dyn AnyExtension>> = None;
+static mut SUBSCRIBTION: Option<Box<dyn Subscription>> = None;
+static mut INIT_FN: Option<InitFn> = None;
+
+/// Initializes the resolver extension with the provided directives using the closure
+/// function created with the `register_extension!` macro.
+pub(super) fn init(directives: Vec<Directive>, config: Configuration) -> Result<(), Box<dyn std::error::Error>> {
+    // Safety: This function is only called from the SDK macro, so we can assume that there is only one caller at a time.
+    unsafe {
+        let init = INIT_FN.as_ref().expect("Resolver extension not initialized correctly.");
+        EXTENSION = Some(init(directives, config)?);
+    }
+
+    Ok(())
+}
+
+/// This function gets called when the extension is registered in the user code with the `register_extension!` macro.
+///
+/// This should never be called manually by the user.
+#[doc(hidden)]
+pub(crate) fn register_extension(f: InitFn) {
+    // Safety: This function is only called from the SDK macro, so we can assume that there is only one caller at a time.
+    unsafe {
+        INIT_FN = Some(f);
+    }
+}
+
+pub(super) fn extension() -> Result<&'static mut dyn AnyExtension, Error> {
+    // Safety: This is hidden, only called by us. Every extension call to an instance happens
+    // in a single-threaded environment. Do not call this multiple times from different threads.
+    unsafe {
+        EXTENSION.as_deref_mut().ok_or_else(|| Error {
+            message: "Extension was not initialized correctly.".to_string(),
+            extensions: Vec::new(),
+        })
+    }
+}
+
+pub(super) fn set_subscription(subscription: Box<dyn Subscription>) {
+    unsafe {
+        SUBSCRIBTION = Some(subscription);
+    }
+}
+
+pub(super) fn subscription() -> Result<&'static mut dyn Subscription, Error> {
+    unsafe {
+        SUBSCRIBTION.as_deref_mut().ok_or_else(|| Error {
+            message: "No active subscription.".to_string(),
+            extensions: Vec::new(),
+        })
+    }
+}

--- a/crates/grafbase-sdk/src/extension.rs
+++ b/crates/grafbase-sdk/src/extension.rs
@@ -1,23 +1,17 @@
-#![allow(static_mut_refs)]
-
 pub mod authentication;
 pub mod resolver;
 
 pub use authentication::Authenticator;
 pub use resolver::Resolver;
 
-use crate::{
-    types::{Configuration, FieldInputs},
-    wit::{Directive, Error, ExtensionType, FieldDefinition, FieldOutput, Guest, Headers, SharedContext, Token},
-    Component,
-};
+use crate::types::Configuration;
 
 /// A trait representing an extension that can be initialized from schema directives.
 ///
 /// This trait is intended to define a common interface for extensions in Grafbase Gateway,
 /// particularly focusing on their initialization. Extensions are constructed using
 /// a vector of `Directive` instances provided by the type definitions in the schema.
-pub trait Extension {
+pub trait Extension: 'static {
     /// Creates a new instance of the extension from the given schema directives.
     ///
     /// The directives must be defined in the extension configuration, and written
@@ -29,69 +23,4 @@ pub trait Extension {
     ) -> Result<Self, Box<dyn std::error::Error>>
     where
         Self: Sized;
-}
-
-impl Guest for Component {
-    fn init_gateway_extension(
-        r#type: ExtensionType,
-        directives: Vec<Directive>,
-        configuration: Vec<u8>,
-    ) -> Result<(), String> {
-        let directives = directives.into_iter().map(Into::into).collect();
-        let config = Configuration::new(configuration);
-
-        let result = match r#type {
-            ExtensionType::Resolver => resolver::init(directives, config),
-            ExtensionType::Authentication => authentication::init(directives, config),
-        };
-
-        result.map_err(|e| e.to_string())
-    }
-
-    fn resolve_field(
-        context: SharedContext,
-        directive: Directive,
-        definition: FieldDefinition,
-        inputs: Vec<Vec<u8>>,
-    ) -> Result<FieldOutput, Error> {
-        let result = resolver::get_extension()?.resolve_field(
-            context,
-            directive.into(),
-            definition.into(),
-            FieldInputs::new(inputs),
-        );
-
-        result.map(Into::into)
-    }
-
-    fn resolve_subscription(
-        context: SharedContext,
-        directive: Directive,
-        definition: FieldDefinition,
-    ) -> Result<(), Error> {
-        let subscriber =
-            resolver::get_extension()?.resolve_subscription(context, directive.into(), definition.into())?;
-
-        resolver::set_subscriber(subscriber);
-
-        Ok(())
-    }
-
-    fn resolve_next_subscription_item() -> Result<Option<FieldOutput>, Error> {
-        Ok(resolver::get_subscriber()?.next()?.map(Into::into))
-    }
-
-    fn authenticate(headers: Headers) -> Result<Token, crate::wit::ErrorResponse> {
-        let result = authentication::get_extension()
-            .map_err(|_| crate::wit::ErrorResponse {
-                status_code: 500,
-                errors: vec![Error {
-                    extensions: Vec::new(),
-                    message: String::from("internal server error"),
-                }],
-            })?
-            .authenticate(headers);
-
-        result.map(Into::into).map_err(Into::into)
-    }
 }

--- a/crates/grafbase-sdk/src/extension/authentication.rs
+++ b/crates/grafbase-sdk/src/extension/authentication.rs
@@ -1,49 +1,10 @@
 use crate::{
-    types::{Configuration, Directive, ErrorResponse, Token},
+    component::AnyExtension,
+    types::{ErrorResponse, Token},
     wit::Headers,
-    Error,
 };
 
 use super::Extension;
-
-type InitFn = Box<dyn Fn(Vec<Directive>, Configuration) -> Result<Box<dyn Authenticator>, Box<dyn std::error::Error>>>;
-
-pub(super) static mut EXTENSION: Option<Box<dyn Authenticator>> = None;
-pub static mut INIT_FN: Option<InitFn> = None;
-
-pub(super) fn get_extension() -> Result<&'static mut dyn Authenticator, Error> {
-    // Safety: This is hidden, only called by us. Every extension call to an instance happens
-    // in a single-threaded environment. Do not call this multiple times from different threads.
-    unsafe {
-        EXTENSION.as_deref_mut().ok_or_else(|| Error {
-            message: "Resolver extension not initialized correctly.".to_string(),
-            extensions: Vec::new(),
-        })
-    }
-}
-
-/// Initializes the resolver extension with the provided directives using the closure
-/// function created with the `register_extension!` macro.
-pub(super) fn init(directives: Vec<Directive>, configuration: Configuration) -> Result<(), Box<dyn std::error::Error>> {
-    // Safety: This function is only called from the SDK macro, so we can assume that there is only one caller at a time.
-    unsafe {
-        let init = INIT_FN.as_ref().expect("Resolver extension not initialized correctly.");
-        EXTENSION = Some(init(directives, configuration)?);
-    }
-
-    Ok(())
-}
-
-/// This function gets called when the extension is registered in the user code with the `register_extension!` macro.
-///
-/// This should never be called manually by the user.
-#[doc(hidden)]
-pub fn register(f: InitFn) {
-    // Safety: This function is only called from the SDK macro, so we can assume that there is only one caller at a time.
-    unsafe {
-        INIT_FN = Some(f);
-    }
-}
 
 /// A trait that extends `Extension` and provides authentication functionality.
 pub trait Authenticator: Extension {
@@ -56,4 +17,20 @@ pub trait Authenticator: Extension {
     /// * `Ok(Token)` - A valid authentication token if successful.
     /// * `Err(ErrorResponse)` - An error response if authentication fails.
     fn authenticate(&mut self, headers: Headers) -> Result<Token, ErrorResponse>;
+}
+
+#[doc(hidden)]
+pub fn register<T: Authenticator>() {
+    pub(super) struct Proxy<T: Authenticator>(T);
+
+    impl<T: Authenticator> AnyExtension for Proxy<T> {
+        fn authenticate(&mut self, headers: Headers) -> Result<Token, ErrorResponse> {
+            Authenticator::authenticate(&mut self.0, headers)
+        }
+    }
+
+    crate::component::register_extension(Box::new(|schema_directives, config| {
+        <T as Extension>::new(schema_directives, config)
+            .map(|extension| Box::new(Proxy(extension)) as Box<dyn AnyExtension>)
+    }))
 }

--- a/crates/grafbase-sdk/src/host_io/pubsub.rs
+++ b/crates/grafbase-sdk/src/host_io/pubsub.rs
@@ -4,22 +4,4 @@
 //! implementations of subscribing to field output streams, allowing extensions to
 //! handle field outputs in a transport-agnostic way.
 
-use crate::{types::FieldOutput, Error};
-
 pub mod nats;
-
-/// A trait for consuming field outputs from streams.
-///
-/// This trait provides an abstraction over different implementations
-/// of subscriptions to field output streams. Implementors should handle
-/// the details of their specific transport mechanism while providing a
-/// consistent interface for consumers.
-pub trait Subscription {
-    /// Retrieves the next field output from the subscription.
-    ///
-    /// Returns:
-    /// - `Ok(Some(FieldOutput))` if a field output was available
-    /// - `Ok(None)` if the subscription has ended normally
-    /// - `Err(Error)` if an error occurred while retrieving the next field output
-    fn next(&mut self) -> Result<Option<FieldOutput>, Error>;
-}

--- a/crates/grafbase-sdk/src/host_io/pubsub/nats.rs
+++ b/crates/grafbase-sdk/src/host_io/pubsub/nats.rs
@@ -5,7 +5,7 @@
 //! This module provides a high-level client for connecting to and interacting with NATS servers.
 //! It supports both authenticated and unauthenticated connections to one or more NATS servers.
 
-use crate::{types, wit, Error};
+use crate::{extension::resolver::Subscription, types, wit, Error};
 
 /// A client for interacting with NATS servers
 pub struct NatsClient {
@@ -39,23 +39,23 @@ impl NatsClient {
     /// # Returns
     ///
     /// Result containing the subscription or an error if subscription fails
-    pub fn subscribe(&self, subject: &str) -> Result<NatsSubscriber, Box<dyn std::error::Error>> {
+    pub fn subscribe(&self, subject: &str) -> Result<NatsSubscription, Box<dyn std::error::Error>> {
         Ok(self.inner.subscribe(subject).map(Into::into)?)
     }
 }
 
 /// A subscription to a NATS subject that receives messages published to that subject
-pub struct NatsSubscriber {
+pub struct NatsSubscription {
     inner: wit::NatsSubscriber,
 }
 
-impl From<wit::NatsSubscriber> for NatsSubscriber {
+impl From<wit::NatsSubscriber> for NatsSubscription {
     fn from(inner: wit::NatsSubscriber) -> Self {
-        NatsSubscriber { inner }
+        NatsSubscription { inner }
     }
 }
 
-impl NatsSubscriber {
+impl NatsSubscription {
     /// Gets the next message from the subscription
     ///
     /// # Returns
@@ -136,9 +136,9 @@ pub fn connect_with_auth(
     Ok(NatsClient { inner })
 }
 
-impl super::Subscription for NatsSubscriber {
+impl Subscription for NatsSubscription {
     fn next(&mut self) -> Result<Option<types::FieldOutput>, Error> {
-        let item = match NatsSubscriber::next(self) {
+        let item = match NatsSubscription::next(self) {
             Some(item) => item,
             None => return Ok(None),
         };

--- a/crates/grafbase-sdk/src/lib.rs
+++ b/crates/grafbase-sdk/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(missing_docs)]
 #![expect(unsafe_op_in_unsafe_fn)]
 
+mod component;
 #[doc(hidden)]
 pub mod extension;
 pub mod host_io;
@@ -11,13 +12,11 @@ pub mod jq_selection;
 pub mod test;
 pub mod types;
 
-pub use extension::{Authenticator, Extension, Resolver};
+pub use extension::{resolver::Subscription, Authenticator, Extension, Resolver};
 pub use grafbase_sdk_derive::{AuthenticationExtension, ResolverExtension};
-#[doc(hidden)]
-pub use wit::ExtensionType;
 pub use wit::{Error, Headers, NatsAuth, SharedContext};
 
-struct Component;
+use component::Component;
 
 #[cfg(target_arch = "wasm32")]
 #[unsafe(link_section = "sdk:minimum-gateway-version")]

--- a/crates/grafbase-sdk/src/test/runner.rs
+++ b/crates/grafbase-sdk/src/test/runner.rs
@@ -422,7 +422,7 @@ where
     ///
     /// * `name` - The header name
     /// * `value` - The header value
-    pub fn with_header<K, V>(mut self, name: K, value: HeaderValue) -> Self
+    pub fn with_header<K>(mut self, name: K, value: HeaderValue) -> Self
     where
         K: IntoHeaderName,
     {

--- a/crates/grafbase-sdk/src/types.rs
+++ b/crates/grafbase-sdk/src/types.rs
@@ -172,6 +172,13 @@ impl ErrorResponse {
         })
     }
 
+    /// Add a new error to the response and return self
+    #[must_use]
+    pub fn with_error(mut self, error: crate::wit::Error) -> Self {
+        self.0.errors.push(error);
+        self
+    }
+
     /// Adds a new error to the response.
     pub fn push_error(&mut self, error: crate::wit::Error) {
         self.0.errors.push(error);

--- a/crates/grafbase-sdk/wit/world.wit
+++ b/crates/grafbase-sdk/wit/world.wit
@@ -46,11 +46,6 @@ interface types {
       outputs: list<result<list<u8>, error>>
     }
 
-    enum extension-type {
-        resolver,
-        authentication,
-    }
-
     // A sender for the system access log.
     resource access-log {
         // Sends the data to the access log.
@@ -196,13 +191,12 @@ interface types {
 }
 
 interface extension {
-    use types.{directive, shared-context, error-response, error, field-definition, field-output, extension-type, access-log, log-error, nats-auth, nats-client, http-client, http-request, http-response, http-method, http-version, http-error, headers, token, cache};
+    use types.{directive, shared-context, error-response, error, field-definition, field-output, access-log, log-error, nats-auth, nats-client, http-client, http-request, http-response, http-method, http-version, http-error, headers, token, cache};
 
     // initialization function called to set up the wasm extension
     // if an error happens here, the gateway will refuse to continue.
     // Receives a list of schema directives associated with the extension
     init-gateway-extension: func(
-        extension-type: extension-type,
         schema-directives: list<directive>,
         configuration: list<u8>,
     ) -> result<_, string>;

--- a/crates/wasi-component-loader/examples/Cargo.lock
+++ b/crates/wasi-component-loader/examples/Cargo.lock
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-hooks"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "grafbase-hooks-derive",
  "serde",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.2.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "grafbase-sdk-derive",

--- a/crates/wasi-component-loader/examples/extensions/simple-resolver/src/lib.rs
+++ b/crates/wasi-component-loader/examples/extensions/simple-resolver/src/lib.rs
@@ -1,6 +1,5 @@
 use grafbase_sdk::{
-    Error, Extension, Resolver, ResolverExtension, SharedContext,
-    host_io::pubsub::Subscription,
+    Error, Extension, Resolver, ResolverExtension, SharedContext, Subscription,
     types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
 };
 

--- a/crates/wasi-component-loader/src/extension/loader.rs
+++ b/crates/wasi-component-loader/src/extension/loader.rs
@@ -11,7 +11,6 @@ use wasmtime::{
 use crate::{cache::Cache, config::build_extensions_context, state::WasiState};
 pub struct ExtensionLoader {
     component_config: WasiExtensionsConfig,
-    r#type: wit::ExtensionType,
     guest_config: Vec<u8>,
     #[allow(unused)] // MUST be unused, or at least immutable, we self-reference to it
     schema_directives: Vec<SchemaDirective>,
@@ -100,7 +99,6 @@ impl ExtensionLoader {
         Ok(Self {
             shared,
             component_config,
-            r#type: guest_config.r#type.into(),
             guest_config: minicbor_serde::to_vec(&guest_config.configuration)
                 .context("Could not serialize configuration")?,
             schema_directives,
@@ -121,7 +119,7 @@ impl ExtensionLoader {
         inner.call_register_extension(&mut store).await?;
         inner
             .grafbase_sdk_extension()
-            .call_init_gateway_extension(&mut store, self.r#type, &self.wit_schema_directives, &self.guest_config)
+            .call_init_gateway_extension(&mut store, &self.wit_schema_directives, &self.guest_config)
             .await??;
         Ok(ExtensionInstance {
             store,

--- a/crates/wasi-component-loader/src/extension/types_impl.rs
+++ b/crates/wasi-component-loader/src/extension/types_impl.rs
@@ -9,12 +9,3 @@ use super::wit::*;
 use crate::state::WasiState;
 
 impl Host for WasiState {}
-
-impl From<extension_catalog::KindDiscriminants> for ExtensionType {
-    fn from(value: extension_catalog::KindDiscriminants) -> Self {
-        match value {
-            extension_catalog::KindDiscriminants::FieldResolver => ExtensionType::Resolver,
-            extension_catalog::KindDiscriminants::Authenticator => ExtensionType::Authentication,
-        }
-    }
-}

--- a/extensions/nats/src/lib.rs
+++ b/extensions/nats/src/lib.rs
@@ -6,13 +6,10 @@ use std::{cell::RefCell, collections::HashMap, rc::Rc, str::FromStr};
 
 use config::AuthConfig;
 use grafbase_sdk::{
-    host_io::pubsub::{
-        nats::{self, NatsClient},
-        Subscription,
-    },
+    host_io::pubsub::nats::{self, NatsClient},
     jq_selection::JqSelection,
     types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
-    Error, Extension, NatsAuth, Resolver, ResolverExtension, SharedContext,
+    Error, Extension, NatsAuth, Resolver, ResolverExtension, SharedContext, Subscription,
 };
 use subscription::FilteredSubscription;
 use types::{DirectiveKind, NatsPublishResult, PublishArguments, SubscribeArguments};

--- a/extensions/nats/src/subscription.rs
+++ b/extensions/nats/src/subscription.rs
@@ -1,23 +1,20 @@
 use std::{cell::RefCell, rc::Rc};
 
 use grafbase_sdk::{
-    host_io::pubsub::{
-        nats::{self, NatsSubscriber},
-        Subscription,
-    },
+    host_io::pubsub::nats::{self, NatsSubscription},
     jq_selection::JqSelection,
     types::FieldOutput,
-    Error,
+    Error, Subscription,
 };
 
 pub struct FilteredSubscription {
-    nats: nats::NatsSubscriber,
+    nats: nats::NatsSubscription,
     jq_selection: Rc<RefCell<JqSelection>>,
     selection: Option<String>,
 }
 
 impl FilteredSubscription {
-    pub fn new(nats: NatsSubscriber, jq_selection: Rc<RefCell<JqSelection>>, selection: Option<String>) -> Self {
+    pub fn new(nats: NatsSubscription, jq_selection: Rc<RefCell<JqSelection>>, selection: Option<String>) -> Self {
         Self {
             nats,
             jq_selection,

--- a/extensions/rest/src/lib.rs
+++ b/extensions/rest/src/lib.rs
@@ -2,11 +2,8 @@ mod selection_filter;
 mod types;
 
 use grafbase_sdk::{
-    Error, Extension, Resolver, ResolverExtension, SharedContext,
-    host_io::{
-        http::{self, HttpRequest, Url},
-        pubsub::Subscription,
-    },
+    Error, Extension, Resolver, ResolverExtension, SharedContext, Subscription,
+    host_io::http::{self, HttpRequest, Url},
     jq_selection::JqSelection,
     types::{Configuration, Directive, FieldDefinition, FieldInputs, FieldOutput},
 };

--- a/gateway/tests/telemetry/metrics/request.rs
+++ b/gateway/tests/telemetry/metrics/request.rs
@@ -23,6 +23,7 @@ fn basic() {
                 WHERE ServiceName = ? AND StartTimeUnix >= ?
                     AND ScopeName = 'grafbase'
                     AND MetricName = 'http.server.request.duration'
+                    AND Attributes['http.request.method'] = 'POST'
                 "#,
             )
             .bind(&service_name)
@@ -83,6 +84,7 @@ fn request_error() {
                 WHERE ServiceName = ? AND StartTimeUnix >= ?
                     AND ScopeName = 'grafbase'
                     AND MetricName = 'http.server.request.duration'
+                    AND Attributes['http.request.method'] = 'POST'
                 "#,
             )
             .bind(&service_name)
@@ -146,6 +148,7 @@ fn field_error() {
                 WHERE ServiceName = ?
                     AND ScopeName = 'grafbase'
                     AND MetricName = 'http.server.request.duration'
+                    AND Attributes['http.request.method'] = 'POST'
                 "#,
             )
             .bind(&service_name)
@@ -204,6 +207,7 @@ fn field_error_data_null() {
                 WHERE ServiceName = ?
                     AND ScopeName = 'grafbase'
                     AND MetricName = 'http.server.request.duration'
+                    AND Attributes['http.request.method'] = 'POST'
                 "#,
             )
             .bind(&service_name)
@@ -259,6 +263,7 @@ fn client() {
                 WHERE ServiceName = ? AND StartTimeUnix >= ?
                     AND ScopeName = 'grafbase'
                     AND MetricName = 'http.server.request.duration'
+                    AND Attributes['http.request.method'] = 'POST'
                 "#,
             )
             .bind(&service_name)


### PR DESCRIPTION
Removed a bunch of duplicated boilerplate code and the extension type. All extension state is managed by the same code in `grafbase_sdk::component` with the other implementation details of the component <-> extension mapping. Had to add an extra `AnyExtension` trait, but still feels simpler IMHO.

Also including the hooks v0.3.0 release, the CI isn't super happy to have only this for some reason.

I'm also making the grafbase cli more robust, it's an absolute pain today with breaking changes. So changing the generated `Cargo.toml` to use the local `grafbase-sdk`.
