### PR TITLE
fix: utilize unfold with extension subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8890,7 +8890,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.11",
  "tokio",
- "tokio-stream",
  "toml",
  "tracing",
  "ulid",

--- a/crates/wasi-component-loader/Cargo.toml
+++ b/crates/wasi-component-loader/Cargo.toml
@@ -29,7 +29,6 @@ serde_json.workspace = true
 strum = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["time", "rt"] }
-tokio-stream.workspace = true
 tracing.workspace = true
 ulid.workspace = true
 url.workspace = true

--- a/extensions/jwt/Cargo.lock
+++ b/extensions/jwt/Cargo.lock
@@ -1542,7 +1542,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-tungstenite",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk-derive"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/extensions/nats/Cargo.lock
+++ b/extensions/nats/Cargo.lock
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-tungstenite",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk-derive"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/extensions/rest/Cargo.lock
+++ b/extensions/rest/Cargo.lock
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-tungstenite",
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk-derive"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
We avoid taking the instance out from the pool, and can reuse it for the next request.