### PR TITLE
gateway: enable automatic subgraph response compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +358,22 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+dependencies = [
+ "brotli",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -1056,6 +1087,27 @@ dependencies = [
  "futures-io",
  "futures-lite 2.6.0",
  "piper",
+]
+
+[[package]]
+name = "brotli"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -7221,6 +7273,7 @@ version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes",
  "futures-channel",

--- a/crates/grafbase-workspace-hack/Cargo.toml
+++ b/crates/grafbase-workspace-hack/Cargo.toml
@@ -103,7 +103,7 @@ rand_core = { version = "0.6", default-features = false, features = ["std"] }
 regex = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "unicode"] }
 regex-syntax = { version = "0.8" }
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "http2", "json", "rustls-tls", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "http2", "json", "rustls-tls", "stream", "zstd"] }
 rsa = { version = "0.9" }
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "logging", "ring", "std", "tls12"] }
 rustls-webpki = { version = "0.102", default-features = false, features = ["aws_lc_rs", "ring", "std"] }
@@ -229,7 +229,7 @@ rand_core = { version = "0.6", default-features = false, features = ["std"] }
 regex = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "unicode"] }
 regex-syntax = { version = "0.8" }
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "http2", "json", "rustls-tls", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "http2", "json", "rustls-tls", "stream", "zstd"] }
 rsa = { version = "0.9" }
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "logging", "ring", "std", "tls12"] }
 rustls-webpki = { version = "0.102", default-features = false, features = ["aws_lc_rs", "ring", "std"] }

--- a/crates/integration-tests/tests/federation/basic/headers.rs
+++ b/crates/integration-tests/tests/federation/basic/headers.rs
@@ -32,6 +32,10 @@ fn test_default_headers() {
             "value": "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8"
           },
           {
+            "name": "accept-encoding",
+            "value": "gzip, br, zstd, deflate"
+          },
+          {
             "name": "content-length",
             "value": "59"
           },
@@ -83,6 +87,10 @@ fn test_default_headers_forwarding() {
           {
             "name": "accept",
             "value": "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8"
+          },
+          {
+            "name": "accept-encoding",
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",
@@ -145,6 +153,10 @@ fn test_subgraph_specific_header_forwarding() {
           {
             "name": "accept",
             "value": "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8"
+          },
+          {
+            "name": "accept-encoding",
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",
@@ -221,6 +233,10 @@ fn should_not_propagate_blacklisted_headers() {
                 "value": "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8"
               },
               {
+                "name": "accept-encoding",
+                "value": "gzip, br, zstd, deflate"
+              },
+              {
                 "name": "content-length",
                 "value": "59"
               },
@@ -269,6 +285,10 @@ fn test_regex_header_forwarding() {
           {
             "name": "accept",
             "value": "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8"
+          },
+          {
+            "name": "accept-encoding",
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",
@@ -329,6 +349,10 @@ fn test_regex_header_forwarding_should_not_duplicate() {
             "value": "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8"
           },
           {
+            "name": "accept-encoding",
+            "value": "gzip, br, zstd, deflate"
+          },
+          {
             "name": "content-length",
             "value": "59"
           },
@@ -381,6 +405,10 @@ fn test_header_forwarding_with_rename() {
             "value": "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8"
           },
           {
+            "name": "accept-encoding",
+            "value": "gzip, br, zstd, deflate"
+          },
+          {
             "name": "content-length",
             "value": "59"
           },
@@ -424,6 +452,10 @@ fn test_header_forwarding_with_default() {
           {
             "name": "accept",
             "value": "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8"
+          },
+          {
+            "name": "accept-encoding",
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",
@@ -472,6 +504,10 @@ fn test_header_forwarding_with_default_and_existing_header() {
           {
             "name": "accept",
             "value": "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8"
+          },
+          {
+            "name": "accept-encoding",
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",
@@ -525,6 +561,10 @@ fn test_regex_header_forwarding_then_delete() {
           {
             "name": "accept",
             "value": "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8"
+          },
+          {
+            "name": "accept-encoding",
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",
@@ -581,6 +621,10 @@ fn test_regex_header_forwarding_then_delete_with_regex() {
             "value": "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8"
           },
           {
+            "name": "accept-encoding",
+            "value": "gzip, br, zstd, deflate"
+          },
+          {
             "name": "content-length",
             "value": "59"
           },
@@ -627,6 +671,10 @@ fn test_rename_duplicate_no_default() {
           {
             "name": "accept",
             "value": "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8"
+          },
+          {
+            "name": "accept-encoding",
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "bar",
@@ -682,6 +730,10 @@ fn test_rename_duplicate_default() {
             "value": "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8"
           },
           {
+            "name": "accept-encoding",
+            "value": "gzip, br, zstd, deflate"
+          },
+          {
             "name": "bar",
             "value": "lol"
           },
@@ -730,6 +782,10 @@ fn test_rename_duplicate_default_with_missing_value() {
           {
             "name": "accept",
             "value": "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8"
+          },
+          {
+            "name": "accept-encoding",
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "bar",
@@ -784,6 +840,10 @@ fn regex_header_regex_forwarding_should_forward_duplicates_too() {
             "value": "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8"
           },
           {
+            "name": "accept-encoding",
+            "value": "gzip, br, zstd, deflate"
+          },
+          {
             "name": "content-length",
             "value": "59"
           },
@@ -834,6 +894,10 @@ fn regex_header_forwarding_should_forward_duplicates() {
           {
             "name": "accept",
             "value": "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8"
+          },
+          {
+            "name": "accept-encoding",
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",
@@ -889,6 +953,10 @@ fn regex_header_forwarding_should_forward_duplicates_with_rename() {
             "value": "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8"
           },
           {
+            "name": "accept-encoding",
+            "value": "gzip, br, zstd, deflate"
+          },
+          {
             "name": "content-length",
             "value": "59"
           },
@@ -941,6 +1009,10 @@ fn header_remove_should_remove_duplicates() {
             "value": "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8"
           },
           {
+            "name": "accept-encoding",
+            "value": "gzip, br, zstd, deflate"
+          },
+          {
             "name": "content-length",
             "value": "59"
           },
@@ -983,6 +1055,10 @@ fn header_regex_remove_should_remove_duplicates() {
           {
             "name": "accept",
             "value": "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8"
+          },
+          {
+            "name": "accept-encoding",
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",

--- a/crates/runtime-local/Cargo.toml
+++ b/crates/runtime-local/Cargo.toml
@@ -49,7 +49,7 @@ tracing.workspace = true
 tungstenite = { workspace = true, features = ["url", "handshake"] }
 url = { workspace = true, optional = true }
 
-reqwest = { workspace = true, features = ["json", "rustls-tls"] }
+reqwest = { workspace = true, features = ["json", "rustls-tls", "gzip", "brotli", "deflate", "zstd"] }
 
 anyhow.workspace = true
 deadpool = { workspace = true, optional = true }

--- a/gateway/changelog/unreleased.md
+++ b/gateway/changelog/unreleased.md
@@ -1,0 +1,3 @@
+## Improvements
+
+- The gateway now transparently supports gzip, brotli, deflate, and zstd compression for subgraph responses. It will advertise support through the `Accept-Encoding` header. That does not apply to the body of requests from the gateway to the subgraph, only responses. If you need opt-in request body compression, please contact us and it will be added in short notice. (https://github.com/grafbase/grafbase/pull/2743)

--- a/gateway/tests/telemetry/tracing.rs
+++ b/gateway/tests/telemetry/tracing.rs
@@ -36,7 +36,7 @@ fn no_traceparent_no_propagation() {
                 .send()
                 .await;
 
-            response.assert_header_names(&["accept", "content-length", "content-type"]);
+            response.assert_header_names(&["accept", "accept-encoding", "content-length", "content-type"]);
         },
     );
 }
@@ -113,7 +113,14 @@ fn tracecontext_traceparent_propagation() {
                 .send()
                 .await;
 
-            response.assert_header_names(&["accept", "content-length", "content-type", "traceparent", "tracestate"]);
+            response.assert_header_names(&[
+                "accept",
+                "accept-encoding",
+                "content-length",
+                "content-type",
+                "traceparent",
+                "tracestate",
+            ]);
             response.assert_header_content("tracestate", "");
 
             let trace_parent = response.assert_header("traceparent");
@@ -180,6 +187,7 @@ fn tracecontext_and_baggage_propagation() {
 
             response.assert_header_names(&[
                 "accept",
+                "accept-encoding",
                 "baggage",
                 "content-length",
                 "content-type",
@@ -277,7 +285,7 @@ fn baggage_propagation() {
                 .send()
                 .await;
 
-            response.assert_header_names(&["accept", "baggage", "content-length", "content-type"]);
+            response.assert_header_names(&["accept", "accept-encoding", "baggage", "content-length", "content-type"]);
             let values = response.assert_header("baggage");
             let mut values: Vec<_> = values.split(',').collect();
             values.sort();
@@ -315,7 +323,14 @@ fn aws_xray_propagation() {
                 .send()
                 .await;
 
-            response.assert_header_names(&["accept", "content-length", "content-type", "traceparent", "tracestate"]);
+            response.assert_header_names(&[
+                "accept",
+                "accept-encoding",
+                "content-length",
+                "content-type",
+                "traceparent",
+                "tracestate",
+            ]);
             response.assert_header_content("tracestate", "");
 
             let trace_parent = response.assert_header("traceparent");


### PR DESCRIPTION
Adds support for gzip, brotli, zstd, deflate. The HTTP client used to issue requests to subgraphs will send them in the `Accept-Encoding` header and transparently decompress them.