### PR TITLE
fix: prevent renovate updates for certain crates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,15 @@
       "matchPackageNames": ["axum"],
       "matchFileNames": ["crates/graphql-mocks/Cargo.toml"],
       "matchUpdateTypes": ["patch"]
-    }
+    },
+    {
+      "matchPackageNames": ["async-tungstenite", "ory-client"],
+      "enabled": false
+    },
+    {
+      "matchPackageNames": ["rand"],
+      "matchPaths": ["crates/integration-tests/Cargo.toml"],
+      "enabled": false
+    },
   ]
 }


### PR DESCRIPTION
There are a few crates we just cannot upgrade right now due to broken version compatibilities with other crates. We'll revisit when the other crates work better with these.