### PR TITLE
fix: build cli and gateway always in extensions run

### DIFF
--- a/.github/workflows/rust-prs.yml
+++ b/.github/workflows/rust-prs.yml
@@ -379,7 +379,7 @@ jobs:
           tool: nextest
 
       - name: Build CLI and Gateway
-        if: needs.what-changed.outputs.cargo-bin-specs
+        # if: needs.what-chaged.outputs.cargo-bin-specs
         shell: bash
         run: |
           cargo build -p grafbase -p grafbase-gateway


### PR DESCRIPTION
We should make sure the binaries are built always if we run extension tests.