### PR TITLE
chore: add docs, fix cbor ser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3646,7 +3646,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3646,7 +3646,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3664,6 +3664,7 @@ dependencies = [
  "jaq-core",
  "jaq-json",
  "jaq-std",
+ "minicbor",
  "minicbor-serde",
  "reqwest 0.12.12",
  "semver 1.0.25",

--- a/cli/tests/extension/mod.rs
+++ b/cli/tests/extension/mod.rs
@@ -37,12 +37,12 @@ fn init_resolver() {
     codegen-units = 1
 
     [dependencies]
-    grafbase-sdk = "0.5.2"
+    grafbase-sdk = "0.5.4"
 
     [dev-dependencies]
     indoc = "2"
     insta = { version = "1.42.1", features = ["json"] }
-    grafbase-sdk = { version = "0.5.2", features = ["test-utils"] }
+    grafbase-sdk = { version = "0.5.4", features = ["test-utils"] }
     tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }
     serde_json = "1"
     "#);
@@ -281,12 +281,12 @@ fn init_auth() {
     codegen-units = 1
 
     [dependencies]
-    grafbase-sdk = "0.5.2"
+    grafbase-sdk = "0.5.4"
 
     [dev-dependencies]
     indoc = "2"
     insta = { version = "1.42.1", features = ["json"] }
-    grafbase-sdk = { version = "0.5.2", features = ["test-utils"] }
+    grafbase-sdk = { version = "0.5.4", features = ["test-utils"] }
     tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }
     serde_json = "1"
     "#);

--- a/crates/grafbase-sdk/Cargo.toml
+++ b/crates/grafbase-sdk/Cargo.toml
@@ -55,6 +55,7 @@ indoc = { workspace = true, optional = true }
 jaq-core = { version = "2.1.1", optional = true }
 jaq-json = { version = "1.1.1", features = ["serde_json"], optional = true }
 jaq-std = { version = "2.1.0", optional = true }
+minicbor = "0.26.0"
 minicbor-serde = { workspace = true, features = ["alloc"] }
 reqwest = { workspace = true, features = ["json"], optional = true }
 serde.workspace = true

--- a/crates/grafbase-sdk/Cargo.toml
+++ b/crates/grafbase-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-sdk"
-version = "0.5.3"
+version = "0.5.4"
 description = "An SDK to implement extensions for the Grafbase Gateway"
 edition = "2021"
 license.workspace = true

--- a/crates/grafbase-sdk/Cargo.toml
+++ b/crates/grafbase-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-sdk"
-version = "0.5.2"
+version = "0.5.3"
 description = "An SDK to implement extensions for the Grafbase Gateway"
 edition = "2021"
 license.workspace = true

--- a/crates/grafbase-sdk/src/cbor.rs
+++ b/crates/grafbase-sdk/src/cbor.rs
@@ -1,0 +1,396 @@
+//! Remove this when this PR is merged and a new version of minicbor-serde is released.
+//! https://github.com/twittner/minicbor/pull/20
+
+use minicbor::encode::{Encoder, Write};
+use minicbor_serde::error::EncodeError;
+use serde::ser::{self, SerializeSeq, SerializeTuple, SerializeTupleStruct};
+use serde::ser::{SerializeMap, SerializeStruct, SerializeStructVariant, SerializeTupleVariant};
+use serde::Serialize;
+
+/// Serialise a type implementing [`serde::Serialize`] and return the encoded byte vector.
+pub fn to_vec<T: Serialize>(val: T) -> Result<Vec<u8>, EncodeError<core::convert::Infallible>> {
+    let mut v = Vec::new();
+    val.serialize(&mut Serializer::new(&mut v))?;
+    Ok(v)
+}
+
+/// An implementation of [`serde::Serializer`] using a [`minicbor::Encoder`].
+#[derive(Debug, Clone)]
+pub struct Serializer<W> {
+    encoder: Encoder<W>,
+}
+
+impl<W: Write> Serializer<W> {
+    pub fn new(w: W) -> Self {
+        Self::from(Encoder::new(w))
+    }
+
+    pub fn encoder(&self) -> &Encoder<W> {
+        &self.encoder
+    }
+
+    pub fn encoder_mut(&mut self) -> &mut Encoder<W> {
+        &mut self.encoder
+    }
+
+    pub fn into_encoder(self) -> Encoder<W> {
+        self.encoder
+    }
+}
+
+impl<W: Write> From<Encoder<W>> for Serializer<W> {
+    fn from(e: Encoder<W>) -> Self {
+        Self { encoder: e }
+    }
+}
+
+impl<'a, W: Write> ser::Serializer for &'a mut Serializer<W>
+where
+    <W as Write>::Error: core::error::Error + 'static,
+{
+    type Ok = ();
+    type Error = EncodeError<W::Error>;
+
+    type SerializeSeq = SeqSerializer<'a, W>;
+    type SerializeTuple = SeqSerializer<'a, W>;
+    type SerializeTupleStruct = SeqSerializer<'a, W>;
+    type SerializeTupleVariant = SeqSerializer<'a, W>;
+    type SerializeMap = SeqSerializer<'a, W>;
+    type SerializeStruct = SeqSerializer<'a, W>;
+    type SerializeStructVariant = SeqSerializer<'a, W>;
+
+    fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+        self.encoder.bool(v)?;
+        Ok(())
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        self.encoder.i8(v)?;
+        Ok(())
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        self.encoder.i16(v)?;
+        Ok(())
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        self.encoder.i32(v)?;
+        Ok(())
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        self.encoder.i64(v)?;
+        Ok(())
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        self.encoder.u8(v)?;
+        Ok(())
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        self.encoder.u16(v)?;
+        Ok(())
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        self.encoder.u32(v)?;
+        Ok(())
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        self.encoder.u64(v)?;
+        Ok(())
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        self.encoder.f32(v)?;
+        Ok(())
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        self.encoder.f64(v)?;
+        Ok(())
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        self.encoder.char(v)?;
+        Ok(())
+    }
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        self.encoder.str(v)?;
+        Ok(())
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        self.encoder.bytes(v)?;
+        Ok(())
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        self.encoder.null()?;
+        Ok(())
+    }
+
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        self.encoder.null()?;
+
+        Ok(())
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        self.serialize_unit()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        variant.serialize(self)
+    }
+
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        self.encoder.map(1)?.str(variant)?;
+        value.serialize(self)
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        if let Some(n) = len {
+            self.encoder.array(n as u64)?;
+        } else {
+            self.encoder.begin_array()?;
+        }
+        Ok(SeqSerializer {
+            serializer: self,
+            indefinite: len.is_none(),
+        })
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        self.encoder.array(len as u64)?;
+        Ok(SeqSerializer {
+            serializer: self,
+            indefinite: false,
+        })
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        self.serialize_tuple(len)
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        self.encoder.map(1)?.str(variant)?;
+        self.serialize_tuple(len)
+    }
+
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        if let Some(n) = len {
+            self.encoder.map(n as u64)?;
+        } else {
+            self.encoder.begin_map()?;
+        }
+        Ok(SeqSerializer {
+            serializer: self,
+            indefinite: len.is_none(),
+        })
+    }
+
+    fn serialize_struct(self, _name: &'static str, len: usize) -> Result<Self::SerializeStruct, Self::Error> {
+        self.encoder.map(len as u64)?;
+        Ok(SeqSerializer {
+            serializer: self,
+            indefinite: false,
+        })
+    }
+
+    fn serialize_struct_variant(
+        self,
+        name: &'static str,
+        _index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        self.encoder.map(1)?.str(variant)?;
+        self.serialize_struct(name, len)
+    }
+
+    fn collect_str<T: core::fmt::Display + ?Sized>(self, _val: &T) -> Result<Self::Ok, Self::Error> {
+        Err(minicbor::encode::Error::message("collect_str requires features `alloc` or `std`").into())
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+}
+
+pub struct SeqSerializer<'a, W> {
+    serializer: &'a mut Serializer<W>,
+    indefinite: bool,
+}
+
+impl<W: Write> SerializeSeq for SeqSerializer<'_, W>
+where
+    <W as Write>::Error: core::error::Error + 'static,
+{
+    type Ok = ();
+    type Error = minicbor_serde::error::EncodeError<W::Error>;
+
+    fn serialize_element<T: Serialize + ?Sized>(&mut self, x: &T) -> Result<(), Self::Error> {
+        x.serialize(&mut *self.serializer)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        if self.indefinite {
+            self.serializer.encoder.end()?;
+        }
+        Ok(())
+    }
+}
+
+impl<W: Write> SerializeTuple for SeqSerializer<'_, W>
+where
+    <W as Write>::Error: core::error::Error + 'static,
+{
+    type Ok = ();
+    type Error = minicbor_serde::error::EncodeError<W::Error>;
+
+    fn serialize_element<T: Serialize + ?Sized>(&mut self, x: &T) -> Result<(), Self::Error> {
+        x.serialize(&mut *self.serializer)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl<W: Write> SerializeTupleStruct for SeqSerializer<'_, W>
+where
+    <W as Write>::Error: core::error::Error + 'static,
+{
+    type Ok = ();
+    type Error = EncodeError<W::Error>;
+
+    fn serialize_field<T: Serialize + ?Sized>(&mut self, x: &T) -> Result<(), Self::Error> {
+        x.serialize(&mut *self.serializer)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl<W: Write> SerializeTupleVariant for SeqSerializer<'_, W>
+where
+    <W as Write>::Error: core::error::Error + 'static,
+{
+    type Ok = ();
+    type Error = EncodeError<W::Error>;
+
+    fn serialize_field<T: Serialize + ?Sized>(&mut self, x: &T) -> Result<(), Self::Error> {
+        x.serialize(&mut *self.serializer)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl<W: Write> SerializeMap for SeqSerializer<'_, W>
+where
+    <W as Write>::Error: core::error::Error + 'static,
+{
+    type Ok = ();
+    type Error = EncodeError<W::Error>;
+
+    fn serialize_key<T: Serialize + ?Sized>(&mut self, k: &T) -> Result<(), Self::Error> {
+        k.serialize(&mut *self.serializer)
+    }
+
+    fn serialize_value<T: Serialize + ?Sized>(&mut self, v: &T) -> Result<(), Self::Error> {
+        v.serialize(&mut *self.serializer)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        if self.indefinite {
+            self.serializer.encoder.end()?;
+        }
+        Ok(())
+    }
+}
+
+impl<W: Write> SerializeStruct for SeqSerializer<'_, W>
+where
+    <W as Write>::Error: core::error::Error + 'static,
+{
+    type Ok = ();
+    type Error = EncodeError<W::Error>;
+
+    fn serialize_field<T>(&mut self, key: &'static str, val: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        key.serialize(&mut *self.serializer)?;
+        val.serialize(&mut *self.serializer)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl<W: Write> SerializeStructVariant for SeqSerializer<'_, W>
+where
+    <W as Write>::Error: core::error::Error + 'static,
+{
+    type Ok = ();
+    type Error = EncodeError<W::Error>;
+
+    fn serialize_field<T>(&mut self, key: &'static str, val: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        key.serialize(&mut *self.serializer)?;
+        val.serialize(&mut *self.serializer)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}

--- a/crates/grafbase-sdk/src/host_io/cache.rs
+++ b/crates/grafbase-sdk/src/host_io/cache.rs
@@ -26,7 +26,7 @@ where
         Ok(minicbor_serde::from_slice(&value)?)
     } else {
         let value = init()?;
-        let serialized = minicbor_serde::to_vec(&value.value)?;
+        let serialized = crate::cbor::to_vec(&value.value)?;
 
         crate::wit::Cache::set(key, &serialized, value.duration.map(|d| d.as_millis() as u64));
 

--- a/crates/grafbase-sdk/src/lib.rs
+++ b/crates/grafbase-sdk/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(missing_docs)]
 #![expect(unsafe_op_in_unsafe_fn)]
 
+mod cbor;
 mod component;
 #[doc(hidden)]
 pub mod extension;

--- a/crates/grafbase-sdk/src/test/config.rs
+++ b/crates/grafbase-sdk/src/test/config.rs
@@ -19,6 +19,8 @@ pub enum LogLevel {
     Warn,
     /// Show only error messages.
     Error,
+    /// Show all output from engine, debug upwards.
+    EngineDebug,
 }
 
 impl AsRef<str> for LogLevel {
@@ -29,6 +31,7 @@ impl AsRef<str> for LogLevel {
             LogLevel::Info => "info",
             LogLevel::Warn => "warn",
             LogLevel::Error => "error",
+            LogLevel::EngineDebug => "engine=debug",
         }
     }
 }

--- a/crates/grafbase-sdk/src/test/runner.rs
+++ b/crates/grafbase-sdk/src/test/runner.rs
@@ -142,7 +142,7 @@ impl TestRunner {
 
         let mut expr = duct::cmd(&self.config.gateway_path, args);
 
-        if !self.config.enable_stderr {
+        if !dbg!(self.config.enable_stderr) {
             expr = expr.stderr_null();
         }
 

--- a/crates/grafbase-sdk/src/types.rs
+++ b/crates/grafbase-sdk/src/types.rs
@@ -1,7 +1,7 @@
 //! Type definitions of the input and output data structures of the SDK.
 
 pub use http::StatusCode;
-pub use minicbor_serde::error::DecodeError;
+use minicbor_serde::error::DecodeError;
 pub use serde::Deserialize;
 use serde::Serialize;
 
@@ -90,8 +90,7 @@ impl FieldOutput {
     where
         T: Serialize,
     {
-        let output =
-            minicbor_serde::to_vec(output).expect("serialization error is Infallible, so it should never happen");
+        let output = crate::cbor::to_vec(output).expect("serialization error is Infallible, so it should never happen");
 
         self.0.outputs.push(Ok(output));
     }
@@ -205,8 +204,7 @@ impl Token {
         T: serde::Serialize,
     {
         Self {
-            claims: minicbor_serde::to_vec(&claims)
-                .expect("serialization error is Infallible, so it should never happen"),
+            claims: crate::cbor::to_vec(&claims).expect("serialization error is Infallible, so it should never happen"),
         }
     }
 }

--- a/extensions/jwt/Cargo.lock
+++ b/extensions/jwt/Cargo.lock
@@ -1945,6 +1945,7 @@ dependencies = [
  "graphql-ws-client",
  "http 1.2.0",
  "indoc",
+ "minicbor",
  "minicbor-serde",
  "reqwest 0.12.12",
  "semver 1.0.25",

--- a/extensions/jwt/Cargo.lock
+++ b/extensions/jwt/Cargo.lock
@@ -1931,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/extensions/jwt/Cargo.lock
+++ b/extensions/jwt/Cargo.lock
@@ -1931,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/extensions/nats/Cargo.lock
+++ b/extensions/nats/Cargo.lock
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/extensions/nats/Cargo.lock
+++ b/extensions/nats/Cargo.lock
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/extensions/nats/Cargo.lock
+++ b/extensions/nats/Cargo.lock
@@ -1944,6 +1944,7 @@ dependencies = [
  "jaq-core",
  "jaq-json",
  "jaq-std",
+ "minicbor",
  "minicbor-serde",
  "reqwest",
  "semver 1.0.25",

--- a/extensions/nats/definitions.graphql
+++ b/extensions/nats/definitions.graphql
@@ -241,3 +241,7 @@ input Body {
   """
   static: JSON
 }
+
+type NatsPublishResult {
+  success: Boolean!
+}

--- a/extensions/nats/src/lib.rs
+++ b/extensions/nats/src/lib.rs
@@ -258,7 +258,7 @@ impl Nats {
                 let value = match store.get::<serde_json::Value>(args.key) {
                     Ok(Some(value)) => value,
                     Ok(None) => {
-                        output.push_value(Option::<serde_json::Value>::None);
+                        output.push_value(serde_json::Value::Null);
                         return Ok(output);
                     }
                     Err(error) => {

--- a/extensions/nats/src/lib.rs
+++ b/extensions/nats/src/lib.rs
@@ -12,10 +12,7 @@ use grafbase_sdk::{
     Error, Extension, NatsAuth, Resolver, ResolverExtension, SharedContext, Subscription,
 };
 use subscription::FilteredSubscription;
-use types::{
-    DirectiveKind, KeyValueAction, KeyValueArguments, NatsKvCreateResult, NatsKvDeleteResult, NatsPublishResult,
-    PublishArguments, RequestArguments, SubscribeArguments,
-};
+use types::{DirectiveKind, KeyValueAction, KeyValueArguments, PublishArguments, RequestArguments, SubscribeArguments};
 
 #[derive(ResolverExtension)]
 struct Nats {
@@ -163,10 +160,7 @@ impl Nats {
         });
 
         let mut output = FieldOutput::new();
-
-        output.push_value(NatsPublishResult {
-            success: result.is_ok(),
-        });
+        output.push_value(result.is_ok());
 
         Ok(output)
     }
@@ -238,7 +232,7 @@ impl Nats {
                 let body = args.body().unwrap_or(&serde_json::Value::Null);
 
                 match store.create(args.key, body) {
-                    Ok(sequence) => output.push_value(NatsKvCreateResult { sequence }),
+                    Ok(sequence) => output.push_value(sequence.to_string()),
                     Err(error) => {
                         return Err(Error {
                             extensions: Vec::new(),
@@ -251,7 +245,7 @@ impl Nats {
                 let body = args.body().unwrap_or(&serde_json::Value::Null);
 
                 match store.put(args.key, body) {
-                    Ok(sequence) => output.push_value(NatsKvCreateResult { sequence }),
+                    Ok(sequence) => output.push_value(sequence.to_string()),
                     Err(error) => {
                         return Err(Error {
                             extensions: Vec::new(),
@@ -301,7 +295,7 @@ impl Nats {
                 }
             }
             KeyValueAction::Delete => match store.delete(args.key) {
-                Ok(()) => output.push_value(NatsKvDeleteResult { success: true }),
+                Ok(()) => output.push_value(true),
                 Err(error) => {
                     return Err(Error {
                         extensions: Vec::new(),

--- a/extensions/nats/src/types.rs
+++ b/extensions/nats/src/types.rs
@@ -114,24 +114,6 @@ pub struct RestInput {
     input: Option<serde_json::Value>,
 }
 
-#[derive(Debug, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct NatsPublishResult {
-    pub success: bool,
-}
-
-#[derive(Debug, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct NatsKvCreateResult {
-    pub sequence: u64,
-}
-
-#[derive(Debug, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct NatsKvDeleteResult {
-    pub success: bool,
-}
-
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubscribeArguments<'a> {

--- a/extensions/rest/Cargo.lock
+++ b/extensions/rest/Cargo.lock
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/extensions/rest/Cargo.lock
+++ b/extensions/rest/Cargo.lock
@@ -1935,6 +1935,7 @@ dependencies = [
  "jaq-core",
  "jaq-json",
  "jaq-std",
+ "minicbor",
  "minicbor-serde",
  "reqwest",
  "semver 1.0.25",

--- a/extensions/rest/Cargo.lock
+++ b/extensions/rest/Cargo.lock
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/extensions/rest/definitions.graphql
+++ b/extensions/rest/definitions.graphql
@@ -1,39 +1,139 @@
+extend schema @link(url: "https://specs.grafbase.com/grafbase", import: ["InputValueSet", "UrlTemplate"])
+
+"""
+@restEndpoint directive enables defining named REST endpoints for the schema.
+The directive can be used multiple times on a schema to define different endpoints.
+
+Example:
 extend schema
-  @link(
-    url: "https://specs.grafbase.com/grafbase"
-    import: ["InputValueSet", "UrlTemplate"]
+  @restEndpoint(name: "weather", baseURL: "https://api.weather.com")
+  @restEndpoint(name: "users", baseURL: "https://api.users.example.com")
+"""
+directive @restEndpoint(
+  """
+  A unique identifier for the REST endpoint
+  """
+  name: String!
+  """
+  The base URL for the REST API
+  """
+  baseURL: String!
+) repeatable on SCHEMA
+
+"""
+@rest directive allows you to define RESTful API integrations for GraphQL fields.
+This directive maps GraphQL fields to REST endpoints, enabling seamless integration
+between your GraphQL schema and external REST APIs.
+
+Example:
+type Query {
+  users: [User] @rest(
+    endpoint: "users",
+    http: { method: GET, path: "/users" },
+    selection: "*"
   )
-
-directive @restEndpoint(name: String!, baseURL: String!) repeatable on SCHEMA
-
+}
+"""
 directive @rest(
+  """
+  The name of the REST endpoint to use, as defined by @restEndpoint
+  """
   endpoint: String!
+
+  """
+  HTTP request configuration including method and path
+  """
   http: HttpRequestDefinition!
+
+  """
+  Specifies which fields from the GraphQL selection to include in the response
+  """
   selection: String!
+
+  """
+  Configuration for the request body, can include static values or
+  selections from the GraphQL arguments
+  """
   body: Body = { selection: "*" }
 ) on FIELD_DEFINITION
 
 scalar JSON
 
+"""
+Body input type defines how to construct the request body for REST API calls.
+It allows for dynamic construction from GraphQL arguments or static values.
+"""
 input Body {
+  """
+  Specifies which GraphQL arguments to include in the request body.
+  Use "*" to include all arguments, or provide specific field names.
+  """
   selection: InputValueSet
+
+  """
+  Static JSON content to include in the request body,
+  which will be merged with any selected values.
+  """
   static: JSON
 }
 
+"""
+HttpRequestDefinition configures the HTTP request that will be made
+to the REST endpoint, including both the method and path.
+"""
 input HttpRequestDefinition {
+  """
+  The HTTP method to use for the request, such as GET, POST, etc.
+  """
   method: HttpMethod!
+
+  """
+  The path template for the request, which can include
+  variable substitutions from GraphQL arguments.
+  This supports templating using GraphQL arguments: {{args.myArgument}}
+  """
   path: UrlTemplate!
 }
 
+"""
+HttpMethod enum represents the standard HTTP methods supported
+for REST API interactions.
+"""
 enum HttpMethod {
+  """
+  HTTP GET method for retrieving resources
+  """
   GET
+  """
+  HTTP POST method for creating resources
+  """
   POST
+  """
+  HTTP PUT method for replacing resources
+  """
   PUT
+  """
+  HTTP DELETE method for removing resources
+  """
   DELETE
+  """
+  HTTP HEAD method for retrieving headers only
+  """
   HEAD
+  """
+  HTTP OPTIONS method for describing communication options
+  """
   OPTIONS
+  """
+  HTTP CONNECT method for establishing tunnels
+  """
   CONNECT
+  """
+  HTTP TRACE method for diagnostic testing
+  """
   TRACE
+  """
+  HTTP PATCH method for partial modifications
+  """
   PATCH
 }
-

--- a/extensions/rest/src/lib.rs
+++ b/extensions/rest/src/lib.rs
@@ -120,12 +120,17 @@ impl Resolver for RestExtension {
             message: format!("Error deserializing response: {e}"),
         })?;
 
+        let mut results = FieldOutput::new();
+
+        if !(data.is_object() || data.is_array()) {
+            results.push_value(data);
+            return Ok(results);
+        }
+
         let filtered = self.jq_selection.select(rest.selection, data).map_err(|e| Error {
             extensions: Vec::new(),
             message: format!("Error selecting result value: {e}"),
         })?;
-
-        let mut results = FieldOutput::new();
 
         for result in filtered {
             match result {


### PR DESCRIPTION
This starts the docs effort for NATS, but does not document anything NATS related yet. Preliminary things I found when testing:

- Minicbor is not serializing nulls correctly. We have an open PR but we need to vendor this code until it is merged
- Simplify NATS return types for static return values like booleans or integers
- document REST directives