### PR TITLE
fix: runtime fetch fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2802,6 +2802,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3793,6 +3805,7 @@ dependencies = [
  "anyhow",
  "arrayvec 0.7.6",
  "ascii",
+ "async-compression",
  "axum 0.8.1",
  "axum-core 0.5.0",
  "base16ct",
@@ -3849,6 +3862,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "iana-time-zone",
+ "idna",
  "indexmap 2.7.1",
  "insta",
  "lazy_static",
@@ -4315,6 +4329,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-proto"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand 0.8.5",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hifijson"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4365,6 +4424,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
 ]
 
 [[package]]
@@ -5064,6 +5134,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
+name = "ipconfig"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-sys 0.48.0",
+ "winreg",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5536,6 +5618,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
 name = "lz4_flex"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5549,6 +5640,12 @@ checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
@@ -6915,6 +7012,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quick-xml"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7381,6 +7484,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.8",
+ "hickory-resolver",
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -7431,6 +7535,16 @@ dependencies = [
  "pin-project-lite",
  "reqwest 0.12.12",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
+dependencies = [
+ "hostname",
+ "quick-error",
 ]
 
 [[package]]
@@ -7570,6 +7684,7 @@ dependencies = [
  "grafbase-telemetry",
  "grafbase-workspace-hack",
  "http 1.2.0",
+ "reqwest 0.12.12",
  "semver 1.0.25",
  "serde",
  "serde_json",
@@ -10281,6 +10396,12 @@ dependencies = [
  "rustix",
  "winsafe",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
 
 [[package]]
 name = "wiggle"

--- a/crates/engine/src/execution/error.rs
+++ b/crates/engine/src/execution/error.rs
@@ -8,7 +8,7 @@ use crate::response::{ErrorCode, GraphqlError};
 pub enum ExecutionError {
     #[error("Internal error: {0}")]
     Internal(Cow<'static, str>),
-    #[error("Request to subgraph '{subgraph_name}' failed with: {error}")]
+    #[error("Request to subgraph '{subgraph_name}' failed.")]
     Fetch { subgraph_name: String, error: FetchError },
     #[error(transparent)]
     RateLimit(#[from] runtime::rate_limiting::Error),

--- a/crates/engine/src/resolver/graphql/request/execute.rs
+++ b/crates/engine/src/resolver/graphql/request/execute.rs
@@ -122,6 +122,7 @@ pub(crate) async fn execute_subgraph_request<R: Runtime>(
                 http_span.record_http_status_code(response.status());
             }
             Err(ref err) => {
+                tracing::error!("Request to subgraph {} failed with: {err}", endpoint.subgraph_name());
                 http_span.set_as_http_error(err.as_invalid_status_code());
             }
         };

--- a/crates/grafbase-workspace-hack/Cargo.toml
+++ b/crates/grafbase-workspace-hack/Cargo.toml
@@ -107,7 +107,7 @@ rand_core = { version = "0.6", default-features = false, features = ["std"] }
 regex = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "unicode"] }
 regex-syntax = { version = "0.8" }
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "http2", "json", "multipart", "rustls-tls", "stream", "zstd"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "hickory-dns", "http2", "json", "multipart", "rustls-tls", "stream"] }
 rsa = { version = "0.9" }
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "logging", "ring", "std", "tls12"] }
 rustls-webpki = { version = "0.102", default-features = false, features = ["aws_lc_rs", "ring", "std"] }
@@ -240,7 +240,7 @@ rand_core = { version = "0.6", default-features = false, features = ["std"] }
 regex = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "unicode"] }
 regex-syntax = { version = "0.8" }
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "http2", "json", "multipart", "rustls-tls", "stream", "zstd"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "hickory-dns", "http2", "json", "multipart", "rustls-tls", "stream"] }
 rsa = { version = "0.9" }
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "logging", "ring", "std", "tls12"] }
 rustls-webpki = { version = "0.102", default-features = false, features = ["aws_lc_rs", "ring", "std"] }
@@ -287,10 +287,12 @@ zstd-sys = { version = "2", default-features = false, features = ["legacy", "std
 
 [target.aarch64-apple-darwin.dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
+async-compression = { version = "0.4", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
 axum = { version = "0.8" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+idna = { version = "1" }
 libc = { version = "0.2", features = ["extra_traits"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["with-alloc"] }
 mio = { version = "1", features = ["net", "os-ext"] }
@@ -301,10 +303,12 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 
 [target.aarch64-apple-darwin.build-dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
+async-compression = { version = "0.4", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
 axum = { version = "0.8" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+idna = { version = "1" }
 libc = { version = "0.2", features = ["extra_traits"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["with-alloc"] }
 mio = { version = "1", features = ["net", "os-ext"] }
@@ -315,10 +319,12 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 
 [target.x86_64-apple-darwin.dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
+async-compression = { version = "0.4", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
 axum = { version = "0.8" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+idna = { version = "1" }
 libc = { version = "0.2", features = ["extra_traits"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["with-alloc"] }
 mio = { version = "1", features = ["net", "os-ext"] }
@@ -330,10 +336,12 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 
 [target.x86_64-apple-darwin.build-dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
+async-compression = { version = "0.4", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
 axum = { version = "0.8" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+idna = { version = "1" }
 libc = { version = "0.2", features = ["extra_traits"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["with-alloc"] }
 mio = { version = "1", features = ["net", "os-ext"] }
@@ -344,31 +352,37 @@ stable_deref_trait = { version = "1" }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features = false, features = ["log", "timeout"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
+async-compression = { version = "0.4", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
 axum = { version = "0.8" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
+idna = { version = "1" }
 rustix = { version = "0.38", features = ["event", "fs", "net"] }
 spin = { version = "0.9" }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features = false, features = ["log", "timeout"] }
-winapi = { version = "0.3", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-default", "knownfolders", "minwinbase", "minwindef", "objbase", "processenv", "processthreadsapi", "profileapi", "shlobj", "synchapi", "timezoneapi", "winbase", "winerror", "winnt", "winuser"] }
+winapi = { version = "0.3", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-default", "knownfolders", "minwinbase", "minwindef", "objbase", "processenv", "processthreadsapi", "profileapi", "shlobj", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "winerror", "winnt", "winuser"] }
 windows-sys-73dcd821b1037cfd = { package = "windows-sys", version = "0.59", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Win32_Globalization", "Win32_NetworkManagement_IpHelper", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_Diagnostics_Debug", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Kernel", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Performance", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell"] }
 windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
+async-compression = { version = "0.4", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
 axum = { version = "0.8" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
+idna = { version = "1" }
 rustix = { version = "0.38", features = ["event", "fs", "net"] }
 spin = { version = "0.9" }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features = false, features = ["log", "timeout"] }
-winapi = { version = "0.3", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-default", "knownfolders", "minwinbase", "minwindef", "objbase", "processenv", "processthreadsapi", "profileapi", "shlobj", "synchapi", "timezoneapi", "winbase", "winerror", "winnt", "winuser"] }
+winapi = { version = "0.3", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-default", "knownfolders", "minwinbase", "minwindef", "objbase", "processenv", "processthreadsapi", "profileapi", "shlobj", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "winerror", "winnt", "winuser"] }
 windows-sys-73dcd821b1037cfd = { package = "windows-sys", version = "0.59", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Win32_Globalization", "Win32_NetworkManagement_IpHelper", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_Diagnostics_Debug", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Kernel", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Performance", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell"] }
 windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
 
 [target.x86_64-unknown-linux-musl.dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
+async-compression = { version = "0.4", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
 axum = { version = "0.8" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+idna = { version = "1" }
 libc = { version = "0.2", features = ["extra_traits"] }
 linux-raw-sys = { version = "0.4", default-features = false, features = ["elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "std", "xdp"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["with-alloc"] }
@@ -381,10 +395,12 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 
 [target.x86_64-unknown-linux-musl.build-dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
+async-compression = { version = "0.4", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
 axum = { version = "0.8" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+idna = { version = "1" }
 libc = { version = "0.2", features = ["extra_traits"] }
 linux-raw-sys = { version = "0.4", default-features = false, features = ["elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "std", "xdp"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["with-alloc"] }
@@ -397,10 +413,12 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 
 [target.aarch64-unknown-linux-musl.dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
+async-compression = { version = "0.4", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
 axum = { version = "0.8" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+idna = { version = "1" }
 libc = { version = "0.2", features = ["extra_traits"] }
 linux-raw-sys = { version = "0.4", default-features = false, features = ["elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "std", "xdp"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["with-alloc"] }
@@ -412,10 +430,12 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 
 [target.aarch64-unknown-linux-musl.build-dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
+async-compression = { version = "0.4", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
 axum = { version = "0.8" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+idna = { version = "1" }
 libc = { version = "0.2", features = ["extra_traits"] }
 linux-raw-sys = { version = "0.4", default-features = false, features = ["elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "std", "xdp"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["with-alloc"] }

--- a/crates/integration-tests/src/fetch.rs
+++ b/crates/integration-tests/src/fetch.rs
@@ -56,7 +56,7 @@ impl DynFetcher for MockFetch {
             .get(host)
             .and_then(|responses| responses.pop())
             .map(|bytes| http::Response::builder().body(bytes.into()).unwrap())
-            .ok_or(FetchError::any("No more responses"));
+            .ok_or(FetchError::from("No more responses"));
 
         (result, None)
     }

--- a/crates/integration-tests/tests/federation/basic/headers.rs
+++ b/crates/integration-tests/tests/federation/basic/headers.rs
@@ -33,7 +33,7 @@ fn test_default_headers() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, zstd, deflate"
+            "value": "gzip, br, deflate"
           },
           {
             "name": "content-length",
@@ -90,7 +90,7 @@ fn test_default_headers_forwarding() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, zstd, deflate"
+            "value": "gzip, br, deflate"
           },
           {
             "name": "content-length",
@@ -156,7 +156,7 @@ fn test_subgraph_specific_header_forwarding() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, zstd, deflate"
+            "value": "gzip, br, deflate"
           },
           {
             "name": "content-length",
@@ -234,7 +234,7 @@ fn should_not_propagate_blacklisted_headers() {
               },
               {
                 "name": "accept-encoding",
-                "value": "gzip, br, zstd, deflate"
+                "value": "gzip, br, deflate"
               },
               {
                 "name": "content-length",
@@ -288,7 +288,7 @@ fn test_regex_header_forwarding() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, zstd, deflate"
+            "value": "gzip, br, deflate"
           },
           {
             "name": "content-length",
@@ -350,7 +350,7 @@ fn test_regex_header_forwarding_should_not_duplicate() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, zstd, deflate"
+            "value": "gzip, br, deflate"
           },
           {
             "name": "content-length",
@@ -406,7 +406,7 @@ fn test_header_forwarding_with_rename() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, zstd, deflate"
+            "value": "gzip, br, deflate"
           },
           {
             "name": "content-length",
@@ -455,7 +455,7 @@ fn test_header_forwarding_with_default() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, zstd, deflate"
+            "value": "gzip, br, deflate"
           },
           {
             "name": "content-length",
@@ -507,7 +507,7 @@ fn test_header_forwarding_with_default_and_existing_header() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, zstd, deflate"
+            "value": "gzip, br, deflate"
           },
           {
             "name": "content-length",
@@ -564,7 +564,7 @@ fn test_regex_header_forwarding_then_delete() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, zstd, deflate"
+            "value": "gzip, br, deflate"
           },
           {
             "name": "content-length",
@@ -622,7 +622,7 @@ fn test_regex_header_forwarding_then_delete_with_regex() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, zstd, deflate"
+            "value": "gzip, br, deflate"
           },
           {
             "name": "content-length",
@@ -674,7 +674,7 @@ fn test_rename_duplicate_no_default() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, zstd, deflate"
+            "value": "gzip, br, deflate"
           },
           {
             "name": "bar",
@@ -731,7 +731,7 @@ fn test_rename_duplicate_default() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, zstd, deflate"
+            "value": "gzip, br, deflate"
           },
           {
             "name": "bar",
@@ -785,7 +785,7 @@ fn test_rename_duplicate_default_with_missing_value() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, zstd, deflate"
+            "value": "gzip, br, deflate"
           },
           {
             "name": "bar",
@@ -841,7 +841,7 @@ fn regex_header_regex_forwarding_should_forward_duplicates_too() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, zstd, deflate"
+            "value": "gzip, br, deflate"
           },
           {
             "name": "content-length",
@@ -897,7 +897,7 @@ fn regex_header_forwarding_should_forward_duplicates() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, zstd, deflate"
+            "value": "gzip, br, deflate"
           },
           {
             "name": "content-length",
@@ -954,7 +954,7 @@ fn regex_header_forwarding_should_forward_duplicates_with_rename() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, zstd, deflate"
+            "value": "gzip, br, deflate"
           },
           {
             "name": "content-length",
@@ -1010,7 +1010,7 @@ fn header_remove_should_remove_duplicates() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, zstd, deflate"
+            "value": "gzip, br, deflate"
           },
           {
             "name": "content-length",
@@ -1058,7 +1058,7 @@ fn header_regex_remove_should_remove_duplicates() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, zstd, deflate"
+            "value": "gzip, br, deflate"
           },
           {
             "name": "content-length",

--- a/crates/integration-tests/tests/federation/subgraphs/not_reachable.rs
+++ b/crates/integration-tests/tests/federation/subgraphs/not_reachable.rs
@@ -50,7 +50,7 @@ fn subgraph_not_reachable_does_not_leak_subgraph_url() {
           },
           "errors": [
             {
-              "message": "Request to subgraph 'fst' failed with: error sending request",
+              "message": "Request to subgraph 'fst' failed.",
               "path": [
                 "user"
               ],

--- a/crates/integration-tests/tests/federation/timeouts.rs
+++ b/crates/integration-tests/tests/federation/timeouts.rs
@@ -75,12 +75,12 @@ fn subgraph_timeout() {
 
         let response = engine.post("query { serverVersion verySlow: delay(ms: 1500) }").await;
 
-        insta::assert_json_snapshot!(response, @r###"
+        insta::assert_json_snapshot!(response, @r#"
         {
           "data": null,
           "errors": [
             {
-              "message": "Request to subgraph 'slow' failed with: Timeout",
+              "message": "Request to subgraph 'slow' failed.",
               "path": [
                 "verySlow"
               ],
@@ -90,13 +90,13 @@ fn subgraph_timeout() {
             }
           ]
         }
-        "###);
+        "#);
 
         let response = engine
             .post("query { serverVersion verySlow: nullableDelay(ms: 1500) }")
             .await;
 
-        insta::assert_json_snapshot!(response, @r###"
+        insta::assert_json_snapshot!(response, @r#"
         {
           "data": {
             "serverVersion": "1",
@@ -104,7 +104,7 @@ fn subgraph_timeout() {
           },
           "errors": [
             {
-              "message": "Request to subgraph 'slow' failed with: Timeout",
+              "message": "Request to subgraph 'slow' failed.",
               "path": [
                 "verySlow"
               ],
@@ -114,6 +114,6 @@ fn subgraph_timeout() {
             }
           ]
         }
-        "###);
+        "#);
     })
 }

--- a/crates/runtime-local/Cargo.toml
+++ b/crates/runtime-local/Cargo.toml
@@ -50,7 +50,7 @@ tracing.workspace = true
 tungstenite = { workspace = true, features = ["url", "handshake"] }
 url = { workspace = true, optional = true }
 
-reqwest = { workspace = true, features = ["json", "rustls-tls", "gzip", "brotli", "deflate", "zstd"] }
+reqwest = { workspace = true, features = ["json", "rustls-tls", "gzip", "brotli", "deflate", "hickory-dns"] }
 
 anyhow.workspace = true
 deadpool = { workspace = true, optional = true }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -25,6 +25,7 @@ grafbase-telemetry.workspace = true
 grafbase-workspace-hack.workspace = true
 http.workspace = true
 id-derives = { path = "../engine/id-derives", package = "engine-id-derives" }
+reqwest.workspace = true
 semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/gateway/tests/access_logs/mod.rs
+++ b/gateway/tests/access_logs/mod.rs
@@ -321,12 +321,12 @@ fn with_broken_subgraph() {
             .send()
             .await;
 
-        insta::assert_json_snapshot!(resp, @r###"
+        insta::assert_json_snapshot!(resp, @r#"
         {
           "data": null,
           "errors": [
             {
-              "message": "Request to subgraph 'accounts' failed with: error sending request",
+              "message": "Request to subgraph 'accounts' failed.",
               "path": [
                 "me"
               ],
@@ -336,7 +336,7 @@ fn with_broken_subgraph() {
             }
           ]
         }
-        "###);
+        "#);
     });
 
     let result = std::fs::read_to_string(tmpdir.path().join("access.log")).unwrap();
@@ -407,12 +407,12 @@ fn with_broken_subgraph_retried() {
             .send()
             .await;
 
-        insta::assert_json_snapshot!(resp, @r###"
+        insta::assert_json_snapshot!(resp, @r#"
         {
           "data": null,
           "errors": [
             {
-              "message": "Request to subgraph 'accounts' failed with: error sending request",
+              "message": "Request to subgraph 'accounts' failed.",
               "path": [
                 "me"
               ],
@@ -422,7 +422,7 @@ fn with_broken_subgraph_retried() {
             }
           ]
         }
-        "###);
+        "#);
     });
 
     let result = std::fs::read_to_string(tmpdir.path().join("access.log")).unwrap();
@@ -596,12 +596,12 @@ fn with_subgraph_status_500() {
             .send()
             .await;
 
-        insta::assert_json_snapshot!(resp, @r###"
+        insta::assert_json_snapshot!(resp, @r#"
         {
           "data": null,
           "errors": [
             {
-              "message": "Request to subgraph 'accounts' failed with: Invalid status code: 500",
+              "message": "Request to subgraph 'accounts' failed.",
               "path": [
                 "me"
               ],
@@ -611,7 +611,7 @@ fn with_subgraph_status_500() {
             }
           ]
         }
-        "###);
+        "#);
     });
 
     let result = std::fs::read_to_string(tmpdir.path().join("access.log")).unwrap();
@@ -682,12 +682,12 @@ fn with_subgraph_status_500_retried() {
             .send()
             .await;
 
-        insta::assert_json_snapshot!(resp, @r###"
+        insta::assert_json_snapshot!(resp, @r#"
         {
           "data": null,
           "errors": [
             {
-              "message": "Request to subgraph 'accounts' failed with: Invalid status code: 500",
+              "message": "Request to subgraph 'accounts' failed.",
               "path": [
                 "me"
               ],
@@ -697,7 +697,7 @@ fn with_subgraph_status_500_retried() {
             }
           ]
         }
-        "###);
+        "#);
     });
 
     let result = std::fs::read_to_string(tmpdir.path().join("access.log")).unwrap();

--- a/gateway/tests/integration_tests.rs
+++ b/gateway/tests/integration_tests.rs
@@ -576,7 +576,7 @@ fn trace_log_level() {
               "data": null,
               "errors": [
                 {
-                  "message": "Request to subgraph 'accounts' failed with: error sending request",
+                  "message": "Request to subgraph 'accounts' failed.",
                   "path": [
                     "me"
                   ],
@@ -606,12 +606,12 @@ fn no_config() {
         let result: serde_json::Value = client.gql(query).send().await;
         let result = serde_json::to_string_pretty(&result).unwrap();
 
-        insta::assert_snapshot!(&result, @r###"
+        insta::assert_snapshot!(&result, @r#"
         {
           "data": null,
           "errors": [
             {
-              "message": "Request to subgraph 'accounts' failed with: error sending request",
+              "message": "Request to subgraph 'accounts' failed.",
               "path": [
                 "me"
               ],
@@ -621,7 +621,7 @@ fn no_config() {
             }
           ]
         }
-        "###);
+        "#);
     })
 }
 
@@ -641,12 +641,12 @@ fn static_schema() {
         let result: serde_json::Value = client.gql(query).send().await;
         let result = serde_json::to_string_pretty(&result).unwrap();
 
-        insta::assert_snapshot!(&result, @r###"
+        insta::assert_snapshot!(&result, @r#"
         {
           "data": null,
           "errors": [
             {
-              "message": "Request to subgraph 'accounts' failed with: error sending request",
+              "message": "Request to subgraph 'accounts' failed.",
               "path": [
                 "me"
               ],
@@ -656,7 +656,7 @@ fn static_schema() {
             }
           ]
         }
-        "###);
+        "#);
     })
 }
 
@@ -768,12 +768,12 @@ fn custom_path() {
         let result: serde_json::Value = client.gql(query).send().await;
         let result = serde_json::to_string_pretty(&result).unwrap();
 
-        insta::assert_snapshot!(&result, @r###"
+        insta::assert_snapshot!(&result, @r#"
         {
           "data": null,
           "errors": [
             {
-              "message": "Request to subgraph 'accounts' failed with: error sending request",
+              "message": "Request to subgraph 'accounts' failed.",
               "path": [
                 "me"
               ],
@@ -783,7 +783,7 @@ fn custom_path() {
             }
           ]
         }
-        "###);
+        "#);
     })
 }
 
@@ -833,12 +833,12 @@ fn csrf_with_header() {
         let result: serde_json::Value = client.gql(query).send().await;
         let result = serde_json::to_string_pretty(&result).unwrap();
 
-        insta::assert_snapshot!(&result, @r###"
+        insta::assert_snapshot!(&result, @r#"
         {
           "data": null,
           "errors": [
             {
-              "message": "Request to subgraph 'accounts' failed with: error sending request",
+              "message": "Request to subgraph 'accounts' failed.",
               "path": [
                 "me"
               ],
@@ -848,7 +848,7 @@ fn csrf_with_header() {
             }
           ]
         }
-        "###);
+        "#);
     })
 }
 
@@ -868,12 +868,12 @@ fn hybrid_graph() {
         let result: serde_json::Value = client.gql(query).send().await;
         let result = serde_json::to_string_pretty(&result).unwrap();
 
-        insta::assert_snapshot!(&result, @r###"
+        insta::assert_snapshot!(&result, @r#"
         {
           "data": null,
           "errors": [
             {
-              "message": "Request to subgraph 'accounts' failed with: error sending request",
+              "message": "Request to subgraph 'accounts' failed.",
               "path": [
                 "me"
               ],
@@ -883,7 +883,7 @@ fn hybrid_graph() {
             }
           ]
         }
-        "###);
+        "#);
     });
 }
 

--- a/gateway/tests/telemetry/metrics/operation.rs
+++ b/gateway/tests/telemetry/metrics/operation.rs
@@ -125,7 +125,7 @@ fn used_fields_should_be_unique() {
           "data": null,
           "errors": [
             {
-              "message": "Request to subgraph 'accounts' failed with: error sending request",
+              "message": "Request to subgraph 'accounts' failed.",
               "path": [
                 "me"
               ],
@@ -288,12 +288,12 @@ fn field_error() {
             .send()
             .await;
 
-        insta::assert_json_snapshot!(resp, @r###"
+        insta::assert_json_snapshot!(resp, @r#"
         {
           "data": null,
           "errors": [
             {
-              "message": "Request to subgraph 'accounts' failed with: error sending request",
+              "message": "Request to subgraph 'accounts' failed.",
               "path": [
                 "me"
               ],
@@ -303,7 +303,7 @@ fn field_error() {
             }
           ]
         }
-        "###);
+        "#);
 
         tokio::time::sleep(METRICS_DELAY).await;
 
@@ -344,12 +344,12 @@ fn field_error_data_null() {
             .send()
             .await;
 
-        insta::assert_json_snapshot!(resp, @r###"
+        insta::assert_json_snapshot!(resp, @r#"
         {
           "data": null,
           "errors": [
             {
-              "message": "Request to subgraph 'accounts' failed with: error sending request",
+              "message": "Request to subgraph 'accounts' failed.",
               "path": [
                 "me"
               ],
@@ -359,7 +359,7 @@ fn field_error_data_null() {
             }
           ]
         }
-        "###);
+        "#);
 
         tokio::time::sleep(METRICS_DELAY).await;
 
@@ -744,12 +744,12 @@ fn graphql_errors() {
             .send()
             .await;
 
-        insta::assert_json_snapshot!(resp, @r###"
+        insta::assert_json_snapshot!(resp, @r#"
         {
           "data": null,
           "errors": [
             {
-              "message": "Request to subgraph 'accounts' failed with: error sending request",
+              "message": "Request to subgraph 'accounts' failed.",
               "path": [
                 "me"
               ],
@@ -759,7 +759,7 @@ fn graphql_errors() {
             }
           ]
         }
-        "###);
+        "#);
 
         tokio::time::sleep(METRICS_DELAY).await;
 

--- a/gateway/tests/telemetry/metrics/operation/subgraph.rs
+++ b/gateway/tests/telemetry/metrics/operation/subgraph.rs
@@ -10,12 +10,12 @@ fn request_duration() {
             .send()
             .await;
 
-        insta::assert_json_snapshot!(response, @r###"
+        insta::assert_json_snapshot!(response, @r#"
         {
           "data": null,
           "errors": [
             {
-              "message": "Request to subgraph 'accounts' failed with: error sending request",
+              "message": "Request to subgraph 'accounts' failed.",
               "path": [
                 "me"
               ],
@@ -25,7 +25,7 @@ fn request_duration() {
             }
           ]
         }
-        "###);
+        "#);
 
         tokio::time::sleep(METRICS_DELAY).await;
 
@@ -143,12 +143,12 @@ fn retries() {
             .send()
             .await;
 
-        insta::assert_json_snapshot!(response, @r###"
+        insta::assert_json_snapshot!(response, @r#"
         {
           "data": null,
           "errors": [
             {
-              "message": "Request to subgraph 'accounts' failed with: error sending request",
+              "message": "Request to subgraph 'accounts' failed.",
               "path": [
                 "me"
               ],
@@ -158,7 +158,7 @@ fn retries() {
             }
           ]
         }
-        "###);
+        "#);
 
         tokio::time::sleep(METRICS_DELAY).await;
 
@@ -208,12 +208,12 @@ fn inflight() {
             .send()
             .await;
 
-        insta::assert_json_snapshot!(response, @r###"
+        insta::assert_json_snapshot!(response, @r#"
         {
           "data": null,
           "errors": [
             {
-              "message": "Request to subgraph 'accounts' failed with: error sending request",
+              "message": "Request to subgraph 'accounts' failed.",
               "path": [
                 "me"
               ],
@@ -223,7 +223,7 @@ fn inflight() {
             }
           ]
         }
-        "###);
+        "#);
 
         tokio::time::sleep(METRICS_DELAY).await;
 

--- a/gateway/tests/telemetry/metrics/request.rs
+++ b/gateway/tests/telemetry/metrics/request.rs
@@ -126,7 +126,7 @@ fn field_error() {
           "data": null,
           "errors": [
             {
-              "message": "Request to subgraph 'accounts' failed with: error sending request",
+              "message": "Request to subgraph 'accounts' failed.",
               "path": [
                 "me"
               ],
@@ -185,7 +185,7 @@ fn field_error_data_null() {
           "data": null,
           "errors": [
             {
-              "message": "Request to subgraph 'accounts' failed with: error sending request",
+              "message": "Request to subgraph 'accounts' failed.",
               "path": [
                 "me"
               ],


### PR DESCRIPTION
A few improvements for HTTP requests:
- hide the error details in the GraphQL error and instead log it as `ERROR`. The error now displays more information as `reqwest` hides information with `std::fmt::Display` but not with `std::fmt::Debug`.
- Use hickory DNS resolver in reqwest
- Use a pool idle timeout of 5s. Unclear why, but this does help picking up DNS changes even within a benchmark that is ramping up traffic.
- disable zstd from reqwest, doesn't seem to work well.