### PR TITLE
fix(cli/introspect): header argument should not grab all values

### DIFF
--- a/cli/src/cli_input/introspect.rs
+++ b/cli/src/cli_input/introspect.rs
@@ -3,7 +3,7 @@ pub struct IntrospectCommand {
     /// GraphQL URL to introspect
     pub(crate) url: String,
     /// Add a header to the introspection request
-    #[clap(short = 'H', long, value_parser, num_args = 0..)]
+    #[clap(short = 'H', long, value_parser)]
     header: Vec<String>,
     /// Disable syntax highlighting of the introspected GraphQL
     #[clap(long)]


### PR DESCRIPTION
Makes it impossible to write something like:
`grafbase introspect -H '...' <url>`
