### PR TITLE
hooks release 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3645,7 +3645,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-hooks"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "grafbase-hooks-derive",
  "serde",

--- a/crates/grafbase-hooks/Cargo.toml
+++ b/crates/grafbase-hooks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-hooks"
-version = "0.3.0"
+version = "0.4.0"
 description = "An SDK to implement hooks for the Grafbase Gateway"
 edition.workspace = true
 license.workspace = true

--- a/crates/wasi-component-loader/examples/Cargo.lock
+++ b/crates/wasi-component-loader/examples/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-hooks"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "grafbase-hooks-derive",
  "serde",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "grafbase-sdk-derive",

--- a/crates/wasi-component-loader/src/instance.rs
+++ b/crates/wasi-component-loader/src/instance.rs
@@ -97,13 +97,13 @@ impl ComponentInstance {
 
         match self.instance.get_typed_func(&mut self.store, function_name) {
             Ok(function) => {
-                tracing::debug!("instantized the {function_name} hook Wasm function");
+                tracing::debug!("instantiating the {function_name} hook Wasm function");
                 self.function_cache.push((function_name, Some(Box::new(function))));
                 Some(function)
             }
             Err(e) => {
                 // Shouldn't happen, so we keep spamming errors to be sure it's seen.
-                tracing::error!("error instantizing the {function_name} hook Wasm function: {e}");
+                tracing::error!("error instantiating the {function_name} hook Wasm function: {e}");
                 None
             }
         }


### PR DESCRIPTION
Changed the `extensions` field in `error` type to have a binary value rather than a String.
