### PR TITLE
fix: subgraph url can be nullable

### DIFF
--- a/cli/src/backend/api/graphql/api.graphql
+++ b/cli/src/backend/api/graphql/api.graphql
@@ -399,7 +399,7 @@ enum DeploymentStepStatus {
 type DeploymentSubgraph {
   name: String!
   versionNumber: Int!
-  url: String!
+  url: String
 }
 
 """
@@ -1526,7 +1526,7 @@ input PublishInput {
   projectSlug: String
   branch: String
   subgraph: String!
-  url: String!
+  url: String
   schema: String!
   message: String
 }
@@ -2678,7 +2678,7 @@ type StandaloneGraphsNoLongerSupportedError {
 
 type Subgraph {
   name: String!
-  url: String!
+  url: String
   schema: String!
   createdAt: DateTime!
   updatedAt: DateTime!

--- a/cli/src/backend/api/graphql/types/mutations.rs
+++ b/cli/src/backend/api/graphql/types/mutations.rs
@@ -216,7 +216,7 @@ pub struct PublishInput<'a> {
     pub graph_slug: Option<&'a str>,
     pub schema: &'a str,
     pub subgraph: &'a str,
-    pub url: &'a str,
+    pub url: Option<&'a str>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]

--- a/cli/src/backend/api/graphql/types/queries/subgraph_schemas_by_branch.rs
+++ b/cli/src/backend/api/graphql/types/queries/subgraph_schemas_by_branch.rs
@@ -23,5 +23,5 @@ pub struct Branch {
 pub struct Subgraph {
     pub name: String,
     pub schema: String,
-    pub url: String,
+    pub url: Option<String>,
 }

--- a/cli/src/backend/api/publish.rs
+++ b/cli/src/backend/api/publish.rs
@@ -20,7 +20,7 @@ pub async fn publish(
     graph_slug: &str,
     branch: Option<&str>,
     subgraph_name: &str,
-    url: &str,
+    url: Option<&str>,
     schema: &str,
     message: Option<&str>,
 ) -> Result<PublishOutcome, ApiError> {

--- a/cli/src/backend/dev/hot_reload.rs
+++ b/cli/src/backend/dev/hot_reload.rs
@@ -411,7 +411,7 @@ async fn reload_subgraphs(
         .filter(|(name, _)| !overridden_subgraphs.contains(**name))
     {
         let sdl = cynic_parser::parse_type_system_document(&remote_subgraph.schema)?;
-        subgraphs.ingest(&sdl, name, Some(&remote_subgraph.url));
+        subgraphs.ingest(&sdl, name, remote_subgraph.url.as_deref());
     }
 
     // we're not passing in the graph ref to avoid fetching the remote subgraphs again

--- a/cli/src/cli_input/publish.rs
+++ b/cli/src/cli_input/publish.rs
@@ -1,5 +1,5 @@
 use super::FullGraphRef;
-use clap::Parser;
+use clap::{Args, Parser};
 use url::Url;
 
 /// Publish a subgraph
@@ -17,11 +17,23 @@ pub struct PublishCommand {
     #[arg(long("schema"))]
     pub(crate) schema_path: Option<String>,
 
-    /// The URL to the GraphQL endpoint
-    #[arg(long)]
-    pub(crate) url: Url,
-
     /// The message to annotate the publication with
     #[arg(long, short = 'm')]
     pub(crate) message: Option<String>,
+
+    #[command(flatten)]
+    pub(crate) source: SubgraphSource,
+}
+
+#[derive(Debug, Args)]
+#[group(required = true, multiple = false)]
+pub(crate) struct SubgraphSource {
+    /// The URL to the GraphQL endpoint. Can be omitted if the subgraph is virtual and completely defined
+    /// by an extension.
+    #[arg(long)]
+    pub(crate) url: Option<Url>,
+
+    /// Subgraph does not exist, but is handled by an extension.
+    #[arg(long)]
+    pub(crate) r#virtual: bool,
 }

--- a/cli/src/publish.rs
+++ b/cli/src/publish.rs
@@ -11,7 +11,7 @@ pub(crate) async fn publish(
     PublishCommand {
         subgraph_name,
         graph_ref,
-        url,
+        source,
         schema_path,
         message,
         ..
@@ -40,7 +40,7 @@ pub(crate) async fn publish(
         graph_ref.graph(),
         graph_ref.branch(),
         &subgraph_name,
-        url.as_str(),
+        source.url.as_ref().map(|url| url.as_str()),
         &schema,
         message.as_deref(),
     )


### PR DESCRIPTION
Add --virtual to the call to define the subgraph as virtual, e.g. to be managed by an extension.