### PR TITLE
cli: make grafbase extension install touch up the lockfile

### DIFF
--- a/cli/src/cli_input/extension.rs
+++ b/cli/src/cli_input/extension.rs
@@ -23,7 +23,7 @@ pub enum ExtensionSubCommand {
     /// Update the lockfile (grafbase-extensions.locks)
     Update(ExtensionUpdateCommand),
     /// Download the extensions captured in the lockfile.
-    Install,
+    Install(ExtensionInstallCommand),
 }
 
 #[derive(Debug, Parser)]
@@ -72,6 +72,13 @@ pub(crate) struct ExtensionUpdateCommand {
     /// The name of the extension(s) to update. This argument can be passed multiple times. If no --name is passed, all extensions are updated.
     #[arg(short, long)]
     pub name: Option<Vec<String>>,
+    /// The location of the gateway configuration file that contains the version requirements. Default: `./grafbase.toml`.
+    #[arg(short, long, default_value = DEFAULT_GATEWAY_CONFIG_FILE_PATH)]
+    pub config: PathBuf,
+}
+
+#[derive(Debug, Parser)]
+pub(crate) struct ExtensionInstallCommand {
     /// The location of the gateway configuration file that contains the version requirements. Default: `./grafbase.toml`.
     #[arg(short, long, default_value = DEFAULT_GATEWAY_CONFIG_FILE_PATH)]
     pub config: PathBuf,

--- a/cli/src/cli_input/sub_command.rs
+++ b/cli/src/cli_input/sub_command.rs
@@ -61,7 +61,9 @@ impl RequiresLogin for SubCommand {
                 | SubCommand::Schema(_)
                 | SubCommand::Dev(DevCommand { graph_ref: Some(_), .. })
                 | SubCommand::Extension(ExtensionCommand {
-                    command: ExtensionSubCommand::Publish(_) | ExtensionSubCommand::Update(_)
+                    command: ExtensionSubCommand::Publish(_)
+                        | ExtensionSubCommand::Update(_)
+                        | ExtensionSubCommand::Install(_)
                 })
         )
     }

--- a/cli/src/extension.rs
+++ b/cli/src/extension.rs
@@ -14,6 +14,6 @@ pub(crate) fn execute(cmd: ExtensionCommand) -> anyhow::Result<()> {
         ExtensionSubCommand::Build(cmd) => build::execute(cmd),
         ExtensionSubCommand::Publish(cmd) => publish::execute(cmd),
         ExtensionSubCommand::Update(cmd) => update::execute(cmd),
-        ExtensionSubCommand::Install => install::execute(),
+        ExtensionSubCommand::Install(cmd) => install::execute(cmd),
     }
 }

--- a/cli/src/extension/install.rs
+++ b/cli/src/extension/install.rs
@@ -1,23 +1,25 @@
-use std::path::Path;
-
+use crate::{backend::api, cli_input::ExtensionInstallCommand, output::report};
+use extension::lockfile;
+use extension_catalog::PUBLIC_EXTENSION_REGISTRY_URL;
 use futures::stream::FuturesUnordered;
+use std::path::Path;
 use tokio::fs;
 use tokio_stream::StreamExt as _;
 
-use crate::output::report;
-
 #[tokio::main]
-pub(super) async fn execute() -> anyhow::Result<()> {
-    let lockfile_path = Path::new(extension::lockfile::EXTENSION_LOCKFILE_NAME);
-    let lockfile_str = fs::read_to_string(lockfile_path)
-        .await
-        .map_err(|err| anyhow::anyhow!("Failed to read lockfile at {}. Cause: {err}", lockfile_path.display()))?;
+pub(super) async fn execute(cmd: ExtensionInstallCommand) -> anyhow::Result<()> {
+    let new_lockfile = handle_lockfile(&cmd.config).await?;
+    download_extensions(new_lockfile).await
+}
 
-    let extension::lockfile::VersionedLockfile::V1(lockfile) = toml::from_str(&lockfile_str)
-        .map_err(|err| anyhow::anyhow!("Failed to parse lockfile at {}. Cause: {err}", lockfile_path.display()))?;
-
+async fn download_extensions(new_lockfile: lockfile::Lockfile) -> anyhow::Result<()> {
     let extensions_directory = Path::new(extension_catalog::EXTENSION_DIR_NAME);
     let http_client = reqwest::Client::new();
+
+    let base_registry_url: url::Url = std::env::var("EXTENSION_REGISTRY_URL")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_else(|| PUBLIC_EXTENSION_REGISTRY_URL.parse().unwrap());
 
     fs::create_dir_all(extensions_directory).await.map_err(|err| {
         anyhow::anyhow!(
@@ -30,14 +32,15 @@ pub(super) async fn execute() -> anyhow::Result<()> {
 
     report::extension_install_start(extensions_directory);
 
-    let progress_bar = indicatif::ProgressBar::new(lockfile.extensions.len() as u64);
+    let progress_bar = indicatif::ProgressBar::new(new_lockfile.extensions.len() as u64);
 
-    for extension in lockfile.extensions {
+    for extension in new_lockfile.extensions {
         futures.push(extension_catalog::download_extension_from_registry(
             &http_client,
             extensions_directory,
             extension.name,
             extension.version,
+            &base_registry_url,
         ));
     }
 
@@ -48,4 +51,97 @@ pub(super) async fn execute() -> anyhow::Result<()> {
     progress_bar.finish_with_message("All extensions downloaded in ....");
 
     Ok(())
+}
+
+/// Returns the new up to date lockfile.
+async fn handle_lockfile(config_path: &Path) -> anyhow::Result<lockfile::Lockfile> {
+    let mut has_updated = false;
+    let lockfile_path = Path::new(extension::lockfile::EXTENSION_LOCKFILE_NAME);
+    let lockfile_str = match fs::read_to_string(lockfile_path).await {
+        Ok(str) => Some(str),
+        Err(err) => match err.kind() {
+            std::io::ErrorKind::NotFound => None,
+            _ => anyhow::bail!("Failed to read lockfile at {}. Cause: {err}", lockfile_path.display()),
+        },
+    };
+
+    let lockfile: lockfile::Lockfile = if let Some(lockfile_str) = lockfile_str {
+        let extension::lockfile::VersionedLockfile::V1(lockfile) = toml::from_str(&lockfile_str)
+            .map_err(|err| anyhow::anyhow!("Failed to parse lockfile at {}. Cause: {err}", lockfile_path.display()))?;
+
+        lockfile
+    } else {
+        lockfile::Lockfile::default()
+    };
+
+    let config_str = fs::read_to_string(config_path)
+        .await
+        .map_err(|err| anyhow::anyhow!("Failed to read config at {}. Cause: {err}", config_path.display()))?;
+
+    let config: gateway_config::Config = toml::from_str(&config_str)
+        .map_err(|err| anyhow::anyhow!("Failed to parse config at {}. Cause: {err}", config_path.display()))?;
+
+    let mut new_version_requirements: Vec<(String, semver::VersionReq)> = Vec::new();
+
+    let mut extensions_from_config = config.extensions.unwrap_or_default();
+
+    if extensions_from_config.is_empty() {
+        report::no_extension_defined_in_config();
+        std::process::exit(0)
+    }
+
+    let mut new_lockfile = lockfile::Lockfile::default();
+
+    for ext in lockfile.extensions {
+        match extensions_from_config.remove(&ext.name) {
+            Some(requirement) => {
+                if requirement.version().matches(&ext.version) {
+                    new_lockfile.extensions.push(ext);
+                } else {
+                    new_version_requirements.push((ext.name, requirement.version().clone()));
+                }
+            }
+            None => {
+                has_updated = true;
+            }
+        }
+    }
+
+    for (name, ext) in extensions_from_config {
+        new_version_requirements.push((name, ext.version().clone()));
+    }
+
+    if !new_version_requirements.is_empty() {
+        has_updated = true;
+
+        let matches = api::extension_versions_by_version_requirement::extension_versions_by_version_requirement(
+            new_version_requirements
+                .iter()
+                .map(|(name, version)| (name.clone(), version.clone())),
+        )
+        .await?;
+
+        for (i, m) in matches.into_iter().enumerate() {
+            match m {
+                api::extension_versions_by_version_requirement::ExtensionVersionMatch::Match { name, version } => {
+                    new_lockfile.extensions.push(lockfile::Extension { name, version });
+                }
+                api::extension_versions_by_version_requirement::ExtensionVersionMatch::ExtensionDoesNotExist => {
+                    super::update::handle_extension_does_not_exist(&new_version_requirements[i].0);
+                }
+                api::extension_versions_by_version_requirement::ExtensionVersionMatch::ExtensionVersionDoesNotExist => {
+                    let (name, version) = &new_version_requirements[i];
+                    super::update::handle_extension_version_does_not_exist(name, version);
+                }
+            }
+        }
+    }
+
+    if has_updated {
+        let new_lockfile_str = toml::ser::to_string_pretty(&lockfile::VersionedLockfile::V1(new_lockfile.clone()))
+            .map_err(|err| anyhow::anyhow!("Failed to serialize new lockfile: {err}"))?;
+        fs::write(lockfile_path, new_lockfile_str.as_bytes()).await?;
+    }
+
+    Ok(new_lockfile)
 }

--- a/cli/src/extension/update.rs
+++ b/cli/src/extension/update.rs
@@ -124,12 +124,12 @@ pub(super) async fn execute(cmd: ExtensionUpdateCommand) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn handle_extension_does_not_exist(name: &str) {
+pub(super) fn handle_extension_does_not_exist(name: &str) {
     report::extension_update_extension_does_not_exist(name);
     std::process::exit(1);
 }
 
-fn handle_extension_version_does_not_exist(name: &str, version: &semver::VersionReq) {
+pub(super) fn handle_extension_version_does_not_exist(name: &str, version: &semver::VersionReq) {
     report::extension_update_extension_version_does_not_exist(name, version);
     std::process::exit(1);
 }

--- a/cli/src/output/report.rs
+++ b/cli/src/output/report.rs
@@ -310,3 +310,7 @@ pub(crate) fn extension_published(name: &str, version: &str) {
 pub(crate) fn extension_install_start(target_path: &Path) {
     watercolor::output!("🕒 Downloading the extensions from the lockfile to \"{}\"...", target_path.display(), @BrightBlue);
 }
+
+pub(crate) fn no_extension_defined_in_config() {
+    watercolor::output!("✅ No extensions defined in config", @BrightGreen);
+}

--- a/cli/tests/extension/install.rs
+++ b/cli/tests/extension/install.rs
@@ -1,0 +1,274 @@
+use crate::cargo_bin;
+use std::fs;
+use std::process;
+use tempfile::tempdir;
+use wiremock::matchers;
+
+#[tokio::test]
+async fn install_with_up_to_date_lockfile() {
+    let temp_dir = tempdir().unwrap();
+    let project_path = temp_dir.path().join("test_project");
+    std::fs::create_dir_all(&project_path).unwrap();
+
+    // Create a grafbase.toml file with extension version requirements
+    let grafbase_toml_content = r#"
+[extensions]
+echo.version = "^1.0"
+jwt.version = "*"
+rest.version = "0.3.0"
+spicedb.version = "2"
+"#;
+
+    fs::write(project_path.join("grafbase.toml"), grafbase_toml_content).unwrap();
+
+    // Setup mock server
+    let mock_server = wiremock::MockServer::start().await;
+
+    // Mock response for extension version query
+    wiremock::Mock::given(matchers::method("POST"))
+        .and(matchers::path("/graphql"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": {
+                "extensionVersionsByVersionRequirement": [
+                    { "__typename": "ExtensionVersion", "version": "1.1.1", "extension": { "name": "echo" } },
+                    { "__typename": "ExtensionVersion", "version": "0.19.7", "extension": { "name": "jwt" } },
+                    { "__typename": "ExtensionVersion", "version": "0.3.0", "extension": { "name": "rest" } },
+                    { "__typename": "ExtensionVersion", "version": "2.7.0", "extension": { "name": "spicedb" } },
+                ]
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    // Run extension update command
+    let mut update_command = process::Command::new(cargo_bin("grafbase"));
+    update_command
+        .args(["extension", "update"])
+        .env("GRAFBASE_API_URL", format!("{}/graphql", mock_server.uri()))
+        .env("GRAFBASE_ACCESS_TOKEN", "test-value-of-the-access-token")
+        .current_dir(&project_path);
+
+    let update_output = update_command.output().unwrap();
+
+    if !update_output.status.success() {
+        panic!("Update failed\n{update_output:#?}");
+    }
+
+    let original_lockfile_contents = std::fs::read_to_string(project_path.join("grafbase-extensions.lock")).unwrap();
+
+    // Now run grafbase install
+
+    wiremock::Mock::given(matchers::method("GET"))
+        .and(matchers::path_regex("/extensions.*"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_json("{}"))
+        .mount(&mock_server)
+        .await;
+
+    let mut install_command = process::Command::new(cargo_bin("grafbase"));
+    install_command
+        .args(["extension", "install"])
+        .env("GRAFBASE_API_URL", format!("{}/graphql", mock_server.uri()))
+        .env("GRAFBASE_ACCESS_TOKEN", "test-value-of-the-access-token")
+        .env("EXTENSION_REGISTRY_URL", mock_server.uri())
+        .current_dir(&project_path);
+
+    let install_output = install_command.output().unwrap();
+
+    if !install_output.status.success() {
+        panic!("Install failed\n{install_output:#?}");
+    }
+
+    let updated_lockfile_contents = std::fs::read_to_string(project_path.join("grafbase-extensions.lock")).unwrap();
+
+    // Check if lockfile was updated
+    assert_eq!(original_lockfile_contents, updated_lockfile_contents);
+}
+
+#[tokio::test]
+async fn install_with_no_lockfile() {
+    let temp_dir = tempdir().unwrap();
+    let project_path = temp_dir.path().join("test_project");
+    std::fs::create_dir_all(&project_path).unwrap();
+
+    // Create a grafbase.toml file with extension version requirements
+    let grafbase_toml_content = r#"
+[extensions]
+echo.version = "^1.0"
+jwt.version = "*"
+rest.version = "0.3.0"
+spicedb.version = "2"
+"#;
+
+    fs::write(project_path.join("grafbase.toml"), grafbase_toml_content).unwrap();
+
+    // Setup mock server
+    let mock_server = wiremock::MockServer::start().await;
+
+    // Mock response for extension version query
+    wiremock::Mock::given(matchers::method("POST"))
+        .and(matchers::path("/graphql"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+        "data": {
+        "extensionVersionsByVersionRequirement": [
+        { "__typename": "ExtensionVersion", "version": "1.1.1", "extension": { "name": "echo" } },
+        { "__typename": "ExtensionVersion", "version": "0.19.7", "extension": { "name": "jwt" } },
+        { "__typename": "ExtensionVersion", "version": "0.3.0", "extension": { "name": "rest" } },
+        { "__typename": "ExtensionVersion", "version": "2.7.0", "extension": { "name": "spicedb" } },
+        ]
+        }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    // Now run grafbase install
+
+    wiremock::Mock::given(matchers::method("GET"))
+        .and(matchers::path_regex("/extensions.*"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_json("{}"))
+        .mount(&mock_server)
+        .await;
+
+    let mut install_command = process::Command::new(cargo_bin("grafbase"));
+    install_command
+        .args(["extension", "install"])
+        .env("GRAFBASE_API_URL", format!("{}/graphql", mock_server.uri()))
+        .env("GRAFBASE_ACCESS_TOKEN", "test-value-of-the-access-token")
+        .env("EXTENSION_REGISTRY_URL", mock_server.uri())
+        .current_dir(&project_path);
+
+    let install_output = install_command.output().unwrap();
+
+    if !install_output.status.success() {
+        panic!("Install failed\n{install_output:#?}");
+    }
+
+    let updated_lockfile_contents = std::fs::read_to_string(project_path.join("grafbase-extensions.lock")).unwrap();
+
+    insta::assert_snapshot!(updated_lockfile_contents, @r#"
+    version = "1"
+
+    [[extensions]]
+    name = "echo"
+    version = "1.1.1"
+
+    [[extensions]]
+    name = "jwt"
+    version = "0.19.7"
+
+    [[extensions]]
+    name = "rest"
+    version = "0.3.0"
+
+    [[extensions]]
+    name = "spicedb"
+    version = "2.7.0"
+    "#);
+}
+
+#[tokio::test]
+async fn install_with_lockfile_with_one_missing_one_outdated_and_one_extra_extension() {
+    let temp_dir = tempdir().unwrap();
+    let project_path = temp_dir.path().join("test_project");
+    std::fs::create_dir_all(&project_path).unwrap();
+
+    // Create a grafbase.toml file with extension version requirements
+    let grafbase_toml_content = r#"
+[extensions]
+echo.version = "^1.0"
+jwt.version = "*"
+rest.version = "0.3.0"
+spicedb.version = "2"
+"#;
+
+    fs::write(project_path.join("grafbase.toml"), grafbase_toml_content).unwrap();
+
+    // foo isn't in the config
+    // rest doesn't match the version in the config
+    // echo is not completely up to date, but it won't be updated because it is locked
+    // spicedb is in the config but missing here
+    let extensions_lock = r#"
+        version = "1"
+
+        [[extensions]]
+        name = "echo"
+        version = "1.1.0"
+
+        [[extensions]]
+        name = "jwt"
+        version = "0.19.7"
+
+        [[extensions]]
+        name = "foo"
+        version = "0.19.7"
+
+        [[extensions]]
+        name = "rest"
+        version = "0.2.0"
+    "#;
+
+    fs::write(project_path.join("grafbase-extensions.lock"), extensions_lock).unwrap();
+
+    // Setup mock server
+    let mock_server = wiremock::MockServer::start().await;
+
+    // Mock response for extension version query
+    wiremock::Mock::given(matchers::method("POST"))
+        .and(matchers::path("/graphql"))
+        .and(matchers::body_partial_json(serde_json::json!({
+            "variables":{"requirements":[{"extensionName":"rest","version":"^0.3.0"},{"extensionName":"spicedb","version":"^2"}]},
+        })))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+        "data": {
+            "extensionVersionsByVersionRequirement": [
+                { "__typename": "ExtensionVersion", "version": "0.3.0", "extension": { "name": "rest" } },
+                { "__typename": "ExtensionVersion", "version": "2.7.0", "extension": { "name": "spicedb" } },
+            ]
+        }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    // Now run grafbase install
+
+    wiremock::Mock::given(matchers::method("GET"))
+        .and(matchers::path_regex("/extensions.*"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_json("{}"))
+        .mount(&mock_server)
+        .await;
+
+    let mut install_command = process::Command::new(cargo_bin("grafbase"));
+    install_command
+        .args(["extension", "install"])
+        .env("GRAFBASE_API_URL", format!("{}/graphql", mock_server.uri()))
+        .env("GRAFBASE_ACCESS_TOKEN", "test-value-of-the-access-token")
+        .env("EXTENSION_REGISTRY_URL", mock_server.uri())
+        .current_dir(&project_path);
+
+    let install_output = install_command.output().unwrap();
+
+    if !install_output.status.success() {
+        panic!("Install failed\n{install_output:#?}");
+    }
+
+    let updated_lockfile_contents = std::fs::read_to_string(project_path.join("grafbase-extensions.lock")).unwrap();
+
+    insta::assert_snapshot!(updated_lockfile_contents, @r#"
+    version = "1"
+
+    [[extensions]]
+    name = "echo"
+    version = "1.1.0"
+
+    [[extensions]]
+    name = "jwt"
+    version = "0.19.7"
+
+    [[extensions]]
+    name = "rest"
+    version = "0.3.0"
+
+    [[extensions]]
+    name = "spicedb"
+    version = "2.7.0"
+    "#);
+}

--- a/cli/tests/extension/mod.rs
+++ b/cli/tests/extension/mod.rs
@@ -1,3 +1,4 @@
+mod install;
 mod publish;
 mod update;
 

--- a/crates/extension/src/lockfile/v1.rs
+++ b/crates/extension/src/lockfile/v1.rs
@@ -1,9 +1,9 @@
-#[derive(serde::Deserialize, serde::Serialize, Default)]
+#[derive(serde::Deserialize, serde::Serialize, Default, Clone)]
 pub struct Lockfile {
     pub extensions: Vec<Extension>,
 }
 
-#[derive(serde::Deserialize, serde::Serialize)]
+#[derive(serde::Deserialize, serde::Serialize, Clone)]
 pub struct Extension {
     pub name: String,
     pub version: semver::Version,

--- a/crates/federated-server/src/server/gateway/create_extension_catalog.rs
+++ b/crates/federated-server/src/server/gateway/create_extension_catalog.rs
@@ -1,4 +1,4 @@
-use extension_catalog::{Extension, ExtensionCatalog, VersionedManifest};
+use extension_catalog::{Extension, ExtensionCatalog, PUBLIC_EXTENSION_REGISTRY_URL, VersionedManifest};
 use gateway_config::Config;
 use std::{env, fs::File, io, path::Path};
 
@@ -85,11 +85,17 @@ async fn create_extension_catalog_impl(gateway_config: &Config, cwd: &Path) -> R
             continue;
         };
 
+        let base_registry_url = std::env::var("EXTENSION_REGISTRY_URL")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| PUBLIC_EXTENSION_REGISTRY_URL.parse().unwrap());
+
         extension_catalog::download_extension_from_registry(
             &http_client,
             &grafbase_extensions_dir_path,
             extension_name.clone(),
             extension_in_lockfile.version.clone(),
+            &base_registry_url,
         )
         .await
         .map_err(Error::Download)?;


### PR DESCRIPTION
Implements the CLI part of the RFC at https://linear.app/grafbase/document/install-centric-extension-management-e1742a0ed539

closes GB-8618