### PR TITLE
feat: extension subscription deduplication

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -36,3 +36,7 @@ runs:
       if: ${{ inputs.target }}
       shell: bash
       run: rustup target add ${{ inputs.target }}
+
+    - name: Install toolchain
+      shell: bash
+      run: rustup show active-toolchain || rustup toolchain install

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9781,6 +9781,7 @@ dependencies = [
  "thiserror 2.0.12",
  "time 0.3.37",
  "tokio",
+ "tokio-stream",
  "toml",
  "tracing",
  "ulid",

--- a/crates/grafbase-sdk/src/component/extension.rs
+++ b/crates/grafbase-sdk/src/component/extension.rs
@@ -34,6 +34,15 @@ pub(crate) trait AnyExtension {
         Err("Resolver extension not initialized correctly.".into())
     }
 
+    fn subscription_identifier(
+        &mut self,
+        headers: &Headers,
+        subgraph_name: &str,
+        directive: FieldDefinitionDirective<'_>,
+    ) -> Result<Option<Vec<u8>>, Error> {
+        Err("Resolver extension not initialized correctly.".into())
+    }
+
     fn authorize_query<'a>(&'a mut self, elements: QueryElements<'a>) -> Result<AuthorizationDecisions, ErrorResponse> {
         Err(ErrorResponse::internal_server_error(
             "Authorization extension not initialized correctly.",

--- a/crates/grafbase-sdk/src/component/extension.rs
+++ b/crates/grafbase-sdk/src/component/extension.rs
@@ -34,7 +34,7 @@ pub(crate) trait AnyExtension {
         Err("Resolver extension not initialized correctly.".into())
     }
 
-    fn subscription_identifier(
+    fn subscription_key(
         &mut self,
         headers: &Headers,
         subgraph_name: &str,

--- a/crates/grafbase-sdk/src/component/mod.rs
+++ b/crates/grafbase-sdk/src/component/mod.rs
@@ -47,12 +47,12 @@ impl Guest for Component {
         Ok(())
     }
 
-    fn subscription_identifier(
+    fn subscription_key(
         headers: Headers,
         subgraph_name: String,
         directive: FieldDefinitionDirective,
     ) -> Result<Option<Vec<u8>>, Error> {
-        let result = state::extension()?.subscription_identifier(&headers, &subgraph_name, (&directive).into())?;
+        let result = state::extension()?.subscription_key(&headers, &subgraph_name, (&directive).into())?;
 
         Ok(result)
     }

--- a/crates/grafbase-sdk/src/component/mod.rs
+++ b/crates/grafbase-sdk/src/component/mod.rs
@@ -47,6 +47,16 @@ impl Guest for Component {
         Ok(())
     }
 
+    fn subscription_identifier(
+        headers: Headers,
+        subgraph_name: String,
+        directive: FieldDefinitionDirective,
+    ) -> Result<Option<Vec<u8>>, Error> {
+        let result = state::extension()?.subscription_identifier(&headers, &subgraph_name, (&directive).into())?;
+
+        Ok(result)
+    }
+
     fn resolve_next_subscription_item() -> Result<Option<FieldOutput>, Error> {
         Ok(state::subscription()?.next()?.map(Into::into))
     }

--- a/crates/grafbase-sdk/src/extension/resolver.rs
+++ b/crates/grafbase-sdk/src/extension/resolver.rs
@@ -52,10 +52,10 @@ pub trait Resolver: Extension {
         directive: FieldDefinitionDirective<'_>,
     ) -> Result<Box<dyn Subscription>, Error>;
 
-    /// Returns an identifier for a subscription field.
+    /// Returns a key for a subscription field.
     ///
     /// This method is used to identify unique subscription channels or connections
-    /// when managing multiple active subscriptions. The returned identifier can be
+    /// when managing multiple active subscriptions. The returned key can be
     /// used to track, manage, or deduplicate subscriptions.
     ///
     /// # Arguments
@@ -66,10 +66,10 @@ pub trait Resolver: Extension {
     ///
     /// # Returns
     ///
-    /// Returns an `Option<String>` containing either a unique identifier for this
+    /// Returns an `Option<Vec<u8>>` containing either a unique key for this
     /// subscription or `None` if no deduplication is desired.
     #[allow(unused)]
-    fn subscription_identifier(
+    fn subscription_key(
         &mut self,
         headers: &Headers,
         subgraph_name: &str,
@@ -118,13 +118,13 @@ pub fn register<T: Resolver>() {
             Resolver::resolve_subscription(&mut self.0, headers, subgraph_name, directive)
         }
 
-        fn subscription_identifier(
+        fn subscription_key(
             &mut self,
             headers: &Headers,
             subgraph_name: &str,
             directive: FieldDefinitionDirective<'_>,
         ) -> Result<Option<Vec<u8>>, Error> {
-            Ok(Resolver::subscription_identifier(
+            Ok(Resolver::subscription_key(
                 &mut self.0,
                 headers,
                 subgraph_name,

--- a/crates/grafbase-sdk/src/test/config.rs
+++ b/crates/grafbase-sdk/src/test/config.rs
@@ -21,6 +21,8 @@ pub enum LogLevel {
     Error,
     /// Show all output from engine, debug upwards.
     EngineDebug,
+    /// LOL
+    WasiDebug,
 }
 
 impl AsRef<str> for LogLevel {
@@ -32,6 +34,7 @@ impl AsRef<str> for LogLevel {
             LogLevel::Warn => "warn",
             LogLevel::Error => "error",
             LogLevel::EngineDebug => "engine=debug",
+            LogLevel::WasiDebug => "wasi_component_loader=debug",
         }
     }
 }

--- a/crates/grafbase-sdk/src/types/directive.rs
+++ b/crates/grafbase-sdk/src/types/directive.rs
@@ -58,11 +58,8 @@ impl<'a> FieldDefinitionDirective<'a> {
         minicbor_serde::from_slice(&self.0.arguments).map_err(Into::into)
     }
 
-    /// Returns the raw arguments byte array from the directive.
-    ///
-    /// This provides access to the underlying CBOR-encoded argument data
-    /// for cases where direct access to the bytes is needed.
-    pub fn raw_arguments(&self) -> &[u8] {
+    ///Serialized arguments as sent by the host. There is no guarantee on the bytes.
+    pub fn arguments_bytes(&self) -> &[u8] {
         &self.0.arguments
     }
 

--- a/crates/grafbase-sdk/src/types/directive.rs
+++ b/crates/grafbase-sdk/src/types/directive.rs
@@ -58,6 +58,14 @@ impl<'a> FieldDefinitionDirective<'a> {
         minicbor_serde::from_slice(&self.0.arguments).map_err(Into::into)
     }
 
+    /// Returns the raw arguments byte array from the directive.
+    ///
+    /// This provides access to the underlying CBOR-encoded argument data
+    /// for cases where direct access to the bytes is needed.
+    pub fn raw_arguments(&self) -> &[u8] {
+        &self.0.arguments
+    }
+
     /// The site information for this directive
     #[inline]
     pub fn site(&self) -> FieldDefinitionDirectiveSite<'a> {

--- a/crates/grafbase-sdk/wit/world.wit
+++ b/crates/grafbase-sdk/wit/world.wit
@@ -349,6 +349,17 @@ interface extension {
        inputs: list<list<u8>>
     ) -> result<field-output, error>;
 
+    // This function generates a unique identifier for a GraphQL subscription.
+    //
+    // The identifier is used to share the same subscription between multiple clients.
+    // The extension decides what makes a subscription unique. If the value is none,
+    // then it is considered not unique and every subscriber gets their own subscription.
+    subscription-identifier: func(
+        headers: headers,
+        subgraph-name: string,
+        directive: field-definition-directive,
+    ) -> result<option<list<u8>>, error>;
+
     // initializes a new subscription stream
     resolve-subscription: func(
         headers: headers,

--- a/crates/grafbase-sdk/wit/world.wit
+++ b/crates/grafbase-sdk/wit/world.wit
@@ -349,12 +349,12 @@ interface extension {
        inputs: list<list<u8>>
     ) -> result<field-output, error>;
 
-    // This function generates a unique identifier for a GraphQL subscription.
+    // This function generates a unique key for a GraphQL subscription.
     //
-    // The identifier is used to share the same subscription between multiple clients.
+    // The key is used to share the same subscription between multiple clients.
     // The extension decides what makes a subscription unique. If the value is none,
     // then it is considered not unique and every subscriber gets their own subscription.
-    subscription-identifier: func(
+    subscription-key: func(
         headers: headers,
         subgraph-name: string,
         directive: field-definition-directive,

--- a/crates/integration-tests/src/federation/runtime/extension.rs
+++ b/crates/integration-tests/src/federation/runtime/extension.rs
@@ -196,7 +196,7 @@ impl runtime::extension::ExtensionRuntime for TestExtensions {
         &'ctx self,
         _: http::HeaderMap,
         _: ExtensionFieldDirective<'ctx, impl Anything<'ctx>>,
-    ) -> Result<BoxStream<'f, Result<Data, PartialGraphqlError>>, PartialGraphqlError>
+    ) -> Result<BoxStream<'f, Result<Arc<Data>, PartialGraphqlError>>, PartialGraphqlError>
     where
         'ctx: 'f,
     {

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -99,6 +99,16 @@ impl PartialGraphqlError {
             extensions: Vec::new(),
         }
     }
+
+    pub fn stream_lag() -> Self {
+        PartialGraphqlError {
+            message: Cow::Borrowed(
+                "The stream is lagging behind due to not being able to keep up with the data. Events are being dropped.",
+            ),
+            code: PartialErrorCode::ExtensionError,
+            extensions: Vec::new(),
+        }
+    }
 }
 
 impl fmt::Display for PartialGraphqlError {

--- a/crates/runtime/src/extension.rs
+++ b/crates/runtime/src/extension.rs
@@ -1,4 +1,4 @@
-use std::future::Future;
+use std::{future::Future, sync::Arc};
 
 use engine_schema::{DirectiveSite, FieldDefinition, Subgraph};
 use extension_catalog::ExtensionId;
@@ -60,7 +60,7 @@ pub trait ExtensionRuntime: Send + Sync + 'static {
         &'ctx self,
         headers: http::HeaderMap,
         directive: ExtensionFieldDirective<'ctx, impl Anything<'ctx>>,
-    ) -> impl Future<Output = Result<BoxStream<'f, Result<Data, PartialGraphqlError>>, PartialGraphqlError>> + Send + 'f
+    ) -> impl Future<Output = Result<BoxStream<'f, Result<Arc<Data>, PartialGraphqlError>>, PartialGraphqlError>> + Send + 'f
     where
         'ctx: 'f;
 
@@ -116,7 +116,7 @@ impl ExtensionRuntime for () {
         &'ctx self,
         _: http::HeaderMap,
         _: ExtensionFieldDirective<'ctx, impl Anything<'ctx>>,
-    ) -> Result<BoxStream<'f, Result<Data, PartialGraphqlError>>, PartialGraphqlError>
+    ) -> Result<BoxStream<'f, Result<Arc<Data>, PartialGraphqlError>>, PartialGraphqlError>
     where
         'ctx: 'f,
     {

--- a/crates/runtime/src/extension.rs
+++ b/crates/runtime/src/extension.rs
@@ -12,7 +12,7 @@ use crate::{
     hooks::Anything,
 };
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Data {
     JsonBytes(Vec<u8>),
     CborBytes(Vec<u8>),

--- a/crates/wasi-component-loader/Cargo.toml
+++ b/crates/wasi-component-loader/Cargo.toml
@@ -31,6 +31,7 @@ strum = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 time.workspace = true
 tokio = { workspace = true, features = ["time", "rt"] }
+tokio-stream.workspace = true
 tracing.workspace = true
 ulid.workspace = true
 url.workspace = true

--- a/crates/wasi-component-loader/src/extension/instance.rs
+++ b/crates/wasi-component-loader/src/extension/instance.rs
@@ -49,7 +49,7 @@ impl ExtensionInstance {
         Ok(output)
     }
 
-    pub async fn subscription_identifier(
+    pub async fn subscription_key(
         &mut self,
         headers: http::HeaderMap,
         subgraph_name: &str,
@@ -60,10 +60,10 @@ impl ExtensionInstance {
         let headers = self.store.data_mut().push_resource(wit::Headers::borrow(headers))?;
         let headers_rep = headers.rep();
 
-        let identifier = self
+        let key = self
             .inner
             .grafbase_sdk_extension()
-            .call_subscription_identifier(&mut self.store, headers, subgraph_name, directive)
+            .call_subscription_key(&mut self.store, headers, subgraph_name, directive)
             .await??;
 
         let headers = self
@@ -75,7 +75,7 @@ impl ExtensionInstance {
 
         self.poisoned = false;
 
-        Ok((headers, identifier))
+        Ok((headers, key))
     }
 
     pub async fn resolve_subscription(

--- a/crates/wasi-component-loader/src/extension/instance.rs
+++ b/crates/wasi-component-loader/src/extension/instance.rs
@@ -49,6 +49,35 @@ impl ExtensionInstance {
         Ok(output)
     }
 
+    pub async fn subscription_identifier(
+        &mut self,
+        headers: http::HeaderMap,
+        subgraph_name: &str,
+        directive: wit::FieldDefinitionDirective<'_>,
+    ) -> Result<(http::HeaderMap, Option<Vec<u8>>), crate::Error> {
+        self.poisoned = true;
+
+        let headers = self.store.data_mut().push_resource(wit::Headers::borrow(headers))?;
+        let headers_rep = headers.rep();
+
+        let identifier = self
+            .inner
+            .grafbase_sdk_extension()
+            .call_subscription_identifier(&mut self.store, headers, subgraph_name, directive)
+            .await??;
+
+        let headers = self
+            .store
+            .data_mut()
+            .take_resource::<wit::Headers>(headers_rep)?
+            .into_owned()
+            .unwrap();
+
+        self.poisoned = false;
+
+        Ok((headers, identifier))
+    }
+
     pub async fn resolve_subscription(
         &mut self,
         headers: http::HeaderMap,

--- a/crates/wasi-component-loader/src/extension/runtime.rs
+++ b/crates/wasi-component-loader/src/extension/runtime.rs
@@ -72,7 +72,7 @@ impl ExtensionsWasiRuntime {
         mut instance: ExtensionGuard,
         headers: http::HeaderMap,
         subgraph: Subgraph<'ctx>,
-        directive: wit::FieldDefinitionDirective<'ctx>,
+        directive: wit::FieldDefinitionDirective<'_>,
     ) -> Result<BoxStream<'f, Result<Arc<Data>, PartialGraphqlError>>, PartialGraphqlError>
     where
         'ctx: 'f,
@@ -133,7 +133,7 @@ impl ExtensionsWasiRuntime {
         headers: http::HeaderMap,
         identifier: Vec<u8>,
         subgraph: Subgraph<'ctx>,
-        directive: wit::FieldDefinitionDirective<'ctx>,
+        directive: wit::FieldDefinitionDirective<'_>,
     ) -> Result<BoxStream<'f, Result<Arc<Data>, PartialGraphqlError>>, PartialGraphqlError>
     where
         'ctx: 'f,
@@ -303,7 +303,7 @@ impl ExtensionRuntime for ExtensionsWasiRuntime {
                     parent_type_name: field.parent_entity().name(),
                     field_name: field.name(),
                 },
-                arguments: cbor::to_vec(arguments).unwrap(),
+                arguments: &cbor::to_vec(arguments).unwrap(),
             };
 
             let output = instance
@@ -360,7 +360,7 @@ impl ExtensionRuntime for ExtensionsWasiRuntime {
         } = directive;
 
         let mut instance = self.get(ExtensionPoolId::Resolver(extension_id)).await?;
-        let arguments = cbor::to_vec(arguments).unwrap();
+        let arguments = &cbor::to_vec(arguments).unwrap();
 
         let site = wit::FieldDefinitionDirectiveSite {
             parent_type_name: field.parent_entity().name(),

--- a/crates/wasi-component-loader/src/extension/runtime/subscription.rs
+++ b/crates/wasi-component-loader/src/extension/runtime/subscription.rs
@@ -1,0 +1,12 @@
+mod dedup;
+mod unique;
+
+use std::sync::Arc;
+
+use futures::stream::BoxStream;
+use runtime::{error::PartialGraphqlError, extension::Data};
+
+pub(super) type SubscriptionStream<'f> = BoxStream<'f, Result<Arc<Data>, PartialGraphqlError>>;
+
+pub(super) use dedup::DeduplicatedSubscription;
+pub(super) use unique::UniqueSubscription;

--- a/crates/wasi-component-loader/src/extension/runtime/subscription/dedup.rs
+++ b/crates/wasi-component-loader/src/extension/runtime/subscription/dedup.rs
@@ -1,0 +1,132 @@
+use std::sync::Arc;
+
+use engine_schema::Subgraph;
+use runtime::{
+    error::{PartialErrorCode, PartialGraphqlError},
+    extension::Data,
+};
+use tokio::sync::broadcast;
+use tokio_stream::{StreamExt, wrappers::BroadcastStream};
+
+use crate::extension::{pool::ExtensionGuard, runtime::Subscriptions, wit};
+
+use super::SubscriptionStream;
+
+/// A subscription that deduplicates multiple identical subscription requests.
+///
+/// This struct manages GraphQL subscription streams by creating
+/// a single underlying subscription and broadcasting the results to multiple clients.
+///
+/// The extension determines if and how to deduplicate the subscription requests.
+pub struct DeduplicatedSubscription<'ctx, 'wit> {
+    pub subscriptions: Subscriptions,
+    pub instance: ExtensionGuard,
+    pub headers: http::HeaderMap,
+    pub key: Vec<u8>,
+    pub subgraph: Subgraph<'ctx>,
+    pub directive: wit::FieldDefinitionDirective<'wit>,
+}
+
+impl<'ctx> DeduplicatedSubscription<'ctx, '_> {
+    pub async fn resolve<'f>(self) -> Result<SubscriptionStream<'f>, PartialGraphqlError>
+    where
+        'ctx: 'f,
+    {
+        let DeduplicatedSubscription {
+            subscriptions,
+            mut instance,
+            headers,
+            key,
+            subgraph,
+            directive,
+        } = self;
+
+        let receiver = subscriptions.get(&key).as_ref().map(|channel| channel.subscribe());
+
+        let (sender, receiver) = match receiver {
+            Some(receiver) => {
+                tracing::debug!("reuse existing channel");
+
+                let stream = BroadcastStream::new(receiver).map(|result| match result {
+                    Ok(data) => data,
+                    Err(_) => Err(PartialGraphqlError::stream_lag()),
+                });
+
+                return Ok(Box::pin(stream));
+            }
+            None => {
+                tracing::debug!("create new channel");
+                broadcast::channel(1000)
+            }
+        };
+
+        let sender = subscriptions.entry(key.clone()).or_insert(sender).to_owned();
+
+        instance
+            .resolve_subscription(headers, subgraph.name(), directive)
+            .await
+            .map_err(|err| err.into_graphql_error(PartialErrorCode::ExtensionError))?;
+
+        tokio::spawn(async move {
+            let mut registerations_closed = false;
+
+            loop {
+                let item = loop {
+                    if registerations_closed && sender.receiver_count() == 0 {
+                        return;
+                    }
+
+                    match instance.resolve_next_subscription_item().await {
+                        Ok(Some(item)) if item.outputs.is_empty() => {
+                            continue;
+                        }
+                        Ok(Some(item)) => {
+                            tracing::debug!("subscription item resolved");
+
+                            break item;
+                        }
+                        Ok(None) => {
+                            tracing::debug!("subscription ended");
+                            subscriptions.remove(&key);
+
+                            return;
+                        }
+                        Err(err) => {
+                            tracing::error!("subscription item error: {err}");
+                            subscriptions.remove(&key);
+
+                            return;
+                        }
+                    }
+                };
+
+                for item in item.outputs {
+                    let data = match item {
+                        Ok(item) => Ok(Arc::new(Data::CborBytes(item))),
+                        Err(err) => Err(err.into_graphql_error(PartialErrorCode::InternalServerError)),
+                    };
+
+                    if sender.send(data).is_err() {
+                        tracing::debug!("all subscribers are gone");
+                        subscriptions.remove(&key);
+
+                        if registerations_closed {
+                            return;
+                        }
+
+                        registerations_closed = true;
+
+                        break;
+                    }
+                }
+            }
+        });
+
+        let stream = BroadcastStream::new(receiver).map(|result| match result {
+            Ok(data) => data,
+            Err(_) => Err(PartialGraphqlError::stream_lag()),
+        });
+
+        Ok(Box::pin(stream))
+    }
+}

--- a/crates/wasi-component-loader/src/extension/runtime/subscription/unique.rs
+++ b/crates/wasi-component-loader/src/extension/runtime/subscription/unique.rs
@@ -1,0 +1,81 @@
+use std::{collections::VecDeque, sync::Arc};
+
+use super::SubscriptionStream;
+use crate::extension::{pool::ExtensionGuard, wit};
+use engine_schema::Subgraph;
+use futures::stream;
+use runtime::{
+    error::{PartialErrorCode, PartialGraphqlError},
+    extension::Data,
+};
+
+/// A subscription without deduplication, reserving one extension instance for each subscription.
+///
+/// The system uses this when the extension does not define a deduplication key.
+pub struct UniqueSubscription<'ctx, 'wit> {
+    pub instance: ExtensionGuard,
+    pub headers: http::HeaderMap,
+    pub subgraph: Subgraph<'ctx>,
+    pub directive: wit::FieldDefinitionDirective<'wit>,
+}
+
+impl<'ctx> UniqueSubscription<'ctx, '_> {
+    pub async fn resolve<'f>(self) -> Result<SubscriptionStream<'f>, PartialGraphqlError>
+    where
+        'ctx: 'f,
+    {
+        let UniqueSubscription {
+            mut instance,
+            headers,
+            subgraph,
+            directive,
+        } = self;
+
+        instance
+            .resolve_subscription(headers, subgraph.name(), directive)
+            .await
+            .map_err(|err| err.into_graphql_error(PartialErrorCode::ExtensionError))?;
+
+        let stream = stream::unfold((instance, VecDeque::new()), async move |(mut instance, mut tail)| {
+            if let Some(data) = tail.pop_front() {
+                return Some((data, (instance, tail)));
+            }
+
+            let item = loop {
+                match instance.resolve_next_subscription_item().await {
+                    Ok(Some(item)) if item.outputs.is_empty() => {
+                        continue;
+                    }
+                    Ok(Some(item)) => {
+                        tracing::debug!("subscription item resolved");
+                        break item;
+                    }
+                    Ok(None) => {
+                        tracing::debug!("subscription completed");
+                        return None;
+                    }
+                    Err(e) => {
+                        tracing::error!("Error resolving subscription item: {e}");
+                        return Some((Err(PartialGraphqlError::internal_extension_error()), (instance, tail)));
+                    }
+                }
+            };
+
+            for item in item.outputs {
+                match item {
+                    Ok(item) => {
+                        tail.push_back(Ok(Arc::new(Data::CborBytes(item))));
+                    }
+                    Err(error) => {
+                        let error = error.into_graphql_error(PartialErrorCode::InternalServerError);
+                        tail.push_back(Err(error));
+                    }
+                }
+            }
+
+            tail.pop_front().map(|item| (item, (instance, tail)))
+        });
+
+        Ok(Box::pin(stream))
+    }
+}

--- a/crates/wasi-component-loader/src/extension/wit/directive.rs
+++ b/crates/wasi-component-loader/src/extension/wit/directive.rs
@@ -45,7 +45,7 @@ pub struct FieldDefinitionDirectiveSite<'a> {
 pub struct FieldDefinitionDirective<'a> {
     pub name: &'a str,
     pub site: FieldDefinitionDirectiveSite<'a>,
-    pub arguments: Vec<u8>,
+    pub arguments: &'a [u8],
 }
 
 #[derive(Debug, ComponentType, Lower)]

--- a/crates/wasi-component-loader/src/extension/wit/directive.rs
+++ b/crates/wasi-component-loader/src/extension/wit/directive.rs
@@ -11,14 +11,6 @@ pub struct SchemaDirective<'a> {
 
 #[derive(Debug, ComponentType, Lower)]
 #[component(record)]
-pub struct FieldDefinitionDirective<'a> {
-    pub name: &'a str,
-    pub site: FieldDefinitionDirectiveSite<'a>,
-    pub arguments: Vec<u8>,
-}
-
-#[derive(Debug, ComponentType, Lower)]
-#[component(record)]
 pub struct QueryElements<'a> {
     #[component(name = "directive-names")]
     pub directive_names: Vec<(&'a str, u32, u32)>,
@@ -39,13 +31,21 @@ pub struct ObjectDirectiveSite<'a> {
     pub object_name: &'a str,
 }
 
-#[derive(Debug, ComponentType, Lower)]
+#[derive(Clone, Debug, ComponentType, Lower)]
 #[component(record)]
 pub struct FieldDefinitionDirectiveSite<'a> {
     #[component(name = "parent-type-name")]
     pub parent_type_name: &'a str,
     #[component(name = "field-name")]
     pub field_name: &'a str,
+}
+
+#[derive(Clone, Debug, ComponentType, Lower)]
+#[component(record)]
+pub struct FieldDefinitionDirective<'a> {
+    pub name: &'a str,
+    pub site: FieldDefinitionDirectiveSite<'a>,
+    pub arguments: Vec<u8>,
 }
 
 #[derive(Debug, ComponentType, Lower)]

--- a/crates/wasi-component-loader/src/tests/extensions.rs
+++ b/crates/wasi-component-loader/src/tests/extensions.rs
@@ -54,7 +54,7 @@ async fn simple_resolver() {
             parent_type_name: "Query",
             field_name: "cats",
         },
-        arguments: cbor::to_vec(&FieldArgs { name: "cat" }).unwrap(),
+        arguments: &cbor::to_vec(&FieldArgs { name: "cat" }).unwrap(),
     };
 
     let output = loader

--- a/extensions/jwt/extension.toml
+++ b/extensions/jwt/extension.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "jwt"
-version = "0.1.2"
+version = "0.2.0"
 kind = "auth"
 description = "JWT authenticator extension."
 

--- a/extensions/nats/Cargo.lock
+++ b/extensions/nats/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1884,7 +1884,7 @@ dependencies = [
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3003,7 +3003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3482,7 +3482,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5880,7 +5880,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5897,7 +5897,7 @@ checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5906,7 +5906,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5916,7 +5916,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5925,7 +5934,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5934,7 +5943,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5943,15 +5967,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -5961,9 +5991,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5979,9 +6021,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5991,9 +6045,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/extensions/nats/README.md
+++ b/extensions/nats/README.md
@@ -1,10 +1,12 @@
 # NATS Extension
 
-This is a NATS extension for the Grafbase Gateway. It allows you to define NATS endpoints and map them to GraphQL fields.
+This is a NATS extension for the Grafbase Gateway. It allows you to publish and subscribe, use the NATS key-value store and use the NATS request-response system.
 
 This serves as an example of how to build extensions dealing with pub/sub services, but it also functions as a fully operational extension you can use right now, or use as a starting point for your own extensions.
 
 This extension expects JSON payloads. If you use a different format, fork the extension and modify it to fit your needs. For static formats such as Protobuf, we recommend customizing the extension.
+
+Keep in mind that if using the JetStream API, the messages are acknowledged automatically and it might not be what you want in all cases.
 
 ## Installing
 
@@ -12,12 +14,12 @@ Add the following to your gateway configuration ("grafbase.toml"):
 
 ```toml
 [extensions.nats]
-version = "0.2"
+version = "0.3"
 ```
 
 Then run `grafbase extension install`. The extension will be installed in the `grafbase_extensions` directory. That directory must be present when the gateway is started.
 
-## Building from source
+## Building From Source
 
 Build this extension manually and copy the artifacts to a location where the gateway can find them until we complete the Grafbase Extension Registry.
 

--- a/extensions/nats/extension.toml
+++ b/extensions/nats/extension.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "nats"
-version = "0.2.3"
+version = "0.3.0"
 kind = "resolver"
 description = "Map NATS endpoints to GraphQL fields. Supports regular and JetStream subscriptions, as well as request/reply messaging and the key/value store."
 # homepage_url = "https://example.com/my-extension"

--- a/extensions/nats/src/lib.rs
+++ b/extensions/nats/src/lib.rs
@@ -87,6 +87,23 @@ impl Resolver for Nats {
         }
     }
 
+    fn subscription_identifier(
+        &mut self,
+        _: &Headers,
+        subgraph_name: &str,
+        directive: FieldDefinitionDirective<'_>,
+    ) -> Option<Vec<u8>> {
+        let mut identifier = Vec::new();
+
+        identifier.extend(subgraph_name.as_bytes());
+        identifier.extend(directive.name().as_bytes());
+        identifier.extend(directive.site().parent_type_name().as_bytes());
+        identifier.extend(directive.site().field_name().as_bytes());
+        identifier.extend(directive.raw_arguments());
+
+        Some(identifier)
+    }
+
     fn resolve_subscription(
         &mut self,
         _: Headers,

--- a/extensions/nats/src/lib.rs
+++ b/extensions/nats/src/lib.rs
@@ -87,7 +87,7 @@ impl Resolver for Nats {
         }
     }
 
-    fn subscription_identifier(
+    fn subscription_key(
         &mut self,
         _: &Headers,
         subgraph_name: &str,
@@ -99,7 +99,7 @@ impl Resolver for Nats {
         identifier.extend(directive.name().as_bytes());
         identifier.extend(directive.site().parent_type_name().as_bytes());
         identifier.extend(directive.site().field_name().as_bytes());
-        identifier.extend(directive.raw_arguments());
+        identifier.extend(directive.arguments_bytes());
 
         Some(identifier)
     }

--- a/extensions/nats/tests/integration_tests.rs
+++ b/extensions/nats/tests/integration_tests.rs
@@ -298,6 +298,9 @@ async fn test_subscribe_with_filter() {
         .with_gateway(GATEWAY_PATH)
         .with_subgraph(subgraph())
         .enable_networking()
+        .enable_stderr()
+        .enable_stdout()
+        .log_level(grafbase_sdk::test::LogLevel::WasiDebug)
         .build(config())
         .unwrap();
 
@@ -333,7 +336,7 @@ async fn test_subscribe_with_filter() {
             }
         });
 
-        let events = tokio::time::timeout(Duration::from_secs(15), subscription.take(2).collect::<Vec<_>>())
+        let events = tokio::time::timeout(Duration::from_secs(30), subscription.take(2).collect::<Vec<_>>())
             .await
             .unwrap();
 
@@ -378,7 +381,7 @@ async fn test_subscribe_with_filter() {
         }
     });
 
-    let events = tokio::time::timeout(Duration::from_secs(15), subscription.take(2).collect::<Vec<_>>())
+    let events = tokio::time::timeout(Duration::from_secs(30), subscription.take(2).collect::<Vec<_>>())
         .await
         .unwrap();
 

--- a/extensions/rest/Cargo.lock
+++ b/extensions/rest/Cargo.lock
@@ -642,7 +642,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1875,7 +1875,7 @@ dependencies = [
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3019,7 +3019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3464,7 +3464,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5771,7 +5771,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5788,7 +5788,7 @@ checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5797,7 +5797,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5807,7 +5807,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5816,7 +5825,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5825,7 +5834,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5834,15 +5858,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -5852,9 +5882,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5870,9 +5912,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5882,9 +5936,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/extensions/rest/README.md
+++ b/extensions/rest/README.md
@@ -11,7 +11,7 @@ Add the following to your gateway configuration ("grafbase.toml"):
 
 ```toml
 [extensions.rest]
-version = "0.2"
+version = "0.3"
 ```
 
 Then run `grafbase extension install`. The extension will be installed in the `grafbase_extensions` directory. That directory must be present when the gateway is started.

--- a/extensions/rest/extension.toml
+++ b/extensions/rest/extension.toml
@@ -1,6 +1,6 @@
 [extension]
 name = "rest"
-version = "0.2.2"
+version = "0.3.0"
 kind = "resolver"
 description = "Declarative REST resolver extension."
 


### PR DESCRIPTION
Extension has a new optional method to implement for returning a unique ID based on subscription input:

- If two subscription calls have the same unique ID, they will share one subscription and get the same data from that place.
- If the IDs are different, both callers use their own instances and streams
- If the ID is `None`, we continue to use the old path and every caller gets their own instance.