### PR TITLE
chore: install aws cli manually on release

### DIFF
--- a/.github/workflows/gateway-partial-release.yml
+++ b/.github/workflows/gateway-partial-release.yml
@@ -158,6 +158,10 @@ jobs:
           CLOUDFLARE_ASSETS_R2_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_ASSETS_R2_SECRET_ACCESS_KEY }}
         run: |
           if [[ $INPUT_PRERELEASE == "false" ]]; then
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+            unzip awscliv2.zip
+            sudo ./aws/install --update
+
             cd cli/install
             sed -i 's/{{LATEST_VERSION}}/${{ env.VERSION_BUMP }}/g' gateway
             ./upload.sh gateway

--- a/.github/workflows/grafbase-partial-release.yml
+++ b/.github/workflows/grafbase-partial-release.yml
@@ -165,6 +165,10 @@ jobs:
           CLOUDFLARE_ASSETS_R2_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_ASSETS_R2_SECRET_ACCESS_KEY }}
         run: |
           if [[ $INPUT_PRERELEASE == "false" ]]; then
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+            unzip awscliv2.zip
+            sudo ./aws/install --update
+
             cd cli/install
             sed -i 's/{{LATEST_VERSION}}/${{ env.VERSION_BUMP }}/g' cli
             ./upload.sh cli


### PR DESCRIPTION
This broke randomly in the last few days. Might be that our github runner has now too old aws, without --checksum-algorithm available. Oh well, let's try to install it manually!