### PR TITLE
Install latest version of AWS CLI in release workflows

### DIFF
--- a/.github/workflows/gateway-partial-release.yml
+++ b/.github/workflows/gateway-partial-release.yml
@@ -149,6 +149,9 @@ jobs:
             gateway/release/github/grafbase-gateway-lambda-aarch64-unknown-linux-musl
             gateway/release/github/grafbase-gateway-lambda-x86_64-unknown-linux-musl
 
+      - id: install-aws-cli
+        uses: unfor19/install-aws-cli-action@v1
+
       - name: Publish gateway install script
         shell: bash
         env:

--- a/.github/workflows/grafbase-partial-release.yml
+++ b/.github/workflows/grafbase-partial-release.yml
@@ -156,6 +156,9 @@ jobs:
             cli/npm/github/grafbase-x86_64-unknown-linux-musl
             cli/npm/github/grafbase-aarch64-unknown-linux-musl
 
+      - id: install-aws-cli
+        uses: unfor19/install-aws-cli-action@v1
+
       - name: Publish CLI install script
         shell: bash
         env:

--- a/.github/workflows/rust-prs.yml
+++ b/.github/workflows/rust-prs.yml
@@ -163,6 +163,19 @@ jobs:
       - name: Fetch CLI assets
         uses: ./.github/actions/fetch-assets
 
+      # TO BE REMOVED — this is for testing
+      - name: Install aws cli
+        shell: bash
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          sudo ./aws/install --update
+
+      - name: Print aws cli version
+        shell: bash
+        run: |
+          aws --version
+
       - name: Dump inputs for debugging
         shell: bash
         run: |


### PR DESCRIPTION
There has been a regression in the github actions default image version. We need the algorithm argument to publish to R2.