### PR TITLE
cli: release 0.86.1

### DIFF
--- a/.github/workflows/grafbase-partial-release.yml
+++ b/.github/workflows/grafbase-partial-release.yml
@@ -122,25 +122,6 @@ jobs:
           cargo about generate -c cli/about.toml -o "licenses.html" cli/about.hbs
           find cli/npm -maxdepth 1 -type d -exec cp cli/licenses.html {} \;
 
-      - name: Publish npm
-        shell: bash
-        env:
-          INPUT_PRERELEASE: ${{ inputs.prerelease && 'true' || 'false' }}
-        run: |
-          npm set "//registry.npmjs.org/:_authToken" ${{ secrets.NPM_ACCESS_TOKEN }}
-          cd cli/npm
-          PUBLISH_ARGUMENTS=()
-          if [[ $INPUT_PRERELEASE != "false" ]]; then
-              echo "Running prerelease: $INPUT_PRERELEASE"
-              PUBLISH_ARGUMENTS+=(--tag next)
-          fi
-          (cd aarch64-apple-darwin && npm publish "${PUBLISH_ARGUMENTS[@]}")
-          (cd x86_64-apple-darwin && npm publish "${PUBLISH_ARGUMENTS[@]}")
-          (cd x86_64-pc-windows-msvc && npm publish "${PUBLISH_ARGUMENTS[@]}")
-          (cd x86_64-unknown-linux-musl && npm publish "${PUBLISH_ARGUMENTS[@]}")
-          (cd aarch64-unknown-linux-musl && npm publish "${PUBLISH_ARGUMENTS[@]}")
-          (cd cli && npm publish "${PUBLISH_ARGUMENTS[@]}")
-
       - name: Github release
         id: gh-release-grafbase
         uses: softprops/action-gh-release@v2
@@ -169,3 +150,22 @@ jobs:
             sed -i 's/{{LATEST_VERSION}}/${{ env.VERSION_BUMP }}/g' cli
             ./upload.sh cli
           fi
+
+      - name: Publish npm
+        shell: bash
+        env:
+          INPUT_PRERELEASE: ${{ inputs.prerelease && 'true' || 'false' }}
+        run: |
+          npm set "//registry.npmjs.org/:_authToken" ${{ secrets.NPM_ACCESS_TOKEN }}
+          cd cli/npm
+          PUBLISH_ARGUMENTS=()
+          if [[ $INPUT_PRERELEASE != "false" ]]; then
+              echo "Running prerelease: $INPUT_PRERELEASE"
+              PUBLISH_ARGUMENTS+=(--tag next)
+          fi
+          (cd aarch64-apple-darwin && npm publish "${PUBLISH_ARGUMENTS[@]}")
+          (cd x86_64-apple-darwin && npm publish "${PUBLISH_ARGUMENTS[@]}")
+          (cd x86_64-pc-windows-msvc && npm publish "${PUBLISH_ARGUMENTS[@]}")
+          (cd x86_64-unknown-linux-musl && npm publish "${PUBLISH_ARGUMENTS[@]}")
+          (cd aarch64-unknown-linux-musl && npm publish "${PUBLISH_ARGUMENTS[@]}")
+          (cd cli && npm publish "${PUBLISH_ARGUMENTS[@]}")

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3537,7 +3537,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.86.0"
+version = "0.86.1"
 dependencies = [
  "anyhow",
  "askama",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.86.0"
+version = "0.86.1"
 name = "grafbase"
 description = "The Grafbase command line interface"
 categories = ["command-line-utilities"]

--- a/cli/changelog/0.86.1.md
+++ b/cli/changelog/0.86.1.md
@@ -1,0 +1,5 @@
+Re-release of 0.86.0 with a fix for the CLI release pipeline.
+
+## Fixes
+
+- Avoid publishing to npm until we have publised to assets.grafbase.com.

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.86.0",
+  "version": "0.86.1",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.86.0",
+  "version": "0.86.1",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.86.0",
+  "version": "0.86.1",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.86.0",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.86.0",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.86.0",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.86.0",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.86.0"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.86.1",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.86.1",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.86.1",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.86.1",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.86.1"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.86.0",
+  "version": "0.86.1",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.86.0",
+  "version": "0.86.1",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.86.0",
+  "version": "0.86.1",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
Re-release of 0.86.0 with a fix for the CLI release pipeline.

## Fixes

- Avoid publishing to npm until we have publised to assets.grafbase.com.