### PR TITLE
chore: Remove Extension trait

### DIFF
--- a/cli/templates/extension/src/auth.rs.template
+++ b/cli/templates/extension/src/auth.rs.template
@@ -1,21 +1,17 @@
 use grafbase_sdk::{
     types::{Configuration, SchemaDirective, ErrorResponse, Token},
-    AuthenticationExtension, Extension, Headers,
+    AuthenticationExtension, Headers, Error
 };
 
 #[derive(AuthenticationExtension)]
 struct {{name}};
 
-impl Extension for {{name}} {
-    fn new(schema_directives: Vec<SchemaDirective>, config: Configuration) -> Result<Self, Box<dyn std::error::Error>>
-    where
-        Self: Sized,
+impl AuthenticationExtension for {{name}} {
+    fn new(config: Configuration) -> Result<Self, Error>
     {
         todo!()
     }
-}
 
-impl AuthenticationExtension for {{name}} {
     fn authenticate(&mut self, headers: Headers) -> Result<Token, ErrorResponse> {
         todo!()
     }

--- a/cli/templates/extension/src/resolver.rs.template
+++ b/cli/templates/extension/src/resolver.rs.template
@@ -1,18 +1,16 @@
 use grafbase_sdk::{
     types::{Configuration, SchemaDirective, FieldDefinitionDirective, FieldInputs, FieldOutput},
-    Error, Extension, Headers, ResolverExtension, Subscription
+    Error, Headers, ResolverExtension, Subscription
 };
 
 #[derive(ResolverExtension)]
 struct {{name}};
 
-impl Extension for {{name}} {
-    fn new(schema_directives: Vec<SchemaDirective>, config: Configuration) -> Result<Self, Box<dyn std::error::Error>> {
+impl ResolverExtension for {{name}} {
+    fn new(schema_directives: Vec<SchemaDirective>, config: Configuration) -> Result<Self, Error> {
         Ok(Self)
     }
-}
 
-impl ResolverExtension for {{name}} {
     fn resolve_field(
         &mut self,
         headers: Headers,

--- a/cli/tests/extension/mod.rs
+++ b/cli/tests/extension/mod.rs
@@ -97,19 +97,17 @@ fn init_resolver() {
     insta::assert_snapshot!(&lib_rs, @r##"
     use grafbase_sdk::{
         types::{Configuration, SchemaDirective, FieldDefinitionDirective, FieldInputs, FieldOutput},
-        Error, Extension, Headers, ResolverExtension, Subscription
+        Error, Headers, ResolverExtension, Subscription
     };
 
     #[derive(ResolverExtension)]
     struct TestProject;
 
-    impl Extension for TestProject {
-        fn new(schema_directives: Vec<SchemaDirective>, config: Configuration) -> Result<Self, Box<dyn std::error::Error>> {
+    impl ResolverExtension for TestProject {
+        fn new(schema_directives: Vec<SchemaDirective>, config: Configuration) -> Result<Self, Error> {
             Ok(Self)
         }
-    }
 
-    impl ResolverExtension for TestProject {
         fn resolve_field(
             &mut self,
             headers: Headers,
@@ -348,22 +346,18 @@ fn init_auth() {
     insta::assert_snapshot!(&lib_rs, @r##"
     use grafbase_sdk::{
         types::{Configuration, SchemaDirective, ErrorResponse, Token},
-        AuthenticationExtension, Extension, Headers,
+        AuthenticationExtension, Headers, Error
     };
 
     #[derive(AuthenticationExtension)]
     struct TestProject;
 
-    impl Extension for TestProject {
-        fn new(schema_directives: Vec<SchemaDirective>, config: Configuration) -> Result<Self, Box<dyn std::error::Error>>
-        where
-            Self: Sized,
+    impl AuthenticationExtension for TestProject {
+        fn new(config: Configuration) -> Result<Self, Error>
         {
             todo!()
         }
-    }
 
-    impl AuthenticationExtension for TestProject {
         fn authenticate(&mut self, headers: Headers) -> Result<Token, ErrorResponse> {
             todo!()
         }

--- a/cli/tests/integration/data/echo_extension/src/lib.rs
+++ b/cli/tests/integration/data/echo_extension/src/lib.rs
@@ -1,19 +1,10 @@
 use grafbase_sdk::{
-    Error, Extension, Headers, ResolverExtension, Subscription,
+    Error, Headers, ResolverExtension, Subscription,
     types::{Configuration, FieldDefinitionDirective, FieldInputs, FieldOutput, SchemaDirective},
 };
 
 #[derive(ResolverExtension)]
 struct EchoExtension;
-
-impl Extension for EchoExtension {
-    fn new(
-        _schema_directives: Vec<SchemaDirective>,
-        _config: Configuration,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        Ok(Self)
-    }
-}
 
 #[derive(serde::Deserialize)]
 struct HelloArguments {
@@ -21,6 +12,10 @@ struct HelloArguments {
 }
 
 impl ResolverExtension for EchoExtension {
+    fn new(_schema_directives: Vec<SchemaDirective>, _config: Configuration) -> Result<Self, Error> {
+        Ok(Self)
+    }
+
     fn resolve_field(
         &mut self,
         _headers: Headers,

--- a/crates/grafbase-sdk/src/component/state.rs
+++ b/crates/grafbase-sdk/src/component/state.rs
@@ -8,8 +8,7 @@ use crate::{
 
 use super::extension::AnyExtension;
 
-type InitFn =
-    Box<dyn Fn(Vec<SchemaDirective>, Configuration) -> Result<Box<dyn AnyExtension>, Box<dyn std::error::Error>>>;
+type InitFn = Box<dyn Fn(Vec<SchemaDirective>, Configuration) -> Result<Box<dyn AnyExtension>, crate::Error>>;
 
 static mut INIT_FN: Option<InitFn> = None;
 static mut EXTENSION: Option<Box<dyn AnyExtension>> = None;
@@ -17,7 +16,7 @@ static mut SUBSCRIPTION: Option<Box<dyn Subscription>> = None;
 
 /// Initializes the resolver extension with the provided directives using the closure
 /// function created with the `register_extension!` macro.
-pub(super) fn init(directives: Vec<SchemaDirective>, config: Configuration) -> Result<(), Box<dyn std::error::Error>> {
+pub(super) fn init(directives: Vec<SchemaDirective>, config: Configuration) -> Result<(), Error> {
     // Safety: This function is only called from the SDK macro, so we can assume that there is only one caller at a time.
     unsafe {
         let init = INIT_FN.as_ref().expect("Resolver extension not initialized correctly.");

--- a/crates/grafbase-sdk/src/extension.rs
+++ b/crates/grafbase-sdk/src/extension.rs
@@ -5,24 +5,3 @@ pub mod resolver;
 pub use authentication::AuthenticationExtension;
 pub use authorization::AuthorizationExtension;
 pub use resolver::ResolverExtension;
-
-use crate::types::Configuration;
-
-/// A trait representing an extension that can be initialized from schema directives.
-///
-/// This trait is intended to define a common interface for extensions in Grafbase Gateway,
-/// particularly focusing on their initialization. Extensions are constructed using
-/// a vector of `Directive` instances provided by the type definitions in the schema.
-pub trait Extension: 'static {
-    /// Creates a new instance of the extension from the given schema directives.
-    ///
-    /// The directives must be defined in the extension configuration, and written
-    /// to the federated schema. The directives are deserialized from their GraphQL
-    /// definitions to the corresponding `Directive` instances.
-    fn new(
-        schema_directives: Vec<crate::types::SchemaDirective>,
-        config: Configuration,
-    ) -> Result<Self, Box<dyn std::error::Error>>
-    where
-        Self: Sized;
-}

--- a/crates/grafbase-sdk/src/lib.rs
+++ b/crates/grafbase-sdk/src/lib.rs
@@ -15,7 +15,7 @@ pub mod test;
 pub mod types;
 
 pub use component::SdkError;
-pub use extension::{resolver::Subscription, AuthenticationExtension, Extension, ResolverExtension};
+pub use extension::{resolver::Subscription, AuthenticationExtension, ResolverExtension};
 pub use grafbase_sdk_derive::{AuthenticationExtension, ResolverExtension};
 pub use host::{AuthorizationContext, Headers};
 pub use types::{Error, ErrorResponse, Token};

--- a/crates/grafbase-sdk/src/types.rs
+++ b/crates/grafbase-sdk/src/types.rs
@@ -20,7 +20,7 @@ pub use http::StatusCode;
 pub use serde::Deserialize;
 use serde::Serialize;
 
-use crate::{cbor, wit};
+use crate::{cbor, wit, SdkError};
 
 /// Output responses from the field resolver.
 pub struct FieldOutput(wit::FieldOutput);
@@ -79,13 +79,13 @@ impl FieldInputs {
     }
 
     /// Deserializes each byte slice in the `FieldInputs` to a collection of items.
-    pub fn deserialize<'de, T>(&'de self) -> Result<Vec<T>, Box<dyn std::error::Error>>
+    pub fn deserialize<'de, T>(&'de self) -> Result<Vec<T>, SdkError>
     where
         T: Deserialize<'de>,
     {
         self.0
             .iter()
-            .map(|input| cbor::from_slice(input).map_err(|e| Box::new(e) as Box<dyn std::error::Error>))
+            .map(|input| cbor::from_slice(input).map_err(Into::into))
             .collect()
     }
 }
@@ -104,11 +104,11 @@ impl Configuration {
     /// # Errors
     ///
     /// Returns an error if deserialization fails.
-    pub fn deserialize<'de, T>(&'de self) -> Result<T, Box<dyn std::error::Error>>
+    pub fn deserialize<'de, T>(&'de self) -> Result<T, SdkError>
     where
         T: Deserialize<'de>,
     {
-        cbor::from_slice(&self.0).map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
+        cbor::from_slice(&self.0).map_err(Into::into)
     }
 }
 

--- a/crates/wasi-component-loader/examples/extensions/caching-auth/src/lib.rs
+++ b/crates/wasi-component-loader/examples/extensions/caching-auth/src/lib.rs
@@ -1,9 +1,9 @@
 use std::time::Duration;
 
 use grafbase_sdk::{
-    AuthenticationExtension, Extension, Headers,
+    AuthenticationExtension, Error, Headers,
     host_io::cache::{self, CachedItem},
-    types::{Configuration, ErrorResponse, SchemaDirective, StatusCode, Token},
+    types::{Configuration, ErrorResponse, StatusCode, Token},
 };
 
 #[derive(AuthenticationExtension)]
@@ -21,18 +21,13 @@ struct Jwks {
     key: String,
 }
 
-impl Extension for CachingProvider {
-    fn new(_: Vec<SchemaDirective>, config: Configuration) -> Result<Self, Box<dyn std::error::Error>>
-    where
-        Self: Sized,
-    {
+impl AuthenticationExtension for CachingProvider {
+    fn new(config: Configuration) -> Result<Self, Error> {
         let config: ProviderConfig = config.deserialize()?;
 
         Ok(Self { config })
     }
-}
 
-impl AuthenticationExtension for CachingProvider {
     fn authenticate(&mut self, headers: Headers) -> Result<Token, ErrorResponse> {
         let header = headers
             .get("Authorization")

--- a/crates/wasi-component-loader/examples/extensions/simple-resolver/src/lib.rs
+++ b/crates/wasi-component-loader/examples/extensions/simple-resolver/src/lib.rs
@@ -1,5 +1,5 @@
 use grafbase_sdk::{
-    Error, Extension, Headers, ResolverExtension, Subscription,
+    Error, Headers, ResolverExtension, Subscription,
     types::{Configuration, FieldDefinitionDirective, FieldInputs, FieldOutput, SchemaDirective},
 };
 
@@ -24,8 +24,8 @@ struct ResponseOutput<'a> {
     name: &'a str,
 }
 
-impl Extension for SimpleResolver {
-    fn new(schema_directives: Vec<SchemaDirective>, _: Configuration) -> Result<Self, Box<dyn std::error::Error>> {
+impl ResolverExtension for SimpleResolver {
+    fn new(schema_directives: Vec<SchemaDirective>, _: Configuration) -> Result<Self, Error> {
         let schema_args = schema_directives
             .into_iter()
             .filter(|d| d.name() == "schemaArgs")
@@ -35,9 +35,7 @@ impl Extension for SimpleResolver {
 
         Ok(Self { schema_args })
     }
-}
 
-impl ResolverExtension for SimpleResolver {
     fn resolve_field(
         &mut self,
         _: Headers,

--- a/extensions/jwt/Cargo.lock
+++ b/extensions/jwt/Cargo.lock
@@ -1438,7 +1438,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "thiserror 2.0.12",
- "time 0.3.37",
+ "time 0.3.39",
  "winnow 0.6.8",
 ]
 
@@ -1960,7 +1960,7 @@ dependencies = [
  "serde_urlencoded",
  "tempfile",
  "thiserror 2.0.12",
- "time 0.3.37",
+ "time 0.3.39",
  "tokio",
  "toml",
  "tungstenite 0.26.2",
@@ -2118,7 +2118,7 @@ dependencies = [
  "subtle",
  "syn 2.0.98",
  "sync_wrapper 1.0.2",
- "time 0.3.37",
+ "time 0.3.39",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -4677,7 +4677,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_with_macros",
- "time 0.3.37",
+ "time 0.3.39",
 ]
 
 [[package]]
@@ -5243,9 +5243,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
 dependencies = [
  "deranged",
  "itoa",
@@ -5253,14 +5253,14 @@ dependencies = [
  "powerfmt",
  "serde",
  "time-core",
- "time-macros 0.2.19",
+ "time-macros 0.2.20",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
 
 [[package]]
 name = "time-macros"
@@ -5274,9 +5274,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
 dependencies = [
  "num-conv",
  "time-core",

--- a/extensions/nats/src/lib.rs
+++ b/extensions/nats/src/lib.rs
@@ -9,7 +9,7 @@ use grafbase_sdk::{
     host_io::pubsub::nats::{self, NatsClient, NatsStreamConfig},
     jq_selection::JqSelection,
     types::{Configuration, FieldDefinitionDirective, FieldInputs, FieldOutput, SchemaDirective},
-    Error, Extension, Headers, NatsAuth, ResolverExtension, Subscription,
+    Error, Headers, NatsAuth, ResolverExtension, Subscription,
 };
 use subscription::FilteredSubscription;
 use types::{DirectiveKind, KeyValueAction, KeyValueArguments, PublishArguments, RequestArguments, SubscribeArguments};
@@ -20,8 +20,8 @@ struct Nats {
     jq_selection: Rc<RefCell<JqSelection>>,
 }
 
-impl Extension for Nats {
-    fn new(_: Vec<SchemaDirective>, config: Configuration) -> Result<Self, Box<dyn std::error::Error>> {
+impl ResolverExtension for Nats {
+    fn new(_: Vec<SchemaDirective>, config: Configuration) -> Result<Self, Error> {
         let mut clients = HashMap::new();
         let config: config::NatsConfig = config.deserialize()?;
 
@@ -48,9 +48,7 @@ impl Extension for Nats {
             jq_selection: Rc::new(RefCell::new(JqSelection::default())),
         })
     }
-}
 
-impl ResolverExtension for Nats {
     fn resolve_field(
         &mut self,
         _: Headers,


### PR DESCRIPTION
The `Extension` trait is redundant with the other `ResolverExtension` etc. trait. So moved the `new` method in there. This also cleans up the `new` for authentication & authorization as they will never receive any schema directives.

This plus the previous `Resolver` -> `ResolverExtension` rename, makes the extension definition simpler as a simple import is necessary the `XExtension` trait & macro.

I've changed the few uses I've seen of `Box<dyn std::error::Error>` also. We're returning GraphQL errors which can have extensions, so IMHO it's a better default type and makes this more consistent overall.

The SDK namespace is not very consistent though. `Error` and `Headers` are part of the root namespace but others like `QueryElements` for authorization aren't. Should we add all the types in the root namespace at least?