### PR TITLE
ci: fix S3 uploads again

### DIFF
--- a/cli/install/upload.sh
+++ b/cli/install/upload.sh
@@ -18,6 +18,8 @@ key="install/$1"
 
 echo "Collecting the files to be uploaded…"
 
+export PATH=/usr/local/bin:$PATH
+
 aws configure set default.s3.max_concurrent_requests 8
 aws configure set default.s3.multipart_threshold 512MB
 aws configure set default.s3.multipart_chunksize 128MB


### PR DESCRIPTION
The release scripts are still failing although we install the latest version of the AWS CLI now. See https://github.com/grafbase/grafbase/actions/runs/13677011915/job/38241424173.

So make sure the installed version comes first in $PATH.

closes GB-8630