### PR TITLE
gateway-config: env var expansion in extensions config

### DIFF
--- a/crates/serde-dynamic-string/src/lib.rs
+++ b/crates/serde-dynamic-string/src/lib.rs
@@ -27,6 +27,10 @@ where
     pub fn from_const_value(value: impl Into<T>) -> Self {
         Self(value.into())
     }
+
+    pub fn into_inner(self) -> T {
+        self.0
+    }
 }
 
 impl<T> FromStr for DynamicString<T>


### PR DESCRIPTION
Treat every string value inside `[extensions.<name>.config]` as a `DynamicString<String>`, meaning environment variables will be expanded:

```toml
[extensions.snowflake.config]
warehouse = "Test"

[extensions.snowflake.config.authentication]
private_key = "{{ env.SNOWFLAKE_PRIVATE_KEY }}"
```

closes GB-8647