### PR TITLE
cli: grafbase compose command

### DIFF
--- a/cli/src/backend/dev.rs
+++ b/cli/src/backend/dev.rs
@@ -4,8 +4,12 @@ mod hot_reload;
 mod pathfinder;
 mod subgraphs;
 
+pub(crate) use self::{
+    configurations::get_and_merge_configurations, extensions::detect_extensions, subgraphs::fetch_remote_subgraphs,
+};
+
 use super::errors::BackendError;
-use configurations::get_and_merge_configurations;
+use crate::cli_input::FullGraphRef;
 use federated_server::{GraphFetchMethod, ServeConfig, ServerRuntime};
 use hot_reload::hot_reload;
 use pathfinder::{export_assets, get_pathfinder_router};
@@ -18,13 +22,6 @@ use tokio::{
     sync::{broadcast, mpsc, watch},
     task::spawn_blocking,
 };
-
-#[derive(Clone, Debug)]
-pub struct FullGraphRef {
-    pub account: String,
-    pub graph: String,
-    pub branch: Option<String>,
-}
 
 const DEFAULT_PORT: u16 = 5000;
 

--- a/cli/src/backend/dev/configurations.rs
+++ b/cli/src/backend/dev/configurations.rs
@@ -11,7 +11,7 @@ pub struct DevConfiguration {
     pub merged_configuration: Config,
 }
 
-pub async fn get_and_merge_configurations(
+pub(crate) async fn get_and_merge_configurations(
     gateway_config_path: Option<&PathBuf>,
     graph_overrides_path: Option<&PathBuf>,
 ) -> Result<DevConfiguration, BackendError> {

--- a/cli/src/backend/dev/extensions.rs
+++ b/cli/src/backend/dev/extensions.rs
@@ -4,12 +4,12 @@ use futures::{TryFutureExt as _, future::join_all};
 use url::Url;
 
 #[derive(Debug)]
-pub(super) struct DetectedExtension {
-    pub(super) url: String,
-    pub(super) name: String,
+pub(crate) struct DetectedExtension {
+    pub(crate) url: String,
+    pub(crate) name: String,
 }
 
-pub(super) async fn detect_extensions(parsed_schema: &TypeSystemDocument) -> Vec<DetectedExtension> {
+pub(crate) async fn detect_extensions(parsed_schema: &TypeSystemDocument) -> Vec<DetectedExtension> {
     let link_directives = parsed_schema
         .definitions()
         .filter_map(|definition| match definition {

--- a/cli/src/backend/dev/subgraphs.rs
+++ b/cli/src/backend/dev/subgraphs.rs
@@ -203,17 +203,17 @@ async fn handle_overridden_subgraph(
     }
 }
 
-async fn fetch_remote_subgraphs(graph_ref: &FullGraphRef) -> Result<Vec<Subgraph>, BackendError> {
+pub(crate) async fn fetch_remote_subgraphs(graph_ref: &FullGraphRef) -> Result<Vec<Subgraph>, BackendError> {
     let platform_data = PlatformData::get();
 
     let client = create_client().await.map_err(BackendError::ApiError)?;
 
-    let branch = graph_ref.branch.as_deref().unwrap_or(DEFAULT_BRANCH);
+    let branch = graph_ref.branch().unwrap_or(DEFAULT_BRANCH);
 
     let query = SubgraphSchemasByBranch::build(SubgraphSchemasByBranchVariables {
-        account_slug: &graph_ref.account,
+        account_slug: graph_ref.account(),
         name: branch,
-        graph_slug: &graph_ref.graph,
+        graph_slug: graph_ref.graph(),
     });
 
     let response = client

--- a/cli/src/cli_input.rs
+++ b/cli/src/cli_input.rs
@@ -2,6 +2,7 @@ mod branch;
 mod branch_ref;
 mod check;
 mod completions;
+mod compose;
 mod create;
 mod dev;
 mod extension;
@@ -17,7 +18,7 @@ mod sub_command;
 mod subgraphs;
 mod trust;
 
-pub(crate) use self::{check::CheckCommand, extension::*, trust::TrustCommand};
+pub(crate) use self::{check::CheckCommand, compose::*, extension::*, trust::TrustCommand};
 pub(crate) use branch::BranchSubCommand;
 pub(crate) use branch_ref::BranchRef;
 pub(crate) use completions::CompletionsCommand;

--- a/cli/src/cli_input/compose.rs
+++ b/cli/src/cli_input/compose.rs
@@ -1,0 +1,18 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+use super::FullGraphRef;
+
+/// Compose a federated schema.
+#[derive(Debug, Parser)]
+pub(crate) struct ComposeCommand {
+    #[arg(short('r'), long("graph-ref"), help = FullGraphRef::ARG_DESCRIPTION)]
+    pub(crate) graph_ref: Option<FullGraphRef>,
+    /// The path of the gateway configuration file
+    #[arg(short('c'), long("gateway-config"))]
+    pub(crate) gateway_config: Option<PathBuf>,
+    /// The path of the graph overrides configuration file
+    #[arg(short('o'), long("graph-overrides"))]
+    pub(crate) graph_overrides: Option<PathBuf>,
+}

--- a/cli/src/cli_input/graph_ref.rs
+++ b/cli/src/cli_input/graph_ref.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, fmt, str};
 use graph_ref::GraphRef;
 /// Parsed graph reference. A graph reference is a string of the form `account/graph@branch`.
 #[derive(Clone, Debug)]
-pub struct FullGraphRef {
+pub(crate) struct FullGraphRef {
     account: String,
     graph: String,
     branch: Option<String>,

--- a/cli/src/cli_input/sub_command.rs
+++ b/cli/src/cli_input/sub_command.rs
@@ -4,7 +4,8 @@ use crate::{cli_input::ExtensionSubCommand, is_not_direct_install};
 
 use super::{
     CheckCommand, CompletionsCommand, CreateCommand, DevCommand, ExtensionCommand, IntrospectCommand, LintCommand,
-    LoginCommand, PublishCommand, SchemaCommand, SubgraphsCommand, branch::BranchCommand, trust::TrustCommand,
+    LoginCommand, PublishCommand, SchemaCommand, SubgraphsCommand, branch::BranchCommand, compose::ComposeCommand,
+    trust::TrustCommand,
 };
 
 #[derive(Debug, Parser, strum::AsRefStr, strum::Display)]
@@ -21,6 +22,9 @@ pub enum SubCommand {
     Logout,
     /// Set up and deploy a new graph
     Create(CreateCommand),
+    /// Compose a federated graph from subgraph schemas
+    #[clap(hide = true)]
+    Compose(ComposeCommand),
     /// Introspect a graph and print its schema
     Introspect(IntrospectCommand),
     /// List subgraphs
@@ -59,6 +63,7 @@ impl RequiresLogin for SubCommand {
                 | SubCommand::Check(_)
                 | SubCommand::Branch(_)
                 | SubCommand::Schema(_)
+                | SubCommand::Compose(ComposeCommand { graph_ref: Some(_), .. })
                 | SubCommand::Dev(DevCommand { graph_ref: Some(_), .. })
                 | SubCommand::Extension(ExtensionCommand {
                     command: ExtensionSubCommand::Publish(_)

--- a/cli/src/compose.rs
+++ b/cli/src/compose.rs
@@ -1,0 +1,108 @@
+use std::collections::HashMap;
+
+use crate::{
+    backend::dev::{detect_extensions, fetch_remote_subgraphs, get_and_merge_configurations},
+    cli_input::ComposeCommand,
+    output::report,
+};
+
+#[tokio::main]
+pub(crate) async fn compose(
+    ComposeCommand {
+        graph_ref,
+        gateway_config,
+        graph_overrides,
+    }: ComposeCommand,
+) -> anyhow::Result<()> {
+    let dev_configuration = get_and_merge_configurations(gateway_config.as_ref(), graph_overrides.as_ref()).await?;
+
+    if graph_ref.is_none() && dev_configuration.merged_configuration.subgraphs.is_empty() {
+        return Err(anyhow::anyhow!("No subgraphs found"));
+    }
+
+    let remote_subgraphs = if let Some(graph_ref) = &graph_ref {
+        fetch_remote_subgraphs(graph_ref).await?
+    } else {
+        Vec::new()
+    };
+
+    let mut subgraph_schemas: HashMap<String, (String, Option<String>)> = HashMap::with_capacity(
+        remote_subgraphs
+            .len()
+            .max(dev_configuration.merged_configuration.subgraphs.len()),
+    );
+
+    for subgraph in remote_subgraphs {
+        subgraph_schemas.insert(subgraph.name, (subgraph.schema, subgraph.url));
+    }
+
+    for (subgraph_name, subgraph) in dev_configuration.merged_configuration.subgraphs {
+        let subgraph_url = subgraph.introspection_url.or(subgraph.url);
+
+        if let Some(schema_path) = subgraph.schema_path {
+            let schema_path = if let Some(graph_overrides) = &graph_overrides {
+                if schema_path.is_absolute() {
+                    schema_path
+                } else {
+                    graph_overrides
+                        .parent()
+                        .map(|parent| parent.join(&schema_path))
+                        .unwrap_or(schema_path)
+                }
+            } else {
+                schema_path
+            };
+
+            let schema = std::fs::read_to_string(&schema_path)
+                .map_err(|err| anyhow::anyhow!("Failed to read schema file at {}: {}", schema_path.display(), err))?;
+            subgraph_schemas.insert(subgraph_name, (schema, subgraph_url.map(|url| url.to_string())));
+        } else if let Some(url) = subgraph_url {
+            let headers: Vec<(&String, _)> = subgraph
+                .introspection_headers
+                .as_ref()
+                .map(|intropection_headers| intropection_headers.iter().collect())
+                .unwrap_or_default();
+
+            // FIXME: do it concurrently
+            let sdl = grafbase_graphql_introspection::introspect(url.as_str(), &headers)
+                .await
+                .map_err(|err| anyhow::anyhow!("Failed to introspect subgraph {subgraph_name}: {err}"))?;
+
+            subgraph_schemas.insert(subgraph_name, (sdl, Some(url.to_string())));
+        }
+    }
+
+    let mut subgraphs = graphql_composition::Subgraphs::default();
+
+    for (subgraph_name, (schema, url)) in subgraph_schemas {
+        let parsed_schema = cynic_parser::parse_type_system_document(&schema)
+            .map_err(|err| anyhow::anyhow!("Failed to parse schema for subgraph {subgraph_name}: {err}"))?;
+
+        subgraphs.ingest(&parsed_schema, &subgraph_name, url.as_deref());
+
+        // FIXME: do it concurrently
+        let detected_extensions = detect_extensions(&parsed_schema).await;
+
+        subgraphs.ingest_loaded_extensions(
+            detected_extensions
+                .into_iter()
+                .map(|ext| graphql_composition::LoadedExtension::new(ext.url, ext.name)),
+        );
+    }
+
+    let composed = graphql_composition::compose(&subgraphs).into_result();
+
+    match composed {
+        Ok(schema) => {
+            let rendered = graphql_composition::render_federated_sdl(&schema).expect("rendering to succeed");
+
+            println!("{rendered}");
+
+            Ok(())
+        }
+        Err(diagnostics) => {
+            report::composition_diagnostics(&diagnostics);
+            std::process::exit(1)
+        }
+    }
+}

--- a/cli/src/dev.rs
+++ b/cli/src/dev.rs
@@ -1,13 +1,6 @@
 use crate::{backend, cli_input::DevCommand, errors::CliError};
 
-pub fn dev(cmd: DevCommand) -> Result<(), CliError> {
-    // temporary, until we use `GraphRef`
-    let full_graph_ref = cmd.graph_ref.map(|graph_ref| backend::dev::FullGraphRef {
-        account: graph_ref.account().to_owned(),
-        graph: graph_ref.graph().to_owned(),
-        branch: graph_ref.branch().map(|branch| branch.to_owned()),
-    });
-
-    backend::dev::start(full_graph_ref, cmd.gateway_config, cmd.graph_overrides, cmd.port)
+pub(crate) fn dev(cmd: DevCommand) -> Result<(), CliError> {
+    backend::dev::start(cmd.graph_ref, cmd.gateway_config, cmd.graph_overrides, cmd.port)
         .map_err(CliError::BackendError)
 }

--- a/cli/src/errors.rs
+++ b/cli/src/errors.rs
@@ -63,9 +63,8 @@ pub enum CliError {
     /// wraps an error originating in the local-backend crate
     #[error(transparent)]
     BackendError(BackendError),
-    /// wraps an error with extension subcommand
     #[error(transparent)]
-    ExtensionError(#[from] anyhow::Error),
+    GenericError(#[from] anyhow::Error),
 }
 
 impl CliError {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,6 +5,7 @@ mod branch;
 mod check;
 mod cli_input;
 mod common;
+mod compose;
 mod create;
 mod dev;
 mod errors;
@@ -115,6 +116,7 @@ fn try_main(args: Args) -> Result<(), CliError> {
         }
         SubCommand::Logout => logout(),
         SubCommand::Create(cmd) => create(&cmd.create_arguments()),
+        SubCommand::Compose(cmd) => Ok(compose::compose(cmd)?),
         SubCommand::Subgraphs(cmd) => subgraphs::subgraphs(cmd),
         SubCommand::Schema(cmd) => schema::schema(cmd),
         SubCommand::Publish(cmd) => publish::publish(cmd),

--- a/cli/src/output/report.rs
+++ b/cli/src/output/report.rs
@@ -29,6 +29,18 @@ pub fn error(error: &CliError) {
     }
 }
 
+pub(crate) fn composition_diagnostics(diagnostics: &graphql_composition::Diagnostics) {
+    for diagnostic in diagnostics.iter_warnings() {
+        watercolor::output!("- ⚠️ Warning: {}", diagnostic, @BrightYellow);
+        println!();
+    }
+
+    for diagnostic in diagnostics.iter_errors() {
+        watercolor::output!("- ❌ Error: {}", diagnostic, @BrightRed);
+        println!();
+    }
+}
+
 pub fn warnings(warnings: &[Warning]) {
     for warning in warnings {
         let msg = warning.message();


### PR DESCRIPTION
This is long overdue. The options and the logic to fetch subgraph schemas are taken from `grafbase dev`. If `--graph-ref` is passed, the subgraphs from the given remote graph are taken into account, in addition to the subgraphs from the local configuration toml (if present). One of `--graph-ref` or the local paths must be present.

closes GB-6934