### PR TITLE
Replace public-facing extension.grafbase.com URLs

### DIFF
--- a/crates/graphql-composition/tests/composition/extensions_basic/extensions.toml
+++ b/crates/graphql-composition/tests/composition/extensions_basic/extensions.toml
@@ -1,5 +1,5 @@
 [[extensions]]
-url = "https://extensions.grafbase.com/extensions/kafka/v1.0.0"
+url = "https://grafbase.com/extensions/kafka/v1.0.0"
 name = "kafka-connector"
 
 [[extensions]]
@@ -7,7 +7,7 @@ url = "file:///home/lellison/src/oracle-grafbase-extension/dist"
 name = "oracle-connector"
 
 [[extensions]]
-url = "https://extensions.grafbase.com/extensions/rest"
+url = "https://grafbase.com/extensions/rest"
 name = "rest-connector"
 
 [[extensions]]

--- a/crates/graphql-composition/tests/composition/extensions_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/extensions_basic/federated.graphql.snap
@@ -98,9 +98,9 @@ enum join__Graph
 
 enum extension__Link
 {
-    KAFKA_CONNECTOR @extension__link(url: "https://extensions.grafbase.com/extensions/kafka/v1.0.0")
+    KAFKA_CONNECTOR @extension__link(url: "https://grafbase.com/extensions/kafka/v1.0.0")
     ORACLE_CONNECTOR @extension__link(url: "file:///home/lellison/src/oracle-grafbase-extension/dist")
-    REST_CONNECTOR @extension__link(url: "https://extensions.grafbase.com/extensions/rest")
+    REST_CONNECTOR @extension__link(url: "https://grafbase.com/extensions/rest")
     UNUSED_EXTENSION @extension__link(url: "https://example.com/unused/unused-extension/v1.0.0")
 }
 

--- a/crates/graphql-composition/tests/composition/extensions_basic/subgraphs/appointments.graphql
+++ b/crates/graphql-composition/tests/composition/extensions_basic/subgraphs/appointments.graphql
@@ -1,6 +1,6 @@
 extend schema
   @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key", "@shareable"])
-  @link(url: "https://extensions.grafbase.com/extensions/kafka/v1.0.0", import: ["@post"])
+  @link(url: "https://grafbase.com/extensions/kafka/v1.0.0", import: ["@post"])
 
 type Query {
   appointments: [Appointment!]!

--- a/crates/graphql-composition/tests/composition/extensions_basic/subgraphs/doctors.graphql
+++ b/crates/graphql-composition/tests/composition/extensions_basic/subgraphs/doctors.graphql
@@ -1,8 +1,8 @@
 extend schema
   @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@shareable"])
   @link(url: "file:///home/lellison/src/oracle-grafbase-extension/dist", as: "oracle")
-  @link(url: "https://extensions.grafbase.com/extensions/rest")
-  @link(url: "https://extensions.grafbase.com/extensions/kafka/v1.0.0")
+  @link(url: "https://grafbase.com/extensions/rest")
+  @link(url: "https://grafbase.com/extensions/kafka/v1.0.0")
 
 type Query {
   doctors: [Doctor!]!

--- a/crates/graphql-composition/tests/composition/extensions_basic/subgraphs/patients.graphql
+++ b/crates/graphql-composition/tests/composition/extensions_basic/subgraphs/patients.graphql
@@ -1,7 +1,7 @@
 extend schema
   @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key", "@shareable"])
   @link(url: "https://facebook.com/grafbase-extensions/groups")
-  @link(url: "https://extensions.grafbase.com/extensions/kafka/v1.0.0", as: "queue")
+  @link(url: "https://grafbase.com/extensions/kafka/v1.0.0", as: "queue")
 
 type Query {
   patients: [Patient!]!

--- a/extensions/authenticated/README.md
+++ b/extensions/authenticated/README.md
@@ -12,7 +12,7 @@ version = "1.0"
 ## Usage
 
 ```graphql
-extend schema @link(url: "https://extensions.grafbase.com/extensions/authenticated/1.0.0", import: ["@authenticated"])
+extend schema @link(url: "https://grafbase.com/extensions/authenticated/1.0.0", import: ["@authenticated"])
 
 type Query {
   public: String!

--- a/extensions/requires-scopes/README.md
+++ b/extensions/requires-scopes/README.md
@@ -13,7 +13,7 @@ version = "1.0"
 
 ```graphql
 extend schema
-  @link(url: "https://extensions.grafbase.com/extensions/requires-scopes/1.0.0", import: ["@requiresScopes"])
+  @link(url: "https://grafbase.com/extensions/requires-scopes/1.0.0", import: ["@requiresScopes"])
 
 type Query {
   public: String!


### PR DESCRIPTION
Use grafbase.com/extensions instead, since the manifest and wasm modules can now be downloaded from there, and the experience of navigating to that link for humans is much nicer because you get to see the README and all the relevant info.