### PR TITLE
feat(engine): Faster response deserialization

### DIFF
--- a/crates/engine/codegen/domain/query_plan.graphql
+++ b/crates/engine/codegen/domain/query_plan.graphql
@@ -36,10 +36,10 @@ type ResponseObjectSetDefinition @meta(module: "response_object_set") @indexed(i
 # ----------------
 
 type PartitionSelectionSet @meta(module: "selection_set", derive: ["Default"]) @copy {
-  data_fields_ordered_by_type_conditions_then_position: [PartitionDataField!]!
-    @field(record_field_name: "data_field_ids_ordered_by_type_conditions_then_position")
-  typename_fields_ordered_by_type_conditions_then_position: [PartitionTypenameField!]!
-    @field(record_field_name: "typename_field_ids_ordered_by_type_conditions_then_position")
+  data_fields_ordered_by_type_conditions_then_key: [PartitionDataField!]!
+    @field(record_field_name: "data_field_ids_ordered_by_type_conditions_then_key")
+  typename_fields_ordered_by_type_conditions_then_key: [PartitionTypenameField!]!
+    @field(record_field_name: "typename_field_ids_ordered_by_type_conditions_then_key")
 }
 
 scalar PartitionDataField @record @indexed

--- a/crates/engine/src/prepare/cached/query_plan/field/data.rs
+++ b/crates/engine/src/prepare/cached/query_plan/field/data.rs
@@ -79,6 +79,9 @@ impl<'a> PartitionDataField<'a> {
     pub(crate) fn parent_field(&self) -> Option<PartitionDataField<'a>> {
         self.as_ref().parent_field_id.walk(self.ctx)
     }
+}
+
+impl PartitionDataFieldRecord {
     pub(crate) fn key(&self) -> PositionedResponseKey {
         PositionedResponseKey {
             query_position: self.query_position,

--- a/crates/engine/src/prepare/cached/query_plan/field/typename.rs
+++ b/crates/engine/src/prepare/cached/query_plan/field/typename.rs
@@ -1,5 +1,5 @@
 use id_newtypes::IdRange;
-use operation::{Location, QueryPosition, ResponseKey};
+use operation::{Location, PositionedResponseKey, QueryPosition, ResponseKey};
 use query_solver::TypeConditionSharedVecId;
 use walker::Walk;
 
@@ -35,6 +35,15 @@ impl<'a> PartitionTypenameField<'a> {
     #[allow(clippy::should_implement_trait)]
     pub(crate) fn as_ref(&self) -> &'a PartitionTypenameFieldRecord {
         &self.ctx.cached.query_plan[self.id]
+    }
+}
+
+impl PartitionTypenameFieldRecord {
+    pub(crate) fn key(&self) -> PositionedResponseKey {
+        PositionedResponseKey {
+            query_position: self.query_position,
+            response_key: self.response_key,
+        }
     }
 }
 

--- a/crates/engine/src/prepare/cached/query_plan/generated/selection_set.rs
+++ b/crates/engine/src/prepare/cached/query_plan/generated/selection_set.rs
@@ -13,16 +13,16 @@ use walker::{Iter, Walk};
 ///
 /// ```custom,{.language-graphql}
 /// type PartitionSelectionSet @meta(module: "selection_set", derive: ["Default"]) @copy {
-///   data_fields_ordered_by_type_conditions_then_position: [PartitionDataField!]!
-///     @field(record_field_name: "data_field_ids_ordered_by_type_conditions_then_position")
-///   typename_fields_ordered_by_type_conditions_then_position: [PartitionTypenameField!]!
-///     @field(record_field_name: "typename_field_ids_ordered_by_type_conditions_then_position")
+///   data_fields_ordered_by_type_conditions_then_key: [PartitionDataField!]!
+///     @field(record_field_name: "data_field_ids_ordered_by_type_conditions_then_key")
+///   typename_fields_ordered_by_type_conditions_then_key: [PartitionTypenameField!]!
+///     @field(record_field_name: "typename_field_ids_ordered_by_type_conditions_then_key")
 /// }
 /// ```
 #[derive(Debug, serde::Serialize, serde::Deserialize, Default, Clone, Copy)]
 pub(crate) struct PartitionSelectionSetRecord {
-    pub data_field_ids_ordered_by_type_conditions_then_position: IdRange<PartitionDataFieldId>,
-    pub typename_field_ids_ordered_by_type_conditions_then_position: IdRange<PartitionTypenameFieldId>,
+    pub data_field_ids_ordered_by_type_conditions_then_key: IdRange<PartitionDataFieldId>,
+    pub typename_field_ids_ordered_by_type_conditions_then_key: IdRange<PartitionTypenameFieldId>,
 }
 
 #[derive(Clone, Copy)]
@@ -44,18 +44,18 @@ impl<'a> PartitionSelectionSet<'a> {
     pub(crate) fn as_ref(&self) -> &PartitionSelectionSetRecord {
         &self.item
     }
-    pub(crate) fn data_fields_ordered_by_type_conditions_then_position(
+    pub(crate) fn data_fields_ordered_by_type_conditions_then_key(
         &self,
     ) -> impl Iter<Item = PartitionDataField<'a>> + 'a {
         self.as_ref()
-            .data_field_ids_ordered_by_type_conditions_then_position
+            .data_field_ids_ordered_by_type_conditions_then_key
             .walk(self.ctx)
     }
-    pub(crate) fn typename_fields_ordered_by_type_conditions_then_position(
+    pub(crate) fn typename_fields_ordered_by_type_conditions_then_key(
         &self,
     ) -> impl Iter<Item = PartitionTypenameField<'a>> + 'a {
         self.as_ref()
-            .typename_field_ids_ordered_by_type_conditions_then_position
+            .typename_field_ids_ordered_by_type_conditions_then_key
             .walk(self.ctx)
     }
 }
@@ -82,12 +82,12 @@ impl std::fmt::Debug for PartitionSelectionSet<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PartitionSelectionSet")
             .field(
-                "data_fields_ordered_by_type_conditions_then_position",
-                &self.data_fields_ordered_by_type_conditions_then_position(),
+                "data_fields_ordered_by_type_conditions_then_key",
+                &self.data_fields_ordered_by_type_conditions_then_key(),
             )
             .field(
-                "typename_fields_ordered_by_type_conditions_then_position",
-                &self.typename_fields_ordered_by_type_conditions_then_position(),
+                "typename_fields_ordered_by_type_conditions_then_key",
+                &self.typename_fields_ordered_by_type_conditions_then_key(),
             )
             .finish()
     }

--- a/crates/engine/src/prepare/cached/query_plan/selection_set.rs
+++ b/crates/engine/src/prepare/cached/query_plan/selection_set.rs
@@ -4,10 +4,10 @@ use super::{PartitionDataField, PartitionSelectionSet, PartitionTypenameField};
 
 impl<'a> PartitionSelectionSet<'a> {
     pub(crate) fn data_fields(&self) -> impl Iter<Item = PartitionDataField<'a>> + 'a {
-        self.data_fields_ordered_by_type_conditions_then_position()
+        self.data_fields_ordered_by_type_conditions_then_key()
     }
 
     pub(crate) fn typename_fields(&self) -> impl Iter<Item = PartitionTypenameField<'a>> + 'a {
-        self.typename_fields_ordered_by_type_conditions_then_position()
+        self.typename_fields_ordered_by_type_conditions_then_key()
     }
 }

--- a/crates/engine/src/prepare/cached/shape/concrete.rs
+++ b/crates/engine/src/prepare/cached/shape/concrete.rs
@@ -16,7 +16,8 @@ pub(crate) struct ConcreteShapeRecord {
     pub set_id: Option<ResponseObjectSetDefinitionId>,
     pub identifier: ObjectIdentifier,
     pub typename_response_keys: Vec<PositionedResponseKey>,
-    // Sorted by expected_key
+    // Ordered by PartitionDataFieldId which should more or less match the ordering of fields
+    // coming in from resolvers.
     pub field_shape_ids: IdRange<FieldShapeId>,
 }
 

--- a/crates/engine/src/prepare/operation_plan/model/selection_set.rs
+++ b/crates/engine/src/prepare/operation_plan/model/selection_set.rs
@@ -12,15 +12,13 @@ pub(crate) struct SubgraphSelectionSet<'a> {
 #[allow(unused)]
 impl<'a> SubgraphSelectionSet<'a> {
     pub(crate) fn fields(&self) -> impl Iterator<Item = SubgraphField<'a>> + 'a {
-        self.fields_ordered_by_type_condition_then_position()
+        self.fields_ordered_by_type_condition_then_key()
     }
 
-    pub(crate) fn fields_ordered_by_type_condition_then_position(
-        &self,
-    ) -> impl Iterator<Item = SubgraphField<'a>> + 'a {
+    pub(crate) fn fields_ordered_by_type_condition_then_key(&self) -> impl Iterator<Item = SubgraphField<'a>> + 'a {
         let ctx = self.ctx;
         self.item
-            .data_field_ids_ordered_by_type_conditions_then_position
+            .data_field_ids_ordered_by_type_conditions_then_key
             .into_iter()
             .filter(|id| self.ctx.plan.query_modifications.included_subgraph_request_data_fields[*id])
             .map(move |id| SubgraphField { ctx, id })

--- a/crates/engine/src/resolver/graphql/request/prepare.rs
+++ b/crates/engine/src/resolver/graphql/request/prepare.rs
@@ -196,7 +196,7 @@ impl QueryBuilderContext {
 
         let ParentType::CompositeType(parent_type) = parent_type else {
             let entity_fields = selection_set
-                .fields_ordered_by_type_condition_then_position()
+                .fields_ordered_by_type_condition_then_key()
                 .chunk_by(|field| field.definition().parent_entity());
 
             // Parent is Any or any other type that will accept anything.
@@ -215,7 +215,7 @@ impl QueryBuilderContext {
         }
 
         let entity_fields = selection_set
-            .fields_ordered_by_type_condition_then_position()
+            .fields_ordered_by_type_condition_then_key()
             .chunk_by(|field| field.definition().parent_entity());
 
         let maybe_parent_interface_id = parent_type.as_interface().map(|interface| interface.id);

--- a/crates/integration-tests/tests/federation/extensions/authorization/deny_all.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/deny_all.rs
@@ -67,11 +67,11 @@ fn can_deny_all() {
               "locations": [
                 {
                   "line": 1,
-                  "column": 18
+                  "column": 9
                 }
               ],
               "path": [
-                "forbidden"
+                "greeting"
               ],
               "extensions": {
                 "code": "UNAUTHORIZED"
@@ -82,11 +82,11 @@ fn can_deny_all() {
               "locations": [
                 {
                   "line": 1,
-                  "column": 9
+                  "column": 18
                 }
               ],
               "path": [
-                "greeting"
+                "forbidden"
               ],
               "extensions": {
                 "code": "UNAUTHORIZED"

--- a/crates/integration-tests/tests/federation/response_extensions.rs
+++ b/crates/integration-tests/tests/federation/response_extensions.rs
@@ -520,7 +520,7 @@ fn complex_query_plan() {
                     "__typename": "GraphqlResolver",
                     "subgraphName": "products",
                     "request": {
-                      "query": "query($var0: [_Any!]!) { _entities(representations: $var0) { ... on Product { upc weight(unit: KILOGRAM) price } } }"
+                      "query": "query($var0: [_Any!]!) { _entities(representations: $var0) { ... on Product { weight(unit: KILOGRAM) upc price } } }"
                     }
                   },
                   {

--- a/extensions/requires-scopes/tests/integration_tests.rs
+++ b/extensions/requires-scopes/tests/integration_tests.rs
@@ -111,6 +111,21 @@ async fn anonymous_token() {
           "message": "Not authorized",
           "locations": [
             {
+              "line": 4,
+              "column": 5
+            }
+          ],
+          "path": [
+            "hasReadScope"
+          ],
+          "extensions": {
+            "code": "UNAUTHORIZED"
+          }
+        },
+        {
+          "message": "Not authorized",
+          "locations": [
+            {
               "line": 5,
               "column": 5
             }
@@ -132,21 +147,6 @@ async fn anonymous_token() {
           ],
           "path": [
             "hasReadOrWriteScope"
-          ],
-          "extensions": {
-            "code": "UNAUTHORIZED"
-          }
-        },
-        {
-          "message": "Not authorized",
-          "locations": [
-            {
-              "line": 4,
-              "column": 5
-            }
-          ],
-          "path": [
-            "hasReadScope"
           ],
           "extensions": {
             "code": "UNAUTHORIZED"
@@ -182,6 +182,21 @@ async fn token_without_scopes() {
           "message": "Not authorized: insufficient scopes",
           "locations": [
             {
+              "line": 4,
+              "column": 5
+            }
+          ],
+          "path": [
+            "hasReadScope"
+          ],
+          "extensions": {
+            "code": "UNAUTHORIZED"
+          }
+        },
+        {
+          "message": "Not authorized: insufficient scopes",
+          "locations": [
+            {
               "line": 5,
               "column": 5
             }
@@ -203,21 +218,6 @@ async fn token_without_scopes() {
           ],
           "path": [
             "hasReadOrWriteScope"
-          ],
-          "extensions": {
-            "code": "UNAUTHORIZED"
-          }
-        },
-        {
-          "message": "Not authorized: insufficient scopes",
-          "locations": [
-            {
-              "line": 4,
-              "column": 5
-            }
-          ],
-          "path": [
-            "hasReadScope"
           ],
           "extensions": {
             "code": "UNAUTHORIZED"
@@ -253,6 +253,21 @@ async fn token_with_insufficient_scopes() {
           "message": "Not authorized: insufficient scopes",
           "locations": [
             {
+              "line": 4,
+              "column": 5
+            }
+          ],
+          "path": [
+            "hasReadScope"
+          ],
+          "extensions": {
+            "code": "UNAUTHORIZED"
+          }
+        },
+        {
+          "message": "Not authorized: insufficient scopes",
+          "locations": [
+            {
               "line": 5,
               "column": 5
             }
@@ -274,21 +289,6 @@ async fn token_with_insufficient_scopes() {
           ],
           "path": [
             "hasReadOrWriteScope"
-          ],
-          "extensions": {
-            "code": "UNAUTHORIZED"
-          }
-        },
-        {
-          "message": "Not authorized: insufficient scopes",
-          "locations": [
-            {
-              "line": 4,
-              "column": 5
-            }
-          ],
-          "path": [
-            "hasReadScope"
           ],
           "extensions": {
             "code": "UNAUTHORIZED"
@@ -365,12 +365,12 @@ async fn token_with_write_scope() {
           "message": "Not authorized: insufficient scopes",
           "locations": [
             {
-              "line": 5,
+              "line": 4,
               "column": 5
             }
           ],
           "path": [
-            "hasReadAndWriteScope"
+            "hasReadScope"
           ],
           "extensions": {
             "code": "UNAUTHORIZED"
@@ -380,12 +380,12 @@ async fn token_with_write_scope() {
           "message": "Not authorized: insufficient scopes",
           "locations": [
             {
-              "line": 4,
+              "line": 5,
               "column": 5
             }
           ],
           "path": [
-            "hasReadScope"
+            "hasReadAndWriteScope"
           ],
           "extensions": {
             "code": "UNAUTHORIZED"


### PR DESCRIPTION
One of the parts that took significant time in deserialization was the
binary search to detect which field we're currently reading from the
subgraph response as we don't rely on any particular ordering.

I've replaced with a linear search with a increasing offset if the
subgraph response does come in the expected order (for a GraphQL query
at least). It's ~10% faster on big subgraph responses.

We shouldn't have any negative effects from switching to a linear search
as having more than a few dozens of fields is already very unlikely.
