### PR TITLE
chore: Remove useless otlp feature flag and fix HTTP exporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6350,7 +6350,6 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tonic",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ openidconnect = "4.0.0"
 opentelemetry = "0.28"
 opentelemetry-appender-tracing = "0.28"
 opentelemetry-aws = "0.16"
-opentelemetry-otlp = "0.28"
+opentelemetry-otlp = { version = "0.28", default-features = false }
 opentelemetry-stdout = "0.28"
 opentelemetry_sdk = "0.28"
 ory-client = "=1.9.0"

--- a/crates/federated-server/Cargo.toml
+++ b/crates/federated-server/Cargo.toml
@@ -25,7 +25,7 @@ engine-axum.workspace = true
 futures-lite.workspace = true
 futures-util.workspace = true
 gateway-config.workspace = true
-grafbase-telemetry = { workspace = true, features = ["otlp"] }
+grafbase-telemetry = { workspace = true }
 grafbase-workspace-hack.workspace = true
 graph-ref.workspace = true
 graphql-composition.workspace = true

--- a/crates/gateway-config/Cargo.toml
+++ b/crates/gateway-config/Cargo.toml
@@ -9,10 +9,6 @@ repository.workspace = true
 [lints]
 workspace = true
 
-[features]
-# historic feature flag used for telemetry config, maybe should be removed?
-otlp = ["dep:tonic"]
-
 [dependencies]
 ascii = { workspace = true, features = ["serde"] }
 cfg-if.workspace = true
@@ -27,7 +23,7 @@ serde-dynamic-string.workspace = true
 serde_regex.workspace = true
 size.workspace = true
 toml.workspace = true
-tonic = { workspace = true, optional = true, features = ["tls-roots"] }
+tonic = { workspace = true, features = ["tls-roots"] }
 tower-http = { workspace = true, features = ["cors", "timeout"] }
 url = { workspace = true, features = ["serde"] }
 

--- a/crates/gateway-config/src/telemetry/exporters/otlp.rs
+++ b/crates/gateway-config/src/telemetry/exporters/otlp.rs
@@ -87,7 +87,6 @@ pub struct OtlpExporterTlsConfig {
     pub ca: Option<PathBuf>,
 }
 
-#[cfg(feature = "otlp")]
 impl TryFrom<OtlpExporterTlsConfig> for tonic::transport::ClientTlsConfig {
     type Error = std::io::Error;
 

--- a/crates/gateway-config/src/telemetry/mod.rs
+++ b/crates/gateway-config/src/telemetry/mod.rs
@@ -3,7 +3,6 @@ pub mod exporters;
 use std::collections::HashMap;
 
 use exporters::GlobalExporterConfig;
-// #[cfg(feature = "otlp")]
 pub use exporters::{
     Headers, OtlpExporterConfig, OtlpExporterGrpcConfig, OtlpExporterHttpConfig, OtlpExporterProtocol,
     OtlpExporterTlsConfig,
@@ -58,7 +57,6 @@ impl TelemetryConfig {
         }
     }
 
-    #[cfg(feature = "otlp")]
     pub fn tracing_otlp_config(&self) -> Option<&OtlpExporterConfig> {
         match self.tracing.exporters.otlp.as_ref() {
             Some(config) if config.enabled => Some(config),
@@ -68,15 +66,9 @@ impl TelemetryConfig {
     }
 
     pub fn tracing_exporters_enabled(&self) -> bool {
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "otlp")] {
-                self.tracing_otlp_config().is_some()
-                    || self.tracing_stdout_config().is_some()
-                    || self.grafbase_otlp_config().is_some()
-            } else {
-                self.tracing_stdout_config().is_some()
-            }
-        }
+        self.tracing_otlp_config().is_some()
+            || self.tracing_stdout_config().is_some()
+            || self.grafbase_otlp_config().is_some()
     }
 
     pub fn metrics_stdout_config(&self) -> Option<&StdoutExporterConfig> {
@@ -87,7 +79,6 @@ impl TelemetryConfig {
         }
     }
 
-    #[cfg(feature = "otlp")]
     pub fn metrics_otlp_config(&self) -> Option<&OtlpExporterConfig> {
         match self.metrics.as_ref().and_then(|c| c.exporters.otlp.as_ref()) {
             Some(config) if config.enabled => Some(config),
@@ -104,7 +95,6 @@ impl TelemetryConfig {
         }
     }
 
-    #[cfg(feature = "otlp")]
     pub fn logs_otlp_config(&self) -> Option<&OtlpExporterConfig> {
         match self.logs.as_ref().and_then(|c| c.exporters.otlp.as_ref()) {
             Some(config) if config.enabled => Some(config),
@@ -114,16 +104,9 @@ impl TelemetryConfig {
     }
 
     pub fn logs_exporters_enabled(&self) -> bool {
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "otlp")] {
-                self.logs_otlp_config().is_some() || self.logs_stdout_config().is_some()
-            } else {
-                self.logs_stdout_config().is_some()
-            }
-        }
+        self.logs_otlp_config().is_some() || self.logs_stdout_config().is_some()
     }
 
-    #[cfg(feature = "otlp")]
     pub fn grafbase_otlp_config(&self) -> Option<&OtlpExporterConfig> {
         self.grafbase.as_ref()
     }
@@ -133,16 +116,11 @@ impl TelemetryConfig {
 mod tests {
     use super::*;
 
-    #[cfg(feature = "otlp")]
     use ascii::AsciiString;
-    #[cfg(feature = "otlp")]
     use chrono::Duration;
     use indoc::indoc;
-    #[cfg(feature = "otlp")]
     use std::path::PathBuf;
-    #[cfg(feature = "otlp")]
     use std::str::FromStr;
-    #[cfg(feature = "otlp")]
     use url::Url;
 
     #[test]
@@ -234,7 +212,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "otlp")]
     #[test]
     fn no_exporters() {
         // prepare
@@ -250,7 +227,6 @@ mod tests {
         assert!(config.exporters.stdout.is_none());
     }
 
-    #[cfg(feature = "otlp")]
     #[test]
     fn default_otlp_exporter() {
         // prepare
@@ -277,7 +253,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "otlp")]
     #[test]
     fn otlp_exporter_custom_partial_batch_config() {
         // prepare
@@ -308,7 +283,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "otlp")]
     #[test]
     fn otlp_exporter_kitchen_sink() {
         let input = indoc! {r#"
@@ -465,7 +439,6 @@ mod tests {
         assert!(expected.is_some());
     }
 
-    #[cfg(feature = "otlp")]
     #[test]
     fn tracing_otlp_default_config() {
         let input = indoc! {r#"
@@ -503,7 +476,6 @@ mod tests {
         assert!(expected.is_some());
     }
 
-    #[cfg(feature = "otlp")]
     #[test]
     fn tracing_otlp_alternative_config_not_enabled() {
         let input = indoc! {r#"
@@ -563,7 +535,6 @@ mod tests {
         assert_eq!(None, config.tracing_otlp_config());
     }
 
-    #[cfg(feature = "otlp")]
     #[test]
     fn tracing_otlp_alternative_config_enabled() {
         let input = indoc! {r#"
@@ -711,7 +682,6 @@ mod tests {
         assert!(expected.is_some());
     }
 
-    #[cfg(feature = "otlp")]
     #[test]
     fn metrics_otlp_default_config() {
         let input = indoc! {r#"
@@ -749,7 +719,6 @@ mod tests {
         assert!(expected.is_some());
     }
 
-    #[cfg(feature = "otlp")]
     #[test]
     fn metrics_otlp_alternative_config_not_enabled() {
         let input = indoc! {r#"
@@ -809,7 +778,6 @@ mod tests {
         assert_eq!(None, config.metrics_otlp_config());
     }
 
-    #[cfg(feature = "otlp")]
     #[test]
     fn metrics_otlp_alternative_config_enabled() {
         let input = indoc! {r#"
@@ -958,7 +926,6 @@ mod tests {
         assert!(expected.is_some());
     }
 
-    #[cfg(feature = "otlp")]
     #[test]
     fn logs_otlp_default_config() {
         let input = indoc! {r#"
@@ -996,7 +963,6 @@ mod tests {
         assert!(expected.is_some());
     }
 
-    #[cfg(feature = "otlp")]
     #[test]
     fn logs_otlp_alternative_config_not_enabled() {
         let input = indoc! {r#"
@@ -1055,7 +1021,6 @@ mod tests {
         assert_eq!(None, config.logs_otlp_config());
     }
 
-    #[cfg(feature = "otlp")]
     #[test]
     fn logs_otlp_alternative_config_enabled() {
         let input = indoc! {r#"
@@ -1151,7 +1116,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "otlp")]
     #[test]
     fn tls_config() {
         use tonic::transport::ClientTlsConfig;

--- a/crates/grafbase-workspace-hack/Cargo.toml
+++ b/crates/grafbase-workspace-hack/Cargo.toml
@@ -128,7 +128,6 @@ subtle = { version = "2" }
 sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
 time = { version = "0.3", features = ["serde-well-known"] }
 tokio = { version = "1", features = ["full", "test-util"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tokio-stream = { version = "0.1", features = ["net", "sync"] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
 toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
@@ -261,7 +260,6 @@ syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "vis
 sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
 time = { version = "0.3", features = ["serde-well-known"] }
 tokio = { version = "1", features = ["full", "test-util"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tokio-stream = { version = "0.1", features = ["net", "sync"] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
 toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
@@ -297,6 +295,7 @@ object = { version = "0.36", default-features = false, features = ["archive", "r
 rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["event", "mm", "net", "param", "pipe", "process", "procfs", "stdio", "termios", "thread", "time"] }
 rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "termios"] }
 stable_deref_trait = { version = "1" }
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features = false, features = ["log", "timeout"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
@@ -313,6 +312,7 @@ object = { version = "0.36", default-features = false, features = ["archive", "r
 rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["event", "mm", "net", "param", "pipe", "process", "procfs", "stdio", "termios", "thread", "time"] }
 rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "termios"] }
 stable_deref_trait = { version = "1" }
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features = false, features = ["log", "timeout"] }
 
 [target.x86_64-apple-darwin.dependencies]
@@ -330,6 +330,7 @@ rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["ev
 rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "termios"] }
 spin = { version = "0.9" }
 stable_deref_trait = { version = "1" }
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features = false, features = ["log", "timeout"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
@@ -347,6 +348,7 @@ rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["ev
 rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "termios"] }
 spin = { version = "0.9" }
 stable_deref_trait = { version = "1" }
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features = false, features = ["log", "timeout"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
@@ -356,6 +358,7 @@ getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-f
 idna = { version = "1" }
 rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["event", "fs", "net"] }
 spin = { version = "0.9" }
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features = false, features = ["log", "timeout"] }
 winapi = { version = "0.3", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-default", "knownfolders", "minwinbase", "minwindef", "objbase", "processenv", "processthreadsapi", "profileapi", "shlobj", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "winerror", "winnt", "winuser"] }
 windows-sys-73dcd821b1037cfd = { package = "windows-sys", version = "0.59", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Win32_Globalization", "Win32_NetworkManagement_IpHelper", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_Diagnostics_Debug", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Kernel", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Performance", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell"] }
@@ -368,6 +371,7 @@ getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-f
 idna = { version = "1" }
 rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["event", "fs", "net"] }
 spin = { version = "0.9" }
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features = false, features = ["log", "timeout"] }
 winapi = { version = "0.3", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-default", "knownfolders", "minwinbase", "minwindef", "objbase", "processenv", "processthreadsapi", "profileapi", "shlobj", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "winerror", "winnt", "winuser"] }
 windows-sys-73dcd821b1037cfd = { package = "windows-sys", version = "0.59", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Win32_Globalization", "Win32_NetworkManagement_IpHelper", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_Diagnostics_Debug", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Kernel", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Performance", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell"] }
@@ -388,6 +392,7 @@ rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["ev
 rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "termios"] }
 spin = { version = "0.9" }
 stable_deref_trait = { version = "1" }
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features = false, features = ["log", "timeout"] }
 
 [target.x86_64-unknown-linux-musl.build-dependencies]
@@ -405,6 +410,7 @@ rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["ev
 rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "termios"] }
 spin = { version = "0.9" }
 stable_deref_trait = { version = "1" }
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features = false, features = ["log", "timeout"] }
 
 [target.aarch64-unknown-linux-musl.dependencies]
@@ -421,6 +427,7 @@ object = { version = "0.36", default-features = false, features = ["archive", "r
 rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["event", "mm", "net", "param", "pipe", "process", "procfs", "stdio", "termios", "thread", "time"] }
 rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "termios"] }
 stable_deref_trait = { version = "1" }
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features = false, features = ["log", "timeout"] }
 
 [target.aarch64-unknown-linux-musl.build-dependencies]
@@ -437,6 +444,7 @@ object = { version = "0.36", default-features = false, features = ["archive", "r
 rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["event", "mm", "net", "param", "pipe", "process", "procfs", "stdio", "termios", "thread", "time"] }
 rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "termios"] }
 stable_deref_trait = { version = "1" }
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features = false, features = ["log", "timeout"] }
 
 ### END HAKARI SECTION

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -26,7 +26,7 @@ serde.workspace = true
 serde-dynamic-string.workspace = true
 strum.workspace = true
 thiserror.workspace = true
-tonic = { workspace = true, optional = true, features = ["tls-roots"] }
+tonic = { workspace = true, features = ["tls-roots"] }
 url = { workspace = true, features = ["serde"] }
 
 # tracing
@@ -38,15 +38,16 @@ opentelemetry = { workspace = true, features = ["trace"] }
 opentelemetry-appender-tracing = { workspace = true, features = [
     "experimental_metadata_attributes",
 ] }
-opentelemetry-otlp = { workspace = true, features = [
+opentelemetry-otlp = { workspace = true, default-features = false, features = [
     "grpc-tonic",
     "http-proto",
     "logs",
     "reqwest-client",
     "tls",
     "tonic",
+    "trace",
     "metrics",
-], optional = true }
+] }
 opentelemetry-stdout = { workspace = true, features = [
     "trace",
     "metrics",
@@ -64,7 +65,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [features]
 default = []
-otlp = ["dep:opentelemetry-otlp", "dep:tonic", "gateway-config/otlp"]
 lambda = []
 
 [dev-dependencies]

--- a/crates/telemetry/src/otel.rs
+++ b/crates/telemetry/src/otel.rs
@@ -1,5 +1,4 @@
 /// exporter
-#[cfg(feature = "otlp")]
 pub mod exporter;
 /// Contains opentelemetry tracing integrations, namely [tracing_subscriber::Layer]'s and
 pub mod layer;

--- a/crates/telemetry/src/otel/logs.rs
+++ b/crates/telemetry/src/otel/logs.rs
@@ -7,64 +7,56 @@ pub(super) fn build_logs_provider(
     config: &TelemetryConfig,
     resource: Resource,
 ) -> Result<Option<SdkLoggerProvider>, TracingError> {
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "otlp")] {
-            use opentelemetry_otlp::{LogExporter, WithExportConfig, WithHttpConfig, WithTonicConfig};
-            use crate::otel::exporter::{build_metadata, build_tls_config};
-            use opentelemetry_sdk::logs::{BatchConfigBuilder, BatchLogProcessor};
-            use std::time::Duration;
+    use crate::otel::exporter::{build_metadata, build_tls_config};
+    use opentelemetry_otlp::{LogExporter, WithExportConfig, WithHttpConfig, WithTonicConfig};
+    use opentelemetry_sdk::logs::{BatchConfigBuilder, BatchLogProcessor};
+    use std::time::Duration;
 
-            let mut builder = SdkLoggerProvider::builder().with_resource(resource);
+    let mut builder = SdkLoggerProvider::builder().with_resource(resource);
 
-            if let Some(config) = config.logs_otlp_config() {
-                let exporter_timeout = Duration::from_secs(config.timeout.num_seconds() as u64);
+    if let Some(config) = config.logs_otlp_config() {
+        let exporter_timeout = Duration::from_secs(config.timeout.num_seconds() as u64);
 
-                let exporter = match config.protocol {
-                    gateway_config::OtlpExporterProtocol::Grpc => {
-                        let grpc_config = config.grpc.clone().unwrap_or_default();
+        let exporter = match config.protocol {
+            gateway_config::OtlpExporterProtocol::Grpc => {
+                let grpc_config = config.grpc.clone().unwrap_or_default();
 
-                        LogExporter::builder()
-                            .with_tonic()
-                            .with_endpoint(config.endpoint.to_string())
-                            .with_timeout(exporter_timeout)
-                            .with_metadata(build_metadata(grpc_config.headers))
-                            .with_tls_config(build_tls_config(grpc_config.tls)?)
-                            .build()
-                            .map_err(|e| TracingError::LogsExporterSetup(e.to_string()))?
-                    },
-                    gateway_config::OtlpExporterProtocol::Http => {
-                        let http_config = config.http.clone().unwrap_or_default();
+                LogExporter::builder()
+                    .with_tonic()
+                    .with_endpoint(config.endpoint.to_string())
+                    .with_timeout(exporter_timeout)
+                    .with_metadata(build_metadata(grpc_config.headers))
+                    .with_tls_config(build_tls_config(grpc_config.tls)?)
+                    .build()
+                    .map_err(|e| TracingError::LogsExporterSetup(e.to_string()))?
+            }
+            gateway_config::OtlpExporterProtocol::Http => {
+                let http_config = config.http.clone().unwrap_or_default();
 
-                        LogExporter::builder()
-                            .with_http()
-                            .with_endpoint(config.endpoint.to_string())
-                            .with_headers(http_config.headers.into_map())
-                            .with_timeout(exporter_timeout)
-                            .build()
-                            .map_err(|e| TracingError::LogsExporterSetup(e.to_string()))?
-                    },
-                };
+                LogExporter::builder()
+                    .with_http()
+                    .with_endpoint(config.endpoint.to_string())
+                    .with_headers(http_config.headers.into_map())
+                    .with_timeout(exporter_timeout)
+                    .build()
+                    .map_err(|e| TracingError::LogsExporterSetup(e.to_string()))?
+            }
+        };
 
-                let processor = {
-                    let config = config.batch_export;
+        let processor = {
+            let config = config.batch_export;
 
-                    let config = BatchConfigBuilder::default()
-                        .with_max_queue_size(config.max_queue_size)
-                        .with_scheduled_delay(Duration::from_secs(config.scheduled_delay.num_seconds() as u64))
-                        .with_max_export_batch_size(config.max_export_batch_size)
-                        .build();
+            let config = BatchConfigBuilder::default()
+                .with_max_queue_size(config.max_queue_size)
+                .with_scheduled_delay(Duration::from_secs(config.scheduled_delay.num_seconds() as u64))
+                .with_max_export_batch_size(config.max_export_batch_size)
+                .build();
 
-                    BatchLogProcessor::builder(exporter)
-                        .with_batch_config(config)
-                        .build()
-                };
+            BatchLogProcessor::builder(exporter).with_batch_config(config).build()
+        };
 
-                builder = builder.with_log_processor(processor);
-            };
+        builder = builder.with_log_processor(processor);
+    };
 
-            Ok(Some(builder.build()))
-        } else {
-            Ok(None)
-        }
-    }
+    Ok(Some(builder.build()))
 }

--- a/crates/telemetry/src/otel/metrics.rs
+++ b/crates/telemetry/src/otel/metrics.rs
@@ -62,12 +62,10 @@ pub(super) fn build_meter_provider(
         provider = provider.with_reader(reader);
     }
 
-    #[cfg(feature = "otlp")]
     if let Some(config) = config.metrics_otlp_config() {
         provider = attach_reader(config, provider)?;
     }
 
-    #[cfg(feature = "otlp")]
     if let Some(config) = config.grafbase_otlp_config() {
         provider = attach_reader(config, provider)?;
     }
@@ -75,7 +73,6 @@ pub(super) fn build_meter_provider(
     Ok(provider.build())
 }
 
-#[cfg(feature = "otlp")]
 fn attach_reader(
     config: &crate::config::OtlpExporterConfig,
     provider: opentelemetry_sdk::metrics::MeterProviderBuilder,

--- a/crates/telemetry/src/otel/traces.rs
+++ b/crates/telemetry/src/otel/traces.rs
@@ -53,69 +53,65 @@ fn setup_exporters(
         tracer_provider_builder = tracer_provider_builder.with_span_processor(span_processor);
     }
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "otlp")] {
-            use opentelemetry_otlp::{SpanExporter, WithExportConfig, WithHttpConfig, WithTonicConfig};
-            use super::exporter::{build_metadata, build_tls_config};
-            use gateway_config::OtlpExporterConfig;
+    use super::exporter::{build_metadata, build_tls_config};
+    use gateway_config::OtlpExporterConfig;
+    use opentelemetry_otlp::{SpanExporter, WithExportConfig, WithHttpConfig, WithTonicConfig};
 
-            let build_otlp_exporter = |config: &OtlpExporterConfig| {
-                let exporter_timeout = Duration::from_secs(config.timeout.num_seconds() as u64);
+    let build_otlp_exporter = |config: &OtlpExporterConfig| {
+        let exporter_timeout = Duration::from_secs(config.timeout.num_seconds() as u64);
 
-                let exporter = match config.protocol {
-                    gateway_config::OtlpExporterProtocol::Grpc => {
-                        let grpc_config = config.grpc.clone().unwrap_or_default();
+        let exporter = match config.protocol {
+            gateway_config::OtlpExporterProtocol::Grpc => {
+                let grpc_config = config.grpc.clone().unwrap_or_default();
 
-                        SpanExporter::builder()
-                            .with_tonic()
-                            .with_endpoint(config.endpoint.to_string())
-                            .with_timeout(exporter_timeout)
-                            .with_metadata(build_metadata(grpc_config.headers))
-                            .with_tls_config(build_tls_config(grpc_config.tls)?)
-                            .build()
-                            .map_err(|e| TracingError::SpanExporterSetup(e.to_string()))?
-                    }
-                    gateway_config::OtlpExporterProtocol::Http => {
-                        let http_config = config.http.clone().unwrap_or_default();
-
-                        SpanExporter::builder()
-                            .with_http()
-                            .with_endpoint(config.endpoint.to_string())
-                            .with_headers(http_config.headers.into_map())
-                            .with_timeout(exporter_timeout)
-                            .build()
-                            .map_err(|e| TracingError::SpanExporterSetup(e.to_string()))?
-                    }
-                };
-
-                Result::<SpanExporter, TracingError>::Ok(exporter)
-            };
-
-            // otlp
-            if let Some(otlp_exporter_config) = config.tracing_otlp_config() {
-                let span_exporter = build_otlp_exporter(otlp_exporter_config)?;
-
-                let span_processor = build_batched_span_processor(
-                    otlp_exporter_config.timeout,
-                    &otlp_exporter_config.batch_export,
-                    span_exporter,
-                );
-
-                tracer_provider_builder = tracer_provider_builder.with_span_processor(span_processor);
+                SpanExporter::builder()
+                    .with_tonic()
+                    .with_endpoint(config.endpoint.to_string())
+                    .with_timeout(exporter_timeout)
+                    .with_metadata(build_metadata(grpc_config.headers))
+                    .with_tls_config(build_tls_config(grpc_config.tls)?)
+                    .build()
+                    .map_err(|e| TracingError::SpanExporterSetup(e.to_string()))?
             }
+            gateway_config::OtlpExporterProtocol::Http => {
+                let http_config = config.http.clone().unwrap_or_default();
 
-            if let Some(otlp_exporter_config) = config.grafbase_otlp_config() {
-                let span_exporter = build_otlp_exporter(otlp_exporter_config)?;
-
-                let span_processor = build_batched_span_processor(
-                    otlp_exporter_config.timeout,
-                    &otlp_exporter_config.batch_export,
-                    span_exporter,
-                );
-
-                tracer_provider_builder = tracer_provider_builder.with_span_processor(span_processor);
+                SpanExporter::builder()
+                    .with_http()
+                    .with_endpoint(config.endpoint.to_string())
+                    .with_headers(http_config.headers.into_map())
+                    .with_timeout(exporter_timeout)
+                    .build()
+                    .map_err(|e| TracingError::SpanExporterSetup(e.to_string()))?
             }
-        }
+        };
+
+        Result::<SpanExporter, TracingError>::Ok(exporter)
+    };
+
+    // otlp
+    if let Some(otlp_exporter_config) = config.tracing_otlp_config() {
+        let span_exporter = build_otlp_exporter(otlp_exporter_config)?;
+
+        let span_processor = build_batched_span_processor(
+            otlp_exporter_config.timeout,
+            &otlp_exporter_config.batch_export,
+            span_exporter,
+        );
+
+        tracer_provider_builder = tracer_provider_builder.with_span_processor(span_processor);
+    }
+
+    if let Some(otlp_exporter_config) = config.grafbase_otlp_config() {
+        let span_exporter = build_otlp_exporter(otlp_exporter_config)?;
+
+        let span_processor = build_batched_span_processor(
+            otlp_exporter_config.timeout,
+            &otlp_exporter_config.batch_export,
+            span_exporter,
+        );
+
+        tracer_provider_builder = tracer_provider_builder.with_span_processor(span_processor);
     }
 
     Ok(tracer_provider_builder)

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -22,7 +22,7 @@ chrono.workspace = true
 clap = { workspace = true, features = ["cargo", "wrap_help", "derive", "env"] }
 federated-server.workspace = true
 gateway-config.workspace = true
-grafbase-telemetry = { workspace = true, features = ["otlp"] }
+grafbase-telemetry = { workspace = true }
 grafbase-workspace-hack.workspace = true
 graph-ref.workspace = true
 itertools.workspace = true


### PR DESCRIPTION
Remove useless flag and disable default feature of `opentelmetry-otlp`, they changed 2 months ago to use `reqwest-blocking-client` which led to a conflict with our own `reqwest-client` one.