### PR TITLE
chore(engine): Split ErrorCode, GraphqlError and ErrorResponse into separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,6 +2579,7 @@ dependencies = [
  "bytes",
  "crossbeam-queue",
  "engine-auth",
+ "engine-error",
  "engine-id-derives",
  "engine-id-newtypes",
  "engine-operation",
@@ -2612,8 +2613,6 @@ dependencies = [
  "serde_urlencoded",
  "sha2 0.10.8",
  "sonic-rs",
- "strum 0.27.1",
- "strum_macros 0.27.1",
  "thiserror 2.0.12",
  "tower 0.5.2",
  "tracing",
@@ -2681,6 +2680,19 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "xshell",
+]
+
+[[package]]
+name = "engine-error"
+version = "0.0.0"
+dependencies = [
+ "engine-operation",
+ "grafbase-workspace-hack",
+ "http 1.2.0",
+ "serde",
+ "serde_json",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
 ]
 
 [[package]]
@@ -3801,7 +3813,6 @@ name = "grafbase-workspace-hack"
 version = "0.1.0"
 dependencies = [
  "addr2line",
- "ahash",
  "aho-corasick",
  "anyhow",
  "arrayvec 0.7.6",
@@ -3820,7 +3831,6 @@ dependencies = [
  "clap",
  "clap_builder",
  "combine",
- "concurrent-queue",
  "console",
  "cranelift-bitset",
  "crc32fast",
@@ -3855,7 +3865,6 @@ dependencies = [
  "getrandom 0.3.1",
  "gimli",
  "group",
- "hashbrown 0.14.5",
  "hashbrown 0.15.2",
  "hex",
  "http-types",
@@ -7676,6 +7685,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
+ "engine-error",
  "engine-id-derives",
  "engine-schema",
  "extension",
@@ -7707,6 +7717,7 @@ dependencies = [
  "deadpool 0.12.2",
  "ed25519-compact",
  "elliptic-curve",
+ "engine",
  "engine-schema",
  "enumflags2",
  "extension-catalog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/engine/operation",
     "crates/engine/walker",
     "crates/engine/schema",
+    "crates/engine/error",
     "crates/engine/query-solver",
     "crates/engine/id-derives",
     "crates/engine/id-newtypes",

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -15,15 +15,20 @@ doctest = false
 workspace = true
 
 [dependencies]
+async-sse.workspace = true
 base64.workspace = true
 blake3.workspace = true
 bytes.workspace = true
 crossbeam-queue.workspace = true
+engine-auth = { path = "./auth" }
+error = { path = "./error", package = "engine-error" }
+extension-catalog.workspace = true
 fixedbitset.workspace = true
 futures.workspace = true
 futures-lite.workspace = true
 futures-util.workspace = true
 grafbase-telemetry.workspace = true
+grafbase-workspace-hack.workspace = true
 headers.workspace = true
 hex.workspace = true
 http.workspace = true
@@ -32,33 +37,26 @@ id-newtypes = { path = "./id-newtypes", package = "engine-id-newtypes" }
 im.workspace = true
 itertools.workspace = true
 mediatype.workspace = true
+mime.workspace = true
+minicbor-serde = { workspace = true, features = ["alloc"] }
+multipart-stream.workspace = true
+operation = { path = "./operation", package = "engine-operation" }
 percent-encoding.workspace = true
+query-solver = { path = "./query-solver", package = "engine-query-solver" }
 ramhorns.workspace = true
+rand.workspace = true
+runtime.workspace = true
+schema = { path = "./schema", package = "engine-schema" }
 serde = { workspace = true, features = ["rc"] }
 serde-value.workspace = true
 serde_json = { workspace = true, features = ["raw_value"] }
 serde_urlencoded.workspace = true
 sha2.workspace = true
 sonic-rs.workspace = true
-strum.workspace = true
-strum_macros.workspace = true
 thiserror.workspace = true
 tower = { workspace = true, features = ["retry"] }
 tracing.workspace = true
 url.workspace = true
-
-async-sse.workspace = true
-engine-auth = { path = "./auth" }
-extension-catalog.workspace = true
-grafbase-workspace-hack.workspace = true
-mime.workspace = true
-minicbor-serde = { workspace = true, features = ["alloc"] }
-multipart-stream.workspace = true
-operation = { path = "./operation", package = "engine-operation" }
-query-solver = { path = "./query-solver", package = "engine-query-solver" }
-rand.workspace = true
-runtime.workspace = true
-schema = { path = "./schema", package = "engine-schema" }
 walker = { path = "./walker", package = "engine-walker" }
 
 [dev-dependencies]

--- a/crates/engine/error/Cargo.toml
+++ b/crates/engine/error/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+authors = ["Grafbase"]
+description = ""
+edition = "2024"
+homepage = "https://grafbase.com"
+keywords = ["graphql", "engine", "grafbase"]
+license = "MPL-2.0"
+name = "engine-error"
+repository = "https://github.com/grafbase/grafbase"
+publish = false
+
+[lib]
+doctest = false
+
+[lints]
+workspace = true
+
+[dependencies]
+grafbase-workspace-hack.workspace = true
+http.workspace = true
+operation = { path = "../operation", package = "engine-operation" }
+serde.workspace = true
+serde_json.workspace = true
+strum.workspace = true
+strum_macros.workspace = true

--- a/crates/engine/error/src/path.rs
+++ b/crates/engine/error/src/path.rs
@@ -2,10 +2,8 @@ use std::{cell::RefMut, ops::Deref};
 
 use operation::{PositionedResponseKey, ResponseKey};
 
-use crate::response::ResponseValueId;
-
 #[derive(Debug, Clone)]
-pub(crate) struct ErrorPath(Vec<ErrorPathSegment>);
+pub struct ErrorPath(Vec<ErrorPathSegment>);
 
 impl std::ops::Deref for ErrorPath {
     type Target = [ErrorPathSegment];
@@ -15,10 +13,10 @@ impl std::ops::Deref for ErrorPath {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum ErrorPathSegment {
+pub enum ErrorPathSegment {
     Field(ResponseKey),
     Index(usize),
-    UnknownField(String),
+    UnknownField(Box<str>),
 }
 
 impl From<ResponseKey> for ErrorPathSegment {
@@ -47,12 +45,21 @@ impl From<u32> for ErrorPathSegment {
 
 impl From<String> for ErrorPathSegment {
     fn from(name: String) -> Self {
-        ErrorPathSegment::UnknownField(name)
+        ErrorPathSegment::UnknownField(name.into_boxed_str())
     }
 }
 
-impl<Segment: Into<ErrorPathSegment>> From<(&Vec<ResponseValueId>, Segment)> for ErrorPath {
-    fn from((path, segment): (&Vec<ResponseValueId>, Segment)) -> Self {
+impl From<Vec<ErrorPathSegment>> for ErrorPath {
+    fn from(segments: Vec<ErrorPathSegment>) -> Self {
+        ErrorPath(segments)
+    }
+}
+
+impl<S1, S2: Into<ErrorPathSegment>> From<(&Vec<S1>, S2)> for ErrorPath
+where
+    for<'a> &'a S1: Into<ErrorPathSegment>,
+{
+    fn from((path, segment): (&Vec<S1>, S2)) -> Self {
         let mut segments = Vec::with_capacity(path.len() + 1);
         for segment in path {
             segments.push(segment.into());
@@ -62,26 +69,29 @@ impl<Segment: Into<ErrorPathSegment>> From<(&Vec<ResponseValueId>, Segment)> for
     }
 }
 
-impl<Segment: Into<ErrorPathSegment>> From<(RefMut<'_, Vec<ResponseValueId>>, Segment)> for ErrorPath {
-    fn from((path, segment): (RefMut<'_, Vec<ResponseValueId>>, Segment)) -> Self {
+impl<S1, S2: Into<ErrorPathSegment>> From<(RefMut<'_, Vec<S1>>, S2)> for ErrorPath
+where
+    for<'a> &'a S1: Into<ErrorPathSegment>,
+{
+    fn from((path, segment): (RefMut<'_, Vec<S1>>, S2)) -> Self {
         (path.deref(), segment).into()
     }
 }
 
-impl From<RefMut<'_, Vec<ResponseValueId>>> for ErrorPath {
-    fn from(path: RefMut<'_, Vec<ResponseValueId>>) -> Self {
-        ErrorPath(path.iter().map(ErrorPathSegment::from).collect())
+impl<S> From<RefMut<'_, Vec<S>>> for ErrorPath
+where
+    for<'a> &'a S: Into<ErrorPathSegment>,
+{
+    fn from(path: RefMut<'_, Vec<S>>) -> Self {
+        ErrorPath(path.iter().map(Into::into).collect())
     }
 }
 
-impl From<&Vec<ResponseValueId>> for ErrorPath {
-    fn from(path: &Vec<ResponseValueId>) -> Self {
-        ErrorPath(path.iter().map(ErrorPathSegment::from).collect())
-    }
-}
-
-impl From<Vec<ErrorPathSegment>> for ErrorPath {
-    fn from(segments: Vec<ErrorPathSegment>) -> Self {
-        ErrorPath(segments)
+impl<S> From<&Vec<S>> for ErrorPath
+where
+    for<'a> &'a S: Into<ErrorPathSegment>,
+{
+    fn from(path: &Vec<S>) -> Self {
+        ErrorPath(path.iter().map(Into::into).collect())
     }
 }

--- a/crates/engine/src/engine/auth_extension.rs
+++ b/crates/engine/src/engine/auth_extension.rs
@@ -1,7 +1,7 @@
+use error::ErrorResponse;
 use extension_catalog::ExtensionId;
 use runtime::{
     auth::LegacyToken,
-    error::ErrorResponse,
     extension::{AuthorizerId, ExtensionRuntime},
 };
 use schema::{AuthConfig, AuthProviderConfig};

--- a/crates/engine/src/engine/execute.rs
+++ b/crates/engine/src/engine/execute.rs
@@ -4,10 +4,11 @@ mod stream;
 
 use ::runtime::{hooks::Hooks, rate_limiting::RateLimitKey};
 use bytes::Bytes;
+use error::ErrorResponse;
 use futures::StreamExt;
 use grafbase_telemetry::grafbase_client::Client;
 use operation::{BatchRequest, QueryParamsRequest, Request};
-use runtime::{auth::LegacyToken, error::ErrorResponse};
+use runtime::auth::LegacyToken;
 use std::{future::Future, sync::Arc};
 
 use crate::{

--- a/crates/engine/src/execution/hooks/authorized.rs
+++ b/crates/engine/src/execution/hooks/authorized.rs
@@ -1,8 +1,5 @@
 use futures::FutureExt;
-use runtime::{
-    error::PartialGraphqlError,
-    hooks::{AuthorizedHooks, EdgeDefinition, Hooks, NodeDefinition},
-};
+use runtime::hooks::{AuthorizedHooks, EdgeDefinition, Hooks, NodeDefinition};
 use schema::{Definition, FieldDefinition, SchemaInputValue};
 
 use crate::{
@@ -33,7 +30,6 @@ impl<H: Hooks> super::RequestHooks<'_, H> {
             //        Otherwise is not correctly evaluated to be Send due to the impl IntoIterator
             .boxed()
             .await
-            .map_err(Into::into)
     }
 
     pub async fn authorize_parent_edge_post_execution(
@@ -41,7 +37,7 @@ impl<H: Hooks> super::RequestHooks<'_, H> {
         definition: FieldDefinition<'_>,
         parents: ResponseObjectsView<'_>,
         metadata: Option<SchemaInputValue<'_>>,
-    ) -> Result<Vec<Result<(), PartialGraphqlError>>, GraphqlError> {
+    ) -> Result<Vec<Result<(), GraphqlError>>, GraphqlError> {
         self.hooks
             .authorized()
             .authorize_parent_edge_post_execution(
@@ -58,7 +54,6 @@ impl<H: Hooks> super::RequestHooks<'_, H> {
             //        Otherwise is not correctly evaluated to be Send due to the impl IntoIterator
             .boxed()
             .await
-            .map_err(Into::into)
     }
 
     pub async fn authorize_edge_node_post_execution(
@@ -66,7 +61,7 @@ impl<H: Hooks> super::RequestHooks<'_, H> {
         definition: FieldDefinition<'_>,
         nodes: ResponseObjectsView<'_>,
         metadata: Option<SchemaInputValue<'_>>,
-    ) -> Result<Vec<Result<(), PartialGraphqlError>>, GraphqlError> {
+    ) -> Result<Vec<Result<(), GraphqlError>>, GraphqlError> {
         self.hooks
             .authorized()
             .authorize_edge_node_post_execution(
@@ -83,7 +78,6 @@ impl<H: Hooks> super::RequestHooks<'_, H> {
             //        Otherwise is not correctly evaluated to be Send due to the impl IntoIterator
             .boxed()
             .await
-            .map_err(Into::into)
     }
 
     pub async fn authorize_node_pre_execution(
@@ -105,6 +99,5 @@ impl<H: Hooks> super::RequestHooks<'_, H> {
             //        Otherwise is not correctly evaluated to be Send due to the impl IntoIterator
             .boxed()
             .await
-            .map_err(Into::into)
     }
 }

--- a/crates/engine/src/execution/hooks/responses.rs
+++ b/crates/engine/src/execution/hooks/responses.rs
@@ -7,19 +7,13 @@ impl<H: Hooks> super::RequestHooks<'_, H> {
         &self,
         request: ExecutedSubgraphRequest<'_>,
     ) -> Result<H::OnSubgraphResponseOutput, GraphqlError> {
-        self.hooks
-            .on_subgraph_response(self.context, request)
-            .await
-            .map_err(Into::into)
+        self.hooks.on_subgraph_response(self.context, request).await
     }
 
     pub async fn on_operation_response(
         &self,
         operation: ExecutedOperation<'_, H::OnSubgraphResponseOutput>,
     ) -> Result<H::OnOperationResponseOutput, GraphqlError> {
-        self.hooks
-            .on_operation_response(self.context, operation)
-            .await
-            .map_err(Into::into)
+        self.hooks.on_operation_response(self.context, operation).await
     }
 }

--- a/crates/engine/src/execution/hooks/subgraph.rs
+++ b/crates/engine/src/execution/hooks/subgraph.rs
@@ -11,6 +11,5 @@ impl<H: Hooks> super::RequestHooks<'_, H> {
         self.hooks
             .on_subgraph_request(self.context, subgraph_name, request)
             .await
-            .map_err(Into::into)
     }
 }

--- a/crates/engine/src/execution/response_modifier.rs
+++ b/crates/engine/src/execution/response_modifier.rs
@@ -63,11 +63,8 @@ impl<'ctx, R: Runtime> ExecutionContext<'ctx, R> {
                         Ok(result) => {
                             if result.len() == input.len() {
                                 result
-                                    .into_iter()
-                                    .map(|res| res.map_err(GraphqlError::from))
-                                    .collect::<Vec<_>>()
                             } else if result.len() == 1 {
-                                let res = result.into_iter().next().unwrap().map_err(GraphqlError::from);
+                                let res = result.into_iter().next().unwrap();
                                 (0..input.len()).map(|_| res.clone()).collect()
                             } else {
                                 tracing::error!("Incorrect number of authorization replies");
@@ -121,11 +118,8 @@ impl<'ctx, R: Runtime> ExecutionContext<'ctx, R> {
                         Ok(result) => {
                             if result.len() == input.len() {
                                 result
-                                    .into_iter()
-                                    .map(|res| res.map_err(GraphqlError::from))
-                                    .collect::<Vec<_>>()
                             } else if result.len() == 1 {
-                                let res = result.into_iter().next().unwrap().map_err(GraphqlError::from);
+                                let res = result.into_iter().next().unwrap();
                                 (0..input.len()).map(|_| res.clone()).collect()
                             } else {
                                 tracing::error!("Incorrect number of authorization replies");

--- a/crates/engine/src/graphql_over_http/mod.rs
+++ b/crates/engine/src/graphql_over_http/mod.rs
@@ -5,13 +5,12 @@
 mod format;
 mod response;
 
+use error::ErrorCode;
 pub(crate) use format::*;
 use futures_util::stream::BoxStream;
 use grafbase_telemetry::graphql::GraphqlExecutionTelemetry;
 pub(crate) use response::*;
 use runtime::bytes::OwnedOrSharedBytes;
-
-pub use crate::response::error::code::ErrorCode;
 
 pub enum Body {
     Bytes(OwnedOrSharedBytes),

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -12,6 +12,7 @@ mod utils;
 pub mod websocket;
 
 pub use self::engine::{Engine, RequestContext, Runtime, WebsocketSession};
-pub use graphql_over_http::{Body, ErrorCode, HooksExtension, TelemetryExtension};
+pub use error::{ErrorCode, ErrorResponse, GraphqlError};
+pub use graphql_over_http::{Body, HooksExtension, TelemetryExtension};
 pub use prepare::cached::CachedOperation;
 pub use schema::{BuildError, Schema, Version as SchemaVersion};

--- a/crates/engine/src/prepare/operation_plan/error.rs
+++ b/crates/engine/src/prepare/operation_plan/error.rs
@@ -1,4 +1,4 @@
-use runtime::error::ErrorResponse;
+use error::ErrorResponse;
 
 use crate::response::GraphqlError;
 

--- a/crates/engine/src/prepare/operation_plan/mod.rs
+++ b/crates/engine/src/prepare/operation_plan/mod.rs
@@ -3,11 +3,11 @@ mod error;
 mod model;
 mod query_modifications;
 
+use ::error::ErrorResponse;
 pub(crate) use error::*;
 pub(crate) use model::*;
 use operation::Variables;
 pub(crate) use query_modifications::*;
-use runtime::error::ErrorResponse;
 
 use crate::{
     ErrorCode, Runtime,

--- a/crates/engine/src/prepare/operation_plan/query_modifications.rs
+++ b/crates/engine/src/prepare/operation_plan/query_modifications.rs
@@ -187,17 +187,17 @@ where
         match decisions {
             AuthorizationDecisions::GrantAll => (),
             AuthorizationDecisions::DenyAll(error) => {
-                let error_id = self.push_error(error.into());
+                let error_id = self.push_error(error);
                 for modifier in &modifiers[modifier_ids] {
                     self.deny_field(modifier, error_id);
                 }
             }
             AuthorizationDecisions::DenySome {
                 element_to_error,
-                errors,
+                mut errors,
             } => {
                 let offset = self.modifications.errors.len();
-                self.modifications.errors.extend(errors.into_iter().map(Into::into));
+                self.modifications.errors.append(&mut errors);
                 for (element_ix, error_ix) in element_to_error {
                     let modifier = &modifiers[modifier_ids.get(element_ix as usize).unwrap()];
                     self.deny_field(modifier, (offset + error_ix as usize).into());

--- a/crates/engine/src/resolver/extension/subscription.rs
+++ b/crates/engine/src/resolver/extension/subscription.rs
@@ -43,7 +43,7 @@ impl FieldResolverExtension {
             .resolve_subscription(headers, extension_directive)
             .boxed()
             .await
-            .map_err(|err| GraphqlError::from(err).with_location(field.location()))?;
+            .map_err(|err| err.with_location(field.location()))?;
 
         let stream = stream
             .map_err(move |error| ExecutionError::from(error.to_string()))

--- a/crates/engine/src/resolver/graphql/deserialize/entities.rs
+++ b/crates/engine/src/resolver/graphql/deserialize/entities.rs
@@ -117,7 +117,7 @@ where
         for segment in path {
             match segment {
                 serde_json::Value::String(field) => {
-                    out.push(ErrorPathSegment::UnknownField(field));
+                    out.push(ErrorPathSegment::UnknownField(field.into_boxed_str()));
                 }
                 serde_json::Value::Number(index) => {
                     out.push(ErrorPathSegment::Index(index.as_u64()? as usize));

--- a/crates/engine/src/resolver/graphql/root_fields.rs
+++ b/crates/engine/src/resolver/graphql/root_fields.rs
@@ -239,7 +239,7 @@ pub(super) fn convert_root_error_path(path: serde_json::Value) -> Option<ErrorPa
     for segment in path {
         match segment {
             serde_json::Value::String(field) => {
-                out.push(ErrorPathSegment::UnknownField(field));
+                out.push(ErrorPathSegment::UnknownField(field.into_boxed_str()));
             }
             serde_json::Value::Number(index) => {
                 out.push(ErrorPathSegment::Index(index.as_u64()? as usize));

--- a/crates/engine/src/response/mod.rs
+++ b/crates/engine/src/response/mod.rs
@@ -9,7 +9,7 @@ mod write;
 use std::sync::Arc;
 
 pub(crate) use data::*;
-pub(crate) use error::*;
+pub(crate) use error::{ErrorCode, ErrorCodeCounter, ErrorPath, ErrorPathSegment, GraphqlError};
 use extensions::ResponseExtensions;
 pub(crate) use extensions::*;
 use grafbase_telemetry::graphql::{GraphqlExecutionTelemetry, GraphqlOperationAttributes, GraphqlResponseStatus};
@@ -21,8 +21,6 @@ pub(crate) use value::*;
 pub(crate) use write::*;
 
 use crate::prepare::{CachedOperation, PreparedOperation};
-
-pub(crate) mod error;
 
 pub(crate) enum Response<OnOperationResponseHookOutput> {
     /// Before or while validating we have a well-formed GraphQL-over-HTTP request, we may

--- a/crates/engine/src/response/write/mod.rs
+++ b/crates/engine/src/response/write/mod.rs
@@ -197,7 +197,7 @@ impl ResponseBuilder {
                     }
                 }
                 (ErrorPathSegment::UnknownField(name), ResponseValueId::Field { key, .. }) => {
-                    if name != &self.operation.operation.response_keys[*key] {
+                    if **name != self.operation.operation.response_keys[*key] {
                         return false;
                     }
                 }

--- a/crates/grafbase-workspace-hack/Cargo.toml
+++ b/crates/grafbase-workspace-hack/Cargo.toml
@@ -20,7 +20,6 @@ publish = false
 
 ### BEGIN HAKARI SECTION
 [dependencies]
-ahash = { version = "0.8" }
 aho-corasick = { version = "1" }
 anyhow = { version = "1" }
 arrayvec = { version = "0.7" }
@@ -37,7 +36,6 @@ ciborium = { version = "0.2" }
 clap = { version = "4", features = ["cargo", "derive", "env", "wrap_help"] }
 clap_builder = { version = "4", default-features = false, features = ["cargo", "color", "env", "std", "suggestions", "usage", "wrap_help"] }
 combine = { version = "4", features = ["tokio"] }
-concurrent-queue = { version = "2" }
 console = { version = "0.15", default-features = false, features = ["ansi-parsing", "unicode-width"] }
 cranelift-bitset = { version = "0.117", default-features = false, features = ["enable-serde"] }
 crc32fast = { version = "1" }
@@ -70,8 +68,7 @@ futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
 getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std", "wasm_js"] }
 group = { version = "0.13", default-features = false, features = ["alloc"] }
-hashbrown-3575ec1268b04181 = { package = "hashbrown", version = "0.15", features = ["serde"] }
-hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", features = ["raw", "serde"] }
+hashbrown = { version = "0.15", features = ["serde"] }
 hex = { version = "0.4" }
 http-types = { version = "2" }
 hyper = { version = "1", features = ["full"] }
@@ -150,7 +147,6 @@ zstd-safe = { version = "7", default-features = false, features = ["arrays", "le
 zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
 
 [build-dependencies]
-ahash = { version = "0.8" }
 aho-corasick = { version = "1" }
 anyhow = { version = "1" }
 arrayvec = { version = "0.7" }
@@ -168,7 +164,6 @@ ciborium = { version = "0.2" }
 clap = { version = "4", features = ["cargo", "derive", "env", "wrap_help"] }
 clap_builder = { version = "4", default-features = false, features = ["cargo", "color", "env", "std", "suggestions", "usage", "wrap_help"] }
 combine = { version = "4", features = ["tokio"] }
-concurrent-queue = { version = "2" }
 console = { version = "0.15", default-features = false, features = ["ansi-parsing", "unicode-width"] }
 cranelift-bitset = { version = "0.117", default-features = false, features = ["enable-serde"] }
 crc32fast = { version = "1" }
@@ -201,8 +196,7 @@ futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
 getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std", "wasm_js"] }
 group = { version = "0.13", default-features = false, features = ["alloc"] }
-hashbrown-3575ec1268b04181 = { package = "hashbrown", version = "0.15", features = ["serde"] }
-hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", features = ["raw", "serde"] }
+hashbrown = { version = "0.15", features = ["serde"] }
 hex = { version = "0.4" }
 http-types = { version = "2" }
 hyper = { version = "1", features = ["full"] }

--- a/crates/integration-tests/src/federation/runtime/extension.rs
+++ b/crates/integration-tests/src/federation/runtime/extension.rs
@@ -1,10 +1,10 @@
 use std::{collections::HashMap, future::Future, sync::Arc};
 
+use engine::{ErrorResponse, GraphqlError};
 use engine_schema::{Subgraph, SubgraphId};
 use extension_catalog::{Extension, ExtensionCatalog, ExtensionId, Id, Manifest};
 use futures::stream::BoxStream;
 use runtime::{
-    error::{ErrorResponse, PartialGraphqlError},
     extension::{AuthorizationDecisions, Data, ExtensionFieldDirective, QueryElement, Token},
     hooks::{Anything, DynHookContext},
 };
@@ -127,7 +127,7 @@ pub trait TestExtensionBuilder: Send + Sync + 'static {
 #[async_trait::async_trait]
 pub trait TestExtension: Send + Sync + 'static {
     async fn authenticate(&self, headers: &http::HeaderMap) -> Result<Token, ErrorResponse> {
-        Err(PartialGraphqlError::internal_extension_error().into())
+        Err(GraphqlError::internal_extension_error().into())
     }
 
     async fn resolve_field(
@@ -135,8 +135,8 @@ pub trait TestExtension: Send + Sync + 'static {
         headers: http::HeaderMap,
         directive: ExtensionFieldDirective<'_, serde_json::Value>,
         inputs: Vec<serde_json::Value>,
-    ) -> Result<Vec<Result<Data, PartialGraphqlError>>, PartialGraphqlError> {
-        Err(PartialGraphqlError::internal_extension_error())
+    ) -> Result<Vec<Result<Data, GraphqlError>>, GraphqlError> {
+        Err(GraphqlError::internal_extension_error())
     }
 
     #[allow(clippy::manual_async_fn)]
@@ -145,7 +145,7 @@ pub trait TestExtension: Send + Sync + 'static {
         ctx: Arc<engine::RequestContext>,
         elements_grouped_by_directive_name: Vec<(&str, Vec<QueryElement<'_, serde_json::Value>>)>,
     ) -> Result<AuthorizationDecisions, ErrorResponse> {
-        Err(PartialGraphqlError::internal_extension_error().into())
+        Err(GraphqlError::internal_extension_error().into())
     }
 }
 
@@ -163,7 +163,7 @@ impl runtime::extension::ExtensionRuntime<Arc<engine::RequestContext>> for TestE
             arguments,
         }: ExtensionFieldDirective<'ctx, impl Anything<'ctx>>,
         inputs: impl IntoIterator<Item: Anything<'resp>> + Send,
-    ) -> impl Future<Output = Result<Vec<Result<Data, PartialGraphqlError>>, PartialGraphqlError>> + Send + 'f
+    ) -> impl Future<Output = Result<Vec<Result<Data, GraphqlError>>, GraphqlError>> + Send + 'f
     where
         'ctx: 'f,
     {
@@ -205,7 +205,7 @@ impl runtime::extension::ExtensionRuntime<Arc<engine::RequestContext>> for TestE
         &'ctx self,
         _: http::HeaderMap,
         _: ExtensionFieldDirective<'ctx, impl Anything<'ctx>>,
-    ) -> Result<BoxStream<'f, Result<Arc<Data>, PartialGraphqlError>>, PartialGraphqlError>
+    ) -> Result<BoxStream<'f, Result<Arc<Data>, GraphqlError>>, GraphqlError>
     where
         'ctx: 'f,
     {

--- a/crates/integration-tests/tests/federation/extensions/authorization/deny_all.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/deny_all.rs
@@ -1,15 +1,12 @@
 use std::sync::Arc;
 
-use engine::Engine;
+use engine::{Engine, ErrorResponse, GraphqlError};
 use graphql_mocks::dynamic::DynamicSchema;
 use integration_tests::{
     federation::{EngineExt, TestExtension},
     runtime,
 };
-use runtime::{
-    error::{ErrorResponse, PartialGraphqlError},
-    extension::{AuthorizationDecisions, QueryElement},
-};
+use runtime::extension::{AuthorizationDecisions, QueryElement};
 
 use crate::federation::extensions::authorization::SimpleAuthExt;
 
@@ -24,10 +21,7 @@ impl TestExtension for DenyAll {
         _ctx: Arc<engine::RequestContext>,
         _elements_grouped_by_directive_name: Vec<(&str, Vec<QueryElement<'_, serde_json::Value>>)>,
     ) -> Result<AuthorizationDecisions, ErrorResponse> {
-        Ok(AuthorizationDecisions::DenyAll(PartialGraphqlError::new(
-            "Not authorized",
-            runtime::error::PartialErrorCode::Unauthorized,
-        )))
+        Ok(AuthorizationDecisions::DenyAll(GraphqlError::unauthorized()))
     }
 }
 

--- a/crates/integration-tests/tests/federation/extensions/authorization/deny_some.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/deny_some.rs
@@ -1,15 +1,12 @@
 use std::sync::Arc;
 
-use engine::Engine;
+use engine::{Engine, ErrorResponse, GraphqlError};
 use graphql_mocks::dynamic::DynamicSchema;
 use integration_tests::{
     federation::{EngineExt, TestExtension},
     runtime,
 };
-use runtime::{
-    error::{ErrorResponse, PartialGraphqlError},
-    extension::{AuthorizationDecisions, QueryElement},
-};
+use runtime::extension::{AuthorizationDecisions, QueryElement};
 
 use crate::federation::extensions::authorization::SimpleAuthExt;
 
@@ -25,10 +22,7 @@ impl TestExtension for DenySites {
         elements_grouped_by_directive_name: Vec<(&str, Vec<QueryElement<'_, serde_json::Value>>)>,
     ) -> Result<AuthorizationDecisions, ErrorResponse> {
         let mut element_to_error = Vec::new();
-        let errors = vec![PartialGraphqlError::new(
-            "Not authorized",
-            runtime::error::PartialErrorCode::Unauthorized,
-        )];
+        let errors = vec![GraphqlError::unauthorized()];
 
         let mut i = 0;
         for (_, elements) in elements_grouped_by_directive_name {

--- a/crates/integration-tests/tests/federation/extensions/authorization/error_response.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/error_response.rs
@@ -1,15 +1,12 @@
 use std::sync::Arc;
 
-use engine::Engine;
+use engine::{Engine, ErrorResponse, GraphqlError};
 use graphql_mocks::dynamic::DynamicSchema;
 use integration_tests::{
     federation::{EngineExt, TestExtension},
     runtime,
 };
-use runtime::{
-    error::{ErrorResponse, PartialGraphqlError},
-    extension::{AuthorizationDecisions, QueryElement},
-};
+use runtime::extension::{AuthorizationDecisions, QueryElement};
 
 use crate::federation::extensions::authorization::SimpleAuthExt;
 
@@ -26,10 +23,7 @@ impl TestExtension for Failure {
     ) -> Result<AuthorizationDecisions, ErrorResponse> {
         Err(ErrorResponse {
             status: http::StatusCode::UNAUTHORIZED,
-            errors: vec![PartialGraphqlError::new(
-                "Not authorized",
-                runtime::error::PartialErrorCode::Unauthorized,
-            )],
+            errors: vec![GraphqlError::unauthorized()],
         })
     }
 }

--- a/crates/integration-tests/tests/federation/extensions/authorization/grant_all.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/grant_all.rs
@@ -1,15 +1,12 @@
 use std::sync::Arc;
 
-use engine::Engine;
+use engine::{Engine, ErrorResponse};
 use graphql_mocks::dynamic::DynamicSchema;
 use integration_tests::{
     federation::{EngineExt, TestExtension},
     runtime,
 };
-use runtime::{
-    error::ErrorResponse,
-    extension::{AuthorizationDecisions, QueryElement},
-};
+use runtime::extension::{AuthorizationDecisions, QueryElement};
 
 use crate::federation::extensions::authorization::SimpleAuthExt;
 

--- a/crates/integration-tests/tests/federation/extensions/basic.rs
+++ b/crates/integration-tests/tests/federation/extensions/basic.rs
@@ -1,15 +1,12 @@
 use std::sync::Arc;
 
-use engine::Engine;
+use engine::{Engine, GraphqlError};
 use extension_catalog::Id;
 use integration_tests::{
     federation::{EngineExt, TestExtension, TestExtensionBuilder, TestExtensionConfig, json_data},
     runtime,
 };
-use runtime::{
-    error::PartialGraphqlError,
-    extension::{Data, ExtensionFieldDirective},
-};
+use runtime::extension::{Data, ExtensionFieldDirective};
 
 #[derive(Default, Clone)]
 pub struct GreetExt {
@@ -55,7 +52,7 @@ impl TestExtension for GreetExt {
         _headers: http::HeaderMap,
         _directive: ExtensionFieldDirective<'_, serde_json::Value>,
         inputs: Vec<serde_json::Value>,
-    ) -> Result<Vec<Result<Data, PartialGraphqlError>>, PartialGraphqlError> {
+    ) -> Result<Vec<Result<Data, GraphqlError>>, GraphqlError> {
         Ok(vec![Ok(json_data("Hi!")); inputs.len()])
     }
 }

--- a/crates/integration-tests/tests/federation/extensions/injection/field_set/arguments/mod.rs
+++ b/crates/integration-tests/tests/federation/extensions/injection/field_set/arguments/mod.rs
@@ -7,12 +7,10 @@ mod scalar;
 
 use std::sync::Arc;
 
+use engine::GraphqlError;
 use extension_catalog::Id;
 use integration_tests::federation::{TestExtension, TestExtensionBuilder, TestExtensionConfig, json_data};
-use runtime::{
-    error::PartialGraphqlError,
-    extension::{Data, ExtensionFieldDirective},
-};
+use runtime::extension::{Data, ExtensionFieldDirective};
 
 #[derive(Default)]
 pub struct DoubleEchoExt;
@@ -55,7 +53,7 @@ impl TestExtension for DoubleEchoInstance {
         _headers: http::HeaderMap,
         directive: ExtensionFieldDirective<'_, serde_json::Value>,
         inputs: Vec<serde_json::Value>,
-    ) -> Result<Vec<Result<Data, PartialGraphqlError>>, PartialGraphqlError> {
+    ) -> Result<Vec<Result<Data, GraphqlError>>, GraphqlError> {
         match directive.name {
             "echo" => Ok(inputs
                 .into_iter()

--- a/crates/integration-tests/tests/federation/extensions/injection/template/json.rs
+++ b/crates/integration-tests/tests/federation/extensions/injection/template/json.rs
@@ -1,15 +1,12 @@
 use std::sync::Arc;
 
-use engine::Engine;
+use engine::{Engine, GraphqlError};
 use extension_catalog::Id;
 use integration_tests::{
     federation::{EngineExt, TestExtension, TestExtensionBuilder, TestExtensionConfig},
     runtime,
 };
-use runtime::{
-    error::PartialGraphqlError,
-    extension::{Data, ExtensionFieldDirective},
-};
+use runtime::extension::{Data, ExtensionFieldDirective};
 
 #[derive(Default)]
 pub struct EchoJsonDataExt;
@@ -49,7 +46,7 @@ impl TestExtension for EchoJsonDataExt {
         _: http::HeaderMap,
         directive: ExtensionFieldDirective<'_, serde_json::Value>,
         inputs: Vec<serde_json::Value>,
-    ) -> Result<Vec<Result<Data, PartialGraphqlError>>, PartialGraphqlError> {
+    ) -> Result<Vec<Result<Data, GraphqlError>>, GraphqlError> {
         let data = directive.arguments["data"].as_str().unwrap_or_default();
         Ok(vec![Ok(Data::JsonBytes(data.as_bytes().to_vec())); inputs.len()])
     }

--- a/crates/integration-tests/tests/federation/extensions/resolver/mod.rs
+++ b/crates/integration-tests/tests/federation/extensions/resolver/mod.rs
@@ -2,12 +2,10 @@ mod errors;
 
 use std::sync::Arc;
 
+use engine::GraphqlError;
 use extension_catalog::Id;
 use integration_tests::federation::{TestExtension, TestExtensionBuilder, TestExtensionConfig};
-use runtime::{
-    error::PartialGraphqlError,
-    extension::{Data, ExtensionFieldDirective},
-};
+use runtime::extension::{Data, ExtensionFieldDirective};
 
 #[derive(Clone)]
 pub struct StaticResolverExt {
@@ -51,7 +49,7 @@ impl TestExtension for StaticResolverExt {
         _: http::HeaderMap,
         _: ExtensionFieldDirective<'_, serde_json::Value>,
         inputs: Vec<serde_json::Value>,
-    ) -> Result<Vec<Result<Data, PartialGraphqlError>>, PartialGraphqlError> {
+    ) -> Result<Vec<Result<Data, GraphqlError>>, GraphqlError> {
         Ok(inputs.into_iter().map(|_| Ok(self.data.clone())).collect())
     }
 }

--- a/crates/integration-tests/tests/federation/extensions/validation/mod.rs
+++ b/crates/integration-tests/tests/federation/extensions/validation/mod.rs
@@ -9,16 +9,13 @@ mod scalar;
 
 use std::{collections::HashMap, sync::Arc};
 
-use engine::Engine;
+use engine::{Engine, GraphqlError};
 use extension_catalog::Id;
 use integration_tests::{
     federation::{EngineExt, TestExtension, TestExtensionBuilder, TestExtensionConfig, json_data},
     runtime,
 };
-use runtime::{
-    error::PartialGraphqlError,
-    extension::{Data, ExtensionFieldDirective},
-};
+use runtime::extension::{Data, ExtensionFieldDirective};
 
 #[derive(Default)]
 pub struct EchoExt {
@@ -69,7 +66,7 @@ impl TestExtension for EchoInstance {
         _: http::HeaderMap,
         directive: ExtensionFieldDirective<'_, serde_json::Value>,
         inputs: Vec<serde_json::Value>,
-    ) -> Result<Vec<Result<Data, PartialGraphqlError>>, PartialGraphqlError> {
+    ) -> Result<Vec<Result<Data, GraphqlError>>, GraphqlError> {
         Ok(inputs
             .into_iter()
             .map(|input| {

--- a/crates/integration-tests/tests/federation/hooks/authorize_edge_pre_execution.rs
+++ b/crates/integration-tests/tests/federation/hooks/authorize_edge_pre_execution.rs
@@ -1,9 +1,7 @@
+use engine::{ErrorCode, ErrorResponse, GraphqlError};
 use graphql_mocks::SecureSchema;
 use http::HeaderMap;
-use runtime::{
-    error::{ErrorResponse, PartialErrorCode, PartialGraphqlError},
-    hooks::{DynHookContext, DynHooks, EdgeDefinition},
-};
+use runtime::hooks::{DynHookContext, DynHooks, EdgeDefinition};
 
 use super::with_engine_for_auth;
 
@@ -19,16 +17,16 @@ fn arguments_are_provided() {
             _definition: EdgeDefinition<'_>,
             arguments: serde_json::Value,
             _metadata: Option<serde_json::Value>,
-        ) -> Result<(), PartialGraphqlError> {
+        ) -> Result<(), GraphqlError> {
             #[derive(serde::Deserialize)]
             struct Arguments {
                 id: i64,
             }
             let Arguments { id } = serde_json::from_value(arguments).unwrap();
             if id < 100 {
-                Err(PartialGraphqlError::new(
+                Err(GraphqlError::new(
                     format!("Unauthorized ID: {id}"),
-                    PartialErrorCode::Unauthorized,
+                    ErrorCode::Unauthorized,
                 ))
             } else {
                 Ok(())
@@ -123,14 +121,11 @@ fn metadata_is_provided() {
             _definition: EdgeDefinition<'_>,
             _arguments: serde_json::Value,
             metadata: Option<serde_json::Value>,
-        ) -> Result<(), PartialGraphqlError> {
+        ) -> Result<(), GraphqlError> {
             if extract_role(metadata.as_ref()) == Some("admin") {
                 Ok(())
             } else {
-                Err(PartialGraphqlError::new(
-                    "Unauthorized role",
-                    PartialErrorCode::Unauthorized,
-                ))
+                Err(GraphqlError::new("Unauthorized role", ErrorCode::Unauthorized))
             }
         }
     }
@@ -193,14 +188,11 @@ fn definition_is_provided() {
             definition: EdgeDefinition<'_>,
             _arguments: serde_json::Value,
             _metadata: Option<serde_json::Value>,
-        ) -> Result<(), PartialGraphqlError> {
+        ) -> Result<(), GraphqlError> {
             if definition.parent_type_name == "Check" && definition.field_name == "authorized" {
                 Ok(())
             } else {
-                Err(PartialGraphqlError::new(
-                    "Wrong definition",
-                    PartialErrorCode::Unauthorized,
-                ))
+                Err(GraphqlError::new("Wrong definition", ErrorCode::Unauthorized))
             }
         }
     }
@@ -298,14 +290,11 @@ fn context_is_propagated() {
             _definition: EdgeDefinition<'_>,
             _arguments: serde_json::Value,
             _metadata: Option<serde_json::Value>,
-        ) -> Result<(), PartialGraphqlError> {
+        ) -> Result<(), GraphqlError> {
             if context.get("client").is_some() {
                 Ok(())
             } else {
-                Err(PartialGraphqlError::new(
-                    "Missing client",
-                    PartialErrorCode::Unauthorized,
-                ))
+                Err(GraphqlError::new("Missing client", ErrorCode::Unauthorized))
             }
         }
     }
@@ -361,8 +350,8 @@ fn error_propagation() {
             _definition: EdgeDefinition<'_>,
             _arguments: serde_json::Value,
             _metadata: Option<serde_json::Value>,
-        ) -> Result<(), PartialGraphqlError> {
-            Err(PartialGraphqlError::new("Broken", PartialErrorCode::HookError))
+        ) -> Result<(), GraphqlError> {
+            Err(GraphqlError::new("Broken", ErrorCode::HookError))
         }
     }
 

--- a/crates/integration-tests/tests/federation/hooks/authorize_node_pre_execution.rs
+++ b/crates/integration-tests/tests/federation/hooks/authorize_node_pre_execution.rs
@@ -1,10 +1,8 @@
+use engine::{ErrorCode, ErrorResponse, GraphqlError};
 use graphql_mocks::SecureSchema;
 use http::HeaderMap;
 use integration_tests::federation::DeterministicEngine;
-use runtime::{
-    error::{ErrorResponse, PartialErrorCode, PartialGraphqlError},
-    hooks::{DynHookContext, DynHooks, NodeDefinition},
-};
+use runtime::hooks::{DynHookContext, DynHooks, NodeDefinition};
 use serde_json::json;
 
 use super::with_engine_for_auth;
@@ -20,12 +18,9 @@ fn query_root_type() {
             _context: &DynHookContext,
             definition: NodeDefinition<'_>,
             _metadata: Option<serde_json::Value>,
-        ) -> Result<(), PartialGraphqlError> {
+        ) -> Result<(), GraphqlError> {
             if definition.type_name == "Query" {
-                Err(PartialGraphqlError::new(
-                    "Query is not allowed!",
-                    PartialErrorCode::Unauthorized,
-                ))
+                Err(GraphqlError::new("Query is not allowed!", ErrorCode::Unauthorized))
             } else {
                 Ok(())
             }
@@ -112,12 +107,9 @@ fn mutation_root_type() {
             _context: &DynHookContext,
             definition: NodeDefinition<'_>,
             _metadata: Option<serde_json::Value>,
-        ) -> Result<(), PartialGraphqlError> {
+        ) -> Result<(), GraphqlError> {
             if definition.type_name == "Mutation" {
-                Err(PartialGraphqlError::new(
-                    "Mutation is not allowed!",
-                    PartialErrorCode::Unauthorized,
-                ))
+                Err(GraphqlError::new("Mutation is not allowed!", ErrorCode::Unauthorized))
             } else {
                 Ok(())
             }
@@ -204,11 +196,11 @@ fn subscription_root_type() {
             _context: &DynHookContext,
             definition: NodeDefinition<'_>,
             _metadata: Option<serde_json::Value>,
-        ) -> Result<(), PartialGraphqlError> {
+        ) -> Result<(), GraphqlError> {
             if definition.type_name == "Subscription" {
-                Err(PartialGraphqlError::new(
+                Err(GraphqlError::new(
                     "Subscription is not allowed!",
-                    PartialErrorCode::Unauthorized,
+                    ErrorCode::Unauthorized,
                 ))
             } else {
                 Ok(())
@@ -312,14 +304,11 @@ fn metadata_is_provided() {
             _context: &DynHookContext,
             _definition: NodeDefinition<'_>,
             metadata: Option<serde_json::Value>,
-        ) -> Result<(), PartialGraphqlError> {
+        ) -> Result<(), GraphqlError> {
             if extract_role(metadata.as_ref()) == Some("admin") {
                 Ok(())
             } else {
-                Err(PartialGraphqlError::new(
-                    "Unauthorized role",
-                    PartialErrorCode::Unauthorized,
-                ))
+                Err(GraphqlError::new("Unauthorized role", ErrorCode::Unauthorized))
             }
         }
     }
@@ -398,14 +387,11 @@ fn definition_is_provided() {
             _context: &DynHookContext,
             definition: NodeDefinition<'_>,
             _metadata: Option<serde_json::Value>,
-        ) -> Result<(), PartialGraphqlError> {
+        ) -> Result<(), GraphqlError> {
             if definition.type_name == "AuthorizedNode" {
                 Ok(())
             } else {
-                Err(PartialGraphqlError::new(
-                    "Wrong definition",
-                    PartialErrorCode::Unauthorized,
-                ))
+                Err(GraphqlError::new("Wrong definition", ErrorCode::Unauthorized))
             }
         }
     }
@@ -486,14 +472,11 @@ fn context_is_propagated() {
             context: &DynHookContext,
             _definition: NodeDefinition<'_>,
             _metadata: Option<serde_json::Value>,
-        ) -> Result<(), PartialGraphqlError> {
+        ) -> Result<(), GraphqlError> {
             if context.get("client").is_some() {
                 Ok(())
             } else {
-                Err(PartialGraphqlError::new(
-                    "Missing client",
-                    PartialErrorCode::Unauthorized,
-                ))
+                Err(GraphqlError::new("Missing client", ErrorCode::Unauthorized))
             }
         }
     }
@@ -553,8 +536,8 @@ fn error_propagation() {
             _context: &DynHookContext,
             _definition: NodeDefinition<'_>,
             _metadata: Option<serde_json::Value>,
-        ) -> Result<(), PartialGraphqlError> {
-            Err(PartialGraphqlError::new("Broken", PartialErrorCode::HookError))
+        ) -> Result<(), GraphqlError> {
+            Err(GraphqlError::new("Broken", ErrorCode::HookError))
         }
     }
 

--- a/crates/integration-tests/tests/federation/hooks/on_gateway_request.rs
+++ b/crates/integration-tests/tests/federation/hooks/on_gateway_request.rs
@@ -1,11 +1,9 @@
 use engine::Engine;
+use engine::{ErrorCode, ErrorResponse, GraphqlError};
 use graphql_mocks::{EchoSchema, FakeGithubSchema};
 use http::HeaderMap;
 use integration_tests::{federation::EngineExt, runtime};
-use runtime::{
-    error::{ErrorResponse, PartialErrorCode, PartialGraphqlError},
-    hooks::{DynHookContext, DynHooks},
-};
+use runtime::hooks::{DynHookContext, DynHooks};
 
 #[test]
 fn can_modify_headers() {
@@ -83,8 +81,7 @@ fn error_is_propagated_back_to_the_user() {
             _url: &str,
             _headers: HeaderMap,
         ) -> Result<HeaderMap, ErrorResponse> {
-            let error =
-                PartialGraphqlError::new("impossible error", PartialErrorCode::BadRequest).with_extension("foo", "bar");
+            let error = GraphqlError::new("impossible error", ErrorCode::BadRequest).with_extension("foo", "bar");
 
             Err(ErrorResponse {
                 status: http::StatusCode::BAD_REQUEST,
@@ -130,8 +127,8 @@ fn error_code_is_propagated_back_to_the_user() {
             _url: &str,
             _headers: HeaderMap,
         ) -> Result<HeaderMap, ErrorResponse> {
-            let error = PartialGraphqlError::new("impossible error", PartialErrorCode::BadRequest)
-                .with_extension("code", "IMPOSSIBLE");
+            let error =
+                GraphqlError::new("impossible error", ErrorCode::BadRequest).with_extension("code", "IMPOSSIBLE");
 
             Err(ErrorResponse {
                 status: http::StatusCode::BAD_REQUEST,

--- a/crates/integration-tests/tests/federation/hooks/on_subgraph_request.rs
+++ b/crates/integration-tests/tests/federation/hooks/on_subgraph_request.rs
@@ -1,10 +1,8 @@
 use engine::Engine;
+use engine::{ErrorCode, GraphqlError};
 use graphql_mocks::{EchoSchema, FakeGithubSchema, Stateful, Subgraph};
 use integration_tests::{federation::EngineExt, runtime};
-use runtime::{
-    error::{PartialErrorCode, PartialGraphqlError},
-    hooks::{DynHookContext, DynHooks, SubgraphRequest},
-};
+use runtime::hooks::{DynHookContext, DynHooks, SubgraphRequest};
 use url::Url;
 
 #[test]
@@ -18,7 +16,7 @@ fn can_modify_headers() {
             _context: &DynHookContext,
             _subgraph_name: &str,
             mut request: SubgraphRequest,
-        ) -> Result<SubgraphRequest, PartialGraphqlError> {
+        ) -> Result<SubgraphRequest, GraphqlError> {
             request.headers.insert("b", "22".parse().unwrap());
             request.headers.remove("c");
             Ok(request)
@@ -92,7 +90,7 @@ fn can_modify_url() {
                 _context: &DynHookContext,
                 _subgraph_name: &str,
                 mut request: SubgraphRequest,
-            ) -> Result<SubgraphRequest, PartialGraphqlError> {
+            ) -> Result<SubgraphRequest, GraphqlError> {
                 if request.headers.contains_key("redirect") {
                     request.url = self.url.clone();
                 }
@@ -161,8 +159,8 @@ fn error_is_propagated_back_to_the_user() {
             _context: &DynHookContext,
             _subgraph_name: &str,
             _request: SubgraphRequest,
-        ) -> Result<SubgraphRequest, PartialGraphqlError> {
-            Err(PartialGraphqlError::new("impossible error", PartialErrorCode::HookError).with_extension("foo", "bar"))
+        ) -> Result<SubgraphRequest, GraphqlError> {
+            Err(GraphqlError::new("impossible error", ErrorCode::HookError).with_extension("foo", "bar"))
         }
     }
 
@@ -206,11 +204,8 @@ fn error_code_is_propagated_back_to_the_user() {
             _context: &DynHookContext,
             _subgraph_name: &str,
             _request: SubgraphRequest,
-        ) -> Result<SubgraphRequest, PartialGraphqlError> {
-            Err(
-                PartialGraphqlError::new("impossible error", PartialErrorCode::HookError)
-                    .with_extension("code", "IMPOSSIBLE"),
-            )
+        ) -> Result<SubgraphRequest, GraphqlError> {
+            Err(GraphqlError::new("impossible error", ErrorCode::HookError).with_extension("code", "IMPOSSIBLE"))
         }
     }
 

--- a/crates/runtime-local/Cargo.toml
+++ b/crates/runtime-local/Cargo.toml
@@ -26,6 +26,7 @@ base64.workspace = true
 bytes.workspace = true
 ed25519-compact.workspace = true
 elliptic-curve = { workspace = true, features = ["jwk"] }
+engine.workspace = true
 engine-schema.workspace = true
 extension-catalog.workspace = true
 futures-util.workspace = true

--- a/crates/runtime-local/src/wasi.rs
+++ b/crates/runtime-local/src/wasi.rs
@@ -1,23 +1,12 @@
-use runtime::error::{PartialErrorCode, PartialGraphqlError};
+use engine::{ErrorCode, GraphqlError};
 use wasi_component_loader::GuestError;
 
 pub mod hooks;
 
-fn guest_error_as_gql(error: GuestError, code: PartialErrorCode) -> PartialGraphqlError {
-    let extensions = error
-        .extensions
-        .into_iter()
-        .map(|(key, value)| {
-            let value = String::from_utf8_lossy(&value).into_owned();
-            let value = serde_json::from_str(&value).unwrap_or(serde_json::Value::String(value));
-
-            (key.into(), value)
-        })
-        .collect();
-
-    PartialGraphqlError {
-        message: error.message.into(),
-        code,
-        extensions,
-    }
+fn guest_error_as_gql(error: GuestError, code: ErrorCode) -> GraphqlError {
+    GraphqlError::new(error.message, code).with_extensions(error.extensions.into_iter().map(|(key, value)| {
+        let value = String::from_utf8_lossy(&value).into_owned();
+        let value = serde_json::from_str(&value).unwrap_or(serde_json::Value::String(value));
+        (key, value)
+    }))
 }

--- a/crates/runtime-local/src/wasi/hooks/responses.rs
+++ b/crates/runtime-local/src/wasi/hooks/responses.rs
@@ -1,4 +1,4 @@
-use runtime::error::PartialGraphqlError;
+use engine::GraphqlError;
 use tracing::{Instrument, info_span};
 use wasi_component_loader::{
     CacheStatus, ExecutedHttpRequest, ExecutedOperation, ExecutedSubgraphRequest, FieldError, GraphqlResponseStatus,
@@ -12,7 +12,7 @@ impl HooksWasi {
         &self,
         context: &SharedContext,
         request: runtime::hooks::ExecutedSubgraphRequest<'_>,
-    ) -> Result<Vec<u8>, PartialGraphqlError> {
+    ) -> Result<Vec<u8>, GraphqlError> {
         let Some(ref inner) = self.0 else {
             return Ok(Vec::new());
         };
@@ -78,7 +78,7 @@ impl HooksWasi {
             .await
             .map_err(|err| {
                 tracing::error!("on_subgraph_response error: {err}");
-                PartialGraphqlError::internal_hook_error()
+                GraphqlError::internal_hook_error()
             })
     }
 
@@ -86,7 +86,7 @@ impl HooksWasi {
         &self,
         context: &SharedContext,
         operation: runtime::hooks::ExecutedOperation<'_, Vec<u8>>,
-    ) -> Result<Vec<u8>, PartialGraphqlError> {
+    ) -> Result<Vec<u8>, GraphqlError> {
         let Some(ref inner) = self.0 else {
             return Ok(Vec::new());
         };
@@ -141,7 +141,7 @@ impl HooksWasi {
             .await
             .map_err(|err| {
                 tracing::error!("on_gateway_response error: {err}");
-                PartialGraphqlError::internal_hook_error()
+                GraphqlError::internal_hook_error()
             })
     }
 
@@ -149,7 +149,7 @@ impl HooksWasi {
         &self,
         context: &SharedContext,
         request: runtime::hooks::ExecutedHttpRequest<Vec<u8>>,
-    ) -> Result<(), PartialGraphqlError> {
+    ) -> Result<(), GraphqlError> {
         let Some(ref inner) = self.0 else {
             return Ok(());
         };
@@ -181,7 +181,7 @@ impl HooksWasi {
             .await
             .map_err(|err| {
                 tracing::error!("on_http_response error: {err}");
-                PartialGraphqlError::internal_hook_error()
+                GraphqlError::internal_hook_error()
             })
     }
 }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -19,6 +19,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 bytes.workspace = true
 engine-schema.workspace = true
+error = { path = "../engine/error", package = "engine-error" }
 extension.workspace = true
 extension-catalog.workspace = true
 fixedbitset.workspace = true

--- a/crates/runtime/src/hooks.rs
+++ b/crates/runtime/src/hooks.rs
@@ -11,7 +11,7 @@ use std::future::Future;
 
 pub use http::HeaderMap;
 
-use crate::error::{ErrorResponse, PartialErrorCode, PartialGraphqlError};
+use error::{ErrorCode, ErrorResponse, GraphqlError};
 
 pub struct NodeDefinition<'a> {
     pub type_name: &'a str,
@@ -39,8 +39,8 @@ impl std::fmt::Display for EdgeDefinition<'_> {
 pub trait Anything<'a>: serde::Serialize + Send + 'a {}
 impl<'a, T> Anything<'a> for T where T: serde::Serialize + Send + 'a {}
 
-pub type AuthorizationVerdict = Result<(), PartialGraphqlError>;
-pub type AuthorizationVerdicts = Result<Vec<AuthorizationVerdict>, PartialGraphqlError>;
+pub type AuthorizationVerdict = Result<(), GraphqlError>;
+pub type AuthorizationVerdicts = Result<Vec<AuthorizationVerdict>, GraphqlError>;
 
 #[derive(Debug)]
 pub struct SubgraphRequest {
@@ -68,7 +68,7 @@ pub trait Hooks: Send + Sync + 'static {
         context: &Self::Context,
         subgraph_name: &str,
         request: SubgraphRequest,
-    ) -> impl Future<Output = Result<SubgraphRequest, PartialGraphqlError>> + Send {
+    ) -> impl Future<Output = Result<SubgraphRequest, GraphqlError>> + Send {
         async { Ok(request) }
     }
 
@@ -76,19 +76,19 @@ pub trait Hooks: Send + Sync + 'static {
         &self,
         context: &Self::Context,
         request: ExecutedSubgraphRequest<'_>,
-    ) -> impl Future<Output = Result<Self::OnSubgraphResponseOutput, PartialGraphqlError>> + Send;
+    ) -> impl Future<Output = Result<Self::OnSubgraphResponseOutput, GraphqlError>> + Send;
 
     fn on_operation_response(
         &self,
         context: &Self::Context,
         operation: ExecutedOperation<'_, Self::OnSubgraphResponseOutput>,
-    ) -> impl Future<Output = Result<Self::OnOperationResponseOutput, PartialGraphqlError>> + Send;
+    ) -> impl Future<Output = Result<Self::OnOperationResponseOutput, GraphqlError>> + Send;
 
     fn on_http_response(
         &self,
         context: &Self::Context,
         request: ExecutedHttpRequest<Self::OnOperationResponseOutput>,
-    ) -> impl Future<Output = Result<(), PartialGraphqlError>> + Send;
+    ) -> impl Future<Output = Result<(), GraphqlError>> + Send;
 
     fn authorized(&self) -> &impl AuthorizedHooks<Self::Context> {
         &()
@@ -173,7 +173,7 @@ impl Hooks for () {
         &self,
         _context: &Self::Context,
         _request: ExecutedSubgraphRequest<'_>,
-    ) -> Result<Self::OnSubgraphResponseOutput, PartialGraphqlError> {
+    ) -> Result<Self::OnSubgraphResponseOutput, GraphqlError> {
         Ok(())
     }
 
@@ -181,7 +181,7 @@ impl Hooks for () {
         &self,
         _context: &Self::Context,
         _operation: ExecutedOperation<'_, ()>,
-    ) -> Result<Self::OnOperationResponseOutput, PartialGraphqlError> {
+    ) -> Result<Self::OnOperationResponseOutput, GraphqlError> {
         Ok(())
     }
 
@@ -189,7 +189,7 @@ impl Hooks for () {
         &self,
         _context: &Self::Context,
         _request: ExecutedHttpRequest<()>,
-    ) -> Result<(), PartialGraphqlError> {
+    ) -> Result<(), GraphqlError> {
         Ok(())
     }
 }
@@ -202,9 +202,9 @@ impl<C: Send + Sync> AuthorizedHooks<C> for () {
         _: impl Anything<'a>,
         _: Option<impl Anything<'a>>,
     ) -> AuthorizationVerdict {
-        Err(PartialGraphqlError::new(
+        Err(GraphqlError::new(
             "@authorized directive cannot be used, so access was denied",
-            PartialErrorCode::Unauthorized,
+            ErrorCode::Unauthorized,
         ))
     }
 
@@ -214,9 +214,9 @@ impl<C: Send + Sync> AuthorizedHooks<C> for () {
         _: NodeDefinition<'a>,
         _: Option<impl Anything<'a>>,
     ) -> AuthorizationVerdict {
-        Err(PartialGraphqlError::new(
+        Err(GraphqlError::new(
             "@authorized directive cannot be used, so access was denied",
-            PartialErrorCode::Unauthorized,
+            ErrorCode::Unauthorized,
         ))
     }
 
@@ -227,9 +227,9 @@ impl<C: Send + Sync> AuthorizedHooks<C> for () {
         _: impl IntoIterator<Item: Anything<'a>> + Send,
         _: Option<impl Anything<'a>>,
     ) -> AuthorizationVerdicts {
-        Err(PartialGraphqlError::new(
+        Err(GraphqlError::new(
             "@authorized directive cannot be used, so access was denied",
-            PartialErrorCode::Unauthorized,
+            ErrorCode::Unauthorized,
         ))
     }
 
@@ -240,9 +240,9 @@ impl<C: Send + Sync> AuthorizedHooks<C> for () {
         _: impl IntoIterator<Item: Anything<'a>> + Send,
         _: Option<impl Anything<'a>>,
     ) -> AuthorizationVerdicts {
-        Err(PartialGraphqlError::new(
+        Err(GraphqlError::new(
             "@authorized directive cannot be used, so access was denied",
-            PartialErrorCode::Unauthorized,
+            ErrorCode::Unauthorized,
         ))
     }
 
@@ -253,9 +253,9 @@ impl<C: Send + Sync> AuthorizedHooks<C> for () {
         _: impl IntoIterator<Item: Anything<'a>> + Send,
         _: Option<impl Anything<'a>>,
     ) -> AuthorizationVerdicts {
-        Err(PartialGraphqlError::new(
+        Err(GraphqlError::new(
             "@authorized directive cannot be used, so access was denied",
-            PartialErrorCode::Unauthorized,
+            ErrorCode::Unauthorized,
         ))
     }
 
@@ -270,9 +270,9 @@ impl<C: Send + Sync> AuthorizedHooks<C> for () {
         Parent: Anything<'a>,
         Nodes: IntoIterator<Item: Anything<'a>> + Send,
     {
-        Err(PartialGraphqlError::new(
+        Err(GraphqlError::new(
             "@authorized directive cannot be used, so access was denied",
-            PartialErrorCode::Unauthorized,
+            ErrorCode::Unauthorized,
         ))
     }
 }

--- a/crates/runtime/src/hooks/test_utils.rs
+++ b/crates/runtime/src/hooks/test_utils.rs
@@ -32,9 +32,9 @@ pub trait DynHooks: Send + Sync + 'static {
         arguments: serde_json::Value,
         metadata: Option<serde_json::Value>,
     ) -> AuthorizationVerdict {
-        Err(PartialGraphqlError::new(
+        Err(GraphqlError::new(
             "authorize_edge_pre_execution is not implemented",
-            PartialErrorCode::Unauthorized,
+            ErrorCode::Unauthorized,
         ))
     }
 
@@ -44,9 +44,9 @@ pub trait DynHooks: Send + Sync + 'static {
         definition: NodeDefinition<'_>,
         metadata: Option<serde_json::Value>,
     ) -> AuthorizationVerdict {
-        Err(PartialGraphqlError::new(
+        Err(GraphqlError::new(
             "authorize_node_pre_execution is not implemented",
-            PartialErrorCode::Unauthorized,
+            ErrorCode::Unauthorized,
         ))
     }
 
@@ -57,9 +57,9 @@ pub trait DynHooks: Send + Sync + 'static {
         nodes: Vec<serde_json::Value>,
         metadata: Option<serde_json::Value>,
     ) -> AuthorizationVerdicts {
-        Err(PartialGraphqlError::new(
+        Err(GraphqlError::new(
             "authorize_node_post_execution is not implemented",
-            PartialErrorCode::Unauthorized,
+            ErrorCode::Unauthorized,
         ))
     }
 
@@ -70,9 +70,9 @@ pub trait DynHooks: Send + Sync + 'static {
         parents: Vec<serde_json::Value>,
         metadata: Option<serde_json::Value>,
     ) -> AuthorizationVerdicts {
-        Err(PartialGraphqlError::new(
+        Err(GraphqlError::new(
             "authorize_parent_edge_post_execution is not implemented",
-            PartialErrorCode::Unauthorized,
+            ErrorCode::Unauthorized,
         ))
     }
 
@@ -83,9 +83,9 @@ pub trait DynHooks: Send + Sync + 'static {
         nodes: Vec<serde_json::Value>,
         metadata: Option<serde_json::Value>,
     ) -> AuthorizationVerdicts {
-        Err(PartialGraphqlError::new(
+        Err(GraphqlError::new(
             "authorize_edge_node_post_execution is not implemented",
-            PartialErrorCode::Unauthorized,
+            ErrorCode::Unauthorized,
         ))
     }
 
@@ -96,9 +96,9 @@ pub trait DynHooks: Send + Sync + 'static {
         edges: Vec<(serde_json::Value, Vec<serde_json::Value>)>,
         metadata: Option<serde_json::Value>,
     ) -> AuthorizationVerdicts {
-        Err(PartialGraphqlError::new(
+        Err(GraphqlError::new(
             "authorize_edge_post_execution is not implemented",
-            PartialErrorCode::Unauthorized,
+            ErrorCode::Unauthorized,
         ))
     }
 
@@ -107,7 +107,7 @@ pub trait DynHooks: Send + Sync + 'static {
         context: &DynHookContext,
         subgraph_name: &str,
         request: SubgraphRequest,
-    ) -> Result<SubgraphRequest, PartialGraphqlError> {
+    ) -> Result<SubgraphRequest, GraphqlError> {
         Ok(request)
     }
 
@@ -115,7 +115,7 @@ pub trait DynHooks: Send + Sync + 'static {
         &self,
         context: &DynHookContext,
         request: ExecutedSubgraphRequest<'_>,
-    ) -> Result<Vec<u8>, PartialGraphqlError> {
+    ) -> Result<Vec<u8>, GraphqlError> {
         Ok(Vec::new())
     }
 
@@ -123,7 +123,7 @@ pub trait DynHooks: Send + Sync + 'static {
         &self,
         context: &DynHookContext,
         request: ExecutedOperation<'_, Vec<u8>>,
-    ) -> Result<Vec<u8>, PartialGraphqlError> {
+    ) -> Result<Vec<u8>, GraphqlError> {
         Ok(Vec::new())
     }
 
@@ -131,7 +131,7 @@ pub trait DynHooks: Send + Sync + 'static {
         &self,
         context: &DynHookContext,
         request: ExecutedHttpRequest<Vec<u8>>,
-    ) -> Result<(), PartialGraphqlError> {
+    ) -> Result<(), GraphqlError> {
         Ok(())
     }
 }
@@ -219,7 +219,7 @@ impl Hooks for DynamicHooks {
         context: &DynHookContext,
         subgraph_name: &str,
         request: SubgraphRequest,
-    ) -> Result<SubgraphRequest, PartialGraphqlError> {
+    ) -> Result<SubgraphRequest, GraphqlError> {
         self.0.on_subgraph_request(context, subgraph_name, request).await
     }
 
@@ -227,7 +227,7 @@ impl Hooks for DynamicHooks {
         &self,
         context: &DynHookContext,
         request: ExecutedSubgraphRequest<'_>,
-    ) -> Result<Vec<u8>, PartialGraphqlError> {
+    ) -> Result<Vec<u8>, GraphqlError> {
         self.0.on_subgraph_response(context, request).await
     }
 
@@ -235,7 +235,7 @@ impl Hooks for DynamicHooks {
         &self,
         context: &DynHookContext,
         operation: ExecutedOperation<'_, Self::OnSubgraphResponseOutput>,
-    ) -> Result<Vec<u8>, PartialGraphqlError> {
+    ) -> Result<Vec<u8>, GraphqlError> {
         self.0.on_gateway_response(context, operation).await
     }
 
@@ -243,7 +243,7 @@ impl Hooks for DynamicHooks {
         &self,
         context: &DynHookContext,
         request: ExecutedHttpRequest<Self::OnOperationResponseOutput>,
-    ) -> Result<(), PartialGraphqlError> {
+    ) -> Result<(), GraphqlError> {
         self.0.on_http_response(context, request).await
     }
 
@@ -507,7 +507,7 @@ impl<H: Hooks> DynHooks for DynWrapper<H> {
         context: &'b DynHookContext,
         subgraph_name: &'c str,
         request: SubgraphRequest,
-    ) -> BoxFuture<'fut, Result<SubgraphRequest, PartialGraphqlError>>
+    ) -> BoxFuture<'fut, Result<SubgraphRequest, GraphqlError>>
     where
         'a: 'fut,
         'b: 'fut,

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -4,7 +4,6 @@ pub mod auth;
 pub mod bytes;
 pub mod cursor;
 pub mod entity_cache;
-pub mod error;
 pub mod extension;
 pub mod fetch;
 pub mod hooks;

--- a/crates/wasi-component-loader/src/error.rs
+++ b/crates/wasi-component-loader/src/error.rs
@@ -1,4 +1,4 @@
-use runtime::error::{PartialErrorCode, PartialGraphqlError};
+use engine::{ErrorCode, GraphqlError};
 
 use crate::extension::api::wit;
 
@@ -26,16 +26,13 @@ impl From<Error> for ErrorResponse {
 }
 
 impl ErrorResponse {
-    pub(crate) fn into_graphql_error_response(self, code: PartialErrorCode) -> runtime::error::ErrorResponse {
+    pub(crate) fn into_graphql_error_response(self, code: ErrorCode) -> engine::ErrorResponse {
         match self {
-            ErrorResponse::Internal(error) => runtime::error::ErrorResponse {
+            ErrorResponse::Internal(error) => engine::ErrorResponse {
                 status: http::StatusCode::INTERNAL_SERVER_ERROR,
-                errors: vec![PartialGraphqlError::new(
-                    error.to_string(),
-                    PartialErrorCode::InternalServerError,
-                )],
+                errors: vec![GraphqlError::new(error.to_string(), ErrorCode::InternalServerError)],
             },
-            ErrorResponse::Guest(error) => runtime::error::ErrorResponse {
+            ErrorResponse::Guest(error) => engine::ErrorResponse {
                 status: http::StatusCode::from_u16(error.status_code)
                     .unwrap_or(http::StatusCode::INTERNAL_SERVER_ERROR),
                 errors: error
@@ -60,9 +57,9 @@ pub enum Error {
 }
 
 impl Error {
-    pub(crate) fn into_graphql_error(self, code: PartialErrorCode) -> PartialGraphqlError {
+    pub(crate) fn into_graphql_error(self, code: ErrorCode) -> GraphqlError {
         match self {
-            Error::Internal(error) => PartialGraphqlError::new(error.to_string(), code),
+            Error::Internal(error) => GraphqlError::new(error.to_string(), code),
             Error::Guest(error) => error.into_graphql_error(code),
         }
     }

--- a/crates/wasi-component-loader/src/extension/api/since_0_8_0/types_impl/error.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_8_0/types_impl/error.rs
@@ -1,22 +1,12 @@
-use runtime::error::{PartialErrorCode, PartialGraphqlError};
+use engine::{ErrorCode, GraphqlError};
 
 use crate::{cbor, extension::api::since_0_8_0::wit::grafbase::sdk::types};
 
 impl types::Error {
-    pub(crate) fn into_graphql_error(self, code: PartialErrorCode) -> PartialGraphqlError {
-        let extensions = self
-            .extensions
-            .into_iter()
-            .map(|(key, value)| {
-                let value = cbor::from_slice(&value).unwrap_or_default();
-                (key.into(), value)
-            })
-            .collect();
-
-        PartialGraphqlError {
-            message: self.message.into(),
-            code,
-            extensions,
-        }
+    pub(crate) fn into_graphql_error(self, code: ErrorCode) -> GraphqlError {
+        GraphqlError::new(self.message, code).with_extensions(self.extensions.into_iter().map(|(key, value)| {
+            let value: serde_json::Value = cbor::from_slice(&value).unwrap_or_default();
+            (key, value)
+        }))
     }
 }

--- a/crates/wasi-component-loader/src/extension/api/since_0_9_0/types_impl/error.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_9_0/types_impl/error.rs
@@ -1,22 +1,12 @@
-use runtime::error::{PartialErrorCode, PartialGraphqlError};
+use engine::{ErrorCode, GraphqlError};
 
 use crate::{cbor, extension::api::since_0_9_0::wit::error};
 
 impl error::Error {
-    pub(crate) fn into_graphql_error(self, code: PartialErrorCode) -> PartialGraphqlError {
-        let extensions = self
-            .extensions
-            .into_iter()
-            .map(|(key, value)| {
-                let value = cbor::from_slice(&value).unwrap_or_default();
-                (key.into(), value)
-            })
-            .collect();
-
-        PartialGraphqlError {
-            message: self.message.into(),
-            code,
-            extensions,
-        }
+    pub(crate) fn into_graphql_error(self, code: ErrorCode) -> GraphqlError {
+        GraphqlError::new(self.message, code).with_extensions(self.extensions.into_iter().map(|(key, value)| {
+            let value: serde_json::Value = cbor::from_slice(&value).unwrap_or_default();
+            (key, value)
+        }))
     }
 }

--- a/crates/wasi-component-loader/src/extension/api/since_0_9_0/wit/compatibility.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_9_0/wit/compatibility.rs
@@ -1,4 +1,4 @@
-use runtime::error::PartialErrorCode;
+use engine::ErrorCode;
 
 use crate::extension::api::since_0_8_0::wit::grafbase::sdk::types;
 
@@ -207,16 +207,16 @@ impl From<types::AuthorizationDecisions> for runtime::extension::AuthorizationDe
     fn from(decisions: types::AuthorizationDecisions) -> Self {
         match decisions {
             types::AuthorizationDecisions::GrantAll => runtime::extension::AuthorizationDecisions::GrantAll,
-            types::AuthorizationDecisions::DenyAll(error) => runtime::extension::AuthorizationDecisions::DenyAll(
-                error.into_graphql_error(PartialErrorCode::Unauthorized),
-            ),
+            types::AuthorizationDecisions::DenyAll(error) => {
+                runtime::extension::AuthorizationDecisions::DenyAll(error.into_graphql_error(ErrorCode::Unauthorized))
+            }
             types::AuthorizationDecisions::SparseDeny(types::SparseDenyAuthorizationDecisions {
                 element_to_error,
                 errors,
             }) => {
                 let errors = errors
                     .into_iter()
-                    .map(|err| err.into_graphql_error(PartialErrorCode::Unauthorized))
+                    .map(|err| err.into_graphql_error(ErrorCode::Unauthorized))
                     .collect();
 
                 runtime::extension::AuthorizationDecisions::DenySome {

--- a/crates/wasi-component-loader/src/extension/runtime/authorization.rs
+++ b/crates/wasi-component-loader/src/extension/runtime/authorization.rs
@@ -1,4 +1,4 @@
-use runtime::error::PartialErrorCode;
+use engine::ErrorCode;
 
 use crate::extension::api::wit::authorization as wit_latest;
 
@@ -6,16 +6,16 @@ impl From<wit_latest::AuthorizationDecisions> for runtime::extension::Authorizat
     fn from(decisions: wit_latest::AuthorizationDecisions) -> Self {
         match decisions {
             wit_latest::AuthorizationDecisions::GrantAll => runtime::extension::AuthorizationDecisions::GrantAll,
-            wit_latest::AuthorizationDecisions::DenyAll(error) => runtime::extension::AuthorizationDecisions::DenyAll(
-                error.into_graphql_error(PartialErrorCode::Unauthorized),
-            ),
+            wit_latest::AuthorizationDecisions::DenyAll(error) => {
+                runtime::extension::AuthorizationDecisions::DenyAll(error.into_graphql_error(ErrorCode::Unauthorized))
+            }
             wit_latest::AuthorizationDecisions::DenySome(wit_latest::AuthorizationDecisionsDenySome {
                 element_to_error,
                 errors,
             }) => {
                 let errors = errors
                     .into_iter()
-                    .map(|err| err.into_graphql_error(PartialErrorCode::Unauthorized))
+                    .map(|err| err.into_graphql_error(ErrorCode::Unauthorized))
                     .collect();
 
                 runtime::extension::AuthorizationDecisions::DenySome {

--- a/crates/wasi-component-loader/src/extension/runtime/subscription.rs
+++ b/crates/wasi-component-loader/src/extension/runtime/subscription.rs
@@ -3,10 +3,11 @@ mod unique;
 
 use std::sync::Arc;
 
+use engine::GraphqlError;
 use futures::stream::BoxStream;
-use runtime::{error::PartialGraphqlError, extension::Data};
+use runtime::extension::Data;
 
-pub(super) type SubscriptionStream<'f> = BoxStream<'f, Result<Arc<Data>, PartialGraphqlError>>;
+pub(super) type SubscriptionStream<'f> = BoxStream<'f, Result<Arc<Data>, GraphqlError>>;
 
 pub(super) use dedup::DeduplicatedSubscription;
 pub(super) use unique::UniqueSubscription;


### PR DESCRIPTION
Allows us to remove the `PartialErrorCode` & `PartialGraphqlError` stuff
and makes the overall code simpler.
