### PR TITLE
chore: bump gateway to 0.30.2, cli to 0.87.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.87.1"
+version = "0.87.2"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3632,7 +3632,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "anyhow",
  "ascii",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.87.2] - 2025-03-12
+
+[CHANGELOG](changelog/0.87.2.md)
+
 ## [0.87.1] - 2025-03-12
 
 [CHANGELOG](changelog/0.87.1.md)

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.87.1"
+version = "0.87.2"
 name = "grafbase"
 description = "The Grafbase command line interface"
 categories = ["command-line-utilities"]

--- a/cli/changelog/0.87.2.md
+++ b/cli/changelog/0.87.2.md
@@ -1,0 +1,3 @@
+### Fixes
+
+- Fixed a release issue with AWS CLI v2 installation, try 2

--- a/cli/install/upload.sh
+++ b/cli/install/upload.sh
@@ -34,7 +34,7 @@ env -i \
     AWS_REGION=auto \
     AWS_ACCESS_KEY_ID="$CLOUDFLARE_ASSETS_R2_ACCESS_KEY_ID" \
     AWS_SECRET_ACCESS_KEY="$CLOUDFLARE_ASSETS_R2_SECRET_ACCESS_KEY" \
-    aws --endpoint-url "$endpoint_url" s3 cp --no-progress "$1" "$s3_path" --checksum-algorithm=CRC32
+    aws --endpoint-url "$endpoint_url" s3 cp --no-progress "$1" "$s3_path"
 
 env -i \
     PATH="$PATH" \
@@ -42,6 +42,6 @@ env -i \
     AWS_REGION=auto \
     AWS_ACCESS_KEY_ID="$CLOUDFLARE_ASSETS_R2_ACCESS_KEY_ID" \
     AWS_SECRET_ACCESS_KEY="$CLOUDFLARE_ASSETS_R2_SECRET_ACCESS_KEY" \
-    aws --endpoint-url "$endpoint_url" s3 ls "$s3_path" --human-readable --checksum-algorithm=CRC32
+    aws --endpoint-url "$endpoint_url" s3 ls "$s3_path" --human-readable
 
 echo "Done."

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.87.1",
+  "version": "0.87.2",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.87.1",
+  "version": "0.87.2",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.87.1",
+  "version": "0.87.2",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.87.1",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.87.1",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.87.1",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.87.1",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.87.1"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.87.2",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.87.2",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.87.2",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.87.2",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.87.2"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.87.1",
+  "version": "0.87.2",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.87.1",
+  "version": "0.87.2",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.87.1",
+  "version": "0.87.2",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.30.2] - 2025-03-12
+
+[CHANGELOG](changelog/0.30.2.md)
+
 ## [0.30.1] - 2025-03-12
 
 [CHANGELOG](changelog/0.30.1.md)

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.30.1"
+version = "0.30.2"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/changelog/0.30.2.md
+++ b/gateway/changelog/0.30.2.md
@@ -1,0 +1,3 @@
+### Fixes
+
+- Fixed a release issue with AWS CLI v2 installation, try 2


### PR DESCRIPTION
And remove the crc check from aws upload that fails on CI. This is automatic on newer aws-cli versions anyhow, and I don't have time to fight github the whole day.