### PR TITLE
chore(gb-8682): use depot and sccache to speed up builds

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -35,7 +35,7 @@ concurrency:
 
 jobs:
   detect-change-type:
-    runs-on: ubicloud-standard-2
+    runs-on: depot-ubuntu-24.04-small
     outputs:
       build: ${{ steps.filter.outputs.build }}
     steps:
@@ -60,7 +60,7 @@ jobs:
     name: 'Lint'
     needs: [detect-change-type]
     if: ${{ needs.detect-change-type.outputs.build == 'true' || startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubicloud-standard-8
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - name: Get sources
         uses: actions/checkout@v4
@@ -80,7 +80,7 @@ jobs:
     name: 'Test'
     needs: [lint]
     if: ${{ needs.detect-change-type.outputs.build == 'true' || startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubicloud-standard-8
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - name: Get sources
         uses: actions/checkout@v4
@@ -106,10 +106,13 @@ jobs:
       fail-fast: false
       matrix:
         package: [grafbase, grafbase-gateway, federated-server]
-    runs-on: ubicloud-standard-8
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - name: Get sources
         uses: actions/checkout@v4
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.7
 
       - name: Rust job init
         uses: ./.github/actions/init_rust_job
@@ -121,6 +124,8 @@ jobs:
 
       - name: Individual package build
         shell: bash
+        env:
+          RUSTC_WRAPPER: 'sccache'
         run: |
           set -euo pipefail
           # The actual features used for each dependency depends on what is being built simultaneously.
@@ -132,6 +137,8 @@ jobs:
       - name: Individual package without lambda
         if: ${{ matrix.package == 'grafbase-gateway' }}
         shell: bash
+        env:
+          RUSTC_WRAPPER: 'sccache'
         run: |
           set -euo pipefail
           cargo check --package ${{ matrix.package }}
@@ -139,7 +146,7 @@ jobs:
   docker-gateway:
     needs: [test]
     if: ${{ (needs.detect-change-type.outputs.build == 'true' || startsWith(github.ref, 'refs/tags/')) }}
-    runs-on: ubicloud-standard-16
+    runs-on: depot-ubuntu-24.04-8
     permissions:
       packages: write
     env:
@@ -161,30 +168,31 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build docker images
-        run: |
-          # Re-use the latest layers if possible
-          docker pull ghcr.io/grafbase/gateway:latest || true
-          docker build -f gateway/Dockerfile -t ghcr.io/grafbase/gateway:$COMMIT_SHA .
-
-      - name: Push docker image
-        run: |
-          docker push ghcr.io/grafbase/gateway:$COMMIT_SHA
-
-      - name: Push latest version
+      - name: Build and push tagged image
+        uses: depot/build-push-action@v1
         if: ${{ github.ref == 'refs/heads/main' }}
-        run: |
-          docker tag ghcr.io/grafbase/gateway:$COMMIT_SHA ghcr.io/grafbase/gateway:latest
-          docker push ghcr.io/grafbase/gateway:latest
+        with:
+          project: lc6t0h7bhh
+          token: ${{ secrets.DEPOT_TOKEN }}
+          push: true
+          tags: ghcr.io/grafbase/gateway:${{ env.COMMIT_SHA }}, ghcr.io/grafbase/gateway:latest
+          file: ./gateway/Dockerfile
 
-      - name: Push released gateway version
+      - name: Set release version
         if: ${{ startsWith(github.ref, 'refs/tags') && startsWith(github.ref_name, 'gateway-') }}
         run: |
-          RELEASE_VERSION="$(echo "$REF" | sed -e "s/^refs\/tags\/gateway-//")"
-          docker tag ghcr.io/grafbase/gateway:$COMMIT_SHA ghcr.io/grafbase/gateway:$RELEASE_VERSION
-          docker push ghcr.io/grafbase/gateway:$RELEASE_VERSION
-        env:
-          REF: ${{ github.ref }}
+          RELEASE_VERSION="$(echo "${{ github.ref }}" | sed -e "s/^refs\/tags\/gateway-//")"
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+
+      - name: Build and push versioned image
+        uses: depot/build-push-action@v1
+        if: ${{ startsWith(github.ref, 'refs/tags') && startsWith(github.ref_name, 'gateway-') }}
+        with:
+          project: lc6t0h7bhh
+          token: ${{ secrets.DEPOT_TOKEN }}
+          push: true
+          tags: ghcr.io/grafbase/gateway:${{ env.RELEASE_VERSION }}
+          file: ./gateway/Dockerfile
 
   linux:
     needs: [test]
@@ -193,8 +201,8 @@ jobs:
       matrix:
         archs:
           [
-            { runner: ubicloud-standard-8, target: x86_64-unknown-linux-musl, platform: linux },
-            { runner: ubicloud-standard-8-arm, target: aarch64-unknown-linux-musl, platform: linux-arm },
+            { runner: depot-ubuntu-24.04-8, target: x86_64-unknown-linux-musl, platform: linux },
+            { runner: depot-ubuntu-24.04-arm-8, target: aarch64-unknown-linux-musl, platform: linux-arm },
           ]
     runs-on: ${{ matrix.archs.runner }}
     steps:
@@ -206,6 +214,9 @@ jobs:
         with:
           platform: ${{ matrix.archs.platform }}
 
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.7
+
       - name: Fetch CLI assets
         uses: ./.github/actions/fetch-assets
 
@@ -215,11 +226,15 @@ jobs:
           sudo apt install musl
 
       - name: Build grafbase release
+        env:
+          RUSTC_WRAPPER: 'sccache'
         run: |
           cd cli
           cargo build --release -p grafbase --target ${{ matrix.archs.target }} --timings
 
       - name: Build gateway release
+        env:
+          RUSTC_WRAPPER: 'sccache'
         run: |
           cargo build --release -p grafbase-gateway --target ${{ matrix.archs.target }}
 
@@ -228,7 +243,7 @@ jobs:
           name: ${{ matrix.archs.platform }}-release-timings.html
           path: target/cargo-timings/cargo-timing.html
 
-      - if: ${{ github.event_name == 'pull_request' && matrix.archs.runner != 'ubicloud-standard-8-arm' }}
+      - if: ${{ github.event_name == 'pull_request' && matrix.archs.runner != 'depot-ubuntu-24.04-8-arm' }}
         name: Upload the binaries of the change to R2
         run: |
           aws s3api put-object \
@@ -286,7 +301,7 @@ jobs:
           echo "Building lambda with $BUILD_PROFILE profile"
           cargo build --profile $BUILD_PROFILE -p grafbase-gateway --target ${{ matrix.archs.target }} --features lambda
 
-      - if: ${{ github.event_name == 'pull_request' && matrix.archs.runner != 'ubicloud-standard-8-arm' }}
+      - if: ${{ github.event_name == 'pull_request' && matrix.archs.runner != 'depot-ubuntu-24.04-arm-8' }}
         name: Upload lambda gateway binary to R2
         run: |
           BUILD_PROFILE=release
@@ -309,9 +324,10 @@ jobs:
           name: gateway-lambda-${{ env.VERSION_BUMP }}-${{ matrix.archs.platform }}
           path: |
             target/${{ matrix.archs.target }}/lambda/grafbase-gateway
+
   windows:
     needs: [test]
-    runs-on: windows-latest-8-cores
+    runs-on: depot-windows-2022-8
     steps:
       - name: Get sources
         uses: actions/checkout@v4
@@ -319,6 +335,9 @@ jobs:
         uses: ./.github/actions/init_rust_job
         with:
           platform: windows
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.7
 
       - name: Fetch CLI assets
         uses: ./.github/actions/fetch-assets
@@ -335,6 +354,8 @@ jobs:
 
       - name: Build grafbase release
         shell: bash
+        env:
+          RUSTC_WRAPPER: sccache
         run: |
           cd cli
           cargo build --release -p grafbase --target x86_64-pc-windows-msvc --timings
@@ -361,7 +382,7 @@ jobs:
 
   darwin:
     needs: [test]
-    runs-on: macos-latest-xlarge
+    runs-on: depot-macos-latest
     strategy:
       fail-fast: false
       matrix:
@@ -375,6 +396,9 @@ jobs:
         with:
           platform: macos
 
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.7
+
       - name: Fetch CLI assets
         uses: ./.github/actions/fetch-assets
 
@@ -387,10 +411,14 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build grafbase ${{ matrix.target }} release
+        env:
+          RUSTC_WRAPPER: sccache
         run: |
           cargo build --release -p grafbase --target ${{ matrix.target }} --timings
 
       - name: Build gateway ${{ matrix.target }} release
+        env:
+          RUSTC_WRAPPER: sccache
         run: |
           cargo build --release -p grafbase-gateway --target ${{ matrix.target }}
 
@@ -413,7 +441,7 @@ jobs:
           VERSION_BUMP=${VERSION_BUMP//gateway-} # remove the gateway prefix from the tag
           echo VERSION_BUMP=${VERSION_BUMP} >> $GITHUB_ENV
 
-      - if: ${{ github.event_name == 'pull_request' && matrix.archs.runner != 'ubicloud-standard-8-arm' }}
+      - if: ${{ github.event_name == 'pull_request' && matrix.archs.runner != 'depot-ubuntu-24.04-arm-8' }}
         name: Upload the binaries of the change to R2
         run: |
           curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
@@ -483,7 +511,7 @@ jobs:
     # happen after the builds, hence the `needs`. But it must not be skipped
     # when the builds are cancelled or fail (hence the `if: ${{ always() }}`).
     needs: [linux, darwin]
-    runs-on: ubicloud-standard-2
+    runs-on: depot-ubuntu-24.04-small
     if: ${{ always() }}
     steps:
       - name: Check that the builds succeeded

--- a/.github/workflows/build-gateway-chart.yml
+++ b/.github/workflows/build-gateway-chart.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   detect-change-type:
-    runs-on: ubicloud-standard-2
+    runs-on: depot-ubuntu-24.04-small
     outputs:
       build: ${{ steps.filter.outputs.build }}
     steps:
@@ -38,7 +38,7 @@ jobs:
 
   gateway-helm-release:
     name: Build gateway helm chart
-    runs-on: ubicloud-standard-2
+    runs-on: depot-ubuntu-24.04-small
     needs: [detect-change-type]
     steps:
       - name: Checkout Repository
@@ -47,8 +47,8 @@ jobs:
       - name: Setup helm
         uses: azure/setup-helm@v4.3.0
         with:
-          version: "v3.16.2"
-  
+          version: 'v3.16.2'
+
       - name: Login to ghcr.io
         shell: bash
         run: |

--- a/.github/workflows/cargo-hakari.yml
+++ b/.github/workflows/cargo-hakari.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   what-changed:
-    runs-on: ubicloud-standard-2
+    runs-on: depot-ubuntu-24.04-small
     outputs:
       cargo: ${{ steps.paths-changed.outputs.cargo }}
 
@@ -30,7 +30,7 @@ jobs:
 
   hakari:
     needs: [what-changed]
-    runs-on: ubicloud-standard-2
+    runs-on: depot-ubuntu-24.04-small
     if: needs.what-changed.outputs.cargo == 'true'
     steps:
       - name: Checkout Repository

--- a/.github/workflows/federation-audit.yml
+++ b/.github/workflows/federation-audit.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   what-changed:
-    runs-on: ubicloud-standard-2
+    runs-on: depot-ubuntu-24.04-small
     outputs:
       changed-packages: ${{ steps.rust.outputs.changed-packages }}
       github-action: ${{ steps.paths-changed.outputs.github-action }}
@@ -53,7 +53,7 @@ jobs:
       contains(fromJson(needs.what-changed.outputs.changed-packages), 'engine')
       || contains(fromJson(needs.what-changed.outputs.changed-packages), 'federation-audit-tests')
       || needs.what-changed.outputs.github-action == 'true'
-    runs-on: ubicloud-standard-8
+    runs-on: depot-ubuntu-24.04-8
     permissions:
       checks: write
       pull-requests: write
@@ -78,6 +78,9 @@ jobs:
         with:
           target: x86_64-unknown-linux-gnu
 
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.7
+
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
@@ -95,6 +98,8 @@ jobs:
 
       - name: Build audit tests
         shell: bash
+        env:
+          RUSTC_WRAPPER: sccache
         run: |
           cargo nextest run --no-run --profile ci -p federation-audit-tests
 

--- a/.github/workflows/gateway-partial-release.yml
+++ b/.github/workflows/gateway-partial-release.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   release:
     name: Release gateway
-    runs-on: ubicloud-standard-2
+    runs-on: depot-ubuntu-24.04-small
     steps:
       - name: Parse version tag
         run: |

--- a/.github/workflows/grafbase-partial-release.yml
+++ b/.github/workflows/grafbase-partial-release.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   release:
     name: Release grafbase
-    runs-on: ubicloud-standard-2
+    runs-on: depot-ubuntu-24.04-small
     steps:
       - name: Parse version tag
         run: |

--- a/.github/workflows/rust-prs.yml
+++ b/.github/workflows/rust-prs.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   what-changed:
-    runs-on: ubicloud-standard-2
+    runs-on: depot-ubuntu-24.04-small
     outputs:
       # These 2 are JSON lists
       changed-packages: ${{ steps.rust.outputs.changed-packages }}
@@ -61,7 +61,7 @@ jobs:
   check-licenses:
     needs: [what-changed]
     if: needs.what-changed.outputs.changed-packages != '[]'
-    runs-on: ubicloud-standard-2
+    runs-on: depot-ubuntu-24.04-small
     steps:
       - name: Get sources
         uses: actions/checkout@v4
@@ -84,7 +84,7 @@ jobs:
   check-format:
     needs: [what-changed]
     if: needs.what-changed.outputs.changed-packages != '[]'
-    runs-on: ubicloud-standard-2
+    runs-on: depot-ubuntu-24.04-small
     steps:
       - name: Get sources
         uses: actions/checkout@v4
@@ -113,7 +113,7 @@ jobs:
     if: |
       needs.what-changed.outputs.changed-packages != '[]'
     needs: [what-changed]
-    runs-on: ubicloud-standard-8
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - name: Get sources
         uses: actions/checkout@v4
@@ -121,9 +121,14 @@ jobs:
       - name: Install cargo binstall
         uses: cargo-bins/cargo-binstall@v1.10.21
 
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.7
+
       - name: Build the WASI components for tests
         shell: bash
         working-directory: crates/wasi-component-loader/examples
+        env:
+          RUSTC_WRAPPER: sccache
         run: cargo build --target wasm32-wasip2
 
       - uses: actions/upload-artifact@v4
@@ -147,11 +152,11 @@ jobs:
       matrix:
         platform:
           [
-            { 'target': 'x86_64-unknown-linux-musl', 'runner': 'ubicloud-standard-8' },
-            { 'target': 'aarch64-unknown-linux-musl', 'runner': 'ubicloud-standard-8-arm' },
-            { 'target': 'aarch64-apple-darwin', 'runner': 'macos-latest-xlarge' },
-            { 'target': 'x86_64-apple-darwin', 'runner': 'macos-latest-xlarge' },
-            { 'target': 'x86_64-pc-windows-msvc', 'runner': 'windows-latest-8-cores' },
+            { 'target': 'x86_64-unknown-linux-musl', 'runner': 'depot-ubuntu-24.04-8' },
+            { 'target': 'aarch64-unknown-linux-musl', 'runner': 'depot-ubuntu-24.04-arm-8' },
+            { 'target': 'aarch64-apple-darwin', 'runner': 'depot-macos-latest' },
+            { 'target': 'x86_64-apple-darwin', 'runner': 'depot-macos-latest' },
+            { 'target': 'x86_64-pc-windows-msvc', 'runner': 'depot-windows-2022-8' },
           ]
     runs-on: ${{ matrix.platform.runner }}
     env:
@@ -170,6 +175,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         if: ${{ !startsWith(github.head_ref, 'renovate-') }}
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.7
 
       - name: Install Rust
         uses: ./.github/actions/install-rust
@@ -223,6 +231,8 @@ jobs:
       - name: Build debug binaries
         if: needs.what-changed.outputs.cargo-bin-specs
         shell: bash
+        env:
+          RUSTC_WRAPPER: 'sccache'
         run: |
           cargo build --target ${{ matrix.platform.target }} ${{ needs.what-changed.outputs.cargo-bin-specs }}
 
@@ -250,7 +260,8 @@ jobs:
           && matrix.platform.target == 'x86_64-unknown-linux-musl'
         shell: bash
         working-directory: crates/integration-tests
-        run: docker compose up -d
+        run: |
+          docker compose up -d
 
       - name: Start gateway docker compose
         if: |
@@ -258,7 +269,8 @@ jobs:
           && matrix.platform.target == 'x86_64-unknown-linux-musl'
         shell: bash
         working-directory: gateway
-        run: docker compose up -d
+        run: |
+          docker compose up -d
 
       # It's kinda useful to get build vs run timings on tests, so splitting out the build from the run
       # here
@@ -268,6 +280,8 @@ jobs:
           && matrix.platform.target != 'x86_64-unknown-linux-musl'
           && matrix.platform.target != 'x86_64-apple-darwin'
         shell: bash
+        env:
+          RUSTC_WRAPPER: 'sccache'
         run: |
           cargo nextest run --target ${{ matrix.platform.target }} --no-run --profile ci ${{ needs.what-changed.outputs.cargo-test-specs }}
 
@@ -286,6 +300,8 @@ jobs:
           needs.what-changed.outputs.cargo-docker-test-specs
           && matrix.platform.target == 'x86_64-unknown-linux-musl'
         shell: bash
+        env:
+          RUSTC_WRAPPER: 'sccache'
         run: |
           cargo nextest run --target ${{ matrix.platform.target }} --no-run --profile ci ${{ needs.what-changed.outputs.cargo-docker-test-specs }}
 
@@ -306,9 +322,10 @@ jobs:
     if: |
       needs.what-changed.outputs.gateway-docker == 'true'
       || contains(fromJson(needs.what-changed.outputs.changed-packages), 'grafbase-gateway')
-    runs-on: ubicloud-standard-16
+    runs-on: depot-ubuntu-24.04-8
     permissions:
       packages: write
+      contents: read
     steps:
       - name: Get sources
         if: env.dockerhub_username != ''
@@ -329,24 +346,21 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build Docker image
-        if: env.dockerhub_username != ''
-        run: |
-          # Re-use the latest layers if possible
-          docker pull ghcr.io/grafbase/gateway:latest || true
-          docker build -f gateway/Dockerfile -t ghcr.io/grafbase/gateway:$COMMIT_SHA .
-
-      - name: Push Docker image
-        if: env.dockerhub_username != ''
-        run: |
-          docker push ghcr.io/grafbase/gateway:$COMMIT_SHA
+      - name: Build and push
+        uses: depot/build-push-action@v1
+        with:
+          project: lc6t0h7bhh
+          token: ${{ secrets.DEPOT_TOKEN }}
+          push: true
+          tags: ghcr.io/grafbase/gateway:${{ env.COMMIT_SHA }}
+          file: ./gateway/Dockerfile
 
   extensions:
     needs: [what-changed]
     strategy:
       fail-fast: false
       matrix:
-        platform: [{ 'runner': 'ubicloud-standard-8' }]
+        platform: [{ 'runner': 'depot-ubuntu-24.04-8' }]
     runs-on: ${{ matrix.platform.runner }}
     if: |
       needs.what-changed.outputs.changed-packages != '[]'
@@ -379,8 +393,13 @@ jobs:
         with:
           tool: nextest
 
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.7
+
       - name: Build CLI and Gateway
         shell: bash
+        env:
+          RUSTC_WRAPPER: 'sccache'
         run: |
           cargo build -p grafbase -p grafbase-gateway
           echo "$(pwd)/target/debug" >> $GITHUB_PATH
@@ -408,6 +427,8 @@ jobs:
       - name: Test all extensions
         shell: bash
         working-directory: extensions
+        env:
+          RUSTC_WRAPPER: 'sccache'
         run: |
           cargo run -p test-matrix
 
@@ -416,7 +437,7 @@ jobs:
     # happen after the builds, hence the `needs`. But it must not be skipped
     # when the builds are cancelled or fail (hence the `if: ${{ always() }}`).
     needs: [check-format, builds, docker-gateway, extensions]
-    runs-on: ubicloud-standard-2
+    runs-on: depot-ubuntu-24.04-small
     if: ${{ always() }}
     steps:
       - name: Check that the builds succeeded

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -4,7 +4,9 @@
 FROM rust:1.85-bookworm AS chef
 
 COPY rust-toolchain.toml rust-toolchain.toml
-RUN cargo install cargo-chef
+RUN cargo install --locked cargo-chef sccache
+ENV RUSTC_WRAPPER=sccache SCCACHE_DIR=/sccache
+
 WORKDIR /grafbase
 
 FROM chef AS planner
@@ -15,7 +17,10 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM chef AS builder
 ENV CARGO_INCREMENTAL=0
 COPY --from=planner /grafbase/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
+    cargo chef cook --release --recipe-path recipe.json
 
 COPY Cargo.lock Cargo.lock
 COPY Cargo.toml Cargo.toml
@@ -23,7 +28,10 @@ COPY ./crates ./crates
 COPY ./cli ./cli
 COPY ./gateway ./gateway
 
-RUN cargo build --release --bin grafbase-gateway
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
+    cargo build --release --bin grafbase-gateway
 
 #
 # === Final image ===


### PR DESCRIPTION
Adds a few niceties

- sccache everywhere, so build most of the time just our own crates
- use the depot actions with a bit faster CPU and IO, much faster network
- use their docker setup, which caches heavily. so docker builds are extremely fast (when they most of the time just do nothing)