### PR TITLE
chore(extension): Moving lease logic into wasi-component-loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2610,7 +2610,6 @@ dependencies = [
  "sha2 0.10.8",
  "sonic-rs",
  "thiserror 2.0.12",
- "tokio",
  "tower 0.5.2",
  "tracing",
  "url",
@@ -7697,7 +7696,6 @@ dependencies = [
  "serde_json",
  "strum 0.27.1",
  "thiserror 2.0.12",
- "tokio",
  "url",
 ]
 

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -54,7 +54,6 @@ serde_urlencoded.workspace = true
 sha2.workspace = true
 sonic-rs.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["sync"] }
 tower = { workspace = true, features = ["retry"] }
 tracing.workspace = true
 url.workspace = true

--- a/crates/engine/src/engine/auth_extension.rs
+++ b/crates/engine/src/engine/auth_extension.rs
@@ -2,7 +2,7 @@ use error::ErrorResponse;
 use extension_catalog::ExtensionId;
 use runtime::{
     auth::LegacyToken,
-    extension::{AuthorizerId, ExtensionRuntime, Lease},
+    extension::{AuthorizerId, ExtensionRuntime},
 };
 use schema::{AuthConfig, AuthProviderConfig};
 
@@ -34,11 +34,11 @@ impl AuthExtensionService {
     ) -> Result<(http::HeaderMap, LegacyToken), ErrorResponse> {
         let (headers, token) = runtime
             .extensions()
-            .authenticate(self.extension_id, self.authorizer_id, Lease::Singleton(headers))
+            .authenticate(self.extension_id, self.authorizer_id, headers)
             .await?;
 
         let token = LegacyToken::Extension(token);
 
-        Ok((headers.into_inner().unwrap(), token))
+        Ok((headers, token))
     }
 }

--- a/crates/integration-tests/tests/federation/extensions/authorization/deny_all.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/deny_all.rs
@@ -20,7 +20,7 @@ impl TestExtension for DenyAll {
     async fn authorize_query(
         &self,
         _wasm_context: &DynHookContext,
-        _headers: &mut http::HeaderMap,
+        _headers: &tokio::sync::RwLock<http::HeaderMap>,
         _token: TokenRef<'_>,
         _elements_grouped_by_directive_name: Vec<(&str, Vec<QueryElement<'_, serde_json::Value>>)>,
     ) -> Result<AuthorizationDecisions, ErrorResponse> {

--- a/crates/integration-tests/tests/federation/extensions/authorization/deny_some.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/deny_some.rs
@@ -40,7 +40,7 @@ impl TestExtension for DenySites {
     async fn authorize_query(
         &self,
         _wasm_context: &DynHookContext,
-        _headers: &mut http::HeaderMap,
+        _headers: &tokio::sync::RwLock<http::HeaderMap>,
         _token: TokenRef<'_>,
         elements_grouped_by_directive_name: Vec<(&str, Vec<QueryElement<'_, serde_json::Value>>)>,
     ) -> Result<AuthorizationDecisions, ErrorResponse> {

--- a/crates/integration-tests/tests/federation/extensions/authorization/error_response.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/error_response.rs
@@ -20,7 +20,7 @@ impl TestExtension for Failure {
     async fn authorize_query(
         &self,
         _wasm_context: &DynHookContext,
-        _headers: &mut http::HeaderMap,
+        _headers: &tokio::sync::RwLock<http::HeaderMap>,
         _token: TokenRef<'_>,
         _elements_grouped_by_directive_name: Vec<(&str, Vec<QueryElement<'_, serde_json::Value>>)>,
     ) -> Result<AuthorizationDecisions, ErrorResponse> {

--- a/crates/integration-tests/tests/federation/extensions/authorization/grant_all.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/grant_all.rs
@@ -21,7 +21,7 @@ impl TestExtension for GrantAll {
     async fn authorize_query(
         &self,
         _wasm_context: &DynHookContext,
-        _headers: &mut http::HeaderMap,
+        _headers: &tokio::sync::RwLock<http::HeaderMap>,
         _token: TokenRef<'_>,
         _elements_grouped_by_directive_name: Vec<(&str, Vec<QueryElement<'_, serde_json::Value>>)>,
     ) -> Result<AuthorizationDecisions, ErrorResponse> {

--- a/crates/integration-tests/tests/federation/extensions/authorization/injection/mod.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/injection/mod.rs
@@ -20,7 +20,7 @@ impl TestExtension for EchoInjections {
     async fn authorize_query(
         &self,
         wasm_context: &DynHookContext,
-        _headers: &mut http::HeaderMap,
+        _headers: &tokio::sync::RwLock<http::HeaderMap>,
         _token: TokenRef<'_>,
         elements_grouped_by_directive_name: Vec<(&str, Vec<QueryElement<'_, serde_json::Value>>)>,
     ) -> Result<AuthorizationDecisions, ErrorResponse> {

--- a/crates/integration-tests/tests/federation/extensions/authorization/requires_scopes.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/requires_scopes.rs
@@ -78,7 +78,7 @@ impl TestExtension for RequiresScopes {
     async fn authorize_query(
         &self,
         _wasm_context: &DynHookContext,
-        _headers: &mut http::HeaderMap,
+        _headers: &tokio::sync::RwLock<http::HeaderMap>,
         token: TokenRef<'_>,
         elements_grouped_by_directive_name: Vec<(&str, Vec<QueryElement<'_, serde_json::Value>>)>,
     ) -> Result<AuthorizationDecisions, ErrorResponse> {

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -35,7 +35,6 @@ serde.workspace = true
 serde_json.workspace = true
 strum.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["sync"] }
 url.workspace = true
 
 [features]

--- a/crates/wasi-component-loader/src/extension/api/since_0_10_0/instance.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_10_0/instance.rs
@@ -1,12 +1,17 @@
 use engine::GraphqlError;
 use futures::future::BoxFuture;
-use runtime::extension::{AuthorizationDecisions, Data, Lease, TokenRef};
+use runtime::extension::{AuthorizationDecisions, Data, TokenRef};
 use wasmtime::Store;
 
-use crate::extension::QueryAuthorizationResult;
-use crate::{Error, ErrorResponse, WasiState, extension::instance::ExtensionInstance};
-
-use crate::extension::api::wit::{FieldDefinitionDirective, Headers, QueryElements, ResponseElements};
+use crate::{
+    Error, ErrorResponse, WasiState,
+    extension::{
+        QueryAuthorizationResult,
+        api::wit::{FieldDefinitionDirective, Headers, QueryElements, ResponseElements},
+        instance::ExtensionInstance,
+    },
+    resources::Lease,
+};
 
 use super::world::TokenParam;
 

--- a/crates/wasi-component-loader/src/extension/api/since_0_8_0/instance.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_8_0/instance.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 use engine::GraphqlError;
 use futures::future::BoxFuture;
-use runtime::extension::{AuthorizationDecisions, Data, Lease, Token, TokenRef};
+use runtime::extension::{AuthorizationDecisions, Data, Token, TokenRef};
 use wasmtime::Store;
 
 use crate::{
@@ -11,7 +11,7 @@ use crate::{
         api::wit::{FieldDefinitionDirective, QueryElements, ResponseElements},
         instance::ExtensionInstance,
     },
-    resources::Headers,
+    resources::{Headers, Lease},
     state::WasiState,
 };
 

--- a/crates/wasi-component-loader/src/extension/api/since_0_8_0/wit/directive.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_8_0/wit/directive.rs
@@ -9,7 +9,7 @@ pub struct SchemaDirective<'a> {
     pub arguments: &'a [u8],
 }
 
-#[derive(Debug, ComponentType, Lower)]
+#[derive(Clone, Debug, ComponentType, Lower)]
 #[component(record)]
 pub struct QueryElements<'a> {
     #[component(name = "directive-names")]
@@ -17,14 +17,14 @@ pub struct QueryElements<'a> {
     pub elements: Vec<QueryElement<'a>>,
 }
 
-#[derive(Debug, ComponentType, Lower)]
+#[derive(Clone, Debug, ComponentType, Lower)]
 #[component(record)]
 pub struct QueryElement<'a> {
     pub site: DirectiveSite<'a>,
     pub arguments: Vec<u8>,
 }
 
-#[derive(Debug, ComponentType, Lower)]
+#[derive(Clone, Debug, ComponentType, Lower)]
 #[component(record)]
 pub struct ObjectDirectiveSite<'a> {
     #[component(name = "object-name")]
@@ -48,34 +48,34 @@ pub struct FieldDefinitionDirective<'a> {
     pub arguments: &'a [u8],
 }
 
-#[derive(Debug, ComponentType, Lower)]
+#[derive(Clone, Debug, ComponentType, Lower)]
 #[component(record)]
 pub struct UnionDirectiveSite<'a> {
     #[component(name = "union-name")]
     pub union_name: &'a str,
 }
 
-#[derive(Debug, ComponentType, Lower)]
+#[derive(Clone, Debug, ComponentType, Lower)]
 #[component(record)]
 pub struct InterfaceDirectiveSite<'a> {
     #[component(name = "interface-name")]
     pub interface_name: &'a str,
 }
 
-#[derive(Debug, ComponentType, Lower)]
+#[derive(Clone, Debug, ComponentType, Lower)]
 #[component(record)]
 pub struct EnumDirectiveSite<'a> {
     #[component(name = "enum-name")]
     pub enum_name: &'a str,
 }
-#[derive(Debug, ComponentType, Lower)]
+#[derive(Clone, Debug, ComponentType, Lower)]
 #[component(record)]
 pub struct ScalarDirectiveSite<'a> {
     #[component(name = "scalar-name")]
     pub scalar_name: &'a str,
 }
 
-#[derive(Debug, ComponentType, Lower)]
+#[derive(Clone, Debug, ComponentType, Lower)]
 #[component(variant)]
 pub enum DirectiveSite<'a> {
     #[component(name = "scalar")]

--- a/crates/wasi-component-loader/src/extension/api/since_0_9_0/instance.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_9_0/instance.rs
@@ -1,13 +1,13 @@
 use anyhow::anyhow;
 use engine::GraphqlError;
 use futures::future::BoxFuture;
-use runtime::extension::{AuthorizationDecisions, Data, Lease, TokenRef};
+use runtime::extension::{AuthorizationDecisions, Data, TokenRef};
 use wasmtime::Store;
 
 use crate::{
     Error, ErrorResponse, WasiState,
     extension::{InputList, QueryAuthorizationResult, instance::ExtensionInstance},
-    resources::AuthorizationContext,
+    resources::{AuthorizationContext, Lease},
 };
 
 use super::wit::{

--- a/crates/wasi-component-loader/src/extension/api/since_0_9_0/wit/directive.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_9_0/wit/directive.rs
@@ -9,7 +9,7 @@ use crate::{extension::api::since_0_8_0::wit::directive as since_0_8_0, state::W
 
 impl Host for WasiState {}
 
-#[derive(Debug, ComponentType, Lower)]
+#[derive(Clone, Debug, ComponentType, Lower)]
 #[component(record)]
 pub struct QueryElement<'a> {
     pub id: u32,
@@ -30,15 +30,15 @@ impl<'a> From<QueryElement<'a>> for since_0_8_0::QueryElement<'a> {
 #[component(record)]
 pub struct QueryElements<'a> {
     #[component(name = "directive-names")]
-    pub directive_names: Vec<(&'a str, u32, u32)>,
-    pub elements: Vec<QueryElement<'a>>,
+    pub directive_names: &'a [(&'a str, u32, u32)],
+    pub elements: &'a [QueryElement<'a>],
 }
 
 impl<'a> From<QueryElements<'a>> for since_0_8_0::QueryElements<'a> {
     fn from(value: QueryElements<'a>) -> Self {
         Self {
-            directive_names: value.directive_names,
-            elements: value.elements.into_iter().map(Into::into).collect(),
+            directive_names: value.directive_names.to_vec(),
+            elements: value.elements.iter().map(|e| e.clone().into()).collect(),
         }
     }
 }

--- a/crates/wasi-component-loader/src/extension/instance.rs
+++ b/crates/wasi-component-loader/src/extension/instance.rs
@@ -1,8 +1,8 @@
 use engine::GraphqlError;
 use futures::future::BoxFuture;
-use runtime::extension::{AuthorizationDecisions, Data, Lease, Token, TokenRef};
+use runtime::extension::{AuthorizationDecisions, Data, Token, TokenRef};
 
-use crate::{Error, ErrorResponse};
+use crate::{Error, ErrorResponse, resources::Lease};
 
 use super::api::wit::{FieldDefinitionDirective, QueryElements, ResponseElements};
 

--- a/crates/wasi-component-loader/src/extension/runtime.rs
+++ b/crates/wasi-component-loader/src/extension/runtime.rs
@@ -1,6 +1,10 @@
 mod subscription;
 
-use crate::{SharedContext, cbor, extension::ExtensionLoader, resources::SharedResources};
+use crate::{
+    SharedContext, cbor,
+    extension::ExtensionLoader,
+    resources::{Lease, SharedResources},
+};
 
 use super::{
     ExtensionGuestConfig, InputList,
@@ -12,18 +16,21 @@ use dashmap::DashMap;
 use engine::{ErrorCode, ErrorResponse, GraphqlError};
 use engine_schema::DirectiveSite;
 use extension_catalog::ExtensionId;
-use futures::stream::BoxStream;
+use futures::{
+    TryStreamExt,
+    stream::{BoxStream, FuturesUnordered},
+};
 use futures_util::{StreamExt, stream};
 use gateway_config::WasiExtensionsConfig;
 use runtime::{
     extension::{
-        AuthorizationDecisions, AuthorizerId, Data, ExtensionFieldDirective, ExtensionRuntime, Lease, QueryElement,
-        Token, TokenRef,
+        AuthorizationDecisions, AuthorizerId, Data, ExtensionFieldDirective, ExtensionRuntime,
+        QueryAuthorizationDecisions, QueryElement, Token, TokenRef,
     },
     hooks::Anything,
 };
 use semver::Version;
-use std::{collections::HashMap, future::Future, sync::Arc};
+use std::{collections::HashMap, future::Future, ops::Range, sync::Arc};
 use subscription::{DeduplicatedSubscription, UniqueSubscription};
 use tokio::{sync::broadcast, task::JoinHandle};
 
@@ -159,15 +166,17 @@ impl ExtensionRuntime for ExtensionsWasiRuntime {
         &self,
         extension_id: ExtensionId,
         authorizer_id: AuthorizerId,
-        headers: Lease<http::HeaderMap>,
-    ) -> Result<(Lease<http::HeaderMap>, Token), ErrorResponse> {
+        headers: http::HeaderMap,
+    ) -> Result<(http::HeaderMap, Token), ErrorResponse> {
         let mut instance = self
             .get(ExtensionPoolId::Authorizer(extension_id, authorizer_id))
             .await?;
 
+        let headers = Lease::Singleton(headers);
         instance
             .authenticate(headers)
             .await
+            .map(|(headers, token)| (headers.into_inner().unwrap(), token))
             .map_err(|err| err.into_graphql_error_response(ErrorCode::Unauthenticated))
     }
 
@@ -229,64 +238,115 @@ impl ExtensionRuntime for ExtensionsWasiRuntime {
         }
     }
 
-    fn authorize_query<'ctx, 'fut, Groups, QueryElements, Arguments>(
+    fn authorize_query<'ctx, 'fut, Extensions, Arguments>(
         &'ctx self,
-        extension_id: ExtensionId,
         wasm_context: &'ctx SharedContext,
-        headers: Lease<http::HeaderMap>,
+        headers: http::HeaderMap,
         token: TokenRef<'ctx>,
-        elements_grouped_by_directive_name: Groups,
-    ) -> impl Future<Output = Result<(Lease<http::HeaderMap>, AuthorizationDecisions), ErrorResponse>> + Send + 'fut
+        extensions: Extensions,
+        // (directive name, range within query_elements)
+        directives: impl ExactSizeIterator<Item = (&'ctx str, Range<usize>)>,
+        query_elements: impl ExactSizeIterator<Item = QueryElement<'ctx, Arguments>>,
+    ) -> impl Future<Output = Result<(http::HeaderMap, Vec<QueryAuthorizationDecisions>), ErrorResponse>> + Send + 'fut
     where
         'ctx: 'fut,
-        Groups: IntoIterator<Item = (&'ctx str, QueryElements)>,
-        QueryElements: IntoIterator<Item = QueryElement<'ctx, Arguments>>,
+        // (extension id, range within directives, range within query_elements)
+        Extensions: IntoIterator<
+                Item = (ExtensionId, Range<usize>, Range<usize>),
+                IntoIter: ExactSizeIterator<Item = (ExtensionId, Range<usize>, Range<usize>)>,
+            > + Send
+            + Clone
+            + 'ctx,
         Arguments: Anything<'ctx>,
     {
-        let mut directive_names = Vec::<(&'ctx str, u32, u32)>::new();
-        let mut query_elements = Vec::new();
-        for (directive_name, elements) in elements_grouped_by_directive_name {
-            let start = query_elements.len();
-            for element in elements {
+        let elements = {
+            let mut out = Vec::new();
+            out.reserve_exact(query_elements.len());
+            for element in query_elements {
                 // Some help for rust-analyzer who struggles for some reason.
                 let element: QueryElement<'_, _> = element;
                 let arguments = cbor::to_vec(element.arguments).unwrap();
 
-                query_elements.push(wit::QueryElement {
+                out.push(wit::QueryElement {
                     id: element.site.id().into(),
                     site: element.site.into(),
                     arguments,
                 });
             }
-            let end = query_elements.len();
-            directive_names.push((directive_name, start as u32, end as u32));
+            out
+        };
+
+        let mut directive_names = {
+            let mut out = Vec::<(&'ctx str, u32, u32)>::new();
+            out.reserve_exact(directives.len());
+
+            for (directive_name, query_elements_range) in directives {
+                out.push((
+                    directive_name,
+                    query_elements_range.start as u32,
+                    query_elements_range.end as u32,
+                ));
+            }
+
+            out
+        };
+
+        // The range we have in the current directive_names are relative to the whole elements
+        // array. But we won't send the whole elements array to each extension. We'll only send the
+        // relevant part. So we must adjust the range to take this in account.
+        for (_, _, query_elements_range) in extensions.clone() {
+            for (_, directive_query_elements_start, directive_query_elements_end) in &mut directive_names {
+                *directive_query_elements_start -= query_elements_range.start as u32;
+                *directive_query_elements_end -= query_elements_range.start as u32;
+            }
         }
 
+        let headers = Arc::new(tokio::sync::RwLock::new(headers));
+
         async move {
-            let mut instance = self.get(ExtensionPoolId::Authorization(extension_id)).await?;
-            match instance
-                .authorize_query(
-                    headers,
-                    token,
-                    wit::QueryElements {
-                        directive_names,
-                        elements: query_elements,
+            let headers_ref = &headers;
+            let directive_names = &directive_names;
+            let elements = &elements;
+            let decisions = extensions
+                .into_iter()
+                .map(
+                    move |(extension_id, directive_range, query_elements_range)| async move {
+                        let mut instance = self.get(ExtensionPoolId::Authorization(extension_id)).await?;
+                        match instance
+                            .authorize_query(
+                                Lease::SharedMut(headers_ref.clone()),
+                                token,
+                                wit::QueryElements {
+                                    directive_names: &directive_names[directive_range],
+                                    elements: &elements[query_elements_range.clone()],
+                                },
+                            )
+                            .await
+                        {
+                            Ok((_, decisions, state)) => {
+                                if !state.is_empty() {
+                                    wasm_context
+                                        .authorization_state
+                                        .write()
+                                        .await
+                                        .push((extension_id, state));
+                                }
+                                Ok(QueryAuthorizationDecisions {
+                                    extension_id,
+                                    query_elements_range,
+                                    decisions,
+                                })
+                            }
+                            Err(err) => Err(err.into_graphql_error_response(ErrorCode::Unauthorized)),
+                        }
                     },
                 )
-                .await
-            {
-                Ok((headers, decisions, state)) => {
-                    if !state.is_empty() {
-                        wasm_context
-                            .authorization_state
-                            .write()
-                            .await
-                            .push((extension_id, state));
-                    }
-                    Ok((headers, decisions))
-                }
-                Err(err) => Err(err.into_graphql_error_response(ErrorCode::Unauthorized)),
-            }
+                .collect::<FuturesUnordered<_>>()
+                .try_collect::<Vec<_>>()
+                .await?;
+
+            let headers = Arc::into_inner(headers).unwrap().into_inner();
+            Ok((headers, decisions))
         }
     }
 


### PR DESCRIPTION
Has two benefits:
- engine doesn't depend on tokio anymore and the lease logic which is
  pecular to wasm is kept in wasi-component-loader. (can't pass references so we provide a lease on owned data we want back).
- the logic of whether to create a lock or not can be kept in
  wasi-component-loader. If there is single authorization extension,
  not only can we skip the lock for the headers but also for the
  authorization state later. Not sure how much of a perf impact this
  will make though.
