### PR TITLE
graphql-lint: case checks shouldn't fire on imported/federation types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4049,6 +4049,7 @@ dependencies = [
  "cynic-parser",
  "grafbase-workspace-hack",
  "heck 0.5.0",
+ "regex",
  "thiserror 2.0.12",
 ]
 

--- a/crates/graphql-lint/Cargo.toml
+++ b/crates/graphql-lint/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 cynic-parser.workspace = true
 grafbase-workspace-hack.workspace = true
 heck.workspace = true
+regex.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/graphql-lint/src/lib.rs
+++ b/crates/graphql-lint/src/lib.rs
@@ -133,6 +133,15 @@ impl<'a> SchemaLinter {
     }
 
     fn case_check(current: &'a str, case: Case) -> CaseMatch<'a> {
+        use regex::RegexSet;
+        use std::sync::LazyLock;
+
+        static EXCEPTIONS: LazyLock<RegexSet> = LazyLock::new(|| RegexSet::new(["^_", "^[a-zA-Z]+__."]).unwrap());
+
+        if EXCEPTIONS.is_match(current) {
+            return CaseMatch::Correct;
+        }
+
         let fix = match case {
             Case::Pascal => current.to_pascal_case(),
             Case::ShoutySnake => current.to_shouty_snake_case(),


### PR DESCRIPTION
Types and fields prefixed with `_` like `_Service` are expected.

Imported, namespaced types like `federation__FieldSet` are expected.

closes GB-8713