### PR TITLE
feat(gateway): Add zstd support back for subgraph requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3824,7 +3824,6 @@ dependencies = [
  "anyhow",
  "arrayvec 0.7.6",
  "ascii",
- "async-compression",
  "axum 0.8.1",
  "axum-core 0.5.0",
  "base16ct",

--- a/crates/grafbase-workspace-hack/Cargo.toml
+++ b/crates/grafbase-workspace-hack/Cargo.toml
@@ -103,7 +103,7 @@ rand_core = { version = "0.6", default-features = false, features = ["std"] }
 regex = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "unicode"] }
 regex-syntax = { version = "0.8" }
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "hickory-dns", "http2", "json", "multipart", "rustls-tls", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "hickory-dns", "http2", "json", "multipart", "rustls-tls", "stream", "zstd"] }
 rsa = { version = "0.9" }
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
 rustls-webpki = { version = "0.103", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
@@ -231,7 +231,7 @@ rand_core = { version = "0.6", default-features = false, features = ["std"] }
 regex = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "unicode"] }
 regex-syntax = { version = "0.8" }
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "hickory-dns", "http2", "json", "multipart", "rustls-tls", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "hickory-dns", "http2", "json", "multipart", "rustls-tls", "stream", "zstd"] }
 rsa = { version = "0.9" }
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
 rustls-webpki = { version = "0.103", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
@@ -277,7 +277,6 @@ zstd-sys = { version = "2", default-features = false, features = ["legacy", "std
 
 [target.aarch64-apple-darwin.dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
-async-compression = { version = "0.4", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
 axum = { version = "0.8" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
@@ -294,7 +293,6 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 
 [target.aarch64-apple-darwin.build-dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
-async-compression = { version = "0.4", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
 axum = { version = "0.8" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
@@ -311,7 +309,6 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 
 [target.x86_64-apple-darwin.dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
-async-compression = { version = "0.4", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
 axum = { version = "0.8" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
@@ -329,7 +326,6 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 
 [target.x86_64-apple-darwin.build-dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
-async-compression = { version = "0.4", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
 axum = { version = "0.8" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
@@ -346,7 +342,6 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["loggin
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features = false, features = ["log", "timeout"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-async-compression = { version = "0.4", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
 axum = { version = "0.8" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 idna = { version = "1" }
@@ -359,7 +354,6 @@ windows-sys-73dcd821b1037cfd = { package = "windows-sys", version = "0.59", feat
 windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
-async-compression = { version = "0.4", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
 axum = { version = "0.8" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 idna = { version = "1" }
@@ -373,7 +367,6 @@ windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52", feat
 
 [target.x86_64-unknown-linux-musl.dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
-async-compression = { version = "0.4", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
 axum = { version = "0.8" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
@@ -391,7 +384,6 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 
 [target.x86_64-unknown-linux-musl.build-dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
-async-compression = { version = "0.4", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
 axum = { version = "0.8" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
@@ -409,7 +401,6 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 
 [target.aarch64-unknown-linux-musl.dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
-async-compression = { version = "0.4", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
 axum = { version = "0.8" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
@@ -426,7 +417,6 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 
 [target.aarch64-unknown-linux-musl.build-dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
-async-compression = { version = "0.4", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
 axum = { version = "0.8" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }

--- a/crates/integration-tests/tests/federation/basic/headers.rs
+++ b/crates/integration-tests/tests/federation/basic/headers.rs
@@ -33,7 +33,7 @@ fn test_default_headers() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, deflate"
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",
@@ -90,7 +90,7 @@ fn test_default_headers_forwarding() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, deflate"
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",
@@ -156,7 +156,7 @@ fn test_subgraph_specific_header_forwarding() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, deflate"
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",
@@ -234,7 +234,7 @@ fn should_not_propagate_blacklisted_headers() {
               },
               {
                 "name": "accept-encoding",
-                "value": "gzip, br, deflate"
+                "value": "gzip, br, zstd, deflate"
               },
               {
                 "name": "content-length",
@@ -288,7 +288,7 @@ fn test_regex_header_forwarding() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, deflate"
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",
@@ -350,7 +350,7 @@ fn test_regex_header_forwarding_should_not_duplicate() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, deflate"
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",
@@ -406,7 +406,7 @@ fn test_header_forwarding_with_rename() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, deflate"
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",
@@ -455,7 +455,7 @@ fn test_header_forwarding_with_default() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, deflate"
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",
@@ -507,7 +507,7 @@ fn test_header_forwarding_with_default_and_existing_header() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, deflate"
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",
@@ -564,7 +564,7 @@ fn test_regex_header_forwarding_then_delete() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, deflate"
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",
@@ -622,7 +622,7 @@ fn test_regex_header_forwarding_then_delete_with_regex() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, deflate"
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",
@@ -674,7 +674,7 @@ fn test_rename_duplicate_no_default() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, deflate"
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "bar",
@@ -731,7 +731,7 @@ fn test_rename_duplicate_default() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, deflate"
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "bar",
@@ -785,7 +785,7 @@ fn test_rename_duplicate_default_with_missing_value() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, deflate"
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "bar",
@@ -841,7 +841,7 @@ fn regex_header_regex_forwarding_should_forward_duplicates_too() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, deflate"
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",
@@ -897,7 +897,7 @@ fn regex_header_forwarding_should_forward_duplicates() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, deflate"
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",
@@ -954,7 +954,7 @@ fn regex_header_forwarding_should_forward_duplicates_with_rename() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, deflate"
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",
@@ -1010,7 +1010,7 @@ fn header_remove_should_remove_duplicates() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, deflate"
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",
@@ -1058,7 +1058,7 @@ fn header_regex_remove_should_remove_duplicates() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, deflate"
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",

--- a/crates/integration-tests/tests/federation/extensions/authorization/headers.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/headers.rs
@@ -78,7 +78,7 @@ fn can_inject_token_into_headers() {
           },
           {
             "name": "accept-encoding",
-            "value": "gzip, br, deflate"
+            "value": "gzip, br, zstd, deflate"
           },
           {
             "name": "content-length",

--- a/crates/runtime-local/Cargo.toml
+++ b/crates/runtime-local/Cargo.toml
@@ -17,6 +17,7 @@ wasi = ["wasi-component-loader", "url", "dep:deadpool"]
 redis = ["dep:redis", "dep:deadpool"]
 
 [dependencies]
+anyhow.workspace = true
 async-trait.workspace = true
 async-tungstenite = { workspace = true, features = [
     "tokio-runtime",
@@ -24,14 +25,18 @@ async-tungstenite = { workspace = true, features = [
 ] }
 base64.workspace = true
 bytes.workspace = true
+deadpool = { workspace = true, optional = true }
 ed25519-compact.workspace = true
 elliptic-curve = { workspace = true, features = ["jwk"] }
 engine.workspace = true
 engine-schema.workspace = true
+enumflags2.workspace = true
 extension-catalog.workspace = true
 futures-util.workspace = true
 gateway-config.workspace = true
 governor.workspace = true
+grafbase-telemetry.workspace = true
+grafbase-workspace-hack.workspace = true
 graphql-ws-client.workspace = true
 http.workspace = true
 httpsig.workspace = true
@@ -42,21 +47,14 @@ p256 = { workspace = true, features = ["jwk"] }
 p384 = { workspace = true, features = ["jwk"] }
 postcard.workspace = true
 redis = { workspace = true, optional = true }
+reqwest = { workspace = true, features = ["json", "rustls-tls", "gzip", "brotli", "deflate", "zstd", "hickory-dns"] }
 reqwest-eventsource.workspace = true
 runtime.workspace = true
+semver.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, features = ["raw_value"] }
 tokio = { workspace = true, features = ["macros", "sync"] }
 tracing.workspace = true
 tungstenite = { workspace = true, features = ["url", "handshake"] }
 url = { workspace = true, optional = true }
-
-reqwest = { workspace = true, features = ["json", "rustls-tls", "gzip", "brotli", "deflate", "hickory-dns"] }
-
-anyhow.workspace = true
-deadpool = { workspace = true, optional = true }
-enumflags2.workspace = true
-grafbase-telemetry.workspace = true
-grafbase-workspace-hack.workspace = true
-semver.workspace = true
 wasi-component-loader = { path = "../wasi-component-loader", optional = true }


### PR DESCRIPTION
Now that `reqwest` merged the multi-frame fix in `0.12.13`, should work just fine.