### PR TITLE
docs(gb-8698): add raw byte methods for nats

### DIFF
--- a/crates/wasi-component-loader/src/extension/runtime.rs
+++ b/crates/wasi-component-loader/src/extension/runtime.rs
@@ -112,6 +112,7 @@ impl ExtensionRuntime for WasmExtensions {
             .subscription_key(Lease::Singleton(headers), subgraph.name(), directive.clone())
             .await
             .map_err(|err| err.into_graphql_error(ErrorCode::ExtensionError))?;
+
         let headers = headers.into_inner().unwrap();
 
         match key {


### PR DESCRIPTION
I wrote about using non-JSON payloads, so maybe we should make it easier to access the raw data in NATS.