### PR TITLE
ci: pass target to cargo build in darwin release pipeline

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -414,13 +414,13 @@ jobs:
         env:
           RUSTC_WRAPPER: sccache
         run: |
-          cargo build --release -p grafbase --timings
+          cargo build --release --target=${{ matrix.target }} -p grafbase --timings
 
       - name: Build gateway release
         env:
           RUSTC_WRAPPER: sccache
         run: |
-          cargo build --release -p grafbase-gateway
+          cargo build --release --target=${{ matrix.target }} -p grafbase-gateway
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Otherwise the binaries end up in target/release and not in target/aarch64-apple-darwin/release.

See https://github.com/grafbase/grafbase/actions/runs/13964594443/job/39092784514 for an example.