### PR TITLE
fix: Add wasm authorization test case + fixes

### DIFF
--- a/crates/engine/schema/src/builder/coerce/extension.rs
+++ b/crates/engine/schema/src/builder/coerce/extension.rs
@@ -328,9 +328,9 @@ impl ExtensionDirectiveArgumentsCoercer<'_, '_> {
                 }
                 GrafbaseScalar::FieldSet => {
                     self.current_injection_stage = self.current_injection_stage.max(InjectionStage::Response);
-                    self.coerce_field_set(value)
-                        .map(ExtensionInputValueRecord::FieldSet)
-                        .map_err(Into::into)
+                    let field_set = self.coerce_field_set(value)?;
+                    self.requirements = self.requirements.union(&field_set);
+                    Ok(ExtensionInputValueRecord::FieldSet(field_set))
                 }
                 GrafbaseScalar::UrlTemplate | GrafbaseScalar::JsonTemplate => {
                     self.current_injection_stage = self.current_injection_stage.max(InjectionStage::Query);

--- a/crates/engine/src/prepare/cached/builder/modifiers.rs
+++ b/crates/engine/src/prepare/cached/builder/modifiers.rs
@@ -368,11 +368,8 @@ impl QueryModifiers {
             if let QueryModifierRule::Extension { directive_id, .. } = modifier.rule {
                 let directive = &schema[directive_id];
 
-                let modifier_ix = by_directive
-                    .last()
-                    .map(|(_, range)| range.end)
-                    .unwrap_or(native_end.into());
-                let directive_group_ix = by_directive.len();
+                let modifier_ix: QueryModifierId = native_end.into();
+                let directive_group_ix: usize = 0;
                 let mut extension_group = (
                     directive.extension_id,
                     IdRange::<QueryModifierByDirectiveGroupId>::from(directive_group_ix..directive_group_ix),
@@ -385,11 +382,11 @@ impl QueryModifiers {
                 );
 
                 for (ix, modifier) in iter {
-                    let extension_id = match modifier.rule {
-                        QueryModifierRule::Extension { directive_id, .. } => schema[directive_id].extension_id,
+                    let directive = match modifier.rule {
+                        QueryModifierRule::Extension { directive_id, .. } => &schema[directive_id],
                         _ => unreachable!(),
                     };
-                    if extension_group.0 != extension_id {
+                    if extension_group.0 != directive.extension_id {
                         directive_group.1.end = ix.into();
                         by_directive.push(directive_group);
 
@@ -399,7 +396,7 @@ impl QueryModifiers {
 
                         directive_group = (directive.name_id, (ix..ix).into());
                         let n = by_directive.len();
-                        extension_group = (extension_id, (n..n).into(), (ix..ix).into());
+                        extension_group = (directive.extension_id, (n..n).into(), (ix..ix).into());
                     } else if directive_group.0 != directive.name_id {
                         directive_group.1.end = ix.into();
                         by_directive.push(directive_group);

--- a/crates/grafbase-sdk/src/types/authorization.rs
+++ b/crates/grafbase-sdk/src/types/authorization.rs
@@ -40,22 +40,16 @@ impl AuthorizationDecisions {
 /// To be used when denying some of the elements. By default everything is granted.
 pub struct DenySomeBuilder(wit::AuthorizationDecisionsDenySome);
 
-/// Either a `QueryElement` or a `ResponseItem`.
-pub trait QueryElementOrResponseItem: crate::sealed::Sealed {
-    #[doc(hidden)]
-    fn ix(&self) -> u32;
-}
-
 impl DenySomeBuilder {
     /// Deny access to the specified element in the query with the specified error.
-    pub fn deny(&mut self, element: impl QueryElementOrResponseItem, error: impl Into<Error>) {
+    pub fn deny(&mut self, x: impl private::QueryElementOrResponseItem, error: impl Into<Error>) {
         let error_id = self.push_error(error);
-        self.deny_with_error_id(element, error_id)
+        self.deny_with_error_id(x, error_id)
     }
 
     /// Deny access to the specified element in the query, re-using an existing error.
-    pub fn deny_with_error_id(&mut self, element: impl QueryElementOrResponseItem, error_id: ErrorId) {
-        self.0.element_to_error.push((element.ix(), error_id.0));
+    pub fn deny_with_error_id(&mut self, x: impl private::QueryElementOrResponseItem, error_id: ErrorId) {
+        self.0.element_to_error.push((x.ix(), error_id.0));
     }
 
     /// Returns an ErrorId that can be used to reference this error later in `deny_with_error_id`.
@@ -68,5 +62,13 @@ impl DenySomeBuilder {
     /// Build the final AuthorizationDecisions
     pub fn build(self) -> AuthorizationDecisions {
         AuthorizationDecisions(wit::AuthorizationDecisions::DenySome(self.0))
+    }
+}
+
+pub(super) mod private {
+    /// Either a `QueryElement` or a `ResponseItem`.
+    pub trait QueryElementOrResponseItem: crate::sealed::Sealed {
+        #[doc(hidden)]
+        fn ix(&self) -> u32;
     }
 }

--- a/crates/grafbase-sdk/src/types/elements/query.rs
+++ b/crates/grafbase-sdk/src/types/elements/query.rs
@@ -1,6 +1,9 @@
 use std::iter::Enumerate;
 
-use crate::{types::DirectiveSite, wit, SdkError};
+use crate::{
+    types::{authorization::private::QueryElementOrResponseItem, DirectiveSite},
+    wit, SdkError,
+};
 use serde::Deserialize;
 
 /// A list of elements present in the query on which one of the extension's directive was applied on their definition.
@@ -74,7 +77,7 @@ impl<'a> Iterator for QueryElementsIterator<'a> {
 }
 
 impl crate::sealed::Sealed for QueryElement<'_> {}
-impl crate::types::authorization::QueryElementOrResponseItem for QueryElement<'_> {
+impl QueryElementOrResponseItem for QueryElement<'_> {
     fn ix(&self) -> u32 {
         self.ix
     }

--- a/crates/grafbase-sdk/src/types/elements/response.rs
+++ b/crates/grafbase-sdk/src/types/elements/response.rs
@@ -1,4 +1,4 @@
-use crate::{cbor, wit, SdkError};
+use crate::{cbor, sealed::Sealed, types::authorization::private::QueryElementOrResponseItem, wit, SdkError};
 use serde::Deserialize;
 
 use super::QueryElementId;
@@ -104,10 +104,7 @@ impl<'a> ResponseElement<'a> {
 
     /// Arguments of the directive with any query data injected. Any argument that depends on
     /// response data will not be present here and be provided separately.
-    pub fn items<T>(&self) -> impl ExactSizeIterator<Item = ResponseItem<'a>>
-    where
-        T: Deserialize<'a>,
-    {
+    pub fn items(&self) -> impl ExactSizeIterator<Item = ResponseItem<'a>> {
         let (start, end) = self.items_range;
         self.items[start as usize..end as usize]
             .iter()
@@ -119,8 +116,8 @@ impl<'a> ResponseElement<'a> {
     }
 }
 
-impl crate::sealed::Sealed for ResponseItem<'_> {}
-impl crate::types::authorization::QueryElementOrResponseItem for ResponseItem<'_> {
+impl Sealed for ResponseItem<'_> {}
+impl QueryElementOrResponseItem for ResponseItem<'_> {
     fn ix(&self) -> u32 {
         self.ix
     }

--- a/crates/integration-tests/data/extensions/Cargo.lock
+++ b/crates/integration-tests/data/extensions/Cargo.lock
@@ -37,6 +37,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,7 +104,7 @@ dependencies = [
  "futures-util",
  "handlebars",
  "http",
- "indexmap",
+ "indexmap 2.8.0",
  "mime",
  "multer",
  "num-traits",
@@ -156,7 +171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "741110dda927420a28fbc1c310543d3416f789a6ba96859c2c265843a0a96887"
 dependencies = [
  "bytes",
- "indexmap",
+ "indexmap 2.8.0",
  "serde",
  "serde_json",
 ]
@@ -251,12 +266,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "authorization"
+name = "authenticated"
 version = "0.1.0"
 dependencies = [
  "grafbase-sdk 0.10.0",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "authorization-010"
+version = "0.1.0"
+dependencies = [
+ "grafbase-sdk 0.10.0",
+ "http",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "serde_with",
 ]
 
 [[package]]
@@ -371,6 +398,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
+name = "bytecheck"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50690fb3370fb9fe3550372746084c46f2ac8c9685c583d2be10eefd89d3d1a3"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb7846e0cb180355c2dec69e721edafa36919850f1a9f52ffba4ebc0393cb71"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +457,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +489,12 @@ dependencies = [
  "once_cell",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -468,7 +537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86a21da88ae46f2be6a622880a72f968d05c50b5a797e525332d0c988f693f70"
 dependencies = [
  "ariadne",
- "indexmap",
+ "indexmap 2.8.0",
  "lalrpop-util",
  "logos",
 ]
@@ -480,7 +549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbb0f21f2f8d3134c2e887a16564c165694231f48b6ae2769193299081ecf662"
 dependencies = [
  "ariadne",
- "indexmap",
+ "indexmap 2.8.0",
  "lalrpop-util",
  "logos",
 ]
@@ -554,6 +623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -1015,7 +1085,7 @@ dependencies = [
  "cynic-parser 0.9.1",
  "cynic-parser-deser",
  "graphql-federated-graph",
- "indexmap",
+ "indexmap 2.8.0",
  "itertools",
  "url",
 ]
@@ -1031,7 +1101,7 @@ dependencies = [
  "cynic-parser-deser",
  "grafbase-workspace-hack",
  "graphql-wrapping-types",
- "indexmap",
+ "indexmap 2.8.0",
  "indoc",
  "itertools",
  "serde",
@@ -1078,7 +1148,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.8.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1101,6 +1171,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
@@ -1113,6 +1189,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1216,6 +1298,29 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1371,12 +1476,23 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -1607,6 +1723,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "munge"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0091202c98cf06da46c279fdf50cccb6b1c43b4521abdf6a27b4c7e71d5d9d7"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734799cf91479720b2f970c61a22850940dd91e27d4f02b1c6fc792778df2459"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,6 +1924,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9e76f66d3f9606f44e45598d155cb13ecf09f4a28199e48daf8c8fc937ea90"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1855,6 +2011,15 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "rancor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf5f7161924b9d1cea0e4cabc97c372cea92b5f927fc13c6bca67157a0ad947"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -1946,6 +2111,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rend"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2017,6 +2191,36 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e147371c75553e1e2fcdb483944a8540b8438c31426279553b9a8182a9b7b65"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.15.2",
+ "indexmap 2.8.0",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246b40ac189af6c675d124b802e8ef6d5246c53e17367ce9501f8f66a81abb7a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2147,7 +2351,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap",
+ "indexmap 2.8.0",
  "itoa",
  "memchr",
  "ryu",
@@ -2183,6 +2387,36 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.8.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2222,6 +2456,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -2406,10 +2646,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d9c75b47bdff86fa3334a3db91356b8d7d86a9b839dab7d0bdc5c3d3a077618"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -2417,6 +2659,16 @@ name = "time-core"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29aa485584182073ed57fd5004aa09c371f021325014694e432313345865fd04"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -2544,7 +2796,7 @@ version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap",
+ "indexmap 2.8.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2712,6 +2964,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "uuid"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2839,7 +3097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1d20d0bf2c73c32a5114cf35a5c10ccf9f9aa37a3a2c0114b3e11cbf6faac12"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.8.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2858,7 +3116,7 @@ dependencies = [
  "anyhow",
  "auditable-serde",
  "flate2",
- "indexmap",
+ "indexmap 2.8.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2875,8 +3133,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36e5456165f81e64cb9908a0fe9b9d852c2c74582aa3fe2be3c2da57f937d3ae"
 dependencies = [
  "bitflags",
- "hashbrown",
- "indexmap",
+ "hashbrown 0.15.2",
+ "indexmap 2.8.0",
  "semver",
 ]
 
@@ -2887,8 +3145,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f51cad774fb3c9461ab9bccc9c62dfb7388397b5deda31bf40e8108ccd678b2"
 dependencies = [
  "bitflags",
- "hashbrown",
- "indexmap",
+ "hashbrown 0.15.2",
+ "indexmap 2.8.0",
  "semver",
 ]
 
@@ -2954,6 +3212,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-link"
@@ -3223,7 +3490,7 @@ checksum = "e5ba5b852e976d35dbf6cb745746bf1bd4fc26782bab1e0c615fc71a7d8aac05"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.8.0",
  "prettyplease",
  "syn",
  "wasm-metadata 0.225.0",
@@ -3239,7 +3506,7 @@ checksum = "9d0809dc5ba19e2e98661bf32fc0addc5a3ca5bf3a6a7083aa6ba484085ff3ce"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.8.0",
  "prettyplease",
  "syn",
  "wasm-metadata 0.227.1",
@@ -3285,7 +3552,7 @@ checksum = "2505c917564c1d74774563bbcd3e4f8c216a6508050862fd5f449ee56e3c5125"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.8.0",
  "log",
  "serde",
  "serde_derive",
@@ -3304,7 +3571,7 @@ checksum = "635c3adc595422cbf2341a17fb73a319669cc8d33deed3a48368a841df86b676"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.8.0",
  "log",
  "serde",
  "serde_derive",
@@ -3323,7 +3590,7 @@ checksum = "ebefaa234e47224f10ce60480c5bfdece7497d0f3b87a12b41ff39e5c8377a78"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.8.0",
  "log",
  "semver",
  "serde",
@@ -3341,7 +3608,7 @@ checksum = "ddf445ed5157046e4baf56f9138c124a0824d4d1657e7204d71886ad8ce2fc11"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.8.0",
  "log",
  "semver",
  "serde",

--- a/crates/integration-tests/data/extensions/Cargo.toml
+++ b/crates/integration-tests/data/extensions/Cargo.toml
@@ -20,5 +20,8 @@ lto = true
 [workspace.dependencies]
 base64 = "0.22"
 grafbase-sdk = { path = "../../../grafbase-sdk" }
+http = "1.3"
+rkyv = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_with = "3"

--- a/crates/integration-tests/data/extensions/build.sh
+++ b/crates/integration-tests/data/extensions/build.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+script_dir="$(dirname "$(readlink -f "$0")")"
+cd "$script_dir"
+
 for dir in crates/*; do
     pushd "$dir"
     ../../../../../../target/debug/grafbase extension build

--- a/crates/integration-tests/data/extensions/crates/authorization-010/Cargo.toml
+++ b/crates/integration-tests/data/extensions/crates/authorization-010/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "authenticated"
+name = "authorization-010"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -9,8 +9,11 @@ repository.workspace = true
 
 [dependencies]
 grafbase-sdk.workspace = true
+http.workspace = true
+rkyv.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_with.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/integration-tests/data/extensions/crates/authorization-010/definitions.graphql
+++ b/crates/integration-tests/data/extensions/crates/authorization-010/definitions.graphql
@@ -1,0 +1,5 @@
+extend schema @link(url: "https://specs.grafbase.com/grafbase", import: ["FieldSet"])
+
+directive @deniedIds(ids: [Int!], fields: FieldSet! = "id") on OBJECT
+directive @deny on FIELD_DEFINITION
+

--- a/crates/integration-tests/data/extensions/crates/authorization-010/extension.toml
+++ b/crates/integration-tests/data/extensions/crates/authorization-010/extension.toml
@@ -1,0 +1,6 @@
+[extension]
+name = "authorization-010"
+version = "1.0.0"
+kind = "authorization"
+description = ""
+

--- a/crates/integration-tests/data/extensions/crates/authorization-010/src/lib.rs
+++ b/crates/integration-tests/data/extensions/crates/authorization-010/src/lib.rs
@@ -1,0 +1,111 @@
+use grafbase_sdk::{
+    AuthorizationExtension, Error, IntoQueryAuthorization, SubgraphHeaders, Token,
+    types::{AuthorizationDecisions, Configuration, ErrorResponse, QueryElements, ResponseElements},
+};
+
+#[derive(AuthorizationExtension)]
+struct CustomAuthorization;
+
+#[derive(serde::Deserialize)]
+struct DeniedIdsArgs {
+    ids: Vec<u32>,
+}
+
+#[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, Debug)]
+struct State {
+    denied_ids: Vec<DeniedIds>,
+}
+
+#[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, Debug)]
+struct DeniedIds {
+    query_element_id: u32,
+    denied_ids: Vec<u32>,
+}
+
+#[serde_with::serde_as]
+#[derive(serde::Deserialize)]
+struct Object<'a> {
+    #[serde(borrow, flatten)]
+    #[serde_as(as = "serde_with::Map<_, _>")]
+    fields: Vec<(&'a str, serde_json::Value)>,
+}
+
+impl Object<'_> {
+    fn id_as_u32(&self) -> u32 {
+        println!("{:#?}", self.fields);
+        self.fields.first().and_then(|(_, value)| value.as_u64()).unwrap() as u32
+    }
+}
+
+impl AuthorizationExtension for CustomAuthorization {
+    fn new(_: Configuration) -> Result<Self, Error> {
+        Ok(Self)
+    }
+
+    fn authorize_query(
+        &mut self,
+        headers: &mut SubgraphHeaders,
+        token: Token,
+        elements: QueryElements<'_>,
+    ) -> Result<impl IntoQueryAuthorization, ErrorResponse> {
+        let mut state = State { denied_ids: Vec::new() };
+        let mut builder = AuthorizationDecisions::deny_some_builder();
+        let error_id = builder.push_error(Error::new("Not authorized, query auth SDK010"));
+
+        for (name, elements) in elements.iter_grouped_by_directive_name() {
+            println!("{name}");
+            match name {
+                "deniedIds" => {
+                    for element in elements {
+                        let args: DeniedIdsArgs = element.arguments()?;
+                        state.denied_ids.push(DeniedIds {
+                            query_element_id: element.id().into(),
+                            denied_ids: args.ids,
+                        });
+                    }
+                }
+                "deny" => {
+                    for element in elements {
+                        builder.deny_with_error_id(element, error_id);
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        headers.append(
+            http::HeaderName::from_static("token"),
+            http::HeaderValue::from_bytes(token.as_bytes().unwrap_or_default()).unwrap(),
+        );
+
+        let state = rkyv::api::high::to_bytes_in::<_, rkyv::rancor::Error>(&state, Vec::new()).unwrap();
+        Ok((builder.build(), state))
+    }
+
+    fn authorize_response(
+        &mut self,
+        state: Vec<u8>,
+        elements: ResponseElements<'_>,
+    ) -> Result<AuthorizationDecisions, Error> {
+        let state = rkyv::access::<ArchivedState, rkyv::rancor::Error>(&state).unwrap();
+        let mut builder = AuthorizationDecisions::deny_some_builder();
+        let error_id = builder.push_error(Error::new("Not authorized, response auth SDK010"));
+
+        for element in elements {
+            if let Some(denied) = state
+                .denied_ids
+                .iter()
+                .find(|denied| denied.query_element_id == u32::from(element.query_element_id()))
+            {
+                for item in element.items() {
+                    let object: Object<'_> = item.deserialize()?;
+                    if denied.denied_ids.contains(&(object.id_as_u32().into())) {
+                        builder.deny_with_error_id(item, error_id);
+                    }
+                }
+            }
+        }
+
+        Ok(builder.build())
+    }
+}

--- a/crates/integration-tests/tests/federation/extensions/authorization/backwards_compatibility.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/backwards_compatibility.rs
@@ -1,0 +1,158 @@
+use engine::Engine;
+use graphql_mocks::{EchoSchema, dynamic::DynamicSchema};
+use integration_tests::{federation::EngineExt, runtime};
+
+use crate::federation::extensions::authentication::{AuthenticationExt, static_token::StaticToken};
+
+#[test]
+fn sdk_0100() {
+    runtime().block_on(async move {
+        let engine = Engine::builder()
+            .with_subgraph(EchoSchema)
+            .with_subgraph(
+                DynamicSchema::builder(
+                    r#"
+                    extend schema @link(url: "authorization-010-1.0.0", import: ["@deniedIds", "@deny"])
+
+                    type Query {
+                        users: [User]!
+                        secret: String @deny
+                    }
+
+                    type User @deniedIds(ids: [2, 4, 8]) {
+                        id: Int!
+                        name: String!
+                    }
+                    "#,
+                )
+                .with_resolver(
+                    "Query",
+                    "users",
+                    serde_json::json!([
+                        {"id": 1, "name": "Alice"},
+                        {"id": 2, "name": "Bob"},
+                        {"id": 3, "name": "Charlie"},
+                        {"id": 4, "name": "David"},
+                        {"id": 5, "name": "Eve"},
+                        {"id": 6, "name": "Frank"},
+                        {"id": 7, "name": "Grace"},
+                        {"id": 8, "name": "Helen"}
+                    ]),
+                )
+                .into_subgraph("x"),
+            )
+            .with_extension(AuthenticationExt::new(StaticToken::bytes("Hello world!".into())))
+            .with_extension("authorization-010")
+            .with_toml_config(
+                r#"
+                [[authentication.providers]]
+
+                [authentication.providers.extension]
+                extension = "authentication"
+
+                [extensions.authorization-010]
+                stderr = true
+                stdout = true
+                "#,
+            )
+            .build()
+            .await;
+
+        let response = engine
+            .post(r#"query { secret header(name: "token") users { name } }"#)
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "secret": null,
+            "header": "Hello world!",
+            "users": [
+              {
+                "name": "Alice"
+              },
+              null,
+              {
+                "name": "Charlie"
+              },
+              null,
+              {
+                "name": "Eve"
+              },
+              {
+                "name": "Frank"
+              },
+              {
+                "name": "Grace"
+              },
+              null
+            ]
+          },
+          "errors": [
+            {
+              "message": "Not authorized, query auth SDK010",
+              "locations": [
+                {
+                  "line": 1,
+                  "column": 9
+                }
+              ],
+              "path": [
+                "secret"
+              ],
+              "extensions": {
+                "code": "UNAUTHORIZED"
+              }
+            },
+            {
+              "message": "Not authorized, response auth SDK010",
+              "locations": [
+                {
+                  "line": 1,
+                  "column": 38
+                }
+              ],
+              "path": [
+                "users",
+                1
+              ],
+              "extensions": {
+                "code": "UNAUTHORIZED"
+              }
+            },
+            {
+              "message": "Not authorized, response auth SDK010",
+              "locations": [
+                {
+                  "line": 1,
+                  "column": 38
+                }
+              ],
+              "path": [
+                "users",
+                3
+              ],
+              "extensions": {
+                "code": "UNAUTHORIZED"
+              }
+            },
+            {
+              "message": "Not authorized, response auth SDK010",
+              "locations": [
+                {
+                  "line": 1,
+                  "column": 38
+                }
+              ],
+              "path": [
+                "users",
+                7
+              ],
+              "extensions": {
+                "code": "UNAUTHORIZED"
+              }
+            }
+          ]
+        }
+        "#);
+    });
+}

--- a/crates/integration-tests/tests/federation/extensions/authorization/mod.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/mod.rs
@@ -1,4 +1,5 @@
 mod authenticated;
+mod backwards_compatibility;
 mod deny_all;
 mod deny_some;
 mod error_propagation;
@@ -6,6 +7,7 @@ mod error_response;
 mod grant_all;
 mod headers;
 mod injection;
+mod multiple;
 mod query;
 mod requires_scopes;
 mod response;

--- a/crates/integration-tests/tests/federation/extensions/authorization/multiple.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/multiple.rs
@@ -1,0 +1,265 @@
+use engine::{Engine, ErrorCode, ErrorResponse, GraphqlError};
+use graphql_mocks::dynamic::DynamicSchema;
+use integration_tests::{
+    federation::{DynHookContext, EngineExt, TestExtension},
+    runtime,
+};
+use runtime::extension::{AuthorizationDecisions, QueryElement, TokenRef};
+
+use crate::federation::extensions::authorization::AuthorizationExt;
+
+#[derive(Default)]
+pub struct MultiDirectives;
+
+#[async_trait::async_trait]
+impl TestExtension for MultiDirectives {
+    #[allow(clippy::manual_async_fn)]
+    async fn authorize_query(
+        &self,
+        _wasm_context: &DynHookContext,
+        _headers: &tokio::sync::RwLock<http::HeaderMap>,
+        _token: TokenRef<'_>,
+        elements_grouped_by_directive_name: Vec<(&str, Vec<QueryElement<'_, serde_json::Value>>)>,
+    ) -> Result<AuthorizationDecisions, ErrorResponse> {
+        let mut element_to_error = Vec::new();
+        let errors = vec![GraphqlError::new("Unauthorized", ErrorCode::Unauthorized)];
+        let mut i = 0;
+        for (name, elements) in elements_grouped_by_directive_name {
+            match name {
+                "grant" => {
+                    i += elements.len() as u32;
+                }
+                "deny" => {
+                    for _ in elements {
+                        element_to_error.push((i, 0));
+                        i += 1;
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        Ok(AuthorizationDecisions::DenySome {
+            element_to_error,
+            errors,
+        })
+    }
+}
+
+#[derive(Default)]
+pub struct MultiDirectivesBis;
+
+#[async_trait::async_trait]
+impl TestExtension for MultiDirectivesBis {
+    #[allow(clippy::manual_async_fn)]
+    async fn authorize_query(
+        &self,
+        _wasm_context: &DynHookContext,
+        _headers: &tokio::sync::RwLock<http::HeaderMap>,
+        _token: TokenRef<'_>,
+        elements_grouped_by_directive_name: Vec<(&str, Vec<QueryElement<'_, serde_json::Value>>)>,
+    ) -> Result<AuthorizationDecisions, ErrorResponse> {
+        let mut element_to_error = Vec::new();
+        let errors = vec![GraphqlError::new("Unauthorized by bis", ErrorCode::Unauthorized)];
+        let mut i = 0;
+        for (name, elements) in elements_grouped_by_directive_name {
+            match name {
+                "grantBis" => {
+                    i += elements.len() as u32;
+                }
+                "denyBis" => {
+                    for _ in elements {
+                        element_to_error.push((i, 0));
+                        i += 1;
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        Ok(AuthorizationDecisions::DenySome {
+            element_to_error,
+            errors,
+        })
+    }
+}
+
+#[test]
+fn multiple_directives() {
+    let response = runtime().block_on(async move {
+        let engine = Engine::builder()
+            .with_subgraph(
+                DynamicSchema::builder(
+                    r#"
+                extend schema @link(url: "authorization-1.0.0", import: ["@grant", "@deny"])
+
+                type Query {
+                    greeting: String @grant
+                    forbidden: String @deny
+                }
+                "#,
+                )
+                .with_resolver("Query", "forbidden", serde_json::Value::String("Oh no!".to_owned()))
+                .with_resolver("Query", "greeting", serde_json::Value::String("Hi!".to_owned()))
+                .into_subgraph("x"),
+            )
+            .with_extension(AuthorizationExt::new(MultiDirectives).with_sdl(
+                r#"
+                directive @grant on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+                directive @deny on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+            "#,
+            ))
+            .build()
+            .await;
+
+        engine.post(r#"query { greeting forbidden }"#).await
+    });
+
+    insta::assert_json_snapshot!(response,  @r#"
+    {
+      "data": {
+        "greeting": "Hi!",
+        "forbidden": null
+      },
+      "errors": [
+        {
+          "message": "Unauthorized",
+          "locations": [
+            {
+              "line": 1,
+              "column": 18
+            }
+          ],
+          "path": [
+            "forbidden"
+          ],
+          "extensions": {
+            "code": "UNAUTHORIZED"
+          }
+        }
+      ]
+    }
+    "#);
+}
+
+#[test]
+fn multiple_extensions_and_directives() {
+    let response = runtime().block_on(async move {
+        let engine = Engine::builder()
+            .with_subgraph(
+                DynamicSchema::builder(
+                    r#"
+                extend schema @link(url: "authorization-1.0.0", import: ["@grant", "@deny"])
+                extend schema @link(url: "authorizationBis-1.0.0", import: ["@grantBis", "@denyBis"])
+
+                type Query {
+                    greeting: String @grant @grantBis
+                    forbidden: String @deny
+                    forbiddenBis: String @denyBis
+                    denied1: String @grantBis @deny
+                    denied2: String @grant @denyBis
+                }
+                "#,
+                )
+                .with_resolver("Query", "forbidden", serde_json::Value::String("Oh no!".to_owned()))
+                .with_resolver("Query", "greeting", serde_json::Value::String("Hi!".to_owned()))
+                .into_subgraph("x"),
+            )
+            .with_extension(AuthorizationExt::new(MultiDirectives).with_sdl(
+                r#"
+                directive @grant on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+                directive @deny on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+            "#,
+            ))
+            .with_extension(
+                AuthorizationExt::new(MultiDirectivesBis)
+                    .with_name("authorizationBis")
+                    .with_sdl(
+                        r#"
+                        directive @grantBis on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+                        directive @denyBis on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+                        "#,
+                    ),
+            )
+            .build()
+            .await;
+
+        engine
+            .post(r#"query { greeting forbidden forbiddenBis denied1 denied2 }"#)
+            .await
+    });
+
+    insta::assert_json_snapshot!(response,  @r#"
+    {
+      "data": {
+        "greeting": "Hi!",
+        "forbidden": null,
+        "forbiddenBis": null,
+        "denied1": null,
+        "denied2": null
+      },
+      "errors": [
+        {
+          "message": "Unauthorized",
+          "locations": [
+            {
+              "line": 1,
+              "column": 18
+            }
+          ],
+          "path": [
+            "forbidden"
+          ],
+          "extensions": {
+            "code": "UNAUTHORIZED"
+          }
+        },
+        {
+          "message": "Unauthorized by bis",
+          "locations": [
+            {
+              "line": 1,
+              "column": 28
+            }
+          ],
+          "path": [
+            "forbiddenBis"
+          ],
+          "extensions": {
+            "code": "UNAUTHORIZED"
+          }
+        },
+        {
+          "message": "Unauthorized",
+          "locations": [
+            {
+              "line": 1,
+              "column": 41
+            }
+          ],
+          "path": [
+            "denied1"
+          ],
+          "extensions": {
+            "code": "UNAUTHORIZED"
+          }
+        },
+        {
+          "message": "Unauthorized by bis",
+          "locations": [
+            {
+              "line": 1,
+              "column": 49
+            }
+          ],
+          "path": [
+            "denied2"
+          ],
+          "extensions": {
+            "code": "UNAUTHORIZED"
+          }
+        }
+      ]
+    }
+    "#);
+}


### PR DESCRIPTION
Adding a real wasm extension test case.

- I'm now hiding the internal wasm error and exposing them as error
  logs. Showing a wasm stacktrace in a graphql error is pretty useless.
- I wasn't handling default values correctly. Really need to replace
federated-graph by cynic-parser to avoid logic duplication.
- And there was an issue with multiple directives for a single
authorization extension.
