### PR TITLE
Fix: blocked gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "anyhow",
  "ascii",

--- a/crates/federated-server/src/server/gateway.rs
+++ b/crates/federated-server/src/server/gateway.rs
@@ -65,11 +65,14 @@ pub(super) async fn generate(
         GraphDefinition::Sdl(federated_sdl) => sdl_graph(federated_sdl),
     };
 
+    tracing::debug!("Creating extension catalog.");
     let extension_catalog = create_extension_catalog(gateway_config).await?;
 
+    tracing::debug!("Parsing federated schema.");
     let federated_graph =
         FederatedGraph::from_sdl(&federated_sdl).map_err(|e| crate::Error::SchemaValidationError(e.to_string()))?;
 
+    tracing::debug!("Building engine Schema.");
     let schema = engine::Schema::build(gateway_config, &federated_graph, &extension_catalog, schema_version)
         .await
         .map_err(|err| crate::Error::SchemaValidationError(err.to_string()))?;

--- a/crates/wasi-component-loader/src/extension/manager/mod.rs
+++ b/crates/wasi-component-loader/src/extension/manager/mod.rs
@@ -73,13 +73,16 @@ async fn create_pools(
         .ok()
         // Each extensions takes quite a lot of CPU.
         .map(|num| num.get() / 8)
-        .unwrap_or(1);
+        .unwrap_or_default()
+        // We want at least parallelism of 1, otherwise we'll never move forward even without any
+        // extensions...
+        .max(1);
 
     let mut pools = stream::iter(extensions.into_iter().map(|config| async {
+        tracing::info!("Loading extension {}", config.manifest_id);
+
         let shared = shared_resources.clone();
         std::future::ready(()).await;
-
-        tracing::info!("Loading extension {}", config.manifest_id);
 
         let id = config.id;
         let max_pool_size = config.pool.max_size;

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.31.0"
+version = "0.31.1"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/changelog/0.31.1.md
+++ b/gateway/changelog/0.31.1.md
@@ -1,0 +1,3 @@
+# Fix
+
+- Previous release of the gateway would block on machines with less than 8 cores.


### PR DESCRIPTION
I was doing:
```rust
    let parallelism = std::thread::available_parallelism()
        .ok()
        // Each extensions takes quite a lot of CPU.
        .map(|num| num.get() / 8)
        .unwrap_or(1);
```
which was fine on my 32 cores machine, but I guess the gateway has less than that in k8s. So it ended up being 0, and instead of panicking we were just waiting forever on something that will never start despite the fact that there were no tasks to do.

+ release `0.31.1`