### PR TITLE
docs: update on_gateway_request with the url parameter

### DIFF
--- a/crates/grafbase-hooks/README.md
+++ b/crates/grafbase-hooks/README.md
@@ -55,11 +55,14 @@ impl Hooks for MyHooks {
     fn on_gateway_request(
         &mut self,
         context: Context,
+        url: String,
         headers: Headers
     ) -> Result<(), ErrorResponse> {
         if let Some(ref auth_header) = headers.get("authorization") {
            context.set("auth", auth_header);
         }
+
+        context.set("url", &url);
 
         Ok(())
     }

--- a/examples/gateway-hooks/hooks/src/lib.rs
+++ b/examples/gateway-hooks/hooks/src/lib.rs
@@ -1,8 +1,8 @@
 mod common;
 use common::*;
 use grafbase_hooks::{
-    grafbase_hooks, Context, EdgeNodePostExecutionArguments, EdgePreExecutionArguments, Error, ErrorResponse, Headers,
-    Hooks, ParentEdgePostExecutionArguments, SharedContext,
+    Context, EdgeNodePostExecutionArguments, EdgePreExecutionArguments, Error, ErrorResponse, Headers, Hooks,
+    ParentEdgePostExecutionArguments, SharedContext, grafbase_hooks,
 };
 
 // Individual interface implementations
@@ -19,7 +19,7 @@ impl Hooks for Component {
         Self
     }
 
-    fn on_gateway_request(&mut self, context: Context, headers: Headers) -> Result<(), ErrorResponse> {
+    fn on_gateway_request(&mut self, context: Context, url: String, headers: Headers) -> Result<(), ErrorResponse> {
         init_logging();
 
         if let Some(id) = headers.get("x-current-user-id") {
@@ -31,6 +31,8 @@ impl Hooks for Component {
             tracing::info!("Current role: {role}");
             context.set("role", &role);
         }
+
+        context.set("url", &url);
 
         Ok(())
     }


### PR DESCRIPTION
This patch update the doc and example for the `grafbase-hooks` to reflect the latest changes introduced in the [crate](https://crates.io/crates/grafbase-hooks) 

There's breaking change introduced in `grafbase-hooks-0.3.0`: A new parameter `url: String` is introduced but the doc is not update-to-date.

Before 0.3.0:
[link to the method signature for grafbase-hooks-0.2.0](https://docs.rs/grafbase-hooks/0.2.0/grafbase_hooks/trait.Hooks.html#method.on_gateway_request)
```Rust
fn on_gateway_request(&mut self, context: Context, headers: Headers) -> Result<(), ErrorResponse> {
    todo!()
}
```
[link to the method signature for grafbase-hooks-0.4.1](https://docs.rs/grafbase-hooks/0.4.1/grafbase_hooks/trait.Hooks.html#method.on_gateway_request)
```Rust
fn on_gateway_request(&mut self, context: Context, url: String, headers: Headers) -> Result<(), ErrorResponse> {
    todo!()
}
```