### PR TITLE
feat: Add prepare_field to runtime extension trait

### DIFF
--- a/crates/engine/src/resolver/extension/mod.rs
+++ b/crates/engine/src/resolver/extension/mod.rs
@@ -1,9 +1,14 @@
 mod query_or_mutation;
 mod subscription;
 
+use futures::FutureExt;
+use runtime::extension::ExtensionRuntime;
 use schema::{ExtensionDirectiveId, FieldResolverExtensionDefinition};
 
-use crate::prepare::{PartitionDataFieldId, PlanQueryPartition};
+use crate::{
+    Runtime,
+    prepare::{PartitionDataFieldId, PlanQueryPartition, PlanResult, PrepareContext},
+};
 
 use super::Resolver;
 
@@ -11,22 +16,38 @@ use super::Resolver;
 pub(crate) struct FieldResolverExtension {
     pub directive_id: ExtensionDirectiveId,
     pub field_id: PartitionDataFieldId,
+    pub prepared_data: Vec<u8>,
 }
 
 impl FieldResolverExtension {
-    pub(in crate::resolver) fn prepare(
+    pub(in crate::resolver) async fn prepare(
+        ctx: &PrepareContext<'_, impl Runtime>,
         definition: FieldResolverExtensionDefinition<'_>,
         plan_query_partition: PlanQueryPartition<'_>,
-    ) -> Resolver {
+    ) -> PlanResult<Resolver> {
         let field = plan_query_partition
             .selection_set()
             .fields()
             .next()
             .expect("At least one field must be present");
 
-        Resolver::FieldResolverExtension(Self {
+        let prepared_data = ctx
+            .runtime()
+            .extensions()
+            .prepare_field(
+                definition.directive(),
+                field.definition(),
+                definition.directive().static_arguments(),
+            )
+            // FIXME: Unfortunately, boxing seems to be the only solution for the bug explained here:
+            //        https://github.com/rust-lang/rust/issues/110338#issuecomment-1513761297
+            .boxed()
+            .await?;
+
+        Ok(Resolver::FieldResolverExtension(Self {
             directive_id: definition.directive_id,
             field_id: field.id,
-        })
+            prepared_data,
+        }))
     }
 }

--- a/crates/engine/src/resolver/extension/subscription.rs
+++ b/crates/engine/src/resolver/extension/subscription.rs
@@ -1,6 +1,6 @@
 use futures::{TryStreamExt, stream::BoxStream};
 use futures_lite::{FutureExt, StreamExt};
-use runtime::extension::{Data, ExtensionFieldDirective, ExtensionRuntime};
+use runtime::extension::{Data, ExtensionRuntime};
 use walker::Walk;
 
 use crate::{
@@ -28,18 +28,10 @@ impl FieldResolverExtension {
         let query_view =
             create_extension_directive_query_view(ctx.schema(), directive, field.arguments(), ctx.variables());
 
-        let extension_directive = ExtensionFieldDirective {
-            extension_id: directive.extension_id,
-            subgraph: directive.subgraph(),
-            field: field_definition,
-            name: directive.name(),
-            arguments: query_view,
-        };
-
         let stream = ctx
             .runtime()
             .extensions()
-            .resolve_subscription(headers, extension_directive)
+            .resolve_subscription(directive, field_definition, &self.prepared_data, headers, query_view)
             .boxed()
             .await
             .map_err(|err| err.with_location(field.location()))?;

--- a/crates/engine/src/resolver/graphql/federation.rs
+++ b/crates/engine/src/resolver/graphql/federation.rs
@@ -58,13 +58,13 @@ impl FederationEntityResolver {
         )
     }
 
-    pub fn prepare_request<'ctx, R: Runtime>(
+    pub fn build_executor<'ctx, R: Runtime>(
         &'ctx self,
         ctx: &SubgraphContext<'ctx, R>,
         plan: Plan<'ctx>,
         root_response_objects: ResponseObjectsView<'_>,
         subgraph_response: SubgraphResponse,
-    ) -> ExecutionResult<FederationEntityRequest<'ctx>> {
+    ) -> ExecutionResult<FederationEntityExecutor<'ctx>> {
         ctx.span().in_scope(|| {
             let extra_fields = vec![(
                 "__typename".into(),
@@ -86,7 +86,7 @@ impl FederationEntityResolver {
                 }
             }
 
-            Ok(FederationEntityRequest {
+            Ok(FederationEntityExecutor {
                 resolver: self,
                 subgraph_response,
                 entities_to_fetch,
@@ -106,14 +106,14 @@ struct EntityWithoutExpectedRequirements {
     error: serde_json::Error,
 }
 
-pub(crate) struct FederationEntityRequest<'ctx> {
+pub(crate) struct FederationEntityExecutor<'ctx> {
     resolver: &'ctx FederationEntityResolver,
     subgraph_response: SubgraphResponse,
     entities_to_fetch: Vec<EntityToFetch>,
     entities_without_expected_requirements: Vec<EntityWithoutExpectedRequirements>,
 }
 
-impl<'ctx> FederationEntityRequest<'ctx> {
+impl<'ctx> FederationEntityExecutor<'ctx> {
     pub async fn execute<R: Runtime>(self, ctx: &mut SubgraphContext<'ctx, R>) -> ExecutionResult<SubgraphResponse> {
         let Self {
             resolver: FederationEntityResolver { subgraph_operation, .. },

--- a/crates/integration-tests/tests/federation/extensions/basic.rs
+++ b/crates/integration-tests/tests/federation/extensions/basic.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
 use engine::{Engine, GraphqlError};
+use engine_schema::{ExtensionDirective, FieldDefinition};
 use extension_catalog::Id;
 use integration_tests::{
     federation::{EngineExt, TestExtension, TestExtensionBuilder, TestManifest, json_data},
     runtime,
 };
-use runtime::extension::{Data, ExtensionFieldDirective};
+use runtime::extension::Data;
 
 #[derive(Default, Clone)]
 pub struct GreetExt {
@@ -46,8 +47,11 @@ impl TestExtensionBuilder for GreetExt {
 impl TestExtension for GreetExt {
     async fn resolve_field(
         &self,
-        _headers: http::HeaderMap,
-        _directive: ExtensionFieldDirective<'_, serde_json::Value>,
+        _directive: ExtensionDirective<'_>,
+        _field_definition: FieldDefinition<'_>,
+        _prepared_data: &[u8],
+        _subgraph_headers: http::HeaderMap,
+        _directive_arguments: serde_json::Value,
         inputs: Vec<serde_json::Value>,
     ) -> Result<Vec<Result<Data, GraphqlError>>, GraphqlError> {
         Ok(vec![Ok(json_data("Hi!")); inputs.len()])

--- a/crates/integration-tests/tests/federation/extensions/resolver/injection/template/json.rs
+++ b/crates/integration-tests/tests/federation/extensions/resolver/injection/template/json.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
 use engine::{Engine, GraphqlError};
+use engine_schema::{ExtensionDirective, FieldDefinition};
 use extension_catalog::Id;
 use integration_tests::{
     federation::{EngineExt, TestExtension, TestExtensionBuilder, TestManifest},
     runtime,
 };
-use runtime::extension::{Data, ExtensionFieldDirective};
+use runtime::extension::Data;
 
 #[derive(Default)]
 pub struct EchoJsonDataExt;
@@ -40,11 +41,14 @@ impl TestExtensionBuilder for EchoJsonDataExt {
 impl TestExtension for EchoJsonDataExt {
     async fn resolve_field(
         &self,
-        _: http::HeaderMap,
-        directive: ExtensionFieldDirective<'_, serde_json::Value>,
+        _directive: ExtensionDirective<'_>,
+        _field_definition: FieldDefinition<'_>,
+        _prepared_data: &[u8],
+        _subgraph_headers: http::HeaderMap,
+        directive_arguments: serde_json::Value,
         inputs: Vec<serde_json::Value>,
     ) -> Result<Vec<Result<Data, GraphqlError>>, GraphqlError> {
-        let data = directive.arguments["data"].as_str().unwrap_or_default();
+        let data = directive_arguments["data"].as_str().unwrap_or_default();
         Ok(vec![Ok(Data::JsonBytes(data.as_bytes().to_vec())); inputs.len()])
     }
 }

--- a/crates/integration-tests/tests/federation/extensions/resolver/mod.rs
+++ b/crates/integration-tests/tests/federation/extensions/resolver/mod.rs
@@ -6,9 +6,10 @@ mod validation;
 use std::sync::Arc;
 
 use engine::GraphqlError;
+use engine_schema::{ExtensionDirective, FieldDefinition};
 use extension_catalog::Id;
 use integration_tests::federation::{TestExtension, TestExtensionBuilder, TestManifest};
-use runtime::extension::{Data, ExtensionFieldDirective};
+use runtime::extension::Data;
 
 #[derive(Clone)]
 pub struct StaticResolverExt {
@@ -46,8 +47,11 @@ impl TestExtensionBuilder for StaticResolverExt {
 impl TestExtension for StaticResolverExt {
     async fn resolve_field(
         &self,
-        _: http::HeaderMap,
-        _: ExtensionFieldDirective<'_, serde_json::Value>,
+        _directive: ExtensionDirective<'_>,
+        _field_definition: FieldDefinition<'_>,
+        _prepared_data: &[u8],
+        _subgraph_headers: http::HeaderMap,
+        _directive_arguments: serde_json::Value,
         inputs: Vec<serde_json::Value>,
     ) -> Result<Vec<Result<Data, GraphqlError>>, GraphqlError> {
         Ok(inputs.into_iter().map(|_| Ok(self.data.clone())).collect())

--- a/crates/integration-tests/tests/federation/extensions/resolver/validation/mod.rs
+++ b/crates/integration-tests/tests/federation/extensions/resolver/validation/mod.rs
@@ -10,12 +10,13 @@ mod scalar;
 use std::{collections::HashMap, sync::Arc};
 
 use engine::{Engine, GraphqlError};
+use engine_schema::{ExtensionDirective, FieldDefinition};
 use extension_catalog::Id;
 use integration_tests::{
     federation::{EngineExt, TestExtension, TestExtensionBuilder, TestManifest, json_data},
     runtime,
 };
-use runtime::extension::{Data, ExtensionFieldDirective};
+use runtime::extension::Data;
 
 #[derive(Default)]
 pub struct EchoExt {
@@ -60,8 +61,11 @@ struct EchoInstance {
 impl TestExtension for EchoInstance {
     async fn resolve_field(
         &self,
-        _: http::HeaderMap,
-        directive: ExtensionFieldDirective<'_, serde_json::Value>,
+        _directive: ExtensionDirective<'_>,
+        _field_definition: FieldDefinition<'_>,
+        _prepared_data: &[u8],
+        _subgraph_headers: http::HeaderMap,
+        directive_arguments: serde_json::Value,
         inputs: Vec<serde_json::Value>,
     ) -> Result<Vec<Result<Data, GraphqlError>>, GraphqlError> {
         Ok(inputs
@@ -69,7 +73,7 @@ impl TestExtension for EchoInstance {
             .map(|input| {
                 Ok(json_data(serde_json::json!({
                     "schema": self.schema_directives,
-                    "directive": directive.arguments,
+                    "directive": directive_arguments,
                     "input": input
                 })))
             })

--- a/crates/runtime/src/extension/authorization.rs
+++ b/crates/runtime/src/extension/authorization.rs
@@ -1,0 +1,27 @@
+use std::ops::Range;
+
+use engine_schema::DirectiveSite;
+use error::GraphqlError;
+use extension_catalog::ExtensionId;
+
+#[derive(Clone, Debug)]
+pub struct QueryElement<'a, A> {
+    pub site: DirectiveSite<'a>,
+    pub arguments: A,
+}
+
+#[derive(Debug)]
+pub enum AuthorizationDecisions {
+    GrantAll,
+    DenyAll(GraphqlError),
+    DenySome {
+        element_to_error: Vec<(u32, u32)>,
+        errors: Vec<GraphqlError>,
+    },
+}
+
+pub struct QueryAuthorizationDecisions {
+    pub extension_id: ExtensionId,
+    pub query_elements_range: Range<usize>,
+    pub decisions: AuthorizationDecisions,
+}

--- a/crates/runtime/src/extension/resolver.rs
+++ b/crates/runtime/src/extension/resolver.rs
@@ -1,0 +1,5 @@
+#[derive(Clone, Debug)]
+pub enum Data {
+    JsonBytes(Vec<u8>),
+    CborBytes(Vec<u8>),
+}

--- a/crates/runtime/src/extension/token.rs
+++ b/crates/runtime/src/extension/token.rs
@@ -1,0 +1,43 @@
+#[derive(Clone, Debug)]
+pub enum Token {
+    Anonymous,
+    Bytes(Vec<u8>),
+}
+
+impl Token {
+    pub fn as_bytes(&self) -> Option<&[u8]> {
+        match self {
+            Token::Anonymous => None,
+            Token::Bytes(bytes) => Some(bytes),
+        }
+    }
+
+    pub fn as_ref(&self) -> TokenRef<'_> {
+        match self {
+            Token::Anonymous => TokenRef::Anonymous,
+            Token::Bytes(bytes) => TokenRef::Bytes(bytes),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum TokenRef<'a> {
+    Anonymous,
+    Bytes(&'a [u8]),
+}
+
+impl TokenRef<'_> {
+    pub fn as_bytes(&self) -> Option<&[u8]> {
+        match self {
+            TokenRef::Anonymous => None,
+            TokenRef::Bytes(bytes) => Some(bytes),
+        }
+    }
+
+    pub fn to_owned(&self) -> Token {
+        match self {
+            TokenRef::Anonymous => Token::Anonymous,
+            TokenRef::Bytes(bytes) => Token::Bytes(bytes.to_vec()),
+        }
+    }
+}


### PR DESCRIPTION
Allows extensions to prepare their execution and cache it as part of the
operation plan.
