### PR TITLE
feat: Include extension catalog as part of operation hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,6 +2781,7 @@ name = "engine-schema"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "blake3",
  "cynic-parser",
  "cynic-parser-deser",
  "engine-id-derives",

--- a/crates/engine/schema/Cargo.toml
+++ b/crates/engine/schema/Cargo.toml
@@ -14,39 +14,39 @@ anyhow.workspace = true
 rand.workspace = true
 
 [dependencies]
-fxhash.workspace = true
-gateway-config.workspace = true
-hex.workspace = true
-id-derives = { path = "../id-derives", package = "engine-id-derives" }
-id-newtypes = { path = "../id-newtypes", package = "engine-id-newtypes" }
-indexmap.workspace = true
-itertools.workspace = true
-rapidhash.workspace = true
-serde.workspace = true
-serde_with.workspace = true
-strum = { workspace = true, features = ["derive"] }
-strum_macros.workspace = true
-thiserror.workspace = true
-url.workspace = true
-walker = { path = "../walker", package = "engine-walker" }
-
+blake3.workspace = true
 cynic-parser.workspace = true
 cynic-parser-deser.workspace = true
 extension-catalog.workspace = true
 federated-graph.workspace = true
+fxhash.workspace = true
+gateway-config.workspace = true
 grafbase-workspace-hack.workspace = true
+hex.workspace = true
 http.workspace = true
+id-derives = { path = "../id-derives", package = "engine-id-derives" }
+id-newtypes = { path = "../id-newtypes", package = "engine-id-newtypes" }
+indexmap.workspace = true
+itertools.workspace = true
 ramhorns.workspace = true
+rapidhash.workspace = true
 regex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 serde_regex.workspace = true
+serde_with.workspace = true
+strum = { workspace = true, features = ["derive"] }
+strum_macros.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
+url.workspace = true
+walker = { path = "../walker", package = "engine-walker" }
 wrapping.workspace = true
 
 [dev-dependencies]
 insta.workspace = true
 postcard.workspace = true
 rstest.workspace = true
-serde_json.workspace = true
 serde_path_to_error.workspace = true
 tokio.workspace = true
 toml.workspace = true

--- a/crates/engine/schema/src/builder/hash.rs
+++ b/crates/engine/schema/src/builder/hash.rs
@@ -1,0 +1,35 @@
+use extension_catalog::ExtensionCatalog;
+
+mod built_info {
+    // The file has been placed there by the build script.
+    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+
+/// A unique identifier of this build of the engine to version cache keys.
+/// If built in a git repository, the cache version is taken from the git commit id.
+/// For builds outside of a git repository, the build time is used.
+fn build_identifier() -> Vec<u8> {
+    match built_info::GIT_COMMIT_HASH {
+        Some(hash) => hex::decode(hash).expect("Expect hex format"),
+        None => built_info::BUILD_TOKEN.as_bytes().to_vec(),
+    }
+}
+
+pub(super) fn compute(federated_sdl: &str, extension_catalog: &ExtensionCatalog) -> [u8; 32] {
+    let build_id = build_identifier();
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&build_id.len().to_ne_bytes());
+    hasher.update(&build_id);
+    hasher.update(&federated_sdl.len().to_ne_bytes());
+    hasher.update(federated_sdl.as_bytes());
+
+    hasher.update(&extension_catalog.len().to_ne_bytes());
+    for extension in extension_catalog.iter() {
+        serde_json::to_writer(&mut hasher, &extension.manifest).unwrap();
+        hasher
+            .update_reader(std::fs::File::open(&extension.wasm_path).unwrap())
+            .unwrap();
+    }
+
+    hasher.finalize().into()
+}

--- a/crates/engine/src/engine/cache.rs
+++ b/crates/engine/src/engine/cache.rs
@@ -73,10 +73,7 @@ impl std::fmt::Display for CacheKey<'_> {
             // backwards-compatibility
             CacheKey::Operation { schema, document } => {
                 let mut hasher = blake3::Hasher::new();
-                hasher.update(&Schema::build_identifier().len().to_ne_bytes());
-                hasher.update(Schema::build_identifier());
-                hasher.update(&schema.version.len().to_ne_bytes());
-                hasher.update(&schema.version);
+                hasher.update(&schema.hash);
 
                 match document {
                     DocumentKey::AutomaticPersistedQuery { operation_name, ext } => {

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -15,4 +15,4 @@ pub use self::engine::{Engine, Runtime, WebsocketSession};
 pub use error::{ErrorCode, ErrorResponse, GraphqlError};
 pub use graphql_over_http::{Body, HooksExtension, TelemetryExtension};
 pub use prepare::cached::CachedOperation;
-pub use schema::{BuildError, Schema, Version as SchemaVersion};
+pub use schema::{BuildError, Schema};

--- a/crates/runtime/src/extension/mod.rs
+++ b/crates/runtime/src/extension/mod.rs
@@ -19,6 +19,8 @@ pub use token::*;
 pub trait ExtensionRuntime: Send + Sync + 'static {
     type SharedContext: Send + Sync + 'static;
 
+    /// The data will be cached as part of the operation plan. Beware that the cache key will be
+    /// depended on the schema & extensions, but not on the configuration.
     fn prepare_field<'ctx>(
         &'ctx self,
         directive: ExtensionDirective<'ctx>,

--- a/taplo.toml
+++ b/taplo.toml
@@ -5,6 +5,7 @@ include = [
     "Cargo.toml",
     "crates/**/Cargo.toml",
     "gateway/**/Cargo.toml",
+    "crates/engine/**/Cargo.toml",
     "cli/**/Cargo.toml",
     "examples/**/Cargo.toml",
 ]
@@ -48,7 +49,7 @@ formatting = { reorder_keys = true }
 # All crates inside `src`, `tests` must use `workspace = true` instead.
 [[rule]]
 schema = { path = ".config/workspace-schema.json" }
-include = ["crates/**/Cargo.toml", "gateway/**/Cargo.toml", "cli/**/Cargo.toml"]
+include = ["crates/**/Cargo.toml", "gateway/**/Cargo.toml", "cli/**/Cargo.toml", "crates/engine/**/Cargo.toml"]
 exclude = [
     "crates/wasi-component-loader/examples/**/Cargo.toml",
     "crates/integration-tests/data/**/Cargo.toml",


### PR DESCRIPTION
Previously only the schema & grafbase code, through the commit hash, would be.