### PR TITLE
gateway-config: deserialize duration strings in telemetry exporters 

### DIFF
--- a/crates/gateway-config/src/telemetry/exporters.rs
+++ b/crates/gateway-config/src/telemetry/exporters.rs
@@ -5,13 +5,15 @@ pub mod response_extension;
 pub mod stdout;
 pub mod tracing;
 
+use std::time::Duration;
+
 pub use logs::LogsConfig;
 pub use metrics::MetricsConfig;
 pub use otlp::*;
 pub use response_extension::*;
 pub use tracing::{DEFAULT_SAMPLING, PropagationConfig, TracingCollectConfig, TracingConfig};
 
-use serde::{Deserialize, Deserializer};
+use serde::Deserialize;
 pub use stdout::StdoutExporterConfig;
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
@@ -35,8 +37,8 @@ pub struct OpenTelemetryExportersConfig {
 pub struct BatchExportConfig {
     /// The delay, in seconds, between two consecutive processing of batches.
     /// The default value is 5 seconds.
-    #[serde(deserialize_with = "deserialize_duration")]
-    pub scheduled_delay: chrono::Duration,
+    #[serde(deserialize_with = "duration_str::deserialize_duration")]
+    pub scheduled_delay: Duration,
 
     /// The maximum queue size to buffer spans for delayed processing. If the
     /// queue gets full it drops the spans.
@@ -59,8 +61,8 @@ pub struct BatchExportConfig {
 }
 
 impl BatchExportConfig {
-    pub(crate) fn default_scheduled_delay() -> chrono::Duration {
-        chrono::Duration::try_seconds(5).expect("must be fine")
+    pub(crate) fn default_scheduled_delay() -> Duration {
+        Duration::from_secs(5)
     }
 
     pub(crate) fn default_max_queue_size() -> usize {
@@ -87,24 +89,6 @@ impl Default for BatchExportConfig {
     }
 }
 
-pub(crate) fn default_export_timeout() -> chrono::Duration {
-    chrono::Duration::try_seconds(60).expect("must be fine")
-}
-
-fn deserialize_duration<'de, D>(deserializer: D) -> Result<chrono::Duration, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let input = i64::deserialize(deserializer)?;
-
-    Ok(chrono::Duration::try_seconds(input).expect("must be fine"))
-}
-
-fn deserialize_duration_opt<'de, D>(deserializer: D) -> Result<Option<chrono::Duration>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let input = Option::<i64>::deserialize(deserializer)?;
-
-    Ok(input.map(|input| chrono::Duration::try_seconds(input).expect("must be fine")))
+pub(crate) fn default_export_timeout() -> std::time::Duration {
+    std::time::Duration::from_secs(60)
 }

--- a/crates/gateway-config/src/telemetry/exporters/otlp.rs
+++ b/crates/gateway-config/src/telemetry/exporters/otlp.rs
@@ -2,8 +2,8 @@ mod headers;
 
 pub use headers::Headers;
 
-use super::{BatchExportConfig, default_export_timeout, deserialize_duration_opt};
-use std::path::PathBuf;
+use super::{BatchExportConfig, default_export_timeout};
+use std::{path::PathBuf, time::Duration};
 use url::Url;
 
 // FIXME: Please make me disappear me, so horrible.
@@ -18,7 +18,7 @@ impl LayeredOtlExporterConfig {
         self.local.enabled.or(self.global.enabled).unwrap_or_default()
     }
 
-    pub fn timeout(&self) -> chrono::Duration {
+    pub fn timeout(&self) -> Duration {
         self.local
             .timeout
             .or(self.global.timeout)
@@ -64,8 +64,8 @@ pub struct OtlpExporterConfig {
     pub http: Option<OtlpExporterHttpConfig>,
     /// The maximum duration to export data.
     /// The default value is 60 seconds.
-    #[serde(deserialize_with = "deserialize_duration_opt")]
-    pub timeout: Option<chrono::Duration>,
+    #[serde(deserialize_with = "duration_str::deserialize_option_duration")]
+    pub timeout: Option<std::time::Duration>,
 }
 
 /// OTLP Exporter protocol

--- a/crates/gateway-config/src/telemetry/exporters/stdout.rs
+++ b/crates/gateway-config/src/telemetry/exporters/stdout.rs
@@ -1,4 +1,6 @@
-use super::{BatchExportConfig, default_export_timeout, deserialize_duration};
+use std::time::Duration;
+
+use super::{BatchExportConfig, default_export_timeout};
 
 /// Stdout exporter configuration
 #[derive(Debug, Clone, PartialEq, serde::Deserialize)]
@@ -10,8 +12,8 @@ pub struct StdoutExporterConfig {
     pub batch_export: Option<BatchExportConfig>,
     /// The maximum duration to export data.
     /// The default value is 60 seconds.
-    #[serde(deserialize_with = "deserialize_duration")]
-    pub timeout: chrono::Duration,
+    #[serde(deserialize_with = "duration_str::deserialize_duration")]
+    pub timeout: Duration,
 }
 
 impl Default for StdoutExporterConfig {

--- a/crates/gateway-config/src/telemetry/mod.rs
+++ b/crates/gateway-config/src/telemetry/mod.rs
@@ -119,6 +119,7 @@ mod tests {
     use indoc::indoc;
     use std::path::PathBuf;
     use std::str::FromStr;
+    use std::time::Duration;
     use url::Url;
 
     #[test]
@@ -260,7 +261,7 @@ mod tests {
             endpoint = "http://localhost:1234"
 
             [exporters.otlp.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
         "#};
 
         // act
@@ -272,7 +273,7 @@ mod tests {
                 endpoint: Some(Url::parse("http://localhost:1234").unwrap()),
                 enabled: Some(true),
                 batch_export: Some(BatchExportConfig {
-                    scheduled_delay: chrono::Duration::try_seconds(10).expect("must be fine"),
+                    scheduled_delay: Duration::from_secs(10),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -290,10 +291,10 @@ mod tests {
             enabled = true
             endpoint = "http://localhost:1234"
             protocol = "grpc"
-            timeout = 120
+            timeout = "120s"
 
             [exporters.otlp.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -320,7 +321,7 @@ mod tests {
                 endpoint: Some(Url::parse("http://localhost:1234").unwrap()),
                 enabled: Some(true),
                 batch_export: Some(BatchExportConfig {
-                    scheduled_delay: chrono::Duration::try_seconds(10).expect("must be fine"),
+                    scheduled_delay: Duration::from_secs(10),
                     max_queue_size: 10,
                     max_export_batch_size: 10,
                     max_concurrent_exports: 10,
@@ -344,7 +345,7 @@ mod tests {
                         AsciiString::from_ascii("header1").unwrap()
                     )]),
                 }),
-                timeout: Some(chrono::Duration::try_seconds(120).expect("must be fine")),
+                timeout: Some(Duration::from_secs(120)),
             }),
             config.exporters.otlp
         );
@@ -357,10 +358,10 @@ mod tests {
 
             [exporters.stdout]
             enabled = true
-            timeout = 10
+            timeout = "10s"
 
             [exporters.stdout.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -380,20 +381,20 @@ mod tests {
 
             [exporters.stdout]
             enabled = true
-            timeout = 10
+            timeout = "10s"
 
             [exporters.stdout.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
 
             [tracing.exporters.stdout]
             enabled = false
-            timeout = 9
+            timeout = "9s"
 
             [tracing.exporters.stdout.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -411,20 +412,20 @@ mod tests {
 
             [exporters.stdout]
             enabled = true
-            timeout = 10
+            timeout = "10s"
 
             [exporters.stdout.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
 
             [tracing.exporters.stdout]
             enabled = true
-            timeout = 9
+            timeout = "9s"
 
             [tracing.exporters.stdout.batch_export]
-            scheduled_delay = 9
+            scheduled_delay = "9s"
             max_queue_size = 9
             max_export_batch_size = 9
             max_concurrent_exports = 9
@@ -446,10 +447,10 @@ mod tests {
             enabled = true
             endpoint = "http://localhost:1234"
             protocol = "grpc"
-            timeout = 120
+            timeout = "120s"
 
             [exporters.otlp.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -497,10 +498,7 @@ mod tests {
                     ),
                     batch_export: Some(
                         BatchExportConfig {
-                            scheduled_delay: TimeDelta {
-                                secs: 10,
-                                nanos: 0,
-                            },
+                            scheduled_delay: 10s,
                             max_queue_size: 10,
                             max_export_batch_size: 10,
                             max_concurrent_exports: 10,
@@ -554,10 +552,7 @@ mod tests {
                         },
                     ),
                     timeout: Some(
-                        TimeDelta {
-                            secs: 120,
-                            nanos: 0,
-                        },
+                        120s,
                     ),
                 },
                 local: OtlpExporterConfig {
@@ -583,10 +578,10 @@ mod tests {
             enabled = true
             endpoint = "http://localhost:1234"
             protocol = "grpc"
-            timeout = 120
+            timeout = "120s"
 
             [exporters.otlp.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -607,10 +602,10 @@ mod tests {
             enabled = false
             endpoint = "http://localhost:1234"
             protocol = "grpc"
-            timeout = 120
+            timeout = "120s"
 
             [tracing.exporters.otlp.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -642,10 +637,10 @@ mod tests {
             enabled = true
             endpoint = "http://localhost:1234"
             protocol = "grpc"
-            timeout = 120
+            timeout = "120s"
 
             [exporters.otlp.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -666,10 +661,10 @@ mod tests {
             enabled = true
             endpoint = "http://localhost:1234"
             protocol = "grpc"
-            timeout = 120
+            timeout = "120s"
 
             [tracing.exporters.otlp.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -717,10 +712,7 @@ mod tests {
                     ),
                     batch_export: Some(
                         BatchExportConfig {
-                            scheduled_delay: TimeDelta {
-                                secs: 10,
-                                nanos: 0,
-                            },
+                            scheduled_delay: 10s,
                             max_queue_size: 10,
                             max_export_batch_size: 10,
                             max_concurrent_exports: 10,
@@ -774,10 +766,7 @@ mod tests {
                         },
                     ),
                     timeout: Some(
-                        TimeDelta {
-                            secs: 120,
-                            nanos: 0,
-                        },
+                        120s,
                     ),
                 },
                 local: OtlpExporterConfig {
@@ -805,10 +794,7 @@ mod tests {
                     ),
                     batch_export: Some(
                         BatchExportConfig {
-                            scheduled_delay: TimeDelta {
-                                secs: 10,
-                                nanos: 0,
-                            },
+                            scheduled_delay: 10s,
                             max_queue_size: 10,
                             max_export_batch_size: 10,
                             max_concurrent_exports: 10,
@@ -862,10 +848,7 @@ mod tests {
                         },
                     ),
                     timeout: Some(
-                        TimeDelta {
-                            secs: 120,
-                            nanos: 0,
-                        },
+                        120s,
                     ),
                 },
             },
@@ -880,10 +863,10 @@ mod tests {
 
             [exporters.stdout]
             enabled = true
-            timeout = 10
+            timeout = "10s"
 
             [exporters.stdout.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -903,20 +886,20 @@ mod tests {
 
             [exporters.stdout]
             enabled = true
-            timeout = 10
+            timeout = "10s"
 
             [exporters.stdout.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
 
             [metrics.exporters.stdout]
             enabled = false
-            timeout = 9
+            timeout = "9s"
 
             [metrics.exporters.stdout.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -933,20 +916,20 @@ mod tests {
 
             [exporters.stdout]
             enabled = true
-            timeout = 10
+            timeout = "10s"
 
             [exporters.stdout.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
 
             [metrics.exporters.stdout]
             enabled = true
-            timeout = 9
+            timeout = "9s"
 
             [metrics.exporters.stdout.batch_export]
-            scheduled_delay = 9
+            scheduled_delay = "9s"
             max_queue_size = 9
             max_export_batch_size = 9
             max_concurrent_exports = 9
@@ -968,10 +951,10 @@ mod tests {
             enabled = true
             endpoint = "http://localhost:1234"
             protocol = "grpc"
-            timeout = 120
+            timeout = "120s"
 
             [exporters.otlp.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -1018,10 +1001,7 @@ mod tests {
                     ),
                     batch_export: Some(
                         BatchExportConfig {
-                            scheduled_delay: TimeDelta {
-                                secs: 10,
-                                nanos: 0,
-                            },
+                            scheduled_delay: 10s,
                             max_queue_size: 10,
                             max_export_batch_size: 10,
                             max_concurrent_exports: 10,
@@ -1075,10 +1055,7 @@ mod tests {
                         },
                     ),
                     timeout: Some(
-                        TimeDelta {
-                            secs: 120,
-                            nanos: 0,
-                        },
+                        120s,
                     ),
                 },
                 local: OtlpExporterConfig {
@@ -1104,10 +1081,10 @@ mod tests {
             enabled = true
             endpoint = "http://localhost:1234"
             protocol = "grpc"
-            timeout = 120
+            timeout = "120s"
 
             [exporters.otlp.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -1128,10 +1105,10 @@ mod tests {
             enabled = false
             endpoint = "http://localhost:1234"
             protocol = "grpc"
-            timeout = 120
+            timeout = "120s"
 
             [metrics.exporters.otlp.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -1162,10 +1139,10 @@ mod tests {
             enabled = true
             endpoint = "http://localhost:1234"
             protocol = "grpc"
-            timeout = 120
+            timeout = "120s"
 
             [exporters.otlp.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -1186,10 +1163,10 @@ mod tests {
             enabled = true
             endpoint = "http://localhost:1234"
             protocol = "grpc"
-            timeout = 120
+            timeout = "120s"
 
             [metrics.exporters.otlp.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -1236,10 +1213,7 @@ mod tests {
                     ),
                     batch_export: Some(
                         BatchExportConfig {
-                            scheduled_delay: TimeDelta {
-                                secs: 10,
-                                nanos: 0,
-                            },
+                            scheduled_delay: 10s,
                             max_queue_size: 10,
                             max_export_batch_size: 10,
                             max_concurrent_exports: 10,
@@ -1293,10 +1267,7 @@ mod tests {
                         },
                     ),
                     timeout: Some(
-                        TimeDelta {
-                            secs: 120,
-                            nanos: 0,
-                        },
+                        120s,
                     ),
                 },
                 local: OtlpExporterConfig {
@@ -1324,10 +1295,7 @@ mod tests {
                     ),
                     batch_export: Some(
                         BatchExportConfig {
-                            scheduled_delay: TimeDelta {
-                                secs: 10,
-                                nanos: 0,
-                            },
+                            scheduled_delay: 10s,
                             max_queue_size: 10,
                             max_export_batch_size: 10,
                             max_concurrent_exports: 10,
@@ -1381,10 +1349,7 @@ mod tests {
                         },
                     ),
                     timeout: Some(
-                        TimeDelta {
-                            secs: 120,
-                            nanos: 0,
-                        },
+                        120s,
                     ),
                 },
             },
@@ -1399,10 +1364,10 @@ mod tests {
 
             [exporters.stdout]
             enabled = true
-            timeout = 10
+            timeout = "10s"
 
             [exporters.stdout.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -1422,20 +1387,20 @@ mod tests {
 
             [exporters.stdout]
             enabled = true
-            timeout = 10
+            timeout = "10s"
 
             [exporters.stdout.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
 
             [logs.exporters.stdout]
             enabled = false
-            timeout = 9
+            timeout = "9s"
 
             [logs.exporters.stdout.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -1453,20 +1418,20 @@ mod tests {
 
             [exporters.stdout]
             enabled = true
-            timeout = 10
+            timeout = "10s"
 
             [exporters.stdout.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
 
             [logs.exporters.stdout]
             enabled = true
-            timeout = 9
+            timeout = "9s"
 
             [logs.exporters.stdout.batch_export]
-            scheduled_delay = 9
+            scheduled_delay = "9s"
             max_queue_size = 9
             max_export_batch_size = 9
             max_concurrent_exports = 9
@@ -1488,10 +1453,10 @@ mod tests {
             enabled = true
             endpoint = "http://localhost:1234"
             protocol = "grpc"
-            timeout = 120
+            timeout = "120s"
 
             [exporters.otlp.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -1538,10 +1503,7 @@ mod tests {
                     ),
                     batch_export: Some(
                         BatchExportConfig {
-                            scheduled_delay: TimeDelta {
-                                secs: 10,
-                                nanos: 0,
-                            },
+                            scheduled_delay: 10s,
                             max_queue_size: 10,
                             max_export_batch_size: 10,
                             max_concurrent_exports: 10,
@@ -1595,10 +1557,7 @@ mod tests {
                         },
                     ),
                     timeout: Some(
-                        TimeDelta {
-                            secs: 120,
-                            nanos: 0,
-                        },
+                        120s,
                     ),
                 },
                 local: OtlpExporterConfig {
@@ -1624,10 +1583,10 @@ mod tests {
             enabled = true
             endpoint = "http://localhost:1234"
             protocol = "grpc"
-            timeout = 120
+            timeout = "120s"
 
             [exporters.otlp.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -1648,10 +1607,10 @@ mod tests {
             enabled = false
             endpoint = "http://localhost:1234"
             protocol = "grpc"
-            timeout = 120
+            timeout = "120s"
 
             [logs.exporters.otlp.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -1682,10 +1641,10 @@ mod tests {
             enabled = true
             endpoint = "http://localhost:1234"
             protocol = "grpc"
-            timeout = 120
+            timeout = "120s"
 
             [exporters.otlp.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -1706,10 +1665,10 @@ mod tests {
             enabled = true
             endpoint = "http://localhost:1234"
             protocol = "grpc"
-            timeout = 120
+            timeout = "120s"
 
             [logs.exporters.otlp.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -1756,10 +1715,7 @@ mod tests {
                     ),
                     batch_export: Some(
                         BatchExportConfig {
-                            scheduled_delay: TimeDelta {
-                                secs: 10,
-                                nanos: 0,
-                            },
+                            scheduled_delay: 10s,
                             max_queue_size: 10,
                             max_export_batch_size: 10,
                             max_concurrent_exports: 10,
@@ -1813,10 +1769,7 @@ mod tests {
                         },
                     ),
                     timeout: Some(
-                        TimeDelta {
-                            secs: 120,
-                            nanos: 0,
-                        },
+                        120s,
                     ),
                 },
                 local: OtlpExporterConfig {
@@ -1844,10 +1797,7 @@ mod tests {
                     ),
                     batch_export: Some(
                         BatchExportConfig {
-                            scheduled_delay: TimeDelta {
-                                secs: 10,
-                                nanos: 0,
-                            },
+                            scheduled_delay: 10s,
                             max_queue_size: 10,
                             max_export_batch_size: 10,
                             max_concurrent_exports: 10,
@@ -1901,10 +1851,7 @@ mod tests {
                         },
                     ),
                     timeout: Some(
-                        TimeDelta {
-                            secs: 120,
-                            nanos: 0,
-                        },
+                        120s,
                     ),
                 },
             },
@@ -1918,10 +1865,10 @@ mod tests {
         let input = indoc! {r#"
             [exporters.stdout]
             enabled = true
-            timeout = 10
+            timeout = "10s"
 
             [exporters.stdout.batch_export]
-            scheduled_delay = 10
+            scheduled_delay = "10s"
             max_queue_size = 10
             max_export_batch_size = 10
             max_concurrent_exports = 10
@@ -1935,12 +1882,12 @@ mod tests {
             Some(StdoutExporterConfig {
                 enabled: true,
                 batch_export: Some(BatchExportConfig {
-                    scheduled_delay: chrono::Duration::try_seconds(10).expect("must be fine"),
+                    scheduled_delay: Duration::from_secs(10),
                     max_queue_size: 10,
                     max_export_batch_size: 10,
                     max_concurrent_exports: 10,
                 }),
-                timeout: chrono::Duration::try_seconds(10).expect("must be fine"),
+                timeout: Duration::from_secs(10),
             }),
             config.exporters.stdout
         );

--- a/crates/grafbase-sdk/changelog/unreleased.md
+++ b/crates/grafbase-sdk/changelog/unreleased.md
@@ -1,3 +1,3 @@
 ## Features
 
-- Directives now have a `.deserialize_arguments_seed()` method for stateful deserialization of the arguments.
+- Directives now have a `.arguments_seed()` method for stateful deserialization of the arguments.

--- a/crates/grafbase-sdk/src/types/directive.rs
+++ b/crates/grafbase-sdk/src/types/directive.rs
@@ -59,7 +59,7 @@ impl<'a> FieldDefinitionDirective<'a> {
     }
 
     /// Deserialize the arguments of the directive using a `DeserializeSeed`.
-    pub fn deserialize_arguments_seed<T>(&self, seed: T) -> Result<T::Value, SdkError>
+    pub fn arguments_seed<T>(&self, seed: T) -> Result<T::Value, SdkError>
     where
         T: serde::de::DeserializeSeed<'a>,
     {

--- a/crates/telemetry/src/otel/logs.rs
+++ b/crates/telemetry/src/otel/logs.rs
@@ -12,12 +12,11 @@ pub(super) fn build_logs_provider(
     use crate::otel::exporter::{build_metadata, build_tls_config};
     use opentelemetry_otlp::{LogExporter, WithExportConfig, WithHttpConfig, WithTonicConfig};
     use opentelemetry_sdk::logs::{BatchConfigBuilder, BatchLogProcessor};
-    use std::time::Duration;
 
     let mut builder = SdkLoggerProvider::builder().with_resource(resource);
 
     if let Some(config) = config.logs_otlp_config() {
-        let exporter_timeout = Duration::from_secs(config.timeout().num_seconds() as u64);
+        let exporter_timeout = config.timeout();
 
         let exporter = match config.protocol() {
             OtlpExporterProtocolConfig::Grpc(grpc_config) => LogExporter::builder()
@@ -66,7 +65,7 @@ pub(super) fn build_logs_provider(
 
             let config = BatchConfigBuilder::default()
                 .with_max_queue_size(config.max_queue_size)
-                .with_scheduled_delay(Duration::from_secs(config.scheduled_delay.num_seconds() as u64))
+                .with_scheduled_delay(config.scheduled_delay)
                 .with_max_export_batch_size(config.max_export_batch_size)
                 .build();
 

--- a/crates/telemetry/src/otel/traces.rs
+++ b/crates/telemetry/src/otel/traces.rs
@@ -59,7 +59,7 @@ fn setup_exporters(
     use opentelemetry_otlp::{SpanExporter, WithExportConfig, WithHttpConfig, WithTonicConfig};
 
     let build_otlp_exporter = |config: &LayeredOtlExporterConfig| {
-        let exporter_timeout = Duration::from_secs(config.timeout().num_seconds() as u64);
+        let exporter_timeout = config.timeout();
 
         let exporter = match config.protocol() {
             OtlpExporterProtocolConfig::Grpc(grpc_config) => SpanExporter::builder()
@@ -137,7 +137,7 @@ fn setup_exporters(
 }
 
 fn build_batched_span_processor(
-    timeout: chrono::Duration,
+    timeout: Duration,
     config: &BatchExportConfig,
     exporter: impl trace::SpanExporter + 'static,
 ) -> BatchSpanProcessor {
@@ -146,9 +146,9 @@ fn build_batched_span_processor(
             BatchConfigBuilder::default()
                 .with_max_concurrent_exports(config.max_concurrent_exports)
                 .with_max_export_batch_size(config.max_export_batch_size)
-                .with_max_export_timeout(Duration::from_secs(timeout.num_seconds() as u64))
+                .with_max_export_timeout(timeout)
                 .with_max_queue_size(config.max_queue_size)
-                .with_scheduled_delay(Duration::from_secs(config.scheduled_delay.num_seconds() as u64))
+                .with_scheduled_delay(config.scheduled_delay)
                 .build(),
         )
         .build()

--- a/examples/access-logs/grafbase.toml
+++ b/examples/access-logs/grafbase.toml
@@ -23,5 +23,5 @@ path = "./logs"
 # protocol = "grpc"
 
 # [telemetry.exporters.otlp.batch_export]
-# scheduled_delay = 1
+# scheduled_delay = "1s"
 # max_export_batch_size = 1

--- a/examples/tracing/grafbase/v2/gateway-config.toml
+++ b/examples/tracing/grafbase/v2/gateway-config.toml
@@ -18,7 +18,7 @@ endpoint = "http://localhost:4317"
 protocol = "grpc"
 
 [telemetry.tracing.exporters.otlp.batch_export]
-scheduled_delay = 10
+scheduled_delay = "10s"
 max_queue_size = 10
 max_export_batch_size = 10
 max_concurrent_exports = 10

--- a/gateway/changelog/unreleased.md
+++ b/gateway/changelog/unreleased.md
@@ -1,0 +1,3 @@
+## Breaking Changes
+
+- The `scheduled_delay` and `timeout` configuration options for telemetry exporters have been updated to accept a duration string instead of a number (https://github.com/grafbase/grafbase/pull/2962).

--- a/gateway/src/args.rs
+++ b/gateway/src/args.rs
@@ -2,7 +2,7 @@ mod lambda;
 mod log;
 mod std;
 
-use ::std::{net::SocketAddr, path::Path, sync::OnceLock};
+use ::std::{net::SocketAddr, path::Path, sync::OnceLock, time::Duration};
 
 use anyhow::Context;
 use ascii::AsciiString;
@@ -74,7 +74,7 @@ pub(crate) trait Args {
             .and_then(|v| v.parse::<usize>().ok())
         {
             BatchExportConfig {
-                scheduled_delay: chrono::Duration::seconds(seconds as i64),
+                scheduled_delay: Duration::from_secs(seconds as u64),
                 ..Default::default()
             }
         } else {

--- a/gateway/tests/access_logs/mod.rs
+++ b/gateway/tests/access_logs/mod.rs
@@ -829,7 +829,7 @@ where
         protocol = "grpc"
 
         [telemetry.exporters.otlp.batch_export]
-        scheduled_delay = 1
+        scheduled_delay = "1s"
         max_export_batch_size = 1
 
         {config}

--- a/gateway/tests/telemetry/logs.rs
+++ b/gateway/tests/telemetry/logs.rs
@@ -29,7 +29,7 @@ fn with_otel() {
         protocol = "grpc"
 
         [telemetry.exporters.otlp.batch_export]
-        scheduled_delay = 1
+        scheduled_delay = "1s"
         max_export_batch_size = 1
     "#};
 
@@ -75,7 +75,7 @@ fn with_otel_reload() {
         protocol = "grpc"
 
         [telemetry.exporters.otlp.batch_export]
-        scheduled_delay = 1
+        scheduled_delay = "1s"
         max_export_batch_size = 1
     "#};
 
@@ -121,7 +121,7 @@ fn with_otel_with_different_endpoint() {
         protocol = "grpc"
 
         [telemetry.exporters.otlp.batch_export]
-        scheduled_delay = 1
+        scheduled_delay = "1s"
         max_export_batch_size = 1
 
         [telemetry.logs.exporters.otlp]
@@ -130,7 +130,7 @@ fn with_otel_with_different_endpoint() {
         protocol = "grpc"
 
         [telemetry.logs.exporters.otlp.batch_export]
-        scheduled_delay = 1
+        scheduled_delay = "1s"
         max_export_batch_size = 1
     "#};
 

--- a/gateway/tests/telemetry/metrics.rs
+++ b/gateway/tests/telemetry/metrics.rs
@@ -74,7 +74,7 @@ where
         protocol = "grpc"
 
         [telemetry.exporters.otlp.batch_export]
-        scheduled_delay = 1
+        scheduled_delay = "1s"
         max_export_batch_size = 1
     "#};
 
@@ -120,7 +120,7 @@ where
         protocol = "grpc"
 
         [telemetry.exporters.otlp.batch_export]
-        scheduled_delay = 1
+        scheduled_delay = "1s"
         max_export_batch_size = 1
 
         {config}
@@ -169,7 +169,7 @@ where
         protocol = "grpc"
 
         [telemetry.exporters.otlp.batch_export]
-        scheduled_delay = 1
+        scheduled_delay = "1s"
         max_export_batch_size = 1
 
         {config}

--- a/gateway/tests/telemetry/metrics/gdn.rs
+++ b/gateway/tests/telemetry/metrics/gdn.rs
@@ -27,7 +27,7 @@ fn gdn_update() {
         protocol = "grpc"
 
         [telemetry.exporters.otlp.batch_export]
-        scheduled_delay = 1
+        scheduled_delay = "1s"
         max_export_batch_size = 1
     "#};
 

--- a/gateway/tests/telemetry/mod.rs
+++ b/gateway/tests/telemetry/mod.rs
@@ -64,7 +64,7 @@ fn with_otel() {
         protocol = "grpc"
 
         [telemetry.exporters.otlp.batch_export]
-        scheduled_delay = 1
+        scheduled_delay = "1s"
         max_export_batch_size = 1
     "#};
 
@@ -125,7 +125,7 @@ fn extra_resource_attributes() {
         protocol = "grpc"
 
         [telemetry.exporters.otlp.batch_export]
-        scheduled_delay = 1
+        scheduled_delay = "1s"
         max_export_batch_size = 1
     "#};
 

--- a/gateway/tests/telemetry/tracing.rs
+++ b/gateway/tests/telemetry/tracing.rs
@@ -529,7 +529,7 @@ fn with_mock_subgraph<T, F>(
         {exporter_config}
 
         [telemetry.tracing.exporters.otlp.batch_export]
-        scheduled_delay = 1
+        scheduled_delay = "1s"
         max_export_batch_size = 1
 
         {config}


### PR DESCRIPTION
For consistency with the rest of the configuration, where we deserialize durations from strings with the `duration_str` crate (e.g. "60s"). This is also what's documented in the public docs. Here we expected integers.

closes GB-8828