### PR TITLE
chore: rename Engine to Gateway in integration-tests

### DIFF
--- a/crates/federation-audit-tests/tests/audit_tests.rs
+++ b/crates/federation-audit-tests/tests/audit_tests.rs
@@ -3,7 +3,7 @@ use federation_audit_tests::{
     audit_server::{AuditServer, ExpectedResponse, Test},
     cached_tests,
 };
-use integration_tests::federation::TestGatewayBuilder;
+use integration_tests::federation::GatewayBuilder;
 use libtest_mimic::{Arguments, Failed, Trial};
 
 fn main() {
@@ -33,7 +33,7 @@ fn runner_for(test: CachedTest) -> impl FnOnce() -> Result<(), Failed> + Send + 
 }
 
 async fn run_test(supergraph_sdl: String, mut test: Test) {
-    let server = TestGatewayBuilder::default()
+    let server = GatewayBuilder::default()
         .with_federated_sdl(&supergraph_sdl)
         .build()
         .await;

--- a/crates/integration-tests/src/federation/mod.rs
+++ b/crates/integration-tests/src/federation/mod.rs
@@ -19,7 +19,7 @@ use url::Url;
 use websocket_request::WebsocketRequest;
 
 #[derive(Clone)]
-pub struct TestGateway {
+pub struct Gateway {
     router: axum::Router,
     #[allow(unused)]
     engine: Arc<engine::Engine<TestRuntime>>,
@@ -66,7 +66,11 @@ impl DockerSubgraph {
     }
 }
 
-impl TestGateway {
+impl Gateway {
+    pub fn builder() -> GatewayBuilder {
+        GatewayBuilder::default()
+    }
+
     pub fn get(&self, request: impl Into<GraphQlRequest>) -> TestRequest {
         self.execute(http::Method::GET, "/graphql", request)
     }

--- a/crates/integration-tests/tests/federation/apq.rs
+++ b/crates/integration-tests/tests/federation/apq.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::FakeGithubSchema;
 use indoc::indoc;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn when_disabled() {
@@ -11,7 +10,7 @@ fn when_disabled() {
             enabled = false
         "#};
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_toml_config(config)
             .with_subgraph(FakeGithubSchema)
             .build()
@@ -58,7 +57,7 @@ fn when_disabled() {
 #[test]
 fn single_field_from_single_server() {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         let query = "query { serverVersion }";
         let apq_ext = serde_json::json!({

--- a/crates/integration-tests/tests/federation/auth/authenticated.rs
+++ b/crates/integration-tests/tests/federation/auth/authenticated.rs
@@ -1,13 +1,12 @@
-use engine::Engine;
 use futures::Future;
 use graphql_mocks::SecureSchema;
 use integration_tests::{
-    federation::{EngineExt, TestGateway},
+    federation::Gateway,
     openid::{CoreClientExt, JWKS_URI, OryHydraOpenIDProvider},
     runtime,
 };
 
-pub(super) fn with_secure_schema<F, O>(f: impl FnOnce(TestGateway) -> F) -> O
+pub(super) fn with_secure_schema<F, O>(f: impl FnOnce(Gateway) -> F) -> O
 where
     F: Future<Output = O>,
 {
@@ -26,7 +25,7 @@ where
             [authentication.providers.anonymous]
         "#};
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(SecureSchema)
             .with_toml_config(config)
             .build()

--- a/crates/integration-tests/tests/federation/auth/jwt.rs
+++ b/crates/integration-tests/tests/federation/auth/jwt.rs
@@ -1,11 +1,10 @@
 use std::collections::HashMap;
 
-use engine::Engine;
 use graphql_mocks::FakeGithubSchema;
 use integration_tests::federation::GraphqlResponse;
 use integration_tests::openid::{CoreClientExt, OryHydraOpenIDProvider};
 use integration_tests::{
-    federation::EngineExt,
+    federation::Gateway,
     openid::{AUDIENCE, JWKS_URI, OTHER_AUDIENCE},
     runtime,
 };
@@ -23,7 +22,7 @@ fn test_provider() {
             url = "{JWKS_URI}"
         "#};
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_toml_config(config)
             .build()
@@ -66,7 +65,7 @@ fn test_different_header_location() {
             value_prefix = "Bearer2 "
         "#};
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_toml_config(config)
             .build()
@@ -105,7 +104,7 @@ fn test_unauthorized() {
             url = "{JWKS_URI}"
         "#};
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_toml_config(config)
             .build()
@@ -177,7 +176,7 @@ fn test_tampered_jwt() {
             url = "{JWKS_URI}"
         "#};
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_toml_config(config)
             .build()
@@ -243,7 +242,7 @@ fn test_wrong_provider() {
             url = "{JWKS_URI}"
         "#};
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_toml_config(config)
             .build()
@@ -288,7 +287,7 @@ fn test_audience() {
             audience = "{AUDIENCE}"
         "#};
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_toml_config(config)
             .build()

--- a/crates/integration-tests/tests/federation/auth/multiple.rs
+++ b/crates/integration-tests/tests/federation/auth/multiple.rs
@@ -1,9 +1,8 @@
-use engine::Engine;
 use graphql_mocks::FakeGithubSchema;
 use integration_tests::federation::GraphqlResponse;
 use integration_tests::openid::{CoreClientExt, OryHydraOpenIDProvider};
 use integration_tests::{
-    federation::EngineExt,
+    federation::Gateway,
     openid::{AUDIENCE, JWKS_URI, JWKS_URI_2},
     runtime,
 };
@@ -29,7 +28,7 @@ fn test_provider() {
             url = "{JWKS_URI_2}"
         "#};
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_toml_config(config)
             .build()

--- a/crates/integration-tests/tests/federation/basic/empty_config.rs
+++ b/crates/integration-tests/tests/federation/basic/empty_config.rs
@@ -1,10 +1,9 @@
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn works_with_empty_config() {
     runtime().block_on(async {
-        let engine = Engine::builder().build().await;
+        let engine = Gateway::builder().build().await;
         let response = engine.post("{ __typename }").await;
         insta::assert_json_snapshot!(response, @r###"
         {

--- a/crates/integration-tests/tests/federation/basic/enums.rs
+++ b/crates/integration-tests/tests/federation/basic/enums.rs
@@ -1,11 +1,10 @@
-use engine::Engine;
 use graphql_mocks::TeaShop;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn enum_values_with_some_inaccessible() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(TeaShop::default()).build().await;
+        let engine = Gateway::builder().with_subgraph(TeaShop::default()).build().await;
 
         engine
             .post("query { recommendedTeas { id name style } teaWithInaccessibleStyle { name style } }")

--- a/crates/integration-tests/tests/federation/basic/error_extensions.rs
+++ b/crates/integration-tests/tests/federation/basic/error_extensions.rs
@@ -1,12 +1,11 @@
 use async_graphql::ServerError;
-use engine::Engine;
 use graphql_mocks::dynamic::DynamicSchema;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn should_keep_original_error_code() {
     runtime().block_on(async move {
-        let gateway = Engine::builder()
+        let gateway = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -47,7 +46,7 @@ fn should_keep_original_error_code() {
 #[test]
 fn should_keep_original_extensions_but_add_error_code_if_not_present() {
     runtime().block_on(async move {
-        let gateway = Engine::builder()
+        let gateway = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"

--- a/crates/integration-tests/tests/federation/basic/errors.rs
+++ b/crates/integration-tests/tests/federation/basic/errors.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use indoc::indoc;
 use integration_tests::{
-    federation::{DeterministicEngine, EngineExt as _},
+    federation::{DeterministicEngine, Gateway},
     runtime,
 };
 use serde_json::json;
@@ -478,7 +477,7 @@ fn null_entity_with_error() {
 #[test]
 fn unknown_argument() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_federated_sdl(SCHEMA).build().await;
+        let engine = Gateway::builder().with_federated_sdl(SCHEMA).build().await;
 
         engine.post(r#"query { me(name: "Tom") { id } }"#).await
     });

--- a/crates/integration-tests/tests/federation/basic/fragments.rs
+++ b/crates/integration-tests/tests/federation/basic/fragments.rs
@@ -1,11 +1,10 @@
-use engine::Engine;
 use graphql_mocks::FakeGithubSchema;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn named_fragment_on_object() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         engine
             .post(
@@ -61,7 +60,7 @@ fn named_fragment_on_object() {
 #[test]
 fn named_fragment_cycle() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         engine
             .post(
@@ -114,7 +113,7 @@ fn named_fragment_cycle() {
 #[test]
 fn inline_fragment_on_object() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         engine
             .post(
@@ -157,7 +156,7 @@ fn inline_fragment_on_object() {
 #[test]
 fn inline_fragment_on_object_with_type_condition() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         engine
             .post(
@@ -211,7 +210,7 @@ fn inline_fragment_on_object_with_type_condition() {
 #[test]
 fn inline_fragments_on_polymorphic_types() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         engine
             .post(
@@ -280,7 +279,7 @@ fn inline_fragments_on_polymorphic_types() {
 #[test]
 fn named_fragments_on_polymorphic_types() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         engine
             .post(

--- a/crates/integration-tests/tests/federation/basic/headers.rs
+++ b/crates/integration-tests/tests/federation/basic/headers.rs
@@ -1,13 +1,12 @@
 //! Tests of header forwarding behaviour
 
-use engine::Engine;
 use graphql_mocks::EchoSchema;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn test_default_headers() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema)
             .with_toml_config(
                 r#"
@@ -56,7 +55,7 @@ fn test_default_headers() {
 #[test]
 fn test_default_headers_forwarding() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema)
             .with_toml_config(
                 r#"
@@ -117,7 +116,7 @@ fn test_default_headers_forwarding() {
 #[test]
 fn test_subgraph_specific_header_forwarding() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema)
             .with_toml_config(
                 r#"
@@ -183,7 +182,7 @@ fn test_subgraph_specific_header_forwarding() {
 #[test]
 fn should_not_propagate_blacklisted_headers() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema)
             .with_toml_config(
                 r###"
@@ -258,7 +257,7 @@ fn should_not_propagate_blacklisted_headers() {
 #[test]
 fn test_regex_header_forwarding() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema)
             .with_toml_config(
                 r###"
@@ -315,7 +314,7 @@ fn test_regex_header_forwarding() {
 #[test]
 fn test_regex_header_forwarding_should_not_duplicate() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema)
             .with_toml_config(
                 r###"
@@ -377,7 +376,7 @@ fn test_regex_header_forwarding_should_not_duplicate() {
 #[test]
 fn test_header_forwarding_with_rename() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema)
             .with_toml_config(
                 r###"
@@ -429,7 +428,7 @@ fn test_header_forwarding_with_rename() {
 #[test]
 fn test_header_forwarding_with_default() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema)
             .with_toml_config(
                 r###"
@@ -478,7 +477,7 @@ fn test_header_forwarding_with_default() {
 #[test]
 fn test_header_forwarding_with_default_and_existing_header() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema)
             .with_toml_config(
                 r###"
@@ -530,7 +529,7 @@ fn test_header_forwarding_with_default_and_existing_header() {
 #[test]
 fn test_regex_header_forwarding_then_delete() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema)
             .with_toml_config(
                 r###"
@@ -587,7 +586,7 @@ fn test_regex_header_forwarding_then_delete() {
 #[test]
 fn test_regex_header_forwarding_then_delete_with_regex() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema)
             .with_toml_config(
                 r###"
@@ -645,7 +644,7 @@ fn test_regex_header_forwarding_then_delete_with_regex() {
 #[test]
 fn test_rename_duplicate_no_default() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema)
             .with_toml_config(
                 r###"
@@ -701,7 +700,7 @@ fn test_rename_duplicate_no_default() {
 #[test]
 fn test_rename_duplicate_default() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema)
             .with_toml_config(
                 r###"
@@ -758,7 +757,7 @@ fn test_rename_duplicate_default() {
 #[test]
 fn test_rename_duplicate_default_with_missing_value() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema)
             .with_toml_config(
                 r###"
@@ -812,7 +811,7 @@ fn test_rename_duplicate_default_with_missing_value() {
 #[test]
 fn regex_header_regex_forwarding_should_forward_duplicates_too() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema)
             .with_toml_config(
                 r###"
@@ -868,7 +867,7 @@ fn regex_header_regex_forwarding_should_forward_duplicates_too() {
 #[test]
 fn regex_header_forwarding_should_forward_duplicates() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema)
             .with_toml_config(
                 r###"
@@ -924,7 +923,7 @@ fn regex_header_forwarding_should_forward_duplicates() {
 #[test]
 fn regex_header_forwarding_should_forward_duplicates_with_rename() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema)
             .with_toml_config(
                 r###"
@@ -981,7 +980,7 @@ fn regex_header_forwarding_should_forward_duplicates_with_rename() {
 #[test]
 fn header_remove_should_remove_duplicates() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema)
             .with_toml_config(
                 r###"
@@ -1029,7 +1028,7 @@ fn header_remove_should_remove_duplicates() {
 #[test]
 fn header_regex_remove_should_remove_duplicates() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema)
             .with_toml_config(
                 r###"

--- a/crates/integration-tests/tests/federation/basic/mod.rs
+++ b/crates/integration-tests/tests/federation/basic/mod.rs
@@ -19,14 +19,13 @@ mod streaming;
 mod typename;
 mod variables;
 
-use engine::Engine;
 use graphql_mocks::FakeGithubSchema;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn single_field_from_single_server() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         engine.post("query { serverVersion }").await
     });
@@ -43,7 +42,7 @@ fn single_field_from_single_server() {
 #[test]
 fn top_level_typename() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         engine.post("query { __typename }").await
     });
@@ -60,7 +59,7 @@ fn top_level_typename() {
 #[test]
 fn only_typename() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         engine
             .post(
@@ -102,7 +101,7 @@ fn only_typename() {
 #[test]
 fn response_with_lists() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         engine.post("query { allBotPullRequests { title } }").await
     });

--- a/crates/integration-tests/tests/federation/basic/mutation.rs
+++ b/crates/integration-tests/tests/federation/basic/mutation.rs
@@ -1,11 +1,10 @@
-use engine::Engine;
 use graphql_mocks::Stateful;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn mutations_should_be_executed_sequentially() {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(Stateful::default()).build().await;
+        let engine = Gateway::builder().with_subgraph(Stateful::default()).build().await;
 
         // sanity check
         let response = engine.post("query { value }").await;
@@ -56,7 +55,7 @@ fn mutations_should_be_executed_sequentially() {
 #[test]
 fn mutation_failure_should_stop_later_executions_if_required() {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(Stateful::default()).build().await;
+        let engine = Gateway::builder().with_subgraph(Stateful::default()).build().await;
 
         // sanity check
         let response = engine.post("query { value }").await;

--- a/crates/integration-tests/tests/federation/basic/operation_limits.rs
+++ b/crates/integration-tests/tests/federation/basic/operation_limits.rs
@@ -1,6 +1,5 @@
-use engine::Engine;
 use graphql_mocks::FakeGithubSchema;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[rstest::rstest]
 #[case( // 1
@@ -169,7 +168,7 @@ fn test_operation_limits(
     #[case] error: Option<&'static str>,
 ) {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_toml_config(operation_limits_config)
             .with_subgraph(FakeGithubSchema)
             .build()

--- a/crates/integration-tests/tests/federation/basic/operations.rs
+++ b/crates/integration-tests/tests/federation/basic/operations.rs
@@ -1,11 +1,10 @@
-use engine::Engine;
 use graphql_mocks::FakeGithubSchema;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn multiple_operations_without_providing_operation_name_in_request() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         engine
             .post(
@@ -44,7 +43,7 @@ fn multiple_operations_without_providing_operation_name_in_request() {
 #[test]
 fn multiple_operations() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         engine
             .post(
@@ -86,7 +85,7 @@ fn multiple_operations() {
 #[test]
 fn only_one_named_operation() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         engine
             .post(
@@ -120,7 +119,7 @@ fn only_one_named_operation() {
 #[test]
 fn unknown_operation_name() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         engine
             .post(

--- a/crates/integration-tests/tests/federation/basic/scalars.rs
+++ b/crates/integration-tests/tests/federation/basic/scalars.rs
@@ -1,12 +1,11 @@
-use engine::Engine;
 use graphql_mocks::{AlmostEmptySchema, FakeGithubSchema, dynamic::DynamicSchema};
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 use serde_json::json;
 
 #[test]
 fn should_not_raise_an_error_on_null_for_required_json() {
     runtime().block_on(async move {
-        let gateway = Engine::builder()
+        let gateway = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -40,7 +39,7 @@ fn should_not_raise_an_error_on_null_for_required_json() {
 #[test]
 fn supports_custom_scalars() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         engine.post("query { favoriteRepository }").await
     });
@@ -60,7 +59,7 @@ fn supports_custom_scalars() {
 #[test]
 fn supports_unused_builtin_scalars() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(AlmostEmptySchema).build().await;
+        let engine = Gateway::builder().with_subgraph(AlmostEmptySchema).build().await;
 
         engine
             .post("query Blah($id: ID!) { string(input: $id) }")
@@ -94,7 +93,7 @@ fn supports_unused_builtin_scalars() {
 #[test]
 fn coerces_ints_to_floats() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -124,7 +123,7 @@ fn coerces_ints_to_floats() {
 #[test]
 fn coerces_floats_to_ints_where_possible() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -154,7 +153,7 @@ fn coerces_floats_to_ints_where_possible() {
 #[test]
 fn refuses_to_lose_precision_when_converting_floats_to_ints() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -195,7 +194,7 @@ fn refuses_to_lose_precision_when_converting_floats_to_ints() {
 #[test]
 fn coerces_variable_ints_to_floats() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -228,7 +227,7 @@ fn coerces_variable_ints_to_floats() {
 #[test]
 fn coerces_variable_floats_to_ints_where_possible() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -261,7 +260,7 @@ fn coerces_variable_floats_to_ints_where_possible() {
 #[test]
 fn refuses_to_lose_precision_when_converting_variable_floats_to_ints() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"

--- a/crates/integration-tests/tests/federation/basic/shapes/interface/mod.rs
+++ b/crates/integration-tests/tests/federation/basic/shapes/interface/mod.rs
@@ -5,22 +5,18 @@ mod two_interfaces;
 
 use std::future::Future;
 
-use engine::Engine;
 use graphql_mocks::dynamic::DynamicSchema;
-use integration_tests::{
-    federation::{EngineExt, TestGateway},
-    runtime,
-};
+use integration_tests::{federation::Gateway, runtime};
 
-fn with_gateway<F: Future>(schema: &str, nodes: serde_json::Value, f: impl FnOnce(TestGateway) -> F) -> F::Output {
+fn with_gateway<F: Future>(schema: &str, nodes: serde_json::Value, f: impl FnOnce(Gateway) -> F) -> F::Output {
     runtime().block_on(async move {
         let gateway = build(schema, nodes).await;
         f(gateway).await
     })
 }
 
-async fn build(schema: &str, nodes: serde_json::Value) -> TestGateway {
-    Engine::builder()
+async fn build(schema: &str, nodes: serde_json::Value) -> Gateway {
+    Gateway::builder()
         .with_subgraph(
             DynamicSchema::builder(
                 [

--- a/crates/integration-tests/tests/federation/basic/skip_include.rs
+++ b/crates/integration-tests/tests/federation/basic/skip_include.rs
@@ -1,11 +1,10 @@
-use engine::Engine;
 use graphql_mocks::FakeGithubSchema;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn skip_include() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         engine
             .post(
@@ -62,7 +61,7 @@ fn skip_include() {
 #[test]
 fn skip_include_propagate_between_spreads() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         engine
             .post(
@@ -100,7 +99,7 @@ fn skip_include_propagate_between_spreads() {
 #[test]
 fn skip_include_multiple_instances_same_field() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         engine
             .post(

--- a/crates/integration-tests/tests/federation/basic/streaming.rs
+++ b/crates/integration-tests/tests/federation/basic/streaming.rs
@@ -2,14 +2,13 @@
 //!
 //! Subscrition specific tests will probably live elsewhere
 
-use engine::Engine;
 use graphql_mocks::Stateful;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn can_run_a_query_via_execute_stream() {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(Stateful::default()).build().await;
+        let engine = Gateway::builder().with_subgraph(Stateful::default()).build().await;
 
         let response = engine
             .post("query { value }")
@@ -33,7 +32,7 @@ fn can_run_a_query_via_execute_stream() {
 #[test]
 fn can_run_a_mutation_via_execute_stream() {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(Stateful::default()).build().await;
+        let engine = Gateway::builder().with_subgraph(Stateful::default()).build().await;
 
         let response = engine
             .post(

--- a/crates/integration-tests/tests/federation/basic/typename.rs
+++ b/crates/integration-tests/tests/federation/basic/typename.rs
@@ -1,11 +1,10 @@
-use engine::Engine;
 use graphql_mocks::FakeGithubSchema;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn typename_alias_should_work() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         engine
             .post(

--- a/crates/integration-tests/tests/federation/basic/variables.rs
+++ b/crates/integration-tests/tests/federation/basic/variables.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::EchoSchema;
 use integration_tests::{
-    federation::{EngineExt, GraphqlResponse},
+    federation::{Gateway, GraphqlResponse},
     runtime,
 };
 use serde::Serialize;
@@ -615,7 +614,7 @@ fn undefined_variable() {
     let query = "query($var: String) { inputObject(input: { string: $var, int: 10 }) }";
     let response = runtime().block_on({
         async move {
-            let engine = Engine::builder().with_subgraph(EchoSchema).build().await;
+            let engine = Gateway::builder().with_subgraph(EchoSchema).build().await;
 
             engine.post(query).variables(json!({})).await
         }
@@ -669,7 +668,7 @@ fn do_error_test(query: &str, input: serde_json::Value) -> Vec<String> {
 fn run_query(query: &str, input: &serde_json::Value) -> GraphqlResponse {
     runtime().block_on({
         async move {
-            let engine = Engine::builder().with_subgraph(EchoSchema).build().await;
+            let engine = Gateway::builder().with_subgraph(EchoSchema).build().await;
 
             engine.post(query).variables(input).await
         }

--- a/crates/integration-tests/tests/federation/complexity_control.rs
+++ b/crates/integration-tests/tests/federation/complexity_control.rs
@@ -1,6 +1,5 @@
-use engine::Engine;
 use graphql_mocks::{MockGraphQlServer, Subgraph, dynamic::DynamicSchema};
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 const LIMIT_CONFIG: &str = r#"
 [complexity_control]
@@ -11,7 +10,7 @@ limit = 100
 #[test]
 fn test_uncomplex_query() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(ComplexitySchema)
             .with_toml_config(LIMIT_CONFIG)
             .build()
@@ -26,7 +25,7 @@ fn test_uncomplex_query() {
 #[test]
 fn test_complex_query_while_off() {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(ComplexitySchema).build().await;
+        let engine = Gateway::builder().with_subgraph(ComplexitySchema).build().await;
 
         let response = engine.post("query { cheapField expensiveField  }").await;
 
@@ -40,7 +39,7 @@ fn test_complex_query_while_off() {
 #[test]
 fn test_complex_query_with_measure() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(ComplexitySchema)
             .with_toml_config(
                 r#"
@@ -64,7 +63,7 @@ fn test_complex_query_with_measure() {
 #[test]
 fn test_complex_query_with_enforce() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(ComplexitySchema)
             .with_toml_config(LIMIT_CONFIG)
             .build()
@@ -101,7 +100,7 @@ fn test_complex_query_with_enforce() {
 #[test]
 fn test_assumed_list_size() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(ComplexitySchema)
             .with_toml_config(LIMIT_CONFIG)
             .build()
@@ -131,7 +130,7 @@ fn test_assumed_list_size() {
 #[test]
 fn test_sliced_list_size() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(ComplexitySchema)
             .with_toml_config(LIMIT_CONFIG)
             .build()
@@ -168,7 +167,7 @@ fn test_sliced_list_size() {
 #[test]
 fn test_require_one_slicing_argument() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(ComplexitySchema)
             .with_toml_config(LIMIT_CONFIG)
             .build()
@@ -228,7 +227,7 @@ fn test_require_one_slicing_argument() {
 #[test]
 fn test_sized_fields() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(ComplexitySchema)
             .with_toml_config(LIMIT_CONFIG)
             .build()
@@ -282,7 +281,7 @@ fn test_sized_fields() {
 #[test]
 fn test_argument_complexity() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(ComplexitySchema)
             .with_toml_config(LIMIT_CONFIG)
             .build()

--- a/crates/integration-tests/tests/federation/compression.rs
+++ b/crates/integration-tests/tests/federation/compression.rs
@@ -1,6 +1,5 @@
-use engine::Engine;
 use graphql_mocks::dynamic::DynamicSchema;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 use rand::{Rng as _, distributions::Alphanumeric};
 
 #[test]
@@ -12,7 +11,7 @@ fn supports_zstd_compression() {
             .map(char::from)
             .collect();
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(r#"type Query { str: String! }"#)
                     .with_resolver("Query", "str", serde_json::Value::String(s.clone()))

--- a/crates/integration-tests/tests/federation/config.rs
+++ b/crates/integration-tests/tests/federation/config.rs
@@ -1,13 +1,12 @@
-use engine::Engine;
 use graphql_mocks::FederatedAccountsSchema;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn subgraph_url_override() {
     runtime().block_on(async {
         let subgraph_server = graphql_mocks::MockGraphQlServer::new(FederatedAccountsSchema).await;
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_federated_sdl(
                 r###"
             enum join__Graph {

--- a/crates/integration-tests/tests/federation/entity_caching.rs
+++ b/crates/integration-tests/tests/federation/entity_caching.rs
@@ -1,8 +1,7 @@
 use std::time::Duration;
 
-use engine::Engine;
 use graphql_mocks::{ErrorSchema, FederatedInventorySchema, FederatedProductsSchema, FederatedReviewsSchema};
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 use serde_json::json;
 
 mod directive_scopes;
@@ -12,7 +11,7 @@ mod subgraph_cache_control;
 #[test]
 fn root_level_entity_caching() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FederatedProductsSchema)
             .with_toml_config(
                 r#"
@@ -74,7 +73,7 @@ fn root_level_entity_caching() {
 #[test]
 fn different_queries_dont_share_cache() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FederatedProductsSchema)
             .with_toml_config(
                 r#"
@@ -100,7 +99,7 @@ fn different_queries_dont_share_cache() {
 #[test]
 fn test_cache_expiry() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FederatedProductsSchema)
             .with_toml_config(
                 r#"
@@ -168,7 +167,7 @@ fn test_cache_expiry() {
 #[test]
 fn cache_skipped_if_subgraph_errors() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(ErrorSchema::default())
             .with_toml_config(
                 r#"
@@ -195,7 +194,7 @@ fn cache_skipped_if_subgraph_errors() {
 #[test]
 fn entity_request_caching() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FederatedProductsSchema)
             .with_subgraph(FederatedReviewsSchema)
             .with_subgraph(FederatedInventorySchema)
@@ -242,7 +241,7 @@ fn entity_request_caching() {
 #[test]
 fn entity_request_cache_partial_hit() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FederatedProductsSchema)
             .with_subgraph(FederatedReviewsSchema)
             .with_subgraph(FederatedInventorySchema)
@@ -316,7 +315,7 @@ fn entity_request_cache_partial_hit() {
 #[test]
 fn test_headers_impact_root_field_caching() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FederatedProductsSchema)
             .with_toml_config(
                 r#"
@@ -360,7 +359,7 @@ fn test_headers_impact_root_field_caching() {
 #[test]
 fn test_headers_impact_entity_field_caching() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FederatedProductsSchema)
             .with_subgraph(FederatedReviewsSchema)
             .with_subgraph(FederatedInventorySchema)

--- a/crates/integration-tests/tests/federation/entity_caching/directive_scopes.rs
+++ b/crates/integration-tests/tests/federation/entity_caching/directive_scopes.rs
@@ -1,10 +1,9 @@
 //! Tests that we handle `@authenticated` & `@requiresScopes` directives on parent fields/types
 //! correctly when doing entity caching
 
-use engine::Engine;
 use graphql_mocks::{FederatedInventorySchema, FederatedProductsSchema, FederatedReviewsSchema, SecureFederatedSchema};
 use integration_tests::{
-    federation::{EngineExt, TestGateway},
+    federation::Gateway,
     openid::{CoreClientExt, JWKS_URI, OryHydraOpenIDProvider},
     runtime,
 };
@@ -165,8 +164,8 @@ async fn jwt_token(scope: &str) -> String {
         .await
 }
 
-async fn engine() -> TestGateway {
-    Engine::builder()
+async fn engine() -> Gateway {
+    Gateway::builder()
         .with_subgraph(FederatedProductsSchema)
         .with_subgraph(FederatedReviewsSchema)
         .with_subgraph(SecureFederatedSchema)

--- a/crates/integration-tests/tests/federation/entity_caching/redis.rs
+++ b/crates/integration-tests/tests/federation/entity_caching/redis.rs
@@ -1,6 +1,5 @@
-use engine::Engine;
 use graphql_mocks::FederatedProductsSchema;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 use rand::Rng;
 
 #[test]
@@ -13,7 +12,7 @@ fn entity_caching_via_redis() {
         .collect::<String>();
 
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FederatedProductsSchema)
             .with_toml_config(format!(
                 r#"

--- a/crates/integration-tests/tests/federation/entity_caching/subgraph_cache_control.rs
+++ b/crates/integration-tests/tests/federation/entity_caching/subgraph_cache_control.rs
@@ -1,9 +1,8 @@
 use std::time::Duration;
 
-use engine::Engine;
 use graphql_mocks::{FederatedInventorySchema, FederatedProductsSchema, FederatedReviewsSchema};
 use headers::{Age, CacheControl};
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 struct CacheControlReviewSubgraph {
     header: CacheControl,
@@ -53,7 +52,7 @@ impl graphql_mocks::Subgraph for CacheControlProductSubgraph {
 #[test]
 fn test_private_cache_control_entity_request() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FederatedProductsSchema)
             .with_subgraph(CacheControlReviewSubgraph {
                 header: CacheControl::new().with_private(),
@@ -90,7 +89,7 @@ fn test_private_cache_control_entity_request() {
 #[test]
 fn test_nostore_cache_control_entity_request() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FederatedProductsSchema)
             .with_subgraph(CacheControlReviewSubgraph {
                 header: CacheControl::new().with_no_store(),
@@ -127,7 +126,7 @@ fn test_nostore_cache_control_entity_request() {
 #[test]
 fn test_max_age_without_age_entity_request() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FederatedProductsSchema)
             .with_subgraph(CacheControlReviewSubgraph {
                 header: CacheControl::new().with_max_age(Duration::from_secs(1)),
@@ -168,7 +167,7 @@ fn test_max_age_without_age_entity_request() {
 #[test]
 fn test_max_age_with_age_entity_request() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FederatedProductsSchema)
             .with_subgraph(CacheControlReviewSubgraph {
                 header: CacheControl::new().with_max_age(Duration::from_secs(2)),
@@ -209,7 +208,7 @@ fn test_max_age_with_age_entity_request() {
 #[test]
 fn test_private_cache_control_root_request() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(CacheControlProductSubgraph {
                 header: CacheControl::new().with_private(),
                 age: None,
@@ -246,7 +245,7 @@ fn test_private_cache_control_root_request() {
 #[test]
 fn test_nostore_cache_control_root_request() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(CacheControlProductSubgraph {
                 header: CacheControl::new().with_no_store(),
                 age: None,
@@ -283,7 +282,7 @@ fn test_nostore_cache_control_root_request() {
 #[test]
 fn test_max_age_without_age_root_request() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(CacheControlProductSubgraph {
                 header: CacheControl::new().with_max_age(Duration::from_secs(1)),
                 age: None,
@@ -324,7 +323,7 @@ fn test_max_age_without_age_root_request() {
 #[test]
 fn test_max_age_with_age_root_request() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(CacheControlProductSubgraph {
                 header: CacheControl::new().with_max_age(Duration::from_secs(2)),
                 age: Some(Age::from_secs(1)),

--- a/crates/integration-tests/tests/federation/extensions/authentication/backwards_compatibility.rs
+++ b/crates/integration-tests/tests/federation/extensions/authentication/backwards_compatibility.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::{EchoSchema, Schema as _};
 use integration_tests::{
-    federation::{AuthorizationExt, EngineExt},
+    federation::{AuthorizationExt, Gateway},
     runtime,
 };
 
@@ -10,7 +9,7 @@ use crate::federation::extensions::authorization::InsertTokenAsHeader;
 #[test]
 fn sdk_080() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema.with_sdl(
                 r#"
                 extend schema @link(url: "authorization-1.0.0", import: ["@auth"])
@@ -78,7 +77,7 @@ fn sdk_080() {
 #[test]
 fn sdk_090() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema.with_sdl(
                 r#"
                 extend schema @link(url: "authorization-1.0.0", import: ["@auth"])

--- a/crates/integration-tests/tests/federation/extensions/authentication/default.rs
+++ b/crates/integration-tests/tests/federation/extensions/authentication/default.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::{EchoSchema, Schema as _};
 use integration_tests::{
-    federation::{AuthorizationExt, EngineExt},
+    federation::{AuthorizationExt, Gateway},
     runtime,
 };
 
@@ -10,7 +9,7 @@ use crate::federation::extensions::authorization::InsertTokenAsHeader;
 #[test]
 fn no_extension() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema.with_sdl(
                 r#"
                 extend schema @link(url: "authorization-1.0.0", import: ["@auth"])
@@ -38,7 +37,7 @@ fn no_extension() {
 #[test]
 fn no_extension_with_anonymous_default() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema.with_sdl(
                 r#"
                 extend schema @link(url: "authorization-1.0.0", import: ["@auth"])
@@ -72,7 +71,7 @@ fn no_extension_with_anonymous_default() {
 #[test]
 fn no_extension_with_deny_default() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema.with_sdl(
                 r#"
                 extend schema @link(url: "authorization-1.0.0", import: ["@auth"])

--- a/crates/integration-tests/tests/federation/extensions/authentication/multiple.rs
+++ b/crates/integration-tests/tests/federation/extensions/authentication/multiple.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::{EchoSchema, Schema as _};
 use integration_tests::{
-    federation::{AuthorizationExt, EngineExt},
+    federation::{AuthorizationExt, Gateway},
     runtime,
 };
 
@@ -10,7 +9,7 @@ use crate::federation::extensions::authorization::InsertTokenAsHeader;
 #[test]
 fn double_authentication() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema.with_sdl(
                 r#"
                 extend schema @link(url: "authorization-1.0.0", import: ["@auth"])
@@ -94,7 +93,7 @@ fn double_authentication() {
 #[test]
 fn double_authentication_with_deny_default() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema.with_sdl(
                 r#"
                 extend schema @link(url: "authorization-1.0.0", import: ["@auth"])
@@ -168,7 +167,7 @@ fn double_authentication_with_deny_default() {
 #[test]
 fn double_authentication_with_anonymous_default() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema.with_sdl(
                 r#"
                 extend schema @link(url: "authorization-1.0.0", import: ["@auth"])

--- a/crates/integration-tests/tests/federation/extensions/authentication/static_token.rs
+++ b/crates/integration-tests/tests/federation/extensions/authentication/static_token.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
-use engine::{Engine, ErrorCode, ErrorResponse, GraphqlError};
+use engine::{ErrorCode, ErrorResponse, GraphqlError};
 use graphql_mocks::FakeGithubSchema;
 use integration_tests::{
-    federation::{AuthenticationExt, AuthenticationTestExtension, EngineExt},
+    federation::{AuthenticationExt, AuthenticationTestExtension, Gateway},
     runtime,
 };
 use runtime::extension::Token;
@@ -39,7 +39,7 @@ impl AuthenticationTestExtension for StaticToken {
 #[test]
 fn anonymous_token() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_extension(AuthenticationExt::new(StaticToken::anonymous()))
             .build()
@@ -60,7 +60,7 @@ fn anonymous_token() {
 #[test]
 fn bytes_token() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_extension(AuthenticationExt::new(StaticToken::bytes(Vec::new())))
             .build()
@@ -81,7 +81,7 @@ fn bytes_token() {
 #[test]
 fn error_response() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_extension(AuthenticationExt::new(StaticToken::error_response(GraphqlError::new(
                 "My error message",

--- a/crates/integration-tests/tests/federation/extensions/authorization/authenticated.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/authenticated.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::dynamic::DynamicSchema;
 use integration_tests::{
-    federation::{AuthenticationExt, EngineExt},
+    federation::{AuthenticationExt, Gateway},
     runtime,
 };
 
@@ -10,7 +9,7 @@ use crate::federation::extensions::authentication::static_token::StaticToken;
 #[test]
 fn can_load_authenticated_extension() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -74,7 +73,7 @@ fn can_load_authenticated_extension() {
 #[test]
 fn can_access_token() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"

--- a/crates/integration-tests/tests/federation/extensions/authorization/backwards_compatibility.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/backwards_compatibility.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::{EchoSchema, dynamic::DynamicSchema};
 use integration_tests::{
-    federation::{AuthenticationExt, EngineExt},
+    federation::{AuthenticationExt, Gateway},
     runtime,
 };
 
@@ -10,7 +9,7 @@ use crate::federation::extensions::authentication::static_token::StaticToken;
 #[test]
 fn sdk_0100() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema)
             .with_subgraph(
                 DynamicSchema::builder(

--- a/crates/integration-tests/tests/federation/extensions/authorization/deny_all.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/deny_all.rs
@@ -1,7 +1,7 @@
-use engine::{Engine, ErrorResponse, GraphqlError};
+use engine::{ErrorResponse, GraphqlError};
 use graphql_mocks::dynamic::DynamicSchema;
 use integration_tests::{
-    federation::{AuthorizationExt, AuthorizationTestExtension, DynHookContext, EngineExt},
+    federation::{AuthorizationExt, AuthorizationTestExtension, DynHookContext, Gateway},
     runtime,
 };
 use runtime::extension::{AuthorizationDecisions, QueryElement, TokenRef};
@@ -26,7 +26,7 @@ impl AuthorizationTestExtension for DenyAll {
 #[test]
 fn can_deny_all() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"

--- a/crates/integration-tests/tests/federation/extensions/authorization/deny_some.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/deny_some.rs
@@ -1,8 +1,8 @@
-use engine::{Engine, ErrorCode, ErrorResponse, GraphqlError};
+use engine::{ErrorCode, ErrorResponse, GraphqlError};
 use engine_schema::DirectiveSite;
 use graphql_mocks::dynamic::DynamicSchema;
 use integration_tests::{
-    federation::{AuthorizationExt, AuthorizationTestExtension, DynHookContext, EngineExt},
+    federation::{AuthorizationExt, AuthorizationTestExtension, DynHookContext, Gateway},
     runtime,
 };
 use runtime::extension::{AuthorizationDecisions, QueryElement, TokenRef};
@@ -82,7 +82,7 @@ impl AuthorizationTestExtension for DenySites {
 #[test]
 fn can_deny_some() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"

--- a/crates/integration-tests/tests/federation/extensions/authorization/error_propagation/list.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/error_propagation/list.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::dynamic::DynamicSchema;
 use integration_tests::{
-    federation::{AuthorizationExt, EngineExt},
+    federation::{AuthorizationExt, Gateway},
     runtime,
 };
 
@@ -10,7 +9,7 @@ use crate::federation::extensions::authorization::{deny_all::DenyAll, user};
 #[test]
 fn required_item_required_parent() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -119,7 +118,7 @@ fn required_item_required_parent() {
 #[test]
 fn required_item_nullable_parent() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -230,7 +229,7 @@ fn required_item_nullable_parent() {
 #[test]
 fn nullable_item() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"

--- a/crates/integration-tests/tests/federation/extensions/authorization/error_propagation/nested_field.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/error_propagation/nested_field.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::dynamic::DynamicSchema;
 use integration_tests::{
-    federation::{AuthorizationExt, EngineExt},
+    federation::{AuthorizationExt, Gateway},
     runtime,
 };
 
@@ -10,7 +9,7 @@ use crate::federation::extensions::authorization::{deny_all::DenyAll, user};
 #[test]
 fn required_field_required_parent() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -101,7 +100,7 @@ fn required_field_required_parent() {
 #[test]
 fn required_field_nullable_parent() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -194,7 +193,7 @@ fn required_field_nullable_parent() {
 #[test]
 fn nullable_field() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"

--- a/crates/integration-tests/tests/federation/extensions/authorization/error_response.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/error_response.rs
@@ -1,7 +1,7 @@
-use engine::{Engine, ErrorResponse, GraphqlError};
+use engine::{ErrorResponse, GraphqlError};
 use graphql_mocks::dynamic::DynamicSchema;
 use integration_tests::{
-    federation::{AuthorizationExt, AuthorizationTestExtension, DynHookContext, EngineExt},
+    federation::{AuthorizationExt, AuthorizationTestExtension, DynHookContext, Gateway},
     runtime,
 };
 use runtime::extension::{AuthorizationDecisions, QueryElement, TokenRef};
@@ -29,7 +29,7 @@ impl AuthorizationTestExtension for Failure {
 #[test]
 fn can_return_error_response() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"

--- a/crates/integration-tests/tests/federation/extensions/authorization/grant_all.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/grant_all.rs
@@ -1,8 +1,8 @@
-use engine::{Engine, ErrorResponse, GraphqlError};
+use engine::{ErrorResponse, GraphqlError};
 use engine_schema::DirectiveSite;
 use graphql_mocks::dynamic::DynamicSchema;
 use integration_tests::{
-    federation::{AuthorizationExt, AuthorizationTestExtension, DynHookContext, EngineExt},
+    federation::{AuthorizationExt, AuthorizationTestExtension, DynHookContext, Gateway},
     runtime,
 };
 use runtime::extension::{AuthorizationDecisions, QueryElement, TokenRef};
@@ -37,7 +37,7 @@ impl AuthorizationTestExtension for GrantAll {
 #[test]
 fn can_grant_all() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"

--- a/crates/integration-tests/tests/federation/extensions/authorization/headers.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/headers.rs
@@ -1,7 +1,7 @@
-use engine::{Engine, ErrorResponse};
+use engine::ErrorResponse;
 use graphql_mocks::{EchoSchema, Schema};
 use integration_tests::{
-    federation::{AuthenticationExt, AuthorizationExt, AuthorizationTestExtension, DynHookContext, EngineExt},
+    federation::{AuthenticationExt, AuthorizationExt, AuthorizationTestExtension, DynHookContext, Gateway},
     runtime,
 };
 use runtime::extension::{AuthorizationDecisions, QueryElement, TokenRef};
@@ -33,7 +33,7 @@ impl AuthorizationTestExtension for InsertTokenAsHeader {
 #[test]
 fn can_inject_token_into_headers() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema.with_sdl(
                 r#"
                 extend schema @link(url: "authorization-1.0.0", import: ["@auth"])

--- a/crates/integration-tests/tests/federation/extensions/authorization/injection/complex.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/injection/complex.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::dynamic::DynamicSchema;
 use integration_tests::{
-    federation::{AuthorizationExt, EngineExt},
+    federation::{AuthorizationExt, Gateway},
     runtime,
 };
 
@@ -10,7 +9,7 @@ use crate::federation::extensions::authorization::{injection::EchoInjections, us
 #[test]
 fn complex_field_set() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"

--- a/crates/integration-tests/tests/federation/extensions/authorization/injection/field.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/injection/field.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::dynamic::{DynamicSchema, DynamicSubgraph};
 use integration_tests::{
-    federation::{AuthorizationExt, EngineExt},
+    federation::{AuthorizationExt, Gateway},
     runtime,
 };
 
@@ -50,7 +49,7 @@ fn subgraph() -> DynamicSubgraph {
 #[test]
 fn object_field() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(EchoInjections))
             .build()
@@ -115,7 +114,7 @@ fn object_field() {
 #[test]
 fn interface_field() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(EchoInjections))
             .build()

--- a/crates/integration-tests/tests/federation/extensions/authorization/injection/interface.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/injection/interface.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::dynamic::{DynamicSchema, DynamicSubgraph};
 use integration_tests::{
-    federation::{AuthorizationExt, EngineExt},
+    federation::{AuthorizationExt, Gateway},
     runtime,
 };
 
@@ -38,7 +37,7 @@ fn subgraph() -> DynamicSubgraph {
 #[test]
 fn object_field() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(EchoInjections))
             .build()

--- a/crates/integration-tests/tests/federation/extensions/authorization/injection/object.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/injection/object.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::dynamic::{DynamicSchema, DynamicSubgraph};
 use integration_tests::{
-    federation::{AuthorizationExt, EngineExt},
+    federation::{AuthorizationExt, Gateway},
     runtime,
 };
 
@@ -75,7 +74,7 @@ fn subgraph() -> DynamicSubgraph {
 #[test]
 fn object() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(EchoInjections))
             .build()
@@ -134,7 +133,7 @@ fn object() {
 #[test]
 fn object_within_list() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(EchoInjections))
             .build()
@@ -245,7 +244,7 @@ fn object_within_list() {
 #[test]
 fn object_within_union() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(EchoInjections))
             .build()
@@ -313,7 +312,7 @@ fn object_within_union() {
 #[test]
 fn object_behind_interface() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(EchoInjections))
             .build()

--- a/crates/integration-tests/tests/federation/extensions/authorization/multiple.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/multiple.rs
@@ -1,7 +1,7 @@
-use engine::{Engine, ErrorCode, ErrorResponse, GraphqlError};
+use engine::{ErrorCode, ErrorResponse, GraphqlError};
 use graphql_mocks::dynamic::DynamicSchema;
 use integration_tests::{
-    federation::{AuthorizationExt, AuthorizationTestExtension, DynHookContext, EngineExt},
+    federation::{AuthorizationExt, AuthorizationTestExtension, DynHookContext, Gateway},
     runtime,
 };
 use runtime::extension::{AuthorizationDecisions, QueryElement, TokenRef};
@@ -85,7 +85,7 @@ impl AuthorizationTestExtension for MultiDirectivesBis {
 #[test]
 fn multiple_directives() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -143,7 +143,7 @@ fn multiple_directives() {
 #[test]
 fn multiple_extensions_and_directives() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"

--- a/crates/integration-tests/tests/federation/extensions/authorization/query/enum_.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/query/enum_.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::dynamic::DynamicSchema;
 use integration_tests::{
-    federation::{AuthorizationExt, EngineExt},
+    federation::{AuthorizationExt, Gateway},
     runtime,
 };
 
@@ -10,7 +9,7 @@ use crate::federation::extensions::authorization::deny_some::DenySites;
 #[test]
 fn scalar() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"

--- a/crates/integration-tests/tests/federation/extensions/authorization/query/interface.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/query/interface.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::dynamic::DynamicSchema;
 use integration_tests::{
-    federation::{AuthorizationExt, EngineExt},
+    federation::{AuthorizationExt, Gateway},
     runtime,
 };
 
@@ -10,7 +9,7 @@ use crate::federation::extensions::authorization::deny_some::DenySites;
 #[test]
 fn interface_fields() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -85,7 +84,7 @@ fn interface_fields() {
 #[test]
 fn interface_type() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"

--- a/crates/integration-tests/tests/federation/extensions/authorization/query/object.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/query/object.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::dynamic::DynamicSchema;
 use integration_tests::{
-    federation::{AuthorizationExt, EngineExt},
+    federation::{AuthorizationExt, Gateway},
     runtime,
 };
 
@@ -10,7 +9,7 @@ use crate::federation::extensions::authorization::{deny_all::DenyAll, user};
 #[test]
 fn object_type() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -75,7 +74,7 @@ fn object_type() {
 #[test]
 fn object_within_list() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -140,7 +139,7 @@ fn object_within_list() {
 #[test]
 fn object_within_union() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -224,7 +223,7 @@ fn object_within_union() {
 #[test]
 fn explicit_object_behind_interface() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"

--- a/crates/integration-tests/tests/federation/extensions/authorization/query/scalar.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/query/scalar.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::dynamic::DynamicSchema;
 use integration_tests::{
-    federation::{AuthorizationExt, EngineExt},
+    federation::{AuthorizationExt, Gateway},
     runtime,
 };
 
@@ -10,7 +9,7 @@ use crate::federation::extensions::authorization::deny_some::DenySites;
 #[test]
 fn scalar() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"

--- a/crates/integration-tests/tests/federation/extensions/authorization/requires_scopes.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/requires_scopes.rs
@@ -1,7 +1,7 @@
-use engine::{Engine, ErrorCode, ErrorResponse, GraphqlError};
+use engine::{ErrorCode, ErrorResponse, GraphqlError};
 use graphql_mocks::dynamic::DynamicSchema;
 use integration_tests::{
-    federation::{AuthenticationExt, AuthorizationExt, AuthorizationTestExtension, DynHookContext, EngineExt},
+    federation::{AuthenticationExt, AuthorizationExt, AuthorizationTestExtension, DynHookContext, Gateway},
     runtime,
 };
 use runtime::extension::{AuthorizationDecisions, QueryElement, TokenRef};
@@ -59,7 +59,7 @@ impl AuthorizationTestExtension for RequiresScopes {
 #[test]
 fn anonymous() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -124,7 +124,7 @@ fn anonymous() {
 #[test]
 fn missing_claim() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -189,7 +189,7 @@ fn missing_claim() {
 #[test]
 fn missing_scope() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -272,7 +272,7 @@ fn missing_scope() {
 #[test]
 fn valid_scope() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"

--- a/crates/integration-tests/tests/federation/extensions/authorization/response/field.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/response/field.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::dynamic::{DynamicSchema, DynamicSubgraph};
 use integration_tests::{
-    federation::{AuthorizationExt, EngineExt},
+    federation::{AuthorizationExt, Gateway},
     runtime,
 };
 
@@ -46,7 +45,7 @@ fn subgraph() -> DynamicSubgraph {
 #[test]
 fn grant_object_field() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(GrantAll))
             .build()
@@ -75,7 +74,7 @@ fn grant_object_field() {
 #[test]
 fn deny_object_field_at_query_stage() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(DenySites::query(vec!["User.pets"])))
             .build()
@@ -125,7 +124,7 @@ fn deny_object_field_at_query_stage() {
 #[test]
 fn deny_object_field_at_response_stage() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(DenySites::response(vec!["User.pets"])))
             .build()
@@ -163,7 +162,7 @@ fn deny_object_field_at_response_stage() {
 #[test]
 fn grant_interface_field() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(GrantAll))
             .build()
@@ -185,7 +184,7 @@ fn grant_interface_field() {
 #[test]
 fn deny_interface_field_at_query_stage() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(DenySites::query(vec!["Node.name"])))
             .build()
@@ -237,7 +236,7 @@ fn deny_interface_field_at_query_stage() {
 #[test]
 fn deny_interface_field_at_response_stage() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(DenySites::response(vec!["Node.name"])))
             .build()

--- a/crates/integration-tests/tests/federation/extensions/authorization/response/interface.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/response/interface.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::dynamic::{DynamicSchema, DynamicSubgraph};
 use integration_tests::{
-    federation::{AuthorizationExt, EngineExt},
+    federation::{AuthorizationExt, Gateway},
     runtime,
 };
 
@@ -38,7 +37,7 @@ fn subgraph() -> DynamicSubgraph {
 #[test]
 fn grant_interface_type() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(GrantAll))
             .build()
@@ -60,7 +59,7 @@ fn grant_interface_type() {
 #[test]
 fn deny_interface_type_at_query_stage() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(DenySites::query(["Node"])))
             .build()
@@ -109,7 +108,7 @@ fn deny_interface_type_at_query_stage() {
 #[test]
 fn deny_interface_type_at_response_stage() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(DenySites::response(["Node"])))
             .build()

--- a/crates/integration-tests/tests/federation/extensions/authorization/response/object.rs
+++ b/crates/integration-tests/tests/federation/extensions/authorization/response/object.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::dynamic::{DynamicSchema, DynamicSubgraph};
 use integration_tests::{
-    federation::{AuthorizationExt, EngineExt},
+    federation::{AuthorizationExt, Gateway},
     runtime,
 };
 
@@ -57,7 +56,7 @@ fn subgraph() -> DynamicSubgraph {
 #[test]
 fn grant_object() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(GrantAll))
             .build()
@@ -79,7 +78,7 @@ fn grant_object() {
 #[test]
 fn deny_object_at_query_stage() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(DenySites::query(["User"])))
             .build()
@@ -128,7 +127,7 @@ fn deny_object_at_query_stage() {
 #[test]
 fn deny_object_at_response_stage() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(DenySites::response(["User"])))
             .build()
@@ -165,7 +164,7 @@ fn deny_object_at_response_stage() {
 #[test]
 fn grant_object_within_list() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(GrantAll))
             .build()
@@ -192,7 +191,7 @@ fn grant_object_within_list() {
 #[test]
 fn deny_object_within_list_at_query_stage() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(DenySites::query(["User"])))
             .build()
@@ -241,7 +240,7 @@ fn deny_object_within_list_at_query_stage() {
 #[test]
 fn deny_object_within_list_at_response_stage() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(DenySites::response(["User"])))
             .build()
@@ -298,7 +297,7 @@ fn deny_object_within_list_at_response_stage() {
 #[test]
 fn grant_object_within_union() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(GrantAll))
             .build()
@@ -327,7 +326,7 @@ fn grant_object_within_union() {
 #[test]
 fn deny_object_within_union_at_query_stage() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(DenySites::query(["Dog"])))
             .build()
@@ -385,7 +384,7 @@ fn deny_object_within_union_at_query_stage() {
 #[test]
 fn deny_object_within_union_at_response_stage() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(DenySites::response(["Dog"])))
             .build()
@@ -431,7 +430,7 @@ fn deny_object_within_union_at_response_stage() {
 #[test]
 fn grant_object_behind_interface() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(GrantAll))
             .build()
@@ -453,7 +452,7 @@ fn grant_object_behind_interface() {
 #[test]
 fn deny_object_behind_interface_at_query_stage() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(DenySites::query(["User"])))
             .build()
@@ -503,7 +502,7 @@ fn deny_object_behind_interface_at_query_stage() {
 #[test]
 fn deny_object_behind_interface_at_response_stage() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph())
             .with_extension(AuthorizationExt::new(DenySites::response(["User"])))
             .build()

--- a/crates/integration-tests/tests/federation/extensions/basic.rs
+++ b/crates/integration-tests/tests/federation/extensions/basic.rs
@@ -1,7 +1,7 @@
-use engine::{Engine, GraphqlError};
+use engine::GraphqlError;
 use engine_schema::{ExtensionDirective, FieldDefinition};
 use integration_tests::{
-    federation::{EngineExt, FieldResolverExt, FieldResolverTestExtension, json_data},
+    federation::{FieldResolverExt, FieldResolverTestExtension, Gateway, json_data},
     runtime,
 };
 use runtime::extension::Data;
@@ -38,7 +38,7 @@ impl FieldResolverTestExtension for GreetExt {
 #[test]
 fn simple_resolver_from_federated_sdl() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_federated_sdl(
                 r#"
                 enum extension__Link {
@@ -73,7 +73,7 @@ fn simple_resolver_from_federated_sdl() {
 #[test]
 fn simple_resolver_from_subgraph_sdl() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/backwards_compatibility.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/backwards_compatibility.rs
@@ -1,10 +1,9 @@
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn resolver_080() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -43,7 +42,7 @@ fn resolver_080() {
 #[test]
 fn resolver_090() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/errors.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/errors.rs
@@ -1,12 +1,11 @@
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 use crate::federation::extensions::field_resolver::StaticFieldResolverExt;
 
 #[test]
 fn invalid_json() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/default_value.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/default_value.rs
@@ -1,12 +1,10 @@
-use engine::Engine;
-
 use crate::federation::extensions::field_resolver::injection::field_set::arguments::DoubleEchoExt;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn default_values() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -52,7 +50,7 @@ fn default_values() {
 #[test]
 fn default_values_partial_override() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -98,7 +96,7 @@ fn default_values_partial_override() {
 #[test]
 fn default_values_override() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/enum_.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/enum_.rs
@@ -1,12 +1,10 @@
-use engine::Engine;
-
 use crate::federation::extensions::field_resolver::injection::field_set::arguments::DoubleEchoExt;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn valid_enum_value() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -48,7 +46,7 @@ fn valid_enum_value() {
 #[test]
 fn unknown_enum_value() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -82,7 +80,7 @@ fn unknown_enum_value() {
 #[test]
 fn invalid_enum_value() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -111,7 +109,7 @@ fn invalid_enum_value() {
         )
         "#);
 
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/fields.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/fields.rs
@@ -1,12 +1,10 @@
-use engine::Engine;
-
 use crate::federation::extensions::field_resolver::injection::field_set::arguments::DoubleEchoExt;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn missing_nullable_field() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -48,7 +46,7 @@ fn missing_nullable_field() {
 #[test]
 fn missing_required_field() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -82,7 +80,7 @@ fn missing_required_field() {
 #[test]
 fn too_many_fields() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -116,7 +114,7 @@ fn too_many_fields() {
 #[test]
 fn not_an_object() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/list.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/list.rs
@@ -1,11 +1,10 @@
 use crate::federation::extensions::field_resolver::injection::field_set::arguments::DoubleEchoExt;
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn list_coercion() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -45,7 +44,7 @@ fn list_coercion() {
 #[test]
 fn list_list_coercion() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -87,7 +86,7 @@ fn list_list_coercion() {
 #[test]
 fn incompatible_list_wrapping() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/non_null.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/non_null.rs
@@ -1,12 +1,10 @@
-use engine::Engine;
-
 use crate::federation::extensions::field_resolver::injection::field_set::arguments::DoubleEchoExt;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn unexpected_null() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -36,7 +34,7 @@ fn unexpected_null() {
 #[test]
 fn missing_required_argument() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -66,7 +64,7 @@ fn missing_required_argument() {
 #[test]
 fn missing_nullable_argument() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -102,7 +100,7 @@ fn missing_nullable_argument() {
 #[test]
 fn distinguish_providing_null_from_not_present() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/scalar/boolean.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/scalar/boolean.rs
@@ -1,12 +1,10 @@
-use engine::Engine;
-
 use crate::federation::extensions::field_resolver::injection::field_set::arguments::DoubleEchoExt;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn valid_boolean() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -44,7 +42,7 @@ fn valid_boolean() {
 #[test]
 fn invalid_boolean() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/scalar/custom.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/scalar/custom.rs
@@ -1,12 +1,10 @@
-use engine::Engine;
-
 use crate::federation::extensions::field_resolver::injection::field_set::arguments::DoubleEchoExt;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn valid_any() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -50,7 +48,7 @@ fn valid_any() {
 #[test]
 fn valid_any_array() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/scalar/float.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/scalar/float.rs
@@ -1,12 +1,10 @@
-use engine::Engine;
-
 use crate::federation::extensions::field_resolver::injection::field_set::arguments::DoubleEchoExt;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn valid_float() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -44,7 +42,7 @@ fn valid_float() {
 #[test]
 fn int_to_float_conversion() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -82,7 +80,7 @@ fn int_to_float_conversion() {
 #[test]
 fn invalid_float() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/scalar/id.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/scalar/id.rs
@@ -1,12 +1,10 @@
-use engine::Engine;
-
 use crate::federation::extensions::field_resolver::injection::field_set::arguments::DoubleEchoExt;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn valid_id() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -44,7 +42,7 @@ fn valid_id() {
 #[test]
 fn invalid_id() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/scalar/int.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/scalar/int.rs
@@ -1,12 +1,10 @@
-use engine::Engine;
-
 use crate::federation::extensions::field_resolver::injection::field_set::arguments::DoubleEchoExt;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn valid_int() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -44,7 +42,7 @@ fn valid_int() {
 #[test]
 fn float_to_int_coercion() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -82,7 +80,7 @@ fn float_to_int_coercion() {
 #[test]
 fn invalid_int() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -107,7 +105,7 @@ fn invalid_int() {
         )
         "#);
 
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/scalar/string.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/arguments/scalar/string.rs
@@ -1,12 +1,10 @@
-use engine::Engine;
-
 use crate::federation::extensions::field_resolver::injection::field_set::arguments::DoubleEchoExt;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn valid_string() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -44,7 +42,7 @@ fn valid_string() {
 #[test]
 fn invalid_string() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/mod.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/injection/field_set/mod.rs
@@ -4,17 +4,16 @@ mod type_condition;
 mod validation;
 
 use crate::federation::extensions::field_resolver::validation::EchoExt;
-use engine::Engine;
 use graphql_mocks::dynamic::{DynamicSchema, DynamicSchemaBuilder};
 use integration_tests::{
-    federation::{EngineExt, GraphqlResponse},
+    federation::{Gateway, GraphqlResponse},
     runtime,
 };
 use serde_json::json;
 
 fn run_with_field_set(subgraph: DynamicSchemaBuilder, field_set: &str) -> Result<GraphqlResponse, String> {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph(subgraph.into_subgraph("a"))
             .with_subgraph_sdl(
                 "b",
@@ -128,7 +127,7 @@ fn basic_field_set() {
 #[test]
 fn default_value() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph(graphql_subgraph().into_subgraph("a"))
             .with_subgraph_sdl(
                 "b",

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/injection/input_value_set/mod.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/injection/input_value_set/mod.rs
@@ -3,13 +3,12 @@ mod validation;
 mod wrapping;
 
 use crate::federation::extensions::field_resolver::validation::EchoExt;
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn basic_input_value_set() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/injection/input_value_set/selection_set.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/injection/input_value_set/selection_set.rs
@@ -1,11 +1,10 @@
 use crate::federation::extensions::field_resolver::validation::EchoExt;
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn multiple_fields() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -67,7 +66,7 @@ fn multiple_fields() {
 #[test]
 fn all() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -131,7 +130,7 @@ fn all() {
 #[test]
 fn nested_all() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -194,7 +193,7 @@ fn nested_all() {
 #[test]
 fn default_values() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -256,7 +255,7 @@ fn default_values() {
 #[test]
 fn default_values_star() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -320,7 +319,7 @@ fn default_values_star() {
 #[test]
 fn extension_directive_default_value() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/injection/input_value_set/validation.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/injection/input_value_set/validation.rs
@@ -1,11 +1,10 @@
 use crate::federation::extensions::field_resolver::validation::EchoExt;
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn invalid_location_but_not_used() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -36,7 +35,7 @@ fn invalid_location_but_not_used() {
 #[test]
 fn invalid_location() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -71,7 +70,7 @@ fn invalid_location() {
 #[test]
 fn unknown_field() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -116,7 +115,7 @@ fn unknown_field() {
 #[test]
 fn unknown_nested_field() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -161,7 +160,7 @@ fn unknown_nested_field() {
 #[test]
 fn cannot_have_selection_set() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -206,7 +205,7 @@ fn cannot_have_selection_set() {
 #[test]
 fn cannot_have_fragments() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -251,7 +250,7 @@ fn cannot_have_fragments() {
 #[test]
 fn must_be_valid_selection_set() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/injection/input_value_set/wrapping.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/injection/input_value_set/wrapping.rs
@@ -1,11 +1,10 @@
 use crate::federation::extensions::field_resolver::validation::EchoExt;
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn nullable_input_value_set() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -49,7 +48,7 @@ fn nullable_input_value_set() {
 #[test]
 fn nullable_input_value_set_not_provided() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -91,7 +90,7 @@ fn nullable_input_value_set_not_provided() {
 #[test]
 fn list_of_input_value_set() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/injection/link.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/injection/link.rs
@@ -1,12 +1,11 @@
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 use crate::federation::extensions::basic::GreetExt;
 
 #[test]
 fn invalid_link() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -39,7 +38,7 @@ fn invalid_link() {
 #[test]
 fn valid_link() {
     runtime().block_on(async move {
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/injection/template/json.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/injection/template/json.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use engine::{Engine, GraphqlError};
+use engine::GraphqlError;
 use engine_schema::{ExtensionDirective, FieldDefinition};
 use extension_catalog::Id;
 use integration_tests::{
-    federation::{AnyExtension, EngineExt, ExtensionsBuilder, FieldResolverTestExtension, TestManifest},
+    federation::{AnyExtension, ExtensionsBuilder, FieldResolverTestExtension, Gateway, TestManifest},
     runtime,
 };
 use runtime::extension::Data;
@@ -56,7 +56,7 @@ impl FieldResolverTestExtension for EchoJsonDataExt {
 #[test]
 fn json_template() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -111,7 +111,7 @@ fn json_template() {
 #[test]
 fn json_should_escape_string_content() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -143,7 +143,7 @@ fn json_should_escape_string_content() {
 #[test]
 fn json_should_render_objects_as_json() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -180,7 +180,7 @@ fn json_should_render_objects_as_json() {
 #[test]
 fn json_should_render_lists_as_json() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -217,7 +217,7 @@ fn json_should_render_lists_as_json() {
 #[test]
 fn iterate_object_within_list() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -256,7 +256,7 @@ fn iterate_object_within_list() {
 #[test]
 fn iterate_string_list() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -295,7 +295,7 @@ fn iterate_string_list() {
 #[test]
 fn object_section() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -330,7 +330,7 @@ fn object_section() {
 #[test]
 fn string_section() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -366,7 +366,7 @@ fn string_section() {
 #[test]
 fn null_section() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -402,7 +402,7 @@ fn null_section() {
 #[test]
 fn int_section() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -438,7 +438,7 @@ fn int_section() {
 #[test]
 fn boolean_section() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/injection/template/url.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/injection/template/url.rs
@@ -1,11 +1,10 @@
 use crate::federation::extensions::field_resolver::validation::EchoExt;
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn url_template() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -56,7 +55,7 @@ fn url_template() {
 #[test]
 fn url_template_should_escape_strings() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -100,7 +99,7 @@ fn url_template_should_escape_strings() {
 #[test]
 fn url_template_should_encode_objects_as_json_and_then_escape() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -144,7 +143,7 @@ fn url_template_should_encode_objects_as_json_and_then_escape() {
 #[test]
 fn url_template_should_encode_lists_as_json_and_then_escape() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/validation/default_value.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/validation/default_value.rs
@@ -1,12 +1,11 @@
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 use super::EchoExt;
 
 #[test]
 fn default_values() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -65,7 +64,7 @@ fn default_values() {
 #[test]
 fn default_values_partial_override() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -124,7 +123,7 @@ fn default_values_partial_override() {
 #[test]
 fn default_values_override() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/validation/definition.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/validation/definition.rs
@@ -1,5 +1,4 @@
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 use super::EchoExt;
 
@@ -7,7 +6,7 @@ use super::EchoExt;
 fn unknown_type() {
     runtime().block_on(async move {
         // Invalid field directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -37,7 +36,7 @@ fn unknown_type() {
         "#);
 
         // Invalid schema directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -73,7 +72,7 @@ fn unknown_type() {
 fn not_a_input_type() {
     runtime().block_on(async move {
         // Invalid field directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -105,7 +104,7 @@ fn not_a_input_type() {
         "#);
 
         // Invalid schema directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/validation/enum_.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/validation/enum_.rs
@@ -1,12 +1,11 @@
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 use super::EchoExt;
 
 #[test]
 fn valid_enum_value() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -60,7 +59,7 @@ fn valid_enum_value() {
 fn unknown_enum_value() {
     runtime().block_on(async move {
         // Invalid field directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -92,7 +91,7 @@ fn unknown_enum_value() {
         "#);
 
         // Invalid schema directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -130,7 +129,7 @@ fn unknown_enum_value() {
 fn invalid_enum_value() {
     runtime().block_on(async move {
         // Invalid field directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -162,7 +161,7 @@ fn invalid_enum_value() {
         "#);
 
         // Invalid schema directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/validation/fields.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/validation/fields.rs
@@ -1,12 +1,11 @@
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 use super::EchoExt;
 
 #[test]
 fn missing_nullable_field() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -59,7 +58,7 @@ fn missing_nullable_field() {
 fn missing_required_field() {
     runtime().block_on(async move {
         // Invalid field directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -91,7 +90,7 @@ fn missing_required_field() {
         "#);
 
         // Invalid schema directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -129,7 +128,7 @@ fn missing_required_field() {
 fn too_many_fields() {
     runtime().block_on(async move {
         // Invalid field directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -161,7 +160,7 @@ fn too_many_fields() {
         "#);
 
         // Invalid schema directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -199,7 +198,7 @@ fn too_many_fields() {
 fn not_an_object() {
     runtime().block_on(async move {
         // Invalid field directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -231,7 +230,7 @@ fn not_an_object() {
         "#);
 
         // Invalid schema directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/validation/list.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/validation/list.rs
@@ -1,12 +1,11 @@
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 use super::EchoExt;
 
 #[test]
 fn list_coercion() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -59,7 +58,7 @@ fn list_coercion() {
 #[test]
 fn list_list_coercion() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -117,7 +116,7 @@ fn list_list_coercion() {
 fn incompatible_list_wrapping() {
     runtime().block_on(async move {
         // Invalid field directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -145,7 +144,7 @@ fn incompatible_list_wrapping() {
         "#);
 
         // Invalid schema directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/validation/location.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/validation/location.rs
@@ -1,5 +1,4 @@
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 use super::EchoExt;
 
@@ -7,7 +6,7 @@ use super::EchoExt;
 fn invalid_location() {
     runtime().block_on(async move {
         // Invalid field directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -37,7 +36,7 @@ fn invalid_location() {
         "#);
 
         // Invalid schema directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/validation/mod.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/validation/mod.rs
@@ -9,12 +9,12 @@ mod scalar;
 
 use std::{collections::HashMap, sync::Arc};
 
-use engine::{Engine, GraphqlError};
+use engine::GraphqlError;
 use engine_schema::{ExtensionDirective, FieldDefinition};
 use extension_catalog::Id;
 use integration_tests::{
     federation::{
-        AnyExtension, EngineExt, FieldResolverTestExtension, FieldResolverTestExtensionBuilder, TestManifest, json_data,
+        AnyExtension, FieldResolverTestExtension, FieldResolverTestExtensionBuilder, Gateway, TestManifest, json_data,
     },
     runtime,
 };
@@ -92,7 +92,7 @@ impl FieldResolverTestExtension for EchoInstance {
 #[test]
 fn simple_echo() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -142,7 +142,7 @@ fn simple_echo() {
 fn too_many_arguments() {
     runtime().block_on(async move {
         // Invalid field directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -172,7 +172,7 @@ fn too_many_arguments() {
         "#);
 
         // Invalid schema directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/validation/non_null.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/validation/non_null.rs
@@ -1,5 +1,4 @@
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 use super::EchoExt;
 
@@ -7,7 +6,7 @@ use super::EchoExt;
 fn unexpected_null() {
     runtime().block_on(async move {
         // Invalid field directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -35,7 +34,7 @@ fn unexpected_null() {
         "#);
 
         // Invalid schema directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -69,7 +68,7 @@ fn unexpected_null() {
 fn missing_required_argument() {
     runtime().block_on(async move {
         // Invalid field directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -97,7 +96,7 @@ fn missing_required_argument() {
         "#);
 
         // Invalid schema directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -130,7 +129,7 @@ fn missing_required_argument() {
 #[test]
 fn missing_nullable_argument() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -174,7 +173,7 @@ fn missing_nullable_argument() {
 #[test]
 fn distinquish_providing_null_from_not_present_at_all() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/validation/scalar/big_int.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/validation/scalar/big_int.rs
@@ -1,12 +1,11 @@
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 use super::EchoExt;
 
 #[test]
 fn valid_big_int() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -55,7 +54,7 @@ fn valid_big_int() {
 #[test]
 fn float_to_big_int_coercion() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -105,7 +104,7 @@ fn float_to_big_int_coercion() {
 fn invalid_big_int() {
     runtime().block_on(async move {
         // Invalid field directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -133,7 +132,7 @@ fn invalid_big_int() {
         "#);
 
         // Invalid schema directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/validation/scalar/boolean.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/validation/scalar/boolean.rs
@@ -1,12 +1,11 @@
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 use super::EchoExt;
 
 #[test]
 fn valid_boolean() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -56,7 +55,7 @@ fn valid_boolean() {
 fn invalid_boolean() {
     runtime().block_on(async move {
         // Invalid field directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -84,7 +83,7 @@ fn invalid_boolean() {
         "#);
 
         // Invalid schema directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/validation/scalar/custom.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/validation/scalar/custom.rs
@@ -1,12 +1,11 @@
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 use super::EchoExt;
 
 #[test]
 fn valid_string() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/validation/scalar/float.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/validation/scalar/float.rs
@@ -1,12 +1,11 @@
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 use super::EchoExt;
 
 #[test]
 fn valid_float() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -55,7 +54,7 @@ fn valid_float() {
 #[test]
 fn int_to_float_conversion() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -105,7 +104,7 @@ fn int_to_float_conversion() {
 fn invalid_float() {
     runtime().block_on(async move {
         // Invalid field directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -133,7 +132,7 @@ fn invalid_float() {
         "#);
 
         // Invalid schema directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/validation/scalar/id.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/validation/scalar/id.rs
@@ -1,12 +1,11 @@
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 use super::EchoExt;
 
 #[test]
 fn valid_id() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -56,7 +55,7 @@ fn valid_id() {
 fn invalid_id() {
     runtime().block_on(async move {
         // Invalid field directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -84,7 +83,7 @@ fn invalid_id() {
         "#);
 
         // Invalid schema directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/validation/scalar/int.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/validation/scalar/int.rs
@@ -1,12 +1,11 @@
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 use super::EchoExt;
 
 #[test]
 fn valid_int() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -55,7 +54,7 @@ fn valid_int() {
 #[test]
 fn float_to_int_coercion() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -105,7 +104,7 @@ fn float_to_int_coercion() {
 fn invalid_int() {
     runtime().block_on(async move {
         // Invalid field directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -133,7 +132,7 @@ fn invalid_int() {
         "#);
 
         // Invalid schema directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/field_resolver/validation/scalar/string.rs
+++ b/crates/integration-tests/tests/federation/extensions/field_resolver/validation/scalar/string.rs
@@ -1,12 +1,11 @@
-use engine::Engine;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 use super::EchoExt;
 
 #[test]
 fn valid_string() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -56,7 +55,7 @@ fn valid_string() {
 fn invalid_string() {
     runtime().block_on(async move {
         // Invalid field directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"
@@ -84,7 +83,7 @@ fn invalid_string() {
         "#);
 
         // Invalid schema directive
-        let result = Engine::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/selection_set_resolver/mod.rs
+++ b/crates/integration-tests/tests/federation/extensions/selection_set_resolver/mod.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use engine::{Engine, GraphqlError};
+use engine::GraphqlError;
 use engine_schema::Subgraph;
 use extension_catalog::{ExtensionId, Id};
 use integration_tests::{
-    federation::{AnyExtension, EngineExt, SelectionSetResolverTestExtension, TestManifest},
+    federation::{AnyExtension, Gateway, SelectionSetResolverTestExtension, TestManifest},
     runtime,
 };
 use runtime::extension::{ArgumentsId, Data};
@@ -56,7 +56,7 @@ impl SelectionSetResolverTestExtension for StaticSelectionSetResolverExt {
 #[test]
 fn basic() {
     runtime().block_on(async {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph_sdl(
                 "a",
                 r#"

--- a/crates/integration-tests/tests/federation/extensions/subgraph.rs
+++ b/crates/integration-tests/tests/federation/extensions/subgraph.rs
@@ -1,6 +1,5 @@
-use engine::Engine;
 use graphql_mocks::dynamic::DynamicSchema;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 use serde_json::json;
 
 use crate::federation::extensions::basic::GreetExt;
@@ -8,7 +7,7 @@ use crate::federation::extensions::basic::GreetExt;
 #[test]
 fn extension_mixed_with_graphql_subgraph_root_fields() {
     runtime().block_on(async move {
-        let response = Engine::builder()
+        let response = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"

--- a/crates/integration-tests/tests/federation/graphql_over_http/application_graphql_response_json.rs
+++ b/crates/integration-tests/tests/federation/graphql_over_http/application_graphql_response_json.rs
@@ -1,7 +1,6 @@
 use super::{APPLICATION_GRAPHQL_RESPONSE_JSON, APPLICATION_JSON};
-use engine::Engine;
 use graphql_mocks::FakeGithubSchema;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 // If the URL is not used for other purposes, the server SHOULD use a 4xx status code to respond to a request that is not a well-formed GraphQL-over-HTTP request.
 #[rstest::rstest]
@@ -9,7 +8,7 @@ use integration_tests::{federation::EngineExt, runtime};
 #[case::post(http::Method::POST)]
 fn ill_formed_graphql_over_http_request(#[case] method: http::Method) {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         let response = engine
             .raw_execute(
@@ -46,7 +45,7 @@ fn ill_formed_graphql_over_http_request(#[case] method: http::Method) {
 #[case::post(http::Method::POST)]
 fn request_error(#[case] method: http::Method) {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         let response = engine
             .execute(method, "/graphql", "query { unknown }")
@@ -81,7 +80,7 @@ fn request_error(#[case] method: http::Method) {
 #[case::post(http::Method::POST)]
 fn field_error(#[case] method: http::Method) {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         let response = engine
             .execute(method, "/graphql", "query { fail }")

--- a/crates/integration-tests/tests/federation/graphql_over_http/application_json.rs
+++ b/crates/integration-tests/tests/federation/graphql_over_http/application_json.rs
@@ -1,7 +1,6 @@
 use super::APPLICATION_JSON;
-use engine::Engine;
 use graphql_mocks::FakeGithubSchema;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 // If the URL is not used for other purposes, the server SHOULD use a 4xx status code to respond to a request that is not a well-formed GraphQL-over-HTTP request.
 #[rstest::rstest]
@@ -9,7 +8,7 @@ use integration_tests::{federation::EngineExt, runtime};
 #[case::post(http::Method::POST)]
 fn ill_formed_graphql_over_http_request(#[case] method: http::Method) {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         let response = engine
             .raw_execute(
@@ -49,7 +48,7 @@ fn ill_formed_graphql_over_http_request(#[case] method: http::Method) {
 #[case::post(http::Method::POST)]
 fn request_error(#[case] method: http::Method) {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         let response = engine
             .execute(method, "/graphql", "query { unknown }")
@@ -86,7 +85,7 @@ fn request_error(#[case] method: http::Method) {
 #[case::post(http::Method::POST)]
 fn field_error(#[case] method: http::Method) {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         let response = engine
             .execute(method, "/graphql", "query { fail }")

--- a/crates/integration-tests/tests/federation/graphql_over_http/batch.rs
+++ b/crates/integration-tests/tests/federation/graphql_over_http/batch.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::FakeGithubSchema;
 use indoc::indoc;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn success() {
@@ -11,7 +10,7 @@ fn success() {
             enabled = true
         "#};
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_toml_config(config)
             .with_subgraph(FakeGithubSchema)
             .build()
@@ -59,7 +58,7 @@ fn success() {
 #[test]
 fn disabled() {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         // Query should work
         let response = engine
@@ -107,7 +106,7 @@ fn limit_reached() {
             limit = 1
         "#};
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_toml_config(config)
             .with_subgraph(FakeGithubSchema)
             .build()
@@ -159,7 +158,7 @@ fn just_in_limit() {
             limit = 2
         "#};
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_toml_config(config)
             .with_subgraph(FakeGithubSchema)
             .build()
@@ -212,7 +211,7 @@ fn invalid_request() {
             enabled = true
         "#};
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_toml_config(config)
             .with_subgraph(FakeGithubSchema)
             .build()
@@ -270,7 +269,7 @@ fn request_error() {
             enabled = true
         "#};
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_toml_config(config)
             .with_subgraph(FakeGithubSchema)
             .build()

--- a/crates/integration-tests/tests/federation/graphql_over_http/mod.rs
+++ b/crates/integration-tests/tests/federation/graphql_over_http/mod.rs
@@ -2,9 +2,8 @@ mod application_graphql_response_json;
 mod application_json;
 mod batch;
 
-use engine::Engine;
 use graphql_mocks::{FakeGithubSchema, Stateful};
-use integration_tests::{federation::EngineExt, openid::JWKS_URI, runtime};
+use integration_tests::{federation::Gateway, openid::JWKS_URI, runtime};
 
 const APPLICATION_JSON: &str = "application/json";
 const APPLICATION_GRAPHQL_RESPONSE_JSON: &str = "application/graphql-response+json";
@@ -28,7 +27,7 @@ fn authentication_returns_401(#[case] method: http::Method, #[case] accept: &'st
             url = "{JWKS_URI}"
         "#};
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_toml_config(config)
             .build()
@@ -60,7 +59,7 @@ fn authentication_returns_401(#[case] method: http::Method, #[case] accept: &'st
 #[test]
 fn missing_accept_header() {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         let response = engine
             .raw_execute(
@@ -95,7 +94,7 @@ fn missing_accept_header() {
 #[test]
 fn star_accept_header_should_be_accepted() {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         let response = engine
             .raw_execute(
@@ -164,7 +163,7 @@ fn star_accept_header_should_be_accepted() {
 #[test]
 fn unsupported_accept_header() {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         let response = engine
             .raw_execute(
@@ -198,7 +197,7 @@ fn unsupported_accept_header() {
 #[test]
 fn one_valid_acccept_header() {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         let response = engine
             .raw_execute(
@@ -242,7 +241,7 @@ fn one_valid_acccept_header() {
 #[case::gql_json(APPLICATION_GRAPHQL_RESPONSE_JSON)]
 fn missing_content_type(#[case] accept: &'static str) {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         let response = engine
             .raw_execute(
@@ -278,7 +277,7 @@ fn missing_content_type(#[case] accept: &'static str) {
 #[case::gql_json(APPLICATION_GRAPHQL_RESPONSE_JSON)]
 fn content_type_with_parameters(#[case] accept: &'static str) {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         let response = engine
             .raw_execute(
@@ -323,7 +322,7 @@ fn content_type_with_parameters(#[case] accept: &'static str) {
 #[case::gql_json(APPLICATION_GRAPHQL_RESPONSE_JSON)]
 fn get_must_not_be_used_for_mutations(#[case] accept: &'static str) {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(Stateful::default()).build().await;
+        let engine = Gateway::builder().with_subgraph(Stateful::default()).build().await;
 
         // Query should work
         let response = engine.get("query { value }").header(http::header::ACCEPT, accept).await;
@@ -364,7 +363,7 @@ fn get_must_not_be_used_for_mutations(#[case] accept: &'static str) {
 #[case::gql_json(APPLICATION_GRAPHQL_RESPONSE_JSON)]
 fn get_must_not_be_used_for_mutations_with_sse(#[case] accept: &'static str) {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(Stateful::default()).build().await;
+        let engine = Gateway::builder().with_subgraph(Stateful::default()).build().await;
 
         let accept = format!("text/event-stream,{accept};q=0.9");
 

--- a/crates/integration-tests/tests/federation/hooks/authorize_edge_node_post_execution.rs
+++ b/crates/integration-tests/tests/federation/hooks/authorize_edge_node_post_execution.rs
@@ -1,11 +1,11 @@
 use std::sync::{Arc, atomic::AtomicBool};
 
 use super::with_engine_for_auth;
-use engine::{Engine, ErrorCode, ErrorResponse, GraphqlError};
+use engine::{ErrorCode, ErrorResponse, GraphqlError};
 use graphql_mocks::dynamic::{DynamicSchema, EntityResolverContext};
 use http::HeaderMap;
 use integration_tests::{
-    federation::{DynHookContext, DynHooks, EngineExt},
+    federation::{DynHookContext, DynHooks, Gateway},
     runtime,
 };
 use runtime::hooks::EdgeDefinition;
@@ -37,7 +37,7 @@ fn single_decision_applies_to_all() {
     runtime().block_on(async move {
         let hooks = TestHooks::default();
 
-        let gateway = Engine::builder()
+        let gateway = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -158,7 +158,7 @@ fn continue_execution() {
     }
 
     runtime().block_on(async move {
-        let gateway = Engine::builder()
+        let gateway = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"

--- a/crates/integration-tests/tests/federation/hooks/authorize_parent_edge_post_execution.rs
+++ b/crates/integration-tests/tests/federation/hooks/authorize_parent_edge_post_execution.rs
@@ -1,9 +1,8 @@
-use engine::Engine;
 use engine::{ErrorCode, ErrorResponse, GraphqlError};
 use graphql_mocks::TeaShop;
 use http::HeaderMap;
 use integration_tests::federation::{DynHookContext, DynHooks};
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 use runtime::hooks::EdgeDefinition;
 
 use super::with_engine_for_auth;
@@ -56,7 +55,7 @@ fn after_pre_execution_hook() {
     }
 
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(TeaShop::with_sdl(
                 r###"
                 type Query {

--- a/crates/integration-tests/tests/federation/hooks/mod.rs
+++ b/crates/integration-tests/tests/federation/hooks/mod.rs
@@ -5,20 +5,19 @@ mod authorize_parent_edge_post_execution;
 mod on_gateway_request;
 mod on_subgraph_request;
 
-use engine::Engine;
 use futures::Future;
 use graphql_mocks::SecureSchema;
 use integration_tests::{
-    federation::{DynamicHooks, EngineExt, TestGateway},
+    federation::{DynamicHooks, Gateway},
     runtime,
 };
 
-fn with_engine_for_auth<F, O>(hooks: impl Into<DynamicHooks>, f: impl FnOnce(TestGateway) -> F) -> O
+fn with_engine_for_auth<F, O>(hooks: impl Into<DynamicHooks>, f: impl FnOnce(Gateway) -> F) -> O
 where
     F: Future<Output = O>,
 {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(SecureSchema)
             .with_mock_hooks(hooks)
             .build()

--- a/crates/integration-tests/tests/federation/hooks/on_gateway_request.rs
+++ b/crates/integration-tests/tests/federation/hooks/on_gateway_request.rs
@@ -1,9 +1,8 @@
-use engine::Engine;
 use engine::{ErrorCode, ErrorResponse, GraphqlError};
 use graphql_mocks::{EchoSchema, FakeGithubSchema};
 use http::HeaderMap;
 use integration_tests::federation::{DynHookContext, DynHooks};
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn can_modify_headers() {
@@ -31,7 +30,7 @@ fn can_modify_headers() {
             pattern = ".*"
         "#};
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_mock_hooks(TestHooks)
             .with_subgraph(EchoSchema)
             .with_toml_config(config)
@@ -91,7 +90,7 @@ fn error_is_propagated_back_to_the_user() {
     }
 
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_mock_hooks(TestHooks)
             .with_subgraph(FakeGithubSchema)
             .build()
@@ -138,7 +137,7 @@ fn error_code_is_propagated_back_to_the_user() {
     }
 
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_mock_hooks(TestHooks)
             .with_subgraph(FakeGithubSchema)
             .build()

--- a/crates/integration-tests/tests/federation/hooks/on_subgraph_request.rs
+++ b/crates/integration-tests/tests/federation/hooks/on_subgraph_request.rs
@@ -1,8 +1,7 @@
-use engine::Engine;
 use engine::{ErrorCode, GraphqlError};
 use graphql_mocks::{EchoSchema, FakeGithubSchema, Stateful, Subgraph};
 use integration_tests::federation::{DynHookContext, DynHooks};
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 use runtime::hooks::SubgraphRequest;
 use url::Url;
 
@@ -39,7 +38,7 @@ fn can_modify_headers() {
             name = "c"
         "#};
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_mock_hooks(TestHooks)
             .with_subgraph(EchoSchema)
             .with_toml_config(config)
@@ -99,7 +98,7 @@ fn can_modify_url() {
             }
         }
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_mock_hooks(TestHooks { url: subgraph.url() })
             .with_subgraph(Stateful::default())
             .with_toml_config(
@@ -166,7 +165,7 @@ fn error_is_propagated_back_to_the_user() {
     }
 
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_mock_hooks(TestHooks)
             .with_subgraph(FakeGithubSchema)
             .build()
@@ -211,7 +210,7 @@ fn error_code_is_propagated_back_to_the_user() {
     }
 
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_mock_hooks(TestHooks)
             .with_subgraph(FakeGithubSchema)
             .build()

--- a/crates/integration-tests/tests/federation/inaccessible/object_behind_interface.rs
+++ b/crates/integration-tests/tests/federation/inaccessible/object_behind_interface.rs
@@ -1,11 +1,7 @@
 use std::future::Future;
 
-use engine::Engine;
 use graphql_mocks::dynamic::DynamicSchema;
-use integration_tests::{
-    federation::{EngineExt, TestGateway},
-    runtime,
-};
+use integration_tests::{federation::Gateway, runtime};
 use serde_json::json;
 
 const SCHEMA: &str = r#"
@@ -29,9 +25,9 @@ type B implements Node @inaccessible {
 }
 "#;
 
-fn with_gateway<F: Future>(nodes: serde_json::Value, f: impl FnOnce(TestGateway) -> F) -> F::Output {
+fn with_gateway<F: Future>(nodes: serde_json::Value, f: impl FnOnce(Gateway) -> F) -> F::Output {
     runtime().block_on(async move {
-        let gateway = Engine::builder()
+        let gateway = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(SCHEMA)
                     .with_resolver("Query", "node", nodes[0].clone())
@@ -219,7 +215,7 @@ fn partially_inaccessible() {
 #[test]
 fn inaccessible_extra() {
     runtime().block_on(async move {
-        let gateway = Engine::builder()
+        let gateway = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(SCHEMA)
                     .with_resolver("Query", "node", json!({"__typename": "B", "id": "b"}))

--- a/crates/integration-tests/tests/federation/inaccessible/object_behind_union.rs
+++ b/crates/integration-tests/tests/federation/inaccessible/object_behind_union.rs
@@ -1,11 +1,7 @@
 use std::future::Future;
 
-use engine::Engine;
 use graphql_mocks::dynamic::DynamicSchema;
-use integration_tests::{
-    federation::{EngineExt, TestGateway},
-    runtime,
-};
+use integration_tests::{federation::Gateway, runtime};
 use serde_json::json;
 
 const SCHEMA: &str = r#"
@@ -27,9 +23,9 @@ type B @inaccessible {
 }
 "#;
 
-fn with_gateway<F: Future>(nodes: serde_json::Value, f: impl FnOnce(TestGateway) -> F) -> F::Output {
+fn with_gateway<F: Future>(nodes: serde_json::Value, f: impl FnOnce(Gateway) -> F) -> F::Output {
     runtime().block_on(async move {
-        let gateway = Engine::builder()
+        let gateway = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(SCHEMA)
                     .with_resolver("Query", "node", nodes[0].clone())
@@ -217,7 +213,7 @@ fn partially_inaccessible() {
 #[test]
 fn inaccessible_extra() {
     runtime().block_on(async move {
-        let gateway = Engine::builder()
+        let gateway = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(SCHEMA)
                     .with_resolver("Query", "node", json!({"__typename": "B", "id": "b"}))

--- a/crates/integration-tests/tests/federation/introspection.rs
+++ b/crates/integration-tests/tests/federation/introspection.rs
@@ -1,12 +1,11 @@
 use cynic::{QueryBuilder, http::ReqwestExt};
 use cynic_introspection::{CapabilitiesQuery, IntrospectionQuery, SpecificationVersion};
-use engine::Engine;
 use graphql_mocks::{
     EchoSchema, FakeGithubSchema, FederatedAccountsSchema, FederatedInventorySchema, FederatedProductsSchema,
     FederatedReviewsSchema,
 };
 use indoc::indoc;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 pub const PATHFINDER_INTROSPECTION_QUERY: &str = include_str!("../../data/introspection.graphql");
 
@@ -18,7 +17,7 @@ pub const CONFIG: &str = indoc! {r#"
 #[test]
 fn can_run_pathfinder_introspection_query() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_toml_config(CONFIG)
             .build()
@@ -94,7 +93,7 @@ fn can_run_pathfinder_introspection_query() {
 #[test]
 fn can_run_2018_introspection_query() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_toml_config(CONFIG)
             .build()
@@ -174,7 +173,7 @@ fn can_run_2018_introspection_query() {
 #[test]
 fn can_run_2021_introspection_query() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_toml_config(CONFIG)
             .build()
@@ -254,7 +253,7 @@ fn can_run_2021_introspection_query() {
 #[test]
 fn echo_subgraph_introspection() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(EchoSchema)
             .with_toml_config(CONFIG)
             .build()
@@ -315,7 +314,7 @@ fn echo_subgraph_introspection() {
 #[test]
 fn can_run_capability_introspection_query() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_toml_config(CONFIG)
             .build()
@@ -339,7 +338,7 @@ fn can_run_capability_introspection_query() {
 fn introspection_output_matches_source() {
     use reqwest::Client;
     let (response, _upstream_sdl) = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_toml_config(CONFIG)
             .build()
@@ -370,7 +369,7 @@ fn introspection_output_matches_source() {
 #[test]
 fn raw_introspetion_output() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_subgraph(EchoSchema)
             .with_toml_config(CONFIG)
@@ -387,7 +386,7 @@ fn raw_introspetion_output() {
 #[test]
 fn can_introsect_when_multiple_subgraphs() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_subgraph(EchoSchema)
             .with_toml_config(CONFIG)
@@ -501,7 +500,7 @@ fn can_introsect_when_multiple_subgraphs() {
 #[test]
 fn supports_the_type_field() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_toml_config(CONFIG)
             .build()
@@ -583,7 +582,7 @@ fn supports_the_type_field() {
 #[test]
 fn type_field_returns_null_on_missing_type() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_toml_config(CONFIG)
             .with_subgraph(FakeGithubSchema)
             .build()
@@ -615,7 +614,7 @@ fn type_field_returns_null_on_missing_type() {
 #[test]
 fn supports_recursing_through_types() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_toml_config(CONFIG)
             .with_subgraph(FakeGithubSchema)
             .build()
@@ -790,7 +789,7 @@ fn supports_recursing_through_types() {
 #[test]
 fn rejects_bogus_introspection_queries() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_toml_config(CONFIG)
             .with_subgraph(FakeGithubSchema)
             .build()
@@ -834,7 +833,7 @@ fn rejects_bogus_introspection_queries() {
 #[test]
 fn introspection_on_multiple_federation_subgraphs() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_toml_config(CONFIG)
             .with_subgraph(FederatedAccountsSchema)
             .with_subgraph(FederatedProductsSchema)
@@ -955,7 +954,7 @@ fn introspection_on_multiple_federation_subgraphs() {
 #[test]
 fn default_values() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_toml_config(CONFIG)
             .with_subgraph(FakeGithubSchema)
             .build()

--- a/crates/integration-tests/tests/federation/issues.rs
+++ b/crates/integration-tests/tests/federation/issues.rs
@@ -1,6 +1,5 @@
-use engine::Engine;
 use graphql_mocks::dynamic::DynamicSchema;
-use integration_tests::{federation::EngineExt, fetch::MockFetch, runtime};
+use integration_tests::{federation::Gateway, fetch::MockFetch, runtime};
 use serde_json::json;
 
 #[test]
@@ -41,7 +40,7 @@ fn gb6873_wrong_enum_sent_to_subgraph() {
 
     runtime().block_on(async move {
         let fetcher = MockFetch::default().with_responses("a", vec![json!({"data": {"doStuff": "Hi!"}})]);
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_federated_sdl(SDL)
             .with_mock_fetcher(fetcher.clone())
             .build()
@@ -162,7 +161,7 @@ fn gb7323_join_field_may_not_be_present() {
 
     runtime().block_on(async move {
         let fetcher = MockFetch::default().with_responses("localhost", vec![json!({"data": {"product": {"id": "1"}}})]);
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_federated_sdl(SDL)
             .with_mock_fetcher(fetcher.clone())
             .build()
@@ -191,7 +190,7 @@ fn gb7323_join_field_may_not_be_present() {
 #[test]
 fn gb8273_gateway_reports_missing_fields_present_in_subgraph_response() {
     runtime().block_on(async move {
-        let gateway = Engine::builder()
+        let gateway = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"

--- a/crates/integration-tests/tests/federation/mcp.rs
+++ b/crates/integration-tests/tests/federation/mcp.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::dynamic::DynamicSchema;
 use indoc::indoc;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 use serde_json::json;
 
 static CONFIG: &str = r#"
@@ -48,7 +47,7 @@ fn server_info_no_mutations() {
         .into_subgraph("a");
 
     let server_info = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph)
             .with_toml_config(CONFIG)
             .build()
@@ -96,7 +95,7 @@ fn server_info_mutations() {
         .into_subgraph("a");
 
     let server_info = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph)
             .with_toml_config(MUT_CONFIG)
             .build()
@@ -158,7 +157,7 @@ fn list_no_mutations() {
         .into_subgraph("a");
 
     let tools = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph)
             .with_toml_config(CONFIG)
             .build()
@@ -296,7 +295,7 @@ fn list_with_mutations() {
         .into_subgraph("a");
 
     let tools = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph)
             .with_toml_config(MUT_CONFIG)
             .build()
@@ -450,7 +449,7 @@ fn introspect_type() {
         .into_subgraph("a");
 
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph)
             .with_toml_config(CONFIG)
             .build()
@@ -522,7 +521,7 @@ fn run_query_no_params() {
         .into_subgraph("a");
 
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph)
             .with_toml_config(CONFIG)
             .build()
@@ -568,7 +567,7 @@ fn run_query_with_params() {
         .into_subgraph("a");
 
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph)
             .with_toml_config(CONFIG)
             .build()
@@ -624,7 +623,7 @@ fn mutation_rejected_when_disabled() {
         .into_subgraph("a");
 
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph)
             .with_toml_config(CONFIG) // Using the config where mutations are not enabled
             .build()
@@ -683,7 +682,7 @@ fn mutation_allowed_when_enabled() {
         .into_subgraph("a");
 
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph)
             .with_toml_config(MUT_CONFIG)
             .build()

--- a/crates/integration-tests/tests/federation/message_signing.rs
+++ b/crates/integration-tests/tests/federation/message_signing.rs
@@ -1,10 +1,9 @@
 use std::io::Write;
 
 use elliptic_curve::pkcs8::{DecodePrivateKey, EncodePrivateKey};
-use engine::Engine;
 use graphql_mocks::FakeGithubSchema;
 use httpsig::prelude::SharedKey;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 const SHARED_KEY_BASE64: &str = "aGVsbG8K";
 
@@ -258,7 +257,7 @@ fn test_message_signing_hmac_sha256_jwt_happy_path() {
 
 fn signature_success_test(schema: SignedGithubSchema, config: String) {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(schema)
             .with_toml_config(config)
             .build()
@@ -287,7 +286,7 @@ fn test_message_signing_with_derived_components() {
     );
 
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph)
             .with_toml_config(config)
             .build()
@@ -336,7 +335,7 @@ fn test_message_signing_with_nonce_and_expiry() {
     );
 
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(subgraph)
             .with_toml_config(config)
             .build()
@@ -365,7 +364,7 @@ fn test_message_signing_with_nonce_and_expiry() {
 #[test]
 fn test_message_signing_failures() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(SignedGithubSchema {
                 key: shared_key(),
                 kid: None,

--- a/crates/integration-tests/tests/federation/response_extensions.rs
+++ b/crates/integration-tests/tests/federation/response_extensions.rs
@@ -1,15 +1,14 @@
-use engine::Engine;
 use graphql_mocks::{
     FakeGithubSchema, FederatedAccountsSchema, FederatedInventorySchema, FederatedProductsSchema,
     FederatedReviewsSchema, FederatedShippingSchema,
     dynamic::{DynamicSchema, ServerError},
 };
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn grafbase_extension_on_successful_request() {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         let response = engine
             .post("query { serverVersion }")
@@ -49,7 +48,7 @@ fn grafbase_extension_on_successful_request() {
 #[test]
 fn dot_not_include_query_plan() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_toml_config(
                 r#"
@@ -86,7 +85,7 @@ fn dot_not_include_query_plan() {
 #[test]
 fn dot_not_include_trace_id() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_toml_config(
                 r#"
@@ -134,7 +133,7 @@ fn dot_not_include_trace_id() {
 #[test]
 fn grafbase_extension_on_subgraph_error() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(r#"type Query { hi: String }"#)
                     .with_resolver("Query", "hi", ServerError::new("Failed", None))
@@ -186,7 +185,7 @@ fn grafbase_extension_on_subgraph_error() {
 #[test]
 fn grafbase_extension_on_invalid_request() {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         let response = engine.post("query x }").header("x-grafbase-telemetry", "yes").await;
 
@@ -222,7 +221,7 @@ fn grafbase_extension_on_invalid_request() {
 #[test]
 fn grafbase_extension_secret_value() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_toml_config(
                 r#"
@@ -303,7 +302,7 @@ fn grafbase_extension_secret_value() {
 #[test]
 fn grafbase_extension_denied() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_toml_config(
                 r#"
@@ -336,7 +335,7 @@ fn grafbase_extension_denied() {
 #[test]
 fn grafbase_extension_on_ill_formed_graphql_over_http_request() {
     runtime().block_on(async move {
-        let engine = Engine::builder().with_subgraph(FakeGithubSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
 
         let response = engine
             .raw_execute(
@@ -379,7 +378,7 @@ fn grafbase_extension_on_ill_formed_graphql_over_http_request() {
 #[test]
 fn complex_query_plan() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FederatedAccountsSchema)
             .with_subgraph(FederatedProductsSchema)
             .with_subgraph(FederatedReviewsSchema)

--- a/crates/integration-tests/tests/federation/subgraph_retries.rs
+++ b/crates/integration-tests/tests/federation/subgraph_retries.rs
@@ -1,6 +1,5 @@
-use engine::Engine;
 use graphql_mocks::Stateful;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn subgraph_retries_mutations_disabled() {
@@ -12,7 +11,7 @@ fn subgraph_retries_mutations_disabled() {
             retry_percent = 0.01
         "#};
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(Stateful::default())
             .with_toml_config(config)
             .build()
@@ -94,7 +93,7 @@ fn subgraph_retries_mutations_enabled() {
             retry_mutations = true
         "#};
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(Stateful::default())
             .with_toml_config(config)
             .build()

--- a/crates/integration-tests/tests/federation/subgraphs/mod.rs
+++ b/crates/integration-tests/tests/federation/subgraphs/mod.rs
@@ -7,18 +7,17 @@ mod shared_root;
 mod sibling_dependencies;
 mod simple_key;
 
-use engine::Engine;
 use graphql_mocks::{
     FederatedAccountsSchema, FederatedInventorySchema, FederatedProductsSchema, FederatedReviewsSchema,
     FederatedShippingSchema,
 };
 use integration_tests::{
-    federation::{EngineExt, GraphqlResponse},
+    federation::{Gateway, GraphqlResponse},
     runtime,
 };
 
 async fn execute(request: &str) -> GraphqlResponse {
-    let engine = Engine::builder()
+    let engine = Gateway::builder()
         .with_subgraph(FederatedAccountsSchema)
         .with_subgraph(FederatedProductsSchema)
         .with_subgraph(FederatedReviewsSchema)

--- a/crates/integration-tests/tests/federation/subgraphs/not_reachable.rs
+++ b/crates/integration-tests/tests/federation/subgraphs/not_reachable.rs
@@ -1,5 +1,4 @@
-use engine::Engine;
-use integration_tests::{federation::EngineExt as _, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 const SDL: &str = r#"
 directive @core(feature: String!) repeatable on SCHEMA
@@ -39,7 +38,7 @@ type Query {
 #[test]
 fn subgraph_not_reachable_does_not_leak_subgraph_url() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_federated_sdl(SDL)
             .with_toml_config(
                 r#"

--- a/crates/integration-tests/tests/federation/subgraphs/overrride.rs
+++ b/crates/integration-tests/tests/federation/subgraphs/overrride.rs
@@ -1,11 +1,10 @@
-use engine::Engine;
 use graphql_mocks::FederatedAccountsSchema;
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn simple_override() {
     let response = runtime().block_on(async {
-        let engine = Engine::builder().with_subgraph(FederatedAccountsSchema).build().await;
+        let engine = Gateway::builder().with_subgraph(FederatedAccountsSchema).build().await;
         engine
             .post(
                 r"

--- a/crates/integration-tests/tests/federation/subgraphs/requires.rs
+++ b/crates/integration-tests/tests/federation/subgraphs/requires.rs
@@ -1,7 +1,6 @@
-use engine::Engine;
 use graphql_mocks::dynamic::{DynamicSchema, EntityResolverContext};
 use integration_tests::{
-    federation::{EngineExt, GraphqlResponse},
+    federation::{Gateway, GraphqlResponse},
     runtime,
 };
 use serde_json::json;
@@ -131,7 +130,7 @@ fn requires_with_arguments() {
 #[test]
 fn requires_with_fragments() {
     async fn run_with_user(user: serde_json::Value) -> GraphqlResponse {
-        let gateway = Engine::builder()
+        let gateway = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -238,7 +237,7 @@ fn requires_with_fragments() {
 #[test]
 fn nested_requires() {
     runtime().block_on(async move {
-        let gateway = Engine::builder()
+        let gateway = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"
@@ -326,7 +325,7 @@ fn nested_requires() {
 #[test]
 fn nested_requires_with_intermediate_plan() {
     runtime().block_on(async move {
-        let gateway = Engine::builder()
+        let gateway = Gateway::builder()
             .with_subgraph(
                 DynamicSchema::builder(
                     r#"

--- a/crates/integration-tests/tests/federation/subscriptions/multipart.rs
+++ b/crates/integration-tests/tests/federation/subscriptions/multipart.rs
@@ -1,13 +1,12 @@
-use engine::Engine;
 use graphql_mocks::{
     FederatedAccountsSchema, FederatedInventorySchema, FederatedProductsSchema, FederatedReviewsSchema,
 };
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn single_subgraph_subscription() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FederatedProductsSchema)
             .with_websocket_urls()
             .build()
@@ -58,7 +57,7 @@ fn single_subgraph_subscription() {
 #[test]
 fn actual_federated_subscription() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_websocket_urls()
             .with_subgraph(FederatedAccountsSchema)
             .with_subgraph(FederatedProductsSchema)

--- a/crates/integration-tests/tests/federation/subscriptions/sse.rs
+++ b/crates/integration-tests/tests/federation/subscriptions/sse.rs
@@ -1,13 +1,12 @@
-use engine::Engine;
 use graphql_mocks::{
     FederatedAccountsSchema, FederatedInventorySchema, FederatedProductsSchema, FederatedReviewsSchema,
 };
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn single_subgraph_subscription() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FederatedProductsSchema)
             .with_websocket_urls()
             .build()
@@ -58,7 +57,7 @@ fn single_subgraph_subscription() {
 #[test]
 fn request_error() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FederatedProductsSchema)
             .with_websocket_urls()
             .build()
@@ -104,7 +103,7 @@ fn request_error() {
 #[test]
 fn actual_federated_subscription() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_websocket_urls()
             .with_subgraph(FederatedAccountsSchema)
             .with_subgraph(FederatedProductsSchema)

--- a/crates/integration-tests/tests/federation/subscriptions/sse_subgraph.rs
+++ b/crates/integration-tests/tests/federation/subscriptions/sse_subgraph.rs
@@ -1,9 +1,8 @@
 use std::future::IntoFuture;
 
-use engine::Engine;
 use futures::FutureExt;
 use integration_tests::{
-    federation::{DockerSubgraph, EngineExt},
+    federation::{DockerSubgraph, Gateway},
     runtime,
 };
 use pretty_assertions::assert_eq;
@@ -12,7 +11,7 @@ use serde_json::json;
 #[test]
 fn docker_see_subgraph_is_working() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_docker_subgraph(DockerSubgraph::Sse)
             .build()
             .await;
@@ -40,7 +39,7 @@ fn docker_see_subgraph_is_working() {
 #[test]
 fn sse_subgraph_subscription() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_docker_subgraph(DockerSubgraph::Sse)
             .build()
             .await;
@@ -110,7 +109,7 @@ fn sse_subgraph_subscription() {
 fn gqlgen_subgraph_sse_subscription_with_initial_data() {
     let user = ulid::Ulid::new().to_string();
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_docker_subgraph(DockerSubgraph::Gqlgen)
             .with_toml_config(
                 r#"
@@ -184,7 +183,7 @@ fn gqlgen_subgraph_sse_subscription_with_initial_data() {
 fn gqlgen_subgraph_sse_subscription_without_initial_data() {
     let user = ulid::Ulid::new().to_string();
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_docker_subgraph(DockerSubgraph::Gqlgen)
             .with_toml_config(
                 r#"

--- a/crates/integration-tests/tests/federation/subscriptions/websockets.rs
+++ b/crates/integration-tests/tests/federation/subscriptions/websockets.rs
@@ -1,12 +1,11 @@
-use engine::Engine;
 use futures::StreamExt as _;
 use graphql_mocks::FederatedProductsSchema;
-use integration_tests::{federation::EngineExt as _, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn custom_websocket_path() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FederatedProductsSchema)
             .with_websocket_urls()
             .with_toml_config(
@@ -60,7 +59,7 @@ fn custom_websocket_path() {
 #[test]
 fn websockets_basic_no_init_payload() {
     let (first, second) = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FederatedProductsSchema)
             .with_websocket_urls()
             .build()
@@ -98,7 +97,7 @@ fn websockets_basic_no_init_payload() {
 #[test]
 fn websockets_forward_subgraph_headers() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FederatedProductsSchema)
             .with_websocket_urls()
             .with_toml_config(
@@ -146,7 +145,7 @@ fn websockets_forward_subgraph_headers() {
 #[test]
 fn websocket_connection_init_payload() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FederatedProductsSchema)
             .with_websocket_urls()
             .build()
@@ -198,7 +197,7 @@ fn websocket_connection_init_payload() {
 #[test]
 fn websocket_connection_init_payload_forwarding_disabled() {
     let response = runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FederatedProductsSchema)
             .with_toml_config(
                 "

--- a/crates/integration-tests/tests/federation/timeouts.rs
+++ b/crates/integration-tests/tests/federation/timeouts.rs
@@ -1,11 +1,10 @@
-use engine::Engine;
 use graphql_mocks::{FakeGithubSchema, SlowSchema};
-use integration_tests::{federation::EngineExt, runtime};
+use integration_tests::{federation::Gateway, runtime};
 
 #[test]
 fn gateway_timeout() {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(SlowSchema)
             .with_toml_config(
                 r###"
@@ -52,7 +51,7 @@ fn subgraph_timeout() {
             timeout = "1s"
         "#};
 
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(SlowSchema)
             .with_subgraph(FakeGithubSchema)
             .with_toml_config(config)

--- a/crates/integration-tests/tests/federation/trusted_documents.rs
+++ b/crates/integration-tests/tests/federation/trusted_documents.rs
@@ -1,9 +1,8 @@
-use engine::Engine;
 use futures::Future;
 use graphql_mocks::FakeGithubSchema;
 use integration_tests::{
     TestTrustedDocument,
-    federation::{EngineExt, GraphQlRequest, TestGateway},
+    federation::{Gateway, GraphQlRequest},
     runtime,
 };
 use runtime::trusted_documents_client::TrustedDocumentsEnforcementMode;
@@ -26,11 +25,11 @@ const TRUSTED_DOCUMENTS: &[TestTrustedDocument] = &[
 
 fn test<Fn, Fut>(enforcement_mode: TrustedDocumentsEnforcementMode, test_fn: Fn)
 where
-    Fn: FnOnce(TestGateway) -> Fut,
+    Fn: FnOnce(Gateway) -> Fut,
     Fut: Future<Output = ()>,
 {
     runtime().block_on(async move {
-        let engine = Engine::builder()
+        let engine = Gateway::builder()
             .with_subgraph(FakeGithubSchema)
             .with_mock_trusted_documents(enforcement_mode, TRUSTED_DOCUMENTS.to_owned())
             .build()


### PR DESCRIPTION
We want to test as much as possible in integration-tests that don't spawn a separate process, hence why we go through `federated-server`. So renamed all `Engine::builder()` to `Gateway::builder()` as we're actually testing the gateway not the engine directly.
