### PR TITLE
gateway: release 0.32.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "ascii",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.31.2"
+version = "0.32.0"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/changelog/0.32.0.md
+++ b/gateway/changelog/0.32.0.md
@@ -1,0 +1,28 @@
+## Breaking Changes
+
+- The `scheduled_delay` and `timeout` configuration options for telemetry exporters have been updated to accept a duration string instead of a number (https://github.com/grafbase/grafbase/pull/2962).
+
+## Features
+
+- Made the GDN poll url configurable (#2990)
+
+  For enterprise platform users who do not use the GDN (Graph Delivery Network), but instead their own HTTP endpoint to serve schemas.
+
+  The feature takes the form of a new gateway configuration option:
+
+  ```
+  [graph]
+  schema-fetch-url = "https://my-custom-s3-bucket/my-account-id/{{ graph-ref.graph }}/{{ graph-ref.branch }}"
+  ```
+
+  The following variables are available in the url template:
+
+  - `graph-ref.graph` : the graph name from the graph ref the gateway was started with.
+  - `graph-ref.branch`: the optional branch name from the graph ref the gateway was started with.
+
+- Opt-in MCP server support. Stay tuned for a release announcement.
+
+## Improvements
+
+- Improved the error messages on extension loading
+- Extension versions are now taken into account in operation caching (#2946)

--- a/gateway/changelog/unreleased.md
+++ b/gateway/changelog/unreleased.md
@@ -1,3 +1,0 @@
-## Breaking Changes
-
-- The `scheduled_delay` and `timeout` configuration options for telemetry exporters have been updated to accept a duration string instead of a number (https://github.com/grafbase/grafbase/pull/2962).


### PR DESCRIPTION
## Breaking Changes

- The `scheduled_delay` and `timeout` configuration options for telemetry exporters have been updated to accept a duration string instead of a number (https://github.com/grafbase/grafbase/pull/2962).

## Features

- Made the GDN poll url configurable (#2990)

  For enterprise platform users who do not use the GDN (Graph Delivery Network), but instead their own HTTP endpoint to serve schemas.

  The feature takes the form of a new gateway configuration option:

  ```
  [graph]
  schema-fetch-url = "https://my-custom-s3-bucket/my-account-id/{{ graph-ref.graph }}/{{ graph-ref.branch }}"
  ```

  The following variables are available in the url template:

  - `graph-ref.graph` : the graph name from the graph ref the gateway was started with.
  - `graph-ref.branch`: the optional branch name from the graph ref the gateway was started with.

- Opt-in MCP server support. Stay tuned for a release announcement.

## Improvements

- Improved the error messages on extension loading
- Extension versions are now taken into account in operation caching (#2946)
