### PR TITLE
feat(gateway): Accept application/cbor content-type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5389,6 +5389,7 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "mimalloc",
+ "minicbor-serde",
  "multipart-stream",
  "openidconnect",
  "ory-client",

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -14,7 +14,7 @@ use std::{borrow::Cow, future::Future, sync::Arc};
 use crate::{
     Body, HooksExtension,
     execution::{EarlyHttpContext, RequestContext, StreamResponse},
-    graphql_over_http::{Http, ResponseFormat, StreamingResponseFormat},
+    graphql_over_http::{ContentType, Http, ResponseFormat, StreamingResponseFormat},
     prepare::OperationDocument,
     response::Response,
     websocket::{self, InitPayload},
@@ -126,6 +126,7 @@ impl<R: Runtime> Engine<R> {
             uri: parts.uri,
             response_format,
             include_grafbase_response_extension: false,
+            content_type: ContentType::Json,
         };
 
         let (request_context, wasm_context) = self

--- a/crates/engine/src/execution/request/context.rs
+++ b/crates/engine/src/execution/request/context.rs
@@ -1,7 +1,11 @@
 use grafbase_telemetry::grafbase_client::Client;
 use runtime::authentication::LegacyToken;
 
-use crate::{Runtime, engine::WasmContext, graphql_over_http::ResponseFormat};
+use crate::{
+    Runtime,
+    engine::WasmContext,
+    graphql_over_http::{ContentType, ResponseFormat},
+};
 
 /// Context only used early in the request processing before generating the RequestContext used
 /// everywhere else. Contrary to the RequestContext this one never fails to be created.
@@ -9,6 +13,7 @@ pub(crate) struct EarlyHttpContext {
     pub method: http::method::Method,
     pub uri: http::Uri,
     pub response_format: ResponseFormat,
+    pub content_type: ContentType,
     pub include_grafbase_response_extension: bool,
 }
 

--- a/crates/engine/src/execution/request/errors.rs
+++ b/crates/engine/src/execution/request/errors.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 
 use crate::{
     Body,
-    graphql_over_http::{Http, ResponseFormat},
+    graphql_over_http::{ContentType, Http, ResponseFormat},
     response::{ErrorCode, GraphqlError, Response},
 };
 
@@ -21,12 +21,20 @@ pub(crate) fn not_acceptable_error(format: ResponseFormat) -> http::Response<Bod
     )
 }
 
-pub(crate) fn unsupported_media_type(format: ResponseFormat) -> http::Response<Body> {
+pub(crate) fn unsupported_content_type(format: ResponseFormat) -> http::Response<Body> {
     Http::error(
         format,
         refuse_request_with::<()>(
             http::StatusCode::UNSUPPORTED_MEDIA_TYPE,
-            "Missing or invalid Content-Type header. Only 'application/json' is supported.",
+            format!(
+                "Missing or invalid Content-Type header. You must specify one of: {}",
+                ContentType::supported()
+                    .iter()
+                    .format_with(", ", |media_type, f| f(&format_args!(
+                        "'{}'",
+                        media_type.to_str().unwrap()
+                    ))),
+            ),
         ),
     )
 }

--- a/crates/engine/src/graphql_over_http/response.rs
+++ b/crates/engine/src/graphql_over_http/response.rs
@@ -183,7 +183,7 @@ impl Http {
         let status_code = compute_status_code(ResponseFormat::Complete(format), response);
         let mut headers = http::HeaderMap::new();
 
-        headers.insert(http::header::CONTENT_TYPE, format.to_content_type());
+        headers.insert(http::header::CONTENT_TYPE, format.to_content_type_header_value());
         headers.typed_insert(headers::ContentLength(bytes.len() as u64));
 
         let mut http_response = http::Response::new(Body::Bytes(bytes));

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -40,6 +40,7 @@ httpsig.workspace = true
 indoc.workspace = true
 insta.workspace = true
 itertools.workspace = true
+minicbor-serde.workspace = true
 multipart-stream.workspace = true
 openidconnect.workspace = true
 ory-client.workspace = true # overridden by patch, pointing to their last release on GitHub

--- a/crates/integration-tests/tests/gateway/graphql_over_http/cbor.rs
+++ b/crates/integration-tests/tests/gateway/graphql_over_http/cbor.rs
@@ -1,0 +1,31 @@
+use graphql_mocks::FakeGithubSchema;
+use integration_tests::{gateway::Gateway, runtime};
+
+#[test]
+fn content_type() {
+    runtime().block_on(async move {
+        let engine = Gateway::builder().with_subgraph(FakeGithubSchema).build().await;
+
+        let response = engine
+            .raw_execute(
+                http::Request::builder()
+                    .uri("http://localhost/graphql")
+                    .method(http::Method::POST)
+                    .header(http::header::ACCEPT, "application/json")
+                    .header(http::header::CONTENT_TYPE, "application/cbor")
+                    .body(minicbor_serde::to_vec(serde_json::json!({"query": "{ __typename }"})).unwrap())
+                    .unwrap(),
+            )
+            .await;
+        let status = response.status();
+        let body: serde_json::Value = serde_json::from_slice(&response.into_body()).unwrap();
+        insta::assert_json_snapshot!(body, @r#"
+        {
+          "data": {
+            "__typename": "Query"
+          }
+        }
+        "#);
+        assert_eq!(status, 200);
+    })
+}

--- a/crates/integration-tests/tests/gateway/graphql_over_http/mod.rs
+++ b/crates/integration-tests/tests/gateway/graphql_over_http/mod.rs
@@ -1,6 +1,7 @@
 mod application_graphql_response_json;
 mod application_json;
 mod batch;
+mod cbor;
 
 use graphql_mocks::{FakeGithubSchema, Stateful};
 use integration_tests::{gateway::Gateway, openid::JWKS_URI, runtime};
@@ -255,18 +256,18 @@ fn missing_content_type(#[case] accept: &'static str) {
             .await;
         let status = response.status();
         let body: serde_json::Value = serde_json::from_slice(&response.into_body()).unwrap();
-        insta::assert_json_snapshot!(body, @r###"
+        insta::assert_json_snapshot!(body, @r#"
         {
           "errors": [
             {
-              "message": "Missing or invalid Content-Type header. Only 'application/json' is supported.",
+              "message": "Missing or invalid Content-Type header. You must specify one of: 'application/json', 'application/cbor'",
               "extensions": {
                 "code": "BAD_REQUEST"
               }
             }
           ]
         }
-        "###);
+        "#);
         assert_eq!(status, 415);
     })
 }


### PR DESCRIPTION
Wanted it for the mcp execute tool as it's faster, might as well just support it