### PR TITLE
chore(engine): Better operation errors

### DIFF
--- a/crates/engine/operation/src/bind/error.rs
+++ b/crates/engine/operation/src/bind/error.rs
@@ -1,4 +1,7 @@
 use cynic_parser::Span;
+use schema::{
+    CompositeTypeId, DirectiveSiteId, EntityDefinitionId, FieldDefinitionId, TypeDefinitionId, UnionDefinitionId,
+};
 
 use crate::Location;
 
@@ -10,34 +13,60 @@ pub(crate) enum BindError {
     UnknownType { name: String, span: Span },
     #[error("The field `{field_name}` does not have an argument named `{argument_name}")]
     UnknownArgument {
+        site_id: FieldDefinitionId,
         field_name: String,
         argument_name: String,
         span: Span,
     },
-    #[error("{container} does not have a field named '{name}'")]
+    #[error("{ty} does not have a field named '{name}'.")]
     UnknownField {
-        container: String,
+        ty: String,
         name: String,
         span: Span,
+        site_id: EntityDefinitionId,
     },
-    #[error("Unknown fragment named '{name}'")]
+    #[error("Unknown fragment named '{name}'.")]
     UnknownFragment { name: String, span: Span },
     #[error(
         "Field '{name}' does not exists on {ty}, it's a union. Only interfaces and objects have fields, consider using a fragment with a type condition."
     )]
-    UnionHaveNoFields { name: String, ty: String, span: Span },
+    UnionHaveNoFields {
+        name: String,
+        ty: String,
+        span: Span,
+        site_id: UnionDefinitionId,
+    },
     #[error("Field '{name}' cannot have a selection set, it's a {ty}. Only interfaces, unions and objects can.")]
-    CannotHaveSelectionSet { name: String, ty: String, span: Span },
+    CannotHaveSelectionSet {
+        name: String,
+        ty: String,
+        span: Span,
+        site_id: TypeDefinitionId,
+    },
     #[error("Type conditions cannot be declared on '{name}', only on unions, interfaces or objects.")]
-    InvalidTypeConditionTargetType { name: String, span: Span },
+    InvalidTypeConditionTargetType {
+        name: String,
+        span: Span,
+        site_id: TypeDefinitionId,
+    },
     #[error("Type condition on '{name}' cannot be used in a '{parent}' selection_set")]
-    DisjointTypeCondition { parent: String, name: String, span: Span },
+    DisjointTypeCondition {
+        parent: String,
+        name: String,
+        span: Span,
+        site_id: CompositeTypeId,
+    },
     #[error("Mutations are not defined on this schema.")]
     NoMutationDefined,
     #[error("Subscriptions are not defined on this schema.")]
     NoSubscriptionDefined,
     #[error("Leaf field '{name}' must be a scalar or an enum, but is a {ty}.")]
-    LeafMustBeAScalarOrEnum { name: String, ty: String, span: Span },
+    LeafMustBeAScalarOrEnum {
+        name: String,
+        ty: String,
+        span: Span,
+        site_id: CompositeTypeId,
+    },
     #[error(
         "Variable named '${name}' does not have a valid input type. Can only be a scalar, enum or input object. Found: '{ty}'."
     )]
@@ -53,7 +82,12 @@ pub(crate) enum BindError {
     #[error("{0}")]
     InvalidInputValue(#[from] super::coercion::InputValueError),
     #[error("Missing argument named '{name}' for field '{field}'")]
-    MissingArgument { field: String, name: String, span: Span },
+    MissingArgument {
+        field: String,
+        name: String,
+        span: Span,
+        site_id: FieldDefinitionId,
+    },
     #[error("Missing argument named '{name}' for directive '{directive}'")]
     MissingDirectiveArgument {
         name: &'static str,
@@ -63,7 +97,7 @@ pub(crate) enum BindError {
 }
 
 impl BindError {
-    pub fn location(self, operation: &ParsedOperation) -> Option<Location> {
+    pub fn maybe_location(&self, operation: &ParsedOperation) -> Option<Location> {
         match self {
             BindError::UnknownField { span, .. }
             | BindError::UnknownArgument { span, .. }
@@ -76,12 +110,34 @@ impl BindError {
             | BindError::InvalidVariableType { span, .. }
             | BindError::LeafMustBeAScalarOrEnum { span, .. }
             | BindError::MissingArgument { span, .. }
-            | BindError::MissingDirectiveArgument { span, .. } => Some(operation.span_to_location(span)),
+            | BindError::MissingDirectiveArgument { span, .. } => Some(operation.span_to_location(*span)),
             BindError::DuplicateVariable { location, .. } | BindError::UnusedVariable { location, .. } => {
-                Some(location)
+                Some(*location)
             }
-            BindError::InvalidInputValue(ref err) => Some(err.location()),
+            BindError::InvalidInputValue(err) => Some(err.location()),
             BindError::NoMutationDefined | BindError::NoSubscriptionDefined => None,
+        }
+    }
+
+    pub fn maybe_site_id(&self) -> Option<DirectiveSiteId> {
+        match self {
+            BindError::UnknownArgument { site_id, .. } => Some((*site_id).into()),
+            BindError::UnknownField { site_id, .. } => Some((*site_id).into()),
+            BindError::UnionHaveNoFields { site_id, .. } => Some((*site_id).into()),
+            BindError::InvalidTypeConditionTargetType { site_id, .. } => Some((*site_id).into()),
+            BindError::CannotHaveSelectionSet { site_id, .. } => Some((*site_id).into()),
+            BindError::DisjointTypeCondition { site_id, .. } => Some((*site_id).into()),
+            BindError::LeafMustBeAScalarOrEnum { site_id, .. } => Some((*site_id).into()),
+            BindError::MissingArgument { site_id, .. } => Some((*site_id).into()),
+            BindError::NoMutationDefined
+            | BindError::NoSubscriptionDefined
+            | BindError::InvalidVariableType { .. }
+            | BindError::MissingDirectiveArgument { .. }
+            | BindError::UnknownType { .. }
+            | BindError::UnknownFragment { .. }
+            | BindError::DuplicateVariable { .. }
+            | BindError::UnusedVariable { .. }
+            | BindError::InvalidInputValue(_) => None,
         }
     }
 }

--- a/crates/engine/operation/src/error.rs
+++ b/crates/engine/operation/src/error.rs
@@ -1,51 +1,62 @@
 use std::borrow::Cow;
 
+use schema::DirectiveSiteId;
+
 use crate::{Location, OperationAttributes};
 
-pub(crate) type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Errors>;
 
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("{message}")]
-    Parsing {
-        message: Cow<'static, str>,
-        locations: Vec<Location>,
-    },
-    #[error("{message}")]
-    Validation {
-        message: Cow<'static, str>,
-        locations: Vec<Location>,
-        attributes: OperationAttributes,
-    },
+#[derive(Debug)]
+pub struct Errors {
+    pub items: Vec<Error>,
+    pub attributes: Option<OperationAttributes>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ErrorKind {
+    Parsing,
+    Validation,
+}
+
+#[derive(Debug)]
+pub struct Error {
+    pub kind: ErrorKind,
+    pub message: Cow<'static, str>,
+    pub locations: Vec<Location>,
+    pub site_id: Option<DirectiveSiteId>,
 }
 
 impl Error {
     pub(crate) fn parsing(message: impl Into<Cow<'static, str>>) -> Self {
-        Error::Parsing {
+        Error {
+            kind: ErrorKind::Parsing,
             message: message.into(),
             locations: Vec::new(),
+            site_id: None,
         }
     }
 
-    pub(crate) fn validation(message: impl Into<Cow<'static, str>>, attributes: OperationAttributes) -> Self {
-        Error::Validation {
+    pub(crate) fn validation(message: impl Into<Cow<'static, str>>) -> Self {
+        Error {
+            kind: ErrorKind::Validation,
             message: message.into(),
             locations: Vec::new(),
-            attributes,
+            site_id: None,
         }
+    }
+
+    pub(crate) fn with_maybe_site_id(mut self, site_id: Option<DirectiveSiteId>) -> Self {
+        self.site_id = site_id;
+        self
     }
 
     pub(crate) fn with_location(mut self, location: Location) -> Self {
-        match &mut self {
-            Error::Parsing { locations, .. } | Error::Validation { locations, .. } => locations.push(location),
-        }
+        self.locations.push(location);
         self
     }
 
     pub(crate) fn with_locations(mut self, locations: impl IntoIterator<Item = Location>) -> Self {
-        match &mut self {
-            Error::Parsing { locations: loc, .. } | Error::Validation { locations: loc, .. } => loc.extend(locations),
-        }
+        self.locations.extend(locations);
         self
     }
 }

--- a/crates/engine/operation/src/lib.rs
+++ b/crates/engine/operation/src/lib.rs
@@ -24,17 +24,39 @@ impl Operation {
         let parsed_operation = parse::parse_operation(operation_name, document)?;
         let attributes = attributes::extract_attributes(&parsed_operation);
 
-        if let Err(err) = validation::after_parsing::validate(schema, &parsed_operation) {
-            return Err(Error::validation(err.to_string(), attributes)
-                .with_location(parsed_operation.span_to_location(err.span())));
+        if let Err(errors) = validation::after_parsing::validate(schema, &parsed_operation) {
+            return Err(Errors {
+                items: errors
+                    .into_iter()
+                    .map(|err| {
+                        Error::validation(err.to_string()).with_location(parsed_operation.span_to_location(err.span()))
+                    })
+                    .collect(),
+                attributes: Some(attributes),
+            });
         }
 
-        let operation = bind::bind_operation(schema, &parsed_operation, attributes).map_err(|(err, attributes)| {
-            Error::validation(err.to_string(), attributes).with_locations(err.location(&parsed_operation))
-        })?;
+        let operation =
+            bind::bind_operation(schema, &parsed_operation, attributes).map_err(|(errors, attributes)| Errors {
+                items: errors
+                    .into_iter()
+                    .map(|err| {
+                        Error::validation(err.to_string())
+                            .with_locations(err.maybe_location(&parsed_operation))
+                            .with_maybe_site_id(err.maybe_site_id())
+                    })
+                    .collect(),
+                attributes: Some(attributes),
+            })?;
 
-        if let Err(err) = validation::after_binding::validate(schema, &operation) {
-            return Err(Error::validation(err.to_string(), operation.attributes).with_locations(err.location()));
+        if let Err(errors) = validation::after_binding::validate(schema, &operation) {
+            return Err(Errors {
+                items: errors
+                    .into_iter()
+                    .map(|err| Error::validation(err.to_string()).with_locations(err.location()))
+                    .collect(),
+                attributes: Some(operation.attributes),
+            });
         }
 
         Ok(operation)

--- a/crates/engine/operation/src/parse/mod.rs
+++ b/crates/engine/operation/src/parse/mod.rs
@@ -4,6 +4,8 @@ mod offsets;
 use cynic_parser::{ExecutableDocument, executable::OperationDefinition};
 use offsets::LineOffsets;
 
+use crate::Errors;
+
 use self::error::{ParseError, ParseResult};
 use super::Location;
 
@@ -41,8 +43,10 @@ impl ParsedOperation {
 pub(crate) fn parse_operation(operation_name: Option<&str>, document_str: &str) -> crate::Result<ParsedOperation> {
     let line_offsets = LineOffsets::new(document_str);
 
-    let (name, document) =
-        parse_impl(operation_name, document_str).map_err(|err| err.into_graphql_error(&line_offsets))?;
+    let (name, document) = parse_impl(operation_name, document_str).map_err(|err| Errors {
+        items: vec![err.into_graphql_error(&line_offsets)],
+        attributes: None,
+    })?;
 
     Ok(ParsedOperation {
         name,

--- a/crates/engine/operation/src/validation/after_binding.rs
+++ b/crates/engine/operation/src/validation/after_binding.rs
@@ -21,12 +21,17 @@ impl ValidationError {
     }
 }
 
-pub(crate) fn validate(schema: &Schema, operation: &Operation) -> Result<(), ValidationError> {
+pub(crate) fn validate(schema: &Schema, operation: &Operation) -> Result<(), Vec<ValidationError>> {
     let ctx = OperationContext { schema, operation };
-    enforce_operation_limits(ctx)?;
-    ensure_introspection_is_accepted(ctx)?;
+    let mut errors = Vec::new();
+    if let Err(err) = enforce_operation_limits(ctx) {
+        errors.push(err);
+    }
+    if let Err(err) = ensure_introspection_is_accepted(ctx) {
+        errors.push(err);
+    }
 
-    Ok(())
+    if errors.is_empty() { Ok(()) } else { Err(errors) }
 }
 
 fn ensure_introspection_is_accepted(ctx: OperationContext<'_>) -> Result<(), ValidationError> {

--- a/crates/engine/schema/src/definition.rs
+++ b/crates/engine/schema/src/definition.rs
@@ -1,8 +1,8 @@
 use walker::Walk;
 
 use crate::{
-    CompositeType, CompositeTypeId, EntityDefinition, EntityDefinitionId, TypeDefinition, TypeDefinitionId,
-    TypeSystemDirective, TypeSystemDirectiveId,
+    CompositeType, CompositeTypeId, DeprecatedDirective, EntityDefinition, EntityDefinitionId, TypeDefinition,
+    TypeDefinitionId, TypeSystemDirective, TypeSystemDirectiveId,
 };
 
 impl<'a> TypeDefinition<'a> {
@@ -14,6 +14,17 @@ impl<'a> TypeDefinition<'a> {
             TypeDefinition::Object(item) => item.name(),
             TypeDefinition::Scalar(item) => item.name(),
             TypeDefinition::Union(item) => item.name(),
+        }
+    }
+
+    pub fn description(&self) -> Option<&'a str> {
+        match self {
+            TypeDefinition::Enum(item) => item.description(),
+            TypeDefinition::InputObject(item) => item.description(),
+            TypeDefinition::Interface(item) => item.description(),
+            TypeDefinition::Object(item) => item.description(),
+            TypeDefinition::Scalar(item) => item.description(),
+            TypeDefinition::Union(item) => item.description(),
         }
     }
 
@@ -84,6 +95,10 @@ impl<'a> TypeDefinition<'a> {
             TypeDefinition::Scalar(scalar) => scalar.is_inaccessible(),
             TypeDefinition::Union(union) => union.is_inaccessible(),
         }
+    }
+
+    pub fn has_deprecated(&self) -> Option<DeprecatedDirective<'_>> {
+        self.directives().find_map(|directive| directive.as_deprecated())
     }
 }
 

--- a/crates/engine/schema/src/directive_site.rs
+++ b/crates/engine/schema/src/directive_site.rs
@@ -20,6 +20,20 @@ impl std::fmt::Display for DirectiveSite<'_> {
     }
 }
 
+impl DirectiveSiteId {
+    pub fn as_type_definition(self) -> Option<TypeDefinitionId> {
+        match self {
+            DirectiveSiteId::Scalar(id) => Some(TypeDefinitionId::Scalar(id)),
+            DirectiveSiteId::Object(id) => Some(TypeDefinitionId::Object(id)),
+            DirectiveSiteId::Interface(id) => Some(TypeDefinitionId::Interface(id)),
+            DirectiveSiteId::Union(id) => Some(TypeDefinitionId::Union(id)),
+            DirectiveSiteId::Enum(id) => Some(TypeDefinitionId::Enum(id)),
+            DirectiveSiteId::InputObject(id) => Some(TypeDefinitionId::InputObject(id)),
+            _ => None,
+        }
+    }
+}
+
 impl From<TypeDefinitionId> for DirectiveSiteId {
     fn from(definition: TypeDefinitionId) -> Self {
         match definition {

--- a/crates/engine/schema/src/entity.rs
+++ b/crates/engine/schema/src/entity.rs
@@ -1,8 +1,8 @@
 use walker::{Iter, Walk};
 
 use crate::{
-    CompositeType, CompositeTypeId, EntityDefinition, EntityDefinitionId, FieldDefinition, InterfaceDefinition,
-    InterfaceDefinitionId, ObjectDefinitionId, TypeDefinitionId, TypeSystemDirective,
+    CompositeType, CompositeTypeId, DeprecatedDirective, EntityDefinition, EntityDefinitionId, FieldDefinition,
+    InterfaceDefinition, InterfaceDefinitionId, ObjectDefinitionId, TypeDefinitionId, TypeSystemDirective,
 };
 
 impl EntityDefinitionId {
@@ -27,6 +27,20 @@ impl<'a> EntityDefinition<'a> {
         match self {
             EntityDefinition::Object(item) => item.name(),
             EntityDefinition::Interface(item) => item.name(),
+        }
+    }
+
+    pub fn description(&self) -> Option<&'a str> {
+        match self {
+            EntityDefinition::Object(item) => item.description(),
+            EntityDefinition::Interface(item) => item.description(),
+        }
+    }
+
+    pub fn has_deprecated(&self) -> Option<DeprecatedDirective<'a>> {
+        match self {
+            EntityDefinition::Object(item) => item.has_deprecated(),
+            EntityDefinition::Interface(item) => item.has_deprecated(),
         }
     }
 

--- a/crates/engine/schema/src/enum_value.rs
+++ b/crates/engine/schema/src/enum_value.rs
@@ -1,8 +1,12 @@
-use crate::EnumValue;
+use crate::{DeprecatedDirective, EnumValue};
 
 impl EnumValue<'_> {
     pub fn is_inaccessible(&self) -> bool {
         self.schema.graph.inaccessible_enum_values[self.id]
+    }
+
+    pub fn has_deprecated(&self) -> Option<DeprecatedDirective<'_>> {
+        self.directives().find_map(|directive| directive.as_deprecated())
     }
 }
 

--- a/crates/engine/schema/src/field.rs
+++ b/crates/engine/schema/src/field.rs
@@ -1,5 +1,6 @@
 use crate::{
-    CostDirective, FieldDefinition, FieldSet, InputValueDefinition, ListSizeDirective, SubgraphId, TypeSystemDirective,
+    CostDirective, DeprecatedDirective, FieldDefinition, FieldSet, InputValueDefinition, ListSizeDirective, SubgraphId,
+    TypeSystemDirective,
 };
 
 impl<'a> FieldDefinition<'a> {
@@ -43,5 +44,9 @@ impl<'a> FieldDefinition<'a> {
             TypeSystemDirective::ListSize(list_size_directive) => Some(list_size_directive),
             _ => None,
         })
+    }
+
+    pub fn has_deprecated(&self) -> Option<DeprecatedDirective<'_>> {
+        self.directives().find_map(|directive| directive.as_deprecated())
     }
 }

--- a/crates/engine/schema/src/input_value_def.rs
+++ b/crates/engine/schema/src/input_value_def.rs
@@ -5,3 +5,13 @@ impl InputValueDefinition<'_> {
         self.schema.graph.inaccessible_input_value_definitions[self.id]
     }
 }
+
+impl std::fmt::Display for InputValueDefinition<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.name(), self.ty())?;
+        if let Some(default_value) = self.default_value() {
+            write!(f, " = {}", default_value)?;
+        }
+        Ok(())
+    }
+}

--- a/crates/engine/schema/src/interface.rs
+++ b/crates/engine/schema/src/interface.rs
@@ -1,4 +1,4 @@
-use crate::{FieldDefinition, InterfaceDefinition, ObjectDefinitionId, SubgraphId};
+use crate::{DeprecatedDirective, FieldDefinition, InterfaceDefinition, ObjectDefinitionId, SubgraphId};
 
 impl<'a> InterfaceDefinition<'a> {
     pub fn has_implementor(&self, id: ObjectDefinitionId) -> bool {
@@ -23,6 +23,10 @@ impl<'a> InterfaceDefinition<'a> {
 
     pub fn has_inaccessible_implementor(&self) -> bool {
         self.schema.graph.interface_has_inaccessible_implementor[self.id]
+    }
+
+    pub fn has_deprecated(&self) -> Option<DeprecatedDirective<'a>> {
+        self.directives().find_map(|directive| directive.as_deprecated())
     }
 }
 

--- a/crates/engine/schema/src/object.rs
+++ b/crates/engine/schema/src/object.rs
@@ -1,4 +1,6 @@
-use crate::{FieldDefinition, InterfaceDefinitionId, ObjectDefinition, ObjectDefinitionRecord, SubgraphId};
+use crate::{
+    DeprecatedDirective, FieldDefinition, InterfaceDefinitionId, ObjectDefinition, ObjectDefinitionRecord, SubgraphId,
+};
 
 impl ObjectDefinitionRecord {
     pub fn implements_interface_in_subgraph(
@@ -28,6 +30,10 @@ impl<'a> ObjectDefinition<'a> {
 
     pub fn is_inaccessible(&self) -> bool {
         self.schema.graph.inaccessible_object_definitions[self.id]
+    }
+
+    pub fn has_deprecated(&self) -> Option<DeprecatedDirective<'a>> {
+        self.directives().find_map(|directive| directive.as_deprecated())
     }
 }
 

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -119,12 +119,10 @@ impl<R: Runtime> Engine<R> {
         parts: http::request::Parts,
         payload: InitPayload,
     ) -> Result<WebsocketSession<R>, Cow<'static, str>> {
-        let response_format = ResponseFormat::Streaming(StreamingResponseFormat::GraphQLOverWebSocket);
-
         let ctx = EarlyHttpContext {
             method: parts.method,
             uri: parts.uri,
-            response_format,
+            response_format: ResponseFormat::Streaming(StreamingResponseFormat::GraphQLOverWebSocket),
             include_grafbase_response_extension: false,
             content_type: ContentType::Json,
         };

--- a/crates/engine/src/prepare/mod.rs
+++ b/crates/engine/src/prepare/mod.rs
@@ -27,7 +27,7 @@ use crate::{
 impl<R: Runtime> Engine<R> {
     pub(crate) fn warm_operation(&self, document: OperationDocument<'_>) -> Result<CachedOperation, String> {
         let operation = Operation::parse(&self.schema, document.operation_name(), &document.content)
-            .map_err(|err| err.to_string())?;
+            .map_err(|errors| errors.items.into_iter().next().unwrap().message)?;
         crate::prepare::solve(&self.schema, document, operation).map_err(|err| err.to_string())
     }
 }

--- a/crates/integration-tests/tests/gateway/basic/errors.rs
+++ b/crates/integration-tests/tests/gateway/basic/errors.rs
@@ -164,11 +164,11 @@ fn request_error() {
         .execute()
         .await
     });
-    insta::assert_json_snapshot!(response, @r###"
+    insta::assert_json_snapshot!(response, @r#"
     {
       "errors": [
         {
-          "message": "Query does not have a field named '_typean_'",
+          "message": "Query does not have a field named '_typean_'.",
           "locations": [
             {
               "line": 3,
@@ -181,7 +181,7 @@ fn request_error() {
         }
       ]
     }
-    "###);
+    "#);
 }
 
 #[test]

--- a/crates/integration-tests/tests/gateway/basic/variables.rs
+++ b/crates/integration-tests/tests/gateway/basic/variables.rs
@@ -491,11 +491,12 @@ fn variables_are_input_types_validation() {
             "query($one: Query) { string(input: $one)}",
             json!({})
         ),
-        @r###"
+        @r#"
     [
-      "Variable named '$one' does not have a valid input type. Can only be a scalar, enum or input object. Found: 'Query'."
+      "Variable named '$one' does not have a valid input type. Can only be a scalar, enum or input object. Found: 'Query'.",
+      "Unknown variable $one"
     ]
-    "###
+    "#
     );
 }
 

--- a/crates/integration-tests/tests/gateway/graphql_over_http/application_graphql_response_json.rs
+++ b/crates/integration-tests/tests/gateway/graphql_over_http/application_graphql_response_json.rs
@@ -51,11 +51,11 @@ fn request_error(#[case] method: http::Method) {
             .execute(method, "/graphql", "query { unknown }")
             .header(http::header::ACCEPT, APPLICATION_GRAPHQL_RESPONSE_JSON)
             .await;
-        insta::assert_json_snapshot!(response, @r###"
+        insta::assert_json_snapshot!(response, @r#"
         {
           "errors": [
             {
-              "message": "Query does not have a field named 'unknown'",
+              "message": "Query does not have a field named 'unknown'.",
               "locations": [
                 {
                   "line": 1,
@@ -68,7 +68,7 @@ fn request_error(#[case] method: http::Method) {
             }
           ]
         }
-        "###);
+        "#);
         assert_eq!(response.status, 400);
     })
 }

--- a/crates/integration-tests/tests/gateway/graphql_over_http/application_json.rs
+++ b/crates/integration-tests/tests/gateway/graphql_over_http/application_json.rs
@@ -54,11 +54,11 @@ fn request_error(#[case] method: http::Method) {
             .execute(method, "/graphql", "query { unknown }")
             .header(http::header::ACCEPT, APPLICATION_JSON)
             .await;
-        insta::assert_json_snapshot!(response, @r###"
+        insta::assert_json_snapshot!(response, @r#"
         {
           "errors": [
             {
-              "message": "Query does not have a field named 'unknown'",
+              "message": "Query does not have a field named 'unknown'.",
               "locations": [
                 {
                   "line": 1,
@@ -71,7 +71,7 @@ fn request_error(#[case] method: http::Method) {
             }
           ]
         }
-        "###);
+        "#);
         assert_eq!(response.status, 200);
     })
 }

--- a/crates/integration-tests/tests/gateway/graphql_over_http/batch.rs
+++ b/crates/integration-tests/tests/gateway/graphql_over_http/batch.rs
@@ -296,7 +296,7 @@ fn request_error() {
 
         let status = response.status();
         let body: serde_json::Value = serde_json::from_slice(&response.into_body()).unwrap();
-        insta::assert_json_snapshot!(body, @r###"
+        insta::assert_json_snapshot!(body, @r#"
         [
           {
             "data": {
@@ -306,7 +306,7 @@ fn request_error() {
           {
             "errors": [
               {
-                "message": "Query does not have a field named 'unknown'",
+                "message": "Query does not have a field named 'unknown'.",
                 "locations": [
                   {
                     "line": 1,
@@ -320,7 +320,7 @@ fn request_error() {
             ]
           }
         ]
-        "###);
+        "#);
         assert_eq!(status, 200);
     })
 }

--- a/crates/integration-tests/tests/gateway/inaccessible/mod.rs
+++ b/crates/integration-tests/tests/gateway/inaccessible/mod.rs
@@ -194,7 +194,7 @@ fn inaccessible_object() {
         {
           "errors": [
             {
-              "message": "Query does not have a field named 'inaccessibleObject'",
+              "message": "Query does not have a field named 'inaccessibleObject'.",
               "locations": [
                 {
                   "line": 1,
@@ -223,7 +223,7 @@ fn inaccessible_scalar() {
         {
           "errors": [
             {
-              "message": "Query does not have a field named 'inaccessibleScalar'",
+              "message": "Query does not have a field named 'inaccessibleScalar'.",
               "locations": [
                 {
                   "line": 1,
@@ -252,7 +252,7 @@ fn inaccessible_interface() {
         {
           "errors": [
             {
-              "message": "Query does not have a field named 'inaccessibleInterface'",
+              "message": "Query does not have a field named 'inaccessibleInterface'.",
               "locations": [
                 {
                   "line": 1,
@@ -282,7 +282,7 @@ fn inaccessible_union() {
         {
           "errors": [
             {
-              "message": "Query does not have a field named 'inaccessibleUnion'",
+              "message": "Query does not have a field named 'inaccessibleUnion'.",
               "locations": [
                 {
                   "line": 1,
@@ -311,7 +311,7 @@ fn inaccessible_field() {
         {
           "errors": [
             {
-              "message": "Query does not have a field named 'inaccessibleField'",
+              "message": "Query does not have a field named 'inaccessibleField'.",
               "locations": [
                 {
                   "line": 1,

--- a/crates/integration-tests/tests/gateway/introspection.rs
+++ b/crates/integration-tests/tests/gateway/introspection.rs
@@ -810,11 +810,11 @@ fn rejects_bogus_introspection_queries() {
             .await
     });
 
-    insta::assert_json_snapshot!(response, @r###"
+    insta::assert_json_snapshot!(response, @r#"
     {
       "errors": [
         {
-          "message": "__Type does not have a field named 'blarg'",
+          "message": "__Type does not have a field named 'blarg'.",
           "locations": [
             {
               "line": 5,
@@ -827,7 +827,7 @@ fn rejects_bogus_introspection_queries() {
         }
       ]
     }
-    "###);
+    "#);
 }
 
 #[test]

--- a/crates/integration-tests/tests/gateway/subscriptions/sse.rs
+++ b/crates/integration-tests/tests/gateway/subscriptions/sse.rs
@@ -77,12 +77,12 @@ fn request_error() {
             .await
     });
 
-    insta::assert_json_snapshot!(response.messages, @r###"
+    insta::assert_json_snapshot!(response.messages, @r#"
     [
       {
         "errors": [
           {
-            "message": "Subscription does not have a field named 'unknown'",
+            "message": "Subscription does not have a field named 'unknown'.",
             "locations": [
               {
                 "line": 3,
@@ -96,7 +96,7 @@ fn request_error() {
         ]
       }
     ]
-    "###);
+    "#);
     assert_eq!(response.status, http::StatusCode::OK);
 }
 

--- a/gateway/tests/telemetry/metrics/operation.rs
+++ b/gateway/tests/telemetry/metrics/operation.rs
@@ -175,11 +175,11 @@ fn generate_operation_name() {
             .send()
             .await;
 
-        insta::assert_json_snapshot!(response, @r###"
+        insta::assert_json_snapshot!(response, @r#"
         {
           "errors": [
             {
-              "message": "Query does not have a field named 'myFavoriteField'",
+              "message": "Query does not have a field named 'myFavoriteField'.",
               "locations": [
                 {
                   "line": 1,
@@ -189,10 +189,22 @@ fn generate_operation_name() {
               "extensions": {
                 "code": "OPERATION_VALIDATION_ERROR"
               }
+            },
+            {
+              "message": "Query does not have a field named 'ignoreMe'.",
+              "locations": [
+                {
+                  "line": 1,
+                  "column": 39
+                }
+              ],
+              "extensions": {
+                "code": "OPERATION_VALIDATION_ERROR"
+              }
             }
           ]
         }
-        "###);
+        "#);
         tokio::time::sleep(METRICS_DELAY).await;
 
         let row = clickhouse
@@ -231,11 +243,11 @@ fn request_error() {
             .gql::<serde_json::Value>("query Faulty { __typ__ename }")
             .send()
             .await;
-        insta::assert_json_snapshot!(resp, @r###"
+        insta::assert_json_snapshot!(resp, @r#"
         {
           "errors": [
             {
-              "message": "Query does not have a field named '__typ__ename'",
+              "message": "Query does not have a field named '__typ__ename'.",
               "locations": [
                 {
                   "line": 1,
@@ -248,7 +260,7 @@ fn request_error() {
             }
           ]
         }
-        "###);
+        "#);
         tokio::time::sleep(METRICS_DELAY).await;
 
         let row = clickhouse


### PR DESCRIPTION
Until now we were stopping at the first error. But for MCP we want to
return as much information as possible and it's useful for clients anyway.

Additionally I'm now tracking relevant `DirectiveSiteId`s so that I can
later send the relevant SDL to the LLMs based on the errors. So instead
of just saying "Oops this field doesn't exist!" I'll include the type's
GraphQL definition.
