### PR TITLE
ci: make gateway docker images on GHCR multi-platform

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -175,6 +175,7 @@ jobs:
           project: lc6t0h7bhh
           token: ${{ secrets.DEPOT_TOKEN }}
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ghcr.io/grafbase/gateway:${{ env.COMMIT_SHA }}, ghcr.io/grafbase/gateway:latest
           file: ./gateway/Dockerfile
 
@@ -191,6 +192,7 @@ jobs:
           project: lc6t0h7bhh
           token: ${{ secrets.DEPOT_TOKEN }}
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ghcr.io/grafbase/gateway:${{ env.RELEASE_VERSION }}
           file: ./gateway/Dockerfile
 


### PR DESCRIPTION
So we also publish arm64 images that will show up in pages like https://github.com/grafbase/grafbase/pkgs/container/gateway

Let's use the approach documented here: https://depot.dev/blog/multi-platform-docker-images-in-github-actions

closes GB-8876